### PR TITLE
refactor(wework): centralize chat runtime state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Wegent is an open-source AI-native operating system for defining, organizing, an
 - English version: [`docs/en/developer-guide/wework-cloud-connection.md`](docs/en/developer-guide/wework-cloud-connection.md)
 - Wework performance diagnostics: [`docs/zh/developer-guide/wework-performance-diagnostics.md`](docs/zh/developer-guide/wework-performance-diagnostics.md)
 - English version: [`docs/en/developer-guide/wework-performance-diagnostics.md`](docs/en/developer-guide/wework-performance-diagnostics.md)
+- Wework chat state sources: [`docs/zh/developer-guide/wework-chat-state-sources.md`](docs/zh/developer-guide/wework-chat-state-sources.md)
+- English version: [`docs/en/developer-guide/wework-chat-state-sources.md`](docs/en/developer-guide/wework-chat-state-sources.md)
 
 **📚 Documentation Writing Rules:**
 - All documentation files MUST include frontmatter with `sidebar_position` for ordering:
@@ -148,7 +150,7 @@ Task = Team + Workspace (代码仓库)
 
 10. **Avoid backward compatibility - design for the ideal state**: When implementing changes, design as if there is no legacy burden - consider "what would be the best approach if we were starting fresh". Avoid writing compatibility shims or workarounds for old logic. If backward compatibility is absolutely unavoidable, consult with the user before proceeding.
 
-11. **Do not implement features in fallback paths**: The primary path should be efficient, elegant, and safe. Avoid adding excessive fallback logic as a substitute for a well-designed main flow; it makes code harder to understand and can eventually create a confusing dual-track structure where both the main path and fallback path behave like first-class implementations. Use fallbacks only for truly exceptional recovery or compatibility cases.
+11. **Do not implement features in fallback paths**: The primary path should be efficient, elegant, and safe. Avoid adding excessive fallback logic as a substitute for a well-designed main flow; it makes code harder to understand and can eventually create a confusing dual-track structure where both the main path and fallback path behave like first-class implementations. Do not use fallback logic to hide state, event, synchronization, or data-shape bugs. When the primary path is wrong or incomplete, fix that path directly instead of adding a fallback. Use fallbacks only for truly exceptional recovery or compatibility cases after confirming they will not mask product bugs.
 
 ### Python (Backend, Executor, Shared)
 

