### PR TITLE
[codex] Add Wework typecheck gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   lint-backend:
     name: Lint Backend (Black & isort)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,7 +141,7 @@ jobs:
         run: pnpm --filter wework lint
 
       - name: Run TypeScript check
-        run: pnpm --filter wework exec tsc --noEmit
+        run: pnpm --filter wework typecheck
 
   check-settings-config:
     name: Check Settings Configuration

--- a/frontend/.husky/pre-push
+++ b/frontend/.husky/pre-push
@@ -4,13 +4,6 @@
 PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$PROJECT_ROOT" || exit 1
 
-# Run Wework tests before allowing a push.
-if [ -d "wework" ]; then
-    echo "🧪 Running wework tests before push..."
-    pnpm --dir wework exec vitest run --coverage --passWithNoTests || exit $?
-    echo "✅ Wework tests passed"
-fi
-
 # Run AI push gate script
 if [ -f "scripts/hooks/ai-push-gate.sh" ]; then
     bash scripts/hooks/ai-push-gate.sh "$@"

--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -394,7 +394,7 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
         fi
 
         echo -e "   Running unit tests..."
-        pnpm --filter wework test --coverage --passWithNoTests > "$TEMP_DIR/wework_test.log" 2>&1
+        pnpm --filter wework test --coverage > "$TEMP_DIR/wework_test.log" 2>&1
         TEST_EXIT=$?
         if [ $TEST_EXIT -eq 0 ]; then
             echo -e "   ${GREEN}✅ Unit Tests: PASSED${NC}"

--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -220,16 +220,18 @@ echo ""
 # Count by module
 BACKEND_COUNT=$(echo "$CHANGED_FILES" | grep -c "^backend/" 2>/dev/null || echo 0)
 FRONTEND_COUNT=$(echo "$CHANGED_FILES" | grep -c "^frontend/" 2>/dev/null || echo 0)
+WEWORK_COUNT=$(echo "$CHANGED_FILES" | grep -c "^wework/" 2>/dev/null || echo 0)
 EXECUTOR_COUNT=$(echo "$CHANGED_FILES" | grep -c "^executor/" 2>/dev/null || echo 0)
 EXECUTOR_MGR_COUNT=$(echo "$CHANGED_FILES" | grep -c "^executor_manager/" 2>/dev/null || echo 0)
 SHARED_COUNT=$(echo "$CHANGED_FILES" | grep -c "^shared/" 2>/dev/null || echo 0)
 KNOWLEDGE_ENGINE_COUNT=$(echo "$CHANGED_FILES" | grep -c "^knowledge_engine/" 2>/dev/null || echo 0)
 KNOWLEDGE_RUNTIME_COUNT=$(echo "$CHANGED_FILES" | grep -c "^knowledge_runtime/" 2>/dev/null || echo 0)
-OTHER_COUNT=$(echo "$CHANGED_FILES" | grep -cvE "^(backend|frontend|executor|executor_manager|shared|knowledge_engine|knowledge_runtime)/" 2>/dev/null || echo 0)
+OTHER_COUNT=$(echo "$CHANGED_FILES" | grep -cvE "^(backend|frontend|wework|executor|executor_manager|shared|knowledge_engine|knowledge_runtime)/" 2>/dev/null || echo 0)
 
 echo -e "   ${BLUE}Modules affected:${NC}"
 [ "$BACKEND_COUNT" -gt 0 ] 2>/dev/null && echo -e "   - Backend: $BACKEND_COUNT file(s)"
 [ "$FRONTEND_COUNT" -gt 0 ] 2>/dev/null && echo -e "   - Frontend: $FRONTEND_COUNT file(s)"
