### PR TITLE
[codex] fix deterministic runtime stream message ids

### DIFF
--- a/backend/app/services/chat/webpage_websocket_chat_emitter.py
+++ b/backend/app/services/chat/webpage_websocket_chat_emitter.py
@@ -109,6 +109,7 @@ class WebSocketEmitter:
         result: Optional[Dict[str, Any]] = None,
         block_id: Optional[str] = None,
         block_offset: Optional[int] = None,
+        message_id: Optional[int] = None,
     ) -> None:
         """
         Emit chat:chunk event to task room.
@@ -121,6 +122,7 @@ class WebSocketEmitter:
             result: Optional full result data (for executor tasks with thinking/workbench)
             block_id: Optional block ID for text block streaming (append content to specific block)
             block_offset: Optional character offset within the current text block
+            message_id: Message ID for deterministic stream identity
         """
         payload = {
             "subtask_id": subtask_id,
@@ -128,6 +130,8 @@ class WebSocketEmitter:
             "offset": offset,
             "task_id": task_id,  # Add task_id for page refresh recovery
         }
+        if message_id is not None:
+            payload["message_id"] = message_id
         # Include block_id if provided (for text block streaming)
         if block_id is not None:
             payload["block_id"] = block_id

--- a/backend/app/services/chat/webpage_ws_chat_emitter.py
+++ b/backend/app/services/chat/webpage_ws_chat_emitter.py
@@ -109,6 +109,7 @@ class WebPageSocketEmitter:
         result: Optional[Dict[str, Any]] = None,
         block_id: Optional[str] = None,
         block_offset: Optional[int] = None,
+        message_id: Optional[int] = None,
     ) -> None:
         """
         Emit chat:chunk event to task room.
@@ -121,6 +122,7 @@ class WebPageSocketEmitter:
             result: Optional full result data (for executor tasks with thinking/workbench)
             block_id: Optional block ID for text block streaming (append content to specific block)
             block_offset: Optional character offset within the current text block
+            message_id: Message ID for deterministic stream identity
         """
         payload = {
             "subtask_id": subtask_id,
@@ -128,6 +130,8 @@ class WebPageSocketEmitter:
             "offset": offset,
             "task_id": task_id,  # Add task_id for page refresh recovery
         }
+        if message_id is not None:
+            payload["message_id"] = message_id
         # Include block_id if provided (for text block streaming)
         if block_id is not None:
             payload["block_id"] = block_id

--- a/backend/app/services/chat/ws_emitter.py
+++ b/backend/app/services/chat/ws_emitter.py
@@ -109,6 +109,7 @@ class WebSocketEmitter:
         result: Optional[Dict[str, Any]] = None,
         block_id: Optional[str] = None,
         block_offset: Optional[int] = None,
+        message_id: Optional[int] = None,
     ) -> None:
         """
         Emit chat:chunk event to task room.
@@ -121,6 +122,7 @@ class WebSocketEmitter:
             result: Optional full result data (for executor tasks with thinking/workbench)
             block_id: Optional block ID for text block streaming (append content to specific block)
             block_offset: Optional character offset within the current text block
+            message_id: Message ID for deterministic stream identity
         """
         payload = {
             "subtask_id": subtask_id,
@@ -128,6 +130,8 @@ class WebSocketEmitter:
             "offset": offset,
             "task_id": task_id,  # Add task_id for page refresh recovery
         }
+        if message_id is not None:
+            payload["message_id"] = message_id
         # Include block_id if provided (for text block streaming)
         if block_id is not None:
             payload["block_id"] = block_id

--- a/backend/app/services/execution/emitters/websocket.py
+++ b/backend/app/services/execution/emitters/websocket.py
@@ -115,6 +115,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
                 result=event.result,
                 block_id=block_id,
                 block_offset=block_offset,
+                message_id=event.message_id,
             )
 
         elif event.type == EventType.TOOL_START.value:
@@ -149,6 +150,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
                 content="",
                 offset=event.offset,
                 result={"reasoning_chunk": event.content},
+                message_id=event.message_id,
             )
 
         elif event.type == EventType.DONE.value:

--- a/backend/tests/services/execution/test_emitters.py
+++ b/backend/tests/services/execution/test_emitters.py
@@ -75,7 +75,9 @@ class TestWebSocketResultEmitter:
             mock_get.return_value = mock_ws
 
             emitter = WebSocketResultEmitter(task_id=1, subtask_id=1)
-            await emitter.emit_chunk(task_id=1, subtask_id=1, content="Hello", offset=0)
+            await emitter.emit_chunk(
+                task_id=1, subtask_id=1, content="Hello", offset=0, message_id=100
+            )
 
             mock_ws.emit_chat_chunk.assert_called_once()
             call_kwargs = mock_ws.emit_chat_chunk.call_args[1]
