### PR TITLE
fix(wework): show codex context compaction

### DIFF
--- a/executor/src/runtime_work/codex_notifications.rs
+++ b/executor/src/runtime_work/codex_notifications.rs
@@ -5,8 +5,9 @@
 use serde_json::Value;
 
 use super::util::{
-    codex_wrapped_item_payload, is_codex_tool_item_type, is_codex_tool_output_item_type,
-    is_likely_codex_tool_item_type, is_likely_codex_tool_output_item_type, item_type,
+    codex_wrapped_item_payload, is_codex_context_compaction_item_type, is_codex_tool_item_type,
+    is_codex_tool_output_item_type, is_likely_codex_tool_item_type,
+    is_likely_codex_tool_output_item_type, item_type,
 };
 
 pub(crate) struct CodexNotification<'a> {
@@ -79,6 +80,11 @@ fn wrapped_item_method(wrapper_type: &str, payload_type: &str) -> Option<&'stati
         }
         ("eventmsg", "subagentactivity") | ("responseitem", "subagentactivity") => {
             Some("subagent/activity")
+        }
+        ("eventmsg" | "responseitem", payload_type)
+            if is_codex_context_compaction_item_type(payload_type) =>
+        {
+            Some("context/compaction")
         }
         ("eventmsg", "collabagenttoolcall") | ("responseitem", "collabagenttoolcall") => {
             Some("collab-agent/activity")
@@ -219,6 +225,20 @@ mod tests {
         });
         let notification = codex_notification(&message);
         assert_eq!(notification.method, "item/completed");
+    }
+
+    #[test]
+    fn maps_codex_context_compacted_event_to_stream_method() {
+        let message = json!({
+            "type": "event_msg",
+            "payload": {
+                "id": "ctx-1",
+                "type": "context_compacted"
+            }
+        });
+        let notification = codex_notification(&message);
+        assert_eq!(notification.method, "context/compaction");
+        assert_eq!(notification.params["type"], "context_compacted");
     }
 
     #[test]

--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -19,8 +19,8 @@ use super::{
     codex_notifications::{codex_notification, debug_ignored_codex_notification},
     transcript::{tool_block_from_notification, tool_update_from_notification},
     util::{
-        completed_plan_item_text, extract_text, now_ms, raw_string_field, reasoning_content,
-        string_field,
+        completed_plan_item_text, extract_text, item_id, now_ms, raw_string_field,
+        reasoning_content, string_field,
     },
 };
 
@@ -209,6 +209,15 @@ impl CodexNotificationEventMapper {
             }
             "subagent/activity" => {
                 emit_subagent_activity(
+                    event_tx,
+                    device_id,
+                    local_task_id,
+                    request,
+                    notification.params,
+                );
+            }
+            "context/compaction" => {
+                emit_context_compaction_event(
                     event_tx,
                     device_id,
                     local_task_id,
@@ -511,6 +520,35 @@ fn emit_reasoning_delta(
         request,
         json!({"delta": delta}),
     );
+}
+
+fn emit_context_compaction_event(
+    event_tx: &Option<broadcast::Sender<Value>>,
+    device_id: &str,
+    local_task_id: &str,
+    request: &ExecutionRequest,
+    params: &Value,
+) {
+    emit_response_event(
+        event_tx,
+        device_id,
+        "response.block.created",
+        local_task_id,
+        request,
+        json!({"block": context_compaction_block(params)}),
+    );
+}
+
+fn context_compaction_block(params: &Value) -> Value {
+    let block_id = item_id(params, "context_compaction");
+    json!({
+        "id": block_id,
+        "type": "tool",
+        "tool_use_id": block_id,
+        "tool_name": "context_compaction",
+        "status": "done",
+        "timestamp": now_ms(),
+    })
 }
 
 fn emit_tool_start(
@@ -1027,6 +1065,40 @@ mod tests {
             event["payload"]["data"]["block"]["content"],
             "I will inspect."
         );
+    }
+
+    #[test]
+    fn maps_codex_context_compacted_event_to_completed_tool_block() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: 7,
+            subtask_id: 8,
+            ..ExecutionRequest::default()
+        };
+
+        map_codex_notification(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "type": "event_msg",
+                "payload": {
+                    "id": "ctx-1",
+                    "type": "context_compacted"
+                }
+            }),
+        );
+
+        let event = event_rx.try_recv().expect("event should be emitted");
+        assert_eq!(event["event"], "response.block.created");
+        assert_eq!(event["payload"]["data"]["block"]["id"], "ctx-1");
+        assert_eq!(event["payload"]["data"]["block"]["type"], "tool");
+        assert_eq!(
+            event["payload"]["data"]["block"]["tool_name"],
+            "context_compaction"
+        );
+        assert_eq!(event["payload"]["data"]["block"]["status"], "done");
     }
 
     #[test]

