### PR TITLE
[codex] refine wework workspace tab hover styling

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -3172,14 +3172,15 @@ describe('DesktopWorkbenchLayout', () => {
     expect(closeButton).toHaveClass(
       'h-[18px]',
       'w-[18px]',
+      'absolute',
+      'right-1',
       'rounded-full',
-      'border',
-      'bg-muted',
       'opacity-0',
       'group-hover:opacity-100',
       'focus-visible:opacity-100'
     )
-    expect(closeButton).toHaveClass('ml-auto')
+    expect(closeButton).not.toHaveClass('ml-auto')
+    expect(closeButton).not.toHaveClass('border', 'bg-muted')
     expect(screen.getByTestId('right-workspace-new-tab-button')).toBeInTheDocument()
     expect(await screen.findByTestId('workspace-file-tree')).toBeInTheDocument()
   })
@@ -3320,14 +3321,17 @@ describe('DesktopWorkbenchLayout', () => {
     expect(closeButton).toHaveClass(
       'h-[18px]',
       'w-[18px]',
+      'absolute',
+      'right-1',
       'rounded-full',
-      'border',
-      'bg-muted',
       'opacity-0',
+      'hover:bg-black/70',
+      'hover:text-white',
       'group-hover:opacity-100',
       'focus-visible:opacity-100'
     )
-    expect(closeButton).toHaveClass('ml-auto')
+    expect(closeButton).not.toHaveClass('ml-auto')
+    expect(closeButton).not.toHaveClass('border', 'bg-muted')
     expect(screen.getByTestId('right-workspace-new-tab-button')).toBeInTheDocument()
     expect(await screen.findByTestId('file-changes-review-panel')).toHaveTextContent('src/env.ts')
     expect(baseProps.onLoadEnvironmentDiff).toHaveBeenCalledTimes(1)

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -99,7 +99,7 @@ export function BottomWorkspacePanel({
     <section
       data-testid={testId('bottom-workspace-panel')}
       className={cn(
-        'relative flex shrink-0 flex-col overflow-hidden bg-background transition-[height,opacity,transform] duration-300 ease-out',
+        'relative flex shrink-0 flex-col overflow-hidden rounded-t-xl bg-background transition-[height,opacity,transform] duration-300 ease-out',
         open
           ? 'pointer-events-auto translate-y-0 border-t border-border opacity-100'
           : 'pointer-events-none translate-y-3 border-t border-transparent opacity-0'
@@ -208,9 +208,9 @@ function BottomWorkspaceTitleTab({
       onClick={onSelect}
       onKeyDown={handleKeyDown}
       className={cn(
-        'group relative flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 overflow-hidden rounded-md py-1 pl-2 pr-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'group relative flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl py-1 pl-2 pr-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         active
-          ? 'border border-border bg-white text-text-primary shadow-sm after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
+          ? 'border border-border bg-white text-text-primary shadow-sm'
           : 'border border-transparent text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
       )}
     >
@@ -226,7 +226,7 @@ function BottomWorkspaceTitleTab({
           event.stopPropagation()
           onClose()
         }}
-        className="ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-hover hover:text-text-primary"
+        className="pointer-events-none absolute right-1 top-1/2 flex h-[18px] w-[18px] -translate-y-1/2 items-center justify-center rounded-full text-text-secondary opacity-0 transition-colors hover:bg-black/70 hover:text-white focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
         aria-label={t('workbench.close_terminal', '关闭终端')}
       >
         <X className="h-3 w-3" />

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -290,7 +290,7 @@ function RightWorkspaceTitleTab({
       onClick={onSelect}
       onKeyDown={handleKeyDown}
       className={cn(
-        'group flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 rounded-md py-1 pl-2 pr-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'group relative flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 rounded-md py-1 pl-2 pr-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         active
           ? 'bg-muted text-text-primary'
           : 'text-text-secondary hover:bg-muted hover:text-text-primary'
@@ -309,7 +309,7 @@ function RightWorkspaceTitleTab({
           event.stopPropagation()
           onClose()
         }}
-        className="pointer-events-none ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border border-border bg-muted text-text-secondary opacity-0 transition-colors hover:border-text-muted hover:bg-hover hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
+        className="pointer-events-none absolute right-1 top-1/2 flex h-[18px] w-[18px] -translate-y-1/2 items-center justify-center rounded-full text-text-secondary opacity-0 transition-colors hover:bg-black/70 hover:text-white focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
         aria-label={t('workbench.close_right_workspace_panel')}
       >
         <X className="h-3 w-3" />

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -604,9 +604,9 @@ export function WorkspacePanelCards({
               return (
                 <div
                   key={session.session_id}
-                  className={`group relative flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-md border border-transparent transition-colors ${
+                  className={`group relative flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-xl border border-transparent transition-colors ${
                     isActive
-                      ? 'border-border bg-white text-text-primary shadow-sm after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
+                      ? 'border-border bg-white text-text-primary shadow-sm'
                       : 'text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
                   }`}
                   title={terminalTabLabel || session.device_id}
@@ -626,10 +626,10 @@ export function WorkspacePanelCards({
                     type="button"
                     data-testid={testId('workspace-terminal-close-button')}
                     onClick={() => handleCloseTerminalSession(session.session_id)}
-                    className="flex h-8 w-7 shrink-0 items-center justify-center text-text-secondary transition-colors group-hover:text-text-primary"
+                    className="pointer-events-none absolute right-1 top-1/2 flex h-[18px] w-[18px] -translate-y-1/2 items-center justify-center rounded-full text-text-secondary opacity-0 transition-colors hover:bg-black/70 hover:text-white focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
                     aria-label={t('workbench.close_terminal', '关闭终端')}
                   >
-                    <X className="h-3.5 w-3.5" />
+                    <X className="h-3 w-3" />
                   </button>
                 </div>
               )


### PR DESCRIPTION
## Summary

- Refine Wework workspace terminal tabs with larger rounded corners and no active underline.
- Make terminal and right-panel tab close buttons float over the tab instead of taking layout space.
- Use a dark hover treatment for the floating close buttons.
- Update layout tests to assert the new close-button behavior.

## Root Cause

The close buttons were participating in tab layout or using the previous light hover treatment, which made the hover state look visually wrong and could shift or crowd tab labels.

## Validation

- `git diff --check HEAD~1..HEAD`
- `npx --no-install vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx` from `wework/`: 120 tests passed
- Pre-push hook: `pnpm --dir wework exec vitest run --coverage --passWithNoTests`: 102 files passed, 953 tests passed
- Pre-push AI quality gate: all quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated workspace panel tabs and close buttons for a cleaner, more consistent appearance.
  * Refined tab shapes and active-state styling across top, right, and bottom workspace areas.
  * Improved close-button behavior so it appears on hover/focus with clearer positioning and visibility.
  * Adjusted panel rounding for a more polished layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->