### PR TITLE
[codex] Add Wework performance diagnostics toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Wegent is an open-source AI-native operating system for defining, organizing, an
 - English version: [`docs/en/developer-guide/runtime-local-work.md`](docs/en/developer-guide/runtime-local-work.md)
 - Wework local-first cloud connection: [`docs/zh/developer-guide/wework-cloud-connection.md`](docs/zh/developer-guide/wework-cloud-connection.md)
 - English version: [`docs/en/developer-guide/wework-cloud-connection.md`](docs/en/developer-guide/wework-cloud-connection.md)
+- Wework performance diagnostics: [`docs/zh/developer-guide/wework-performance-diagnostics.md`](docs/zh/developer-guide/wework-performance-diagnostics.md)
+- English version: [`docs/en/developer-guide/wework-performance-diagnostics.md`](docs/en/developer-guide/wework-performance-diagnostics.md)
 
 **📚 Documentation Writing Rules:**
 - All documentation files MUST include frontmatter with `sidebar_position` for ordering:

--- a/docs/en/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/developer-guide/wework-performance-diagnostics.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 33
+---
+
+# Performance Diagnostics
+
+Wework includes an opt-in frontend performance diagnostics switch for investigating release builds that become slow after running for a while. The diagnostics code only runs after it is explicitly enabled; when disabled, the app does not install React Profiler and does not collect interval samples.
+
+## Enabling Diagnostics
+
+Press the hidden shortcut in the Wework window:
+
+```text
+macOS: Cmd + Option + Shift + P
+Windows/Linux: Ctrl + Alt + Shift + P
+```
+
+The shortcut toggles the `wework:perf-debug` flag in `localStorage` and reloads the app. Press the same shortcut again to disable diagnostics and reload.
+
+Development builds can also toggle diagnostics through a URL parameter:
+
+```text
+?weworkPerf=1  # enable
+?weworkPerf=0  # disable
+```
+
+For local reproduction, set `VITE_WEWORK_PERF_DEBUG=1` to enable diagnostics by default.
+
+## Collected Data
+
+When enabled, the diagnostics module records:
+
+- Browser long tasks.
+- Event loop lag above 120ms.
+- A 5-second sample of memory, DOM node count, resource count, and visibility state.
+- React root commit durations above 24ms.
+- Manual mark events.
+
+The latest 300 events are kept in memory and exposed through `window.__WEWORK_PERF__`. Diagnostics data is not uploaded to the server.
+
+## Capturing Evidence
+
+If Web Inspector is available in a debug or release build, run this after the app becomes slow:
+
+```js
+window.__WEWORK_PERF__.snapshot()
+```
+
+The snapshot includes the current URL, page visibility, DOM node count, memory snapshot, navigation timing, resource count, and recent events. When comparing multiple snapshots, focus on:
+
+- Whether `memory.usedJSHeapSize` keeps growing.
+- Whether `domNodeCount` keeps growing.
+- Dense `longtask` or `event-loop-lag` events.
+- Repeated `slow-react-commit` events.
+
+Manual marks can also be added:
+
+```js
+window.__WEWORK_PERF__.mark('before-open-task', { taskId: '...' })
+```
+
+## Disabling Diagnostics
+
+Press the hidden shortcut again to disable diagnostics and reload. The console can also disable it:
+
+```js
+localStorage.removeItem('wework:perf-debug')
+location.reload()
+```
+
+After diagnostics are disabled, `window.__WEWORK_PERF__` is not installed and React Profiler no longer wraps the app root.

