### PR TITLE
feat(wework): stream file change line counts

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -43,6 +43,10 @@ const DEFAULT_PROVIDER_NAME: &str = "wecode openai";
 const DEFAULT_REASONING_EFFORT: &str = "medium";
 const DEFAULT_NO_PROXY: &str = "localhost,127.0.0.1,::1,host.docker.internal";
 const MACOS_CODEX_APP_BINARY: &str = "/Applications/Codex.app/Contents/Resources/codex";
+const CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE: &str =
+    "features.apply_patch_streaming_events=true";
+const CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE: &str =
+    "suppress_unstable_features_warning=true";
 const IMAGE_MIME_TYPES: &[&str] = &[
     "image/png",
     "image/jpeg",
@@ -1924,6 +1928,9 @@ fn build_codex_launch_config(request: &ExecutionRequest) -> CodexLaunchConfig {
     launch_config
         .config_overrides
         .push(shell_path_config_override());
+    launch_config
+        .config_overrides
+        .extend(codex_streaming_patch_config_overrides());
 
     if let Some(model) = &model {
         launch_config
@@ -1995,6 +2002,13 @@ fn shell_path_config_override() -> String {
         env::var("PATH").ok().as_deref().unwrap_or_default(),
     );
     format!("shell_environment_policy.set.PATH={}", toml_value(&path))
+}
+
+fn codex_streaming_patch_config_overrides() -> Vec<String> {
+    vec![
+        CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE.to_owned(),
+        CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE.to_owned(),
+    ]
 }
 
 fn thread_config(
@@ -3224,6 +3238,26 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn codex_launch_config_enables_streaming_patch_updates() {
+        let request = ExecutionRequest {
+            prompt: Value::String("create a file".to_owned()),
+            model_config: json!({
+                "model_id": "gpt-5.5-codex",
+            }),
+            ..ExecutionRequest::default()
+        };
+
+        let launch_config = build_codex_launch_config(&request);
+
+        assert!(launch_config
+            .config_overrides
+            .contains(&CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE.to_owned()));
+        assert!(launch_config
+            .config_overrides
+            .contains(&CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE.to_owned()));
+    }
 
     #[test]
     fn codex_run_state_keeps_commentary_agent_delta_out_of_final_content() {

--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -16,7 +16,8 @@ use super::{
         TextChunkMapping,
     },
     transcript::{
-        completed_workbench_block_from_notification, tool_update_from_notification,
+        completed_workbench_block_from_notification, file_changes_block_from_patch_updated,
+        file_changes_update_from_patch_updated, tool_update_from_notification,
         workbench_block_from_notification,
     },
     util::{extract_text, is_completed_plan_item, item_id, now_ms, raw_string_field, string_field},
@@ -164,6 +165,15 @@ impl CodexNotificationEventMapper {
             }
             "item/plan/delta" => {
                 self.emit_plan_delta(
+                    event_tx,
+                    device_id,
+                    local_task_id,
+                    request,
+                    notification.params,
+                );
+            }
+            "item/fileChange/patchUpdated" => {
+                self.emit_file_change_patch_updated(
                     event_tx,
                     device_id,
                     local_task_id,
@@ -612,6 +622,51 @@ impl CodexNotificationEventMapper {
                 }
             }),
         );
+    }
+
+    fn emit_file_change_patch_updated(
+        &mut self,
+        event_tx: &Option<broadcast::Sender<Value>>,
+        device_id: &str,
+        local_task_id: &str,
+        request: &ExecutionRequest,
+        params: &Value,
+    ) {
+        let Some((block_id, updates)) = file_changes_update_from_patch_updated(
+            params,
+            &request.subtask_id,
+            device_id,
+            request.cwd().unwrap_or_default(),
+            "streaming",
+        ) else {
+            return;
+        };
+
+        emit_response_event(
+            event_tx,
+            device_id,
+            "response.block.updated",
+            local_task_id,
+            request,
+            json!({"block_id": block_id, "updates": updates}),
+        );
+
+        if let Some(block) = file_changes_block_from_patch_updated(
+            params,
+            &request.subtask_id,
+            device_id,
+            request.cwd().unwrap_or_default(),
+            "streaming",
+        ) {
+            emit_response_event(
+                event_tx,
+                device_id,
+                "response.block.created",
+                local_task_id,
+                request,
+                json!({"block": block}),
+            );
+        }
     }
 
     fn reset_process_text(&mut self) {
@@ -2447,5 +2502,104 @@ mod tests {
         assert_eq!(block["file_changes"]["file_count"], 1);
         assert_eq!(block["file_changes"]["files"][0]["path"], "helloworld.html");
         assert!(event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn maps_started_codex_file_change_to_pending_file_changes_block() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: "task-1".to_owned(),
+            subtask_id: "turn-1".to_owned(),
+            project_workspace_path: Some("/workspace/repo".to_owned()),
+            ..ExecutionRequest::default()
+        };
+
+        map_codex_notification(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "file-change-1",
+                        "type": "fileChange",
+                        "status": "inProgress",
+                        "changes": [
+                            {
+                                "path": "/workspace/repo/helloworld.html",
+                                "kind": { "type": "add" },
+                                "diff": ""
+                            }
+                        ]
+                    }
+                }
+            }),
+        );
+
+        let event = event_rx
+            .try_recv()
+            .expect("started file changes event should be emitted");
+        let block = &event["payload"]["data"]["block"];
+        assert_eq!(event["event"], "response.block.created");
+        assert_eq!(block["type"], "file_changes");
+        assert_eq!(block["status"], "pending");
+        assert_eq!(block["file_changes"]["additions"], 0);
+        assert_eq!(block["file_changes"]["deletions"], 0);
+    }
+
+    #[test]
+    fn maps_codex_patch_updates_to_streaming_file_changes_block() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: "task-1".to_owned(),
+            subtask_id: "turn-1".to_owned(),
+            project_workspace_path: Some("/workspace/repo".to_owned()),
+            ..ExecutionRequest::default()
+        };
+
+        map_codex_notification(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/fileChange/patchUpdated",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "itemId": "call-1",
+                    "changes": [
+                        {
+                            "path": "/workspace/repo/live.txt",
+                            "kind": { "type": "add" },
+                            "diff": "first\nsecond\n"
+                        }
+                    ]
+                }
+            }),
+        );
+
+        let updated = event_rx
+            .try_recv()
+            .expect("patch update should emit a block update");
+        assert_eq!(updated["event"], "response.block.updated");
+        assert_eq!(
+            updated["payload"]["data"]["block_id"],
+            "file-changes-call-1"
+        );
+        assert_eq!(
+            updated["payload"]["data"]["updates"]["file_changes"]["additions"],
+            2
+        );
+
+        let created = event_rx
+            .try_recv()
+            .expect("patch update should ensure a block exists");
+        let block = &created["payload"]["data"]["block"];
+        assert_eq!(created["event"], "response.block.created");
+        assert_eq!(block["id"], "file-changes-call-1");
+        assert_eq!(block["status"], "streaming");
     }
 }

