### PR TITLE
[codex] Fix wework runtime task toggle action

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -57,11 +57,8 @@ function project(overrides: Partial<ProjectWithTasks> = {}): ProjectWithTasks {
   }
 }
 
-function renderSidebar(
-  overrides: Partial<Parameters<typeof DesktopSidebar>[0]> = {},
-  cloudConnection?: Partial<CloudConnectionContextValue>
-) {
-  const props: Parameters<typeof DesktopSidebar>[0] = {
+function createSidebarProps(overrides: Partial<Parameters<typeof DesktopSidebar>[0]> = {}) {
+  return {
     user: { id: 1, user_name: 'alice', email: 'alice@example.com' },
     projects: [project()],
     devices: [localDevice()],
@@ -79,6 +76,13 @@ function renderSidebar(
     onLogout: vi.fn(),
     ...overrides,
   }
+}
+
+function renderSidebar(
+  overrides: Partial<Parameters<typeof DesktopSidebar>[0]> = {},
+  cloudConnection?: Partial<CloudConnectionContextValue>
+) {
+  const props: Parameters<typeof DesktopSidebar>[0] = createSidebarProps(overrides)
 
   const tree = <DesktopSidebar {...props} />
   if (cloudConnection) {
@@ -2202,13 +2206,13 @@ describe('DesktopSidebar', () => {
 
     expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(15)
     expect(screen.getByTestId('project-runtime-tasks-expand-7')).toHaveTextContent('展开显示')
-    expect(screen.getByTestId('project-runtime-tasks-collapse-7')).toHaveTextContent('折叠显示')
+    expect(screen.queryByTestId('project-runtime-tasks-collapse-7')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('project-runtime-tasks-expand-7'))
 
     expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(25)
     expect(screen.getByTestId('project-runtime-tasks-expand-7')).toBeInTheDocument()
-    expect(screen.getByTestId('project-runtime-tasks-collapse-7')).toBeInTheDocument()
+    expect(screen.queryByTestId('project-runtime-tasks-collapse-7')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('project-runtime-tasks-expand-7'))
 
@@ -2220,6 +2224,53 @@ describe('DesktopSidebar', () => {
 
     expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(5)
     expect(screen.getByTestId('project-runtime-tasks-expand-7')).toBeInTheDocument()
+    expect(screen.queryByTestId('project-runtime-tasks-collapse-7')).not.toBeInTheDocument()
+  })
+
+  test('shows one project runtime task action after the task list grows past the current limit', async () => {
+    const runtimeWorkWithTaskCount = (count: number) => ({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          totalLocalTasks: count,
+          deviceWorkspaces: [
+            {
+              id: 91,
+              deviceId: 'local-device',
+              deviceName: 'Local Mac',
+              deviceStatus: 'online',
+              available: true,
+              workspacePath: '/repo/Wegent',
+              localTasks: Array.from({ length: count }, (_, index) => ({
+                localTaskId: `task-${index + 1}`,
+                workspacePath: '/repo/Wegent',
+                title: `Task ${index + 1}`,
+                runtime: 'codex',
+                updatedAt: '2026-06-20T06:00:00Z',
+              })),
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalLocalTasks: count,
+    })
+
+    const view = renderSidebar({ runtimeWork: runtimeWorkWithTaskCount(6) })
+
+    await userEvent.click(screen.getByTestId('project-item-button'))
+    await userEvent.click(screen.getByTestId('project-runtime-tasks-expand-7'))
+
+    expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(6)
+    expect(screen.queryByTestId('project-runtime-tasks-expand-7')).not.toBeInTheDocument()
+    expect(screen.getByTestId('project-runtime-tasks-collapse-7')).toBeInTheDocument()
+
+    view.rerender(
+      <DesktopSidebar {...createSidebarProps({ runtimeWork: runtimeWorkWithTaskCount(16) })} />
+    )
+
+    expect(screen.getAllByTestId(/^runtime-local-task-row-/)).toHaveLength(6)
+    expect(screen.getByTestId('project-runtime-tasks-expand-7')).toHaveTextContent('展开显示')
     expect(screen.queryByTestId('project-runtime-tasks-collapse-7')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1665,7 +1665,7 @@ function ProjectItem({
                 ))}
                 {(hasHiddenRuntimeTasks || canCollapseRuntimeTasks) && (
                   <div className="ml-9 flex h-8 items-center gap-2">
-                    {hasHiddenRuntimeTasks && (
+                    {hasHiddenRuntimeTasks ? (
                       <button
                         type="button"
                         data-testid={`project-runtime-tasks-expand-${project.id}`}
@@ -1681,8 +1681,7 @@ function ProjectItem({
                       >
                         {t('workbench.expand_display', '展开显示')}
                       </button>
-                    )}
-                    {canCollapseRuntimeTasks && (
+                    ) : (
                       <button
                         type="button"
                         data-testid={`project-runtime-tasks-collapse-${project.id}`}

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -570,7 +570,7 @@ export function MobileDrawer({
                               })}
                               {(hasHiddenTasks || canCollapseTasks) && (
                                 <div className="flex h-10 items-center gap-2">
-                                  {hasHiddenTasks && (
+                                  {hasHiddenTasks ? (
                                     <button
                                       type="button"
                                       data-testid={`mobile-project-runtime-tasks-expand-${project.id}`}
@@ -587,8 +587,7 @@ export function MobileDrawer({
                                     >
                                       {t('workbench.expand_display', '展开显示')}
                                     </button>
-                                  )}
-                                  {canCollapseTasks && (
+                                  ) : (
                                     <button
                                       type="button"
                                       data-testid={`mobile-project-runtime-tasks-collapse-${project.id}`}

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -1569,15 +1569,13 @@ describe('MobileWorkbenchLayout', () => {
     expect(screen.getByTestId('mobile-project-runtime-tasks-expand-1')).toHaveTextContent(
       '展开显示'
     )
-    expect(screen.getByTestId('mobile-project-runtime-tasks-collapse-1')).toHaveTextContent(
-      '折叠显示'
-    )
+    expect(screen.queryByTestId('mobile-project-runtime-tasks-collapse-1')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('mobile-project-runtime-tasks-expand-1'))
 
     expect(screen.getAllByTestId('mobile-runtime-task-button')).toHaveLength(25)
     expect(screen.getByTestId('mobile-project-runtime-tasks-expand-1')).toBeInTheDocument()
-    expect(screen.getByTestId('mobile-project-runtime-tasks-collapse-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-project-runtime-tasks-collapse-1')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('mobile-project-runtime-tasks-expand-1'))
 


### PR DESCRIPTION
## Summary

Fixes the Wework sidebar runtime task list controls so the project task footer renders a single action at a time.

## Root Cause

When a project task list had already been expanded beyond the preview limit, later task growth could make both conditions true at once: there were hidden tasks and the list was also considered expandable/collapsible. That rendered both `展开显示` and `折叠显示` together.

## Changes

- Make desktop project runtime task footer actions mutually exclusive.
- Apply the same mutually exclusive behavior to the mobile drawer.
- Update existing desktop/mobile expectations.
- Add a regression test for task lists that grow after reaching the current visible limit.

## Validation

- `pnpm --filter wework test -- src/components/layout/DesktopSidebar.test.tsx src/components/layout/MobileWorkbenchLayout.test.tsx`
- Pre-push gate passed: ESLint, TypeScript, unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expand/collapse behavior for project runtime task lists in both desktop and mobile layouts.
  * The controls now appear more consistently as task counts change, reducing cases where the wrong action was shown.
  * Mobile views now better handle larger task lists, with collapse controls appearing only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->