### PR TITLE
[codex] Fix Wework local stream chunk dedupe

### DIFF
--- a/docs/en/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/developer-guide/wework-performance-diagnostics.md
@@ -37,6 +37,20 @@ The **Debug Panel** command in the Developer Commands menu helps diagnose the cu
 
 The Debug Panel can be expanded, collapsed, refreshed, copied as a snapshot, and cleared. When collapsed, it leaves only a small status bar in the lower-right corner so it does not block the main UI.
 
+## Local Codex Streaming Logs
+
+The local executor keeps Codex delta details enabled by default so developers can diagnose streaming order, phase classification, and final-content overwrite issues. By default, it records raw Codex delta events and run-state classification summaries.
+
+To avoid excessive logs in debug builds during long responses or high-frequency token output, runtime work cache/emit mapping logs are disabled by default. Those logs add extra records for the cache path and UI event dispatch path of the same delta, and are only needed when diagnosing local runtime work routing.
+
+Available environment variables:
+
+```text
+WEGENT_CODEX_STREAM_DEBUG=0          # disable raw Codex delta / classification details
+WEGENT_CODEX_STREAM_DEBUG=1          # enable raw Codex delta / classification details (default)
+WEGENT_CODEX_STREAM_MAPPING_DEBUG=1  # enable runtime work cache/emit mapping details
+```
+
 ## Collected Data
 
 When enabled, the diagnostics module records:

--- a/docs/zh/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/developer-guide/wework-performance-diagnostics.md
@@ -37,6 +37,20 @@ Developer Commands 菜单中的 **Debug Panel** 用于排查 Wework 当前运行
 
 Debug 面板可以展开、收起、刷新、复制快照和清空日志。收起后只保留右下角状态条，避免遮挡主界面。
 
+## 本地 Codex 流式日志
+
+本地 executor 的 Codex 调试日志默认保留 delta 详情，便于定位流式输出顺序、阶段识别和最终内容覆盖问题。默认会记录 Codex 原始 delta 与运行态分类摘要。
+
+为避免 debug 包在长回复或高频 token 输出时产生过多日志，runtime work 内部的 cache/emit mapping 日志默认关闭。这类日志会为同一个 delta 额外记录缓存和 UI 事件分发路径，只有排查本地 runtime work 路由时才需要打开。
+
+可用环境变量：
+
+```text
+WEGENT_CODEX_STREAM_DEBUG=0          # 关闭 Codex 原始 delta / 分类详情
+WEGENT_CODEX_STREAM_DEBUG=1          # 开启 Codex 原始 delta / 分类详情（默认）
+WEGENT_CODEX_STREAM_MAPPING_DEBUG=1  # 开启 runtime work cache/emit mapping 详情
+```
+
 ## 采集内容
 
 开启后，诊断模块会采集：

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -32,6 +32,7 @@ use crate::{
     process_environment,
     protocol::ExecutionRequest,
     runner::{AgentEngine, ExecutionOutcome},
+    runtime_work::codex_stream_debug_enabled,
 };
 
 use super::{model_id, prompt_text};
