### PR TITLE
feat(wework): add runtime debug panel

### DIFF
--- a/docs/en/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/developer-guide/wework-performance-diagnostics.md
@@ -15,7 +15,7 @@ macOS: Cmd + Option + Shift + P
 Windows/Linux: Ctrl + Alt + Shift + P
 ```
 
-The shortcut toggles the `wework:perf-debug` flag in `localStorage` and reloads the app. Press the same shortcut again to disable diagnostics and reload.
+The shortcut opens the **Developer Commands** menu. Select **Enable Performance Diagnostics** to write the `wework:perf-debug` flag in `localStorage` and reload the app; open the menu again and select **Disable Performance Diagnostics** to disable diagnostics and reload.
 
 Development builds can also toggle diagnostics through a URL parameter:
 
@@ -25,6 +25,17 @@ Development builds can also toggle diagnostics through a URL parameter:
 ```
 
 For local reproduction, set `VITE_WEWORK_PERF_DEBUG=1` to enable diagnostics by default.
+
+## Debug Panel
+
+The **Debug Panel** command in the Developer Commands menu helps diagnose the currently active Wework runtime task. It shows:
+
+- The active runtime task address, whether the task is known, the raw `running` value, task status, and pane-derived running state.
+- The current pane send phase, message counts, queued messages, transcript loading state, subagent state, and goal state.
+- A field and expected UI style comparison between transcript-loaded messages and the current streaming output.
+- Recent `console.debug` logs.
+
+The Debug Panel can be expanded, collapsed, refreshed, copied as a snapshot, and cleared. When collapsed, it leaves only a small status bar in the lower-right corner so it does not block the main UI.
 
 ## Collected Data
 
@@ -43,7 +54,7 @@ The latest 300 events are kept in memory and exposed through `window.__WEWORK_PE
 If Web Inspector is available in a debug or release build, run this after the app becomes slow:
 
 ```js
-window.__WEWORK_PERF__.snapshot()
+window.__WEWORK_PERF__.snapshot();
 ```
 
 The snapshot includes the current URL, page visibility, DOM node count, memory snapshot, navigation timing, resource count, and recent events. When comparing multiple snapshots, focus on:
@@ -56,16 +67,16 @@ The snapshot includes the current URL, page visibility, DOM node count, memory s
 Manual marks can also be added:
 
 ```js
-window.__WEWORK_PERF__.mark('before-open-task', { taskId: '...' })
+window.__WEWORK_PERF__.mark("before-open-task", { taskId: "..." });
 ```
 
 ## Disabling Diagnostics
 
-Press the hidden shortcut again to disable diagnostics and reload. The console can also disable it:
+Press the hidden shortcut to open the Developer Commands menu, then select **Disable Performance Diagnostics** to disable diagnostics and reload. The console can also disable it:
 
 ```js
-localStorage.removeItem('wework:perf-debug')
-location.reload()
+localStorage.removeItem("wework:perf-debug");
+location.reload();
 ```
 
 After diagnostics are disabled, `window.__WEWORK_PERF__` is not installed and React Profiler no longer wraps the app root.

--- a/docs/zh/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/developer-guide/wework-performance-diagnostics.md
@@ -15,7 +15,7 @@ macOS: Cmd + Option + Shift + P
 Windows/Linux: Ctrl + Alt + Shift + P
 ```
 
-快捷键会切换 `localStorage` 中的 `wework:perf-debug` 标记并自动刷新应用。再次按同一快捷键会关闭诊断并刷新。
+快捷键会打开 **Developer Commands** 菜单。选择 **Enable Performance Diagnostics** 会写入 `localStorage` 中的 `wework:perf-debug` 标记并自动刷新应用；再次打开菜单选择 **Disable Performance Diagnostics** 会关闭诊断并刷新。
 
 开发环境也可以通过 URL 参数临时切换：
 
@@ -25,6 +25,17 @@ Windows/Linux: Ctrl + Alt + Shift + P
 ```
 
 也可以设置构建/运行环境变量 `VITE_WEWORK_PERF_DEBUG=1`，用于本地复现时默认开启。
+
+## Debug 面板
+
+Developer Commands 菜单中的 **Debug Panel** 用于排查 Wework 当前运行任务的问题。面板会展示：
+
+- 当前活跃 runtime task 的地址、任务是否可识别、`running` 原始值、任务状态和 pane 派生运行状态。
+- 当前 pane 的发送阶段、消息数量、队列、transcript 加载状态、subagent 状态和 goal 状态。
+- Transcript 加载消息与当前流式输出消息的字段和预期 UI 样式对比。
+- 最近的 `console.debug` 日志。
+
+Debug 面板可以展开、收起、刷新、复制快照和清空日志。收起后只保留右下角状态条，避免遮挡主界面。
 
 ## 采集内容
 
@@ -43,7 +54,7 @@ Windows/Linux: Ctrl + Alt + Shift + P
 如果 debug 包或 release 包能打开 Web Inspector，在卡顿后执行：
 
 ```js
-window.__WEWORK_PERF__.snapshot()
+window.__WEWORK_PERF__.snapshot();
 ```
 
 返回值包含当前 URL、页面可见性、DOM 节点数、内存快照、导航时序、resource 数量和最近事件。需要持续观察时可以多次执行，重点比较：
@@ -56,16 +67,16 @@ window.__WEWORK_PERF__.snapshot()
 也可以手动打点：
 
 ```js
-window.__WEWORK_PERF__.mark('before-open-task', { taskId: '...' })
+window.__WEWORK_PERF__.mark("before-open-task", { taskId: "..." });
 ```
 
 ## 关闭方式
 
-再次按隐藏快捷键会关闭诊断并刷新应用。也可以在控制台执行：
+再次按隐藏快捷键打开 Developer Commands 菜单，然后选择 **Disable Performance Diagnostics** 会关闭诊断并刷新应用。也可以在控制台执行：
 
 ```js
