### PR TITLE
feat(backend): add open knowledge document operations

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -9,7 +9,6 @@ REST API endpoints delegate business logic to KnowledgeOrchestrator,
 which provides a unified interface for both REST API and MCP tools.
 """
 
-import asyncio
 import logging
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -19,6 +18,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
+from app.api.knowledge_document_side_effects import (
+    schedule_kb_summary_updates_after_deletion,
+)
 from app.core import security
 from app.core.config import settings
 from app.core.exceptions import CustomHTTPException
@@ -63,9 +65,7 @@ from app.services.knowledge.orchestrator import (
 )
 from shared.telemetry.decorators import (
     add_span_event,
-    capture_trace_context,
     trace_async,
-    trace_background,
     trace_sync,
 )
 
@@ -797,14 +797,11 @@ def delete_document(
                 f"[KnowledgeAPI] Scheduling KB summary update after deletion: "
                 f"kb_id={result.kb_id}, document_id={document_id}"
             )
-            # Capture trace context for propagation to background task
-            trace_ctx = capture_trace_context()
-            background_tasks.add_task(
-                _update_kb_summary_after_deletion,
-                kb_id=result.kb_id,
+            schedule_kb_summary_updates_after_deletion(
+                background_tasks,
+                kb_ids=[result.kb_id],
                 user_id=current_user.id,
                 user_name=current_user.user_name,
-                trace_context=trace_ctx,
             )
 
         return None
@@ -950,16 +947,12 @@ def batch_delete_documents(
             f"[KnowledgeAPI] Scheduling KB summary updates after batch deletion: "
             f"kb_ids={kb_ids}, deleted_count={result.success_count}"
         )
-        # Capture trace context for propagation to background tasks
-        trace_ctx = capture_trace_context()
-        for kb_id in kb_ids:
-            background_tasks.add_task(
-                _update_kb_summary_after_deletion,
-                kb_id=kb_id,
-                user_id=current_user.id,
-                user_name=current_user.user_name,
-                trace_context=trace_ctx,
-            )
+        schedule_kb_summary_updates_after_deletion(
+            background_tasks,
+            kb_ids=kb_ids,
+            user_id=current_user.id,
+            user_name=current_user.user_name,
+        )
 
     return result
 
@@ -1659,74 +1652,6 @@ async def _run_document_summary_refresh(doc_id: int, user_id: int, user_name: st
         )
     finally:
         new_db.close()
-
-
-@trace_background("kb_summary_after_deletion_background", "knowledge.worker")
-def _update_kb_summary_after_deletion(
-    kb_id: int,
-    user_id: int,
-    user_name: str,
-    trace_context: Optional[dict] = None,
-):
-    """
-    Background task to update KB summary after document deletion.
-
-    - If no active documents remain, clear the summary
-    - If active documents remain, regenerate the summary
-    - Errors are logged but don't affect the deletion operation
-    - Respects debounce pattern (skip if summary is currently generating)
-
-    This is a synchronous function that creates its own event loop to run
-    the async summary service methods. This is necessary because FastAPI's
-    BackgroundTasks runs tasks in a thread pool without an event loop.
-
-    Args:
-        kb_id: Knowledge base ID
-        user_id: User who triggered the deletion
-        user_name: Username for placeholder resolution
-        trace_context: Trace context for distributed tracing
-    """
-    from app.services.knowledge import get_summary_service
-
-    logger.info(
-        f"[KnowledgeAPI] Starting KB summary update after deletion: kb_id={kb_id}"
-    )
-
-    # Create a new database session for the background task
-    db = SessionLocal()
-    try:
-        summary_service = get_summary_service(db)
-
-        # Trigger KB summary with clear_if_empty=True
-        # This will:
-        # - Clear summary if no active documents remain
-        # - Regenerate summary if active documents exist with completed summaries
-        # - Skip if currently generating (debounce)
-        # Use a dedicated event loop and ensure proper cleanup
-        # to avoid "no running event loop" errors during garbage collection
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(
-                summary_service.trigger_kb_summary(
-                    kb_id, user_id, user_name, force=False, clear_if_empty=True
-                )
-            )
-        finally:
-            # Properly shutdown async generators and close the loop
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            loop.close()
-
-    except Exception as e:
-        # Log error but don't re-raise - deletion should succeed regardless
-        logger.error(
-            f"[KnowledgeAPI] Failed to update KB summary after deletion: "
-            f"kb_id={kb_id}, error={str(e)}",
-            exc_info=True,
-        )
-    finally:
-        db.close()
-        logger.info(f"[KnowledgeAPI] KB summary update task completed: kb_id={kb_id}")
 
 
 # ============== Chunk Management Endpoints ==============

--- a/backend/app/api/endpoints/knowledge_open.py
+++ b/backend/app/api/endpoints/knowledge_open.py
@@ -11,12 +11,18 @@ wegent-username header.  Business logic is fully delegated to
 KnowledgeOrchestrator so that REST API and MCP tools share the same path.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
+from app.api.knowledge_document_side_effects import (
+    schedule_kb_summary_updates_after_deletion,
+)
 from app.core.security import AuthContext, get_auth_context
 from app.schemas.knowledge import (
+    BatchDocumentIds,
+    BatchDocumentMoveRequest,
+    BatchOperationResult,
     DocumentContentReadResponse,
     DocumentContentUpdate,
     DocumentContentUpdateResponse,
@@ -589,6 +595,100 @@ async def search_documents_open(
 # ---------------------------------------------------------------------------
 
 
+@router.post(
+    "/documents/batch/delete",
+    response_model=BatchOperationResult,
+)
+@trace_sync("batch_delete_documents_open", "knowledge.api")
+def batch_delete_documents_open(
+    data: BatchDocumentIds,
+    background_tasks: BackgroundTasks,
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: Session = Depends(get_db),
+) -> BatchOperationResult:
+    """Batch delete multiple documents from accessible knowledge bases."""
+    current_user = auth_context.user
+    batch_result = KnowledgeService.batch_delete_documents(
+        db=db,
+        document_ids=data.document_ids,
+        user_id=current_user.id,
+    )
+    result = batch_result.result
+    kb_ids = batch_result.kb_ids
+
+    add_span_event(
+        "knowledge.documents.batch_deleted.open",
+        {
+            "success_count": str(result.success_count),
+            "failed_count": str(result.failed_count),
+            "kb_ids": str(list(kb_ids)) if kb_ids else "[]",
+            "user_id": str(current_user.id),
+        },
+    )
+
+    if result.success_count == 0 and result.failed_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only Owner or Maintainer can delete documents from this knowledge base",
+        )
+
+    schedule_kb_summary_updates_after_deletion(
+        background_tasks,
+        kb_ids=kb_ids,
+        user_id=current_user.id,
+        user_name=current_user.user_name,
+    )
+    return result
+
+
+@router.post(
+    "/documents/batch/move",
+    response_model=BatchOperationResult,
+)
+@trace_sync("batch_move_documents_open", "knowledge.api")
+def batch_move_documents_open(
+    data: BatchDocumentMoveRequest,
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: Session = Depends(get_db),
+) -> BatchOperationResult:
+    """Batch move multiple documents to a folder. Use folder_id=0 for root."""
+    current_user = auth_context.user
+    result = KnowledgeFolderService.batch_move_documents(
+        db=db,
+        document_ids=data.document_ids,
+        folder_id=data.folder_id,
+        user_id=current_user.id,
+    )
+
+    add_span_event(
+        "knowledge.documents.batch_moved.open",
+        {
+            "success_count": str(result.success_count),
+            "failed_count": str(result.failed_count),
+            "user_id": str(current_user.id),
+        },
+    )
+
+    if result.success_count == 0 and result.failed_count > 0:
+        error_msg = result.message.lower() if result.message else ""
+        if "not found" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=result.message,
+            )
+        if "permission" in error_msg or "access denied" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=result.message,
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=result.message,
+        )
+
+    return result
+
+
 @router.put("/documents/{document_id}", response_model=KnowledgeDocumentResponse)
 @trace_sync("update_document_open", "knowledge.api")
 def update_document_open(
@@ -624,6 +724,92 @@ def update_document_open(
             detail="Document not found",
         )
     return KnowledgeDocumentResponse.model_validate(document)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /knowledge/documents/{document_id}  — delete document
+# ---------------------------------------------------------------------------
+
+
+@router.delete(
+    "/documents/{document_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@trace_sync("delete_document_open", "knowledge.api")
+def delete_document_open(
+    document_id: int,
+    background_tasks: BackgroundTasks,
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a document, its RAG index, and associated attachment."""
+    current_user = auth_context.user
+    try:
+        result = KnowledgeService.delete_document(
+            db=db,
+            document_id=document_id,
+            user_id=current_user.id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+
+    if not result.success:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found or access denied",
+        )
+
+    add_span_event(
+        "knowledge.document.deleted.open",
+        {
+            "document_id": str(document_id),
+            "kb_id": str(result.kb_id) if result.kb_id else "unknown",
+            "user_id": str(current_user.id),
+        },
+    )
+    schedule_kb_summary_updates_after_deletion(
+        background_tasks,
+        kb_ids=[result.kb_id] if result.kb_id is not None else [],
+        user_id=current_user.id,
+        user_name=current_user.user_name,
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# POST /knowledge/documents/{document_id}/reindex  — re-index document
+# ---------------------------------------------------------------------------
+
+
+@router.post("/documents/{document_id}/reindex")
+@trace_async("reindex_document_open", "knowledge.api")
+async def reindex_document_open(
+    document_id: int,
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Trigger re-indexing for a document via the configured RAG runtime."""
+    current_user = auth_context.user
+    try:
+        result = knowledge_orchestrator.reindex_document(
+            db=db,
+            user=current_user,
+            document_id=document_id,
+            trigger_summary=False,
+        )
+        add_span_event(
+            "knowledge.document.reindex.scheduled.open",
+            {
+                "document_id": str(document_id),
+                "user_id": str(current_user.id),
+            },
+        )
+        return result
+    except ValueError as exc:
+        _raise_open_knowledge_http_error(exc)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/endpoints/knowledge_open.py
+++ b/backend/app/api/endpoints/knowledge_open.py
@@ -627,9 +627,24 @@ def batch_delete_documents_open(
     )
 
     if result.success_count == 0 and result.failed_count > 0:
+        error_msg = result.message.lower() if result.message else ""
+        if "not found" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=result.message,
+            )
+        if (
+            "permission" in error_msg
+            or "access denied" in error_msg
+            or "owner or maintainer" in error_msg
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=result.message,
+            )
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only Owner or Maintainer can delete documents from this knowledge base",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=result.message,
         )
 
     schedule_kb_summary_updates_after_deletion(

--- a/backend/app/api/endpoints/knowledge_transfer.py
+++ b/backend/app/api/endpoints/knowledge_transfer.py
@@ -11,7 +11,9 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
-from app.api.endpoints.knowledge import _update_kb_summary_after_deletion
+from app.api.knowledge_document_side_effects import (
+    schedule_kb_summary_updates_after_deletion,
+)
 from app.core import security
 from app.core.exceptions import CustomHTTPException, StructuredValidationException
 from app.models.user import User
@@ -27,7 +29,6 @@ from app.services.knowledge import KnowledgeFolderService, KnowledgeService
 from app.services.knowledge.knowledge_transfer import KB_MIGRATE_CONFLICT
 from shared.telemetry.decorators import (
     add_span_event,
-    capture_trace_context,
     trace_sync,
 )
 
@@ -179,20 +180,11 @@ def transfer_documents_to_kb(
             },
         )
         if result.transferred_document_count > 0:
-            trace_ctx = capture_trace_context()
-            background_tasks.add_task(
-                _update_kb_summary_after_deletion,
-                kb_id=knowledge_base_id,
+            schedule_kb_summary_updates_after_deletion(
+                background_tasks,
+                kb_ids=[knowledge_base_id, data.target_kb_id],
                 user_id=current_user.id,
                 user_name=current_user.user_name,
-                trace_context=trace_ctx,
-            )
-            background_tasks.add_task(
-                _update_kb_summary_after_deletion,
-                kb_id=data.target_kb_id,
-                user_id=current_user.id,
-                user_name=current_user.user_name,
-                trace_context=trace_ctx,
             )
         return result
     except (CustomHTTPException, StructuredValidationException):

--- a/backend/app/api/knowledge_document_side_effects.py
+++ b/backend/app/api/knowledge_document_side_effects.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared API side effects for knowledge document operations."""
+
+import asyncio
+import logging
+from collections.abc import Iterable
+from typing import Optional
+
+from fastapi import BackgroundTasks
+
+from app.db.session import SessionLocal
+from shared.telemetry.decorators import capture_trace_context, trace_background
+
+logger = logging.getLogger(__name__)
+
+
+@trace_background("kb_summary_after_deletion_background", "knowledge.worker")
+def update_kb_summary_after_deletion(
+    kb_id: int,
+    user_id: int,
+    user_name: str,
+    trace_context: Optional[dict] = None,
+):
+    """
+    Background task to update KB summary after document deletion.
+
+    - If no active documents remain, clear the summary
+    - If active documents remain, regenerate the summary
+    - Errors are logged but don't affect the deletion operation
+    - Respects debounce pattern (skip if summary is currently generating)
+    """
+    from app.services.knowledge import get_summary_service
+
+    logger.info(
+        f"[KnowledgeAPI] Starting KB summary update after deletion: kb_id={kb_id}"
+    )
+
+    db = SessionLocal()
+    try:
+        summary_service = get_summary_service(db)
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(
+                summary_service.trigger_kb_summary(
+                    kb_id, user_id, user_name, force=False, clear_if_empty=True
+                )
+            )
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+    except Exception as e:
+        logger.error(
+            f"[KnowledgeAPI] Failed to update KB summary after deletion: "
+            f"kb_id={kb_id}, error={str(e)}",
+            exc_info=True,
+        )
+    finally:
+        db.close()
+        logger.info(f"[KnowledgeAPI] KB summary update task completed: kb_id={kb_id}")
+
+
+def schedule_kb_summary_updates_after_deletion(
+    background_tasks: BackgroundTasks,
+    *,
+    kb_ids: Iterable[int],
+    user_id: int,
+    user_name: str,
+) -> None:
+    """Schedule one KB summary refresh task per affected knowledge base."""
+    unique_kb_ids = list(dict.fromkeys(kb_id for kb_id in kb_ids if kb_id is not None))
+    if not unique_kb_ids:
+        return
+
+    trace_ctx = capture_trace_context()
+    for kb_id in unique_kb_ids:
+        background_tasks.add_task(
+            update_kb_summary_after_deletion,
+            kb_id=kb_id,
+            user_id=user_id,
+            user_name=user_name,
+            trace_context=trace_ctx,
+        )

--- a/backend/app/api/knowledge_document_side_effects.py
+++ b/backend/app/api/knowledge_document_side_effects.py
@@ -42,22 +42,16 @@ def update_kb_summary_after_deletion(
     try:
         summary_service = get_summary_service(db)
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(
-                summary_service.trigger_kb_summary(
-                    kb_id, user_id, user_name, force=False, clear_if_empty=True
-                )
+        asyncio.run(
+            summary_service.trigger_kb_summary(
+                kb_id, user_id, user_name, force=False, clear_if_empty=True
             )
-        finally:
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            loop.close()
+        )
 
     except Exception as e:
         logger.error(
             f"[KnowledgeAPI] Failed to update KB summary after deletion: "
-            f"kb_id={kb_id}, error={str(e)}",
+            f"kb_id={kb_id}, error={e!s}",
             exc_info=True,
         )
     finally:

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -1434,7 +1434,7 @@ class KnowledgeService:
                     except Exception as e:
                         # Log error but don't fail the document deletion
                         logger.error(
-                            f"Failed to delete RAG index for doc_ref '{doc_ref}': {str(e)}",
+                            f"Failed to delete RAG index for doc_ref '{doc_ref}': {e!s}",
                             exc_info=True,
                         )
 
@@ -1457,7 +1457,7 @@ class KnowledgeService:
             except Exception as e:
                 # Log error but don't fail the document deletion
                 logger.error(
-                    f"Failed to delete attachment context {attachment_id}: {str(e)}",
+                    f"Failed to delete attachment context {attachment_id}: {e!s}",
                     exc_info=True,
                 )
 
@@ -1480,7 +1480,7 @@ class KnowledgeService:
             except Exception as e:
                 # Log error but don't fail the document deletion
                 logger.error(
-                    f"Failed to delete converted attachment context {converted_attachment_id}: {str(e)}",
+                    f"Failed to delete converted attachment context {converted_attachment_id}: {e!s}",
                     exc_info=True,
                 )
 
@@ -2948,6 +2948,37 @@ class KnowledgeService:
     # ============== Batch Document Operations ==============
 
     @staticmethod
+    def _build_batch_delete_message(
+        success_count: int,
+        failed_ids: list[int],
+        failure_messages: list[str],
+    ) -> str:
+        """Build a batch delete message that preserves the failure class."""
+        message = (
+            f"Successfully deleted {success_count} documents, {len(failed_ids)} failed"
+        )
+        if success_count > 0 or not failed_ids:
+            return message
+
+        lower_messages = [
+            failure_message.lower() for failure_message in failure_messages
+        ]
+        if lower_messages and all("not found" in msg for msg in lower_messages):
+            return "Document not found"
+        if any(
+            "permission" in msg
+            or "access denied" in msg
+            or "owner or maintainer" in msg
+            for msg in lower_messages
+        ):
+            return (
+                "Only Owner or Maintainer can delete documents from this knowledge base"
+            )
+        if failure_messages:
+            return failure_messages[0]
+        return message
+
+    @staticmethod
     def batch_delete_documents(
         db: Session,
         document_ids: list[int],
@@ -2966,6 +2997,7 @@ class KnowledgeService:
         """
         success_count = 0
         failed_ids = []
+        failure_messages = []
         kb_ids = set()  # Collect unique KB IDs from deleted documents
 
         for doc_id in document_ids:
@@ -2977,14 +3009,20 @@ class KnowledgeService:
                         kb_ids.add(result.kb_id)
                 else:
                     failed_ids.append(doc_id)
-            except (ValueError, Exception):
+                    failure_messages.append(result.error or "Document not found")
+            except ValueError as exc:
+                failed_ids.append(doc_id)
+                failure_messages.append(str(exc))
+            except Exception:
                 failed_ids.append(doc_id)
 
         operation_result = BatchOperationResult(
             success_count=success_count,
             failed_count=len(failed_ids),
             failed_ids=failed_ids,
-            message=f"Successfully deleted {success_count} documents, {len(failed_ids)} failed",
+            message=KnowledgeService._build_batch_delete_message(
+                success_count, failed_ids, failure_messages
+            ),
         )
 
         return BatchDeleteResult(

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -61,7 +61,7 @@ from app.services.knowledge.permission_policy import (
     can_manage_accessible_knowledge_document,
 )
 
-logger = logging.getLogger(__name__)
+batch_logger = logging.getLogger(__name__)
 
 
 def _build_attachment_filename(name: str, file_extension: str) -> str:
@@ -1339,6 +1339,8 @@ class KnowledgeService:
         Raises:
             ValueError: If permission denied
         """
+        logger = logging.getLogger(__name__)
+
         from app.services.context import context_service
         from app.services.knowledge.index_runtime import get_kb_index_info_by_record
 
@@ -3018,7 +3020,7 @@ class KnowledgeService:
             except Exception as exc:  # noqa: BLE001 - continue deleting remaining docs
                 failed_ids.append(doc_id)
                 failure_messages.append(str(exc))
-                logger.exception("Unexpected error deleting document %s", doc_id)
+                batch_logger.exception("Unexpected error deleting document %s", doc_id)
 
         operation_result = BatchOperationResult(
             success_count=success_count,
@@ -3071,7 +3073,7 @@ class KnowledgeService:
                 failed_ids.append(doc_id)
             except Exception:  # noqa: BLE001 - continue updating remaining docs
                 failed_ids.append(doc_id)
-                logger.exception("Unexpected error enabling document %s", doc_id)
+                batch_logger.exception("Unexpected error enabling document %s", doc_id)
 
         return BatchOperationResult(
             success_count=success_count,
@@ -3117,7 +3119,7 @@ class KnowledgeService:
                 failed_ids.append(doc_id)
             except Exception:  # noqa: BLE001 - continue updating remaining docs
                 failed_ids.append(doc_id)
-                logger.exception("Unexpected error disabling document %s", doc_id)
+                batch_logger.exception("Unexpected error disabling document %s", doc_id)
 
         return BatchOperationResult(
             success_count=success_count,

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -3004,7 +3004,9 @@ class KnowledgeService:
         failure_messages = []
         kb_ids = set()  # Collect unique KB IDs from deleted documents
 
-        for doc_id in document_ids:
+        requested_ids = list(dict.fromkeys(document_ids))
+
+        for doc_id in requested_ids:
             try:
                 result = KnowledgeService.delete_document(db, doc_id, user_id)
                 if result.success:

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -7,6 +7,7 @@ Knowledge base and document service using kinds table.
 """
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -59,6 +60,8 @@ from app.services.knowledge.permission_policy import (
     can_manage_accessible_knowledge_base_documents,
     can_manage_accessible_knowledge_document,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _build_attachment_filename(name: str, file_extension: str) -> str:
@@ -1336,12 +1339,9 @@ class KnowledgeService:
         Raises:
             ValueError: If permission denied
         """
-        import logging
-
         from app.services.context import context_service
         from app.services.knowledge.index_runtime import get_kb_index_info_by_record
 
-        logger = logging.getLogger(__name__)
         rag_gateway = _get_delete_gateway()
 
         doc = KnowledgeService.get_document(db, document_id, user_id)
@@ -2959,6 +2959,8 @@ class KnowledgeService:
         )
         if success_count > 0 or not failed_ids:
             return message
+        if len(failure_messages) != len(failed_ids):
+            return message
 
         lower_messages = [
             failure_message.lower() for failure_message in failure_messages
@@ -2974,7 +2976,7 @@ class KnowledgeService:
             return (
                 "Only Owner or Maintainer can delete documents from this knowledge base"
             )
-        if failure_messages:
+        if len(failure_messages) == 1:
             return failure_messages[0]
         return message
 
@@ -3013,8 +3015,10 @@ class KnowledgeService:
             except ValueError as exc:
                 failed_ids.append(doc_id)
                 failure_messages.append(str(exc))
-            except Exception:
+            except Exception as exc:  # noqa: BLE001 - continue deleting remaining docs
                 failed_ids.append(doc_id)
+                failure_messages.append(str(exc))
+                logger.exception("Unexpected error deleting document %s", doc_id)
 
         operation_result = BatchOperationResult(
             success_count=success_count,
@@ -3063,8 +3067,11 @@ class KnowledgeService:
                     success_count += 1
                 else:
                     failed_ids.append(doc_id)
-            except (ValueError, Exception):
+            except ValueError:
                 failed_ids.append(doc_id)
+            except Exception:  # noqa: BLE001 - continue updating remaining docs
+                failed_ids.append(doc_id)
+                logger.exception("Unexpected error enabling document %s", doc_id)
 
         return BatchOperationResult(
             success_count=success_count,
@@ -3106,8 +3113,11 @@ class KnowledgeService:
                     success_count += 1
                 else:
                     failed_ids.append(doc_id)
-            except (ValueError, Exception):
+            except ValueError:
                 failed_ids.append(doc_id)
+            except Exception:  # noqa: BLE001 - continue updating remaining docs
+                failed_ids.append(doc_id)
+                logger.exception("Unexpected error disabling document %s", doc_id)
 
         return BatchOperationResult(
             success_count=success_count,

--- a/backend/tests/api/test_knowledge_open_scope.py
+++ b/backend/tests/api/test_knowledge_open_scope.py
@@ -205,3 +205,195 @@ def test_open_folder_create_move_and_list_documents(
     assert tree_response.status_code == 200
     tree_folder_ids = {item["id"] for item in tree_response.json()}
     assert folder_id in tree_folder_ids
+
+
+def test_open_delete_document_removes_document_and_schedules_summary_update(
+    test_client: TestClient,
+    test_db: Session,
+    test_user,
+    test_api_key,
+    monkeypatch,
+) -> None:
+    kb_id = _create_kb(test_db, test_user.id, "open-delete-kb")
+    document = _create_document(test_db, kb_id, test_user.id, "delete-me.md")
+    scheduled: dict = {}
+
+    def fake_schedule_summary_update(background_tasks, **kwargs):
+        scheduled.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.schedule_kb_summary_updates_after_deletion",
+        fake_schedule_summary_update,
+    )
+
+    response = test_client.delete(
+        f"/api/knowledge/documents/{document.id}",
+        headers=_api_key_headers(test_api_key[0]),
+    )
+
+    assert response.status_code == 204
+    assert KnowledgeService.get_document(test_db, document.id, test_user.id) is None
+    assert scheduled["kb_ids"] == [kb_id]
+    assert scheduled["user_id"] == test_user.id
+
+
+def test_open_delete_document_returns_404_for_missing_document(
+    test_client: TestClient,
+    test_api_key,
+) -> None:
+    response = test_client.delete(
+        "/api/knowledge/documents/999999",
+        headers=_api_key_headers(test_api_key[0]),
+    )
+
+    assert response.status_code == 404
+
+
+def test_open_reindex_document_uses_orchestrator(
+    test_client: TestClient,
+    test_db: Session,
+    test_user,
+    test_api_key,
+    monkeypatch,
+) -> None:
+    kb_id = _create_kb(test_db, test_user.id, "open-reindex-kb")
+    document = _create_document(test_db, kb_id, test_user.id, "reindex-me.md")
+    captured: dict = {}
+
+    def fake_reindex_document(**kwargs):
+        captured.update(kwargs)
+        return {"message": "Reindexing started", "document_id": document.id}
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.knowledge_orchestrator.reindex_document",
+        fake_reindex_document,
+    )
+
+    response = test_client.post(
+        f"/api/knowledge/documents/{document.id}/reindex",
+        headers=_api_key_headers(test_api_key[0]),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["document_id"] == document.id
+    assert captured["document_id"] == document.id
+    assert captured["user"].id == test_user.id
+    assert captured["trigger_summary"] is False
+
+
+def test_open_reindex_document_returns_403_for_permission_error(
+    test_client: TestClient,
+    test_db: Session,
+    test_user,
+    test_api_key,
+    monkeypatch,
+) -> None:
+    kb_id = _create_kb(test_db, test_user.id, "open-reindex-permission-kb")
+    document = _create_document(test_db, kb_id, test_user.id, "reindex-denied.md")
+
+    def fake_reindex_document(**kwargs):
+        raise ValueError(
+            "You do not have permission to manage this document in this knowledge base"
+        )
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.knowledge_orchestrator.reindex_document",
+        fake_reindex_document,
+    )
+
+    response = test_client.post(
+        f"/api/knowledge/documents/{document.id}/reindex",
+        headers=_api_key_headers(test_api_key[0]),
+    )
+
+    assert response.status_code == 403
+    assert "permission" in response.json()["detail"]
+
+
+def test_open_batch_delete_documents_allows_partial_success(
+    test_client: TestClient,
+    test_db: Session,
+    test_user,
+    test_api_key,
+    monkeypatch,
+) -> None:
+    kb_id = _create_kb(test_db, test_user.id, "open-batch-delete-kb")
+    document = _create_document(test_db, kb_id, test_user.id, "batch-delete.md")
+    missing_document_id = 999999
+    scheduled: dict = {}
+
+    def fake_schedule_summary_update(background_tasks, **kwargs):
+        scheduled.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.schedule_kb_summary_updates_after_deletion",
+        fake_schedule_summary_update,
+    )
+
+    response = test_client.post(
+        "/api/knowledge/documents/batch/delete",
+        headers=_api_key_headers(test_api_key[0]),
+        json={"document_ids": [document.id, missing_document_id]},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success_count"] == 1
+    assert payload["failed_count"] == 1
+    assert payload["failed_ids"] == [missing_document_id]
+    assert KnowledgeService.get_document(test_db, document.id, test_user.id) is None
+    assert scheduled["kb_ids"] == [kb_id]
+
+
+def test_open_batch_delete_documents_returns_403_when_all_fail(
+    test_client: TestClient,
+    test_api_key,
+    monkeypatch,
+) -> None:
+    def fake_schedule_summary_update(background_tasks, **kwargs):
+        raise AssertionError("Summary update should not be scheduled")
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.schedule_kb_summary_updates_after_deletion",
+        fake_schedule_summary_update,
+    )
+
+    response = test_client.post(
+        "/api/knowledge/documents/batch/delete",
+        headers=_api_key_headers(test_api_key[0]),
+        json={"document_ids": [999998, 999999]},
+    )
+
+    assert response.status_code == 403
+
+
+def test_open_batch_move_documents_moves_documents_to_folder(
+    test_client: TestClient,
+    test_db: Session,
+    test_user,
+    test_api_key,
+) -> None:
+    kb_id = _create_kb(test_db, test_user.id, "open-batch-move-kb")
+    folder = _create_folder(test_db, kb_id, test_user.id, "target")
+    first_doc = _create_document(test_db, kb_id, test_user.id, "first.md")
+    second_doc = _create_document(test_db, kb_id, test_user.id, "second.md")
+
+    response = test_client.post(
+        "/api/knowledge/documents/batch/move",
+        headers=_api_key_headers(test_api_key[0]),
+        json={
+            "document_ids": [first_doc.id, second_doc.id],
+            "folder_id": folder.id,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success_count"] == 2
+
+    folder_docs_response = test_client.get(
+        "/api/knowledge/documents",
+        headers=_api_key_headers(test_api_key[0]),
+        params={"knowledge_base_id": kb_id, "folder_id": folder.id},
+    )
+    folder_doc_ids = {item["id"] for item in folder_docs_response.json()["items"]}
+    assert folder_doc_ids == {first_doc.id, second_doc.id}

--- a/backend/tests/api/test_knowledge_open_scope.py
+++ b/backend/tests/api/test_knowledge_open_scope.py
@@ -2,10 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.schemas.knowledge import (
+    BatchOperationResult,
     DocumentSourceType,
     KnowledgeBaseCreate,
     KnowledgeDocumentCreate,
@@ -358,6 +362,22 @@ def test_open_batch_delete_documents_returns_403_when_all_fail(
         fake_schedule_summary_update,
     )
 
+    def fake_batch_delete_documents(**kwargs):
+        return SimpleNamespace(
+            result=BatchOperationResult(
+                success_count=0,
+                failed_count=2,
+                failed_ids=[999998, 999999],
+                message="Only Owner or Maintainer can delete documents from this knowledge base",
+            ),
+            kb_ids=[],
+        )
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.KnowledgeService.batch_delete_documents",
+        fake_batch_delete_documents,
+    )
+
     response = test_client.post(
         "/api/knowledge/documents/batch/delete",
         headers=_api_key_headers(test_api_key[0]),
@@ -365,6 +385,29 @@ def test_open_batch_delete_documents_returns_403_when_all_fail(
     )
 
     assert response.status_code == 403
+
+
+def test_open_batch_delete_documents_returns_404_when_all_missing(
+    test_client: TestClient,
+    test_api_key,
+    monkeypatch,
+) -> None:
+    def fake_schedule_summary_update(background_tasks, **kwargs):
+        raise AssertionError("Summary update should not be scheduled")
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.schedule_kb_summary_updates_after_deletion",
+        fake_schedule_summary_update,
+    )
+
+    response = test_client.post(
+        "/api/knowledge/documents/batch/delete",
+        headers=_api_key_headers(test_api_key[0]),
+        json={"document_ids": [999998, 999999]},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Document not found"
 
 
 def test_open_batch_move_documents_moves_documents_to_folder(
@@ -397,3 +440,44 @@ def test_open_batch_move_documents_moves_documents_to_folder(
     )
     folder_doc_ids = {item["id"] for item in folder_docs_response.json()["items"]}
     assert folder_doc_ids == {first_doc.id, second_doc.id}
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_status"),
+    [
+        ("Document not found", 404),
+        ("You do not have permission to move these documents", 403),
+        ("Invalid folder_id", 400),
+    ],
+)
+def test_open_batch_move_documents_maps_zero_success_errors(
+    test_client: TestClient,
+    test_api_key,
+    monkeypatch,
+    message: str,
+    expected_status: int,
+) -> None:
+    def fake_batch_move_documents(**kwargs):
+        return BatchOperationResult(
+            success_count=0,
+            failed_count=1,
+            failed_ids=[999999],
+            message=message,
+        )
+
+    monkeypatch.setattr(
+        "app.api.endpoints.knowledge_open.KnowledgeFolderService.batch_move_documents",
+        fake_batch_move_documents,
+    )
+
+    response = test_client.post(
+        "/api/knowledge/documents/batch/move",
+        headers=_api_key_headers(test_api_key[0]),
+        json={
+            "document_ids": [999999],
+            "folder_id": 0,
+        },
+    )
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"] == message

--- a/backend/tests/services/knowledge/test_document_transfer.py
+++ b/backend/tests/services/knowledge/test_document_transfer.py
@@ -729,7 +729,7 @@ def test_transfer_endpoint_uses_extracted_module(
         ) as mock_transfer,
         patch(
             "app.api.endpoints.knowledge_transfer.schedule_kb_summary_updates_after_deletion"
-        ),
+        ) as mock_schedule,
     ):
         response = test_client.post(
             "/api/knowledge-bases/10/transfer-documents",
@@ -744,6 +744,8 @@ def test_transfer_endpoint_uses_extracted_module(
     assert response.status_code == 200
     assert response.json()["transferred_document_count"] == 1
     mock_transfer.assert_called_once()
+    mock_schedule.assert_called_once()
+    assert mock_schedule.call_args.kwargs["kb_ids"] == [10, 20]
     assert mock_transfer.call_args.kwargs["source_kb_id"] == 10
     assert mock_transfer.call_args.kwargs["target_kb_id"] == 20
 

--- a/backend/tests/services/knowledge/test_document_transfer.py
+++ b/backend/tests/services/knowledge/test_document_transfer.py
@@ -728,10 +728,8 @@ def test_transfer_endpoint_uses_extracted_module(
             return_value=transfer_response,
         ) as mock_transfer,
         patch(
-            "app.api.endpoints.knowledge_transfer.capture_trace_context",
-            return_value={"traceparent": "test"},
+            "app.api.endpoints.knowledge_transfer.schedule_kb_summary_updates_after_deletion"
         ),
-        patch("app.api.endpoints.knowledge_transfer._update_kb_summary_after_deletion"),
     ):
         response = test_client.post(
             "/api/knowledge-bases/10/transfer-documents",

--- a/backend/tests/services/test_summary_service.py
+++ b/backend/tests/services/test_summary_service.py
@@ -153,7 +153,7 @@ class TestTriggerKbSummaryClearIfEmpty:
             )
             mock_executor.with_managed_sessions.return_value = mock_instance
 
-            result = await summary_service.trigger_kb_summary(
+            await summary_service.trigger_kb_summary(
                 test_knowledge_base.id,
                 test_user.id,
                 test_user.user_name,
@@ -921,6 +921,43 @@ class TestKnowledgeServiceBatchDeleteDocuments:
         assert result.result.failed_count == 1
         assert 99999 in result.result.failed_ids
         assert expected_kb_id in result.kb_ids
+
+    def test_batch_delete_mixed_unexpected_failure_uses_generic_message(
+        self,
+        test_db: Session,
+        test_user: User,
+        monkeypatch,
+        caplog,
+    ):
+        """Test mixed unexpected failures do not look like pure not-found errors."""
+        from app.services.knowledge import KnowledgeService
+        from app.services.knowledge.knowledge_service import DocumentDeleteResult
+
+        def fake_delete_document(db, document_id, user_id):
+            if document_id == 99999:
+                return DocumentDeleteResult(
+                    success=False,
+                    error="Document not found",
+                )
+            raise RuntimeError("storage cleanup failed")
+
+        monkeypatch.setattr(KnowledgeService, "delete_document", fake_delete_document)
+
+        with caplog.at_level(
+            "ERROR", logger="app.services.knowledge.knowledge_service"
+        ):
+            result = KnowledgeService.batch_delete_documents(
+                db=test_db,
+                document_ids=[99999, 100000],
+                user_id=test_user.id,
+            )
+
+        assert result.result.success_count == 0
+        assert result.result.failed_count == 2
+        assert result.result.failed_ids == [99999, 100000]
+        assert result.result.message == "Successfully deleted 0 documents, 2 failed"
+        assert result.kb_ids == []
+        assert "Unexpected error deleting document 100000" in caplog.text
 
 
 class TestTriggerDocumentSummaryDeletionRace:

--- a/backend/tests/services/test_summary_service.py
+++ b/backend/tests/services/test_summary_service.py
@@ -922,6 +922,29 @@ class TestKnowledgeServiceBatchDeleteDocuments:
         assert 99999 in result.result.failed_ids
         assert expected_kb_id in result.kb_ids
 
+    def test_batch_delete_deduplicates_document_ids(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_knowledge_base: Kind,
+        test_documents: list[KnowledgeDocument],
+    ):
+        """Test batch delete processes duplicated document IDs only once."""
+        from app.services.knowledge import KnowledgeService
+
+        document_id = test_documents[0].id
+
+        result = KnowledgeService.batch_delete_documents(
+            db=test_db,
+            document_ids=[document_id, document_id],
+            user_id=test_user.id,
+        )
+
+        assert result.result.success_count == 1
+        assert result.result.failed_count == 0
+        assert result.result.failed_ids == []
+        assert test_knowledge_base.id in result.kb_ids
+
     def test_batch_delete_mixed_unexpected_failure_uses_generic_message(
         self,
         test_db: Session,

--- a/docs/en/reference/knowledge-open-api.md
+++ b/docs/en/reference/knowledge-open-api.md
@@ -220,6 +220,66 @@ Request body:
 
 Use `folder_id=0` to move the document to root.
 
+### Delete Document
+
+```http
+DELETE /api/knowledge/documents/{document_id}
+```
+
+Physically deletes the document, deletes associated attachments, and removes the corresponding RAG index. A successful deletion returns `204 No Content`.
+
+### Re-index Document
+
+```http
+POST /api/knowledge/documents/{document_id}/reindex
+```
+
+Re-indexes the document with the knowledge base's current retrieval configuration. Use this endpoint for index repair or manual rebuilds after configuration changes.
+
+### Batch Delete Documents
+
+```http
+POST /api/knowledge/documents/batch/delete
+```
+
+Request body:
+
+```json
+{
+  "document_ids": [101, 102]
+}
+```
+
+Response:
+
+```json
+{
+  "success_count": 1,
+  "failed_count": 1,
+  "failed_ids": [102],
+  "message": "Successfully deleted 1 documents, 1 failed"
+}
+```
+
+Batch delete allows partial success. Successfully deleted documents have their associated attachments and RAG indexes removed, and the affected knowledge base summaries are refreshed.
+
+### Batch Move Documents
+
+```http
+POST /api/knowledge/documents/batch/move
+```
+
+Request body:
+
+```json
+{
+  "document_ids": [101, 102],
+  "folder_id": 10
+}
+```
+
+Use `folder_id=0` to batch move documents to root. The endpoint allows partial success, and failed document IDs are returned in `failed_ids`.
+
 ## Folders
 
 Folders are knowledge document metadata, not attachment metadata. The generic attachment upload API does not accept `folder_id`.

--- a/docs/en/reference/knowledge-open-api.md
+++ b/docs/en/reference/knowledge-open-api.md
@@ -261,7 +261,7 @@ Response:
 }
 ```
 
-Batch delete allows partial success. Successfully deleted documents have their associated attachments and RAG indexes removed, and the affected knowledge base summaries are refreshed.
+Batch delete allows partial success. Duplicate `document_ids` are deduplicated in first-seen order before deletion, and `success_count`, `failed_count`, and `failed_ids` are calculated from the deduplicated document set. Successfully deleted documents have their associated attachments and RAG indexes removed, and the affected knowledge base summaries are refreshed.
 
 ### Batch Move Documents
 

--- a/docs/zh/reference/knowledge-open-api.md
+++ b/docs/zh/reference/knowledge-open-api.md
@@ -261,7 +261,7 @@ POST /api/knowledge/documents/batch/delete
 }
 ```
 
-批量删除允许部分成功。成功删除的文档会清理关联附件和 RAG 索引，并触发对应知识库摘要刷新。
+批量删除允许部分成功。重复的 `document_ids` 会按首次出现顺序去重后处理，`success_count`、`failed_count` 和 `failed_ids` 均按去重后的文档集合计算。成功删除的文档会清理关联附件和 RAG 索引，并触发对应知识库摘要刷新。
 
 ### 批量移动文档
 

--- a/docs/zh/reference/knowledge-open-api.md
+++ b/docs/zh/reference/knowledge-open-api.md
@@ -220,6 +220,66 @@ PUT /api/knowledge/documents/{document_id}/move
 
 `folder_id=0` 表示移动到根目录。
 
+### 删除文档
+
+```http
+DELETE /api/knowledge/documents/{document_id}
+```
+
+物理删除文档，删除关联附件，并清理对应 RAG 索引。删除成功返回 `204 No Content`。
+
+### 重新索引文档
+
+```http
+POST /api/knowledge/documents/{document_id}/reindex
+```
+
+使用知识库当前检索配置重新索引指定文档。该接口用于索引修复或配置调整后的手动重建。
+
+### 批量删除文档
+
+```http
+POST /api/knowledge/documents/batch/delete
+```
+
+请求体：
+
+```json
+{
+  "document_ids": [101, 102]
+}
+```
+
+响应：
+
+```json
+{
+  "success_count": 1,
+  "failed_count": 1,
+  "failed_ids": [102],
+  "message": "Successfully deleted 1 documents, 1 failed"
+}
+```
+
+批量删除允许部分成功。成功删除的文档会清理关联附件和 RAG 索引，并触发对应知识库摘要刷新。
+
+### 批量移动文档
+
+```http
+POST /api/knowledge/documents/batch/move
+```
+
+请求体：
+
+```json
+{
+  "document_ids": [101, 102],
+  "folder_id": 10
+}
+```
+
+`folder_id=0` 表示批量移动到根目录。接口允许部分成功，失败文档 ID 会出现在 `failed_ids` 中。
+
 ## 目录管理
 
 目录是知识库文档属性，不是附件属性；通用附件上传接口不会接收 `folder_id`。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added knowledge-document management endpoints: delete, batch delete, batch move, and reindex.
* **Bug Fixes**
  * Deletions/transfers now more reliably refresh related knowledge-base summaries in the background.
  * Improved batch operation error mapping and clearer partial-success messaging (missing vs permission vs other failures).
* **Documentation**
  * Updated English and Chinese API reference docs for the new endpoints.
* **Tests**
  * Expanded API and service coverage for deletion, reindexing, batch delete/move, partial success, and HTTP status/detail mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->