### PR TITLE
[codex] Align Wework Codex transcript rendering

### DIFF
--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -20,7 +20,10 @@ import { AppUpdateTitlebarButton } from '@/components/topnav/AppUpdateTitlebarBu
 import { LocalRuntimeInitializer } from '@/features/local-runtime/LocalRuntimeInitializer'
 import { CloudConnectionProvider } from '@/features/cloud-connection/CloudConnectionProvider'
 import { LocalExecutorCloudBridge } from '@/features/cloud-connection/LocalExecutorCloudBridge'
-import { useDesktopSidebarCollapsed } from '@/components/layout/useDesktopSidebarCollapsed'
+import {
+  requestDesktopSidebarToggle,
+  useDesktopSidebarCollapsed,
+} from '@/components/layout/useDesktopSidebarCollapsed'
 import { DESKTOP_TOP_BAR_BUTTON_CLASS } from '@/components/layout/DesktopTopBar'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
@@ -208,7 +211,11 @@ function TitlebarSidebarToggle() {
     <button
       type="button"
       data-testid={sidebarCollapsed ? 'expand-sidebar-button' : 'collapse-sidebar-button'}
-      onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+      onClick={() => {
+        if (!requestDesktopSidebarToggle()) {
+          setSidebarCollapsed(!sidebarCollapsed)
+        }
+      }}
       className={DESKTOP_TOP_BAR_BUTTON_CLASS}
       title={label}
       aria-label={label}

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1259,12 +1259,16 @@ describe('ChatInput', () => {
     await userEvent.click(screen.getByTestId('model-selector-button'))
 
     expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
+    expect(screen.getByTestId('model-selector-menu').parentElement).toHaveClass('right-0', 'w-64')
     expect(screen.getByTestId('model-selector-submenu')).toBeInTheDocument()
     expect(screen.getByTestId('model-family-gpt')).toBeInTheDocument()
+    expect(screen.getByTestId('model-family-gpt')).toHaveTextContent('海外:gpt-5.5')
+    expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ left: '256px' })
     expect(screen.getByTestId('model-control-reasoning-high')).toBeInTheDocument()
-    expect(screen.getByTestId('model-control-collaborationMode-default')).toBeInTheDocument()
-    expect(screen.getByTestId('model-control-collaborationMode-plan')).toBeInTheDocument()
-    expect(screen.getByTestId('model-control-speed-fast')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-control-collaborationMode-default')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('model-control-collaborationMode-plan')).not.toBeInTheDocument()
+    expect(screen.getByTestId('model-control-menu-speed')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-control-speed-fast')).not.toBeInTheDocument()
     expect(screen.queryByTestId('model-option-default')).not.toBeInTheDocument()
     expect(screen.getByTestId('model-selector-button')).toHaveTextContent('海外:gpt-5.5 High')
     const modelOption = screen.getByTestId('model-option-overseas-gpt-5.5')
@@ -1281,6 +1285,91 @@ describe('ChatInput', () => {
     await userEvent.click(screen.getByTestId('model-option-overseas-gpt-5.5'))
 
     expect(setSelectedModel).toHaveBeenCalledWith(model)
+  })
+
+  test('opens desktop speed options from a collapsed model control submenu', async () => {
+    const model: UnifiedModel = {
+      name: 'overseas-gpt-5.5',
+      type: 'user',
+      displayName: '海外:gpt-5.5',
+      config: {
+        ui: {
+          family: 'gpt',
+          region: 'overseas',
+          modelLabel: 'gpt-5.5',
+          sortOrder: 10,
+          controls: ['speed'],
+        },
+      },
+    }
+    const setSelectedModelOption = vi.fn()
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [model],
+          selectedModel: model,
+          selectedModelOptions: { reasoning: 'high', speed: 'standard' },
+          setSelectedModelOption,
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+
+    expect(screen.queryByTestId('model-control-speed-fast')).not.toBeInTheDocument()
+
+    await userEvent.hover(screen.getByTestId('model-control-menu-speed'))
+
+    expect(screen.getByTestId('model-control-speed-standard')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-speed-fast')).toBeInTheDocument()
+    expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ left: '256px' })
+
+    await userEvent.click(screen.getByTestId('model-control-speed-fast'))
+
+    expect(setSelectedModelOption).toHaveBeenCalledWith('speed', 'fast')
+  })
+
+  test('hides the desktop model submenu after the pointer leaves the menu', async () => {
+    const model: UnifiedModel = {
+      name: 'overseas-gpt-5.5',
+      type: 'user',
+      displayName: '海外:gpt-5.5',
+      config: {
+        ui: {
+          family: 'gpt',
+          region: 'overseas',
+          modelLabel: 'gpt-5.5',
+          sortOrder: 10,
+        },
+      },
+    }
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [model],
+          selectedModel: model,
+          selectedModelOptions: { reasoning: 'high' },
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+
+    expect(screen.getByTestId('model-selector-submenu')).toBeInTheDocument()
+
+    fireEvent.mouseLeave(screen.getByTestId('model-selector-menu').parentElement as HTMLElement)
+
+    expect(screen.queryByTestId('model-selector-submenu')).not.toBeInTheDocument()
   })
 
   test('keeps the desktop model menu in narrow Tauri windows', async () => {
@@ -1587,7 +1676,7 @@ describe('ChatInput', () => {
     })
   })
 
-  test('selects Codex plan mode from the desktop model menu', async () => {
+  test('omits Codex plan mode from the desktop model menu', async () => {
     const model: UnifiedModel = {
       name: 'codex-gpt-5.5',
       type: 'user',
@@ -1601,7 +1690,6 @@ describe('ChatInput', () => {
         },
       },
     }
-    const setSelectedModelOption = vi.fn()
     render(
       <ChatInput
         value=""
@@ -1613,18 +1701,17 @@ describe('ChatInput', () => {
           models: [model],
           selectedModel: model,
           selectedModelOptions: { reasoning: 'high' },
-          setSelectedModelOption,
         })}
       />
     )
 
     await userEvent.click(screen.getByTestId('model-selector-button'))
-    await userEvent.click(screen.getByTestId('model-control-collaborationMode-plan'))
 
-    expect(setSelectedModelOption).toHaveBeenCalledWith('collaborationMode', 'plan')
-    await waitFor(() => {
-      expect(screen.queryByTestId('model-selector-menu')).not.toBeInTheDocument()
-    })
+    const menu = within(screen.getByTestId('model-selector-menu'))
+    expect(screen.queryByTestId('model-control-collaborationMode-default')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('model-control-collaborationMode-plan')).not.toBeInTheDocument()
+    expect(menu.queryByText('运行模式')).not.toBeInTheDocument()
+    expect(menu.queryByText('计划模式')).not.toBeInTheDocument()
   })
 
   test('keeps reasoning controls for the selected GPT model while hovering another family', async () => {

--- a/wework/src/components/chat/FileChangesCard.test.tsx
+++ b/wework/src/components/chat/FileChangesCard.test.tsx
@@ -126,10 +126,13 @@ describe('FileChangesCard', () => {
       act(() => vi.advanceTimersByTime(1))
       const preview = screen.getByTestId('file-change-diff-preview')
       expect(preview).toHaveAttribute('data-placement', 'below')
+      expect(preview).toHaveStyle({ width: '640px' })
       expect(preview).toHaveClass('fixed', 'z-[9999]', 'pointer-events-auto', 'select-text')
       expect(preview).not.toHaveClass('pointer-events-none')
-      expect(preview).toHaveTextContent('github-pr-flow.md')
-      expect(preview.firstElementChild).not.toHaveTextContent('references/')
+      expect(preview.lastElementChild).toHaveClass('max-h-[min(24rem,calc(100vh-9rem))]')
+      expect(preview.firstElementChild).toHaveTextContent(
+        '/workspace/project/references/github-pr-flow.md'
+      )
       expect(preview).toHaveTextContent('+3')
       expect(preview).toHaveTextContent('-0')
       expect(preview).toHaveTextContent('After the PR is created')
@@ -153,7 +156,7 @@ describe('FileChangesCard', () => {
     }
   })
 
-  test('shows only the file name in the diff preview header for absolute paths', () => {
+  test('shows the absolute file path in the diff preview header', () => {
     vi.useFakeTimers()
     try {
       renderCard({
@@ -184,8 +187,54 @@ describe('FileChangesCard', () => {
       act(() => vi.advanceTimersByTime(500))
 
       const previewHeader = screen.getByTestId('file-change-diff-preview').firstElementChild
-      expect(previewHeader).toHaveTextContent('SKILL.md')
-      expect(previewHeader).not.toHaveTextContent('/Users/crystal/dev/git')
+      expect(previewHeader).toHaveTextContent(
+        '/Users/crystal/dev/git/if/skills/wegent-dev/SKILL.md'
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('keeps more than the first fourteen diff lines available in the scroll preview', () => {
+    vi.useFakeTimers()
+    try {
+      renderCard({
+        summary: {
+          ...summary,
+          file_count: 1,
+          additions: 20,
+          deletions: 0,
+          files: [
+            {
+              path: 'executor/src/runtime_work/mod.rs',
+              change_type: 'modified',
+              additions: 20,
+              deletions: 0,
+              binary: false,
+            },
+          ],
+          diff: [
+            '@@ -1,2 +1,22 @@',
+            ' fn demo() {',
+            ...Array.from(
+              { length: 20 },
+              (_, index) => `+    let value_${index + 1} = ${index + 1};`
+            ),
+            ' }',
+          ].join('\n'),
+        },
+      })
+
+      fireEvent.pointerEnter(screen.getByTestId('file-change-trigger'))
+      act(() => vi.advanceTimersByTime(500))
+
+      const preview = screen.getByTestId('file-change-diff-preview')
+      expect(preview.firstElementChild).toHaveTextContent(
+        '/workspace/project/executor/src/runtime_work/mod.rs'
+      )
+      expect(preview).toHaveTextContent('let value_1 = 1;')
+      expect(preview).toHaveTextContent('let value_20 = 20;')
+      expect(preview).not.toHaveTextContent('...')
     } finally {
       vi.useRealTimers()
     }

--- a/wework/src/components/chat/FileChangesCard.tsx
+++ b/wework/src/components/chat/FileChangesCard.tsx
@@ -11,9 +11,9 @@ import { parseUnifiedDiff } from './parseUnifiedDiff'
 const DEFAULT_VISIBLE_FILE_COUNT = 3
 const DIFF_PREVIEW_CLOSE_DELAY_MS = 140
 const DIFF_PREVIEW_DELAY_MS = 500
-const DIFF_PREVIEW_ESTIMATED_HEIGHT = 340
-const DIFF_PREVIEW_MAX_LINES = 14
-const DIFF_PREVIEW_MAX_WIDTH = 704
+const DIFF_PREVIEW_ESTIMATED_HEIGHT = 424
+const DIFF_PREVIEW_MAX_LINES = 240
+const DIFF_PREVIEW_MAX_WIDTH = 640
 const DIFF_PREVIEW_VIEWPORT_GUTTER = 32
 const DIFF_PREVIEW_VERTICAL_GAP = 8
 
@@ -236,6 +236,7 @@ function basename(path: string): string {
 
 interface DiffPreview {
   path: string
+  displayPath: string
   additions: number
   deletions: number
   lines: DiffPreviewLine[]
@@ -382,11 +383,13 @@ function FileChangeDiffPreview({
       onPointerLeave={onPointerLeave}
     >
       <div className="flex h-10 items-center gap-3 border-b border-border px-4 text-[13px] font-semibold">
-        <span className="min-w-0 flex-1 truncate">{basename(preview.path)}</span>
+        <span className="min-w-0 flex-1 truncate" title={preview.displayPath}>
+          {preview.displayPath}
+        </span>
         <span className="shrink-0 font-medium text-green-400">+{preview.additions}</span>
         <span className="shrink-0 font-medium text-red-400">-{preview.deletions}</span>
       </div>
-      <div className="max-h-[18rem] overflow-auto py-1 font-mono text-[12px] leading-5">
+      <div className="max-h-[min(24rem,calc(100vh-9rem))] overflow-auto py-1 font-mono text-[12px] leading-5">
         {preview.lines.map(line =>
           line.type === 'separator' ? (
             <div key={line.key} className="my-1 h-px bg-border" />
@@ -440,11 +443,23 @@ function buildFileDiffPreview(
 
   return {
     path: file.path,
+    displayPath: absoluteFilePath(summary.workspace_path, file.path),
     additions: file.additions,
     deletions: file.deletions,
     lines: lines.slice(0, DIFF_PREVIEW_MAX_LINES),
     truncated: lines.length > DIFF_PREVIEW_MAX_LINES,
   }
+}
+
+function absoluteFilePath(workspacePath: string, filePath: string): string {
+  if (isAbsolutePath(filePath)) return filePath
+  const normalizedWorkspacePath = workspacePath.replace(/[\\/]+$/, '')
+  if (!normalizedWorkspacePath) return filePath
+  return `${normalizedWorkspacePath}/${filePath.replace(/^[\\/]+/, '')}`
+}
+
+function isAbsolutePath(path: string): boolean {
+  return /^(?:\/|[A-Za-z]:[\\/]|\\\\)/.test(path)
 }
 
 function fileDiffLines(file: TurnFileChangeItem, summary: TurnFileChangesSummary): string[] {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -178,6 +178,33 @@ describe('MessageList', () => {
     expect(screen.queryByText(/proposed_plan/)).not.toBeInTheDocument()
   })
 
+  test('renders Codex plan implementation user messages as the chosen option label', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'user-plan-implementation',
+            role: 'user',
+            content: [
+              'PLEASE IMPLEMENT THIS PLAN:',
+              '# Wework 输入框 Codex 化视觉优化计划',
+              '',
+              '## Summary',
+              '- 保持输入框视觉与 Codex App 一致。',
+            ].join('\n'),
+            status: 'done',
+            createdAt: '2026-06-11T10:00:00Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('user-message-content')).toHaveTextContent('是的，执行此计划')
+    expect(screen.queryByText(/PLEASE IMPLEMENT THIS PLAN/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Wework 输入框 Codex 化视觉优化计划/)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('toggle-user-message-button')).not.toBeInTheDocument()
+  })
+
   test('renders answered request user input as an assistant question summary', () => {
     render(
       <MessageList
@@ -256,7 +283,11 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getByTestId('assistant-plan-card')).toHaveTextContent('计划')
+    const planCard = screen.getByTestId('assistant-plan-card')
+    expect(planCard).toHaveTextContent('计划')
+    expect(planCard).toHaveAttribute('role', 'button')
+    expect(screen.getByTestId('assistant-plan-card-preview').className).toContain('max-h-[168px]')
+    expect(screen.getByTestId('assistant-plan-card-content').className).toContain('text-sm')
     expect(screen.queryByText('套餐')).not.toBeInTheDocument()
     expect(screen.queryByTestId('assistant-plan-like-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('assistant-plan-dislike-button')).not.toBeInTheDocument()
@@ -265,10 +296,16 @@ describe('MessageList', () => {
       expect.stringContaining('Wegent 代码质量与前端一致性巡检计划')
     )
     expect(await screen.findByTestId('assistant-plan-copy-success')).toHaveTextContent('已复制')
-    await user.click(screen.getByTestId('assistant-plan-expand-button'))
+    expect(onOpenAssistantPlan).not.toHaveBeenCalled()
+    await user.click(planCard)
     expect(onOpenAssistantPlan).toHaveBeenCalledWith(
       expect.stringContaining('Wegent 代码质量与前端一致性巡检计划')
     )
+    await user.click(screen.getByTestId('assistant-plan-expand-button'))
+    expect(onOpenAssistantPlan).toHaveBeenLastCalledWith(
+      expect.stringContaining('Wegent 代码质量与前端一致性巡检计划')
+    )
+    expect(onOpenAssistantPlan).toHaveBeenCalledTimes(2)
     expect(screen.queryByTestId('assistant-plan-reading-panel')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1,5 +1,6 @@
 import { Fragment, memo, useEffect, useMemo, useRef, useState } from 'react'
 import type {
+  KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
   ReactNode,
   TransitionEvent as ReactTransitionEvent,
@@ -33,6 +34,7 @@ import { cn } from '@/lib/utils'
 import { AssistantMarkdown } from './AssistantMarkdown'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
+import { CODEX_IMPLEMENT_PLAN_RESPONSE_LABEL } from './requestUserInputMessages'
 import type { RequestUserInputPayload } from './RequestUserInputCard'
 import { isWebSearchToolName } from './blocks/toolBlockActivity'
 import { WebSearchSourcesChip } from './blocks/WebSearchSources'
@@ -78,6 +80,7 @@ const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
 const CODEX_FILE_MENTION_LINE_PATTERN = /^##\s+(.+?):\s+(.+)$/gm
 const CODEX_PLAN_TAG_PATTERN = /<\/?\s*proposed_plan\s*>/gi
 const CODEX_PLAN_SECTION_PATTERN = /^##\s+(Summary|Key Changes|Test Plan|Assumptions)\s*$/im
+const CODEX_IMPLEMENT_PLAN_USER_MESSAGE_PREFIX = 'PLEASE IMPLEMENT THIS PLAN:'
 const LOCAL_IMAGE_EXTENSION_PATTERN = /\.(?:apng|avif|gif|jpe?g|png|webp|bmp|svg)$/i
 const CODEX_TRANSIENT_CLIPBOARD_IMAGE_PATTERN =
   /\/(?:var\/folders|private\/var\/folders)\/.*\/codex-clipboard-[^/]+\.(?:apng|avif|gif|jpe?g|png|webp|bmp|svg)$/i
@@ -380,7 +383,9 @@ function UserMessage({
     () => parseCodexLocalFileMentions(message.content),
     [message.content]
   )
-  const displayContent = codexLocalFileMentions?.requestText ?? message.content
+  const displayContent = normalizeCodexUserMessageContent(
+    codexLocalFileMentions?.requestText ?? message.content
+  )
   const imageAttachments = useMemo(
     () => (message.attachments ?? []).filter(isImageAttachment),
     [message.attachments]
@@ -567,27 +572,54 @@ function AssistantPlanCard({
     URL.revokeObjectURL(url)
   }
 
+  const openPlan = () => {
+    onOpenPlan?.(content)
+  }
+
+  const handleCardClick = (event: ReactMouseEvent<HTMLElement>) => {
+    if (isNestedInteractiveElement(event.target, event.currentTarget)) return
+    openPlan()
+  }
+
+  const handleCardKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    if (isNestedInteractiveElement(event.target, event.currentTarget)) return
+    event.preventDefault()
+    openPlan()
+  }
+
   return (
     <section
       data-testid="assistant-plan-card"
-      className="my-3 min-w-0 overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
+      role={onOpenPlan ? 'button' : undefined}
+      tabIndex={onOpenPlan ? 0 : undefined}
+      aria-label={onOpenPlan ? t('plan_card.expand') : undefined}
+      onClick={onOpenPlan ? handleCardClick : undefined}
+      onKeyDown={onOpenPlan ? handleCardKeyDown : undefined}
+      className={cn(
+        'my-2 min-w-0 overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_2px_rgba(15,23,42,0.04)]',
+        onOpenPlan &&
+          'cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/70'
+      )}
     >
-      <div className="flex min-h-10 items-center justify-between gap-3 px-4 py-2 text-text-muted">
+      <div className="flex min-h-9 items-center justify-between gap-3 px-4 py-1.5 text-text-muted">
         <div className="inline-flex min-w-0 items-center gap-2 text-sm font-medium">
           <ListChecks className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden="true" />
           <span>{t('plan_card.title')}</span>
         </div>
-        <PlanCardActions
-          content={content}
-          onDownload={handleDownload}
-          onExpand={() => onOpenPlan?.(content)}
-        />
+        <PlanCardActions content={content} onDownload={handleDownload} onExpand={openPlan} />
       </div>
-      <div className="relative max-h-[360px] overflow-hidden px-4 pb-4 pt-3">
-        <div className="assistant-plan-card-content text-[15px] leading-7 text-text-primary">
+      <div
+        data-testid="assistant-plan-card-preview"
+        className="relative max-h-[168px] overflow-hidden px-4 pb-3 pt-2"
+      >
+        <div
+          data-testid="assistant-plan-card-content"
+          className="assistant-plan-card-content text-sm leading-6 text-text-primary [&_.assistant-markdown_h1]:mb-3 [&_.assistant-markdown_h1]:mt-2 [&_.assistant-markdown_h2]:mb-2 [&_.assistant-markdown_h2]:mt-3 [&_.assistant-markdown_p]:mb-2 [&_.assistant-markdown_p]:leading-5 [&_.assistant-markdown_ul]:mb-2 [&_.assistant-markdown_ul]:space-y-1 [&_.assistant-markdown_li]:leading-5"
+        >
           <AssistantMarkdown content={content} />
         </div>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-background to-transparent" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
       </div>
     </section>
   )
@@ -655,7 +687,10 @@ function PlanCardActions({
           data-testid={action.testId}
           aria-label={action.label}
           title={action.label}
-          onClick={action.onClick}
+          onClick={event => {
+            event.stopPropagation()
+            action.onClick()
+          }}
           className="flex h-8 w-8 items-center justify-center rounded-md text-text-muted hover:bg-muted hover:text-text-primary"
         >
           {action.icon}
@@ -675,6 +710,21 @@ function isAssistantPlanContent(content: string): boolean {
     normalizedContent !== content ||
     (/^#\s+.+/m.test(normalizedContent) && CODEX_PLAN_SECTION_PATTERN.test(normalizedContent))
   )
+}
+
+function isNestedInteractiveElement(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const interactiveTarget = target.closest('button,a,input,textarea,select')
+  return Boolean(interactiveTarget && interactiveTarget !== currentTarget)
+}
+
+function normalizeCodexUserMessageContent(content: string): string {
+  return content.trimStart().startsWith(CODEX_IMPLEMENT_PLAN_USER_MESSAGE_PREFIX)
+    ? CODEX_IMPLEMENT_PLAN_RESPONSE_LABEL
+    : content
 }
 
 function parseCodexLocalFileMentions(content: string): {

--- a/wework/src/components/chat/RequestUserInputCard.test.tsx
+++ b/wework/src/components/chat/RequestUserInputCard.test.tsx
@@ -64,8 +64,8 @@ describe('RequestUserInputCard', () => {
           questions: [
             {
               id: 'implement',
-              question: '实施此计划?',
-              options: [{ label: '是，实施此计划' }],
+              question: '执行此计划?',
+              options: [{ label: '是的，执行此计划' }],
             },
             {
               id: 'adjustment',
@@ -84,7 +84,7 @@ describe('RequestUserInputCard', () => {
       requestId: undefined,
       itemId: undefined,
       answers: {
-        implement: { answers: ['是，实施此计划'] },
+        implement: { answers: ['是的，执行此计划'] },
       },
     })
   })
@@ -99,8 +99,8 @@ describe('RequestUserInputCard', () => {
           questions: [
             {
               id: 'implement',
-              question: '实施此计划?',
-              options: [{ label: '是，实施此计划' }],
+              question: '执行此计划?',
+              options: [{ label: '是的，执行此计划' }],
             },
             {
               id: 'adjustment',

--- a/wework/src/components/chat/RequestUserInputCard.tsx
+++ b/wework/src/components/chat/RequestUserInputCard.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, CornerDownLeft, MessageCircleQuestion, Pencil } from 'luci
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { RequestUserInputResponse } from '@/types/api'
+import { hasImplementationPlanText } from './requestUserInputMessages'
 
 interface RequestUserInputOption {
   label?: string
@@ -374,7 +375,7 @@ function shouldSubmitOnOptionSelect(
 ): boolean {
   if (questions.length === 1) return true
   if (question.id === 'implement') return true
-  return option.label?.includes('实施此计划') ?? false
+  return hasImplementationPlanText(option.label)
 }
 
 function isImplementationPlanQuestions(questions: ReturnType<typeof normalizeQuestions>): boolean {
@@ -386,8 +387,8 @@ function implementationPlanOptionQuestion(
 ): ReturnType<typeof normalizeQuestions>[number] | undefined {
   return questions.find(question => {
     if (question.id.trim().toLowerCase() === 'implement') return true
-    if (question.question.includes('实施此计划')) return true
-    return question.options.some(option => option.label?.includes('实施此计划'))
+    if (hasImplementationPlanText(question.question)) return true
+    return question.options.some(option => hasImplementationPlanText(option.label))
   })
 }
 

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -225,6 +225,58 @@ describe('ToolBlockItem', () => {
     expect(screen.getByText('enabled: true')).toBeInTheDocument()
   })
 
+  test('renders apply_patch blocks with file names parsed from the patch body', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'patch-1',
+          turnId: 1,
+          type: 'tool',
+          toolName: 'apply_patch',
+          toolInput: {
+            input: [
+              '*** Begin Patch',
+              '*** Update File: /workspace/project/executor/src/server/mod.rs',
+              '@@',
+              '-old',
+              '+new',
+              '*** End Patch',
+            ].join('\n'),
+          },
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+      />
+    )
+
+    expect(screen.getByText('已编辑 mod.rs')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /展开工具详情/ }))
+
+    expect(screen.getByText('/workspace/project/executor/src/server/mod.rs')).toBeInTheDocument()
+  })
+
+  test('renders unknown edit targets without an awkward file fallback', () => {
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'edit-unknown',
+          turnId: 1,
+          type: 'tool',
+          toolName: 'apply_patch',
+          toolInput: { input: 'invalid patch text' },
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+      />
+    )
+
+    expect(screen.getByText('已编辑文件')).toBeInTheDocument()
+    expect(screen.queryByText('已编辑 文件')).not.toBeInTheDocument()
+  })
+
   test('renders process text code blocks with shared syntax highlighting', () => {
     render(
       <ToolBlockItem

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -10,6 +10,7 @@ import { parseUnifiedDiff } from '../parseUnifiedDiff'
 import { isWebSearchToolName } from './toolBlockActivity'
 import {
   getFileInputPath,
+  getFileInputPaths,
   getInputField,
   isCommandToolName,
   isFileCreateToolName,
@@ -536,19 +537,13 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
     return { icon: <TerminalIcon />, label: `${prefix.running} ${shortCmd}` }
   }
   if (isFileCreateToolName(name)) {
-    const filePath = getFileInputPath(block)
-    const fileName = filePath ? filePath.split('/').pop() : '文件'
-    return { icon: <FileIcon />, label: `${prefix.create} ${fileName}` }
+    return { icon: <FileIcon />, label: getFileToolLabel(prefix.create, block, '新增') }
   }
   if (isFileEditToolName(name)) {
-    const filePath = getFileInputPath(block)
-    const fileName = filePath ? filePath.split('/').pop() : '文件'
-    return { icon: <EditIcon />, label: `${prefix.edit} ${fileName}` }
+    return { icon: <EditIcon />, label: getFileToolLabel(prefix.edit, block, '编辑') }
   }
   if (isFileReadToolName(name)) {
-    const filePath = getFileInputPath(block)
-    const fileName = filePath ? filePath.split('/').pop() : '文件'
-    return { icon: <FileIcon />, label: `${prefix.read} ${fileName}` }
+    return { icon: <FileIcon />, label: getFileToolLabel(prefix.read, block, '读取') }
   }
   if (isWebSearchToolName(name)) {
     return {
@@ -560,6 +555,19 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
     return { icon: <ToolIcon />, label: prefix.guidance }
   }
   return { icon: <ToolIcon />, label: prefix.generic }
+}
+
+function getFileToolLabel(prefix: string, block: ToolBlock, action: string): string {
+  const filePaths = getFileInputPaths(block)
+  if (filePaths.length === 1) return `${prefix} ${basename(filePaths[0])}`
+  if (filePaths.length > 1) return `${prefix} ${filePaths.length} 个文件`
+  return fileToolFallbackLabel(block.status, action)
+}
+
+function fileToolFallbackLabel(status: ToolBlock['status'], action: string): string {
+  if (status === 'error') return `${action}文件失败`
+  if (status === 'done') return `已${action}文件`
+  return `正在${action}文件`
 }
 
 function getToolStatusPrefix(block: ToolBlock) {
@@ -814,11 +822,15 @@ function BashBlockDetail({ block }: { block: ToolBlock }) {
 }
 
 function FileWriteDetail({ block }: { block: ToolBlock }) {
-  const filePath = getFileInputPath(block)
+  const filePaths = getFileInputPaths(block)
   const content = getInputField(block, 'content', 'file_text', 'fileText')
   return (
     <div className="min-w-0 space-y-1 overflow-x-hidden">
-      {filePath && <p className="break-words text-xs text-text-muted">{filePath}</p>}
+      {filePaths.map(filePath => (
+        <p key={filePath} className="break-words text-xs text-text-muted">
+          {filePath}
+        </p>
+      ))}
       {content && (
         <pre className="max-h-40 max-w-full overflow-auto rounded-lg bg-code-bg px-3 py-2 text-xs leading-5 text-text-primary">
           {content.length > 500 ? content.substring(0, 500) + '...' : content}
@@ -829,11 +841,15 @@ function FileWriteDetail({ block }: { block: ToolBlock }) {
 }
 
 function FileEditDetail({ block }: { block: ToolBlock }) {
-  const filePath = getFileInputPath(block)
+  const filePaths = getFileInputPaths(block)
   const previews = getEditPreviews(block)
   return (
     <div className="min-w-0 space-y-1 overflow-x-hidden">
-      {filePath && <p className="break-words text-xs text-text-muted">{filePath}</p>}
+      {filePaths.map(filePath => (
+        <p key={filePath} className="break-words text-xs text-text-muted">
+          {filePath}
+        </p>
+      ))}
       {previews.map((preview, index) => (
         <div
           key={`${index}:${preview.oldText ?? ''}:${preview.newText ?? ''}`}

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -212,6 +212,180 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getAllByTestId('web-search-source-icon').length).toBeGreaterThanOrEqual(2)
   })
 
+  test('renders read file activity details as file rows instead of shell commands', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            id: 'read-command-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command: 'nl -ba wework/src/components/chat/blocks/toolBlockActivity.ts',
+            },
+            status: 'done',
+            createdAt: 1770000000000,
+          },
+          {
+            id: 'read-command-2',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command:
+                '/bin/zsh -lc "sed -n \'1,120p\' wework/src/components/chat/blocks/toolBlockKinds.ts"',
+            },
+            status: 'done',
+            createdAt: 1770000000001,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+    fireEvent.click(screen.getByRole('button', { name: /已读取 2 个文件/ }))
+
+    expect(screen.getByText('Read toolBlockActivity.ts')).toBeInTheDocument()
+    expect(screen.getByText('Read toolBlockKinds.ts')).toBeInTheDocument()
+    expect(screen.queryByText(/已运行 nl -ba/)).not.toBeInTheDocument()
+  })
+
+  test('renders code search activity details as search summaries instead of shell commands', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            id: 'rg-command-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command:
+                '/bin/zsh -lc "rg -n \'ToolBlockItem|toolBlock|file_changes|renderPayload|read.*file|command\'"',
+              workdir: '/Users/crystal/dev/git/Wegent/wework/src/components/chat/blocks',
+            },
+            status: 'done',
+            createdAt: 1770000000000,
+          },
+          {
+            id: 'rg-command-2',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command: "rg -n '已编辑|edited|edited_file|edit.*file' wework",
+            },
+            status: 'done',
+            createdAt: 1770000000001,
+          },
+          {
+            id: 'git-command-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command: 'git diff --name-only',
+            },
+            status: 'done',
+            createdAt: 1770000000002,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    const activityToggle = screen.getByRole('button', {
+      name: /已搜索代码 已运行 1 条命令/,
+    })
+    expect(screen.getByTestId('processing-activity-search-icon')).toBeInTheDocument()
+
+    fireEvent.click(activityToggle)
+
+    expect(screen.getByText('已运行 git diff --name-only')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Searched for ToolBlockItem|toolBlock|file_changes|renderPayload|read.*file|command in blocks'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Searched for 已编辑|edited|edited_file|edit.*file in wework')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/已运行 rg -n/)).not.toBeInTheDocument()
+  })
+
+  test('renders mixed code search and read file activity with specialized rows', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            id: 'rg-command-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command: 'rg -n "toolBlock" wework/src/components/chat/blocks',
+            },
+            status: 'done',
+            createdAt: 1770000000000,
+          },
+          {
+            id: 'read-command-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: {
+              command: "sed -n '1,220p' wework/src/components/chat/blocks/toolBlockActivity.ts",
+            },
+            status: 'done',
+            createdAt: 1770000000001,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+    fireEvent.click(screen.getByRole('button', { name: /已读取 1 个文件 已搜索代码/ }))
+
+    const activityContent = screen.getByTestId('processing-activity-group-content')
+      .firstElementChild?.firstElementChild as HTMLElement
+    expect(activityContent).toHaveClass('mt-1.5', 'gap-1.5')
+    expect(activityContent).not.toHaveClass('border-l', 'pl-4', 'gap-3')
+    expect(screen.getByText('Searched for toolBlock in blocks')).toBeInTheDocument()
+    expect(screen.getByText('Read toolBlockActivity.ts')).toBeInTheDocument()
+    expect(screen.queryByText(/已运行 sed -n/)).not.toBeInTheDocument()
+  })
+
+  test('hides internal stdin polling tools from completed activity', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          completedGuidanceBlock,
+          {
+            id: 'stdin-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'write_stdin',
+            toolInput: { session_id: 90870, chars: '' },
+            status: 'done',
+            createdAt: 1770000000001,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByTestId('processing-activity-group-label')).toHaveTextContent('已引导对话')
+    expect(screen.queryByRole('button', { name: /已执行 1 个工具/ })).not.toBeInTheDocument()
+    expect(screen.queryByText('已执行')).not.toBeInTheDocument()
+  })
+
   test('renders file changes inside completed processing details', () => {
     render(<ToolBlocksDisplay blocks={[completedFileChangesBlock]} isStreaming={false} />)
 
@@ -232,6 +406,73 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByTestId('process-file-change-diff')).toHaveTextContent(
       'BACKEND_URL=127.0.0.1'
     )
+  })
+
+  test('uses an edit icon for completed edit activity groups', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            id: 'patch-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'apply_patch',
+            toolInput: {
+              input: [
+                '*** Begin Patch',
+                '*** Update File: /workspace/project/executor/src/server/mod.rs',
+                '@@',
+                '-old',
+                '+new',
+                '*** End Patch',
+              ].join('\n'),
+            },
+            status: 'done',
+            createdAt: 1770000000000,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByRole('button', { name: /已编辑 1 个文件/ })).toBeInTheDocument()
+    expect(screen.getByTestId('processing-activity-edit-icon')).toBeInTheDocument()
+  })
+
+  test('hides redundant apply_patch activity when file changes are already rendered', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            id: 'patch-1',
+            turnId: 1,
+            type: 'tool',
+            toolName: 'apply_patch',
+            toolInput: {
+              input: [
+                '*** Begin Patch',
+                '*** Update File: /tmp/project/scripts/env',
+                '@@',
+                '-OLD_ENV=remote',
+                '+BACKEND_URL=127.0.0.1',
+                '*** End Patch',
+              ].join('\n'),
+            },
+            status: 'done',
+            createdAt: 1770000000000,
+          },
+          completedFileChangesBlock,
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.queryByTestId('processing-activity-group-toggle')).not.toBeInTheDocument()
+    expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('已编辑 1 个文件')
   })
 
   test('only persists the top-level processing expansion state', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode, TransitionEvent } from 'react'
-import { Archive, ChevronDown, MessageCircle, Search, SquareTerminal } from 'lucide-react'
+import {
+  Archive,
+  ChevronDown,
+  FileText,
+  MessageCircle,
+  Pencil,
+  Search,
+  SquareTerminal,
+} from 'lucide-react'
 import type { RequestUserInputResponse } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import {
@@ -17,8 +25,12 @@ import {
 } from '../RequestUserInputCard'
 import {
   buildProcessingDisplayRows,
-  isContextCompactionToolBlock,
+  getToolActivityFilePaths,
+  getToolActivityGroupKind,
+  getToolActivityKind,
+  getToolActivitySearchItem,
   isCommandToolName,
+  isContextCompactionToolBlock,
   isGuidanceActivityGroup,
   isWebSearchActivityGroup,
   type ProcessingDisplayRow,
@@ -380,22 +392,11 @@ function ToolActivityGroup({
         />
       </button>
       <CollapsibleProcessingContent expanded={expanded} testId="processing-activity-group-content">
-        <div
-          className={[
-            'mt-2 flex min-w-0 flex-col gap-3',
-            isWebSearchGroup ? '' : 'border-l border-border pl-4',
-          ].join(' ')}
-        >
+        <div className="mt-1.5 flex min-w-0 flex-col gap-1.5">
           {isWebSearchGroup ? (
             <WebSearchActivityDetails blocks={row.blocks} />
           ) : (
-            row.blocks.map(block => (
-              <ToolBlockItem
-                key={block.id}
-                block={block}
-                onOpenWorkspaceFile={onOpenWorkspaceFile}
-              />
-            ))
+            <ToolActivityDetails blocks={row.blocks} onOpenWorkspaceFile={onOpenWorkspaceFile} />
           )}
         </div>
       </CollapsibleProcessingContent>
@@ -439,16 +440,126 @@ function WebSearchActivityDetails({ blocks }: { blocks: ToolBlock[] }) {
   return <WebSearchActivityRows items={items} />
 }
 
+function ToolActivityDetails({
+  blocks,
+  onOpenWorkspaceFile,
+}: {
+  blocks: ToolBlock[]
+  onOpenWorkspaceFile?: (path: string) => void
+}) {
+  return (
+    <>
+      {blocks.map(block => {
+        const item = getToolActivitySearchItem(block)
+        if (item) {
+          return <CodeSearchActivityRow key={item.id} label={item.label} />
+        }
+
+        const paths = getToolActivityFilePaths(block)
+        if (paths.length > 0) {
+          return paths.map(path => (
+            <FileReadActivityRow
+              key={`${block.id}:${path}`}
+              path={path}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
+            />
+          ))
+        }
+
+        return (
+          <ToolBlockItem key={block.id} block={block} onOpenWorkspaceFile={onOpenWorkspaceFile} />
+        )
+      })}
+    </>
+  )
+}
+
+function CodeSearchActivityRow({ label }: { label: string }) {
+  return (
+    <div
+      data-testid="code-search-activity-row"
+      className="flex max-w-full text-[13px] leading-5 text-text-muted"
+    >
+      <span className="min-w-0 break-words">{label}</span>
+    </div>
+  )
+}
+
+function FileReadActivityRow({
+  path,
+  onOpenWorkspaceFile,
+}: {
+  path: string
+  onOpenWorkspaceFile?: (path: string) => void
+}) {
+  const label = `Read ${basename(path)}`
+  const content = (
+    <span data-testid="file-read-activity-row" className="min-w-0 truncate">
+      {label}
+    </span>
+  )
+
+  if (onOpenWorkspaceFile) {
+    return (
+      <button
+        type="button"
+        className="flex max-w-full items-center gap-1.5 text-left text-text-muted hover:text-text-secondary"
+        onClick={() => onOpenWorkspaceFile(path)}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return <div className="flex max-w-full items-center gap-1.5 text-text-muted">{content}</div>
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
+}
+
 function hasCommandBlocks(blocks: ToolBlock[]): boolean {
   return blocks.some(block => isCommandToolName(block.toolName))
 }
 
+function hasCodeSearchBlocks(blocks: ToolBlock[]): boolean {
+  return blocks.some(block => getToolActivityKind(block) === 'search')
+}
+
 function renderActivityGroupIcon(blocks: ToolBlock[]) {
+  if (hasCodeSearchBlocks(blocks)) {
+    return (
+      <Search
+        data-testid="processing-activity-search-icon"
+        className="h-4 w-4 shrink-0"
+        strokeWidth={1.7}
+      />
+    )
+  }
   if (hasCommandBlocks(blocks)) {
     return <SquareTerminal className="h-4 w-4 shrink-0" strokeWidth={1.7} />
   }
   if (isGuidanceActivityGroup(blocks)) {
     return <MessageCircle className="h-4 w-4 shrink-0" strokeWidth={1.7} />
+  }
+  const kind = getToolActivityGroupKind(blocks)
+  if (kind === 'edit') {
+    return (
+      <Pencil
+        data-testid="processing-activity-edit-icon"
+        className="h-4 w-4 shrink-0"
+        strokeWidth={1.7}
+      />
+    )
+  }
+  if (kind === 'create' || kind === 'file') {
+    return (
+      <FileText
+        data-testid="processing-activity-file-icon"
+        className="h-4 w-4 shrink-0"
+        strokeWidth={1.7}
+      />
+    )
   }
   return <Search className="h-4 w-4 shrink-0" strokeWidth={1.7} />
 }

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
-import { buildProcessingDisplayRows, summarizeToolBlocks } from './toolBlockActivity'
+import {
+  buildProcessingDisplayRows,
+  getToolActivityFilePaths,
+  getToolActivitySearchItem,
+  summarizeToolBlocks,
+} from './toolBlockActivity'
 
 function tool(
   id: string,
@@ -57,6 +62,52 @@ describe('toolBlockActivity', () => {
     ).toBe('已搜索代码')
   })
 
+  test('extracts read file paths from shell read commands', () => {
+    expect(
+      getToolActivityFilePaths(
+        tool('nl-1', 'nl -ba wework/src/components/chat/blocks/toolBlockActivity.ts')
+      )
+    ).toEqual(['wework/src/components/chat/blocks/toolBlockActivity.ts'])
+
+    expect(
+      getToolActivityFilePaths(
+        tool(
+          'sed-1',
+          '/bin/zsh -lc "sed -n \'1,120p\' wework/src/components/chat/blocks/toolBlockKinds.ts"'
+        )
+      )
+    ).toEqual(['wework/src/components/chat/blocks/toolBlockKinds.ts'])
+  })
+
+  test('extracts code search summaries from shell search commands', () => {
+    expect(
+      getToolActivitySearchItem({
+        ...tool(
+          'rg-1',
+          '/bin/zsh -lc "rg -n \'ToolBlockItem|toolBlock|file_changes|renderPayload|read.*file|command\'"'
+        ),
+        toolInput: {
+          command:
+            '/bin/zsh -lc "rg -n \'ToolBlockItem|toolBlock|file_changes|renderPayload|read.*file|command\'"',
+          workdir: '/Users/crystal/dev/git/Wegent/wework/src/components/chat/blocks',
+        },
+      })
+    ).toMatchObject({
+      query: 'ToolBlockItem|toolBlock|file_changes|renderPayload|read.*file|command',
+      scope: 'blocks',
+      label:
+        'Searched for ToolBlockItem|toolBlock|file_changes|renderPayload|read.*file|command in blocks',
+    })
+
+    expect(
+      getToolActivitySearchItem(tool('rg-2', "rg -n '已编辑|edited|edited_file|edit.*file' wework"))
+    ).toMatchObject({
+      query: '已编辑|edited|edited_file|edit.*file',
+      scope: 'wework',
+      label: 'Searched for 已编辑|edited|edited_file|edit.*file in wework',
+    })
+  })
+
   test('summarizes mid-turn user guidance activity', () => {
     expect(
       summarizeToolBlocks([
@@ -71,6 +122,35 @@ describe('toolBlockActivity', () => {
         },
       ])
     ).toBe('已引导对话')
+  })
+
+  test('hides internal stdin polling tools from activity rows', () => {
+    const rows = buildProcessingDisplayRows([
+      {
+        id: 'guidance-1',
+        turnId: 1,
+        type: 'tool',
+        toolName: 'conversation_guidance',
+        toolInput: { message: 'follow this file' },
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+      {
+        id: 'stdin-1',
+        turnId: 1,
+        type: 'tool',
+        toolName: 'write_stdin',
+        toolInput: { session_id: 90870, chars: '' },
+        status: 'done',
+        createdAt: 1770000000001,
+      },
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      type: 'activity_group',
+      label: '已引导对话',
+    })
   })
 
   test('classifies Claude multi-file edit tools as edit activity', () => {

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -1,5 +1,6 @@
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import {
+  getFileInputPaths,
   getInputField,
   isCommandToolName,
   isFileCreateToolName,
@@ -7,13 +8,28 @@ import {
   isFileReadToolName,
   isGuidanceToolName,
   isContextCompactionToolName,
+  isPatchApplyToolName,
 } from './toolBlockKinds'
 
 export type ProcessingDisplayRow =
   | { type: 'block'; id: string; block: ProcessingBlock }
   | { type: 'activity_group'; id: string; blocks: ToolBlock[]; label: string }
 
-type ToolActivityKind = 'file' | 'search' | 'command' | 'create' | 'edit' | 'guidance' | 'tool'
+export type ToolActivityKind =
+  | 'file'
+  | 'search'
+  | 'command'
+  | 'create'
+  | 'edit'
+  | 'guidance'
+  | 'tool'
+
+export interface ToolActivitySearchItem {
+  id: string
+  query: string
+  scope?: string
+  label: string
+}
 
 interface ActivityStats {
   files: number
@@ -30,6 +46,7 @@ interface ActivityStats {
 const SEARCH_TOOL_HINTS = ['search', 'grep', 'glob']
 const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag', 'ack'])
 const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'du', 'file'])
+const HIDDEN_ACTIVITY_TOOLS = new Set(['write_stdin', 'functions.write_stdin'])
 
 export function buildProcessingDisplayRows(
   blocks: ProcessingBlock[],
@@ -38,6 +55,7 @@ export function buildProcessingDisplayRows(
   const groupCompletedTools = options.groupCompletedTools ?? true
   const rows: ProcessingDisplayRow[] = []
   let completedTools: ToolBlock[] = []
+  const hasFileChangesBlock = blocks.some(block => block.type === 'file_changes')
 
   const flushCompletedTools = () => {
     if (completedTools.length === 0) return
@@ -54,6 +72,14 @@ export function buildProcessingDisplayRows(
     if (block.type === 'tool' && isContextCompactionToolName(block.toolName)) {
       flushCompletedTools()
       rows.push({ type: 'block', id: block.id, block })
+      continue
+    }
+
+    if (isHiddenToolActivityBlock(block)) {
+      continue
+    }
+
+    if (hasFileChangesBlock && isRedundantPatchApplyBlock(block)) {
       continue
     }
 
@@ -129,7 +155,7 @@ function getActivityStats(blocks: ToolBlock[]): ActivityStats {
   )
 }
 
-function getToolActivityKind(block: ToolBlock): ToolActivityKind {
+export function getToolActivityKind(block: ToolBlock): ToolActivityKind {
   const name = block.toolName.toLowerCase()
   if (isFileReadToolName(name)) return 'file'
   if (isFileCreateToolName(name)) return 'create'
@@ -142,6 +168,55 @@ function getToolActivityKind(block: ToolBlock): ToolActivityKind {
   return 'tool'
 }
 
+export function getToolActivityFilePaths(block: ToolBlock): string[] {
+  const name = block.toolName.toLowerCase()
+  if (isFileReadToolName(name)) return getFileInputPaths(block)
+  if (!isCommandToolName(name)) return []
+
+  const command = getInputField(block, 'command', 'cmd', 'commandLine')
+  if (getCommandActivityKind(command) !== 'file') return []
+  return getReadCommandFilePaths(command)
+}
+
+export function getToolActivitySearchItem(block: ToolBlock): ToolActivitySearchItem | undefined {
+  const name = block.toolName.toLowerCase()
+  if (isWebSearchToolName(name) || getToolActivityKind(block) !== 'search') return undefined
+
+  if (isCommandToolName(name)) {
+    const command = getInputField(block, 'command', 'cmd', 'commandLine')
+    const summary = getSearchCommandSummary(command, getCommandWorkingDirectory(block))
+    if (!summary) return undefined
+    return {
+      id: `${block.id}-code-search`,
+      query: summary.query,
+      scope: summary.scope,
+      label: formatSearchLabel(summary),
+    }
+  }
+
+  const query = getInputField(block, 'query', 'pattern', 'search')
+  if (!query) return undefined
+  const scopePath = getInputField(block, 'path', 'directory', 'dir', 'root')
+  const scope = formatSearchScope(scopePath ? [scopePath] : [], getCommandWorkingDirectory(block))
+  return {
+    id: `${block.id}-code-search`,
+    query,
+    scope,
+    label: formatSearchLabel({ query, scope }),
+  }
+}
+
+export function getToolActivityGroupKind(blocks: ToolBlock[]): ToolActivityKind {
+  const kinds = blocks.map(getToolActivityKind)
+  if (kinds.length === 0) return 'tool'
+
+  const primaryKinds = kinds.filter(kind => kind !== 'tool')
+  if (primaryKinds.length === 0) return 'tool'
+
+  const firstKind = primaryKinds[0]
+  return primaryKinds.every(kind => kind === firstKind) ? firstKind : 'tool'
+}
+
 function getCommandActivityKind(command?: string): ToolActivityKind {
   const executable = getCommandExecutable(command)
   if (!executable) return 'command'
@@ -150,6 +225,288 @@ function getCommandActivityKind(command?: string): ToolActivityKind {
   if (executable === 'git' && command?.includes(' grep ')) return 'search'
   if (executable === 'git' && command?.includes(' ls-files')) return 'search'
   return 'command'
+}
+
+function getReadCommandFilePaths(command?: string): string[] {
+  const words = splitShellWords(unwrapShellCommand(command ?? ''))
+  const executableIndex = getExecutableWordIndex(words)
+  const executable = words[executableIndex]?.split('/').pop()?.toLowerCase()
+  if (!executable || !FILE_COMMANDS.has(executable)) return []
+
+  const args = getFirstCommandSegment(words.slice(executableIndex + 1))
+  if (executable === 'sed') return getSedInputPaths(args)
+  return getPathArguments(args, READ_COMMAND_OPTIONS_WITH_VALUES)
+}
+
+function getSearchCommandSummary(
+  command: string | undefined,
+  cwd: string | undefined
+): { query: string; scope?: string } | undefined {
+  const words = splitShellWords(unwrapShellCommand(command ?? ''))
+  const executableIndex = getExecutableWordIndex(words)
+  const executable = words[executableIndex]?.split('/').pop()?.toLowerCase()
+  if (!executable) return undefined
+
+  const args = getFirstCommandSegment(words.slice(executableIndex + 1))
+  if (executable === 'git') return getGitSearchCommandSummary(args, cwd)
+  if (executable === 'find') return getFindSearchCommandSummary(args, cwd)
+  if (PATTERN_SEARCH_COMMANDS.has(executable)) {
+    const parsed = getPatternSearchArguments(args)
+    if (!parsed?.query) return undefined
+    return { query: parsed.query, scope: formatSearchScope(parsed.scopes, cwd) }
+  }
+  return undefined
+}
+
+const PATTERN_SEARCH_COMMANDS = new Set(['rg', 'grep', 'ag', 'ack', 'fd'])
+const SEARCH_PATTERN_OPTIONS = new Set(['-e', '--regexp', '--pattern'])
+const SEARCH_COMMAND_OPTIONS_WITH_VALUES = new Set([
+  '-A',
+  '--after-context',
+  '-B',
+  '--before-context',
+  '-C',
+  '--context',
+  '-f',
+  '--file',
+  '-g',
+  '--glob',
+  '-j',
+  '--threads',
+  '-m',
+  '--max-count',
+  '--max-depth',
+  '--sort',
+  '--sortr',
+  '-t',
+  '--type',
+  '-T',
+  '--type-not',
+  '--colors',
+  '--color',
+  '--engine',
+  '--encoding',
+  '--ignore-file',
+  '--path-separator',
+])
+
+function getGitSearchCommandSummary(
+  args: string[],
+  cwd: string | undefined
+): { query: string; scope?: string } | undefined {
+  const grepIndex = args.indexOf('grep')
+  if (grepIndex === -1) return undefined
+
+  const grepArgs = args.slice(grepIndex + 1)
+  const separatorIndex = grepArgs.indexOf('--')
+  const searchArgs = separatorIndex === -1 ? grepArgs : grepArgs.slice(0, separatorIndex)
+  const pathspecs = separatorIndex === -1 ? [] : grepArgs.slice(separatorIndex + 1)
+  const parsed = getPatternSearchArguments(searchArgs)
+  if (!parsed?.query) return undefined
+  return {
+    query: parsed.query,
+    scope: formatSearchScope(pathspecs.length > 0 ? pathspecs : parsed.scopes, cwd),
+  }
+}
+
+function getPatternSearchArguments(args: string[]):
+  | {
+      query: string
+      scopes: string[]
+    }
+  | undefined {
+  let query: string | undefined
+  let queryFromOption = false
+  const positional: string[] = []
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!arg) continue
+    if (arg === '--') {
+      positional.push(...args.slice(index + 1).filter(isLikelyPathArgument))
+      break
+    }
+    if (arg.startsWith('-')) {
+      const optionName = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg
+      if (SEARCH_PATTERN_OPTIONS.has(optionName)) {
+        if (!query) {
+          query = arg.includes('=') ? arg.slice(arg.indexOf('=') + 1) : args[index + 1]
+          queryFromOption = true
+        }
+        if (!arg.includes('=')) index += 1
+        continue
+      }
+      if (!arg.includes('=') && SEARCH_COMMAND_OPTIONS_WITH_VALUES.has(optionName)) index += 1
+      continue
+    }
+    positional.push(arg)
+  }
+
+  query = query ?? positional[0]
+  if (!query) return undefined
+  return { query, scopes: queryFromOption ? positional : positional.slice(1) }
+}
+
+function getFindSearchCommandSummary(
+  args: string[],
+  cwd: string | undefined
+): { query: string; scope?: string } | undefined {
+  const expressionIndex = args.findIndex(arg => arg.startsWith('-') || arg === '(' || arg === '!')
+  const scopes = expressionIndex > 0 ? args.slice(0, expressionIndex) : []
+  const expression = expressionIndex === -1 ? args : args.slice(expressionIndex)
+  const query = getFindExpressionQuery(expression)
+  if (!query) return undefined
+  return { query, scope: formatSearchScope(scopes, cwd) }
+}
+
+const FIND_QUERY_OPTIONS = new Set(['-name', '-iname', '-path', '-ipath', '-regex', '-iregex'])
+
+function getFindExpressionQuery(expression: string[]): string | undefined {
+  for (let index = 0; index < expression.length; index += 1) {
+    const arg = expression[index]
+    if (FIND_QUERY_OPTIONS.has(arg)) return expression[index + 1]
+  }
+  return undefined
+}
+
+function formatSearchLabel(summary: { query: string; scope?: string }): string {
+  return summary.scope
+    ? `Searched for ${summary.query} in ${summary.scope}`
+    : `Searched for ${summary.query}`
+}
+
+function formatSearchScope(scopes: string[], cwd: string | undefined): string | undefined {
+  const scope = scopes.find(item => item && item !== '.' && item !== './') ?? cwd ?? scopes[0]
+  if (!scope) return undefined
+  return basename(scope)
+}
+
+function getCommandWorkingDirectory(block: Pick<ToolBlock, 'toolInput'>): string | undefined {
+  return getInputField(block, 'cwd', 'workdir', 'workingDirectory')
+}
+
+const READ_COMMAND_OPTIONS_WITH_VALUES = new Set([
+  '-n',
+  '--lines',
+  '-c',
+  '--bytes',
+  '-m',
+  '--max-count',
+  '-t',
+  '--type',
+])
+
+function getSedInputPaths(args: string[]): string[] {
+  const nonOptionArgs = getPathArguments(args, new Set(['-e', '--expression', '-f', '--file']))
+  if (nonOptionArgs.length <= 1) return []
+  return nonOptionArgs.slice(1)
+}
+
+function getPathArguments(args: string[], optionsWithValues: ReadonlySet<string>): string[] {
+  const paths: string[] = []
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!arg) continue
+    if (arg === '--') {
+      paths.push(...args.slice(index + 1).filter(isLikelyPathArgument))
+      break
+    }
+    if (arg.startsWith('-')) {
+      const optionName = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg
+      if (!arg.includes('=') && optionsWithValues.has(optionName)) index += 1
+      continue
+    }
+    if (isLikelyPathArgument(arg)) paths.push(arg)
+  }
+
+  return Array.from(new Set(paths))
+}
+
+function isLikelyPathArgument(arg: string): boolean {
+  return arg.length > 0 && !arg.startsWith('>') && !arg.startsWith('<')
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
+}
+
+function getFirstCommandSegment(words: string[]): string[] {
+  const boundaryIndex = words.findIndex(word => COMMAND_BOUNDARIES.has(word))
+  return boundaryIndex === -1 ? words : words.slice(0, boundaryIndex)
+}
+
+const COMMAND_BOUNDARIES = new Set(['|', '||', '&&', ';'])
+
+function getExecutableWordIndex(words: string[]): number {
+  let index = 0
+  if (words[index] === 'env') {
+    index += 1
+    while (words[index]?.includes('=')) index += 1
+  }
+  if (words[index] === 'sudo') index += 1
+  return index
+}
+
+function splitShellWords(command: string): string[] {
+  const words: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  const pushCurrent = () => {
+    if (current.length === 0) return
+    words.push(current)
+    current = ''
+  }
+
+  for (const char of command) {
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+
+    if (char === '\\' && quote !== "'") {
+      escaped = true
+      continue
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      pushCurrent()
+      continue
+    }
+
+    if (char === '|' || char === ';' || char === '&') {
+      pushCurrent()
+      const previous = words[words.length - 1]
+      if ((char === '|' || char === '&') && previous === char) {
+        words[words.length - 1] = `${char}${char}`
+      } else {
+        words.push(char)
+      }
+      continue
+    }
+
+    current += char
+  }
+
+  pushCurrent()
+  return words
 }
 
 function getCommandExecutable(command?: string): string {
@@ -172,6 +529,14 @@ function isCompletedToolBlock(block: ToolBlock): boolean {
 
 export function isContextCompactionToolBlock(block: ProcessingBlock): block is ToolBlock {
   return block.type === 'tool' && isContextCompactionToolName(block.toolName)
+}
+
+function isRedundantPatchApplyBlock(block: ProcessingBlock): boolean {
+  return block.type === 'tool' && block.status === 'done' && isPatchApplyToolName(block.toolName)
+}
+
+function isHiddenToolActivityBlock(block: ProcessingBlock): boolean {
+  return block.type === 'tool' && HIDDEN_ACTIVITY_TOOLS.has(block.toolName.toLowerCase())
 }
 
 export function isWebSearchToolName(name: string): boolean {

--- a/wework/src/components/chat/blocks/toolBlockKinds.ts
+++ b/wework/src/components/chat/blocks/toolBlockKinds.ts
@@ -22,6 +22,7 @@ const EDIT_TOOLS = new Set([
   'apply_patch',
   'functions.apply_patch',
 ])
+const PATCH_APPLY_TOOLS = new Set(['apply_patch', 'functions.apply_patch'])
 const GUIDANCE_TOOLS = new Set(['conversation_guidance', 'user_guidance'])
 const CONTEXT_COMPACTION_TOOLS = new Set(['context_compaction', 'contextcompaction'])
 
@@ -59,6 +60,10 @@ export function isFileEditToolName(name: string): boolean {
   return matchesToolName(name, EDIT_TOOLS)
 }
 
+export function isPatchApplyToolName(name: string): boolean {
+  return matchesToolName(name, PATCH_APPLY_TOOLS)
+}
+
 export function isGuidanceToolName(name: string): boolean {
   return matchesToolName(name, GUIDANCE_TOOLS)
 }
@@ -77,8 +82,19 @@ export function getInputField(block: Pick<ToolBlock, 'toolInput'>, ...keys: stri
 }
 
 export function getFileInputPath(block: Pick<ToolBlock, 'toolInput'>): string | undefined {
-  return getInputField(
-    block,
+  return getFileInputPaths(block)[0]
+}
+
+export function getFileInputPaths(block: Pick<ToolBlock, 'toolInput'>): string[] {
+  const directPath = getDirectFileInputPath(block.toolInput)
+  if (directPath) return [directPath]
+  return getPatchFilePaths(block.toolInput)
+}
+
+function getDirectFileInputPath(input: Record<string, unknown> | undefined): string | undefined {
+  if (!input) return undefined
+  const directPath = getStringField(
+    input,
     'file_path',
     'filePath',
     'filepath',
@@ -90,4 +106,41 @@ export function getFileInputPath(block: Pick<ToolBlock, 'toolInput'>): string | 
     'notebook_path',
     'notebookPath'
   )
+  if (directPath) return directPath
+
+  for (const nestedKey of ['input', 'arguments']) {
+    const nestedValue = input[nestedKey]
+    if (isRecord(nestedValue)) {
+      const nestedPath = getDirectFileInputPath(nestedValue)
+      if (nestedPath) return nestedPath
+    }
+  }
+
+  return undefined
+}
+
+function getPatchFilePaths(input: Record<string, unknown> | undefined): string[] {
+  if (!input) return []
+  const patchText = getStringField(input, 'patch', 'input', 'arguments', 'content')
+  if (!patchText) return []
+
+  const paths = new Set<string>()
+  for (const line of patchText.split('\n')) {
+    const match = line.match(/^\*\*\* (?:Add|Delete|Update) File:\s*(.+)$/)
+    const path = match?.[1]?.trim()
+    if (path) paths.add(path)
+  }
+  return Array.from(paths)
+}
+
+function getStringField(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string') return value
+  }
+  return undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -19,19 +19,21 @@ import {
   groupModelsByFamily,
   inferModelFamily,
 } from '@/lib/model-ui'
+import { cn } from '@/lib/utils'
 import type { ModelCompatibilityDisabledReason, ModelOptions, UnifiedModel } from '@/types/api'
 import { useOutsideClick } from './useOutsideClick'
 
 const MAIN_MENU_WIDTH = 256
 const SUBMENU_WIDTH = 288
-const SUBMENU_GAP = 8
+const SUBMENU_GAP = 0
 const VIEWPORT_MARGIN = 16
 const DESKTOP_MENU_VIEWPORT_TOP = 64
-const MAIN_MENU_TRIGGER_GAP = 20
+const MAIN_MENU_TRIGGER_GAP = 8
 const MAIN_MENU_MAX_HEIGHT = 608
 const SUBMENU_RIGHT_OFFSET = MAIN_MENU_WIDTH + SUBMENU_GAP
 const SUBMENU_MAX_HEIGHT = 448
 const SUBMENU_VIEWPORT_VERTICAL_GAP = 128
+const DESKTOP_HIDDEN_CONTROL_IDS = new Set(['collaborationMode'])
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
 type DesktopSubmenuTarget =
@@ -76,6 +78,7 @@ export function ModelSelector({
   const mobileCloseButtonRef = useRef<HTMLButtonElement>(null)
   const handledOpenSignalRef = useRef<number | undefined>(undefined)
   const familyButtonRefs = useRef(new Map<string, HTMLButtonElement>())
+  const controlButtonRefs = useRef(new Map<string, HTMLButtonElement>())
   const [open, setOpen] = useState(false)
   const [mobileQuery, setMobileQuery] = useState('')
   const [desktopMenuTop, setDesktopMenuTop] = useState(0)
@@ -238,6 +241,13 @@ export function ModelSelector({
     },
     [updateSubmenuLayout]
   )
+  const activateControl = useCallback(
+    (controlId: string, target?: HTMLElement | null) => {
+      setActiveDesktopSubmenu({ type: 'control', id: controlId })
+      updateSubmenuLayout(target ?? controlButtonRefs.current.get(controlId) ?? null)
+    },
+    [updateSubmenuLayout]
+  )
   const clearDesktopSubmenu = useCallback(() => {
     setActiveDesktopSubmenu({ type: 'none' })
   }, [])
@@ -249,8 +259,16 @@ export function ModelSelector({
 
   useLayoutEffect(() => {
     if (!open) return
-    updateSubmenuLayout(familyButtonRefs.current.get(displayedFamilyId) ?? null)
-  }, [activeDesktopSubmenu, displayedFamilyId, open, updateSubmenuLayout])
+    if (activeDesktopSubmenu?.type === 'family') {
+      updateSubmenuLayout(familyButtonRefs.current.get(activeDesktopSubmenu.id) ?? null)
+      return
+    }
+    if (activeDesktopSubmenu?.type === 'control') {
+      updateSubmenuLayout(controlButtonRefs.current.get(activeDesktopSubmenu.id) ?? null)
+      return
+    }
+    updateSubmenuLayout(null)
+  }, [activeDesktopSubmenu, open, updateSubmenuLayout])
 
   useEffect(() => {
     if (!open || !isMobile) return
@@ -279,6 +297,17 @@ export function ModelSelector({
   const controlsBelowModels = selectedModelControls.filter(
     control => control.placement === 'belowModels'
   )
+  const desktopControlsAboveFamilies = controlsAboveFamilies.filter(
+    control => !DESKTOP_HIDDEN_CONTROL_IDS.has(control.id)
+  )
+  const desktopControlsBelowModels = controlsBelowModels.filter(
+    control => !DESKTOP_HIDDEN_CONTROL_IDS.has(control.id)
+  )
+  const activeControl =
+    activeDesktopSubmenu?.type === 'control'
+      ? desktopControlsBelowModels.find(control => control.id === activeDesktopSubmenu.id)
+      : undefined
+  const activeFamilySubmenuGroup = activeDesktopSubmenu?.type === 'family' ? activeGroup : undefined
 
   useLayoutEffect(() => {
     if (!open || isMobile) return
@@ -288,8 +317,8 @@ export function ModelSelector({
     return () => window.removeEventListener('resize', updateDesktopMenuLayout)
   }, [
     activeGroup?.models.length,
-    controlsAboveFamilies.length,
-    controlsBelowModels.length,
+    desktopControlsAboveFamilies.length,
+    desktopControlsBelowModels.length,
     familyGroups.length,
     isMobile,
     open,
@@ -316,9 +345,16 @@ export function ModelSelector({
     })
   }, [activeGroup, normalizedMobileQuery, resolveControlLabel, selectedModelOptions])
 
-  function renderControlSection(control: ModelControlConfig) {
+  function renderControlSection(
+    control: ModelControlConfig,
+    { clearSubmenuOnHover = true }: { clearSubmenuOnHover?: boolean } = {}
+  ) {
     return (
-      <div key={control.id} onMouseEnter={clearDesktopSubmenu} onPointerEnter={clearDesktopSubmenu}>
+      <div
+        key={control.id}
+        onMouseEnter={clearSubmenuOnHover ? clearDesktopSubmenu : undefined}
+        onPointerEnter={clearSubmenuOnHover ? clearDesktopSubmenu : undefined}
+      >
         <div className="px-3 pb-1 pt-0.5 text-sm font-semibold text-text-muted">
           {control.labelKey ? t(control.labelKey) : control.label}
         </div>
@@ -334,7 +370,7 @@ export function ModelSelector({
                   key={option.value}
                   type="button"
                   data-testid={`model-control-${control.id}-${option.value}`}
-                  onFocus={clearDesktopSubmenu}
+                  onFocus={clearSubmenuOnHover ? clearDesktopSubmenu : undefined}
                   onClick={() => handleSelectModelOption(control.id, option.value)}
                   className="flex min-h-8 w-full items-center gap-3 rounded-lg px-3 py-1.5 text-left text-sm text-text-primary hover:bg-muted"
                 >
@@ -357,6 +393,49 @@ export function ModelSelector({
         </div>
       </div>
     )
+  }
+
+  function renderControlMenuItem(control: ModelControlConfig) {
+    const active =
+      activeDesktopSubmenu?.type === 'control' && activeDesktopSubmenu.id === control.id
+
+    return (
+      <button
+        ref={node => {
+          if (node) {
+            controlButtonRefs.current.set(control.id, node)
+          } else {
+            controlButtonRefs.current.delete(control.id)
+          }
+        }}
+        key={control.id}
+        type="button"
+        data-testid={`model-control-menu-${control.id}`}
+        onMouseEnter={event => activateControl(control.id, event.currentTarget)}
+        onPointerEnter={event => activateControl(control.id, event.currentTarget)}
+        onFocus={event => activateControl(control.id, event.currentTarget)}
+        onClick={event => activateControl(control.id, event.currentTarget)}
+        className={[
+          'flex h-9 w-full items-center gap-2 rounded-lg px-3 text-left text-[13px] font-medium leading-[18px]',
+          active
+            ? 'bg-muted text-text-primary'
+            : 'text-text-secondary hover:bg-muted hover:text-text-primary',
+        ].join(' ')}
+      >
+        <span className="min-w-0 flex-1 truncate">
+          {control.labelKey ? t(control.labelKey) : control.label}
+        </span>
+        <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
+      </button>
+    )
+  }
+
+  function getFamilyMenuLabel(group: (typeof familyGroups)[number]): string {
+    const modelForLabel =
+      selectedModel && selectedFamily === group.config.id ? selectedModel : group.models[0]
+    return modelForLabel
+      ? getModelDisplayLabel(modelForLabel, {}, resolveControlLabel) || group.config.label
+      : group.config.label
   }
 
   function renderAutomaticReasoningSection() {
@@ -658,10 +737,8 @@ export function ModelSelector({
       {open && !isMobile && (
         <div
           style={{ top: desktopMenuTop }}
-          className={[
-            'absolute left-0 z-popover w-[min(46rem,calc(100vw-2rem))]',
-            menuClassName,
-          ].join(' ')}
+          className={cn('absolute right-0 z-popover w-64', menuClassName)}
+          onMouseLeave={clearDesktopSubmenu}
         >
           <div
             ref={menuPanelRef}
@@ -669,10 +746,10 @@ export function ModelSelector({
             style={{ maxHeight: desktopMenuMaxHeight }}
             className="w-64 shrink-0 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]"
           >
-            {(controlsAboveFamilies.length > 0 || activeGroup) && (
+            {(desktopControlsAboveFamilies.length > 0 || activeGroup) && (
               <>
                 <div className="mb-1.5 space-y-1.5">
-                  {controlsAboveFamilies.map(renderControlSection)}
+                  {desktopControlsAboveFamilies.map(control => renderControlSection(control))}
                   {!supportsReasoningControl && renderAutomaticReasoningSection()}
                 </div>
                 <div className="mx-3 mb-1.5 border-t border-border" />
@@ -706,24 +783,33 @@ export function ModelSelector({
                         : 'text-text-secondary hover:bg-muted hover:text-text-primary',
                     ].join(' ')}
                   >
-                    <span className="min-w-0 flex-1 truncate">{group.config.label}</span>
+                    <span className="min-w-0 flex-1 truncate">{getFamilyMenuLabel(group)}</span>
                     <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
                   </button>
                 )
               })}
             </div>
 
-            {controlsBelowModels.length > 0 && (
+            {desktopControlsBelowModels.length > 0 && (
               <>
                 <div className="mx-3 my-1.5 border-t border-border" />
-                <div className="mb-0.5 space-y-1.5">
-                  {controlsBelowModels.map(renderControlSection)}
+                <div className="space-y-0.5">
+                  {desktopControlsBelowModels.map(renderControlMenuItem)}
                 </div>
               </>
             )}
           </div>
 
-          {activeGroup ? (
+          {activeControl ? (
+            <div
+              ref={submenuPanelRef}
+              data-testid="model-selector-submenu"
+              style={{ top: submenuOffset, left: submenuLeft, width: submenuWidth }}
+              className="absolute max-h-[min(28rem,calc(100vh-8rem))] w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]"
+            >
+              {renderControlSection(activeControl, { clearSubmenuOnHover: false })}
+            </div>
+          ) : activeFamilySubmenuGroup ? (
             <div
               ref={submenuPanelRef}
               data-testid="model-selector-submenu"
@@ -734,7 +820,7 @@ export function ModelSelector({
                 {t('workbench.model_version')}
               </div>
               <div className="space-y-0.5">
-                {activeGroup.models.map(model => {
+                {activeFamilySubmenuGroup.models.map(model => {
                   const selected =
                     model.name === selectedModel?.name && model.type === selectedModel?.type
                   const modelDisabled = Boolean(model.compatibilityDisabled)
@@ -786,7 +872,7 @@ export function ModelSelector({
                 })}
               </div>
             </div>
-          ) : (
+          ) : activeDesktopSubmenu?.type === 'family' ? (
             <div
               ref={submenuPanelRef}
               data-testid="model-selector-submenu"
@@ -795,7 +881,7 @@ export function ModelSelector({
             >
               {t('workbench.no_models')}
             </div>
-          )}
+          ) : null}
         </div>
       )}
       <button

--- a/wework/src/components/chat/requestUserInputMessages.ts
+++ b/wework/src/components/chat/requestUserInputMessages.ts
@@ -3,6 +3,16 @@ import type { ProcessingBlock, ToolBlock, WorkbenchMessage } from '@/types/workb
 import type { RequestUserInputPayload } from './RequestUserInputCard'
 
 const EMPTY_HIDDEN_REQUEST_USER_INPUT_IDS = new Set<string>()
+export const CODEX_IMPLEMENT_PLAN_QUESTION = '执行此计划?'
+export const CODEX_IMPLEMENT_PLAN_RESPONSE_LABEL = '是的，执行此计划'
+const IMPLEMENT_PLAN_TEXT_MARKERS = ['实施此计划', '执行此计划']
+
+export function hasImplementationPlanText(text: string | null | undefined): boolean {
+  const normalizedText = text?.trim()
+  return Boolean(
+    normalizedText && IMPLEMENT_PLAN_TEXT_MARKERS.some(marker => normalizedText.includes(marker))
+  )
+}
 
 export type RequestUserInputBlock = ToolBlock & {
   renderPayload: RequestUserInputPayload
@@ -46,8 +56,8 @@ export function isImplementationPlanRequestUserInput(
     const id = question.id?.trim().toLowerCase()
     const text = question.question?.trim()
     if (id === 'implement') return true
-    if (text?.includes('实施此计划')) return true
-    return question.options?.some(option => option.label?.includes('实施此计划')) ?? false
+    if (hasImplementationPlanText(text)) return true
+    return question.options?.some(option => hasImplementationPlanText(option.label)) ?? false
   })
 }
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -28,6 +28,7 @@ import {
   TITLEBAR_ACTIONS_PORTAL_ID,
   TITLEBAR_RIGHT_PANEL_PORTAL_ID,
 } from '@/components/topnav/TitlebarActionsPortal'
+import { requestDesktopSidebarToggle } from './useDesktopSidebarCollapsed'
 import { DesktopWorkbenchLayout as ActualDesktopWorkbenchLayout } from './DesktopWorkbenchLayout'
 import { WorkspaceFilePreview } from './workspace-panels/WorkspaceFilePreview'
 
@@ -596,8 +597,8 @@ describe('DesktopWorkbenchLayout', () => {
             questions: [
               {
                 id: 'implement',
-                question: '实施此计划?',
-                options: [{ label: '是，实施此计划' }],
+                question: '执行此计划?',
+                options: [{ label: '是的，执行此计划' }],
               },
             ],
           },
@@ -1017,7 +1018,7 @@ describe('DesktopWorkbenchLayout', () => {
         requestId: 42,
         itemId: undefined,
         answers: {
-          implement: { answers: ['是，实施此计划'] },
+          implement: { answers: ['是的，执行此计划'] },
         },
       },
       { appendUserMessage: true, forceDefaultCollaborationMode: true }
@@ -1101,7 +1102,11 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    expect(screen.getByTestId('desktop-workbench-content')).toHaveClass('pt-11')
+    const desktopContent = screen.getByTestId('desktop-workbench-content')
+    expect(desktopContent).toHaveClass('pt-11')
+    expect(desktopContent.style.getPropertyValue('--desktop-floating-composer-clearance')).toBe(
+      '136px'
+    )
     expect(screen.getByTestId('desktop-chat-scroll')).toHaveClass(
       'h-full',
       'overflow-x-hidden',
@@ -1677,6 +1682,28 @@ describe('DesktopWorkbenchLayout', () => {
     })
     fireEvent.resize(window)
 
+    await waitFor(() => expect(sidebar).toHaveStyle({ width: '240px' }))
+    expect(sidebar).toHaveAttribute('aria-hidden', 'false')
+  })
+
+  test('expands an auto-collapsed sidebar from the titlebar toggle request', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 920,
+    })
+
+    render(<DesktopWorkbenchLayout {...baseProps} />)
+
+    const sidebar = screen.getByTestId('desktop-sidebar')
+    await waitFor(() => expect(sidebar).toHaveStyle({ width: '0px' }))
+    expect(sidebar).toHaveAttribute('aria-hidden', 'true')
+
+    let handled = false
+    act(() => {
+      handled = requestDesktopSidebarToggle()
+    })
+
+    expect(handled).toBe(true)
     await waitFor(() => expect(sidebar).toHaveStyle({ width: '240px' }))
     expect(sidebar).toHaveAttribute('aria-hidden', 'false')
   })

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -23,7 +23,10 @@ import { ContinueInImDialog } from '@/components/chat/ContinueInImDialog'
 import { TransientNotice } from '@/components/common/TransientNotice'
 import { DesktopWorkbenchMain } from './DesktopWorkbenchMain'
 import { WorkbenchSearchDialog } from './WorkbenchSearchDialog'
-import { useDesktopSidebarCollapsed } from './useDesktopSidebarCollapsed'
+import {
+  useDesktopSidebarCollapsed,
+  useDesktopSidebarToggleRequest,
+} from './useDesktopSidebarCollapsed'
 import { ConnectionsSettingsPage } from '@/components/settings/ConnectionsSettingsPage'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useWorkbenchShellEventHandlers } from './workbenchShellEvents'
@@ -195,6 +198,10 @@ export function DesktopWorkbenchLayout() {
   const collapseSidebar = useCallback(() => {
     updateSidebarCollapsed(true)
   }, [updateSidebarCollapsed])
+
+  useDesktopSidebarToggleRequest(() => {
+    updateSidebarCollapsed(!effectiveSidebarCollapsed)
+  })
 
   useWorkbenchShellEventHandlers({
     onCreateProjectMode: openProjectFromWorkMenu,

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -137,8 +137,8 @@ function createPendingRequestUserInputMessage(): WorkbenchMessage {
           questions: [
             {
               id: 'implement',
-              question: '实施此计划?',
-              options: [{ label: '是，实施此计划' }],
+              question: '执行此计划?',
+              options: [{ label: '是的，执行此计划' }],
             },
           ],
         },
@@ -515,7 +515,7 @@ describe('MobileWorkbenchLayout', () => {
         requestId: 42,
         itemId: undefined,
         answers: {
-          implement: { answers: ['是，实施此计划'] },
+          implement: { answers: ['是的，执行此计划'] },
         },
       },
       { appendUserMessage: true, forceDefaultCollaborationMode: true }

--- a/wework/src/components/layout/requestUserInputOverlay.test.ts
+++ b/wework/src/components/layout/requestUserInputOverlay.test.ts
@@ -170,8 +170,8 @@ describe('pendingRequestUserInputPayload', () => {
       questions: [
         {
           id: 'implement',
-          question: '实施此计划?',
-          options: [{ label: '是，实施此计划' }],
+          question: '执行此计划?',
+          options: [{ label: '是的，执行此计划' }],
         },
         {
           id: 'adjustment',
@@ -202,7 +202,7 @@ describe('pendingRequestUserInputPayload', () => {
       {
         id: 'user-after-plan',
         role: 'user',
-        content: '是，实施此计划',
+        content: '是的，执行此计划',
         status: 'done',
         createdAt: '2026-06-30T00:00:02.000Z',
       },

--- a/wework/src/components/layout/requestUserInputOverlay.ts
+++ b/wework/src/components/layout/requestUserInputOverlay.ts
@@ -1,5 +1,9 @@
 import type { RequestUserInputPayload } from '@/components/chat/RequestUserInputCard'
-import { isPendingRequestUserInputBlock } from '@/components/chat/requestUserInputMessages'
+import {
+  CODEX_IMPLEMENT_PLAN_QUESTION,
+  CODEX_IMPLEMENT_PLAN_RESPONSE_LABEL,
+  isPendingRequestUserInputBlock,
+} from '@/components/chat/requestUserInputMessages'
 import type { WorkbenchMessage } from '@/types/workbench'
 
 const CODEX_PLAN_TAG_PATTERN = /<\/?\s*proposed_plan\s*>/gi
@@ -31,8 +35,8 @@ function pendingImplementationPlanPayload(
     questions: [
       {
         id: 'implement',
-        question: '实施此计划?',
-        options: [{ label: '是，实施此计划' }],
+        question: CODEX_IMPLEMENT_PLAN_QUESTION,
+        options: [{ label: CODEX_IMPLEMENT_PLAN_RESPONSE_LABEL }],
       },
       {
         id: 'adjustment',

--- a/wework/src/components/layout/useDesktopSidebarCollapsed.ts
+++ b/wework/src/components/layout/useDesktopSidebarCollapsed.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'wework.desktop.sidebar.collapsed'
 const SIDEBAR_COLLAPSED_EVENT = 'wework:desktop-sidebar-collapsed-change'
+const SIDEBAR_TOGGLE_REQUEST_EVENT = 'wework:desktop-sidebar-toggle-request'
 
 function readStoredSidebarCollapsed(): boolean {
   if (typeof window === 'undefined') return false
@@ -50,4 +51,24 @@ export function useDesktopSidebarCollapsed() {
     sidebarCollapsed,
     setSidebarCollapsed,
   }
+}
+
+export function requestDesktopSidebarToggle(): boolean {
+  if (typeof window === 'undefined') return false
+
+  const event = new Event(SIDEBAR_TOGGLE_REQUEST_EVENT, { cancelable: true })
+  window.dispatchEvent(event)
+  return event.defaultPrevented
+}
+
+export function useDesktopSidebarToggleRequest(onToggleSidebar: () => void) {
+  useEffect(() => {
+    const handleToggleRequest = (event: Event) => {
+      event.preventDefault()
+      onToggleSidebar()
+    }
+
+    window.addEventListener(SIDEBAR_TOGGLE_REQUEST_EVENT, handleToggleRequest)
+    return () => window.removeEventListener(SIDEBAR_TOGGLE_REQUEST_EVENT, handleToggleRequest)
+  }, [onToggleSidebar])
 }

--- a/wework/src/components/topnav/ChromeTitlebar.test.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.test.tsx
@@ -117,7 +117,11 @@ describe('ChromeTitlebar', () => {
     const spacer = screen.getByTestId('macos-traffic-light-spacer')
     const beforeTabs = screen.getByTestId('chrome-titlebar-before-tabs')
     const activeTab = screen.getByTestId('chrome-tab-wework')
+    const toggleButton = screen.getByRole('button', { name: 'Toggle sidebar' })
     expect(beforeTabs).toHaveTextContent('Toggle sidebar')
+    expect(screen.getByTestId('chrome-titlebar')).not.toHaveAttribute('data-tauri-drag-region')
+    expect(toggleButton.closest('[data-tauri-drag-region]')).toBeNull()
+    expect(activeTab.closest('[data-tauri-drag-region]')).toBeNull()
     expect(
       spacer.compareDocumentPosition(beforeTabs) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
@@ -149,8 +153,10 @@ describe('ChromeTitlebar', () => {
     mockUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
     enableTauri()
     render(<ChromeTitlebar tabs={mockTabs} activeKey="wework" onNavigate={vi.fn()} />)
-    const dragRegion = document.querySelector('[data-tauri-drag-region]')
+    const dragRegion = screen.getByTestId('chrome-titlebar').lastElementChild
     expect(dragRegion).toBeInTheDocument()
+    expect(dragRegion).toHaveAttribute('data-tauri-drag-region')
+    expect(dragRegion).toHaveClass('w-[138px]')
     // Windows spacer is last child (right side)
     expect(dragRegion?.parentElement?.lastChild).toBe(dragRegion)
     disableTauri()

--- a/wework/src/components/topnav/ChromeTitlebar.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.tsx
@@ -40,7 +40,6 @@ export function ChromeTitlebar({
   return (
     <div
       data-testid="chrome-titlebar"
-      {...(isTauri ? { 'data-tauri-drag-region': '' } : {})}
       className={cn(
         'z-titlebar flex h-[38px] shrink-0 items-center bg-surface pr-2 select-none',
         className

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -992,7 +992,7 @@ function FollowUpProbe() {
           void paneSession.sendRequestUserInputResponse(
             {
               answers: {
-                implement: { answers: ['是，实施此计划'] },
+                implement: { answers: ['是的，执行此计划'] },
               },
             },
             { appendUserMessage: true, forceDefaultCollaborationMode: true }
@@ -3695,7 +3695,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('follow-up-collaboration-mode')).toHaveTextContent('default')
     expect(sendRuntimeMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: '是，实施此计划',
+        message: '是的，执行此计划',
         modelOptions: { collaborationMode: 'default' },
       })
     )

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest'
-import { createRuntimeTaskStreamHandlers } from './runtimePaneMessages'
+import {
+  createRuntimeTaskStreamHandlers,
+  runtimeMessagesToWorkbenchMessages,
+} from './runtimePaneMessages'
 import type { RuntimePaneMessageAction } from './runtimePaneMessages'
 import type { RuntimeTaskAddress } from '@/types/api'
 
@@ -85,5 +88,86 @@ describe('createRuntimeTaskStreamHandlers', () => {
         renderPayload,
       },
     })
+  })
+
+  test('strips Codex UI directives from completed assistant content', () => {
+    const address: RuntimeTaskAddress = {
+      deviceId: 'device-1',
+      localTaskId: 'local-task-1',
+    }
+    const actions: RuntimePaneMessageAction[] = []
+    const handlers = createRuntimeTaskStreamHandlers(address, {
+      onMessageAction: action => actions.push(action),
+    })
+
+    handlers.onChatDone?.({
+      subtask_id: 9,
+      local_task_id: 'local-task-1',
+      device_id: 'device-1',
+      offset: 0,
+      result: {
+        value: [
+          '当前分支比 origin/main ahead 1，可以直接 push。',
+          '',
+          '::git-stage{cwd="/workspace/project"} ::git-commit{cwd="/workspace/project"}',
+        ].join('\n'),
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      type: 'assistant_done',
+      content: '当前分支比 origin/main ahead 1，可以直接 push。',
+    })
+  })
+})
+
+describe('runtimeMessagesToWorkbenchMessages', () => {
+  test('strips Codex UI directives from restored assistant transcript content', () => {
+    const messages = runtimeMessagesToWorkbenchMessages([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: [
+          '完成了。',
+          '',
+          '```text',
+          '::git-stage{cwd="/workspace/project"}',
+          '```',
+          '',
+          '::git-commit{cwd="/workspace/project"}',
+        ].join('\n'),
+      },
+    ])
+
+    expect(messages[0].content).toBe(
+      ['完成了。', '', '```text', '::git-stage{cwd="/workspace/project"}', '```'].join('\n')
+    )
+  })
+
+  test('keeps user-authored Codex directive text unchanged', () => {
+    const messages = runtimeMessagesToWorkbenchMessages([
+      {
+        id: 'user-1',
+        role: 'user',
+        content: '解释一下 ::git-stage{cwd="/workspace/project"} 是什么',
+      },
+    ])
+
+    expect(messages[0].content).toBe('解释一下 ::git-stage{cwd="/workspace/project"} 是什么')
+  })
+
+  test('keeps assistant prose that mentions a Codex directive inline', () => {
+    const messages = runtimeMessagesToWorkbenchMessages([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '这类 ::git-stage{cwd="/workspace/project"} 指令会刷新 Git UI。',
+      },
+    ])
+
+    expect(messages[0].content).toBe(
+      '这类 ::git-stage{cwd="/workspace/project"} 指令会刷新 Git UI。'
+    )
   })
 })

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -14,6 +14,7 @@ import type {
   TurnFileChangesSummary,
 } from '@/types/api'
 import type { MessageSource, ProcessingBlock, WorkbenchMessage } from '@/types/workbench'
+import { stripCodexUiDirectives } from '@/lib/codex-directives'
 import { normalizeTurnFileChanges } from './turnFileChanges'
 import { normalizeWorkbenchBlockStatus, type WorkbenchMessageAction } from '@wegent/chat-core'
 
@@ -77,7 +78,10 @@ export function createRuntimeTaskStreamHandlers(
         type: 'assistant_done',
         messageId,
         turnId: payload.subtask_id,
-        content: typeof payload.result.value === 'string' ? payload.result.value : undefined,
+        content:
+          typeof payload.result.value === 'string'
+            ? stripCodexUiDirectives(payload.result.value)
+            : undefined,
         blocks: getResultBlocks(payload.subtask_id, payload.result),
         fileChanges: normalizeTurnFileChanges(payload.result.file_changes),
       })
@@ -279,7 +283,7 @@ function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): Wo
     id: message.id,
     role,
     turnId,
-    content: message.content,
+    content: role === 'assistant' ? stripCodexUiDirectives(message.content) : message.content,
     runtimeMessageIndex,
     status,
     runtimeStatus,

--- a/wework/src/lib/codex-directives.test.ts
+++ b/wework/src/lib/codex-directives.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest'
+import { stripCodexUiDirectives } from './codex-directives'
+
+describe('stripCodexUiDirectives', () => {
+  test('strips Codex UI directive lines outside code fences', () => {
+    expect(
+      stripCodexUiDirectives(
+        [
+          '当前分支已经准备好。',
+          '::git-stage{cwd="/workspace/project"} ::git-commit{cwd="/workspace/project"}',
+          '可以继续提交。',
+        ].join('\n')
+      )
+    ).toBe('当前分支已经准备好。\n\n可以继续提交。')
+  })
+
+  test('preserves directive-like text inside code fences', () => {
+    const content = [
+      '```text',
+      '::git-stage{cwd="/workspace/project"}',
+      '::git-commit{cwd="/workspace/project"}',
+      '```',
+    ].join('\n')
+
+    expect(stripCodexUiDirectives(content)).toBe(content)
+  })
+
+  test('keeps mixed directive and non-directive content readable', () => {
+    expect(
+      stripCodexUiDirectives(
+        [
+          '已完成 rebase。',
+          '::git-push{cwd="/workspace/project" branch="codex/example"}',
+          'PR 已更新。',
+          '普通的 ::git-push 文本不会被处理。',
+        ].join('\n')
+      )
+    ).toBe(['已完成 rebase。', '', 'PR 已更新。', '普通的 ::git-push 文本不会被处理。'].join('\n'))
+  })
+
+  test('collapses blank lines introduced by multiple stripped directives', () => {
+    expect(
+      stripCodexUiDirectives(
+        [
+          '第一段',
+          '',
+          '::git-stage{cwd="/workspace/project"}',
+          '',
+          '::git-commit{cwd="/workspace/project"}',
+          '',
+          '第二段',
+        ].join('\n')
+      )
+    ).toBe('第一段\n\n第二段')
+  })
+})

--- a/wework/src/lib/codex-directives.ts
+++ b/wework/src/lib/codex-directives.ts
@@ -1,0 +1,52 @@
+const CODEX_UI_DIRECTIVE_NAMES = [
+  'archive-thread',
+  'automation-citation',
+  'code-comment',
+  'created-thread',
+  'github-details',
+  'git-commit',
+  'git-create-branch',
+  'git-create-pr',
+  'git-push',
+  'git-stage',
+  'inbox-item',
+  'pr-auto-fix-progress',
+]
+
+const CODE_FENCE_PATTERN = /^\s*(```|~~~)/
+const CODEX_UI_DIRECTIVE_LINE_PATTERN = new RegExp(
+  `^\\s*::(?::)?(?:${CODEX_UI_DIRECTIVE_NAMES.join('|')})(?:\\b|\\{).*`
+)
+
+export function stripCodexUiDirectives(content: string): string {
+  let inCodeFence = false
+  let changed = false
+  const lines: string[] = []
+
+  for (const line of content.split('\n')) {
+    if (CODE_FENCE_PATTERN.test(line)) {
+      inCodeFence = !inCodeFence
+      lines.push(line)
+      continue
+    }
+
+    if (inCodeFence) {
+      lines.push(line)
+      continue
+    }
+
+    if (CODEX_UI_DIRECTIVE_LINE_PATTERN.test(line)) {
+      changed = true
+      lines.push('')
+      continue
+    }
+    lines.push(line)
+  }
+
+  if (!changed) return content
+
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}


### PR DESCRIPTION
## Summary

- Align Wework Codex transcript rendering with Codex App for tool activity rows, file change cards, plan cards, request-user-input confirmations, and hidden Codex UI directives.
- Tighten Codex-like popovers/selectors and desktop chat layout details, including sidebar/titlebar behavior and floating composer clearance.
- Add focused tests for transcript normalization, plan confirmation display, tool summaries, file changes, and layout interactions.

## Conflict Resolution

- Rebased the branch onto latest `origin/main` (`afab8869c`).
- Resolved conflicts in `wework/src/components/chat/requestUserInputMessages.ts` by keeping the main-branch `RequestUserInputBlock` type guard structure while retaining the new Codex plan-confirmation labels and compatibility checks.
- Resolved conflicts in `wework/src/components/layout/DesktopWorkbenchMain.tsx` by keeping the main-branch split floating-composer clearance constants and reapplying the Wework UI parity changes.

## Validation

- `pnpm --dir wework exec prettier --check <touched files>`
- `pnpm --dir wework exec eslint <touched files>`
- `pnpm --dir wework exec tsc -b`
- `pnpm --dir wework test -- --runInBand` (109 files, 1054 tests)
- `git push` pre-push hook passed with `AI_VERIFIED=1` after verifying this UI-only Wework change does not require docs updates. The hook also passed frontend, Wework, backend syntax/format, knowledge syntax, executor cargo test/clippy, executor-manager syntax, and Alembic multi-head checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop sidebar toggle interactions are more consistent, including reliable external toggle requests.
  * Tool activity summaries now better support multi-file changes, code-search/read summaries, and clearer labels.
  * Assistant plan cards and implementation-plan prompts now use updated wording and more accessible interactions.

* **Bug Fixes**
  * Improved collapsed model submenu behavior and hover/mouse-exit handling.
  * File diff previews now use larger/tuned sizing and show full paths.
  * Codex UI directive markup is stripped from displayed assistant content.

* **Tests**
  * Updated and added coverage for submenu, plan interactions, diffs, tool rows, and directive sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->