--- a/executor/src/runtime_work/runtime_handle_messages.rs
+++ b/executor/src/runtime_work/runtime_handle_messages.rs
@@ -20,7 +20,7 @@ use super::{
     store::RuntimeWorkStore,
     transcript::{tool_block_from_notification, tool_update_from_notification},
     util::{
-        completed_plan_item_text, extract_text, integer_field, now_ms, raw_string_field,
+        completed_plan_item_text, extract_text, integer_field, item_id, now_ms, raw_string_field,
         reasoning_content, string_field,
     },
 };
@@ -178,6 +178,9 @@ impl CodexNotificationCacheMapper {
             "thread/started" => {
                 self.observe_root_thread(params);
                 cache_runtime_thread_id(store, local_task_id, params);
+            }
+            "context/compaction" => {
+                cache_runtime_context_compaction(store, local_task_id, request, params)
             }
             "turn/completed" if is_root_codex_turn_event(params) => {
                 complete_runtime_assistant_message(store, local_task_id, request)
@@ -554,6 +557,32 @@ fn mutate_existing_cached_assistant_message(
         link.updated_at = now_ms();
         set_runtime_handle_messages(&mut link.runtime_handle, messages);
     });
+}
+
+fn cache_runtime_context_compaction(
+    store: &RuntimeWorkStore,
+    local_task_id: &str,
+    request: &ExecutionRequest,
+    params: &Value,
+) {
+    cache_runtime_assistant_block(
+        store,
+        local_task_id,
+        request,
+        context_compaction_block(params),
+    );
+}
+
+fn context_compaction_block(params: &Value) -> Value {
+    let block_id = item_id(params, "context_compaction");
+    json!({
+        "id": block_id,
+        "type": "tool",
+        "tool_use_id": block_id,
+        "tool_name": "context_compaction",
+        "status": "done",
+        "timestamp": now_ms(),
+    })
 }
 
 fn merge_cached_message_fields(mut codex_message: Value, cached_message: &Value) -> Value {
@@ -1025,6 +1054,49 @@ mod tests {
         assert_eq!(messages[0]["blocks"][2]["tool_name"], "exec_command");
         assert_eq!(messages[0]["blocks"][2]["tool_output"], "runtime.rs");
         assert_eq!(messages[0]["blocks"][2]["status"], "done");
+
+        let _ = fs::remove_file(index_path);
+    }
+
+    #[test]
+    fn cache_codex_notification_preserves_context_compaction_as_tool_block() {
+        let index_path = temp_index_path("context-compaction-cache");
+        let store = RuntimeWorkStore::new(index_path.clone());
+        let local_task_id = "runtime-cache";
+        store.upsert_task(RuntimeTaskLink::new_pending(
+            local_task_id.to_owned(),
+            "/tmp/project".to_owned(),
+            "Runtime cache".to_owned(),
+        ));
+        let request = ExecutionRequest {
+            task_id: 1,
+            subtask_id: 42,
+            ..ExecutionRequest::default()
+        };
+
+        cache_codex_notification(
+            &store,
+            local_task_id,
+            &request,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "id": "ctx-1",
+                    "type": "context_compacted"
+                }
+            }),
+        );
+
+        let link = store
+            .get_task(local_task_id)
+            .expect("runtime task should exist");
+        let messages = cached_messages(&link);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["blocks"][0]["id"], "ctx-1");
+        assert_eq!(messages[0]["blocks"][0]["type"], "tool");
+        assert_eq!(messages[0]["blocks"][0]["tool_name"], "context_compaction");
+        assert_eq!(messages[0]["blocks"][0]["status"], "done");
 
         let _ = fs::remove_file(index_path);
     }

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -7,10 +7,11 @@ use std::{collections::HashSet, path::Path};
 use serde_json::{json, Map, Value};
 
 use super::util::{
-    bool_field, codex_wrapped_item_payload, extract_text, integer_field, is_codex_tool_item_type,
-    is_codex_tool_output_item_type, is_likely_codex_tool_item_type,
-    is_likely_codex_tool_output_item_type, item_id, item_type, normalize_workspace_path, now_ms,
-    raw_string_field, reasoning_content, string_field, timestamp_ms_field,
+    bool_field, codex_wrapped_item_payload, extract_text, integer_field,
+    is_codex_context_compaction_item_type, is_codex_tool_item_type, is_codex_tool_output_item_type,
+    is_likely_codex_tool_item_type, is_likely_codex_tool_output_item_type, item_id, item_type,
+    normalize_workspace_path, now_ms, raw_string_field, reasoning_content, string_field,
+    timestamp_ms_field,
 };
 
 pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value> {
@@ -133,12 +134,10 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                             merge_file_changes(assistant.file_changes.take(), summary);
                     }
                 }
