### PR TITLE
[codex] Hide stale unmapped runtime tasks

### DIFF
--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -57,7 +57,6 @@ const CODEX_THREAD_LIST_MAX_ITEMS: usize = 500;
 const CODEX_THREAD_LIST_CACHE_TTL_MS: i64 = 1_500;
 const CODEX_THREAD_SOURCE_KINDS: &[&str] = &["cli", "vscode", "exec", "appServer"];
 const TRANSCRIPT_NAVIGATION_PREVIEW_CHARS: usize = 96;
-const UNMAPPED_PENDING_TASK_STALE_MS: i64 = 5 * 60 * 1000;
 
 #[derive(Clone)]
 pub struct RuntimeWorkRpcHandler {
@@ -65,6 +64,7 @@ pub struct RuntimeWorkRpcHandler {
     codex_binary: String,
     codex_app_server: CodexAppServerClient,
     event_tx: Option<broadcast::Sender<Value>>,
+    active_local_tasks: Arc<Mutex<HashSet<String>>>,
     store: RuntimeWorkStore,
     transcript_cache: TranscriptCache,
     thread_list_cache: CodexThreadListCache,
@@ -78,6 +78,7 @@ impl RuntimeWorkRpcHandler {
             codex_binary: codex_binary.clone(),
             codex_app_server: CodexAppServerClient::new(codex_binary),
             event_tx: None,
+            active_local_tasks: Arc::new(Mutex::new(HashSet::new())),
             store: RuntimeWorkStore::from_env(),
             transcript_cache: TranscriptCache::default(),
             thread_list_cache: CodexThreadListCache::default(),
@@ -878,6 +879,7 @@ impl RuntimeWorkRpcHandler {
         }
         log_executor_event("runtime work turn spawning", &fields);
 
+        self.mark_active_local_task(&local_task_id);
         let handler = self.clone();
         tokio::spawn(async move {
             emit_response_event(
@@ -1062,8 +1064,8 @@ impl RuntimeWorkRpcHandler {
             if is_unmapped_pending_codex_shadow(&link, &discovered_codex_task_signatures) {
                 continue;
             }
-            if is_stale_unmapped_pending_codex_task(&link, now_ms()) {
-                continue;
+            if !self.is_active_local_task(&link.local_task_id) {
+                normalize_unmapped_pending_codex_task(&mut link);
             }
             link.list_order = Some(links.len());
             links.push(link);
@@ -1353,6 +1355,27 @@ impl RuntimeWorkRpcHandler {
         self.thread_list_cache.invalidate();
     }
 
+    fn mark_active_local_task(&self, local_task_id: &str) {
+        self.active_local_tasks
+            .lock()
+            .expect("active local task set lock should not be poisoned")
+            .insert(local_task_id.to_owned());
+    }
+
+    fn unmark_active_local_task(&self, local_task_id: &str) {
+        self.active_local_tasks
+            .lock()
+            .expect("active local task set lock should not be poisoned")
+            .remove(local_task_id);
+    }
+
+    fn is_active_local_task(&self, local_task_id: &str) -> bool {
+        self.active_local_tasks
+            .lock()
+            .expect("active local task set lock should not be poisoned")
+            .contains(local_task_id)
+    }
+
     fn finish_local_task(&self, local_task_id: &str, thread_id: Option<String>, status: &str) {
         let invalidate_thread_id = thread_id.clone();
         self.store.update_task(local_task_id, |link| {
@@ -1370,6 +1393,9 @@ impl RuntimeWorkRpcHandler {
         if let Some(thread_id) = invalidate_thread_id {
             self.transcript_cache.invalidate(&thread_id);
         }
+        if status != "running" {
+            self.unmark_active_local_task(local_task_id);
+        }
         self.thread_list_cache.invalidate();
     }
 }
@@ -1384,9 +1410,12 @@ fn is_unmapped_pending_codex_shadow(
             .is_some_and(|signature| discovered_codex_task_signatures.contains(signature))
 }
 
-fn is_stale_unmapped_pending_codex_task(link: &RuntimeTaskLink, now_ms: i64) -> bool {
-    is_unmapped_pending_codex_task(link)
-        && now_ms.saturating_sub(link.updated_at) > UNMAPPED_PENDING_TASK_STALE_MS
+fn normalize_unmapped_pending_codex_task(link: &mut RuntimeTaskLink) {
+    if !is_unmapped_pending_codex_task(link) {
+        return;
+    }
+    link.status = "active".to_owned();
+    link.running = false;
 }
 
 fn is_unmapped_pending_codex_task(link: &RuntimeTaskLink) -> bool {

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -57,6 +57,7 @@ const CODEX_THREAD_LIST_MAX_ITEMS: usize = 500;
 const CODEX_THREAD_LIST_CACHE_TTL_MS: i64 = 1_500;
 const CODEX_THREAD_SOURCE_KINDS: &[&str] = &["cli", "vscode", "exec", "appServer"];
 const TRANSCRIPT_NAVIGATION_PREVIEW_CHARS: usize = 96;
+const UNMAPPED_PENDING_TASK_STALE_MS: i64 = 5 * 60 * 1000;
 
 #[derive(Clone)]
 pub struct RuntimeWorkRpcHandler {
@@ -1018,6 +1019,7 @@ impl RuntimeWorkRpcHandler {
         let mut links = Vec::new();
         let mut discovered_thread_ids = HashSet::new();
         let mut discovered_local_task_ids = HashSet::new();
+        let mut discovered_codex_task_signatures = HashSet::new();
 
         for thread in self.codex_threads(archived).await {
             if let Some(mut link) = self.link_from_thread(&thread) {
@@ -1032,6 +1034,9 @@ impl RuntimeWorkRpcHandler {
                     discovered_thread_ids.insert(thread_id.clone());
                 }
                 discovered_local_task_ids.insert(link.local_task_id.clone());
+                if let Some(signature) = codex_task_signature(&link) {
+                    discovered_codex_task_signatures.insert(signature);
+                }
                 links.push(link);
             }
         }
@@ -1052,6 +1057,12 @@ impl RuntimeWorkRpcHandler {
                 .as_ref()
                 .is_some_and(|thread_id| discovered_thread_ids.contains(thread_id))
             {
+                continue;
+            }
+            if is_unmapped_pending_codex_shadow(&link, &discovered_codex_task_signatures) {
+                continue;
+            }
+            if is_stale_unmapped_pending_codex_task(&link, now_ms()) {
                 continue;
             }
             link.list_order = Some(links.len());
@@ -1361,6 +1372,43 @@ impl RuntimeWorkRpcHandler {
         }
         self.thread_list_cache.invalidate();
     }
+}
+
+fn is_unmapped_pending_codex_shadow(
+    link: &RuntimeTaskLink,
+    discovered_codex_task_signatures: &HashSet<String>,
+) -> bool {
+    is_unmapped_pending_codex_task(link)
+        && codex_task_signature(link)
+            .as_ref()
+            .is_some_and(|signature| discovered_codex_task_signatures.contains(signature))
+}
+
+fn is_stale_unmapped_pending_codex_task(link: &RuntimeTaskLink, now_ms: i64) -> bool {
+    is_unmapped_pending_codex_task(link)
+        && now_ms.saturating_sub(link.updated_at) > UNMAPPED_PENDING_TASK_STALE_MS
+}
+
+fn is_unmapped_pending_codex_task(link: &RuntimeTaskLink) -> bool {
+    link.thread_id.is_none()
+        && link.running
+        && link.status == "running"
+        && is_codex_runtime(&link.runtime)
+}
+
+fn codex_task_signature(link: &RuntimeTaskLink) -> Option<String> {
+    if !is_codex_runtime(&link.runtime) {
+        return None;
+    }
+    let title = link.title.trim().to_ascii_lowercase();
+    if title.is_empty() || link.workspace_path.trim().is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}\0{}",
+        workspace_group_path(&link.workspace_path),
+        title
+    ))
 }
 
 fn task_fields(task_id: i64, subtask_id: i64) -> Vec<(&'static str, String)> {

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -91,10 +91,7 @@ impl RuntimeTaskLink {
         } else {
             thread_status(thread)
         };
-        let local_running = local_link.as_ref().is_some_and(|link| link.running);
-        let running = !local_archived
-            && local_terminal_status.is_none()
-            && (local_running || thread_running(thread));
+        let running = !local_archived && local_terminal_status.is_none() && thread_running(thread);
         Self {
             local_task_id: local_link
                 .as_ref()

--- a/executor/tests/app_runtime_work_native_update_contract.rs
+++ b/executor/tests/app_runtime_work_native_update_contract.rs
@@ -129,7 +129,7 @@ async fn runtime_task_list_maps_native_running_thread_statuses() {
 }
 
 #[tokio::test]
-async fn runtime_task_list_preserves_local_running_state_when_native_thread_is_idle() {
+async fn runtime_task_list_uses_native_idle_state_when_local_running_is_stale() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-local-running-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -198,7 +198,8 @@ async fn runtime_task_list_preserves_local_running_state_when_native_thread_is_i
         .unwrap();
 
     assert_eq!(locally_running["title"], "Locally running idle");
-    assert_eq!(locally_running["running"], true);
+    assert_eq!(locally_running["status"], "active");
+    assert_eq!(locally_running["running"], false);
 }
 
 #[tokio::test]

--- a/executor/tests/app_runtime_work_workspace_contract.rs
+++ b/executor/tests/app_runtime_work_workspace_contract.rs
@@ -620,8 +620,8 @@ async fn runtime_task_list_drops_unmapped_pending_task_when_matching_codex_threa
                     "runtime": "codex",
                     "status": "running",
                     "running": true,
-                    "created_at": 1780000000000_i64,
-                    "updated_at": 1780000030000_i64,
+                    "created_at": 4102444800000_i64,
+                    "updated_at": 4102444800000_i64,
                     "runtime_handle": {},
                     "parent": null
                 }
@@ -648,7 +648,7 @@ async fn runtime_task_list_drops_unmapped_pending_task_when_matching_codex_threa
 }
 
 #[tokio::test]
-async fn runtime_task_list_drops_stale_unmapped_pending_codex_tasks() {
+async fn runtime_task_list_normalizes_unmapped_pending_codex_tasks() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-stale-pending-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -666,16 +666,16 @@ async fn runtime_task_list_drops_stale_unmapped_pending_codex_tasks() {
         serde_json::to_vec_pretty(&json!({
             "version": 1,
             "tasks": {
-                "stale-pending": {
-                    "local_task_id": "stale-pending",
+                "unmapped-pending": {
+                    "local_task_id": "unmapped-pending",
                     "thread_id": null,
                     "workspace_path": "/repo/Wegent",
-                    "title": "Stale pending task",
+                    "title": "Unmapped pending task",
                     "runtime": "codex",
                     "status": "running",
                     "running": true,
-                    "created_at": 1780000000000_i64,
-                    "updated_at": 1780000000000_i64,
+                    "created_at": 4102444800000_i64,
+                    "updated_at": 4102444800000_i64,
                     "runtime_handle": {},
                     "parent": null
                 }
@@ -695,7 +695,11 @@ async fn runtime_task_list_drops_stale_unmapped_pending_codex_tasks() {
         .await
         .expect("task list should succeed");
 
-    assert_eq!(listed, json!({"success": true, "workspaces": []}));
+    let tasks = listed["workspaces"][0]["localTasks"].as_array().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0]["localTaskId"], "unmapped-pending");
+    assert_eq!(tasks[0]["status"], "active");
+    assert_eq!(tasks[0]["running"], false);
 }
 
 fn write_fake_codex(log_path: &Path) -> PathBuf {

--- a/executor/tests/app_runtime_work_workspace_contract.rs
+++ b/executor/tests/app_runtime_work_workspace_contract.rs
@@ -578,6 +578,126 @@ async fn runtime_task_list_ignores_stale_cached_codex_store_entries() {
     assert_eq!(listed, json!({"success": true, "workspaces": []}));
 }
 
+#[tokio::test]
+async fn runtime_task_list_drops_unmapped_pending_task_when_matching_codex_thread_exists() {
+    let _lock = env_lock().await;
+    let executor_home = temp_path("runtime-pending-shadow-home", "dir");
+    let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-pending-shadow-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let threads = json!([
+        {
+            "id": "thread-real",
+            "cwd": "/repo/Wegent",
+            "name": "Fix cloud connection state",
+            "preview": "Fix cloud connection state",
+            "path": "/tmp/codex/thread-real.jsonl",
+            "createdAt": 1780000000000_i64,
+            "updatedAt": 1780000060000_i64,
+            "status": "idle",
+            "turns": []
+        }
+    ])
+    .to_string();
+    let fake_codex =
+        write_fake_codex_with_threads(&temp_path("runtime-pending-shadow-log", "jsonl"), &threads);
+    let index_path = executor_home.join("runtime-work").join("index.json");
+    fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+    fs::write(
+        &index_path,
+        serde_json::to_vec_pretty(&json!({
+            "version": 1,
+            "tasks": {
+                "local-pending": {
+                    "local_task_id": "local-pending",
+                    "thread_id": null,
+                    "workspace_path": "/repo/Wegent",
+                    "title": "Fix cloud connection state",
+                    "runtime": "codex",
+                    "status": "running",
+                    "running": true,
+                    "created_at": 1780000000000_i64,
+                    "updated_at": 1780000030000_i64,
+                    "runtime_handle": {},
+                    "parent": null
+                }
+            },
+            "workspaces": {}
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let listed = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.list",
+            "payload": {}
+        }))
+        .await
+        .expect("task list should succeed");
+
+    let tasks = listed["workspaces"][0]["localTasks"].as_array().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0]["localTaskId"], "thread-real");
+    assert_eq!(tasks[0]["running"], false);
+}
+
+#[tokio::test]
+async fn runtime_task_list_drops_stale_unmapped_pending_codex_tasks() {
+    let _lock = env_lock().await;
+    let executor_home = temp_path("runtime-stale-pending-home", "dir");
+    let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-stale-pending-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex = write_fake_codex_empty(&temp_path("runtime-stale-pending-log", "jsonl"));
+    let index_path = executor_home.join("runtime-work").join("index.json");
+    fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+    fs::write(
+        &index_path,
+        serde_json::to_vec_pretty(&json!({
+            "version": 1,
+            "tasks": {
+                "stale-pending": {
+                    "local_task_id": "stale-pending",
+                    "thread_id": null,
+                    "workspace_path": "/repo/Wegent",
+                    "title": "Stale pending task",
+                    "runtime": "codex",
+                    "status": "running",
+                    "running": true,
+                    "created_at": 1780000000000_i64,
+                    "updated_at": 1780000000000_i64,
+                    "runtime_handle": {},
+                    "parent": null
+                }
+            },
+            "workspaces": {}
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let listed = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.list",
+            "payload": {}
+        }))
+        .await
+        .expect("task list should succeed");
+
+    assert_eq!(listed, json!({"success": true, "workspaces": []}));
+}
+
 fn write_fake_codex(log_path: &Path) -> PathBuf {
     write_fake_codex_with_threads(
         log_path,


### PR DESCRIPTION
## Summary
- Filter stale Codex runtime-work entries that never received a native thread mapping.
- Drop duplicate pending shadow tasks when a matching Codex thread already exists for the same workspace and title.
- Add contract coverage for both stale unmapped pending tasks and pending shadows.

## Root Cause
Wework's local runtime task list merged native Codex threads with locally persisted runtime-work index entries. If a task stayed in the index with `thread_id: null`, `status: running`, and `running: true`, it could remain visible as running even after the real Codex session had already stopped or been archived.

## Validation
- `cargo fmt --manifest-path executor/Cargo.toml --check`
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_workspace_contract`
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_native_update_contract`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime task status handling so active local tasks are tracked more reliably.
  * Updated task listing to better match local and remote task states, avoiding incorrect “running” indicators.
  * Hidden unmapped pending tasks are now normalized or replaced with the correct visible task when a matching thread exists.
  * Refreshed task lists after completion so updates appear promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->