### PR TITLE
fix(executor-manager): clear stale sandbox metadata

### DIFF
--- a/executor_manager/routers/e2b.py
+++ b/executor_manager/routers/e2b.py
@@ -422,7 +422,9 @@ async def get_sandbox(sandbox_id: str, http_request: Request):
     # Try to find sandbox by e2b_sandbox_id in metadata
     sandbox = await _find_sandbox_by_e2b_id(manager, sandbox_id)
 
-    if sandbox is None:
+    if sandbox is not None:
+        sandbox = await manager.get_sandbox(sandbox.sandbox_id)
+    else:
         # Fallback: try direct lookup (for internal sandbox_id)
         sandbox = await manager.get_sandbox(sandbox_id)
 

--- a/executor_manager/routers/wegent_e2b_proxy.py
+++ b/executor_manager/routers/wegent_e2b_proxy.py
@@ -70,9 +70,11 @@ async def _get_sandbox_info(sandbox_id: str) -> tuple:
 
     # Find sandbox by e2b_sandbox_id
     sandbox = await _find_sandbox_by_e2b_id(manager, sandbox_id)
-    if sandbox is None:
+    if sandbox is not None:
+        sandbox = await manager.get_sandbox(sandbox.sandbox_id, check_health=True)
+    else:
         # Fallback: try direct lookup
-        sandbox = await manager.get_sandbox(sandbox_id, check_health=False)
+        sandbox = await manager.get_sandbox(sandbox_id, check_health=True)
 
     if sandbox is None:
         raise HTTPException(

--- a/executor_manager/services/sandbox/manager.py
+++ b/executor_manager/services/sandbox/manager.py
@@ -429,8 +429,15 @@ class SandboxManager(metaclass=SingletonMeta):
         if check_health and sandbox.base_url:
             is_healthy = self._health_checker.check_health_sync(sandbox.base_url)
             if not is_healthy:
-                sandbox.status = SandboxStatus.FAILED
-                sandbox.base_url = None
+                logger.info(
+                    "[SandboxManager] Sandbox health check failed; cleaning stale "
+                    "metadata: sandbox_id=%s container=%s base_url=%s",
+                    sandbox.sandbox_id,
+                    sandbox.container_name,
+                    sandbox.base_url,
+                )
+                await self._cleanup_dead_sandbox(sandbox)
+                return None
 
         return sandbox
 

--- a/executor_manager/tests/services/test_sandbox_manager.py
+++ b/executor_manager/tests/services/test_sandbox_manager.py
@@ -546,19 +546,20 @@ class TestSandboxManager:
         sample_sandbox_redis_data,
         mocker,
     ):
-        """Test status set to FAILED when health check fails."""
+        """Test stale sandbox metadata is cleared when health check fails."""
         manager = sandbox_manager_with_mock_redis
         mock_redis_client.hget.return_value = sample_sandbox_redis_data
         mocker.patch.object(
             manager._health_checker, "check_health_sync", return_value=False
         )
+        delete_sandbox = mocker.patch.object(
+            manager._repository, "delete_sandbox", return_value=True
+        )
 
         sandbox = await manager.get_sandbox("12345", check_health=True)
 
-        assert sandbox is not None
-        from executor_manager.models.sandbox import SandboxStatus
-
-        assert sandbox.status == SandboxStatus.FAILED
+        assert sandbox is None
+        delete_sandbox.assert_called_once_with("12345")
 
     # ----- terminate_sandbox Tests -----
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stale sandboxes are now cleaned up automatically when health checks fail, reducing the chance of showing outdated or unusable sandbox entries.
  * Sandbox lookups now re-verify the sandbox before returning details, helping ensure users see current availability and connection info.
  * Requests for sandbox information are more consistently validated against the latest health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->