### PR TITLE
[codex] fix Wework archived worktree cleanup

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1465,7 +1465,7 @@ describe('DesktopSidebar', () => {
     await user.click(screen.getByTestId('archive-project-conversations-dialog-7-confirm-button'))
 
     await waitFor(() => {
-      expect(onArchiveProjectConversations).toHaveBeenCalledWith('project:7')
+      expect(onArchiveProjectConversations).toHaveBeenCalledWith('project:7', undefined)
     })
     expect(confirmSpy).not.toHaveBeenCalled()
 
@@ -1816,7 +1816,7 @@ describe('DesktopSidebar', () => {
       screen.getByTestId('projects-section-archive-conversations-dialog-confirm-button')
     )
     await waitFor(() => {
-      expect(onArchiveProjectsConversations).toHaveBeenCalledWith(['project:7'])
+      expect(onArchiveProjectsConversations).toHaveBeenCalledWith(['project:7'], undefined)
     })
 
     await user.click(screen.getByTestId('runtime-chat-section-new-chat-button'))
@@ -1838,13 +1838,16 @@ describe('DesktopSidebar', () => {
     )
 
     await waitFor(() => {
-      expect(onArchiveChatConversations).toHaveBeenCalledWith([
-        {
-          deviceId: 'local-device',
-          workspacePath: '/workspace/chats/chat-1',
-          localTaskId: 'chat-1',
-        },
-      ])
+      expect(onArchiveChatConversations).toHaveBeenCalledWith(
+        [
+          {
+            deviceId: 'local-device',
+            workspacePath: '/workspace/chats/chat-1',
+            localTaskId: 'chat-1',
+          },
+        ],
+        undefined
+      )
     })
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -60,6 +60,7 @@ import type {
 import type { DockerRemoteDeviceCommandResponse } from '@/types/devices'
 import type { CloudWorkStatus } from '@/types/workbench'
 import type {
+  ArchiveRuntimeConversationsResult,
   ArchiveRuntimeLocalTaskOptions,
   ArchiveRuntimeLocalTaskResult,
 } from '@/features/workbench/workbenchContextTypes'
@@ -110,9 +111,18 @@ interface DesktopSidebarProps {
     address: RuntimeTaskAddress,
     options?: ArchiveRuntimeLocalTaskOptions
   ) => Promise<ArchiveRuntimeLocalTaskResult | void> | ArchiveRuntimeLocalTaskResult | void
-  onArchiveProjectConversations?: (runtimeProjectKey: string) => Promise<void> | void
-  onArchiveProjectsConversations?: (runtimeProjectKeys: string[]) => Promise<void> | void
-  onArchiveChatConversations?: (addresses: RuntimeTaskAddress[]) => Promise<void> | void
+  onArchiveProjectConversations?: (
+    runtimeProjectKey: string,
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult | void> | ArchiveRuntimeConversationsResult | void
+  onArchiveProjectsConversations?: (
+    runtimeProjectKeys: string[],
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult | void> | ArchiveRuntimeConversationsResult | void
+  onArchiveChatConversations?: (
+    addresses: RuntimeTaskAddress[],
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult | void> | ArchiveRuntimeConversationsResult | void
   onToggleRuntimeTaskNotification?: (
     address: RuntimeTaskAddress,
     subscribed: boolean
@@ -1385,7 +1395,10 @@ function ProjectItem({
     address: RuntimeTaskAddress,
     options?: ArchiveRuntimeLocalTaskOptions
   ) => Promise<ArchiveRuntimeLocalTaskResult | void> | ArchiveRuntimeLocalTaskResult | void
-  onArchiveProjectConversations?: (runtimeProjectKey: string) => Promise<void> | void
+  onArchiveProjectConversations?: (
+    runtimeProjectKey: string,
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult | void> | ArchiveRuntimeConversationsResult | void
   onToggleRuntimeTaskNotification?: (
     address: RuntimeTaskAddress,
     subscribed: boolean
@@ -1402,6 +1415,7 @@ function ProjectItem({
   )
   const [projectArchiving, setProjectArchiving] = useState(false)
   const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false)
+  const [forceArchiveConfirmOpen, setForceArchiveConfirmOpen] = useState(false)
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
   const [removingProject, setRemovingProject] = useState(false)
   const pinnedTaskKeysStorageRef = useRef(pinnedTaskKeysStorageKey)
@@ -1466,17 +1480,31 @@ function ProjectItem({
       setArchiveConfirmOpen(false)
     }
   }
-  const confirmArchiveProjectConversations = async () => {
+  const runArchiveProjectConversations = async (options?: ArchiveRuntimeLocalTaskOptions) => {
     const runtimeProjectKey = runtimeProjectWork?.project.key
     if (!runtimeProjectKey || !onArchiveProjectConversations) return
     setProjectArchiving(true)
     try {
-      await onArchiveProjectConversations(runtimeProjectKey)
+      const result = await onArchiveProjectConversations(runtimeProjectKey, options)
+      if (result?.status === 'dirty_worktree') {
+        setArchiveConfirmOpen(false)
+        setForceArchiveConfirmOpen(true)
+        return
+      }
       setArchiveConfirmOpen(false)
+      setForceArchiveConfirmOpen(false)
     } finally {
       setProjectArchiving(false)
     }
   }
+  const confirmArchiveProjectConversations = () => runArchiveProjectConversations()
+  const closeForceArchiveConfirm = () => {
+    if (!projectArchiving) {
+      setForceArchiveConfirmOpen(false)
+    }
+  }
+  const confirmForceArchiveProjectConversations = () =>
+    runArchiveProjectConversations({ force: true })
   const closeRemoveConfirm = () => {
     if (!removingProject) {
       setRemoveConfirmOpen(false)
@@ -1703,6 +1731,17 @@ function ProjectItem({
         onClose={closeRemoveConfirm}
         onConfirm={confirmRemoveProject}
       />
+      <ArchiveConversationsConfirmDialog
+        open={forceArchiveConfirmOpen}
+        title={t('workbench.archive_runtime_task_dirty_worktree_title')}
+        description={t('workbench.archive_runtime_task_dirty_worktree_force_desc')}
+        confirmLabel={t('workbench.archive_runtime_task_force_confirm')}
+        cancelLabel={t('workbench.cancel', '取消')}
+        submitting={projectArchiving}
+        testId={`archive-project-force-dialog-${project.id}`}
+        onClose={closeForceArchiveConfirm}
+        onConfirm={confirmForceArchiveProjectConversations}
+      />
     </div>
   )
 }
@@ -1780,6 +1819,9 @@ export function DesktopSidebar({
   const [imNotificationMenuOpen, setImNotificationMenuOpen] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [archiveSectionMode, setArchiveSectionMode] = useState<'projects' | 'chats' | null>(null)
+  const [forceArchiveSectionMode, setForceArchiveSectionMode] = useState<
+    'projects' | 'chats' | null
+  >(null)
   const [isArchivingProjectSection, setIsArchivingProjectSection] = useState(false)
   const [isArchivingChatSection, setIsArchivingChatSection] = useState(false)
   const settingsMenuRef = useRef<HTMLDivElement>(null)
@@ -1971,29 +2013,61 @@ export function DesktopSidebar({
       setArchiveSectionMode(null)
     }
   }
-  const confirmArchiveSectionConversations = async () => {
-    if (archiveSectionMode === 'projects') {
+  const forceArchiveSectionDialogTestId =
+    forceArchiveSectionMode === 'chats'
+      ? 'runtime-chat-section-force-archive-dialog'
+      : 'projects-section-force-archive-dialog'
+  const runArchiveSectionConversations = async (
+    mode: 'projects' | 'chats',
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => {
+    if (mode === 'projects') {
       if (!onArchiveProjectsConversations || projectSectionArchiveKeys.length === 0) return
       setIsArchivingProjectSection(true)
       try {
-        await onArchiveProjectsConversations(projectSectionArchiveKeys)
+        const result = await onArchiveProjectsConversations(projectSectionArchiveKeys, options)
+        if (result?.status === 'dirty_worktree') {
+          setArchiveSectionMode(null)
+          setForceArchiveSectionMode('projects')
+          return
+        }
         setArchiveSectionMode(null)
+        setForceArchiveSectionMode(null)
       } finally {
         setIsArchivingProjectSection(false)
       }
       return
     }
 
-    if (archiveSectionMode === 'chats') {
+    if (mode === 'chats') {
       if (!onArchiveChatConversations || chatSectionArchiveAddresses.length === 0) return
       setIsArchivingChatSection(true)
       try {
-        await onArchiveChatConversations(chatSectionArchiveAddresses)
+        const result = await onArchiveChatConversations(chatSectionArchiveAddresses, options)
+        if (result?.status === 'dirty_worktree') {
+          setArchiveSectionMode(null)
+          setForceArchiveSectionMode('chats')
+          return
+        }
         setArchiveSectionMode(null)
+        setForceArchiveSectionMode(null)
       } finally {
         setIsArchivingChatSection(false)
       }
     }
+  }
+  const confirmArchiveSectionConversations = () => {
+    if (!archiveSectionMode) return
+    void runArchiveSectionConversations(archiveSectionMode)
+  }
+  const closeForceArchiveSectionDialog = () => {
+    if (!isArchiveSectionSubmitting) {
+      setForceArchiveSectionMode(null)
+    }
+  }
+  const confirmForceArchiveSectionConversations = () => {
+    if (!forceArchiveSectionMode) return
+    void runArchiveSectionConversations(forceArchiveSectionMode, { force: true })
   }
   const displayedExpandedProjectIds = visibleExpandedProjectIds
   const autoExpandedProjectKeyRef = useRef<string | null>(null)
@@ -2552,6 +2626,17 @@ export function DesktopSidebar({
             testId={archiveSectionDialogTestId}
             onClose={closeArchiveSectionDialog}
             onConfirm={confirmArchiveSectionConversations}
+          />
+          <ArchiveConversationsConfirmDialog
+            open={forceArchiveSectionMode !== null}
+            title={t('workbench.archive_runtime_task_dirty_worktree_title')}
+            description={t('workbench.archive_runtime_tasks_dirty_worktree_force_desc')}
+            confirmLabel={t('workbench.archive_runtime_task_force_confirm')}
+            cancelLabel={t('workbench.cancel', '取消')}
+            submitting={isArchiveSectionSubmitting}
+            testId={forceArchiveSectionDialogTestId}
+            onClose={closeForceArchiveSectionDialog}
+            onConfirm={confirmForceArchiveSectionConversations}
           />
           <TextInputDialog
             open={renamingProject !== null}

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -260,6 +260,18 @@ function createRuntimeWorkApiMock(overrides: Record<string, unknown> = {}) {
       workspacePath: '/workspace/project-alpha',
       runtime: 'codex',
     }),
+    archiveProjectConversations: vi.fn().mockResolvedValue({
+      accepted: true,
+      requestedCount: 1,
+      acceptedCount: 1,
+      results: [],
+    }),
+    archiveAllConversations: vi.fn().mockResolvedValue({
+      accepted: true,
+      requestedCount: 1,
+      acceptedCount: 1,
+      results: [],
+    }),
     cancelRuntimeTask: vi.fn().mockResolvedValue({
       accepted: true,
       localTaskId: 'runtime-a',
@@ -812,6 +824,37 @@ function ArchiveRuntimeTaskProbe() {
         }
       >
         force archive worktree task
+      </button>
+    </div>
+  )
+}
+
+function ArchiveProjectConversationsProbe() {
+  const workbench = useWorkbench()
+  const [lastArchiveResult, setLastArchiveResult] = useState('')
+  return (
+    <div>
+      <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
+      <span data-testid="archive-result">{lastArchiveResult}</span>
+      <button
+        type="button"
+        onClick={() =>
+          void workbench
+            .archiveProjectsConversations(['project:7'])
+            .then(result => setLastArchiveResult(result?.status ?? 'none'))
+        }
+      >
+        archive project conversations
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void workbench
+            .archiveProjectsConversations(['project:7'], { force: true })
+            .then(result => setLastArchiveResult(result?.status ?? 'none'))
+        }
+      >
+        force archive project conversations
       </button>
     </div>
   )
@@ -3000,6 +3043,88 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(runtimeWorkApi.archiveConversation.mock.invocationCallOrder[0]).toBeLessThan(
       removeCallOrder ?? 0
     )
+  })
+
+  test('prompts before force archiving project conversations with dirty worktrees', async () => {
+    const executeCommand = vi.fn().mockImplementation(async (_deviceId, data) => {
+      if (data.command_key === 'git_status_porcelain') {
+        return { success: true, stdout: ' M src/App.tsx\n', stderr: '' }
+      }
+      if (data.command_key === 'git_worktree_remove') {
+        return { success: true, stdout: '', stderr: '' }
+      }
+      throw new Error(`unexpected command: ${data.command_key}`)
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, key: 'project:7', name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  id: 92,
+                  projectId: 7,
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/worktrees/9/project-alpha',
+                  workspaceKind: 'worktree',
+                  worktreeId: '9',
+                  available: true,
+                  localTasks: [
+                    {
+                      localTaskId: 'runtime-worktree',
+                      workspacePath: '/workspace/worktrees/9/project-alpha',
+                      workspaceKind: 'worktree',
+                      worktreeId: '9',
+                      title: 'Worktree task',
+                      runtime: 'codex',
+                    },
+                  ],
+                },
+              ],
+              totalLocalTasks: 1,
+            },
+          ],
+          totalLocalTasks: 1,
+        })
+      ),
+    })
+    const services = createWorkbenchServices({
+      deviceApi: { executeCommand } as Partial<
+        WorkbenchServices['deviceApi']
+      > as WorkbenchServices['deviceApi'],
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ArchiveProjectConversationsProbe />, services)
+
+    await waitFor(() =>
+      expect(screen.getByText('archive project conversations')).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByText('archive project conversations'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-result')).toHaveTextContent('dirty_worktree')
+    )
+    expect(runtimeWorkApi.archiveProjectConversations).not.toHaveBeenCalled()
+    expect(executeCommand).not.toHaveBeenCalledWith(
+      'device-1',
+      expect.objectContaining({ command_key: 'git_worktree_remove' })
+    )
+
+    await userEvent.click(screen.getByText('force archive project conversations'))
+
+    await waitFor(() => expect(runtimeWorkApi.archiveProjectConversations).toHaveBeenCalledTimes(1))
+    expect(executeCommand).toHaveBeenCalledWith('device-1', {
+      command_key: 'git_worktree_remove',
+      path: '/workspace/worktrees/9/project-alpha',
+      args: ['/workspace/worktrees/9/project-alpha', '/workspace/worktrees/9/project-alpha'],
+      timeout_seconds: 30,
+      max_output_bytes: 8192,
+    })
+    await waitFor(() => expect(screen.getByTestId('archive-result')).toHaveTextContent('archived'))
   })
 
   test('renders streaming local task chunks when the socket connects after chat start', async () => {

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -40,6 +40,7 @@ import type { WorkbenchServices } from './workbenchServices'
 import type {
   ArchiveRuntimeLocalTaskOptions,
   ArchiveRuntimeLocalTaskResult,
+  ArchiveRuntimeConversationsResult,
 } from './workbenchContextTypes'
 
 interface UseWorkbenchRuntimeTasksOptions {
@@ -203,20 +204,21 @@ export function useWorkbenchRuntimeTasks({
     [clearCurrentRuntimeTaskView]
   )
 
-  const archiveRuntimeLocalTask = useCallback(
+  const prepareWorktreeArchive = useCallback(
     async (
-      address: RuntimeTaskAddress,
+      worktreeTargets: RuntimeTaskWorktreeTarget[],
       options: ArchiveRuntimeLocalTaskOptions = {}
-    ): Promise<ArchiveRuntimeLocalTaskResult> => {
-      const worktreeTarget = findRuntimeTaskWorktree(state.runtimeWork, address)
-      if (worktreeTarget && !options.force) {
-        let hasUncommittedChanges: boolean
+    ): Promise<'ready' | 'dirty_worktree' | 'failed'> => {
+      if (options.force || worktreeTargets.length === 0) return 'ready'
+
+      for (const target of uniqueRuntimeTaskWorktreeTargets(worktreeTargets)) {
         try {
-          hasUncommittedChanges = await workspaceHasUncommittedChanges(
+          const hasUncommittedChanges = await workspaceHasUncommittedChanges(
             executorClient.commands,
-            worktreeTarget.workspace.deviceId,
-            worktreeTarget.workspace.workspacePath
+            target.workspace.deviceId,
+            target.workspace.workspacePath
           )
+          if (hasUncommittedChanges) return 'dirty_worktree'
         } catch (error) {
           dispatch({
             type: 'error_set',
@@ -225,24 +227,23 @@ export function useWorkbenchRuntimeTasks({
                 ? error.message
                 : t('workbench.archive_runtime_task_check_failed'),
           })
-          return { status: 'failed' }
-        }
-        if (hasUncommittedChanges) {
-          return { status: 'dirty_worktree' }
+          return 'failed'
         }
       }
 
-      const response = await executorClient.runtime.archiveConversation(address)
-      if (!response.accepted) {
-        dispatch({ type: 'error_set', error: response.error || 'Failed to archive runtime task' })
-        return { status: 'failed' }
-      }
-      if (worktreeTarget) {
+      return 'ready'
+    },
+    [dispatch, executorClient, t]
+  )
+
+  const removeArchivedWorktrees = useCallback(
+    async (worktreeTargets: RuntimeTaskWorktreeTarget[]) => {
+      for (const target of uniqueRuntimeTaskWorktreeTargets(worktreeTargets)) {
         try {
           await removeGitWorktree(
             executorClient.commands,
-            worktreeTarget.workspace.deviceId,
-            worktreeTarget.workspace.workspacePath
+            target.workspace.deviceId,
+            target.workspace.workspacePath
           )
         } catch (error) {
           dispatch({
@@ -256,6 +257,27 @@ export function useWorkbenchRuntimeTasks({
           })
         }
       }
+    },
+    [dispatch, executorClient, t]
+  )
+
+  const archiveRuntimeLocalTask = useCallback(
+    async (
+      address: RuntimeTaskAddress,
+      options: ArchiveRuntimeLocalTaskOptions = {}
+    ): Promise<ArchiveRuntimeLocalTaskResult> => {
+      const worktreeTarget = findRuntimeTaskWorktree(state.runtimeWork, address)
+      const worktreeTargets = worktreeTarget ? [worktreeTarget] : []
+      const prepareResult = await prepareWorktreeArchive(worktreeTargets, options)
+      if (prepareResult === 'dirty_worktree') return { status: 'dirty_worktree' }
+      if (prepareResult === 'failed') return { status: 'failed' }
+
+      const response = await executorClient.runtime.archiveConversation(address)
+      if (!response.accepted) {
+        dispatch({ type: 'error_set', error: response.error || 'Failed to archive runtime task' })
+        return { status: 'failed' }
+      }
+      await removeArchivedWorktrees(worktreeTargets)
       if (isSameRuntimeTaskAddress(state.currentRuntimeTask, address)) {
         clearCurrentRuntimeTaskView()
       }
@@ -266,10 +288,11 @@ export function useWorkbenchRuntimeTasks({
       clearCurrentRuntimeTaskView,
       dispatch,
       executorClient,
+      prepareWorktreeArchive,
       refreshWorkLists,
+      removeArchivedWorktrees,
       state.currentRuntimeTask,
       state.runtimeWork,
-      t,
     ]
   )
 
@@ -286,34 +309,53 @@ export function useWorkbenchRuntimeTasks({
   )
 
   const archiveProjectConversations = useCallback(
-    async (runtimeProjectKey: string) => {
+    async (
+      runtimeProjectKey: string,
+      options: ArchiveRuntimeLocalTaskOptions = {}
+    ): Promise<ArchiveRuntimeConversationsResult> => {
+      const addresses = projectTaskAddresses(state.runtimeWork, [runtimeProjectKey])
+      const worktreeTargets = findRuntimeTaskWorktrees(state.runtimeWork, addresses)
+      const prepareResult = await prepareWorktreeArchive(worktreeTargets, options)
+      if (prepareResult === 'dirty_worktree') return { status: 'dirty_worktree' }
+      if (prepareResult === 'failed') return { status: 'failed' }
+
       const response = await executorClient.runtime.archiveProjectConversations({
         runtimeProjectKey,
       })
       if (!response.accepted) {
         dispatch({ type: 'error_set', error: response.error || 'Failed to archive project' })
-        return
+        return { status: 'failed' }
       }
-      clearCurrentRuntimeTaskIfArchived(
-        projectTaskAddresses(state.runtimeWork, [runtimeProjectKey])
-      )
+      await removeArchivedWorktrees(worktreeTargets)
+      clearCurrentRuntimeTaskIfArchived(addresses)
       await refreshWorkLists()
+      return { status: 'archived' }
     },
     [
       clearCurrentRuntimeTaskIfArchived,
       dispatch,
       executorClient,
+      prepareWorktreeArchive,
       refreshWorkLists,
+      removeArchivedWorktrees,
       state.runtimeWork,
     ]
   )
 
   const archiveProjectsConversations = useCallback(
-    async (runtimeProjectKeys: string[]) => {
+    async (
+      runtimeProjectKeys: string[],
+      options: ArchiveRuntimeLocalTaskOptions = {}
+    ): Promise<ArchiveRuntimeConversationsResult> => {
       const uniqueProjectKeys = [...new Set(runtimeProjectKeys.filter(Boolean))]
-      if (uniqueProjectKeys.length === 0) return
+      if (uniqueProjectKeys.length === 0) return { status: 'archived' }
 
       const archivedAddresses = projectTaskAddresses(state.runtimeWork, uniqueProjectKeys)
+      const worktreeTargets = findRuntimeTaskWorktrees(state.runtimeWork, archivedAddresses)
+      const prepareResult = await prepareWorktreeArchive(worktreeTargets, options)
+      if (prepareResult === 'dirty_worktree') return { status: 'dirty_worktree' }
+      if (prepareResult === 'failed') return { status: 'failed' }
+
       const responses = await Promise.all(
         uniqueProjectKeys.map(runtimeProjectKey =>
           executorClient.runtime.archiveProjectConversations({ runtimeProjectKey })
@@ -325,24 +367,36 @@ export function useWorkbenchRuntimeTasks({
           type: 'error_set',
           error: failedResponse.error || 'Failed to archive project conversations',
         })
-        return
+        return { status: 'failed' }
       }
 
+      await removeArchivedWorktrees(worktreeTargets)
       clearCurrentRuntimeTaskIfArchived(archivedAddresses)
       await refreshWorkLists()
+      return { status: 'archived' }
     },
     [
       clearCurrentRuntimeTaskIfArchived,
       dispatch,
       executorClient,
+      prepareWorktreeArchive,
       refreshWorkLists,
+      removeArchivedWorktrees,
       state.runtimeWork,
     ]
   )
 
   const archiveChatConversations = useCallback(
-    async (addresses: RuntimeTaskAddress[]) => {
-      if (addresses.length === 0) return
+    async (
+      addresses: RuntimeTaskAddress[],
+      options: ArchiveRuntimeLocalTaskOptions = {}
+    ): Promise<ArchiveRuntimeConversationsResult> => {
+      if (addresses.length === 0) return { status: 'archived' }
+
+      const worktreeTargets = findRuntimeTaskWorktrees(state.runtimeWork, addresses)
+      const prepareResult = await prepareWorktreeArchive(worktreeTargets, options)
+      if (prepareResult === 'dirty_worktree') return { status: 'dirty_worktree' }
+      if (prepareResult === 'failed') return { status: 'failed' }
 
       const responses = await Promise.all(
         addresses.map(address => executorClient.runtime.archiveConversation(address))
@@ -353,13 +407,23 @@ export function useWorkbenchRuntimeTasks({
           type: 'error_set',
           error: failedResponse.error || 'Failed to archive chat conversations',
         })
-        return
+        return { status: 'failed' }
       }
 
+      await removeArchivedWorktrees(worktreeTargets)
       clearCurrentRuntimeTaskIfArchived(addresses)
       await refreshWorkLists()
+      return { status: 'archived' }
     },
-    [clearCurrentRuntimeTaskIfArchived, dispatch, executorClient, refreshWorkLists]
+    [
+      clearCurrentRuntimeTaskIfArchived,
+      dispatch,
+      executorClient,
+      prepareWorktreeArchive,
+      refreshWorkLists,
+      removeArchivedWorktrees,
+      state.runtimeWork,
+    ]
   )
 
   const searchRuntimeWork = useCallback(
@@ -442,10 +506,12 @@ export function useWorkbenchRuntimeTasks({
   }
 }
 
+type RuntimeTaskWorktreeTarget = { workspace: RuntimeDeviceWorkspace; task: LocalTaskSummary }
+
 function findRuntimeTaskWorktree(
   runtimeWork: WorkbenchState['runtimeWork'],
   address: RuntimeTaskAddress
-): { workspace: RuntimeDeviceWorkspace; task: LocalTaskSummary } | null {
+): RuntimeTaskWorktreeTarget | null {
   if (!runtimeWork) return null
   const workspaces = [
     ...runtimeWork.chats,
@@ -463,6 +529,29 @@ function findRuntimeTaskWorktree(
   }
 
   return null
+}
+
+function findRuntimeTaskWorktrees(
+  runtimeWork: WorkbenchState['runtimeWork'],
+  addresses: RuntimeTaskAddress[]
+): RuntimeTaskWorktreeTarget[] {
+  return addresses
+    .map(address => findRuntimeTaskWorktree(runtimeWork, address))
+    .filter((target): target is RuntimeTaskWorktreeTarget => Boolean(target))
+}
+
+function uniqueRuntimeTaskWorktreeTargets(
+  targets: RuntimeTaskWorktreeTarget[]
+): RuntimeTaskWorktreeTarget[] {
+  const seen = new Set<string>()
+  const uniqueTargets: RuntimeTaskWorktreeTarget[] = []
+  for (const target of targets) {
+    const key = `${target.workspace.deviceId}:${target.workspace.workspacePath}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    uniqueTargets.push(target)
+  }
+  return uniqueTargets
 }
 
 function isRuntimeTaskWorktree(workspace: RuntimeDeviceWorkspace, task: LocalTaskSummary): boolean {

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -60,6 +60,8 @@ export type ArchiveRuntimeLocalTaskResult = {
   status: 'archived' | 'dirty_worktree' | 'failed'
 }
 
+export type ArchiveRuntimeConversationsResult = ArchiveRuntimeLocalTaskResult
+
 export interface SendCurrentInputOptions {
   codeCommentContexts?: CodeCommentContext[]
   initialGoal?: RuntimeGoalCreateInput | null
@@ -129,9 +131,18 @@ export interface WorkbenchContextValue {
     address: RuntimeTaskAddress,
     options?: ArchiveRuntimeLocalTaskOptions
   ) => Promise<ArchiveRuntimeLocalTaskResult>
-  archiveProjectConversations: (runtimeProjectKey: string) => Promise<void>
-  archiveProjectsConversations: (runtimeProjectKeys: string[]) => Promise<void>
-  archiveChatConversations: (addresses: RuntimeTaskAddress[]) => Promise<void>
+  archiveProjectConversations: (
+    runtimeProjectKey: string,
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult>
+  archiveProjectsConversations: (
+    runtimeProjectKeys: string[],
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult>
+  archiveChatConversations: (
+    addresses: RuntimeTaskAddress[],
+    options?: ArchiveRuntimeLocalTaskOptions
+  ) => Promise<ArchiveRuntimeConversationsResult>
   forkCurrentRuntimeTask: (target: RuntimeTaskForkTarget) => Promise<void>
   getRuntimeGoal: (address: RuntimeTaskAddress) => Promise<RuntimeGoalGetResponse>
   setRuntimeGoal: (request: RuntimeGoalSetRequest) => Promise<RuntimeGoalSetResponse>

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -66,6 +66,7 @@
     "archive_runtime_task_notice_close": "Dismiss archive notice",
     "archive_runtime_task_dirty_worktree_title": "Worktree has uncommitted code",
     "archive_runtime_task_dirty_worktree_force_desc": "Force archiving will delete this worktree directory. Uncommitted changes cannot be recovered.",
+    "archive_runtime_tasks_dirty_worktree_force_desc": "Force archiving will delete the worktree directories for these conversations. Uncommitted changes cannot be recovered.",
     "archive_runtime_task_force_confirm": "Force archive",
     "archive_runtime_task_check_failed": "Failed to check worktree changes before archiving",
     "archive_runtime_task_remove_failed": "Task archived, but failed to remove the worktree",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -66,6 +66,7 @@
     "archive_runtime_task_notice_close": "关闭归档提示",
     "archive_runtime_task_dirty_worktree_title": "工作树有未提交代码",
     "archive_runtime_task_dirty_worktree_force_desc": "强制归档会删除这个工作树目录，未提交的更改将无法恢复。",
+    "archive_runtime_tasks_dirty_worktree_force_desc": "强制归档会删除这些会话对应的工作树目录，未提交的更改将无法恢复。",
     "archive_runtime_task_force_confirm": "强制归档",
     "archive_runtime_task_check_failed": "归档前检查工作树变更失败",
     "archive_runtime_task_remove_failed": "任务已归档，但删除工作树失败",


### PR DESCRIPTION
## Summary
- Clean runtime Git worktrees after Wework archive flows complete successfully.
- Add dirty worktree checks to single, project, project-section, and chat-section archive actions.
- Show a force archive confirmation before deleting worktrees with uncommitted changes.

## Root Cause
Runtime archive operations only marked Codex conversations archived. Bulk archive paths did not run the frontend worktree cleanup flow, leaving managed worktree directories under the local executor workspace.

## Impact
Archived Wework Codex conversations now clean their managed worktree directories consistently. Uncommitted worktree changes are protected by default and require explicit force archive confirmation before deletion.

## Validation
- `pnpm --dir wework lint`
- `pnpm --dir wework typecheck`
- `pnpm --dir wework test -- DesktopSidebar.test.tsx WorkbenchProvider.test.tsx`
- Pre-push Wework quality gate: ESLint, TypeScript, unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a force-confirmation path when archiving conversations that have uncommitted changes.
  * Archive actions now report clearer outcomes, including whether archiving succeeded or needs force confirmation.
  * Updated confirmation messages to warn that uncommitted changes may be lost.

* **Bug Fixes**
  * Improved archive flows for projects, multiple chats, and individual chats to handle dirty worktrees more reliably.
  * Archive actions now better preserve the correct dialog flow before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->