### PR TITLE
[codex] fix wework runtime task timestamp normalization

### DIFF
--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -98,6 +98,52 @@ describe('createLocalAppServices', () => {
     })
   })
 
+  test('preserves numeric runtime task timestamps from local executor lists', async () => {
+    const request = vi.fn().mockResolvedValue({
+      workspaces: [
+        {
+          workspace_path: '/Users/me/project',
+          local_tasks: [
+            {
+              local_task_id: 'newer-task',
+              workspace_path: '/Users/me/project',
+              title: 'Newer task',
+              runtime: 'codex',
+              createdAt: 1780000100000,
+              updatedAt: 1780000120000,
+            },
+            {
+              local_task_id: 'older-task',
+              workspace_path: '/Users/me/project',
+              title: 'Older task',
+              runtime: 'codex',
+              created_at: 1780000000000,
+              updated_at: 1780000060000,
+            },
+          ],
+        },
+      ],
+    })
+    const services = createLocalAppServices({
+      ensure: vi.fn().mockResolvedValue({ running: true, ready: true, deviceId: 'device-uuid' }),
+      request,
+      subscribe: vi.fn(),
+    })
+
+    const response = await services.runtimeWorkApi?.listRuntimeWork()
+    const tasks = response?.projects[0].deviceWorkspaces[0].localTasks
+
+    expect(tasks?.map(task => task.localTaskId)).toEqual(['newer-task', 'older-task'])
+    expect(tasks?.[0]).toMatchObject({
+      createdAt: 1780000100000,
+      updatedAt: 1780000120000,
+    })
+    expect(tasks?.[1]).toMatchObject({
+      createdAt: 1780000000000,
+      updatedAt: 1780000060000,
+    })
+  })
+
   test('keeps local device visible when executor startup fails', async () => {
     const services = createLocalAppServices({
       ensure: vi.fn().mockRejectedValue(new Error('sidecar missing')),

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -202,6 +202,11 @@ function stringValue(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value : null
 }
 
+function timestampValue(value: unknown): string | number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  return stringValue(value)
+}
+
 function runtimeAddressDebug(value: Record<string, unknown>): Record<string, unknown> {
   const address = recordValue(value.address)
   return {
@@ -258,8 +263,8 @@ function normalizeRuntimeTaskSummary(
   const workspaceKind =
     stringValue(taskRecord.workspaceKind) ?? stringValue(taskRecord.workspace_kind)
   const worktreeId = stringValue(taskRecord.worktreeId) ?? stringValue(taskRecord.worktree_id)
-  const createdAt = stringValue(taskRecord.createdAt) ?? stringValue(taskRecord.created_at)
-  const updatedAt = stringValue(taskRecord.updatedAt) ?? stringValue(taskRecord.updated_at)
+  const createdAt = timestampValue(taskRecord.createdAt) ?? timestampValue(taskRecord.created_at)
+  const updatedAt = timestampValue(taskRecord.updatedAt) ?? timestampValue(taskRecord.updated_at)
   const gitInfo = taskRecord.gitInfo ?? taskRecord.git_info
   const runtimeHandle = recordValue(taskRecord.runtimeHandle ?? taskRecord.runtime_handle)
 

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -328,8 +328,8 @@ export interface LocalTaskSummary {
   gitInfo?: Record<string, unknown> | null
   title: string
   runtime: RuntimeName
-  createdAt?: string | null
-  updatedAt?: string | null
+  createdAt?: string | number | null
+  updatedAt?: string | number | null
   running?: boolean
   status?: string | null
   runtimeHandle?: Record<string, unknown> | null


### PR DESCRIPTION
## Summary

Fixes Wework runtime task ordering after submitting a task by preserving numeric `createdAt` and `updatedAt` values returned by the local executor.

## Root Cause

The local executor returns runtime task timestamps as millisecond numbers, but Wework normalized task timestamps with a string-only helper. Numeric timestamps were dropped, leaving new tasks without a usable sort key and allowing them to appear at the end of task lists.

## Changes

- Accept string or numeric task timestamps during local runtime task normalization.
- Update `LocalTaskSummary` timestamp types to match executor responses.
- Add coverage for camelCase and snake_case numeric timestamps from local executor task lists.

## Validation

- `git diff --check HEAD~1 HEAD`
- Attempted `pnpm --dir wework test -- localServices.test.ts`, but this environment does not have `pnpm` installed (`zsh: command not found: pnpm`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved timestamp values in local task listings, so `createdAt` and `updatedAt` now remain accurate whether they arrive as numbers or strings.
  * Improved handling of invalid timestamp input by filtering out unsupported values.
* **Tests**
  * Added coverage to verify local task ordering and timestamp preservation in task list responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->