### PR TITLE
[codex] fix wework project task pane state reset

### DIFF
--- a/wework/src/components/layout/workbenchPaneStack.test.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.test.tsx
@@ -201,6 +201,37 @@ describe('workbenchPaneStack', () => {
     expect(screen.getByTestId('standalone-local-message')).toHaveTextContent('empty')
   })
 
+  test('uses standalone chat key to create a fresh project chat pane', async () => {
+    function RuntimePaneStackProbe() {
+      const [standaloneChatKey, setStandaloneChatKey] = useState(0)
+      return (
+        <div>
+          <button type="button" onClick={() => setStandaloneChatKey(value => value + 1)}>
+            start fresh project chat
+          </button>
+          <CachedWorkbenchPaneStack
+            activePane={{
+              currentRuntimeTask: null,
+              currentProject: { id: 7, name: 'Wegent', tasks: [] },
+              standaloneChatKey,
+            }}
+            maxPanes={2}
+            renderPane={activePane => <StandaloneLocalStatePane pane={activePane} />}
+          />
+        </div>
+      )
+    }
+
+    render(<RuntimePaneStackProbe />)
+
+    await userEvent.click(screen.getByText('seed local message'))
+    expect(screen.getByTestId('standalone-local-message')).toHaveTextContent('hi')
+
+    await userEvent.click(screen.getByText('start fresh project chat'))
+
+    expect(screen.getByTestId('standalone-local-message')).toHaveTextContent('empty')
+  })
+
   test('derives running runtime pane keys from task ids', () => {
     expect(
       getRunningRuntimeWorkbenchPaneKeys({
@@ -214,8 +245,20 @@ describe('workbenchPaneStack', () => {
                 available: true,
                 mapped: true,
                 tasks: [
-                  { taskId: 101, workspacePath: '/workspace/project-alpha', title: 'A', runtime: 'codex', running: true },
-                  { taskId: 102, workspacePath: '/workspace/project-alpha', title: 'B', runtime: 'codex', running: false },
+                  {
+                    taskId: 101,
+                    workspacePath: '/workspace/project-alpha',
+                    title: 'A',
+                    runtime: 'codex',
+                    running: true,
+                  },
+                  {
+                    taskId: 102,
+                    workspacePath: '/workspace/project-alpha',
+                    title: 'B',
+                    runtime: 'codex',
+                    running: false,
+                  },
                 ],
               },
             ],

--- a/wework/src/components/layout/workbenchPaneStack.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.tsx
@@ -27,7 +27,10 @@ export function getWorkbenchPaneKey({
   if (currentRuntimeTask) {
     return ['runtime', currentRuntimeTask.deviceId, currentRuntimeTask.taskId].join(':')
   }
-  return currentProject ? `project:${currentProject.id}` : `standalone:${standaloneChatKey ?? 0}`
+  const blankPaneKey = standaloneChatKey ?? 0
+  return currentProject
+    ? `project:${currentProject.id}:${blankPaneKey}`
+    : `standalone:${blankPaneKey}`
 }
 
 export function getRunningRuntimeWorkbenchPaneKeys(

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -692,6 +692,9 @@ function RuntimePaneStackItem({ pane }: { pane: WorkbenchPaneIdentity }) {
       <button type="button" onClick={() => workbench.selectProjectWorkspace(7, 22)}>
         select mapped project workspace
       </button>
+      <button type="button" onClick={() => workbench.startNewProjectChat(7)}>
+        start new project task
+      </button>
       <button type="button" onClick={() => void paneSession.setCurrentGoal()}>
         set pane goal
       </button>
@@ -2221,6 +2224,74 @@ describe('WorkbenchProvider runtime tasks', () => {
       )
     )
     expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+  })
+
+  test('starts a fresh project pane after creating a runtime task in the same project', async () => {
+    const initialRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              tasks: [],
+            },
+          ],
+          totalTasks: 0,
+        },
+      ],
+      chats: [],
+      totalTasks: 0,
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(initialRuntimeWork),
+      createRuntimeTask: vi.fn().mockResolvedValue({
+        accepted: true,
+        deviceId: 'device-1',
+        taskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+      }),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimePaneSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
+    await userEvent.click(await screen.findByText('select mapped project workspace'))
+    await userEvent.click(screen.getByText('set pane input'))
+    await userEvent.click(screen.getByText('send pane input'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:runtime-created:/workspace/project-alpha'
+      )
+    )
+    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+
+    await userEvent.click(screen.getByText('start new project task'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent('none')
+    )
+    expect(screen.getByTestId('active-pane-key')).toHaveTextContent('project:7')
+    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('')
+    expect(screen.getByTestId('pane-goal-draft-active')).toHaveTextContent('inactive')
   })
 
   test('keeps streamed assistant content when the resolved address adds a workspace path', async () => {

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -1028,6 +1028,7 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
         pendingProjectWorkspaceProjectId: null,
         standaloneWorkspacePath: null,
         currentRuntimeTask: null,
+        standaloneChatKey: state.standaloneChatKey + 1,
       }
     case 'device_workspace_prepared':
       return {
@@ -1074,6 +1075,7 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
           action.deviceWorkspaceId === null ? action.project.id : null,
         standaloneWorkspacePath: null,
         currentRuntimeTask: null,
+        standaloneChatKey: state.standaloneChatKey + 1,
       }
     case 'project_updated':
       return {


### PR DESCRIPTION
## Summary

Fixes stale Wework project task UI state when starting a new task in the same project after an existing runtime task has been opened or started.

## Root Cause

Desktop workbench panes were cached by `project:${id}` for blank project chats. Starting a new task in the same project reused the same cached pane, so pane-local state such as messages, goal draft state, and active assistant status could leak from the previous task.

## Changes

- Include the blank chat generation key in project pane cache keys.
- Increment the blank chat generation when selecting a project or project workspace for a new task.
- Add regression coverage for fresh project panes and same-project runtime task reset behavior.

## Validation

- `pnpm --filter wework test -- wework/src/components/layout/workbenchPaneStack.test.tsx wework/src/features/workbench/WorkbenchProvider.test.tsx`
  - Result: 119 test files / 1180 tests passed.
- Pre-push hook:
  - ESLint passed.
  - TypeScript check passed.
  - Unit tests passed.

Documentation was reviewed; this is an internal UI state bug fix with no user-facing workflow, configuration, or documented behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Starting a new project chat now opens a fresh conversation and resets prior messages.
  * Switching projects or project workspaces now creates a new chat session for the selected project.

* **Bug Fixes**
  * Fixed pane switching so project chat state no longer carries over between different project selections.
  * Improved pane identity handling to ensure the correct project chat is shown after starting over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->