--- a/docs/zh/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/developer-guide/wework-performance-diagnostics.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 33
+---
+
+# 性能诊断
+
+Wework 内置一个默认关闭的前端性能诊断开关，用于定位 release 包中“运行一段时间后变卡”的问题。诊断代码只在显式开启后运行；关闭时不会安装 React Profiler，也不会采集定时样本。
+
+## 开启方式
+
+在 Wework 窗口中按隐藏快捷键：
+
+```text
+macOS: Cmd + Option + Shift + P
+Windows/Linux: Ctrl + Alt + Shift + P
+```
+
+快捷键会切换 `localStorage` 中的 `wework:perf-debug` 标记并自动刷新应用。再次按同一快捷键会关闭诊断并刷新。
+
+开发环境也可以通过 URL 参数临时切换：
+
+```text
+?weworkPerf=1  # 开启
+?weworkPerf=0  # 关闭
+```
+
+也可以设置构建/运行环境变量 `VITE_WEWORK_PERF_DEBUG=1`，用于本地复现时默认开启。
+
+## 采集内容
+
+开启后，诊断模块会采集：
+
+- 浏览器 Long Task。
+- 事件循环延迟，超过 120ms 时记录。
+- 每 5 秒一次的内存、DOM 节点数、resource 数量和可见性状态。
+- React root commit 耗时，超过 24ms 时记录。
+- 手动标记事件。
+
+最近 300 条事件保存在内存中，并暴露在 `window.__WEWORK_PERF__` 上。诊断数据不会上传到服务端。
+
+## 现场取证
+
+如果 debug 包或 release 包能打开 Web Inspector，在卡顿后执行：
+
+```js
+window.__WEWORK_PERF__.snapshot()
+```
+
+返回值包含当前 URL、页面可见性、DOM 节点数、内存快照、导航时序、resource 数量和最近事件。需要持续观察时可以多次执行，重点比较：
+
+- `memory.usedJSHeapSize` 是否持续上涨。
+- `domNodeCount` 是否持续上涨。
+- 是否存在密集 `longtask` 或 `event-loop-lag`。
+- 是否存在重复的 `slow-react-commit`。
+
+也可以手动打点：
+
+```js
+window.__WEWORK_PERF__.mark('before-open-task', { taskId: '...' })
+```
+
+## 关闭方式
+
+再次按隐藏快捷键会关闭诊断并刷新应用。也可以在控制台执行：
+
+```js
+localStorage.removeItem('wework:perf-debug')
+location.reload()
+```
+
+关闭后 `window.__WEWORK_PERF__` 不再安装，React Profiler 也不会包裹应用根节点。

