### PR TITLE
[codex] fix wework file change activity layout

### DIFF
--- a/wework/src/components/chat/FileChangesCard.tsx
+++ b/wework/src/components/chat/FileChangesCard.tsx
@@ -14,6 +14,7 @@ const DIFF_PREVIEW_DELAY_MS = 500
 const DIFF_PREVIEW_ESTIMATED_HEIGHT = 424
 const DIFF_PREVIEW_MAX_LINES = 240
 const DIFF_PREVIEW_MAX_WIDTH = 640
+const DIFF_PREVIEW_HORIZONTAL_OFFSET = 12
 const DIFF_PREVIEW_VIEWPORT_GUTTER = 32
 const DIFF_PREVIEW_VERTICAL_GAP = 8
 
@@ -322,7 +323,10 @@ function useDelayedDiffPreview(preview: DiffPreview | null) {
           Math.max(280, window.innerWidth - DIFF_PREVIEW_VIEWPORT_GUTTER * 2)
         )
         const maxLeft = window.innerWidth - width - DIFF_PREVIEW_VIEWPORT_GUTTER
-        const left = Math.min(Math.max(rect.left, DIFF_PREVIEW_VIEWPORT_GUTTER), maxLeft)
+        const left = Math.min(
+          Math.max(rect.left - DIFF_PREVIEW_HORIZONTAL_OFFSET, DIFF_PREVIEW_VIEWPORT_GUTTER),
+          maxLeft
+        )
         const top =
           nextPlacement === 'above'
             ? Math.max(DIFF_PREVIEW_VIEWPORT_GUTTER, rect.top - DIFF_PREVIEW_VERTICAL_GAP)

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -208,12 +208,15 @@ type FileChangeStatBlock = {
 type FileChangeStatBlockStyle = CSSProperties & {
   '--file-change-stat-addition-height': string
   '--file-change-stat-deletion-height': string
+  '--file-change-stat-blocks-width': string
   '--file-change-stat-x': string
   '--file-change-stat-alpha': string
 }
 
 function FileChangeLineStats({ summary }: { summary: TurnFileChangesSummary }) {
   const [statBlocks, setStatBlocks] = useState<FileChangeStatBlock[]>([])
+  const visibleStatBlocks =
+    statBlocks.length > 0 ? statBlocks : buildStaticFileChangeStatBlocks(summary)
   const previousRef = useRef({
     artifactId: summary.artifact_id,
     additions: summary.additions,
@@ -256,16 +259,36 @@ function FileChangeLineStats({ summary }: { summary: TurnFileChangesSummary }) {
   }, [summary.additions, summary.artifact_id, summary.deletions])
 
   return (
-    <span className="relative flex shrink-0 items-center gap-1 pr-14 text-xs font-medium tabular-nums">
+    <span className="flex shrink-0 items-center gap-2 text-xs font-medium tabular-nums">
       <span className="inline-flex items-center text-green-600">
         +<AnimatedChangeNumber value={summary.additions} deltaPrefix="+" />
       </span>
       <span className="inline-flex items-center text-red-500">
         -<AnimatedChangeNumber value={summary.deletions} deltaPrefix="-" />
       </span>
-      <FileChangeStatBlocks blocks={statBlocks} />
+      {visibleStatBlocks.length > 0 ? <FileChangeStatBlocks blocks={visibleStatBlocks} /> : null}
     </span>
   )
+}
+
+function buildStaticFileChangeStatBlocks(summary: TurnFileChangesSummary): FileChangeStatBlock[] {
+  const changedFiles = summary.files.filter(file => !file.binary)
+  if (changedFiles.length > 0) {
+    return changedFiles.slice(-6).map(file => ({
+      id: `${file.path}:${file.additions}:${file.deletions}`,
+      additions: file.additions,
+      deletions: file.deletions,
+    }))
+  }
+
+  if (summary.additions === 0 && summary.deletions === 0) return []
+  return [
+    {
+      id: `${summary.artifact_id}:${summary.additions}:${summary.deletions}`,
+      additions: summary.additions,
+      deletions: summary.deletions,
+    },
+  ]
 }
 
 function AnimatedChangeNumber({ value, deltaPrefix }: { value: number; deltaPrefix: '+' | '-' }) {
@@ -310,8 +333,14 @@ function AnimatedChangeNumber({ value, deltaPrefix }: { value: number; deltaPref
 }
 
 function FileChangeStatBlocks({ blocks }: { blocks: FileChangeStatBlock[] }) {
+  const width = Math.max(6, (blocks.length - 1) * 7 + 6)
+
   return (
-    <span className="file-change-stat-blocks" aria-hidden="true">
+    <span
+      className="file-change-stat-blocks"
+      aria-hidden="true"
+      style={{ '--file-change-stat-blocks-width': `${width}px` } as FileChangeStatBlockStyle}
+    >
       {blocks.map((block, index) => {
         const age = blocks.length - index - 1
         const additionHeight = block.additions > 0 ? Math.min(10, 3 + block.additions * 1.6) : 0

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -441,6 +441,56 @@ describe('ToolBlocksDisplay', () => {
     ).toBeInTheDocument()
   })
 
+  test('merges consecutive file change blocks into one activity row', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          completedFileChangesBlock,
+          {
+            ...completedFileChangesBlock,
+            id: 'file-changes-2',
+            createdAt: 1770000003001,
+            fileChanges: {
+              ...completedFileChangesBlock.fileChanges,
+              artifact_id: 'artifact-2',
+              additions: 3,
+              deletions: 0,
+              files: [
+                {
+                  path: 'scripts/env',
+                  change_type: 'modified',
+                  additions: 3,
+                  deletions: 0,
+                  binary: false,
+                },
+              ],
+            },
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    const fileChangeBlocks = screen.getAllByTestId('process-file-changes-block')
+    expect(fileChangeBlocks).toHaveLength(1)
+    expect(fileChangeBlocks[0]).toHaveTextContent('已编辑 1 个文件')
+    expect(fileChangeBlocks[0]).toHaveTextContent('+5')
+    expect(fileChangeBlocks[0]).toHaveTextContent('-1')
+  })
+
+  test('renders static file change stat bars for historical file changes', () => {
+    render(<ToolBlocksDisplay blocks={[completedFileChangesBlock]} isStreaming={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    const statBars = screen
+      .getByTestId('process-file-changes-block')
+      .querySelectorAll('.file-change-stat-block')
+    expect(statBars).toHaveLength(1)
+  })
+
   test('uses an edit icon for completed edit activity groups', () => {
     render(
       <ToolBlocksDisplay

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -24,6 +24,42 @@ function tool(
   }
 }
 
+function fileChangesBlock(
+  id: string,
+  path: string,
+  additions: number,
+  deletions: number,
+  createdAt = 1770000000000
+): ProcessingBlock {
+  return {
+    id,
+    subtaskId: 1,
+    type: 'file_changes',
+    status: 'done',
+    createdAt,
+    fileChanges: {
+      version: 1,
+      status: 'active',
+      artifact_id: id,
+      device_id: 'device-1',
+      workspace_path: '/tmp/project',
+      file_count: 1,
+      additions,
+      deletions,
+      files: [
+        {
+          path,
+          change_type: 'modified',
+          additions,
+          deletions,
+          binary: false,
+        },
+      ],
+      diff: `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-old\n+new`,
+    },
+  }
+}
+
 describe('toolBlockActivity', () => {
   test('summarizes completed file, search, command, and failed command blocks', () => {
     expect(
@@ -151,6 +187,54 @@ describe('toolBlockActivity', () => {
       type: 'activity_group',
       label: '已引导对话',
     })
+  })
+
+  test('merges consecutive file changes into a single display row', () => {
+    const rows = buildProcessingDisplayRows([
+      fileChangesBlock('file-changes-1', 'src/config.ts', 3, 3),
+      fileChangesBlock('file-changes-2', 'src/config.ts', 3, 0, 1770000000001),
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      type: 'block',
+      id: 'file-changes-file-changes-1-file-changes-2',
+      block: {
+        type: 'file_changes',
+        fileChanges: {
+          file_count: 1,
+          additions: 6,
+          deletions: 3,
+          files: [
+            {
+              path: 'src/config.ts',
+              additions: 6,
+              deletions: 3,
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test('does not merge file changes across ordinary activity', () => {
+    const rows = buildProcessingDisplayRows([
+      fileChangesBlock('file-changes-1', 'src/config.ts', 3, 3),
+      {
+        id: 'text-1',
+        subtaskId: 1,
+        type: 'text',
+        content: 'Explaining the edit.',
+        status: 'done',
+        createdAt: 1770000000001,
+      },
+      fileChangesBlock('file-changes-2', 'src/config.ts', 3, 0, 1770000000002),
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toMatchObject({ type: 'block', id: 'file-changes-1' })
+    expect(rows[1]).toMatchObject({ type: 'block', id: 'text-1' })
+    expect(rows[2]).toMatchObject({ type: 'block', id: 'file-changes-2' })
   })
 
   test('classifies Claude multi-file edit tools as edit activity', () => {

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -1,4 +1,5 @@
-import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
+import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
+import type { FileChangesBlock, ProcessingBlock, ToolBlock } from '@/types/workbench'
 import {
   getFileInputPaths,
   getInputField,
@@ -55,6 +56,7 @@ export function buildProcessingDisplayRows(
   const groupCompletedTools = options.groupCompletedTools ?? true
   const rows: ProcessingDisplayRow[] = []
   let completedTools: ToolBlock[] = []
+  let consecutiveFileChanges: FileChangesBlock[] = []
   const hasFileChangesBlock = blocks.some(block => block.type === 'file_changes')
 
   const flushCompletedTools = () => {
@@ -68,9 +70,20 @@ export function buildProcessingDisplayRows(
     completedTools = []
   }
 
+  const flushFileChanges = () => {
+    if (consecutiveFileChanges.length === 0) return
+    const block =
+      consecutiveFileChanges.length === 1
+        ? consecutiveFileChanges[0]
+        : mergeConsecutiveFileChanges(consecutiveFileChanges)
+    rows.push({ type: 'block', id: block.id, block })
+    consecutiveFileChanges = []
+  }
+
   for (const block of blocks) {
     if (block.type === 'tool' && isContextCompactionToolName(block.toolName)) {
       flushCompletedTools()
+      flushFileChanges()
       rows.push({ type: 'block', id: block.id, block })
       continue
     }
@@ -83,17 +96,81 @@ export function buildProcessingDisplayRows(
       continue
     }
 
+    if (block.type === 'file_changes') {
+      flushCompletedTools()
+      consecutiveFileChanges.push(block)
+      continue
+    }
+
     if (groupCompletedTools && block.type === 'tool' && isCompletedToolBlock(block)) {
+      flushFileChanges()
       completedTools.push(block)
       continue
     }
 
     flushCompletedTools()
+    flushFileChanges()
     rows.push({ type: 'block', id: block.id, block })
   }
 
   flushCompletedTools()
+  flushFileChanges()
   return rows
+}
+
+function mergeConsecutiveFileChanges(blocks: FileChangesBlock[]): FileChangesBlock {
+  const first = blocks[0]
+  const latest = blocks[blocks.length - 1]
+  const summaries = blocks.map(block => block.fileChanges)
+  const files = mergeFileChangeItems(summaries.flatMap(summary => summary.files))
+  const diff = summaries
+    .map(summary => summary.diff?.trim())
+    .filter((value): value is string => Boolean(value))
+    .join('\n')
+
+  return {
+    ...latest,
+    id: `file-changes-${first.id}-${latest.id}`,
+    fileChanges: {
+      ...latest.fileChanges,
+      artifact_id: summaries.map(summary => summary.artifact_id).join(':'),
+      additions: sumFileChangeValues(summaries, 'additions'),
+      deletions: sumFileChangeValues(summaries, 'deletions'),
+      file_count: files.length,
+      files,
+      ...(diff ? { diff } : {}),
+      revertible: summaries.every(summary => summary.revertible !== false),
+    },
+  }
+}
+
+function mergeFileChangeItems(files: TurnFileChangeItem[]): TurnFileChangeItem[] {
+  const merged = new Map<string, TurnFileChangeItem>()
+
+  files.forEach(file => {
+    const key = `${file.old_path ?? ''}\0${file.path}`
+    const existing = merged.get(key)
+    if (!existing) {
+      merged.set(key, { ...file })
+      return
+    }
+
+    merged.set(key, {
+      ...file,
+      additions: existing.additions + file.additions,
+      deletions: existing.deletions + file.deletions,
+      binary: existing.binary || file.binary,
+    })
+  })
+
+  return Array.from(merged.values())
+}
+
+function sumFileChangeValues(
+  summaries: TurnFileChangesSummary[],
+  key: 'additions' | 'deletions'
+): number {
+  return summaries.reduce((sum, summary) => sum + summary[key], 0)
 }
 
 export function summarizeToolBlocks(blocks: ToolBlock[]): string {

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -230,13 +230,13 @@ button:disabled {
   }
 
   .file-change-stat-blocks {
-    position: absolute;
-    inset-block-start: 50%;
-    inset-inline-end: 0;
-    width: 2.875rem;
+    position: relative;
+    display: inline-block;
+    width: var(--file-change-stat-blocks-width, 0);
     height: 1.5rem;
+    flex-shrink: 0;
     pointer-events: none;
-    transform: translateY(-50%) translateZ(0);
+    transform: translateZ(0);
   }
 
   .file-change-stat-block {


### PR DESCRIPTION
## What changed

- Merge consecutive Wework file-change activity blocks into a single display row.
- Keep file-change stat bars visible for historical rows while sizing them to their actual bar count.
- Tighten spacing between file-change text, line counts, stat bars, and chevron controls.
- Shift file diff hover previews slightly left.

## Why

Consecutive edit activity rows were noisy, and the stat bar layout reserved fixed horizontal space even when the visible content did not need it. This made the chevron appear detached from the row content.

## Validation

- `pnpm --filter wework test -- --run src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx`
- Pre-push hook: ESLint, TypeScript, and unit tests passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File change summaries now combine consecutive updates into a single row, making chat activity easier to scan.
  * Historical file-change items now show a compact, static stats display when no animated updates are available.
* **Bug Fixes**
  * Adjusted file-change preview placement so it aligns better on screen and stays within the visible viewport.
  * Improved spacing and sizing for file-change stat bars to keep counts readable and consistently positioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->