### PR TITLE
[codex] Fix Wework Codex runtime failure state

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -490,11 +490,7 @@ impl JsonRpcConnection {
                 return response_result(message);
             }
             if message.get("method").and_then(Value::as_str) == Some("error") {
-                return Err(message_params(&message)
-                    .get("message")
-                    .and_then(Value::as_str)
-                    .unwrap_or("codex app-server error")
-                    .to_owned());
+                return Err(codex_error_message(message_params(&message)));
             }
         }
     }
@@ -605,11 +601,7 @@ impl CodexRunState {
                 let params = message_params(message);
                 log_codex_run_state_error(params);
                 Some(ExecutionOutcome::Failed {
-                    message: params
-                        .get("message")
-                        .and_then(Value::as_str)
-                        .unwrap_or("codex app-server error")
-                        .to_owned(),
+                    message: codex_error_message(params),
                 })
             }
             _ => None,
@@ -774,12 +766,13 @@ fn log_codex_run_state_text(
 }
 
 fn log_codex_run_state_error(params: &Value) {
+    let message = codex_error_message(params);
     let params_json = serde_json::to_string(params)
         .unwrap_or_else(|error| format!("failed to serialize codex error params: {error}"));
     log_executor_event(
         "codex run state error",
         &[
-            ("message", json_string_field(params, "message")),
+            ("message", message),
             ("code", json_string_field(params, "code")),
             ("params_len", params_json.len().to_string()),
             ("params_preview", truncate_log_text(&params_json, 500)),
@@ -2019,6 +2012,40 @@ fn response_result(message: Value) -> Result<Value, String> {
 
 fn message_params(message: &Value) -> &Value {
     message.get("params").unwrap_or(message)
+}
+
+fn codex_error_message(params: &Value) -> String {
+    let nested_error = params.get("error");
+    let message = params
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            nested_error
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+        })
+        .or_else(|| nested_error.and_then(Value::as_str));
+    let details = params
+        .get("additionalDetails")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            nested_error
+                .and_then(|error| error.get("additionalDetails"))
+                .and_then(Value::as_str)
+        });
+
+    match (
+        message.filter(|value| !value.trim().is_empty()),
+        details.filter(|value| !value.trim().is_empty()),
+    ) {
+        (Some(message), Some(details)) if message != details => format!("{message}: {details}"),
+        (Some(message), _) => message.to_owned(),
+        (_, Some(details)) => details.to_owned(),
+        _ => nested_error
+            .map(Value::to_string)
+            .filter(|value| value != "null")
+            .unwrap_or_else(|| "codex app-server error".to_owned()),
+    }
 }
 
 fn extract_text(item: &Value) -> Option<String> {

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -81,13 +81,20 @@ impl RuntimeTaskLink {
         let local_archived = local_link
             .as_ref()
             .is_some_and(|link| link.status == "archived");
+        let local_terminal_status = local_link
+            .as_ref()
+            .and_then(|link| local_terminal_status_if_current(link, thread));
         let status = if local_archived {
             "archived".to_owned()
+        } else if let Some(status) = &local_terminal_status {
+            status.clone()
         } else {
             thread_status(thread)
         };
         let local_running = local_link.as_ref().is_some_and(|link| link.running);
-        let running = !local_archived && (local_running || thread_running(thread));
+        let running = !local_archived
+            && local_terminal_status.is_none()
+            && (local_running || thread_running(thread));
         Self {
             local_task_id: local_link
                 .as_ref()
@@ -114,6 +121,23 @@ impl RuntimeTaskLink {
             list_order: None,
         }
     }
+}
+
+fn local_terminal_status_if_current(link: &RuntimeTaskLink, thread: &Value) -> Option<String> {
+    if link.running || !is_terminal_status(&link.status) {
+        return None;
+    }
+    let local_is_current = timestamp_ms_field(thread, "updatedAt")
+        .map(|thread_updated_at| link.updated_at >= thread_updated_at)
+        .unwrap_or(true);
+    local_is_current.then(|| link.status.clone())
+}
+
+fn is_terminal_status(status: &str) -> bool {
+    matches!(
+        status.replace(['_', '-'], "").to_ascii_lowercase().as_str(),
+        "done" | "complete" | "completed" | "failed" | "error" | "cancelled" | "canceled"
+    )
 }
 
 impl Default for RuntimeTaskLink {

--- a/executor/tests/app_runtime_work_native_update_contract.rs
+++ b/executor/tests/app_runtime_work_native_update_contract.rs
@@ -201,6 +201,64 @@ async fn runtime_task_list_preserves_local_running_state_when_native_thread_is_i
     assert_eq!(locally_running["running"], true);
 }
 
+#[tokio::test]
+async fn runtime_task_list_preserves_local_failed_state_when_native_rollout_still_looks_running() {
+    let _lock = env_lock().await;
+    let executor_home = temp_path("runtime-local-failed-home", "dir");
+    let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-local-failed-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let index_path = executor_home.join("runtime-work").join("index.json");
+    fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+    fs::write(
+        &index_path,
+        serde_json::to_vec_pretty(&json!({
+            "version": 1,
+            "tasks": {
+                "local-failed-running-rollout": {
+                    "local_task_id": "local-failed-running-rollout",
+                    "thread_id": "thread-running-rollout",
+                    "workspace_path": "/tmp/project",
+                    "title": "Locally failed running rollout",
+                    "runtime": "codex",
+                    "status": "failed",
+                    "running": false,
+                    "created_at": 1780000000000_i64,
+                    "updated_at": 1780000070000_i64,
+                    "runtime_handle": {"threadId": "thread-running-rollout"},
+                    "parent": null
+                }
+            },
+            "workspaces": {}
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let fake_codex = write_fake_codex(&temp_path("runtime-local-failed-log", "jsonl"));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let listed = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.list",
+            "payload": {}
+        }))
+        .await
+        .expect("task list should succeed");
+
+    let tasks = listed["workspaces"][0]["localTasks"].as_array().unwrap();
+    let locally_failed = tasks
+        .iter()
+        .find(|task| task["localTaskId"] == "local-failed-running-rollout")
+        .unwrap();
+
+    assert_eq!(locally_failed["status"], "failed");
+    assert_eq!(locally_failed["running"], false);
+}
+
 fn write_fake_codex(log_path: &Path) -> PathBuf {
     let path = temp_path("fake-codex-native-status", "sh");
     let active_rollout = temp_path("runtime-native-active-rollout", "jsonl");

--- a/executor/tests/codex_app_server_contract.rs
+++ b/executor/tests/codex_app_server_contract.rs
@@ -432,6 +432,34 @@ async fn codex_app_server_engine_times_out_unresponsive_rpc() {
     );
 }
 
+#[tokio::test]
+async fn codex_app_server_engine_reports_nested_turn_error_details() {
+    let _lock = env_lock().await;
+    let fake_codex = write_fake_codex_nested_turn_error();
+    let engine = CodexAppServerEngine::new(fake_codex.display().to_string());
+    let request = ExecutionRequest {
+        prompt: json!("implement feature"),
+        bot: json!([{"shell_type": "ClaudeCode"}]),
+        model_config: json!({
+            "model": "openai",
+            "model_id": "gpt-5",
+            "protocol": "openai-responses"
+        }),
+        ..ExecutionRequest::default()
+    };
+
+    let outcome = engine.run(request).await;
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Failed {
+            message:
+                "Reconnecting... 2/5: stream disconnected before completion: tls handshake eof"
+                    .to_owned()
+        }
+    );
+}
+
 async fn env_lock() -> MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(())).lock().await
