### PR TITLE
feat: add wework pane title

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -969,7 +969,7 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    expect(screen.getByTestId('desktop-workbench-content')).toHaveClass('pt-[52px]')
+    expect(screen.getByTestId('desktop-workbench-content')).toHaveClass('pt-11')
     expect(screen.getByTestId('desktop-chat-scroll')).toHaveClass(
       'h-full',
       'overflow-x-hidden',
@@ -1012,6 +1012,29 @@ describe('DesktopWorkbenchLayout', () => {
         {...baseProps}
         state={{
           ...baseProps.state,
+          runtimeWork: {
+            projects: [],
+            chats: [
+              {
+                deviceId: 'device-1',
+                deviceName: 'Runtime Device',
+                workspacePath: '/workspace/project-alpha',
+                workspaceKind: 'workspace',
+                localTasks: [
+                  {
+                    localTaskId: 'runtime-empty',
+                    workspacePath: '/workspace/project-alpha',
+                    title: 'Fix pane title',
+                    runtime: 'codex',
+                    createdAt: '2026-06-20T00:00:00.000Z',
+                    updatedAt: '2026-06-20T00:00:00.000Z',
+                    running: true,
+                  },
+                ],
+              },
+            ],
+            totalLocalTasks: 1,
+          },
           currentRuntimeTask: {
             deviceId: 'device-1',
             workspacePath: '/workspace/project-alpha',
@@ -1024,6 +1047,15 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(screen.getByTestId('desktop-floating-composer-layer')).toBeInTheDocument()
     expect(screen.queryByTestId('desktop-empty-composer-frame')).not.toBeInTheDocument()
+    const paneTitle = screen.getByTestId('workbench-pane-task-title')
+    expect(paneTitle).toHaveTextContent('Fix pane title')
+    expect(paneTitle).toHaveClass('truncate', 'text-[13px]', 'text-text-primary')
+    expect(screen.getByTestId('workbench-topbar')).toHaveClass(
+      'h-11',
+      'border-b',
+      'border-border/50',
+      'bg-background/95'
+    )
   })
 
   test('opens continue-in-im dialog from the active runtime task topbar button', async () => {
@@ -1546,7 +1578,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('titlebar-actions')).toContainElement(
       screen.getByTestId('environment-info-button')
     )
-    expect(screen.getByTestId('desktop-workbench-content')).not.toHaveClass('pt-[52px]')
+    expect(screen.getByTestId('desktop-workbench-content')).not.toHaveClass('pt-11')
     expect(getDesktopWorkbenchMainElement()).toHaveClass('mb-1.5', 'mr-1.5')
     expect(getDesktopWorkbenchMainElement()).not.toHaveClass('mt-1.5')
   })

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -51,6 +51,7 @@ import {
   type DesktopReviewMetadata,
   type DesktopReviewState,
 } from './desktopWorkbenchPaneTypes'
+import { findRuntimeLocalTask } from '@/features/workbench/workbenchRuntimeHelpers'
 import { useWorkbenchPaneEnvironment } from './useWorkbenchPaneEnvironment'
 import { useWorkbenchProjectWorkControls } from './useWorkbenchProjectWorkControls'
 import { useRuntimeTaskContinueInIm } from './useRuntimeTaskContinueInIm'
@@ -617,6 +618,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     />
   )
   const workspacePanelActions = renderWorkspacePanelActions('all')
+  const runtimeTaskTitle =
+    findRuntimeLocalTask(runtimeWork, currentRuntimeTask)?.title.trim() || null
+  const paneTaskTitle = runtimeTaskTitle ? (
+    <div
+      data-testid="workbench-pane-task-title"
+      className="min-w-0 max-w-[min(52rem,calc(100vw-28rem))] truncate text-[13px] font-medium leading-none text-text-primary"
+      title={runtimeTaskTitle}
+    >
+      {runtimeTaskTitle}
+    </div>
+  ) : undefined
   const topBarLeftActions = !isTauri ? (
     sidebarCollapsed ? (
       <DesktopWindowControls
@@ -631,7 +643,14 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       />
     )
   ) : undefined
-  const showPageTopBar = !isTauri || Boolean(topBarLeftActions)
+  const topBarLeftContent =
+    topBarLeftActions || paneTaskTitle ? (
+      <>
+        {topBarLeftActions}
+        {paneTaskTitle}
+      </>
+    ) : undefined
+  const showPageTopBar = !isTauri || Boolean(topBarLeftContent)
   const canForkCurrentRuntimeTask = Boolean(currentRuntimeTask && forkCurrentRuntimeTask)
   const forkTaskButton = canForkCurrentRuntimeTask ? (
     <button
@@ -741,11 +760,12 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <DesktopTopBar
             testId="workbench-topbar"
             className={cn(
-              'absolute left-0 top-0 z-chrome overflow-hidden bg-transparent pl-2 pr-7',
+              'absolute left-0 top-0 z-chrome h-11 overflow-hidden border-b border-border/50 bg-background/95 pl-4 pr-7 backdrop-blur supports-[backdrop-filter]:bg-background/80',
               rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
             )}
             style={{ width: chatColumnWidth }}
-            left={topBarLeftActions}
+            left={topBarLeftContent}
+            leftClassName="min-w-0 max-w-[calc(100%-12rem)] gap-2"
           />
         )}
       </WorkbenchPaneActiveOnly>
@@ -754,7 +774,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         className={cn(
           'relative flex min-w-0 flex-none flex-col overflow-hidden',
           rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
-          showPageTopBar && 'pt-[52px]',
+          showPageTopBar && 'pt-11',
           rightPanelOpen && 'border-r border-border'
         )}
         style={


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop workbench now shows the current runtime task title in the top bar when available.
  * The top bar layout has been updated to better accommodate left-side content.

* **Bug Fixes**
  * Adjusted desktop content spacing to match the updated layout.
  * Refined top bar appearance with updated height, border, background, and padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->