### PR TITLE
[codex] Show Wework edit tool messages

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -191,6 +191,40 @@ describe('ToolBlockItem', () => {
     expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/crystal/package.json')
   })
 
+  test('renders Claude MultiEdit blocks as editable file activity', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'edit-1',
+          turnId: 1,
+          type: 'tool',
+          toolName: 'MultiEdit',
+          toolInput: {
+            file_path: '/Users/crystal/src/config.ts',
+            edits: [
+              {
+                old_string: 'enabled: false',
+                new_string: 'enabled: true',
+              },
+            ],
+          },
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+      />
+    )
+
+    expect(screen.getByText('已编辑 config.ts')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /展开工具详情/ }))
+
+    expect(screen.getByText('/Users/crystal/src/config.ts')).toBeInTheDocument()
+    expect(screen.getByText('enabled: false')).toBeInTheDocument()
+    expect(screen.getByText('enabled: true')).toBeInTheDocument()
+  })
+
   test('renders process text code blocks with shared syntax highlighting', () => {
     render(
       <ToolBlockItem

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -7,7 +7,16 @@ import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { MarkdownCodeBlock } from '../MarkdownCodeBlock'
 import { parseUnifiedDiff } from '../parseUnifiedDiff'
-import { isCommandToolName, isGuidanceToolName, isWebSearchToolName } from './toolBlockActivity'
+import { isWebSearchToolName } from './toolBlockActivity'
+import {
+  getFileInputPath,
+  getInputField,
+  isCommandToolName,
+  isFileCreateToolName,
+  isFileEditToolName,
+  isGuidanceToolName,
+  isFileReadToolName,
+} from './toolBlockKinds'
 import { WebSearchActivityRows } from './WebSearchSources'
 import { getWebSearchActivityItems } from './webSearchActivity'
 
@@ -526,17 +535,17 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
     const shortCmd = command ? truncate(command.split('\n')[0], 40) : block.toolName
     return { icon: <TerminalIcon />, label: `${prefix.running} ${shortCmd}` }
   }
-  if (name === 'write' || name === 'create_file' || name === 'write_file') {
+  if (isFileCreateToolName(name)) {
     const filePath = getFileInputPath(block)
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <FileIcon />, label: `${prefix.create} ${fileName}` }
   }
-  if (name === 'edit' || name === 'str_replace_editor' || name === 'edit_file') {
+  if (isFileEditToolName(name)) {
     const filePath = getFileInputPath(block)
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <EditIcon />, label: `${prefix.edit} ${fileName}` }
   }
-  if (name === 'read' || name === 'read_file') {
+  if (isFileReadToolName(name)) {
     const filePath = getFileInputPath(block)
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <FileIcon />, label: `${prefix.read} ${fileName}` }
@@ -667,10 +676,10 @@ function renderBlockDetail(block: ToolBlock) {
   if (isCommandToolName(name)) {
     return <BashBlockDetail block={block} />
   }
-  if (name === 'write' || name === 'create_file' || name === 'write_file') {
+  if (isFileCreateToolName(name)) {
     return <FileWriteDetail block={block} />
   }
-  if (name === 'edit' || name === 'str_replace_editor' || name === 'edit_file') {
+  if (isFileEditToolName(name)) {
     return <FileEditDetail block={block} />
   }
   if (isWebSearchToolName(name)) {
@@ -687,12 +696,8 @@ function hasBlockDetail(block: ToolBlock): boolean {
   const name = block.toolName.toLowerCase()
   return (
     isCommandToolName(name) ||
-    name === 'write' ||
-    name === 'create_file' ||
-    name === 'write_file' ||
-    name === 'edit' ||
-    name === 'str_replace_editor' ||
-    name === 'edit_file' ||
+    isFileCreateToolName(name) ||
+    isFileEditToolName(name) ||
     isWebSearchToolName(name)
   )
 }
@@ -711,16 +716,7 @@ function WebSearchBlockDetail({ block }: { block: ToolBlock }) {
 
 function getWorkspaceFilePath(block: ToolBlock): string | undefined {
   const name = block.toolName.toLowerCase()
-  if (
-    name !== 'read' &&
-    name !== 'read_file' &&
-    name !== 'write' &&
-    name !== 'create_file' &&
-    name !== 'write_file' &&
-    name !== 'edit' &&
-    name !== 'str_replace_editor' &&
-    name !== 'edit_file'
-  ) {
+  if (!isFileReadToolName(name) && !isFileCreateToolName(name) && !isFileEditToolName(name)) {
     return undefined
   }
   return getFileInputPath(block)
@@ -834,46 +830,59 @@ function FileWriteDetail({ block }: { block: ToolBlock }) {
 
 function FileEditDetail({ block }: { block: ToolBlock }) {
   const filePath = getFileInputPath(block)
-  const oldStr = getInputField(block, 'old_string', 'old_str', 'oldString')
-  const newStr = getInputField(block, 'new_string', 'new_str', 'newString')
+  const previews = getEditPreviews(block)
   return (
     <div className="min-w-0 space-y-1 overflow-x-hidden">
       {filePath && <p className="break-words text-xs text-text-muted">{filePath}</p>}
-      {oldStr && (
-        <pre className="max-h-24 max-w-full overflow-auto rounded-lg bg-red-50 px-3 py-2 text-xs leading-5 text-red-700">
-          {oldStr.length > 300 ? oldStr.substring(0, 300) + '...' : oldStr}
-        </pre>
-      )}
-      {newStr && (
-        <pre className="max-h-24 max-w-full overflow-auto rounded-lg bg-green-50 px-3 py-2 text-xs leading-5 text-green-700">
-          {newStr.length > 300 ? newStr.substring(0, 300) + '...' : newStr}
-        </pre>
-      )}
+      {previews.map((preview, index) => (
+        <div
+          key={`${index}:${preview.oldText ?? ''}:${preview.newText ?? ''}`}
+          className="space-y-1"
+        >
+          {preview.oldText && (
+            <pre className="max-h-24 max-w-full overflow-auto rounded-lg bg-red-50 px-3 py-2 text-xs leading-5 text-red-700">
+              {truncate(preview.oldText, 300)}
+            </pre>
+          )}
+          {preview.newText && (
+            <pre className="max-h-24 max-w-full overflow-auto rounded-lg bg-green-50 px-3 py-2 text-xs leading-5 text-green-700">
+              {truncate(preview.newText, 300)}
+            </pre>
+          )}
+        </div>
+      ))}
     </div>
   )
 }
 
-function getInputField(block: ToolBlock, ...keys: string[]): string | undefined {
-  if (!block.toolInput) return undefined
-  for (const key of keys) {
-    const val = block.toolInput[key]
-    if (typeof val === 'string') return val
+function getEditPreviews(block: ToolBlock): Array<{ oldText?: string; newText?: string }> {
+  const directOldText = getInputField(block, 'old_string', 'old_str', 'oldString')
+  const directNewText = getInputField(block, 'new_string', 'new_str', 'newString', 'new_source')
+  if (directOldText || directNewText) {
+    return [{ oldText: directOldText, newText: directNewText }]
   }
-  return undefined
+
+  const edits = block.toolInput?.edits
+  if (!Array.isArray(edits)) return []
+
+  return edits.flatMap(edit => {
+    if (!isRecord(edit)) return []
+    const oldText = getStringField(edit, 'old_string', 'old_str', 'oldString')
+    const newText = getStringField(edit, 'new_string', 'new_str', 'newString')
+    return oldText || newText ? [{ oldText, newText }] : []
+  })
 }
 
-function getFileInputPath(block: ToolBlock): string | undefined {
-  return getInputField(
-    block,
-    'file_path',
-    'filePath',
-    'filepath',
-    'path',
-    'file',
-    'filename',
-    'target_file',
-    'targetFile'
-  )
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getStringField(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string') return value
+  }
+  return undefined
 }
 
 function truncate(str: string, maxLen: number): string {

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -73,6 +73,30 @@ describe('toolBlockActivity', () => {
     ).toBe('已引导对话')
   })
 
+  test('classifies Claude multi-file edit tools as edit activity', () => {
+    expect(
+      summarizeToolBlocks([
+        {
+          id: 'edit-1',
+          turnId: 1,
+          type: 'tool',
+          toolName: 'MultiEdit',
+          toolInput: {
+            file_path: '/workspace/src/config.ts',
+            edits: [
+              {
+                old_string: 'enabled: false',
+                new_string: 'enabled: true',
+              },
+            ],
+          },
+          status: 'done',
+          createdAt: 1770000000000,
+        },
+      ])
+    ).toBe('已编辑 1 个文件')
+  })
+
   test('groups completed tools while preserving running tools as standalone rows', () => {
     const thinking: ProcessingBlock = {
       id: 'thinking-1',

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -1,4 +1,12 @@
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
+import {
+  getInputField,
+  isCommandToolName,
+  isFileCreateToolName,
+  isFileEditToolName,
+  isFileReadToolName,
+  isGuidanceToolName,
+} from './toolBlockKinds'
 
 export type ProcessingDisplayRow =
   | { type: 'block'; id: string; block: ProcessingBlock }
@@ -18,17 +26,6 @@ interface ActivityStats {
   failedTools: number
 }
 
-const COMMAND_TOOLS = new Set([
-  'bash',
-  'exec_command',
-  'execute_command',
-  'functions.exec_command',
-  'run_terminal_command',
-])
-const FILE_TOOLS = new Set(['read', 'read_file'])
-const CREATE_TOOLS = new Set(['write', 'create_file', 'write_file'])
-const EDIT_TOOLS = new Set(['edit', 'str_replace_editor', 'edit_file'])
-const GUIDANCE_TOOLS = new Set(['conversation_guidance', 'user_guidance'])
 const SEARCH_TOOL_HINTS = ['search', 'grep', 'glob']
 const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag', 'ack'])
 const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'du', 'file'])
@@ -127,10 +124,10 @@ function getActivityStats(blocks: ToolBlock[]): ActivityStats {
 
 function getToolActivityKind(block: ToolBlock): ToolActivityKind {
   const name = block.toolName.toLowerCase()
-  if (FILE_TOOLS.has(name)) return 'file'
-  if (CREATE_TOOLS.has(name)) return 'create'
-  if (EDIT_TOOLS.has(name)) return 'edit'
-  if (GUIDANCE_TOOLS.has(name)) return 'guidance'
+  if (isFileReadToolName(name)) return 'file'
+  if (isFileCreateToolName(name)) return 'create'
+  if (isFileEditToolName(name)) return 'edit'
+  if (isGuidanceToolName(name)) return 'guidance'
   if (SEARCH_TOOL_HINTS.some(hint => name.includes(hint))) return 'search'
   if (isCommandToolName(name)) {
     return getCommandActivityKind(getInputField(block, 'command', 'cmd', 'commandLine'))
@@ -166,10 +163,6 @@ function isCompletedToolBlock(block: ToolBlock): boolean {
   return block.status === 'done' || block.status === 'error'
 }
 
-export function isCommandToolName(name: string): boolean {
-  return COMMAND_TOOLS.has(name.toLowerCase())
-}
-
 export function isWebSearchToolName(name: string): boolean {
   return name.toLowerCase() === 'web_search'
 }
@@ -182,23 +175,12 @@ export function isGuidanceActivityGroup(blocks: ToolBlock[]): boolean {
   return blocks.length > 0 && blocks.every(block => isGuidanceToolName(block.toolName))
 }
 
-export function isGuidanceToolName(name: string): boolean {
-  return GUIDANCE_TOOLS.has(name.toLowerCase())
-}
+export { isCommandToolName, isGuidanceToolName }
 
 function getToolGroupId(blocks: ToolBlock[]): string {
   const first = blocks[0]?.id ?? 'empty'
   const last = blocks[blocks.length - 1]?.id ?? first
   return `tool-group-${first}-${last}`
-}
-
-function getInputField(block: ToolBlock, ...keys: string[]): string | undefined {
-  if (!block.toolInput) return undefined
-  for (const key of keys) {
-    const val = block.toolInput[key]
-    if (typeof val === 'string') return val
-  }
-  return undefined
 }
 
 function formatCount(count: number, unit: string): string {

--- a/wework/src/components/chat/blocks/toolBlockKinds.ts
+++ b/wework/src/components/chat/blocks/toolBlockKinds.ts
@@ -1,0 +1,88 @@
+import type { ToolBlock } from '@/types/workbench'
+
+const COMMAND_TOOLS = new Set([
+  'bash',
+  'exec_command',
+  'execute_command',
+  'functions.exec_command',
+  'run_terminal_command',
+])
+
+const FILE_TOOLS = new Set(['read', 'read_file'])
+const CREATE_TOOLS = new Set(['write', 'create_file', 'write_file'])
+const EDIT_TOOLS = new Set([
+  'edit',
+  'edit_file',
+  'multi_edit',
+  'multiedit',
+  'notebook_edit',
+  'notebookedit',
+  'str_replace',
+  'str_replace_editor',
+  'apply_patch',
+  'functions.apply_patch',
+])
+const GUIDANCE_TOOLS = new Set(['conversation_guidance', 'user_guidance'])
+
+function normalizeToolName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+function toolNameCandidates(name: string): string[] {
+  const normalized = normalizeToolName(name)
+  const doubleUnderscoreParts = normalized.split('__')
+  const lastDoubleUnderscorePart = doubleUnderscoreParts[doubleUnderscoreParts.length - 1]
+  const dotParts = normalized.split('.')
+  const lastDotPart = dotParts[dotParts.length - 1]
+
+  return Array.from(new Set([normalized, lastDoubleUnderscorePart, lastDotPart]))
+}
+
+function matchesToolName(name: string, names: Set<string>): boolean {
+  return toolNameCandidates(name).some(candidate => names.has(candidate))
+}
+
+export function isCommandToolName(name: string): boolean {
+  return matchesToolName(name, COMMAND_TOOLS)
+}
+
+export function isFileReadToolName(name: string): boolean {
+  return matchesToolName(name, FILE_TOOLS)
+}
+
+export function isFileCreateToolName(name: string): boolean {
+  return matchesToolName(name, CREATE_TOOLS)
+}
+
+export function isFileEditToolName(name: string): boolean {
+  return matchesToolName(name, EDIT_TOOLS)
+}
+
+export function isGuidanceToolName(name: string): boolean {
+  return matchesToolName(name, GUIDANCE_TOOLS)
+}
+
+export function getInputField(block: Pick<ToolBlock, 'toolInput'>, ...keys: string[]) {
+  if (!block.toolInput) return undefined
+  for (const key of keys) {
+    const value = block.toolInput[key]
+    if (typeof value === 'string') return value
+  }
+  return undefined
+}
+
+export function getFileInputPath(block: Pick<ToolBlock, 'toolInput'>): string | undefined {
+  return getInputField(
+    block,
+    'file_path',
+    'filePath',
+    'filepath',
+    'path',
+    'file',
+    'filename',
+    'target_file',
+    'targetFile',
+    'notebook_path',
+    'notebookPath'
+  )
+}


### PR DESCRIPTION
## Summary
- Add shared Wework chat tool-name classification for file read/create/edit, command, and guidance tools.
- Render Claude `MultiEdit`/`NotebookEdit`-style edit tool blocks as file edit activity instead of generic executed tools.
- Add regression coverage for edit tool activity summaries and expanded `MultiEdit` details.

## Root Cause
Wework only recognized a narrow set of edit tool names (`edit`, `edit_file`, `str_replace_editor`). Claude edit tools such as `MultiEdit` fell through to the generic tool path, so edit activity appeared as a generic executed tool rather than an edit message.

## Validation
- `pnpm --dir wework test src/components/chat/blocks/toolBlockActivity.test.ts src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/components/chat/MessageList.test.tsx`
- `pnpm --dir wework exec tsc -p tsconfig.app.json --noEmit`
- `pnpm --dir wework exec eslint src/components/chat/blocks/toolBlockActivity.ts src/components/chat/blocks/toolBlockActivity.test.ts src/components/chat/blocks/ToolBlockItem.tsx src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/blocks/toolBlockKinds.ts`
- Pre-push hook: 103 wework test files passed, 966 tests passed, quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File-edit tool messages now show clearer activity labels and expanded edit details, including multiple edit previews for a single file.
  * Multi-edit tool blocks are recognized as editable file activity and summarized accordingly.

* **Bug Fixes**
  * Improved detection of file-related tool names, so tool activity and details display more consistently across naming variations.
  * Expanded file-path handling to surface the correct file location in tool details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->