### PR TITLE
[codex] fix Wework HTTP link opening

### DIFF
--- a/wework/src-tauri/capabilities/default.json
+++ b/wework/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "core:webview:allow-set-webview-focus",
     "opener:allow-open-url",
     "opener:allow-default-urls",
+    "shell:allow-open",
     "updater:default",
     "process:allow-restart",
     {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -11,6 +11,7 @@ import type {
   WorkbenchContextValue,
   WorkbenchPaneContextValue,
 } from '@/features/workbench/workbenchContextTypes'
+import { openExternalUrl } from '@/lib/external-links'
 import {
   closeLocalTerminal,
   getLocalExecutorDeviceId,
@@ -35,6 +36,10 @@ vi.mock('./useWorkbenchPaneSession', () => ({
   useWorkbenchPaneSession: () => paneSessionMockRef.current,
 }))
 
+vi.mock('@/lib/external-links', () => ({
+  openExternalUrl: vi.fn(),
+}))
+
 const tauriMenuMocks = vi.hoisted(() => ({
   getCurrentWindow: vi.fn(),
   menuNew: vi.fn(),
@@ -44,6 +49,8 @@ const tauriMenuMocks = vi.hoisted(() => ({
 const authMocks = vi.hoisted(() => ({
   logout: vi.fn(),
 }))
+
+const openExternalUrlMock = vi.mocked(openExternalUrl)
 
 function createRect({
   left,
@@ -416,6 +423,7 @@ describe('DesktopWorkbenchLayout', () => {
     getLocalExecutorDeviceIdMock.mockResolvedValue(null)
     localPathExistsMock.mockResolvedValue(false)
     openLocalWorkspaceMock.mockResolvedValue(undefined)
+    openExternalUrlMock.mockResolvedValue(true)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
     fetchQuotaMock.mockResolvedValue({
@@ -1556,7 +1564,6 @@ describe('DesktopWorkbenchLayout', () => {
       configurable: true,
       value: {},
     })
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
     render(
       <DesktopWorkbenchLayout
@@ -1594,7 +1601,7 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('open-code-server-titlebar-button'))
 
     await waitFor(() => expect(startCodeServerSessionMock).toHaveBeenCalledWith(1))
-    expect(openSpy).toHaveBeenCalledWith('http://localhost/ide', '_blank', 'noopener')
+    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/ide')
     expect(screen.getByTestId('titlebar-actions')).toContainElement(
       screen.getByTestId('open-code-server-titlebar-button')
     )

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { createProjectApi } from '@/api/projects'
+import { openExternalUrl } from '@/lib/external-links'
 import { isLocalTerminalAvailable, openLocalWorkspace } from '@/lib/local-terminal'
 import { WorkspacePanelActions } from './WorkspacePanelActions'
 
@@ -22,7 +23,12 @@ vi.mock('@/lib/local-terminal', () => ({
   openLocalWorkspace: vi.fn(),
 }))
 
+vi.mock('@/lib/external-links', () => ({
+  openExternalUrl: vi.fn(),
+}))
+
 const createProjectApiMock = vi.mocked(createProjectApi)
+const openExternalUrlMock = vi.mocked(openExternalUrl)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startCodeServerSessionMock = vi.fn()
@@ -57,6 +63,7 @@ describe('WorkspacePanelActions', () => {
     createProjectApiMock.mockReturnValue({
       startCodeServerSession: startCodeServerSessionMock,
     } as unknown as ReturnType<typeof createProjectApi>)
+    openExternalUrlMock.mockResolvedValue(true)
   })
 
   test('shows environment info while loading and keeps it when environment context is available', () => {
@@ -201,5 +208,40 @@ describe('WorkspacePanelActions', () => {
         path: '/Users/me/project38',
       })
     )
+  })
+
+  test('opens cloud IDE sessions through the external URL helper', async () => {
+    render(
+      <WorkspacePanelActions
+        {...baseProps}
+        currentProject={{
+          id: 7,
+          name: 'project38',
+          config: {
+            execution: {
+              targetType: 'cloud',
+              deviceId: 'device-1',
+            },
+          },
+          tasks: [],
+        }}
+        devices={[
+          {
+            id: 1,
+            device_id: 'device-1',
+            name: 'Cloud Device',
+            status: 'online',
+            is_default: false,
+            device_type: 'cloud',
+            bind_shell: 'claudecode',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('open-code-server-titlebar-button'))
+
+    await waitFor(() => expect(startCodeServerSessionMock).toHaveBeenCalledWith(7))
+    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/ide')
   })
 })

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -14,6 +14,7 @@ import { configuredWorkspacePath } from '@/lib/project-workspace'
 import { getProjectDeviceId } from '@/lib/workbench-device'
 import { EnvironmentInfoPopover } from '../EnvironmentInfoPopover'
 import { DESKTOP_TOP_BAR_BUTTON_CLASS } from '../DesktopTopBar'
+import { openExternalUrl } from '@/lib/external-links'
 import { cn } from '@/lib/utils'
 import { LocalWorkspaceOpenerIcon, LocalWorkspaceOpenerPicker } from './LocalWorkspaceOpenerMenu'
 import type { DeviceInfo, ProjectWithTasks } from '@/types/api'
@@ -116,7 +117,7 @@ export function WorkspacePanelActions({
       if (!session.url) {
         throw new Error('IDE session URL is missing')
       }
-      window.open(session.url, '_blank', 'noopener')
+      await openExternalUrl(session.url)
     } catch (error) {
       console.error('Failed to start project IDE:', error)
       setIdeError(getStartFailedMessage(error))

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -6,6 +6,7 @@ import { createDeviceApi } from '@/api/devices'
 import { createProjectApi } from '@/api/projects'
 import { createUserApi } from '@/api/users'
 import { AppearanceProvider } from '@/features/appearance'
+import { openExternalUrl } from '@/lib/external-links'
 import { getLocalExecutorDeviceId, isLocalTerminalAvailable } from '@/lib/local-terminal'
 import '@/i18n'
 import type { DeviceInfo } from '@/types/devices'
@@ -50,6 +51,10 @@ vi.mock('@/lib/local-terminal', () => ({
   isLocalTerminalAvailable: vi.fn(),
 }))
 
+vi.mock('@/lib/external-links', () => ({
+  openExternalUrl: vi.fn(),
+}))
+
 vi.mock('@/components/layout/workspace-panels/RemoteTerminal', () => ({
   RemoteTerminal: ({ sessionId, active }: { sessionId: string; active: boolean }) => (
     <div
@@ -63,6 +68,7 @@ vi.mock('@/components/layout/workspace-panels/RemoteTerminal', () => ({
 const createDeviceApiMock = vi.mocked(createDeviceApi)
 const createProjectApiMock = vi.mocked(createProjectApi)
 const createUserApiMock = vi.mocked(createUserApi)
+const openExternalUrlMock = vi.mocked(openExternalUrl)
 const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 
@@ -162,6 +168,7 @@ describe('ConnectionsSettingsPage', () => {
     window.history.pushState({}, '', '/')
     isLocalTerminalAvailableMock.mockReturnValue(true)
     getLocalExecutorDeviceIdMock.mockResolvedValue('local-claude')
+    openExternalUrlMock.mockResolvedValue(true)
     api.openLocalTerminal.mockResolvedValue(undefined)
     api.getMetrics.mockResolvedValue({
       cpu_usage: 42,
@@ -933,6 +940,27 @@ describe('ConnectionsSettingsPage', () => {
       'data-session-id',
       'terminal-1'
     )
+  })
+
+  test('opens URL-based terminal sessions through the external URL helper', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    api.getAllDevices.mockResolvedValue([cloudDevice()])
+    api.startTerminal.mockResolvedValue({
+      session_id: 'terminal-1',
+      device_id: 'device-1',
+      type: 'terminal',
+      path: '/workspace',
+      url: 'http://localhost/terminal',
+      transport: 'http',
+    })
+
+    render(<ConnectionsSettingsPage onBack={vi.fn()} />)
+
+    await userEvent.click(await screen.findByTestId('connection-terminal-button-device-1'))
+
+    await waitFor(() => expect(api.startTerminal).toHaveBeenCalledWith('device-1'))
+    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/terminal')
+    expect(openSpy).not.toHaveBeenCalled()
   })
 
   test('keeps local device terminal hidden outside the WeWork macOS app', async () => {

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -600,7 +600,7 @@ function DeviceCard({ device, onChanged }: { device: DeviceInfo; onChanged: () =
 
       const result = await createSettingsDeviceApi(cloudConnection).startTerminal(device.device_id)
       if (result.url) {
-        window.open(result.url, '_blank', 'noopener')
+        await openExternalUrl(result.url)
         return
       }
       setTerminalSession(result)

--- a/wework/src/components/topnav/AppIframe.test.tsx
+++ b/wework/src/components/topnav/AppIframe.test.tsx
@@ -28,4 +28,13 @@ describe('AppIframe', () => {
     const iframe = screen.getByTestId('app-iframe-wegent')
     expect(iframe).toHaveAttribute('sandbox')
   })
+
+  test('allows popup links to escape the iframe sandbox', () => {
+    render(<AppIframe src="http://localhost:3000" title="Wegent" />)
+    const iframe = screen.getByTestId('app-iframe-wegent')
+    expect(iframe).toHaveAttribute(
+      'sandbox',
+      expect.stringContaining('allow-popups-to-escape-sandbox')
+    )
+  })
 })

--- a/wework/src/components/topnav/AppIframe.tsx
+++ b/wework/src/components/topnav/AppIframe.tsx
@@ -6,6 +6,14 @@ interface AppIframeProps {
   title: string
 }
 
+const APP_IFRAME_SANDBOX = [
+  'allow-scripts',
+  'allow-same-origin',
+  'allow-forms',
+  'allow-popups',
+  'allow-popups-to-escape-sandbox',
+].join(' ')
+
 export function AppIframe({ src, title }: AppIframeProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -23,7 +31,10 @@ export function AppIframe({ src, title }: AppIframeProps) {
           <span className="text-sm text-text-secondary">Failed to load {title}</span>
           <button
             type="button"
-            onClick={() => { setError(false); setLoading(true) }}
+            onClick={() => {
+              setError(false)
+              setLoading(true)
+            }}
             className="text-sm text-primary hover:underline"
           >
             Retry
@@ -36,7 +47,7 @@ export function AppIframe({ src, title }: AppIframeProps) {
         className="w-full h-full border-none"
         onLoad={() => setLoading(false)}
         onError={() => setError(true)}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+        sandbox={APP_IFRAME_SANDBOX}
         data-testid={`app-iframe-${title.toLowerCase()}`}
       />
     </div>


### PR DESCRIPTION
## Summary

Fix Wework HTTP link opening in the Tauri app by routing native Wework URL launches through the shared external opener and allowing iframe-hosted app popups to leave the iframe sandbox.

## Root Cause

HTTP links could fail in the desktop app because some native Wework flows still used direct `window.open`, and iframe-hosted content could invoke Tauri's `shell.open` path without the matching capability. That produced `shell.open not allowed` permission errors instead of opening the system default browser.

## Changes

- Add `shell:allow-open` to the Wework Tauri capability for system link opening.
- Allow iframe popup links to escape the iframe sandbox.
- Replace remaining native Wework terminal/IDE `window.open` calls with `openExternalUrl()`.
- Add regression coverage for iframe sandbox policy and native external URL launch paths.
- Update the desktop workbench titlebar test to assert the shared external opener path.

## Validation

- `git diff --check`
- `python3 -m json.tool wework/src-tauri/capabilities/default.json >/dev/null`
- `npx vitest run src/components/topnav/AppIframe.test.tsx src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx src/components/settings/ConnectionsSettingsPage.test.tsx`
- `npx vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx`
- Pre-push hook: `pnpm --dir wework exec vitest run --coverage --passWithNoTests` via a temporary PATH shim because the local global `pnpm@11.7.0` requires Node >= 22.13 while this machine only has older Node versions on PATH. Result: 102 files passed, 956 tests passed.
- Pre-push AI quality gate passed.