### PR TITLE
fix: fix executor port

### DIFF
--- a/executor/src/app/mod.rs
+++ b/executor/src/app/mod.rs
@@ -71,9 +71,14 @@ impl From<crate::server::ServerConfigError> for AppError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StartupPlan {
+    pub http_server: Option<HttpServerPlan>,
+    pub socket_sidecar: Option<SocketSidecarPlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpServerPlan {
     pub host: String,
     pub port: u16,
-    pub socket_sidecar: Option<SocketSidecarPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,7 +87,7 @@ pub struct SocketSidecarPlan {
     pub device_id: String,
 }
 
-impl StartupPlan {
+impl HttpServerPlan {
     pub fn bind_addr(&self) -> Result<SocketAddr, AppError> {
         self.server_config().bind_addr().map_err(AppError::from)
     }
@@ -120,15 +125,25 @@ pub async fn run(args: CliArgs) -> Result<(), AppError> {
     let config = load_device_config(args.config_path.as_deref())?;
     init_executor_logging(&config);
     let plan = startup_plan_for_config(&config)?;
-    let server_config = plan.server_config();
-    let Some(socket_sidecar) = plan.socket_sidecar else {
-        return server::serve(server_config).await.map_err(AppError::Server);
-    };
 
-    let socket_sidecar_future = serve_socket_sidecar(config, socket_sidecar);
-    tokio::select! {
-        result = server::serve(server_config) => result.map_err(AppError::Server),
-        result = socket_sidecar_future => result.map_err(AppError::Server),
+    match (plan.http_server, plan.socket_sidecar) {
+        (Some(http_server), None) => server::serve(http_server.server_config())
+            .await
+            .map_err(AppError::Server),
+        (None, Some(socket_sidecar)) => serve_socket_sidecar(config, socket_sidecar)
+            .await
+            .map_err(AppError::Server),
+        (Some(http_server), Some(socket_sidecar)) => {
+            let server_config = http_server.server_config();
+            let socket_sidecar_future = serve_socket_sidecar(config, socket_sidecar);
+            tokio::select! {
+                result = server::serve(server_config) => result.map_err(AppError::Server),
+                result = socket_sidecar_future => result.map_err(AppError::Server),
+            }
+        }
+        (None, None) => Err(AppError::Server(
+            "startup plan has no runtime target".to_owned(),
+        )),
     }
 }
 
@@ -178,19 +193,22 @@ pub fn startup_plan(args: CliArgs) -> Result<StartupPlan, AppError> {
 fn startup_plan_for_config(
     config: &crate::config::device::DeviceConfig,
 ) -> Result<StartupPlan, AppError> {
-    let server = ServerConfig::from_env()?;
-    let socket_sidecar = if config.runtime_mode() == crate::config::device::RuntimeMode::Docker {
-        None
-    } else {
-        Some(SocketSidecarPlan {
-            backend_enabled: !config.connection.backend_url.trim().is_empty(),
-            device_id: normalize_device_id(config.device_id.clone()),
-        })
-    };
+    if config.runtime_mode() == crate::config::device::RuntimeMode::Docker {
+        let server = ServerConfig::from_env()?;
+        return Ok(StartupPlan {
+            http_server: Some(HttpServerPlan {
+                host: server.host,
+                port: server.port,
+            }),
+            socket_sidecar: None,
+        });
+    }
 
     Ok(StartupPlan {
-        host: server.host,
-        port: server.port,
-        socket_sidecar,
+        http_server: None,
+        socket_sidecar: Some(SocketSidecarPlan {
+            backend_enabled: !config.connection.backend_url.trim().is_empty(),
+            device_id: normalize_device_id(config.device_id.clone()),
+        }),
     })
 }

--- a/executor/tests/app_startup_contract.rs
+++ b/executor/tests/app_startup_contract.rs
@@ -8,7 +8,7 @@ use axum::{routing::get, Json, Router};
 use serde_json::json;
 use tokio::net::TcpListener;
 use wegent_executor::{
-    app::{cli::CliArgs, run, startup_plan, SocketSidecarPlan, StartupPlan},
+    app::{cli::CliArgs, run, startup_plan, HttpServerPlan, SocketSidecarPlan, StartupPlan},
     services::updater::binary_name_for,
     version::get_version,
 };
@@ -48,7 +48,7 @@ impl Drop for EnvGuard {
 }
 
 #[test]
-fn default_startup_mode_plans_http_server_with_image_defaults() {
+fn default_startup_mode_plans_socket_sidecar_without_http_server() {
     let _lock = env_lock();
     let _mode = EnvGuard::remove("EXECUTOR_MODE");
     let _backend = EnvGuard::remove("WEGENT_BACKEND_URL");
@@ -64,15 +64,13 @@ fn default_startup_mode_plans_http_server_with_image_defaults() {
     assert_eq!(
         plan,
         StartupPlan {
-            host: "0.0.0.0".to_owned(),
-            port: 10088,
+            http_server: None,
             socket_sidecar: Some(SocketSidecarPlan {
                 backend_enabled: false,
                 device_id: plan.socket_sidecar.as_ref().unwrap().device_id.clone(),
             }),
         }
     );
-    assert_eq!(plan.bind_addr().unwrap().to_string(), "0.0.0.0:10088");
     let socket_sidecar = plan.socket_sidecar.unwrap();
     assert!(!socket_sidecar.backend_enabled);
     assert!(socket_sidecar.device_id.starts_with("device-"));
@@ -80,7 +78,7 @@ fn default_startup_mode_plans_http_server_with_image_defaults() {
 }
 
 #[test]
-fn startup_plan_with_backend_keeps_http_and_enables_backend_sidecar() {
+fn startup_plan_with_backend_enables_backend_sidecar_without_http_server() {
     let _lock = env_lock();
     let _mode = EnvGuard::remove("EXECUTOR_MODE");
     let _port = EnvGuard::set("PORT", "10089");
@@ -95,8 +93,7 @@ fn startup_plan_with_backend_keeps_http_and_enables_backend_sidecar() {
     assert_eq!(
         plan,
         StartupPlan {
-            host: "0.0.0.0".to_owned(),
-            port: 10089,
+            http_server: None,
             socket_sidecar: Some(SocketSidecarPlan {
                 backend_enabled: true,
                 device_id: "device-1".to_owned(),
@@ -121,8 +118,10 @@ fn docker_executor_mode_plans_http_without_socket_sidecar() {
     assert_eq!(
         plan,
         StartupPlan {
-            host: "0.0.0.0".to_owned(),
-            port: 10090,
+            http_server: Some(HttpServerPlan {
+                host: "0.0.0.0".to_owned(),
+                port: 10090,
+            }),
             socket_sidecar: None,
         }
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup now distinguishes between an HTTP server and a socket sidecar, allowing either one or both to run based on the selected runtime mode.

* **Bug Fixes**
  * Startup behavior now correctly handles cases where only one runtime target is configured and returns an error when none are set.
  * Docker mode now consistently starts the HTTP server with the expected host and port settings.

* **Tests**
  * Updated startup coverage to match the new runtime planning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->