### PR TITLE
[codex] fix mobile correction model selection

### DIFF
--- a/frontend/src/__tests__/components/model-select/model-cascade-content.test.tsx
+++ b/frontend/src/__tests__/components/model-select/model-cascade-content.test.tsx
@@ -182,4 +182,30 @@ describe('ModelCascadeContent', () => {
       expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
     })
   })
+
+  it('lets mobile users navigate groups before selecting a model', () => {
+    const onSelectModel = jest.fn()
+
+    render(
+      <ModelCascadeContent
+        models={models}
+        labels={labels}
+        searchValue=""
+        onSearchValueChange={jest.fn()}
+        onSelectModel={onSelectModel}
+        variant="mobile"
+      />
+    )
+
+    expect(screen.getByTestId('model-mobile-primary-groups')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('model-mobile-primary-group-Primary-One'))
+    expect(screen.getByTestId('model-mobile-secondary-groups')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('model-mobile-secondary-group-Secondary-One'))
+    expect(screen.getByTestId('model-mobile-models')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('model-mobile-option-model-a'))
+    expect(onSelectModel).toHaveBeenCalledWith(models[0])
+  })
 })

--- a/frontend/src/components/model-select/ModelCascadeSelect.tsx
+++ b/frontend/src/components/model-select/ModelCascadeSelect.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Check, ChevronsUpDown, Search } from 'lucide-react'
+import { Check, ChevronLeft, ChevronRight, ChevronsUpDown, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -51,6 +51,7 @@ interface ModelCascadeContentProps<T extends GroupableModel> {
   renderModelMeta?: (model: T) => React.ReactNode
   footer?: React.ReactNode
   className?: string
+  variant?: 'desktop' | 'mobile'
 }
 
 interface GroupedModelSelectProps<T extends GroupableModel> extends Omit<
@@ -98,6 +99,8 @@ function getGroupCountLabel(count: number): string {
   return String(count)
 }
 
+type MobileCascadeStep = 'primary' | 'secondary' | 'models'
+
 export function ModelCascadeContent<T extends GroupableModel>({
   models,
   selectedModel,
@@ -113,6 +116,7 @@ export function ModelCascadeContent<T extends GroupableModel>({
   renderModelMeta,
   footer,
   className,
+  variant = 'desktop',
 }: ModelCascadeContentProps<T>) {
   const groups = useMemo(
     () =>
@@ -124,6 +128,7 @@ export function ModelCascadeContent<T extends GroupableModel>({
   )
   const [activeGroupName, setActiveGroupName] = useState<string>('')
   const [activeSubGroupName, setActiveSubGroupName] = useState<string>('')
+  const [mobileStep, setMobileStep] = useState<MobileCascadeStep>('primary')
   const selectedModelOptionRef = useRef<HTMLButtonElement | null>(null)
   const selectedModelKey = selectedModel ? getModelKey(selectedModel) : null
 
@@ -148,6 +153,12 @@ export function ModelCascadeContent<T extends GroupableModel>({
     setActiveGroupName(nextGroup.name)
     setActiveSubGroupName(nextSubGroup?.name ?? '')
   }, [activeGroupName, activeSubGroupName, groups, labels, selectedModel])
+
+  useEffect(() => {
+    if (groups.length === 0) {
+      setMobileStep('primary')
+    }
+  }, [groups.length])
 
   const activeGroup = groups.find(group => group.name === activeGroupName) ?? groups[0]
   const activeSubGroup =
@@ -237,10 +248,227 @@ export function ModelCascadeContent<T extends GroupableModel>({
     )
   }
 
+  const renderMobileSpecialOption = (option: SpecialModelOption, withBorder: boolean) => {
+    const isSelected = selectedSpecialKey === option.key
+
+    return (
+      <button
+        key={option.key}
+        type="button"
+        data-testid={`model-mobile-special-option-${sanitizeTestId(option.key)}`}
+        onClick={() => onSelectSpecialOption?.(option.key)}
+        className={cn(
+          'flex min-h-[44px] w-full items-center justify-between gap-3 px-3 py-2.5 text-left',
+          'active:bg-hover focus:bg-hover focus:outline-none',
+          isSelected && 'bg-primary/10 text-primary',
+          withBorder && 'border-b border-border'
+        )}
+      >
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium text-text-primary">
+            {option.label}
+          </span>
+          {option.description && (
+            <span className="block truncate text-xs text-text-muted">{option.description}</span>
+          )}
+        </span>
+        <Check className={cn('h-4 w-4 shrink-0', isSelected ? 'opacity-100' : 'opacity-0')} />
+      </button>
+    )
+  }
+
+  const renderMobileModelOption = (model: T, showPath: boolean, withBorder: boolean) => {
+    const modelKey = getModelKey(model)
+    const isSelected = selectedModelKey === modelKey
+    const groupPath = `${getModelGroupName(model, labels)} / ${getModelSubGroupName(model, labels)}`
+
+    return (
+      <button
+        key={modelKey}
+        type="button"
+        data-model-key={modelKey}
+        data-testid={`model-mobile-option-${sanitizeTestId(model.name)}`}
+        onClick={() => onSelectModel(model)}
+        className={cn(
+          'flex min-h-[44px] w-full items-start justify-between gap-3 px-3 py-2.5 text-left',
+          'active:bg-hover focus:bg-hover focus:outline-none',
+          isSelected && 'bg-primary/10 text-primary',
+          withBorder && 'border-b border-border'
+        )}
+      >
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span
+              className="truncate text-sm font-medium text-text-primary"
+              title={getModelDisplayName(model)}
+            >
+              {getModelDisplayName(model)}
+            </span>
+            {renderModelBadges?.(model)}
+          </span>
+          {showPath && <span className="block truncate text-xs text-text-muted">{groupPath}</span>}
+          {renderModelMeta?.(model)}
+        </span>
+        <Check
+          className={cn('mt-0.5 h-4 w-4 shrink-0', isSelected ? 'opacity-100' : 'opacity-0')}
+        />
+      </button>
+    )
+  }
+
+  const renderMobileBackButton = (label: string, onClick: () => void) => (
+    <button
+      type="button"
+      data-testid="model-mobile-back-button"
+      onClick={onClick}
+      className="mb-2 flex min-h-[44px] items-center gap-1 text-primary active:opacity-70"
+    >
+      <ChevronLeft className="h-5 w-5" />
+      <span className="truncate text-sm font-medium">{label}</span>
+    </button>
+  )
+
+  const renderMobilePrimaryGroups = () => (
+    <div
+      data-testid="model-mobile-primary-groups"
+      className="overflow-hidden rounded-lg border border-border bg-base"
+    >
+      {specialOptions.map((option, index) =>
+        renderMobileSpecialOption(option, index < specialOptions.length - 1 || groups.length > 0)
+      )}
+      {groups.map((group, index) => {
+        const isLast = index === groups.length - 1
+
+        return (
+          <button
+            key={group.name}
+            type="button"
+            data-testid={`model-mobile-primary-group-${sanitizeTestId(group.name)}`}
+            onClick={() => {
+              setActiveGroupName(group.name)
+              setActiveSubGroupName(group.subGroups[0]?.name ?? '')
+              setMobileStep('secondary')
+            }}
+            className={cn(
+              'flex min-h-[44px] w-full items-center justify-between gap-3 px-3 py-2.5 text-left',
+              'active:bg-hover focus:bg-hover focus:outline-none',
+              !isLast && 'border-b border-border'
+            )}
+          >
+            <span className="min-w-0 truncate text-sm font-medium text-text-primary">
+              {group.name}
+            </span>
+            <span className="flex shrink-0 items-center gap-2">
+              <span className="rounded-full bg-surface px-2 py-0.5 text-xs text-text-muted">
+                {getGroupCountLabel(group.count)}
+              </span>
+              <ChevronRight className="h-4 w-4 text-text-muted" />
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+
+  const renderMobileSecondaryGroups = () => (
+    <div>
+      {renderMobileBackButton(labels.primaryGroups, () => setMobileStep('primary'))}
+      <div
+        data-testid="model-mobile-secondary-groups"
+        className="overflow-hidden rounded-lg border border-border bg-base"
+      >
+        {activeGroup?.subGroups.map((subGroup, index) => {
+          const isLast = index === activeGroup.subGroups.length - 1
+
+          return (
+            <button
+              key={subGroup.name}
+              type="button"
+              data-testid={`model-mobile-secondary-group-${sanitizeTestId(subGroup.name)}`}
+              onClick={() => {
+                setActiveSubGroupName(subGroup.name)
+                setMobileStep('models')
+              }}
+              className={cn(
+                'flex min-h-[44px] w-full items-center justify-between gap-3 px-3 py-2.5 text-left',
+                'active:bg-hover focus:bg-hover focus:outline-none',
+                !isLast && 'border-b border-border'
+              )}
+            >
+              <span className="min-w-0 truncate text-sm font-medium text-text-primary">
+                {subGroup.name}
+              </span>
+              <span className="flex shrink-0 items-center gap-2">
+                <span className="rounded-full bg-surface px-2 py-0.5 text-xs text-text-muted">
+                  {getGroupCountLabel(subGroup.count)}
+                </span>
+                <ChevronRight className="h-4 w-4 text-text-muted" />
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+
+  const renderMobileModels = () => (
+    <div>
+      {renderMobileBackButton(activeGroup?.name ?? labels.secondaryGroups, () =>
+        setMobileStep('secondary')
+      )}
+      <div
+        data-testid="model-mobile-models"
+        className="overflow-hidden rounded-lg border border-border bg-base"
+      >
+        {activeSubGroup?.models.map((model, index) =>
+          renderMobileModelOption(model, false, index !== activeSubGroup.models.length - 1)
+        )}
+      </div>
+    </div>
+  )
+
+  const renderMobileSearchResults = () => (
+    <div
+      data-testid="model-mobile-search-results"
+      className="max-h-[min(58vh,420px)] overflow-y-auto px-3 py-3"
+    >
+      <div className="overflow-hidden rounded-lg border border-border bg-base">
+        {specialSearchResults.map((option, index) =>
+          renderMobileSpecialOption(
+            option,
+            index < specialSearchResults.length - 1 || searchResults.length > 0
+          )
+        )}
+        {searchResults.map((model, index) =>
+          renderMobileModelOption(model, true, index !== searchResults.length - 1)
+        )}
+        {specialSearchResults.length === 0 && searchResults.length === 0 && (
+          <div className="px-3 py-6 text-center text-sm text-text-muted">{labels.noMatch}</div>
+        )}
+      </div>
+    </div>
+  )
+
+  const renderMobileCascade = () => (
+    <div
+      data-testid="model-mobile-cascade"
+      className="max-h-[min(58vh,420px)] overflow-y-auto px-3 py-3"
+    >
+      {mobileStep === 'secondary'
+        ? renderMobileSecondaryGroups()
+        : mobileStep === 'models'
+          ? renderMobileModels()
+          : renderMobilePrimaryGroups()}
+    </div>
+  )
+
   return (
     <div
       className={cn(
-        'flex max-h-[min(520px,var(--radix-popover-content-available-height))] w-[min(760px,calc(100vw-32px))] flex-col overflow-hidden bg-base',
+        'flex flex-col overflow-hidden bg-base',
+        variant === 'mobile'
+          ? 'max-h-[min(72vh,560px)] w-full min-w-0'
+          : 'max-h-[min(520px,var(--radix-popover-content-available-height))] w-[min(760px,calc(100vw-32px))]',
         className
       )}
     >
@@ -260,21 +488,29 @@ export function ModelCascadeContent<T extends GroupableModel>({
       {models.length === 0 && specialOptions.length === 0 ? (
         <div className="px-4 py-8 text-center text-sm text-text-muted">{labels.noModels}</div>
       ) : isSearching ? (
-        <ScrollArea
-          data-testid="model-cascade-search-results"
-          className="h-[clamp(120px,calc(var(--radix-popover-content-available-height,520px)-112px),360px)] min-h-0"
-        >
-          <div className="px-2 py-2">
-            <div className="px-2 pb-1 text-xs font-medium text-text-muted">
-              {labels.searchResults}
+        variant === 'mobile' ? (
+          renderMobileSearchResults()
+        ) : (
+          <ScrollArea
+            data-testid="model-cascade-search-results"
+            className="h-[clamp(120px,calc(var(--radix-popover-content-available-height,520px)-112px),360px)] min-h-0"
+          >
+            <div className="px-2 py-2">
+              <div className="px-2 pb-1 text-xs font-medium text-text-muted">
+                {labels.searchResults}
+              </div>
+              {specialSearchResults.map(renderSpecialOption)}
+              {searchResults.map(model => renderModelOption(model, true))}
+              {specialSearchResults.length === 0 && searchResults.length === 0 && (
+                <div className="px-3 py-6 text-center text-sm text-text-muted">
+                  {labels.noMatch}
+                </div>
+              )}
             </div>
-            {specialSearchResults.map(renderSpecialOption)}
-            {searchResults.map(model => renderModelOption(model, true))}
-            {specialSearchResults.length === 0 && searchResults.length === 0 && (
-              <div className="px-3 py-6 text-center text-sm text-text-muted">{labels.noMatch}</div>
-            )}
-          </div>
-        </ScrollArea>
+          </ScrollArea>
+        )
+      ) : variant === 'mobile' ? (
+        renderMobileCascade()
       ) : (
         <div
           data-testid="model-cascade-grid"
@@ -379,6 +615,7 @@ export function GroupedModelSelect<T extends GroupableModel>({
   contentClassName,
   dataTestId = 'grouped-model-select',
   align = 'start',
+  variant,
 }: GroupedModelSelectProps<T>) {
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState('')
@@ -438,6 +675,7 @@ export function GroupedModelSelect<T extends GroupableModel>({
           renderModelBadges={renderModelBadges}
           renderModelMeta={renderModelMeta}
           footer={footer}
+          variant={variant}
         />
       </PopoverContent>
     </Popover>

--- a/frontend/src/features/tasks/components/MobileCorrectionModeToggle.tsx
+++ b/frontend/src/features/tasks/components/MobileCorrectionModeToggle.tsx
@@ -157,7 +157,7 @@ export default function MobileCorrectionModeToggle({
         <div className="flex items-center gap-3">
           <Sparkles className="h-4 w-4 text-text-muted" />
           <div className="flex flex-col">
-            <span className="text-sm">纠错模式</span>
+            <span className="text-sm">{t('chat:correction.label')}</span>
             {enabled && correctionModelName && (
               <span className="text-xs text-text-muted truncate max-w-[120px]">
                 {correctionModelName}
@@ -182,7 +182,7 @@ export default function MobileCorrectionModeToggle({
 
       {/* Model Selection Dialog */}
       <Dialog open={showModelSelector} onOpenChange={handleDialogClose}>
-        <DialogContent className="max-w-[calc(100vw-16px)] overflow-x-auto sm:max-w-3xl">
+        <DialogContent className="max-w-[calc(100vw-24px)] overflow-hidden p-4 sm:max-w-3xl sm:p-6">
           <DialogHeader>
             <DialogTitle>{t('chat:correction.select_model')}</DialogTitle>
             <DialogDescription>{t('chat:correction.select_model_desc')}</DialogDescription>
@@ -200,7 +200,8 @@ export default function MobileCorrectionModeToggle({
               onSearchValueChange={setSearchQuery}
               onSelectModel={handleModelSelect}
               getModelKey={model => `${model.type}-${model.name}`}
-              className="w-[min(720px,calc(100vw-48px))]"
+              variant="mobile"
+              className="w-full"
               renderModelBadges={model => (
                 <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-text-muted">
                   {model.type === 'public'


### PR DESCRIPTION
## Summary

Fixes the mobile AI cross-validation model selector so users can actually reach and select concrete models after choosing first- and second-level model groups.

## Root Cause

The mobile cross-validation dialog reused the desktop three-column model cascade. On narrow screens, the third column containing the actual model list was clipped, leaving only the primary and secondary groups visible.

## Changes

- Added a mobile variant to the shared model cascade selector with a step-by-step flow: primary group -> secondary group -> model list.
- Switched the mobile cross-validation dialog to use that mobile cascade variant and removed the horizontal overflow layout.
- Replaced the hardcoded mobile correction label with the existing chat i18n key.
- Added a component test covering mobile group navigation and model selection.

## Validation

- `pnpm --dir frontend test -- --runTestsByPath src/__tests__/components/model-select/model-cascade-content.test.tsx`
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- Pre-commit hook: prettier, eslint, translation checker
- Pre-push hook: frontend ESLint, TypeScript check, unit tests

## Documentation

Checked existing README/docs references for AI cross-validation and model selection. This is a UI bug fix that keeps the documented behavior unchanged, so no documentation update is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly model selection flow with step-by-step navigation, back controls, and mobile-optimized search results.
  * Enabled the model picker to render in either desktop or mobile mode.

* **Bug Fixes**
  * Improved the mobile correction mode dialog layout for better fit and scrolling behavior.
  * Replaced a hard-coded label with a localized version for more consistent language support.

* **Tests**
  * Added coverage for the mobile model selection experience, including option navigation and model selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->