### PR TITLE
[codex] Persist Wework app logs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       "@tauri-apps/plugin-http":
         specifier: ^2.5.0
         version: 2.5.9
+      "@tauri-apps/plugin-log":
+        specifier: ^2.8.0
+        version: 2.8.0
       "@tauri-apps/plugin-opener":
         specifier: ~2.5.4
         version: 2.5.4
@@ -4079,6 +4082,12 @@ packages:
     resolution:
       {
         integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==,
+      }
+
+  "@tauri-apps/plugin-log@2.8.0":
+    resolution:
+      {
+        integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==,
       }
 
   "@tauri-apps/plugin-opener@2.5.4":
@@ -14820,6 +14829,10 @@ snapshots:
       "@tauri-apps/cli-win32-x64-msvc": 2.11.2
 
   "@tauri-apps/plugin-http@2.5.9":
+    dependencies:
+      "@tauri-apps/api": 2.11.0
+
+  "@tauri-apps/plugin-log@2.8.0":
     dependencies:
       "@tauri-apps/api": 2.11.0
 

--- a/wework/package.json
+++ b/wework/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-virtual": "3.14.2",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-http": "^2.5.0",
+    "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "~2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/wework/src-tauri/capabilities/default.json
+++ b/wework/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:webview:allow-set-webview-position",
     "core:webview:allow-set-webview-size",
     "core:webview:allow-set-webview-focus",
+    "log:default",
     "opener:allow-open-url",
     "opener:allow-default-urls",
     "shell:allow-open",

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -28,6 +28,101 @@ const TRAY_MENU_QUIT_ID: &str = "quit";
 const TRAY_MENU_TASK_PREFIX: &str = "task:";
 #[cfg(desktop)]
 const TRAY_ID: &str = "wework-main";
+#[cfg(desktop)]
+const LOG_DIRECTORY_APP_NAME: &str = "Wework";
+#[cfg(desktop)]
+const LOG_DIRECTORY_VENDOR_NAME: &str = "Wegent";
+#[cfg(desktop)]
+const RUST_LOG_FILE_NAME: &str = "wework-tauri";
+#[cfg(desktop)]
+const WEBVIEW_LOG_FILE_NAME: &str = "wework-frontend";
+
+#[cfg(desktop)]
+fn app_log_directory(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+    #[cfg(target_os = "macos")]
+    {
+        return Ok(app
+            .path()
+            .home_dir()
+            .map_err(|error| format!("Failed to locate home directory: {error}"))?
+            .join("Library")
+            .join("Logs")
+            .join(LOG_DIRECTORY_VENDOR_NAME)
+            .join(LOG_DIRECTORY_APP_NAME));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return Ok(app
+            .path()
+            .local_data_dir()
+            .map_err(|error| format!("Failed to locate local data directory: {error}"))?
+            .join(LOG_DIRECTORY_VENDOR_NAME)
+            .join(LOG_DIRECTORY_APP_NAME)
+            .join("logs"));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return Ok(app
+            .path()
+            .data_dir()
+            .map_err(|error| format!("Failed to locate data directory: {error}"))?
+            .join(LOG_DIRECTORY_VENDOR_NAME)
+            .join(LOG_DIRECTORY_APP_NAME)
+            .join("logs"));
+    }
+
+    #[allow(unreachable_code)]
+    app.path()
+        .app_log_dir()
+        .map_err(|error| format!("Failed to locate app log directory: {error}"))
+}
+
+#[cfg(desktop)]
+fn create_log_plugin(
+    app: &tauri::AppHandle,
+) -> Result<tauri::plugin::TauriPlugin<tauri::Wry>, String> {
+    let log_directory = app_log_directory(app)?;
+    Ok(tauri_plugin_log::Builder::default()
+        .clear_targets()
+        .level(log::LevelFilter::Debug)
+        .target(
+            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
+                path: log_directory.clone(),
+                file_name: Some(RUST_LOG_FILE_NAME.into()),
+            })
+            .filter(|metadata| {
+                !metadata
+                    .target()
+                    .starts_with(tauri_plugin_log::WEBVIEW_TARGET)
+            }),
+        )
+        .target(
+            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
+                path: log_directory,
+                file_name: Some(WEBVIEW_LOG_FILE_NAME.into()),
+            })
+            .filter(|metadata| {
+                metadata
+                    .target()
+                    .starts_with(tauri_plugin_log::WEBVIEW_TARGET)
+            }),
+        )
+        .build())
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+fn get_app_log_directory(app: tauri::AppHandle) -> Result<String, String> {
+    Ok(app_log_directory(&app)?.to_string_lossy().to_string())
+}
+
+#[cfg(not(desktop))]
+#[tauri::command]
+fn get_app_log_directory(_app: tauri::AppHandle) -> Result<String, String> {
+    Err("App log directory is only available on desktop".to_string())
+}
 
 fn normalized_non_empty(value: String) -> Option<String> {
     let trimmed = value.trim();
@@ -896,13 +991,17 @@ pub fn run() {
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
             }
 
-            if cfg!(debug_assertions) {
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        .build(),
-                )?;
-            }
+            #[cfg(desktop)]
+            app.handle().plugin(
+                create_log_plugin(app.handle())
+                    .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?,
+            )?;
+
+            log::info!(
+                "Wework app logs are written to {}",
+                get_app_log_directory(app.handle().clone()).unwrap_or_else(|error| error)
+            );
+
             #[cfg(desktop)]
             setup_system_tray(app)?;
             Ok(())
