### PR TITLE
[codex] persist wework local user preferences

### DIFF
--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { LOCAL_USER } from './localSession'
+import { getLocalUser, LOCAL_USER } from './localSession'
 import { createLocalAppServices } from './localServices'
 import {
   clearLocalModelConfigs,
@@ -8,6 +8,7 @@ import {
 
 describe('createLocalAppServices', () => {
   beforeEach(() => {
+    localStorage.clear()
     clearLocalModelConfigs()
   })
 
@@ -106,9 +107,24 @@ describe('createLocalAppServices', () => {
         bind_shell: 'claudecode',
       }),
     ])
-    await expect(services.userApi?.updateCurrentUser({ preferences: {} })).resolves.toEqual(
-      LOCAL_USER
-    )
+    const preferences = {
+      wework_new_chat_model_selection: {
+        modelName: 'gpt-5.5',
+        modelType: 'runtime' as const,
+        options: { collaborationMode: 'plan' },
+      },
+      wework_project_work_preferences: {
+        'project:7': {
+          executionMode: 'git_worktree' as const,
+          worktreeBranch: 'feature/alpha',
+        },
+      },
+    }
+    await expect(services.userApi?.updateCurrentUser({ preferences })).resolves.toEqual({
+      ...LOCAL_USER,
+      preferences,
+    })
+    expect(getLocalUser().preferences).toEqual(preferences)
     await expect(services.runtimeWorkApi?.listRuntimeWork()).resolves.toEqual({
       projects: [],
       chats: [],

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -77,7 +77,7 @@ import {
 } from '@/features/model-settings/localModelSettings'
 import { createLocalChatStream } from './localChatStream'
 import { createLocalAttachmentApi } from './localAttachments'
-import { LOCAL_USER } from './localSession'
+import { LOCAL_USER, saveLocalUserPreferences } from './localSession'
 
 const LOCAL_DEVICE_ID = 'local-device'
 
@@ -1664,10 +1664,8 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
       runtimeWorkApi,
     }),
     userApi: {
-      updateCurrentUser: async (data: { preferences?: User['preferences'] }) => ({
-        ...LOCAL_USER,
-        preferences: data.preferences ?? LOCAL_USER.preferences,
-      }),
+      updateCurrentUser: async (data: { preferences?: User['preferences'] }) =>
+        saveLocalUserPreferences(data.preferences ?? LOCAL_USER.preferences),
       getRuntimeConfig: () => cloudConnectionRequired('getRuntimeConfig'),
       updateRuntimeConfig: () => cloudConnectionRequired('updateRuntimeConfig'),
       getProxyConfig: () => cloudConnectionRequired('getProxyConfig'),


### PR DESCRIPTION
## Summary
- Persist local wework user preference updates through the existing local preference storage path.
- Cover model selection and project worktree preference persistence in the local app services test.

## Root Cause
The local-mode `updateCurrentUser` implementation returned updated preferences in memory but did not write them to `wework.localUser.preferences`, so app restarts restored an empty local user preference object.

## Impact
Wework now keeps the selected new-worktree mode and right-side model choice after closing and reopening the app.

## Validation
- `pnpm --dir wework test -- src/api/local/localServices.test.ts`
- `pnpm --dir wework test -- src/features/workbench/workbenchProjectChatHooks.test.tsx src/features/workbench/WorkbenchProvider.test.tsx`
- pre-push Wework checks: ESLint, TypeScript, unit tests

Docs were reviewed; this is an internal persistence bugfix with no user-facing documentation changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User preference updates in local/offline mode now persist correctly and are reflected when reloading local user data.
  * Improved local test coverage to ensure preference changes are saved and returned as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->