### PR TITLE
fix: preserve task-bound team identity

### DIFF
--- a/backend/app/services/adapters/task_kinds/converters.py
+++ b/backend/app/services/adapters/task_kinds/converters.py
@@ -75,6 +75,34 @@ def get_task_execution_workspace_path(task_crd: Task) -> str | None:
     return None
 
 
+def resolve_task_ref_team(
+    db: Session, task_crd: Task, viewer_user_id: int
+) -> Kind | None:
+    team_ref = task_crd.spec.teamRef
+    team_ref_user_id = getattr(team_ref, "user_id", None)
+    if team_ref_user_id is not None:
+        team = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == team_ref_user_id,
+                Kind.kind == KindType.TEAM.value,
+                Kind.namespace == team_ref.namespace,
+                Kind.name == team_ref.name,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+        return team
+
+    return kindReader.get_by_name_and_namespace(
+        db,
+        viewer_user_id,
+        KindType.TEAM,
+        team_ref.namespace,
+        team_ref.name,
+    )
+
+
 def convert_to_task_dict(task: Kind, db: Session, user_id: int) -> Dict[str, Any]:
     """
     Convert kinds Task to task-like dictionary.
@@ -115,15 +143,7 @@ def convert_to_task_dict(task: Kind, db: Session, user_id: int) -> Dict[str, Any
             # Handle workspaces with incomplete repository data
             pass
 
-    # Get team data (including shared teams)
-    team = kindReader.get_by_name_and_namespace(
-        db,
-        user_id,
-        KindType.TEAM,
-        task_crd.spec.teamRef.namespace,
-        task_crd.spec.teamRef.name,
-    )
-
+    team = resolve_task_ref_team(db, task_crd, user_id)
     team_id = team.id if team else None
 
     # Parse timestamps

--- a/backend/app/services/adapters/task_kinds/helpers.py
+++ b/backend/app/services/adapters/task_kinds/helpers.py
@@ -47,6 +47,12 @@ REPORTER_OR_HIGHER_ROLES = (
 )
 
 
+def _team_ref_key(name: str, namespace: str, user_id: int | None = None) -> str:
+    if user_id is None:
+        return f"{name}:{namespace}"
+    return f"{name}:{namespace}:{user_id}"
+
+
 def create_subtasks(
     db: Session, task: Kind, team: Kind, user_id: int, user_prompt: str
 ) -> None:
@@ -233,7 +239,13 @@ def get_tasks_related_data_batch(
             )
 
         if hasattr(task_crd.spec, "teamRef") and task_crd.spec.teamRef:
-            team_refs.add((task_crd.spec.teamRef.name, task_crd.spec.teamRef.namespace))
+            team_refs.add(
+                (
+                    task_crd.spec.teamRef.name,
+                    task_crd.spec.teamRef.namespace,
+                    getattr(task_crd.spec.teamRef, "user_id", None),
+                )
+            )
 
         device_id = getattr(task_crd.spec, "device_id", None)
         if device_id:
@@ -273,7 +285,11 @@ def get_tasks_related_data_batch(
         )
 
         # Get team data
-        team_key = f"{task_crd.spec.teamRef.name}:{task_crd.spec.teamRef.namespace}"
+        team_key = _team_ref_key(
+            task_crd.spec.teamRef.name,
+            task_crd.spec.teamRef.namespace,
+            getattr(task_crd.spec.teamRef, "user_id", None),
+        )
         task_team = team_data.get(team_key)
         team_id = task_team.id if task_team else None
         team_name = task_team.name if task_team else task_crd.spec.teamRef.name
@@ -400,6 +416,38 @@ def _batch_query_teams(db: Session, team_refs: set, user_id: int) -> Dict[str, K
     if not team_refs:
         return {}
 
+    exact_team_refs = {
+        (name, namespace, ref_user_id)
+        for name, namespace, ref_user_id in (
+            (*ref, None) if len(ref) == 2 else ref for ref in team_refs
+        )
+        if ref_user_id is not None
+    }
+    access_resolved_refs = {
+        (name, namespace)
+        for name, namespace, ref_user_id in (
+            (*ref, None) if len(ref) == 2 else ref for ref in team_refs
+        )
+        if ref_user_id is None
+    }
+
+    team_data: Dict[str, Kind] = {}
+    if exact_team_refs:
+        exact_teams = (
+            db.query(Kind)
+            .filter(
+                Kind.kind == "Team",
+                tuple_(Kind.name, Kind.namespace, Kind.user_id).in_(exact_team_refs),
+                Kind.is_active.is_(True),
+            )
+            .all()
+        )
+        for team in exact_teams:
+            team_data[_team_ref_key(team.name, team.namespace, team.user_id)] = team
+
+    if not access_resolved_refs:
+        return team_data
+
     team_resource_type_variants = [ResourceType.TEAM.value, ResourceType.TEAM.name]
     approved_status_variants = [MemberStatus.APPROVED.value, "APPROVED"]
     accessible_team_ids = _get_accessible_team_ids(
@@ -415,17 +463,16 @@ def _batch_query_teams(db: Session, team_refs: set, user_id: int) -> Dict[str, K
         db.query(Kind)
         .filter(
             Kind.kind == "Team",
-            tuple_(Kind.name, Kind.namespace).in_(team_refs),
+            tuple_(Kind.name, Kind.namespace).in_(access_resolved_refs),
             Kind.is_active.is_(True),
             access_filter,
         )
         .all()
     )
 
-    team_data: Dict[str, Kind] = {}
     team_priorities: Dict[str, int] = {}
     for team in accessible_teams:
-        key = f"{team.name}:{team.namespace}"
+        key = _team_ref_key(team.name, team.namespace)
         priority = _get_team_scope_priority(team, user_id)
         if key not in team_data or priority < team_priorities[key]:
             team_data[key] = team

--- a/backend/tests/services/adapters/test_task_detail_converter_project_id.py
+++ b/backend/tests/services/adapters/test_task_detail_converter_project_id.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlalchemy.orm import Session
 
+from app.models.kind import Kind
 from app.models.task import TaskResource
 from app.schemas.kind import Task as TaskCrd
 from app.services.adapters.task_kinds.converters import (
@@ -27,11 +28,15 @@ from app.services.adapters.task_kinds.converters import (
 def _task_crd(
     execution_workspace: dict | None = None,
     external_knowledge_refs: list[dict] | None = None,
+    team_user_id: int | None = None,
 ) -> dict:
+    team_ref = {"name": "team-a", "namespace": "default"}
+    if team_user_id is not None:
+        team_ref["user_id"] = team_user_id
     spec = {
         "title": "Demo",
         "prompt": "hello",
-        "teamRef": {"name": "team-a", "namespace": "default"},
+        "teamRef": team_ref,
         "workspaceRef": {"name": "workspace-a", "namespace": "default"},
         "knowledgeBaseRefs": [],
     }
@@ -57,13 +62,16 @@ def _build_kind_task(
     project_id,
     execution_workspace: dict | None = None,
     external_knowledge_refs: list[dict] | None = None,
+    team_user_id: int | None = None,
 ):
     task = Mock(spec=TaskResource)
     task.id = 42
     task.user_id = 1
     task.project_id = project_id
     task.client_origin = "wework"
-    task.json = _task_crd(execution_workspace, external_knowledge_refs)
+    task.json = _task_crd(
+        execution_workspace, external_knowledge_refs, team_user_id=team_user_id
+    )
     return task
 
 
@@ -87,6 +95,38 @@ def test_convert_to_task_dict_includes_project_id_for_project_task():
         result = convert_to_task_dict(task, db, user_id=1)
 
     assert result["project_id"] == 1821
+
+
+@pytest.mark.unit
+def test_convert_to_task_dict_uses_task_team_ref_owner_when_names_overlap(test_db):
+    public_team = Kind(
+        user_id=0,
+        kind="Team",
+        name="team-a",
+        namespace="default",
+        json={},
+        is_active=True,
+    )
+    personal_team = Kind(
+        user_id=2,
+        kind="Team",
+        name="team-a",
+        namespace="default",
+        json={},
+        is_active=True,
+    )
+    test_db.add_all([public_team, personal_team])
+    test_db.commit()
+
+    task = _build_kind_task(project_id=0, team_user_id=0)
+
+    with patch(
+        "app.services.readers.users.userReader.get_by_id",
+        return_value=SimpleNamespace(user_name="alice"),
+    ):
+        result = convert_to_task_dict(task, test_db, user_id=2)
+
+    assert result["team_id"] == public_team.id
 
 
 @pytest.mark.unit

--- a/backend/tests/services/test_task_lite_batch_loading.py
+++ b/backend/tests/services/test_task_lite_batch_loading.py
@@ -21,10 +21,14 @@ from app.services.adapters.task_kinds.helpers import (
     _get_team_icon,
     build_lite_task_groups,
     build_lite_task_list,
+    get_tasks_related_data_batch,
 )
 
 
-def _task_json(title: str) -> dict:
+def _task_json(title: str, team_user_id: int | None = None) -> dict:
+    team_ref = {"name": "team-a", "namespace": "default"}
+    if team_user_id is not None:
+        team_ref["user_id"] = team_user_id
     return {
         "apiVersion": "agent.wecode.io/v1",
         "kind": "Task",
@@ -36,7 +40,7 @@ def _task_json(title: str) -> dict:
         "spec": {
             "title": title,
             "prompt": "test",
-            "teamRef": {"name": "team-a", "namespace": "default"},
+            "teamRef": team_ref,
             "workspaceRef": {"name": "workspace-a", "namespace": "default"},
             "knowledgeBaseRefs": [],
         },
@@ -44,11 +48,16 @@ def _task_json(title: str) -> dict:
     }
 
 
-def _build_task(task_id: int, title: str, project_id: int = 0) -> Mock:
+def _build_task(
+    task_id: int,
+    title: str,
+    project_id: int = 0,
+    team_user_id: int | None = None,
+) -> Mock:
     task = Mock(spec=TaskResource)
     task.id = task_id
     task.project_id = project_id
-    task.json = _task_json(title)
+    task.json = _task_json(title, team_user_id=team_user_id)
     now = datetime.now()
     task.created_at = now
     task.updated_at = now
@@ -293,6 +302,37 @@ def test_batch_query_teams_includes_public_system_team_metadata(test_db):
     assert team.user_id == 0
     assert _get_team_display_name(team) == "Wegent Chat"
     assert _get_team_icon(team) == "users"
+
+
+@pytest.mark.unit
+def test_get_tasks_related_data_batch_uses_task_team_ref_owner_when_names_overlap(
+    test_db,
+):
+    public_team = Kind(
+        user_id=0,
+        kind="Team",
+        name="team-a",
+        namespace="default",
+        json=_team_json("team-a", "Public Team", "globe"),
+        is_active=True,
+    )
+    personal_team = Kind(
+        user_id=7,
+        kind="Team",
+        name="team-a",
+        namespace="default",
+        json=_team_json("team-a", "Personal Team", "user"),
+        is_active=True,
+    )
+    test_db.add_all([public_team, personal_team])
+    test_db.commit()
+
+    task = _build_task(1, "Task One", team_user_id=0)
+
+    related_data = get_tasks_related_data_batch(test_db, [task], user_id=7)
+
+    assert related_data["1"]["team_id"] == public_team.id
+    assert related_data["1"]["team_display_name"] == "Public Team"
 
 
 @pytest.mark.unit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team matching for tasks when public and personal teams share the same name.
  * Task details and batch loading now resolve the correct team based on the team reference owner, reducing incorrect team associations.
  * Updated handling so task-related team information is more accurate when multiple teams overlap by name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->