### PR TITLE
[codex] fix wework project conversation ordering

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1946,7 +1946,7 @@ describe('DesktopSidebar', () => {
     })
   })
 
-  test('limits project runtime tasks to five rows and preserves append order', async () => {
+  test('limits project runtime tasks to five newest rows', async () => {
     renderSidebar({
       runtimeWork: {
         projects: [
@@ -2019,13 +2019,13 @@ describe('DesktopSidebar', () => {
     const collapsedRows = screen.getAllByTestId(/^runtime-local-task-row-/)
     expect(collapsedRows).toHaveLength(5)
     expect(collapsedRows.map(row => row.textContent)).toEqual([
-      expect.stringContaining('Oldest hidden task'),
-      expect.stringContaining('Third task'),
       expect.stringContaining('Newest task'),
-      expect.stringContaining('Fifth task'),
       expect.stringContaining('Second task'),
+      expect.stringContaining('Third task'),
+      expect.stringContaining('Fourth task'),
+      expect.stringContaining('Fifth task'),
     ])
-    expect(screen.queryByText('Fourth task')).not.toBeInTheDocument()
+    expect(screen.queryByText('Oldest hidden task')).not.toBeInTheDocument()
 
     expect(screen.getByTestId('project-runtime-tasks-expand-7')).toHaveTextContent('展开显示')
 
@@ -2038,7 +2038,7 @@ describe('DesktopSidebar', () => {
     await userEvent.click(screen.getByTestId('project-runtime-tasks-collapse-7'))
 
     expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(5)
-    expect(screen.queryByText('Fourth task')).not.toBeInTheDocument()
+    expect(screen.queryByText('Oldest hidden task')).not.toBeInTheDocument()
   })
 
   test('toggles a project when its sidebar row is clicked', async () => {

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -1273,7 +1273,7 @@ describe('MobileWorkbenchLayout', () => {
     })
   })
 
-  test('limits mobile project runtime tasks to five rows and preserves append order', async () => {
+  test('limits mobile project runtime tasks to five newest rows', async () => {
     render(
       <MobileWorkbenchLayout
         state={{
@@ -1356,13 +1356,13 @@ describe('MobileWorkbenchLayout', () => {
     const collapsedRows = screen.getAllByTestId('mobile-runtime-task-button')
     expect(collapsedRows).toHaveLength(5)
     expect(collapsedRows.map(row => row.textContent)).toEqual([
-      expect.stringContaining('Oldest hidden task'),
-      expect.stringContaining('Third task'),
       expect.stringContaining('Newest task'),
-      expect.stringContaining('Fifth task'),
       expect.stringContaining('Second task'),
+      expect.stringContaining('Third task'),
+      expect.stringContaining('Fourth task'),
+      expect.stringContaining('Fifth task'),
     ])
-    expect(screen.queryByText('Fourth task')).not.toBeInTheDocument()
+    expect(screen.queryByText('Oldest hidden task')).not.toBeInTheDocument()
     expect(screen.getByTestId('mobile-project-runtime-tasks-expand-1')).toHaveTextContent(
       '展开显示'
     )
@@ -1378,7 +1378,7 @@ describe('MobileWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('mobile-project-runtime-tasks-collapse-1'))
 
     expect(screen.getAllByTestId('mobile-runtime-task-button')).toHaveLength(5)
-    expect(screen.queryByText('Fourth task')).not.toBeInTheDocument()
+    expect(screen.queryByText('Oldest hidden task')).not.toBeInTheDocument()
   })
 
   test('opens project actions on long press without expanding the project', async () => {

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
@@ -3,8 +3,8 @@ import type { RuntimeDeviceWorkspace } from '@/types/api'
 import { getRuntimeSidebarTaskItems, getRuntimeTaskAddress } from './runtimeTaskSidebarHelpers'
 
 describe('runtimeTaskSidebarHelpers', () => {
-  test('keeps runtime task items in workspace order', () => {
-    const workspace: RuntimeDeviceWorkspace = {
+  test('sorts runtime task items newest first across workspaces', () => {
+    const oldWorkspace: RuntimeDeviceWorkspace = {
       deviceId: 'device-1',
       workspacePath: '/workspace/repo',
       available: true,
@@ -27,11 +27,26 @@ describe('runtimeTaskSidebarHelpers', () => {
         },
       ],
     }
+    const newWorkspace: RuntimeDeviceWorkspace = {
+      deviceId: 'device-1',
+      workspacePath: '/workspace/repo/.worktrees/new-task',
+      workspaceKind: 'worktree',
+      available: true,
+      localTasks: [
+        {
+          localTaskId: 'new-worktree-task',
+          workspacePath: '/workspace/repo/.worktrees/new-task',
+          title: 'New worktree task',
+          runtime: 'codex',
+          running: true,
+          updatedAt: '2026-06-03T00:00:00.000Z',
+        },
+      ],
+    }
 
-    expect(getRuntimeSidebarTaskItems([workspace]).map(item => item.task.localTaskId)).toEqual([
-      'older-running',
-      'newer-idle',
-    ])
+    expect(
+      getRuntimeSidebarTaskItems([oldWorkspace, newWorkspace]).map(item => item.task.localTaskId)
+    ).toEqual(['new-worktree-task', 'newer-idle', 'older-running'])
   })
 
   test('carries runtime handle into task addresses when present', () => {

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -30,7 +30,9 @@ export function getRuntimeTaskRuntimeLabel(runtime: string) {
 export function getRuntimeSidebarTaskItems(
   workspaces: RuntimeDeviceWorkspace[] = []
 ): RuntimeSidebarTaskItem[] {
-  return workspaces.flatMap(workspace => workspace.localTasks.map(task => ({ workspace, task })))
+  return sortRuntimeTaskItems(
+    workspaces.flatMap(workspace => workspace.localTasks.map(task => ({ workspace, task })))
+  )
 }
 
 export function getRuntimeChatSidebarTaskItems(


### PR DESCRIPTION
## Summary
- Sort Wework project runtime conversation rows newest-first in the shared sidebar helper.
- Apply the same ordering to desktop and mobile project conversation previews.
- Update tests to cover cross-workspace ordering, including new worktree conversations after refresh.

## Root cause
New conversations were optimistically inserted at the top of the selected workspace. After the create request resolved, refreshWorkLists could return the real task under a different worktree workspace. The sidebar flattened workspaces in workspace order, so the conversation could move to the bottom about a second after creation.

## Validation
- PATH="$HOME/.nvm/versions/node/v24.1.0/bin:$PATH" node "$HOME/.cache/node/corepack/pnpm/11.7.0/bin/pnpm.mjs" --dir wework exec vitest run src/components/layout/runtimeTaskSidebarHelpers.test.ts src/components/layout/DesktopSidebar.test.tsx src/components/layout/MobileWorkbenchLayout.test.tsx
- git diff --check
- pre-push hook: pnpm --dir wework exec vitest run --coverage --passWithNoTests, 103 files passed / 962 tests passed, AI quality gate passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime task lists now show the most recent tasks first, including across multiple workspaces.
  * Desktop and mobile layouts now consistently display the five newest tasks when the list is collapsed.
  * Hidden older tasks are no longer shown in the limited task view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->