### PR TITLE
fix: fix titlebar dragging

### DIFF
--- a/wework/src/components/topnav/ChromeTitlebar.test.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.test.tsx
@@ -1,8 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { ChromeTitlebar } from './ChromeTitlebar'
 import type { AppTab } from '@/config/apps'
+
+const startDragging = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ startDragging }),
+}))
 
 const mockTabs: AppTab[] = [
   { key: 'wework', label: 'WeWork', mode: 'native', requiresAuth: true },
@@ -38,6 +44,10 @@ function disableTauri() {
 }
 
 describe('ChromeTitlebar', () => {
+  beforeEach(() => {
+    startDragging.mockClear()
+  })
+
   test('renders all tab buttons', () => {
     render(<ChromeTitlebar tabs={mockTabs} activeKey="wework" onNavigate={vi.fn()} />)
     expect(screen.getByTestId('chrome-tab-wework')).toBeInTheDocument()
@@ -144,8 +154,27 @@ describe('ChromeTitlebar', () => {
     render(<ChromeTitlebar tabs={mockTabs} activeKey="wework" onNavigate={vi.fn()} />)
     const dragRegion = screen.getByTestId('macos-traffic-light-spacer')
     expect(dragRegion.className).toContain('w-[95px]')
+    expect(dragRegion).toHaveClass('self-stretch')
+    expect(within(dragRegion).getByTestId('macos-titlebar-drag-region')).toHaveAttribute(
+      'data-tauri-drag-region'
+    )
     // macOS spacer is first child (left side)
     expect(dragRegion?.parentElement?.firstChild).toBe(dragRegion)
+    disableTauri()
+  })
+
+  test('starts native dragging from the Tauri titlebar window drag region', async () => {
+    mockUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    enableTauri()
+    render(<ChromeTitlebar tabs={mockTabs} activeKey="wework" onNavigate={vi.fn()} />)
+
+    const dragRegion = screen.getByTestId('chrome-titlebar-window-drag-region')
+    expect(dragRegion).toHaveClass('self-stretch')
+    fireEvent.mouseDown(within(dragRegion).getByTestId('macos-titlebar-drag-region'), {
+      button: 0,
+    })
+
+    await waitFor(() => expect(startDragging).toHaveBeenCalledTimes(1))
     disableTauri()
   })
 
@@ -156,7 +185,10 @@ describe('ChromeTitlebar', () => {
     const dragRegion = screen.getByTestId('chrome-titlebar').lastElementChild
     expect(dragRegion).toBeInTheDocument()
     expect(dragRegion).toHaveAttribute('data-tauri-drag-region')
-    expect(dragRegion).toHaveClass('w-[138px]')
+    expect(dragRegion).toHaveClass('w-[138px]', 'self-stretch')
+    expect(
+      within(dragRegion as HTMLElement).getByTestId('macos-titlebar-drag-region')
+    ).toHaveAttribute('data-tauri-drag-region')
     // Windows spacer is last child (right side)
     expect(dragRegion?.parentElement?.lastChild).toBe(dragRegion)
     disableTauri()

--- a/wework/src/components/topnav/ChromeTitlebar.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.tsx
@@ -4,6 +4,7 @@ import type { AppTab } from '@/config/apps'
 import { Grid3X3, Globe2 } from 'lucide-react'
 import { TITLEBAR_ACTIONS_PORTAL_ID, TITLEBAR_RIGHT_PANEL_PORTAL_ID } from './TitlebarActionsPortal'
 import { TitlebarExtensionSlot } from '@extensions/titlebar'
+import { MacOSTitleBarDragRegion } from '@/components/layout/MacOSTitleBarDragRegion'
 import type { ReactNode } from 'react'
 
 function getPlatform(): 'mac' | 'win' | 'linux' {
@@ -48,10 +49,12 @@ export function ChromeTitlebar({
       {/* macOS: traffic light spacer (left) */}
       {isTauri && platform === 'mac' && (
         <div
-          className="w-[95px] shrink-0"
+          className="w-[95px] shrink-0 self-stretch"
           data-testid="macos-traffic-light-spacer"
           data-tauri-drag-region
-        />
+        >
+          <MacOSTitleBarDragRegion />
+        </div>
       )}
 
       {beforeTabs && (
@@ -109,7 +112,13 @@ export function ChromeTitlebar({
         </div>
       )}
 
-      <div className="min-w-6 flex-1" {...(isTauri ? { 'data-tauri-drag-region': '' } : {})} />
+      <div
+        data-testid="chrome-titlebar-window-drag-region"
+        className="min-w-6 flex-1 self-stretch"
+        {...(isTauri ? { 'data-tauri-drag-region': '' } : {})}
+      >
+        {isTauri && <MacOSTitleBarDragRegion />}
+      </div>
       {isTauri && <TitlebarExtensionSlot />}
       <div
         data-testid="titlebar-right-workspace-zone"
@@ -132,7 +141,9 @@ export function ChromeTitlebar({
 
       {/* Windows/Linux: right spacer for native window controls */}
       {isTauri && platform !== 'mac' && (
-        <div className="w-[138px] shrink-0" data-tauri-drag-region />
+        <div className="w-[138px] shrink-0 self-stretch" data-tauri-drag-region>
+          <MacOSTitleBarDragRegion />
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title bar drag behavior across macOS, Windows, and Linux in Tauri-based builds.
  * Updated the window control spacer areas so dragging the title bar works more reliably, including the macOS traffic-light region.
  * Added stronger validation for drag regions to help prevent layout and interaction regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->