### PR TITLE
fix(executor): preserve Codex runtime task titles

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -140,7 +140,7 @@ impl AgentEngine for CodexAppServerEngine {
     fn run(&self, request: ExecutionRequest) -> Self::RunFuture {
         let binary = self.binary.clone();
         Box::pin(async move {
-            match run_codex_app_server_turn(&binary, request, None, None).await {
+            match run_codex_app_server_turn(&binary, request, None, None, None).await {
                 Ok(turn) => turn.outcome,
                 Err(message) => ExecutionOutcome::Failed { message },
             }
@@ -265,6 +265,7 @@ pub async fn run_codex_app_server_turn(
     binary: &str,
     request: ExecutionRequest,
     resume_thread_id: Option<String>,
+    initial_thread_name: Option<String>,
     notifications: Option<CodexNotificationSender>,
 ) -> Result<CodexAppServerTurn, String> {
     let prepared = prepare_codex_execution_request(request);
@@ -350,6 +351,22 @@ pub async fn run_codex_app_server_turn(
                     }
                 }
             }));
+        }
+        if let Some(name) = initial_thread_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            with_rpc_timeout(
+                "thread/name/set",
+                timeout_seconds,
+                rpc.request(
+                    "thread/name/set",
+                    json!({"threadId": thread_id.clone(), "name": name}),
+                    &mut state,
+                ),
+            )
+            .await?;
         }
 
         let turn_input = turn_input(&request.prompt);

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -571,13 +571,16 @@ impl RuntimeWorkRpcHandler {
         };
         apply_runtime_payload_metadata(&mut request, &payload);
 
-        let mut link =
-            RuntimeTaskLink::new_pending(local_task_id.clone(), workspace_path.clone(), title);
+        let mut link = RuntimeTaskLink::new_pending(
+            local_task_id.clone(),
+            workspace_path.clone(),
+            title.clone(),
+        );
         if let Some(message) = cached_user_message(&local_task_id, &request, &payload) {
             set_runtime_handle_messages(&mut link.runtime_handle, vec![message]);
         }
         self.upsert_local_task(link);
-        self.spawn_turn(local_task_id.clone(), request, None);
+        self.spawn_turn(local_task_id.clone(), request, None, Some(title));
 
         Ok(json!({
             "success": true,
@@ -656,7 +659,7 @@ impl RuntimeWorkRpcHandler {
             &request,
             &payload,
         );
-        self.spawn_turn(local_task_id.clone(), request, Some(thread_id));
+        self.spawn_turn(local_task_id.clone(), request, Some(thread_id), None);
 
         Ok(json!({
             "success": true,
@@ -876,6 +879,7 @@ impl RuntimeWorkRpcHandler {
         local_task_id: String,
         request: ExecutionRequest,
         resume_thread_id: Option<String>,
+        initial_thread_name: Option<String>,
     ) {
         let mut fields = task_fields(request.task_id, request.subtask_id);
         fields.push(("local_task_id", local_task_id.clone()));
@@ -906,6 +910,7 @@ impl RuntimeWorkRpcHandler {
                 &handler.codex_binary,
                 request.clone(),
                 resume_thread_id,
+                initial_thread_name,
                 notifications,
             )
             .await;

--- a/executor/src/runtime_work/store.rs
+++ b/executor/src/runtime_work/store.rs
@@ -8,6 +8,7 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use serde::{Deserialize, Serialize};
@@ -121,9 +122,26 @@ impl RuntimeWorkStore {
             workspaces: index.workspaces.clone(),
         });
         if let Ok(payload) = payload {
-            let _ = fs::write(&self.index_path, payload);
+            let temp_path = temporary_index_path(&self.index_path);
+            if fs::write(&temp_path, payload).is_ok() {
+                if fs::rename(&temp_path, &self.index_path).is_err() {
+                    let _ = fs::remove_file(temp_path);
+                }
+            }
         }
     }
+}
+
+fn temporary_index_path(index_path: &Path) -> PathBuf {
+    let file_name = index_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("index.json");
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    index_path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), nanos))
 }
 
 fn default_index_path() -> PathBuf {


### PR DESCRIPTION
## Summary
- preserve the initial Wegent runtime task title by applying it to the Codex thread after thread creation
- keep follow-up sends from changing the Codex thread name
- write the runtime-work index via a temporary file and atomic rename to avoid partial reads

## Tests
- cargo fmt --manifest-path executor/Cargo.toml
- cargo test --manifest-path executor/Cargo.toml runtime_work --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New tasks can now start with a title shown as the conversation/thread name.
  * Thread names can be set automatically when a task begins, making work easier to identify.

* **Bug Fixes**
  * Runtime index updates are now saved more safely, reducing the chance of partial writes if saving is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->