### PR TITLE
[codex] fix Wework right workspace tabs on task switch

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1034,6 +1034,94 @@ describe('DesktopWorkbenchLayout', () => {
     )
   }
 
+  function createLocalRuntimeTaskPanelFixture() {
+    const runtimeProject = {
+      id: 35,
+      name: 'Wegent',
+      tasks: [],
+    }
+    const localDevice = {
+      id: 43,
+      device_id: 'local-device',
+      name: 'Mac',
+      status: 'online' as const,
+      is_default: false,
+      device_type: 'local' as const,
+      bind_shell: 'claudecode',
+      executor_version: '1.8.5',
+    }
+    const runtimeWork = {
+      projects: [
+        {
+          project: {
+            id: runtimeProject.id,
+            key: 'project:wegent',
+            name: runtimeProject.name,
+          },
+          deviceWorkspaces: [
+            {
+              id: 44,
+              deviceId: localDevice.device_id,
+              deviceStatus: 'online' as const,
+              available: true,
+              workspacePath: '/Users/me/Wegent',
+              workspaceSource: 'local' as const,
+              localTasks: [
+                {
+                  localTaskId: 'runtime-a',
+                  workspacePath: '/Users/me/Wegent/.worktrees/a',
+                  title: 'Task A',
+                  runtime: 'codex',
+                },
+                {
+                  localTaskId: 'runtime-b',
+                  workspacePath: '/Users/me/Wegent/.worktrees/b',
+                  title: 'Task B',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalLocalTasks: 2,
+    }
+    const taskA = {
+      deviceId: localDevice.device_id,
+      workspacePath: '/Users/me/Wegent/.worktrees/a',
+      localTaskId: 'runtime-a',
+    }
+    const taskB = {
+      deviceId: localDevice.device_id,
+      workspacePath: '/Users/me/Wegent/.worktrees/b',
+      localTaskId: 'runtime-b',
+    }
+    const propsForTask = (task: typeof taskA) => ({
+      ...baseProps,
+      state: {
+        ...baseProps.state,
+        currentProject: runtimeProject,
+        currentRuntimeTask: task,
+        projects: [runtimeProject],
+        devices: [localDevice],
+        runtimeWork,
+      },
+      projectWork: {
+        ...baseProps.projectWork,
+        projects: [runtimeProject],
+        devices: [localDevice],
+        runtimeWork,
+        currentProject: runtimeProject,
+        currentProjectId: runtimeProject.id,
+        selectedDeviceWorkspaceId: 44,
+        executionMode: 'current_workspace' as const,
+      },
+    })
+
+    return { localDevice, propsForTask, runtimeWork, runtimeProject, taskA, taskB }
+  }
+
   test('submits implementation plan confirmation as a user message response', async () => {
     const onRequestUserInputSubmit = vi.fn().mockResolvedValue(true)
 
@@ -3700,6 +3788,41 @@ describe('DesktopWorkbenchLayout', () => {
     }
   })
 
+  test('does not show inactive runtime task right workspace tabs in the Tauri titlebar', async () => {
+    const previousTauriInternals = (window as typeof window & { __TAURI_INTERNALS__?: unknown })
+      .__TAURI_INTERNALS__
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+
+    const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
+
+    try {
+      mockDesktopWorkbenchMainWidth(1000)
+      const { rerender } = render(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
+
+      await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
+      await userEvent.click(screen.getByTestId('right-workspace-file-option'))
+
+      const titlebarRightPanel = screen.getByTestId('titlebar-right-panel')
+      expect(within(titlebarRightPanel).getByTestId('right-workspace-file-tab')).toBeInTheDocument()
+
+      rerender(<DesktopWorkbenchLayout {...propsForTask(taskB)} />)
+
+      expect(within(titlebarRightPanel).queryByTestId('right-workspace-file-tab')).toBeNull()
+    } finally {
+      if (previousTauriInternals === undefined) {
+        delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+      } else {
+        Object.defineProperty(window, '__TAURI_INTERNALS__', {
+          configurable: true,
+          value: previousTauriInternals,
+        })
+      }
+    }
+  })
+
   test('right workspace panel restores the previous tab after closing and reopening', async () => {
     renderWorkspacePanelLayout()
 
@@ -5471,96 +5594,13 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('preserves bottom terminal state per runtime task', async () => {
-    const runtimeProject = {
-      id: 35,
-      name: 'Wegent',
-      tasks: [],
-    }
-    const localDevice = {
-      id: 43,
-      device_id: 'local-device',
-      name: 'Mac',
-      status: 'online' as const,
-      is_default: false,
-      device_type: 'local' as const,
-      bind_shell: 'claudecode',
-      executor_version: '1.8.5',
-    }
-    const runtimeWork = {
-      projects: [
-        {
-          project: {
-            id: runtimeProject.id,
-            key: 'project:wegent',
-            name: runtimeProject.name,
-          },
-          deviceWorkspaces: [
-            {
-              id: 44,
-              deviceId: localDevice.device_id,
-              deviceStatus: 'online' as const,
-              available: true,
-              workspacePath: '/Users/me/Wegent',
-              workspaceSource: 'local' as const,
-              localTasks: [
-                {
-                  localTaskId: 'runtime-a',
-                  workspacePath: '/Users/me/Wegent/.worktrees/a',
-                  title: 'Task A',
-                  runtime: 'codex',
-                },
-                {
-                  localTaskId: 'runtime-b',
-                  workspacePath: '/Users/me/Wegent/.worktrees/b',
-                  title: 'Task B',
-                  runtime: 'codex',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      chats: [],
-      totalLocalTasks: 2,
-    }
-    const taskA = {
-      deviceId: localDevice.device_id,
-      workspacePath: '/Users/me/Wegent/.worktrees/a',
-      localTaskId: 'runtime-a',
-    }
-    const taskB = {
-      deviceId: localDevice.device_id,
-      workspacePath: '/Users/me/Wegent/.worktrees/b',
-      localTaskId: 'runtime-b',
-    }
+    const { localDevice, propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
     isLocalTerminalAvailableMock.mockReturnValue(true)
     getLocalExecutorDeviceIdMock.mockResolvedValue(localDevice.device_id)
     localPathExistsMock.mockResolvedValue(true)
     startLocalTerminalMock
       .mockResolvedValueOnce('local-terminal-a')
       .mockResolvedValueOnce('local-terminal-b')
-
-    const propsForTask = (task: typeof taskA) => ({
-      ...baseProps,
-      state: {
-        ...baseProps.state,
-        currentProject: runtimeProject,
-        currentRuntimeTask: task,
-        projects: [runtimeProject],
-        devices: [localDevice],
-        runtimeWork,
-      },
-      projectWork: {
-        ...baseProps.projectWork,
-        projects: [runtimeProject],
-        devices: [localDevice],
-        runtimeWork,
-        currentProject: runtimeProject,
-        currentProjectId: runtimeProject.id,
-        selectedDeviceWorkspaceId: 44,
-        executionMode: 'current_workspace' as const,
-      },
-    })
     const visibleLocalTerminals = () =>
       within(screen.getByTestId('desktop-workbench-main'))
         .queryAllByTestId('embedded-local-terminal')

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -47,6 +47,7 @@ import { pendingRequestUserInputPayload } from './requestUserInputOverlay'
 import {
   CachedWorkbenchPaneStack,
   getWorkbenchPaneKey,
+  useWorkbenchPaneActive,
   WorkbenchPaneActiveOnly,
   type WorkbenchPaneIdentity,
 } from './workbenchPaneStack'
@@ -148,6 +149,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const currentRuntimeTask = pane.currentRuntimeTask
   const currentProject = pane.currentProject
   const paneKey = getWorkbenchPaneKey(pane)
+  const paneActive = useWorkbenchPaneActive()
   const paneSession = useWorkbenchPaneSession({ currentRuntimeTask })
   const projectWork = useWorkbenchProjectWorkControls({
     pane,
@@ -1103,7 +1105,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         >
           {shouldRenderRightPanel && (
             <RightWorkspacePanel
-              visible={rightPanelOpen}
+              visible={paneActive && rightPanelOpen}
               activeView={rightPanelView}
               openTabs={rightPanelTabs}
               currentProject={workspaceProject}


### PR DESCRIPTION
## Summary

Fixes stale Wework right workspace tabs appearing in the Tauri titlebar after switching runtime tasks.

## Root Cause

Desktop workbench panes are cached per task so each task can preserve local UI state. The right workspace panel could still render its titlebar portal from an inactive cached pane, so tabs opened in a previous task could remain visible in the shared titlebar area after switching tasks.

## Changes

- Gate right workspace titlebar rendering on the active workbench pane as well as the panel open state.
- Preserve per-task right workspace state while preventing inactive panes from writing to the shared Tauri titlebar portal.
- Add a regression test for switching runtime tasks after opening a right workspace tab.
- Extract a shared runtime task panel test fixture used by the new regression test and existing bottom terminal isolation test.

## Validation

- `pnpm --filter wework test -- DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-side panel visibility so tabs only show for the currently active workbench pane.
  * Fixed an issue where switching between runtime tasks could leave tabs visible from an inactive task.
  * Preserved terminal state correctly when moving between different runtime tasks.
* **Tests**
  * Added and updated coverage for task switching, active-tab behavior, and terminal state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->