--- a/executor/src/runtime_work/runtime_handle_messages.rs
+++ b/executor/src/runtime_work/runtime_handle_messages.rs
@@ -17,7 +17,8 @@ use super::{
     response::RuntimeTaskLink,
     store::RuntimeWorkStore,
     transcript::{
-        completed_workbench_block_from_notification, tool_update_from_notification,
+        completed_workbench_block_from_notification, file_changes_block_from_patch_updated,
+        file_changes_update_from_patch_updated, tool_update_from_notification,
         workbench_block_from_notification,
     },
     util::{
@@ -120,6 +121,32 @@ impl CodexNotificationCacheMapper {
                         "plan",
                         notification_item_id(params),
                         delta,
+                    );
+                }
+            }
+            "item/fileChange/patchUpdated" => {
+                if let Some(block) = file_changes_block_from_patch_updated(
+                    params,
+                    &request.subtask_id,
+                    request.device_id.as_deref().unwrap_or_default(),
+                    request.cwd().unwrap_or_default(),
+                    "streaming",
+                ) {
+                    cache_runtime_assistant_block(store, local_task_id, request, block);
+                }
+                if let Some((block_id, updates)) = file_changes_update_from_patch_updated(
+                    params,
+                    &request.subtask_id,
+                    request.device_id.as_deref().unwrap_or_default(),
+                    request.cwd().unwrap_or_default(),
+                    "streaming",
+                ) {
+                    update_runtime_assistant_block(
+                        store,
+                        local_task_id,
+                        request,
+                        &block_id,
+                        updates,
                     );
                 }
             }

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -369,6 +369,40 @@ pub(crate) fn completed_workbench_block_from_notification(
         .then_some(block)
 }
 
