### PR TITLE
[codex] Buffer Wework chat input draft

### DIFF
--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -72,10 +72,10 @@ export interface ProjectWorkControls {
   onWorktreeBranchChange?: (branchName: string | null) => void
 }
 
-interface ChatInputProps {
+export interface ChatInputProps {
   value: string
   onChange: (value: string) => void
-  onSubmit: () => void
+  onSubmit: (valueOverride?: string) => void | Promise<void>
   disabled: boolean
   error?: string | null
   disabledReason?: string

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import { BufferedChatInput } from './BufferedChatInput'
+
+function renderBufferedChatInput(props?: {
+  value?: string
+  onChange?: (value: string) => void
+  onSubmit?: (valueOverride?: string) => void
+}) {
+  const onChange = props?.onChange ?? vi.fn()
+  const onSubmit = props?.onSubmit ?? vi.fn()
+
+  render(
+    <BufferedChatInput
+      value={props?.value ?? ''}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      disabled={false}
+    />
+  )
+
+  return { onChange, onSubmit }
+}
+
+describe('BufferedChatInput', () => {
+  test('keeps typing local until submit', () => {
+    const { onChange, onSubmit } = renderBufferedChatInput()
+    const input = screen.getByTestId('chat-message-input')
+
+    fireEvent.change(input, { target: { value: 'hello' } })
+
+    expect(input).toHaveValue('hello')
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onSubmit).toHaveBeenCalledWith('hello')
+    expect(input).toHaveValue('')
+  })
+
+  test('syncs external value changes into the draft', () => {
+    const { rerender } = render(
+      <BufferedChatInput value="" onChange={vi.fn()} onSubmit={vi.fn()} disabled={false} />
+    )
+
+    rerender(
+      <BufferedChatInput
+        value="queued message"
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+      />
+    )
+
+    expect(screen.getByTestId('chat-message-input')).toHaveValue('queued message')
+  })
+})

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react'
+import { ChatInput, type ChatInputProps } from '@/components/chat/ChatInput'
+
+export function BufferedChatInput({ value, onSubmit, ...props }: ChatInputProps) {
+  const [draftState, setDraftState] = useState(() => ({
+    sourceValue: value,
+    draft: value,
+  }))
+  const draft = draftState.sourceValue === value ? draftState.draft : value
+  const setDraft = useCallback(
+    (nextDraft: string) => {
+      setDraftState({ sourceValue: value, draft: nextDraft })
+    },
+    [value]
+  )
+
+  const handleSubmit = useCallback(() => {
+    const submittedDraft = draft
+    void onSubmit(submittedDraft)
+    if (submittedDraft.trim()) {
+      setDraftState({ sourceValue: value, draft: '' })
+    }
+  }, [draft, onSubmit, value])
+
+  return <ChatInput {...props} value={draft} onChange={setDraft} onSubmit={handleSubmit} />
+}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
 import { ArrowLeftRight, MessageCircle } from 'lucide-react'
-import { ChatInput } from '@/components/chat/ChatInput'
 import type { ProjectChatControls } from '@/components/chat/ChatInput'
 import { RequestUserInputCard } from '@/components/chat/RequestUserInputCard'
 import { ScrollableMessageArea } from '@/components/chat/ScrollableMessageArea'
@@ -66,6 +65,7 @@ import { useRuntimeTaskContinueInIm } from './useRuntimeTaskContinueInIm'
 import { requestOpenCloudDeviceSettings } from './workbenchShellEvents'
 import { SubagentStatusIndicator } from './SubagentStatusIndicator'
 import { WEWORK_OPEN_TERMINAL_EVENT } from '@/lib/keybindings'
+import { BufferedChatInput } from './BufferedChatInput'
 
 const DESKTOP_CHAT_CONTENT_BASE_CLASS =
   'mx-auto min-w-0 px-0 transition-[width,max-width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'
@@ -1020,7 +1020,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                       onIgnore={() => paneSession.ignoreRequestUserInput(pendingRequestUserInput)}
                     />
                   ) : (
-                    <ChatInput
+                    <BufferedChatInput
                       value={paneSession.input}
                       onChange={paneSession.setInput}
                       onSubmit={paneSession.send}
@@ -1079,7 +1079,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                   hideAvailableUpdates
                   className="mb-3"
                 />
-                <ChatInput
+                <BufferedChatInput
                   value={paneSession.input}
                   onChange={paneSession.setInput}
                   onSubmit={paneSession.send}

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -1,6 +1,5 @@
 import { ArrowLeftRight, Bot, Menu, MessageCircle } from 'lucide-react'
 import { memo, useEffect, useMemo, useState } from 'react'
-import { ChatInput } from '@/components/chat/ChatInput'
 import type { ProjectChatControls } from '@/components/chat/ChatInput'
 import { RequestUserInputCard } from '@/components/chat/RequestUserInputCard'
 import { ModelSelector } from '@/components/chat/composer/ModelSelector'
@@ -42,6 +41,7 @@ import { useWorkbenchProjectWorkControls } from './useWorkbenchProjectWorkContro
 import { useRuntimeTaskContinueInIm } from './useRuntimeTaskContinueInIm'
 import { pendingRequestUserInputPayload } from './requestUserInputOverlay'
 import { SubagentStatusIndicator } from './SubagentStatusIndicator'
+import { BufferedChatInput } from './BufferedChatInput'
 
 export function MobileWorkbenchLayout() {
   const { state } = useWorkbench()
@@ -358,7 +358,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                     onIgnore={() => paneSession.ignoreRequestUserInput(pendingRequestUserInput)}
                   />
                 ) : (
-                  <ChatInput
+                  <BufferedChatInput
                     value={paneSession.input}
                     onChange={paneSession.setInput}
                     onSubmit={paneSession.send}
@@ -447,7 +447,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                 compact
                 className="mb-2"
               />
-              <ChatInput
+              <BufferedChatInput
                 value={paneSession.input}
                 onChange={paneSession.setInput}
                 onSubmit={paneSession.send}

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -720,153 +720,71 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   }, [paneStatus.canSendQueuedMessage, queuedMessages, sendRuntimeMessage])
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  const send = useCallback(async () => {
-    const submittedInput = input.trim()
-    const currentAttachments = projectChat.attachments
-    const hasCodeComments = codeCommentContexts.length > 0
+  const send: (inputOverride?: string) => Promise<void> = useCallback(
+    async inputOverride => {
+      const submittedInput = (inputOverride ?? input).trim()
+      const currentAttachments = projectChat.attachments
+      const hasCodeComments = codeCommentContexts.length > 0
 
-    if (goalDraftActive) {
-      if (!submittedInput) {
-        setWorkbenchError(i18n.t('workbench.goal_objective_required'))
-        return
-      }
-      if (hasCodeComments) {
-        setWorkbenchError(i18n.t('workbench.runtime_task_code_comments_not_supported'))
-        return
-      }
-
-      setInput('')
-      setSendPhase('submitting')
-      try {
-        if (currentRuntimeTask) {
-          const response = await setRuntimeGoal({
-            address: currentRuntimeTask,
-            objective: submittedInput,
-            status: 'active',
-          })
-          if (!response.accepted) {
-            setWorkbenchError(response.error || i18n.t('workbench.goal_set_failed'))
-            return
-          }
-          setThreadGoal(response.goal)
-          setGoalDraftActive(false)
-          const queuedMessage: RuntimePaneQueuedMessage = {
-            id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
-            content: submittedInput,
-            status: 'queued',
-            createdAt: new Date().toISOString(),
-            attachments: currentAttachments,
-            runtimeGoalRequest: true,
-            ...getRuntimeModelFields(),
-          }
-
-          projectChat.resetAttachments()
-          if (paneStatus.isBusy) {
-            setQueuedMessages(messages => [...messages, queuedMessage])
-            return
-          }
-
-          const sent = await sendRuntimeMessage(queuedMessage)
-          if (sent) {
-            setCodeCommentContexts([])
-          }
+      if (goalDraftActive) {
+        if (!submittedInput) {
+          setWorkbenchError(i18n.t('workbench.goal_objective_required'))
+          return
+        }
+        if (hasCodeComments) {
+          setWorkbenchError(i18n.t('workbench.runtime_task_code_comments_not_supported'))
           return
         }
 
-        const draftGoal = createPendingRuntimeGoal(submittedInput)
-        const initialGoal = runtimeGoalCreateInput(draftGoal)
-        setPendingGoalState({ goal: draftGoal, targetKey: null, targetIdentityKey: null })
-        setGoalDraftActive(false)
-        const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments, {
-          runtimeGoalRequest: true,
-        })
-        let seededGoalAddress: RuntimeTaskAddress | null = null
-        const sent = await sendCurrentInput(submittedInput, {
-          initialGoal,
-          onRuntimeTaskOptimisticOpen: (address, context) => {
-            setPendingGoalState(current =>
-              current
-                ? {
-                    ...current,
-                    targetKey: runtimeTranscriptPaneKey(address),
-                    targetIdentityKey: runtimeTranscriptPaneIdentityKey(address),
-                  }
-                : current
-            )
-            const previousMessages = context?.previousAddress
-              ? getRuntimePaneMessageSnapshot(context.previousAddress)
-              : []
-            seedRuntimePaneGoal(address, draftGoal)
-            seededGoalAddress = address
-            const seededMessages =
-              previousMessages.length > 0 ? previousMessages : [optimisticMessage]
-            debugRuntimePaneMessageFlow('seed-goal-first-open', {
-              address: runtimeAddressDebug(address),
-              previousAddress: context?.previousAddress
-                ? runtimeAddressDebug(context.previousAddress)
-                : null,
-              previousCount: previousMessages.length,
-              seededCount: seededMessages.length,
-              seededMessages: summarizeWorkbenchMessages(seededMessages),
+        setInput('')
+        setSendPhase('submitting')
+        try {
+          if (currentRuntimeTask) {
+            const response = await setRuntimeGoal({
+              address: currentRuntimeTask,
+              objective: submittedInput,
+              status: 'active',
             })
-            seedRuntimePaneMessages(address, seededMessages)
-          },
-        })
-        if (sent) {
-          setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
-          if (!isRuntimeTaskAddress(sent)) {
-            appendLocalUserMessage(submittedInput, currentAttachments, {
+            if (!response.accepted) {
+              setWorkbenchError(response.error || i18n.t('workbench.goal_set_failed'))
+              return
+            }
+            setThreadGoal(response.goal)
+            setGoalDraftActive(false)
+            const queuedMessage: RuntimePaneQueuedMessage = {
+              id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
+              content: submittedInput,
+              status: 'queued',
+              createdAt: new Date().toISOString(),
+              attachments: currentAttachments,
               runtimeGoalRequest: true,
-            })
-          } else {
-            setPendingGoalState(current =>
-              current
-                ? {
-                    ...current,
-                    targetKey: runtimeTranscriptPaneKey(sent),
-                    targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
-                  }
-                : current
-            )
-          }
-        } else {
-          if (seededGoalAddress) {
-            clearRuntimePaneGoalSeed(seededGoalAddress)
-          }
-          setGoalDraftActive(true)
-          setPendingGoalState(null)
-          setSendPhase('idle')
-        }
-        return
-      } finally {
-        setSendPhase(current => (current === 'submitting' ? 'idle' : current))
-      }
-    }
+              ...getRuntimeModelFields(),
+            }
 
-    const pendingInitialGoal =
-      !currentRuntimeTask && pendingGoalState && isUnboundPendingGoalState(pendingGoalState)
-        ? runtimeGoalCreateInput(pendingGoalState.goal)
-        : null
-    const effectiveSubmittedInput = submittedInput || pendingInitialGoal?.objective.trim() || ''
-    if (!effectiveSubmittedInput && currentAttachments.length === 0 && !hasCodeComments) {
-      void sendCurrentInput('', { codeCommentContexts })
-      return
-    }
+            projectChat.resetAttachments()
+            if (paneStatus.isBusy) {
+              setQueuedMessages(messages => [...messages, queuedMessage])
+              return
+            }
 
-    setInput('')
-    setSendPhase('submitting')
-    try {
-      if (!currentRuntimeTask) {
-        const optimisticMessage = createLocalUserMessage(
-          effectiveSubmittedInput,
-          currentAttachments,
-          { runtimeGoalRequest: Boolean(pendingInitialGoal) }
-        )
-        const sent = await sendCurrentInput(effectiveSubmittedInput, {
-          codeCommentContexts,
-          initialGoal: pendingInitialGoal,
-          onRuntimeTaskOptimisticOpen: (address, context) => {
-            if (pendingInitialGoal) {
+            const sent = await sendRuntimeMessage(queuedMessage)
+            if (sent) {
+              setCodeCommentContexts([])
+            }
+            return
+          }
+
+          const draftGoal = createPendingRuntimeGoal(submittedInput)
+          const initialGoal = runtimeGoalCreateInput(draftGoal)
+          setPendingGoalState({ goal: draftGoal, targetKey: null, targetIdentityKey: null })
+          setGoalDraftActive(false)
+          const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments, {
+            runtimeGoalRequest: true,
+          })
+          let seededGoalAddress: RuntimeTaskAddress | null = null
+          const sent = await sendCurrentInput(submittedInput, {
+            initialGoal,
+            onRuntimeTaskOptimisticOpen: (address, context) => {
               setPendingGoalState(current =>
                 current
                   ? {
@@ -876,94 +794,179 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
                     }
                   : current
               )
+              const previousMessages = context?.previousAddress
+                ? getRuntimePaneMessageSnapshot(context.previousAddress)
+                : []
+              seedRuntimePaneGoal(address, draftGoal)
+              seededGoalAddress = address
+              const seededMessages =
+                previousMessages.length > 0 ? previousMessages : [optimisticMessage]
+              debugRuntimePaneMessageFlow('seed-goal-first-open', {
+                address: runtimeAddressDebug(address),
+                previousAddress: context?.previousAddress
+                  ? runtimeAddressDebug(context.previousAddress)
+                  : null,
+                previousCount: previousMessages.length,
+                seededCount: seededMessages.length,
+                seededMessages: summarizeWorkbenchMessages(seededMessages),
+              })
+              seedRuntimePaneMessages(address, seededMessages)
+            },
+          })
+          if (sent) {
+            setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+            if (!isRuntimeTaskAddress(sent)) {
+              appendLocalUserMessage(submittedInput, currentAttachments, {
+                runtimeGoalRequest: true,
+              })
+            } else {
+              setPendingGoalState(current =>
+                current
+                  ? {
+                      ...current,
+                      targetKey: runtimeTranscriptPaneKey(sent),
+                      targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
+                    }
+                  : current
+              )
             }
-            const previousMessages = context?.previousAddress
-              ? getRuntimePaneMessageSnapshot(context.previousAddress)
-              : []
-            if (pendingInitialGoal && pendingGoalState) {
-              seedRuntimePaneGoal(address, pendingGoalState.goal)
+          } else {
+            if (seededGoalAddress) {
+              clearRuntimePaneGoalSeed(seededGoalAddress)
             }
-            const seededMessages =
-              previousMessages.length > 0 ? previousMessages : [optimisticMessage]
-            debugRuntimePaneMessageFlow('seed-optimistic-open', {
-              address: runtimeAddressDebug(address),
-              previousAddress: context?.previousAddress
-                ? runtimeAddressDebug(context.previousAddress)
-                : null,
-              previousCount: previousMessages.length,
-              seededCount: seededMessages.length,
-              seededMessages: summarizeWorkbenchMessages(seededMessages),
-            })
-            seedRuntimePaneMessages(address, seededMessages)
-          },
-        })
-        if (sent) {
-          setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
-          if (!isRuntimeTaskAddress(sent)) {
-            appendLocalUserMessage(effectiveSubmittedInput, currentAttachments, {
-              runtimeGoalRequest: Boolean(pendingInitialGoal),
-            })
-          } else if (pendingInitialGoal) {
-            setPendingGoalState(current =>
-              current
-                ? {
-                    ...current,
-                    targetKey: runtimeTranscriptPaneKey(sent),
-                    targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
-                  }
-                : current
-            )
+            setGoalDraftActive(true)
+            setPendingGoalState(null)
+            setSendPhase('idle')
           }
-          setCodeCommentContexts([])
-        } else {
-          setSendPhase('idle')
+          return
+        } finally {
+          setSendPhase(current => (current === 'submitting' ? 'idle' : current))
         }
+      }
+
+      const pendingInitialGoal =
+        !currentRuntimeTask && pendingGoalState && isUnboundPendingGoalState(pendingGoalState)
+          ? runtimeGoalCreateInput(pendingGoalState.goal)
+          : null
+      const effectiveSubmittedInput = submittedInput || pendingInitialGoal?.objective.trim() || ''
+      if (!effectiveSubmittedInput && currentAttachments.length === 0 && !hasCodeComments) {
+        void sendCurrentInput('', { codeCommentContexts })
         return
       }
 
-      if (hasCodeComments) {
-        void sendCurrentInput(submittedInput, { codeCommentContexts })
-        return
-      }
+      setInput('')
+      setSendPhase('submitting')
+      try {
+        if (!currentRuntimeTask) {
+          const optimisticMessage = createLocalUserMessage(
+            effectiveSubmittedInput,
+            currentAttachments,
+            { runtimeGoalRequest: Boolean(pendingInitialGoal) }
+          )
+          const sent = await sendCurrentInput(effectiveSubmittedInput, {
+            codeCommentContexts,
+            initialGoal: pendingInitialGoal,
+            onRuntimeTaskOptimisticOpen: (address, context) => {
+              if (pendingInitialGoal) {
+                setPendingGoalState(current =>
+                  current
+                    ? {
+                        ...current,
+                        targetKey: runtimeTranscriptPaneKey(address),
+                        targetIdentityKey: runtimeTranscriptPaneIdentityKey(address),
+                      }
+                    : current
+                )
+              }
+              const previousMessages = context?.previousAddress
+                ? getRuntimePaneMessageSnapshot(context.previousAddress)
+                : []
+              if (pendingInitialGoal && pendingGoalState) {
+                seedRuntimePaneGoal(address, pendingGoalState.goal)
+              }
+              const seededMessages =
+                previousMessages.length > 0 ? previousMessages : [optimisticMessage]
+              debugRuntimePaneMessageFlow('seed-optimistic-open', {
+                address: runtimeAddressDebug(address),
+                previousAddress: context?.previousAddress
+                  ? runtimeAddressDebug(context.previousAddress)
+                  : null,
+                previousCount: previousMessages.length,
+                seededCount: seededMessages.length,
+                seededMessages: summarizeWorkbenchMessages(seededMessages),
+              })
+              seedRuntimePaneMessages(address, seededMessages)
+            },
+          })
+          if (sent) {
+            setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+            if (!isRuntimeTaskAddress(sent)) {
+              appendLocalUserMessage(effectiveSubmittedInput, currentAttachments, {
+                runtimeGoalRequest: Boolean(pendingInitialGoal),
+              })
+            } else if (pendingInitialGoal) {
+              setPendingGoalState(current =>
+                current
+                  ? {
+                      ...current,
+                      targetKey: runtimeTranscriptPaneKey(sent),
+                      targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
+                    }
+                  : current
+              )
+            }
+            setCodeCommentContexts([])
+          } else {
+            setSendPhase('idle')
+          }
+          return
+        }
 
-      const queuedMessage: RuntimePaneQueuedMessage = {
-        id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
-        content: submittedInput,
-        status: 'queued',
-        createdAt: new Date().toISOString(),
-        attachments: currentAttachments,
-        ...getRuntimeModelFields(),
-      }
+        if (hasCodeComments) {
+          void sendCurrentInput(submittedInput, { codeCommentContexts })
+          return
+        }
 
-      projectChat.resetAttachments()
-      if (paneStatus.isBusy) {
-        setQueuedMessages(messages => [...messages, queuedMessage])
-        return
-      }
+        const queuedMessage: RuntimePaneQueuedMessage = {
+          id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
+          content: submittedInput,
+          status: 'queued',
+          createdAt: new Date().toISOString(),
+          attachments: currentAttachments,
+          ...getRuntimeModelFields(),
+        }
 
-      const sent = await sendRuntimeMessage(queuedMessage)
-      if (sent) {
-        setCodeCommentContexts([])
+        projectChat.resetAttachments()
+        if (paneStatus.isBusy) {
+          setQueuedMessages(messages => [...messages, queuedMessage])
+          return
+        }
+
+        const sent = await sendRuntimeMessage(queuedMessage)
+        if (sent) {
+          setCodeCommentContexts([])
+        }
+      } finally {
+        setSendPhase(current => (current === 'submitting' ? 'idle' : current))
       }
-    } finally {
-      setSendPhase(current => (current === 'submitting' ? 'idle' : current))
-    }
-  }, [
-    appendLocalUserMessage,
-    codeCommentContexts,
-    currentRuntimeTask,
-    goalDraftActive,
-    getRuntimeModelFields,
-    input,
-    pendingGoalState,
-    paneStatus.isBusy,
-    projectChat,
-    queuedMessages.length,
-    sendCurrentInput,
-    sendRuntimeMessage,
-    setRuntimeGoal,
-    setWorkbenchError,
-  ])
+    },
+    [
+      appendLocalUserMessage,
+      codeCommentContexts,
+      currentRuntimeTask,
+      goalDraftActive,
+      getRuntimeModelFields,
+      input,
+      pendingGoalState,
+      paneStatus.isBusy,
+      projectChat,
+      queuedMessages.length,
+      sendCurrentInput,
+      sendRuntimeMessage,
+      setRuntimeGoal,
+      setWorkbenchError,
+    ]
+  )
 
   const addCodeComment = useCallback((context: CodeCommentContext) => {
     setCodeCommentContexts(current => [...current.filter(item => item.id !== context.id), context])


### PR DESCRIPTION
## Summary

This PR buffers Wework chat composer draft text locally inside the layout-level composer wrapper. The desktop and mobile workbench panes now avoid sending every keystroke through the pane session state, while still passing the submitted draft into the existing send path.

## Root Cause

The chat input value lived in `useWorkbenchPaneSession`, which is consumed near the top of the desktop and mobile workbench panes. Every character typed into the composer caused those heavier pane trees, including message and workspace surfaces, to re-render. As conversations and workspace state accumulate over time, that can make typing feel slow even when CPU is not obviously saturated.

## Changes

- Added `BufferedChatInput` to keep draft edits local until submit.
- Updated desktop and mobile Wework panes to use the buffered composer wrapper.
- Extended pane session `send` to accept an input override for locally buffered drafts.
- Added focused coverage for buffered typing and external draft synchronization.

## Validation

- `pnpm --filter wework exec vitest run src/components/layout/BufferedChatInput.test.tsx`
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- Pre-push Wework quality gate: ESLint, TypeScript, and unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a buffered chat input experience on desktop and mobile, letting you keep typing locally before sending.
  * Chat submission now supports sending a specific text value directly, improving input handling in chat flows.

* **Bug Fixes**
  * Chat drafts now stay in sync with external updates and clear correctly after sending.
  * Improved message submission behavior across workbench views for more consistent chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->