### PR TITLE
[codex] fix wework sidebar relative time refresh

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import '@/i18n'
 import { DesktopSidebar } from './DesktopSidebar'
 import type { DeviceInfo, ProjectWithTasks } from '@/types/api'
@@ -115,6 +115,10 @@ describe('DesktopSidebar', () => {
     localStorage.clear()
     enableTauri()
     Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test('keeps section header actions out of the flex layout while hidden', () => {
@@ -489,6 +493,47 @@ describe('DesktopSidebar', () => {
       workspacePath: chatPath,
       localTaskId: 'chat-1',
     })
+  })
+
+  test('refreshes relative runtime task time while the sidebar stays mounted', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-03T12:01:00.000Z'))
+
+    renderSidebar({
+      projects: [],
+      runtimeWork: {
+        projects: [],
+        chats: [
+          {
+            deviceId: 'local-device',
+            deviceName: 'Local Mac',
+            deviceStatus: 'online',
+            available: true,
+            workspacePath: '/workspace/chats/chat-time',
+            workspaceKind: 'chat',
+            localTasks: [
+              {
+                localTaskId: 'chat-time',
+                workspacePath: '/workspace/chats/chat-time',
+                workspaceKind: 'chat',
+                title: 'Time sensitive chat',
+                runtime: 'codex',
+                updatedAt: '2026-07-03T12:00:00.000Z',
+              },
+            ],
+          },
+        ],
+        totalLocalTasks: 1,
+      },
+    })
+
+    expect(screen.getByTestId('runtime-local-task-time-chat-time')).toHaveTextContent('1m')
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(screen.getByTestId('runtime-local-task-time-chat-time')).toHaveTextContent('2m')
   })
 
   test('renames a runtime conversation from double click dialog', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -80,6 +80,7 @@ import {
   RUNTIME_PROJECT_TASK_PREVIEW_LIMIT,
   type RuntimeSidebarTaskItem,
 } from './runtimeTaskSidebarHelpers'
+import { formatRelativeSidebarTime, useSidebarRelativeTimeRefresh } from './runtimeSidebarTime'
 import { useResizableSidebar } from './useResizableSidebar'
 
 interface DesktopSidebarProps {
@@ -509,23 +510,6 @@ function SidebarSectionHeader({
       </div>
     </div>
   )
-}
-
-function formatRelativeSidebarTime(value?: string | number) {
-  if (!value) return ''
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-  const elapsedMs = Math.max(0, Date.now() - date.getTime())
-  const minutes = Math.floor(elapsedMs / 60000)
-  if (minutes < 60) return `${Math.max(1, minutes)}m`
-
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h`
-
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d`
-
-  return `${Math.floor(days / 7)}w`
 }
 
 type SidebarDeviceStatus = DeviceInfo['status'] | 'unavailable'
@@ -1794,6 +1778,7 @@ export function DesktopSidebar({
   onPointerEnter,
   onPointerLeave,
 }: DesktopSidebarProps) {
+  useSidebarRelativeTimeRefresh()
   const { t } = useTranslation('common')
   const { sidebarWidth, resizing, handleResizeStart } = useResizableSidebar({
     onCollapse: onResizeCollapse,

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -45,6 +45,7 @@ import {
   isRuntimeWorktreeTask,
   RUNTIME_PROJECT_TASK_PREVIEW_LIMIT,
 } from './runtimeTaskSidebarHelpers'
+import { formatRelativeSidebarTime, useSidebarRelativeTimeRefresh } from './runtimeSidebarTime'
 
 const MOBILE_RUNNING_SPINNER_CLASS = 'h-3.5 w-3.5 shrink-0 animate-spin'
 type ProjectCreateMode = 'scratch' | 'existing' | 'git'
@@ -83,24 +84,6 @@ interface MobileDrawerProps {
   onRefreshWorkLists?: () => Promise<void>
 }
 
-function formatRelativeTime(value?: string | number) {
-  if (!value) return ''
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-
-  const elapsedMs = Math.max(0, Date.now() - date.getTime())
-  const minutes = Math.floor(elapsedMs / 60000)
-  if (minutes < 60) return `${Math.max(1, minutes)}m`
-
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h`
-
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d`
-
-  return `${Math.floor(days / 7)}w`
-}
-
 export function MobileDrawer({
   open,
   user,
@@ -129,6 +112,7 @@ export function MobileDrawer({
   onOpenRuntimeLocalTask,
   onRefreshWorkLists,
 }: MobileDrawerProps) {
+  useSidebarRelativeTimeRefresh()
   const { t } = useTranslation('common')
   const {
     scrollRef,
@@ -398,7 +382,7 @@ export function MobileDrawer({
                               >
                                 <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
                               </span>
-                              <span>{formatRelativeTime(getRuntimeTaskTime(task))}</span>
+                              <span>{formatRelativeSidebarTime(getRuntimeTaskTime(task))}</span>
                             </span>
                           )}
                         </button>
@@ -562,7 +546,9 @@ export function MobileDrawer({
                                             aria-label="Worktree"
                                           />
                                         )}
-                                        <span>{formatRelativeTime(getRuntimeTaskTime(task))}</span>
+                                        <span>
+                                          {formatRelativeSidebarTime(getRuntimeTaskTime(task))}
+                                        </span>
                                       </span>
                                     )}
                                   </button>

--- a/wework/src/components/layout/runtimeSidebarTime.test.ts
+++ b/wework/src/components/layout/runtimeSidebarTime.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+import { formatRelativeSidebarTime } from './runtimeSidebarTime'
+
+describe('runtimeSidebarTime', () => {
+  test('formats relative sidebar time from the supplied clock', () => {
+    const now = new Date('2026-07-03T12:00:00.000Z').getTime()
+
+    expect(formatRelativeSidebarTime('2026-07-03T11:59:30.000Z', now)).toBe('1m')
+    expect(formatRelativeSidebarTime('2026-07-03T11:58:00.000Z', now)).toBe('2m')
+    expect(formatRelativeSidebarTime('2026-07-03T10:00:00.000Z', now)).toBe('2h')
+    expect(formatRelativeSidebarTime('2026-07-01T12:00:00.000Z', now)).toBe('2d')
+    expect(formatRelativeSidebarTime('2026-06-12T12:00:00.000Z', now)).toBe('3w')
+  })
+
+  test('returns an empty string for missing or invalid values', () => {
+    expect(formatRelativeSidebarTime()).toBe('')
+    expect(formatRelativeSidebarTime('not-a-date')).toBe('')
+  })
+})

--- a/wework/src/components/layout/runtimeSidebarTime.ts
+++ b/wework/src/components/layout/runtimeSidebarTime.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+const SIDEBAR_TIME_REFRESH_INTERVAL_MS = 60_000
+
+export function formatRelativeSidebarTime(value?: string | number, nowMs = Date.now()) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const elapsedMs = Math.max(0, nowMs - date.getTime())
+  const minutes = Math.floor(elapsedMs / 60_000)
+  if (minutes < 60) return `${Math.max(1, minutes)}m`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d`
+
+  return `${Math.floor(days / 7)}w`
+}
+
+export function useSidebarRelativeTimeRefresh() {
+  const [, setRefreshTick] = useState(0)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setRefreshTick(tick => tick + 1)
+    }, SIDEBAR_TIME_REFRESH_INTERVAL_MS)
+
+    return () => window.clearInterval(timer)
+  }, [])
+}


### PR DESCRIPTION
## Summary
- Add a shared sidebar relative-time formatter and refresh hook for Wework.
- Wire desktop sidebar and mobile drawer runtime task timestamps to refresh once per minute while mounted.
- Add regression coverage for formatter boundaries and mounted sidebar refresh behavior.

## Root Cause
Runtime task timestamps were formatted with Date.now() during render, but no state update was scheduled as time passed. The labels only changed after a full app restart or another unrelated rerender.

## Validation
- pnpm --filter wework test -- src/components/layout/runtimeSidebarTime.test.ts src/components/layout/DesktopSidebar.test.tsx
- pnpm --filter wework lint
- pre-push hook: ESLint, TypeScript check, unit tests

## Docs
No documentation update needed; this is a UI refresh bug fix with no API, config, or user workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar runtime task times now update automatically while the page stays open, keeping relative times accurate.
  * Relative time labels in desktop and mobile sidebars are now shown in a more compact format.

* **Bug Fixes**
  * Improved handling for missing or invalid time values so sidebar timestamps render more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->