@@ -563,6 +591,44 @@ fn write_fake_codex_hang() -> PathBuf {
         r#"#!/bin/sh
 while IFS= read -r _line; do
   sleep 30
+done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn write_fake_codex_nested_turn_error() -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "fake-codex-nested-turn-error-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    fs::write(
+        &path,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"id":1,"result":{"protocolVersion":1}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/start"'*)
+      printf '%s\n' '{"id":2,"result":{"thread":{"id":"thread-1"}}}'
+      ;;
+    *'"method":"turn/start"'*)
+      printf '%s\n' '{"id":3,"result":{"turn":{"id":"turn-1","status":"inProgress"}}}'
+      printf '%s\n' '{"method":"error","params":{"error":{"additionalDetails":"stream disconnected before completion: tls handshake eof","message":"Reconnecting... 2/5"},"threadId":"thread-1","turnId":"turn-1","willRetry":true}}'
+      exit 0
+      ;;
+  esac
 done
 "#,
     )


### PR DESCRIPTION
## Summary

- Preserve local terminal task state when Codex rollout metadata still appears active, so failed Wework runtime tasks no longer remain displayed as running.
- Surface nested Codex app-server error details from `params.error.message` and `params.error.additionalDetails` instead of falling back to `codex app-server error`.
- Add regression coverage for failed local task list state and detailed nested turn errors.

## Root Cause

`runtime.tasks.list` merged local task links with Codex thread state and allowed rollout-tail running inference to override a local `failed/running=false` link. Separately, Codex error handling only read top-level `params.message`, while app-server stream errors can arrive as nested `params.error` objects.

## Validation

- `uv run cargo test --test app_runtime_work_native_update_contract --test codex_app_server_contract`
- `uv run cargo test runtime_work`
- `git diff --check -- executor/src/agents/codex.rs executor/src/runtime_work/response.rs executor/tests/codex_app_server_contract.rs executor/tests/app_runtime_work_native_update_contract.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages from Codex runs so nested details are surfaced together, making failures easier to understand.
  * Updated runtime task status handling so locally failed tasks remain marked as failed instead of appearing running after a rollout.
  * Refined task state resolution to better respect terminal statuses for the current thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->