### PR TITLE
[codex] Fix completed Codex commentary process blocks

### DIFF
--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -87,6 +87,7 @@ pub(crate) struct CodexNotificationEventMapper {
 
 struct ProcessTextStream {
     id: String,
+    item_id: Option<String>,
     content: String,
 }
 
@@ -195,6 +196,27 @@ impl CodexNotificationEventMapper {
                     self.agent_message_phases.forget_item(notification.params);
                     return;
                 }
+                let phase = self
+                    .agent_message_phases
+                    .phase_for_item(notification.params);
+                if codex_phase_is_process(phase.as_deref()) {
+                    log_codex_event_mapper_text(
+                        local_task_id,
+                        &notification.method,
+                        "emit_completed_process_block",
+                        phase.as_deref(),
+                        notification.params,
+                    );
+                    self.emit_completed_process_text(
+                        event_tx,
+                        device_id,
+                        local_task_id,
+                        request,
+                        notification.params,
+                    );
+                    self.agent_message_phases.forget_item(notification.params);
+                    return;
+                }
                 if is_completed_plan_item(notification.params) {
                     self.reset_process_text();
                     if let Some(text) = plan_item_text(notification.params) {
@@ -297,8 +319,11 @@ impl CodexNotificationEventMapper {
         let Some(delta) = agent_text(params) else {
             return;
         };
+        let item_id = notification_item_id(params);
 
-        if let Some(process_text) = self.process_text.as_mut() {
+        if let Some(process_text) = self.process_text.as_mut().filter(|process_text| {
+            process_text.item_id.is_none() || item_id.is_none() || process_text.item_id == item_id
+        }) {
             process_text.content.push_str(&delta);
             emit_response_event(
                 event_tx,
@@ -324,6 +349,7 @@ impl CodexNotificationEventMapper {
         );
         self.process_text = Some(ProcessTextStream {
             id: id.clone(),
+            item_id,
             content: delta.clone(),
         });
         emit_response_event(
@@ -338,6 +364,64 @@ impl CodexNotificationEventMapper {
                     "type": "text",
                     "content": delta,
                     "status": "streaming",
+                    "timestamp": now_ms(),
+                }
+            }),
+        );
+    }
+
+    fn emit_completed_process_text(
+        &mut self,
+        event_tx: &Option<broadcast::Sender<Value>>,
+        device_id: &str,
+        local_task_id: &str,
+        request: &ExecutionRequest,
+        params: &Value,
+    ) {
+        let Some(text) = completed_agent_text(params) else {
+            return;
+        };
+        let item_id = notification_item_id(params);
+
+        if let Some(process_text) = self.process_text.as_mut().filter(|process_text| {
+            process_text.item_id.is_none() || item_id.is_none() || process_text.item_id == item_id
+        }) {
+            process_text.content = text.clone();
+            emit_response_event(
+                event_tx,
+                device_id,
+                "response.block.updated",
+                local_task_id,
+                request,
+                json!({
+                    "block_id": process_text.id.clone(),
+                    "updates": {
+                        "content": text,
+                        "status": "done",
+                    }
+                }),
+            );
+            self.reset_process_text();
+            return;
+        }
+
+        self.process_text_count += 1;
+        let id = format!(
+            "text-{local_task_id}-{}-{}",
+            request.subtask_id, self.process_text_count
+        );
+        emit_response_event(
+            event_tx,
+            device_id,
+            "response.block.created",
+            local_task_id,
+            request,
+            json!({
+                "block": {
+                    "id": id,
+                    "type": "text",
+                    "content": text,
+                    "status": "done",
                     "timestamp": now_ms(),
                 }
             }),
@@ -590,6 +674,13 @@ fn log_codex_event_mapper_text(
 
 fn agent_text(params: &Value) -> Option<String> {
     raw_string_field(params, "delta").or_else(|| extract_text(params))
+}
+
+fn completed_agent_text(params: &Value) -> Option<String> {
+    params
+        .get("item")
+        .and_then(extract_text)
+        .or_else(|| agent_text(params))
 }
 
 fn json_string_field(value: &Value, key: &str) -> String {
@@ -1223,6 +1314,118 @@ mod tests {
             event["payload"]["data"]["block"]["content"],
             "I will inspect."
         );
+    }
+
+    #[test]
+    fn maps_completed_codex_commentary_agent_messages_to_process_text_blocks() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: 7,
+            subtask_id: 8,
+            ..ExecutionRequest::default()
+        };
+
+        map_codex_notification(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "id": "msg-commentary",
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": "I will inspect."
+                    }
+                }
+            }),
+        );
+
+        let event = event_rx.try_recv().expect("event should be emitted");
+        assert_eq!(event["event"], "response.block.created");
+        assert_eq!(event["payload"]["data"]["block"]["type"], "text");
+        assert_eq!(
+            event["payload"]["data"]["block"]["content"],
+            "I will inspect."
+        );
+        assert_eq!(event["payload"]["data"]["block"]["status"], "done");
+    }
+
+    #[test]
+    fn completes_streamed_codex_commentary_agent_message_without_duplicate_block() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: 7,
+            subtask_id: 8,
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "msg-commentary",
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": ""
+                    }
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "itemId": "msg-commentary",
+                    "delta": "I will inspect."
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "id": "msg-commentary",
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": "I will inspect."
+                    }
+                }
+            }),
+        );
+
+        let created = event_rx
+            .try_recv()
+            .expect("created event should be emitted");
+        let updated = event_rx
+            .try_recv()
+            .expect("updated event should be emitted");
+
+        assert_eq!(created["event"], "response.block.created");
+        assert_eq!(updated["event"], "response.block.updated");
+        assert_eq!(
+            updated["payload"]["data"]["block_id"],
+            created["payload"]["data"]["block"]["id"]
+        );
+        assert_eq!(updated["payload"]["data"]["updates"]["status"], "done");
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[test]

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -198,12 +198,7 @@ export function ToolBlocksDisplay({
           }
 
           return item.type === 'activity_group' ? (
-            <ToolActivityGroup
-              key={item.id}
-              row={item}
-              stateKey={stateKey ? `${stateKey}:${item.id}` : undefined}
-              onOpenWorkspaceFile={onOpenWorkspaceFile}
-            />
+            <ToolActivityGroup key={item.id} row={item} onOpenWorkspaceFile={onOpenWorkspaceFile} />
           ) : isContextCompactionToolBlock(item.block) ? (
             <ContextCompactionIndicator key={item.id} block={item.block} />
           ) : (
@@ -357,7 +352,6 @@ function ToolActivityGroup({
   onOpenWorkspaceFile,
 }: {
   row: Extract<ProcessingDisplayRow, { type: 'activity_group' }>
-  stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
 }) {
   const [expanded, setExpanded] = useState(false)


### PR DESCRIPTION
## Summary

- Map completed Codex commentary agent messages into process text blocks instead of dropping them.
- Mark an existing streamed commentary process block as done on completion without creating a duplicate block.
- Remove an unused Wework activity-group stateKey prop.

## Root Cause

Codex can emit commentary text only in an item/completed agentMessage. The executor resolved the process phase but did not emit a text process block for completed agent messages, so the UI could appear stuck even though Codex had produced commentary.

## Validation

- cargo test -q runtime_work::events
- pnpm --dir wework exec tsc --noEmit --pretty false
- pre-push: Wework ESLint, TypeScript, unit tests; executor cargo fmt, cargo test --all-features, cargo clippy