+[ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null && echo -e "   - Wework: $WEWORK_COUNT file(s)"
 [ "$EXECUTOR_COUNT" -gt 0 ] 2>/dev/null && echo -e "   - Executor: $EXECUTOR_COUNT file(s)"
 [ "$EXECUTOR_MGR_COUNT" -gt 0 ] 2>/dev/null && echo -e "   - Executor Manager: $EXECUTOR_MGR_COUNT file(s)"
 [ "$SHARED_COUNT" -gt 0 ] 2>/dev/null && echo -e "   - Shared: $SHARED_COUNT file(s)"
@@ -268,7 +270,7 @@ if [ -n "$CONFIG_FILES" ]; then
 fi
 
 # Any code change → Consider updating AGENTS.md and README
-ANY_CODE=$(echo "$CHANGED_FILES" | grep -E "^(backend|frontend|executor|executor_manager|shared|knowledge_engine|knowledge_runtime)/.*\.(py|rs|ts|tsx)$" || true)
+ANY_CODE=$(echo "$CHANGED_FILES" | grep -E "^(backend|frontend|wework|executor|executor_manager|shared|knowledge_engine|knowledge_runtime)/.*\.(py|rs|ts|tsx)$" || true)
 if [ -n "$ANY_CODE" ]; then
     DOC_REMINDERS+=("Code changed → Consider updating AGENTS.md and README.md/README_zh.md if needed")
 fi
@@ -351,6 +353,57 @@ if [ "$FRONTEND_COUNT" -gt 0 ] 2>/dev/null; then
         # TypeScript check above already validates type correctness.
         # Full build verification should be done in CI pipeline.
         
+    fi
+    echo ""
+fi
+
+# -----------------------------------------------------------------------------
+# Wework Checks (if wework files changed)
+# -----------------------------------------------------------------------------
+if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
+    echo -e "${BLUE}🔍 Wework Checks:${NC}"
+
+    # Check if workspace dependencies are installed.
+    if [ ! -d "node_modules" ] || [ ! -d "wework/node_modules" ]; then
+        echo -e "   ${YELLOW}⚠️ SKIP: node_modules not found${NC}"
+        echo -e "   ${YELLOW}   Run 'pnpm install' from the repository root to install dependencies${NC}"
+        WARNINGS+=("Wework: node_modules not found, checks skipped")
+    else
+        echo -e "   Running ESLint..."
+        pnpm --filter wework lint > "$TEMP_DIR/wework_eslint.log" 2>&1
+        ESLINT_EXIT=$?
+        if [ $ESLINT_EXIT -eq 0 ]; then
+            echo -e "   ${GREEN}✅ ESLint: PASSED${NC}"
+        else
+            echo -e "   ${RED}❌ ESLint: FAILED${NC}"
+            CHECK_FAILED=1
+            FAILED_CHECKS+=("Wework ESLint")
+            FAILED_LOGS+=("$TEMP_DIR/wework_eslint.log")
+        fi
+
+        echo -e "   Running TypeScript check..."
+        pnpm --filter wework typecheck > "$TEMP_DIR/wework_tsc.log" 2>&1
+        TSC_EXIT=$?
+        if [ $TSC_EXIT -eq 0 ]; then
+            echo -e "   ${GREEN}✅ TypeScript: PASSED${NC}"
+        else
+            echo -e "   ${RED}❌ TypeScript: FAILED${NC}"
+            CHECK_FAILED=1
+            FAILED_CHECKS+=("Wework TypeScript")
+            FAILED_LOGS+=("$TEMP_DIR/wework_tsc.log")
+        fi
+
+        echo -e "   Running unit tests..."
+        pnpm --filter wework exec vitest run --coverage --passWithNoTests > "$TEMP_DIR/wework_test.log" 2>&1
+        TEST_EXIT=$?
+        if [ $TEST_EXIT -eq 0 ]; then
+            echo -e "   ${GREEN}✅ Unit Tests: PASSED${NC}"
+        else
+            echo -e "   ${RED}❌ Unit Tests: FAILED${NC}"
+            CHECK_FAILED=1
+            FAILED_CHECKS+=("Wework Unit Tests")
+            FAILED_LOGS+=("$TEMP_DIR/wework_test.log")
+        fi
     fi
     echo ""
 fi

--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -394,7 +394,7 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
         fi
 
         echo -e "   Running unit tests..."
-        pnpm --filter wework exec vitest run --coverage --passWithNoTests > "$TEMP_DIR/wework_test.log" 2>&1
+        pnpm --filter wework test --coverage --passWithNoTests > "$TEMP_DIR/wework_test.log" 2>&1
         TEST_EXIT=$?
         if [ $TEST_EXIT -eq 0 ]; then
             echo -e "   ${GREEN}✅ Unit Tests: PASSED${NC}"

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -120,7 +120,7 @@ if ! grep -qE '^pnpm --filter wework typecheck$' "$CALL_LOG"; then
     exit 1
 fi
 
-if ! grep -qE '^pnpm --filter wework test --coverage --passWithNoTests$' "$CALL_LOG"; then
+if ! grep -qE '^pnpm --filter wework test --coverage$' "$CALL_LOG"; then
     echo "Expected Wework changes to run unit tests through the Wework package script."
     echo "Calls:"
     cat "$CALL_LOG"

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -7,8 +7,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 CALL_LOG="$TMP_DIR/calls.log"
+ROOT_NODE_MODULES_CREATED=0
+WEWORK_NODE_MODULES_CREATED=0
 
 cleanup() {
+    if [ "$ROOT_NODE_MODULES_CREATED" = "1" ]; then
+        rmdir "$PROJECT_ROOT/node_modules" 2>/dev/null || true
+    fi
+    if [ "$WEWORK_NODE_MODULES_CREATED" = "1" ]; then
+        rmdir "$PROJECT_ROOT/wework/node_modules" 2>/dev/null || true
+    fi
     rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
@@ -27,17 +35,29 @@ STUB
     chmod +x "$path"
 }
 
-for cmd in uv black isort pytest npm npx; do
+for cmd in cargo uv black isort pytest npm npx pnpm; do
     create_stub "$cmd"
 done
 
 export CALL_LOG
 
-# This historical range changes only executor Python files. It exercises the
-# Python module branch without pulling frontend or backend-only auxiliary checks
-# into the regression test.
-REMOTE_SHA="e0cb1f2e0663fdc9a1d878e6952cacc27201f307"
-LOCAL_SHA="85d48d64437aefebe0c0fa156d2e403f35d3d103"
+ensure_wework_node_modules() {
+    if [ ! -d "$PROJECT_ROOT/node_modules" ]; then
+        mkdir "$PROJECT_ROOT/node_modules"
+        ROOT_NODE_MODULES_CREATED=1
+    fi
+
+    if [ ! -d "$PROJECT_ROOT/wework/node_modules" ]; then
+        mkdir "$PROJECT_ROOT/wework/node_modules"
+        WEWORK_NODE_MODULES_CREATED=1
+    fi
+}
+
+# This historical range changes only backend Python files. It exercises the
+# Python module branch without pulling frontend or executor checks into the
+# regression test.
+REMOTE_SHA="32219870e7b781dfaa4b0046db9e4ac5aeb02aa4"
+LOCAL_SHA="6342ce3b9624f3ce05f831d52b2b3b56edf2c36c"
 
 AI_VERIFIED=1 \
 PATH="$TMP_DIR/bin:$PATH" \
@@ -63,6 +83,28 @@ EOF
 
 if ! grep -qE '(^| )pytest tests/' "$CALL_LOG"; then
     echo "Expected AI_PUSH_FULL_TESTS=1 to run the full Python pytest suite."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+> "$CALL_LOG"
+
+# This historical range changes only Wework files. It verifies the pre-push
+# gate runs Wework's project-reference TypeScript check when Wework changes.
+WEWORK_REMOTE_SHA="6e79ac169145a729973c9b7b231f47acba72b50c"
+WEWORK_LOCAL_SHA="2f77b34aae02d0e9d5254530b503655835072cc7"
+
+ensure_wework_node_modules
+
+AI_VERIFIED=1 \
+PATH="$TMP_DIR/bin:$PATH" \
+bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >/tmp/ai-push-gate-test-wework.out 2>&1
+refs/heads/topic $WEWORK_LOCAL_SHA refs/heads/topic $WEWORK_REMOTE_SHA
+EOF
+
+if ! grep -qE '^pnpm --filter wework typecheck$' "$CALL_LOG"; then
+    echo "Expected Wework changes to run the Wework TypeScript check."
     echo "Calls:"
     cat "$CALL_LOG"
     exit 1

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -7,6 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 CALL_LOG="$TMP_DIR/calls.log"
+DEFAULT_TEST_OUT="$(mktemp "${TMP_DIR}/default-test.XXXXXX")"
+FULL_TEST_OUT="$(mktemp "${TMP_DIR}/full-test.XXXXXX")"
+WEWORK_TEST_OUT="$(mktemp "${TMP_DIR}/wework-test.XXXXXX")"
 ROOT_NODE_MODULES_CREATED=0
 WEWORK_NODE_MODULES_CREATED=0
 
@@ -61,7 +64,7 @@ LOCAL_SHA="6342ce3b9624f3ce05f831d52b2b3b56edf2c36c"
 
 AI_VERIFIED=1 \
 PATH="$TMP_DIR/bin:$PATH" \
-bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >/tmp/ai-push-gate-test.out 2>&1
+bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >"$DEFAULT_TEST_OUT" 2>&1
 refs/heads/topic $LOCAL_SHA refs/heads/topic $REMOTE_SHA
 EOF
 
@@ -72,12 +75,19 @@ if grep -qE '(^| )pytest tests/' "$CALL_LOG"; then
     exit 1
 fi
 
-> "$CALL_LOG"
+if grep -qE '^pnpm --filter wework typecheck$' "$CALL_LOG"; then
+    echo "Expected non-Wework changes not to run the Wework TypeScript check."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+: > "$CALL_LOG"
 
 AI_VERIFIED=1 \
 AI_PUSH_FULL_TESTS=1 \
 PATH="$TMP_DIR/bin:$PATH" \
-bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >/tmp/ai-push-gate-test-full.out 2>&1
+bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >"$FULL_TEST_OUT" 2>&1
 refs/heads/topic $LOCAL_SHA refs/heads/topic $REMOTE_SHA
 EOF
 
@@ -88,7 +98,7 @@ if ! grep -qE '(^| )pytest tests/' "$CALL_LOG"; then
     exit 1
 fi
 
-> "$CALL_LOG"
+: > "$CALL_LOG"
 
 # This historical range changes only Wework files. It verifies the pre-push
 # gate runs Wework's project-reference TypeScript check when Wework changes.
@@ -99,12 +109,19 @@ ensure_wework_node_modules
 
 AI_VERIFIED=1 \
 PATH="$TMP_DIR/bin:$PATH" \
-bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >/tmp/ai-push-gate-test-wework.out 2>&1
+bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >"$WEWORK_TEST_OUT" 2>&1
 refs/heads/topic $WEWORK_LOCAL_SHA refs/heads/topic $WEWORK_REMOTE_SHA
 EOF
 
 if ! grep -qE '^pnpm --filter wework typecheck$' "$CALL_LOG"; then
     echo "Expected Wework changes to run the Wework TypeScript check."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+if ! grep -qE '^pnpm --filter wework test --coverage --passWithNoTests$' "$CALL_LOG"; then
+    echo "Expected Wework changes to run unit tests through the Wework package script."
     echo "Calls:"
     cat "$CALL_LOG"
     exit 1

--- a/wework/eslint.config.js
+++ b/wework/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'src-tauri/target']),
+  globalIgnores(['coverage', 'dist', 'src-tauri/target']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/wework/package.json
+++ b/wework/package.json
@@ -14,6 +14,7 @@
     "build:ios": "bash scripts/build-ios-app.sh",
     "tauri:build": "tauri build",
     "lint": "eslint .",
+    "typecheck": "tsc -b",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/wework/src/components/chat/requestUserInputMessages.ts
+++ b/wework/src/components/chat/requestUserInputMessages.ts
@@ -4,6 +4,10 @@ import type { RequestUserInputPayload } from './RequestUserInputCard'
 
 const EMPTY_HIDDEN_REQUEST_USER_INPUT_IDS = new Set<string>()
 
+export type RequestUserInputBlock = ToolBlock & {
+  renderPayload: RequestUserInputPayload
+}
+
 export function requestUserInputPayloadKey(
   payload: RequestUserInputPayload | null | undefined
 ): string | null {
@@ -47,7 +51,7 @@ export function isImplementationPlanRequestUserInput(
   })
 }
 