--- a/wework/src/lib/performanceDiagnostics.ts
+++ b/wework/src/lib/performanceDiagnostics.ts
@@ -1,0 +1,279 @@
+const PERFORMANCE_DIAGNOSTICS_STORAGE_KEY = 'wework:perf-debug'
+const PERFORMANCE_DIAGNOSTICS_QUERY_PARAM = 'weworkPerf'
+const TOGGLE_SHORTCUT_KEY = 'P'
+const MAX_EVENTS = 300
+const SAMPLE_INTERVAL_MS = 5000
+const EVENT_LOOP_SAMPLE_INTERVAL_MS = 1000
+const EVENT_LOOP_LAG_WARN_MS = 120
+const SLOW_REACT_COMMIT_MS = 24
+
+type DiagnosticsEventType = 'sample' | 'longtask' | 'event-loop-lag' | 'react-commit' | 'mark'
+
+interface DiagnosticsEvent {
+  type: DiagnosticsEventType
+  timestamp: number
+  data: Record<string, unknown>
+}
+
+interface MemorySnapshot {
+  usedJSHeapSize?: number
+  totalJSHeapSize?: number
+  jsHeapSizeLimit?: number
+}
+
+interface DiagnosticsSnapshot {
+  timestamp: number
+  url: string
+  visibilityState: DocumentVisibilityState
+  domNodeCount: number
+  activeElement: string | null
+  memory: MemorySnapshot | null
+  resourceCount: number
+  navigation: Record<string, number | string | null>
+  recentEvents: DiagnosticsEvent[]
+}
+
+export interface PerformanceDiagnosticsController {
+  enabled: boolean
+  mark: (name: string, data?: Record<string, unknown>) => void
+  snapshot: () => DiagnosticsSnapshot
+  stop: () => void
+  getEvents: () => DiagnosticsEvent[]
+}
+
+declare global {
+  interface Window {
+    __WEWORK_PERF__?: PerformanceDiagnosticsController
+  }
+
+  interface Performance {
+    memory?: MemorySnapshot
+  }
+}
+
+let controller: PerformanceDiagnosticsController | null = null
+
+export function installPerformanceDiagnosticsToggle() {
+  window.addEventListener('keydown', handlePerformanceDiagnosticsToggleKeyDown, {
+    capture: true,
+  })
+}
+
+export function isPerformanceDiagnosticsEnabled(): boolean {
+  const queryValue = new URLSearchParams(window.location.search).get(
+    PERFORMANCE_DIAGNOSTICS_QUERY_PARAM
+  )
+  if (queryValue === '1' || queryValue === 'true') {
+    localStorage.setItem(PERFORMANCE_DIAGNOSTICS_STORAGE_KEY, '1')
+    return true
+  }
+  if (queryValue === '0' || queryValue === 'false') {
+    localStorage.removeItem(PERFORMANCE_DIAGNOSTICS_STORAGE_KEY)
+    return false
+  }
+
+  return (
+    localStorage.getItem(PERFORMANCE_DIAGNOSTICS_STORAGE_KEY) === '1' ||
+    import.meta.env.VITE_WEWORK_PERF_DEBUG === '1'
+  )
+}
+
+function handlePerformanceDiagnosticsToggleKeyDown(event: KeyboardEvent) {
+  if (!event.shiftKey || !event.altKey || !(event.metaKey || event.ctrlKey)) return
+  if (event.code !== `Key${TOGGLE_SHORTCUT_KEY}`) return
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  const enabled = localStorage.getItem(PERFORMANCE_DIAGNOSTICS_STORAGE_KEY) === '1'
+  if (enabled) {
+    localStorage.removeItem(PERFORMANCE_DIAGNOSTICS_STORAGE_KEY)
+    console.info('[Wework perf] diagnostics disabled. Reloading...')
+  } else {
+    localStorage.setItem(PERFORMANCE_DIAGNOSTICS_STORAGE_KEY, '1')
+    console.info('[Wework perf] diagnostics enabled. Reloading...')
+  }
+  window.location.reload()
+}
+
+export function installPerformanceDiagnostics(): PerformanceDiagnosticsController | null {
+  if (!isPerformanceDiagnosticsEnabled()) return null
+  if (controller) return controller
+
+  const events: DiagnosticsEvent[] = []
+  const cleanupCallbacks: Array<() => void> = []
+  let stopped = false
+
+  const pushEvent = (type: DiagnosticsEventType, data: Record<string, unknown>) => {
+    if (stopped) return
+    const event = {
+      type,
+      timestamp: Date.now(),
+      data,
+    }
+    events.push(event)
+    while (events.length > MAX_EVENTS) {
+      events.shift()
+    }
+    if (type !== 'sample') {
+      console.warn('[Wework perf]', type, data)
+    }
+  }
+
+  const snapshot = (): DiagnosticsSnapshot => ({
+    timestamp: Date.now(),
+    url: window.location.href,
+    visibilityState: document.visibilityState,
+    domNodeCount: document.getElementsByTagName('*').length,
+    activeElement: describeElement(document.activeElement),
+    memory: getMemorySnapshot(),
+    resourceCount: performance.getEntriesByType('resource').length,
+    navigation: getNavigationSnapshot(),
+    recentEvents: [...events],
+  })
+
+  controller = {
+    enabled: true,
+    mark: (name, data = {}) => pushEvent('mark', { name, ...data }),
+    snapshot,
+    stop: () => {
+      stopped = true
+      cleanupCallbacks.splice(0).forEach(cleanup => cleanup())
+      if (window.__WEWORK_PERF__ === controller) {
+        delete window.__WEWORK_PERF__
+      }
+      controller = null
+    },
+    getEvents: () => [...events],
+  }
+  window.__WEWORK_PERF__ = controller
+
+  installLongTaskObserver(pushEvent, cleanupCallbacks)
+  installPeriodicSampler(pushEvent, cleanupCallbacks)
+  installEventLoopLagSampler(pushEvent, cleanupCallbacks)
+
+  console.info(
+    '[Wework perf] diagnostics enabled. Use window.__WEWORK_PERF__.snapshot() to inspect current state.'
+  )
+  return controller
+}
+
+export function recordReactCommit(
+  id: string,
+  phase: string,
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number
+) {
+  if (!controller || actualDuration < SLOW_REACT_COMMIT_MS) return
+
+  controller.mark('slow-react-commit', {
+    id,
+    phase,
+    actualDuration: Math.round(actualDuration * 10) / 10,
+    baseDuration: Math.round(baseDuration * 10) / 10,
+    startTime: Math.round(startTime * 10) / 10,
+    commitTime: Math.round(commitTime * 10) / 10,
+  })
+}
+
+function installLongTaskObserver(
+  pushEvent: (type: DiagnosticsEventType, data: Record<string, unknown>) => void,
+  cleanupCallbacks: Array<() => void>
+) {
+  if (typeof PerformanceObserver === 'undefined') return
+
+  try {
+    const observer = new PerformanceObserver(list => {
+      list.getEntries().forEach(entry => {
+        pushEvent('longtask', {
+          name: entry.name,
+          duration: Math.round(entry.duration * 10) / 10,
+          startTime: Math.round(entry.startTime * 10) / 10,
+        })
+      })
+    })
+    observer.observe({ type: 'longtask', buffered: true })
+    cleanupCallbacks.push(() => observer.disconnect())
+  } catch (error) {
+    console.warn('[Wework perf] long task observer unavailable', error)
+  }
+}
+
+function installPeriodicSampler(
+  pushEvent: (type: DiagnosticsEventType, data: Record<string, unknown>) => void,
+  cleanupCallbacks: Array<() => void>
+) {
+  const sample = () => {
+    pushEvent('sample', {
+      memory: getMemorySnapshot(),
+      domNodeCount: document.getElementsByTagName('*').length,
+      resourceCount: performance.getEntriesByType('resource').length,
+      visibilityState: document.visibilityState,
+      path: window.location.pathname,
+    })
+  }
+
+  sample()
+  const timer = window.setInterval(sample, SAMPLE_INTERVAL_MS)
+  cleanupCallbacks.push(() => window.clearInterval(timer))
+}
+
+function installEventLoopLagSampler(
+  pushEvent: (type: DiagnosticsEventType, data: Record<string, unknown>) => void,
+  cleanupCallbacks: Array<() => void>
+) {
+  let expectedAt = performance.now() + EVENT_LOOP_SAMPLE_INTERVAL_MS
+  const timer = window.setInterval(() => {
+    const now = performance.now()
+    const lag = now - expectedAt
+    expectedAt = now + EVENT_LOOP_SAMPLE_INTERVAL_MS
+    if (lag < EVENT_LOOP_LAG_WARN_MS) return
+
+    pushEvent('event-loop-lag', {
+      lag: Math.round(lag * 10) / 10,
+      visibilityState: document.visibilityState,
+      path: window.location.pathname,
+    })
+  }, EVENT_LOOP_SAMPLE_INTERVAL_MS)
+
+  cleanupCallbacks.push(() => window.clearInterval(timer))
+}
+
+function getMemorySnapshot(): MemorySnapshot | null {
+  if (!performance.memory) return null
+  return {
+    usedJSHeapSize: performance.memory.usedJSHeapSize,
+    totalJSHeapSize: performance.memory.totalJSHeapSize,
+    jsHeapSizeLimit: performance.memory.jsHeapSizeLimit,
+  }
+}
+
+function getNavigationSnapshot(): Record<string, number | string | null> {
+  const navigation = performance.getEntriesByType('navigation')[0]
+  if (!navigation) return {}
+
+  const entry = navigation as PerformanceNavigationTiming
+  return {
+    type: entry.type,
+    domInteractive: roundTiming(entry.domInteractive),
+    domComplete: roundTiming(entry.domComplete),
+    loadEventEnd: roundTiming(entry.loadEventEnd),
+    responseEnd: roundTiming(entry.responseEnd),
+  }
+}
+
+function roundTiming(value: number): number | null {
+  if (!Number.isFinite(value) || value <= 0) return null
+  return Math.round(value * 10) / 10
+}
+
+function describeElement(element: Element | null): string | null {
+  if (!element) return null
+
+  const id = element.id ? `#${element.id}` : ''
+  const testId = element.getAttribute('data-testid')
+  const testIdPart = testId ? `[data-testid="${testId}"]` : ''
+  return `${element.tagName.toLowerCase()}${id}${testIdPart}`
+}

