### PR TITLE
[codex] Persist local worktree preferences

### DIFF
--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test, vi } from 'vitest'
-import { LOCAL_USER } from './localSession'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { getLocalUser, LOCAL_USER } from './localSession'
 import { createLocalAppServices } from './localServices'
 
 describe('createLocalAppServices', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   test('returns local bootstrap data without backend', async () => {
     const request = vi.fn().mockResolvedValue({ projects: [], chats: [], totalLocalTasks: 0 })
     const ensure = vi.fn().mockResolvedValue({
@@ -51,6 +55,58 @@ describe('createLocalAppServices', () => {
       totalLocalTasks: 0,
     })
     expect(request).toHaveBeenCalledWith('runtime.tasks.list', {})
+  })
+
+  test('persists local user preferences across local service instances', async () => {
+    const firstServices = createLocalAppServices({
+      ensure: vi.fn().mockResolvedValue({
+        running: true,
+        ready: true,
+        deviceId: 'local-device',
+      }),
+      request: vi.fn().mockResolvedValue({ projects: [], chats: [], totalLocalTasks: 0 }),
+      subscribe: vi.fn(),
+    })
+
+    await firstServices.userApi?.updateCurrentUser({
+      preferences: {
+        wework_project_work_preferences: {
+          'project:7': {
+            executionMode: 'git_worktree',
+            worktreeBranch: 'feature/alpha',
+          },
+        },
+      },
+    })
+
+    const secondServices = createLocalAppServices({
+      ensure: vi.fn().mockResolvedValue({
+        running: true,
+        ready: true,
+        deviceId: 'local-device',
+      }),
+      request: vi.fn().mockResolvedValue({ projects: [], chats: [], totalLocalTasks: 0 }),
+      subscribe: vi.fn(),
+    })
+
+    await expect(secondServices.userApi?.updateCurrentUser({})).resolves.toMatchObject({
+      preferences: {
+        wework_project_work_preferences: {
+          'project:7': {
+            executionMode: 'git_worktree',
+            worktreeBranch: 'feature/alpha',
+          },
+        },
+      },
+    })
+    expect(getLocalUser().preferences).toMatchObject({
+      wework_project_work_preferences: {
+        'project:7': {
+          executionMode: 'git_worktree',
+          worktreeBranch: 'feature/alpha',
+        },
+      },
+    })
   })
 
   test('normalizes runtime handles returned by local executor task lists', async () => {

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -56,7 +56,7 @@ import { buildManagedWorktreePath } from '@/lib/device-workspace-path'
 import { WEWORK_MIN_EXECUTOR_VERSION } from '@/lib/device-capabilities'
 import { createLocalChatStream } from './localChatStream'
 import { createLocalAttachmentApi } from './localAttachments'
-import { LOCAL_USER } from './localSession'
+import { getLocalUser, LOCAL_USER, saveLocalUserPreferences } from './localSession'
 
 const LOCAL_DEVICE_ID = 'local-device'
 
@@ -1273,10 +1273,10 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
       runtimeWorkApi,
     }),
     userApi: {
-      updateCurrentUser: async (data: { preferences?: User['preferences'] }) => ({
-        ...LOCAL_USER,
-        preferences: data.preferences ?? LOCAL_USER.preferences,
-      }),
+      updateCurrentUser: async (data: { preferences?: User['preferences'] }) =>
+        Object.prototype.hasOwnProperty.call(data, 'preferences')
+          ? saveLocalUserPreferences(data.preferences ?? {})
+          : getLocalUser(),
       getRuntimeConfig: () => cloudConnectionRequired('getRuntimeConfig'),
       updateRuntimeConfig: () => cloudConnectionRequired('updateRuntimeConfig'),
       getProxyConfig: () => cloudConnectionRequired('getProxyConfig'),

--- a/wework/src/api/local/localSession.ts
+++ b/wework/src/api/local/localSession.ts
@@ -1,4 +1,4 @@
-import type { User } from '@/types/api'
+import type { User, UserPreferences } from '@/types/api'
 
 export const LOCAL_USER = {
   id: 0,
@@ -7,6 +7,43 @@ export const LOCAL_USER = {
   preferences: {},
 } satisfies User
 
+const LOCAL_USER_PREFERENCES_STORAGE_KEY = 'wework.localUser.preferences'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readLocalUserPreferences(): UserPreferences {
+  try {
+    const raw = globalThis.localStorage?.getItem(LOCAL_USER_PREFERENCES_STORAGE_KEY)
+    if (!raw) return LOCAL_USER.preferences
+
+    const parsed = JSON.parse(raw)
+    return isRecord(parsed) ? (parsed as UserPreferences) : LOCAL_USER.preferences
+  } catch {
+    return LOCAL_USER.preferences
+  }
+}
+
+export function saveLocalUserPreferences(preferences: UserPreferences): User {
+  try {
+    globalThis.localStorage?.setItem(
+      LOCAL_USER_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(preferences)
+    )
+  } catch {
+    // Keep the in-session return value even if local persistence is unavailable.
+  }
+
+  return {
+    ...LOCAL_USER,
+    preferences,
+  }
+}
+
 export function getLocalUser(): User {
-  return LOCAL_USER
+  return {
+    ...LOCAL_USER,
+    preferences: readLocalUserPreferences(),
+  }
 }


### PR DESCRIPTION
## What changed

- Persist Wework local-first user preferences to `localStorage` instead of returning them only from the current `updateCurrentUser` call.
- Restore local user preferences through `getLocalUser()` so project work mode preferences survive app restarts.
- Add a local services regression test covering project worktree preference recovery across local service instances.

## Why

In local-first mode, selecting `新工作树` updated the in-memory Workbench user preferences, but the local user API did not write those preferences anywhere durable. The next app launch recreated the local user from empty defaults, so the project fell back to the current workspace mode.

## Validation

- `git commit` pre-commit hook passed: Prettier and ESLint for staged Wework files.
- `pnpm --dir wework test src/api/local/localServices.test.ts`: 1 test file passed, 14 tests passed.
- Pre-push hook passed with Node v22.13.1 and pnpm 11.7.0: Wework test suite 103 files passed, 963 tests passed, then AI quality checks passed.

Note: the machine default Node v24.1.0 triggers a Corepack pnpm shim error (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`), so validation and push hooks were run with Node v22.13.1 and a temporary pnpm wrapper pointing at pnpm 11.7.0's ESM entrypoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local user preferences are now saved and restored automatically, so changes persist across separate app sessions.
* **Bug Fixes**
  * Fixed an issue where local preferences could be lost when reopening or recreating the app service.
  * Improved handling of invalid or unavailable stored data so the app falls back safely to default preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->