### PR TITLE
style(wework): refine desktop composer and chrome visuals

### DIFF
--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -136,6 +136,12 @@ describe('App center route', () => {
     await userEvent.click(await screen.findByTestId('chrome-tab-apps'))
 
     await waitFor(() => expect(window.location.pathname).toBe('/apps'))
+    expect(screen.getByTestId('chrome-tab-wework')).toHaveClass('w-8', 'min-w-0', 'px-0')
+    expect(screen.getByTestId('chrome-tab-apps')).toHaveClass('w-8', 'min-w-0', 'px-0')
+    expect(screen.getByTestId('titlebar-sidebar-toggle-placeholder')).toHaveClass(
+      'invisible',
+      'pointer-events-none'
+    )
     expect(screen.getByTestId('apps-page')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: '管理你的办公与编码应用' })).toBeInTheDocument()
     expect(await screen.findByText('Executor 状态')).toBeInTheDocument()
@@ -144,6 +150,22 @@ describe('App center route', () => {
     expect(screen.queryByText('Skills')).not.toBeInTheDocument()
     expect(screen.queryByText('MCP')).not.toBeInTheDocument()
     expect(screen.queryByText('插件包')).not.toBeInTheDocument()
+  })
+
+  test('overlays the workbench titlebar so the sidebar can reach the window top', async () => {
+    window.history.pushState({}, '', '/')
+
+    render(<App />)
+
+    await waitForStartupScreenToClose()
+    expect(screen.getByTestId('chrome-titlebar')).toHaveClass(
+      'absolute',
+      'inset-x-0',
+      'top-0',
+      'z-system',
+      'bg-transparent'
+    )
+    expect(screen.getByTestId('chrome-tab-wework')).toHaveClass('w-8', 'min-w-0', 'px-0')
   })
 
   test('keeps the app center sidebar available on desktop app widths', async () => {

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -23,6 +23,7 @@ import { LocalExecutorCloudBridge } from '@/features/cloud-connection/LocalExecu
 import { useDesktopSidebarCollapsed } from '@/components/layout/useDesktopSidebarCollapsed'
 import { DESKTOP_TOP_BAR_BUTTON_CLASS } from '@/components/layout/DesktopTopBar'
 import { useTranslation } from '@/hooks/useTranslation'
+import { cn } from '@/lib/utils'
 
 const WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS = 6000
 
@@ -104,6 +105,7 @@ function AppShell() {
   const { user, isLoading } = useAuth()
   const { activeAppKey, tabs, navigateToApp } = useChromeTabs(path)
   const isTauri = isTauriRuntime()
+  const titlebarOverlaysContent = isTauri && activeAppKey === 'wework'
   const [workbenchStartupReady, setWorkbenchStartupReady] = useState(false)
   const [workbenchStartupRevealTimedOut, setWorkbenchStartupRevealTimedOut] = useState(false)
 
@@ -148,21 +150,50 @@ function AppShell() {
   return (
     <LocalRuntimeInitializer startupReady={workbenchStartupReady || workbenchStartupRevealTimedOut}>
       <LocalExecutorCloudBridge />
-      <div className="flex h-dvh flex-col overflow-hidden bg-surface">
+      <div
+        className={cn(
+          'h-dvh overflow-hidden bg-surface',
+          titlebarOverlaysContent ? 'relative' : 'flex flex-col'
+        )}
+      >
         {isTauri && (
           <ChromeTitlebar
             tabs={tabs}
             activeKey={activeAppKey}
             onNavigate={navigateToApp}
-            beforeTabs={activeAppKey === 'wework' ? <TitlebarSidebarToggle /> : undefined}
+            beforeTabs={
+              activeAppKey === 'wework' ? (
+                <TitlebarSidebarToggle />
+              ) : (
+                <TitlebarSidebarTogglePlaceholder />
+              )
+            }
             afterTabs={<AppUpdateTitlebarButton />}
+            iconOnlyTabs={isTauri}
+            className={
+              titlebarOverlaysContent
+                ? 'absolute inset-x-0 top-0 z-system bg-transparent'
+                : undefined
+            }
           />
         )}
-        <div className="min-h-0 flex-1 overflow-hidden">
+        <div
+          className={cn('min-h-0 overflow-hidden', titlebarOverlaysContent ? 'h-full' : 'flex-1')}
+        >
           <AppRoutes onWorkbenchStartupReadyChange={setWorkbenchStartupReady} />
         </div>
       </div>
     </LocalRuntimeInitializer>
+  )
+}
+
+function TitlebarSidebarTogglePlaceholder() {
+  return (
+    <div
+      data-testid="titlebar-sidebar-toggle-placeholder"
+      aria-hidden="true"
+      className={cn(DESKTOP_TOP_BAR_BUTTON_CLASS, 'invisible pointer-events-none')}
+    />
   )
 }
 

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -167,12 +167,17 @@ describe('ChatInput', () => {
     )
 
     expect(screen.getByTestId('project-chat-composer-form')).toHaveClass(
-      'min-h-[100px]',
-      'pb-4',
+      'min-h-[76px]',
+      'pb-1.5',
       'pt-2'
     )
     expect(screen.getByTestId('chat-message-input')).toHaveAttribute('rows', '2')
-    expect(screen.getByTestId('chat-message-input')).toHaveClass('min-h-8', 'max-h-[116px]')
+    expect(screen.getByTestId('chat-message-input')).toHaveClass(
+      'min-h-[48px]',
+      'max-h-[112px]',
+      'pt-1',
+      'placeholder:text-text-muted/55'
+    )
     expect(screen.queryByTestId('custom-mode-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('model-selector-button')).toBeInTheDocument()
     expect(screen.queryByTestId('skill-selector-button')).not.toBeInTheDocument()

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -115,7 +115,7 @@ export function ChatInput({
   onPause,
 }: ChatInputProps) {
   const { t } = useTranslation('common')
-  const inputPlaceholder = placeholder ?? t('workbench.input_placeholder', '尽管问')
+  const inputPlaceholder = placeholder ?? t('workbench.input_placeholder', '随心输入')
   const controls: ProjectChatControls = projectChat ?? {
     models: [],
     skills: [],

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -353,7 +353,8 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByTestId('message-user').parentElement).toHaveClass('gap-4')
-    expect(screen.getByTestId('message-user').parentElement).toHaveClass('pt-11', 'pb-2')
+    expect(screen.getByTestId('message-user').parentElement).toHaveClass('pt-8', 'pb-2')
+    expect(screen.getByTestId('user-message-content')).toHaveClass('py-1.5')
     expect(screen.getAllByTestId('message-hover-actions')[0]).toHaveClass('min-h-5')
   })
 

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -97,8 +97,8 @@ export const MessageList = memo(function MessageList({
     isWaitingForAssistant &&
     !messages.some(message => message.role === 'assistant' && message.status === 'streaming')
   const listLayoutClass = className
-    ? 'mx-auto flex min-w-0 flex-col gap-4 overflow-x-hidden pb-2 pt-11'
-    : 'mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 overflow-x-hidden px-6 pb-2 pt-11'
+    ? 'mx-auto flex min-w-0 flex-col gap-4 overflow-x-hidden pb-2 pt-8'
+    : 'mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 overflow-x-hidden px-6 pb-2 pt-8'
 
   if (visibleMessages.length === 0 && !shouldShowWaitingIndicator) {
     return null
@@ -471,7 +471,7 @@ function UserMessage({
             <div
               data-testid="user-message-content"
               className={[
-                'relative overflow-hidden break-words whitespace-pre-wrap bg-muted px-4 py-3',
+                'relative overflow-hidden break-words whitespace-pre-wrap bg-muted px-4 py-1.5',
                 shouldCollapse && !isExpanded ? 'max-h-44' : '',
               ].join(' ')}
             >

--- a/wework/src/components/chat/composer/AddContextMenu.tsx
+++ b/wework/src/components/chat/composer/AddContextMenu.tsx
@@ -1,7 +1,7 @@
 import { Paperclip, Plus } from 'lucide-react'
 import type { ChangeEvent } from 'react'
 import { useCallback, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from '@/hooks/useTranslation'
 import { useOutsideClick } from './useOutsideClick'
 
 interface AddContextMenuProps {
@@ -61,7 +61,7 @@ export function AddContextMenu({ disabled, onFileSelect }: AddContextMenuProps) 
         data-testid="add-context-button"
         onClick={() => !disabled && setOpen(current => !current)}
         disabled={disabled}
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full p-0 text-text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full p-0 text-text-secondary/85 hover:bg-background/70 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
         aria-expanded={open}
         aria-label={t('workbench.add_context', '添加上下文')}
       >

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -38,11 +38,11 @@ export function ComposerToolbar({
   const { t } = useTranslation('common')
 
   return (
-    <div className="mt-auto flex min-h-9 items-center justify-between gap-4">
-      <div className="-ml-2 flex min-w-0 items-center gap-2">
+    <div className="mt-auto flex min-h-8 items-center justify-between gap-3 pt-1">
+      <div className="flex min-w-0 items-center gap-2">
         <AddContextMenu disabled={disabled} onFileSelect={onFileSelect} />
       </div>
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-1.5">
         {isModelSelectionReady ? (
           <ModelSelector
             models={models}
@@ -53,6 +53,7 @@ export function ComposerToolbar({
             onSelectModel={onSelectModel}
             onSelectModelOption={onSelectModelOption}
             onBlockedModelSelect={onBlockedModelSelect}
+            buttonClassName="opacity-90 hover:opacity-100"
           />
         ) : (
           <div className="h-11 w-32 shrink-0" data-testid="model-selector-loading" />
@@ -62,7 +63,7 @@ export function ComposerToolbar({
             type="button"
             data-testid="pause-response-button"
             onClick={onPause}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1a1a1a] p-0 text-white hover:bg-[#333]"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1f1f1f] p-0 text-white hover:bg-[#333]"
             aria-label={t('workbench.pause_response', '暂停回复')}
           >
             <Square className="h-3.5 w-3.5 fill-current" />
@@ -72,7 +73,7 @@ export function ComposerToolbar({
             type="submit"
             data-testid="send-message-button"
             disabled={!canSend}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1a1a1a] p-0 text-white disabled:cursor-not-allowed disabled:bg-[#d9d9d9]"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1f1f1f] p-0 text-white disabled:cursor-not-allowed disabled:bg-text-muted/45 disabled:text-background"
             aria-label={t('workbench.send_message', '发送消息')}
           >
             <ArrowUp className="h-4 w-4" />

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -5,6 +5,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import type { DragEventHandler } from 'react'
 import { useEffect, useRef } from 'react'
 import { isTauriRuntime } from '@/lib/runtime-environment'
+import { cn } from '@/lib/utils'
 import type { ProjectWorkControls } from '../ChatInput'
 import { AttachmentBadges } from './AttachmentBadges'
 import { ComposerToolbar } from './ComposerToolbar'
@@ -139,11 +140,14 @@ export function ProjectChatComposer({
   }, [disabled, onFileSelect])
 
   return (
-    <div className="relative w-full rounded-[28px] bg-surface shadow-[0_16px_44px_rgba(0,0,0,0.08)]">
+    <div className="relative w-full rounded-[26px] border border-border/30 bg-background shadow-[0_18px_44px_rgba(0,0,0,0.09)]">
       <form
         ref={formRef}
         data-testid="project-chat-composer-form"
-        className="flex min-h-[100px] w-full flex-col rounded-[28px] border border-border bg-background pb-4 pl-4 pr-2 pt-2"
+        className={cn(
+          'relative z-10 flex min-h-[76px] w-full flex-col rounded-[26px] border border-border/45 bg-surface px-4 pb-1.5 pt-2',
+          showProjectWorkBar && 'border-b-border/35'
+        )}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
         onSubmit={event => {
@@ -177,7 +181,7 @@ export function ProjectChatComposer({
           placeholder={placeholder}
           rows={2}
           onPasteFiles={onFileSelect}
-          className="max-h-[116px] min-h-8 w-full resize-none overflow-y-auto bg-transparent p-0 text-sm leading-5 text-text-primary outline-none placeholder:text-text-muted"
+          className="max-h-[112px] min-h-[48px] w-full resize-none overflow-y-auto bg-transparent px-0 pb-0 pt-1 text-[15px] leading-6 text-text-primary outline-none placeholder:text-text-muted/55"
           skillMenuClassName="left-[-1rem] right-[-0.5rem]"
           onListLocalSkills={onListLocalSkills}
           selectedModel={selectedModel}
@@ -224,7 +228,8 @@ export function ProjectChatComposer({
           onCreateBranch={projectWork.onCreateBranch}
           worktreeBranch={projectWork.worktreeBranch}
           onWorktreeBranchChange={projectWork.onWorktreeBranchChange}
-          className="min-h-11 px-4"
+          className="min-h-10 rounded-b-[26px] bg-background px-4"
+          buttonClassName="h-9 px-2.5 text-[13px] leading-[18px] text-text-secondary hover:bg-surface/70 hover:text-text-primary"
         />
       )}
     </div>

--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -604,7 +604,7 @@ export function ProjectWorkBar({
               isMobile
                 ? 'fixed inset-x-0 bottom-0 z-modal flex max-h-[45dvh] flex-col rounded-t-[28px] border border-border bg-background shadow-[0_-18px_48px_rgba(0,0,0,0.18)]'
                 : 'absolute left-0 z-popover flex w-80 flex-col rounded-2xl border border-border bg-background p-1.5 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
-              !isMobile && (menuLayout.placement === 'below' ? 'top-11' : 'bottom-11'),
+              !isMobile && (menuLayout.placement === 'below' ? 'top-9' : 'bottom-9'),
               !isMobile && menuClassName
             )}
             style={isMobile ? undefined : { maxHeight: menuLayout.maxHeight }}
@@ -890,8 +890,8 @@ export function ProjectWorkBar({
           data-testid="project-work-button"
           onClick={handleToggleMenu}
           className={cn(
-            'flex h-9 min-w-[44px] items-center gap-2 rounded-full px-2 text-[13px] font-medium leading-[18px] text-text-secondary transition-[background-color,color,box-shadow] hover:bg-background hover:text-text-primary hover:shadow-[0_10px_28px_rgba(0,0,0,0.14)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
-            open && 'bg-background text-text-primary shadow-[0_10px_28px_rgba(0,0,0,0.14)]',
+            'flex h-9 min-w-[44px] items-center gap-2 rounded-full px-2 text-[14px] font-medium leading-5 text-text-secondary transition-[background-color,color,box-shadow] hover:bg-background/70 hover:text-text-primary hover:shadow-[0_8px_22px_rgba(0,0,0,0.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
+            open && 'bg-background/70 text-text-primary shadow-[0_8px_22px_rgba(0,0,0,0.10)]',
             buttonClassName
           )}
           aria-expanded={open}
@@ -993,9 +993,9 @@ export function ProjectWorkBar({
             data-testid="execution-mode-button"
             onClick={handleToggleExecutionModeMenu}
             className={cn(
-              'flex h-9 min-w-[44px] items-center gap-2 rounded-full px-2 text-[13px] font-medium leading-[18px] text-text-secondary transition-[background-color,color,box-shadow] hover:bg-background hover:text-text-primary hover:shadow-[0_10px_28px_rgba(0,0,0,0.14)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
+              'flex h-9 min-w-[44px] items-center gap-2 rounded-full px-2 text-[14px] font-medium leading-5 text-text-secondary transition-[background-color,color,box-shadow] hover:bg-background/70 hover:text-text-primary hover:shadow-[0_8px_22px_rgba(0,0,0,0.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
               executionModeOpen &&
-                'bg-background text-text-primary shadow-[0_10px_28px_rgba(0,0,0,0.14)]'
+                'bg-background/70 text-text-primary shadow-[0_8px_22px_rgba(0,0,0,0.10)]'
             )}
             aria-expanded={executionModeOpen}
             aria-label={t('workbench.execution_mode_label', '启动模式')}

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -43,6 +43,7 @@ import {
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from '@/hooks/useTranslation'
 import { isCloudDevice, isRemoteDevice } from '@/lib/device-capabilities'
+import { isTauriRuntime } from '@/lib/runtime-environment'
 import { runtimeProjectToProject, runtimeProjectUiId } from '@/lib/runtime-project'
 import { cn } from '@/lib/utils'
 import type {
@@ -1755,6 +1756,7 @@ export function DesktopSidebar({
     onResizeStateChange,
   })
   const showCloudConnectionEntry = isCloudConnectionUiAvailable()
+  const usesOverlayTitlebar = isTauriRuntime()
 
   const storageScope = getDesktopSidebarStorageScope(user)
   const projectsExpandedStorageKey = getDesktopSidebarStorageKey(storageScope, 'projectsExpanded')
@@ -2170,7 +2172,10 @@ export function DesktopSidebar({
     >
       <div className="h-full overflow-hidden">
         <div
-          className="relative flex h-full flex-col px-1.5 pb-4 pt-1.5"
+          className={cn(
+            'relative flex h-full flex-col px-1.5 pb-4',
+            usesOverlayTitlebar ? 'pt-[44px]' : 'pt-1.5'
+          )}
           style={{ width: sidebarWidth }}
         >
           <nav className="space-y-0.5">

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1634,6 +1634,55 @@ describe('DesktopWorkbenchLayout', () => {
     expect(getDesktopWorkbenchMainElement()).not.toHaveClass('mt-1.5')
   })
 
+  test('keeps a collapsed Tauri task title clear of titlebar controls', () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    localStorage.setItem('wework.desktop.sidebar.collapsed', 'true')
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          runtimeWork: {
+            projects: [],
+            chats: [
+              {
+                deviceId: 'device-1',
+                deviceName: 'Runtime Device',
+                workspacePath: '/workspace/project-alpha',
+                workspaceKind: 'workspace',
+                localTasks: [
+                  {
+                    localTaskId: 'runtime-empty',
+                    workspacePath: '/workspace/project-alpha',
+                    title: 'Fix pane title',
+                    runtime: 'codex',
+                    createdAt: '2026-06-20T00:00:00.000Z',
+                    updatedAt: '2026-06-20T00:00:00.000Z',
+                    running: true,
+                  },
+                ],
+              },
+            ],
+            totalLocalTasks: 1,
+          },
+          currentRuntimeTask: {
+            deviceId: 'device-1',
+            workspacePath: '/workspace/project-alpha',
+            localTaskId: 'runtime-empty',
+          },
+        }}
+        messages={[]}
+      />
+    )
+
+    expect(screen.getByTestId('workbench-topbar')).toHaveClass('pl-[14rem]')
+    expect(screen.getByTestId('workbench-pane-task-title')).toHaveTextContent('Fix pane title')
+  })
+
   test('opens project code-server from the Tauri titlebar', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -761,7 +761,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <DesktopTopBar
             testId="workbench-topbar"
             className={cn(
-              'absolute left-0 top-0 z-chrome h-11 overflow-visible border-b border-border/50 bg-background/95 pl-4 pr-7 backdrop-blur supports-[backdrop-filter]:bg-background/80',
+              'absolute left-0 top-0 z-chrome h-11 overflow-visible border-b border-border/50 bg-background/95 pr-7 backdrop-blur supports-[backdrop-filter]:bg-background/80',
+              isTauri && sidebarCollapsed ? 'pl-[14rem]' : 'pl-4',
               rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
             )}
             style={{ width: chatColumnWidth }}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -62,11 +62,12 @@ const DESKTOP_CHAT_CONTENT_BASE_CLASS =
   'mx-auto min-w-0 px-0 transition-[width,max-width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[width,max-width]'
 const DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(46rem,calc(100%_-_2rem))] max-w-[calc(100%_-_2rem)]`
 const DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(72rem,calc(100%_-_1.5rem))] max-w-[calc(100%_-_1.5rem)]`
-const DESKTOP_CENTERED_COMPOSER_FRAME_CLASS = `${DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS} -translate-y-12`
+const DESKTOP_CENTERED_COMPOSER_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(46rem,calc(100%_-_2rem))] max-w-[calc(100%_-_2rem)]`
+const DESKTOP_CENTERED_COMPOSER_FRAME_CLASS = `${DESKTOP_CENTERED_COMPOSER_WIDTH_CLASS} -translate-y-12`
 const DESKTOP_DOCKED_COMPOSER_FRAME_CLASS = `${DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS} -translate-y-12`
 const DESKTOP_FLOATING_COMPOSER_CLASS =
   'pointer-events-none absolute bottom-2 left-1/2 z-chrome -translate-x-1/2'
-const DESKTOP_CENTERED_FLOATING_COMPOSER_CLASS = `${DESKTOP_FLOATING_COMPOSER_CLASS} ${DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS}`
+const DESKTOP_CENTERED_FLOATING_COMPOSER_CLASS = `${DESKTOP_FLOATING_COMPOSER_CLASS} ${DESKTOP_CENTERED_COMPOSER_WIDTH_CLASS}`
 const DESKTOP_DOCKED_FLOATING_COMPOSER_CLASS = `${DESKTOP_FLOATING_COMPOSER_CLASS} ${DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS}`
 const DESKTOP_CENTERED_MESSAGE_LIST_CLASS = `${DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS} px-0`
 const DESKTOP_DOCKED_MESSAGE_LIST_CLASS = `${DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS} px-0`
@@ -935,7 +936,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               }
               data-testid="desktop-empty-composer-frame"
             >
-              <h1 className="mb-9 text-center text-[28px] font-medium leading-9 tracking-normal">
+              <h1 className="mb-10 text-center text-[28px] font-normal leading-9 tracking-normal text-text-primary/95">
                 {emptyTitle}
               </h1>
               <DeviceStatusPrompt
@@ -955,7 +956,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 disabled={composerDisabled}
                 error={errorMessage}
                 disabledReason={inlineComposerDisabledReason}
-                placeholder={t('workbench.input_placeholder', '尽管问')}
+                placeholder={t('workbench.input_placeholder', '随心输入')}
                 variant="desktop"
                 projectChat={projectChatWithModelSelectorSignal}
                 projectWork={paneProjectWork}

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -154,6 +154,7 @@ describe('ConnectionsSettingsPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
@@ -272,6 +273,19 @@ describe('ConnectionsSettingsPage', () => {
       updated_at: '2026-06-09T00:00:00Z',
     })
     createUserApiMock.mockReturnValue(userApi as ReturnType<typeof createUserApi>)
+  })
+
+  test('adds titlebar clearance for the settings back button in Tauri', () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    api.getAllDevices.mockResolvedValue([])
+
+    render(<ConnectionsSettingsPage onBack={vi.fn()} />)
+
+    expect(screen.getByTestId('settings-sidebar-topbar')).toHaveClass('h-[76px]', 'pt-6', 'mb-1')
+    expect(screen.getByTestId('settings-back-button')).toBeInTheDocument()
   })
 
   test('keeps the cloud device creation notice visible after the create request resolves', async () => {

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -37,6 +37,7 @@ import { useOptionalCloudConnection } from '@/features/cloud-connection/useCloud
 import { useTranslation } from '@/hooks/useTranslation'
 import { openExternalUrl } from '@/lib/external-links'
 import { navigateTo } from '@/lib/navigation'
+import { isTauriRuntime } from '@/lib/runtime-environment'
 import { cn } from '@/lib/utils'
 import { DesktopTopBar } from '@/components/layout/DesktopTopBar'
 import { RemoteTerminal } from '@/components/layout/workspace-panels/RemoteTerminal'
@@ -1383,6 +1384,7 @@ export function ConnectionsSettingsPage({
 }: ConnectionsSettingsPageProps) {
   const { t } = useTranslation('common')
   const { sidebarWidth, handleResizeStart } = useResizableSidebar()
+  const usesOverlayTitlebar = isTauriRuntime()
   const [activeNav, setActiveNav] = useState(() => getSettingsNavFromPath(window.location.pathname))
 
   useEffect(() => {
@@ -1404,7 +1406,10 @@ export function ConnectionsSettingsPage({
       >
         <DesktopTopBar
           testId="settings-sidebar-topbar"
-          className={cn('-mx-1.5 mb-2 w-[calc(100%+0.75rem)] bg-transparent pr-2', 'pl-2')}
+          className={cn(
+            '-mx-1.5 mb-1 w-[calc(100%+0.75rem)] bg-transparent pr-2 pl-2',
+            usesOverlayTitlebar && 'h-[76px] pt-6'
+          )}
           left={
             <button
               type="button"

--- a/wework/src/components/topnav/ChromeTitlebar.test.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.test.tsx
@@ -15,6 +15,11 @@ const mockTabs: AppTab[] = [
   },
 ]
 
+const appTabs: AppTab[] = [
+  { key: 'wework', label: 'WeWork', mode: 'native', requiresAuth: true },
+  { key: 'apps', label: '应用', mode: 'native', requiresAuth: true },
+]
+
 function mockUserAgent(ua: string) {
   Object.defineProperty(navigator, 'userAgent', {
     configurable: true,
@@ -59,6 +64,20 @@ describe('ChromeTitlebar', () => {
     )
     expect(screen.getByTestId('chrome-titlebar')).toHaveClass('h-[38px]', 'bg-surface')
     expect(screen.getByTestId('titlebar-actions')).toBeInTheDocument()
+  })
+
+  test('renders app tabs as icon-only controls with hover labels', () => {
+    render(<ChromeTitlebar tabs={appTabs} activeKey="wework" onNavigate={vi.fn()} iconOnlyTabs />)
+
+    const weworkTab = screen.getByTestId('chrome-tab-wework')
+    const appsTab = screen.getByTestId('chrome-tab-apps')
+
+    expect(weworkTab).toHaveClass('w-8', 'min-w-0', 'px-0')
+    expect(appsTab).toHaveClass('w-8', 'min-w-0', 'px-0')
+    expect(weworkTab).toHaveAttribute('title', 'WeWork')
+    expect(appsTab).toHaveAttribute('title', '应用')
+    expect(weworkTab.querySelector('.sr-only')).toHaveTextContent('WeWork')
+    expect(appsTab.querySelector('.sr-only')).toHaveTextContent('应用')
   })
 
   test('renders after-tabs content between tabs and titlebar actions', () => {

--- a/wework/src/components/topnav/ChromeTitlebar.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.tsx
@@ -21,6 +21,8 @@ interface ChromeTitlebarProps {
   onNavigate: (appKey: string) => void
   beforeTabs?: ReactNode
   afterTabs?: ReactNode
+  className?: string
+  iconOnlyTabs?: boolean
 }
 
 export function ChromeTitlebar({
@@ -29,6 +31,8 @@ export function ChromeTitlebar({
   onNavigate,
   beforeTabs,
   afterTabs,
+  className,
+  iconOnlyTabs = false,
 }: ChromeTitlebarProps) {
   const isTauri = isTauriRuntime()
   const platform = getPlatform()
@@ -37,7 +41,10 @@ export function ChromeTitlebar({
     <div
       data-testid="chrome-titlebar"
       {...(isTauri ? { 'data-tauri-drag-region': '' } : {})}
-      className="z-titlebar flex h-[38px] shrink-0 items-center bg-surface pr-2 select-none"
+      className={cn(
+        'z-titlebar flex h-[38px] shrink-0 items-center bg-surface pr-2 select-none',
+        className
+      )}
     >
       {/* macOS: traffic light spacer (left) */}
       {isTauri && platform === 'mac' && (
@@ -55,29 +62,47 @@ export function ChromeTitlebar({
       )}
 
       {/* Tab strip */}
-      <div className="flex min-w-0 items-center gap-1 overflow-hidden">
-        {tabs.map(tab => (
-          <button
-            key={tab.key}
-            type="button"
-            data-testid={`chrome-tab-${tab.key}`}
-            onClick={() => onNavigate(tab.key)}
-            className={cn(
-              'flex h-7 max-w-[220px] min-w-24 items-center justify-center gap-2.5 rounded-lg px-3 text-center text-[13px] leading-none font-medium transition-colors',
-              activeKey === tab.key
-                ? 'bg-black/[0.045] text-text-primary'
-                : 'text-text-secondary hover:bg-black/[0.04]'
-            )}
-          >
-            {tab.key === 'wework' && (
-              <Globe2 aria-hidden="true" className="h-4 w-4 shrink-0 stroke-[1.8]" />
-            )}
-            {tab.key === 'apps' && (
-              <Grid3X3 aria-hidden="true" className="h-4 w-4 shrink-0 stroke-[1.8]" />
-            )}
-            <span className="truncate">{tab.label}</span>
-          </button>
-        ))}
+      <div
+        className={cn(
+          'flex min-w-0 items-center gap-1',
+          iconOnlyTabs ? 'overflow-visible' : 'overflow-hidden'
+        )}
+      >
+        {tabs.map(tab => {
+          const tabSupportsIconOnly = tab.key === 'wework' || tab.key === 'apps'
+          const showIconOnly = iconOnlyTabs && tabSupportsIconOnly
+
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              data-testid={`chrome-tab-${tab.key}`}
+              onClick={() => onNavigate(tab.key)}
+              title={tab.label}
+              aria-label={tab.label}
+              className={cn(
+                'group relative flex h-7 items-center justify-center rounded-lg text-center text-[13px] font-medium leading-none transition-colors',
+                showIconOnly ? 'w-8 min-w-0 px-0' : 'max-w-[220px] min-w-24 gap-2.5 px-3',
+                activeKey === tab.key
+                  ? 'bg-black/[0.045] text-text-primary'
+                  : 'text-text-secondary hover:bg-black/[0.04]'
+              )}
+            >
+              {tab.key === 'wework' && (
+                <Globe2 aria-hidden="true" className="h-4 w-4 shrink-0 stroke-[1.8]" />
+              )}
+              {tab.key === 'apps' && (
+                <Grid3X3 aria-hidden="true" className="h-4 w-4 shrink-0 stroke-[1.8]" />
+              )}
+              <span className={showIconOnly ? 'sr-only' : 'truncate'}>{tab.label}</span>
+              {showIconOnly && (
+                <span className="pointer-events-none absolute left-1/2 top-[calc(100%+0.375rem)] z-popover -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-background px-2 py-1 text-xs font-medium leading-none text-text-primary opacity-0 shadow-[0_8px_20px_rgba(0,0,0,0.14)] transition-opacity group-hover:opacity-100">
+                  {tab.label}
+                </span>
+              )}
+            </button>
+          )
+        })}
       </div>
       {afterTabs && (
         <div data-testid="chrome-titlebar-after-tabs" className="ml-3 flex shrink-0 items-center">

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -283,7 +283,7 @@
     "settings_category_coding": "Code",
     "empty_title": "What should we do?",
     "project_empty_title": "What should we build in {{projectName}}?",
-    "input_placeholder": "Ask anything",
+    "input_placeholder": "Type freely",
     "follow_up_placeholder": "Request follow-up changes",
     "mobile_input_placeholder": "Ask Wework",
     "continue_im_title": "Continue in IM",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -283,7 +283,7 @@
     "settings_category_coding": "编码",
     "empty_title": "我们该做什么？",
     "project_empty_title": "我们应该在 {{projectName}} 中构建什么？",
-    "input_placeholder": "尽管问",
+    "input_placeholder": "随心输入",
     "follow_up_placeholder": "要求后续变更",
     "mobile_input_placeholder": "询问 Wework",
     "continue_im_title": "继续到私聊",


### PR DESCRIPTION
## Summary
- Refine the desktop project chat composer to better match the Codex visual style, including panel contrast, typography, spacing, and toolbar treatment.
- Align the Tauri desktop titlebar/sidebar chrome with the Codex-like layout, including icon-only app tabs, sidebar top alignment, collapsed sidebar spacing, and settings back-button clearance.
- Tighten first-message bubble spacing and preserve existing interaction/test IDs.

## Testing
- pnpm --dir wework test -- MessageList ChromeTitlebar App.apps DesktopSidebar DesktopWorkbenchLayout ConnectionsSettingsPage
- pnpm --dir wework lint
- git diff --check
- Pre-push hook: wework tests with coverage, ESLint, TypeScript, frontend unit tests, Python syntax checks, cargo fmt/test/clippy, Alembic multi-head check

## Notes
- Documentation updates were verified as unnecessary because this PR only changes WeWork desktop UI visuals, i18n wording, and tests; it does not change API contracts, data models, runtime configuration, or user-facing setup flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact, icon-only navigation tabs in the top title bar for a cleaner desktop layout.
  * Improved desktop app and settings pages to better handle an overlaid window title bar.

* **Bug Fixes**
  * Adjusted chat composer, message spacing, and sidebar layout for a more consistent desktop experience.
  * Updated placeholder text in the chat input to “Type freely” / “随心输入”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->