--- a/wework/src/main.tsx
+++ b/wework/src/main.tsx
@@ -1,18 +1,31 @@
 import './i18n'
-import { StrictMode } from 'react'
+import { Profiler, StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './styles/globals.css'
 import App from './App.tsx'
 import { installExternalLinkHandler } from './lib/external-links'
 import { installPageZoomGuard } from './lib/pageZoomGuard'
+import {
+  installPerformanceDiagnostics,
+  installPerformanceDiagnosticsToggle,
+  recordReactCommit,
+} from './lib/performanceDiagnostics'
 import { installDesktopExtensions } from '@extensions/desktop'
 
 installDesktopExtensions()
 installExternalLinkHandler()
 installPageZoomGuard()
+installPerformanceDiagnosticsToggle()
+const performanceDiagnostics = installPerformanceDiagnostics()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    {performanceDiagnostics ? (
+      <Profiler id="wework-root" onRender={recordReactCommit}>
+        <App />
+      </Profiler>
+    ) : (
+      <App />
+    )}
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- Add opt-in Wework frontend performance diagnostics for release/debug builds.
- Add a hidden keyboard toggle and URL/env based enable paths.
- Document the diagnostics workflow in Chinese and English and reference it from AGENTS.md.

## Why
This gives us runtime evidence for reports that Wework becomes slow after extended use, instead of changing behavior based on guesses.

## Validation
- pnpm --dir wework typecheck
- pnpm --dir wework lint
- pre-push Wework ESLint, TypeScript, and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in performance diagnostics tool for troubleshooting slowdowns in the app.
  * Users can now enable or disable diagnostics with a hidden shortcut, a URL parameter, or a local environment setting.
  * Added a snapshot view of current performance data for easier debugging, plus manual markers to flag important moments.
  * Published new developer guides in English and Chinese for the diagnostics workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->