### PR TITLE
fix(frontend): keep agent dialog state after bot creation

### DIFF
--- a/frontend/src/__tests__/features/settings/components/SimpleTeamEditDialog.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/SimpleTeamEditDialog.test.tsx
@@ -392,6 +392,8 @@ describe('Simple TeamEditDialog', () => {
   })
 
   it('saves a new simple solo agent through bot and team payloads', async () => {
+    const onSaved = jest.fn().mockResolvedValue(undefined)
+
     render(
       <TeamEditDialog
         open
@@ -402,6 +404,7 @@ describe('Simple TeamEditDialog', () => {
         bots={[]}
         setBots={jest.fn()}
         toast={jest.fn()}
+        onSaved={onSaved}
       />
     )
 
@@ -442,6 +445,7 @@ describe('Simple TeamEditDialog', () => {
           bots: [{ bot_id: 42, bot_prompt: '', role: 'leader' }],
         })
       )
+      expect(onSaved).toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/__tests__/features/settings/components/TeamEditDialog.drawer-close.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/TeamEditDialog.drawer-close.test.tsx
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import TeamEditDialog from '@/features/settings/components/TeamEditDialog'
+import type { Bot } from '@/types/api'
+
+const dialogContentProps: Array<{ preventOutsideClick?: boolean }> = []
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'common:teams.create_title': 'Create agent',
+        'common:teams.description': 'Agent settings',
+        'settings:team.simple.advanced_toggle': 'Advanced mode',
+        'settings:team.simple.advanced_toggle_description': 'Use full configuration.',
+        'settings:team.simple.non_solo_notice': 'This agent uses advanced collaboration.',
+        'team_model.solo': 'Solo',
+      })[key] || key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+jest.mock('@/features/settings/services/teams', () => ({
+  createTeam: jest.fn(),
+  updateTeam: jest.fn(),
+}))
+
+jest.mock('@/features/settings/components/team-modes', () => ({
+  getSelectableTeamModes: () => ['solo'],
+  getAllowedAgentsForTeamMode: () => undefined,
+  getFilteredBotsForMode: (bots: unknown[]) => bots,
+  getActualShellType: (shellType: string) => shellType,
+}))
+
+jest.mock('@/apis/bots', () => ({
+  botApis: {
+    createBot: jest.fn(),
+    updateBot: jest.fn(),
+  },
+}))
+
+jest.mock('@/apis/models', () => ({
+  modelApis: {
+    getUnifiedModels: jest.fn().mockResolvedValue({ data: [] }),
+  },
+}))
+
+jest.mock('@/apis/shells', () => {
+  const actual = jest.requireActual('@/apis/shells')
+  return {
+    ...actual,
+    shellApis: {
+      ...actual.shellApis,
+      getUnifiedShells: jest.fn().mockResolvedValue({ data: [] }),
+    },
+  }
+})
+
+jest.mock('@/apis/skills', () => ({
+  fetchUnifiedSkillsList: jest.fn().mockResolvedValue({ data: [] }),
+  fetchPublicSkillsList: jest.fn().mockResolvedValue({ data: [] }),
+}))
+
+jest.mock('@/contexts/TeamContext', () => ({
+  useTeamContext: () => ({
+    refreshTeams: jest.fn(),
+  }),
+}))
+
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open?: boolean }) =>
+    open === false ? null : <div>{children}</div>,
+  DialogContent: ({
+    children,
+    preventOutsideClick,
+  }: {
+    children: ReactNode
+    preventOutsideClick?: boolean
+  }) => {
+    dialogContentProps.push({ preventOutsideClick })
+    return <div>{children}</div>
+  },
+  DialogDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}))
+
+jest.mock('@/components/ui/switch', () => ({
+  Switch: ({
+    checked,
+    disabled,
+    onCheckedChange,
+    ...props
+  }: {
+    checked?: boolean
+    disabled?: boolean
+    onCheckedChange?: (checked: boolean) => void
+  } & React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      onChange={event => onCheckedChange?.(event.target.checked)}
+      {...props}
+    />
+  ),
+}))
+
+jest.mock('@/features/settings/components/teams/TeamIconPicker', () => ({
+  TeamIconPicker: () => null,
+}))
+
+jest.mock('@/features/settings/components/team-edit/TeamBasicInfoForm', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('@/features/settings/components/team-edit/TeamModeEditor', () => ({
+  __esModule: true,
+  default: ({ onCreateBot }: { onCreateBot: () => void }) => (
+    <button type="button" onClick={onCreateBot}>
+      Create bot
+    </button>
+  ),
+}))
+
+jest.mock('@/features/settings/components/team-edit/TeamModeChangeDialog', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('@/features/settings/components/team-edit/SimpleTeamEditForm', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('@/features/settings/components/TeamEditDrawer', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+function makeBot(overrides: Partial<Bot> = {}): Bot {
+  return {
+    id: 42,
+    name: 'new-bot',
+    namespace: 'default',
+    shell_name: 'Chat',
+    shell_type: 'Chat',
+    agent_config: {},
+    system_prompt: '',
+    mcp_servers: {},
+    default_knowledge_base_refs: [],
+    skills: [],
+    is_active: true,
+    created_at: '2026-07-02T00:00:00Z',
+    updated_at: '2026-07-02T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TeamEditDialog nested bot drawer dismissal', () => {
+  beforeEach(() => {
+    dialogContentProps.length = 0
+  })
+
+  it('prevents outside-click close while the bot drawer is open', async () => {
+    render(
+      <TeamEditDialog
+        open
+        onClose={jest.fn()}
+        teams={[]}
+        setTeams={jest.fn()}
+        editingTeamId={0}
+        initialTeam={null}
+        bots={[]}
+        setBots={jest.fn()}
+        toast={jest.fn()}
+      />
+    )
+
+    expect(dialogContentProps.at(-1)?.preventOutsideClick).toBeFalsy()
+
+    fireEvent.click(screen.getByTestId('advanced-mode-switch'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create bot' }))
+
+    await waitFor(() => {
+      expect(dialogContentProps.at(-1)?.preventOutsideClick).toBe(true)
+    })
+  })
+
+  it('keeps advanced mode enabled when the bot list changes during new team creation', async () => {
+    const { rerender } = render(
+      <TeamEditDialog
+        open
+        onClose={jest.fn()}
+        teams={[]}
+        setTeams={jest.fn()}
+        editingTeamId={0}
+        initialTeam={null}
+        bots={[]}
+        setBots={jest.fn()}
+        toast={jest.fn()}
+      />
+    )
+
+    const advancedSwitch = screen.getByTestId('advanced-mode-switch')
+    fireEvent.click(advancedSwitch)
+    expect(advancedSwitch).toBeChecked()
+
+    rerender(
+      <TeamEditDialog
+        open
+        onClose={jest.fn()}
+        teams={[]}
+        setTeams={jest.fn()}
+        editingTeamId={0}
+        initialTeam={null}
+        bots={[makeBot()]}
+        setBots={jest.fn()}
+        toast={jest.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('advanced-mode-switch')).toBeChecked()
+    })
+  })
+})

--- a/frontend/src/features/settings/components/TeamEditDialog.tsx
+++ b/frontend/src/features/settings/components/TeamEditDialog.tsx
@@ -80,6 +80,7 @@ interface TeamEditDialogProps {
   toast: ReturnType<typeof import('@/hooks/use-toast').useToast>['toast']
   scope?: 'personal' | 'group' | 'all'
   groupName?: string
+  onSaved?: () => void | Promise<void>
 }
 
 const SIMPLE_BIND_MODES = new Set<TaskType>(['chat', 'code', 'task'])
@@ -146,6 +147,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
     toast,
     scope = 'personal',
     groupName,
+    onSaved,
   } = props
 
   const { t } = useTranslation()
@@ -181,6 +183,13 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
 
   // Store unsaved team prompts
   const [unsavedPrompts, setUnsavedPrompts] = useState<Record<string, string>>({})
+
+  const handleAfterTeamSave = useCallback(async () => {
+    await onSaved?.()
+    refreshTeams().catch(err => console.error('Failed to refresh teams after save:', err))
+    setUnsavedPrompts({})
+    onClose()
+  }, [onSaved, refreshTeams, onClose])
 
   // Store requireConfirmation settings for pipeline mode (botId -> boolean)
   const [requireConfirmationMap, setRequireConfirmationMap] = useState<Record<number, boolean>>({})
@@ -221,6 +230,10 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
 
   // Ref for BotEdit in solo mode
   const botEditRef = useRef<BotEditRef | null>(null)
+  const previousResetDepsRef = useRef<{
+    open: boolean
+    formTeamId: number | null
+  } | null>(null)
 
   // Load shells data on mount
   useEffect(() => {
@@ -293,6 +306,20 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
   // Reset form when dialog opens
   useEffect(() => {
     if (!open) return
+
+    const previous = previousResetDepsRef.current
+    const current = {
+      open,
+      formTeamId: formTeam?.id ?? null,
+    }
+    previousResetDepsRef.current = current
+
+    const onlyNewTeamBotsChanged =
+      !formTeam && previous?.open === current.open && previous?.formTeamId === current.formTeamId
+
+    if (onlyNewTeamBotsChanged) {
+      return
+    }
 
     if (formTeam) {
       setName(formTeam.name)
@@ -688,9 +715,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
         setTeams(prev => [created, ...prev])
       }
 
-      refreshTeams().catch(err => console.error('Failed to refresh teams after save:', err))
-      setUnsavedPrompts({})
-      onClose()
+      await handleAfterTeamSave()
     } catch (error) {
       toast({
         variant: 'destructive',
@@ -791,11 +816,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
             setTeams(prev => [created, ...prev])
           }
 
-          // Refresh TeamContext so Chat page gets updated bot agent_config
-          refreshTeams().catch(err => console.error('Failed to refresh teams after save:', err))
-
-          setUnsavedPrompts({})
-          onClose()
+          await handleAfterTeamSave()
         } catch (error) {
           toast({
             variant: 'destructive',
@@ -892,10 +913,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
         })
         setTeams(prev => [created, ...prev])
       }
-      // Refresh TeamContext so Chat page gets updated bot agent_config
-      refreshTeams().catch(err => console.error('Failed to refresh teams after save:', err))
-      setUnsavedPrompts({})
-      onClose()
+      await handleAfterTeamSave()
     } catch (error) {
       toast({
         variant: 'destructive',
@@ -915,7 +933,10 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
   return (
     <>
       <Dialog open={open} onOpenChange={open => !open && onClose()}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+        <DialogContent
+          className="max-w-4xl max-h-[90vh] overflow-hidden flex flex-col"
+          preventOutsideClick={editingBotDrawerVisible}
+        >
           <DialogHeader>
             <DialogTitle>
               {isEditing ? t('common:teams.edit_title') : t('common:teams.create_title')}

--- a/frontend/src/features/settings/components/TeamList.tsx
+++ b/frontend/src/features/settings/components/TeamList.tsx
@@ -167,9 +167,11 @@ export default function TeamList({
     [setBots]
   )
 
-  useEffect(() => {
-    async function loadData() {
-      setIsLoading(true)
+  const loadData = useCallback(
+    async (showLoading = true) => {
+      if (showLoading) {
+        setIsLoading(true)
+      }
       try {
         const [teamsData, botsData] = await Promise.all([
           fetchTeamsList(scope, groupName),
@@ -183,11 +185,21 @@ export default function TeamList({
           title: t('teams.loading'),
         })
       } finally {
-        setIsLoading(false)
+        if (showLoading) {
+          setIsLoading(false)
+        }
       }
-    }
+    },
+    [groupName, scope, setBotsSorted, t, toast]
+  )
+
+  useEffect(() => {
     loadData()
-  }, [toast, setBotsSorted, t, scope, groupName])
+  }, [loadData])
+
+  const handleTeamSaved = useCallback(async () => {
+    await loadData(false)
+  }, [loadData])
 
   // Load groups where user has at least Developer role (for copy target selection)
   useEffect(() => {
@@ -945,6 +957,7 @@ export default function TeamList({
         groupName={
           editingTeamId === 0 && createTarget.scope === 'group' ? createTarget.groupName : groupName
         }
+        onSaved={handleTeamSaved}
       />
 
       <TeamChildNamespaceAuthorizationDialog


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team editing so changes are saved more reliably, and the team list refreshes after a successful save without unnecessary loading flicker.
  * Fixed dialog behavior so the editor doesn’t close when interacting with the bot drawer, and advanced mode stays enabled when bot options update.
* **Tests**
  * Added coverage for save completion, dialog dismissal behavior, and advanced mode persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->