--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 18
+---
+
+# Wework Chat State Sources
+
+This document records the state sources for the Wework chat path. The goal is to make UI code read one explicit derived status instead of letting the send button, message stream, queue, and runtime task list override each other.
+
+## Core Principles
+
+1. `useWorkbenchPaneSession` is the state boundary for a chat pane.
+2. `paneSession.status` is the only chat runtime status entry point for layouts.
+3. `runtimePaneMessages.ts` only converts runtime stream events into message actions.
+4. `runtimePaneStatus.ts` derives runtime status from messages, the local send phase, and the runtime work execution snapshot.
+5. Compatibility fields `paneSession.sending` and `paneSession.waitingForAssistant` must be derived from `paneSession.status`; they must not become independent state again.
+
+## State Source Inventory
+
+| State | Single Source | Derived Values / Consumers | Maintenance Rule |
+| --- | --- | --- | --- |
+| Message content and status | `useWorkbenchPaneSession.messages` | `MessageList`, export, file changes, request user input | Update only through transcript reset or `reduceWorkbenchMessages` |
+| Whether the assistant is streaming | `paneSession.status.isAssistantStreaming` | Desktop/mobile composer pause button, close-task guard | Derived from the latest `assistant + streaming` message; layouts must not scan messages directly |
+| Local send phase | `sendPhase: idle/submitting/awaiting_assistant` | `status.isSubmitting`, `status.isWaitingForAssistantIndicator`, compatibility fields `sending/waitingForAssistant` | Use `submitting` while the API call is in flight, `awaiting_assistant` after runtime accepts the request, and `idle` after start/done/error or a settled transcript |
+| Current runtime execution snapshot | `getRuntimePaneTaskExecution(state.runtimeWork, address)` | `status.taskExecution`, queue advancement, `currentRuntimeTaskRunning` | Read only from `RuntimeWorkListResponse.localTasks[].running/status` |
+| Whether the pane is busy | `paneSession.status.isBusy` | Whether the current pane queue may advance | Composed from `isSubmitting`, `isAwaitingAssistant`, `isAssistantStreaming`, and `taskExecution.running` |
+| Queued messages | `queuedMessages` | `ConversationQueuePanel`, automatic next follow-up send | Mutate only inside the pane session; advancement must use `status.canSendQueuedMessage` |
+| Guidance messages | `guidanceMessages` | `ConversationQueuePanel` | Pane-local state; must not participate in composer runtime status |
+| Transcript loading and pagination | `transcriptLoading`, `transcriptHasMoreBefore`, `transcriptBeforeCursor`, `loadedTranscriptRanges` | Infinite scroll, turn navigation | Update only from transcript API responses |
+| Runtime goal | `threadGoal` + `pendingGoalState` | Goal bar, goal draft, first-message initial goal | Persisted goals come from the runtime goal API; goals before task creation live in pending seeds |
+| Answered request user input ids | `answeredRequestUserInputIds` | Hide already submitted or ignored request user input cards | Update only from submit or ignore actions |
+| Attachment/model/skill selection | `projectChat` context | Send payload, composer controls | In-task option locking is derived from `projectChat.isOptionsLocked` |
+| Device availability | `state.devices` + current task/project device selection | Composer disabled reason, device prompts | Use only for send preconditions; never for assistant streaming status |
+
+## Runtime Event Flow
+
+1. A new message submit sets `sendPhase` to `submitting`.
+2. After runtime accepts the request, `sendPhase` becomes `awaiting_assistant`.
+3. `chat:start` becomes `assistant_started`; the reducer creates or updates the assistant streaming message and `sendPhase` returns to `idle`.
+4. `chat:chunk` and block events update only `messages`.
+5. `chat:done`, `chat:error`, and cancellation events settle the assistant message through the reducer and refresh the work list.
+6. If runtime work and message state disagree, do not settle it with fallback logic; fix the missing stream event, transcript data, or reducer action.
+
+## Audit Result
+
+- Desktop and mobile layouts no longer scan `messages` directly to decide whether the assistant is streaming; they read `paneSession.status.isAssistantStreaming`.
+- Composer disabled state no longer reads independent `paneSession.sending`; it reads `paneSession.status.isSubmitting`.
+- Message waiting indicators no longer combine `sending || waitingForAssistant`; they read `paneSession.status.isWaitingForAssistantIndicator`.
+- Queue advancement no longer uses scattered `currentRuntimeTask && !busy`; it reads `paneSession.status.canSendQueuedMessage`.
+- `currentRuntimeTaskRunning` is derived through `getRuntimePaneTaskExecution`, avoiding another implementation of runtime running lookup.
+- `runtimePaneMessages.ts` no longer owns active assistant lookup; status queries are centralized in `runtimePaneStatus.ts`.
+
+## Maintenance Rules
+
+- Add new chat runtime state by extending `RuntimePaneStatus` first, then read it from layouts or components.
+- Do not recompute `assistant streaming`, `busy`, or `can send queued message` in layouts.
+- Do not add independent `isSending`, `isRunning`, or `isStreaming` React state unless it represents a new external fact source and this document is updated.
+- When runtime work and message state disagree, do not override display inside UI components and do not add fallback settlement; fix the primary path.

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 18
+---
+
+# Wework 聊天状态信源
+
+本文记录 Wework 聊天链路的状态信源和维护规则。目标是让 UI 只读取明确的单一派生状态，避免发送按钮、消息流、队列和 runtime 任务状态互相覆盖。
+
+## 核心原则
+
+1. `useWorkbenchPaneSession` 是聊天 pane 的状态边界。
+2. `paneSession.status` 是布局层判断聊天运行态的唯一入口。
+3. `runtimePaneMessages.ts` 只负责把 runtime stream 事件转换成 message action，不再承载 UI 状态判断。
+4. `runtimePaneStatus.ts` 负责从消息、发送阶段和 runtime work 执行快照派生运行态。
+5. 兼容字段 `paneSession.sending` 和 `paneSession.waitingForAssistant` 只能由 `paneSession.status` 派生，不能再独立写入。
+
+## 状态信源清单
+
+| 状态 | 唯一信源 | 派生值/使用方 | 维护规则 |
+| --- | --- | --- | --- |
+| 消息内容与消息状态 | `useWorkbenchPaneSession.messages` | `MessageList`、导出、文件变更、request user input | 只能通过 transcript reset 或 `reduceWorkbenchMessages` 更新 |
+| assistant 是否正在输出 | `paneSession.status.isAssistantStreaming` | 桌面/移动 composer 的暂停按钮、关闭任务提示 | 由 `messages` 中最后一个 `assistant + streaming` 消息派生，布局层不能自行扫描 |
+| 本地发送阶段 | `sendPhase: idle/submitting/awaiting_assistant` | `status.isSubmitting`、`status.isWaitingForAssistantIndicator`、兼容字段 `sending/waitingForAssistant` | API 调用中为 `submitting`，请求被 runtime 接受后为 `awaiting_assistant`，收到 start/done/error 或 transcript 已结算后回到 `idle` |
+| 当前 runtime 执行快照 | `getRuntimePaneTaskExecution(state.runtimeWork, address)` | `status.taskExecution`、队列推进、`currentRuntimeTaskRunning` | 只能从 `RuntimeWorkListResponse.localTasks[].running/status` 读取 |
+| pane 是否忙碌 | `paneSession.status.isBusy` | 当前 pane 队列是否可推进 | 由 `isSubmitting`、`isAwaitingAssistant`、`isAssistantStreaming`、`taskExecution.running` 合成 |
+| 队列消息 | `queuedMessages` | `ConversationQueuePanel`、自动发送下一条 follow-up | 只在 pane session 内增删改；推进条件必须使用 `status.canSendQueuedMessage` |
+| 引导消息 | `guidanceMessages` | `ConversationQueuePanel` | 当前为 pane-local 状态，不能参与 composer 运行态判断 |
+| transcript 加载与分页 | `transcriptLoading`、`transcriptHasMoreBefore`、`transcriptBeforeCursor`、`loadedTranscriptRanges` | 滚动加载、turn navigation | 只由 transcript API 响应更新 |
+| runtime goal | `threadGoal` + `pendingGoalState` | goal bar、goal draft、首条消息 initial goal | 已持久化目标来自 runtime goal API；新建任务前目标暂存在 pending seed |
+| request user input 已处理集合 | `answeredRequestUserInputIds` | 隐藏已响应/忽略的 request user input 卡片 | 只由提交或忽略动作更新 |
+| 附件/模型/技能选择 | `projectChat` context | send payload、composer 控件 | 当前 LocalTask 内选项锁定由 `projectChat.isOptionsLocked` 派生 |
+| 设备可用性 | `state.devices` + 当前任务/项目设备选择 | composer disabled reason、设备提示 | 只用于发送前置条件，不参与 assistant streaming 判断 |
+
+## Runtime 事件流
+
+1. 新消息提交时，`sendPhase` 进入 `submitting`。
+2. runtime 接受请求后，`sendPhase` 进入 `awaiting_assistant`。
+3. `chat:start` 转换为 `assistant_started`，消息 reducer 创建/更新 assistant streaming 消息，`sendPhase` 回到 `idle`。
+4. `chat:chunk` 和 block 事件只更新 `messages`。
+5. `chat:done`、`chat:error`、取消事件通过 reducer 结算 assistant 消息，并触发 work list 刷新。
+6. 如果 runtime work 与消息状态不一致，不做兜底结算；必须修正缺失的 stream event、transcript 数据或 reducer action。
+
+## 审核结果
+
+- 桌面和移动布局不再直接扫描 `messages` 判断是否 streaming，统一读取 `paneSession.status.isAssistantStreaming`。
+- composer 禁用状态不再读取独立 `paneSession.sending`，统一读取 `paneSession.status.isSubmitting`。
+- 消息等待指示不再拼接 `sending || waitingForAssistant`，统一读取 `paneSession.status.isWaitingForAssistantIndicator`。
+- 队列推进不再使用散落的 `currentRuntimeTask && !busy`，统一读取 `paneSession.status.canSendQueuedMessage`。
+- `currentRuntimeTaskRunning` 改为通过 `getRuntimePaneTaskExecution` 派生，避免重复实现 runtime running 读取逻辑。
+- `runtimePaneMessages.ts` 删除了 active assistant 查询逻辑，状态查询集中到 `runtimePaneStatus.ts`。
+
+## 后续维护规则
+
+- 新增聊天运行态时，先扩展 `RuntimePaneStatus`，再由布局或组件读取。
+- 不要在布局层重新计算 `assistant streaming`、`busy`、`can send queued message`。
+- 不要新增独立的 `isSending`、`isRunning`、`isStreaming` React state；除非它是新的外部事实信源，并且写入本表。
+- runtime work 与消息状态冲突时，不允许在 UI 组件里临时覆盖显示，也不允许新增 fallback 结算；必须修主路径。

