### PR TITLE
fix(backend): cleanup response executor by task id

### DIFF
--- a/backend/app/services/adapters/task_kinds/operations.py
+++ b/backend/app/services/adapters/task_kinds/operations.py
@@ -608,6 +608,31 @@ class TaskOperationsMixin:
                 db, task=workspace, payload=workspace_crd.model_dump()
             )
 
+    def _cleanup_executor_runtime_by_task_id(
+        self, runtime_client: Any, task_id: int
+    ) -> None:
+        """Delete executor runtime by task_id when binding is missing."""
+        from app.core.async_utils import execute_async_safely
+
+        cleanup_result = execute_async_safely(
+            runtime_client.cleanup_sandbox_by_task_id,
+            task_id=task_id,
+            archive_before_delete=False,
+            timeout=180.0,
+        )
+        if cleanup_result is None:
+            logger.info(
+                "[delete_task] Runtime cleanup by task_id timed out or failed task_id=%s",
+                task_id,
+            )
+            return
+
+        logger.info(
+            "[delete_task] Runtime cleanup by task_id result task_id=%s result=%s",
+            task_id,
+            cleanup_result,
+        )
+
     def delete_task(
         self,
         db: Session,
@@ -736,6 +761,7 @@ class TaskOperationsMixin:
 
         if cleanup_mode in {"executor", "fallback"}:
             # Stop running subtasks on executor
+            executor_cleanup_succeeded = False
             if not unique_executor_keys:
                 logger.info(
                     "[delete_task] No executor cleanup targets found for task_id=%s mode=%s",
@@ -750,10 +776,13 @@ class TaskOperationsMixin:
                     executor_kinds_service.delete_executor_task_sync(
                         executor_name, executor_namespace
                     )
+                    executor_cleanup_succeeded = True
                 except Exception as e:
                     logger.warning(
                         f"Failed to delete executor task ns={executor_namespace} name={executor_name}: {str(e)}"
                     )
+            if not executor_cleanup_succeeded and not device_ids:
+                self._cleanup_executor_runtime_by_task_id(runtime_client, task_id)
 
         # Close device sessions for device tasks
         for device_id in device_ids:

--- a/backend/tests/api/test_openapi_responses.py
+++ b/backend/tests/api/test_openapi_responses.py
@@ -1694,6 +1694,96 @@ class TestOpenAPIResponsesDelete:
         )
         assert get_response.status_code == 404
 
+    def test_delete_response_cleans_runtime_by_task_id_when_binding_missing(
+        self,
+        test_client: TestClient,
+        test_api_key,
+        test_db: Session,
+        test_user: User,
+        test_team: Kind,
+    ):
+        """Deleting an executor response should clean runtime even before executor binding is persisted."""
+        task_json = {
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Task",
+            "metadata": {
+                "name": "task-runtime-binding-missing",
+                "namespace": "default",
+                "labels": {"source": "api"},
+            },
+            "spec": {
+                "title": "Running task",
+                "prompt": "Hello",
+                "teamRef": {"name": "test-team", "namespace": "default"},
+                "workspaceRef": {"name": "workspace-1", "namespace": "default"},
+            },
+            "status": {
+                "status": "RUNNING",
+                "progress": 10,
+                "result": None,
+                "errorMessage": "",
+                "createdAt": datetime.now().isoformat(),
+                "updatedAt": datetime.now().isoformat(),
+            },
+        }
+        task = TaskResource(
+            user_id=test_user.id,
+            kind="Task",
+            name="task-runtime-binding-missing",
+            namespace="default",
+            json=task_json,
+            is_active=True,
+        )
+        test_db.add(task)
+        test_db.flush()
+
+        running_subtask = Subtask(
+            user_id=test_user.id,
+            task_id=task.id,
+            team_id=test_team.id,
+            title="Assistant response",
+            bot_ids=[1],
+            role=SubtaskRole.ASSISTANT,
+            executor_namespace="",
+            executor_name="",
+            prompt="",
+            status=SubtaskStatus.RUNNING,
+            progress=10,
+            message_id=1,
+            parent_id=0,
+            error_message="",
+            completed_at=datetime(1970, 1, 1, 0, 0, 0),
+            result=None,
+            sender_type=SenderType.TEAM,
+            sender_user_id=0,
+        )
+        test_db.add(running_subtask)
+        test_db.commit()
+        test_db.refresh(task)
+
+        runtime_client = MagicMock()
+        runtime_client.get_sandbox = AsyncMock(return_value=(None, None))
+        runtime_client.delete_sandbox = AsyncMock(return_value=(True, None))
+        runtime_client.cleanup_sandbox_by_task_id = AsyncMock(
+            return_value={"deleted": True}
+        )
+
+        with patch(
+            "app.services.execution.get_executor_runtime_client",
+            return_value=runtime_client,
+        ):
+            response = test_client.delete(
+                f"/api/v1/responses/resp_{task.id}",
+                headers={"X-API-Key": test_api_key[0]},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["deleted"] is True
+        runtime_client.cleanup_sandbox_by_task_id.assert_awaited_once_with(
+            task_id=task.id,
+            archive_before_delete=False,
+        )
+
     def test_delete_response_user_isolation(
         self,
         test_client: TestClient,

--- a/backend/tests/services/adapters/test_task_kinds_delete_runtime.py
+++ b/backend/tests/services/adapters/test_task_kinds_delete_runtime.py
@@ -145,3 +145,63 @@ def test_delete_task_falls_back_to_executor_cleanup_when_no_sandbox():
         "wb-plat-ide",
     )
     db.commit.assert_called_once()
+
+
+@pytest.mark.unit
+def test_delete_task_cleans_runtime_by_task_id_when_executor_binding_missing():
+    service = TaskKindsService(Kind)
+    db = Mock(spec=Session)
+    task = _create_mock_task_resource(102, 1)
+    subtask = Mock(spec=Subtask)
+    subtask.task_id = 102
+    subtask.executor_name = None
+    subtask.executor_namespace = None
+    subtask.executor_deleted_at = False
+
+    task_query = MagicMock()
+    task_query.filter.return_value = task_query
+    task_query.first.return_value = task
+
+    subtask_query = MagicMock()
+    subtask_query.filter.return_value = subtask_query
+    subtask_query.all.return_value = [subtask]
+    subtask_query.update.return_value = 1
+
+    def query_side_effect(model):
+        if model == TaskResource:
+            return task_query
+        if model == Subtask:
+            return subtask_query
+        raise AssertionError(f"Unexpected model query: {model}")
+
+    db.query.side_effect = query_side_effect
+
+    with (
+        patch.object(service, "_cleanup_task_memories"),
+        patch("app.stores.tasks.sqlalchemy_task_store.flag_modified"),
+        patch(
+            "app.services.execution.get_executor_runtime_client"
+        ) as runtime_client_factory,
+        patch(
+            "app.services.adapters.task_kinds.operations.executor_kinds_service"
+        ) as executor_service,
+    ):
+        runtime_client = MagicMock()
+        runtime_client.get_sandbox = AsyncMock(return_value=(None, None))
+        runtime_client.delete_sandbox = AsyncMock(return_value=(True, None))
+        runtime_client.cleanup_sandbox_by_task_id = AsyncMock(
+            return_value={"deleted": True}
+        )
+        runtime_client_factory.return_value = runtime_client
+        executor_service.delete_executor_task_sync.return_value = {"status": "success"}
+
+        service.delete_task(db=db, task_id=102, user_id=1)
+
+    runtime_client.get_sandbox.assert_awaited_once_with("102")
+    runtime_client.delete_sandbox.assert_not_awaited()
+    executor_service.delete_executor_task_sync.assert_not_called()
+    runtime_client.cleanup_sandbox_by_task_id.assert_awaited_once_with(
+        task_id=102,
+        archive_before_delete=False,
+    )
+    db.commit.assert_called_once()


### PR DESCRIPTION
Task: 3IM6LBSswE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a response/task now cleans up its runtime sandbox even when executor binding information is missing.
  * Improved delete handling so cleanup still succeeds when the usual executor-based path cannot run.
  * Verified the delete endpoint returns success and completes sandbox cleanup as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->