### PR TITLE
[codex] Fix Wework dark terminal contrast

### DIFF
--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -152,7 +152,7 @@ export function ProjectChatComposer({
   }, [disabled, onFileSelect])
 
   return (
-    <div className="relative w-full rounded-[26px] bg-[#f3f3f3] shadow-[0_18px_44px_rgba(0,0,0,0.09)]">
+    <div className="relative w-full rounded-[26px] bg-surface shadow-[0_18px_44px_rgba(0,0,0,0.09)]">
       <form
         ref={formRef}
         data-testid="project-chat-composer-form"
@@ -246,7 +246,7 @@ export function ProjectChatComposer({
           onCreateBranch={projectWork.onCreateBranch}
           worktreeBranch={projectWork.worktreeBranch}
           onWorktreeBranchChange={projectWork.onWorktreeBranchChange}
-          className="min-h-10 rounded-b-[26px] bg-[#f3f3f3] px-4"
+          className="min-h-10 rounded-b-[26px] bg-surface px-4"
           buttonClassName="h-9 px-2.5 text-[13px] leading-[18px] text-text-secondary hover:bg-surface/70 hover:text-text-primary"
         />
       )}

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -127,7 +127,7 @@ export function BottomWorkspacePanel({
           <header
             data-testid={contentTestIdsEnabled ? 'bottom-workspace-tabbar' : undefined}
             role="tablist"
-            className="flex h-10 shrink-0 items-center gap-1.5 overflow-hidden border-b border-border bg-[#fafafa] px-2 pr-12"
+            className="flex h-10 shrink-0 items-center gap-1.5 overflow-hidden border-b border-border bg-surface px-2 pr-12"
           >
             <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
               {tabs.map(tab => (
@@ -161,7 +161,7 @@ export function BottomWorkspacePanel({
                   devices={devices}
                   workspaceTarget={workspaceTarget}
                   defaultOpenTool={panelActive ? 'terminal' : undefined}
-                  onRequestClose={onRequestClose}
+                  onRequestClose={() => closeTab(tab.id)}
                   hideTerminalChrome
                   preferLocalTerminal={preferLocalTerminal}
                   panelActive={panelActive}
@@ -210,7 +210,7 @@ function BottomWorkspaceTitleTab({
       className={cn(
         'group relative flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl py-1 pl-2 pr-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         active
-          ? 'border border-border bg-white text-text-primary shadow-sm'
+          ? 'border border-border bg-background text-text-primary shadow-sm'
           : 'border border-transparent text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
       )}
     >

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -8,21 +8,35 @@ import {
   resizeLocalTerminal,
   writeLocalTerminal,
 } from '@/lib/local-terminal'
+import {
+  applyTerminalTheme,
+  createTerminalThemeScheduler,
+  getTerminalTheme,
+  observeTerminalTheme,
+} from '@/lib/xterm-theme'
 
 interface EmbeddedLocalTerminalProps {
   sessionId: string
   active: boolean
+  onExit?: () => void
   testIdsEnabled?: boolean
 }
 
 export function EmbeddedLocalTerminal({
   sessionId,
   active,
+  onExit,
   testIdsEnabled = true,
 }: EmbeddedLocalTerminalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const terminalRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
+  const activeRef = useRef(active)
+  const lastSizeRef = useRef<{ rows: number; cols: number } | null>(null)
+
+  useEffect(() => {
+    activeRef.current = active
+  }, [active])
 
   useEffect(() => {
     const container = containerRef.current
@@ -35,12 +49,7 @@ export function EmbeddedLocalTerminal({
       fontSize: 13,
       lineHeight: 1.2,
       scrollback: 2000,
-      theme: {
-        background: '#ffffff',
-        foreground: '#1a1a1a',
-        cursor: '#14b8a6',
-        selectionBackground: '#d8f3ee',
-      },
+      theme: getTerminalTheme(),
     })
     const fitAddon = new FitAddon()
     const dataDisposable = terminal.onData(data => {
@@ -53,15 +62,30 @@ export function EmbeddedLocalTerminal({
     terminal.open(container)
     terminalRef.current = terminal
     fitAddonRef.current = fitAddon
+    applyTerminalTheme(terminal, container)
+    const scheduleThemeSync = createTerminalThemeScheduler(terminal, container)
+    const unobserveTheme = observeTerminalTheme(theme => {
+      applyTerminalTheme(terminal, container, theme)
+    })
 
     const fitAndResize = () => {
       if (disposed || !container.isConnected) return
       try {
         fitAddon.fit()
-        void resizeLocalTerminal(sessionId, terminal.rows, terminal.cols)
+        syncTerminalSize()
       } catch (error) {
         console.error('Failed to resize local terminal:', error)
       }
+    }
+
+    const syncTerminalSize = () => {
+      if (!activeRef.current || terminal.rows <= 0 || terminal.cols <= 0) return
+
+      const lastSize = lastSizeRef.current
+      if (lastSize?.rows === terminal.rows && lastSize.cols === terminal.cols) return
+
+      lastSizeRef.current = { rows: terminal.rows, cols: terminal.cols }
+      void resizeLocalTerminal(sessionId, terminal.rows, terminal.cols)
     }
 
     const resizeObserver = new ResizeObserver(fitAndResize)
@@ -71,6 +95,7 @@ export function EmbeddedLocalTerminal({
     void listenLocalTerminalOutput(payload => {
       if (!disposed && payload.session_id === sessionId) {
         terminal.write(payload.data)
+        scheduleThemeSync()
       }
     }).then(unlisten => {
       if (disposed) {
@@ -82,7 +107,7 @@ export function EmbeddedLocalTerminal({
 
     void listenLocalTerminalExit(payload => {
       if (!disposed && payload.session_id === sessionId) {
-        terminal.writeln('\r\n[Process exited]')
+        onExit?.()
       }
     }).then(unlisten => {
       if (disposed) {
@@ -94,6 +119,7 @@ export function EmbeddedLocalTerminal({
 
     return () => {
       disposed = true
+      unobserveTheme()
       resizeObserver.disconnect()
       dataDisposable.dispose()
       unlisteners.forEach(unlisten => unlisten())
@@ -109,12 +135,20 @@ export function EmbeddedLocalTerminal({
     const frame = requestAnimationFrame(() => {
       const terminal = terminalRef.current
       const fitAddon = fitAddonRef.current
-      if (!terminal || !fitAddon) return
+      const container = containerRef.current
+      if (!terminal || !fitAddon || !container) return
 
       try {
+        applyTerminalTheme(terminal, container)
         fitAddon.fit()
         terminal.focus()
-        void resizeLocalTerminal(sessionId, terminal.rows, terminal.cols)
+        if (terminal.rows > 0 && terminal.cols > 0) {
+          const lastSize = lastSizeRef.current
+          if (lastSize?.rows !== terminal.rows || lastSize.cols !== terminal.cols) {
+            lastSizeRef.current = { rows: terminal.rows, cols: terminal.cols }
+            void resizeLocalTerminal(sessionId, terminal.rows, terminal.cols)
+          }
+        }
       } catch (error) {
         console.error('Failed to activate local terminal:', error)
       }
@@ -129,7 +163,7 @@ export function EmbeddedLocalTerminal({
     <div
       ref={containerRef}
       data-testid={testIdsEnabled ? 'embedded-local-terminal' : undefined}
-      className="h-full min-h-0 w-full overflow-hidden bg-white px-2 py-2"
+      className="h-full min-h-0 w-full overflow-hidden bg-background px-2 py-2"
       hidden={!active}
     />
   )

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -15,6 +15,7 @@ const testState = vi.hoisted(() => ({
     open: ReturnType<typeof vi.fn>
     dispose: ReturnType<typeof vi.fn>
     focus: ReturnType<typeof vi.fn>
+    options: { theme?: unknown }
   }>,
   resizeObserverInstances: [] as Array<{
     trigger: () => void
@@ -48,6 +49,7 @@ vi.mock('@xterm/xterm', () => ({
       open: vi.fn(),
       dispose: vi.fn(),
       focus: vi.fn(),
+      options: {},
     }
     testState.terminalInstances.push(terminal)
     return terminal
@@ -122,30 +124,59 @@ describe('RemoteTerminal', () => {
     testState.terminalInstances[0].emitData('pwd\r')
 
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to write to remote terminal:',
-        error
-      )
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to write to remote terminal:', error)
     })
   })
 
-  test('catches rejected resize observer syncs', async () => {
-    const error = new Error('resize failed')
+  test('calls exit handler without writing process exited text', () => {
+    let exitHandler: ((payload: { session_id: string }) => void) | null = null
     const client = createClient({
       attach: vi.fn(() => new Promise(() => undefined)),
-      resize: vi.fn().mockRejectedValue(error),
+      onExit: vi.fn(handler => {
+        exitHandler = handler
+        return vi.fn()
+      }),
+    })
+    const onExit = vi.fn()
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    render(<RemoteTerminal sessionId="terminal-1" active={false} onExit={onExit} />)
+    exitHandler?.({ session_id: 'terminal-1' })
+
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(testState.terminalInstances[0].writeln).not.toHaveBeenCalledWith(
+      expect.stringContaining('Process exited')
+    )
+  })
+
+  test('skips resize observer syncs while inactive', () => {
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
     })
     createRemoteTerminalClientMock.mockReturnValue(client)
 
     render(<RemoteTerminal sessionId="terminal-1" active={false} />)
     testState.resizeObserverInstances[0].trigger()
 
-    await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to resize remote terminal:',
-        error
-      )
+    expect(client.resize).not.toHaveBeenCalled()
+  })
+
+  test('does not resend unchanged terminal size when reactivated', async () => {
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
     })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    const { rerender } = render(<RemoteTerminal sessionId="terminal-1" active />)
+
+    await waitFor(() => {
+      expect(client.resize).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(<RemoteTerminal sessionId="terminal-1" active={false} />)
+    rerender(<RemoteTerminal sessionId="terminal-1" active />)
+
+    expect(client.resize).toHaveBeenCalledTimes(1)
   })
 
   test('catches rejected active terminal size syncs', async () => {

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -3,18 +3,36 @@ import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { useEffect, useRef } from 'react'
 import { createRemoteTerminalClient, type RemoteTerminalClient } from '@/lib/remote-terminal-socket'
+import {
+  applyTerminalTheme,
+  createTerminalThemeScheduler,
+  getTerminalTheme,
+  observeTerminalTheme,
+} from '@/lib/xterm-theme'
 
 interface RemoteTerminalProps {
   sessionId: string
   active: boolean
+  onExit?: () => void
   testIdsEnabled?: boolean
 }
 
-export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: RemoteTerminalProps) {
+export function RemoteTerminal({
+  sessionId,
+  active,
+  onExit,
+  testIdsEnabled = true,
+}: RemoteTerminalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const terminalRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const clientRef = useRef<RemoteTerminalClient | null>(null)
+  const activeRef = useRef(active)
+  const lastSizeRef = useRef<{ rows: number; cols: number } | null>(null)
+
+  useEffect(() => {
+    activeRef.current = active
+  }, [active])
 
   useEffect(() => {
     const container = containerRef.current
@@ -27,16 +45,12 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
       fontSize: 13,
       lineHeight: 1.2,
       scrollback: 2000,
-      theme: {
-        background: '#ffffff',
-        foreground: '#1a1a1a',
-        cursor: '#14b8a6',
-        selectionBackground: '#d8f3ee',
-      },
+      theme: getTerminalTheme(),
     })
     const fitAddon = new FitAddon()
     const client = createRemoteTerminalClient(sessionId)
     let disposed = false
+    let scheduleThemeSync: () => void = () => undefined
 
     const dataDisposable = terminal.onData(data => {
       void client.write(data).catch(error => {
@@ -48,11 +62,12 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
     const unsubscribeOutput = client.onOutput(payload => {
       if (!disposed && payload.session_id === sessionId) {
         terminal.write(payload.data)
+        scheduleThemeSync()
       }
     })
     const unsubscribeExit = client.onExit(payload => {
       if (!disposed && payload.session_id === sessionId) {
-        terminal.writeln('\r\n[Process exited]')
+        onExit?.()
       }
     })
 
@@ -61,6 +76,11 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
     terminalRef.current = terminal
     fitAddonRef.current = fitAddon
     clientRef.current = client
+    applyTerminalTheme(terminal, container)
+    scheduleThemeSync = createTerminalThemeScheduler(terminal, container)
+    const unobserveTheme = observeTerminalTheme(theme => {
+      applyTerminalTheme(terminal, container, theme)
+    })
 
     const fitAndResize = () => {
       if (disposed || !container.isConnected) return
@@ -70,11 +90,21 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
         console.error('Failed to resize remote terminal:', error)
         return
       }
-      void client.resize(terminal.rows, terminal.cols).catch(error => {
+      syncTerminalSize(error => {
         if (!disposed) {
           console.error('Failed to resize remote terminal:', error)
         }
       })
+    }
+
+    const syncTerminalSize = (onError: (error: unknown) => void) => {
+      if (!activeRef.current || terminal.rows <= 0 || terminal.cols <= 0) return
+
+      const lastSize = lastSizeRef.current
+      if (lastSize?.rows === terminal.rows && lastSize.cols === terminal.cols) return
+
+      lastSizeRef.current = { rows: terminal.rows, cols: terminal.cols }
+      void client.resize(terminal.rows, terminal.cols).catch(onError)
     }
 
     const resizeObserver = new ResizeObserver(fitAndResize)
@@ -94,6 +124,7 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
 
     return () => {
       disposed = true
+      unobserveTheme()
       resizeObserver.disconnect()
       dataDisposable.dispose()
       unsubscribeOutput()
@@ -118,15 +149,23 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
       const terminal = terminalRef.current
       const fitAddon = fitAddonRef.current
       const client = clientRef.current
-      if (!terminal || !fitAddon || !client) return
+      const container = containerRef.current
+      if (!terminal || !fitAddon || !client || !container) return
 
       try {
+        applyTerminalTheme(terminal, container)
         fitAddon.fit()
         terminal.focus()
       } catch (error) {
         console.error('Failed to activate remote terminal:', error)
         return
       }
+      if (terminal.rows <= 0 || terminal.cols <= 0) return
+
+      const lastSize = lastSizeRef.current
+      if (lastSize?.rows === terminal.rows && lastSize.cols === terminal.cols) return
+
+      lastSizeRef.current = { rows: terminal.rows, cols: terminal.cols }
       void client.resize(terminal.rows, terminal.cols).catch(error => {
         console.error('Failed to sync remote terminal size on activate:', error)
       })
@@ -141,7 +180,7 @@ export function RemoteTerminal({ sessionId, active, testIdsEnabled = true }: Rem
     <div
       ref={containerRef}
       data-testid={testIdsEnabled ? 'remote-terminal' : undefined}
-      className="h-full min-h-0 w-full flex-1 overflow-hidden bg-white px-2 py-2"
+      className="h-full min-h-0 w-full flex-1 overflow-hidden bg-background px-2 py-2"
       hidden={!active}
     />
   )

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -48,19 +48,43 @@ vi.mock('@/lib/local-terminal', () => ({
 }))
 
 vi.mock('./EmbeddedLocalTerminal', () => ({
-  EmbeddedLocalTerminal: ({ active, sessionId }: { active: boolean; sessionId: string }) => (
-    <div data-testid="embedded-local-terminal" data-session-id={sessionId} hidden={!active} />
+  EmbeddedLocalTerminal: ({
+    active,
+    sessionId,
+    onExit,
+  }: {
+    active: boolean
+    sessionId: string
+    onExit?: () => void
+  }) => (
+    <div data-testid="embedded-local-terminal" data-session-id={sessionId} hidden={!active}>
+      <button
+        type="button"
+        data-testid={`embedded-local-terminal-exit-${sessionId}`}
+        onClick={onExit}
+      />
+    </div>
   ),
 }))
 
 vi.mock('./RemoteTerminal', () => ({
-  RemoteTerminal: ({ active, sessionId }: { active: boolean; sessionId: string }) => (
+  RemoteTerminal: ({
+    active,
+    sessionId,
+    onExit,
+  }: {
+    active: boolean
+    sessionId: string
+    onExit?: () => void
+  }) => (
     <div
       data-testid="remote-terminal"
       data-session-id={sessionId}
       className="h-full w-full"
       hidden={!active}
-    />
+    >
+      <button type="button" data-testid={`remote-terminal-exit-${sessionId}`} onClick={onExit} />
+    </div>
   ),
 }))
 
@@ -217,7 +241,7 @@ describe('WorkspacePanelCards', () => {
     await waitFor(() => expect(api.startTerminalSession).toHaveBeenCalledWith(7))
     expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
     expect(screen.queryByTestId('workspace-terminal-frame')).not.toBeInTheDocument()
-    expect(screen.getByTestId('workspace-terminal-window')).toHaveClass('bg-white')
+    expect(screen.getByTestId('workspace-terminal-window')).toHaveClass('bg-background')
     expect(screen.getByTestId('workspace-terminal-tab')).toHaveTextContent('project38')
     expect(screen.getByTestId('workspace-terminal-new-tab-button')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-terminal-close-button')).toBeInTheDocument()
@@ -268,6 +292,18 @@ describe('WorkspacePanelCards', () => {
     expect(screen.getAllByTestId('workspace-terminal-tab')).toHaveLength(1)
     expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
     expect(screen.getByTestId('remote-terminal')).not.toHaveAttribute('hidden')
+  })
+
+  test('removes the terminal session when the process exits', async () => {
+    render(<WorkspacePanelCards currentProject={cloudProject} devices={cloudDevices} />)
+
+    await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
+    await waitFor(() => expect(screen.getByTestId('remote-terminal')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByTestId('remote-terminal-exit-terminal-1'))
+
+    expect(screen.queryByTestId('remote-terminal')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workspace-tool-launcher')).toBeInTheDocument()
   })
 
   test('opens the project IDE in a new page without a preflight probe', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -453,6 +453,14 @@ export function WorkspacePanelCards({
       void closeLocalTerminal(sessionId)
     }
 
+    removeTerminalSession(sessionId)
+  }
+
+  const handleTerminalSessionExit = (sessionId: string) => {
+    removeTerminalSession(sessionId)
+  }
+
+  const removeTerminalSession = (sessionId: string) => {
     setTerminalSessions(sessions => {
       const closeIndex = sessions.findIndex(session => session.session_id === sessionId)
       const remaining = sessions.filter(session => session.session_id !== sessionId)
@@ -467,6 +475,10 @@ export function WorkspacePanelCards({
 
       return remaining
     })
+
+    if (hideTerminalChrome && terminalSessions.length <= 1) {
+      onRequestClose?.()
+    }
   }
 
   const handleIdeClick = async (
@@ -593,10 +605,10 @@ export function WorkspacePanelCards({
   const terminalWindow = activeTerminalSession ? (
     <div
       data-testid={testId('workspace-terminal-window')}
-      className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-white"
+      className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background"
     >
       {!hideTerminalChrome && (
-        <div className="flex h-10 shrink-0 items-center gap-2 overflow-hidden border-b border-border bg-[#fafafa] px-2">
+        <div className="flex h-10 shrink-0 items-center gap-2 overflow-hidden border-b border-border bg-surface px-2">
           <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
             {terminalSessions.map(session => {
               const isActive = session.session_id === activeTerminalSession.session_id
@@ -606,7 +618,7 @@ export function WorkspacePanelCards({
                   key={session.session_id}
                   className={`group relative flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-xl border border-transparent transition-colors ${
                     isActive
-                      ? 'border-border bg-white text-text-primary shadow-sm'
+                      ? 'border-border bg-background text-text-primary shadow-sm'
                       : 'text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
                   }`}
                   title={terminalTabLabel || session.device_id}
@@ -652,6 +664,7 @@ export function WorkspacePanelCards({
             key={session.session_id}
             sessionId={session.session_id}
             active={panelActive && isActive}
+            onExit={() => handleTerminalSessionExit(session.session_id)}
             testIdsEnabled={testIdsEnabled}
           />
         ) : (
@@ -659,6 +672,7 @@ export function WorkspacePanelCards({
             key={session.session_id}
             sessionId={session.session_id}
             active={panelActive && isActive}
+            onExit={() => handleTerminalSessionExit(session.session_id)}
             testIdsEnabled={testIdsEnabled}
           />
         )

--- a/wework/src/lib/xterm-theme.test.ts
+++ b/wework/src/lib/xterm-theme.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { applyTerminalTheme, getTerminalTheme, observeTerminalTheme } from './xterm-theme'
+
+function setThemeVariables() {
+  const root = document.documentElement
+  root.style.setProperty('--color-bg-base', '17 19 22')
+  root.style.setProperty('--color-text-primary', '241 245 249')
+  root.style.setProperty('--color-primary', '45 212 191')
+}
+
+describe('xterm-theme', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.removeAttribute('class')
+    document.documentElement.removeAttribute('style')
+    vi.restoreAllMocks()
+  })
+
+  test('builds terminal colors from active theme tokens', () => {
+    document.documentElement.dataset.theme = 'dark'
+    setThemeVariables()
+
+    expect(getTerminalTheme()).toEqual({
+      background: 'rgb(17, 19, 22)',
+      foreground: 'rgb(241, 245, 249)',
+      cursor: 'rgb(45, 212, 191)',
+      selectionBackground: 'rgba(45, 212, 191, 0.28)',
+    })
+  })
+
+  test('observes root appearance changes', async () => {
+    const onChange = vi.fn()
+    const disconnect = observeTerminalTheme(onChange)
+
+    document.documentElement.dataset.theme = 'dark'
+    setThemeVariables()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        background: 'rgb(17, 19, 22)',
+        foreground: 'rgb(241, 245, 249)',
+      })
+    )
+
+    disconnect()
+  })
+
+  test('applies terminal background to generated xterm nodes', () => {
+    document.documentElement.dataset.theme = 'dark'
+    setThemeVariables()
+    const terminal = { options: {} }
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="xterm">
+        <div class="xterm-viewport"></div>
+        <div class="xterm-screen"></div>
+      </div>
+    `
+
+    applyTerminalTheme(terminal as never, container)
+
+    expect(terminal.options).toEqual({
+      theme: expect.objectContaining({ background: 'rgb(17, 19, 22)' }),
+    })
+    expect(container.style.backgroundColor).toBe('rgb(17, 19, 22)')
+    expect(container.querySelector<HTMLElement>('.xterm-viewport')?.style.backgroundColor).toBe(
+      'rgb(17, 19, 22)'
+    )
+    expect(container.querySelector<HTMLElement>('.xterm-screen')?.style.backgroundColor).toBe(
+      'rgb(17, 19, 22)'
+    )
+  })
+})

--- a/wework/src/lib/xterm-theme.ts
+++ b/wework/src/lib/xterm-theme.ts
@@ -1,0 +1,124 @@
+import type { ITheme, Terminal } from '@xterm/xterm'
+
+type RequiredTerminalTheme = Required<
+  Pick<ITheme, 'background' | 'foreground' | 'cursor' | 'selectionBackground'>
+>
+
+const LIGHT_TERMINAL_THEME: RequiredTerminalTheme = {
+  background: '#ffffff',
+  foreground: '#1a1a1a',
+  cursor: '#14b8a6',
+  selectionBackground: 'rgba(20, 184, 166, 0.2)',
+}
+
+const DARK_TERMINAL_THEME: RequiredTerminalTheme = {
+  background: '#111316',
+  foreground: '#f1f5f9',
+  cursor: '#2dd4bf',
+  selectionBackground: 'rgba(45, 212, 191, 0.28)',
+}
+
+function isDarkAppearance(): boolean {
+  if (typeof document === 'undefined') return false
+
+  const root = document.documentElement
+  if (root.dataset.theme === 'dark' || root.classList.contains('dark')) {
+    return true
+  }
+  if (root.dataset.theme === 'light') {
+    return false
+  }
+
+  return Boolean(window.matchMedia?.('(prefers-color-scheme: dark)').matches)
+}
+
+function cssVariableColor(name: string, fallback: string, alpha?: number): string {
+  if (typeof document === 'undefined') return fallback
+
+  const rawValue = window.getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  if (!rawValue) return fallback
+
+  const channels = rawValue
+    .split('/')[0]
+    .trim()
+    .split(/\s+/)
+    .map(channel => Number(channel))
+
+  if (channels.length !== 3 || channels.some(channel => Number.isNaN(channel))) {
+    return fallback
+  }
+
+  const [red, green, blue] = channels
+  if (alpha != null) return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+  return `rgb(${red}, ${green}, ${blue})`
+}
+
+export function getTerminalTheme(): ITheme {
+  const fallbackTheme = isDarkAppearance() ? DARK_TERMINAL_THEME : LIGHT_TERMINAL_THEME
+
+  return {
+    background: cssVariableColor('--color-bg-base', fallbackTheme.background),
+    foreground: cssVariableColor('--color-text-primary', fallbackTheme.foreground),
+    cursor: cssVariableColor('--color-primary', fallbackTheme.cursor),
+    selectionBackground: cssVariableColor(
+      '--color-primary',
+      fallbackTheme.selectionBackground ?? DARK_TERMINAL_THEME.selectionBackground,
+      isDarkAppearance() ? 0.28 : 0.2
+    ),
+  }
+}
+
+export function applyTerminalTheme(
+  terminal: Terminal,
+  container: HTMLElement,
+  theme = getTerminalTheme()
+): ITheme {
+  const appliedTheme = { ...theme }
+  terminal.options.theme = appliedTheme
+
+  if (appliedTheme.background) {
+    container.style.backgroundColor = appliedTheme.background
+    container
+      .querySelectorAll<HTMLElement>(
+        '.xterm, .xterm-viewport, .xterm-screen, .xterm-scrollable-element'
+      )
+      .forEach(element => {
+        element.style.backgroundColor = appliedTheme.background ?? ''
+      })
+  }
+
+  return appliedTheme
+}
+
+export function createTerminalThemeScheduler(
+  terminal: Terminal,
+  container: HTMLElement
+): () => void {
+  let frameId: number | null = null
+
+  return () => {
+    if (frameId != null) return
+
+    frameId = window.requestAnimationFrame(() => {
+      frameId = null
+      applyTerminalTheme(terminal, container)
+    })
+  }
+}
+
+export function observeTerminalTheme(onChange: (theme: ITheme) => void): () => void {
+  if (typeof document === 'undefined' || typeof MutationObserver === 'undefined') {
+    return () => undefined
+  }
+
+  const observer = new MutationObserver(() => {
+    onChange(getTerminalTheme())
+  })
+
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class', 'data-theme', 'style'],
+  })
+
+  return () => observer.disconnect()
+}


### PR DESCRIPTION
## Summary
- Use theme tokens for Wework project composer work bar and terminal panel chrome in dark mode.
- Add shared xterm theme handling so terminal body follows the active appearance tokens.
- Close terminal sessions automatically on process exit and avoid duplicate resize syncs while toggling terminal visibility.

## Testing
- pnpm --dir wework exec tsc -b --pretty false
- pnpm --dir wework exec vitest run src/components/layout/workspace-panels/RemoteTerminal.test.tsx src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx src/lib/xterm-theme.test.ts src/components/layout/DesktopWorkbenchLayout.test.tsx
- git push pre-push hook: frontend lint/typecheck/unit tests, wework lint/typecheck/unit tests, Python syntax checks, executor cargo test --all-features, cargo clippy, alembic multi-head check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal panels now follow the app’s theme automatically for a more consistent light/dark appearance.
  * Terminal exits now close the session cleanly instead of showing a static exit message.

* **Bug Fixes**
  * Improved terminal resizing to reduce unnecessary refreshes and keep sizing stable when switching tabs.
  * Updated workspace and composer styling to better match the current theme across panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->