### PR TITLE
[codex] fix wework command exit status rendering

### DIFF
--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -1554,11 +1554,11 @@ fn tool_status(item: &Value) -> String {
             "inProgress".to_owned()
         }
     });
-    if status.eq_ignore_ascii_case("failed")
+    if command_exit_code(item).is_some() {
+        "done".to_owned()
+    } else if status.eq_ignore_ascii_case("failed")
         || status.eq_ignore_ascii_case("failure")
         || status.eq_ignore_ascii_case("error")
-        || integer_field(item, "exit_code").is_some_and(|exit_code| exit_code != 0)
-        || integer_field(item, "exitCode").is_some_and(|exit_code| exit_code != 0)
         || bool_field(item, "success").is_some_and(|success| !success)
         || item.get("error").is_some()
     {
@@ -1573,6 +1573,10 @@ fn tool_status(item: &Value) -> String {
     } else {
         "pending".to_owned()
     }
+}
+
+fn command_exit_code(item: &Value) -> Option<i64> {
+    integer_field(item, "exit_code").or_else(|| integer_field(item, "exitCode"))
 }
 
 fn file_changes(value: &Value) -> Option<Value> {
@@ -2559,6 +2563,86 @@ mod tests {
         assert_eq!(block["tool_input"]["cwd"], "/tmp/project");
         assert_eq!(block["tool_output"], "/tmp/project\n");
         assert_eq!(block["status"], "done");
+    }
+
+    #[test]
+    fn transcript_treats_non_zero_command_exit_as_done() {
+        let thread = json!({
+            "id": "thread-1",
+            "cwd": "/tmp/project",
+            "turns": [
+                {
+                    "id": "turn-1",
+                    "startedAt": 1_780_000_000,
+                    "status": "running",
+                    "items": [
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "id": "call-1",
+                                "type": "function_call",
+                                "call_id": "call-1",
+                                "name": "exec_command",
+                                "arguments": "{\"cmd\":\"grep missing file.txt\",\"workdir\":\"/tmp/project\"}"
+                            }
+                        },
+                        {
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "exec_command_end",
+                                "call_id": "call-1",
+                                "command": ["/bin/zsh", "-lc", "grep missing file.txt"],
+                                "cwd": "/tmp/project",
+                                "aggregated_output": "",
+                                "status": "failed",
+                                "exit_code": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let messages = transcript_messages(&thread, "device-1");
+        let block = &messages[0]["blocks"][0];
+
+        assert_eq!(block["type"], "tool");
+        assert_eq!(block["tool_name"], "exec_command");
+        assert_eq!(block["status"], "done");
+    }
+
+    #[test]
+    fn transcript_keeps_command_failures_without_exit_code_as_error() {
+        let thread = json!({
+            "id": "thread-1",
+            "cwd": "/tmp/project",
+            "turns": [
+                {
+                    "id": "turn-1",
+                    "startedAt": 1_780_000_000,
+                    "status": "running",
+                    "items": [
+                        {
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "exec_command_end",
+                                "call_id": "call-1",
+                                "command": ["missing-binary"],
+                                "cwd": "/tmp/project",
+                                "status": "failed",
+                                "error": "No such file or directory"
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let messages = transcript_messages(&thread, "device-1");
+        let block = &messages[0]["blocks"][0];
+
+        assert_eq!(block["type"], "tool");
+        assert_eq!(block["status"], "error");
     }
 
     #[test]

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -1554,7 +1554,7 @@ fn tool_status(item: &Value) -> String {
             "inProgress".to_owned()
         }
     });
-    if command_exit_code(item).is_some() {
+    if is_command_status_item_type(&item_type) && command_exit_code(item).is_some() {
         "done".to_owned()
     } else if status.eq_ignore_ascii_case("failed")
         || status.eq_ignore_ascii_case("failure")
@@ -1577,6 +1577,13 @@ fn tool_status(item: &Value) -> String {
 
 fn command_exit_code(item: &Value) -> Option<i64> {
     integer_field(item, "exit_code").or_else(|| integer_field(item, "exitCode"))
+}
+
+fn is_command_status_item_type(item_type: &str) -> bool {
+    matches!(
+        item_type,
+        "commandexecution" | "shellcall" | "localshellcall" | "execcommandend"
+    )
 }
 
 fn file_changes(value: &Value) -> Option<Value> {
@@ -2642,6 +2649,50 @@ mod tests {
         let block = &messages[0]["blocks"][0];
 
         assert_eq!(block["type"], "tool");
+        assert_eq!(block["status"], "error");
+    }
+
+    #[test]
+    fn transcript_keeps_non_command_tool_failures_with_exit_code_as_error() {
+        let thread = json!({
+            "id": "thread-1",
+            "cwd": "/tmp/project",
+            "turns": [
+                {
+                    "id": "turn-1",
+                    "startedAt": 1_780_000_000,
+                    "status": "running",
+                    "items": [
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "id": "call-1",
+                                "type": "function_call",
+                                "call_id": "call-1",
+                                "name": "custom_tool",
+                                "arguments": "{\"path\":\"input.json\"}"
+                            }
+                        },
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "type": "function_call_output",
+                                "call_id": "call-1",
+                                "status": "failed",
+                                "output": "{\"exit_code\":2,\"message\":\"tool failed\"}",
+                                "exit_code": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let messages = transcript_messages(&thread, "device-1");
+        let block = &messages[0]["blocks"][0];
+
+        assert_eq!(block["type"], "tool");
+        assert_eq!(block["tool_name"], "custom_tool");
         assert_eq!(block["status"], "error");
     }
 

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -211,4 +211,35 @@ describe('emitResponseApiEvent', () => {
       toolOutput: 'spawn ENOENT',
     })
   })
+
+  test('keeps non-command tool failures with exit code as failed', () => {
+    const onBlockUpdated = vi.fn()
+
+    emitResponseApiEvent(
+      { onBlockUpdated },
+      'response.output_item.done',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          item: {
+            id: 'call-1',
+            type: 'function_call',
+            status: 'failed',
+            output: { exit_code: 2, message: 'tool failed' },
+            exit_code: 2,
+          },
+        },
+      },
+      createResponseApiStreamState()
+    )
+
+    expect(onBlockUpdated).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      subtaskId: '2',
+      blockId: 'call-1',
+      status: 'error',
+      toolOutput: { exit_code: 2, message: 'tool failed' },
+    })
+  })
 })

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -150,4 +150,65 @@ describe('emitResponseApiEvent', () => {
       }),
     })
   })
+
+  test('treats command output with non-zero exit code as completed', () => {
+    const onBlockUpdated = vi.fn()
+
+    emitResponseApiEvent(
+      { onBlockUpdated },
+      'response.output_item.done',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          item: {
+            id: 'call-1',
+            type: 'shell_call',
+            status: 'failed',
+            output: 'usage error',
+            exit_code: 2,
+          },
+        },
+      },
+      createResponseApiStreamState()
+    )
+
+    expect(onBlockUpdated).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      subtaskId: '2',
+      blockId: 'call-1',
+      status: 'done',
+      toolOutput: 'usage error',
+    })
+  })
+
+  test('keeps command startup failures without exit code as failed', () => {
+    const onBlockUpdated = vi.fn()
+
+    emitResponseApiEvent(
+      { onBlockUpdated },
+      'response.output_item.done',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          item: {
+            id: 'call-1',
+            type: 'shell_call',
+            status: 'failed',
+            output: 'spawn ENOENT',
+          },
+        },
+      },
+      createResponseApiStreamState()
+    )
+
+    expect(onBlockUpdated).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      subtaskId: '2',
+      blockId: 'call-1',
+      status: 'error',
+      toolOutput: 'spawn ENOENT',
+    })
+  })
 })

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -249,11 +249,15 @@ function isToolItem(item: Record<string, unknown>): boolean {
   return ['function_call', 'mcp_call', 'shell_call'].includes(stringField(item, 'type') ?? '')
 }
 
