### PR TITLE
[codex] fix wework chat jump on composer interaction

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -47,7 +47,45 @@ describe('MessageList', () => {
     ).toContain('0 ')
   })
 
-  test('disables message row containment while selecting message text', async () => {
+  test('keeps message row containment during a plain text click', () => {
+    const getSelectionSpy = vi.spyOn(document, 'getSelection')
+    getSelectionSpy.mockReturnValue({
+      isCollapsed: true,
+      rangeCount: 0,
+      anchorNode: null,
+      focusNode: null,
+    } as Selection)
+
+    try {
+      render(
+        <MessageList
+          messages={[
+            {
+              id: 'user-clickable',
+              role: 'user',
+              content: 'Click this user message.',
+              status: 'done',
+              createdAt: '2026-06-11T10:00:01Z',
+            },
+          ]}
+        />
+      )
+
+      const article = screen.getByTestId('message-user')
+      const content = screen.getByTestId('user-message-content')
+      expect(article.className).toContain('[content-visibility:auto]')
+
+      fireEvent.pointerDown(content, { button: 0 })
+      fireEvent.pointerUp(document)
+
+      expect(article.className).toContain('[content-visibility:auto]')
+      expect(article.style.getPropertyValue('contain-intrinsic-size')).toContain('0 ')
+    } finally {
+      getSelectionSpy.mockRestore()
+    }
+  })
+
+  test('disables message row containment only while selected message text is active', async () => {
     const getSelectionSpy = vi.spyOn(document, 'getSelection')
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')
@@ -73,11 +111,21 @@ describe('MessageList', () => {
 
       const article = screen.getByTestId('message-assistant')
       const paragraph = screen.getByText('Select this assistant paragraph.')
+      const textNode = paragraph.firstChild
       expect(article.className).toContain('[content-visibility:auto]')
 
-      fireEvent.pointerDown(paragraph, { button: 0 })
-      expect(article.className).not.toContain('[content-visibility:auto]')
-      expect(article.style.getPropertyValue('contain-intrinsic-size')).toBe('')
+      getSelectionSpy.mockReturnValue({
+        isCollapsed: false,
+        rangeCount: 1,
+        anchorNode: textNode,
+        focusNode: textNode,
+      } as Selection)
+      fireEvent(document, new Event('selectionchange'))
+
+      await waitFor(() => {
+        expect(article.className).not.toContain('[content-visibility:auto]')
+        expect(article.style.getPropertyValue('contain-intrinsic-size')).toBe('')
+      })
 
       getSelectionSpy.mockReturnValue({
         isCollapsed: true,

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -2,7 +2,6 @@ import { Fragment, memo, useEffect, useLayoutEffect, useMemo, useRef, useState }
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
-  PointerEvent as ReactPointerEvent,
   ReactNode,
   TransitionEvent as ReactTransitionEvent,
 } from 'react'
@@ -116,7 +115,6 @@ export const MessageList = memo(function MessageList({
   renderGapAfterMessage,
 }: MessageListProps) {
   const listRef = useRef<HTMLDivElement>(null)
-  const isPointerSelectingRef = useRef(false)
   const layoutWidthUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isTextSelectionActive, setIsTextSelectionActive] = useState(false)
   const [layoutWidth, setLayoutWidth] = useState(0)
@@ -174,13 +172,7 @@ export const MessageList = memo(function MessageList({
   }, [])
 
   useEffect(() => {
-    if (!isTextSelectionActive) return
-
     const updateSelectionState = () => {
-      if (isPointerSelectingRef.current) {
-        return
-      }
-
       const selection = document.getSelection?.()
       const root = listRef.current
       if (!selection || !root || selection.isCollapsed || selection.rangeCount === 0) {
@@ -195,12 +187,10 @@ export const MessageList = memo(function MessageList({
     }
 
     const handlePointerUp = () => {
-      isPointerSelectingRef.current = false
       window.requestAnimationFrame(updateSelectionState)
     }
 
     const handleBlur = () => {
-      isPointerSelectingRef.current = false
       updateSelectionState()
     }
 
@@ -215,23 +205,14 @@ export const MessageList = memo(function MessageList({
       document.removeEventListener('selectionchange', updateSelectionState)
       window.removeEventListener('blur', handleBlur)
     }
-  }, [isTextSelectionActive])
-
-  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0 || !isMessageTextSelectionTarget(event.target)) {
-      return
-    }
-
-    isPointerSelectingRef.current = true
-    setIsTextSelectionActive(true)
-  }
+  }, [])
 
   if (visibleMessages.length === 0 && !shouldShowWaitingIndicator) {
     return null
   }
 
   return (
-    <div ref={listRef} className={cn(listLayoutClass, className)} onPointerDown={handlePointerDown}>
+    <div ref={listRef} className={cn(listLayoutClass, className)}>
       {visibleMessages.map((message, index) => {
         const nextMessage = visibleMessages[index + 1]
         return (
@@ -298,16 +279,6 @@ function isNodeInsideElement(node: Node | null, root: HTMLElement): boolean {
   }
 
   return Boolean(node.parentElement && root.contains(node.parentElement))
-}
-
-function isMessageTextSelectionTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false
-
-  return Boolean(
-    target.closest(
-      '.assistant-markdown, [data-testid="user-message-content"], [data-testid="message-hover-time"]'
-    )
-  )
 }
 
 function areMessageListPropsEqual(previous: MessageListProps, next: MessageListProps): boolean {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -195,6 +195,67 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('does not auto-scroll from content resize while auto-scroll is suspended', () => {
+    const resizeCallbacks: ResizeObserverCallback[] = []
+    const originalResizeObserver = globalThis.ResizeObserver
+
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback)
+      }
+
+      observe = vi.fn()
+      disconnect = vi.fn()
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+    try {
+      render(
+        <ScrollableMessageArea
+          autoScrollSuspended
+          messages={[
+            {
+              id: 'resize-suspended',
+              role: 'assistant',
+              content: 'Ready',
+              status: 'done',
+              createdAt: '2026-05-29T00:00:00.000Z',
+            },
+          ]}
+        />
+      )
+
+      const scroller = screen.getByTestId('chat-message-scroll-area')
+      expect(scroller).toHaveClass('[overflow-anchor:none]')
+      expect(screen.getByTestId('chat-message-scroll-area-content')).toHaveClass(
+        '[overflow-anchor:none]'
+      )
+      Object.defineProperty(scroller, 'clientHeight', {
+        value: 200,
+        configurable: true,
+      })
+      Object.defineProperty(scroller, 'scrollHeight', {
+        value: 600,
+        configurable: true,
+      })
+      Object.defineProperty(scroller, 'scrollTop', {
+        value: 352,
+        writable: true,
+        configurable: true,
+      })
+      scroller.scrollTo = vi.fn()
+
+      act(() => {
+        resizeCallbacks.forEach(callback => callback([], {} as ResizeObserver))
+      })
+
+      expect(scroller.scrollTo).not.toHaveBeenCalled()
+    } finally {
+      vi.stubGlobal('ResizeObserver', originalResizeObserver)
+    }
+  })
+
   test('renders a compact left-side navigation for previous user messages', () => {
     render(
       <ScrollableMessageArea

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -67,6 +67,7 @@ interface ScrollableMessageAreaProps {
   onOpenAssistantPlan?: (content: string) => void
   hideRequestUserInputBlocks?: boolean
   hiddenRequestUserInputIds?: ReadonlySet<string>
+  autoScrollSuspended?: boolean
   onLoadMoreBefore?: () => Promise<void> | void
   onLoadTurnNavigationItem?: (item: RuntimeTurnNavigationItem) => Promise<void> | void
   onLoadTranscriptGap?: (gap: RuntimeTranscriptGap) => Promise<void> | void
@@ -166,6 +167,7 @@ function areScrollableMessageAreaPropsEqual(
     previous.hiddenRequestUserInputIds !== next.hiddenRequestUserInputIds
       ? 'hiddenRequestUserInputIds'
       : null,
+    previous.autoScrollSuspended !== next.autoScrollSuspended ? 'autoScrollSuspended' : null,
     previous.onLoadMoreBefore !== next.onLoadMoreBefore ? 'onLoadMoreBefore' : null,
     previous.onLoadTurnNavigationItem !== next.onLoadTurnNavigationItem
       ? 'onLoadTurnNavigationItem'
@@ -271,6 +273,7 @@ function ScrollableMessagePaneContent({
   onOpenAssistantPlan,
   hideRequestUserInputBlocks,
   hiddenRequestUserInputIds,
+  autoScrollSuspended = false,
   onLoadMoreBefore,
   onLoadTurnNavigationItem,
   onLoadTranscriptGap,
@@ -586,7 +589,7 @@ function ScrollableMessagePaneContent({
       return
     }
 
-    if (isTurnNavigationAutoScrollSuspended()) {
+    if (autoScrollSuspended || isTurnNavigationAutoScrollSuspended()) {
       clearScheduledScrolls()
       return
     }
@@ -603,6 +606,7 @@ function ScrollableMessagePaneContent({
   }, [
     conversationKey,
     activationVersion,
+    autoScrollSuspended,
     currentScrollKey,
     clearScheduledScrolls,
     isTurnNavigationAutoScrollSuspended,
@@ -648,7 +652,7 @@ function ScrollableMessagePaneContent({
         return
       }
 
-      if (isTurnNavigationAutoScrollSuspended()) {
+      if (autoScrollSuspended || isTurnNavigationAutoScrollSuspended()) {
         return
       }
 
@@ -661,6 +665,7 @@ function ScrollableMessagePaneContent({
     return () => resizeObserver.disconnect()
   }, [
     currentScrollKey,
+    autoScrollSuspended,
     isTurnNavigationAutoScrollSuspended,
     restoreSavedScrollPosition,
     scrollToBottom,
@@ -696,7 +701,7 @@ function ScrollableMessagePaneContent({
         data-testid={scrollTestId}
         className={cn(
           'h-full overflow-x-hidden overflow-y-auto',
-          turnNavigationLoading && '[overflow-anchor:none]',
+          (turnNavigationLoading || autoScrollSuspended) && '[overflow-anchor:none]',
           scrollerClassName
         )}
         onScroll={() => {
@@ -717,7 +722,7 @@ function ScrollableMessagePaneContent({
           data-testid={`${scrollTestId}-content`}
           className={cn(
             'min-w-0 overflow-x-hidden',
-            turnNavigationLoading && '[overflow-anchor:none]'
+            (turnNavigationLoading || autoScrollSuspended) && '[overflow-anchor:none]'
           )}
         >
           {messages.length === 0 ? (

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -180,6 +180,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [openFileRequest, setOpenFileRequest] = useState<WorkspaceFileOpenRequest | null>(null)
   const [forkDialogOpen, setForkDialogOpen] = useState(false)
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
+  const [composerPointerActive, setComposerPointerActive] = useState(false)
   const workbenchMainRef = useRef<HTMLElement | null>(null)
   const [workbenchMainWidth, setWorkbenchMainWidth] = useState(0)
   const floatingComposerCardRef = useRef<HTMLDivElement | null>(null)
@@ -785,6 +786,20 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     activeDeviceUnavailable,
   ])
 
+  useLayoutEffect(() => {
+    if (!composerPointerActive) return
+
+    const clearComposerPointerActive = () => setComposerPointerActive(false)
+    window.addEventListener('pointerup', clearComposerPointerActive)
+    window.addEventListener('pointercancel', clearComposerPointerActive)
+    window.addEventListener('blur', clearComposerPointerActive)
+    return () => {
+      window.removeEventListener('pointerup', clearComposerPointerActive)
+      window.removeEventListener('pointercancel', clearComposerPointerActive)
+      window.removeEventListener('blur', clearComposerPointerActive)
+    }
+  }, [composerPointerActive])
+
   return (
     <main
       ref={workbenchMainRef}
@@ -913,6 +928,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 onOpenAssistantPlan={openAssistantPlan}
                 hideRequestUserInputBlocks={Boolean(pendingRequestUserInput)}
                 hiddenRequestUserInputIds={paneSession.answeredRequestUserInputIds}
+                autoScrollSuspended={composerPointerActive}
               />
               <div
                 className={DESKTOP_FLOATING_COMPOSER_BACKDROP_CLASS}
@@ -929,6 +945,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                   ref={floatingComposerCardRef}
                   className="pointer-events-auto"
                   data-testid="desktop-floating-composer-card"
+                  onPointerDownCapture={() => setComposerPointerActive(true)}
                 >
                   {showConversationDeviceBanner ? (
                     <ConversationDeviceOfflineBanner


### PR DESCRIPTION
## Summary

- Prevent plain message clicks from disabling message row containment unless real text selection is active.
- Suspend desktop message auto-scroll and overflow anchoring while the floating composer is being pressed.
- Add regression coverage for message containment and suspended resize auto-scroll behavior.

## Root Cause

Clicking text and interacting with the floating composer could trigger message layout recalculation or browser scroll anchoring while the transcript was near the bottom. That caused the visible conversation to shift downward during pointer interaction.

## Validation

- `pnpm --dir wework test ScrollableMessageArea.test.tsx MessageList.test.tsx`
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`
- Pre-push Wework gate: ESLint, TypeScript, unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message selection behavior so text highlighting no longer interferes with chat row containment during normal clicks.
  * Auto-scroll now stays paused while interacting with the floating message composer, preventing unexpected jumps.
  * Scrolling behavior now better respects active text selection and suspended auto-scroll states, including during content resize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->