--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -161,7 +161,6 @@ impl CodexNotificationEventMapper {
                     return;
                 }
                 self.agent_message_phases.observe_item(notification.params);
-                self.reset_process_text();
                 emit_tool_start(
                     event_tx,
                     device_id,
@@ -1756,6 +1755,102 @@ mod tests {
         assert_eq!(
             updated["payload"]["data"]["updates"]["content"],
             "I will inspect."
+        );
+    }
+
+    #[test]
+    fn keeps_codex_process_text_stream_open_across_tool_start() {
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+        let request = ExecutionRequest {
+            task_id: 7,
+            subtask_id: 8,
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "msg-commentary",
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": ""
+                    }
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "itemId": "msg-commentary",
+                    "delta": "I found "
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "call-1",
+                        "type": "commandExecution",
+                        "command": "pwd",
+                        "status": "inProgress"
+                    }
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "itemId": "msg-commentary",
+                    "delta": "the issue."
+                }
+            }),
+        );
+
+        let created = event_rx
+            .try_recv()
+            .expect("process text created event should be emitted");
+        let tool_created = event_rx
+            .try_recv()
+            .expect("tool created event should be emitted");
+        let updated = event_rx
+            .try_recv()
+            .expect("process text updated event should be emitted");
+        let block_id = created["payload"]["data"]["block"]["id"]
+            .as_str()
+            .expect("block id should be present");
+
+        assert_eq!(created["event"], "response.block.created");
+        assert_eq!(created["payload"]["data"]["block"]["type"], "text");
+        assert_eq!(tool_created["event"], "response.block.created");
+        assert_eq!(tool_created["payload"]["data"]["block"]["type"], "tool");
+        assert_eq!(updated["event"], "response.block.updated");
+        assert_eq!(updated["payload"]["data"]["block_id"], block_id);
+        assert_eq!(
+            updated["payload"]["data"]["updates"]["content"],
+            "I found the issue."
         );
     }
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -40,6 +40,41 @@ vi.mock('./useWorkbenchPaneSession', () => ({
   useWorkbenchPaneSession: () => paneSessionMockRef.current,
 }))
 
+function createPaneStatus({
+  messages = [],
+  sending = false,
+  waitingForAssistant = false,
+  taskRunning = false,
+}: {
+  messages?: WorkbenchMessage[]
+  sending?: boolean
+  waitingForAssistant?: boolean
+  taskRunning?: boolean
+} = {}) {
+  const activeAssistantMessage =
+    [...messages]
+      .reverse()
+      .find(message => message.role === 'assistant' && message.status === 'streaming') ?? null
+  const isSubmitting = Boolean(sending)
+  const isAwaitingAssistant = Boolean(waitingForAssistant)
+  const isAssistantStreaming = Boolean(activeAssistantMessage)
+  const isResponseActive = isAwaitingAssistant || isAssistantStreaming
+  const isBusy = isSubmitting || isResponseActive || taskRunning
+
+  return {
+    sendPhase: isSubmitting ? 'submitting' : isAwaitingAssistant ? 'awaiting_assistant' : 'idle',
+    activeAssistantMessage,
+    taskExecution: { known: taskRunning, running: taskRunning, status: null },
+    isSubmitting,
+    isAwaitingAssistant,
+    isAssistantStreaming,
+    isResponseActive,
+    isBusy,
+    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant,
+    canSendQueuedMessage: !isBusy,
+  }
+}
+
 vi.mock('@/lib/external-links', () => ({
   openExternalUrl: vi.fn(),
 }))
