### PR TITLE
fix(backend): keep successful claude tasks completed despite preview gaps

### DIFF
--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -1327,6 +1327,7 @@ class SessionManager:
         subtask_id: int,
         *,
         termination_reason: Optional[str] = None,
+        terminal_status: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Finalize any pending text block and return all blocks.
 
@@ -1351,6 +1352,7 @@ class SessionManager:
                 blocks = self._finalize_unresolved_preview_tool_blocks(
                     blocks,
                     termination_reason=termination_reason,
+                    terminal_status=terminal_status,
                 )
                 logger.info(
                     f"[SessionManager] Finalized blocks for subtask {subtask_id}: "
@@ -1370,12 +1372,18 @@ class SessionManager:
         blocks: List[Dict[str, Any]],
         *,
         termination_reason: Optional[str] = None,
+        terminal_status: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Convert unresolved preview-only tool blocks into terminal error blocks.
 
         Preview tool blocks are created while tool arguments stream, before real tool
         execution begins. If the turn ends without a matching TOOL_RESULT, those
         blocks would otherwise stay stuck in a pending state in the final result.
+
+        A successful Claude Code terminal result is authoritative. In that case,
+        unresolved preview-only blocks are treated as display-state loss and
+        closed as done so UI recovery cannot turn a completed task into a failure.
+        Explicit unexecuted-tool termination still stays an error.
 
         Only preview-only blocks without tool_output are rewritten. Legitimate
         pending blocks that already carry a semantic output payload (for example
@@ -1384,6 +1392,7 @@ class SessionManager:
         inferred_tool_limit = (
             termination_reason == "completed_with_unexecuted_tool_calls"
         )
+        successful_terminal = str(terminal_status or "").upper() == "COMPLETED"
         has_explicit_tool_error = any(
             block.get("type") == "tool"
             and block.get("status") == BlockStatus.ERROR.value
@@ -1402,6 +1411,14 @@ class SessionManager:
                 and block.get("status") in UNRESOLVED_PREVIEW_TOOL_BLOCK_STATUSES
                 and not block.get("tool_output")
             ):
+                if successful_terminal and not inferred_tool_limit:
+                    finalized_blocks.append(
+                        {
+                            **block,
+                            "status": BlockStatus.DONE.value,
+                        }
+                    )
+                    continue
                 finalized_blocks.append(
                     {
                         **block,

--- a/backend/app/services/chat/trigger/lifecycle.py
+++ b/backend/app/services/chat/trigger/lifecycle.py
@@ -437,6 +437,7 @@ async def collect_completed_result(
     blocks = await chat_storage.session_manager.finalize_and_get_blocks(
         subtask_id,
         termination_reason=termination_reason,
+        terminal_status=normalized_status,
     )
 
     has_payload = bool(

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -321,6 +321,32 @@ class StatusUpdatingEmitter(ResultEmitter):
                 if render_payload is not None:
                     update_kwargs["render_payload"] = render_payload
                 await session_manager.update_tool_block_status(**update_kwargs)
+        elif event.type == EventType.BLOCK_CREATED.value:
+            block = event.data.get("block") if event.data else None
+            if isinstance(block, dict):
+                await session_manager.add_block(self._subtask_id, block)
+        elif event.type == EventType.BLOCK_UPDATED.value:
+            block_id = event.data.get("block_id") if event.data else None
+            updates = event.data.get("updates") if event.data else None
+            if block_id and isinstance(updates, dict):
+                blocks = await session_manager.get_blocks(self._subtask_id)
+                existing_block = next(
+                    (block for block in blocks if block.get("id") == str(block_id)),
+                    None,
+                )
+                if existing_block is not None:
+                    existing_block.update(updates)
+                    await session_manager.add_block(self._subtask_id, existing_block)
+                else:
+                    await session_manager.add_block(
+                        self._subtask_id,
+                        {
+                            "id": str(block_id),
+                            "type": "tool",
+                            "tool_use_id": str(block_id),
+                            **updates,
+                        },
+                    )
         elif event.type in STREAM_CONTENT_EVENT_TYPES:
             # Content is persisted by the 1s stream storage buffer.
             pass

--- a/backend/tests/services/chat/storage/test_session_blocks.py
+++ b/backend/tests/services/chat/storage/test_session_blocks.py
@@ -333,6 +333,34 @@ async def test_finalize_and_get_blocks_uses_generic_message_without_limit_reason
 
 
 @pytest.mark.asyncio
+async def test_finalize_and_get_blocks_closes_preview_blocks_on_successful_terminal():
+    manager = SessionManager()
+    redis_client = FakeRedisClient()
+    manager._cache = FakeCache(redis_client)
+
+    await manager.add_tool_block(
+        subtask_id=508,
+        tool_use_id="write_1",
+        tool_name="Write",
+        tool_input={"file_path": "/tmp/evals.json"},
+    )
+    await manager.update_tool_block_status(
+        subtask_id=508,
+        tool_use_id="write_1",
+        status="pending",
+        tool_input={"file_path": "/tmp/evals.json"},
+    )
+
+    blocks = await manager.finalize_and_get_blocks(
+        508,
+        terminal_status="COMPLETED",
+    )
+
+    assert blocks[0]["status"] == "done"
+    assert "tool_output" not in blocks[0]
+
+
+@pytest.mark.asyncio
 async def test_finalize_and_get_blocks_uses_generic_message_when_explicit_tool_error_exists():
     manager = SessionManager()
     redis_client = FakeRedisClient()

--- a/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
+++ b/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
@@ -12,7 +12,11 @@ class _SessionManager:
         return ""
 
     async def finalize_and_get_blocks(
-        self, _subtask_id: int, *, termination_reason: str | None = None
+        self,
+        _subtask_id: int,
+        *,
+        termination_reason: str | None = None,
+        terminal_status: str | None = None,
     ) -> list[dict]:
         return [
             {
@@ -44,7 +48,11 @@ class _TextBlockSessionManager:
         return ""
 
     async def finalize_and_get_blocks(
-        self, _subtask_id: int, *, termination_reason: str | None = None
+        self,
+        _subtask_id: int,
+        *,
+        termination_reason: str | None = None,
+        terminal_status: str | None = None,
     ) -> list[dict]:
         return [
             {
@@ -61,7 +69,11 @@ class _OutputTextBlockSessionManager:
         return ""
 
     async def finalize_and_get_blocks(
-        self, _subtask_id: int, *, termination_reason: str | None = None
+        self,
+        _subtask_id: int,
+        *,
+        termination_reason: str | None = None,
+        terminal_status: str | None = None,
     ) -> list[dict]:
         return [
             {

--- a/backend/tests/services/execution/test_status_updating_emitter.py
+++ b/backend/tests/services/execution/test_status_updating_emitter.py
@@ -305,6 +305,71 @@ async def test_tool_events_persist_mcp_protocol_metadata():
 
 
 @pytest.mark.asyncio
+async def test_direct_block_updates_are_persisted_before_done():
+    from app.services.execution.emitters import StatusUpdatingEmitter
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(wrapped=wrapped, task_id=101, subtask_id=202)
+    mock_session_manager = AsyncMock()
+    pending_block = {
+        "id": "call_write_1",
+        "type": "tool",
+        "tool_use_id": "call_write_1",
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/tmp/evals.json"},
+        "status": "pending",
+    }
+    done_block = {
+        **pending_block,
+        "status": "done",
+        "tool_output": "The file has been updated successfully.",
+    }
+
+    mock_session_manager.get_blocks.return_value = [pending_block]
+
+    block_created = ExecutionEvent(
+        type=EventType.BLOCK_CREATED.value,
+        task_id=101,
+        subtask_id=202,
+        data={"block": pending_block},
+    )
+    block_updated = ExecutionEvent(
+        type=EventType.BLOCK_UPDATED.value,
+        task_id=101,
+        subtask_id=202,
+        data={
+            "block_id": "call_write_1",
+            "updates": {
+                "status": "done",
+                "tool_output": "The file has been updated successfully.",
+            },
+        },
+    )
+    done = ExecutionEvent(
+        type=EventType.DONE.value,
+        task_id=101,
+        subtask_id=202,
+    )
+    handle_done = AsyncMock()
+
+    with (
+        patch("app.services.chat.storage.session_manager", mock_session_manager),
+        patch.object(emitter, "_handle_done", new=handle_done),
+    ):
+        await emitter.emit(block_created)
+        await emitter.emit(block_updated)
+        await emitter.emit(done)
+
+    mock_session_manager.add_block.assert_has_awaits(
+        [
+            call(202, pending_block),
+            call(202, done_block),
+        ]
+    )
+    handle_done.assert_awaited_once_with(done)
+
+
+@pytest.mark.asyncio
 async def test_interactive_form_tool_result_persists_render_payload_on_real_tool_block():
     from app.services.execution.emitters import StatusUpdatingEmitter
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool block updates are now saved immediately as events arrive, so the latest block state is reflected sooner.
* **Bug Fixes**
  * Finalized chat results now handle unfinished preview-only tool blocks more accurately.
  * When a run completes successfully, pending preview tool blocks are now marked as done instead of being turned into errors.
* **Tests**
  * Added coverage for successful finalization of preview tool blocks and for persisting direct block updates before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->