### PR TITLE
[codex] Fix Wework local executor startup hang

### DIFF
--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -35,6 +35,7 @@ const LOCAL_EXECUTOR_LOG_TAIL_BYTES: u64 = 200 * 1024;
 const LOCAL_EXECUTOR_LOG_TAIL_LINES: usize = 20;
 const LOCAL_EXECUTOR_CONNECT_RETRIES: usize = 120;
 const LOCAL_EXECUTOR_CONNECT_RETRY_MS: u64 = 250;
+const LOCAL_EXECUTOR_READY_TIMEOUT_SECS: u64 = 10;
 const LOCAL_EXECUTOR_PROCESS_GROUP_GRACE_MS: u64 = 500;
 const LOCAL_EXECUTOR_PROCESS_GROUP_POLL_MS: u64 = 20;
 
@@ -310,6 +311,13 @@ struct LocalExecutorSocketDebug {
     path: String,
     exists: bool,
     file_type: String,
+}
+
+#[cfg(unix)]
+struct PreparedExecutorStream {
+    reader: BufReader<UnixStream>,
+    writer: UnixStream,
+    ready_line: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -867,13 +875,9 @@ fn connect_sidecar_socket() -> Result<UnixStream, String> {
 }
 
 #[cfg(unix)]
-fn attach_connected_stream(
-    app: tauri::AppHandle,
-    state: &LocalExecutorState,
-    stream: UnixStream,
-) -> Result<(), String> {
+fn prepare_connected_stream(stream: UnixStream) -> Result<PreparedExecutorStream, String> {
     stream
-        .set_read_timeout(Some(Duration::from_secs(10)))
+        .set_read_timeout(Some(Duration::from_secs(LOCAL_EXECUTOR_READY_TIMEOUT_SECS)))
         .map_err(|error| format!("Failed to configure local executor socket timeout: {error}"))?;
     let mut reader = BufReader::new(stream);
     let mut ready_line = String::new();
@@ -891,13 +895,50 @@ fn attach_connected_stream(
         .get_ref()
         .try_clone()
         .map_err(|error| format!("Failed to clone local executor socket: {error}"))?;
+
+    Ok(PreparedExecutorStream {
+        reader,
+        writer,
+        ready_line,
+    })
+}
+
+#[cfg(unix)]
+fn connect_and_prepare_sidecar_socket() -> Result<PreparedExecutorStream, String> {
+    prepare_connected_stream(connect_sidecar_socket()?)
+}
+
+#[cfg(unix)]
+async fn connect_and_prepare_sidecar_socket_with_timeout() -> Result<PreparedExecutorStream, String>
+{
+    let (sender, receiver) = mpsc::channel();
+    tauri::async_runtime::spawn_blocking(move || {
+        let _ = sender.send(connect_and_prepare_sidecar_socket());
+    });
+
+    tauri::async_runtime::spawn_blocking(move || {
+        receiver
+            .recv_timeout(Duration::from_secs(LOCAL_EXECUTOR_READY_TIMEOUT_SECS + 1))
+            .unwrap_or_else(|_| Err("Timed out waiting for local executor ready event".to_string()))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[cfg(unix)]
+fn attach_prepared_stream(
+    app: tauri::AppHandle,
+    state: &LocalExecutorState,
+    prepared: PreparedExecutorStream,
+) -> Result<(), String> {
+    let mut reader = prepared.reader;
     let generation = {
         let mut inner = state
             .inner
             .lock()
             .map_err(|_| "Failed to lock local executor state".to_string())?;
         inner.generation = inner.generation.saturating_add(1);
-        inner.stream = Some(writer);
+        inner.stream = Some(prepared.writer);
         inner.running = true;
         inner.ready = false;
         inner.device_id = Some(
@@ -909,7 +950,7 @@ fn attach_connected_stream(
         inner.error = None;
         inner.generation
     };
-    handle_executor_line_inner(&app, &state.inner, &ready_line)?;
+    handle_executor_line_inner(&app, &state.inner, &prepared.ready_line)?;
     {
         let inner = state
             .inner
@@ -944,6 +985,15 @@ fn attach_connected_stream(
     });
 
     Ok(())
+}
+
+#[cfg(unix)]
+async fn connect_and_attach_sidecar_socket(
+    app: tauri::AppHandle,
+    state: &LocalExecutorState,
+) -> Result<(), String> {
+    let prepared = connect_and_prepare_sidecar_socket_with_timeout().await?;
+    attach_prepared_stream(app, state, prepared)
 }
 
 #[cfg(unix)]
@@ -1115,16 +1165,16 @@ async fn start_executor_if_needed_unlocked(
         }
     }
 
-    let mut last_error = match connect_sidecar_socket() {
-        Ok(stream) => return attach_connected_stream(app, state, stream),
+    let mut last_error = match connect_and_attach_sidecar_socket(app.clone(), state).await {
+        Ok(()) => return Ok(()),
         Err(error) => error,
     };
 
     spawn_sidecar_if_needed(app.clone(), state).await?;
 
     for _ in 0..LOCAL_EXECUTOR_CONNECT_RETRIES {
-        match connect_sidecar_socket() {
-            Ok(stream) => return attach_connected_stream(app.clone(), state, stream),
+        match connect_and_attach_sidecar_socket(app.clone(), state).await {
+            Ok(()) => return Ok(()),
             Err(error) => {
                 last_error = error;
                 retry_connect_delay().await;
@@ -1527,9 +1577,11 @@ mod tests {
         let previous_home = std::env::var_os("HOME");
         let previous_executor_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
         let previous_socket = std::env::var_os(LOCAL_EXECUTOR_SOCKET_ENV);
+        let previous_log_dir = std::env::var_os(LOCAL_EXECUTOR_LOG_DIR_ENV);
         std::env::set_var("HOME", "/tmp/wework-test-home");
         std::env::remove_var(LOCAL_EXECUTOR_HOME_ENV);
         std::env::remove_var(LOCAL_EXECUTOR_SOCKET_ENV);
+        std::env::remove_var(LOCAL_EXECUTOR_LOG_DIR_ENV);
 
         let home = local_executor_home_path().expect("executor home should resolve");
         let socket = app_ipc_socket_path().expect("socket path should resolve");
@@ -1538,6 +1590,7 @@ mod tests {
         restore_env("HOME", previous_home);
         restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_executor_home);
         restore_env(LOCAL_EXECUTOR_SOCKET_ENV, previous_socket);
+        restore_env(LOCAL_EXECUTOR_LOG_DIR_ENV, previous_log_dir);
 
         assert_eq!(
             home,
@@ -1652,8 +1705,10 @@ mod tests {
         let _guard = env_lock();
         let previous_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
         let previous_socket = std::env::var_os(LOCAL_EXECUTOR_SOCKET_ENV);
+        let previous_log_dir = std::env::var_os(LOCAL_EXECUTOR_LOG_DIR_ENV);
         std::env::set_var(LOCAL_EXECUTOR_HOME_ENV, "/tmp/wework-instance-executor");
         std::env::remove_var(LOCAL_EXECUTOR_SOCKET_ENV);
+        std::env::remove_var(LOCAL_EXECUTOR_LOG_DIR_ENV);
         let inner = LocalExecutorInner {
             backend_connection: Some(LocalExecutorBackendConnection {
                 backend_url: "https://cloud.example.com".to_string(),
@@ -1669,6 +1724,7 @@ mod tests {
 
         restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_home);
         restore_env(LOCAL_EXECUTOR_SOCKET_ENV, previous_socket);
+        restore_env(LOCAL_EXECUTOR_LOG_DIR_ENV, previous_log_dir);
 
         assert_eq!(
             envs.get("WEGENT_BACKEND_URL").map(String::as_str),

--- a/wework/src/tauri/localExecutor.ts
+++ b/wework/src/tauri/localExecutor.ts
@@ -53,8 +53,18 @@ export interface LocalExecutorBackendConnection {
   authToken: string
 }
 
+let ensureLocalExecutorStartedPromise: Promise<LocalExecutorStatus> | null = null
+
 export function ensureLocalExecutorStarted(): Promise<LocalExecutorStatus> {
-  return invoke<LocalExecutorStatus>(LOCAL_EXECUTOR_COMMANDS.ensure)
+  if (!ensureLocalExecutorStartedPromise) {
+    ensureLocalExecutorStartedPromise = invoke<LocalExecutorStatus>(
+      LOCAL_EXECUTOR_COMMANDS.ensure
+    ).finally(() => {
+      ensureLocalExecutorStartedPromise = null
+    })
+  }
+
+  return ensureLocalExecutorStartedPromise
 }
 
 export function getLocalExecutorStatus(): Promise<LocalExecutorStatus> {


### PR DESCRIPTION
## Summary
- Move local executor socket ready-handshake work behind a bounded blocking path so `local_executor_ensure_started` cannot hold the startup lock indefinitely.
- Reuse an in-flight frontend `ensureLocalExecutorStarted` invoke to avoid duplicate startup commands from dev-mode repeated initialization.
- Isolate local executor path tests from inherited log directory environment variables.

## Root Cause
Wework could issue concurrent `local_executor_ensure_started` calls while the executor IPC socket was already healthy. If one startup command became stuck in the Tauri-side startup path, the next command waited behind the shared startup lock and the frontend stayed on the startup screen.

## Validation
- `cargo fmt --manifest-path wework/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path wework/src-tauri/Cargo.toml local_executor -- --nocapture`
- `pnpm --dir wework test -- localExecutor`
- Pre-push Wework checks: ESLint, TypeScript, unit tests

Docs were checked; this is an internal startup bugfix with no user-facing configuration or API documentation changes required.