### PR TITLE
feat(backend): forward agent (Team) identity headers to model backend

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -459,8 +459,17 @@ class Settings(BaseSettings):
         False  # Force re-initialize YAML resources (delete and recreate)
     )
 
-    # default header
-    EXECUTOR_ENV: str = '{"DEFAULT_HEADERS":{"user":"${task_data.user.name}"}}'
+    # Default headers forwarded to the model backend on every LLM call.
+    # Keys are sent verbatim as HTTP headers (resolved by model_resolver against
+    # task_data). The wegent-agent-* group carries agent (Team) identity; when a
+    # placeholder resolves empty (non-Team paths), the group is dropped downstream.
+    EXECUTOR_ENV: str = (
+        '{"DEFAULT_HEADERS":{'
+        '"user":"${task_data.user.name}",'
+        '"wegent-agent-namespace":"${task_data.team.namespace}",'
+        '"wegent-agent-name":"${task_data.team.name}"'
+        "}}"
+    )
 
     # File upload configuration
     MAX_UPLOAD_FILE_SIZE_MB: int = 100  # Maximum file size in MB

--- a/backend/app/services/chat/config/__init__.py
+++ b/backend/app/services/chat/config/__init__.py
@@ -21,6 +21,7 @@ from .model_resolver import (
     extract_and_process_model_config,
     get_bot_system_prompt,
     get_model_config_for_bot,
+    strip_empty_wegent_headers,
 )
 from .shell_checker import (
     get_shell_type,
@@ -36,6 +37,7 @@ __all__ = [
     "get_bot_system_prompt",
     "extract_and_process_model_config",
     "build_default_headers_with_placeholders",
+    "strip_empty_wegent_headers",
     # Shell checker
     "get_shell_type",
     "get_team_first_bot_shell_type",

--- a/backend/app/services/chat/config/model_resolver.py
+++ b/backend/app/services/chat/config/model_resolver.py
@@ -224,6 +224,37 @@ def build_default_headers_with_placeholders(
     return result_headers
 
 
+# Prefix identifying the agent/team identity header group forwarded to the model
+# backend (e.g. wegent-agent-namespace, wegent-agent-name). New identity fields
+# should reuse this prefix so they share the empty-strip behavior.
+WEGENT_IDENTITY_HEADER_PREFIX = "wegent-agent-"
+
+
+def strip_empty_wegent_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop wegent-agent-* headers whose value is empty.
+
+    Placeholder resolution yields "" when a data source is missing (e.g.
+    non-Team execution paths such as wizard/correction that carry no team
+    context). Emitting blank identity headers is undesirable, so only the
+    wegent-agent-* group is removed when empty; all other headers (including
+    the legacy ``user`` header) keep their existing behavior.
+
+    Args:
+        headers: Default headers after placeholder replacement.
+
+    Returns:
+        Headers with empty wegent-agent-* entries removed.
+    """
+    return {
+        key: value
+        for key, value in headers.items()
+        if not (
+            key.lower().startswith(WEGENT_IDENTITY_HEADER_PREFIX)
+            and (value is None or (isinstance(value, str) and not value.strip()))
+        )
+    }
+
+
 def _process_model_config_placeholders(
     model_config: Dict[str, Any],
     user_id: int,
@@ -269,6 +300,18 @@ def _process_model_config_placeholders(
     if "user" not in effective_task_data:
         effective_task_data = {**effective_task_data, "user": user_info}
 
+    # Expose Team (UI "Agent") identity as a nested object so placeholders can use
+    # the same dotted style as ${task_data.user.name}, e.g. ${task_data.team.name}.
+    # Derived from the flat ExecutionRequest fields; absent context resolves to "".
+    if "team" not in effective_task_data:
+        effective_task_data = {
+            **effective_task_data,
+            "team": {
+                "name": effective_task_data.get("team_name") or "",
+                "namespace": effective_task_data.get("team_namespace") or "",
+            },
+        }
+
     # Build data_sources for placeholder replacement
     # This mirrors the chat.py logic for handling ${user.name}, ${task_data.user.name}, etc.
     data_sources = {
@@ -295,6 +338,9 @@ def _process_model_config_placeholders(
         processed_headers = build_default_headers_with_placeholders(
             raw_default_headers, data_sources
         )
+        # Drop wegent-agent-* identity headers that resolved to empty (e.g. paths
+        # without Team context), so we never emit blank identity headers.
+        processed_headers = strip_empty_wegent_headers(processed_headers)
         model_config["default_headers"] = processed_headers
         logger.info(f"[model_resolver] Processed default_headers with placeholders")
 

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -219,6 +219,8 @@ class TaskRequestBuilder:
             force_override=force_override,
             task_id=task.id,
             team_id=team.id,
+            team_name=team.name,
+            team_namespace=team.namespace,
             runtime_model_config=runtime_model_config,
         )
 
@@ -846,6 +848,8 @@ class TaskRequestBuilder:
         force_override: bool,
         task_id: int,
         team_id: int,
+        team_name: str = "",
+        team_namespace: str | None = None,
         runtime_model_config: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Get model configuration for the bot.
@@ -865,6 +869,8 @@ class TaskRequestBuilder:
             force_override: Whether override takes priority
             task_id: Task ID for placeholder replacement
             team_id: Team ID for placeholder replacement
+            team_name: Team (agent) name for identity header placeholder replacement
+            team_namespace: Team (agent) namespace for identity header replacement
             runtime_model_config: Optional already-resolved runtime model config
 
         Returns:
@@ -897,6 +903,8 @@ class TaskRequestBuilder:
         task_data = ExecutionRequest(
             task_id=task_id,
             team_id=team_id,
+            team_name=team_name,
+            team_namespace=team_namespace,
             user=user_info,
         )
 
@@ -919,6 +927,8 @@ class TaskRequestBuilder:
                 user_name=user_name,
                 task_id=task_id,
                 team_id=team_id,
+                team_name=team_name,
+                team_namespace=team_namespace,
             )
             if secondary_model_config:
                 model_config["secondary_model_config"] = secondary_model_config
@@ -932,6 +942,8 @@ class TaskRequestBuilder:
         user_name: str,
         task_id: int,
         team_id: int,
+        team_name: str = "",
+        team_namespace: str | None = None,
     ) -> dict[str, Any] | None:
         """Get secondary model configuration from bot's secondaryModelRef.
 
@@ -944,6 +956,8 @@ class TaskRequestBuilder:
             user_name: User name for placeholder replacement
             task_id: Task ID for placeholder replacement
             team_id: Team ID for placeholder replacement
+            team_name: Team (agent) name for identity header placeholder replacement
+            team_namespace: Team (agent) namespace for identity header replacement
 
         Returns:
             Secondary model configuration dictionary or None if not configured
@@ -988,6 +1002,8 @@ class TaskRequestBuilder:
         task_data = ExecutionRequest(
             task_id=task_id,
             team_id=team_id,
+            team_name=team_name,
+            team_namespace=team_namespace,
             user=user_info,
         )
 

--- a/backend/app/services/rag/embedding/factory.py
+++ b/backend/app/services/rag/embedding/factory.py
@@ -13,9 +13,6 @@ from llama_index.core.base.embeddings.base import BaseEmbedding
 from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
-from app.services.chat.config.model_resolver import (
-    build_default_headers_with_placeholders,
-)
 from knowledge_engine.embedding.capabilities import (
     embedding_supports_image_input,
     normalize_additional_input_modalities,

--- a/backend/tests/services/chat/test_model_resolver_wegent_headers.py
+++ b/backend/tests/services/chat/test_model_resolver_wegent_headers.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for wegent-agent-* agent identity headers in model_resolver.
+
+Covers:
+- strip_empty_wegent_headers: only wegent-agent-* empty headers are dropped.
+- _process_model_config_placeholders: nested ${task_data.team.*} resolution and
+  the empty-strip behavior for paths without Team context.
+- The EXECUTOR_ENV default declares the identity header group.
+"""
+
+import json
+
+from app.core.config import Settings
+from app.services.chat.config.model_resolver import (
+    _process_model_config_placeholders,
+    strip_empty_wegent_headers,
+)
+from shared.models.execution import ExecutionRequest
+
+# Header keys used by the EXECUTOR_ENV default (see app/core/config.py).
+NS_HEADER = "wegent-agent-namespace"
+NAME_HEADER = "wegent-agent-name"
+
+# Default headers as declared in EXECUTOR_ENV (placeholders, pre-resolution).
+IDENTITY_HEADERS = {
+    "user": "${task_data.user.name}",
+    NS_HEADER: "${task_data.team.namespace}",
+    NAME_HEADER: "${task_data.team.name}",
+}
+
+
+class TestStripEmptyWegentHeaders:
+    """Unit tests for strip_empty_wegent_headers."""
+
+    def test_drops_empty_wegent_header(self):
+        result = strip_empty_wegent_headers({NAME_HEADER: "", NS_HEADER: "default"})
+        assert result == {NS_HEADER: "default"}
+
+    def test_drops_whitespace_only_wegent_header(self):
+        result = strip_empty_wegent_headers({NAME_HEADER: "   "})
+        assert result == {}
+
+    def test_drops_none_wegent_header(self):
+        result = strip_empty_wegent_headers({NAME_HEADER: None})
+        assert result == {}
+
+    def test_keeps_non_empty_wegent_header(self):
+        headers = {NAME_HEADER: "wegent-chat", NS_HEADER: "default"}
+        assert strip_empty_wegent_headers(headers) == headers
+
+    def test_preserves_empty_non_wegent_header(self):
+        # The legacy ``user`` header keeps its existing behavior (not stripped).
+        result = strip_empty_wegent_headers({"user": "", NAME_HEADER: ""})
+        assert result == {"user": ""}
+
+    def test_prefix_match_is_case_insensitive(self):
+        result = strip_empty_wegent_headers({"WEGENT-Agent-Name": ""})
+        assert result == {}
+
+
+class TestTeamPlaceholderResolution:
+    """Integration tests for ${task_data.team.*} resolution via the funnel."""
+
+    def _resolve(self, task_data):
+        model_config = {"default_headers": dict(IDENTITY_HEADERS)}
+        processed = _process_model_config_placeholders(
+            model_config=model_config,
+            user_id=5,
+            user_name="alice",
+            task_data=task_data,
+        )
+        return processed["default_headers"]
+
+    def test_team_context_resolves_identity_headers(self):
+        """teamRef name/namespace -> wegent-agent-name/namespace."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            team_id=2,
+            team_name="wegent-chat",
+            team_namespace="default",
+            user={"id": 5, "name": "alice"},
+        )
+        headers = self._resolve(task_data)
+        assert headers == {
+            "user": "alice",
+            NS_HEADER: "default",
+            NAME_HEADER: "wegent-chat",
+        }
+
+    def test_missing_team_context_strips_identity_headers(self):
+        """No team fields -> identity headers resolve empty and are dropped."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            team_id=2,
+            user={"id": 5, "name": "alice"},
+        )
+        headers = self._resolve(task_data)
+        assert headers == {"user": "alice"}
+
+    def test_none_task_data_strips_identity_headers(self):
+        """Without task_data, user is injected from user_name; team is dropped."""
+        headers = self._resolve(None)
+        assert headers == {"user": "alice"}
+
+
+class TestExecutorEnvDefault:
+    """The shipped EXECUTOR_ENV default declares the identity header group."""
+
+    def test_default_declares_identity_headers(self):
+        default_env = Settings.model_fields["EXECUTOR_ENV"].default
+        parsed = json.loads(default_env)
+        headers = parsed["DEFAULT_HEADERS"]
+        assert headers["user"] == "${task_data.user.name}"
+        assert headers[NS_HEADER] == "${task_data.team.namespace}"
+        assert headers[NAME_HEADER] == "${task_data.team.name}"


### PR DESCRIPTION
Add wegent-agent-namespace / wegent-agent-name to the DEFAULT_HEADERS group so every model call (chat_shell, ClaudeCode, Agno, Codex, Dify) carries the executing agent's Team identity, mirroring the existing `user` header.

- config.py: declare the identity headers in EXECUTOR_ENV via ${task_data.team.namespace} / ${task_data.team.name} placeholders.
- model_resolver.py: expose Team identity as a nested `team` object for placeholder resolution (dotted style, consistent with task_data.user), and add strip_empty_wegent_headers() to drop the wegent-agent-* group when it resolves empty (non-Team paths such as wizard/correction) so we never emit blank identity headers.
- request_builder.py: thread team_name/team_namespace into the task_data used for placeholder resolution (primary and secondary model configs).
- rag/embedding/factory.py: remove dead build_default_headers_with_placeholders import.

Resolution stays centralized in the backend TaskRequestBuilder funnel, so all executor types consume already-resolved headers with zero per-executor changes.

Tests: add test_model_resolver_wegent_headers.py (strip helper, nested team resolution with/without Team context, EXECUTOR_ENV default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved request metadata forwarding so tasks can include user and team identity details in execution headers.
  * Added support for automatically removing empty identity headers when team information is unavailable.

* **Bug Fixes**
  * Prevented empty or blank `wegent-agent-*` headers from being sent.
  * Ensured team-based placeholders resolve correctly for both primary and secondary model configurations.

* **Tests**
  * Added coverage for header cleanup and placeholder resolution across populated and missing team context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->