-localStorage.removeItem('wework:perf-debug')
-location.reload()
+localStorage.removeItem("wework:perf-debug");
+location.reload();
 ```
 
 关闭后 `window.__WEWORK_PERF__` 不再安装，React Profiler 也不会包裹应用根节点。

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import i18n from '@/i18n'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
+import {
+  compareMessageStyles,
+  summarizeMessages,
+  updateRuntimePaneDebugSnapshot,
+} from '@/lib/debugPanel'
 import type { RuntimePaneMessageAction } from '@/features/workbench/runtimePaneMessages'
 import {
   deriveRuntimePaneStatus,
@@ -1151,6 +1156,43 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   }, [clearRuntimeGoal, currentRuntimeTask, goal])
 
   const cancelGuidanceMessage = useCallback(() => undefined, [])
+
+  useEffect(() => {
+    updateRuntimePaneDebugSnapshot({
+      currentRuntimeTask,
+      status: paneStatus,
+      messageSummary: summarizeMessages(messages),
+      messageStyleComparison: compareMessageStyles(messages),
+      queuedMessages,
+      guidanceMessages,
+      codeCommentContextCount: codeCommentContexts.length,
+      inputLength: input.length,
+      transcript: {
+        loading: transcriptLoading,
+        hasMoreBefore: transcriptHasMoreBefore,
+        loadingMoreBefore: transcriptLoadingMoreBefore,
+        turnNavigationCount: turnNavigation.length,
+      },
+      subagentStatuses,
+      goal,
+      goalDraftActive,
+    })
+  }, [
+    codeCommentContexts.length,
+    currentRuntimeTask,
+    goal,
+    goalDraftActive,
+    guidanceMessages,
+    input.length,
+    messages,
+    paneStatus,
+    queuedMessages,
+    subagentStatuses,
+    transcriptHasMoreBefore,
+    transcriptLoading,
+    transcriptLoadingMoreBefore,
+    turnNavigation.length,
+  ])
 
   return {
     messages,

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { useOptionalCloudConnection } from '@/features/cloud-connection/useCloudConnection'
 import { getPreferredStandaloneDeviceId } from '@/lib/device-selection'
+import { updateWorkbenchDebugSnapshot } from '@/lib/debugPanel'
 import { navigateTo } from '@/lib/navigation'
 import { supportsGitWorktreeExecution } from '@/lib/projectClassification'
 import { getActiveWorkbenchDeviceId } from '@/lib/workbench-device'
@@ -347,6 +348,15 @@ export function WorkbenchProvider({
       executorClient,
       services: resolvedServices,
     })
+
+  useEffect(() => {
+    updateWorkbenchDebugSnapshot({
+      state,
+      currentRuntimeTaskRunning,
+      cloudWorkStatus,
+    })
+  }, [cloudWorkStatus, currentRuntimeTaskRunning, state])
+
   const { upgradingDevices, upgradeDevice } = useWorkbenchDeviceUpgrades({
     state,
     dispatch,

--- a/wework/src/lib/debugPanel.ts
+++ b/wework/src/lib/debugPanel.ts
@@ -1,0 +1,460 @@
+import type { RuntimePaneStatus } from '@/features/workbench/runtimePaneStatus'
+import type {
+  LocalTaskSummary,
+  RuntimeDeviceWorkspace,
+  RuntimeTaskAddress,
+  RuntimeWorkListResponse,
+} from '@/types/api'
+import type {
+  CloudWorkStatus,
+  GuidanceWorkbenchMessage,
+  QueuedWorkbenchMessage,
+  RuntimeSubagentStatus,
+  WorkbenchMessage,
+  WorkbenchState,
+} from '@/types/workbench'
+
+type ConsoleDebug = (...args: unknown[]) => void
+
+export interface DebugLogEntry {
+  id: number
+  timestamp: string
+  args: string[]
+}
+
+export interface WorkbenchDebugSnapshot {
+  updatedAt: string
+  workbench: {
+    isBootstrapping: boolean
+    error: string | null
+    currentProject: WorkbenchState['currentProject']
+    currentRuntimeTask: RuntimeTaskAddress | null
+    currentRuntimeTaskRunning: boolean
+    runningState: RuntimeTaskRunningDebugState
+    activeTask: LocalTaskSummary | null
+    activeWorkspace: RuntimeDeviceWorkspace | null
+    runtimeWorkSummary: RuntimeWorkSummary
+    devices: WorkbenchState['devices']
+    standaloneDeviceId: string | null
+    standaloneWorkspacePath: string | null
+    selectedDeviceWorkspaceId: number | null
+    cloudWorkStatus: CloudWorkStatus
+  } | null
+  pane: RuntimePaneDebugSnapshot | null
+  logs: DebugLogEntry[]
+  logLimit: number
+}
+
+export interface RuntimePaneDebugSnapshot {
+  updatedAt: string
+  currentRuntimeTask: RuntimeTaskAddress | null
+  status: RuntimePaneStatus
+  messageSummary: MessageSummary
+  messageStyleComparison: MessageStyleComparison
+  queuedMessages: QueuedWorkbenchMessage[]
+  guidanceMessages: GuidanceWorkbenchMessage[]
+  codeCommentContextCount: number
+  inputLength: number
+  transcript: {
+    loading: boolean
+    hasMoreBefore: boolean
+    loadingMoreBefore: boolean
+    turnNavigationCount: number
+  }
+  subagentStatuses: RuntimeSubagentStatus[]
+  goal: unknown
+  goalDraftActive: boolean
+}
+
+export interface RuntimeTaskRunningDebugState {
+  hasCurrentRuntimeTask: boolean
+  activeTaskKnown: boolean
+  activeTaskRunning: boolean | null
+  activeTaskStatus: string | null
+  providerRunning: boolean
+}
+
+export interface MessageStyleComparison {
+  transcriptLoaded: MessageStyleSample | null
+  currentStreaming: MessageStyleSample | null
+  fieldDiff: MessageStyleFieldDiff[]
+  renderingRules: string[]
+}
+
+export interface MessageStyleSample {
+  label: string
+  id: string
+  role: WorkbenchMessage['role']
+  status: WorkbenchMessage['status']
+  runtimeStatus: WorkbenchMessage['runtimeStatus'] | null
+  runtimeMessageIndex: number | null
+  turnId: number | null
+  createdAt: string
+  completedAt: string | number | null
+  contentPreview: string
+  hasVisibleContent: boolean
+  blockCount: number
+  runningBlockCount: number
+  hasFileChanges: boolean
+  referenceCount: number
+  memoryCitationCount: number
+  expectedUi: string[]
+}
+
+export interface MessageStyleFieldDiff {
+  field: string
+  transcriptLoaded: unknown
+  currentStreaming: unknown
+}
+
+interface RuntimeWorkSummary {
+  totalLocalTasks: number
+  projectCount: number
+  projectWorkspaceCount: number
+  chatWorkspaceCount: number
+  runningTaskCount: number
+}
+
+interface MessageSummary {
+  total: number
+  byRole: Record<string, number>
+  byStatus: Record<string, number>
+  activeAssistantMessage: WorkbenchMessage | null
+  lastMessage: WorkbenchMessage | null
+}
+
+const DEBUG_LOG_LIMIT = 500
+
+let installed = false
+let debugLogSequence = 0
+let originalDebug: ConsoleDebug | null = null
+let workbenchSnapshot: WorkbenchDebugSnapshot['workbench'] = null
+let paneSnapshot: RuntimePaneDebugSnapshot | null = null
+const debugLogs: DebugLogEntry[] = []
+
+export function installDebugPanelLogCapture() {
+  if (installed) return
+  installed = true
+  originalDebug = console.debug.bind(console)
+
+  console.debug = (...args: unknown[]) => {
+    recordDebugLog(args)
+    originalDebug?.(...args)
+  }
+}
+
+export function updateWorkbenchDebugSnapshot({
+  state,
+  currentRuntimeTaskRunning,
+  cloudWorkStatus,
+}: {
+  state: WorkbenchState
+  currentRuntimeTaskRunning: boolean
+  cloudWorkStatus: CloudWorkStatus
+}) {
+  const activeTask = findRuntimeLocalTask(state.runtimeWork, state.currentRuntimeTask)
+  workbenchSnapshot = {
+    isBootstrapping: state.isBootstrapping,
+    error: state.error,
+    currentProject: state.currentProject,
+    currentRuntimeTask: state.currentRuntimeTask,
+    currentRuntimeTaskRunning,
+    runningState: {
+      hasCurrentRuntimeTask: Boolean(state.currentRuntimeTask),
+      activeTaskKnown: Boolean(activeTask),
+      activeTaskRunning: activeTask?.running ?? null,
+      activeTaskStatus: activeTask?.status ?? null,
+      providerRunning: currentRuntimeTaskRunning,
+    },
+    activeTask,
+    activeWorkspace: findRuntimeWorkspace(state.runtimeWork, state.currentRuntimeTask),
+    runtimeWorkSummary: summarizeRuntimeWork(state.runtimeWork),
+    devices: state.devices,
+    standaloneDeviceId: state.standaloneDeviceId,
+    standaloneWorkspacePath: state.standaloneWorkspacePath,
+    selectedDeviceWorkspaceId: state.selectedDeviceWorkspaceId,
+    cloudWorkStatus,
+  }
+}
+
+export function updateRuntimePaneDebugSnapshot(
+  snapshot: Omit<RuntimePaneDebugSnapshot, 'updatedAt'>
+) {
+  paneSnapshot = {
+    ...snapshot,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+export function clearWorkbenchDebugLogs() {
+  debugLogs.splice(0, debugLogs.length)
+}
+
+export function getWorkbenchDebugSnapshot(): WorkbenchDebugSnapshot {
+  return {
+    updatedAt: new Date().toISOString(),
+    workbench: workbenchSnapshot,
+    pane: paneSnapshot,
+    logs: [...debugLogs],
+    logLimit: DEBUG_LOG_LIMIT,
+  }
+}
+
+export function summarizeMessages(messages: WorkbenchMessage[]): MessageSummary {
+  return {
+    total: messages.length,
+    byRole: countBy(messages, message => message.role || 'unknown'),
+    byStatus: countBy(messages, message => message.status || 'unknown'),
+    activeAssistantMessage:
+      [...messages]
+        .reverse()
+        .find(message => message.role === 'assistant' && message.status === 'streaming') ?? null,
+    lastMessage: messages.at(-1) ?? null,
+  }
+}
+
+export function compareMessageStyles(messages: WorkbenchMessage[]): MessageStyleComparison {
+  const transcriptMessage =
+    [...messages]
+      .reverse()
+      .find(
+        message =>
+          message.role === 'assistant' &&
+          message.status !== 'streaming' &&
+          typeof message.runtimeMessageIndex === 'number'
+      ) ??
+    [...messages]
+      .reverse()
+      .find(message => message.role === 'assistant' && message.status !== 'streaming') ??
+    null
+  const streamingMessage =
+    [...messages]
+      .reverse()
+      .find(message => message.role === 'assistant' && message.status === 'streaming') ?? null
+  const transcriptLoaded = transcriptMessage
+    ? createMessageStyleSample('Transcript loaded assistant message', transcriptMessage)
+    : null
+  const currentStreaming = streamingMessage
+    ? createMessageStyleSample('Current streaming assistant message', streamingMessage)
+    : null
+
+  return {
+    transcriptLoaded,
+    currentStreaming,
+    fieldDiff: buildMessageStyleFieldDiff(transcriptLoaded, currentStreaming),
+    renderingRules: [
+      'Both paths render through MessageList -> AssistantMessage with the same base assistant container classes.',
+      'Streaming messages set status=streaming, hide hover actions, pass isStreaming=true to ToolBlocksDisplay, suppress final artifacts, and may show AssistantThinkingIndicator.',
+      'Loaded transcript messages usually have status=done, runtimeMessageIndex, completedAt/runtimeStatus from the transcript API, can show hover actions, final references, memory citations, web search sources, and file changes.',
+      'A transcript message can still render as streaming if the transcript API returns a runtime status such as running, active, busy, pending, or streaming.',
+    ],
+  }
+}
+
+function recordDebugLog(args: unknown[]) {
+  debugLogs.push({
+    id: ++debugLogSequence,
+    timestamp: new Date().toISOString(),
+    args: args.map(serializeLogArgument),
+  })
+
+  if (debugLogs.length > DEBUG_LOG_LIMIT) {
+    debugLogs.splice(0, debugLogs.length - DEBUG_LOG_LIMIT)
+  }
+}
+
+function createMessageStyleSample(label: string, message: WorkbenchMessage): MessageStyleSample {
+  const blocks = message.blocks ?? []
+  const runningBlockCount = blocks.filter(
+    block => block.status !== 'done' && block.status !== 'error'
+  ).length
+  const hasVisibleContent = Boolean(message.content.trim())
+  const isStreaming = message.status === 'streaming'
+  const hasRunningBlocks = runningBlockCount > 0
+  const isAssistantRunning = isStreaming || hasRunningBlocks
+
+  return {
+    label,
+    id: message.id,
+    role: message.role,
+    status: message.status,
+    runtimeStatus: message.runtimeStatus ?? null,
+    runtimeMessageIndex:
+      typeof message.runtimeMessageIndex === 'number' ? message.runtimeMessageIndex : null,
+    turnId: typeof message.turnId === 'number' ? message.turnId : null,
+    createdAt: message.createdAt,
+    completedAt: message.completedAt ?? null,
+    contentPreview: truncatePreview(message.content.trim() || '[empty]'),
+    hasVisibleContent,
+    blockCount: blocks.length,
+    runningBlockCount,
+    hasFileChanges: Boolean(message.fileChanges),
+    referenceCount: message.references?.length ?? 0,
+    memoryCitationCount: message.memoryCitations?.length ?? 0,
+    expectedUi: buildExpectedMessageUi({
+      isStreaming,
+      isAssistantRunning,
+      hasRunningBlocks,
+      hasVisibleContent,
+      hasBlocks: blocks.length > 0,
+      hasFileChanges: Boolean(message.fileChanges),
+      referenceCount: message.references?.length ?? 0,
+      memoryCitationCount: message.memoryCitations?.length ?? 0,
+    }),
+  }
+}
+
+function buildExpectedMessageUi({
+  isStreaming,
+  isAssistantRunning,
+  hasRunningBlocks,
+  hasVisibleContent,
+  hasBlocks,
+  hasFileChanges,
+  referenceCount,
+  memoryCitationCount,
+}: {
+  isStreaming: boolean
+  isAssistantRunning: boolean
+  hasRunningBlocks: boolean
+  hasVisibleContent: boolean
+  hasBlocks: boolean
+  hasFileChanges: boolean
+  referenceCount: number
+  memoryCitationCount: number
+}): string[] {
+  const entries = [
+    'base assistant: min-w-0 overflow-x-hidden text-[13px] leading-6 text-text-primary',
+  ]
+  if (hasBlocks || isAssistantRunning) {
+    entries.push(`ToolBlocksDisplay isStreaming=${isStreaming}`)
+  }
+  if (isAssistantRunning && (!hasVisibleContent || hasRunningBlocks)) {
+    entries.push('AssistantThinkingIndicator visible')
+  }
+  if (hasVisibleContent) {
+    entries.push('AssistantMarkdown visible')
+  }
+  if (!isAssistantRunning && referenceCount > 0) {
+    entries.push('CodexReferenceList visible')
+  }
+  if (!isAssistantRunning && memoryCitationCount > 0) {
+    entries.push('CodexMemoryCitations visible')
+  }
+  if (!isAssistantRunning && hasFileChanges) {
+    entries.push('FileChangesCard visible')
+  }
+  entries.push(
+    isStreaming
+      ? 'MessageHoverActions hidden while streaming'
+      : 'MessageHoverActions available on hover'
+  )
+  return entries
+}
+
+function buildMessageStyleFieldDiff(
+  transcriptLoaded: MessageStyleSample | null,
+  currentStreaming: MessageStyleSample | null
+): MessageStyleFieldDiff[] {
+  const fields: (keyof MessageStyleSample)[] = [
+    'status',
+    'runtimeStatus',
+    'runtimeMessageIndex',
+    'completedAt',
+    'blockCount',
+    'runningBlockCount',
+    'hasFileChanges',
+    'referenceCount',
+    'memoryCitationCount',
+    'hasVisibleContent',
+  ]
+
+  return fields.map(field => ({
+    field,
+    transcriptLoaded: transcriptLoaded?.[field] ?? null,
+    currentStreaming: currentStreaming?.[field] ?? null,
+  }))
+}
+
+function truncatePreview(value: string): string {
+  return value.length <= 600 ? value : `${value.slice(0, 600)}...`
+}
+
+function serializeLogArgument(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack || `${value.name}: ${value.message}`
+  }
+
+  if (typeof value === 'string') return value
+
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized !== undefined) return serialized
+  } catch {
+    return String(value)
+  }
+
+  return String(value)
+}
+
+function summarizeRuntimeWork(runtimeWork: RuntimeWorkListResponse | null): RuntimeWorkSummary {
+  if (!runtimeWork) {
+    return {
+      totalLocalTasks: 0,
+      projectCount: 0,
+      projectWorkspaceCount: 0,
+      chatWorkspaceCount: 0,
+      runningTaskCount: 0,
+    }
+  }
+
+  const projectWorkspaces = runtimeWork.projects.flatMap(project => project.deviceWorkspaces)
+  const workspaces = [...runtimeWork.chats, ...projectWorkspaces]
+
+  return {
+    totalLocalTasks: runtimeWork.totalLocalTasks,
+    projectCount: runtimeWork.projects.length,
+    projectWorkspaceCount: projectWorkspaces.length,
+    chatWorkspaceCount: runtimeWork.chats.length,
+    runningTaskCount: workspaces.reduce(
+      (count, workspace) => count + workspace.localTasks.filter(task => task.running).length,
+      0
+    ),
+  }
+}
+
+function findRuntimeLocalTask(
+  runtimeWork: RuntimeWorkListResponse | null,
+  address: RuntimeTaskAddress | null
+): LocalTaskSummary | null {
+  const workspace = findRuntimeWorkspace(runtimeWork, address)
+  if (!workspace || !address) return null
+  return workspace.localTasks.find(task => task.localTaskId === address.localTaskId) ?? null
+}
+
+function findRuntimeWorkspace(
+  runtimeWork: RuntimeWorkListResponse | null,
+  address: RuntimeTaskAddress | null
+): RuntimeDeviceWorkspace | null {
+  if (!runtimeWork || !address) return null
+  const workspaces = [
+    ...runtimeWork.chats,
+    ...runtimeWork.projects.flatMap(project => project.deviceWorkspaces),
+  ]
+
+  return (
+    workspaces.find(
+      workspace =>
+        workspace.deviceId === address.deviceId &&
+        workspace.localTasks.some(task => task.localTaskId === address.localTaskId)
+    ) ?? null
+  )
+}
+
+function countBy<T>(items: T[], getKey: (item: T) => string): Record<string, number> {
+  return items.reduce<Record<string, number>>((counts, item) => {
+    const key = getKey(item)
+    counts[key] = (counts[key] ?? 0) + 1
+    return counts
+  }, {})
+}

--- a/wework/src/lib/developerCommandMenu.test.ts
+++ b/wework/src/lib/developerCommandMenu.test.ts
@@ -3,6 +3,8 @@ import { installDeveloperCommandMenu } from './developerCommandMenu'
 
 const invokeMock = vi.hoisted(() => vi.fn())
 const isTauriRuntimeMock = vi.hoisted(() => vi.fn())
+const getWorkbenchDebugSnapshotMock = vi.hoisted(() => vi.fn())
+const clearWorkbenchDebugLogsMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
@@ -10,6 +12,11 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 vi.mock('./runtime-environment', () => ({
   isTauriRuntime: isTauriRuntimeMock,
+}))
+
+vi.mock('./debugPanel', () => ({
+  clearWorkbenchDebugLogs: clearWorkbenchDebugLogsMock,
+  getWorkbenchDebugSnapshot: getWorkbenchDebugSnapshotMock,
 }))
 
 describe('developerCommandMenu', () => {
@@ -20,11 +27,13 @@ describe('developerCommandMenu', () => {
   beforeEach(() => {
     invokeMock.mockResolvedValue(undefined)
     isTauriRuntimeMock.mockReturnValue(true)
+    getWorkbenchDebugSnapshotMock.mockReturnValue(createDebugSnapshot())
     localStorage.clear()
   })
 
   afterEach(() => {
     document.getElementById('wework-developer-command-menu')?.remove()
+    document.getElementById('wework-debug-panel')?.remove()
     vi.clearAllMocks()
   })
 
@@ -32,6 +41,7 @@ describe('developerCommandMenu', () => {
     dispatchDeveloperShortcut()
 
     expect(screenCommand('reload')).toBeInTheDocument()
+    expect(screenCommand('open-debug-panel')).toBeInTheDocument()
     expect(screenCommand('toggle-performance-diagnostics')).toBeInTheDocument()
     expect(screenCommand('print-performance-snapshot')).toBeInTheDocument()
     expect(screenCommand('open-log-directory')).toBeInTheDocument()
@@ -52,6 +62,38 @@ describe('developerCommandMenu', () => {
     screenCommand('open-web-inspector').click()
 
     expect(invokeMock).toHaveBeenCalledWith('open_main_webview_devtools')
+  })
+
+  test('opens the debug panel with active task state and debug logs', () => {
+    dispatchDeveloperShortcut()
+
+    screenCommand('open-debug-panel').click()
+
+    expect(document.getElementById('wework-debug-panel')).toBeInTheDocument()
+    expect(document.body).toHaveTextContent('Active Task State (taskKnown=true')
+    expect(document.body).toHaveTextContent('Transcript vs Streaming Style')
+    expect(document.body).toHaveTextContent('"localTaskId": "task-1"')
+    expect(document.body).toHaveTextContent('Transcript Loaded')
+    expect(document.body).toHaveTextContent('Current Streaming')
+    expect(document.body).toHaveTextContent('loaded transcript response')
+    expect(document.body).toHaveTextContent('streaming response')
+    expect(document.body).toHaveTextContent('[Wework] sample debug')
+  })
+
+  test('collapses and expands the debug panel', () => {
+    dispatchDeveloperShortcut()
+    screenCommand('open-debug-panel').click()
+
+    screenButton('Collapse').click()
+
+    expect(screenCollapsedDebugPanel()).toBeInTheDocument()
+    expect(document.body).toHaveTextContent('Debug Panel collapsed')
+    expect(document.body).not.toHaveTextContent('Transcript vs Streaming Style')
+
+    screenCollapsedDebugPanel().click()
+
+    expect(document.body).toHaveTextContent('Transcript vs Streaming Style')
+    expect(document.body).toHaveTextContent('Collapse')
   })
 })
 
@@ -75,4 +117,180 @@ function screenCommand(commandId: string): HTMLElement {
     throw new Error(`Command was not found: ${commandId}`)
   }
   return element
+}
+
+function screenButton(label: string): HTMLButtonElement {
+  const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+  const button = buttons.find(item => item.textContent === label)
+  if (!button) {
+    throw new Error(`Button was not found: ${label}`)
+  }
+  return button
+}
+
+function screenCollapsedDebugPanel(): HTMLElement {
+  const element = document.querySelector<HTMLElement>('[data-testid="debug-panel-collapsed"]')
+  if (!element) {
+    throw new Error('Collapsed debug panel was not found')
+  }
+  return element
+}
+
+function createDebugSnapshot() {
+  return {
+    updatedAt: '2026-07-03T00:00:00.000Z',
+    workbench: {
+      isBootstrapping: false,
+      error: null,
+      currentProject: null,
+      currentRuntimeTask: {
+        deviceId: 'device-1',
+        workspacePath: '/tmp/workspace',
+        localTaskId: 'task-1',
+      },
+      currentRuntimeTaskRunning: true,
+      runningState: {
+        hasCurrentRuntimeTask: true,
+        activeTaskKnown: true,
+        activeTaskRunning: true,
+        activeTaskStatus: 'running',
+        providerRunning: true,
+      },
+      activeTask: {
+        localTaskId: 'task-1',
+        workspacePath: '/tmp/workspace',
+        title: 'Debug task',
+        runtime: 'codex',
+        running: true,
+        status: 'running',
+      },
+      activeWorkspace: null,
+      runtimeWorkSummary: {
+        totalLocalTasks: 1,
+        projectCount: 0,
+        projectWorkspaceCount: 0,
+        chatWorkspaceCount: 1,
+        runningTaskCount: 1,
+      },
+      devices: [],
+      standaloneDeviceId: null,
+      standaloneWorkspacePath: null,
+      selectedDeviceWorkspaceId: null,
+      cloudWorkStatus: {
+        availability: 'available',
+        checks: {
+          teams: 'available',
+          devices: 'available',
+          runtimeWork: 'available',
+        },
+        error: null,
+        updatedAt: '2026-07-03T00:00:00.000Z',
+      },
+    },
+    pane: {
+      updatedAt: '2026-07-03T00:00:00.000Z',
+      currentRuntimeTask: {
+        deviceId: 'device-1',
+        workspacePath: '/tmp/workspace',
+        localTaskId: 'task-1',
+      },
+      status: {
+        sendPhase: 'awaiting_assistant',
+        activeAssistantMessage: null,
+        taskExecution: {
+          known: true,
+          running: true,
+          status: 'running',
+        },
+        isSubmitting: false,
+        isAwaitingAssistant: true,
+        isAssistantStreaming: true,
+        isResponseActive: true,
+        isBusy: true,
+        isWaitingForAssistantIndicator: true,
+        canSendQueuedMessage: false,
+      },
+      messageSummary: {
+        total: 2,
+        byRole: {
+          assistant: 2,
+        },
+        byStatus: {
+          done: 1,
+          streaming: 1,
+        },
+        activeAssistantMessage: null,
+        lastMessage: null,
+      },
+      messageStyleComparison: {
+        transcriptLoaded: {
+          label: 'Transcript loaded assistant message',
+          id: 'loaded-1',
+          role: 'assistant',
+          status: 'done',
+          runtimeStatus: 'done',
+          runtimeMessageIndex: 1,
+          turnId: 10,
+          createdAt: '2026-07-03T00:00:00.000Z',
+          completedAt: '2026-07-03T00:01:00.000Z',
+          contentPreview: 'loaded transcript response',
+          hasVisibleContent: true,
+          blockCount: 1,
+          runningBlockCount: 0,
+          hasFileChanges: true,
+          referenceCount: 1,
+          memoryCitationCount: 0,
+          expectedUi: ['MessageHoverActions available on hover'],
+        },
+        currentStreaming: {
+          label: 'Current streaming assistant message',
+          id: 'streaming-1',
+          role: 'assistant',
+          status: 'streaming',
+          runtimeStatus: 'streaming',
+          runtimeMessageIndex: null,
+          turnId: 11,
+          createdAt: '2026-07-03T00:02:00.000Z',
+          completedAt: null,
+          contentPreview: 'streaming response',
+          hasVisibleContent: true,
+          blockCount: 1,
+          runningBlockCount: 1,
+          hasFileChanges: false,
+          referenceCount: 0,
+          memoryCitationCount: 0,
+          expectedUi: ['MessageHoverActions hidden while streaming'],
+        },
+        fieldDiff: [
+          {
+            field: 'status',
+            transcriptLoaded: 'done',
+            currentStreaming: 'streaming',
+          },
+        ],
+        renderingRules: ['Streaming messages hide hover actions and suppress final artifacts.'],
+      },
+      queuedMessages: [],
+      guidanceMessages: [],
+      codeCommentContextCount: 0,
+      inputLength: 0,
+      transcript: {
+        loading: false,
+        hasMoreBefore: false,
+        loadingMoreBefore: false,
+        turnNavigationCount: 0,
+      },
+      subagentStatuses: [],
+      goal: null,
+      goalDraftActive: false,
+    },
+    logs: [
+      {
+        id: 1,
+        timestamp: '2026-07-03T00:00:00.000Z',
+        args: ['[Wework] sample debug'],
+      },
+    ],
+    logLimit: 500,
+  }
 }

--- a/wework/src/lib/developerCommandMenu.ts
+++ b/wework/src/lib/developerCommandMenu.ts
@@ -1,5 +1,10 @@
 import { invoke } from '@tauri-apps/api/core'
 import {
+  clearWorkbenchDebugLogs,
+  getWorkbenchDebugSnapshot,
+  type WorkbenchDebugSnapshot,
+} from './debugPanel'
+import {
   isPerformanceDiagnosticsEnabled,
   isPerformanceDiagnosticsShortcut,
   setPerformanceDiagnosticsEnabled,
@@ -7,6 +12,7 @@ import {
 import { isTauriRuntime } from './runtime-environment'
 
 const MENU_ID = 'wework-developer-command-menu'
+const DEBUG_PANEL_ID = 'wework-debug-panel'
 const INSPECTOR_COMMAND = 'open_main_webview_devtools'
 const OPEN_LOG_DIRECTORY_COMMAND = 'open_app_log_directory'
 
@@ -111,6 +117,12 @@ function getDeveloperCommands(): DeveloperCommand[] {
   const diagnosticsEnabled = isPerformanceDiagnosticsEnabled()
   return [
     {
+      id: 'open-debug-panel',
+      label: 'Debug Panel',
+      description: 'Inspect the active runtime task state and recent console.debug logs.',
+      run: () => openDebugPanel(),
+    },
+    {
       id: 'reload',
       label: 'Reload App',
       description: 'Reload the current WebView.',
@@ -169,6 +181,293 @@ function getDeveloperCommands(): DeveloperCommand[] {
       },
     },
   ]
+}
+
+function openDebugPanel() {
+  closeDebugPanel()
+
+  const root = document.createElement('div')
+  root.id = DEBUG_PANEL_ID
+  document.body.appendChild(root)
+  renderDebugPanelShell(root, true)
+}
+
+function closeDebugPanel() {
+  document.getElementById(DEBUG_PANEL_ID)?.remove()
+}
+
+function renderDebugPanelShell(root: HTMLElement, expanded: boolean) {
+  const snapshot = getWorkbenchDebugSnapshot()
+  root.innerHTML = ''
+  root.className = expanded
+    ? 'fixed inset-0 z-[2147483647] flex items-stretch justify-center bg-black/30 p-4'
+    : 'fixed bottom-4 right-4 z-[2147483647]'
+  root.setAttribute('role', 'presentation')
+
+  if (!expanded) {
+    root.onclick = null
+    root.onkeydown = null
+    root.appendChild(createCollapsedDebugPanel(snapshot, () => renderDebugPanelShell(root, true)))
+    return
+  }
+
+  const dialog = document.createElement('div')
+  dialog.className =
+    'flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-lg border border-border bg-background text-text-primary shadow-2xl'
+  dialog.setAttribute('role', 'dialog')
+  dialog.setAttribute('aria-modal', 'true')
+  dialog.setAttribute('aria-label', 'Debug panel')
+
+  const header = document.createElement('div')
+  header.className =
+    'flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3'
+
+  const title = document.createElement('div')
+  title.innerHTML =
+    '<div class="text-sm font-semibold">Debug Panel</div><div class="mt-1 text-xs text-text-muted">Active task state and console.debug logs</div>'
+
+  const body = document.createElement('div')
+  body.className = 'grid min-h-0 flex-1 grid-cols-1 gap-0 overflow-hidden lg:grid-cols-[1fr_1fr]'
+  renderDebugPanelBody(body, snapshot)
+
+  const actions = document.createElement('div')
+  actions.className = 'flex items-center gap-2'
+  actions.append(
+    createDebugPanelButton('Refresh', () =>
+      renderDebugPanelBody(body, getWorkbenchDebugSnapshot())
+    ),
+    createDebugPanelButton('Copy Snapshot', () => copyDebugSnapshot(getWorkbenchDebugSnapshot())),
+    createDebugPanelButton('Clear Logs', () => {
+      clearWorkbenchDebugLogs()
+      renderDebugPanelBody(body, getWorkbenchDebugSnapshot())
+    }),
+    createDebugPanelButton('Collapse', () => renderDebugPanelShell(root, false)),
+    createDebugPanelButton('Close', closeDebugPanel)
+  )
+
+  header.append(title, actions)
+  dialog.append(header, body)
+  root.appendChild(dialog)
+
+  root.onclick = event => {
+    if (event.target === root) renderDebugPanelShell(root, false)
+  }
+  root.onkeydown = event => {
+    if (event.key !== 'Escape') return
+    event.preventDefault()
+    renderDebugPanelShell(root, false)
+  }
+}
+
+function renderDebugPanelBody(container: HTMLElement, snapshot: WorkbenchDebugSnapshot) {
+  container.innerHTML = ''
+  container.append(
+    createDebugPanelSection(
+      `Active Task State (${formatRunningStateLabel(snapshot)})`,
+      formatDebugJson(snapshot)
+    ),
+    createMessageStyleComparisonSection(snapshot),
+    createDebugPanelSection(
+      `Debug Logs (${snapshot.logs.length}/${snapshot.logLimit})`,
+      formatDebugLogs(snapshot)
+    )
+  )
+}
+
+function createCollapsedDebugPanel(snapshot: WorkbenchDebugSnapshot, onExpand: () => void) {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.dataset.testid = 'debug-panel-collapsed'
+  button.className =
+    'flex max-w-[min(420px,calc(100vw-2rem))] items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-left text-xs text-text-primary shadow-2xl hover:bg-muted focus:bg-muted focus:outline-none'
+  button.setAttribute('aria-label', 'Expand debug panel')
+  button.addEventListener('click', onExpand)
+
+  const dot = document.createElement('span')
+  dot.className = snapshot.workbench?.runningState.activeTaskRunning
+    ? 'h-2 w-2 shrink-0 rounded-full bg-primary'
+    : 'h-2 w-2 shrink-0 rounded-full bg-border'
+
+  const text = document.createElement('span')
+  text.className = 'min-w-0 truncate'
+  text.textContent = `Debug Panel collapsed - ${formatRunningStateLabel(snapshot)}`
+
+  const hint = document.createElement('span')
+  hint.className = 'shrink-0 text-text-muted'
+  hint.textContent = 'Expand'
+
+  button.append(dot, text, hint)
+  return button
+}
+
+function formatRunningStateLabel(snapshot: WorkbenchDebugSnapshot): string {
+  const workbenchRunning = snapshot.workbench?.runningState
+  const paneStatus = snapshot.pane?.status
+  if (!workbenchRunning?.hasCurrentRuntimeTask) return 'no active runtime task'
+
+  return [
+    `taskKnown=${workbenchRunning.activeTaskKnown}`,
+    `taskRunning=${String(workbenchRunning.activeTaskRunning)}`,
+    `taskStatus=${workbenchRunning.activeTaskStatus ?? 'null'}`,
+    `paneRunning=${String(paneStatus?.taskExecution.running ?? null)}`,
+    `paneBusy=${String(paneStatus?.isBusy ?? null)}`,
+    `sendPhase=${paneStatus?.sendPhase ?? 'null'}`,
+  ].join(' / ')
+}
+
+function createDebugPanelSection(title: string, content: string): HTMLElement {
+  const section = document.createElement('section')
+  section.className = 'flex min-h-0 flex-col border-b border-border lg:border-b-0 lg:border-r'
+
+  const heading = document.createElement('div')
+  heading.className = 'border-b border-border px-4 py-2 text-xs font-medium text-text-secondary'
+  heading.textContent = title
+
+  const pre = document.createElement('pre')
+  pre.className =
+    'min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-[11px] leading-5 text-text-primary'
+  pre.textContent = content
+
+  section.append(heading, pre)
+  return section
+}
+
+function createMessageStyleComparisonSection(snapshot: WorkbenchDebugSnapshot): HTMLElement {
+  const comparison = snapshot.pane?.messageStyleComparison ?? null
+  const section = document.createElement('section')
+  section.className = 'flex min-h-0 flex-col border-b border-border lg:border-b-0 lg:border-r'
+
+  const heading = document.createElement('div')
+  heading.className = 'border-b border-border px-4 py-2 text-xs font-medium text-text-secondary'
+  heading.textContent = 'Transcript vs Streaming Style'
+
+  const content = document.createElement('div')
+  content.className = 'min-h-0 flex-1 overflow-auto p-4'
+
+  if (!comparison) {
+    const empty = document.createElement('div')
+    empty.className = 'text-xs text-text-muted'
+    empty.textContent = 'No pane snapshot has been captured yet.'
+    content.appendChild(empty)
+  } else {
+    const cards = document.createElement('div')
+    cards.className = 'grid gap-3 xl:grid-cols-2'
+    cards.append(
+      createMessageStyleSampleCard('Transcript Loaded', comparison.transcriptLoaded),
+      createMessageStyleSampleCard('Current Streaming', comparison.currentStreaming)
+    )
+
+    const diff = document.createElement('pre')
+    diff.className =
+      'mt-3 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-surface p-3 font-mono text-[11px] leading-5 text-text-primary'
+    diff.textContent = JSON.stringify(
+      {
+        fieldDiff: comparison.fieldDiff,
+        renderingRules: comparison.renderingRules,
+      },
+      null,
+      2
+    )
+
+    content.append(cards, diff)
+  }
+
+  section.append(heading, content)
+  return section
+}
+
+function createMessageStyleSampleCard(
+  title: string,
+  sample: NonNullable<WorkbenchDebugSnapshot['pane']>['messageStyleComparison']['transcriptLoaded']
+): HTMLElement {
+  const card = document.createElement('div')
+  card.className = 'rounded-md border border-border bg-background p-3'
+
+  const heading = document.createElement('div')
+  heading.className = 'text-xs font-semibold text-text-primary'
+  heading.textContent = title
+
+  if (!sample) {
+    const empty = document.createElement('div')
+    empty.className = 'mt-2 text-xs leading-5 text-text-muted'
+    empty.textContent = 'No matching message in the current pane.'
+    card.append(heading, empty)
+    return card
+  }
+
+  const meta = document.createElement('div')
+  meta.className = 'mt-2 grid gap-1 text-[11px] leading-5 text-text-secondary'
+  ;[
+    `id: ${sample.id}`,
+    `status: ${sample.status}`,
+    `runtimeStatus: ${sample.runtimeStatus ?? 'null'}`,
+    `runtimeMessageIndex: ${sample.runtimeMessageIndex ?? 'null'}`,
+    `turnId: ${sample.turnId ?? 'null'}`,
+    `blocks: ${sample.blockCount} (${sample.runningBlockCount} running)`,
+    `completedAt: ${sample.completedAt ?? 'null'}`,
+  ].forEach(line => {
+    const item = document.createElement('div')
+    item.textContent = line
+    meta.appendChild(item)
+  })
+
+  const preview = document.createElement('div')
+  preview.className =
+    'mt-3 max-h-32 overflow-auto rounded-md border border-border bg-surface px-3 py-2 text-[12px] leading-5 text-text-primary'
+  preview.textContent = sample.contentPreview
+
+  const uiList = document.createElement('ul')
+  uiList.className = 'mt-3 list-disc space-y-1 pl-4 text-[11px] leading-5 text-text-secondary'
+  sample.expectedUi.forEach(rule => {
+    const item = document.createElement('li')
+    item.textContent = rule
+    uiList.appendChild(item)
+  })
+
+  card.append(heading, meta, preview, uiList)
+  return card
+}
+
+function createDebugPanelButton(label: string, onClick: () => void): HTMLButtonElement {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className =
+    'h-8 rounded-md border border-border px-3 text-xs transition-colors hover:bg-muted focus:bg-muted focus:outline-none'
+  button.textContent = label
+  button.addEventListener('click', onClick)
+  return button
+}
+
+function formatDebugJson(snapshot: WorkbenchDebugSnapshot): string {
+  return JSON.stringify(
+    {
+      updatedAt: snapshot.updatedAt,
+      workbench: snapshot.workbench,
+      pane: snapshot.pane,
+    },
+    null,
+    2
+  )
+}
+
+function formatDebugLogs(snapshot: WorkbenchDebugSnapshot): string {
+  if (snapshot.logs.length === 0) return 'No console.debug logs captured yet.'
+
+  return snapshot.logs
+    .map(log => {
+      const message = log.args.join(' ')
+      return `[${log.timestamp}] ${message}`
+    })
+    .join('\n')
+}
+
+async function copyDebugSnapshot(snapshot: WorkbenchDebugSnapshot) {
+  const text = JSON.stringify(snapshot, null, 2)
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch (error) {
+    console.warn('[Wework dev] Failed to copy debug snapshot', error)
+  }
 }
 
 function escapeHtml(value: string): string {

--- a/wework/src/main.tsx
+++ b/wework/src/main.tsx
@@ -4,12 +4,14 @@ import { createRoot } from 'react-dom/client'
 import './styles/globals.css'
 import App from './App.tsx'
 import { installAppLogging } from './lib/app-logging'
+import { installDebugPanelLogCapture } from './lib/debugPanel'
 import { installDeveloperCommandMenu } from './lib/developerCommandMenu'
 import { installExternalLinkHandler } from './lib/external-links'
 import { installPageZoomGuard } from './lib/pageZoomGuard'
 import { installPerformanceDiagnostics, recordReactCommit } from './lib/performanceDiagnostics'
 import { installDesktopExtensions } from '@extensions/desktop'
 
+installDebugPanelLogCapture()
 installAppLogging()
 installDesktopExtensions()
 installExternalLinkHandler()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Debug Panel in the Developer Commands menu for inspecting current workbench/runtime state.
  * The panel can be expanded or collapsed, refreshed, cleared, and copied as a snapshot.
  * It now shows message comparison details, task status, and recent debug logs.

* **Documentation**
  * Updated developer guides to explain how to enable/disable performance diagnostics and use the new debug tools.
  * Clarified the steps for capturing and clearing diagnostic data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->