### PR TITLE
[codex] fix local executor IPC hangs

### DIFF
--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -10,13 +10,14 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
+    time::{Duration, Instant},
 };
 
 use serde_json::{json, Value};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader},
     net::UnixListener,
-    sync::broadcast,
+    sync::{broadcast, mpsc},
 };
 
 use crate::{
@@ -31,6 +32,7 @@ const DEFAULT_DEVICE_ID: &str = "local-device";
 const DEFAULT_SOCKET_NAME: &str = "app-ipc.sock";
 const DEFAULT_TIMEOUT_SECONDS: f64 = 60.0;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+const APP_IPC_REQUEST_TIMEOUT_SECONDS: u64 = 75;
 const WORKSPACE_TREE_SCRIPT: &str = r#"
 import json
 import os
@@ -486,10 +488,22 @@ impl AppIpcServer {
     }
 
     async fn handle_stream(&self, stream: tokio::net::UnixStream) -> Result<(), String> {
-        let (reader, mut writer) = stream.into_split();
-        write_message(&mut writer, &self.ready_event())
+        let (reader, writer) = stream.into_split();
+        let (write_tx, mut write_rx) = mpsc::channel::<Value>(512);
+        let mut writer_task = tokio::spawn(async move {
+            let mut writer = writer;
+            while let Some(message) = write_rx.recv().await {
+                write_message(&mut writer, &message)
+                    .await
+                    .map_err(|error| format!("failed to write app IPC message: {error}"))?;
+            }
+            Ok::<(), String>(())
+        });
+
+        write_tx
+            .send(self.ready_event())
             .await
-            .map_err(|error| format!("failed to write app IPC ready event: {error}"))?;
+            .map_err(|error| format!("failed to queue app IPC ready event: {error}"))?;
 
         let mut reader = BufReader::new(reader);
         let mut events = self.event_tx.subscribe();
@@ -497,26 +511,104 @@ impl AppIpcServer {
         loop {
             line.clear();
             tokio::select! {
+                writer = &mut writer_task => {
+                    return match writer {
+                        Ok(Ok(())) => Ok(()),
+                        Ok(Err(error)) => Err(error),
+                        Err(error) => Err(format!("app IPC writer task failed: {error}")),
+                    };
+                }
                 read = reader.read_line(&mut line) => {
                     let bytes_read = read
                         .map_err(|error| format!("failed to read app IPC request: {error}"))?;
                     if bytes_read == 0 {
                         return Ok(());
                     }
-                    if let Some(response) = self.handle_line(&line).await {
-                        write_message(&mut writer, &response)
-                            .await
-                            .map_err(|error| format!("failed to write app IPC response: {error}"))?;
-                    }
+                    let server = self.clone();
+                    let response_tx = write_tx.clone();
+                    let request_line = line.clone();
+                    let (request_id, method) = app_ipc_request_metadata(&request_line);
+                    tokio::spawn(async move {
+                        let started_at = Instant::now();
+                        log_app_ipc_request(
+                            "app IPC request started",
+                            request_id.as_deref(),
+                            method.as_deref(),
+                            None,
+                            None,
+                        );
+                        let response = match tokio::time::timeout(
+                            Duration::from_secs(APP_IPC_REQUEST_TIMEOUT_SECONDS),
+                            server.handle_line(&request_line),
+                        )
+                        .await
+                        {
+                            Ok(response) => response,
+                            Err(_) => {
+                                log_app_ipc_request(
+                                    "app IPC request timed out",
+                                    request_id.as_deref(),
+                                    method.as_deref(),
+                                    Some(started_at.elapsed().as_millis()),
+                                    None,
+                                );
+                                Some(error_message(
+                                    request_id.as_deref(),
+                                    &AppIpcError::new(
+                                        "request_timeout",
+                                        format!(
+                                            "app IPC request timed out after {APP_IPC_REQUEST_TIMEOUT_SECONDS}s"
+                                        ),
+                                    ),
+                                ))
+                            }
+                        };
+
+                        if let Some(response) = response {
+                            let ok = response.get("ok").and_then(Value::as_bool);
+                            log_app_ipc_request(
+                                "app IPC request finished",
+                                request_id.as_deref(),
+                                method.as_deref(),
+                                Some(started_at.elapsed().as_millis()),
+                                ok,
+                            );
+                            if response_tx.send(response).await.is_err() {
+                                log_app_ipc_request(
+                                    "app IPC response dropped",
+                                    request_id.as_deref(),
+                                    method.as_deref(),
+                                    Some(started_at.elapsed().as_millis()),
+                                    ok,
+                                );
+                            }
+                        } else {
+                            log_app_ipc_request(
+                                "app IPC request ignored",
+                                request_id.as_deref(),
+                                method.as_deref(),
+                                Some(started_at.elapsed().as_millis()),
+                                None,
+                            );
+                        }
+                    });
                 }
                 event = events.recv() => {
                     match event {
                         Ok(message) => {
-                            write_message(&mut writer, &message)
+                            write_tx.send(message)
                                 .await
-                                .map_err(|error| format!("failed to write app IPC event: {error}"))?;
+                                .map_err(|error| format!("failed to queue app IPC event: {error}"))?;
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            let message = self.event_message(
+                                "executor.event_lagged",
+                                json!({ "skipped": skipped }),
+                            );
+                            write_tx.send(message)
+                                .await
+                                .map_err(|error| format!("failed to queue app IPC lag event: {error}"))?;
+                        }
                         Err(broadcast::error::RecvError::Closed) => return Ok(()),
                     }
                 }
@@ -571,6 +663,48 @@ pub fn app_ipc_listening_log_line(device_id: &str, socket_path: &str) -> String 
             ("socket_path", socket_path.to_owned()),
         ],
     )
+}
+
+fn app_ipc_request_metadata(line: &str) -> (Option<String>, Option<String>) {
+    match serde_json::from_str::<Value>(line) {
+        Ok(Value::Object(message)) => {
+            let request_id = message
+                .get("id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned);
+            let method = message
+                .get("method")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned);
+            (request_id, method)
+        }
+        _ => (None, None),
+    }
+}
+
+fn log_app_ipc_request(
+    event: &str,
+    request_id: Option<&str>,
+    method: Option<&str>,
+    elapsed_ms: Option<u128>,
+    ok: Option<bool>,
+) {
+    let mut fields = Vec::new();
+    if let Some(request_id) = request_id {
+        fields.push(("request_id", request_id.to_owned()));
+    }
+    if let Some(method) = method {
+        fields.push(("method", method.to_owned()));
+    }
+    if let Some(elapsed_ms) = elapsed_ms {
+        fields.push(("elapsed_ms", elapsed_ms.to_string()));
+    }
+    if let Some(ok) = ok {
+        fields.push(("ok", ok.to_string()));
+    }
+    write_executor_log_line(&format_executor_log(event, &fields));
 }
 
 pub fn app_ipc_socket_path() -> PathBuf {

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -13,7 +13,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{async_runtime::Mutex as AsyncMutex, Emitter, State};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
@@ -33,10 +33,11 @@ const LOCAL_EXECUTOR_LOG_FILE_NAME: &str = "executor.log";
 const LOCAL_EXECUTOR_RUNTIME_DIR_NAME: &str = "app-runtime";
 const LOCAL_EXECUTOR_LOG_TAIL_BYTES: u64 = 200 * 1024;
 const LOCAL_EXECUTOR_LOG_TAIL_LINES: usize = 20;
-const LOCAL_EXECUTOR_CONNECT_RETRIES: usize = 120;
+const LOCAL_EXECUTOR_CONNECT_RETRIES: usize = 20;
 const LOCAL_EXECUTOR_CONNECT_RETRY_MS: u64 = 250;
 const LOCAL_EXECUTOR_PROCESS_GROUP_GRACE_MS: u64 = 500;
 const LOCAL_EXECUTOR_PROCESS_GROUP_POLL_MS: u64 = 20;
+const LOCAL_EXECUTOR_REQUEST_TIMEOUT_SECONDS: u64 = 60;
 
 type PendingSender = mpsc::Sender<Result<Value, String>>;
 type SharedExecutorInner = Arc<Mutex<LocalExecutorInner>>;
@@ -764,6 +765,33 @@ fn fail_pending_requests_for_generation(
     }
 }
 
+fn fail_unresponsive_request_inner(inner: &SharedExecutorInner, request_id: &str, message: String) {
+    let pending = inner
+        .lock()
+        .map(|mut inner| {
+            let mut pending = Vec::new();
+            if let Some(sender) = inner.pending.remove(request_id) {
+                pending.push(sender);
+            }
+            let failed_pending_count = inner.pending.len();
+            pending.extend(inner.pending.drain().map(|(_, sender)| sender));
+            inner.ready = false;
+            inner.running = false;
+            inner.generation = inner.generation.saturating_add(1);
+            clear_connected_stream(&mut inner);
+            inner.error = Some(message.clone());
+            log::warn!(
+                "Local executor IPC marked unresponsive: request_id={request_id}, failed_pending_count={failed_pending_count}, message={message}"
+            );
+            pending
+        })
+        .unwrap_or_default();
+
+    for sender in pending {
+        let _ = sender.send(Err(message.clone()));
+    }
+}
+
 fn set_executor_error(state: &LocalExecutorState, error: String) {
     set_executor_error_inner(&state.inner, error);
 }
@@ -1193,11 +1221,13 @@ async fn send_executor_request(
     start_executor_if_needed(app, state).await?;
 
     let request_id = next_request_id(state);
+    let method = request.method.clone();
+    let started_at = Instant::now();
     let (sender, receiver) = mpsc::channel::<Result<Value, String>>();
     let message = json!({
         "type": "request",
         "id": request_id,
-        "method": request.method,
+        "method": method,
         "params": request.params,
     });
     let line = format!(
@@ -1211,16 +1241,49 @@ async fn send_executor_request(
             .lock()
             .map_err(|_| "Failed to lock local executor state".to_string())?;
         inner.pending.insert(request_id.clone(), sender);
+        let pending_count = inner.pending.len();
+        log::info!(
+            "Local executor IPC request started: request_id={request_id}, method={method}, pending_count={pending_count}"
+        );
         if let Err(error) = write_request_line(&mut inner, &line) {
             inner.pending.remove(&request_id);
+            log::warn!(
+                "Local executor IPC request write failed: request_id={request_id}, method={method}, error={error}"
+            );
             return Err(error);
         }
     }
 
+    let inner = state.inner.clone();
+    let wait_request_id = request_id.clone();
     tauri::async_runtime::spawn_blocking(move || {
-        receiver
-            .recv()
-            .unwrap_or_else(|_| Err("Local executor disconnected".to_string()))
+        match receiver.recv_timeout(Duration::from_secs(LOCAL_EXECUTOR_REQUEST_TIMEOUT_SECONDS)) {
+            Ok(result) => {
+                log::info!(
+                    "Local executor IPC request finished: request_id={wait_request_id}, method={method}, elapsed_ms={}",
+                    started_at.elapsed().as_millis()
+                );
+                result
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                log::warn!(
+                    "Local executor IPC request disconnected: request_id={wait_request_id}, method={method}, elapsed_ms={}",
+                    started_at.elapsed().as_millis()
+                );
+                Err("Local executor disconnected".to_string())
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let message = format!(
+                    "Local executor request {method} timed out after {LOCAL_EXECUTOR_REQUEST_TIMEOUT_SECONDS}s"
+                );
+                log::warn!(
+                    "Local executor IPC request timed out: request_id={wait_request_id}, method={method}, elapsed_ms={}",
+                    started_at.elapsed().as_millis()
+                );
+                fail_unresponsive_request_inner(&inner, &wait_request_id, message.clone());
+                Err(message)
+            }
+        }
     })
     .await
     .map_err(|error| error.to_string())?
@@ -1527,9 +1590,11 @@ mod tests {
         let previous_home = std::env::var_os("HOME");
         let previous_executor_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
         let previous_socket = std::env::var_os(LOCAL_EXECUTOR_SOCKET_ENV);
+        let previous_log_dir = std::env::var_os(LOCAL_EXECUTOR_LOG_DIR_ENV);
         std::env::set_var("HOME", "/tmp/wework-test-home");
         std::env::remove_var(LOCAL_EXECUTOR_HOME_ENV);
         std::env::remove_var(LOCAL_EXECUTOR_SOCKET_ENV);
+        std::env::remove_var(LOCAL_EXECUTOR_LOG_DIR_ENV);
 
         let home = local_executor_home_path().expect("executor home should resolve");
         let socket = app_ipc_socket_path().expect("socket path should resolve");
@@ -1538,6 +1603,7 @@ mod tests {
         restore_env("HOME", previous_home);
         restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_executor_home);
         restore_env(LOCAL_EXECUTOR_SOCKET_ENV, previous_socket);
+        restore_env(LOCAL_EXECUTOR_LOG_DIR_ENV, previous_log_dir);
 
         assert_eq!(
             home,
@@ -1652,8 +1718,10 @@ mod tests {
         let _guard = env_lock();
         let previous_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
         let previous_socket = std::env::var_os(LOCAL_EXECUTOR_SOCKET_ENV);
+        let previous_log_dir = std::env::var_os(LOCAL_EXECUTOR_LOG_DIR_ENV);
         std::env::set_var(LOCAL_EXECUTOR_HOME_ENV, "/tmp/wework-instance-executor");
         std::env::remove_var(LOCAL_EXECUTOR_SOCKET_ENV);
+        std::env::remove_var(LOCAL_EXECUTOR_LOG_DIR_ENV);
         let inner = LocalExecutorInner {
             backend_connection: Some(LocalExecutorBackendConnection {
                 backend_url: "https://cloud.example.com".to_string(),
@@ -1669,6 +1737,7 @@ mod tests {
 
         restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_home);
         restore_env(LOCAL_EXECUTOR_SOCKET_ENV, previous_socket);
+        restore_env(LOCAL_EXECUTOR_LOG_DIR_ENV, previous_log_dir);
 
         assert_eq!(
             envs.get("WEGENT_BACKEND_URL").map(String::as_str),


### PR DESCRIPTION
## Summary

Fixes a local Wework recovery failure where one hung local executor RPC could block sidebar refreshes, runtime message streaming, and subsequent socket recovery.

## Root Cause

The app IPC server handled each request inline on the same Unix socket loop that also forwards runtime stream events. If a `runtime.*` RPC hung, later refresh requests and stream events were queued behind it. On the Tauri side, `local_executor_request` waited indefinitely for a response, so users had no reliable recovery path after the socket got wedged.

## Changes

- Decouple executor app IPC request handling from the socket event loop by processing requests in spawned tasks and writing responses/events through a queue.
- Add request timeouts on both sides:
  - Wework Tauri IPC waits up to 60s, then marks the executor unresponsive, drops the socket, and fails all pending requests.
  - Executor app IPC waits up to 75s, then returns a `request_timeout` response and logs the stuck method.
- Reduce local executor socket startup wait from about 30s to about 5s so refresh/restart recovers faster.
- Add request lifecycle logs with request id, method, elapsed time, pending count, and timeout/disconnect state.
- Emit an `executor.event_lagged` event when app IPC event broadcast lag is detected instead of silently continuing.
- Fix local executor tests so `WEGENT_EXECUTOR_LOG_DIR` from the environment does not pollute default-path assertions.

## Validation

- `cargo check --manifest-path executor/Cargo.toml`
- `cargo check --manifest-path wework/src-tauri/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml app_ipc -- --nocapture`
- `cargo test --manifest-path wework/src-tauri/Cargo.toml local_executor -- --nocapture --test-threads=1`

## Debugging

After this change, hangs can be correlated with:

```bash
rg "Local executor IPC request|app IPC request" /Users/axb-mac/.wegent-executor/logs
```

A started request without a matching finished line, or a `timed out` line, identifies the stuck method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a request timeout so stalled local executor calls fail faster instead of hanging indefinitely.
  * Improved handling when the local executor becomes unresponsive, clearing queued requests and returning errors promptly.
  * Made IPC message delivery more resilient, with better handling of delayed or skipped messages and clearer logging of request progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->