### PR TITLE
[codex] Animate Wework context compaction status

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -178,7 +178,16 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByTestId('context-compaction-indicator')).toHaveTextContent(
       '正在自动压缩上下文'
     )
+    expect(screen.getByText('正在自动压缩上下文')).toHaveClass('waiting-thinking-text')
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+  })
+
+  test('keeps completed context compaction status static', () => {
+    render(<ToolBlocksDisplay blocks={[completedContextCompactionBlock]} isStreaming={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByText('上下文已自动压缩')).not.toHaveClass('waiting-thinking-text')
   })
 
   test('renders completed web search tools as a Codex-style web search activity', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -432,6 +432,7 @@ function ToolActivityGroup({
 
 function ContextCompactionIndicator({ block }: { block: ToolBlock }) {
   const label = getContextCompactionLabel(block)
+  const isRunning = block.status !== 'done' && block.status !== 'error'
   const textClassName = block.status === 'error' ? 'text-red-500' : 'text-text-muted'
 
   return (
@@ -445,7 +446,9 @@ function ContextCompactionIndicator({ block }: { block: ToolBlock }) {
         className={`inline-flex min-w-0 max-w-full items-center gap-1.5 text-[13px] font-semibold ${textClassName}`}
       >
         <Archive className="h-4 w-4 shrink-0" strokeWidth={1.7} aria-hidden="true" />
-        <span className="min-w-0 truncate">{label}</span>
+        <span className={`min-w-0 truncate ${isRunning ? 'waiting-thinking-text' : ''}`}>
+          {label}
+        </span>
       </span>
       <span className="h-px min-w-6 flex-1 bg-border" aria-hidden="true" />
     </div>


### PR DESCRIPTION
## What changed

- Reuse the existing `waiting-thinking-text` sweep animation for the running context compaction status in Wework chat.
- Keep completed and error context compaction states static.
- Add coverage for both running and completed context compaction display states.

## Why

When Wework automatically compacts context, the running status should visually match the assistant thinking state so users can tell work is still in progress.

## Validation

- `pnpm exec vitest run src/components/chat/blocks/ToolBlocksDisplay.test.tsx`
- `pnpm exec eslint src/components/chat/blocks/ToolBlocksDisplay.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx`
- Pre-push Wework checks: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of context-compaction status in chat.
  * The “auto-compacting context” message now shows the correct loading style while processing, and switches to the completed label once finished.
  * Removed an incorrect generic thinking indicator from this state, making the chat UI clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->