@@ -925,6 +1024,7 @@ pub fn run() {
             local_executor::local_executor_request,
             local_executor::local_executor_restart,
             local_executor::local_executor_status,
+            get_app_log_directory,
             set_tray_menu_state,
             download_local_file_to_downloads,
             save_text_file_to_downloads,

--- a/wework/src/lib/app-logging.ts
+++ b/wework/src/lib/app-logging.ts
@@ -1,0 +1,88 @@
+import { debug, error, info, warn } from '@tauri-apps/plugin-log'
+
+type ConsoleLevel = 'debug' | 'error' | 'info' | 'log' | 'warn'
+
+type TauriWindow = Window &
+  typeof globalThis & {
+    __TAURI_INTERNALS__?: unknown
+  }
+
+const MAX_LOG_ARGUMENT_LENGTH = 4000
+const MAX_LOG_MESSAGE_LENGTH = 12000
+
+let installed = false
+
+function isTauriRuntime() {
+  return typeof window !== 'undefined' && Boolean((window as TauriWindow).__TAURI_INTERNALS__)
+}
+
+function serializeLogArgument(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack || `${value.name}: ${value.message}`
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized !== undefined) {
+      return serialized
+    }
+  } catch {
+    return String(value)
+  }
+
+  return String(value)
+}
+
+function truncateLogValue(value: string, maxLength: number) {
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  return `${value.slice(0, maxLength)}... [truncated ${value.length - maxLength} chars]`
+}
+
+function formatLogMessage(args: unknown[]) {
+  return truncateLogValue(
+    args.map(arg => truncateLogValue(serializeLogArgument(arg), MAX_LOG_ARGUMENT_LENGTH)).join(' '),
+    MAX_LOG_MESSAGE_LENGTH
+  )
+}
+
+function writeTauriLog(level: ConsoleLevel, args: unknown[]) {
+  const message = formatLogMessage(args)
+  const write =
+    level === 'error' ? error : level === 'warn' ? warn : level === 'debug' ? debug : info
+
+  void write(message).catch(() => {
+    // Logging must never break the app or recursively write to console.
+  })
+}
+
+export function installAppLogging() {
+  if (installed || !isTauriRuntime()) {
+    return
+  }
+
+  installed = true
+
+  const originalConsole = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+  } satisfies Record<ConsoleLevel, (...args: unknown[]) => void>
+
+  ;(['debug', 'error', 'info', 'log', 'warn'] as const).forEach(level => {
+    console[level] = (...args: unknown[]) => {
+      originalConsole[level](...args)
+      writeTauriLog(level, args)
+    }
+  })
+
+  info('Frontend logging initialized')
+}

--- a/wework/src/main.tsx
+++ b/wework/src/main.tsx
@@ -3,10 +3,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './styles/globals.css'
 import App from './App.tsx'
+import { installAppLogging } from './lib/app-logging'
 import { installExternalLinkHandler } from './lib/external-links'
 import { installPageZoomGuard } from './lib/pageZoomGuard'
 import { installDesktopExtensions } from '@extensions/desktop'
 
+installAppLogging()
 installDesktopExtensions()
 installExternalLinkHandler()
 installPageZoomGuard()


### PR DESCRIPTION
## Summary
- Configure the Wework Tauri log plugin to always write desktop app logs to a fixed OS-specific Wegent/Wework directory.
- Split Rust/Tauri backend logs and webview frontend logs into separate rotated files.
- Add a frontend console bridge so existing console debug/warn/error output is persisted through the Tauri log plugin.

## Impact
This makes production troubleshooting easier because both the Tauri backend and frontend webview logs are kept in a stable location instead of only appearing in developer consoles. On macOS the directory is `~/Library/Logs/Wegent/Wework`.

## Validation
- `cargo check` in `wework/src-tauri`
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved app logging for desktop use, with logs now captured more consistently across browser and desktop environments.
  * Introduced a way to view the app’s log directory on supported desktop platforms.

* **Bug Fixes**
  * Logging is now more reliable and less likely to interrupt normal app behavior if something goes wrong.
  * Console messages are handled more cleanly, including long messages and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->