-                "contextcompaction" => {
-                    assistant.context_events.push(context_event(
+                item_type if is_codex_context_compaction_item_type(item_type) => {
+                    assistant.blocks.push(context_compaction_block(
                         &item,
-                        created_at,
-                        "context_compaction",
-                        "done",
+                        item_timestamp(&item).unwrap_or(created_at),
                     ));
                 }
                 "agentmessage" => {
@@ -485,10 +484,8 @@ fn is_substantive_process_item_type(item_type: &str) -> bool {
     is_codex_tool_item_type(item_type)
         || is_codex_tool_output_item_type(item_type)
         || is_likely_codex_tool_item_type(item_type)
-        || matches!(
-            item_type,
-            "reasoning" | "filechange" | "patchapplyend" | "contextcompaction"
-        )
+        || matches!(item_type, "reasoning" | "filechange" | "patchapplyend")
+        || is_codex_context_compaction_item_type(item_type)
 }
 
 fn is_default_tool_item(item: &Value) -> bool {
@@ -502,10 +499,10 @@ fn is_default_tool_item(item: &Value) -> bool {
             | "reasoning"
             | "filechange"
             | "patchapplyend"
-            | "contextcompaction"
-    ) && (is_likely_codex_tool_item_type(&item_type)
-        || string_field(item, "call_id").is_some()
-        || string_field(item, "callId").is_some())
+    ) && !is_codex_context_compaction_item_type(&item_type)
+        && (is_likely_codex_tool_item_type(&item_type)
+            || string_field(item, "call_id").is_some()
+            || string_field(item, "callId").is_some())
 }
 
 fn is_default_tool_output_item(item: &Value) -> bool {
@@ -601,7 +598,6 @@ fn apply_turn_completed_at(blocks: &mut [Value], completed_at: Option<i64>) {
 struct AssistantTurnAccumulation {
     blocks: Vec<Value>,
     file_changes: Option<Value>,
-    context_events: Vec<Value>,
     assistant_parts: Vec<String>,
     memory_citations: Vec<Value>,
 }
@@ -611,7 +607,6 @@ impl AssistantTurnAccumulation {
         Self {
             blocks: Vec::new(),
             file_changes,
-            context_events: Vec::new(),
             assistant_parts: Vec::new(),
             memory_citations: Vec::new(),
         }
@@ -619,7 +614,6 @@ impl AssistantTurnAccumulation {
 
     fn has_non_file_output(&self) -> bool {
         !self.blocks.is_empty()
-            || !self.context_events.is_empty()
             || !self.assistant_parts.is_empty()
             || !self.memory_citations.is_empty()
     }
@@ -631,7 +625,6 @@ impl AssistantTurnAccumulation {
     fn clear_after_emit(&mut self) {
         self.blocks.clear();
         self.file_changes = None;
-        self.context_events.clear();
         self.assistant_parts.clear();
         self.memory_citations.clear();
     }
@@ -678,7 +671,6 @@ fn push_accumulated_assistant(
         stopped_notice,
         blocks: &assistant.blocks,
         file_changes: assistant.file_changes.clone(),
-        context_events: &assistant.context_events,
         assistant_parts: &assistant.assistant_parts,
         memory_citations: &assistant.memory_citations,
     }));
@@ -986,7 +978,6 @@ struct AssistantMessageDraft<'a> {
     stopped_notice: bool,
     blocks: &'a [Value],
     file_changes: Option<Value>,
-    context_events: &'a [Value],
     assistant_parts: &'a [String],
     memory_citations: &'a [Value],
 }
@@ -1021,14 +1012,6 @@ fn synthetic_assistant_message(draft: AssistantMessageDraft<'_>) -> Value {
             if let Some(object) = message.as_object_mut() {
                 object.insert("fileChanges".to_owned(), file_changes);
             }
-        }
-    }
-    if !draft.context_events.is_empty() {
-        if let Some(object) = message.as_object_mut() {
-            object.insert(
-                "contextEvents".to_owned(),
-                Value::Array(draft.context_events.to_vec()),
-            );
         }
     }
     if !draft.memory_citations.is_empty() {
@@ -1837,12 +1820,15 @@ fn diff_git_path(prefix: &str, path: &str) -> String {
     }
 }
 
-fn context_event(item: &Value, timestamp: i64, event_type: &str, status: &str) -> Value {
+fn context_compaction_block(item: &Value, timestamp: i64) -> Value {
+    let block_id = item_id(item, "context_compaction");
     json!({
-        "id": item_id(item, event_type),
-        "type": event_type,
-        "status": status,
-        "createdAt": timestamp,
+        "id": block_id,
+        "type": "tool",
+        "tool_use_id": block_id,
+        "tool_name": "context_compaction",
+        "status": "done",
+        "timestamp": timestamp,
     })
 }
 

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -386,6 +386,10 @@ pub(crate) fn is_likely_codex_tool_output_item_type(item_type: &str) -> bool {
                 || item_type.contains("complete")))
 }
 
+pub(crate) fn is_codex_context_compaction_item_type(item_type: &str) -> bool {
+    matches!(item_type, "contextcompaction" | "contextcompacted")
+}
+
 pub(crate) fn item_id(item: &Value, prefix: &str) -> String {
     string_field(item, "id").unwrap_or_else(|| format!("{prefix}-{}", now_ms()))
 }

--- a/executor/tests/app_runtime_work_file_changes_contract.rs
+++ b/executor/tests/app_runtime_work_file_changes_contract.rs
@@ -170,7 +170,7 @@ async fn runtime_transcript_normalizes_codex_rich_turn_items() {
     assert_eq!(assistant["role"], "assistant");
     assert_eq!(assistant["content"], "Done");
     assert!(assistant["subtaskId"].as_i64().unwrap() < 0);
-    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 4);
+    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 5);
     assert_eq!(assistant["blocks"][0]["type"], "thinking");
     assert_eq!(assistant["blocks"][1]["type"], "text");
     assert_eq!(assistant["blocks"][1]["content"], "I checked the files.");
@@ -181,7 +181,7 @@ async fn runtime_transcript_normalizes_codex_rich_turn_items() {
         assistant["blocks"][3]["file_changes"]["files"][0]["path"],
         "src/lib.rs"
     );
-    assert_eq!(assistant["blocks"][3]["timestamp"], 1780000007000_i64);
+    assert_eq!(assistant["blocks"][3]["timestamp"], 1780000000000_i64);
     assert_eq!(assistant["fileChanges"]["device_id"], "device-1");
     assert_eq!(assistant["fileChanges"]["workspace_path"], "/tmp/project");
     assert_eq!(assistant["fileChanges"]["file_count"], 1);
@@ -197,7 +197,10 @@ async fn runtime_transcript_normalizes_codex_rich_turn_items() {
         assistant["memoryCitations"][0]["entries"][0]["path"],
         "MEMORY.md"
     );
-    assert_eq!(assistant["contextEvents"][0]["type"], "context_compaction");
+    assert_eq!(assistant["blocks"][4]["type"], "tool");
+    assert_eq!(assistant["blocks"][4]["tool_name"], "context_compaction");
+    assert_eq!(assistant["blocks"][4]["status"], "done");
+    assert_eq!(assistant["blocks"][4]["timestamp"], 1780000007000_i64);
 }
 
 #[tokio::test]
@@ -839,7 +842,7 @@ while IFS= read -r line; do
     *'"method":"initialized"'*)
       ;;
     *'"method":"thread/read"'*)