@@ -900,6 +935,12 @@ describe('DesktopWorkbenchLayout', () => {
       setInput: props.onInputChange ?? baseProps.onInputChange,
       sending: Boolean(state.isSending),
       waitingForAssistant: Boolean(props.isAwaitingAssistantStart),
+      status: createPaneStatus({
+        messages: props.messages ?? [],
+        sending: Boolean(state.isSending),
+        waitingForAssistant: Boolean(props.isAwaitingAssistantStart),
+        taskRunning: workbenchValue.currentRuntimeTaskRunning,
+      }),
       transcriptLoading: Boolean(props.isRuntimeTranscriptLoading),
       transcriptHasMoreBefore: Boolean(props.runtimeTranscriptHasMoreBefore),
       transcriptLoadingMoreBefore: Boolean(props.isRuntimeTranscriptLoadingMore),

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -320,9 +320,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   )
   const paneQueuedMessages = paneSession.queuedMessages
   const paneGuidanceMessages = paneSession.guidanceMessages
-  const paneIsResponseStreaming = paneMessages.some(
-    message => message.role === 'assistant' && message.status === 'streaming'
-  )
+  const paneIsResponseStreaming = paneSession.status.isAssistantStreaming
   const latestPreviousTurnTurnId = useMemo(() => {
     for (let index = paneMessages.length - 1; index >= 0; index -= 1) {
       const message = paneMessages[index]
@@ -365,7 +363,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     !activeDeviceId &&
     !devices.some(device => device.status === 'online' && isWeWorkCompatibleDevice(device))
   const composerDisabled =
-    paneSession.sending ||
+    paneSession.status.isSubmitting ||
     activeDeviceUnavailable ||
     activeDeviceVersionUnsupported ||
     noStandaloneCompatibleDevice
@@ -875,7 +873,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               <ScrollableMessageArea
                 messages={paneMessages}
                 loading={paneSession.transcriptLoading}
-                isWaitingForAssistant={paneSession.waitingForAssistant}
+                isWaitingForAssistant={paneSession.status.isWaitingForAssistantIndicator}
                 hasMoreBefore={paneSession.transcriptHasMoreBefore}
                 loadingMoreBefore={paneSession.transcriptLoadingMoreBefore}
                 turnNavigation={paneSession.turnNavigation}

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -21,6 +21,41 @@ vi.mock('./useWorkbenchPaneSession', () => ({
   useWorkbenchPaneSession: () => paneSessionMockRef.current,
 }))
 
+function createPaneStatus({
+  messages = [],
+  sending = false,
+  waitingForAssistant = false,
+  taskRunning = false,
+}: {
+  messages?: WorkbenchMessage[]
+  sending?: boolean
+  waitingForAssistant?: boolean
+  taskRunning?: boolean
+} = {}) {
+  const activeAssistantMessage =
+    [...messages]
+      .reverse()
+      .find(message => message.role === 'assistant' && message.status === 'streaming') ?? null
+  const isSubmitting = Boolean(sending)
+  const isAwaitingAssistant = Boolean(waitingForAssistant)
+  const isAssistantStreaming = Boolean(activeAssistantMessage)
+  const isResponseActive = isAwaitingAssistant || isAssistantStreaming
+  const isBusy = isSubmitting || isResponseActive || taskRunning
+
+  return {
+    sendPhase: isSubmitting ? 'submitting' : isAwaitingAssistant ? 'awaiting_assistant' : 'idle',
+    activeAssistantMessage,
+    taskExecution: { known: taskRunning, running: taskRunning, status: null },
+    isSubmitting,
+    isAwaitingAssistant,
+    isAssistantStreaming,
+    isResponseActive,
+    isBusy,
+    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant,
+    canSendQueuedMessage: !isBusy,
+  }
+}
+
 const originalInnerWidth = window.innerWidth
 
 const baseState = {
@@ -305,6 +340,11 @@ function createWorkbenchMocks(props: LegacyMobileWorkbenchLayoutProps) {
     setInput: props.onInputChange ?? vi.fn(),
     sending: Boolean(state.isSending),
     waitingForAssistant: false,
+    status: createPaneStatus({
+      messages: props.messages ?? [],
+      sending: Boolean(state.isSending),
+      taskRunning: workbenchValue.currentRuntimeTaskRunning,
+    }),
     transcriptLoading: false,
     transcriptHasMoreBefore: false,
     transcriptLoadingMoreBefore: false,

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -115,9 +115,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
   )
   const paneQueuedMessages = paneSession.queuedMessages
   const paneGuidanceMessages = paneSession.guidanceMessages
-  const paneIsResponseStreaming = paneMessages.some(
-    message => message.role === 'assistant' && message.status === 'streaming'
-  )
+  const paneIsResponseStreaming = paneSession.status.isAssistantStreaming
   const hasConversation = paneMessages.length > 0 || currentRuntimeTask
   const activeConversationProject = activePaneProject
   const effectiveProjectChat = projectChat ?? {
@@ -163,7 +161,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
     !activeDeviceId &&
     !state.devices.some(device => device.status === 'online' && isWeWorkCompatibleDevice(device))
   const composerDisabled =
-    paneSession.sending ||
+    paneSession.status.isSubmitting ||
     activeDeviceUnavailable ||
     activeDeviceVersionUnsupported ||
     noStandaloneCompatibleDevice
@@ -284,7 +282,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
             <ScrollableMessageArea
               messages={paneMessages}
               loading={paneSession.transcriptLoading}
-              isWaitingForAssistant={paneSession.waitingForAssistant}
+              isWaitingForAssistant={paneSession.status.isWaitingForAssistantIndicator}
               hasMoreBefore={paneSession.transcriptHasMoreBefore}
               loadingMoreBefore={paneSession.transcriptLoadingMoreBefore}
               turnNavigation={paneSession.turnNavigation}

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import i18n from '@/i18n'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
+import type { RuntimePaneMessageAction } from '@/features/workbench/runtimePaneMessages'
 import {
-  findActiveAssistantMessage,
-  type RuntimePaneMessageAction,
-} from '@/features/workbench/runtimePaneMessages'
+  deriveRuntimePaneStatus,
+  getRuntimePaneTaskExecution,
+  hasSettledAssistantMessage,
+  type RuntimePaneSendPhase,
+} from '@/features/workbench/runtimePaneStatus'
 import {
   resolveAutomaticModel,
   selectedModelExecutionFields,
@@ -74,6 +77,7 @@ const RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
 
 export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSessionOptions) {
   const {
+    state: workbenchState,
     projectChat,
     loadRuntimeTranscriptForPane,
     subscribeRuntimeTaskStream,
@@ -90,8 +94,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   const [guidanceMessages] = useState<GuidanceWorkbenchMessage[]>([])
   const [codeCommentContexts, setCodeCommentContexts] = useState<CodeCommentContext[]>([])
   const [input, setInput] = useState('')
-  const [sending, setSending] = useState(false)
-  const [waitingForAssistant, setWaitingForAssistant] = useState(false)
+  const [sendPhase, setSendPhase] = useState<RuntimePaneSendPhase>('idle')
   const [answeredRequestUserInputIds, setAnsweredRequestUserInputIds] = useState<
     ReadonlySet<string>
   >(() => new Set())
@@ -141,9 +144,21 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     },
     [currentRuntimeTask]
   )
-  const activeAssistantMessage = useMemo(() => findActiveAssistantMessage(messages), [messages])
-  const hasActiveAssistant = Boolean(activeAssistantMessage)
-  const busy = sending || waitingForAssistant || hasActiveAssistant
+  const taskExecution = useMemo(
+    () => getRuntimePaneTaskExecution(workbenchState.runtimeWork, currentRuntimeTask),
+    [currentRuntimeTask, workbenchState.runtimeWork]
+  )
+  const paneStatus = useMemo(
+    () =>
+      deriveRuntimePaneStatus({
+        messages,
+        sendPhase,
+        currentRuntimeTask,
+        taskExecution,
+      }),
+    [currentRuntimeTask, messages, sendPhase, taskExecution]
+  )
+  const activeAssistantMessage = paneStatus.activeAssistantMessage
   const goal = useMemo(() => {
     const visibleThreadGoal = visibleRuntimeGoal(threadGoal)
     if (visibleThreadGoal) return visibleThreadGoal
@@ -291,7 +306,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             messages: nextMessages,
           })
           if (hasSettledAssistantMessage(nextMessages)) {
-            setWaitingForAssistant(false)
+            setSendPhase('idle')
           }
           clearRuntimePaneMessageSeed(address)
         }
@@ -331,9 +346,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     const { address } = runtimeTaskLoadTarget
     const unsubscribe = subscribeRuntimeTaskStreamRef.current(address, {
       onMessageAction: dispatchMessages,
-      onAssistantStart: () => setWaitingForAssistant(false),
+      onAssistantStart: () => setSendPhase('idle'),
       onAssistantSettled: () => {
-        setWaitingForAssistant(false)
+        setSendPhase('idle')
         setSubagentStatuses(markRuntimeSubagentsSettled)
         void getRuntimeGoal(address)
           .then(response => {
@@ -537,7 +552,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     async (message: RuntimePaneQueuedMessage): Promise<boolean> => {
       if (!currentRuntimeTask) return false
 
-      setWaitingForAssistant(true)
+      setSendPhase('submitting')
       appendLocalUserMessage(message.content, message.attachments, {
         runtimeGoalRequest: message.runtimeGoalRequest,
       })
@@ -557,8 +572,10 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
         ...(attachments.length > 0 ? { attachments } : {}),
       })
-      if (!sent) {
-        setWaitingForAssistant(false)
+      if (sent) {
+        setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+      } else {
+        setSendPhase('idle')
       }
       return sent
     },
@@ -574,7 +591,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
 
       const message = requestUserInputResponseText(response)
       const requestUserInputKey = requestUserInputResponseKey(response)
-      setWaitingForAssistant(true)
+      setSendPhase('submitting')
       const runtimeModelOverride = options.forceDefaultCollaborationMode
         ? { collaborationMode: 'default' }
         : undefined
@@ -602,8 +619,10 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         ...runtimeModelFields,
         ...(options.appendUserMessage ? {} : { requestUserInputResponse: response }),
       })
-      if (!sent) {
-        setWaitingForAssistant(false)
+      if (sent) {
+        setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+      } else {
+        setSendPhase('idle')
         if (requestUserInputKey) {
           setAnsweredRequestUserInputIds(current => {
             if (!current.has(requestUserInputKey)) return current
@@ -638,12 +657,12 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       }
 
       if (!currentRuntimeTask) {
-        setWaitingForAssistant(false)
+        setSendPhase('idle')
         return
       }
 
       const cancelled = await cancelRuntimePaneTask(currentRuntimeTask)
-      setWaitingForAssistant(false)
+      setSendPhase('idle')
       if (!cancelled) {
         if (requestUserInputKey) {
           setAnsweredRequestUserInputIds(current => {
@@ -666,7 +685,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   )
 
   useEffect(() => {
-    if (!currentRuntimeTask || busy) return
+    if (!paneStatus.canSendQueuedMessage) return
     if (queuedMessages.some(message => message.status === 'sending')) return
     const queuedMessage = queuedMessages.find(message => message.status === 'queued')
     if (!queuedMessage) return
@@ -689,7 +708,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             )
       )
     })
-  }, [busy, currentRuntimeTask, queuedMessages, sendRuntimeMessage])
+  }, [paneStatus.canSendQueuedMessage, queuedMessages, sendRuntimeMessage])
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const send = useCallback(async () => {
@@ -708,7 +727,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       }
 
       setInput('')
-      setSending(true)
+      setSendPhase('submitting')
       try {
         if (currentRuntimeTask) {
           const response = await setRuntimeGoal({
@@ -733,7 +752,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           }
 
           projectChat.resetAttachments()
-          if (busy) {
+          if (paneStatus.isBusy) {
             setQueuedMessages(messages => [...messages, queuedMessage])
             return
           }
@@ -749,7 +768,6 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         const initialGoal = runtimeGoalCreateInput(draftGoal)
         setPendingGoalState({ goal: draftGoal, targetKey: null, targetIdentityKey: null })
         setGoalDraftActive(false)
-        setWaitingForAssistant(true)
         const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments, {
           runtimeGoalRequest: true,
         })
@@ -786,6 +804,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           },
         })
         if (sent) {
+          setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
           if (!isRuntimeTaskAddress(sent)) {
             appendLocalUserMessage(submittedInput, currentAttachments, {
               runtimeGoalRequest: true,
@@ -807,11 +826,11 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           }
           setGoalDraftActive(true)
           setPendingGoalState(null)
-          setWaitingForAssistant(false)
+          setSendPhase('idle')
         }
         return
       } finally {
-        setSending(false)
+        setSendPhase(current => (current === 'submitting' ? 'idle' : current))
       }
     }
 
@@ -826,10 +845,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     }
 
     setInput('')
-    setSending(true)
+    setSendPhase('submitting')
     try {
       if (!currentRuntimeTask) {
-        setWaitingForAssistant(true)
         const optimisticMessage = createLocalUserMessage(
           effectiveSubmittedInput,
           currentAttachments,
@@ -871,6 +889,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           },
         })
         if (sent) {
+          setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
           if (!isRuntimeTaskAddress(sent)) {
             appendLocalUserMessage(effectiveSubmittedInput, currentAttachments, {
               runtimeGoalRequest: Boolean(pendingInitialGoal),
@@ -888,7 +907,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           }
           setCodeCommentContexts([])
         } else {
-          setWaitingForAssistant(false)
+          setSendPhase('idle')
         }
         return
       }
@@ -908,7 +927,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       }
 
       projectChat.resetAttachments()
-      if (busy) {
+      if (paneStatus.isBusy) {
         setQueuedMessages(messages => [...messages, queuedMessage])
         return
       }
@@ -918,17 +937,17 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         setCodeCommentContexts([])
       }
     } finally {
-      setSending(false)
+      setSendPhase(current => (current === 'submitting' ? 'idle' : current))
     }
   }, [
     appendLocalUserMessage,
-    busy,
     codeCommentContexts,
     currentRuntimeTask,
     goalDraftActive,
     getRuntimeModelFields,
     input,
     pendingGoalState,
+    paneStatus.isBusy,
     projectChat,
     queuedMessages.length,
     sendCurrentInput,
@@ -1140,8 +1159,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     codeCommentContexts,
     input,
     setInput,
-    sending,
-    waitingForAssistant,
+    status: paneStatus,
+    sending: paneStatus.isSubmitting,
+    waitingForAssistant: paneStatus.isWaitingForAssistantIndicator,
     answeredRequestUserInputIds,
     transcriptLoading,
     transcriptHasMoreBefore,
@@ -1301,12 +1321,6 @@ function getRuntimePaneMessageSeed(address: RuntimeTaskAddress): WorkbenchMessag
 
 function clearRuntimePaneMessageSeed(address: RuntimeTaskAddress) {
   runtimePaneMessageSeeds.delete(runtimeTranscriptPaneKey(address))
-}
-
-function hasSettledAssistantMessage(messages: WorkbenchMessage[]): boolean {
-  return (
-    messages.some(message => message.role === 'assistant') && !findActiveAssistantMessage(messages)
-  )
 }
 
 function mergeRuntimeTranscriptMessages(

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -617,7 +617,7 @@ function ProjectSendProbe() {
       </button>
       <MessageList
         messages={paneSession.messages}
-        isWaitingForAssistant={paneSession.sending || paneSession.waitingForAssistant}
+        isWaitingForAssistant={paneSession.status.isWaitingForAssistantIndicator}
       />
     </div>
   )
@@ -702,7 +702,7 @@ function RuntimePaneStackItem({ pane }: { pane: WorkbenchPaneIdentity }) {
       </button>
       <MessageList
         messages={paneSession.messages}
-        isWaitingForAssistant={paneSession.waitingForAssistant}
+        isWaitingForAssistant={paneSession.status.isWaitingForAssistantIndicator}
       />
     </WorkbenchPaneActiveOnly>
   )
@@ -976,7 +976,7 @@ function RuntimeOpenProbe() {
       </button>
       <MessageList
         messages={paneSession.messages}
-        isWaitingForAssistant={paneSession.sending || paneSession.waitingForAssistant}
+        isWaitingForAssistant={paneSession.status.isWaitingForAssistantIndicator}
       />
       <button type="button" onClick={() => void paneSession.loadMoreTranscriptBefore()}>
         load older

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -35,8 +35,8 @@ import {
   getBlockedModelSelectionMessage,
   getCurrentRuntimeTaskCompatibilityFamily,
   getNewChatModelSelection,
-  isRuntimeLocalTaskRunning,
 } from './workbenchProviderHelpers'
+import { getRuntimePaneTaskExecution } from './runtimePaneStatus'
 import {
   findSelectableProject,
   findProjectDeviceWorkspace,
@@ -142,7 +142,7 @@ export function WorkbenchProvider({
   >(new Map())
   const isOptionsLocked = Boolean(state.currentRuntimeTask)
   const currentRuntimeTaskRunning = useMemo(
-    () => isRuntimeLocalTaskRunning(state.runtimeWork, state.currentRuntimeTask),
+    () => getRuntimePaneTaskExecution(state.runtimeWork, state.currentRuntimeTask).running,
     [state.currentRuntimeTask, state.runtimeWork]
   )
 

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -190,14 +190,6 @@ export function findFileChangesByTurnId(
   return messages.find(message => message.turnId === turnId)?.fileChanges
 }
 
-export function findActiveAssistantMessage(
-  messages: WorkbenchMessage[]
-): WorkbenchMessage | undefined {
-  return [...messages]
-    .reverse()
-    .find(message => message.role === 'assistant' && message.status === 'streaming')
-}
-
 export function runtimeAddressDebug(address: RuntimeTaskAddress): Record<string, unknown> {
   return {
     deviceId: address.deviceId,

--- a/wework/src/features/workbench/runtimePaneStatus.test.ts
+++ b/wework/src/features/workbench/runtimePaneStatus.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+import type { RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
+import { deriveRuntimePaneStatus, getRuntimePaneTaskExecution } from './runtimePaneStatus'
+
+const runtimeAddress: RuntimeTaskAddress = {
+  deviceId: 'device-1',
+  workspacePath: '/workspace/project',
+  localTaskId: 'runtime-a',
+}
+
+function assistantMessage(status: WorkbenchMessage['status']): WorkbenchMessage {
+  return {
+    id: 'runtime-a:message:1',
+    role: 'assistant',
+    content: 'working',
+    status,
+    createdAt: '2026-07-02T00:00:00.000Z',
+    turnId: 1,
+    blocks: [
+      {
+        id: 'tool-1',
+        turnId: 1,
+        type: 'tool',
+        toolName: 'bash',
+        status: 'streaming',
+        createdAt: 1770000000000,
+      },
+    ],
+  }
+}
+
+function runtimeWork(running: boolean, status?: string | null): RuntimeWorkListResponse {
+  return {
+    projects: [],
+    chats: [
+      {
+        deviceId: 'device-1',
+        deviceName: 'Device',
+        deviceStatus: 'online',
+        workspacePath: '/workspace/project',
+        available: true,
+        localTasks: [
+          {
+            localTaskId: 'runtime-a',
+            workspacePath: '/workspace/project',
+            title: 'Runtime A',
+            runtime: 'codex',
+            running,
+            status,
+          },
+        ],
+      },
+    ],
+    totalLocalTasks: 1,
+  }
+}
+
+describe('runtime pane status', () => {
+  test('derives one busy state from send phase, streaming message, and task execution', () => {
+    const taskExecution = getRuntimePaneTaskExecution(runtimeWork(true), runtimeAddress)
+    const status = deriveRuntimePaneStatus({
+      messages: [assistantMessage('streaming')],
+      sendPhase: 'idle',
+      currentRuntimeTask: runtimeAddress,
+      taskExecution,
+    })
+
+    expect(status.isBusy).toBe(true)
+    expect(status.isAssistantStreaming).toBe(true)
+    expect(status.canSendQueuedMessage).toBe(false)
+    expect(status.taskExecution.running).toBe(true)
+  })
+
+  test('treats submitting as the only composer submitting source', () => {
+    const status = deriveRuntimePaneStatus({
+      messages: [],
+      sendPhase: 'submitting',
+      currentRuntimeTask: runtimeAddress,
+      taskExecution: { known: false, running: false, status: null },
+    })
+
+    expect(status.isSubmitting).toBe(true)
+    expect(status.isWaitingForAssistantIndicator).toBe(true)
+    expect(status.isAssistantStreaming).toBe(false)
+  })
+})

--- a/wework/src/features/workbench/runtimePaneStatus.ts
+++ b/wework/src/features/workbench/runtimePaneStatus.ts
@@ -1,0 +1,90 @@
+import type { LocalTaskSummary, RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
+import { findRuntimeLocalTask } from './workbenchRuntimeHelpers'
+
+export type RuntimePaneSendPhase = 'idle' | 'submitting' | 'awaiting_assistant'
+
+export interface RuntimePaneTaskExecution {
+  known: boolean
+  running: boolean
+  status: string | null
+}
+
+export interface RuntimePaneStatus {
+  sendPhase: RuntimePaneSendPhase
+  activeAssistantMessage: WorkbenchMessage | null
+  taskExecution: RuntimePaneTaskExecution
+  isSubmitting: boolean
+  isAwaitingAssistant: boolean
+  isAssistantStreaming: boolean
+  isResponseActive: boolean
+  isBusy: boolean
+  isWaitingForAssistantIndicator: boolean
+  canSendQueuedMessage: boolean
+}
+
+export function getRuntimePaneTaskExecution(
+  runtimeWork: RuntimeWorkListResponse | null | undefined,
+  address: RuntimeTaskAddress | null | undefined
+): RuntimePaneTaskExecution {
+  const task = findRuntimeLocalTask(runtimeWork, address)
+  if (!task) {
+    return { known: false, running: false, status: null }
+  }
+
+  return {
+    known: true,
+    running: task.running === true,
+    status: normalizeTaskStatus(task),
+  }
+}
+
+export function deriveRuntimePaneStatus({
+  messages,
+  sendPhase,
+  currentRuntimeTask,
+  taskExecution,
+}: {
+  messages: WorkbenchMessage[]
+  sendPhase: RuntimePaneSendPhase
+  currentRuntimeTask: RuntimeTaskAddress | null
+  taskExecution: RuntimePaneTaskExecution
+}): RuntimePaneStatus {
+  const activeAssistantMessage = findActiveAssistantMessage(messages) ?? null
+  const isSubmitting = sendPhase === 'submitting'
+  const isAwaitingAssistant = sendPhase === 'awaiting_assistant'
+  const isAssistantStreaming = Boolean(activeAssistantMessage)
+  const isResponseActive = isAwaitingAssistant || isAssistantStreaming
+  const isBusy = isSubmitting || isResponseActive || taskExecution.running
+
+  return {
+    sendPhase,
+    activeAssistantMessage,
+    taskExecution,
+    isSubmitting,
+    isAwaitingAssistant,
+    isAssistantStreaming,
+    isResponseActive,
+    isBusy,
+    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant,
+    canSendQueuedMessage: Boolean(currentRuntimeTask) && !isBusy,
+  }
+}
+
+export function findActiveAssistantMessage(
+  messages: WorkbenchMessage[]
+): WorkbenchMessage | undefined {
+  return [...messages]
+    .reverse()
+    .find(message => message.role === 'assistant' && message.status === 'streaming')
+}
+
+export function hasSettledAssistantMessage(messages: WorkbenchMessage[]): boolean {
+  return (
+    messages.some(message => message.role === 'assistant') && !findActiveAssistantMessage(messages)
+  )
+}
+
+function normalizeTaskStatus(task: LocalTaskSummary): string | null {
+  return task.status?.trim().toLowerCase() || null
+}

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -51,7 +51,8 @@ import {
   isSameRuntimeTaskIdentity,
 } from './workbenchRuntimeHelpers'
 import type { WorkbenchRuntimeTasks } from './useWorkbenchRuntimeTasks'
-import { findActiveAssistantMessage, findFileChangesByTurnId } from './runtimePaneMessages'
+import { findFileChangesByTurnId } from './runtimePaneMessages'
+import { findActiveAssistantMessage } from './runtimePaneStatus'
 import {
   inferRuntimeName,
   resolveAutomaticModel,

--- a/wework/src/features/workbench/workbenchProviderHelpers.ts
+++ b/wework/src/features/workbench/workbenchProviderHelpers.ts
@@ -72,13 +72,6 @@ export function getCurrentRuntimeTaskCompatibilityFamily(
   return getRuntimeCompatibilityFamily(findRuntimeLocalTask(runtimeWork, address)?.runtime)
 }
 
-export function isRuntimeLocalTaskRunning(
-  runtimeWork: RuntimeWorkListResponse | null | undefined,
-  address: RuntimeTaskAddress | null | undefined
-): boolean {
-  return Boolean(findRuntimeLocalTask(runtimeWork, address)?.running)
-}
-
 export function normalizeGuidanceError(error?: string) {
   if (!error) return '引导发送失败'
   if (error.includes('Chat Shell')) {


### PR DESCRIPTION
## Summary
- Centralize Wework runtime pane status derivation in `runtimePaneStatus` as the single source of truth for send/stream/busy state.
- Remove fallback settlement behavior so stopped/running UI state is driven by primary chat lifecycle signals.
- Update desktop/mobile layout consumers, provider helpers, tests, and add Chinese/English design docs listing state sources and maintenance rules.

## Verification
- `pnpm --dir wework test -- runtimePaneStatus.test.ts` (Vitest ran 118 files / 1143 tests)
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`
- pre-push hook: ESLint, TypeScript, unit tests passed