### PR TITLE
[codex] Fix Wework IME Enter submission

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { StrictMode, useState } from 'react'
 import { describe, expect, test, vi } from 'vitest'
@@ -3157,23 +3157,47 @@ describe('ChatInput', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
-  test('does not submit when Enter confirms IME composition', () => {
-    vi.useFakeTimers()
+  test('submits latest textarea value when Enter is pressed before controlled value updates', () => {
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    render(<ChatInput value="" onChange={onChange} onSubmit={onSubmit} disabled={false} />)
+
+    const input = screen.getByTestId('chat-message-input')
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+    valueSetter?.call(input, 'hello')
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onSubmit).toHaveBeenCalledWith('hello')
+    expect(input).not.toHaveValue('\n')
+  })
+
+  test('submits with Enter after IME composition key press is released', () => {
     const onSubmit = vi.fn()
     render(<ControlledChatInput onSubmit={onSubmit} />)
 
     const input = screen.getByTestId('chat-message-input')
     fireEvent.change(input, { target: { value: 'hello' } })
     fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    fireEvent.keyUp(input, { key: 'Enter' })
     fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test('suppresses Enter keydown that arrives after IME composition ends but before keyup', () => {
+    const onSubmit = vi.fn()
+    render(<ControlledChatInput onSubmit={onSubmit} />)
+
+    const input = screen.getByTestId('chat-message-input')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.compositionStart(input)
     fireEvent.compositionEnd(input)
     fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(onSubmit).not.toHaveBeenCalled()
 
-    act(() => {
-      vi.advanceTimersByTime(101)
-    })
+    fireEvent.keyUp(input, { key: 'Enter' })
     fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(onSubmit).toHaveBeenCalledTimes(1)

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -75,7 +75,7 @@ export interface ProjectWorkControls {
 interface ChatInputProps {
   value: string
   onChange: (value: string) => void
-  onSubmit: () => void
+  onSubmit: (submittedValue?: string) => void
   disabled: boolean
   error?: string | null
   disabledReason?: string

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -19,11 +19,12 @@ import { ComposerTextarea } from './ComposerTextarea'
 import { ComposerModePill, GoalDraftPill } from './GoalDraftPill'
 import { createLongPastedTextAttachment } from './pastedTextAttachment'
 import { useAutoResizeTextarea } from './useAutoResizeTextarea'
+import { debugComposerEvent, textMetrics } from './composerDebug'
 
 interface CompactChatComposerProps {
   value: string
   onChange: (value: string) => void
-  onSubmit: () => void
+  onSubmit: (submittedValue?: string) => void
   disabled: boolean
   disabledReason?: string
   placeholder: string
@@ -198,7 +199,16 @@ export function CompactChatComposer({
         className="flex w-full items-end gap-2"
         onSubmit={event => {
           event.preventDefault()
-          if (canSend) onSubmit()
+          const submittedValue = event.currentTarget.querySelector('textarea')?.value
+          debugComposerEvent('compact-form-submit', {
+            canSend,
+            propValue: textMetrics(value),
+            submittedValue: textMetrics(submittedValue),
+            attachmentsCount: attachments.length,
+            codeCommentsCount: codeComments.length,
+            disabled,
+          })
+          if (canSend) onSubmit(submittedValue)
         }}
       >
         <button

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -14,11 +14,12 @@ import {
 import { createLongPastedTextAttachment } from './pastedTextAttachment'
 import { SlashCommandMenu } from './SlashCommandMenu'
 import { SlashModelMenu } from './SlashModelMenu'
+import { debugComposerEvent, textMetrics } from './composerDebug'
 
 interface ComposerTextareaProps {
   value: string
   onChange: (value: string) => void
-  onSubmit: () => void
+  onSubmit: (submittedValue?: string) => void
   canSend: boolean
   disabled?: boolean
   placeholder: string
@@ -387,8 +388,7 @@ export function ComposerTextarea({
     focused: false,
   })
   const [isComposing, setIsComposing] = useState(false)
-  const compositionJustEndedRef = useRef(false)
-  const compositionResetTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
+  const suppressEnterUntilKeyUpRef = useRef(false)
   const [activeMenu, setActiveMenu] = useState<ActiveComposerMenu | null>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [modelMenuOpen, setModelMenuOpen] = useState(false)
@@ -704,35 +704,23 @@ export function ComposerTextarea({
     }
   }, [closeSlashModelMenu, modelMenuOpen, textareaRef])
 
-  useEffect(() => {
-    return () => {
-      if (compositionResetTimerRef.current) {
-        window.clearTimeout(compositionResetTimerRef.current)
-      }
-    }
-  }, [])
-
-  const clearCompositionResetTimer = () => {
-    if (!compositionResetTimerRef.current) return
-
-    window.clearTimeout(compositionResetTimerRef.current)
-    compositionResetTimerRef.current = null
-  }
-
   const handleCompositionStart = () => {
-    clearCompositionResetTimer()
     setIsComposing(true)
-    compositionJustEndedRef.current = false
+    debugComposerEvent('composition-start', {
+      propValue: textMetrics(value),
+      domValue: textMetrics(textareaRef.current?.value),
+      suppressEnterUntilKeyUp: suppressEnterUntilKeyUpRef.current,
+    })
   }
 
   const handleCompositionEnd = () => {
     setIsComposing(false)
-    compositionJustEndedRef.current = true
-    clearCompositionResetTimer()
-    compositionResetTimerRef.current = window.setTimeout(() => {
-      compositionJustEndedRef.current = false
-      compositionResetTimerRef.current = null
-    }, 100)
+    suppressEnterUntilKeyUpRef.current = true
+    debugComposerEvent('composition-end', {
+      propValue: textMetrics(value),
+      domValue: textMetrics(textareaRef.current?.value),
+      suppressEnterUntilKeyUp: suppressEnterUntilKeyUpRef.current,
+    })
   }
 
   const selectSkill = useCallback(
@@ -845,7 +833,45 @@ export function ComposerTextarea({
   )
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = event => {
-    if (isComposing || event.nativeEvent.isComposing || compositionJustEndedRef.current) {
+    if (event.key === 'Enter') {
+      debugComposerEvent('keydown-enter', {
+        shiftKey: event.shiftKey,
+        canSend,
+        stateIsComposing: isComposing,
+        nativeIsComposing: event.nativeEvent.isComposing,
+        suppressEnterUntilKeyUp: suppressEnterUntilKeyUpRef.current,
+        showSkillMenu,
+        showSlashMenu,
+        activeMenuKind: activeMenu?.kind ?? null,
+        highlightedIndex,
+        activeOptionCount,
+        propValue: textMetrics(value),
+        domValue: textMetrics(event.currentTarget.value),
+      })
+    }
+
+    if (event.key === 'Enter' && (isComposing || event.nativeEvent.isComposing)) {
+      suppressEnterUntilKeyUpRef.current = true
+      debugComposerEvent('keydown-enter-ignored-composition', {
+        stateIsComposing: isComposing,
+        nativeIsComposing: event.nativeEvent.isComposing,
+        suppressEnterUntilKeyUp: suppressEnterUntilKeyUpRef.current,
+        domValue: textMetrics(event.currentTarget.value),
+      })
+      return
+    }
+
+    if (event.key === 'Enter' && suppressEnterUntilKeyUpRef.current) {
+      event.preventDefault()
+      debugComposerEvent('keydown-enter-suppressed-until-keyup', {
+        stateIsComposing: isComposing,
+        nativeIsComposing: event.nativeEvent.isComposing,
+        domValue: textMetrics(event.currentTarget.value),
+      })
+      return
+    }
+
+    if (isComposing || event.nativeEvent.isComposing) {
       return
     }
 
@@ -901,6 +927,11 @@ export function ComposerTextarea({
         canSelectSkillForModel(filteredSkills[highlightedIndex], selectedModel)
       ) {
         event.preventDefault()
+        debugComposerEvent('keydown-enter-select-skill', {
+          highlightedIndex,
+          skillName: filteredSkills[highlightedIndex]?.name,
+          domValue: textMetrics(event.currentTarget.value),
+        })
         selectSkill(filteredSkills[highlightedIndex])
         return
       }
@@ -911,15 +942,44 @@ export function ComposerTextarea({
         filteredSlashCommands[highlightedIndex].enabled !== false
       ) {
         event.preventDefault()
+        debugComposerEvent('keydown-enter-select-slash-command', {
+          highlightedIndex,
+          commandId: filteredSlashCommands[highlightedIndex]?.id,
+          domValue: textMetrics(event.currentTarget.value),
+        })
         selectSlashCommand(filteredSlashCommands[highlightedIndex])
         return
       }
     }
 
-    if (event.key !== 'Enter' || event.shiftKey) return
+    if (event.key !== 'Enter' || event.shiftKey) {
+      if (event.key === 'Enter') {
+        debugComposerEvent('keydown-enter-newline', {
+          shiftKey: event.shiftKey,
+          domValue: textMetrics(event.currentTarget.value),
+        })
+      }
+      return
+    }
+
+    const submittedValue = event.currentTarget.value
+    const canSubmitCurrentValue = submittedValue.trim().length > 0 || canSend
 
     event.preventDefault()
-    if (canSend) onSubmit()
+    debugComposerEvent('keydown-enter-submit-decision', {
+      canSend,
+      canSubmitCurrentValue,
+      submittedValue: textMetrics(submittedValue),
+      propValue: textMetrics(value),
+    })
+    if (canSubmitCurrentValue) {
+      onSubmit(submittedValue)
+    } else {
+      debugComposerEvent('keydown-enter-submit-skipped-empty', {
+        submittedValue: textMetrics(submittedValue),
+        propValue: textMetrics(value),
+      })
+    }
   }
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = event => {
@@ -961,6 +1021,15 @@ export function ComposerTextarea({
         rows={rows}
         value={value}
         onChange={event => {
+          const nativeIsComposing =
+            event.nativeEvent instanceof InputEvent ? event.nativeEvent.isComposing : undefined
+          debugComposerEvent('textarea-change', {
+            propValue: textMetrics(value),
+            nextValue: textMetrics(event.target.value),
+            stateIsComposing: isComposing,
+            nativeIsComposing,
+            suppressEnterUntilKeyUp: suppressEnterUntilKeyUpRef.current,
+          })
           handleValueChange(event.target.value)
           window.requestAnimationFrame(() => {
             updateAutocompleteTrigger()
@@ -978,7 +1047,17 @@ export function ComposerTextarea({
           syncSelection()
         }}
         onKeyDown={handleKeyDown}
-        onKeyUp={syncSelection}
+        onKeyUp={event => {
+          if (suppressEnterUntilKeyUpRef.current) {
+            suppressEnterUntilKeyUpRef.current = false
+            debugComposerEvent('keyup-clear-composition-enter-suppression', {
+              key: event.key,
+              propValue: textMetrics(value),
+              domValue: textMetrics(event.currentTarget.value),
+            })
+          }
+          syncSelection()
+        }}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
         onSelect={() => {

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -12,11 +12,12 @@ import { ComposerToolbar } from './ComposerToolbar'
 import { ComposerTextarea } from './ComposerTextarea'
 import { ProjectWorkBar } from './ProjectWorkBar'
 import { useAutoResizeTextarea } from './useAutoResizeTextarea'
+import { debugComposerEvent, textMetrics } from './composerDebug'
 
 interface ProjectChatComposerProps {
   value: string
   onChange: (value: string) => void
-  onSubmit: () => void
+  onSubmit: (submittedValue?: string) => void
   disabled: boolean
   disabledReason?: string
   placeholder: string
@@ -172,7 +173,17 @@ export function ProjectChatComposer({
         onDrop={handleDrop}
         onSubmit={event => {
           event.preventDefault()
-          if (canSend) onSubmit()
+          const submittedValue = event.currentTarget.querySelector('textarea')?.value
+          debugComposerEvent('project-form-submit', {
+            canSend,
+            propValue: textMetrics(value),
+            submittedValue: textMetrics(submittedValue),
+            attachmentsCount: attachments.length,
+            codeCommentsCount: codeComments.length,
+            disabled,
+            isStreaming,
+          })
+          if (canSend) onSubmit(submittedValue)
         }}
       >
         <AttachmentBadges

--- a/wework/src/components/chat/composer/composerDebug.ts
+++ b/wework/src/components/chat/composer/composerDebug.ts
@@ -1,0 +1,22 @@
+export function debugComposerEvent(event: string, details: Record<string, unknown>) {
+  try {
+    if (globalThis.localStorage?.getItem('wework:debug-composer') !== '1') return
+  } catch {
+    return
+  }
+
+  console.debug('[Wework] Composer submit flow', {
+    event,
+    time: new Date().toISOString(),
+    ...details,
+  })
+}
+
+export function textMetrics(value: string | undefined | null) {
+  const text = value ?? ''
+  return {
+    length: text.length,
+    trimmedLength: text.trim().length,
+    lineCount: text.length > 0 ? text.split('\n').length : 0,
+  }
+}

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -24,6 +24,7 @@ import {
   requestUserInputResponseKey,
 } from '@/components/chat/requestUserInputMessages'
 import type { RequestUserInputPayload } from '@/components/chat/RequestUserInputCard'
+import { debugComposerEvent, textMetrics } from '@/components/chat/composer/composerDebug'
 import { visibleRuntimeGoal } from '@/lib/runtime-goal'
 import type {
   Attachment,
@@ -720,153 +721,83 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   }, [paneStatus.canSendQueuedMessage, queuedMessages, sendRuntimeMessage])
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  const send = useCallback(async () => {
-    const submittedInput = input.trim()
-    const currentAttachments = projectChat.attachments
-    const hasCodeComments = codeCommentContexts.length > 0
+  const send = useCallback(
+    async (submittedValue?: string) => {
+      const submittedInput = (submittedValue ?? input).trim()
+      const currentAttachments = projectChat.attachments
+      const hasCodeComments = codeCommentContexts.length > 0
+      debugComposerEvent('pane-send-called', {
+        hasSubmittedValue: submittedValue !== undefined,
+        submittedValue: textMetrics(submittedValue),
+        stateInput: textMetrics(input),
+        submittedInput: textMetrics(submittedInput),
+        attachmentsCount: currentAttachments.length,
+        codeCommentsCount: codeCommentContexts.length,
+        hasCodeComments,
+        goalDraftActive,
+        hasCurrentRuntimeTask: Boolean(currentRuntimeTask),
+        paneBusy: paneStatus.isBusy,
+      })
 
-    if (goalDraftActive) {
-      if (!submittedInput) {
-        setWorkbenchError(i18n.t('workbench.goal_objective_required'))
-        return
-      }
-      if (hasCodeComments) {
-        setWorkbenchError(i18n.t('workbench.runtime_task_code_comments_not_supported'))
-        return
-      }
-
-      setInput('')
-      setSendPhase('submitting')
-      try {
-        if (currentRuntimeTask) {
-          const response = await setRuntimeGoal({
-            address: currentRuntimeTask,
-            objective: submittedInput,
-            status: 'active',
-          })
-          if (!response.accepted) {
-            setWorkbenchError(response.error || i18n.t('workbench.goal_set_failed'))
-            return
-          }
-          setThreadGoal(response.goal)
-          setGoalDraftActive(false)
-          const queuedMessage: RuntimePaneQueuedMessage = {
-            id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
-            content: submittedInput,
-            status: 'queued',
-            createdAt: new Date().toISOString(),
-            attachments: currentAttachments,
-            runtimeGoalRequest: true,
-            ...getRuntimeModelFields(),
-          }
-
-          projectChat.resetAttachments()
-          if (paneStatus.isBusy) {
-            setQueuedMessages(messages => [...messages, queuedMessage])
-            return
-          }
-
-          const sent = await sendRuntimeMessage(queuedMessage)
-          if (sent) {
-            setCodeCommentContexts([])
-          }
+      if (goalDraftActive) {
+        if (!submittedInput) {
+          setWorkbenchError(i18n.t('workbench.goal_objective_required'))
+          return
+        }
+        if (hasCodeComments) {
+          setWorkbenchError(i18n.t('workbench.runtime_task_code_comments_not_supported'))
           return
         }
 
-        const draftGoal = createPendingRuntimeGoal(submittedInput)
-        const initialGoal = runtimeGoalCreateInput(draftGoal)
-        setPendingGoalState({ goal: draftGoal, targetKey: null, targetIdentityKey: null })
-        setGoalDraftActive(false)
-        const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments, {
-          runtimeGoalRequest: true,
-        })
-        let seededGoalAddress: RuntimeTaskAddress | null = null
-        const sent = await sendCurrentInput(submittedInput, {
-          initialGoal,
-          onRuntimeTaskOptimisticOpen: (address, context) => {
-            setPendingGoalState(current =>
-              current
-                ? {
-                    ...current,
-                    targetKey: runtimeTranscriptPaneKey(address),
-                    targetIdentityKey: runtimeTranscriptPaneIdentityKey(address),
-                  }
-                : current
-            )
-            const previousMessages = context?.previousAddress
-              ? getRuntimePaneMessageSnapshot(context.previousAddress)
-              : []
-            seedRuntimePaneGoal(address, draftGoal)
-            seededGoalAddress = address
-            const seededMessages =
-              previousMessages.length > 0 ? previousMessages : [optimisticMessage]
-            debugRuntimePaneMessageFlow('seed-goal-first-open', {
-              address: runtimeAddressDebug(address),
-              previousAddress: context?.previousAddress
-                ? runtimeAddressDebug(context.previousAddress)
-                : null,
-              previousCount: previousMessages.length,
-              seededCount: seededMessages.length,
-              seededMessages: summarizeWorkbenchMessages(seededMessages),
+        setInput('')
+        setSendPhase('submitting')
+        try {
+          if (currentRuntimeTask) {
+            const response = await setRuntimeGoal({
+              address: currentRuntimeTask,
+              objective: submittedInput,
+              status: 'active',
             })
-            seedRuntimePaneMessages(address, seededMessages)
-          },
-        })
-        if (sent) {
-          setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
-          if (!isRuntimeTaskAddress(sent)) {
-            appendLocalUserMessage(submittedInput, currentAttachments, {
+            if (!response.accepted) {
+              setWorkbenchError(response.error || i18n.t('workbench.goal_set_failed'))
+              return
+            }
+            setThreadGoal(response.goal)
+            setGoalDraftActive(false)
+            const queuedMessage: RuntimePaneQueuedMessage = {
+              id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
+              content: submittedInput,
+              status: 'queued',
+              createdAt: new Date().toISOString(),
+              attachments: currentAttachments,
               runtimeGoalRequest: true,
-            })
-          } else {
-            setPendingGoalState(current =>
-              current
-                ? {
-                    ...current,
-                    targetKey: runtimeTranscriptPaneKey(sent),
-                    targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
-                  }
-                : current
-            )
-          }
-        } else {
-          if (seededGoalAddress) {
-            clearRuntimePaneGoalSeed(seededGoalAddress)
-          }
-          setGoalDraftActive(true)
-          setPendingGoalState(null)
-          setSendPhase('idle')
-        }
-        return
-      } finally {
-        setSendPhase(current => (current === 'submitting' ? 'idle' : current))
-      }
-    }
+              ...getRuntimeModelFields(),
+            }
 
-    const pendingInitialGoal =
-      !currentRuntimeTask && pendingGoalState && isUnboundPendingGoalState(pendingGoalState)
-        ? runtimeGoalCreateInput(pendingGoalState.goal)
-        : null
-    const effectiveSubmittedInput = submittedInput || pendingInitialGoal?.objective.trim() || ''
-    if (!effectiveSubmittedInput && currentAttachments.length === 0 && !hasCodeComments) {
-      void sendCurrentInput('', { codeCommentContexts })
-      return
-    }
+            projectChat.resetAttachments()
+            if (paneStatus.isBusy) {
+              setQueuedMessages(messages => [...messages, queuedMessage])
+              return
+            }
 
-    setInput('')
-    setSendPhase('submitting')
-    try {
-      if (!currentRuntimeTask) {
-        const optimisticMessage = createLocalUserMessage(
-          effectiveSubmittedInput,
-          currentAttachments,
-          { runtimeGoalRequest: Boolean(pendingInitialGoal) }
-        )
-        const sent = await sendCurrentInput(effectiveSubmittedInput, {
-          codeCommentContexts,
-          initialGoal: pendingInitialGoal,
-          onRuntimeTaskOptimisticOpen: (address, context) => {
-            if (pendingInitialGoal) {
+            const sent = await sendRuntimeMessage(queuedMessage)
+            if (sent) {
+              setCodeCommentContexts([])
+            }
+            return
+          }
+
+          const draftGoal = createPendingRuntimeGoal(submittedInput)
+          const initialGoal = runtimeGoalCreateInput(draftGoal)
+          setPendingGoalState({ goal: draftGoal, targetKey: null, targetIdentityKey: null })
+          setGoalDraftActive(false)
+          const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments, {
+            runtimeGoalRequest: true,
+          })
+          let seededGoalAddress: RuntimeTaskAddress | null = null
+          const sent = await sendCurrentInput(submittedInput, {
+            initialGoal,
+            onRuntimeTaskOptimisticOpen: (address, context) => {
               setPendingGoalState(current =>
                 current
                   ? {
@@ -876,94 +807,179 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
                     }
                   : current
               )
+              const previousMessages = context?.previousAddress
+                ? getRuntimePaneMessageSnapshot(context.previousAddress)
+                : []
+              seedRuntimePaneGoal(address, draftGoal)
+              seededGoalAddress = address
+              const seededMessages =
+                previousMessages.length > 0 ? previousMessages : [optimisticMessage]
+              debugRuntimePaneMessageFlow('seed-goal-first-open', {
+                address: runtimeAddressDebug(address),
+                previousAddress: context?.previousAddress
+                  ? runtimeAddressDebug(context.previousAddress)
+                  : null,
+                previousCount: previousMessages.length,
+                seededCount: seededMessages.length,
+                seededMessages: summarizeWorkbenchMessages(seededMessages),
+              })
+              seedRuntimePaneMessages(address, seededMessages)
+            },
+          })
+          if (sent) {
+            setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+            if (!isRuntimeTaskAddress(sent)) {
+              appendLocalUserMessage(submittedInput, currentAttachments, {
+                runtimeGoalRequest: true,
+              })
+            } else {
+              setPendingGoalState(current =>
+                current
+                  ? {
+                      ...current,
+                      targetKey: runtimeTranscriptPaneKey(sent),
+                      targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
+                    }
+                  : current
+              )
             }
-            const previousMessages = context?.previousAddress
-              ? getRuntimePaneMessageSnapshot(context.previousAddress)
-              : []
-            if (pendingInitialGoal && pendingGoalState) {
-              seedRuntimePaneGoal(address, pendingGoalState.goal)
+          } else {
+            if (seededGoalAddress) {
+              clearRuntimePaneGoalSeed(seededGoalAddress)
             }
-            const seededMessages =
-              previousMessages.length > 0 ? previousMessages : [optimisticMessage]
-            debugRuntimePaneMessageFlow('seed-optimistic-open', {
-              address: runtimeAddressDebug(address),
-              previousAddress: context?.previousAddress
-                ? runtimeAddressDebug(context.previousAddress)
-                : null,
-              previousCount: previousMessages.length,
-              seededCount: seededMessages.length,
-              seededMessages: summarizeWorkbenchMessages(seededMessages),
-            })
-            seedRuntimePaneMessages(address, seededMessages)
-          },
-        })
-        if (sent) {
-          setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
-          if (!isRuntimeTaskAddress(sent)) {
-            appendLocalUserMessage(effectiveSubmittedInput, currentAttachments, {
-              runtimeGoalRequest: Boolean(pendingInitialGoal),
-            })
-          } else if (pendingInitialGoal) {
-            setPendingGoalState(current =>
-              current
-                ? {
-                    ...current,
-                    targetKey: runtimeTranscriptPaneKey(sent),
-                    targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
-                  }
-                : current
-            )
+            setGoalDraftActive(true)
+            setPendingGoalState(null)
+            setSendPhase('idle')
           }
-          setCodeCommentContexts([])
-        } else {
-          setSendPhase('idle')
+          return
+        } finally {
+          setSendPhase(current => (current === 'submitting' ? 'idle' : current))
         }
+      }
+
+      const pendingInitialGoal =
+        !currentRuntimeTask && pendingGoalState && isUnboundPendingGoalState(pendingGoalState)
+          ? runtimeGoalCreateInput(pendingGoalState.goal)
+          : null
+      const effectiveSubmittedInput = submittedInput || pendingInitialGoal?.objective.trim() || ''
+      if (!effectiveSubmittedInput && currentAttachments.length === 0 && !hasCodeComments) {
+        void sendCurrentInput('', { codeCommentContexts })
         return
       }
 
-      if (hasCodeComments) {
-        void sendCurrentInput(submittedInput, { codeCommentContexts })
-        return
-      }
+      setInput('')
+      setSendPhase('submitting')
+      try {
+        if (!currentRuntimeTask) {
+          const optimisticMessage = createLocalUserMessage(
+            effectiveSubmittedInput,
+            currentAttachments,
+            { runtimeGoalRequest: Boolean(pendingInitialGoal) }
+          )
+          const sent = await sendCurrentInput(effectiveSubmittedInput, {
+            codeCommentContexts,
+            initialGoal: pendingInitialGoal,
+            onRuntimeTaskOptimisticOpen: (address, context) => {
+              if (pendingInitialGoal) {
+                setPendingGoalState(current =>
+                  current
+                    ? {
+                        ...current,
+                        targetKey: runtimeTranscriptPaneKey(address),
+                        targetIdentityKey: runtimeTranscriptPaneIdentityKey(address),
+                      }
+                    : current
+                )
+              }
+              const previousMessages = context?.previousAddress
+                ? getRuntimePaneMessageSnapshot(context.previousAddress)
+                : []
+              if (pendingInitialGoal && pendingGoalState) {
+                seedRuntimePaneGoal(address, pendingGoalState.goal)
+              }
+              const seededMessages =
+                previousMessages.length > 0 ? previousMessages : [optimisticMessage]
+              debugRuntimePaneMessageFlow('seed-optimistic-open', {
+                address: runtimeAddressDebug(address),
+                previousAddress: context?.previousAddress
+                  ? runtimeAddressDebug(context.previousAddress)
+                  : null,
+                previousCount: previousMessages.length,
+                seededCount: seededMessages.length,
+                seededMessages: summarizeWorkbenchMessages(seededMessages),
+              })
+              seedRuntimePaneMessages(address, seededMessages)
+            },
+          })
+          if (sent) {
+            setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+            if (!isRuntimeTaskAddress(sent)) {
+              appendLocalUserMessage(effectiveSubmittedInput, currentAttachments, {
+                runtimeGoalRequest: Boolean(pendingInitialGoal),
+              })
+            } else if (pendingInitialGoal) {
+              setPendingGoalState(current =>
+                current
+                  ? {
+                      ...current,
+                      targetKey: runtimeTranscriptPaneKey(sent),
+                      targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
+                    }
+                  : current
+              )
+            }
+            setCodeCommentContexts([])
+          } else {
+            setSendPhase('idle')
+          }
+          return
+        }
 
-      const queuedMessage: RuntimePaneQueuedMessage = {
-        id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
-        content: submittedInput,
-        status: 'queued',
-        createdAt: new Date().toISOString(),
-        attachments: currentAttachments,
-        ...getRuntimeModelFields(),
-      }
+        if (hasCodeComments) {
+          void sendCurrentInput(submittedInput, { codeCommentContexts })
+          return
+        }
 
-      projectChat.resetAttachments()
-      if (paneStatus.isBusy) {
-        setQueuedMessages(messages => [...messages, queuedMessage])
-        return
-      }
+        const queuedMessage: RuntimePaneQueuedMessage = {
+          id: `queued-runtime-pane-${Date.now()}-${queuedMessages.length}`,
+          content: submittedInput,
+          status: 'queued',
+          createdAt: new Date().toISOString(),
+          attachments: currentAttachments,
+          ...getRuntimeModelFields(),
+        }
 
-      const sent = await sendRuntimeMessage(queuedMessage)
-      if (sent) {
-        setCodeCommentContexts([])
+        projectChat.resetAttachments()
+        if (paneStatus.isBusy) {
+          setQueuedMessages(messages => [...messages, queuedMessage])
+          return
+        }
+
+        const sent = await sendRuntimeMessage(queuedMessage)
+        if (sent) {
+          setCodeCommentContexts([])
+        }
+      } finally {
+        setSendPhase(current => (current === 'submitting' ? 'idle' : current))
       }
-    } finally {
-      setSendPhase(current => (current === 'submitting' ? 'idle' : current))
-    }
-  }, [
-    appendLocalUserMessage,
-    codeCommentContexts,
-    currentRuntimeTask,
-    goalDraftActive,
-    getRuntimeModelFields,
-    input,
-    pendingGoalState,
-    paneStatus.isBusy,
-    projectChat,
-    queuedMessages.length,
-    sendCurrentInput,
-    sendRuntimeMessage,
-    setRuntimeGoal,
-    setWorkbenchError,
-  ])
+    },
+    [
+      appendLocalUserMessage,
+      codeCommentContexts,
+      currentRuntimeTask,
+      goalDraftActive,
+      getRuntimeModelFields,
+      input,
+      pendingGoalState,
+      paneStatus.isBusy,
+      projectChat,
+      queuedMessages.length,
+      sendCurrentInput,
+      sendRuntimeMessage,
+      setRuntimeGoal,
+      setWorkbenchError,
+    ]
+  )
 
   const addCodeComment = useCallback((context: CodeCommentContext) => {
     setCodeCommentContexts(current => [...current.filter(item => item.id !== context.id), context])


### PR DESCRIPTION
## Summary

- Fix Wework chat composer Enter handling around IME composition.
- Submit the latest textarea DOM value so fast Enter presses do not race controlled React state.
- Add gated composer submit-flow debug logs behind `localStorage['wework:debug-composer'] === '1'`.
- Add regression tests for IME confirmation and controlled-value timing.

## Root Cause

The composer used a time-based `compositionJustEnded` guard. Depending on IME event ordering, the Enter key used to confirm composition could either be swallowed as a newline or treated as a send shortcut. The fix tracks the physical key boundary instead: composition completion suppresses Enter until keyup, and subsequent independent Enter presses can submit normally.

## Validation

- `pnpm --filter wework exec vitest run src/components/chat/ChatInput.test.tsx`
- `pnpm --filter wework typecheck`
- Pre-push hook: ESLint, TypeScript, and unit tests passed

Docs were checked; this is a behavior bug fix and does not require user-facing documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat composer and send flows now submit the text that was actually entered, including when submission is triggered from keyboard input.
  * Enter/composition handling was improved to better respect IME input and prevent accidental submissions.
  * Additional debug logging is available for composer and pane send actions when enabled.

* **Bug Fixes**
  * Fixed cases where the latest typed message could be missed if the input state updated after Enter was pressed.
  * Improved submission behavior so empty messages are not sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->