### PR TITLE
[codex] Stabilize Wework sidebar content width

### DIFF
--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -283,7 +283,7 @@ export function MessageTurnNavigation({
       className="pointer-events-none absolute top-1/2 z-popover hidden -translate-y-1/2 lg:block"
       data-testid="message-turn-navigation"
       style={{
-        left: '8px',
+        left: '16px',
         width: `${MARKER_HIT_AREA_WIDTH_PX}px`,
         height: `${navigationHeight}px`,
         maxHeight: `calc(100% - ${NAVIGATION_VIEWPORT_PADDING_PX}px)`,

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -144,7 +144,7 @@ describe('DesktopSidebar', () => {
 
     const handle = screen.getByTestId('sidebar-resize-handle')
 
-    expect(handle).toHaveClass('right-[-6px]', 'w-3')
+    expect(handle).toHaveClass('right-[-14px]', 'w-[18px]')
     expect(handle).not.toHaveClass('w-10')
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -2017,414 +2017,416 @@ export function DesktopSidebar({
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
       className={cn(
-        'relative z-popover shrink-0 overflow-hidden bg-transparent transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[width]',
+        'relative z-popover shrink-0 overflow-visible bg-transparent transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[width]',
         resizing && 'transition-none',
         collapsed && 'pointer-events-none'
       )}
       style={{ width: collapsed ? 0 : sidebarWidth }}
     >
-      <div
-        className="relative flex h-full flex-col px-1.5 pb-4 pt-1.5"
-        style={{ width: sidebarWidth }}
-      >
-        <nav className="space-y-0.5">
-          <SidebarButton
-            icon={Plus}
-            label={t('workbench.new_chat', '新对话')}
-            testId="new-chat-button"
-            onClick={onNewChat}
-          />
-          {onOpenSearch && (
-            <SidebarButton
-              icon={Search}
-              label={t('workbench.search')}
-              testId="runtime-search-button"
-              onClick={onOpenSearch}
-            />
-          )}
-          {showCloudConnectionEntry && (
-            <CloudConnectionSidebarButton
-              devices={devices}
-              cloudWorkStatus={cloudWorkStatus}
-              onOpenSettings={() => onOpenSettings()}
-              onSelectCloudDevice={deviceId => onSelectStandaloneDevice?.(deviceId)}
-              onAddDevice={() => {
-                setStandaloneRemoteDialogIntent('add-device')
-                setStandaloneWorkspaceDialogMode('remote')
-              }}
-            />
-          )}
-          {SHOW_PLUGINS_NAVIGATION && (
-            <SidebarButton
-              icon={Sparkles}
-              label={t('workbench.plugins', '插件')}
-              testId="plugins-button"
-              selected={activeItem === 'plugins'}
-              onClick={onOpenPlugins}
-            />
-          )}
-        </nav>
-
+      <div className="h-full overflow-hidden">
         <div
-          data-testid="sidebar-worklists-scroll"
-          className="scrollbar-none mt-8 min-h-0 flex-1 overflow-y-auto [overflow-anchor:none]"
+          className="relative flex h-full flex-col px-1.5 pb-4 pt-1.5"
+          style={{ width: sidebarWidth }}
         >
-          <section>
-            <div ref={projectCreateMenuRef}>
+          <nav className="space-y-0.5">
+            <SidebarButton
+              icon={Plus}
+              label={t('workbench.new_chat', '新对话')}
+              testId="new-chat-button"
+              onClick={onNewChat}
+            />
+            {onOpenSearch && (
+              <SidebarButton
+                icon={Search}
+                label={t('workbench.search')}
+                testId="runtime-search-button"
+                onClick={onOpenSearch}
+              />
+            )}
+            {showCloudConnectionEntry && (
+              <CloudConnectionSidebarButton
+                devices={devices}
+                cloudWorkStatus={cloudWorkStatus}
+                onOpenSettings={() => onOpenSettings()}
+                onSelectCloudDevice={deviceId => onSelectStandaloneDevice?.(deviceId)}
+                onAddDevice={() => {
+                  setStandaloneRemoteDialogIntent('add-device')
+                  setStandaloneWorkspaceDialogMode('remote')
+                }}
+              />
+            )}
+            {SHOW_PLUGINS_NAVIGATION && (
+              <SidebarButton
+                icon={Sparkles}
+                label={t('workbench.plugins', '插件')}
+                testId="plugins-button"
+                selected={activeItem === 'plugins'}
+                onClick={onOpenPlugins}
+              />
+            )}
+          </nav>
+
+          <div
+            data-testid="sidebar-worklists-scroll"
+            className="scrollbar-none mt-8 min-h-0 flex-1 overflow-y-auto [overflow-anchor:none]"
+          >
+            <section>
+              <div ref={projectCreateMenuRef}>
+                <SidebarSectionHeader
+                  title={t('workbench.projects', '项目')}
+                  expanded={displayedProjectsExpanded}
+                  hasContent={sidebarProjects.length > 0}
+                  toggleTestId="projects-section-toggle"
+                  iconTestId="projects-section-chevron-right"
+                  onToggle={() => setProjectsExpanded(expanded => !expanded)}
+                >
+                  <div className="flex items-center">
+                    <ActionMenu
+                      ariaLabel={t('workbench.project_list_actions', '项目列表操作')}
+                      testId="projects-section-menu"
+                      items={[
+                        {
+                          label: t('workbench.archive_all_chats', '归档所有聊天'),
+                          icon: Archive,
+                          testId: 'projects-section-archive-all-chats',
+                          disabled:
+                            !onArchiveProjectsConversations ||
+                            projectSectionArchiveCount === 0 ||
+                            isArchivingProjectSection,
+                          onSelect: () => setArchiveSectionMode('projects'),
+                        },
+                      ]}
+                      triggerClassName="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
+                    />
+                    <button
+                      type="button"
+                      aria-label={t('workbench.new_project', '新建项目')}
+                      data-testid="projects-create-button"
+                      onClick={event => {
+                        event.stopPropagation()
+                        openProjectCreateMenu(event.currentTarget)
+                      }}
+                      className="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
+                      aria-expanded={projectCreateMenuOpen}
+                    >
+                      <FolderPlus className="h-4 w-4" />
+                    </button>
+                  </div>
+                </SidebarSectionHeader>
+              </div>
+              {projectCreateMenuOpen &&
+                projectCreateMenuPosition &&
+                createPortal(
+                  <div
+                    ref={projectCreateMenuFloatingRef}
+                    data-testid="projects-create-button-menu"
+                    className="fixed z-modal rounded-xl border border-border bg-surface p-1.5 text-[13px] text-text-primary shadow-lg"
+                    style={{
+                      top: projectCreateMenuPosition.top,
+                      left: projectCreateMenuPosition.left,
+                      width: PROJECT_CREATE_MENU_WIDTH,
+                    }}
+                    onClick={event => event.stopPropagation()}
+                  >
+                    <button
+                      type="button"
+                      data-testid="project-create-blank-option"
+                      onClick={() => {
+                        setProjectCreateMenuOpen(false)
+                        setBlankProjectDialogOpen(true)
+                      }}
+                      className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left hover:bg-muted"
+                    >
+                      <FolderPlus className="h-4 w-4 shrink-0 text-text-secondary" />
+                      <span className="truncate">
+                        {t('workbench.new_blank_project', '新建空白项目')}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="project-create-existing-option"
+                      onClick={() => {
+                        setProjectCreateMenuOpen(false)
+                        setStandaloneWorkspaceDialogMode('existing')
+                      }}
+                      className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left hover:bg-muted"
+                    >
+                      <FolderPlus className="h-4 w-4 shrink-0 text-text-secondary" />
+                      <span className="truncate">
+                        {t('workbench.use_existing_folder', '使用现有文件夹')}
+                      </span>
+                    </button>
+                    <div className="my-1 border-t border-border" />
+                    <button
+                      type="button"
+                      data-testid="project-create-remote-option"
+                      onClick={() => {
+                        setProjectCreateMenuOpen(false)
+                        setStandaloneRemoteDialogIntent('project')
+                        setStandaloneWorkspaceDialogMode('remote')
+                      }}
+                      className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left hover:bg-muted"
+                    >
+                      <Globe2 className="h-4 w-4 shrink-0 text-text-secondary" />
+                      <span className="truncate">{t('workbench.remote_project', '远程项目')}</span>
+                    </button>
+                  </div>,
+                  document.body
+                )}
+              {displayedProjectsExpanded && (
+                <div className="space-y-1">
+                  {sidebarProjects.map(project => (
+                    <ProjectItem
+                      key={project.id}
+                      project={project}
+                      expanded={displayedExpandedProjectIds.has(project.id)}
+                      devices={devices}
+                      runtimeProjectWork={runtimeWorkByProjectId.get(project.id)}
+                      pinnedTaskKeysStorageKey={getDesktopSidebarStorageKey(
+                        storageScope,
+                        `pinnedRuntimeTaskKeys.${project.id}`
+                      )}
+                      currentRuntimeTask={currentRuntimeTask}
+                      unreadTaskKeys={runtimeTaskReadState.unreadKeys}
+                      imNotificationSettings={imNotificationSettings}
+                      showDeviceMarker={false}
+                      onToggleProject={handleToggleProject}
+                      onStartNewProjectChat={onStartNewProjectChat}
+                      onRemoveProject={onRemoveProject}
+                      onRenameProject={setRenamingProject}
+                      onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
+                      onMarkRuntimeTaskRead={markRuntimeTaskRead}
+                      onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
+                      onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
+                      onArchiveProjectConversations={onArchiveProjectConversations}
+                      onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section data-testid="runtime-chat-section" className="mt-8">
               <SidebarSectionHeader
-                title={t('workbench.projects', '项目')}
-                expanded={displayedProjectsExpanded}
-                hasContent={sidebarProjects.length > 0}
-                toggleTestId="projects-section-toggle"
-                iconTestId="projects-section-chevron-right"
-                onToggle={() => setProjectsExpanded(expanded => !expanded)}
+                title={t('workbench.chats', '对话')}
+                expanded={displayedChatsExpanded}
+                hasContent={chatTaskItems.length > 0}
+                toggleTestId="runtime-chat-section-toggle"
+                iconTestId="runtime-chat-section-chevron-right"
+                onToggle={() => setChatsExpanded(expanded => !expanded)}
               >
                 <div className="flex items-center">
                   <ActionMenu
-                    ariaLabel={t('workbench.project_list_actions', '项目列表操作')}
-                    testId="projects-section-menu"
+                    ariaLabel={t('workbench.chat_list_actions', '对话列表操作')}
+                    testId="runtime-chat-section-menu"
                     items={[
                       {
                         label: t('workbench.archive_all_chats', '归档所有聊天'),
                         icon: Archive,
-                        testId: 'projects-section-archive-all-chats',
+                        testId: 'runtime-chat-section-archive-all-chats',
                         disabled:
-                          !onArchiveProjectsConversations ||
-                          projectSectionArchiveCount === 0 ||
-                          isArchivingProjectSection,
-                        onSelect: () => setArchiveSectionMode('projects'),
+                          !onArchiveChatConversations ||
+                          chatSectionArchiveCount === 0 ||
+                          isArchivingChatSection,
+                        onSelect: () => setArchiveSectionMode('chats'),
                       },
                     ]}
                     triggerClassName="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
                   />
                   <button
                     type="button"
-                    aria-label={t('workbench.new_project', '新建项目')}
-                    data-testid="projects-create-button"
+                    aria-label={t('workbench.new_chat', '新对话')}
+                    data-testid="runtime-chat-section-new-chat-button"
                     onClick={event => {
                       event.stopPropagation()
-                      openProjectCreateMenu(event.currentTarget)
+                      onNewChat()
                     }}
                     className="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
-                    aria-expanded={projectCreateMenuOpen}
                   >
-                    <FolderPlus className="h-4 w-4" />
+                    <MessageSquarePlus className="h-4 w-4" />
                   </button>
                 </div>
               </SidebarSectionHeader>
-            </div>
-            {projectCreateMenuOpen &&
-              projectCreateMenuPosition &&
-              createPortal(
-                <div
-                  ref={projectCreateMenuFloatingRef}
-                  data-testid="projects-create-button-menu"
-                  className="fixed z-modal rounded-xl border border-border bg-surface p-1.5 text-[13px] text-text-primary shadow-lg"
-                  style={{
-                    top: projectCreateMenuPosition.top,
-                    left: projectCreateMenuPosition.left,
-                    width: PROJECT_CREATE_MENU_WIDTH,
-                  }}
-                  onClick={event => event.stopPropagation()}
-                >
-                  <button
-                    type="button"
-                    data-testid="project-create-blank-option"
-                    onClick={() => {
-                      setProjectCreateMenuOpen(false)
-                      setBlankProjectDialogOpen(true)
-                    }}
-                    className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left hover:bg-muted"
-                  >
-                    <FolderPlus className="h-4 w-4 shrink-0 text-text-secondary" />
-                    <span className="truncate">
-                      {t('workbench.new_blank_project', '新建空白项目')}
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    data-testid="project-create-existing-option"
-                    onClick={() => {
-                      setProjectCreateMenuOpen(false)
-                      setStandaloneWorkspaceDialogMode('existing')
-                    }}
-                    className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left hover:bg-muted"
-                  >
-                    <FolderPlus className="h-4 w-4 shrink-0 text-text-secondary" />
-                    <span className="truncate">
-                      {t('workbench.use_existing_folder', '使用现有文件夹')}
-                    </span>
-                  </button>
-                  <div className="my-1 border-t border-border" />
-                  <button
-                    type="button"
-                    data-testid="project-create-remote-option"
-                    onClick={() => {
-                      setProjectCreateMenuOpen(false)
-                      setStandaloneRemoteDialogIntent('project')
-                      setStandaloneWorkspaceDialogMode('remote')
-                    }}
-                    className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left hover:bg-muted"
-                  >
-                    <Globe2 className="h-4 w-4 shrink-0 text-text-secondary" />
-                    <span className="truncate">{t('workbench.remote_project', '远程项目')}</span>
-                  </button>
-                </div>,
-                document.body
+              {displayedChatsExpanded && (
+                <div className="space-y-0.5 pb-2">
+                  {chatTaskItems.length === 0 ? (
+                    <div
+                      data-testid="runtime-chat-empty"
+                      className="ml-2 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]"
+                    >
+                      {t('workbench.no_chats', '暂无会话')}
+                    </div>
+                  ) : (
+                    chatTaskItems.map(({ workspace, task }) => (
+                      <RuntimeLocalTaskRow
+                        key={`${workspace.deviceId}:${task.workspacePath}:${task.localTaskId}`}
+                        workspace={workspace}
+                        task={task}
+                        selected={isRuntimeTaskSelected(currentRuntimeTask, workspace, task)}
+                        unread={runtimeTaskReadState.unreadKeys.has(
+                          getRuntimeTaskUnreadKey(workspace, task)
+                        )}
+                        indentClassName="pl-2.5"
+                        imNotificationSettings={imNotificationSettings}
+                        showDeviceMarker={false}
+                        onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
+                        onMarkRuntimeTaskRead={markRuntimeTaskRead}
+                        onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
+                        onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
+                        onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
+                      />
+                    ))
+                  )}
+                </div>
               )}
-            {displayedProjectsExpanded && (
-              <div className="space-y-1">
-                {sidebarProjects.map(project => (
-                  <ProjectItem
-                    key={project.id}
-                    project={project}
-                    expanded={displayedExpandedProjectIds.has(project.id)}
-                    devices={devices}
-                    runtimeProjectWork={runtimeWorkByProjectId.get(project.id)}
-                    pinnedTaskKeysStorageKey={getDesktopSidebarStorageKey(
-                      storageScope,
-                      `pinnedRuntimeTaskKeys.${project.id}`
-                    )}
-                    currentRuntimeTask={currentRuntimeTask}
-                    unreadTaskKeys={runtimeTaskReadState.unreadKeys}
-                    imNotificationSettings={imNotificationSettings}
-                    showDeviceMarker={false}
-                    onToggleProject={handleToggleProject}
-                    onStartNewProjectChat={onStartNewProjectChat}
-                    onRemoveProject={onRemoveProject}
-                    onRenameProject={setRenamingProject}
-                    onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
-                    onMarkRuntimeTaskRead={markRuntimeTaskRead}
-                    onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
-                    onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
-                    onArchiveProjectConversations={onArchiveProjectConversations}
-                    onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
-                  />
-                ))}
-              </div>
-            )}
-          </section>
+            </section>
+          </div>
 
-          <section data-testid="runtime-chat-section" className="mt-8">
-            <SidebarSectionHeader
-              title={t('workbench.chats', '对话')}
-              expanded={displayedChatsExpanded}
-              hasContent={chatTaskItems.length > 0}
-              toggleTestId="runtime-chat-section-toggle"
-              iconTestId="runtime-chat-section-chevron-right"
-              onToggle={() => setChatsExpanded(expanded => !expanded)}
-            >
-              <div className="flex items-center">
-                <ActionMenu
-                  ariaLabel={t('workbench.chat_list_actions', '对话列表操作')}
-                  testId="runtime-chat-section-menu"
-                  items={[
-                    {
-                      label: t('workbench.archive_all_chats', '归档所有聊天'),
-                      icon: Archive,
-                      testId: 'runtime-chat-section-archive-all-chats',
-                      disabled:
-                        !onArchiveChatConversations ||
-                        chatSectionArchiveCount === 0 ||
-                        isArchivingChatSection,
-                      onSelect: () => setArchiveSectionMode('chats'),
-                    },
-                  ]}
-                  triggerClassName="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
-                />
-                <button
-                  type="button"
-                  aria-label={t('workbench.new_chat', '新对话')}
-                  data-testid="runtime-chat-section-new-chat-button"
-                  onClick={event => {
-                    event.stopPropagation()
-                    onNewChat()
-                  }}
-                  className="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
-                >
-                  <MessageSquarePlus className="h-4 w-4" />
-                </button>
-              </div>
-            </SidebarSectionHeader>
-            {displayedChatsExpanded && (
-              <div className="space-y-0.5 pb-2">
-                {chatTaskItems.length === 0 ? (
-                  <div
-                    data-testid="runtime-chat-empty"
-                    className="ml-2 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]"
-                  >
-                    {t('workbench.no_chats', '暂无会话')}
-                  </div>
-                ) : (
-                  chatTaskItems.map(({ workspace, task }) => (
-                    <RuntimeLocalTaskRow
-                      key={`${workspace.deviceId}:${task.workspacePath}:${task.localTaskId}`}
-                      workspace={workspace}
-                      task={task}
-                      selected={isRuntimeTaskSelected(currentRuntimeTask, workspace, task)}
-                      unread={runtimeTaskReadState.unreadKeys.has(
-                        getRuntimeTaskUnreadKey(workspace, task)
-                      )}
-                      indentClassName="pl-2.5"
-                      imNotificationSettings={imNotificationSettings}
-                      showDeviceMarker={false}
-                      onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
-                      onMarkRuntimeTaskRead={markRuntimeTaskRead}
-                      onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
-                      onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
-                      onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
-                    />
-                  ))
-                )}
-              </div>
-            )}
-          </section>
-        </div>
-
-        <div ref={settingsMenuRef} className="mt-4 flex shrink-0 flex-col gap-1">
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              data-testid="settings-button"
-              onClick={() => {
-                setImNotificationMenuOpen(false)
-                setSettingsMenuOpen(open => !open)
-              }}
-              className="flex h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium leading-[18px] text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]"
-              aria-expanded={settingsMenuOpen}
-            >
-              <Settings className="h-4 w-4 shrink-0" />
-              <span className="truncate">{t('workbench.settings', '设置')}</span>
-            </button>
-            <GlobalImNotificationBell
-              devices={devices}
-              imNotificationSettings={imNotificationSettings}
-              menuOpen={imNotificationMenuOpen}
-              onMenuOpenChange={open => {
-                if (open) setSettingsMenuOpen(false)
-                setImNotificationMenuOpen(open)
-              }}
-              onToggleGlobalImNotification={onToggleGlobalImNotification}
-              onOpenGlobalImNotificationSettings={onOpenGlobalImNotificationSettings}
-              onOpenSettings={() => onOpenSettings()}
-              onAddCloudDevice={() => {
-                setStandaloneRemoteDialogIntent('add-device')
-                setStandaloneWorkspaceDialogMode('remote')
-              }}
-            />
-            {onRefreshWorkLists && (
+          <div ref={settingsMenuRef} className="mt-4 flex shrink-0 flex-col gap-1">
+            <div className="flex items-center gap-1">
               <button
                 type="button"
-                data-testid="refresh-worklists-button"
-                disabled={isRefreshing}
-                onClick={async () => {
-                  if (isRefreshing) return
-                  setIsRefreshing(true)
-                  try {
-                    await onRefreshWorkLists()
-                  } finally {
-                    setIsRefreshing(false)
-                  }
+                data-testid="settings-button"
+                onClick={() => {
+                  setImNotificationMenuOpen(false)
+                  setSettingsMenuOpen(open => !open)
                 }}
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))] disabled:cursor-not-allowed disabled:opacity-60"
-                title={t('workbench.refresh_worklists', '刷新')}
-                aria-label={t('workbench.refresh_worklists', '刷新')}
+                className="flex h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium leading-[18px] text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]"
+                aria-expanded={settingsMenuOpen}
               >
-                <RotateCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
+                <Settings className="h-4 w-4 shrink-0" />
+                <span className="truncate">{t('workbench.settings', '设置')}</span>
               </button>
-            )}
-            {settingsMenuOpen && (
-              <DesktopSettingsMenu
-                user={user}
-                onOpenSettings={() => {
-                  setSettingsMenuOpen(false)
-                  onOpenSettings()
+              <GlobalImNotificationBell
+                devices={devices}
+                imNotificationSettings={imNotificationSettings}
+                menuOpen={imNotificationMenuOpen}
+                onMenuOpenChange={open => {
+                  if (open) setSettingsMenuOpen(false)
+                  setImNotificationMenuOpen(open)
                 }}
-                onLogout={onLogout}
+                onToggleGlobalImNotification={onToggleGlobalImNotification}
+                onOpenGlobalImNotificationSettings={onOpenGlobalImNotificationSettings}
+                onOpenSettings={() => onOpenSettings()}
+                onAddCloudDevice={() => {
+                  setStandaloneRemoteDialogIntent('add-device')
+                  setStandaloneWorkspaceDialogMode('remote')
+                }}
               />
-            )}
+              {onRefreshWorkLists && (
+                <button
+                  type="button"
+                  data-testid="refresh-worklists-button"
+                  disabled={isRefreshing}
+                  onClick={async () => {
+                    if (isRefreshing) return
+                    setIsRefreshing(true)
+                    try {
+                      await onRefreshWorkLists()
+                    } finally {
+                      setIsRefreshing(false)
+                    }
+                  }}
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))] disabled:cursor-not-allowed disabled:opacity-60"
+                  title={t('workbench.refresh_worklists', '刷新')}
+                  aria-label={t('workbench.refresh_worklists', '刷新')}
+                >
+                  <RotateCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
+                </button>
+              )}
+              {settingsMenuOpen && (
+                <DesktopSettingsMenu
+                  user={user}
+                  onOpenSettings={() => {
+                    setSettingsMenuOpen(false)
+                    onOpenSettings()
+                  }}
+                  onLogout={onLogout}
+                />
+              )}
+            </div>
           </div>
-        </div>
 
-        {!hideResizeHandle && (
-          <button
-            type="button"
-            data-testid="sidebar-resize-handle"
-            onPointerDown={handleResizeStart}
-            className="absolute right-[-6px] top-0 z-[60] h-full w-3 cursor-col-resize touch-none bg-transparent after:absolute after:right-1.5 after:top-0 after:h-full after:w-px after:bg-transparent after:transition-colors after:duration-150 hover:after:bg-primary/35"
-            aria-label={t('workbench.resize_sidebar', '调整侧边栏宽度')}
+          <StandaloneBlankProjectDialog
+            open={blankProjectDialogOpen}
+            devices={devices}
+            preferredDeviceId={preferredDeviceId}
+            onClose={() => setBlankProjectDialogOpen(false)}
+            onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
+            onListDeviceDirectories={onListDeviceDirectories}
+            onCreateDeviceDirectory={onCreateDeviceDirectory}
+            onOpenStandaloneWorkspace={onOpenStandaloneWorkspace}
           />
-        )}
-
-        <StandaloneBlankProjectDialog
-          open={blankProjectDialogOpen}
-          devices={devices}
-          preferredDeviceId={preferredDeviceId}
-          onClose={() => setBlankProjectDialogOpen(false)}
-          onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
-          onListDeviceDirectories={onListDeviceDirectories}
-          onCreateDeviceDirectory={onCreateDeviceDirectory}
-          onOpenStandaloneWorkspace={onOpenStandaloneWorkspace}
-        />
-        <StandaloneFolderProjectDialog
-          key={standaloneWorkspaceDialogMode ?? 'standalone-folder-closed'}
-          open={standaloneWorkspaceDialogMode !== null}
-          mode={standaloneWorkspaceDialogMode ?? 'existing'}
-          remoteIntent={standaloneRemoteDialogIntent}
-          devices={devices}
-          preferredDeviceId={preferredDeviceId}
-          onClose={() => setStandaloneWorkspaceDialogMode(null)}
-          onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
-          onListDeviceDirectories={onListDeviceDirectories}
-          onCreateDeviceDirectory={onCreateDeviceDirectory}
-          onOpenStandaloneWorkspace={onOpenStandaloneWorkspace}
-          onGetRemoteDeviceStartupCommand={onGetRemoteDeviceStartupCommand}
-          onRefreshDevices={onRefreshDevices}
-        />
-        <ArchiveConversationsConfirmDialog
-          open={archiveSectionMode !== null}
-          title={t(
-            archiveSectionMode === 'chats'
-              ? 'workbench.archive_chats_dialog_title'
-              : 'workbench.archive_projects_dialog_title',
-            {
-              defaultValue: '归档 {{count}} 个对话?',
-              count: archiveSectionDialogCount,
+          <StandaloneFolderProjectDialog
+            key={standaloneWorkspaceDialogMode ?? 'standalone-folder-closed'}
+            open={standaloneWorkspaceDialogMode !== null}
+            mode={standaloneWorkspaceDialogMode ?? 'existing'}
+            remoteIntent={standaloneRemoteDialogIntent}
+            devices={devices}
+            preferredDeviceId={preferredDeviceId}
+            onClose={() => setStandaloneWorkspaceDialogMode(null)}
+            onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
+            onListDeviceDirectories={onListDeviceDirectories}
+            onCreateDeviceDirectory={onCreateDeviceDirectory}
+            onOpenStandaloneWorkspace={onOpenStandaloneWorkspace}
+            onGetRemoteDeviceStartupCommand={onGetRemoteDeviceStartupCommand}
+            onRefreshDevices={onRefreshDevices}
+          />
+          <ArchiveConversationsConfirmDialog
+            open={archiveSectionMode !== null}
+            title={t(
+              archiveSectionMode === 'chats'
+                ? 'workbench.archive_chats_dialog_title'
+                : 'workbench.archive_projects_dialog_title',
+              {
+                defaultValue: '归档 {{count}} 个对话?',
+                count: archiveSectionDialogCount,
+              }
+            )}
+            description={t(
+              archiveSectionMode === 'chats'
+                ? 'workbench.archive_chats_dialog_desc'
+                : 'workbench.archive_projects_dialog_desc',
+              {
+                defaultValue:
+                  archiveSectionMode === 'chats'
+                    ? '这会将对话列表中的对话归档。之后你可以在已归档对话中找到它们'
+                    : '这会将项目中的对话归档。之后你可以在已归档对话中找到它们',
+              }
+            )}
+            confirmLabel={t('workbench.archive_project_dialog_confirm', '全部归档')}
+            cancelLabel={t('workbench.cancel', '取消')}
+            submitting={isArchiveSectionSubmitting}
+            testId={archiveSectionDialogTestId}
+            onClose={closeArchiveSectionDialog}
+            onConfirm={confirmArchiveSectionConversations}
+          />
+          <TextInputDialog
+            open={renamingProject !== null}
+            title={t('workbench.rename_project', '重命名项目')}
+            label={t('workbench.project_name', '项目名称')}
+            initialValue={renamingProject?.name ?? ''}
+            confirmLabel={t('workbench.save', '保存')}
+            cancelLabel={t('workbench.cancel', '取消')}
+            inputTestId="rename-project-input"
+            confirmTestId="confirm-rename-project-button"
+            onClose={() => setRenamingProject(null)}
+            onSubmit={name =>
+              renamingProject ? onUpdateProjectName(renamingProject.id, name) : Promise.resolve()
             }
-          )}
-          description={t(
-            archiveSectionMode === 'chats'
-              ? 'workbench.archive_chats_dialog_desc'
-              : 'workbench.archive_projects_dialog_desc',
-            {
-              defaultValue:
-                archiveSectionMode === 'chats'
-                  ? '这会将对话列表中的对话归档。之后你可以在已归档对话中找到它们'
-                  : '这会将项目中的对话归档。之后你可以在已归档对话中找到它们',
-            }
-          )}
-          confirmLabel={t('workbench.archive_project_dialog_confirm', '全部归档')}
-          cancelLabel={t('workbench.cancel', '取消')}
-          submitting={isArchiveSectionSubmitting}
-          testId={archiveSectionDialogTestId}
-          onClose={closeArchiveSectionDialog}
-          onConfirm={confirmArchiveSectionConversations}
-        />
-        <TextInputDialog
-          open={renamingProject !== null}
-          title={t('workbench.rename_project', '重命名项目')}
-          label={t('workbench.project_name', '项目名称')}
-          initialValue={renamingProject?.name ?? ''}
-          confirmLabel={t('workbench.save', '保存')}
-          cancelLabel={t('workbench.cancel', '取消')}
-          inputTestId="rename-project-input"
-          confirmTestId="confirm-rename-project-button"
-          onClose={() => setRenamingProject(null)}
-          onSubmit={name =>
-            renamingProject ? onUpdateProjectName(renamingProject.id, name) : Promise.resolve()
-          }
-        />
+          />
+        </div>
       </div>
+
+      {!collapsed && !hideResizeHandle && (
+        <button
+          type="button"
+          data-testid="sidebar-resize-handle"
+          onPointerDown={handleResizeStart}
+          className="absolute right-[-14px] top-0 z-[80] h-full w-[18px] cursor-col-resize touch-none bg-transparent after:absolute after:left-1 after:top-0 after:h-full after:w-px after:bg-transparent after:transition-colors after:duration-150 hover:after:bg-primary/35"
+          aria-label={t('workbench.resize_sidebar', '调整侧边栏宽度')}
+        />
+      )}
     </aside>
   )
 }

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -954,9 +954,9 @@ describe('DesktopWorkbenchLayout', () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 
     expect(screen.getByTestId('desktop-empty-composer-frame')).toHaveClass(
-      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'w-[min(46rem,calc(100%_-_2rem))]',
       'min-w-0',
-      'max-w-[calc(100%_-_1.5rem)]',
+      'max-w-[calc(100%_-_2rem)]',
       '-translate-y-12'
     )
   })
@@ -987,9 +987,9 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(screen.getByTestId('desktop-chat-scroll-content')).not.toHaveClass('justify-end')
     expect(screen.getByTestId('desktop-chat-scroll-content').firstElementChild).toHaveClass(
-      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'w-[min(46rem,calc(100%_-_2rem))]',
       'min-w-0',
-      'max-w-[calc(100%_-_1.5rem)]',
+      'max-w-[calc(100%_-_2rem)]',
       'px-0'
     )
     expect(screen.getByTestId('desktop-floating-composer-backdrop')).toHaveClass(
@@ -1500,7 +1500,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(getDesktopWorkbenchMainElement()).toHaveClass('mt-1.5', 'mb-1.5', 'mr-1.5')
     expect(getDesktopWorkbenchMainElement()).not.toHaveClass('ml-1.5')
     expect(screen.getByTestId('collapse-sidebar-button')).toHaveClass('h-7', 'w-7', 'rounded-lg')
-    expect(screen.getByTestId('sidebar-resize-handle')).toHaveClass('right-[-6px]', 'w-3')
+    expect(screen.getByTestId('sidebar-resize-handle')).toHaveClass('right-[-14px]', 'w-[18px]')
     expect(screen.getByTestId('workbench-topbar-left-actions')).toContainElement(
       screen.getByTestId('desktop-window-controls')
     )
@@ -1543,6 +1543,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByText('新对话')).toBeInTheDocument()
     expect(sidebar).toHaveStyle({ width: '240px' })
     expect(sidebar).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getByTestId('desktop-empty-composer-frame')).toHaveClass(
+      'w-[min(46rem,calc(100%_-_2rem))]',
+      'max-w-[calc(100%_-_2rem)]'
+    )
   })
 
   test('slides out a sidebar preview from the left edge without resizing the workspace', async () => {
@@ -3140,9 +3144,9 @@ describe('DesktopWorkbenchLayout', () => {
     expect(rightPanelShell).toHaveStyle({ width: '0px' })
     expect(screen.queryByTestId('right-workspace-panel')).not.toBeInTheDocument()
     expect(screen.getByTestId('desktop-floating-composer-layer')).toHaveClass(
-      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'w-[min(46rem,calc(100%_-_2rem))]',
       'min-w-0',
-      'max-w-[calc(100%_-_1.5rem)]'
+      'max-w-[calc(100%_-_2rem)]'
     )
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -204,7 +204,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const chatColumnWidth = rightPanelOpen ? rightSplitChatWidth : '100%'
   const rightPanelShellWidth = rightPanelOpen ? `calc(100% - ${rightSplitChatWidth}px)` : '0px'
   const shouldRenderRightPanel = rightPanelOpen || rightPanelTabs.length > 0
-  const useDockedChatContentWidth = !sidebarCollapsed || rightPanelOpen
+  const contentDockedChatContentWidth = rightPanelOpen
   const chatContentResizing = sidebarResizing || rightSplitResizing
   const floatingComposerClearance = floatingComposerHeight + FLOATING_COMPOSER_CLEARANCE_GAP_PX
   const workspaceTargetDevice = workspaceTarget?.deviceId
@@ -808,7 +808,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               scrollTestId="desktop-chat-scroll"
               scrollerClassName={cn('scrollbar-soft', DESKTOP_FLOATING_COMPOSER_SCROLL_CLASS)}
               messageListClassName={
-                useDockedChatContentWidth
+                contentDockedChatContentWidth
                   ? cn(DESKTOP_DOCKED_MESSAGE_LIST_CLASS, chatContentResizing && 'transition-none')
                   : cn(
                       DESKTOP_CENTERED_MESSAGE_LIST_CLASS,
@@ -849,7 +849,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             />
             <div
               className={
-                useDockedChatContentWidth
+                contentDockedChatContentWidth
                   ? cn(
                       DESKTOP_DOCKED_FLOATING_COMPOSER_CLASS,
                       chatContentResizing && 'transition-none'
@@ -914,7 +914,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <div className="flex flex-1 items-center justify-center px-10">
             <div
               className={
-                useDockedChatContentWidth
+                contentDockedChatContentWidth
                   ? cn(
                       DESKTOP_DOCKED_COMPOSER_FRAME_CLASS,
                       chatContentResizing && 'transition-none'

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -984,7 +984,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(services.runtimeWorkApi?.listRuntimeWork).toHaveBeenCalledTimes(1)
   })
 
-  test('polls runtime work after bootstrap so externally created tasks appear', async () => {
+  test('does not poll runtime work after bootstrap', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
       const emptyRuntimeWork = createRuntimeWork({
@@ -1033,12 +1033,14 @@ describe('WorkbenchProvider runtime tasks', () => {
       renderWorkbench(<BootstrapProbe />, services)
 
       await waitFor(() => expect(screen.getByTestId('runtime-total')).toHaveTextContent('0'))
+      expect(listRuntimeWork).toHaveBeenCalledTimes(1)
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5000)
       })
 
-      await waitFor(() => expect(screen.getByTestId('runtime-total')).toHaveTextContent('1'))
+      expect(listRuntimeWork).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId('runtime-total')).toHaveTextContent('0')
     } finally {
       vi.useRealTimers()
     }

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { Dispatch } from 'react'
 import type { ExecutorClient } from '@/api/executorAccess'
 import { getPreferredStandaloneDeviceId } from '@/lib/device-selection'
@@ -21,8 +21,6 @@ import type { WorkbenchAction } from './workbenchReducer'
 import { getRememberedStandaloneDeviceId } from './workbenchRuntimeHelpers'
 import type { WorkbenchServices } from './workbenchServices'
 
-const RUNTIME_WORK_REFRESH_INTERVAL_MS = 5000
-
 interface UseWorkbenchDataRefreshOptions {
   user: User
   state: WorkbenchState
@@ -39,7 +37,6 @@ export function useWorkbenchDataRefresh({
   services,
 }: UseWorkbenchDataRefreshOptions) {
   const [cloudWorkStatus, setCloudWorkStatus] = useState<CloudWorkStatus>(EMPTY_CLOUD_WORK_STATUS)
-  const runtimeWorkRefreshInFlightRef = useRef(false)
 
   /* eslint-disable react-hooks/set-state-in-effect -- Cloud work status mirrors service availability and must reset when the service is removed. */
   useEffect(() => {
@@ -240,27 +237,6 @@ export function useWorkbenchDataRefresh({
     state.runtimeWork,
     state.standaloneDeviceId,
   ])
-
-  const refreshRuntimeWork = useCallback(async () => {
-    if (runtimeWorkRefreshInFlightRef.current) return
-    runtimeWorkRefreshInFlightRef.current = true
-    try {
-      const runtimeWork = await executorClient.runtime.listRuntimeWork()
-      dispatch({ type: 'runtime_work_refreshed', runtimeWork })
-    } catch {
-      // Runtime work polling is best-effort; explicit refresh paths surface errors.
-    } finally {
-      runtimeWorkRefreshInFlightRef.current = false
-    }
-  }, [dispatch, executorClient])
-
-  useEffect(() => {
-    if (state.isBootstrapping) return
-    const intervalId = window.setInterval(() => {
-      void refreshRuntimeWork()
-    }, RUNTIME_WORK_REFRESH_INTERVAL_MS)
-    return () => window.clearInterval(intervalId)
-  }, [refreshRuntimeWork, state.isBootstrapping])
 
   const loadDevicesForRefresh = useCallback(
     async (options?: { useCacheFallback?: boolean }): Promise<DeviceInfo[]> => {


### PR DESCRIPTION
## Summary
- Stabilize the Wework desktop chat content width so opening the left sidebar does not unexpectedly widen the middle content area.
- Remove runtime work list polling after bootstrap to avoid periodic UI refresh pressure; startup and explicit refresh paths still load work lists.
- Improve the desktop left sidebar resize hit area by letting the handle extend just outside the clipped sidebar content, while keeping the visual divider aligned.
- Move the message turn navigation markers slightly right so they do not overlap the left split hit area.

## Validation
- `pnpm --dir wework exec tsc -b`
- `pnpm --dir wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx -t "keeps the empty composer|renders the conversation composer|collapses and expands the sidebar|collapses the sidebar when dragging below the close threshold|right workspace panel animates alongside the chat column"`
- `pnpm --dir wework exec vitest run src/components/chat/ScrollableMessageArea.test.tsx -t "renders a compact left-side navigation|keeps message navigation marker spacing fixed|clicks a message navigation marker"`
- `pnpm --dir wework exec vitest run src/features/workbench/WorkbenchProvider.test.tsx -t "does not poll runtime work after bootstrap"`
- Pre-push checks passed with `AI_VERIFIED=1 git push -u fork codex/wework-sidebar-content-width`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted desktop layout spacing and sidebar positioning for a cleaner, more consistent workspace.
  * Updated the work area sizing so the chat and composer adapt more predictably when panels are open or collapsed.
  * Reduced background refresh activity for runtime work, which may improve performance and avoid unnecessary updates.

* **Tests**
  * Updated layout and refresh tests to match the latest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->