@@ -1720,6 +1721,10 @@ fn log_codex_run_state_text(
     item: &Value,
     text: &str,
 ) {
+    if source == "delta" && !codex_stream_debug_enabled() {
+        return;
+    }
+
     log_executor_event(
         "codex run state text classification",
         &[
@@ -1771,6 +1776,14 @@ fn log_codex_run_state_error(params: &Value) {
 
 fn log_codex_raw_turn_message(message: &Value) {
     let method = message.get("method").and_then(Value::as_str).unwrap_or("");
+    if matches!(
+        method,
+        "item/agentMessage/delta" | "item/reasoning/delta" | "item/reasoningSummary/delta"
+    ) && !codex_stream_debug_enabled()
+    {
+        return;
+    }
+
     if !matches!(
         method,
         "item/agentMessage/delta"

--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -12,8 +12,8 @@ use crate::{codex_phase::CodexAgentMessagePhaseTracker, protocol::ExecutionReque
 use super::{
     codex_notifications::{codex_notification, debug_ignored_codex_notification},
     notification_mapping::{
-        log_dropped_notification, log_text_mapping, map_text_chunk, notification_item_id,
-        TextChunkMapping,
+        log_dropped_notification, log_stream_text_mapping, log_text_mapping, map_text_chunk,
+        notification_item_id, TextChunkMapping,
     },
     transcript::{
         completed_workbench_block_from_notification, tool_update_from_notification,
@@ -84,6 +84,7 @@ pub(crate) struct CodexNotificationEventMapper {
     root_thread_id: Option<String>,
     process_text: Option<ProcessTextStream>,
     process_text_count: usize,
+    final_text_offset: usize,
     plan_blocks: BTreeMap<String, String>,
 }
 
@@ -259,6 +260,7 @@ impl CodexNotificationEventMapper {
                 );
             }
             "thread/started" => {
+                self.final_text_offset = 0;
                 self.observe_root_thread(notification.params);
             }
             "thread/goal/updated" => {
@@ -428,7 +430,7 @@ impl CodexNotificationEventMapper {
                 item_id,
                 delta,
             })) => {
-                log_text_mapping(
+                log_stream_text_mapping(
                     emit_context.local_task_id,
                     method,
                     "emit_process_delta",
@@ -446,7 +448,7 @@ impl CodexNotificationEventMapper {
                 true
             }
             Ok(Some(TextChunkMapping::FinalDelta { delta })) => {
-                log_text_mapping(
+                log_stream_text_mapping(
                     emit_context.local_task_id,
                     method,
                     "emit_final_delta",
@@ -455,13 +457,15 @@ impl CodexNotificationEventMapper {
                     &delta,
                 );
                 self.reset_process_text();
+                let offset = self.final_text_offset;
+                self.final_text_offset += delta.chars().count();
                 emit_response_event(
                     emit_context.event_tx,
                     emit_context.device_id,
                     "response.output_text.delta",
                     emit_context.local_task_id,
                     emit_context.request,
-                    json!({"delta": delta}),
+                    json!({"delta": delta, "offset": offset}),
                 );
                 true
             }
@@ -497,6 +501,7 @@ impl CodexNotificationEventMapper {
                     params,
                     "",
                 );
+                self.final_text_offset = 0;
                 true
             }
             Ok(None) => false,
@@ -1471,7 +1476,7 @@ mod tests {
             }),
         );
         mapper.map(
-            &Some(event_tx),
+            &Some(event_tx.clone()),
             "device-1",
             "local-1",
             &request,
@@ -1483,10 +1488,61 @@ mod tests {
                 }
             }),
         );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "itemId": "msg-final",
+                    "delta": " More."
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "thread/started",
+                "params": {
+                    "thread": {
+                        "id": "root-thread-2"
+                    }
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "itemId": "msg-final-2",
+                    "delta": "Next."
+                }
+            }),
+        );
 
-        let event = event_rx.try_recv().expect("event should be emitted");
-        assert_eq!(event["event"], "response.output_text.delta");
-        assert_eq!(event["payload"]["data"]["delta"], "Done.");
+        let first_event = event_rx.try_recv().expect("first event should be emitted");
+        let second_event = event_rx.try_recv().expect("second event should be emitted");
+        let next_event = event_rx
+            .try_recv()
+            .expect("next turn event should be emitted");
+        assert_eq!(first_event["event"], "response.output_text.delta");
+        assert_eq!(first_event["payload"]["data"]["delta"], "Done.");
+        assert_eq!(first_event["payload"]["data"]["offset"], 0);
+        assert_eq!(second_event["event"], "response.output_text.delta");
+        assert_eq!(second_event["payload"]["data"]["delta"], " More.");
+        assert_eq!(second_event["payload"]["data"]["offset"], 5);
+        assert_eq!(next_event["event"], "response.output_text.delta");
+        assert_eq!(next_event["payload"]["data"]["delta"], "Next.");
+        assert_eq!(next_event["payload"]["data"]["offset"], 0);
     }
 
     #[test]

--- a/executor/src/runtime_work/mod.rs
+++ b/executor/src/runtime_work/mod.rs
@@ -18,3 +18,4 @@ mod transcript_page;
 mod util;
 
 pub use handler::RuntimeWorkRpcHandler;
+pub(crate) use notification_mapping::codex_stream_debug_enabled;

--- a/executor/src/runtime_work/notification_mapping.rs
+++ b/executor/src/runtime_work/notification_mapping.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{env, sync::OnceLock};
+
 use serde_json::Value;
 
 use crate::{
@@ -163,6 +165,40 @@ pub(crate) fn log_text_mapping(
             ("text_preview", truncate_log_text(text, 160)),
         ],
     );
+}
+
+pub(crate) fn log_stream_text_mapping(
+    local_task_id: &str,
+    method: &str,
+    action: &str,
+    resolved_phase: Option<&str>,
+    params: &Value,
+    text: &str,
+) {
+    if codex_stream_mapping_debug_enabled() {
+        log_text_mapping(local_task_id, method, action, resolved_phase, params, text);
+    }
+}
+
+pub(crate) fn codex_stream_debug_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env_bool("WEGENT_CODEX_STREAM_DEBUG", true))
+}
+
+fn codex_stream_mapping_debug_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env_bool("WEGENT_CODEX_STREAM_MAPPING_DEBUG", false))
+}
+
+fn env_bool(name: &str, default_value: bool) -> bool {
+    env::var(name)
+        .ok()
+        .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => default_value,
+        })
+        .unwrap_or(default_value)
 }
 
 enum CompletedAssistantTextKind {

--- a/executor/src/runtime_work/runtime_handle_messages.rs
+++ b/executor/src/runtime_work/runtime_handle_messages.rs
@@ -11,8 +11,8 @@ use crate::{codex_phase::CodexAgentMessagePhaseTracker, protocol::ExecutionReque
 use super::{
     codex_notifications::{codex_notification, debug_ignored_codex_notification},
     notification_mapping::{
-        log_dropped_notification, log_text_mapping, map_text_chunk, notification_item_id,
-        TextChunkMapping,
+        log_dropped_notification, log_stream_text_mapping, log_text_mapping, map_text_chunk,
+        notification_item_id, TextChunkMapping,
     },
     response::RuntimeTaskLink,
     store::RuntimeWorkStore,
@@ -248,7 +248,7 @@ impl CodexNotificationCacheMapper {
                 item_id,
                 delta,
             })) => {
-                log_text_mapping(
+                log_stream_text_mapping(
                     local_task_id,
                     method,
                     "cache_process_delta",
@@ -268,7 +268,7 @@ impl CodexNotificationCacheMapper {
                 true
             }
             Ok(Some(TextChunkMapping::FinalDelta { delta })) => {
-                log_text_mapping(
+                log_stream_text_mapping(
                     local_task_id,
                     method,
                     "cache_final_delta",

--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -40,6 +40,83 @@ describe('reduceWorkbenchMessages', () => {
     })
   })
 
+  test('uses chunk offsets to ignore duplicate assistant chunks', () => {
+    const started = reduceWorkbenchMessages([], {
+      type: 'assistant_started',
+      subtaskId: '9'
+    })
+    const withHello = reduceWorkbenchMessages(started, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '你好',
+      offset: 0
+    })
+    const duplicated = reduceWorkbenchMessages(withHello, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '你好',
+      offset: 0
+    })
+    const completed = reduceWorkbenchMessages(duplicated, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '，世界',
+      offset: 2
+    })
+
+    expect(completed[0]).toMatchObject({
+      role: 'assistant',
+      content: '你好，世界',
+      status: 'streaming'
+    })
+  })
+
+  test('uses chunk offsets to append only uncovered overlap suffixes', () => {
+    const started = reduceWorkbenchMessages([], {
+      type: 'assistant_started',
+      subtaskId: '10'
+    })
+    const withPrefix = reduceWorkbenchMessages(started, {
+      type: 'assistant_chunk',
+      subtaskId: '10',
+      content: 'abcdef',
+      offset: 0
+    })
+    const overlapped = reduceWorkbenchMessages(withPrefix, {
+      type: 'assistant_chunk',
+      subtaskId: '10',
+      content: 'defghi',
+      offset: 3
+    })
+
+    expect(overlapped[0]).toMatchObject({
+      role: 'assistant',
+      content: 'abcdefghi',
+      status: 'streaming'
+    })
+  })
+
+  test('tracks chunk offsets when a chunk creates the assistant message', () => {
+    const withHello = reduceWorkbenchMessages([], {
+      type: 'assistant_chunk',
+      subtaskId: '11',
+      content: 'hello',
+      offset: 0
+    })
+    const duplicated = reduceWorkbenchMessages(withHello, {
+      type: 'assistant_chunk',
+      subtaskId: '11',
+      content: 'hello',
+      offset: 0
+    })
+
+    expect(duplicated[0]).toMatchObject({
+      role: 'assistant',
+      content: 'hello',
+      status: 'streaming'
+    })
+  })
+
   test('late assistant stream creates an assistant message when a user message has the same subtask id', () => {
     const state: WorkbenchMessage[] = [
       {

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -78,6 +78,7 @@ export interface WorkbenchMessage<TAttachment = unknown, TFileChanges = unknown>
   runtimeStatus?: WorkbenchRuntimeMessageStatus | null
   completedAt?: string | number | null
   stoppedNotice?: boolean | null
+  streamTextOffset?: number
   createdAt: string
 }
 
@@ -112,6 +113,7 @@ export type WorkbenchMessageAction<TAttachment = unknown, TFileChanges = unknown
       messageId?: string
       subtaskId?: string
       content: string
+      offset?: number
       reasoningChunk?: string
       blocks?: WorkbenchProcessingBlock<TFileChanges>[]
     }
@@ -216,15 +218,17 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
       ]
     case 'assistant_chunk':
       if (!state.some(message => isAssistantMessageForAction(message, action))) {
+        const contentMerge = mergeWorkbenchChunkContent('', undefined, action.content, action.offset)
         const message = createAssistantMessage<TAttachment, TFileChanges>({
           messageId: action.messageId,
           subtaskId: action.subtaskId,
-          content: action.content
+          content: contentMerge.content
         })
         return [
           ...state,
           {
             ...message,
+            streamTextOffset: contentMerge.streamTextOffset,
             blocks: getChunkBlocks(message, action)
           }
         ]
@@ -235,7 +239,12 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
             ? message
             : {
                 ...clearMessageError(message),
-                content: message.content + action.content,
+                ...mergeWorkbenchChunkContent(
+                  message.content,
+                  message.streamTextOffset,
+                  action.content,
+                  action.offset
+                ),
                 status: 'streaming' as const,
                 blocks: getChunkBlocks(message, action)
               }
@@ -260,6 +269,7 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
           ? {
               ...clearMessageError(message),
               content: action.content ?? message.content,
+              streamTextOffset: undefined,
               status: 'done' as const,
               blocks: finalizeProcessingBlocks(action.blocks ?? message.blocks, 'done'),
               fileChanges: action.fileChanges ?? message.fileChanges
@@ -595,6 +605,62 @@ function getChunkBlocks<TAttachment, TFileChanges>(
 
   if (!action.blocks) return withReasoning
   return action.blocks.reduce(mergeProcessingBlock, withReasoning ?? [])
+}
+
+function mergeWorkbenchChunkContent(
+  content: string,
+  streamTextOffset: number | undefined,
+  incomingContent: string,
+  incomingOffset: number | undefined
+): { content: string; streamTextOffset?: number } {
+  if (!incomingContent) {
+    return { content, streamTextOffset }
+  }
+
+  const currentOffset =
+    streamTextOffset ?? (content.length === 0 && incomingOffset === 0 ? 0 : undefined)
+  if (
+    incomingOffset === undefined ||
+    currentOffset === undefined ||
+    incomingOffset > currentOffset
+  ) {
+    return {
+      content: content + incomingContent,
+      streamTextOffset:
+        incomingOffset === undefined
+          ? undefined
+          : incomingOffset + textCodePointLength(incomingContent)
+    }
+  }
+
+  const incomingLength = textCodePointLength(incomingContent)
+  if (incomingOffset < currentOffset) {
+    const coveredLength = currentOffset - incomingOffset
+    if (coveredLength >= incomingLength) {
+      return { content, streamTextOffset: currentOffset }
+    }
+
+    const suffix = sliceTextCodePoints(incomingContent, coveredLength)
+    return {
+      content: content + suffix,
+      streamTextOffset: incomingOffset + incomingLength
+    }
+  }
+
+  return {
+    content: content + incomingContent,
+    streamTextOffset: incomingOffset + incomingLength
+  }
+}
+
+function textCodePointLength(value: string): number {
+  return /^[\x00-\x7F]*$/.test(value) ? value.length : Array.from(value).length
+}
+
+function sliceTextCodePoints(value: string, start: number): string {
+  if (start <= 0) return value
+  if (/^[\x00-\x7F]*$/.test(value)) return value.slice(start)
+  return Array.from(value).slice(start).join('')
 }
 
 function appendThinkingChunk<TFileChanges>(

--- a/wework/src/api/local/localChatStream.test.ts
+++ b/wework/src/api/local/localChatStream.test.ts
@@ -28,7 +28,7 @@ describe('createLocalChatStream', () => {
         taskId: 'task-1',
         subtaskId: '1001',
         deviceId: 'local-device',
-        data: { delta: 'hello' },
+        data: { delta: 'hello', offset: 0 },
       },
     })
 
@@ -38,7 +38,7 @@ describe('createLocalChatStream', () => {
       deviceId: 'local-device',
       content: 'hello',
       offset: 0,
-      result: { delta: 'hello' },
+      result: { delta: 'hello', offset: 0 },
     })
   })
 
@@ -67,7 +67,6 @@ describe('createLocalChatStream', () => {
       taskId: 'task-1',
       subtaskId: '1001',
       deviceId: 'local-device',
-      offset: 0,
       result: { value: 'complete' },
     })
   })

--- a/wework/src/api/local/localChatStream.ts
+++ b/wework/src/api/local/localChatStream.ts
@@ -1,12 +1,19 @@
 import type { ChatCancelAck, ChatCancelPayload, ChatGuideAck, ChatGuidePayload } from '@/types/api'
 import type { ChatStreamHandlers } from '@/stream/chatStream'
 import type { LocalExecutorEvent } from '@/tauri/localExecutor'
-import { createResponseApiStreamState, emitResponseApiEvent } from '@/stream/responseApiStream'
+import {
+  createResponseApiStreamState,
+  emitResponseApiEvent,
+  RESPONSE_API_STREAM_EVENTS,
+} from '@/stream/responseApiStream'
 
 interface LocalChatStreamDeps {
   subscribe: (handler: (event: LocalExecutorEvent) => void) => Promise<() => void>
   request: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
+
+let nextLocalChatStreamSubscriptionId = 1
+let activeLocalChatStreamSubscriptions = 0
 
 export function createLocalChatStream(deps: LocalChatStreamDeps) {
   return {
@@ -23,28 +30,113 @@ export function createLocalChatStream(deps: LocalChatStreamDeps) {
       )
     },
     subscribe(handlers: ChatStreamHandlers): () => void {
+      const subscriptionId = nextLocalChatStreamSubscriptionId++
       let cleanup: (() => void) | null = null
       let active = true
+      let released = false
+      let eventCount = 0
+      let textDeltaCount = 0
       const state = createResponseApiStreamState()
+      activeLocalChatStreamSubscriptions += 1
+      logLocalChatStreamSubscription('subscribed', subscriptionId, {
+        activeSubscriptions: activeLocalChatStreamSubscriptions,
+      })
 
       void deps
         .subscribe(event => {
           if (active) {
+            eventCount += 1
+            if (event.event === 'response.output_text.delta') {
+              textDeltaCount += 1
+            }
+            logLocalChatStreamEvent(subscriptionId, event, eventCount, textDeltaCount)
             emitResponseApiEvent(handlers, event.event, event.payload, state)
           }
         })
         .then(unlisten => {
           if (active) {
             cleanup = unlisten
+            logLocalChatStreamSubscription('native-listener-ready', subscriptionId, {
+              activeSubscriptions: activeLocalChatStreamSubscriptions,
+            })
             return
           }
+          logLocalChatStreamSubscription('late-native-listener-cleanup', subscriptionId, {
+            activeSubscriptions: activeLocalChatStreamSubscriptions,
+          })
           unlisten()
+        })
+        .catch(error => {
+          logLocalChatStreamSubscription('native-listener-failed', subscriptionId, {
+            activeSubscriptions: activeLocalChatStreamSubscriptions,
+            error: error instanceof Error ? error.message : String(error),
+          })
         })
 
       return () => {
+        if (released) return
+        released = true
         active = false
+        activeLocalChatStreamSubscriptions = Math.max(0, activeLocalChatStreamSubscriptions - 1)
+        logLocalChatStreamSubscription('unsubscribed', subscriptionId, {
+          activeSubscriptions: activeLocalChatStreamSubscriptions,
+          eventCount,
+          textDeltaCount,
+          hadNativeCleanup: Boolean(cleanup),
+        })
         cleanup?.()
+        cleanup = null
       }
     },
   }
+}
+
+function logLocalChatStreamSubscription(
+  action: string,
+  subscriptionId: number,
+  details: Record<string, unknown>
+): void {
+  console.debug('[Wework] Local chat stream subscription', {
+    action,
+    subscriptionId,
+    ...details,
+  })
+}
+
+function logLocalChatStreamEvent(
+  subscriptionId: number,
+  event: LocalExecutorEvent,
+  eventCount: number,
+  textDeltaCount: number
+): void {
+  const payload = asRecord(event.payload)
+  const data = asRecord(payload.data)
+  console.debug('[Wework] Local chat stream event', {
+    subscriptionId,
+    activeSubscriptions: activeLocalChatStreamSubscriptions,
+    event: event.event,
+    mapped: isMappedResponseApiEvent(event.event),
+    eventCount,
+    textDeltaCount,
+    taskId: stringField(payload, 'taskId'),
+    subtaskId: stringField(payload, 'subtaskId'),
+    deviceId: stringField(payload, 'deviceId'),
+    deltaLength: typeof data.delta === 'string' ? data.delta.length : undefined,
+    offset: typeof data.offset === 'number' ? data.offset : undefined,
+  })
+}
+
+function isMappedResponseApiEvent(eventName: string): boolean {
+  return (RESPONSE_API_STREAM_EVENTS as readonly string[]).includes(eventName)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' ? value : undefined
 }

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -35,6 +35,7 @@ describe('createRuntimeTaskStreamHandlers', () => {
       type: 'assistant_chunk',
       subtaskId: 'subtask-9',
       content: 'partial',
+      offset: 0,
     })
     expect('messageId' in actions[0]).toBe(false)
   })

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -81,6 +81,7 @@ export function createRuntimeTaskStreamHandlers(
         type: 'assistant_chunk',
         subtaskId: identity.subtaskId,
         content: payload.content,
+        offset: payload.offset,
         reasoningChunk,
         blocks,
       })

