### PR TITLE
[codex] Send explicit Wework collaboration mode

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -3348,6 +3348,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '继续修',
+      modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
   })
@@ -3994,6 +3995,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '继续修',
+      modelOptions: { collaborationMode: 'default' },
     })
     await waitFor(() => expect(screen.getByTestId('queued-messages')).toHaveTextContent(''))
   })
@@ -4140,6 +4142,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '继续修',
+      modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:执行ls')
   })
@@ -4339,6 +4342,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '继续修',
+      modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('')
     expect(screen.getByTestId('guidance-messages')).toHaveTextContent('')
@@ -4589,6 +4593,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '执行ls',
+      modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('')
     expect(screen.getByTestId('queued-errors')).not.toHaveTextContent('当前回复缺少引导上下文')
@@ -4641,6 +4646,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '继续修',
+      modelOptions: { collaborationMode: 'default' },
       attachmentIds: [45],
     })
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
@@ -4689,6 +4695,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         localTaskId: 'runtime-a',
       },
       message: '继续修',
+      modelOptions: { collaborationMode: 'default' },
       attachments: [
         expect.objectContaining({
           id: -45,

--- a/wework/src/features/workbench/runtimeModelSelection.test.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, test } from 'vitest'
 import { selectedModelExecutionFields } from './runtimeModelSelection'
 
 describe('runtimeModelSelection', () => {
+  test('sends default collaboration mode when plan mode is not selected', () => {
+    expect(selectedModelExecutionFields(null, {})).toEqual({
+      modelOptions: { collaborationMode: 'default' },
+    })
+  })
+
   test('keeps model options when the default model is selected', () => {
     expect(selectedModelExecutionFields(null, { collaborationMode: 'plan' })).toEqual({
       modelOptions: { collaborationMode: 'plan' },

--- a/wework/src/features/workbench/runtimeModelSelection.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.ts
@@ -38,17 +38,17 @@ export function selectedModelExecutionFields(
   selectedModel: UnifiedModel | null,
   selectedModelOptions: ModelOptions
 ): Pick<RuntimeSendRequest, 'modelId' | 'modelType' | 'modelOptions'> {
+  const modelOptions = {
+    ...selectedModelOptions,
+    collaborationMode: selectedModelOptions.collaborationMode ?? 'default',
+  }
   if (!selectedModel) {
-    return Object.keys(selectedModelOptions).length > 0
-      ? { modelOptions: { ...selectedModelOptions } }
-      : {}
+    return { modelOptions }
   }
   const executionModel = resolveModelExecutionSelection(selectedModel)
   return {
     modelId: executionModel.modelName,
     modelType: executionModel.modelType,
-    ...(Object.keys(selectedModelOptions).length > 0
-      ? { modelOptions: { ...selectedModelOptions } }
-      : {}),
+    modelOptions,
   }
 }


### PR DESCRIPTION
## Summary
- Always include an explicit `collaborationMode` in Wework runtime model options.
- Preserve plan mode when the toggle is enabled, and send `default` when the toggle is off or unset.
- Update runtime follow-up tests to assert the explicit default mode.

## Root Cause
When the plan mode toggle was off, runtime follow-up sends could omit `collaborationMode` entirely because empty model options were treated as no options. The executor could then continue using the previous plan-mode context instead of receiving an explicit default-mode instruction.

## Validation
- `pnpm --dir wework test -- src/features/workbench/runtimeModelSelection.test.ts src/features/workbench/WorkbenchProvider.test.tsx -t "sends default model options with runtime follow-up messages|sends default collaboration mode when follow-up plan mode is disabled|keeps default model options when creating a runtime local task|uses the latest default model options when plan mode and send happen together|reuses the current runtime task address for follow-up messages|sends queued runtime messages when the task becomes idle|waits for the sent queued runtime message to start before sending the next queued item|pauses the active local task before sending queued guidance|pauses the active local task before sending queued guidance without DB task context|sends image attachments with current runtime task follow-up messages|sends local image attachments with current runtime task follow-up messages|sends default collaboration mode when plan mode is not selected|keeps model options"`
- Pre-push hook: full Wework test suite with coverage, 109 files / 1014 tests passed.
- Pre-push AI quality gate passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime messages now consistently include the default collaboration mode in their model settings.
  * Follow-up, queued, and guidance messages now carry the expected model configuration in more scenarios, including messages with image attachments.
  * When no plan mode is selected, model selection now still applies the default collaboration mode for execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->