@@ -83,6 +85,7 @@ class TestWebSocketResultEmitter:
             assert call_kwargs["subtask_id"] == 1
             assert call_kwargs["content"] == "Hello"
             assert call_kwargs["offset"] == 0
+            assert call_kwargs["message_id"] == 100
 
     @pytest.mark.asyncio
     async def test_emit_done(self):

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2287,11 +2287,13 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(streamHandlers.some(handler => handler.onChatChunk)).toBe(true))
     await act(async () => {
       const startPayload = {
+        message_id: 701,
         subtask_id: 102,
         device_id: 'device-1',
         local_task_id: request.localTaskId,
       }
       const chunkPayload = {
+        message_id: 701,
         subtask_id: 102,
         content: 'streamed answer',
         offset: 0,
@@ -4290,6 +4292,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(streamHandlers.onChatStart).toBeDefined())
     await act(async () => {
       streamHandlers.onChatStart?.({
+        message_id: 701,
         task_id: 77,
         subtask_id: 101,
         shell_type: 'Chat',
@@ -4348,6 +4351,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(streamHandlers.onChatStart).toBeDefined())
     await act(async () => {
       streamHandlers.onChatStart?.({
+        message_id: 701,
         task_id: 77,
         subtask_id: 101,
         shell_type: 'Chat',
@@ -4390,6 +4394,7 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     await act(async () => {
       streamHandlers?.onChatStart?.({
+        message_id: 701,
         task_id: 77,
         subtask_id: 101,
         shell_type: 'Chat',
@@ -4878,6 +4883,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     await act(async () => {
       streamHandlers.onChatStart?.({
+        message_id: 701,
         task_id: 77,
         subtask_id: 101,
         shell_type: 'Chat',
@@ -4977,6 +4983,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     await act(async () => {
       streamHandlers.onChatStart?.({
+        message_id: 701,
         task_id: 77,
         subtask_id: 101,
         shell_type: 'Chat',
@@ -5229,6 +5236,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     await act(async () => {
       streamHandlers.onChatStart?.({
+        message_id: 701,
         subtask_id: 101,
         shell_type: 'Codex',
         device_id: 'device-1',
@@ -5446,12 +5454,14 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     await act(async () => {
       streamHandlers.onChatStart?.({
+        message_id: 701,
         subtask_id: 101,
         shell_type: 'Codex',
         device_id: 'device-1',
         local_task_id: 'runtime-a',
       })
       streamHandlers.onChatDone?.({
+        message_id: 701,
         subtask_id: 101,
         offset: 0,
         result: { value: 'stale runtime a output' },
@@ -5459,12 +5469,14 @@ describe('WorkbenchProvider runtime tasks', () => {
         local_task_id: 'runtime-a',
       })
       streamHandlers.onChatStart?.({
+        message_id: 702,
         subtask_id: 102,
         shell_type: 'Codex',
         device_id: 'device-1',
         local_task_id: 'runtime-b',
       })
       streamHandlers.onChatDone?.({
+        message_id: 702,
         subtask_id: 102,
         offset: 0,
         result: { value: 'current runtime b output' },

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -20,6 +20,7 @@ describe('createRuntimeTaskStreamHandlers', () => {
     handlers.onBlockCreated?.({
       task_id: 1,
       subtask_id: 9,
+      message_id: 42,
       local_task_id: 'local-task-1',
       device_id: 'device-1',
       block: {
@@ -67,6 +68,7 @@ describe('createRuntimeTaskStreamHandlers', () => {
     handlers.onBlockCreated?.({
       task_id: 1,
       subtask_id: 9,
+      message_id: 42,
       local_task_id: 'local-task-1',
       device_id: 'device-1',
       block: {
@@ -103,6 +105,7 @@ describe('createRuntimeTaskStreamHandlers', () => {
     handlers.onChatDone?.({
       task_id: 1,
       subtask_id: 9,
+      message_id: 42,
       local_task_id: 'local-task-1',
       device_id: 'device-1',
       offset: 0,
@@ -136,6 +139,7 @@ describe('createRuntimeTaskStreamHandlers', () => {
     handlers.onChatDone?.({
       task_id: 1,
       subtask_id: 9,
+      message_id: 42,
       offset: 0,
       local_task_id: 'local-task-1',
       device_id: 'device-1',
@@ -167,6 +171,7 @@ describe('createRuntimeTaskStreamHandlers', () => {
     handlers.onChatError?.({
       task_id: 1,
       subtask_id: 9,
+      message_id: 42,
       local_task_id: 'local-task-1',
       device_id: 'device-1',
       error: 'interrupted',
@@ -177,6 +182,29 @@ describe('createRuntimeTaskStreamHandlers', () => {
       type: 'assistant_cancelled',
       turnId: 9,
     })
+  })
+
+  test('ignores runtime stream message events without a message id', () => {
+    const address: RuntimeTaskAddress = {
+      deviceId: 'device-1',
+      localTaskId: 'local-task-1',
+    }
+    const actions: RuntimePaneMessageAction[] = []
+    const handlers = createRuntimeTaskStreamHandlers(address, {
+      onMessageAction: action => actions.push(action),
+    })
+
+    handlers.onChatChunk?.({
+      task_id: 1,
+      subtask_id: 9,
+      local_task_id: 'local-task-1',
+      device_id: 'device-1',
+      content: 'partial',
+      offset: 0,
+      result: {},
+    })
+
+    expect(actions).toHaveLength(0)
   })
 })
 

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -41,6 +41,7 @@ export function createRuntimeTaskStreamHandlers(
     onChatStart: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       const messageId = runtimeStreamMessageId(payload)
+      if (!messageId) return
       debugRuntimeStreamEvent('chat:start', address, payload, true)
       handlers.onAssistantStart?.()
       handlers.onMessageAction({
@@ -55,6 +56,7 @@ export function createRuntimeTaskStreamHandlers(
     onChatChunk: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       const messageId = runtimeStreamMessageId(payload)
+      if (!messageId) return
       debugRuntimeStreamEvent('chat:chunk', address, payload, true, {
         hasContent: Boolean(payload.content),
         hasReasoningChunk: Boolean(getReasoningChunk(payload.result)),
@@ -72,6 +74,7 @@ export function createRuntimeTaskStreamHandlers(
     onChatDone: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       const messageId = runtimeStreamMessageId(payload)
+      if (!messageId) return
       debugRuntimeStreamEvent('chat:done', address, payload, true, {
         hasFileChanges: Boolean(normalizeTurnFileChanges(payload.result.file_changes)),
         blockCount: getResultBlocks(payload.subtask_id, payload.result)?.length ?? 0,
@@ -90,6 +93,7 @@ export function createRuntimeTaskStreamHandlers(
     onChatError: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       const messageId = runtimeStreamMessageId(payload)
+      if (!messageId) return
       debugRuntimeStreamEvent('chat:error', address, payload, true, {
         error: payload.error,
         errorType: payload.type,
@@ -115,6 +119,7 @@ export function createRuntimeTaskStreamHandlers(
     onBlockCreated: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       const messageId = runtimeStreamMessageId(payload)
+      if (!messageId) return
       const block = normalizeChatBlock(payload.subtask_id, payload.block)
       debugRuntimeStreamEvent('block:created', address, payload, true, {
         rawBlockType: isRecord(payload.block) ? payload.block.type : null,
@@ -131,6 +136,7 @@ export function createRuntimeTaskStreamHandlers(
     onBlockUpdated: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       const messageId = runtimeStreamMessageId(payload)
+      if (!messageId) return
       debugRuntimeStreamEvent('block:updated', address, payload, true, {
         blockId: payload.block_id,
         status: payload.status ?? null,
@@ -253,12 +259,12 @@ function runtimeStreamMessageId(
     | ChatBlockCreatedPayload
     | ChatBlockUpdatedPayload
     | RuntimeSubagentActivityPayload
-): string {
+): string | null {
   const rawMessageId = typeof payload.message_id === 'number' ? payload.message_id : null
   if (rawMessageId !== null) {
     return `${payload.local_task_id ?? 'runtime'}:message:${rawMessageId}`
   }
-  return `${payload.local_task_id ?? 'runtime'}:message:${payload.task_id ?? 0}:${payload.subtask_id}`
+  return null
 }
 
 function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): WorkbenchMessage {


### PR DESCRIPTION
## Summary
- propagate `message_id` through backend `chat:chunk` and reasoning chunk WebSocket events
- require runtime stream message/block events to carry `message_id` before updating Wework message state
- update runtime stream tests so valid stream fixtures use deterministic message identities

## Root Cause
`chat:start`, `chat:done`, and `chat:error` already carried `message_id`, but `chat:chunk` did not. Wework therefore synthesized a fallback id from task/subtask fields, which could split one assistant turn into separate streaming and done messages. That could duplicate output and leave the fallback streaming message in the thinking/running state after the real message completed.

## Validation
- `uv run pytest tests/services/execution/test_emitters.py`
- `pnpm --dir wework exec vitest run src/features/workbench/runtimePaneMessages.test.ts src/features/workbench/messageReducer.test.ts src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --filter @wegent/chat-core test -- workbench-message-reducer.test.ts`
- pre-push gate: Wework ESLint, TypeScript, unit tests; Backend Black, isort, syntax; settings config; Alembic multi-head

## Documentation
No user-facing documentation update is needed. This is an internal stream protocol consistency fix and the pre-push doc gate was acknowledged with `AI_VERIFIED=1`.