-      printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"Rich transcript","preview":"rich","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-rich","startedAt":1780000000,"durationMs":7000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"inspect"}}]}},{{"id":"reason-1","type":"reasoning","summary":["thinking"]}},{{"id":"agent-progress","type":"agentMessage","text":"I checked the files.","phase":"analysis"}},{{"type":"function_call","name":"exec_command","arguments":"{{\"cmd\":\"rg -n test\"}}","call_id":"call-1"}},{{"type":"function_call_output","call_id":"call-1","output":"ok"}},{{"id":"patch-1","type":"patch_apply_end","success":true,"changes":{{"/tmp/project/src/lib.rs":{{"type":"update","unified_diff":"@@ -1 +1 @@\n-old\n+new\n","move_path":null}}}}}},{{"id":"ctx-1","type":"contextCompaction"}},{{"id":"agent-1","type":"agentMessage","text":"Done","phase":"final_answer","memoryCitation":{{"entries":[{{"path":"MEMORY.md","lineStart":1,"lineEnd":2,"note":"note"}}],"threadIds":["thread-a"]}}}}]}}]}}}}}}'
+      printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"Rich transcript","preview":"rich","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-rich","startedAt":1780000000,"durationMs":7000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"inspect"}}]}},{{"id":"reason-1","type":"reasoning","summary":["thinking"]}},{{"id":"agent-progress","type":"agentMessage","text":"I checked the files.","phase":"analysis"}},{{"type":"function_call","name":"exec_command","arguments":"{{\"cmd\":\"rg -n test\"}}","call_id":"call-1"}},{{"type":"function_call_output","call_id":"call-1","output":"ok"}},{{"id":"patch-1","type":"patch_apply_end","success":true,"changes":{{"/tmp/project/src/lib.rs":{{"type":"update","unified_diff":"@@ -1 +1 @@\n-old\n+new\n","move_path":null}}}}}},{{"type":"event_msg","payload":{{"id":"ctx-1","type":"context_compacted"}}}},{{"id":"agent-1","type":"agentMessage","text":"Done","phase":"final_answer","memoryCitation":{{"entries":[{{"path":"MEMORY.md","lineStart":1,"lineEnd":2,"note":"note"}}],"threadIds":["thread-a"]}}}}]}}]}}}}}}'
       exit 0
       ;;
   esac

