### PR TITLE
[codex] fix Wework sidebar resize hit area

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -139,6 +139,15 @@ describe('DesktopSidebar', () => {
     )
   })
 
+  test('keeps the resize handle hit area on the sidebar edge', () => {
+    renderSidebar()
+
+    const handle = screen.getByTestId('sidebar-resize-handle')
+
+    expect(handle).toHaveClass('right-[-6px]', 'w-3')
+    expect(handle).not.toHaveClass('w-10')
+  })
+
   test('does not render non-chat runtime workspace groups', async () => {
     const onOpenRuntimeLocalTask = vi.fn()
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -2194,7 +2194,7 @@ export function DesktopSidebar({
             type="button"
             data-testid="sidebar-resize-handle"
             onPointerDown={handleResizeStart}
-            className="absolute right-[-6px] top-0 z-[60] h-full w-10 cursor-col-resize touch-none bg-transparent after:absolute after:right-1.5 after:top-0 after:h-full after:w-px after:bg-transparent after:transition-colors after:duration-150 hover:after:bg-primary/35"
+            className="absolute right-[-6px] top-0 z-[60] h-full w-3 cursor-col-resize touch-none bg-transparent after:absolute after:right-1.5 after:top-0 after:h-full after:w-px after:bg-transparent after:transition-colors after:duration-150 hover:after:bg-primary/35"
             aria-label={t('workbench.resize_sidebar', '调整侧边栏宽度')}
           />
         )}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1460,7 +1460,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(getDesktopWorkbenchMainElement()).toHaveClass('mt-1.5', 'mb-1.5', 'mr-1.5')
     expect(getDesktopWorkbenchMainElement()).not.toHaveClass('ml-1.5')
     expect(screen.getByTestId('collapse-sidebar-button')).toHaveClass('h-7', 'w-7', 'rounded-lg')
-    expect(screen.getByTestId('sidebar-resize-handle')).toHaveClass('right-[-6px]', 'w-10')
+    expect(screen.getByTestId('sidebar-resize-handle')).toHaveClass('right-[-6px]', 'w-3')
     expect(screen.getByTestId('workbench-topbar-left-actions')).toContainElement(
       screen.getByTestId('desktop-window-controls')
     )


### PR DESCRIPTION
## Summary
- Narrow the Wework desktop sidebar resize handle hit area from `w-10` to `w-3` so it stays on the sidebar edge.
- Add regression coverage in `DesktopSidebar.test.tsx` and update the layout-level expectation.

## Root Cause
The transparent sidebar resize button was `w-10` with `right-[-6px]`, so most of its hit area extended over the sidebar content. Hovering near the divider could intercept clicks meant for task row actions.

## Validation
- `pnpm --dir wework exec vitest run src/components/layout/DesktopSidebar.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx` — 134 tests passed.
- `pnpm --dir wework exec eslint src/components/layout/DesktopSidebar.tsx src/components/layout/DesktopSidebar.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx` — passed.
- Pre-push hook: full Wework test suite passed, 101 test files / 942 tests, plus quality checks passed.