### PR TITLE
[codex] fix Wework bundled executor sidecar launch

### DIFF
--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -19,7 +19,7 @@ use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
 const LOCAL_EXECUTOR_EVENT: &str = "local-executor:event";
-const LOCAL_EXECUTOR_SIDECAR: &str = "binaries/wegent-executor";
+const LOCAL_EXECUTOR_SIDECAR: &str = "wegent-executor";
 const LOCAL_EXECUTOR_SIDECAR_ENV: &str = "WEWORK_EXECUTOR_SIDECAR";
 const LOCAL_EXECUTOR_SOCKET_ENV: &str = "WEGENT_EXECUTOR_APP_IPC_SOCKET";
 const LOCAL_EXECUTOR_HOME_ENV: &str = "WEGENT_EXECUTOR_HOME";
@@ -1407,6 +1407,19 @@ mod tests {
 
         assert_eq!(label, "Local executor diagnostic");
         assert!(!label.contains("stderr"));
+    }
+
+    #[test]
+    fn bundled_sidecar_path_uses_bundled_executable_name() {
+        let _guard = env_lock();
+        let previous_sidecar = std::env::var_os(LOCAL_EXECUTOR_SIDECAR_ENV);
+        std::env::remove_var(LOCAL_EXECUTOR_SIDECAR_ENV);
+
+        let (source, path) = sidecar_source_and_path();
+        restore_env(LOCAL_EXECUTOR_SIDECAR_ENV, previous_sidecar);
+
+        assert_eq!(source, "bundled");
+        assert_eq!(path, "wegent-executor");
     }
 
     #[test]

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -217,7 +217,7 @@ describe('LocalRuntimeInitializer', () => {
       processPids: [],
       processPaths: [],
       sidecarSource: 'bundled',
-      sidecarPath: 'binaries/wegent-executor',
+      sidecarPath: 'wegent-executor',
       currentDir: '/tmp/wework',
       executorHome: '~/.wegent-executor',
       backendUrl: null,


### PR DESCRIPTION
## Summary
- Launch the packaged Wework executor sidecar by the bundled executable basename, `wegent-executor`.
- Keep Tauri packaging config pointed at `binaries/wegent-executor`, while runtime diagnostics now report the actual bundled executable name.
- Add a Rust regression test and update the affected local-runtime frontend expectation.

## Root Cause
Tauri bundles `externalBin` entries by copying the target-suffixed source binary into `Contents/MacOS/` with the target suffix and source directory stripped. The runtime used `binaries/wegent-executor` as the native shell sidecar command, so the packaged app attempted to spawn `Contents/MacOS/binaries/wegent-executor`, which does not exist.

## Validation
- `cargo test --manifest-path wework/src-tauri/Cargo.toml local_executor::tests`
- `pnpm --dir wework test src/features/local-runtime/LocalRuntimeInitializer.test.tsx --run`
- Pre-push hook: `pnpm --dir wework exec vitest run --coverage --passWithNoTests` (101 files, 951 tests passed)
- Pre-push AI quality gate passed

## Notes
A local `scripts/release-mac-app.sh` rebuild reached the generated `WeWork.app` bundle and verified `Contents/MacOS/wegent-executor` exists and runs `--version`; the final DMG step failed in this shell due to local PATH/tooling setup, not the sidecar change.