### PR TITLE
[codex] fix wework VS Code titlebar button theme

### DIFF
--- a/wework/src/components/layout/workspace-panels/LocalWorkspaceOpenerMenu.tsx
+++ b/wework/src/components/layout/workspace-panels/LocalWorkspaceOpenerMenu.tsx
@@ -193,7 +193,7 @@ export function LocalWorkspaceOpenerIcon({
   if (opener === 'vscode' || opener === 'vscode-insiders') {
     const color = opener === 'vscode' ? '#1f7fbf' : '#4aa99d'
     return (
-      <span className={cn(wrapperClassName, 'relative bg-white')} aria-hidden="true">
+      <span className={cn(wrapperClassName, 'relative bg-background')} aria-hidden="true">
         <span
           data-testid="local-workspace-vscode-mark"
           className="absolute left-[4px] top-[4px] h-[8px] w-[8px] rotate-45 border-b-[2px] border-l-[2px]"

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -160,7 +160,7 @@ export function WorkspacePanelActions({
         />
       )}
       {showPanelToggles && canOpenCodeServer && localWorkspaceEnabled && (
-        <div className="flex h-7 shrink-0 overflow-hidden rounded-xl border border-[#d8d8d8] bg-white">
+        <div className="flex h-7 shrink-0 overflow-hidden rounded-xl border border-border bg-background">
           <button
             type="button"
             data-testid="open-code-server-titlebar-button"
@@ -168,7 +168,7 @@ export function WorkspacePanelActions({
             disabled={ideLoading}
             className={cn(
               DESKTOP_TOP_BAR_BUTTON_CLASS,
-              'h-7 w-8 rounded-none bg-[#f2f3f5] hover:bg-[#eceef0] active:bg-[#e4e6e8]',
+              'h-7 w-8 rounded-none bg-surface hover:bg-muted active:bg-border/50',
               ideLoading && 'cursor-wait opacity-70'
             )}
             aria-label={t('workbench.open_project_ide_with', {
@@ -190,7 +190,7 @@ export function WorkspacePanelActions({
             disabled={ideLoading}
             buttonClassName={cn(
               DESKTOP_TOP_BAR_BUTTON_CLASS,
-              'h-7 w-6 rounded-none border-l border-[#e8eaed] bg-[#f7f8f9] hover:bg-[#f0f1f2] active:bg-[#e9ebed] [&_svg]:h-3.5 [&_svg]:w-3.5',
+              'h-7 w-6 rounded-none border-l border-border bg-background hover:bg-muted active:bg-border/50 [&_svg]:h-3.5 [&_svg]:w-3.5',
               ideLoading && 'cursor-wait opacity-70'
             )}
             onSelect={handleOpenLocalWorkspace}


### PR DESCRIPTION
## Summary
- Replace hardcoded local VS Code titlebar button surfaces with semantic theme tokens.
- Make the VS Code opener icon background follow the app background token.

## Root Cause
The local workspace VS Code split button used fixed white and gray Tailwind colors, so it did not update when Wework switched page/theme mode.

## Impact
The top-right VS Code action now visually matches light and dark page modes while keeping the existing titlebar action behavior unchanged.

## Validation
- `node /Users/axb-mac/.cache/node/corepack/pnpm/11.7.0/bin/pnpm.mjs --dir wework test -- WorkspacePanelActions.test.tsx theme-token-guard.test.ts --run`
- pre-push hook: `pnpm --dir wework exec vitest run --coverage --passWithNoTests`
- pre-push hook: AI code quality gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated workspace-opening controls to use theme-aware colors for backgrounds, borders, and hover/active states.
  * Improved the visual consistency of local workspace picker and icon rendering across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->