### PR TITLE
feat(backend): expose external knowledge creator info

### DIFF
--- a/backend/app/mcp_server/tools/knowledge_external.py
+++ b/backend/app/mcp_server/tools/knowledge_external.py
@@ -59,7 +59,10 @@ from app.services.knowledge.external_nodes import (
     list_direct_nodes,
     list_recursive_nodes,
 )
-from app.services.knowledge.knowledge_service import KnowledgeService
+from app.services.knowledge.knowledge_service import (
+    ExternalKnowledgeBaseListFilters,
+    KnowledgeService,
+)
 from app.services.knowledge.namespace_utils import (
     NamespaceLevel,
     classify_namespace_level,
@@ -109,12 +112,7 @@ class SearchPreparation:
 class KnowledgeBaseListPreparation:
     """Validated and normalized knowledge base list parameters."""
 
-    scope: ResourceScope
-    group_name: Optional[str]
-    query: Optional[str]
-    owner_user_ids: Optional[list[int]]
-    limit: int
-    offset: int
+    filters: ExternalKnowledgeBaseListFilters
 
 
 def _normalize_url_path(path: str) -> str:
@@ -230,15 +228,19 @@ def validate_knowledge_base_list_params(
     normalized_group_name = (group_name or "").strip() or None
     if scope_enum == ResourceScope.GROUP and not normalized_group_name:
         return None, "group_name is required when scope is group"
+    normalized_keyword = (query or "").strip() or None
+    normalized_owner_user_ids = tuple(dict.fromkeys(owner_user_ids or []))
 
     return (
         KnowledgeBaseListPreparation(
-            scope=scope_enum,
-            group_name=normalized_group_name,
-            query=query,
-            owner_user_ids=owner_user_ids or None,
-            limit=limit,
-            offset=offset,
+            filters=ExternalKnowledgeBaseListFilters(
+                scope=scope_enum,
+                group_name=normalized_group_name,
+                keyword=normalized_keyword,
+                owner_user_ids=normalized_owner_user_ids,
+                limit=limit,
+                offset=offset,
+            ),
         ),
         None,
     )
@@ -275,37 +277,15 @@ def _resolve_external_namespace_fields(
 def _list_knowledge_bases_sync(
     *,
     user_id: int,
-    scope: ResourceScope,
-    group_name: Optional[str],
-    query: Optional[str],
-    owner_user_ids: Optional[list[int]],
-    limit: int,
-    offset: int,
+    filters: ExternalKnowledgeBaseListFilters,
 ) -> str:
     db = SessionLocal()
     try:
-        kbs = KnowledgeService.list_knowledge_bases(
-            db, user_id, scope=scope, group_name=group_name
+        page_kbs, total = KnowledgeService.list_external_knowledge_bases(
+            db,
+            user_id=user_id,
+            filters=filters,
         )
-        keyword = (query or "").strip().lower()
-        if keyword:
-            kbs = [
-                kb
-                for kb in kbs
-                if keyword
-                in ((kb.json.get("spec", {}) or {}).get("name", "") or "").lower()
-                or keyword
-                in (
-                    (kb.json.get("spec", {}) or {}).get("description", "") or ""
-                ).lower()
-            ]
-        if owner_user_ids:
-            owner_user_id_set = set(owner_user_ids)
-            kbs = [kb for kb in kbs if kb.user_id in owner_user_id_set]
-        kbs = sorted(kbs, key=lambda kb: (kb.created_at, kb.id), reverse=True)
-
-        total = len(kbs)
-        page_kbs = kbs[offset : offset + limit]
         counts = get_document_counts(db, [kb.id for kb in page_kbs])
         creator_map = resolve_external_knowledge_creators(
             db,
@@ -343,9 +323,9 @@ def _list_knowledge_bases_sync(
         return ExternalKnowledgeSpaceListResponse(
             total=total,
             total_returned=len(items),
-            has_more=offset + len(items) < total,
-            limit=limit,
-            offset=offset,
+            has_more=filters.offset + len(items) < total,
+            limit=filters.limit,
+            offset=filters.offset,
             items=items,
         ).model_dump_json()
     except Exception as exc:
@@ -681,12 +661,7 @@ async def wegent_kb_list_knowledge_bases(
         partial(
             _list_knowledge_bases_sync,
             user_id=user.id,
-            scope=params.scope,
-            group_name=params.group_name,
-            query=params.query,
-            owner_user_ids=params.owner_user_ids,
-            limit=params.limit,
-            offset=params.offset,
+            filters=params.filters,
         )
     )
 

--- a/backend/app/mcp_server/tools/knowledge_external.py
+++ b/backend/app/mcp_server/tools/knowledge_external.py
@@ -43,6 +43,7 @@ from app.services.knowledge.document_read_service import (
     DOCUMENT_READ_ERROR_NOT_FOUND,
     document_read_service,
 )
+from app.services.knowledge.external_creator import resolve_external_knowledge_creators
 from app.services.knowledge.external_document_access import (
     DOCUMENT_DOWNLOAD_TOKEN_EXPIRES_SECONDS,
     DOWNLOAD_TOKEN_HEADER,
@@ -82,6 +83,7 @@ MAX_SEARCH_QUERY_LENGTH = 2000
 MAX_SEARCH_KNOWLEDGE_BASE_IDS = 100
 DEFAULT_KNOWLEDGE_BASE_LIST_LIMIT = 50
 MAX_KNOWLEDGE_BASE_LIST_LIMIT = 100
+MAX_KNOWLEDGE_BASE_OWNER_USER_IDS = 100
 DEFAULT_DIRECT_NODE_LIMIT = 100
 MAX_DIRECT_NODE_LIMIT = 500
 INTERNAL_ERROR_MESSAGE = "Internal error"
@@ -101,6 +103,18 @@ class SearchPreparation:
     ignored_knowledge_base_ids: list[int]
     warnings: list[str]
     kb_name_map: dict[int, str]
+
+
+@dataclass(frozen=True)
+class KnowledgeBaseListPreparation:
+    """Validated and normalized knowledge base list parameters."""
+
+    scope: ResourceScope
+    group_name: Optional[str]
+    query: Optional[str]
+    owner_user_ids: Optional[list[int]]
+    limit: int
+    offset: int
 
 
 def _normalize_url_path(path: str) -> str:
@@ -166,6 +180,70 @@ def _validate_document_read_paging(offset, limit) -> Optional[str]:
     return None
 
 
+def _validate_owner_user_ids(owner_user_ids) -> Optional[str]:
+    if owner_user_ids is None:
+        return None
+    if not isinstance(owner_user_ids, list):
+        return "owner_user_ids must be a list of integers"
+    if len(owner_user_ids) > MAX_KNOWLEDGE_BASE_OWNER_USER_IDS:
+        return (
+            f"owner_user_ids must contain at most "
+            f"{MAX_KNOWLEDGE_BASE_OWNER_USER_IDS} items"
+        )
+    if any(not _is_int(owner_user_id) for owner_user_id in owner_user_ids):
+        return "owner_user_ids must be a list of integers"
+    return None
+
+
+def validate_knowledge_base_list_params(
+    *,
+    scope: str,
+    group_name: Optional[str],
+    query: Optional[str],
+    owner_user_ids: Optional[list[int]],
+    limit: int,
+    offset: int,
+) -> tuple[Optional[KnowledgeBaseListPreparation], Optional[str]]:
+    """Validate and normalize list-knowledge-bases tool parameters."""
+    if not isinstance(scope, str):
+        return None, "scope must be a string"
+    if group_name is not None and not isinstance(group_name, str):
+        return None, "group_name must be a string"
+    if query is not None and not isinstance(query, str):
+        return None, "query must be a string"
+    owner_user_ids_error = _validate_owner_user_ids(owner_user_ids)
+    if owner_user_ids_error:
+        return None, owner_user_ids_error
+    if not _is_int(limit):
+        return None, "limit must be an integer"
+    if not _is_int(offset):
+        return None, "offset must be an integer"
+    if limit < 1 or limit > MAX_KNOWLEDGE_BASE_LIST_LIMIT:
+        return None, f"limit must be between 1 and {MAX_KNOWLEDGE_BASE_LIST_LIMIT}"
+    if offset < 0:
+        return None, "offset must be greater than or equal to 0"
+
+    try:
+        scope_enum = ResourceScope(scope.strip())
+    except ValueError:
+        return None, "Invalid scope"
+    normalized_group_name = (group_name or "").strip() or None
+    if scope_enum == ResourceScope.GROUP and not normalized_group_name:
+        return None, "group_name is required when scope is group"
+
+    return (
+        KnowledgeBaseListPreparation(
+            scope=scope_enum,
+            group_name=normalized_group_name,
+            query=query,
+            owner_user_ids=owner_user_ids or None,
+            limit=limit,
+            offset=offset,
+        ),
+        None,
+    )
+
+
 def _search_rate_limit_status(user_id: int) -> ExternalMcpRateLimitStatus:
     if not settings.EXTERNAL_KNOWLEDGE_MCP_SEARCH_RATE_LIMIT_ENABLED:
         return ExternalMcpRateLimitStatus.ALLOWED
@@ -200,6 +278,7 @@ def _list_knowledge_bases_sync(
     scope: ResourceScope,
     group_name: Optional[str],
     query: Optional[str],
+    owner_user_ids: Optional[list[int]],
     limit: int,
     offset: int,
 ) -> str:
@@ -220,11 +299,18 @@ def _list_knowledge_bases_sync(
                     (kb.json.get("spec", {}) or {}).get("description", "") or ""
                 ).lower()
             ]
+        if owner_user_ids:
+            owner_user_id_set = set(owner_user_ids)
+            kbs = [kb for kb in kbs if kb.user_id in owner_user_id_set]
         kbs = sorted(kbs, key=lambda kb: (kb.created_at, kb.id), reverse=True)
 
         total = len(kbs)
         page_kbs = kbs[offset : offset + limit]
         counts = get_document_counts(db, [kb.id for kb in page_kbs])
+        creator_map = resolve_external_knowledge_creators(
+            db,
+            [kb.user_id for kb in page_kbs],
+        )
         namespace_map = load_active_namespace_map(
             db,
             [kb.namespace for kb in page_kbs],
@@ -247,6 +333,7 @@ def _list_knowledge_bases_sync(
                     namespace_level=namespace_level,
                     namespace_display_name=namespace_display_name,
                     owner_user_id=kb.user_id,
+                    creator=creator_map.get(kb.user_id),
                     document_count=counts.get(kb.id, 0),
                     created_at=kb.created_at,
                     updated_at=kb.updated_at,
@@ -569,6 +656,7 @@ async def wegent_kb_list_knowledge_bases(
     scope: str = "all",
     group_name: Optional[str] = None,
     query: Optional[str] = None,
+    owner_user_ids: Optional[list[int]] = None,
     limit: int = DEFAULT_KNOWLEDGE_BASE_LIST_LIMIT,
     offset: int = 0,
 ) -> str:
@@ -577,40 +665,28 @@ async def wegent_kb_list_knowledge_bases(
     if not user:
         return _json_error("Authentication required", "unauthorized")
 
-    if not isinstance(scope, str):
-        return _json_error("scope must be a string")
-    if group_name is not None and not isinstance(group_name, str):
-        return _json_error("group_name must be a string")
-    if query is not None and not isinstance(query, str):
-        return _json_error("query must be a string")
-    if not _is_int(limit):
-        return _json_error("limit must be an integer")
-    if not _is_int(offset):
-        return _json_error("offset must be an integer")
-    if limit < 1 or limit > MAX_KNOWLEDGE_BASE_LIST_LIMIT:
-        return _json_error(
-            f"limit must be between 1 and {MAX_KNOWLEDGE_BASE_LIST_LIMIT}"
-        )
-    if offset < 0:
-        return _json_error("offset must be greater than or equal to 0")
-
-    try:
-        scope_enum = ResourceScope(scope.strip())
-    except ValueError:
-        return _json_error("Invalid scope")
-    normalized_group_name = (group_name or "").strip() or None
-    if scope_enum == ResourceScope.GROUP and not normalized_group_name:
-        return _json_error("group_name is required when scope is group")
+    params, error = validate_knowledge_base_list_params(
+        scope=scope,
+        group_name=group_name,
+        query=query,
+        owner_user_ids=owner_user_ids,
+        limit=limit,
+        offset=offset,
+    )
+    if error:
+        return _json_error(error)
+    assert params is not None
 
     return await run_in_threadpool(
         partial(
             _list_knowledge_bases_sync,
             user_id=user.id,
-            scope=scope_enum,
-            group_name=normalized_group_name,
-            query=query,
-            limit=limit,
-            offset=offset,
+            scope=params.scope,
+            group_name=params.group_name,
+            query=params.query,
+            owner_user_ids=params.owner_user_ids,
+            limit=params.limit,
+            offset=params.offset,
         )
     )
 

--- a/backend/app/schemas/knowledge_external.py
+++ b/backend/app/schemas/knowledge_external.py
@@ -6,7 +6,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -16,6 +16,14 @@ class ExternalKnowledgeNodeType(str, Enum):
 
     FOLDER = "folder"
     DOCUMENT = "document"
+
+
+class ExternalKnowledgeCreatorInfo(BaseModel):
+    """Creator information returned by the external knowledge MCP."""
+
+    user_id: int
+    user_name: str
+    attributes: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ExternalKnowledgeSpace(BaseModel):
@@ -28,6 +36,7 @@ class ExternalKnowledgeSpace(BaseModel):
     namespace_level: Literal["personal", "group", "organization"]
     namespace_display_name: str
     owner_user_id: int
+    creator: Optional[ExternalKnowledgeCreatorInfo] = None
     document_count: int = 0
     created_at: datetime
     updated_at: datetime
@@ -62,6 +71,7 @@ class ExternalKnowledgeNode(BaseModel):
     previewable: bool = False
     mime_type: Optional[str] = None
     file_size: Optional[int] = None
+    creator: Optional[ExternalKnowledgeCreatorInfo] = None
     created_at: datetime
     updated_at: datetime
     orphan: bool = False

--- a/backend/app/services/knowledge/external_creator.py
+++ b/backend/app/services/knowledge/external_creator.py
@@ -75,4 +75,5 @@ def resolve_external_knowledge_creators(
         return _creator_resolver(db, normalized_user_ids)
     except Exception as exc:
         logger.exception("External knowledge creator resolver failed: %s", exc)
+        db.rollback()
         return default_external_knowledge_creator_resolver(db, normalized_user_ids)

--- a/backend/app/services/knowledge/external_creator.py
+++ b/backend/app/services/knowledge/external_creator.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Creator resolution helpers for external knowledge MCP responses."""
+
+import logging
+from typing import Callable
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.schemas.knowledge_external import ExternalKnowledgeCreatorInfo
+
+logger = logging.getLogger(__name__)
+
+ExternalKnowledgeCreatorResolver = Callable[
+    [Session, list[int]], dict[int, ExternalKnowledgeCreatorInfo]
+]
+
+
+def _unique_positive_user_ids(user_ids: list[int]) -> list[int]:
+    seen: set[int] = set()
+    result: list[int] = []
+    for user_id in user_ids:
+        if type(user_id) is not int or user_id <= 0 or user_id in seen:
+            continue
+        seen.add(user_id)
+        result.append(user_id)
+    return result
+
+
+def default_external_knowledge_creator_resolver(
+    db: Session,
+    user_ids: list[int],
+) -> dict[int, ExternalKnowledgeCreatorInfo]:
+    """Resolve creator info from the public users table."""
+    normalized_user_ids = _unique_positive_user_ids(user_ids)
+    if not normalized_user_ids:
+        return {}
+
+    rows = db.query(User).filter(User.id.in_(normalized_user_ids)).all()
+    return {
+        user.id: ExternalKnowledgeCreatorInfo(
+            user_id=user.id,
+            user_name=user.user_name,
+            attributes={},
+        )
+        for user in rows
+    }
+
+
+_creator_resolver: ExternalKnowledgeCreatorResolver = (
+    default_external_knowledge_creator_resolver
+)
+
+
+def set_external_knowledge_creator_resolver(
+    resolver: ExternalKnowledgeCreatorResolver,
+) -> None:
+    """Replace the external knowledge creator resolver for a deployment."""
+    global _creator_resolver
+    _creator_resolver = resolver
+
+
+def resolve_external_knowledge_creators(
+    db: Session,
+    user_ids: list[int],
+) -> dict[int, ExternalKnowledgeCreatorInfo]:
+    """Resolve creators without letting resolver failures break main responses."""
+    normalized_user_ids = _unique_positive_user_ids(user_ids)
+    if not normalized_user_ids:
+        return {}
+    try:
+        return _creator_resolver(db, normalized_user_ids)
+    except Exception as exc:
+        logger.exception("External knowledge creator resolver failed: %s", exc)
+        return default_external_knowledge_creator_resolver(db, normalized_user_ids)

--- a/backend/app/services/knowledge/external_nodes.py
+++ b/backend/app/services/knowledge/external_nodes.py
@@ -14,6 +14,7 @@ from app.schemas.knowledge_external import (
     ExternalKnowledgeNode,
     ExternalKnowledgeNodeType,
 )
+from app.services.knowledge.external_creator import resolve_external_knowledge_creators
 from app.services.knowledge.external_document_access import (
     build_document_capabilities,
     load_attachment_map,
@@ -112,6 +113,10 @@ def list_direct_nodes(
         include_inactive=include_inactive,
     )
     attachment_map = load_attachment_map(db, child_documents)
+    creator_map = resolve_external_knowledge_creators(
+        db,
+        [document.user_id for document in child_documents],
+    )
     nodes = [
         _build_folder_node(folder, has_children=child_counts.get(folder.id, 0) > 0)
         for folder in child_folders
@@ -120,6 +125,7 @@ def list_direct_nodes(
         _build_document_node(
             document,
             attachment=attachment_map.get(document.attachment_id),
+            creator=creator_map.get(document.user_id),
         )
         for document in child_documents
     )
@@ -176,6 +182,10 @@ def list_recursive_nodes(
         folders_by_parent.setdefault(folder.parent_id or 0, []).append(folder)
     for document in documents:
         documents_by_folder.setdefault(document.folder_id or 0, []).append(document)
+    creator_map = resolve_external_knowledge_creators(
+        db,
+        [document.user_id for document in documents],
+    )
 
     def build_children(parent_id: int, path: set[int]) -> list[ExternalKnowledgeNode]:
         if len(path) > MAX_RECURSIVE_DEPTH:
@@ -206,6 +216,7 @@ def list_recursive_nodes(
             _build_document_node(
                 document,
                 attachment=attachment_map.get(document.attachment_id),
+                creator=creator_map.get(document.user_id),
             )
             for document in documents_by_folder.get(parent_id, [])
         )
@@ -259,6 +270,7 @@ def list_recursive_nodes(
                 _build_document_node(
                     document,
                     attachment=attachment_map.get(document.attachment_id),
+                    creator=creator_map.get(document.user_id),
                     orphan=True,
                 )
             )
@@ -331,6 +343,10 @@ def _list_recursive_subtree_nodes(
         document for documents in documents_by_folder.values() for document in documents
     ]
     attachment_map = load_attachment_map(db, all_documents)
+    creator_map = resolve_external_knowledge_creators(
+        db,
+        [document.user_id for document in all_documents],
+    )
 
     def build_children(parent_id: int) -> list[ExternalKnowledgeNode]:
         nodes: list[ExternalKnowledgeNode] = []
@@ -347,6 +363,7 @@ def _list_recursive_subtree_nodes(
             _build_document_node(
                 document,
                 attachment=attachment_map.get(document.attachment_id),
+                creator=creator_map.get(document.user_id),
             )
             for document in documents_by_folder.get(parent_id, [])
         )
@@ -388,6 +405,7 @@ def _build_folder_node(
 def _build_document_node(
     document: KnowledgeDocument,
     attachment=None,
+    creator=None,
     orphan: bool = False,
 ) -> ExternalKnowledgeNode:
     capabilities = build_document_capabilities(document, attachment)
@@ -405,6 +423,7 @@ def _build_document_node(
         previewable=capabilities.previewable,
         mime_type=capabilities.mime_type,
         file_size=capabilities.file_size,
+        creator=creator,
         created_at=document.created_at,
         updated_at=document.updated_at,
         orphan=orphan,

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -11,7 +11,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from sqlalchemy import and_, case, func
+from sqlalchemy import and_, case, func, or_
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -146,6 +146,18 @@ class ActiveDocumentTextStats:
     file_size_total: int
     text_length_total: int
     active_document_count: int
+
+
+@dataclass(frozen=True)
+class ExternalKnowledgeBaseListFilters:
+    """Normalized filters for external knowledge base listing."""
+
+    scope: ResourceScope
+    group_name: str | None = None
+    keyword: str | None = None
+    owner_user_ids: tuple[int, ...] = ()
+    offset: int = 0
+    limit: int = 50
 
 
 class KnowledgeService:
@@ -552,6 +564,47 @@ class KnowledgeService:
         )
         total = len(knowledge_bases)
         return knowledge_bases[offset : offset + limit], total
+
+    @staticmethod
+    def list_external_knowledge_bases(
+        db: Session,
+        *,
+        user_id: int,
+        filters: ExternalKnowledgeBaseListFilters,
+    ) -> tuple[list[Kind], int]:
+        """List externally visible knowledge bases with SQL filtering and paging."""
+        query = _KnowledgeBaseVisibilityQueryBuilder.build(
+            db,
+            user_id=user_id,
+            scope=filters.scope,
+            group_name=filters.group_name,
+        )
+
+        if query is None:
+            return [], 0
+
+        if filters.owner_user_ids:
+            query = query.filter(Kind.user_id.in_(filters.owner_user_ids))
+
+        if filters.keyword:
+            keyword_pattern = f"%{_escape_sql_like(filters.keyword.lower())}%"
+            name_text = _knowledge_base_json_text(db, "$.spec.name")
+            description_text = _knowledge_base_json_text(db, "$.spec.description")
+            query = query.filter(
+                or_(
+                    func.lower(name_text).like(keyword_pattern, escape="\\"),
+                    func.lower(description_text).like(keyword_pattern, escape="\\"),
+                )
+            )
+
+        total = query.order_by(None).count()
+        knowledge_bases = (
+            query.order_by(Kind.created_at.desc(), Kind.id.desc())
+            .offset(filters.offset)
+            .limit(filters.limit)
+            .all()
+        )
+        return knowledge_bases, total
 
     @staticmethod
     def update_knowledge_base(
@@ -3267,3 +3320,138 @@ class KnowledgeService:
             folder_ids=folder_ids,
             user_id=user_id,
         )
+
+
+class _KnowledgeBaseVisibilityQueryBuilder:
+    """Build SQL queries for knowledge bases visible to a user."""
+
+    @staticmethod
+    def build(
+        db: Session,
+        *,
+        user_id: int,
+        scope: ResourceScope,
+        group_name: str | None = None,
+    ):
+        base_query = db.query(Kind).filter(
+            Kind.kind == "KnowledgeBase",
+            Kind.is_active == True,
+        )
+
+        if scope == ResourceScope.PERSONAL:
+            return _KnowledgeBaseVisibilityQueryBuilder._build_personal_query(
+                db,
+                base_query=base_query,
+                user_id=user_id,
+            )
+
+        if scope == ResourceScope.GROUP:
+            if not group_name:
+                raise ValueError("group_name is required when scope is GROUP")
+            role = get_effective_role_in_group(db, user_id, group_name)
+            if role is None:
+                return None
+            return base_query.filter(Kind.namespace == group_name)
+
+        if scope == ResourceScope.ORGANIZATION:
+            return base_query.join(Namespace, Kind.namespace == Namespace.name).filter(
+                Namespace.level == GroupLevel.organization.value,
+                Namespace.is_active == True,
+            )
+
+        return _KnowledgeBaseVisibilityQueryBuilder._build_all_query(
+            db,
+            base_query=base_query,
+            user_id=user_id,
+        )
+
+    @staticmethod
+    def _build_personal_query(db: Session, *, base_query, user_id: int):
+        shared_kb_ids = _KnowledgeBaseVisibilityQueryBuilder._shared_kb_ids(
+            db,
+            user_id=user_id,
+            accessible_groups=get_user_groups(db, user_id),
+        )
+        bound_kb_ids = KnowledgeService._get_bound_kb_ids_for_user(db, user_id)
+
+        conditions = [(Kind.user_id == user_id) & (Kind.namespace == "default")]
+        if shared_kb_ids:
+            conditions.append(Kind.id.in_(shared_kb_ids))
+        if bound_kb_ids:
+            conditions.append(Kind.id.in_(bound_kb_ids))
+
+        return base_query.filter(or_(*conditions))
+
+    @staticmethod
+    def _build_all_query(db: Session, *, base_query, user_id: int):
+        accessible_groups = get_user_groups(db, user_id)
+        shared_kb_ids = _KnowledgeBaseVisibilityQueryBuilder._shared_kb_ids(
+            db,
+            user_id=user_id,
+            accessible_groups=accessible_groups,
+        )
+        org_namespace_names = [
+            namespace_name
+            for (namespace_name,) in db.query(Namespace.name)
+            .filter(
+                Namespace.level == GroupLevel.organization.value,
+                Namespace.is_active == True,
+            )
+            .all()
+        ]
+        bound_kb_ids = KnowledgeService._get_bound_kb_ids_for_user(db, user_id)
+
+        conditions = [(Kind.user_id == user_id) & (Kind.namespace == "default")]
+        if accessible_groups:
+            conditions.append(Kind.namespace.in_(accessible_groups))
+        if org_namespace_names:
+            conditions.append(Kind.namespace.in_(org_namespace_names))
+        if shared_kb_ids:
+            conditions.append(Kind.id.in_(shared_kb_ids))
+        if bound_kb_ids:
+            conditions.append(Kind.id.in_(bound_kb_ids))
+
+        return base_query.filter(or_(*conditions))
+
+    @staticmethod
+    def _shared_kb_ids(
+        db: Session,
+        *,
+        user_id: int,
+        accessible_groups: list[str],
+    ) -> list[int]:
+        from app.models.resource_member import MemberStatus, ResourceMember
+        from app.models.share_link import ResourceType
+
+        shared_permissions = (
+            db.query(ResourceMember.resource_id)
+            .filter(
+                ResourceMember.resource_type == ResourceType.KNOWLEDGE_BASE.value,
+                ResourceMember.entity_type == "user",
+                ResourceMember.entity_id == str(user_id),
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
+            .all()
+        )
+        shared_kb_ids = [permission.resource_id for permission in shared_permissions]
+
+        entity_result = KnowledgeService._collect_entity_authorized_kbs(
+            db,
+            user_id,
+            accessible_groups,
+        )
+        entity_kb_ids = {kb.id for kb in entity_result.entity_kbs}
+        return list(set(shared_kb_ids) | entity_kb_ids)
+
+
+def _knowledge_base_json_text(db: Session, path: str):
+    dialect_name = db.get_bind().dialect.name
+    if dialect_name == "mysql":
+        value = func.json_unquote(func.json_extract(Kind.json, path))
+    else:
+        value = func.json_extract(Kind.json, path)
+    return func.coalesce(value, "")
+
+
+def _escape_sql_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/backend/tests/mcp_server/test_knowledge_external.py
+++ b/backend/tests/mcp_server/test_knowledge_external.py
@@ -17,8 +17,13 @@ from app.mcp_server.tools import knowledge_external
 from app.models.knowledge import DocumentIndexStatus, KnowledgeDocument, KnowledgeFolder
 from app.models.namespace import Namespace
 from app.models.subtask_context import ContextType, SubtaskContext
+from app.models.user import User
 from app.schemas.knowledge import ResourceScope
 from app.services.knowledge import external_nodes
+from app.services.knowledge.external_creator import (
+    default_external_knowledge_creator_resolver,
+    set_external_knowledge_creator_resolver,
+)
 from app.services.knowledge.external_document_access import DOWNLOAD_TOKEN_HEADER
 
 
@@ -34,6 +39,7 @@ def _reset_external_user(token) -> None:
 @pytest.fixture(autouse=True)
 def allow_external_search_rate_limit():
     runtime_spec = MagicMock()
+    set_external_knowledge_creator_resolver(default_external_knowledge_creator_resolver)
     with (
         patch.object(
             knowledge_external,
@@ -52,6 +58,7 @@ def allow_external_search_rate_limit():
         ),
     ):
         yield
+    set_external_knowledge_creator_resolver(default_external_knowledge_creator_resolver)
 
 
 def _make_kb(
@@ -133,6 +140,23 @@ async def test_list_knowledge_bases_rejects_invalid_input_types(test_user):
         invalid_query = await knowledge_external.wegent_kb_list_knowledge_bases(
             query=1,
         )
+        invalid_owner_user_ids_type = (
+            await knowledge_external.wegent_kb_list_knowledge_bases(
+                owner_user_ids="1",
+            )
+        )
+        invalid_owner_user_ids_item = (
+            await knowledge_external.wegent_kb_list_knowledge_bases(
+                owner_user_ids=[test_user.id, "2"],
+            )
+        )
+        invalid_owner_user_ids_count = (
+            await knowledge_external.wegent_kb_list_knowledge_bases(
+                owner_user_ids=list(
+                    range(knowledge_external.MAX_KNOWLEDGE_BASE_OWNER_USER_IDS + 1)
+                ),
+            )
+        )
         invalid_limit = await knowledge_external.wegent_kb_list_knowledge_bases(
             limit=knowledge_external.MAX_KNOWLEDGE_BASE_LIST_LIMIT + 1,
         )
@@ -152,6 +176,21 @@ async def test_list_knowledge_bases_rejects_invalid_input_types(test_user):
     }
     assert json.loads(invalid_query) == {
         "error": "query must be a string",
+        "code": "bad_request",
+    }
+    assert json.loads(invalid_owner_user_ids_type) == {
+        "error": "owner_user_ids must be a list of integers",
+        "code": "bad_request",
+    }
+    assert json.loads(invalid_owner_user_ids_item) == {
+        "error": "owner_user_ids must be a list of integers",
+        "code": "bad_request",
+    }
+    assert json.loads(invalid_owner_user_ids_count) == {
+        "error": (
+            "owner_user_ids must contain at most "
+            f"{knowledge_external.MAX_KNOWLEDGE_BASE_OWNER_USER_IDS} items"
+        ),
         "code": "bad_request",
     }
     assert json.loads(invalid_limit) == {
@@ -271,6 +310,94 @@ async def test_list_knowledge_bases_paginates_before_counting_documents(test_use
     assert [item["knowledge_base_id"] for item in payload["items"]] == [2]
     assert payload["items"][0]["document_count"] == 5
     get_counts.assert_called_once_with(mock_db, [2])
+
+
+@pytest.mark.asyncio
+async def test_list_knowledge_bases_filters_by_owner_user_ids_after_query(
+    test_db,
+    test_user,
+):
+    owner = User(user_name="owner-filter", password_hash="x", is_active=True)
+    other_owner = User(user_name="owner-other", password_hash="x", is_active=True)
+    test_db.add_all([owner, other_owner])
+    test_db.flush()
+
+    now = datetime(2026, 1, 2, 10, 0, 0)
+    matching_owner_kb = _make_kb(
+        21,
+        owner.id,
+        "Match Owner",
+        now + timedelta(minutes=2),
+    )
+    matching_other_kb = _make_kb(
+        22,
+        other_owner.id,
+        "Match Other",
+        now + timedelta(minutes=1),
+    )
+    non_matching_owner_kb = _make_kb(23, owner.id, "Different", now)
+
+    token = _set_external_user(test_user)
+    try:
+        with (
+            patch.object(knowledge_external, "SessionLocal", return_value=test_db),
+            patch.object(
+                knowledge_external.KnowledgeService,
+                "list_knowledge_bases",
+                return_value=[
+                    matching_owner_kb,
+                    matching_other_kb,
+                    non_matching_owner_kb,
+                ],
+            ),
+        ):
+            result = await knowledge_external.wegent_kb_list_knowledge_bases(
+                query="match",
+                owner_user_ids=[owner.id],
+            )
+    finally:
+        _reset_external_user(token)
+
+    payload = json.loads(result)
+    assert payload["total"] == 1
+    assert payload["total_returned"] == 1
+    assert payload["has_more"] is False
+    assert [item["knowledge_base_id"] for item in payload["items"]] == [21]
+    assert payload["items"][0]["creator"] == {
+        "user_id": owner.id,
+        "user_name": "owner-filter",
+        "attributes": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_knowledge_bases_empty_owner_user_ids_is_unfiltered(
+    test_db,
+    test_user,
+):
+    now = datetime(2026, 1, 2, 11, 0, 0)
+    first = _make_kb(31, test_user.id, "First", now)
+    second = _make_kb(32, test_user.id + 1, "Second", now + timedelta(minutes=1))
+
+    token = _set_external_user(test_user)
+    try:
+        with (
+            patch.object(knowledge_external, "SessionLocal", return_value=test_db),
+            patch.object(
+                knowledge_external.KnowledgeService,
+                "list_knowledge_bases",
+                return_value=[first, second],
+            ),
+        ):
+            result = await knowledge_external.wegent_kb_list_knowledge_bases(
+                owner_user_ids=[],
+            )
+    finally:
+        _reset_external_user(token)
+
+    payload = json.loads(result)
+    assert payload["total"] == 2
+    assert [item["knowledge_base_id"] for item in payload["items"]] == [32, 31]
 
 
 @pytest.mark.asyncio
@@ -815,9 +942,15 @@ async def test_list_nodes_returns_document_capability_metadata(test_db, test_use
 
     payload = json.loads(result)
     nodes_by_name = {item["name"]: item for item in payload["items"]}
+    assert nodes_by_name["Folder"]["creator"] is None
     assert nodes_by_name["Folder"]["content_readable"] is False
     assert nodes_by_name["Folder"]["downloadable"] is False
     assert nodes_by_name["Folder"]["previewable"] is False
+    assert nodes_by_name["readable.pdf"]["creator"] == {
+        "user_id": test_user.id,
+        "user_name": test_user.user_name,
+        "attributes": {},
+    }
     assert nodes_by_name["readable.pdf"]["content_readable"] is True
     assert nodes_by_name["readable.pdf"]["downloadable"] is True
     assert nodes_by_name["readable.pdf"]["previewable"] is True

--- a/backend/tests/mcp_server/test_knowledge_external.py
+++ b/backend/tests/mcp_server/test_knowledge_external.py
@@ -401,6 +401,50 @@ async def test_list_knowledge_bases_empty_owner_user_ids_is_unfiltered(
 
 
 @pytest.mark.asyncio
+async def test_list_knowledge_bases_falls_back_when_creator_resolver_fails(
+    test_db,
+    test_user,
+):
+    now = datetime(2026, 1, 2, 12, 0, 0)
+    kb = _make_kb(41, test_user.id, "Fallback Owner", now)
+
+    def failing_creator_resolver(db, user_ids):
+        db.add(
+            User(
+                user_name=test_user.user_name,
+                password_hash="duplicate",
+                is_active=True,
+            )
+        )
+        db.flush()
+        return {}
+
+    set_external_knowledge_creator_resolver(failing_creator_resolver)
+
+    token = _set_external_user(test_user)
+    try:
+        with (
+            patch.object(knowledge_external, "SessionLocal", return_value=test_db),
+            patch.object(
+                knowledge_external.KnowledgeService,
+                "list_knowledge_bases",
+                return_value=[kb],
+            ),
+        ):
+            result = await knowledge_external.wegent_kb_list_knowledge_bases()
+    finally:
+        _reset_external_user(token)
+
+    payload = json.loads(result)
+    assert payload["total"] == 1
+    assert payload["items"][0]["creator"] == {
+        "user_id": test_user.id,
+        "user_name": test_user.user_name,
+        "attributes": {},
+    }
+
+
+@pytest.mark.asyncio
 async def test_list_knowledge_bases_returns_namespace_fields(test_db, test_user):
     now = datetime(2026, 1, 4, 8, 0, 0)
     group_namespace = Namespace(

--- a/backend/tests/mcp_server/test_knowledge_external.py
+++ b/backend/tests/mcp_server/test_knowledge_external.py
@@ -14,6 +14,7 @@ import pytest
 from app.core.rate_limit import ExternalMcpRateLimitStatus
 from app.mcp_server import server as mcp_server_module
 from app.mcp_server.tools import knowledge_external
+from app.models.kind import Kind
 from app.models.knowledge import DocumentIndexStatus, KnowledgeDocument, KnowledgeFolder
 from app.models.namespace import Namespace
 from app.models.subtask_context import ContextType, SubtaskContext
@@ -77,6 +78,38 @@ def _make_kb(
         created_at=created_at,
         updated_at=created_at,
     )
+
+
+def _create_kb(
+    db,
+    kb_id: int,
+    user_id: int,
+    name: str,
+    created_at: datetime,
+    *,
+    namespace: str = "default",
+    description: str | None = None,
+):
+    kb = Kind(
+        id=kb_id,
+        user_id=user_id,
+        kind="KnowledgeBase",
+        name=f"kb-{kb_id}",
+        namespace=namespace,
+        json={
+            "spec": {
+                "name": name,
+                "description": (
+                    description if description is not None else f"{name} description"
+                ),
+            }
+        },
+        is_active=True,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db.add(kb)
+    return kb
 
 
 def _make_attachment(
@@ -228,8 +261,8 @@ async def test_list_knowledge_bases_sorts_by_created_at_and_normalizes_group_nam
             patch.object(knowledge_external, "SessionLocal") as session_local,
             patch.object(
                 knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[older, newer],
+                "list_external_knowledge_bases",
+                return_value=([newer, older], 2),
             ) as list_kbs,
             patch.object(
                 knowledge_external,
@@ -262,12 +295,11 @@ async def test_list_knowledge_bases_sorts_by_created_at_and_normalizes_group_nam
     assert payload["items"][0]["document_count"] == 1
     assert payload["items"][0]["namespace_level"] == "group"
     assert payload["items"][0]["namespace_display_name"] == "team-a"
-    list_kbs.assert_called_once_with(
-        mock_db,
-        test_user.id,
-        scope=ResourceScope.GROUP,
-        group_name="team-a",
-    )
+    assert list_kbs.call_args.args == (mock_db,)
+    assert list_kbs.call_args.kwargs["user_id"] == test_user.id
+    filters = list_kbs.call_args.kwargs["filters"]
+    assert filters.scope == ResourceScope.GROUP
+    assert filters.group_name == "team-a"
 
 
 @pytest.mark.asyncio
@@ -282,8 +314,8 @@ async def test_list_knowledge_bases_paginates_before_counting_documents(test_use
             patch.object(knowledge_external, "SessionLocal") as session_local,
             patch.object(
                 knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[older, middle, newer],
+                "list_external_knowledge_bases",
+                return_value=([middle], 3),
             ),
             patch.object(
                 knowledge_external,
@@ -313,7 +345,7 @@ async def test_list_knowledge_bases_paginates_before_counting_documents(test_use
 
 
 @pytest.mark.asyncio
-async def test_list_knowledge_bases_filters_by_owner_user_ids_after_query(
+async def test_list_knowledge_bases_filters_by_owner_user_ids_in_sql_query(
     test_db,
     test_user,
 ):
@@ -322,36 +354,39 @@ async def test_list_knowledge_bases_filters_by_owner_user_ids_after_query(
     test_db.add_all([owner, other_owner])
     test_db.flush()
 
+    namespace = Namespace(
+        name="corp-owner-filter",
+        display_name="Corp Owner Filter",
+        owner_user_id=test_user.id,
+        level="organization",
+        is_active=True,
+    )
+    test_db.add(namespace)
     now = datetime(2026, 1, 2, 10, 0, 0)
-    matching_owner_kb = _make_kb(
+    _create_kb(
+        test_db,
         21,
         owner.id,
         "Match Owner",
         now + timedelta(minutes=2),
+        namespace=namespace.name,
     )
-    matching_other_kb = _make_kb(
+    _create_kb(
+        test_db,
         22,
         other_owner.id,
         "Match Other",
         now + timedelta(minutes=1),
+        namespace=namespace.name,
     )
-    non_matching_owner_kb = _make_kb(23, owner.id, "Different", now)
+    _create_kb(test_db, 23, owner.id, "Different", now, namespace=namespace.name)
+    test_db.commit()
 
     token = _set_external_user(test_user)
     try:
-        with (
-            patch.object(knowledge_external, "SessionLocal", return_value=test_db),
-            patch.object(
-                knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[
-                    matching_owner_kb,
-                    matching_other_kb,
-                    non_matching_owner_kb,
-                ],
-            ),
-        ):
+        with patch.object(knowledge_external, "SessionLocal", return_value=test_db):
             result = await knowledge_external.wegent_kb_list_knowledge_bases(
+                scope=ResourceScope.ORGANIZATION.value,
                 query="match",
                 owner_user_ids=[owner.id],
             )
@@ -371,6 +406,145 @@ async def test_list_knowledge_bases_filters_by_owner_user_ids_after_query(
 
 
 @pytest.mark.asyncio
+async def test_list_knowledge_bases_sql_filters_do_not_expand_access(
+    test_db,
+    test_user,
+):
+    owner = User(user_name="private-owner-filter", password_hash="x", is_active=True)
+    test_db.add(owner)
+    test_db.flush()
+    _create_kb(
+        test_db,
+        24,
+        owner.id,
+        "Private Owner",
+        datetime(2026, 1, 2, 10, 30, 0),
+        namespace="private-team",
+    )
+    test_db.commit()
+
+    token = _set_external_user(test_user)
+    try:
+        with patch.object(knowledge_external, "SessionLocal", return_value=test_db):
+            result = await knowledge_external.wegent_kb_list_knowledge_bases(
+                owner_user_ids=[owner.id],
+            )
+    finally:
+        _reset_external_user(token)
+
+    payload = json.loads(result)
+    assert payload["total"] == 0
+    assert payload["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_knowledge_bases_sql_orders_and_pages_after_filtering(
+    test_db,
+    test_user,
+):
+    namespace = Namespace(
+        name="corp-page-filter",
+        display_name="Corp Page Filter",
+        owner_user_id=test_user.id,
+        level="organization",
+        is_active=True,
+    )
+    test_db.add(namespace)
+    now = datetime(2026, 1, 3, 9, 0, 0)
+    _create_kb(test_db, 51, test_user.id, "Page", now, namespace=namespace.name)
+    _create_kb(
+        test_db,
+        52,
+        test_user.id,
+        "Page",
+        now + timedelta(minutes=1),
+        namespace=namespace.name,
+    )
+    _create_kb(
+        test_db,
+        53,
+        test_user.id,
+        "Page",
+        now + timedelta(minutes=2),
+        namespace=namespace.name,
+    )
+    test_db.commit()
+
+    token = _set_external_user(test_user)
+    try:
+        with (
+            patch.object(knowledge_external, "SessionLocal", return_value=test_db),
+            patch.object(
+                knowledge_external,
+                "get_document_counts",
+                return_value={52: 7},
+            ) as get_counts,
+        ):
+            result = await knowledge_external.wegent_kb_list_knowledge_bases(
+                scope=ResourceScope.ORGANIZATION.value,
+                query="page",
+                limit=1,
+                offset=1,
+            )
+    finally:
+        _reset_external_user(token)
+
+    payload = json.loads(result)
+    assert payload["total"] == 3
+    assert payload["total_returned"] == 1
+    assert payload["has_more"] is True
+    assert [item["knowledge_base_id"] for item in payload["items"]] == [52]
+    get_counts.assert_called_once_with(test_db, [52])
+
+
+@pytest.mark.asyncio
+async def test_list_knowledge_bases_sql_query_escapes_like_wildcards(
+    test_db,
+    test_user,
+):
+    namespace = Namespace(
+        name="corp-like-filter",
+        display_name="Corp Like Filter",
+        owner_user_id=test_user.id,
+        level="organization",
+        is_active=True,
+    )
+    test_db.add(namespace)
+    now = datetime(2026, 1, 3, 10, 0, 0)
+    _create_kb(
+        test_db,
+        61,
+        test_user.id,
+        "Report %_ Literal",
+        now + timedelta(minutes=1),
+        namespace=namespace.name,
+    )
+    _create_kb(
+        test_db,
+        62,
+        test_user.id,
+        "Report XY Literal",
+        now,
+        namespace=namespace.name,
+    )
+    test_db.commit()
+
+    token = _set_external_user(test_user)
+    try:
+        with patch.object(knowledge_external, "SessionLocal", return_value=test_db):
+            result = await knowledge_external.wegent_kb_list_knowledge_bases(
+                scope=ResourceScope.ORGANIZATION.value,
+                query="%_",
+            )
+    finally:
+        _reset_external_user(token)
+
+    payload = json.loads(result)
+    assert payload["total"] == 1
+    assert [item["knowledge_base_id"] for item in payload["items"]] == [61]
+
+
+@pytest.mark.asyncio
 async def test_list_knowledge_bases_empty_owner_user_ids_is_unfiltered(
     test_db,
     test_user,
@@ -385,8 +559,8 @@ async def test_list_knowledge_bases_empty_owner_user_ids_is_unfiltered(
             patch.object(knowledge_external, "SessionLocal", return_value=test_db),
             patch.object(
                 knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[first, second],
+                "list_external_knowledge_bases",
+                return_value=([second, first], 2),
             ),
         ):
             result = await knowledge_external.wegent_kb_list_knowledge_bases(
@@ -427,8 +601,8 @@ async def test_list_knowledge_bases_falls_back_when_creator_resolver_fails(
             patch.object(knowledge_external, "SessionLocal", return_value=test_db),
             patch.object(
                 knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[kb],
+                "list_external_knowledge_bases",
+                return_value=([kb], 1),
             ),
         ):
             result = await knowledge_external.wegent_kb_list_knowledge_bases()
@@ -490,14 +664,17 @@ async def test_list_knowledge_bases_returns_namespace_fields(test_db, test_user)
             patch.object(knowledge_external, "SessionLocal", return_value=test_db),
             patch.object(
                 knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[
-                    personal_kb,
-                    shared_kb,
-                    group_kb,
-                    organization_kb,
-                    missing_namespace_kb,
-                ],
+                "list_external_knowledge_bases",
+                return_value=(
+                    [
+                        personal_kb,
+                        shared_kb,
+                        group_kb,
+                        organization_kb,
+                        missing_namespace_kb,
+                    ],
+                    5,
+                ),
             ),
         ):
             result = await knowledge_external.wegent_kb_list_knowledge_bases()
@@ -558,8 +735,8 @@ async def test_list_knowledge_bases_counts_all_documents(test_db, test_user):
             patch.object(knowledge_external, "SessionLocal", return_value=test_db),
             patch.object(
                 knowledge_external.KnowledgeService,
-                "list_knowledge_bases",
-                return_value=[kb],
+                "list_external_knowledge_bases",
+                return_value=([kb], 1),
             ),
         ):
             result = await knowledge_external.wegent_kb_list_knowledge_bases()

--- a/backend/tests/mcp_server/test_server_routes.py
+++ b/backend/tests/mcp_server/test_server_routes.py
@@ -335,6 +335,10 @@ def test_external_knowledge_mcp_auth_accepts_bearer_api_key(
             "streamable_http_app",
             return_value=fake_streamable_app,
         ),
+        patch(
+            "app.mcp_server.server._external_auth_handler",
+            _default_external_auth_handler,
+        ),
         patch("app.db.session.SessionLocal", return_value=NonClosingSession(test_db)),
     ):
         app = _build_external_knowledge_mcp_app()

--- a/docs/en/developer-guide/external-knowledge-mcp.md
+++ b/docs/en/developer-guide/external-knowledge-mcp.md
@@ -111,6 +111,34 @@ def enterprise_auth_handler(token, request):
 set_external_knowledge_auth_handler(enterprise_auth_handler)
 ```
 
+### Creator Resolution
+
+`wegent_kb_list_knowledge_bases` and `wegent_kb_list_nodes` return `creator` on knowledge bases and document nodes. The default resolver reads `user_id` and `user_name` from the Wegent `users` table and returns empty `attributes`. Folder nodes do not have independent creator information, so their `creator` is `null`.
+
+Internal deployments can replace the creator resolver when they need to map users to employees, organizations, or external accounts. The resolver receives the current database session and a deduplicated list of positive user IDs, then returns an `ExternalKnowledgeCreatorInfo` map keyed by `user_id`. Resolver failures do not fail the main response; the system logs the error and falls back to the default users-table resolver.
+
+```python
+from app.schemas.knowledge_external import ExternalKnowledgeCreatorInfo
+from app.services.knowledge.external_creator import (
+    set_external_knowledge_creator_resolver,
+)
+
+
+def enterprise_creator_resolver(db, user_ids):
+    employees = load_employees_by_user_ids(user_ids)
+    return {
+        user_id: ExternalKnowledgeCreatorInfo(
+            user_id=user_id,
+            user_name=employee.display_name,
+            attributes={"employee_id": employee.employee_id},
+        )
+        for user_id, employee in employees.items()
+    }
+
+
+set_external_knowledge_creator_resolver(enterprise_creator_resolver)
+```
+
 ## Tools
 
 ### `wegent_kb_list_knowledge_bases`
@@ -124,6 +152,7 @@ Parameters:
 | `scope` | `string` | `all` | Visibility scope, matching the internal knowledge list, for example `all`, `personal`, `group`, or `organization` |
 | `group_name` | `string \| null` | `null` | Optional space or group name. Required when `scope=group`; an empty string is treated as missing |
 | `query` | `string \| null` | `null` | Optional keyword filter. It matches knowledge base name and description case-insensitively |
+| `owner_user_ids` | `list[int] \| null` | `null` | Optional creator user ID filter, at most `100` IDs. An empty list is treated as unfiltered |
 | `limit` | `int` | `50` | Number of results to return, from `1` to `100` |
 | `offset` | `int` | `0` | Offset, must be greater than or equal to `0` |
 
@@ -131,6 +160,7 @@ Behavior:
 
 - Results are sorted by `created_at` descending, so callers do not need to sort again for display.
 - `document_count` counts all documents in the knowledge base, including inactive documents, matching the internal knowledge list behavior.
+- Each `items[]` entry returns `owner_user_id` and `creator`; `creator` contains `user_id`, `user_name`, and deployment-extensible `attributes`.
 - Each `items[]` entry returns `namespace_level` and `namespace_display_name`: personal knowledge bases use `personal` / `personal`, group knowledge bases use `group` / the group display name, and organization knowledge bases use `organization` / the organization display name. `namespace_display_name` only represents the space display name and does not encode sharing or creator relation.
 - `document_count` is calculated only for the current page to avoid turning one request into many count queries.
 - `total` is the total number of matching knowledge bases, `total_returned` is the number returned in the current page, and `has_more` indicates whether another page exists. Callers should page with `limit` and `offset`.
@@ -155,6 +185,7 @@ Behavior:
 - Within the same level, folders are returned before documents. Nodes of the same type are sorted by `created_at` descending.
 - `recursive` and `include_inactive` must be strict booleans. The string `"false"` is rejected.
 - `include_inactive` defaults to `true`, so inactive documents are shown to callers, matching the internal MCP behavior. Callers can use `index_status` to determine whether a document is searchable.
+- Document nodes return `creator`; folder nodes do not have independent creator information, so their `creator` is `null`.
 - Non-recursive listing returns `total_available` and `has_more`; callers should page with `limit` and `offset`.
 - `total_returned` counts every node in the returned tree, including nested children.
 - Root recursive listing pre-counts candidate folders and documents. If the result exceeds `MAX_RECURSIVE_NODES`, it returns `result_too_large` before loading the whole tree.

--- a/docs/zh/developer-guide/external-knowledge-mcp.md
+++ b/docs/zh/developer-guide/external-knowledge-mcp.md
@@ -111,6 +111,34 @@ def enterprise_auth_handler(token, request):
 set_external_knowledge_auth_handler(enterprise_auth_handler)
 ```
 
+### 创建者信息解析
+
+`wegent_kb_list_knowledge_bases` 和 `wegent_kb_list_nodes` 会在知识库和文档节点上返回 `creator`。默认解析器从 Wegent `users` 表读取 `user_id` 和 `user_name`，并返回空 `attributes`。文件夹节点没有独立创建者信息，`creator` 为 `null`。
+
+内部部署如果需要把用户映射为员工、组织或外部账号信息，可以替换 creator resolver。resolver 收到当前数据库 session 和已经去重的正整数用户 ID 列表，返回以 `user_id` 为 key 的 `ExternalKnowledgeCreatorInfo` 映射。resolver 异常时主响应不会失败，系统会记录日志并回退到默认用户表解析。
+
+```python
+from app.schemas.knowledge_external import ExternalKnowledgeCreatorInfo
+from app.services.knowledge.external_creator import (
+    set_external_knowledge_creator_resolver,
+)
+
+
+def enterprise_creator_resolver(db, user_ids):
+    employees = load_employees_by_user_ids(user_ids)
+    return {
+        user_id: ExternalKnowledgeCreatorInfo(
+            user_id=user_id,
+            user_name=employee.display_name,
+            attributes={"employee_id": employee.employee_id},
+        )
+        for user_id, employee in employees.items()
+    }
+
+
+set_external_knowledge_creator_resolver(enterprise_creator_resolver)
+```
+
 ## 工具
 
 ### `wegent_kb_list_knowledge_bases`
@@ -124,6 +152,7 @@ set_external_knowledge_auth_handler(enterprise_auth_handler)
 | `scope` | `string` | `all` | 可见范围，取值与内部知识库列表一致，例如 `all`、`personal`、`group`、`organization` |
 | `group_name` | `string \| null` | `null` | 可选的空间或分组名称。`scope=group` 时必填，空字符串会被视为缺失 |
 | `query` | `string \| null` | `null` | 可选关键字，按知识库名称和描述做大小写不敏感过滤 |
+| `owner_user_ids` | `list[int] \| null` | `null` | 可选创建者用户 ID 过滤，最多 `100` 个；空列表按未过滤处理 |
 | `limit` | `int` | `50` | 返回数量，范围 `1..100` |
 | `offset` | `int` | `0` | 偏移量，必须大于等于 `0` |
 
@@ -131,6 +160,7 @@ set_external_knowledge_auth_handler(enterprise_auth_handler)
 
 - 结果按 `created_at` 倒序排序，业务方展示时不需要再次排序。
 - `document_count` 统计知识库下的全部文档，包括 inactive 文档，保持与内部知识库列表口径一致。
+- 每个 `items[]` 会返回 `owner_user_id` 和 `creator`；`creator` 包含 `user_id`、`user_name` 和部署方可扩展的 `attributes`。
 - 每个 `items[]` 会返回 `namespace_level` 和 `namespace_display_name`：个人知识库为 `personal` / `personal`，群组知识库为 `group` / 群组展示名，公司知识库为 `organization` / 公司展示名。`namespace_display_name` 只表达空间展示名，不表达分享或创建者关系。
 - 只对当前页知识库统计 `document_count`，避免一次请求放大成大量统计查询。
 - 响应中的 `total` 表示过滤后的总知识库数量，`total_returned` 表示当前页返回数量，`has_more` 表示是否还有下一页。调用方应使用 `limit`/`offset` 翻页。
@@ -155,6 +185,7 @@ set_external_knowledge_auth_handler(enterprise_auth_handler)
 - 同一层级内先返回文件夹，再返回文档；同类型节点按 `created_at` 倒序排序。
 - `recursive` 和 `include_inactive` 必须是严格 boolean；字符串 `"false"` 不会被接受。
 - `include_inactive` 默认是 `true`，因此 inactive 文档会展示给业务方，与内部 MCP 保持一致。调用方可根据返回的 `index_status` 判断文档是否可用于搜索。
+- 文档节点会返回 `creator`；文件夹节点没有独立创建者信息，`creator` 为 `null`。
 - 非递归模式返回 `total_available` 和 `has_more`，调用方应使用 `limit`/`offset` 翻页。
 - `total_returned` 统计响应树中的全部节点，包括嵌套 children。
 - 根目录递归会先统计候选文件夹和文档数量，超过 `MAX_RECURSIVE_NODES` 时直接返回 `result_too_large`，避免先加载整棵大树。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `owner_user_ids` filtering for listing knowledge bases (empty list treated as unfiltered).
  * Knowledge bases and document nodes now include `creator` details; folder nodes return `creator: null`.
  * Introduced a configurable creator-resolution hook for external knowledge responses.
* **Bug Fixes**
  * Improved `owner_user_ids` validation (type checking, de-duplication, size limits) and ensured responses still succeed when creator resolution fails (fallback applied).
* **Documentation**
  * Updated external-knowledge MCP developer guides for `owner_user_ids` and `creator` fields.
* **Tests**
  * Expanded coverage for owner scoping and creator-resolution fallback/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->