### PR TITLE
fix(executor): 修复 MCP 后端地址占位符兜底

### DIFF
--- a/chat_shell/tests/test_mcp_client_variable_substitution.py
+++ b/chat_shell/tests/test_mcp_client_variable_substitution.py
@@ -79,6 +79,24 @@ class TestBuildConnectionsVariableSubstitution:
         conn = connections["server"]
         assert conn["url"] == "https://gitlab.example.com/mcp/sse"
 
+    def test_empty_backend_url_uses_task_api_domain(self, monkeypatch) -> None:
+        """${{backend_url}} should resolve to the runtime task API domain."""
+        monkeypatch.delenv("EXECUTOR_MODE", raising=False)
+        monkeypatch.delenv("WEGENT_BACKEND_URL", raising=False)
+        monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000")
+        config = {
+            "wegent-knowledge": {
+                "type": "streamable-http",
+                "url": "${{backend_url}}/mcp/knowledge/sse",
+            }
+        }
+        task_data = ExecutionRequest(backend_url="")
+
+        connections = build_connections(config, task_data)
+
+        conn = connections["wegent-knowledge"]
+        assert conn["url"] == "http://backend:8000/mcp/knowledge/sse"
+
     def test_no_task_data_preserves_placeholders(self) -> None:
         """When task_data is None, placeholders should remain in the config."""
         config = {

--- a/executor/src/protocol/execution.rs
+++ b/executor/src/protocol/execution.rs
@@ -136,7 +136,7 @@ impl ExecutionRequest {
         let Value::Object(object) = &mut value else {
             return Value::Object(Map::new());
         };
-        if let Some(backend_url) = backend_url_for_variable_context(self) {
+        if let Some(backend_url) = effective_backend_url(self) {
             object.insert("backend_url".to_owned(), Value::String(backend_url));
         }
         if let Some(task_type) = &self.task_type {
@@ -158,7 +158,7 @@ impl ExecutionRequest {
     }
 }
 
-fn backend_url_for_variable_context(request: &ExecutionRequest) -> Option<String> {
+fn effective_backend_url(request: &ExecutionRequest) -> Option<String> {
     request
         .backend_url
         .as_deref()

--- a/executor/src/protocol/execution.rs
+++ b/executor/src/protocol/execution.rs
@@ -163,6 +163,7 @@ fn effective_backend_url(request: &ExecutionRequest) -> Option<String> {
         .backend_url
         .as_deref()
         .map(str::trim)
+        .map(|value| value.trim_end_matches('/'))
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .or_else(|| {
@@ -171,13 +172,13 @@ fn effective_backend_url(request: &ExecutionRequest) -> Option<String> {
             }
             env::var("WEGENT_BACKEND_URL")
                 .ok()
-                .map(|value| value.trim().to_owned())
+                .map(|value| value.trim().trim_end_matches('/').to_owned())
                 .filter(|value| !value.is_empty())
         })
         .or_else(|| {
             env::var("TASK_API_DOMAIN")
                 .ok()
-                .map(|value| value.trim().to_owned())
+                .map(|value| value.trim().trim_end_matches('/').to_owned())
                 .filter(|value| !value.is_empty())
         })
         .or_else(|| Some("http://wegent-backend:8000".to_owned()))

--- a/executor/src/protocol/execution.rs
+++ b/executor/src/protocol/execution.rs
@@ -4,6 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::env;
 
 pub const FULL_KB_TOOL_ACCESS_MODE: &str = "full";
 
@@ -135,6 +136,9 @@ impl ExecutionRequest {
         let Value::Object(object) = &mut value else {
             return Value::Object(Map::new());
         };
+        if let Some(backend_url) = backend_url_for_variable_context(self) {
+            object.insert("backend_url".to_owned(), Value::String(backend_url));
+        }
         if let Some(task_type) = &self.task_type {
             object.insert("type".to_owned(), Value::String(task_type.clone()));
         }
@@ -152,6 +156,37 @@ impl ExecutionRequest {
             .or_else(|| value_path_string(&self.extra, &["repository", "gitUrl"]))
             .or_else(|| value_path_string(&self.extra, &["repository", "git_url"]))
     }
+}
+
+fn backend_url_for_variable_context(request: &ExecutionRequest) -> Option<String> {
+    request
+        .backend_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            if !is_local_mode() {
+                return None;
+            }
+            env::var("WEGENT_BACKEND_URL")
+                .ok()
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            env::var("TASK_API_DOMAIN")
+                .ok()
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| Some("http://wegent-backend:8000".to_owned()))
+}
+
+fn is_local_mode() -> bool {
+    env::var("EXECUTOR_MODE")
+        .ok()
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("local"))
 }
 
 fn extract_shell_type(bot: &Value) -> Option<String> {

--- a/executor/tests/mcp_utils_contract.rs
+++ b/executor/tests/mcp_utils_contract.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
+use std::{
+    env,
+    sync::{Mutex, OnceLock},
+};
 
 use serde_json::{json, Value};
 use wegent_executor::{
@@ -19,6 +22,11 @@ fn request(value: Value) -> ExecutionRequest {
 
 fn source(request: &ExecutionRequest) -> Value {
     request.variable_context()
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 struct EnvGuard {
@@ -375,9 +383,10 @@ fn mcp_variables_replace_backend_url_and_task_token_alias() {
 
 #[test]
 fn mcp_variables_replace_empty_backend_url_from_task_api_domain() {
+    let _lock = env_lock().lock().unwrap();
     let _mode = EnvGuard::remove("EXECUTOR_MODE");
     let _local_backend = EnvGuard::remove("WEGENT_BACKEND_URL");
-    let _task_api = EnvGuard::set("TASK_API_DOMAIN", "http://backend:8000");
+    let _task_api = EnvGuard::set("TASK_API_DOMAIN", "http://backend:8000/");
     let servers = json!({
         "wegent-knowledge": {
             "type": "streamable-http",
@@ -405,8 +414,9 @@ fn mcp_variables_replace_empty_backend_url_from_task_api_domain() {
 
 #[test]
 fn mcp_variables_prefer_local_backend_url_in_local_mode() {
+    let _lock = env_lock().lock().unwrap();
     let _mode = EnvGuard::set("EXECUTOR_MODE", "local");
-    let _local_backend = EnvGuard::set("WEGENT_BACKEND_URL", "http://localhost:8000");
+    let _local_backend = EnvGuard::set("WEGENT_BACKEND_URL", "http://localhost:8000/");
     let _task_api = EnvGuard::set("TASK_API_DOMAIN", "http://backend:8000");
     let servers = json!({
         "wegent-knowledge": {

--- a/executor/tests/mcp_utils_contract.rs
+++ b/executor/tests/mcp_utils_contract.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::env;
+
 use serde_json::{json, Value};
 use wegent_executor::{
     mcp_utils::{
@@ -17,6 +19,35 @@ fn request(value: Value) -> ExecutionRequest {
 
 fn source(request: &ExecutionRequest) -> Value {
     request.variable_context()
+}
+
+struct EnvGuard {
+    key: &'static str,
+    old_value: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let old_value = env::var(key).ok();
+        env::set_var(key, value);
+        Self { key, old_value }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let old_value = env::var(key).ok();
+        env::remove_var(key);
+        Self { key, old_value }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.old_value {
+            env::set_var(self.key, value);
+        } else {
+            env::remove_var(self.key);
+        }
+    }
 }
 
 #[test]
@@ -339,6 +370,36 @@ fn mcp_variables_replace_backend_url_and_task_token_alias() {
     assert_eq!(
         result["wegent-knowledge"]["headers"]["Authorization"],
         "Bearer test-token-"
+    );
+}
+
+#[test]
+fn mcp_variables_replace_empty_backend_url_from_task_api_domain() {
+    let _mode = EnvGuard::remove("EXECUTOR_MODE");
+    let _local_backend = EnvGuard::remove("WEGENT_BACKEND_URL");
+    let _task_api = EnvGuard::set("TASK_API_DOMAIN", "http://backend:8000");
+    let servers = json!({
+        "wegent-knowledge": {
+            "type": "streamable-http",
+            "url": "${{backend_url}}/mcp/knowledge/sse",
+            "headers": {"Authorization": "Bearer ${{task_token}}"},
+            "timeout": 300
+        }
+    });
+    let task = request(json!({
+        "backend_url": "",
+        "auth_token": "test-token"
+    }));
+
+    let result = replace_mcp_server_variables(&servers, Some(&task));
+
+    assert_eq!(
+        result["wegent-knowledge"]["url"],
+        "http://backend:8000/mcp/knowledge/sse"
+    );
+    assert_eq!(
+        result["wegent-knowledge"]["headers"]["Authorization"],
+        "Bearer test-token"
     );
 }
 

--- a/executor/tests/mcp_utils_contract.rs
+++ b/executor/tests/mcp_utils_contract.rs
@@ -404,6 +404,27 @@ fn mcp_variables_replace_empty_backend_url_from_task_api_domain() {
 }
 
 #[test]
+fn mcp_variables_prefer_local_backend_url_in_local_mode() {
+    let _mode = EnvGuard::set("EXECUTOR_MODE", "local");
+    let _local_backend = EnvGuard::set("WEGENT_BACKEND_URL", "http://localhost:8000");
+    let _task_api = EnvGuard::set("TASK_API_DOMAIN", "http://backend:8000");
+    let servers = json!({
+        "wegent-knowledge": {
+            "type": "streamable-http",
+            "url": "${{backend_url}}/mcp/knowledge/sse"
+        }
+    });
+    let task = request(json!({"backend_url": ""}));
+
+    let result = replace_mcp_server_variables(&servers, Some(&task));
+
+    assert_eq!(
+        result["wegent-knowledge"]["url"],
+        "http://localhost:8000/mcp/knowledge/sse"
+    );
+}
+
+#[test]
 fn mcp_variables_preserve_null_values_as_unknown_placeholders() {
     let servers = json!({"key": "${{user.name}}"});
     let task = request(json!({"user": {"name": null}}));

--- a/shared/models/execution.py
+++ b/shared/models/execution.py
@@ -243,18 +243,19 @@ class ExecutionRequest:
     @property
     def effective_backend_url(self) -> str:
         """Backend URL reachable from the current execution runtime."""
-        if self.backend_url.strip():
-            return self.backend_url.strip()
+        backend_url = (self.backend_url or "").strip().rstrip("/")
+        if backend_url:
+            return backend_url
 
         executor_mode = os.getenv("EXECUTOR_MODE", "")
         if executor_mode.strip().lower() == "local":
-            local_backend_url = os.getenv("WEGENT_BACKEND_URL", "")
-            if local_backend_url.strip():
-                return local_backend_url.strip()
+            local_backend_url = os.getenv("WEGENT_BACKEND_URL", "").strip().rstrip("/")
+            if local_backend_url:
+                return local_backend_url
 
-        task_api_domain = os.getenv("TASK_API_DOMAIN", "")
-        if task_api_domain.strip():
-            return task_api_domain.strip()
+        task_api_domain = os.getenv("TASK_API_DOMAIN", "").strip().rstrip("/")
+        if task_api_domain:
+            return task_api_domain
 
         return "http://wegent-backend:8000"
 

--- a/shared/models/execution.py
+++ b/shared/models/execution.py
@@ -15,6 +15,7 @@ Design principles:
 - All modules import the same classes
 """
 
+import os
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Optional, Union
@@ -238,6 +239,24 @@ class ExecutionRequest:
     def task_token(self) -> str:
         """Alias for auth_token, used by MCP configs as ${{task_token}}."""
         return self.auth_token
+
+    @property
+    def effective_backend_url(self) -> str:
+        """Backend URL reachable from the current execution runtime."""
+        if self.backend_url.strip():
+            return self.backend_url.strip()
+
+        executor_mode = os.getenv("EXECUTOR_MODE", "")
+        if executor_mode.strip().lower() == "local":
+            local_backend_url = os.getenv("WEGENT_BACKEND_URL", "")
+            if local_backend_url.strip():
+                return local_backend_url.strip()
+
+        task_api_domain = os.getenv("TASK_API_DOMAIN", "")
+        if task_api_domain.strip():
+            return task_api_domain.strip()
+
+        return "http://wegent-backend:8000"
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ExecutionRequest":

--- a/shared/tests/utils/test_mcp_utils.py
+++ b/shared/tests/utils/test_mcp_utils.py
@@ -6,8 +6,8 @@ from shared.models.execution import ExecutionRequest
 from shared.utils.mcp_utils import replace_mcp_server_variables
 
 
-def test_replace_mcp_server_variables_replaces_backend_url_and_task_token():
-    mcp_servers = {
+def _knowledge_mcp_servers() -> dict:
+    return {
         "wegent-knowledge": {
             "type": "streamable-http",
             "url": "${{backend_url}}/mcp/knowledge/sse",
@@ -15,6 +15,10 @@ def test_replace_mcp_server_variables_replaces_backend_url_and_task_token():
             "timeout": 300,
         }
     }
+
+
+def test_replace_mcp_server_variables_replaces_backend_url_and_task_token():
+    mcp_servers = _knowledge_mcp_servers()
     task_data = ExecutionRequest(
         backend_url="http://localhost:8000",
         auth_token="test-token-",  # noqa: S106
@@ -27,6 +31,38 @@ def test_replace_mcp_server_variables_replaces_backend_url_and_task_token():
     )
     assert (
         replaced["wegent-knowledge"]["headers"]["Authorization"] == "Bearer test-token-"
+    )
+
+
+def test_replace_empty_backend_url_from_task_api_domain(monkeypatch):
+    monkeypatch.delenv("EXECUTOR_MODE", raising=False)
+    monkeypatch.delenv("WEGENT_BACKEND_URL", raising=False)
+    monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000")
+    task_data = ExecutionRequest(
+        backend_url="",
+        auth_token="test-token",  # noqa: S106
+    )
+
+    replaced = replace_mcp_server_variables(_knowledge_mcp_servers(), task_data)
+
+    assert (
+        replaced["wegent-knowledge"]["url"] == "http://backend:8000/mcp/knowledge/sse"
+    )
+    assert (
+        replaced["wegent-knowledge"]["headers"]["Authorization"] == "Bearer test-token"
+    )
+
+
+def test_replace_empty_backend_url_from_local_backend_url(monkeypatch):
+    monkeypatch.setenv("EXECUTOR_MODE", "local")
+    monkeypatch.setenv("WEGENT_BACKEND_URL", "http://localhost:8000")
+    monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000")
+    task_data = ExecutionRequest(backend_url="")
+
+    replaced = replace_mcp_server_variables(_knowledge_mcp_servers(), task_data)
+
+    assert (
+        replaced["wegent-knowledge"]["url"] == "http://localhost:8000/mcp/knowledge/sse"
     )
 
 

--- a/shared/tests/utils/test_mcp_utils.py
+++ b/shared/tests/utils/test_mcp_utils.py
@@ -37,7 +37,7 @@ def test_replace_mcp_server_variables_replaces_backend_url_and_task_token():
 def test_replace_empty_backend_url_from_task_api_domain(monkeypatch):
     monkeypatch.delenv("EXECUTOR_MODE", raising=False)
     monkeypatch.delenv("WEGENT_BACKEND_URL", raising=False)
-    monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000")
+    monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000/")
     task_data = ExecutionRequest(
         backend_url="",
         auth_token="test-token",  # noqa: S106
@@ -55,7 +55,7 @@ def test_replace_empty_backend_url_from_task_api_domain(monkeypatch):
 
 def test_replace_empty_backend_url_from_local_backend_url(monkeypatch):
     monkeypatch.setenv("EXECUTOR_MODE", "local")
-    monkeypatch.setenv("WEGENT_BACKEND_URL", "http://localhost:8000")
+    monkeypatch.setenv("WEGENT_BACKEND_URL", "http://localhost:8000/")
     monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000")
     task_data = ExecutionRequest(backend_url="")
 
@@ -63,6 +63,19 @@ def test_replace_empty_backend_url_from_local_backend_url(monkeypatch):
 
     assert (
         replaced["wegent-knowledge"]["url"] == "http://localhost:8000/mcp/knowledge/sse"
+    )
+
+
+def test_replace_none_backend_url_from_task_api_domain(monkeypatch):
+    monkeypatch.delenv("EXECUTOR_MODE", raising=False)
+    monkeypatch.delenv("WEGENT_BACKEND_URL", raising=False)
+    monkeypatch.setenv("TASK_API_DOMAIN", "http://backend:8000/")
+    task_data = ExecutionRequest(backend_url=None)  # type: ignore[arg-type]
+
+    replaced = replace_mcp_server_variables(_knowledge_mcp_servers(), task_data)
+
+    assert (
+        replaced["wegent-knowledge"]["url"] == "http://backend:8000/mcp/knowledge/sse"
     )
 
 

--- a/shared/utils/mcp_utils.py
+++ b/shared/utils/mcp_utils.py
@@ -122,6 +122,10 @@ def _get_nested_value(obj: Optional["ExecutionRequest"], path: str) -> Optional[
     current: Any = obj
 
     for key in keys:
+        if key == "backend_url" and hasattr(current, "effective_backend_url"):
+            current = current.effective_backend_url
+            continue
+
         if isinstance(current, list):
             # Try to parse key as integer index
             try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution context variable substitution now supports an auto-resolved “effective” backend URL, using the request value first, then local-mode configuration, then task-domain settings, with a safe default fallback.
* **Bug Fixes**
  * `${{backend_url}}` placeholder replacement now correctly handles empty or null backend URL inputs, including correct Authorization header substitution.
* **Tests**
  * Added/extended unit and contract tests to validate local vs hosted fallback behavior for empty/null backend URL cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->