### PR TITLE
Update task pin

### DIFF
--- a/executor/src/app/mod.rs
+++ b/executor/src/app/mod.rs
@@ -71,9 +71,14 @@ impl From<crate::server::ServerConfigError> for AppError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StartupPlan {
+    pub http_server: Option<HttpServerPlan>,
+    pub socket_sidecar: Option<SocketSidecarPlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpServerPlan {
     pub host: String,
     pub port: u16,
-    pub socket_sidecar: Option<SocketSidecarPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,7 +87,7 @@ pub struct SocketSidecarPlan {
     pub device_id: String,
 }
 
-impl StartupPlan {
+impl HttpServerPlan {
     pub fn bind_addr(&self) -> Result<SocketAddr, AppError> {
         self.server_config().bind_addr().map_err(AppError::from)
     }
@@ -120,15 +125,25 @@ pub async fn run(args: CliArgs) -> Result<(), AppError> {
     let config = load_device_config(args.config_path.as_deref())?;
     init_executor_logging(&config);
     let plan = startup_plan_for_config(&config)?;
-    let server_config = plan.server_config();
-    let Some(socket_sidecar) = plan.socket_sidecar else {
-        return server::serve(server_config).await.map_err(AppError::Server);
-    };
 
-    let socket_sidecar_future = serve_socket_sidecar(config, socket_sidecar);
-    tokio::select! {
-        result = server::serve(server_config) => result.map_err(AppError::Server),
-        result = socket_sidecar_future => result.map_err(AppError::Server),
+    match (plan.http_server, plan.socket_sidecar) {
+        (Some(http_server), None) => server::serve(http_server.server_config())
+            .await
+            .map_err(AppError::Server),
+        (None, Some(socket_sidecar)) => serve_socket_sidecar(config, socket_sidecar)
+            .await
+            .map_err(AppError::Server),
+        (Some(http_server), Some(socket_sidecar)) => {
+            let server_config = http_server.server_config();
+            let socket_sidecar_future = serve_socket_sidecar(config, socket_sidecar);
+            tokio::select! {
+                result = server::serve(server_config) => result.map_err(AppError::Server),
+                result = socket_sidecar_future => result.map_err(AppError::Server),
+            }
+        }
+        (None, None) => Err(AppError::Server(
+            "startup plan has no runtime target".to_owned(),
+        )),
     }
 }
 
@@ -178,19 +193,22 @@ pub fn startup_plan(args: CliArgs) -> Result<StartupPlan, AppError> {
 fn startup_plan_for_config(
     config: &crate::config::device::DeviceConfig,
 ) -> Result<StartupPlan, AppError> {
-    let server = ServerConfig::from_env()?;
-    let socket_sidecar = if config.runtime_mode() == crate::config::device::RuntimeMode::Docker {
-        None
-    } else {
-        Some(SocketSidecarPlan {
-            backend_enabled: !config.connection.backend_url.trim().is_empty(),
-            device_id: normalize_device_id(config.device_id.clone()),
-        })
-    };
+    if config.runtime_mode() == crate::config::device::RuntimeMode::Docker {
+        let server = ServerConfig::from_env()?;
+        return Ok(StartupPlan {
+            http_server: Some(HttpServerPlan {
+                host: server.host,
+                port: server.port,
+            }),
+            socket_sidecar: None,
+        });
+    }
 
     Ok(StartupPlan {
-        host: server.host,
-        port: server.port,
-        socket_sidecar,
+        http_server: None,
+        socket_sidecar: Some(SocketSidecarPlan {
+            backend_enabled: !config.connection.backend_url.trim().is_empty(),
+            device_id: normalize_device_id(config.device_id.clone()),
+        }),
     })
 }

--- a/executor/tests/app_startup_contract.rs
+++ b/executor/tests/app_startup_contract.rs
@@ -8,7 +8,7 @@ use axum::{routing::get, Json, Router};
 use serde_json::json;
 use tokio::net::TcpListener;
 use wegent_executor::{
-    app::{cli::CliArgs, run, startup_plan, SocketSidecarPlan, StartupPlan},
+    app::{cli::CliArgs, run, startup_plan, HttpServerPlan, SocketSidecarPlan, StartupPlan},
     services::updater::binary_name_for,
     version::get_version,
 };
@@ -48,7 +48,7 @@ impl Drop for EnvGuard {
 }
 
 #[test]
-fn default_startup_mode_plans_http_server_with_image_defaults() {
+fn default_startup_mode_plans_socket_sidecar_without_http_server() {
     let _lock = env_lock();
     let _mode = EnvGuard::remove("EXECUTOR_MODE");
     let _backend = EnvGuard::remove("WEGENT_BACKEND_URL");
@@ -64,15 +64,13 @@ fn default_startup_mode_plans_http_server_with_image_defaults() {
     assert_eq!(
         plan,
         StartupPlan {
-            host: "0.0.0.0".to_owned(),
-            port: 10088,
+            http_server: None,
             socket_sidecar: Some(SocketSidecarPlan {
                 backend_enabled: false,
                 device_id: plan.socket_sidecar.as_ref().unwrap().device_id.clone(),
             }),
         }
     );
-    assert_eq!(plan.bind_addr().unwrap().to_string(), "0.0.0.0:10088");
     let socket_sidecar = plan.socket_sidecar.unwrap();
     assert!(!socket_sidecar.backend_enabled);
     assert!(socket_sidecar.device_id.starts_with("device-"));
@@ -80,7 +78,7 @@ fn default_startup_mode_plans_http_server_with_image_defaults() {
 }
 
 #[test]
-fn startup_plan_with_backend_keeps_http_and_enables_backend_sidecar() {
+fn startup_plan_with_backend_enables_backend_sidecar_without_http_server() {
     let _lock = env_lock();
     let _mode = EnvGuard::remove("EXECUTOR_MODE");
     let _port = EnvGuard::set("PORT", "10089");
@@ -95,8 +93,7 @@ fn startup_plan_with_backend_keeps_http_and_enables_backend_sidecar() {
     assert_eq!(
         plan,
         StartupPlan {
-            host: "0.0.0.0".to_owned(),
-            port: 10089,
+            http_server: None,
             socket_sidecar: Some(SocketSidecarPlan {
                 backend_enabled: true,
                 device_id: "device-1".to_owned(),
@@ -121,8 +118,10 @@ fn docker_executor_mode_plans_http_without_socket_sidecar() {
     assert_eq!(
         plan,
         StartupPlan {
-            host: "0.0.0.0".to_owned(),
-            port: 10090,
+            http_server: Some(HttpServerPlan {
+                host: "0.0.0.0".to_owned(),
+                port: 10090,
+            }),
             socket_sidecar: None,
         }
     );

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1288,6 +1288,51 @@ describe('DesktopSidebar', () => {
     ])
   })
 
+  test('excludes pinned runtime tasks from the collapsed project task count', async () => {
+    const user = userEvent.setup()
+
+    renderSidebar({
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Wegent' },
+            totalLocalTasks: 6,
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'local-device',
+                deviceName: 'Local Mac',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/repo/Wegent',
+                localTasks: Array.from({ length: 6 }, (_, index) => ({
+                  localTaskId: `task-${index + 1}`,
+                  workspacePath: '/repo/Wegent',
+                  title: `Task ${index + 1}`,
+                  runtime: 'codex',
+                  updatedAt: `2026-06-2${6 - index}T00:00:00Z`,
+                })),
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalLocalTasks: 6,
+      },
+    })
+
+    await user.click(screen.getByTestId('project-item-button'))
+
+    expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(5)
+    expect(screen.getByTestId('project-runtime-tasks-expand-7')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('runtime-local-task-mark-task-1'))
+
+    expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(6)
+    expect(screen.queryByTestId('project-runtime-tasks-expand-7')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('project-runtime-tasks-collapse-7')).not.toBeInTheDocument()
+  })
+
   test('restores pinned runtime task ordering after remount', async () => {
     const user = userEvent.setup()
     const runtimeWork = {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -72,6 +72,7 @@ import {
   getRuntimeTaskWorkspaceTitle,
   getRuntimeSidebarTaskItems,
   getVisibleRuntimeSidebarTaskItems,
+  hasExpandedRuntimeSidebarTaskItems,
   hasHiddenRuntimeSidebarTaskItems,
   isRuntimeTaskSelected,
   isRuntimeWorktreeTask,
@@ -659,7 +660,7 @@ function prioritizePinnedRuntimeTaskItems(
   const unpinnedItems: RuntimeSidebarTaskItem[] = []
   for (const item of items) {
     if (pinnedTaskKeys.has(getRuntimeTaskPinKey(item.workspace, item.task))) {
-      pinnedItems.push(item)
+      pinnedItems.push({ ...item, pinned: true })
     } else {
       unpinnedItems.push(item)
     }
@@ -1419,9 +1420,10 @@ function ProjectItem({
     prioritizedRuntimeTaskItems,
     runtimeTaskVisibleLimit
   )
-  const canCollapseRuntimeTasks =
-    prioritizedRuntimeTaskItems.length > RUNTIME_PROJECT_TASK_PREVIEW_LIMIT &&
-    visibleRuntimeTaskItems.length > RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
+  const canCollapseRuntimeTasks = hasExpandedRuntimeSidebarTaskItems(
+    prioritizedRuntimeTaskItems,
+    runtimeTaskVisibleLimit
+  )
   const projectDeviceState =
     getRuntimeProjectDeviceState(runtimeProjectWork, devices) ??
     getSidebarDeviceState(getProjectDeviceId(project), devices)

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -39,6 +39,7 @@ import {
   getRuntimeTaskWorkspaceTitle,
   getRuntimeSidebarTaskItems,
   getVisibleRuntimeSidebarTaskItems,
+  hasExpandedRuntimeSidebarTaskItems,
   hasHiddenRuntimeSidebarTaskItems,
   isRuntimeTaskSelected,
   isRuntimeWorktreeTask,
@@ -505,9 +506,10 @@ export function MobileDrawer({
                             taskItems,
                             runtimeTaskVisibleLimit
                           )
-                          const canCollapseTasks =
-                            taskItems.length > RUNTIME_PROJECT_TASK_PREVIEW_LIMIT &&
-                            visibleTaskItems.length > RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
+                          const canCollapseTasks = hasExpandedRuntimeSidebarTaskItems(
+                            taskItems,
+                            runtimeTaskVisibleLimit
+                          )
 
                           return (
                             <>

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import type { RuntimeDeviceWorkspace } from '@/types/api'
 import {
+  hasExpandedRuntimeSidebarTaskItems,
   getNextRuntimeSidebarTaskVisibleLimit,
   getRuntimeSidebarTaskItems,
   getRuntimeTaskAddress,
@@ -127,5 +128,35 @@ describe('runtimeTaskSidebarHelpers', () => {
     expect(finalExpandedLimit).toBe(26)
     expect(getVisibleRuntimeSidebarTaskItems(items, finalExpandedLimit)).toHaveLength(26)
     expect(hasHiddenRuntimeSidebarTaskItems(items, finalExpandedLimit)).toBe(false)
+  })
+
+  test('keeps pinned project runtime tasks out of the collapsed task count', () => {
+    const items = Array.from({ length: 7 }, (_, index) => ({
+      workspace: {
+        deviceId: 'device-1',
+        workspacePath: '/workspace/repo',
+        available: true,
+        localTasks: [],
+      },
+      task: {
+        localTaskId: `task-${index + 1}`,
+        workspacePath: '/workspace/repo',
+        title: `Task ${index + 1}`,
+        runtime: 'codex',
+      },
+      pinned: index < 2,
+    }))
+
+    expect(getVisibleRuntimeSidebarTaskItems(items).map(item => item.task.localTaskId)).toEqual([
+      'task-1',
+      'task-2',
+      'task-3',
+      'task-4',
+      'task-5',
+      'task-6',
+      'task-7',
+    ])
+    expect(hasHiddenRuntimeSidebarTaskItems(items)).toBe(false)
+    expect(hasExpandedRuntimeSidebarTaskItems(items)).toBe(false)
   })
 })

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -3,6 +3,7 @@ import type { LocalTaskSummary, RuntimeDeviceWorkspace, RuntimeTaskAddress } fro
 export interface RuntimeSidebarTaskItem {
   workspace: RuntimeDeviceWorkspace
   task: LocalTaskSummary
+  pinned?: boolean
 }
 
 export const RUNTIME_PROJECT_TASK_PREVIEW_LIMIT = 5
@@ -56,7 +57,11 @@ export function getVisibleRuntimeSidebarTaskItems(
   items: RuntimeSidebarTaskItem[],
   visibleLimit = RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
 ) {
-  return items.slice(0, Math.max(RUNTIME_PROJECT_TASK_PREVIEW_LIMIT, visibleLimit))
+  const { pinnedItems, unpinnedItems } = partitionRuntimeSidebarTaskItems(items)
+  return [
+    ...pinnedItems,
+    ...unpinnedItems.slice(0, Math.max(RUNTIME_PROJECT_TASK_PREVIEW_LIMIT, visibleLimit)),
+  ]
 }
 
 export function getNextRuntimeSidebarTaskVisibleLimit(currentLimit: number, totalCount: number) {
@@ -70,7 +75,19 @@ export function hasHiddenRuntimeSidebarTaskItems(
   items: RuntimeSidebarTaskItem[],
   visibleLimit = RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
 ) {
-  return items.length > Math.max(RUNTIME_PROJECT_TASK_PREVIEW_LIMIT, visibleLimit)
+  const { unpinnedItems } = partitionRuntimeSidebarTaskItems(items)
+  return unpinnedItems.length > Math.max(RUNTIME_PROJECT_TASK_PREVIEW_LIMIT, visibleLimit)
+}
+
+export function hasExpandedRuntimeSidebarTaskItems(
+  items: RuntimeSidebarTaskItem[],
+  visibleLimit = RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
+) {
+  const { unpinnedItems } = partitionRuntimeSidebarTaskItems(items)
+  return (
+    unpinnedItems.slice(0, Math.max(RUNTIME_PROJECT_TASK_PREVIEW_LIMIT, visibleLimit)).length >
+    RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
+  )
 }
 
 export function getRuntimeTaskWorkspaceTitle(workspace: RuntimeDeviceWorkspace) {
@@ -134,6 +151,19 @@ function getWorktreeIdFromPath(path: string) {
   const index = parts.indexOf('worktrees')
   if (index < 0 || index + 1 >= parts.length) return null
   return parts[index + 1] || null
+}
+
+function partitionRuntimeSidebarTaskItems(items: RuntimeSidebarTaskItem[]) {
+  const pinnedItems: RuntimeSidebarTaskItem[] = []
+  const unpinnedItems: RuntimeSidebarTaskItem[] = []
+  for (const item of items) {
+    if (item.pinned) {
+      pinnedItems.push(item)
+    } else {
+      unpinnedItems.push(item)
+    }
+  }
+  return { pinnedItems, unpinnedItems }
 }
 
 export function isRuntimeTaskSelected(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pinned runtime tasks now stay visible in collapsed sidebars on desktop and mobile.
  * The app now chooses between running the HTTP server, the socket sidecar, or both based on startup configuration.

* **Bug Fixes**
  * Collapsed task counts now ignore pinned runtime tasks, so expand/collapse controls appear more accurately.
  * Startup behavior is more consistent across Docker and non-Docker modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->