--- a/wework/src/stream/chatStream.test.ts
+++ b/wework/src/stream/chatStream.test.ts
@@ -21,7 +21,7 @@ describe('createChatStream', () => {
       subtaskId: '202',
       deviceId: 'device-1',
       runtime: 'codex',
-      data: { delta: 'hello' },
+      data: { delta: 'hello', offset: 0 },
     })
 
     expect(onChatChunk).toHaveBeenCalledWith({
@@ -30,7 +30,7 @@ describe('createChatStream', () => {
       deviceId: 'device-1',
       content: 'hello',
       offset: 0,
-      result: { delta: 'hello' },
+      result: { delta: 'hello', offset: 0 },
     })
   })
 

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -2,6 +2,54 @@ import { describe, expect, test, vi } from 'vitest'
 import { createResponseApiStreamState, emitResponseApiEvent } from './responseApiStream'
 
 describe('emitResponseApiEvent', () => {
+  test('reads text delta offsets from response data', () => {
+    const onChatChunk = vi.fn()
+
+    emitResponseApiEvent(
+      { onChatChunk },
+      'response.output_text.delta',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          delta: 'hello',
+          offset: 5,
+        },
+      },
+      createResponseApiStreamState()
+    )
+
+    expect(onChatChunk).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      subtaskId: '2',
+      content: 'hello',
+      offset: 5,
+      result: {
+        delta: 'hello',
+        offset: 5,
+      },
+    })
+  })
+
+  test('leaves text delta offsets undefined when the stream omits them', () => {
+    const onChatChunk = vi.fn()
+
+    emitResponseApiEvent(
+      { onChatChunk },
+      'response.output_text.delta',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          delta: 'hello',
+        },
+      },
+      createResponseApiStreamState()
+    )
+
+    expect(onChatChunk.mock.calls[0]?.[0]).not.toHaveProperty('offset')
+  })
+
   test('does not treat full output snapshots as text deltas', () => {
     const onChatChunk = vi.fn()
 

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -70,11 +70,6 @@ function idField(record: Record<string, unknown>, key: string): string | undefin
   return undefined
 }
 
-function numberField(record: Record<string, unknown>, key: string): number {
-  const value = record[key]
-  return typeof value === 'number' ? value : 0
-}
-
 function optionalNumberField(record: Record<string, unknown>, key: string): number | undefined {
   const value = record[key]
   return typeof value === 'number' ? value : undefined
@@ -116,6 +111,12 @@ function parseRecord(value: unknown): Record<string, unknown> | undefined {
 function eventContent(payload: Record<string, unknown>): string {
   const result = eventResult(payload)
   return stringField(result, 'delta') ?? ''
+}
+
+function eventOffset(payload: Record<string, unknown>): number | undefined {
+  return (
+    optionalNumberField(payload, 'offset') ?? optionalNumberField(eventResult(payload), 'offset')
+  )
 }
 
 function completedContent(data: Record<string, unknown>): string | undefined {
@@ -492,7 +493,7 @@ export function emitResponseApiEvent(
     handlers.onChatChunk?.({
       ...base,
       content,
-      offset: numberField(payload, 'offset'),
+      ...(eventOffset(payload) !== undefined && { offset: eventOffset(payload) }),
       result: eventResult(payload),
     })
     return
@@ -510,7 +511,7 @@ export function emitResponseApiEvent(
     handlers.onChatChunk?.({
       ...base,
       content: '',
-      offset: numberField(payload, 'offset'),
+      ...(eventOffset(payload) !== undefined && { offset: eventOffset(payload) }),
       result: { reasoningChunk: content },
     })
     return
@@ -582,7 +583,7 @@ export function emitResponseApiEvent(
   if (eventName === 'response.completed') {
     handlers.onChatDone?.({
       ...base,
-      offset: numberField(payload, 'offset'),
+      ...(eventOffset(payload) !== undefined && { offset: eventOffset(payload) }),
       result: completedResult(data),
     })
     return

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -1113,7 +1113,7 @@ export interface ChatChunkPayload {
   taskId?: string
   subtaskId?: string
   content: string
-  offset: number
+  offset?: number
   result?: ChatResultPayload
   deviceId?: string
 }
@@ -1121,7 +1121,7 @@ export interface ChatChunkPayload {
 export interface ChatDonePayload {
   taskId?: string
   subtaskId?: string
-  offset: number
+  offset?: number
   result: ChatResultPayload
   deviceId?: string
 }


### PR DESCRIPTION
## Summary

Fixes Wework local runtime streaming corruption where repeated or replayed Codex deltas could be appended multiple times during streaming while the final completed content looked correct.

## Root Cause

Local Codex final deltas did not carry a text offset, and Wework only read offsets from the top-level stream payload instead of `payload.data.offset`. When a send failed or a stream recovered, replayed chunks were treated as new text and appended again.

The issue could also look worse over long sessions, so this PR adds local chat stream subscription diagnostics to expose active listener counts and sampled stream events without logging every chunk.

## Changes

- Emit offsets for local Codex final deltas and reset the offset on new threads/final snapshots.
- Parse response offsets from `payload.data.offset` in Wework response stream handling.
- Pass chunk offsets into the Workbench reducer.
- Replace full-content chunk merging with a lightweight stream cursor (`streamTextOffset`) to ignore duplicates and append only uncovered overlap suffixes.
- Reduce duplicate internal runtime work cache/emit mapping logs by default while keeping Codex delta details enabled.
- Add local chat stream subscribe/unsubscribe diagnostics with active subscription counts and sampled delta events.
- Document Codex stream debug log environment variables in English and Chinese docs.

## Validation

- `pnpm --filter wework exec vitest run src/stream/responseApiStream.test.ts src/api/local/localChatStream.test.ts src/stream/chatStream.test.ts src/features/workbench/runtimePaneMessages.test.ts`
- `pnpm --filter @wegent/chat-core exec vitest run src/workbench-message-reducer.test.ts`
- `pnpm --filter wework typecheck`
- `cargo fmt --check`
- `cargo test runtime_work::events::tests::maps_codex_started_final_agent_message_deltas_to_output_text`
- Pre-push hook: Wework ESLint, TypeScript, unit tests; executor `cargo fmt`, `cargo test --all-features`, `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat and workbench streaming updates now carry chunk offsets, improving how partial responses are assembled.
  * Local diagnostics now include clearer guidance for streaming logs and environment-based log controls.

* **Bug Fixes**
  * Reduced duplicate or overlapping assistant text in streamed messages.
  * Improved handling of streamed responses so completion events and chunk updates stay in sync.

* **Documentation**
  * Added English and Chinese docs for local Codex streaming logs and related logging settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->