### PR TITLE
[codex] Sync Wework file change stat bars after final diff

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -152,7 +152,7 @@ function ProcessFileChangesBlockItem({
       >
         <FileDiff className="h-4 w-4 shrink-0" strokeWidth={1.7} />
         <span className="min-w-0 truncate">{fileChangesSummaryLabel(summary, t, isRunning)}</span>
-        <FileChangeLineStats summary={summary} />
+        <FileChangeLineStats summary={summary} isRunning={isRunning} />
         <ChevronDown
           className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`}
           strokeWidth={2}
@@ -213,10 +213,16 @@ type FileChangeStatBlockStyle = CSSProperties & {
   '--file-change-stat-alpha': string
 }
 
-function FileChangeLineStats({ summary }: { summary: TurnFileChangesSummary }) {
+function FileChangeLineStats({
+  summary,
+  isRunning,
+}: {
+  summary: TurnFileChangesSummary
+  isRunning: boolean
+}) {
   const [statBlocks, setStatBlocks] = useState<FileChangeStatBlock[]>([])
   const visibleStatBlocks =
-    statBlocks.length > 0 ? statBlocks : buildStaticFileChangeStatBlocks(summary)
+    isRunning && statBlocks.length > 0 ? statBlocks : buildStaticFileChangeStatBlocks(summary)
   const previousRef = useRef({
     artifactId: summary.artifact_id,
     additions: summary.additions,
@@ -243,7 +249,7 @@ function FileChangeLineStats({ summary }: { summary: TurnFileChangesSummary }) {
       deletions: summary.deletions,
     }
 
-    if (addedDelta === 0 && deletedDelta === 0) return
+    if (!isRunning || (addedDelta === 0 && deletedDelta === 0)) return
 
     const now = Date.now()
     setStatBlocks(current =>
@@ -256,7 +262,7 @@ function FileChangeLineStats({ summary }: { summary: TurnFileChangesSummary }) {
         },
       ].slice(-6)
     )
-  }, [summary.additions, summary.artifact_id, summary.deletions])
+  }, [isRunning, summary.additions, summary.artifact_id, summary.deletions])
 
   return (
     <span className="flex shrink-0 items-center gap-2 text-xs font-medium tabular-nums">

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1,6 +1,6 @@
 import '@/i18n'
 
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { ToolBlocksDisplay } from './ToolBlocksDisplay'
 import type { ProcessingBlock } from '@/types/workbench'
@@ -489,6 +489,96 @@ describe('ToolBlocksDisplay', () => {
       .getByTestId('process-file-changes-block')
       .querySelectorAll('.file-change-stat-block')
     expect(statBars).toHaveLength(1)
+  })
+
+  test('keeps streaming file change stat animation until final diff replaces the summary', async () => {
+    const streamingSummaryBlock: ProcessingBlock = {
+      ...completedFileChangesBlock,
+      status: 'streaming',
+      fileChanges: {
+        ...completedFileChangesBlock.fileChanges,
+        artifact_id: 'same-artifact',
+        additions: 1,
+        deletions: 0,
+        file_count: 1,
+        files: [
+          {
+            path: 'src/streaming.ts',
+            change_type: 'modified',
+            additions: 1,
+            deletions: 0,
+            binary: false,
+          },
+        ],
+      },
+    }
+    const updatedStreamingSummaryBlock: ProcessingBlock = {
+      ...streamingSummaryBlock,
+      fileChanges: {
+        ...streamingSummaryBlock.fileChanges,
+        additions: 5,
+        file_count: 5,
+        files: Array.from({ length: 5 }, (_, index) => ({
+          path: `src/file-${index}.ts`,
+          change_type: 'modified' as const,
+          additions: 1,
+          deletions: 0,
+          binary: false,
+        })),
+      },
+    }
+    const finalSummaryBlock: ProcessingBlock = {
+      ...updatedStreamingSummaryBlock,
+      status: 'done',
+      fileChanges: {
+        ...updatedStreamingSummaryBlock.fileChanges,
+        additions: 4,
+        deletions: 0,
+        file_count: 1,
+        files: [
+          {
+            path: 'src/final.ts',
+            change_type: 'modified',
+            additions: 4,
+            deletions: 0,
+            binary: false,
+          },
+        ],
+      },
+    }
+
+    const { rerender } = render(
+      <ToolBlocksDisplay blocks={[streamingSummaryBlock]} isStreaming={false} forceExpanded />
+    )
+
+    expect(
+      screen.getByTestId('process-file-changes-block').querySelectorAll('.file-change-stat-block')
+    ).toHaveLength(1)
+
+    rerender(
+      <ToolBlocksDisplay blocks={[updatedStreamingSummaryBlock]} isStreaming={true} forceExpanded />
+    )
+
+    await waitFor(() => {
+      const streamingStatBars = screen
+        .getByTestId('process-file-changes-block')
+        .querySelectorAll<HTMLElement>('.file-change-stat-block')
+      expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('+5')
+      expect(streamingStatBars).toHaveLength(1)
+      expect(
+        streamingStatBars[0].style.getPropertyValue('--file-change-stat-addition-height')
+      ).toBe('9.4px')
+    })
+
+    rerender(<ToolBlocksDisplay blocks={[finalSummaryBlock]} isStreaming={false} forceExpanded />)
+
+    const statBars = screen
+      .getByTestId('process-file-changes-block')
+      .querySelectorAll<HTMLElement>('.file-change-stat-block')
+    expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('+4')
+    expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('-0')
+    expect(statBars).toHaveLength(1)
+    expect(statBars[0].style.getPropertyValue('--file-change-stat-addition-height')).toBe('9.4px')
   })
 
   test('uses an edit icon for completed edit activity groups', () => {


### PR DESCRIPTION
## Summary

Fixes the Wework chat file-change activity summary so the right-side stat bars stay animated while a turn is still streaming, then switch to the finalized diff summary once the file changes are complete.

## Root Cause

The stat bars kept using locally cached streaming delta blocks even after the final file-change summary was available, so the numeric text could show the final diff while the bar visualization still reflected an earlier intermediate state.

## Changes

- Pass the file-change block running state into `FileChangeLineStats`.
- Keep the existing incremental stat-bar animation only while the block is running.
- Use the final `summary.files/additions/deletions` to derive stat bars once the block is complete.
- Add a regression test covering streaming animation followed by final diff replacement.

## Validation

- `pnpm --filter wework test -- ToolBlocksDisplay.test.tsx ToolBlockItem.test.tsx`
- Pre-push Wework checks passed: ESLint, TypeScript, unit tests.

Documentation was checked; this is a visual bug fix with no API, configuration, user workflow, or developer documentation changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-change summary behavior while a process is still running, so animated stats update smoothly and then switch cleanly to the final totals.
  * Fixed the streaming display so intermediate changes no longer cause inconsistent or duplicated stat bars.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->