--- a/wework/src/components/chat/CodexTurnArtifacts.tsx
+++ b/wework/src/components/chat/CodexTurnArtifacts.tsx
@@ -1,41 +1,10 @@
 import { useState } from 'react'
-import { Archive, Box, ChevronDown, ChevronUp, FileText } from 'lucide-react'
+import { Box, ChevronDown, ChevronUp, FileText } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
-import type {
-  CodexContextEvent,
-  CodexMemoryCitation,
-  CodexMemoryCitationEntry,
-  CodexReference,
-} from '@/types/api'
+import type { CodexMemoryCitation, CodexMemoryCitationEntry, CodexReference } from '@/types/api'
 import { basename, fileExtension, getDisplayCodexReferences } from './codexReferences'
 
 const DEFAULT_VISIBLE_REFERENCE_COUNT = 3
-
-export function CodexContextEvents({ events }: { events: CodexContextEvent[] }) {
-  const { t } = useTranslation('chat')
-  const visibleEvents = events.filter(event => isContextCompactionEvent(event))
-  if (visibleEvents.length === 0) return null
-
-  return (
-    <div className="my-4 flex min-w-0 flex-col gap-2" data-testid="codex-context-events">
-      {visibleEvents.map(event => {
-        const isRunning = event.status === 'pending' || event.status === 'streaming'
-        return (
-          <div key={event.id} className="flex min-w-0 items-center gap-3 text-xs text-text-muted">
-            <span className="h-px min-w-6 flex-1 bg-border" />
-            <span className="inline-flex min-w-0 items-center gap-1.5">
-              <Archive className="h-3.5 w-3.5 shrink-0" strokeWidth={1.8} />
-              <span className="truncate">
-                {isRunning ? t('codex_context.compacting') : t('codex_context.compacted')}
-              </span>
-            </span>
-            <span className="h-px min-w-6 flex-1 bg-border" />
-          </div>
-        )
-      })}
-    </div>
-  )
-}
 
 export function CodexMemoryCitations({
   citations,
@@ -182,11 +151,6 @@ function formatReferenceKind(
   const extension = fileExtension(path)
   if (!extension) return t('codex_references.kind')
   return t('codex_references.kind_with_extension', { extension: extension.toUpperCase() })
-}
-
-function isContextCompactionEvent(event: CodexContextEvent): boolean {
-  const type = event.type.toLowerCase().replace(/[_-]/g, '')
-  return type === 'contextcompaction'
 }
 
 function MemoryCitationEntryRow({

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1035,7 +1035,7 @@ describe('MessageList', () => {
     expect(onLoadFileChangesDiff).toHaveBeenCalledWith(42)
   })
 
-  test('renders Codex context events, memory citations, and one-column deduped file references', async () => {
+  test('renders Codex memory citations and one-column deduped file references', async () => {
     const onOpenWorkspaceFile = vi.fn()
     render(
       <MessageList
@@ -1055,14 +1055,6 @@ describe('MessageList', () => {
               { path: '/workspace/project/logs/paas-context.log' },
               { path: '/workspace/project/scripts/notify_pr_ready.sh' },
             ],
-            contextEvents: [
-              {
-                id: 'context-1',
-                type: 'context_compaction',
-                status: 'done',
-                createdAt: Date.parse('2026-06-24T08:00:00.000Z'),
-              },
-            ],
             memoryCitations: [
               {
                 entries: [
@@ -1081,7 +1073,6 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getByTestId('codex-context-events')).toBeInTheDocument()
     expect(screen.queryByText('引用文件')).not.toBeInTheDocument()
     expect(screen.getByTestId('codex-memory-citations')).toBeInTheDocument()
     expect(screen.getByTestId('codex-reference-list')).toBeInTheDocument()

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -37,7 +37,7 @@ import type { RequestUserInputPayload } from './RequestUserInputCard'
 import { isWebSearchToolName } from './blocks/toolBlockActivity'
 import { WebSearchSourcesChip } from './blocks/WebSearchSources'
 import { getWebSearchSourceItems } from './blocks/webSearchActivity'
-import { CodexContextEvents, CodexMemoryCitations, CodexReferenceList } from './CodexTurnArtifacts'
+import { CodexMemoryCitations, CodexReferenceList } from './CodexTurnArtifacts'
 import { getAssistantReferences } from './codexReferences'
 import { FileChangesCard } from './FileChangesCard'
 
@@ -219,11 +219,7 @@ function shouldRenderMessage(message: WorkbenchMessage): boolean {
   if (message.status === 'streaming' || message.status === 'failed') return true
   if (isCancelledAssistantMessage(message)) return true
   if (message.fileChanges) return true
-  if (
-    message.references?.length ||
-    message.memoryCitations?.length ||
-    message.contextEvents?.length
-  ) {
+  if (message.references?.length || message.memoryCitations?.length) {
     return true
   }
 
@@ -1108,7 +1104,6 @@ function AssistantMessage({
   const webSearchSources = isStreaming
     ? []
     : getWebSearchSourceItems(getWebSearchToolBlocks(displayBlocks))
-  const contextEvents = message.contextEvents ?? []
   const memoryCitations = message.memoryCitations ?? []
   const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
 
@@ -1168,7 +1163,6 @@ function AssistantMessage({
             />
           )}
           {shouldShowInitialThinking && <WaitingAssistantIndicator />}
-          {contextEvents.length > 0 && <CodexContextEvents events={contextEvents} />}
           {hasVisibleContent ? (
             isAssistantPlanContent(visibleContent) ? (
               <AssistantPlanCard

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -107,6 +107,15 @@ const completedGuidanceBlock: ProcessingBlock = {
   createdAt: 1770000004000,
 }
 
+const completedContextCompactionBlock: ProcessingBlock = {
+  id: 'ctx-1',
+  subtaskId: 1,
+  type: 'tool',
+  toolName: 'context_compaction',
+  status: 'done',
+  createdAt: 1770000004500,
+}
+
 describe('ToolBlocksDisplay', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -129,6 +138,47 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByTestId('processing-activity-group-label')).toHaveTextContent('已引导对话')
     expect(screen.queryByRole('button', { name: '已引导对话' })).not.toBeInTheDocument()
     expect(screen.queryByTestId('processing-activity-group-content')).not.toBeInTheDocument()
+  })
+
+  test('renders context compaction as an independent divider while preserving tool groups', () => {
+    const completedSearchBlock: ProcessingBlock = {
+      id: 'search-1',
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: "/bin/zsh -lc 'rg -n context .'" },
+      status: 'done',
+      createdAt: 1770000005000,
+    }
+
+    render(
+      <ToolBlocksDisplay
+        blocks={[completedCommandBlock, completedContextCompactionBlock, completedSearchBlock]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByTestId('context-compaction-indicator')).toHaveTextContent('上下文已自动压缩')
+    const activityToggles = screen.getAllByTestId('processing-activity-group-toggle')
+    expect(activityToggles).toHaveLength(2)
+    expect(activityToggles[0]).toHaveTextContent('已运行 1 条命令')
+    expect(activityToggles[1]).toHaveTextContent('已搜索代码')
+  })
+
+  test('renders running context compaction status without the generic thinking placeholder', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[{ ...completedContextCompactionBlock, status: 'streaming' }]}
+        isStreaming={true}
+      />
+    )
+
+    expect(screen.getByTestId('context-compaction-indicator')).toHaveTextContent(
+      '正在自动压缩上下文'
+    )
+    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 
   test('renders completed web search tools as a Codex-style web search activity', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode, TransitionEvent } from 'react'
-import { ChevronDown, MessageCircle, Search, SquareTerminal } from 'lucide-react'
+import { Archive, ChevronDown, MessageCircle, Search, SquareTerminal } from 'lucide-react'
 import type { RequestUserInputResponse } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import {
@@ -17,6 +17,7 @@ import {
 } from '../RequestUserInputCard'
 import {
   buildProcessingDisplayRows,
+  isContextCompactionToolBlock,
   isCommandToolName,
   isGuidanceActivityGroup,
   isWebSearchActivityGroup,
@@ -191,6 +192,8 @@ export function ToolBlocksDisplay({
               stateKey={stateKey ? `${stateKey}:${item.id}` : undefined}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
+          ) : isContextCompactionToolBlock(item.block) ? (
+            <ContextCompactionIndicator key={item.id} block={item.block} />
           ) : (
             <ToolBlockItem
               key={item.id}
@@ -398,6 +401,34 @@ function ToolActivityGroup({
       </CollapsibleProcessingContent>
     </div>
   )
+}
+
+function ContextCompactionIndicator({ block }: { block: ToolBlock }) {
+  const label = getContextCompactionLabel(block)
+  const textClassName = block.status === 'error' ? 'text-red-500' : 'text-text-muted'
+
+  return (
+    <div
+      className="flex w-full min-w-0 items-center gap-3 py-1"
+      data-testid="context-compaction-indicator"
+      aria-label={label}
+    >
+      <span className="h-px min-w-6 flex-1 bg-border" aria-hidden="true" />
+      <span
+        className={`inline-flex min-w-0 max-w-full items-center gap-1.5 text-[13px] font-semibold ${textClassName}`}
+      >
+        <Archive className="h-4 w-4 shrink-0" strokeWidth={1.7} aria-hidden="true" />
+        <span className="min-w-0 truncate">{label}</span>
+      </span>
+      <span className="h-px min-w-6 flex-1 bg-border" aria-hidden="true" />
+    </div>
+  )
+}
+
+function getContextCompactionLabel(block: ToolBlock): string {
+  if (block.status === 'error') return '上下文压缩失败'
+  if (block.status === 'done') return '上下文已自动压缩'
+  return '正在自动压缩上下文'
 }
 
 function WebSearchActivityDetails({ blocks }: { blocks: ToolBlock[] }) {

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -97,7 +97,7 @@ describe('toolBlockActivity', () => {
     ).toBe('已编辑 1 个文件')
   })
 
-  test('groups completed tools while preserving running tools as standalone rows', () => {
+  test('groups completed tools while preserving context compaction and running tools as standalone rows', () => {
     const thinking: ProcessingBlock = {
       id: 'thinking-1',
       turnId: 1,
@@ -116,20 +116,34 @@ describe('toolBlockActivity', () => {
         status: 'done',
         createdAt: 1770000000001,
       },
+      tool('read-before-1', 'cat README.md'),
+      {
+        id: 'ctx-1',
+        turnId: 1,
+        type: 'tool',
+        toolName: 'context_compaction',
+        status: 'done',
+        createdAt: 1770000000002,
+      },
       tool('search-1', 'find . -name package.json'),
       tool('cmd-1', 'python3 analyze.py', 'streaming'),
       tool('read-1', 'cat README.md'),
     ])
 
-    expect(rows).toHaveLength(5)
+    expect(rows).toHaveLength(7)
     expect(rows[0]).toMatchObject({ type: 'block', id: 'thinking-1' })
     expect(rows[1]).toMatchObject({ type: 'block', id: 'text-1' })
     expect(rows[2]).toMatchObject({
       type: 'activity_group',
+      label: '已读取 1 个文件',
+    })
+    expect(rows[3]).toMatchObject({ type: 'block', id: 'ctx-1' })
+    expect(rows[4]).toMatchObject({
+      type: 'activity_group',
       label: '已搜索代码',
     })
-    expect(rows[3]).toMatchObject({ type: 'block', id: 'cmd-1' })
-    expect(rows[4]).toMatchObject({
+    expect(rows[5]).toMatchObject({ type: 'block', id: 'cmd-1' })
+    expect(rows[6]).toMatchObject({
       type: 'activity_group',
       label: '已读取 1 个文件',
     })

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -6,6 +6,7 @@ import {
   isFileEditToolName,
   isFileReadToolName,
   isGuidanceToolName,
+  isContextCompactionToolName,
 } from './toolBlockKinds'
 
 export type ProcessingDisplayRow =
@@ -50,6 +51,12 @@ export function buildProcessingDisplayRows(
   }
 
   for (const block of blocks) {
+    if (block.type === 'tool' && isContextCompactionToolName(block.toolName)) {
+      flushCompletedTools()
+      rows.push({ type: 'block', id: block.id, block })
+      continue
+    }
+
     if (groupCompletedTools && block.type === 'tool' && isCompletedToolBlock(block)) {
       completedTools.push(block)
       continue
@@ -161,6 +168,10 @@ function unwrapShellCommand(command: string): string {
 
 function isCompletedToolBlock(block: ToolBlock): boolean {
   return block.status === 'done' || block.status === 'error'
+}
+
+export function isContextCompactionToolBlock(block: ProcessingBlock): block is ToolBlock {
+  return block.type === 'tool' && isContextCompactionToolName(block.toolName)
 }
 
 export function isWebSearchToolName(name: string): boolean {

--- a/wework/src/components/chat/blocks/toolBlockKinds.ts
+++ b/wework/src/components/chat/blocks/toolBlockKinds.ts
@@ -23,6 +23,7 @@ const EDIT_TOOLS = new Set([
   'functions.apply_patch',
 ])
 const GUIDANCE_TOOLS = new Set(['conversation_guidance', 'user_guidance'])
+const CONTEXT_COMPACTION_TOOLS = new Set(['context_compaction', 'contextcompaction'])
 
 function normalizeToolName(name: string): string {
   return name.trim().toLowerCase()
@@ -60,6 +61,10 @@ export function isFileEditToolName(name: string): boolean {
 
 export function isGuidanceToolName(name: string): boolean {
   return matchesToolName(name, GUIDANCE_TOOLS)
+}
+
+export function isContextCompactionToolName(name: string): boolean {
+  return matchesToolName(name, CONTEXT_COMPACTION_TOOLS)
 }
 
 export function getInputField(block: Pick<ToolBlock, 'toolInput'>, ...keys: string[]) {

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -4,6 +4,42 @@ import type { RuntimePaneMessageAction } from './runtimePaneMessages'
 import type { RuntimeTaskAddress } from '@/types/api'
 
 describe('createRuntimeTaskStreamHandlers', () => {
+  test('passes context compaction through regular block created actions', () => {
+    const address: RuntimeTaskAddress = {
+      deviceId: 'device-1',
+      localTaskId: 'local-task-1',
+    }
+    const actions: RuntimePaneMessageAction[] = []
+    const handlers = createRuntimeTaskStreamHandlers(address, {
+      onMessageAction: action => actions.push(action),
+    })
+
+    handlers.onBlockCreated?.({
+      task_id: 1,
+      subtask_id: 9,
+      local_task_id: 'local-task-1',
+      device_id: 'device-1',
+      block: {
+        id: 'ctx-1',
+        type: 'tool',
+        tool_name: 'context_compaction',
+        status: 'done',
+        timestamp: 1770000000000,
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      type: 'block_created',
+      block: {
+        id: 'ctx-1',
+        type: 'tool',
+        toolName: 'context_compaction',
+        status: 'done',
+      },
+    })
+  })
+
   test('preserves request user input render payload on block created events', () => {
     const address: RuntimeTaskAddress = {
       deviceId: 'device-1',

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -289,7 +289,6 @@ function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): Wo
     fileChanges: normalizeTurnFileChanges(message.fileChanges ?? message.file_changes),
     references: normalizeRuntimeReferences(message.references),
     memoryCitations: normalizeRuntimeMemoryCitations(message),
-    contextEvents: normalizeRuntimeContextEvents(message),
     createdAt,
     completedAt,
     stoppedNotice,
@@ -337,15 +336,6 @@ function normalizeRuntimeMemoryCitations(
   addCitation(message.memory_citation)
 
   return citations.length > 0 ? citations : undefined
-}
-
-function normalizeRuntimeContextEvents(
-  message: NormalizedRuntimeMessage
-): WorkbenchMessage['contextEvents'] {
-  const events = [...(message.contextEvents ?? []), ...(message.context_events ?? [])].filter(
-    event => event && typeof event.id === 'string' && typeof event.type === 'string'
-  )
-  return events.length > 0 ? events : undefined
 }
 
 function isRuntimeStreamingStatus(status: string): boolean {

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -275,8 +275,6 @@ export interface NormalizedRuntimeMessage {
   memory_citations?: CodexMemoryCitation[] | null
   memoryCitation?: CodexMemoryCitation | null
   memory_citation?: CodexMemoryCitation | null
-  contextEvents?: CodexContextEvent[] | null
-  context_events?: CodexContextEvent[] | null
 }
 
 export interface RuntimeTurnNavigationItem {
@@ -310,14 +308,6 @@ export interface CodexMemoryCitation {
   rollout_ids?: string[]
   threadIds?: string[]
   thread_ids?: string[]
-}
-
-export interface CodexContextEvent {
-  id: string
-  type: 'context_compaction' | 'contextCompaction' | string
-  status?: 'pending' | 'streaming' | 'done' | 'error' | string | null
-  createdAt?: number | string | null
-  created_at?: number | string | null
 }
 
 export interface LocalTaskSummary {

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -1,6 +1,5 @@
 import type {
   Attachment,
-  CodexContextEvent,
   CodexMemoryCitation,
   CodexReference,
   DeviceInfo,
@@ -69,7 +68,6 @@ export type WorkbenchMessage = Omit<
   stoppedNotice?: boolean | null
   references?: CodexReference[] | null
   memoryCitations?: CodexMemoryCitation[] | null
-  contextEvents?: CodexContextEvent[] | null
 }
 
 export type QueuedMessageStatus = 'queued' | 'sending' | 'failed'


### PR DESCRIPTION
## Summary
- Map Codex context compaction events to regular completed tool blocks (`context_compaction`) in runtime streaming and transcript normalization.
- Remove the previous `contextEvents` side channel so compaction renders at its actual position in the processing flow.
- Render context compaction as an independent divider row while preserving normal completed-tool aggregation.

## Validation
- `pnpm --dir wework exec vitest run src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/components/chat/blocks/toolBlockActivity.test.ts src/features/workbench/runtimePaneMessages.test.ts`
- Pre-push hook passed: Wework ESLint, TypeScript, unit tests; Executor cargo fmt, cargo test, cargo clippy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated handling and display for context compaction activity in chat and runtime views.
  * Context compaction now appears as a distinct tool block with clearer status indicators during processing and after completion.

* **Bug Fixes**
  * Improved transcript and message rendering so context compaction is preserved consistently across the app.
  * Removed legacy context-event UI paths and updated message handling to better match the current runtime output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->