+function isCommandToolItem(item: Record<string, unknown>): boolean {
+  return ['shell_call', 'local_shell_call'].includes(stringField(item, 'type') ?? '')
+}
+
 function toolStatusFromItem(
   item: Record<string, unknown>,
   fallback: ChatBlock['status']
 ): ChatBlock['status'] {
-  if (commandExitCode(item) !== undefined) return 'done'
+  if (isCommandToolItem(item) && commandExitCode(item) !== undefined) return 'done'
   const status = stringField(item, 'status')
   return status === 'error' || status === 'failed' ? 'error' : fallback
 }

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -75,6 +75,10 @@ function optionalNumberField(record: Record<string, unknown>, key: string): numb
   return typeof value === 'number' ? value : undefined
 }
 
+function commandExitCode(record: Record<string, unknown>): number | undefined {
+  return optionalNumberField(record, 'exit_code') ?? optionalNumberField(record, 'exitCode')
+}
+
 function recordField(record: Record<string, unknown>, key: string): Record<string, unknown> {
   return asRecord(record[key])
 }
@@ -249,6 +253,7 @@ function toolStatusFromItem(
   item: Record<string, unknown>,
   fallback: ChatBlock['status']
 ): ChatBlock['status'] {
+  if (commandExitCode(item) !== undefined) return 'done'
   const status = stringField(item, 'status')
   return status === 'error' || status === 'failed' ? 'error' : fallback
 }


### PR DESCRIPTION
## Summary

Fix Wework command tool status rendering so commands that actually ran but exited with a non-zero code are shown as completed command runs instead of execution failures.

## Root cause

Both the realtime Responses stream mapper and the runtime transcript normalizer treated any failed/error command result, including results with a concrete `exit_code`, as a failed tool block. That made normal command exits such as grep no-match or CLI validation errors appear as if the command itself could not execute.

## Changes

- Treat command tool results with `exit_code` / `exitCode` as completed tool blocks in the Wework realtime stream.
- Apply the same rule when normalizing executor runtime transcripts so refresh/history stays consistent.
- Keep command failures without an exit code as errors, preserving the distinction for commands that could not start or execute.
- Add frontend and executor regression coverage for both cases.

## Validation

- `pnpm --filter wework test -- src/stream/responseApiStream.test.ts` (121 files / 1212 tests passed)
- `cargo test runtime_work::transcript --lib` (21 tests passed)
- Pre-push gate:
  - Wework ESLint passed
  - Wework TypeScript passed
  - Wework unit tests passed
  - Executor cargo fmt passed
  - Executor cargo test --all-features --lib passed
  - Executor cargo clippy passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool and shell command results now show **done** whenever an exit code is present, even if the item reports a failed status.
  * If a command fails without an exit code, streamed updates now correctly show **error**.
  * Tool output mapping for streamed “done” events was aligned so UI completion states match the underlying payload.
* **Tests**
  * Expanded response streaming test coverage for shell and function tool failure/success combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->