### PR TITLE
[codex] Enable Wework release WebView devtools config

### DIFF
--- a/wework/scripts/build-mac-app.sh
+++ b/wework/scripts/build-mac-app.sh
@@ -151,12 +151,46 @@ if [ "${WEWORK_DRY_RUN:-}" = "1" ]; then
 fi
 
 cd "$WEWORK_DIR"
+CONFIG_OVERRIDE=""
+cleanup() {
+  if [ -n "$CONFIG_OVERRIDE" ]; then
+    rm -f "$CONFIG_OVERRIDE"
+  fi
+}
+trap cleanup EXIT
+
 TAURI_ARGS=(build)
 if [ "$BUILD_PROFILE" = "dev" ]; then
   TAURI_ARGS+=(--debug)
 fi
 if [ "$RELEASE_DEVTOOLS" = "1" ]; then
+  CONFIG_OVERRIDE="$(mktemp "$WEWORK_DIR/src-tauri/tauri.devtools.XXXXXX.json")"
+  CONFIG_OVERRIDE="$CONFIG_OVERRIDE" python3 - <<'PY'
+import json
+import os
+
+with open("src-tauri/tauri.conf.json", "r", encoding="utf-8") as handle:
+    base_config = json.load(handle)
+
+windows = base_config.get("app", {}).get("windows", [])
+config = {
+    "app": {
+        "windows": [
+            {
+                **window,
+                "devtools": True,
+            }
+            for window in windows
+        ],
+    },
+}
+
+with open(os.environ["CONFIG_OVERRIDE"], "w", encoding="utf-8") as handle:
+    json.dump(config, handle, indent=2)
+    handle.write("\n")
+PY
   TAURI_ARGS+=(--features release-devtools)
+  TAURI_ARGS+=(--config "$CONFIG_OVERRIDE")
 fi
 if [ -n "$MACOS_BUILD_TARGET" ]; then
   TAURI_ARGS+=(--target "$MACOS_BUILD_TARGET")

--- a/wework/scripts/release-mac-app.sh
+++ b/wework/scripts/release-mac-app.sh
@@ -524,6 +524,8 @@ VERSION="$next_version" \
 UPDATER_ENDPOINT="${download_base_url%/}/latest.json" \
 UPDATER_PUBKEY="$UPDATER_PUBKEY" \
 SIGNING_IDENTITY="$app_sign_identity" \
+RELEASE_DEVTOOLS="$RELEASE_DEVTOOLS" \
+BASE_TAURI_CONFIG="$WEWORK_DIR/src-tauri/tauri.conf.json" \
 ENABLE_INSECURE_TRANSPORT="$([ "$TARGET" = "local" ] && printf 'true' || printf 'false')" \
 CONFIG_OVERRIDE="$config_override" \
 python3 - <<'PY'
@@ -552,6 +554,19 @@ if identity:
 
 if os.environ["ENABLE_INSECURE_TRANSPORT"] == "true":
     config["plugins"]["updater"]["dangerousInsecureTransportProtocol"] = True
+
+if os.environ["RELEASE_DEVTOOLS"] == "1":
+    with open(os.environ["BASE_TAURI_CONFIG"], "r", encoding="utf-8") as handle:
+        base_config = json.load(handle)
+    config["app"] = {
+        "windows": [
+            {
+                **window,
+                "devtools": True,
+            }
+            for window in base_config.get("app", {}).get("windows", [])
+        ],
+    }
 
 with open(os.environ["CONFIG_OVERRIDE"], "w", encoding="utf-8") as handle:
     json.dump(config, handle, indent=2)

--- a/wework/src-tauri/src/in_app_browser.rs
+++ b/wework/src-tauri/src/in_app_browser.rs
@@ -145,7 +145,7 @@ pub fn in_app_browser_create(
     let app_for_page_load = app.clone();
     let label_for_page_load = label.clone();
 
-    let builder = tauri::WebviewBuilder::new(&label, tauri::WebviewUrl::External(parsed_url))
+    let mut builder = tauri::WebviewBuilder::new(&label, tauri::WebviewUrl::External(parsed_url))
         .accept_first_mouse(true)
         .focused(false)
         .initialization_script(INIT_SCRIPT)
@@ -185,6 +185,11 @@ pub fn in_app_browser_create(
                 );
             }
         });
+
+    #[cfg(any(debug_assertions, feature = "release-devtools"))]
+    {
+        builder = builder.devtools(true);
+    }
 
     window
         .add_child(


### PR DESCRIPTION
## Summary

- Set `devtools: true` on the Tauri window config override whenever Wework macOS devtools release builds are requested.
- Apply the same config override for both `build-mac-app.sh` and `release-mac-app.sh`.
- Enable devtools on dynamically-created in-app browser WebViews in debug or `release-devtools` builds.

## Why

PR #1733 only compiled Tauri's `devtools` feature into diagnostic release builds. That makes `open_devtools()` available, but Wry still defaults each WebView's `devtools` attribute to `false` in release builds. As a result the release app could still fail to open Web Inspector. This change makes the diagnostic build set both required pieces: the compiled feature and the WebView-level devtools flag.

## Validation

- `bash -n wework/scripts/build-mac-app.sh && bash -n wework/scripts/release-mac-app.sh`
- `git diff --check -- wework/scripts/build-mac-app.sh wework/scripts/release-mac-app.sh wework/src-tauri/src/in_app_browser.rs`
- `cargo check --features release-devtools` from `wework/src-tauri`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional release mode that enables browser developer tools in desktop app windows for debugging and QA.
  * Updated the macOS build and release flow to support this mode without affecting the default release experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->