-export function isRequestUserInputBlock(block: ProcessingBlock): block is ToolBlock {
+export function isRequestUserInputBlock(block: ProcessingBlock): block is RequestUserInputBlock {
   if (block.type !== 'tool') return false
   return isRequestUserInputPayload(block.renderPayload)
 }
@@ -55,16 +59,16 @@ export function isRequestUserInputBlock(block: ProcessingBlock): block is ToolBl
 export function isPendingRequestUserInputBlock(
   block: ProcessingBlock,
   hiddenRequestUserInputIds: ReadonlySet<string> = EMPTY_HIDDEN_REQUEST_USER_INPUT_IDS
-): block is ToolBlock {
+): block is RequestUserInputBlock {
   if (!isRequestUserInputBlock(block)) return false
   if (block.status === 'error') return false
-  if (hasRequestUserInputResponse(block.renderPayload as RequestUserInputPayload)) return false
+  if (hasRequestUserInputResponse(block.renderPayload)) return false
   return !isHiddenRequestUserInputBlock(block, hiddenRequestUserInputIds)
 }
 
-export function isAnsweredRequestUserInputBlock(block: ProcessingBlock): block is ToolBlock {
+export function isAnsweredRequestUserInputBlock(block: ProcessingBlock): boolean {
   if (!isRequestUserInputBlock(block)) return false
-  return hasRequestUserInputResponse(block.renderPayload as RequestUserInputPayload)
+  return hasRequestUserInputResponse(block.renderPayload)
 }
 
 export function isHiddenRequestUserInputBlock(
@@ -72,7 +76,7 @@ export function isHiddenRequestUserInputBlock(
   hiddenRequestUserInputIds: ReadonlySet<string>
 ): boolean {
   if (!isRequestUserInputBlock(block)) return false
-  const key = requestUserInputPayloadKey(block.renderPayload as RequestUserInputPayload)
+  const key = requestUserInputPayloadKey(block.renderPayload)
   return Boolean(key && hiddenRequestUserInputIds.has(key))
 }
 
@@ -109,7 +113,7 @@ export function applyRequestUserInputResponseToMessages(
         ...block,
         status: 'done' as const,
         renderPayload: {
-          ...(block.renderPayload as RequestUserInputPayload),
+          ...block.renderPayload,
           response,
         },
       }
@@ -151,9 +155,12 @@ function findRequestUserInputMessageIndex(
   return -1
 }
 
-function isMatchingRequestUserInputBlock(block: ProcessingBlock, responseKey: string | null) {
+function isMatchingRequestUserInputBlock(
+  block: ProcessingBlock,
+  responseKey: string | null
+): block is RequestUserInputBlock {
   if (!isPendingRequestUserInputBlock(block)) return false
   if (!responseKey) return true
-  const payloadKey = requestUserInputPayloadKey(block.renderPayload as RequestUserInputPayload)
+  const payloadKey = requestUserInputPayloadKey(block.renderPayload)
   return payloadKey === responseKey
 }


### PR DESCRIPTION
## Summary
- add a Wework `typecheck` script backed by `tsc -b`
- run Wework lint, typecheck, and unit tests from the pre-push gate when Wework files change
- align the GitHub lint workflow with the same Wework typecheck script
- type the request-user-input block guard so `tsc -b` passes
- ignore generated Wework coverage output in ESLint

## Why
Wework TypeScript project-reference checking was not enforced consistently in local pre-push or CI. The new script gives both local and GitHub checks one command path, and the guard fix resolves the type errors exposed by that check.

## Validation
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `bash scripts/hooks/test-ai-push-gate.sh`
- `pnpm --filter wework exec vitest run --coverage --passWithNoTests`
- pre-push gate during `git push` passed frontend and Wework checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the push gate so changes under the Wework area are correctly detected, categorized, and trigger the appropriate lint, typecheck, and test coverage checks (including clearer failure reporting).

* **Chores**
  * Updated CI lint/typecheck behavior for Wework and made workflow token permissions explicitly read-only for code.
  * Added a dedicated Wework `typecheck` script, and adjusted ESLint to ignore `coverage` output.
  * Improved push-gate regression coverage for Wework-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->