### PR TITLE
[codex] add Wework E2E Response API mock

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -1,0 +1,100 @@
+name: Wework E2E
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+    paths:
+      - '.github/workflows/wework-e2e.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'packages/chat-core/**'
+      - 'wework/**'
+  pull_request:
+    branches:
+      - main
+      - master
+      - develop
+    paths:
+      - '.github/workflows/wework-e2e.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'packages/chat-core/**'
+      - 'wework/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  wework-e2e:
+    name: Wework E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-wework-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-wework-playwright-
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./wework
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: ./wework
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run Wework E2E tests
+        env:
+          CI: true
+        run: pnpm --filter wework e2e
+
+      - name: Upload Wework Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-playwright-report
+          path: wework/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Wework Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-playwright-traces
+          path: wework/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Wegent is an open-source AI-native operating system for defining, organizing, an
 - English version: [`docs/en/developer-guide/wework-cloud-connection.md`](docs/en/developer-guide/wework-cloud-connection.md)
 - Wework performance diagnostics: [`docs/zh/developer-guide/wework-performance-diagnostics.md`](docs/zh/developer-guide/wework-performance-diagnostics.md)
 - English version: [`docs/en/developer-guide/wework-performance-diagnostics.md`](docs/en/developer-guide/wework-performance-diagnostics.md)
+- Wework E2E automation: [`docs/zh/developer-guide/wework-e2e-automation.md`](docs/zh/developer-guide/wework-e2e-automation.md)
+- English version: [`docs/en/developer-guide/wework-e2e-automation.md`](docs/en/developer-guide/wework-e2e-automation.md)
 - Wework chat state sources: [`docs/zh/developer-guide/wework-chat-state-sources.md`](docs/zh/developer-guide/wework-chat-state-sources.md)
 - English version: [`docs/en/developer-guide/wework-chat-state-sources.md`](docs/en/developer-guide/wework-chat-state-sources.md)
 

--- a/docs/en/developer-guide/wework-e2e-automation.md
+++ b/docs/en/developer-guide/wework-e2e-automation.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 34
+---
+
+# E2E Automation
+
+Wework provides a dedicated Playwright E2E entrypoint and a test-only frontend automation bridge for operating the Wework Vite/React frontend in CI. The default entrypoint runs in browser mode, which covers most frontend interactions; native window behavior should be covered separately with Tauri/WebDriver tests when needed.
+
+## Running Tests
+
+Install the Playwright browser before the first run:
+
+```bash
+pnpm --filter wework exec playwright install chromium
+```
+
+Run Wework E2E:
+
+```bash
+pnpm --filter wework e2e
+```
+
+The command starts a test-only Vite server through `wework/playwright.config.ts`:
+
+```bash
+pnpm exec vite --host 127.0.0.1 --port 4174 --mode e2e
+```
+
+It also starts a Responses API mock:
+
+```bash
+node e2e/utils/mock-response-api-server.mjs
+```
+
+Default configuration:
+
+- `VITE_WEWORK_E2E=true`
+- `VITE_WEWORK_RUNTIME_MODE=backend`
+- `VITE_LOGIN_MODE=password`
+- `WEWORK_RESPONSE_API_MOCK_URL=http://127.0.0.1:9998`
+
+Tests do not mock backend APIs. When Backend is not running, the login-page smoke test only verifies that the frontend renders the login entrypoint. Business flows after login must start a real Backend and required services in CI.
+
+## Responses API Mock
+
+`wework/e2e/utils/mock-response-api-server.mjs` provides a real HTTP service that simulates the OpenAI Responses API:
+
+- `POST /v1/responses`: returns non-streaming Responses API JSON.
+- `POST /v1/responses` with `stream: true`: returns `text/event-stream` events including `response.created`, `response.output_text.delta`, and `response.completed`.
+- `GET /captured-requests`: reads captured requests.
+- `POST /clear-requests`: clears captured requests.
+- `GET /health`: CI health check.
+
+The mock enables CORS, so the Wework page can call it with a real browser `fetch`. For model connection tests, use this base URL:
+
+```text
+http://127.0.0.1:9998/v1
+```
+
+## Automation Bridge
+
+In test mode, Wework exposes a frontend control bridge at `window.__WEWORK_E2E__`. The bridge is installed only when `import.meta.env.MODE === "e2e"` or `VITE_WEWORK_E2E=true`; normal development and production runs do not enable it by default.
+
+Available methods:
+
+- `isTauri()`: returns whether the app is running in Tauri.
+- `getRuntimeConfig()`: reads the current runtime config.
+- `getRoute()`: returns the current route with the app base path removed.
+- `navigate(path)`: changes route through frontend history and dispatches navigation events.
+- `waitForTestId(testId, options)`: waits for a `data-testid` to appear.
+- `queryTestIds(prefix)`: lists current `data-testid` values, optionally filtered by prefix.
+- `setAuthToken(token)`: stores a real auth token.
+- `clearAuthToken()`: clears the auth token.
+- `clearStorage()`: clears local auth state and browser storage.
+
+## Test Helper
+
+`wework/e2e/fixtures/wework-app.ts` provides a `WeworkApp` Playwright helper that wraps `window.__WEWORK_E2E__` in typed test operations:
+
+```ts
+const app = new WeworkApp(page)
+
+await app.goto("/")
+await app.waitForTestId("login-form")
+await app.navigate("/apps")
+const route = await app.route()
+```
+
+New E2E tests should prefer this helper and `data-testid` locators instead of unstable CSS selectors or visible copy.
+
+## CI Guidance
+
+CI can run Wework E2E as a separate job:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter wework exec playwright install chromium
+pnpm --filter wework e2e
+```
+
+The repository includes a basic workflow at `.github/workflows/wework-e2e.yml`. It runs when Wework, `packages/chat-core`, the pnpm lockfile, or the workflow itself changes.
+
+Authenticated flows should create users and data through backend APIs before the test, then use real login or a real token injection. Do not mock backend HTTP responses in Playwright.

--- a/docs/zh/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/developer-guide/wework-e2e-automation.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 34
+---
+
+# E2E 自动化
+
+Wework 提供独立的 Playwright E2E 入口和测试专用前端自动化接口，用于在 CI 中稳定操作 Wework 的 Vite/React 前端。默认入口运行在浏览器模式，适合覆盖大多数前端交互；需要验证原生窗口能力时，再单独接入 Tauri/WebDriver 测试。
+
+## 运行方式
+
+首次运行需要安装 Playwright 浏览器：
+
+```bash
+pnpm --filter wework exec playwright install chromium
+```
+
+运行 Wework E2E：
+
+```bash
+pnpm --filter wework e2e
+```
+
+该命令会通过 `wework/playwright.config.ts` 启动测试专用 Vite 服务：
+
+```bash
+pnpm exec vite --host 127.0.0.1 --port 4174 --mode e2e
+```
+
+同时会启动 Responses API mock：
+
+```bash
+node e2e/utils/mock-response-api-server.mjs
+```
+
+配置默认设置：
+
+- `VITE_WEWORK_E2E=true`
+- `VITE_WEWORK_RUNTIME_MODE=backend`
+- `VITE_LOGIN_MODE=password`
+- `WEWORK_RESPONSE_API_MOCK_URL=http://127.0.0.1:9998`
+
+测试不 mock 后端 API。没有启动 Backend 时，登录页 smoke 测试只验证前端能渲染登录入口；需要登录后的业务流程时，CI 必须先启动真实 Backend 和依赖服务。
+
+## Responses API Mock
+
+`wework/e2e/utils/mock-response-api-server.mjs` 提供真实 HTTP 服务，用于模拟 OpenAI Responses API：
+
+- `POST /v1/responses`：返回非流式 Responses API JSON。
+- `POST /v1/responses` 且 `stream: true`：返回 `text/event-stream`，事件包含 `response.created`、`response.output_text.delta` 和 `response.completed`。
+- `GET /captured-requests`：读取已捕获请求。
+- `POST /clear-requests`：清空捕获请求。
+- `GET /health`：CI health check。
+
+该 mock 开启 CORS，因此 Wework 页面可以直接从浏览器环境发起真实 `fetch`。测试模型配置时，base URL 使用：
+
+```text
+http://127.0.0.1:9998/v1
+```
+
+## 自动化接口
+
+测试模式下，Wework 会在 `window.__WEWORK_E2E__` 暴露前端控制接口。该接口只在 `import.meta.env.MODE === "e2e"` 或 `VITE_WEWORK_E2E=true` 时安装，普通开发和生产运行不会默认启用。
+
+可用方法：
+
+- `isTauri()`：返回当前是否运行在 Tauri 环境。
+- `getRuntimeConfig()`：读取当前运行配置。
+- `getRoute()`：返回去掉 app base path 后的当前路由。
+- `navigate(path)`：通过前端 history 切换路由，并派发导航事件。
+- `waitForTestId(testId, options)`：等待指定 `data-testid` 出现。
+- `queryTestIds(prefix)`：列出当前页面中的 `data-testid`，可按前缀过滤。
+- `setAuthToken(token)`：写入真实认证 token。
+- `clearAuthToken()`：清除认证 token。
+- `clearStorage()`：清空本地认证和浏览器存储。
+
+## 测试封装
+
+`wework/e2e/fixtures/wework-app.ts` 提供 `WeworkApp` Playwright helper，用于把 `window.__WEWORK_E2E__` 封装成类型安全的测试操作：
+
+```ts
+const app = new WeworkApp(page)
+
+await app.goto("/")
+await app.waitForTestId("login-form")
+await app.navigate("/apps")
+const route = await app.route()
+```
+
+新增 E2E 用例应优先使用该 helper 和 `data-testid` 定位，不要依赖易变的 CSS 选择器或可见文案。
+
+## CI 建议
+
+CI 可以把 Wework E2E 作为独立 job：
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter wework exec playwright install chromium
+pnpm --filter wework e2e
+```
+
+仓库内的基础 workflow 是 `.github/workflows/wework-e2e.yml`，会在 Wework、`packages/chat-core`、pnpm lockfile 或 workflow 自身变化时运行。
+
+登录后流程应在测试前通过后端 API 创建测试用户和测试数据，再使用真实登录或真实 token 注入。不要在 Playwright 中 mock 后端 HTTP 响应。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       "@eslint/js":
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@1.21.7))
+      "@playwright/test":
+        specifier: ^1.57.0
+        version: 1.60.0
       "@tauri-apps/cli":
         specifier: ^2.11.2
         version: 2.11.2

--- a/wework/.gitignore
+++ b/wework/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+playwright-report/
+test-results/
+
 # Vite cache
 .vite
 

--- a/wework/e2e/fixtures/wework-app.ts
+++ b/wework/e2e/fixtures/wework-app.ts
@@ -38,6 +38,9 @@ declare global {
       testLocalModelConnection: (
         input: TestLocalModelConnectionInput
       ) => Promise<TestLocalModelConnectionResult>
+      tripLocalModelConnectionCircuitBreaker: (
+        input: TestLocalModelConnectionInput
+      ) => Promise<TestLocalModelConnectionResult>
     }
   }
 }
@@ -82,6 +85,13 @@ export class WeworkApp {
   async testLocalModelConnection(input: TestLocalModelConnectionInput) {
     return this.page.evaluate(
       value => window.__WEWORK_E2E__?.testLocalModelConnection(value),
+      input
+    )
+  }
+
+  async tripLocalModelConnectionCircuitBreaker(input: TestLocalModelConnectionInput) {
+    return this.page.evaluate(
+      value => window.__WEWORK_E2E__?.tripLocalModelConnectionCircuitBreaker(value),
       input
     )
   }

--- a/wework/e2e/fixtures/wework-app.ts
+++ b/wework/e2e/fixtures/wework-app.ts
@@ -1,0 +1,68 @@
+import { expect, type Page } from '@playwright/test'
+
+type BridgeRuntimeConfig = {
+  appBasePath: string
+  apiBaseUrl: string
+  socketBaseUrl: string
+  socketPath: string
+  runtimeMode: 'local-first' | 'backend'
+  loginMode: 'password' | 'oidc' | 'all'
+  oidcLoginText: string
+  cloudDeviceScalingWikiUrl: string
+}
+
+declare global {
+  interface Window {
+    __WEWORK_E2E__?: {
+      version: 1
+      isEnabled: true
+      isTauri: () => boolean
+      getRuntimeConfig: () => BridgeRuntimeConfig
+      getRoute: () => string
+      navigate: (path: string) => string
+      waitForTestId: (testId: string, options?: { timeoutMs?: number }) => Promise<boolean>
+      queryTestIds: (prefix?: string) => string[]
+      setAuthToken: (token: string) => void
+      clearAuthToken: () => void
+      clearStorage: () => void
+    }
+  }
+}
+
+export class WeworkApp {
+  constructor(private readonly page: Page) {}
+
+  async goto(path = '/') {
+    await this.page.goto(path)
+    await this.waitForBridge()
+  }
+
+  async waitForBridge() {
+    await expect
+      .poll(() => this.page.evaluate(() => Boolean(window.__WEWORK_E2E__?.isEnabled)))
+      .toBe(true)
+  }
+
+  async route() {
+    return this.page.evaluate(() => window.__WEWORK_E2E__?.getRoute() ?? window.location.pathname)
+  }
+
+  async runtimeConfig() {
+    return this.page.evaluate(() => window.__WEWORK_E2E__?.getRuntimeConfig())
+  }
+
+  async navigate(path: string) {
+    await this.page.evaluate(nextPath => window.__WEWORK_E2E__?.navigate(nextPath), path)
+  }
+
+  async waitForTestId(testId: string, timeoutMs = 5000) {
+    await this.page.evaluate(
+      ([id, timeout]) => window.__WEWORK_E2E__?.waitForTestId(id, { timeoutMs: timeout }),
+      [testId, timeoutMs] as const
+    )
+  }
+
+  async testIds(prefix?: string) {
+    return this.page.evaluate(value => window.__WEWORK_E2E__?.queryTestIds(value) ?? [], prefix)
+  }
+}

--- a/wework/e2e/fixtures/wework-app.ts
+++ b/wework/e2e/fixtures/wework-app.ts
@@ -11,6 +11,16 @@ type BridgeRuntimeConfig = {
   cloudDeviceScalingWikiUrl: string
 }
 
+type TestLocalModelConnectionInput = {
+  baseUrl: string
+  modelId: string
+  apiKey?: string | null
+}
+
+type TestLocalModelConnectionResult = {
+  status: number
+}
+
 declare global {
   interface Window {
     __WEWORK_E2E__?: {
@@ -25,6 +35,9 @@ declare global {
       setAuthToken: (token: string) => void
       clearAuthToken: () => void
       clearStorage: () => void
+      testLocalModelConnection: (
+        input: TestLocalModelConnectionInput
+      ) => Promise<TestLocalModelConnectionResult>
     }
   }
 }
@@ -64,5 +77,12 @@ export class WeworkApp {
 
   async testIds(prefix?: string) {
     return this.page.evaluate(value => window.__WEWORK_E2E__?.queryTestIds(value) ?? [], prefix)
+  }
+
+  async testLocalModelConnection(input: TestLocalModelConnectionInput) {
+    return this.page.evaluate(
+      value => window.__WEWORK_E2E__?.testLocalModelConnection(value),
+      input
+    )
   }
 }

--- a/wework/e2e/tests/app-shell.spec.ts
+++ b/wework/e2e/tests/app-shell.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+import { WeworkApp } from '../fixtures/wework-app'
+
+test('exposes a CI automation bridge and renders the login route without Tauri', async ({
+  page,
+}) => {
+  const app = new WeworkApp(page)
+
+  await app.goto('/')
+
+  await expect(page.getByTestId('login-form')).toBeVisible()
+  await expect(page.getByTestId('login-username-input')).toBeVisible()
+  await expect(page.getByTestId('login-password-input')).toBeVisible()
+
+  await expect.poll(() => app.route()).toBe('/login')
+  await expect.poll(async () => (await app.runtimeConfig())?.runtimeMode).toBe('backend')
+
+  const loginTestIds = await app.testIds('login-')
+  expect(loginTestIds).toContain('login-form')
+  expect(loginTestIds).toContain('login-submit-button')
+})

--- a/wework/e2e/tests/response-api-mock.spec.ts
+++ b/wework/e2e/tests/response-api-mock.spec.ts
@@ -68,6 +68,42 @@ test('serves browser-accessible OpenAI Responses API mock responses', async ({ p
   })
 })
 
+test('sends local model connection tests through the Wework Responses API path', async ({
+  page,
+}) => {
+  const app = new WeworkApp(page)
+
+  await app.goto('/')
+
+  await page.evaluate(async mockUrl => {
+    await fetch(`${mockUrl}/clear-requests`, { method: 'POST' })
+  }, responseApiMockUrl)
+
+  const result = await app.testLocalModelConnection({
+    baseUrl: `${responseApiMockUrl}/v1`,
+    modelId: 'mock-response-model',
+    apiKey: 'test-token',
+  })
+
+  const captured = await page.evaluate(
+    async mockUrl => fetch(`${mockUrl}/captured-requests`).then(res => res.json()),
+    responseApiMockUrl
+  )
+
+  expect(result).toEqual({ status: 200 })
+  const matchingRequests = (captured as CapturedRequest[]).filter(request =>
+    JSON.stringify(request.body).includes('Reply with ok.')
+  )
+  expect(matchingRequests).toHaveLength(1)
+  expect(matchingRequests[0]).toMatchObject({
+    method: 'POST',
+    url: '/v1/responses',
+    body: {
+      model: 'mock-response-model',
+    },
+  })
+})
+
 test('streams OpenAI Responses API events from the mock server', async ({ page }) => {
   const app = new WeworkApp(page)
 

--- a/wework/e2e/tests/response-api-mock.spec.ts
+++ b/wework/e2e/tests/response-api-mock.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test'
+import { WeworkApp } from '../fixtures/wework-app'
+
+const responseApiMockUrl = process.env.WEWORK_RESPONSE_API_MOCK_URL || 'http://127.0.0.1:9998'
+
+type CapturedRequest = {
+  method: string
+  url: string
+  body: {
+    model?: string
+    input?: unknown
+  } | null
+}
+
+test('serves browser-accessible OpenAI Responses API mock responses', async ({ page }) => {
+  const app = new WeworkApp(page)
+
+  await app.goto('/')
+
+  const result = await page.evaluate(async mockUrl => {
+    await fetch(`${mockUrl}/clear-requests`, { method: 'POST' })
+
+    const response = await fetch(`${mockUrl}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+      },
+      body: JSON.stringify({
+        model: 'mock-response-model',
+        input: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'Remember CTX_WEWORK_E2E.',
+              },
+            ],
+          },
+        ],
+        store: false,
+      }),
+    })
+
+    const body = await response.json()
+    const captured = await fetch(`${mockUrl}/captured-requests`).then(res => res.json())
+
+    return {
+      status: response.status,
+      outputText: body.output_text,
+      captured,
+    }
+  }, responseApiMockUrl)
+
+  expect(result.status).toBe(200)
+  expect(result.outputText).toContain('CTX_WEWORK_E2E')
+  const matchingRequests = (result.captured as CapturedRequest[]).filter(request =>
+    JSON.stringify(request.body).includes('CTX_WEWORK_E2E')
+  )
+  expect(matchingRequests).toHaveLength(1)
+  expect(matchingRequests[0]).toMatchObject({
+    method: 'POST',
+    url: '/v1/responses',
+    body: {
+      model: 'mock-response-model',
+    },
+  })
+})
+
+test('streams OpenAI Responses API events from the mock server', async ({ page }) => {
+  const app = new WeworkApp(page)
+
+  await app.goto('/')
+
+  const streamText = await page.evaluate(async mockUrl => {
+    const response = await fetch(`${mockUrl}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+      },
+      body: JSON.stringify({
+        model: 'mock-response-model',
+        input: 'Stream CTX_WEWORK_STREAM.',
+        stream: true,
+        store: false,
+      }),
+    })
+
+    const reader = response.body?.getReader()
+    if (!reader) {
+      throw new Error('Expected a readable response body')
+    }
+
+    const decoder = new TextDecoder()
+    let text = ''
+
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) {
+        break
+      }
+      text += decoder.decode(value, { stream: true })
+    }
+
+    text += decoder.decode()
+    return text
+  }, responseApiMockUrl)
+
+  expect(streamText).toContain('response.created')
+  expect(streamText).toContain('response.output_text.delta')
+  expect(streamText).toContain('response.completed')
+  expect(streamText).toContain('[DONE]')
+})

--- a/wework/e2e/tests/response-api-mock.spec.ts
+++ b/wework/e2e/tests/response-api-mock.spec.ts
@@ -75,33 +75,38 @@ test('sends local model connection tests through the Wework Responses API path',
 
   await app.goto('/')
 
-  await page.evaluate(async mockUrl => {
-    await fetch(`${mockUrl}/clear-requests`, { method: 'POST' })
-  }, responseApiMockUrl)
-
-  const result = await app.testLocalModelConnection({
-    baseUrl: `${responseApiMockUrl}/v1`,
-    modelId: 'mock-response-model',
-    apiKey: 'test-token',
-  })
-
-  const captured = await page.evaluate(
-    async mockUrl => fetch(`${mockUrl}/captured-requests`).then(res => res.json()),
-    responseApiMockUrl
-  )
+  const [request, result] = await Promise.all([
+    page.waitForRequest(
+      candidate =>
+        candidate.method() === 'POST' &&
+        candidate.url() === `${responseApiMockUrl}/v1/responses`
+    ),
+    app.testLocalModelConnection({
+      baseUrl: `${responseApiMockUrl}/v1`,
+      modelId: 'mock-response-model',
+      apiKey: 'test-token',
+    }),
+  ])
 
   expect(result).toEqual({ status: 200 })
-  const matchingRequests = (captured as CapturedRequest[]).filter(request =>
-    JSON.stringify(request.body).includes('Reply with ok.')
-  )
-  expect(matchingRequests).toHaveLength(1)
-  expect(matchingRequests[0]).toMatchObject({
-    method: 'POST',
-    url: '/v1/responses',
-    body: {
-      model: 'mock-response-model',
-    },
+  expect(request.postDataJSON()).toMatchObject({
+    model: 'mock-response-model',
   })
+  expect(request.postData()).toContain('Reply with ok.')
+})
+
+test('surfaces local model send circuit breaker failures', async ({ page }) => {
+  const app = new WeworkApp(page)
+
+  await app.goto('/')
+
+  await expect(
+    app.tripLocalModelConnectionCircuitBreaker({
+      baseUrl: `${responseApiMockUrl}/v1`,
+      modelId: 'mock-response-model',
+      apiKey: 'test-token',
+    })
+  ).rejects.toThrow('WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN')
 })
 
 test('streams OpenAI Responses API events from the mock server', async ({ page }) => {

--- a/wework/e2e/utils/mock-response-api-server.mjs
+++ b/wework/e2e/utils/mock-response-api-server.mjs
@@ -1,0 +1,241 @@
+import http from 'node:http'
+
+const PORT = Number.parseInt(process.env.WEWORK_RESPONSE_API_MOCK_PORT || '9998', 10)
+const DEFAULT_RESPONSE_CONTENT =
+  process.env.WEWORK_RESPONSE_API_MOCK_CONTENT ||
+  'Mock Responses API reply from the Wework E2E server.'
+const DEFAULT_CHUNK_DELAY_MS = 20
+
+const capturedRequests = []
+
+function corsHeaders(extra = {}) {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+    ...extra,
+  }
+}
+
+function writeJson(res, status, data) {
+  res.writeHead(status, corsHeaders({ 'Content-Type': 'application/json' }))
+  res.end(JSON.stringify(data, null, 2))
+}
+
+function writeOptions(res) {
+  res.writeHead(204, corsHeaders())
+  res.end()
+}
+
+function parseJsonBody(body) {
+  try {
+    return body ? JSON.parse(body) : null
+  } catch {
+    return null
+  }
+}
+
+function extractText(value) {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => extractText(item)).filter(Boolean).join(' ')
+  }
+
+  if (value && typeof value === 'object') {
+    return ['input', 'content', 'text', 'message', 'prompt']
+      .map(key => extractText(value[key]))
+      .filter(Boolean)
+      .join(' ')
+  }
+
+  return ''
+}
+
+function responseContent(request) {
+  const requestText = extractText(request)
+  const token = requestText.match(/CTX_[A-Z0-9_]+/)?.[0]
+  if (token) {
+    return `Mock Responses API remembered ${token}`
+  }
+  return DEFAULT_RESPONSE_CONTENT
+}
+
+function responseBody(request, content) {
+  const createdAt = Math.floor(Date.now() / 1000)
+  return {
+    id: `resp_mock_${createdAt}`,
+    object: 'response',
+    created_at: createdAt,
+    status: 'completed',
+    model: request?.model || 'mock-response-model',
+    output: [
+      {
+        id: `msg_mock_${createdAt}`,
+        type: 'message',
+        status: 'completed',
+        role: 'assistant',
+        content: [
+          {
+            type: 'output_text',
+            text: content,
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    output_text: content,
+    usage: {
+      input_tokens: 12,
+      output_tokens: Math.max(1, content.split(/\s+/).length),
+      total_tokens: 12 + Math.max(1, content.split(/\s+/).length),
+    },
+  }
+}
+
+function writeSseEvent(res, event) {
+  res.write(`data: ${JSON.stringify(event)}\n\n`)
+}
+
+function writeStreamingResponsesApi(res, request, content) {
+  const response = responseBody(request, content)
+  res.writeHead(
+    200,
+    corsHeaders({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    })
+  )
+
+  writeSseEvent(res, {
+    type: 'response.created',
+    response: { ...response, status: 'in_progress', output: [] },
+  })
+  writeSseEvent(res, {
+    type: 'response.output_item.added',
+    output_index: 0,
+    item: response.output[0],
+  })
+  writeSseEvent(res, {
+    type: 'response.content_part.added',
+    item_id: response.output[0].id,
+    output_index: 0,
+    content_index: 0,
+    part: response.output[0].content[0],
+  })
+
+  const chunks = content.split(' ')
+  let index = 0
+
+  const sendNextChunk = () => {
+    if (index < chunks.length) {
+      const delta = index === 0 ? chunks[index] : ` ${chunks[index]}`
+      writeSseEvent(res, {
+        type: 'response.output_text.delta',
+        item_id: response.output[0].id,
+        output_index: 0,
+        content_index: 0,
+        delta,
+      })
+      index += 1
+      setTimeout(sendNextChunk, DEFAULT_CHUNK_DELAY_MS)
+      return
+    }
+
+    writeSseEvent(res, {
+      type: 'response.output_text.done',
+      item_id: response.output[0].id,
+      output_index: 0,
+      content_index: 0,
+      text: content,
+    })
+    writeSseEvent(res, {
+      type: 'response.completed',
+      response,
+    })
+    res.write('data: [DONE]\n\n')
+    res.end()
+  }
+
+  sendNextChunk()
+}
+
+function handleResponses(req, res, body) {
+  const parsedBody = parseJsonBody(body)
+  if (body && !parsedBody) {
+    writeJson(res, 400, { error: { message: 'Invalid JSON request body' } })
+    return
+  }
+
+  capturedRequests.push({
+    timestamp: new Date().toISOString(),
+    method: req.method || 'GET',
+    url: req.url || '/',
+    headers: req.headers,
+    body: parsedBody,
+  })
+
+  const content = responseContent(parsedBody)
+  if (parsedBody?.stream === true) {
+    writeStreamingResponsesApi(res, parsedBody, content)
+    return
+  }
+
+  writeJson(res, 200, responseBody(parsedBody, content))
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'OPTIONS') {
+    writeOptions(res)
+    return
+  }
+
+  let body = ''
+  req.on('data', chunk => {
+    body += chunk.toString()
+  })
+
+  req.on('end', () => {
+    if (req.url === '/health') {
+      writeJson(res, 200, {
+        status: 'ok',
+        capturedCount: capturedRequests.length,
+      })
+      return
+    }
+
+    if (req.url === '/captured-requests') {
+      writeJson(res, 200, capturedRequests)
+      return
+    }
+
+    if (req.url === '/clear-requests' && req.method === 'POST') {
+      capturedRequests.length = 0
+      writeJson(res, 200, { message: 'Requests cleared' })
+      return
+    }
+
+    if (req.url?.includes('/responses') && req.method === 'POST') {
+      handleResponses(req, res, body)
+      return
+    }
+
+    writeJson(res, 404, { error: { message: 'Not found' } })
+  })
+})
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Wework E2E Responses API mock listening on http://127.0.0.1:${PORT}`)
+})
+
+function shutdown() {
+  server.close(() => {
+    process.exit(0)
+  })
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)

--- a/wework/package.json
+++ b/wework/package.json
@@ -18,7 +18,9 @@
     "typecheck": "tsc -b",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@chenglou/pretext": "0.0.8",
@@ -53,6 +55,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.57.0",
     "@tauri-apps/cli": "^2.11.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/wework/playwright.config.ts
+++ b/wework/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const port = Number(process.env.WEWORK_E2E_PORT ?? 4174)
+const baseURL = process.env.WEWORK_E2E_BASE_URL ?? `http://127.0.0.1:${port}`
+const responseApiMockPort = Number(process.env.WEWORK_RESPONSE_API_MOCK_PORT ?? 9998)
+const responseApiMockURL =
+  process.env.WEWORK_RESPONSE_API_MOCK_URL ?? `http://127.0.0.1:${responseApiMockPort}`
+
+export default defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  outputDir: 'test-results',
+  use: {
+    baseURL,
+    testIdAttribute: 'data-testid',
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off',
+    viewport: { width: 1280, height: 800 },
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'node e2e/utils/mock-response-api-server.mjs',
+      url: `${responseApiMockURL}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+      env: {
+        WEWORK_RESPONSE_API_MOCK_PORT: String(responseApiMockPort),
+      },
+    },
+    {
+      command: `pnpm exec vite --host 127.0.0.1 --port ${port} --mode e2e`,
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000,
+      env: {
+        VITE_WEWORK_E2E: 'true',
+        VITE_WEWORK_RUNTIME_MODE: 'backend',
+        VITE_LOGIN_MODE: 'password',
+        WEWORK_RESPONSE_API_MOCK_URL: responseApiMockURL,
+      },
+    },
+  ],
+  timeout: 60000,
+  expect: {
+    timeout: 10000,
+  },
+})

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -8,6 +8,8 @@ import {
 import { isTauriRuntime } from '@/lib/runtime-environment'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
+const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR =
+  'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
 
 export interface WeworkAutomationBridge {
   version: 1
@@ -22,6 +24,9 @@ export interface WeworkAutomationBridge {
   clearAuthToken: () => void
   clearStorage: () => void
   testLocalModelConnection: (
+    input: TestLocalModelConnectionInput
+  ) => Promise<TestLocalModelConnectionResult>
+  tripLocalModelConnectionCircuitBreaker: (
     input: TestLocalModelConnectionInput
   ) => Promise<TestLocalModelConnectionResult>
 }
@@ -90,6 +95,12 @@ function queryTestIds(prefix?: string): string[] {
   ).sort()
 }
 
+function createLocalModelCircuitBreakerFetcher(): typeof fetch {
+  return (async () => {
+    throw new Error(LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR)
+  }) as typeof fetch
+}
+
 function createBridge(): WeworkAutomationBridge {
   return {
     version: 1,
@@ -114,6 +125,11 @@ function createBridge(): WeworkAutomationBridge {
       sessionStorage.clear()
     },
     testLocalModelConnection,
+    tripLocalModelConnectionCircuitBreaker: input =>
+      testLocalModelConnection(input, {
+        fetcher: createLocalModelCircuitBreakerFetcher(),
+        timeoutMs: 1000,
+      }),
   }
 }
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1,5 +1,10 @@
 import { getRuntimeConfig, joinAppPath, stripAppBasePath } from '@/config/runtime'
 import { removeToken, setToken } from '@/api/auth'
+import {
+  testLocalModelConnection,
+  type TestLocalModelConnectionInput,
+  type TestLocalModelConnectionResult,
+} from '@/features/model-settings/localModelConnectionTest'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
@@ -16,6 +21,9 @@ export interface WeworkAutomationBridge {
   setAuthToken: (token: string) => void
   clearAuthToken: () => void
   clearStorage: () => void
+  testLocalModelConnection: (
+    input: TestLocalModelConnectionInput
+  ) => Promise<TestLocalModelConnectionResult>
 }
 
 declare global {
@@ -105,6 +113,7 @@ function createBridge(): WeworkAutomationBridge {
       localStorage.clear()
       sessionStorage.clear()
     },
+    testLocalModelConnection,
   }
 }
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1,0 +1,117 @@
+import { getRuntimeConfig, joinAppPath, stripAppBasePath } from '@/config/runtime'
+import { removeToken, setToken } from '@/api/auth'
+import { isTauriRuntime } from '@/lib/runtime-environment'
+
+const DEFAULT_WAIT_TIMEOUT_MS = 5000
+
+export interface WeworkAutomationBridge {
+  version: 1
+  isEnabled: true
+  isTauri: () => boolean
+  getRuntimeConfig: () => ReturnType<typeof getRuntimeConfig>
+  getRoute: () => string
+  navigate: (path: string) => string
+  waitForTestId: (testId: string, options?: { timeoutMs?: number }) => Promise<boolean>
+  queryTestIds: (prefix?: string) => string[]
+  setAuthToken: (token: string) => void
+  clearAuthToken: () => void
+  clearStorage: () => void
+}
+
+declare global {
+  interface Window {
+    __WEWORK_E2E__?: WeworkAutomationBridge
+  }
+}
+
+function isAutomationEnabled(): boolean {
+  return import.meta.env.MODE === 'e2e' || import.meta.env.VITE_WEWORK_E2E === 'true'
+}
+
+function normalizeAppPath(path: string): string {
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function dispatchNavigationEvents() {
+  window.dispatchEvent(new PopStateEvent('popstate'))
+  window.dispatchEvent(new CustomEvent('wework:e2e:navigation'))
+}
+
+function hasTestId(testId: string): boolean {
+  return document.querySelector(`[data-testid="${CSS.escape(testId)}"]`) !== null
+}
+
+function waitForTestId(testId: string, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS): Promise<boolean> {
+  if (hasTestId(testId)) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      observer.disconnect()
+      reject(new Error(`Timed out waiting for data-testid="${testId}"`))
+    }, timeoutMs)
+
+    const observer = new MutationObserver(() => {
+      if (!hasTestId(testId)) {
+        return
+      }
+
+      window.clearTimeout(timeout)
+      observer.disconnect()
+      resolve(true)
+    })
+
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-testid'],
+    })
+  })
+}
+
+function queryTestIds(prefix?: string): string[] {
+  const elements = Array.from(document.querySelectorAll<HTMLElement>('[data-testid]'))
+  const values = elements
+    .map(element => element.dataset.testid)
+    .filter((value): value is string => Boolean(value))
+
+  return Array.from(
+    new Set(prefix ? values.filter(value => value.startsWith(prefix)) : values)
+  ).sort()
+}
+
+function createBridge(): WeworkAutomationBridge {
+  return {
+    version: 1,
+    isEnabled: true,
+    isTauri: isTauriRuntime,
+    getRuntimeConfig,
+    getRoute: () => stripAppBasePath(window.location.pathname),
+    navigate: path => {
+      const appPath = normalizeAppPath(path)
+      const nextPath = joinAppPath(getRuntimeConfig().appBasePath, appPath)
+      window.history.pushState(null, '', nextPath)
+      dispatchNavigationEvents()
+      return stripAppBasePath(window.location.pathname)
+    },
+    waitForTestId: (testId, options) => waitForTestId(testId, options?.timeoutMs),
+    queryTestIds,
+    setAuthToken: setToken,
+    clearAuthToken: removeToken,
+    clearStorage: () => {
+      removeToken()
+      localStorage.clear()
+      sessionStorage.clear()
+    },
+  }
+}
+
+export function installWeworkAutomationBridge() {
+  if (!isAutomationEnabled() || typeof window === 'undefined') {
+    return
+  }
+
+  window.__WEWORK_E2E__ = createBridge()
+}

--- a/wework/src/main.tsx
+++ b/wework/src/main.tsx
@@ -9,10 +9,12 @@ import { installDeveloperCommandMenu } from './lib/developerCommandMenu'
 import { installExternalLinkHandler } from './lib/external-links'
 import { installPageZoomGuard } from './lib/pageZoomGuard'
 import { installPerformanceDiagnostics, recordReactCommit } from './lib/performanceDiagnostics'
+import { installWeworkAutomationBridge } from './e2e/automation'
 import { installDesktopExtensions } from '@extensions/desktop'
 
 installDebugPanelLogCapture()
 installAppLogging()
+installWeworkAutomationBridge()
 installDesktopExtensions()
 installExternalLinkHandler()
 installPageZoomGuard()

--- a/wework/vite.config.ts
+++ b/wework/vite.config.ts
@@ -1,9 +1,8 @@
-/// <reference types="vitest/config" />
-
 import path from 'path'
 import fs from 'fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { configDefaults } from 'vitest/config'
 
 const apiProxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000'
 const socketProxyTarget = process.env.VITE_SOCKET_PROXY_TARGET || apiProxyTarget
@@ -56,6 +55,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     globals: true,
+    exclude: [...configDefaults.exclude, 'e2e/**'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'json', 'lcov'],


### PR DESCRIPTION
## Summary

- Add a Wework-specific Playwright E2E harness with a test-only frontend automation bridge.
- Add a real HTTP OpenAI Responses API mock server with non-streaming and streaming coverage.
- Add a dedicated GitHub Actions workflow for Wework E2E and document the workflow in English and Chinese.

## Validation

- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `node --check wework/e2e/utils/mock-response-api-server.mjs`
- `pnpm --filter wework e2e`
