### PR TITLE
[codex] unify wework thinking indicator

### DIFF
--- a/wework/src/components/chat/AssistantThinkingIndicator.tsx
+++ b/wework/src/components/chat/AssistantThinkingIndicator.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from '@/hooks/useTranslation'
+
+export function AssistantThinkingIndicator() {
+  const { t } = useTranslation('chat')
+
+  return (
+    <div className="inline-flex items-center text-[13px]" data-testid="thinking-indicator">
+      <span className="waiting-thinking-text">{t('thinking.running')}</span>
+    </div>
+  )
+}

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -558,6 +558,42 @@ describe('MessageList', () => {
     )
   })
 
+  test('shows trailing thinking after partial content when processing blocks are still running', () => {
+    const runningSearchBlock: ProcessingBlock = {
+      id: 'search-running',
+      turnId: 1,
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: 'rg -n chat src' },
+      status: 'streaming',
+      createdAt: 1770000000000,
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-done-with-running-block',
+            role: 'assistant',
+            content: '我先把硬编码中文改成 chat 命名空间翻译。',
+            status: 'done',
+            createdAt: '2026-06-11T10:00:00Z',
+            blocks: [runningSearchBlock],
+          },
+        ]}
+      />
+    )
+
+    const content = screen.getByText('我先把硬编码中文改成 chat 命名空间翻译。')
+    const thinking = screen.getByTestId('thinking-indicator')
+
+    expect(thinking).toHaveTextContent('正在思考')
+    expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
+    expect(content.compareDocumentPosition(thinking) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
+
   test('renders tagged markdown documents as regular assistant markdown instead of a plan card', () => {
     render(
       <MessageList
@@ -2902,6 +2938,66 @@ describe('MessageList', () => {
     expect(thinkingIndicator).toHaveTextContent('正在思考')
     expect(thinkingIndicator).not.toHaveClass('bg-surface')
     expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
+  })
+
+  test('shows thinking from the message list after completed processing activity', () => {
+    const completedBlock: ProcessingBlock = {
+      id: 'call-1',
+      turnId: 1,
+      type: 'tool',
+      toolName: 'Bash',
+      toolInput: { command: 'pwd' },
+      toolOutput: '/workspace/project',
+      status: 'done',
+      createdAt: 1770000000000,
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+            blocks: [completedBlock],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('已运行 1 条命令')).toBeInTheDocument()
+    expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
+  })
+
+  test('does not duplicate thinking when live process text is visible', () => {
+    const processBlock: ProcessingBlock = {
+      id: 'text-1',
+      turnId: 1,
+      type: 'text',
+      content: 'Let me inspect the repository first.',
+      status: 'streaming',
+      createdAt: 1770000000000,
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+            blocks: [processBlock],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Let me inspect the repository first.')).toBeInTheDocument()
+    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 
   test('keeps running tool rows visible while showing trailing thinking', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -31,11 +31,12 @@ import { isIMSource } from '@/lib/im-source'
 import { ImSourceBadge } from '@/components/common/ImSourceBadge'
 import { cn } from '@/lib/utils'
 import { AssistantMarkdown } from './AssistantMarkdown'
+import { AssistantThinkingIndicator } from './AssistantThinkingIndicator'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
 import { CODEX_IMPLEMENT_PLAN_RESPONSE_LABEL } from './requestUserInputMessages'
 import type { RequestUserInputPayload } from './RequestUserInputCard'
-import { isWebSearchToolName } from './blocks/toolBlockActivity'
+import { buildProcessingDisplayRows, isWebSearchToolName } from './blocks/toolBlockActivity'
 import { WebSearchSourcesChip } from './blocks/WebSearchSources'
 import { getWebSearchSourceItems } from './blocks/webSearchActivity'
 import { CodexMemoryCitations, CodexReferenceList } from './CodexTurnArtifacts'
@@ -277,7 +278,7 @@ export const MessageList = memo(function MessageList({
       })}
       {shouldShowWaitingIndicator && (
         <article className="min-w-0 overflow-x-hidden" data-testid="message-assistant-waiting">
-          <WaitingAssistantIndicator />
+          <AssistantThinkingIndicator />
         </article>
       )}
     </div>
@@ -362,16 +363,6 @@ function shouldRenderMessage(message: WorkbenchMessage): boolean {
   if (visibleContent.trim()) return true
 
   return getDisplayProcessingBlocks(message.blocks).length > 0
-}
-
-function WaitingAssistantIndicator() {
-  const { t } = useTranslation('chat')
-
-  return (
-    <div className="inline-flex items-center text-[13px]" data-testid="thinking-indicator">
-      <span className="waiting-thinking-text">{t('thinking.running')}</span>
-    </div>
-  )
 }
 
 function getTurnStartMs(createdAt: string): number | undefined {
@@ -1122,11 +1113,16 @@ function AssistantMessage({
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = message.status === 'streaming'
-  const canShowFinalArtifacts = !isStreaming
+  const hasRunningBlocks = hasRunningProcessingBlocks(displayBlocks)
+  const isAssistantRunning = isStreaming || hasRunningBlocks
+  const canShowFinalArtifacts = !isAssistantRunning
   const hasStreamedResponse = hasBlocks || hasVisibleContent
-  const shouldShowProcessingSummary = hasBlocks || (isStreaming && hasStreamedResponse)
-  const shouldShowInitialThinking = isStreaming && !hasStreamedResponse
-  const shouldShowTrailingThinking = isStreaming && hasVisibleContent
+  const shouldShowProcessingSummary = hasBlocks || (isAssistantRunning && hasStreamedResponse)
+  const shouldShowThinking = shouldShowAssistantThinkingIndicator({
+    isAssistantRunning,
+    hasVisibleContent,
+    hasLiveProcessingDisplayBlock: hasLiveProcessingDisplayBlock(displayBlocks),
+  })
   const webSearchSources = isStreaming
     ? []
     : getWebSearchSourceItems(getWebSearchToolBlocks(displayBlocks))
@@ -1179,7 +1175,6 @@ function AssistantMessage({
               forceExpanded={isCancelled}
               hasFinalContent={hasVisibleContent}
               showSummary={!isCancelled}
-              showRunningPlaceholder={!hasVisibleContent}
               stateKey={getMessageDisplayStateKey(conversationKey, message)}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
               onRequestUserInputSubmit={onRequestUserInputSubmit}
@@ -1189,11 +1184,11 @@ function AssistantMessage({
               hiddenRequestUserInputIds={hiddenRequestUserInputIds}
             />
           )}
-          {shouldShowInitialThinking && <WaitingAssistantIndicator />}
+          {shouldShowThinking && !hasVisibleContent && <AssistantThinkingIndicator />}
           {hasVisibleContent ? (
             <AssistantMarkdown content={visibleContent} onOpenFile={openFileFromLink} />
           ) : null}
-          {shouldShowTrailingThinking && <WaitingAssistantIndicator />}
+          {shouldShowThinking && hasVisibleContent && <AssistantThinkingIndicator />}
           {canShowFinalArtifacts && hasVisibleContent && webSearchSources.length > 0 && (
             <WebSearchSourcesChip sources={webSearchSources} />
           )}
@@ -1247,6 +1242,37 @@ function getMessageDisplayStateKey(
 ): string {
   const conversationPart = conversationKey == null ? 'default' : String(conversationKey)
   return `${conversationPart}:${message.id}`
+}
+
+function hasRunningProcessingBlocks(blocks: ProcessingBlock[]): boolean {
+  return blocks.some(block => block.status !== 'done' && block.status !== 'error')
+}
+
+function hasLiveProcessingDisplayBlock(blocks: ProcessingBlock[]): boolean {
+  return buildProcessingDisplayRows(blocks).some(row => {
+    if (row.type !== 'block') return false
+
+    const { block } = row
+    return (
+      block.status !== 'done' &&
+      block.status !== 'error' &&
+      (block.type === 'tool' || block.type === 'file_changes' || Boolean(block.content.trim()))
+    )
+  })
+}
+
+function shouldShowAssistantThinkingIndicator({
+  isAssistantRunning,
+  hasVisibleContent,
+  hasLiveProcessingDisplayBlock,
+}: {
+  isAssistantRunning: boolean
+  hasVisibleContent: boolean
+  hasLiveProcessingDisplayBlock: boolean
+}): boolean {
+  if (!isAssistantRunning) return false
+  if (hasVisibleContent) return true
+  return !hasLiveProcessingDisplayBlock
 }
 
 function AssistantErrorCard({

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -627,14 +627,14 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
   })
 
-  test('shows a thinking placeholder while streaming with only completed activity', () => {
+  test('leaves generic thinking placeholders to the message list', () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={true} />)
 
     expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
       'aria-hidden',
       'false'
     )
-    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
+    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 
   test('collapses streaming processing once final content is visible', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -61,7 +61,6 @@ interface ToolBlocksDisplayProps {
   forceExpanded?: boolean
   hasFinalContent?: boolean
   showSummary?: boolean
-  showRunningPlaceholder?: boolean
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
   onRequestUserInputSubmit?: (response: RequestUserInputResponse) => void
@@ -78,7 +77,6 @@ export function ToolBlocksDisplay({
   forceExpanded = false,
   hasFinalContent = false,
   showSummary = true,
-  showRunningPlaceholder = true,
   stateKey,
   onOpenWorkspaceFile,
   onRequestUserInputSubmit,
@@ -166,19 +164,6 @@ export function ToolBlocksDisplay({
   const isLockedOpen = forceExpanded || (isRunning && !hasFinalContent) || hasPlanResponse
   const expanded = isLockedOpen || userExpanded
   const canToggleSummary = showSummary && !isLockedOpen && rows.length > 0
-  const hasLiveDisplayBlock = useMemo(
-    () =>
-      rows.some(
-        row =>
-          row.type === 'block' &&
-          row.block.status !== 'done' &&
-          row.block.status !== 'error' &&
-          (row.block.type === 'tool' ||
-            row.block.type === 'file_changes' ||
-            Boolean(row.block.content))
-      ),
-    [rows]
-  )
   const processingContent = useMemo(
     () => (
       <div className="flex min-w-0 flex-col gap-3 pt-0.5">
@@ -216,18 +201,14 @@ export function ToolBlocksDisplay({
             />
           )
         })}
-        {isRunning && showRunningPlaceholder && !hasLiveDisplayBlock && <ThinkingIndicator />}
       </div>
     ),
     [
       displayItems,
-      hasLiveDisplayBlock,
-      isRunning,
       onOpenWorkspaceFile,
       onOpenAssistantPlan,
       onRequestUserInputIgnore,
       onRequestUserInputSubmit,
-      showRunningPlaceholder,
       stateKey,
     ]
   )
@@ -564,22 +545,6 @@ function renderActivityGroupIcon(blocks: ToolBlock[]) {
     )
   }
   return <Search className="h-4 w-4 shrink-0" strokeWidth={1.7} />
-}
-
-function ThinkingIndicator() {
-  return (
-    <div
-      className="flex items-center gap-1.5 text-[13px] text-text-muted"
-      data-testid="thinking-indicator"
-    >
-      <span>正在思考</span>
-      <span className="flex items-center gap-0.5" aria-hidden="true">
-        <span className="h-1 w-1 animate-pulse rounded-full bg-current" />
-        <span className="h-1 w-1 animate-pulse rounded-full bg-current [animation-delay:150ms]" />
-        <span className="h-1 w-1 animate-pulse rounded-full bg-current [animation-delay:300ms]" />
-      </span>
-    </div>
-  )
 }
 
 function getDurationText(


### PR DESCRIPTION
## Summary
- Centralize the Wework assistant thinking indicator into one shared component.
- Move the generic thinking display decision into MessageList so ToolBlocksDisplay only renders processing activity.
- Keep the trailing thinking indicator visible while assistant output or processing blocks are still running.

## Root Cause
PR #1678 only updated the MessageList streaming-content path. The processing timeline still owned a separate generic thinking indicator with different DOM and styling, and text-only streaming could miss the indicator when message status and processing block state diverged.

## Validation
- pnpm --dir wework test -- MessageList.test.tsx ToolBlocksDisplay.test.tsx
- Pre-push Wework ESLint, TypeScript check, and unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer “thinking” indicator in chat while the assistant is responding.

* **Bug Fixes**
  * Improved chat streaming behavior so the thinking state appears more consistently with partial replies and processing updates.
  * Prevented duplicate thinking indicators from showing in live message content.
  * Kept completed processing summaries visible while the assistant is still active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->