+pub(crate) fn file_changes_block_from_patch_updated(
+    params: &Value,
+    turn_id: &str,
+    device_id: &str,
+    workspace_path: &str,
+    status: &str,
+) -> Option<Value> {
+    let summary = file_changes_from_patch_updated(params, turn_id, device_id, workspace_path)?;
+    let item = patch_updated_item(params);
+    let mut block = file_changes_block(&item, &summary, now_ms());
+    if let Some(object) = block.as_object_mut() {
+        object.insert("status".to_owned(), Value::String(status.to_owned()));
+    }
+    Some(block)
+}
+
+pub(crate) fn file_changes_update_from_patch_updated(
+    params: &Value,
+    turn_id: &str,
+    device_id: &str,
+    workspace_path: &str,
+    status: &str,
+) -> Option<(String, Value)> {
+    let summary = file_changes_from_patch_updated(params, turn_id, device_id, workspace_path)?;
+    let block_id = format!("file-changes-{}", patch_updated_item_id(params));
+    Some((
+        block_id,
+        json!({
+            "file_changes": summary,
+            "status": status,
+        }),
+    ))
+}
+
 pub(crate) fn workbench_block_from_codex_item(
     item: &Value,
     turn_id: &str,
@@ -1692,10 +1726,6 @@ fn file_changes_from_file_change_item(
     device_id: &str,
     workspace_path: &str,
 ) -> Option<Value> {
-    let status = string_field(item, "status").unwrap_or_else(|| "completed".to_owned());
-    if !status.eq_ignore_ascii_case("completed") {
-        return None;
-    }
     let changes = item.get("changes")?.as_array()?;
     let files = changes
         .iter()
@@ -1708,6 +1738,27 @@ fn file_changes_from_file_change_item(
         workspace_path,
         files,
         combined_diff_from_file_change_item(item, workspace_path),
+    )
+}
+
+fn file_changes_from_patch_updated(
+    params: &Value,
+    turn_id: &str,
+    device_id: &str,
+    workspace_path: &str,
+) -> Option<Value> {
+    let changes = params.get("changes")?.as_array()?;
+    let files = changes
+        .iter()
+        .filter_map(|change| file_change_from_codex_change(change, workspace_path))
+        .collect::<Vec<_>>();
+    file_changes_summary(
+        &patch_updated_item_id(params),
+        turn_id,
+        device_id,
+        workspace_path,
+        files,
+        combined_diff_from_patch_updated(params, workspace_path),
     )
 }
 
@@ -1938,6 +1989,41 @@ fn combined_diff_from_patch_apply_end(item: &Value, workspace_path: &str) -> Opt
         .collect::<Vec<_>>()
         .join("\n");
     Some(diff).filter(|diff| !diff.is_empty())
+}
+
+fn combined_diff_from_patch_updated(params: &Value, workspace_path: &str) -> Option<String> {
+    let diff = params
+        .get("changes")?
+        .as_array()?
+        .iter()
+        .filter_map(|change| {
+            let path = string_field(change, "path")?;
+            let move_path = change.get("kind").and_then(|kind| {
+                string_field(kind, "movePath").or_else(|| string_field(kind, "move_path"))
+            });
+            raw_string_field(change, "diff").map(|diff| match move_path {
+                Some(move_path) => {
+                    diff_with_file_header(&move_path, Some(&path), &diff, workspace_path)
+                }
+                None => diff_with_file_header(&path, None, &diff, workspace_path),
+            })
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(diff).filter(|diff| !diff.is_empty())
+}
+
+fn patch_updated_item(params: &Value) -> Value {
+    json!({
+        "id": patch_updated_item_id(params),
+        "type": "fileChange",
+    })
+}
+
+fn patch_updated_item_id(params: &Value) -> String {
+    string_field(params, "itemId")
+        .or_else(|| string_field(params, "item_id"))
+        .unwrap_or_else(|| item_id(params, "file-change"))
 }
 
 fn diff_with_file_header(

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -86,6 +86,7 @@ type ProcessingBlockUpdate = {
   toolInput?: Record<string, unknown>
   toolOutput?: unknown
   renderPayload?: unknown
+  fileChanges?: unknown
   status?: WorkbenchToolBlockStatus
 }
 

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -1,4 +1,5 @@
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { ChevronDown, Copy, CopyCheck, FileDiff, Search } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -135,13 +136,14 @@ function ProcessFileChangesBlockItem({
 }) {
   const { t } = useTranslation('chat')
   const summary = block.fileChanges
+  const isRunning = block.status !== 'done' && block.status !== 'error'
   const [expanded, setExpanded] = useState(false)
   const [expandedFilePath, setExpandedFilePath] = useState<string | null>(null)
 
   if (!summary.files.length) return null
 
   return (
-    <div className="min-w-0 overflow-hidden text-[13px]" data-testid="process-file-changes-block">
+    <div className="min-w-0 overflow-visible text-[13px]" data-testid="process-file-changes-block">
       <button
         type="button"
         aria-expanded={expanded}
@@ -149,7 +151,8 @@ function ProcessFileChangesBlockItem({
         className="flex max-w-full items-center gap-1.5 text-text-muted hover:text-text-secondary"
       >
         <FileDiff className="h-4 w-4 shrink-0" strokeWidth={1.7} />
-        <span className="min-w-0 truncate">{fileChangesSummaryLabel(summary, t)}</span>
+        <span className="min-w-0 truncate">{fileChangesSummaryLabel(summary, t, isRunning)}</span>
+        <FileChangeLineStats summary={summary} />
         <ChevronDown
           className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`}
           strokeWidth={2}
@@ -196,12 +199,158 @@ function ProcessFileChangesBlockItem({
   )
 }
 
+type FileChangeStatBlock = {
+  id: string
+  additions: number
+  deletions: number
+}
+
+type FileChangeStatBlockStyle = CSSProperties & {
+  '--file-change-stat-addition-height': string
+  '--file-change-stat-deletion-height': string
+  '--file-change-stat-x': string
+  '--file-change-stat-alpha': string
+}
+
+function FileChangeLineStats({ summary }: { summary: TurnFileChangesSummary }) {
+  const [statBlocks, setStatBlocks] = useState<FileChangeStatBlock[]>([])
+  const previousRef = useRef({
+    artifactId: summary.artifact_id,
+    additions: summary.additions,
+    deletions: summary.deletions,
+  })
+
+  useEffect(() => {
+    const previous = previousRef.current
+    if (previous.artifactId !== summary.artifact_id) {
+      previousRef.current = {
+        artifactId: summary.artifact_id,
+        additions: summary.additions,
+        deletions: summary.deletions,
+      }
+      setStatBlocks([])
+      return
+    }
+
+    const addedDelta = Math.max(0, summary.additions - previous.additions)
+    const deletedDelta = Math.max(0, summary.deletions - previous.deletions)
+    previousRef.current = {
+      artifactId: summary.artifact_id,
+      additions: summary.additions,
+      deletions: summary.deletions,
+    }
+
+    if (addedDelta === 0 && deletedDelta === 0) return
+
+    const now = Date.now()
+    setStatBlocks(current =>
+      [
+        ...current,
+        {
+          id: `${now}-${addedDelta}-${deletedDelta}`,
+          additions: addedDelta,
+          deletions: deletedDelta,
+        },
+      ].slice(-6)
+    )
+  }, [summary.additions, summary.artifact_id, summary.deletions])
+
+  return (
+    <span className="relative flex shrink-0 items-center gap-1 pr-14 text-xs font-medium tabular-nums">
+      <span className="inline-flex items-center text-green-600">
+        +<AnimatedChangeNumber value={summary.additions} deltaPrefix="+" />
+      </span>
+      <span className="inline-flex items-center text-red-500">
+        -<AnimatedChangeNumber value={summary.deletions} deltaPrefix="-" />
+      </span>
+      <FileChangeStatBlocks blocks={statBlocks} />
+    </span>
+  )
+}
+
+function AnimatedChangeNumber({ value, deltaPrefix }: { value: number; deltaPrefix: '+' | '-' }) {
+  const previousValueRef = useRef(value)
+  const [delta, setDelta] = useState(0)
+  const [animationId, setAnimationId] = useState(0)
+
+  useEffect(() => {
+    if (previousValueRef.current === value) return
+    const deltaValue = Math.abs(value - previousValueRef.current)
+    previousValueRef.current = value
+    setDelta(0)
+    const frame = requestAnimationFrame(() => {
+      setDelta(deltaValue)
+      setAnimationId(current => current + 1)
+    })
+    const timeout = window.setTimeout(() => setDelta(0), 560)
+    return () => {
+      cancelAnimationFrame(frame)
+      window.clearTimeout(timeout)
+    }
+  }, [value])
+
+  return (
+    <span className="file-change-delta-number">
+      <span className="file-change-rolling-viewport">
+        <span
+          key={`${value}-${animationId}`}
+          className={`file-change-rolling-value ${delta > 0 ? 'is-rolling' : ''}`}
+        >
+          {value}
+        </span>
+      </span>
+      {delta > 0 ? (
+        <span key={`${deltaPrefix}${delta}-${value}`} className="file-change-delta-badge">
+          {deltaPrefix}
+          {delta}
+        </span>
+      ) : null}
+    </span>
+  )
+}
+
+function FileChangeStatBlocks({ blocks }: { blocks: FileChangeStatBlock[] }) {
+  return (
+    <span className="file-change-stat-blocks" aria-hidden="true">
+      {blocks.map((block, index) => {
+        const age = blocks.length - index - 1
+        const additionHeight = block.additions > 0 ? Math.min(10, 3 + block.additions * 1.6) : 0
+        const deletionHeight = block.deletions > 0 ? Math.min(10, 3 + block.deletions * 1.6) : 0
+        return (
+          <span
+            key={block.id}
+            className="file-change-stat-block"
+            style={
+              {
+                '--file-change-stat-addition-height': `${additionHeight}px`,
+                '--file-change-stat-deletion-height': `${deletionHeight}px`,
+                '--file-change-stat-x': `${index * 7}px`,
+                '--file-change-stat-alpha': `${Math.max(0.28, 0.96 - age * 0.11)}`,
+              } as FileChangeStatBlockStyle
+            }
+          >
+            {block.additions > 0 ? <span className="file-change-stat-segment is-addition" /> : null}
+            {block.deletions > 0 ? <span className="file-change-stat-segment is-deletion" /> : null}
+          </span>
+        )
+      })}
+    </span>
+  )
+}
+
 function fileChangesSummaryLabel(
   summary: TurnFileChangesSummary,
-  t: ReturnType<typeof useTranslation>['t']
+  t: ReturnType<typeof useTranslation>['t'],
+  isRunning = false
 ): string {
   const changeType = uniformChangeType(summary.files)
   const count = summary.file_count || summary.files.length
+  if (isRunning) {
+    if (changeType === 'created') return t('file_changes.creating_files', { count })
+    if (changeType === 'deleted') return t('file_changes.deleting_files', { count })
+    if (changeType === 'renamed') return t('file_changes.renaming_files', { count })
+    return t('file_changes.editing_files', { count })
+  }
   if (changeType === 'created') return t('file_changes.created_files', { count })
   if (changeType === 'deleted') return t('file_changes.deleted_files', { count })
   if (changeType === 'renamed') return t('file_changes.renamed_files', { count })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -349,6 +349,7 @@ function CollapsibleProcessingContent({
     }
     if (!keepMounted) setIsRendered(false)
   }
+  const allowOverflow = expanded && maxHeight === 'none'
 
   return (
     <div
@@ -357,7 +358,8 @@ function CollapsibleProcessingContent({
       inert={!expanded ? true : undefined}
       onTransitionEnd={handleTransitionEnd}
       className={[
-        'overflow-hidden transition-[max-height,opacity] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+        'transition-[max-height,opacity] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+        allowOverflow ? 'overflow-visible' : 'overflow-hidden',
         expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
       ].join(' ')}
       style={{ maxHeight }}
@@ -366,7 +368,8 @@ function CollapsibleProcessingContent({
         <div
           ref={contentRef}
           className={[
-            'min-h-0 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+            'min-h-0 transition-transform duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+            allowOverflow ? 'overflow-visible' : 'overflow-hidden',
             expanded ? 'translate-y-0' : '-translate-y-1',
           ].join(' ')}
         >

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -172,6 +172,7 @@ export function createRuntimeTaskStreamHandlers(
         hasContent: payload.content !== undefined,
         hasToolInput: payload.toolInput !== undefined,
         hasToolOutput: payload.toolOutput !== undefined,
+        hasFileChanges: payload.fileChanges !== undefined,
       })
       handlers.onMessageAction({
         type: 'block_updated',
@@ -181,6 +182,9 @@ export function createRuntimeTaskStreamHandlers(
           ...(payload.content !== undefined && { content: payload.content }),
           ...(payload.toolInput !== undefined && { toolInput: payload.toolInput }),
           ...(payload.toolOutput !== undefined && { toolOutput: payload.toolOutput }),
+          ...(payload.fileChanges !== undefined && {
+            fileChanges: normalizeTurnFileChanges(payload.fileChanges),
+          }),
           ...(payload.status && { status: normalizeWorkbenchBlockStatus(payload.status) }),
         },
       })

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -52,6 +52,10 @@
     "open_label": "Open {{path}}"
   },
   "file_changes": {
+    "editing_files": "Editing {{count}} files",
+    "creating_files": "Creating {{count}} files",
+    "deleting_files": "Deleting {{count}} files",
+    "renaming_files": "Renaming {{count}} files",
     "edited_files": "Edited {{count}} files",
     "created_files": "Created {{count}} files",
     "deleted_files": "Deleted {{count}} files",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -52,6 +52,10 @@
     "open_label": "打开 {{path}}"
   },
   "file_changes": {
+    "editing_files": "正在编辑 {{count}} 个文件",
+    "creating_files": "正在创建 {{count}} 个文件",
+    "deleting_files": "正在删除 {{count}} 个文件",
+    "renaming_files": "正在重命名 {{count}} 个文件",
     "edited_files": "已编辑 {{count}} 个文件",
     "created_files": "已创建 {{count}} 个文件",
     "deleted_files": "已删除 {{count}} 个文件",

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -56,4 +56,50 @@ describe('emitResponseApiEvent', () => {
       occurredAtMs: 12345,
     })
   })
+
+  test('emits file changes block updates', () => {
+    const onBlockUpdated = vi.fn()
+
+    emitResponseApiEvent(
+      { onBlockUpdated },
+      'response.block.updated',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        deviceId: 'device-1',
+        data: {
+          block_id: 'file-changes-call-1',
+          updates: {
+            status: 'streaming',
+            file_changes: {
+              version: 1,
+              status: 'active',
+              artifact_id: 'artifact-1',
+              device_id: 'device-1',
+              workspace_path: '/repo',
+              file_count: 1,
+              additions: 2,
+              deletions: 1,
+              files: [],
+              reverted_at: null,
+              revertible: false,
+            },
+          },
+        },
+      },
+      createResponseApiStreamState()
+    )
+
+    expect(onBlockUpdated).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      subtaskId: '2',
+      deviceId: 'device-1',
+      blockId: 'file-changes-call-1',
+      status: 'streaming',
+      fileChanges: expect.objectContaining({
+        additions: 2,
+        deletions: 1,
+      }),
+    })
+  })
 })

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -298,6 +298,7 @@ function emitBlockUpdated(
     toolInput?: Record<string, unknown>
     toolOutput?: unknown
     content?: string
+    fileChanges?: ChatBlock['fileChanges']
   }
 ): void {
   if (!blockId) {
@@ -380,6 +381,7 @@ function emitResponseBlockUpdated(
 ): void {
   const updates = recordField(data, 'updates')
   const toolInput = parseRecord(updates.toolInput ?? updates.tool_input)
+  const fileChanges = parseRecord(updates.fileChanges ?? updates.file_changes)
   emitBlockUpdated(
     handlers,
     'response.block.updated',
@@ -391,6 +393,7 @@ function emitResponseBlockUpdated(
         toolOutput: updates.toolOutput ?? updates.tool_output,
       }),
       ...(toolInput && { toolInput }),
+      ...(fileChanges && { fileChanges: fileChanges as unknown as ChatBlock['fileChanges'] }),
       ...(typeof updates.status === 'string' && {
         status: updates.status as ChatBlock['status'],
       }),

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -156,6 +156,143 @@ button:disabled {
     animation: waiting-thinking-text 1.6s linear infinite;
   }
 
+  .file-change-delta-number {
+    position: relative;
+    display: inline-flex;
+    min-width: 1.2em;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    vertical-align: -0.12em;
+  }
+
+  .file-change-rolling-viewport {
+    display: inline-flex;
+    min-width: 1.2em;
+    height: 1.12em;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  .file-change-rolling-value {
+    display: inline-block;
+  }
+
+  .file-change-rolling-value.is-rolling {
+    animation: file-change-number-roll 320ms cubic-bezier(0.2, 0.82, 0.18, 1);
+  }
+
+  .file-change-delta-badge {
+    position: absolute;
+    inset-inline-start: 100%;
+    inset-block-start: -0.8em;
+    margin-inline-start: 2px;
+    color: currentColor;
+    font-size: 10px;
+    font-weight: 650;
+    line-height: 1;
+    pointer-events: none;
+    opacity: 0;
+    animation: file-change-delta-float 560ms ease-out;
+  }
+
+  @keyframes file-change-number-roll {
+    from {
+      opacity: 0.2;
+      transform: translateY(-0.9em);
+    }
+
+    58% {
+      opacity: 1;
+      transform: translateY(0.08em);
+    }
+
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes file-change-delta-float {
+    0% {
+      opacity: 0;
+      transform: translateY(3px) scale(0.96);
+    }
+
+    18% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 0;
+      transform: translateY(-8px) scale(1);
+    }
+  }
+
+  .file-change-stat-blocks {
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-end: 0;
+    width: 2.875rem;
+    height: 1.5rem;
+    pointer-events: none;
+    transform: translateY(-50%) translateZ(0);
+  }
+
+  .file-change-stat-block {
+    position: absolute;
+    inset-block-end: 0.25rem;
+    width: 0.375rem;
+    height: 1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    gap: 1px;
+    border: 1px solid rgb(var(--color-border) / 0.78);
+    border-radius: 0.125rem;
+    background: rgb(var(--color-bg-surface));
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.85),
+      0 1px 2px rgb(0 0 0 / 0.04);
+    opacity: var(--file-change-stat-alpha, 0.9);
+    transform: translateX(var(--file-change-stat-x)) scaleY(1);
+    transform-origin: 50% 100%;
+    animation: file-change-stat-enter 280ms cubic-bezier(0.2, 0.82, 0.18, 1) both;
+    overflow: hidden;
+  }
+
+  .file-change-stat-segment {
+    display: block;
+    min-height: 0;
+    width: 100%;
+  }
+
+  .file-change-stat-segment.is-addition {
+    height: var(--file-change-stat-addition-height);
+    background: linear-gradient(#d3f9d8, #8ce99a);
+  }
+
+  .file-change-stat-segment.is-deletion {
+    height: var(--file-change-stat-deletion-height);
+    background: linear-gradient(#ffd8a8, #ffa94d);
+  }
+
+  @keyframes file-change-stat-enter {
+    0% {
+      opacity: 0;
+      transform: translateX(2.25rem) scaleY(0.36);
+    }
+
+    62% {
+      opacity: var(--file-change-stat-alpha, 0.9);
+      transform: translateX(var(--file-change-stat-x)) translateY(-0.125rem) scaleY(1.06);
+    }
+
+    100% {
+      transform: translateX(var(--file-change-stat-x)) scaleY(1);
+    }
+  }
+
   @keyframes local-runtime-card-settle {
     0%,
     100% {

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -1501,7 +1501,14 @@ export interface InstalledPluginUpdateRequest {
   description?: string
 }
 
-export type ChatBlockType = 'text' | 'tool' | 'thinking' | 'plan' | 'error' | 'guidance'
+export type ChatBlockType =
+  | 'text'
+  | 'tool'
+  | 'thinking'
+  | 'plan'
+  | 'error'
+  | 'guidance'
+  | 'file_changes'
 
 export interface ChatBlock {
   id: string
@@ -1513,6 +1520,8 @@ export interface ChatBlock {
   tool_output?: unknown
   render_payload?: unknown
   renderPayload?: unknown
+  file_changes?: TurnFileChangesSummary
+  fileChanges?: TurnFileChangesSummary
   status?: 'generating_arguments' | 'pending' | 'streaming' | 'done' | 'error'
   timestamp?: number | string | null
   created_at?: number | string | null
@@ -1533,6 +1542,7 @@ export interface ChatBlockUpdatedPayload {
   content?: string
   toolOutput?: unknown
   toolInput?: Record<string, unknown>
+  fileChanges?: TurnFileChangesSummary
   status?: ChatBlock['status'] | 'running'
   deviceId?: string
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File-change activity now appears live in chat and workbench updates, including additions, deletions, renames, and edits.
  * File-change summaries now show animated rolling counts and recent change stats for a clearer real-time view.
* **Bug Fixes**
  * Improved support for expanding processing blocks without clipped content.
  * Added updated status messages for in-progress file operations in English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->