### PR TITLE
[codex] Add Wework temporary sidebar chats

### DIFF
--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -40,6 +40,18 @@ This document records the state sources for the Wework chat path. The goal is to
 5. `chat:done`, `chat:error`, and cancellation events settle the assistant message through the reducer and refresh the work list.
 6. If runtime work and message state disagree, do not settle it with fallback logic; fix the missing stream event, transcript data, or reducer action.
 
+## Right-Side Temporary Chats
+
+The right workspace **Temporary chat** feature starts a short side conversation next to the current local Codex thread. It is not a fork and it is not a normal runtime task shown in the left task list:
+
+- Each temporary chat tab has an independent `chat:<id>` instance id, so the right workspace can hold multiple temporary chats at the same time.
+- UI state lives inside `TemporaryChatPanel`, using the instance id as the `conversationKey` before a runtime thread exists. Hidden temporary chat tabs stay mounted so local messages and input state are not lost when switching tabs.
+- The first message calls `createTemporaryRuntimeTask`, creating an `ephemeral` runtime task with the current main thread as `sideSource`. This task does not enter the left task list and does not navigate the main pane.
+- Follow-up messages must continue the already loaded temporary thread. The Codex app-server path uses `direct_thread_id` and calls `turn/start` directly; it must not use the normal `resume_thread_id` / `thread/resume` path, because temporary threads do not have rollout mappings and would otherwise fail with `no rollout found`.
+- Temporary chats reuse only the current workspace and current thread context. If no main thread source is available, sending should be blocked and the user should be asked to open an existing conversation first.
+
+Maintenance rule: do not add UI fallbacks that insert temporary chats into the left task list, and do not fabricate rollout records for temporary threads in the executor. The primary path is `ephemeral + sideSource + direct_thread_id`.
+
 ## Audit Result
 
 - Desktop and mobile layouts no longer scan `messages` directly to decide whether the assistant is streaming; they read `paneSession.status.isAssistantStreaming`.

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -40,6 +40,18 @@ sidebar_position: 18
 5. `chat:done`、`chat:error`、取消事件通过 reducer 结算 assistant 消息，并触发 work list 刷新。
 6. 如果 runtime work 与消息状态不一致，不做兜底结算；必须修正缺失的 stream event、transcript 数据或 reducer action。
 
+## 右侧临时聊天
+
+右侧工作区的“临时聊天”用于在当前 Codex 本地线程旁边发起一次短对话。它不是 fork，也不是左侧任务列表中的普通 runtime task：
+
+- 每个临时聊天 tab 都有独立的 `chat:<id>` 实例标识，允许在右侧工作区同时打开多个临时聊天。
+- UI 状态保存在 `TemporaryChatPanel` 内部，并以实例标识作为未创建 runtime 线程前的 `conversationKey`；切换 tab 时面板保持挂载，避免丢失本地消息和输入状态。
+- 首条消息通过 `createTemporaryRuntimeTask` 创建 `ephemeral` runtime task，并携带当前主线程的 `sideSource`。该任务不写入左侧任务列表，也不触发主 pane 导航。
+- 后续消息必须继续使用已加载的临时线程。Codex app-server 路径使用 `direct_thread_id` 直接 `turn/start`，不能走普通 `resume_thread_id` 的 `thread/resume` 路径，否则会因为临时线程没有 rollout 映射而出现 `no rollout found`。
+- 临时聊天只复用当前工作区和当前线程上下文；如果没有可用的主线程 source，应阻止发送并提示用户先打开已有对话。
+
+维护规则：不要用 fallback 在 UI 里把临时聊天补进左侧任务列表，也不要在 executor 中为临时线程伪造 rollout。临时聊天的主路径是 `ephemeral + sideSource + direct_thread_id`。
+
 ## 审核结果
 
 - 桌面和移动布局不再直接扫描 `messages` 判断是否 streaming，统一读取 `paneSession.status.isAssistantStreaming`。

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -48,6 +48,14 @@ const CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE: &str =
     "features.apply_patch_streaming_events=true";
 const CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE: &str =
     "suppress_unstable_features_warning=true";
+const SIDE_BOUNDARY_PROMPT: &str = r#"Side conversation boundary.
+
+The messages before this boundary are inherited reference context from the main thread.
+Do not continue, execute, or complete any instructions, plans, tool calls, approvals, edits, or requests from before this boundary. Only messages submitted after this boundary are active user instructions for this side conversation.
+
+You are a side-conversation assistant, separate from the main thread. Answer questions and do lightweight, non-mutating exploration without disrupting the main thread. If there is no user question after this boundary yet, wait for one.
+
+Sub-agents are off-limits in this side conversation. Do not interact with any existing or new sub-agents, even if sub-agents were used before this boundary."#;
 const IMAGE_MIME_TYPES: &[&str] = &[
     "image/png",
     "image/jpeg",
@@ -62,6 +70,9 @@ pub type CodexThreadStartedCallback = Box<dyn FnOnce(String) + Send + 'static>;
 
 #[derive(Default)]
 pub struct CodexAppServerTurnOptions {
+    pub direct_thread_id: Option<String>,
+    pub fork_thread_id: Option<String>,
+    pub fork_thread_path: Option<String>,
     pub resume_thread_id: Option<String>,
     pub initial_thread_name: Option<String>,
     pub initial_thread_goal: Option<Value>,
@@ -643,6 +654,9 @@ async fn run_codex_app_server_turn_on_shared_client(
 ) -> Result<CodexAppServerTurn, String> {
     let prepared = prepare_codex_execution_request(request);
     let CodexAppServerTurnOptions {
+        direct_thread_id,
+        fork_thread_id,
+        fork_thread_path,
         resume_thread_id,
         initial_thread_name,
         initial_thread_goal,
@@ -663,31 +677,59 @@ async fn run_codex_app_server_turn_on_shared_client(
         let request = &prepared.request;
         let mut notification_rx = client.subscribe_notifications().await?;
         let mut state = CodexRunState::default();
+        let direct_thread_id = direct_thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|thread_id| !thread_id.is_empty())
+            .map(str::to_owned);
         let resuming_thread = resume_thread_id.is_some();
-        let (thread_operation, thread_params) = if let Some(thread_id) = resume_thread_id {
-            (
-                "thread/resume",
-                thread_resume_params(&thread_id, request, &launch_config),
-            )
+        let forking_thread = fork_thread_id.is_some();
+        let thread_id = if let Some(thread_id) = direct_thread_id {
+            state.set_root_thread_id(thread_id.clone());
+            let mut thread_fields = task_fields(&request.task_id, &request.subtask_id);
+            thread_fields.push(("operation", "thread/direct".to_owned()));
+            thread_fields.push(("thread_id", thread_id.clone()));
+            log_executor_event("codex shared thread request skipped", &thread_fields);
+            thread_id
         } else {
-            ("thread/start", thread_start_params(request, &launch_config))
+            let (thread_operation, thread_params) = if let Some(thread_id) = fork_thread_id {
+                (
+                    "thread/fork",
+                    thread_fork_params(
+                        &thread_id,
+                        fork_thread_path.as_deref(),
+                        request,
+                        &launch_config,
+                    ),
+                )
+            } else if let Some(thread_id) = resume_thread_id {
+                (
+                    "thread/resume",
+                    thread_resume_params(&thread_id, request, &launch_config),
+                )
+            } else {
+                ("thread/start", thread_start_params(request, &launch_config))
+            };
+            let mut thread_fields = task_fields(&request.task_id, &request.subtask_id);
+            thread_fields.push(("operation", thread_operation.to_owned()));
+            log_executor_event("codex shared thread request started", &thread_fields);
+            let thread = client.request(thread_operation, thread_params).await?;
+            let thread_id = thread
+                .get("thread")
+                .and_then(|thread| thread.get("id"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    format!("codex app-server {thread_operation} did not return thread.id")
+                })?
+                .to_owned();
+            state.set_root_thread_id(thread_id.clone());
+            thread_fields.push(("thread_id", thread_id.clone()));
+            log_executor_event("codex shared thread request finished", &thread_fields);
+            thread_id
         };
-        let mut thread_fields = task_fields(&request.task_id, &request.subtask_id);
-        thread_fields.push(("operation", thread_operation.to_owned()));
-        log_executor_event("codex shared thread request started", &thread_fields);
-        let thread = client.request(thread_operation, thread_params).await?;
-        let thread_id = thread
-            .get("thread")
-            .and_then(|thread| thread.get("id"))
-            .and_then(Value::as_str)
-            .ok_or_else(|| format!("codex app-server {thread_operation} did not return thread.id"))?
-            .to_owned();
-        state.set_root_thread_id(thread_id.clone());
         if let Some(callback) = thread_started {
             callback(thread_id.clone());
         }
-        thread_fields.push(("thread_id", thread_id.clone()));
-        log_executor_event("codex shared thread request finished", &thread_fields);
         if let Some(sender) = &notifications {
             let _ = sender.send(json!({
                 "method": "thread/started",
@@ -698,38 +740,48 @@ async fn run_codex_app_server_turn_on_shared_client(
                 }
             }));
         }
+        if forking_thread && request.ephemeral {
+            client
+                .request(
+                    "thread/inject_items",
+                    side_boundary_inject_params(&thread_id),
+                )
+                .await?;
+        }
 
         let mut goal_run_active = false;
-        if let Some(goal) = initial_thread_goal.as_ref() {
-            let goal_params = thread_goal_set_params(&thread_id, goal)?;
-            let goal_response = client.request("thread/goal/set", goal_params).await?;
-            if goal_response_goal_is_active(&goal_response) {
-                goal_run_active = true;
-                state.set_goal_status("active");
-            }
-        } else if resuming_thread {
-            if let Ok(goal_response) = client
-                .request("thread/goal/get", json!({"threadId": thread_id.clone()}))
-                .await
-            {
+        if !request.ephemeral {
+            if let Some(goal) = initial_thread_goal.as_ref() {
+                let goal_params = thread_goal_set_params(&thread_id, goal)?;
+                let goal_response = client.request("thread/goal/set", goal_params).await?;
                 if goal_response_goal_is_active(&goal_response) {
                     goal_run_active = true;
                     state.set_goal_status("active");
                 }
+            } else if resuming_thread {
+                if let Ok(goal_response) = client
+                    .request("thread/goal/get", json!({"threadId": thread_id.clone()}))
+                    .await
+                {
+                    if goal_response_goal_is_active(&goal_response) {
+                        goal_run_active = true;
+                        state.set_goal_status("active");
+                    }
+                }
             }
-        }
 
-        if let Some(name) = initial_thread_name
-            .as_deref()
-            .map(str::trim)
-            .filter(|name| !name.is_empty())
-        {
-            client
-                .request(
-                    "thread/name/set",
-                    json!({"threadId": thread_id.clone(), "name": name}),
-                )
-                .await?;
+            if let Some(name) = initial_thread_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+            {
+                client
+                    .request(
+                        "thread/name/set",
+                        json!({"threadId": thread_id.clone(), "name": name}),
+                    )
+                    .await?;
+            }
         }
 
         let turn_input = turn_input(&request.prompt);
@@ -802,6 +854,9 @@ pub async fn run_codex_app_server_turn_with_cancel(
 ) -> Result<CodexAppServerTurn, String> {
     let prepared = prepare_codex_execution_request(request);
     let CodexAppServerTurnOptions {
+        direct_thread_id,
+        fork_thread_id,
+        fork_thread_path,
         resume_thread_id,
         initial_thread_name,
         initial_thread_goal,
@@ -858,32 +913,60 @@ pub async fn run_codex_app_server_turn_with_cancel(
         .await?;
 
         let request = &prepared.request;
-        let (thread_operation, thread_params) = if let Some(thread_id) = resume_thread_id {
-            (
-                "thread/resume",
-                thread_resume_params(&thread_id, request, &launch_config),
-            )
+        let direct_thread_id = direct_thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|thread_id| !thread_id.is_empty())
+            .map(str::to_owned);
+        let forking_thread = fork_thread_id.is_some();
+        let thread_id = if let Some(thread_id) = direct_thread_id {
+            state.set_root_thread_id(thread_id.clone());
+            let mut thread_fields = task_fields(&request.task_id, &request.subtask_id);
+            thread_fields.push(("operation", "thread/direct".to_owned()));
+            thread_fields.push(("thread_id", thread_id.clone()));
+            log_executor_event("codex thread request skipped", &thread_fields);
+            thread_id
         } else {
-            ("thread/start", thread_start_params(request, &launch_config))
+            let (thread_operation, thread_params) = if let Some(thread_id) = fork_thread_id {
+                (
+                    "thread/fork",
+                    thread_fork_params(
+                        &thread_id,
+                        fork_thread_path.as_deref(),
+                        request,
+                        &launch_config,
+                    ),
+                )
+            } else if let Some(thread_id) = resume_thread_id {
+                (
+                    "thread/resume",
+                    thread_resume_params(&thread_id, request, &launch_config),
+                )
+            } else {
+                ("thread/start", thread_start_params(request, &launch_config))
+            };
+            let mut thread_fields = task_fields(&request.task_id, &request.subtask_id);
+            thread_fields.push(("operation", thread_operation.to_owned()));
+            log_executor_event("codex thread request started", &thread_fields);
+            let thread = with_rpc_timeout(
+                thread_operation,
+                timeout_seconds,
+                rpc.request(thread_operation, thread_params, &mut state),
+            )
+            .await?;
+            let thread_id = thread
+                .get("thread")
+                .and_then(|thread| thread.get("id"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    format!("codex app-server {thread_operation} did not return thread.id")
+                })?
+                .to_owned();
+            state.set_root_thread_id(thread_id.clone());
+            thread_fields.push(("thread_id", thread_id.clone()));
+            log_executor_event("codex thread request finished", &thread_fields);
+            thread_id
         };
-        let mut thread_fields = task_fields(&request.task_id, &request.subtask_id);
-        thread_fields.push(("operation", thread_operation.to_owned()));
-        log_executor_event("codex thread request started", &thread_fields);
-        let thread = with_rpc_timeout(
-            thread_operation,
-            timeout_seconds,
-            rpc.request(thread_operation, thread_params, &mut state),
-        )
-        .await?;
-        let thread_id = thread
-            .get("thread")
-            .and_then(|thread| thread.get("id"))
-            .and_then(Value::as_str)
-            .ok_or_else(|| format!("codex app-server {thread_operation} did not return thread.id"))?
-            .to_owned();
-        state.set_root_thread_id(thread_id.clone());
-        thread_fields.push(("thread_id", thread_id.clone()));
-        log_executor_event("codex thread request finished", &thread_fields);
         if let Some(sender) = &notifications {
             let _ = sender.send(json!({
                 "method": "thread/started",
@@ -894,30 +977,44 @@ pub async fn run_codex_app_server_turn_with_cancel(
                 }
             }));
         }
-        if let Some(goal) = initial_thread_goal.as_ref() {
-            let goal_params = thread_goal_set_params(&thread_id, goal)?;
+        if forking_thread && request.ephemeral {
             with_rpc_timeout(
-                "thread/goal/set",
-                timeout_seconds,
-                rpc.request("thread/goal/set", goal_params, &mut state),
-            )
-            .await?;
-        }
-        if let Some(name) = initial_thread_name
-            .as_deref()
-            .map(str::trim)
-            .filter(|name| !name.is_empty())
-        {
-            with_rpc_timeout(
-                "thread/name/set",
+                "thread/inject_items",
                 timeout_seconds,
                 rpc.request(
-                    "thread/name/set",
-                    json!({"threadId": thread_id.clone(), "name": name}),
+                    "thread/inject_items",
+                    side_boundary_inject_params(&thread_id),
                     &mut state,
                 ),
             )
             .await?;
+        }
+        if !request.ephemeral {
+            if let Some(goal) = initial_thread_goal.as_ref() {
+                let goal_params = thread_goal_set_params(&thread_id, goal)?;
+                with_rpc_timeout(
+                    "thread/goal/set",
+                    timeout_seconds,
+                    rpc.request("thread/goal/set", goal_params, &mut state),
+                )
+                .await?;
+            }
+            if let Some(name) = initial_thread_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+            {
+                with_rpc_timeout(
+                    "thread/name/set",
+                    timeout_seconds,
+                    rpc.request(
+                        "thread/name/set",
+                        json!({"threadId": thread_id.clone(), "name": name}),
+                        &mut state,
+                    ),
+                )
+                .await?;
+            }
         }
 
         let turn_input = turn_input(&request.prompt);
@@ -2970,7 +3067,53 @@ fn thread_start_params(request: &ExecutionRequest, launch_config: &CodexLaunchCo
         "approvalPolicy".to_owned(),
         Value::String("never".to_owned()),
     );
+    if request.ephemeral {
+        params.insert("ephemeral".to_owned(), Value::Bool(true));
+    }
     Value::Object(params)
+}
+
+fn thread_fork_params(
+    thread_id: &str,
+    thread_path: Option<&str>,
+    request: &ExecutionRequest,
+    launch_config: &CodexLaunchConfig,
+) -> Value {
+    let mut params = serde_json::Map::new();
+    params.insert("threadId".to_owned(), Value::String(thread_id.to_owned()));
+    if let Some(path) = thread_path.map(str::trim).filter(|path| !path.is_empty()) {
+        params.insert("path".to_owned(), Value::String(path.to_owned()));
+    }
+    params.insert("excludeTurns".to_owned(), Value::Bool(true));
+    if let Some(model) = model_id(request) {
+        params.insert("model".to_owned(), Value::String(model));
+    }
+    append_thread_launch_params(&mut params, launch_config);
+    if let Some(cwd) = request.cwd() {
+        params.insert("cwd".to_owned(), Value::String(cwd.to_owned()));
+    }
+    params.insert(
+        "approvalPolicy".to_owned(),
+        Value::String("never".to_owned()),
+    );
+    if request.ephemeral {
+        params.insert("ephemeral".to_owned(), Value::Bool(true));
+    }
+    Value::Object(params)
+}
+
+fn side_boundary_inject_params(thread_id: &str) -> Value {
+    json!({
+        "threadId": thread_id,
+        "items": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_text",
+                "text": SIDE_BOUNDARY_PROMPT,
+            }],
+        }],
+    })
 }
 
 fn thread_goal_set_params(thread_id: &str, goal: &Value) -> Result<Value, String> {

--- a/executor/src/protocol/execution.rs
+++ b/executor/src/protocol/execution.rs
@@ -42,6 +42,7 @@ pub struct ExecutionRequest {
     pub kb_tool_access_mode: String,
     pub skip_git_clone: bool,
     pub new_session: bool,
+    pub ephemeral: bool,
     pub fork_runtime: Option<Value>,
     pub inherited_sessions: Vec<Value>,
     #[serde(alias = "type")]
@@ -91,6 +92,7 @@ impl Default for ExecutionRequest {
             kb_tool_access_mode: FULL_KB_TOOL_ACCESS_MODE.to_owned(),
             skip_git_clone: false,
             new_session: false,
+            ephemeral: false,
             fork_runtime: None,
             inherited_sessions: Vec::new(),
             task_type: None,

--- a/executor/src/protocol/openai.rs
+++ b/executor/src/protocol/openai.rs
@@ -71,6 +71,10 @@ impl OpenAIResponsesRequest {
                 .get("new_session")
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
+            ephemeral: metadata
+                .get("ephemeral")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
             fork_runtime: metadata.get("fork_runtime").cloned(),
             inherited_sessions: metadata
                 .get("inherited_sessions")
@@ -245,6 +249,7 @@ const KNOWN_METADATA_KEYS: &[&str] = &[
     "kb_tool_access_mode",
     "skip_git_clone",
     "new_session",
+    "ephemeral",
     "fork_runtime",
     "inherited_sessions",
     "type",

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -67,6 +67,17 @@ const TRANSCRIPT_NAVIGATION_PREVIEW_CHARS: usize = 96;
 const CODEX_OFFICIAL_PROVIDER_ID: &str = "openai";
 const CODEX_OFFICIAL_PROVIDER_NAME: &str = "CodeX";
 
+struct SpawnTurnRequest {
+    local_task_id: String,
+    request: ExecutionRequest,
+    direct_thread_id: Option<String>,
+    fork_thread_id: Option<String>,
+    fork_thread_path: Option<String>,
+    resume_thread_id: Option<String>,
+    initial_thread_name: Option<String>,
+    initial_thread_goal: Option<Value>,
+}
+
 fn standalone_chat_workspace_path(
     local_task_id: &str,
     request: &ExecutionRequest,
@@ -237,6 +248,11 @@ struct RuntimeThreadEventRoute {
     event_mapper: CodexNotificationEventMapper,
     cache_mapper: CodexNotificationCacheMapper,
     active: bool,
+}
+
+struct SideSourceThread {
+    thread_id: String,
+    thread_path: Option<String>,
 }
 
 impl RuntimeThreadEventRoute {
@@ -1016,18 +1032,28 @@ impl RuntimeWorkRpcHandler {
             workspace_path.clone(),
             title.clone(),
         );
+        link.ephemeral = request.ephemeral || bool_field(&payload, "ephemeral").unwrap_or(false);
         if let Some(message) = cached_user_message(&local_task_id, &request, &payload) {
             set_runtime_handle_messages(&mut link.runtime_handle, vec![message]);
         }
         self.upsert_local_task(link);
         let initial_thread_goal = initial_thread_goal_from_payload(&payload);
-        self.spawn_turn(
-            local_task_id.clone(),
+        let mut side_source = side_source_thread(&payload);
+        if let Some(source) = &mut side_source {
+            if source.thread_path.is_none() {
+                source.thread_path = self.thread_path_for_id(&source.thread_id).await;
+            }
+        }
+        self.spawn_turn(SpawnTurnRequest {
+            local_task_id: local_task_id.clone(),
             request,
-            None,
-            Some(title),
+            direct_thread_id: None,
+            fork_thread_id: side_source.as_ref().map(|source| source.thread_id.clone()),
+            fork_thread_path: side_source.and_then(|source| source.thread_path),
+            resume_thread_id: None,
+            initial_thread_name: Some(title),
             initial_thread_goal,
-        );
+        });
 
         Ok(json!({
             "success": true,
@@ -1112,7 +1138,21 @@ impl RuntimeWorkRpcHandler {
             &request,
             &payload,
         );
-        self.spawn_turn(local_task_id.clone(), request, Some(thread_id), None, None);
+        let ephemeral =
+            request.ephemeral || existing_link.as_ref().is_some_and(|link| link.ephemeral);
+        let direct_thread_id = ephemeral.then(|| thread_id.clone());
+        let resume_thread_id = (!ephemeral).then_some(thread_id);
+
+        self.spawn_turn(SpawnTurnRequest {
+            local_task_id: local_task_id.clone(),
+            request,
+            direct_thread_id,
+            fork_thread_id: None,
+            fork_thread_path: None,
+            resume_thread_id,
+            initial_thread_name: None,
+            initial_thread_goal: None,
+        });
 
         Ok(json!({
             "success": true,
@@ -1219,6 +1259,7 @@ impl RuntimeWorkRpcHandler {
             link.workspace_path = workspace_path.to_owned();
             link.status = "running".to_owned();
             link.running = true;
+            link.ephemeral = link.ephemeral || request.ephemeral;
             link.updated_at = now_ms();
             if let Some(message) = message.clone() {
                 append_runtime_handle_message(&mut link.runtime_handle, message);
@@ -1234,6 +1275,7 @@ impl RuntimeWorkRpcHandler {
             prompt_text(&request.prompt),
         );
         link.thread_id = Some(thread_id.to_owned());
+        link.ephemeral = request.ephemeral;
         if let Some(message) = message {
             set_runtime_handle_messages(&mut link.runtime_handle, vec![message]);
         }
@@ -1386,17 +1428,31 @@ impl RuntimeWorkRpcHandler {
         Ok(task_action_success(&link))
     }
 
-    fn spawn_turn(
-        &self,
-        local_task_id: String,
-        request: ExecutionRequest,
-        resume_thread_id: Option<String>,
-        initial_thread_name: Option<String>,
-        initial_thread_goal: Option<Value>,
-    ) {
+    fn spawn_turn(&self, turn: SpawnTurnRequest) {
+        let SpawnTurnRequest {
+            local_task_id,
+            request,
+            direct_thread_id,
+            fork_thread_id,
+            fork_thread_path,
+            resume_thread_id,
+            initial_thread_name,
+            initial_thread_goal,
+        } = turn;
         let mut fields = task_fields(&request.task_id, &request.subtask_id);
         fields.push(("local_task_id", local_task_id.clone()));
+        fields.push(("direct", direct_thread_id.is_some().to_string()));
+        fields.push(("fork", fork_thread_id.is_some().to_string()));
         fields.push(("resume", resume_thread_id.is_some().to_string()));
+        if let Some(thread_id) = &direct_thread_id {
+            fields.push(("direct_thread_id", thread_id.clone()));
+        }
+        if let Some(thread_id) = &fork_thread_id {
+            fields.push(("fork_thread_id", thread_id.clone()));
+        }
+        if let Some(path) = &fork_thread_path {
+            fields.push(("fork_thread_path", path.clone()));
+        }
         if let Some(thread_id) = &resume_thread_id {
             fields.push(("thread_id", thread_id.clone()));
         }
@@ -1468,6 +1524,9 @@ impl RuntimeWorkRpcHandler {
                 .run_turn_with_cancel(
                     request.clone(),
                     CodexAppServerTurnOptions {
+                        direct_thread_id,
+                        fork_thread_id,
+                        fork_thread_path,
                         resume_thread_id,
                         initial_thread_name,
                         initial_thread_goal,
@@ -1915,6 +1974,9 @@ impl RuntimeWorkRpcHandler {
 
         for thread in self.codex_threads(archived).await {
             if let Some(mut link) = self.link_from_thread(&thread) {
+                if link.ephemeral {
+                    continue;
+                }
                 if archived {
                     link.status = "archived".to_owned();
                     link.running = false;
@@ -1934,6 +1996,9 @@ impl RuntimeWorkRpcHandler {
         }
 
         for mut link in self.local_task_links(true) {
+            if link.ephemeral {
+                continue;
+            }
             let link_archived = link.status == "archived";
             if link_archived != archived {
                 continue;
@@ -2044,6 +2109,15 @@ impl RuntimeWorkRpcHandler {
             ],
         );
         threads
+    }
+
+    async fn thread_path_for_id(&self, thread_id: &str) -> Option<String> {
+        for thread in self.codex_threads(false).await {
+            if string_field(&thread, "id").as_deref() == Some(thread_id) {
+                return string_field(&thread, "path").filter(|path| !path.trim().is_empty());
+            }
+        }
+        None
     }
 
     fn visible_links_for_projects(
@@ -2412,6 +2486,15 @@ impl RuntimeWorkRpcHandler {
             .unwrap_or_else(|| "~/.codex".to_owned());
         let codex_thread = thread_with_rollout_running_status(thread);
         let mut link = RuntimeTaskLink::from_thread(&codex_thread, local_link, workspace_path);
+        if let Some(path) = string_field(&codex_thread, "path") {
+            let mut runtime_handle = link
+                .runtime_handle
+                .as_object()
+                .cloned()
+                .unwrap_or_else(Map::new);
+            runtime_handle.insert("threadPath".to_owned(), Value::String(path));
+            link.runtime_handle = Value::Object(runtime_handle);
+        }
         if local_active {
             link.status = "running".to_owned();
             link.running = true;
@@ -3294,6 +3377,34 @@ fn initial_thread_goal_from_payload(payload: &Value) -> Option<Value> {
         .or_else(|| payload.get("initial_goal"))
         .filter(|goal| goal.is_object())
         .cloned()
+}
+
+fn side_source_thread(payload: &Value) -> Option<SideSourceThread> {
+    let source = payload
+        .get("sideSource")
+        .or_else(|| payload.get("side_source"))?;
+    let handle = source
+        .get("runtimeHandle")
+        .or_else(|| source.get("runtime_handle"));
+    let thread_id = string_field(source, "threadId")
+        .or_else(|| string_field(source, "thread_id"))
+        .or_else(|| handle.and_then(runtime_session_id_from_handle))
+        .filter(|thread_id| !thread_id.trim().is_empty())?;
+    let thread_path = string_field(source, "threadPath")
+        .or_else(|| string_field(source, "thread_path"))
+        .or_else(|| string_field(source, "path"))
+        .or_else(|| {
+            handle.and_then(|handle| {
+                string_field(handle, "threadPath")
+                    .or_else(|| string_field(handle, "thread_path"))
+                    .or_else(|| string_field(handle, "path"))
+            })
+        })
+        .filter(|path| !path.trim().is_empty());
+    Some(SideSourceThread {
+        thread_id,
+        thread_path,
+    })
 }
 
 fn runtime_session_id_from_handle(handle: &Value) -> Option<String> {

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -27,6 +27,7 @@ pub(crate) struct RuntimeTaskLink {
     pub updated_at: i64,
     pub runtime_handle: Value,
     pub parent: Option<Value>,
+    pub ephemeral: bool,
     #[serde(skip)]
     pub list_order: Option<usize>,
     #[serde(skip)]
@@ -47,6 +48,7 @@ impl RuntimeTaskLink {
             updated_at: now_ms(),
             runtime_handle: json!({}),
             parent: None,
+            ephemeral: false,
             list_order: None,
             group_workspace_path: None,
         }
@@ -72,6 +74,7 @@ impl RuntimeTaskLink {
             updated_at: now_ms(),
             runtime_handle,
             parent: Some(parent),
+            ephemeral: false,
             list_order: None,
             group_workspace_path: None,
         }
@@ -124,7 +127,8 @@ impl RuntimeTaskLink {
                 .as_ref()
                 .map(|link| link.runtime_handle.clone())
                 .unwrap_or_else(|| json!({})),
-            parent: local_link.and_then(|link| link.parent),
+            parent: local_link.as_ref().and_then(|link| link.parent.clone()),
+            ephemeral: local_link.as_ref().is_some_and(|link| link.ephemeral),
             list_order: None,
             group_workspace_path: None,
         }
@@ -162,6 +166,7 @@ impl Default for RuntimeTaskLink {
             updated_at: now_ms(),
             runtime_handle: json!({}),
             parent: None,
+            ephemeral: false,
             list_order: None,
             group_workspace_path: None,
         }

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -413,6 +413,208 @@ async fn runtime_tasks_create_sets_initial_goal_before_first_turn() {
 }
 
 #[tokio::test]
+async fn runtime_tasks_create_ephemeral_codex_thread_hidden_from_task_list() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-ephemeral-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-ephemeral-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let log_path = temp_path("runtime-ephemeral-log", "jsonl");
+    let fake_codex = write_fake_codex(&log_path);
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let created = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.create",
+            "payload": {
+                "taskId": "side-chat-1",
+                "workspacePath": "/tmp/project",
+                "message": "quick side question",
+                "ephemeral": true,
+                "sideSource": {
+                    "deviceId": "device-1",
+                    "taskId": "main-task-1",
+                    "workspacePath": "/tmp/project",
+                    "runtimeHandle": {
+                        "threadId": "parent-thread-1",
+                        "threadPath": "/tmp/codex/parent-thread-1.jsonl"
+                    }
+                },
+                "executionRequest": {
+                    "task_id": "side-chat-1",
+                    "subtask_id": "side-turn-1",
+                    "prompt": "quick side question",
+                    "project_workspace_path": "/tmp/project",
+                    "ephemeral": true,
+                    "bot": [{"shell_type": "ClaudeCode"}],
+                    "model_config": {
+                        "model": "openai",
+                        "model_id": "gpt-5.5",
+                        "api_format": "responses"
+                    }
+                }
+            }
+        }))
+        .await
+        .expect("ephemeral create should be accepted");
+    assert_eq!(created["accepted"], true);
+    wait_for_codex_call(&log_path, "thread/fork").await;
+    wait_for_codex_call(&log_path, "thread/inject_items").await;
+    wait_for_codex_call(&log_path, "turn/start").await;
+
+    let calls = read_json_lines(&log_path);
+    let fork_call = calls
+        .iter()
+        .find(|call| call["method"] == "thread/fork")
+        .expect("thread/fork should be called");
+    assert_eq!(fork_call["params"]["threadId"], "parent-thread-1");
+    assert_eq!(
+        fork_call["params"]["path"],
+        "/tmp/codex/parent-thread-1.jsonl"
+    );
+    assert_eq!(fork_call["params"]["ephemeral"], true);
+    let inject_call = calls
+        .iter()
+        .find(|call| call["method"] == "thread/inject_items")
+        .expect("thread/inject_items should be called");
+    assert_eq!(inject_call["params"]["threadId"], "thread-1");
+    assert!(inject_call["params"]["items"][0]["content"][0]["text"]
+        .as_str()
+        .is_some_and(|text| text.contains("Side conversation boundary.")));
+    assert!(calls.iter().all(|call| call["method"] != "thread/start"));
+    assert!(calls.iter().all(|call| call["method"] != "thread/name/set"));
+    assert!(calls.iter().all(|call| call["method"] != "thread/goal/set"));
+
+    let listed = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.list",
+            "payload": {}
+        }))
+        .await
+        .expect("runtime task list should succeed");
+    assert_eq!(listed["success"], true);
+    assert!(listed["workspaces"]
+        .as_array()
+        .is_some_and(|workspaces| workspaces.is_empty()));
+}
+
+#[tokio::test]
+async fn runtime_tasks_send_ephemeral_codex_thread_uses_loaded_thread_directly() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-ephemeral-follow-up-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-ephemeral-follow-up-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let log_path = temp_path("runtime-ephemeral-follow-up-log", "jsonl");
+    let fake_codex = write_fake_codex_ephemeral_two_turns(&log_path);
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.create",
+            "payload": {
+                "taskId": "side-chat-follow-up",
+                "workspacePath": "/tmp/project",
+                "message": "quick side question",
+                "ephemeral": true,
+                "sideSource": {
+                    "deviceId": "device-1",
+                    "taskId": "main-task-1",
+                    "workspacePath": "/tmp/project",
+                    "runtimeHandle": {
+                        "threadId": "parent-thread-1",
+                        "threadPath": "/tmp/codex/parent-thread-1.jsonl"
+                    }
+                },
+                "executionRequest": {
+                    "task_id": "side-chat-follow-up",
+                    "subtask_id": "side-turn-1",
+                    "prompt": "quick side question",
+                    "project_workspace_path": "/tmp/project",
+                    "ephemeral": true,
+                    "bot": [{"shell_type": "ClaudeCode"}],
+                    "model_config": {
+                        "model": "openai",
+                        "model_id": "gpt-5.5",
+                        "api_format": "responses"
+                    }
+                }
+            }
+        }))
+        .await
+        .expect("ephemeral create should be accepted");
+    wait_for_turn_count(&log_path, 1).await;
+    wait_until_task_idle(&handler, "side-chat-follow-up").await;
+
+    let sent = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.send",
+            "payload": {
+                "taskId": "side-chat-follow-up",
+                "workspacePath": "/tmp/project",
+                "message": "follow up",
+                "executionRequest": {
+                    "task_id": "side-chat-follow-up",
+                    "subtask_id": "side-turn-2",
+                    "prompt": "follow up",
+                    "project_workspace_path": "/tmp/project",
+                    "ephemeral": true,
+                    "bot": [{"shell_type": "ClaudeCode"}],
+                    "model_config": {
+                        "model": "openai",
+                        "model_id": "gpt-5.5",
+                        "api_format": "responses"
+                    }
+                }
+            }
+        }))
+        .await
+        .expect("ephemeral follow-up should be accepted");
+    assert_eq!(sent["accepted"], true);
+    wait_for_turn_count(&log_path, 2).await;
+    wait_until_task_idle(&handler, "side-chat-follow-up").await;
+
+    let calls = read_json_lines(&log_path);
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call["method"] == "thread/fork")
+            .count(),
+        1
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call["method"] == "thread/resume")
+            .count(),
+        0
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call["method"] == "turn/start")
+            .count(),
+        2
+    );
+}
+
+#[tokio::test]
 async fn runtime_tasks_reuse_one_codex_process_across_follow_up_turns() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
@@ -1444,6 +1646,12 @@ while IFS= read -r line; do
     *'"method":"thread/start"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"thread":{{"id":"thread-1"}}}}}}'
       ;;
+    *'"method":"thread/fork"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"thread":{{"id":"thread-1"}}}}}}'
+      ;;
+    *'"method":"thread/inject_items"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{}}}}'
+      ;;
     *'"method":"thread/goal/set"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"goal":{{"threadId":"thread-1","objective":"ship goal-first","status":"active","tokenBudget":null,"tokensUsed":0,"timeUsedSeconds":0,"createdAt":1780000000,"updatedAt":1780000000}}}}}}'
       ;;
@@ -1472,6 +1680,49 @@ while IFS= read -r line; do
       printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"delta":"done","phase":"finalAnswer"}}}}'
       printf '%s\n' '{{"method":"turn/completed","params":{{"turn":{{"id":"turn-1","status":"completed"}}}}}}'
       exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display()
+    );
+    write_executable(&path, &content);
+    path
+}
+
+fn write_fake_codex_ephemeral_two_turns(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-ephemeral-two-turns", "sh");
+    let _ = fs::remove_file(log_path);
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+turn_count=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  request_id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/list"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"parent-thread-1","cwd":"/tmp/project","name":"Parent","preview":"parent","path":"/tmp/codex/parent-thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[]}}],"nextCursor":null,"backwardsCursor":null}}}}'
+      ;;
+    *'"method":"thread/fork"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"thread":{{"id":"thread-ephemeral"}}}}}}'
+      ;;
+    *'"method":"thread/inject_items"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{}}}}'
+      ;;
+    *'"method":"thread/resume"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"error":{{"message":"ephemeral thread should not resume"}}}}'
+      ;;
+    *'"method":"turn/start"'*)
+      turn_count=$((turn_count + 1))
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"turn":{{"id":"turn-'"$turn_count"'","status":"inProgress"}}}}}}'
+      printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"threadId":"thread-ephemeral","turnId":"turn-'"$turn_count"'","delta":"done '"$turn_count"'","phase":"finalAnswer"}}}}'
+      printf '%s\n' '{{"method":"turn/completed","params":{{"threadId":"thread-ephemeral","turn":{{"id":"turn-'"$turn_count"'","status":"completed"}}}}}}'
       ;;
   esac
 done
@@ -1988,6 +2239,23 @@ fn call_index(calls: &[Value], method: &str) -> usize {
         .iter()
         .position(|call| call["method"] == method)
         .unwrap_or_else(|| panic!("expected {method} call in {calls:?}"))
+}
+
+async fn wait_for_codex_call(path: &Path, method: &str) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if read_json_lines(path)
+            .iter()
+            .any(|call| call["method"].as_str() == Some(method))
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "codex call {method} was not logged"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
 }
 
 async fn wait_for_thread_mapping(

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -845,6 +845,7 @@ interface BuildLocalRuntimeExecutionRequestInput {
   workspaceSource: LocalRuntimeWorkspaceSource
   branch?: string | null
   newSession: boolean
+  ephemeral?: boolean
 }
 
 function buildLocalRuntimeExecutionRequest(
@@ -906,6 +907,7 @@ function buildLocalRuntimeExecutionRequest(
     execution_target_type: 'local',
     device_id: input.localDeviceId,
     new_session: input.newSession,
+    ephemeral: Boolean(input.ephemeral),
     is_group_chat: false,
     collaboration_model: 'single',
     ...(collaborationMode ? { collaborationMode } : {}),
@@ -1055,6 +1057,7 @@ async function createLocalRuntimeTaskPayload(
       workspaceSource: runtimeWorkspace.workspaceSource,
       branch: runtimeWorkspace.branch,
       newSession: true,
+      ephemeral: normalizedData.ephemeral,
     }),
   } as unknown as Record<string, unknown>
 }
@@ -1106,6 +1109,7 @@ function createLocalRuntimeSendPayload(
         workspacePath,
         workspaceSource: 'local_path',
         newSession: false,
+        ephemeral: data.ephemeral,
       }),
     } as unknown as Record<string, unknown>
   }
@@ -1132,6 +1136,7 @@ function createLocalRuntimeSendPayload(
       workspacePath,
       workspaceSource: 'local_path',
       newSession: false,
+      ephemeral: data.ephemeral,
     }),
   } as unknown as Record<string, unknown>
 }

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2058,10 +2058,16 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workbench-topbar-left-actions')).toHaveClass(
       'max-w-[calc(100%-22rem)]'
     )
-    expect(screen.getByTestId('workbench-pane-task-title')).toHaveClass('truncate')
+    expect(screen.getByTestId('workbench-pane-task-title')).toHaveClass(
+      'w-[18rem]',
+      'shrink-0',
+      'truncate',
+      'whitespace-nowrap'
+    )
     expect(screen.getByTestId('workbench-pane-task-title')).toHaveTextContent(
       'wework的聊天链路现在代码逻辑比较混乱'
     )
+    expect(screen.getByTestId('workbench-pane-task-title')).not.toHaveAttribute('title')
   })
 
   test('opens project code-server from the Tauri titlebar', async () => {
@@ -3674,6 +3680,12 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     expect(screen.getByTestId('right-workspace-launcher')).toBeInTheDocument()
+    expect(screen.getByTestId('right-workspace-file-option')).toHaveClass(
+      'h-11',
+      'rounded-xl',
+      'font-light'
+    )
+    expect(screen.getByTestId('right-workspace-file-option')).toHaveTextContent('⌥⌘F')
     await userEvent.click(screen.getByTestId('right-workspace-file-option'))
 
     const tabbar = screen.getByTestId('right-workspace-tabbar')
@@ -3703,6 +3715,39 @@ describe('DesktopWorkbenchLayout', () => {
     expect(closeButton).not.toHaveClass('border', 'bg-muted')
     expect(screen.getByTestId('right-workspace-new-tab-button')).toBeInTheDocument()
     expect(await screen.findByTestId('workspace-file-tree')).toBeInTheDocument()
+  })
+
+  test('right workspace launcher keyboard shortcut opens the file tab', async () => {
+    renderWorkspacePanelLayout()
+
+    await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
+    expect(screen.getByTestId('right-workspace-launcher')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true, altKey: true })
+
+    expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
+    expect(await screen.findByTestId('workspace-file-tree')).toBeInTheDocument()
+  })
+
+  test('right workspace can open multiple temporary chat tabs', async () => {
+    renderWorkspacePanelLayout()
+
+    await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
+    await userEvent.click(screen.getByTestId('right-workspace-chat-option'))
+
+    const tabbar = screen.getByTestId('right-workspace-tabbar')
+    expect(screen.getByTestId('right-workspace-chat-panel')).toBeInTheDocument()
+    expect(within(tabbar).getAllByText('临时聊天')).toHaveLength(1)
+
+    await userEvent.click(screen.getByTestId('right-workspace-new-tab-button'))
+    await userEvent.click(
+      within(screen.getByTestId('right-workspace-new-tab-menu')).getByTestId(
+        'right-workspace-chat-option'
+      )
+    )
+
+    expect(within(tabbar).getAllByText('临时聊天')).toHaveLength(2)
+    expect(screen.getByTestId('right-workspace-chat-panel')).toBeInTheDocument()
   })
 
   test('moves right workspace tabs into the titlebar in Tauri', async () => {
@@ -3735,6 +3780,17 @@ describe('DesktopWorkbenchLayout', () => {
       expect(titlebarRightPanel).toContainElement(screen.getByTestId('right-workspace-file-tab'))
       expect(titlebarRightPanel).toContainElement(
         screen.getByTestId('right-workspace-new-tab-button')
+      )
+      const rightTitlebarDragRegion = screen.getByTestId('right-workspace-titlebar-drag-region')
+      expect(titlebarRightPanel).toContainElement(rightTitlebarDragRegion)
+      expect(
+        within(rightTitlebarDragRegion).getByTestId('macos-titlebar-drag-region')
+      ).toHaveAttribute('data-tauri-drag-region')
+      expect(screen.getByTestId('right-workspace-file-tab')).not.toContainElement(
+        rightTitlebarDragRegion
+      )
+      expect(screen.getByTestId('right-workspace-new-tab-button')).not.toContainElement(
+        rightTitlebarDragRegion
       )
       expect(screen.getByTestId('right-workspace-titlebar-spacer')).toHaveClass(
         'h-[38px]',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -268,6 +268,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [rightPanelOpen, setRightPanelOpen] = useState(false)
   const [rightPanelView, setRightPanelView] = useState<RightWorkspacePanelView>('launcher')
   const [rightPanelTabs, setRightPanelTabs] = useState<RightWorkspacePanelTab[]>([])
+  const temporaryChatTabSequence = useRef(0)
   const [rightPanelPlanContent, setRightPanelPlanContent] = useState<string | null>(null)
   const [bottomPanelOpenByKey, setBottomPanelOpenByKey] = useState<Record<string, boolean>>({})
   const [bottomPanelContexts, setBottomPanelContexts] = useState<BottomPanelRenderContext[]>([])
@@ -509,6 +510,14 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     setRightPanelTabs(current => (current.includes(tab) ? current : [...current, tab]))
     setRightPanelView(tab)
   }, [])
+  const selectRightPanelTab = useCallback((tab: RightWorkspacePanelTab) => {
+    setRightPanelOpen(true)
+    setRightPanelView(tab)
+  }, [])
+  const openTemporaryChatTab = useCallback(() => {
+    temporaryChatTabSequence.current += 1
+    openRightPanelTab(`chat:${Date.now()}-${temporaryChatTabSequence.current}`)
+  }, [openRightPanelTab])
   const openAssistantPlan = useCallback(
     (content: string) => {
       setRightPanelPlanContent(content)
@@ -635,6 +644,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const selectTerminalView = useCallback(() => {
     openRightPanelTab('terminal')
   }, [openRightPanelTab])
+  const selectChatView = useCallback(() => {
+    openTemporaryChatTab()
+  }, [openTemporaryChatTab])
   const selectPlanView = useCallback(() => {
     openRightPanelTab('plan')
   }, [openRightPanelTab])
@@ -792,8 +804,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const paneTaskTitle = runtimeTaskTitle ? (
     <div
       data-testid="workbench-pane-task-title"
-      className="min-w-0 max-w-[min(52rem,calc(100vw-28rem))] truncate text-[13px] font-medium leading-none text-text-primary"
-      title={runtimeTaskTitle}
+      className="w-[18rem] shrink-0 truncate whitespace-nowrap text-[13px] font-medium leading-none text-text-primary"
     >
       {runtimeTaskTitle}
     </div>
@@ -1234,6 +1245,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               activeView={rightPanelView}
               openTabs={rightPanelTabs}
               currentProject={workspaceProject}
+              currentRuntimeTask={currentRuntimeTask}
               devices={devices}
               workspaceTarget={effectiveWorkspaceTarget}
               preferLocalTerminal={preferLocalWorkspaceTerminal}
@@ -1249,7 +1261,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               onSelectTerminal={selectTerminalView}
               onSelectBrowser={selectBrowserView}
               onSelectFiles={selectFilesView}
+              onSelectChat={selectChatView}
               onSelectPlan={selectPlanView}
+              onSelectTab={selectRightPanelTab}
               onCloseTab={closeRightPanelTab}
               onRefreshReview={reviewState.reloadDiff ? refreshReview : undefined}
             />

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -1,11 +1,22 @@
-import { File, FileDiff, Globe2, ListChecks, Plus, SquareTerminal, X } from 'lucide-react'
-import { useState } from 'react'
-import type { KeyboardEvent } from 'react'
+import {
+  File,
+  FileDiff,
+  Globe2,
+  ListChecks,
+  MessageCircle,
+  Plus,
+  SquareTerminal,
+  X,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 import {
   FileChangesReviewPanel,
   type FileChangesReviewViewOption,
 } from '@/components/chat/FileChangesReviewPanel'
 import { AssistantMarkdown } from '@/components/chat/AssistantMarkdown'
+import { MacOSTitleBarDragRegion } from '@/components/layout/MacOSTitleBarDragRegion'
 import { TitlebarRightPanelPortal } from '@/components/topnav/TitlebarActionsPortal'
 import { useTranslation } from '@/hooks/useTranslation'
 import type {
@@ -16,20 +27,38 @@ import type {
 } from '@/types/workspace-files'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { cn } from '@/lib/utils'
-import type { DeviceInfo, ProjectWithTasks } from '@/types/api'
+import type { DeviceInfo, ProjectWithTasks, RuntimeTaskAddress } from '@/types/api'
+import { isEditableShortcutTarget } from '@/lib/keybindings'
 import { FileWorkspacePanel } from './FileWorkspacePanel'
 import { WorkspaceAddMenu, type WorkspaceAddMenuItem } from './WorkspaceAddMenu'
 import { WorkspaceBrowserPanel } from './WorkspaceBrowserPanel'
 import { WorkspacePanelCards } from './WorkspacePanelCards'
+import { TemporaryChatPanel } from './TemporaryChatPanel'
 
-export type RightWorkspacePanelView =
-  | 'launcher'
+const RIGHT_WORKSPACE_SHORTCUTS = {
+  review: '⌥⌘R',
+  browser: '⌘T',
+  chat: '⌥⌘S',
+  files: '⌥⌘F',
+} as const
+
+export type RightWorkspaceChatTab = `chat:${string}`
+export type RightWorkspacePanelTab =
   | 'review'
   | 'terminal'
   | 'browser'
   | 'files'
   | 'plan'
-export type RightWorkspacePanelTab = Exclude<RightWorkspacePanelView, 'launcher'>
+  | RightWorkspaceChatTab
+export type RightWorkspacePanelView = 'launcher' | RightWorkspacePanelTab
+
+function isRightWorkspaceChatTab(tab: RightWorkspacePanelView): tab is RightWorkspaceChatTab {
+  return tab.startsWith('chat:')
+}
+
+function getRightWorkspaceChatTabSuffix(tab: RightWorkspaceChatTab) {
+  return tab.slice('chat:'.length)
+}
 
 interface RightWorkspaceReviewState {
   loading: boolean
@@ -47,6 +76,7 @@ interface RightWorkspacePanelProps {
   activeView: RightWorkspacePanelView
   openTabs: RightWorkspacePanelTab[]
   currentProject: ProjectWithTasks | null
+  currentRuntimeTask: RuntimeTaskAddress | null
   devices: DeviceInfo[]
   workspaceTarget: WorkspaceTarget | null
   preferLocalTerminal?: boolean
@@ -62,7 +92,9 @@ interface RightWorkspacePanelProps {
   onSelectTerminal: () => void
   onSelectBrowser: () => void
   onSelectFiles: () => void
+  onSelectChat: () => void
   onSelectPlan: () => void
+  onSelectTab: (tab: RightWorkspacePanelTab) => void
   onCloseTab: (tab: RightWorkspacePanelTab) => void
   onRefreshReview?: () => void
 }
@@ -72,6 +104,7 @@ export function RightWorkspacePanel({
   activeView,
   openTabs,
   currentProject,
+  currentRuntimeTask,
   devices,
   workspaceTarget,
   preferLocalTerminal = false,
@@ -87,7 +120,8 @@ export function RightWorkspacePanel({
   onSelectTerminal,
   onSelectBrowser,
   onSelectFiles,
-  onSelectPlan,
+  onSelectChat,
+  onSelectTab,
   onCloseTab,
   onRefreshReview,
 }: RightWorkspacePanelProps) {
@@ -100,11 +134,52 @@ export function RightWorkspacePanel({
   const visibleBrowserFaviconUrl = browserOpen ? browserFaviconUrl : null
   const visibleBrowserTitle = browserOpen ? browserTitle : null
 
-  const openBrowserTab = () => {
+  const openBrowserTab = useCallback(() => {
     setBrowserFaviconUrl(null)
     setBrowserTitle(null)
     onSelectBrowser()
-  }
+  }, [onSelectBrowser])
+
+  useEffect(() => {
+    if (!visible) return
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.defaultPrevented || isEditableShortcutTarget(event.target)) return
+
+      const key = event.key.toLowerCase()
+      const primaryPressed = event.metaKey && !event.ctrlKey && !event.shiftKey
+
+      if (primaryPressed && !event.altKey && key === 't' && !browserOpen) {
+        event.preventDefault()
+        openBrowserTab()
+        return
+      }
+
+      if (!primaryPressed || !event.altKey) return
+
+      if (key === 'r' && canOpenReview) {
+        event.preventDefault()
+        onSelectReview()
+      } else if (key === 's') {
+        event.preventDefault()
+        onSelectChat()
+      } else if (key === 'f') {
+        event.preventDefault()
+        onSelectFiles()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [
+    browserOpen,
+    canOpenReview,
+    onSelectChat,
+    onSelectFiles,
+    onSelectReview,
+    openBrowserTab,
+    visible,
+  ])
 
   const closeTab = (tab: RightWorkspacePanelTab) => {
     if (tab === 'browser') {
@@ -114,13 +189,10 @@ export function RightWorkspacePanel({
     onCloseTab(tab)
   }
 
-  const getTabSelectHandler = (tab: RightWorkspacePanelTab): (() => void) => {
-    if (tab === 'review') return onSelectReview
-    if (tab === 'terminal') return onSelectTerminal ?? (() => {})
-    if (tab === 'browser') return onSelectBrowser
-    if (tab === 'plan') return onSelectPlan
-    return onSelectFiles
-  }
+  const getTabSelectHandler =
+    (tab: RightWorkspacePanelTab): (() => void) =>
+    () =>
+      onSelectTab(tab)
 
   const getNewTabOptions = (): WorkspaceAddMenuItem[] => [
     {
@@ -128,6 +200,7 @@ export function RightWorkspacePanel({
       testId: 'right-workspace-review-option',
       icon: FileDiff,
       label: t('workbench.workspace_tab_review', '审查'),
+      shortcut: RIGHT_WORKSPACE_SHORTCUTS.review,
       disabled: !canOpenReview,
       onSelect: onSelectReview,
     },
@@ -145,15 +218,25 @@ export function RightWorkspacePanel({
             testId: 'right-workspace-browser-option',
             icon: Globe2,
             label: t('workbench.browser'),
+            shortcut: RIGHT_WORKSPACE_SHORTCUTS.browser,
             onSelect: openBrowserTab,
           },
         ]
       : []),
     {
+      id: 'chat',
+      testId: 'right-workspace-chat-option',
+      icon: MessageCircle,
+      label: t('workbench.workspace_tab_chat', '临时聊天'),
+      shortcut: RIGHT_WORKSPACE_SHORTCUTS.chat,
+      onSelect: onSelectChat,
+    },
+    {
       id: 'files',
       testId: 'right-workspace-file-option',
       icon: File,
       label: t('workbench.workspace_tab_files', '文件'),
+      shortcut: RIGHT_WORKSPACE_SHORTCUTS.files,
       onSelect: onSelectFiles,
     },
   ]
@@ -163,8 +246,10 @@ export function RightWorkspacePanel({
       data-testid="right-workspace-tabbar"
       role="tablist"
       className={cn(
-        'relative z-chrome flex shrink-0 items-center gap-1.5 bg-background pointer-events-auto',
-        renderTabsInTitlebar ? 'h-[38px] w-full px-2' : 'h-10 border-b border-border px-3'
+        'relative z-chrome flex shrink-0 items-center gap-1.5 pointer-events-auto',
+        renderTabsInTitlebar
+          ? 'h-[38px] w-full bg-transparent pl-4 pr-2'
+          : 'h-10 border-b border-border bg-background px-3'
       )}
     >
       {openTabs.map(tab => (
@@ -200,8 +285,17 @@ export function RightWorkspacePanel({
           </button>
         )}
       </div>
+      {renderTabsInTitlebar ? (
+        <div
+          data-testid="right-workspace-titlebar-drag-region"
+          className="min-w-0 flex-1 self-stretch"
+        >
+          <MacOSTitleBarDragRegion className="h-full w-full" />
+        </div>
+      ) : null}
     </header>
   ) : null
+  const chatTabs = openTabs.filter(isRightWorkspaceChatTab)
 
   return (
     <section
@@ -218,15 +312,16 @@ export function RightWorkspacePanel({
         tabBar
       )}
       <div className="flex min-h-0 flex-1">
-        {activeView === 'launcher' ? (
+        {!isRightWorkspaceChatTab(activeView) && activeView === 'launcher' ? (
           <RightWorkspaceLauncher
             canOpenReview={canOpenReview}
             browserOpen={browserOpen}
             onSelectReview={onSelectReview}
             onSelectBrowser={openBrowserTab}
             onSelectFiles={onSelectFiles}
+            onSelectChat={onSelectChat}
           />
-        ) : activeView === 'review' ? (
+        ) : !isRightWorkspaceChatTab(activeView) && activeView === 'review' ? (
           <FileChangesReviewPanel
             loading={review.loading}
             diff={review.diff}
@@ -239,7 +334,7 @@ export function RightWorkspacePanel({
             viewOptions={reviewViewOptions}
             onRefresh={onRefreshReview}
           />
-        ) : activeView === 'terminal' ? (
+        ) : !isRightWorkspaceChatTab(activeView) && activeView === 'terminal' ? (
           <WorkspacePanelCards
             currentProject={currentProject}
             devices={devices}
@@ -248,9 +343,9 @@ export function RightWorkspacePanel({
             hideTerminalChrome
             preferLocalTerminal={preferLocalTerminal}
           />
-        ) : activeView === 'plan' ? (
+        ) : !isRightWorkspaceChatTab(activeView) && activeView === 'plan' ? (
           <PlanWorkspacePanel content={planContent ?? ''} />
-        ) : workspaceTargetError ? (
+        ) : !isRightWorkspaceChatTab(activeView) && workspaceTargetError ? (
           <section
             data-testid="workspace-target-error"
             hidden={activeView !== 'files'}
@@ -259,6 +354,7 @@ export function RightWorkspacePanel({
             {workspaceTargetError}
           </section>
         ) : (
+          !isRightWorkspaceChatTab(activeView) &&
           activeView === 'files' && (
             <FileWorkspacePanel
               key={
@@ -271,6 +367,23 @@ export function RightWorkspacePanel({
             />
           )
         )}
+        {chatTabs.map(tab => (
+          <div
+            key={tab}
+            className={cn('min-h-0 flex-1 flex-col', activeView === tab ? 'flex' : 'hidden')}
+          >
+            <TemporaryChatPanel
+              currentProject={currentProject}
+              source={currentRuntimeTask}
+              instanceId={tab}
+              testId={
+                activeView === tab
+                  ? 'right-workspace-chat-panel'
+                  : `right-workspace-chat-panel-${getRightWorkspaceChatTabSuffix(tab)}`
+              }
+            />
+          </div>
+        ))}
         {browserOpen && (
           <WorkspaceBrowserPanel
             active={visible && activeView === 'browser'}
@@ -295,13 +408,13 @@ function RightWorkspaceTitleTab({
   tab: RightWorkspacePanelTab
   active: boolean
   label: string
-  icon: typeof File
+  icon: LucideIcon
   iconSrc?: string | null
   onSelect: () => void
   onClose: () => void
 }) {
   const { t } = useTranslation('common')
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key !== 'Enter' && event.key !== ' ') {
       return
     }
@@ -413,12 +526,14 @@ function RightWorkspaceLauncher({
   onSelectReview,
   onSelectBrowser,
   onSelectFiles,
+  onSelectChat,
 }: {
   canOpenReview: boolean
   browserOpen: boolean
   onSelectReview: () => void
   onSelectBrowser: () => void
   onSelectFiles: () => void
+  onSelectChat: () => void
 }) {
   const { t } = useTranslation('common')
 
@@ -427,43 +542,72 @@ function RightWorkspaceLauncher({
       data-testid="right-workspace-launcher"
       className="flex min-h-0 flex-1 items-center justify-center px-8"
     >
-      <div className="flex w-full max-w-xl flex-col gap-3">
-        <button
-          type="button"
+      <div className="flex w-full max-w-xl flex-col gap-1.5">
+        <RightWorkspaceLauncherItem
           data-testid="right-workspace-review-option"
+          icon={FileDiff}
+          label={t('workbench.workspace_tab_review', '审查')}
+          shortcut={RIGHT_WORKSPACE_SHORTCUTS.review}
           onClick={onSelectReview}
           disabled={!canOpenReview}
-          className="flex h-8 w-full items-center gap-2 rounded-md bg-surface px-3 text-left text-[13px] font-medium leading-[18px] text-text-primary transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <FileDiff className="h-4 w-4 shrink-0 text-text-secondary" />
-          <span className="min-w-0 flex-1 truncate">
-            {t('workbench.workspace_tab_review', '审查')}
-          </span>
-        </button>
+        />
         {!browserOpen && (
-          <button
-            type="button"
+          <RightWorkspaceLauncherItem
             data-testid="right-workspace-browser-option"
+            icon={Globe2}
+            label={t('workbench.browser')}
+            shortcut={RIGHT_WORKSPACE_SHORTCUTS.browser}
             onClick={onSelectBrowser}
-            className="flex h-8 w-full items-center gap-2 rounded-md bg-surface px-3 text-left text-[13px] font-medium leading-[18px] text-text-primary transition-colors hover:bg-muted"
-          >
-            <Globe2 className="h-4 w-4 shrink-0 text-text-secondary" />
-            <span className="min-w-0 flex-1 truncate">{t('workbench.browser')}</span>
-          </button>
+          />
         )}
-        <button
-          type="button"
+        <RightWorkspaceLauncherItem
+          data-testid="right-workspace-chat-option"
+          icon={MessageCircle}
+          label={t('workbench.workspace_tab_chat', '临时聊天')}
+          shortcut={RIGHT_WORKSPACE_SHORTCUTS.chat}
+          onClick={onSelectChat}
+        />
+        <RightWorkspaceLauncherItem
           data-testid="right-workspace-file-option"
+          icon={File}
+          label={t('workbench.workspace_tab_files', '文件')}
+          shortcut={RIGHT_WORKSPACE_SHORTCUTS.files}
           onClick={onSelectFiles}
-          className="flex h-8 w-full items-center gap-2 rounded-md bg-surface px-3 text-left text-[13px] font-medium leading-[18px] text-text-primary transition-colors hover:bg-muted"
-        >
-          <File className="h-4 w-4 shrink-0 text-text-secondary" />
-          <span className="min-w-0 flex-1 truncate">
-            {t('workbench.workspace_tab_files', '文件')}
-          </span>
-        </button>
+        />
       </div>
     </div>
+  )
+}
+
+function RightWorkspaceLauncherItem({
+  icon: Icon,
+  label,
+  shortcut,
+  disabled,
+  onClick,
+  'data-testid': testId,
+}: {
+  icon: typeof File
+  label: string
+  shortcut: string
+  disabled?: boolean
+  onClick: () => void
+  'data-testid': string
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      disabled={disabled}
+      className="flex h-11 w-full items-center gap-2 rounded-xl bg-surface px-3 text-left text-[13px] font-light leading-[18px] text-text-primary transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <Icon className="h-4 w-4 shrink-0 text-text-secondary" />
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="shrink-0 rounded-lg bg-background/80 px-1.5 py-0.5 text-[11px] font-light leading-4 text-text-muted shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]">
+        {shortcut}
+      </span>
+    </button>
   )
 }
 
@@ -475,6 +619,7 @@ function getRightWorkspaceTabLabel(
   if (tab === 'review') return t('workbench.workspace_tab_review', '审查')
   if (tab === 'terminal') return t('workbench.terminal', '终端')
   if (tab === 'browser') return browserTitle || t('workbench.browser_new_tab', '新选项卡')
+  if (isRightWorkspaceChatTab(tab)) return t('workbench.workspace_tab_chat', '临时聊天')
   if (tab === 'plan') return t('workbench.workspace_tab_plan', '计划')
   return t('workbench.workspace_tab_files', '文件')
 }
@@ -482,6 +627,9 @@ function getRightWorkspaceTabLabel(
 function getRightWorkspaceTabTestId(tab: RightWorkspacePanelTab) {
   if (tab === 'terminal') return 'right-workspace-terminal-tab'
   if (tab === 'files') return 'right-workspace-file-tab'
+  if (isRightWorkspaceChatTab(tab)) {
+    return `right-workspace-chat-tab-${getRightWorkspaceChatTabSuffix(tab)}`
+  }
   return `right-workspace-${tab}-tab`
 }
 
@@ -489,6 +637,7 @@ function getRightWorkspaceTabIcon(tab: RightWorkspacePanelTab) {
   if (tab === 'review') return FileDiff
   if (tab === 'terminal') return SquareTerminal
   if (tab === 'browser') return Globe2
+  if (isRightWorkspaceChatTab(tab)) return MessageCircle
   if (tab === 'plan') return ListChecks
   return File
 }

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { MessageCircle } from 'lucide-react'
+import { ScrollableMessageArea } from '@/components/chat/ScrollableMessageArea'
+import { BufferedChatInput } from '@/components/layout/BufferedChatInput'
+import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
+import type { RuntimePaneMessageAction } from '@/features/workbench/runtimePaneMessages'
+import { selectedModelExecutionFields } from '@/features/workbench/runtimeModelSelection'
+import { localRuntimeAttachments, remoteAttachmentIds } from '@/lib/runtime-attachments'
+import type {
+  Attachment,
+  ProjectWithTasks,
+  RuntimeTaskAddress,
+  TurnFileChangesSummary,
+} from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
+import { reduceWorkbenchMessages } from '@wegent/chat-core'
+
+const SIDE_CHAT_MESSAGE_LIST_CLASS = 'w-full max-w-none px-5 pb-4 pt-5'
+
+function createUserMessage(content: string): WorkbenchMessage {
+  const createdAt = new Date().toISOString()
+  return {
+    id: `side-user-${Date.now()}`,
+    role: 'user',
+    content,
+    status: 'done',
+    createdAt,
+  }
+}
+
+interface TemporaryChatPanelProps {
+  currentProject: ProjectWithTasks | null
+  source: RuntimeTaskAddress | null
+  instanceId: string
+  testId?: string
+}
+
+export function TemporaryChatPanel({
+  currentProject,
+  source,
+  instanceId,
+  testId = 'right-workspace-chat-panel',
+}: TemporaryChatPanelProps) {
+  const {
+    state,
+    projectChat,
+    createTemporaryRuntimeTask,
+    sendRuntimePaneMessage,
+    cancelRuntimePaneTask,
+    subscribeRuntimeTaskStream,
+    loadRuntimeTranscriptForPane,
+  } = useWorkbenchPaneContext()
+  const [address, setAddress] = useState<RuntimeTaskAddress | null>(null)
+  const [messages, setMessages] = useState<WorkbenchMessage[]>([])
+  const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [sending, setSending] = useState(false)
+
+  const dispatchMessages = useCallback((action: RuntimePaneMessageAction) => {
+    setMessages(current =>
+      reduceWorkbenchMessages<Attachment, TurnFileChangesSummary>(current, action)
+    )
+  }, [])
+
+  useEffect(() => {
+    if (!address) return
+    let cancelled = false
+    void loadRuntimeTranscriptForPane(address)
+      .then(transcript => {
+        if (!cancelled && transcript.messages.length > 0) {
+          setMessages(transcript.messages)
+        }
+      })
+      .catch(caughtError => {
+        if (!cancelled) {
+          setError(caughtError instanceof Error ? caughtError.message : '加载临时聊天失败')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [address, loadRuntimeTranscriptForPane])
+
+  useEffect(() => {
+    if (!address) return
+    return subscribeRuntimeTaskStream(address, {
+      onMessageAction: dispatchMessages,
+      onAssistantStart: () => setSending(true),
+      onAssistantSettled: () => setSending(false),
+    })
+  }, [address, dispatchMessages, subscribeRuntimeTaskStream])
+
+  const selectedModelFields = useMemo(() => {
+    const selectedModel = projectChat.getSelectedModel?.() ?? projectChat.selectedModel
+    const selectedModelOptions =
+      projectChat.getSelectedModelOptions?.() ?? projectChat.selectedModelOptions
+    return selectedModelExecutionFields(selectedModel, selectedModelOptions)
+  }, [projectChat])
+
+  const send = useCallback(
+    async (valueOverride?: string) => {
+      const message = (valueOverride ?? input).trim()
+      if (!message) return
+      setError(null)
+      setMessages(current => [...current, createUserMessage(message)])
+      setSending(true)
+
+      const currentAttachments = projectChat.attachments
+      const attachmentIds = remoteAttachmentIds(currentAttachments)
+      const attachments = localRuntimeAttachments(currentAttachments)
+      const handleError = (message: string) => {
+        setError(message)
+        setSending(false)
+      }
+
+      const targetAddress =
+        address ??
+        (await createTemporaryRuntimeTask(message, {
+          project: currentProject,
+          source,
+          onError: handleError,
+        }))
+
+      if (!targetAddress) return
+      if (!address) {
+        setAddress(targetAddress)
+        projectChat.resetAttachments()
+        return
+      }
+
+      const sent = await sendRuntimePaneMessage(
+        {
+          address: targetAddress,
+          message,
+          ephemeral: true,
+          ...selectedModelFields,
+          ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
+          ...(attachments.length > 0 ? { attachments } : {}),
+        },
+        { onError: handleError }
+      )
+      if (sent) {
+        projectChat.resetAttachments()
+      } else {
+        setSending(false)
+      }
+    },
+    [
+      address,
+      createTemporaryRuntimeTask,
+      currentProject,
+      input,
+      projectChat,
+      selectedModelFields,
+      sendRuntimePaneMessage,
+      source,
+    ]
+  )
+
+  const pause = useCallback(() => {
+    if (!address) return
+    void cancelRuntimePaneTask(address, {
+      onError: message => setError(message),
+    }).finally(() => setSending(false))
+  }, [address, cancelRuntimePaneTask])
+
+  return (
+    <section data-testid={testId} className="flex min-h-0 flex-1 flex-col">
+      {messages.length === 0 ? (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-8 text-center text-sm text-text-muted">
+          <MessageCircle className="h-5 w-5 text-text-secondary" />
+          <p>临时聊天不会出现在左侧任务列表。</p>
+        </div>
+      ) : (
+        <ScrollableMessageArea
+          messages={messages}
+          isWaitingForAssistant={sending}
+          devices={state.devices}
+          conversationKey={address?.taskId ?? instanceId}
+          className="min-h-0 flex-1"
+          messageListClassName={SIDE_CHAT_MESSAGE_LIST_CLASS}
+          scrollTestId="right-workspace-chat-scroll-area"
+        />
+      )}
+      <div className="shrink-0 bg-background px-4 py-3">
+        <BufferedChatInput
+          value={input}
+          onChange={setInput}
+          onSubmit={send}
+          disabled={false}
+          error={error}
+          placeholder="要求后续变更"
+          variant="desktop"
+          projectChat={projectChat}
+          showProjectWorkBar={false}
+          isStreaming={sending}
+          onPause={pause}
+        />
+      </div>
+    </section>
+  )
+}

--- a/wework/src/components/topnav/ChromeTitlebar.test.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.test.tsx
@@ -178,6 +178,21 @@ describe('ChromeTitlebar', () => {
     disableTauri()
   })
 
+  test('starts native dragging from the empty right workspace titlebar area', async () => {
+    mockUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    enableTauri()
+    render(<ChromeTitlebar tabs={mockTabs} activeKey="wework" onNavigate={vi.fn()} />)
+
+    const rightPanelDragRegion = screen.getByTestId('titlebar-right-panel-drag-region')
+    expect(screen.getByTestId('titlebar-right-panel')).toContainElement(rightPanelDragRegion)
+    fireEvent.mouseDown(within(rightPanelDragRegion).getByTestId('macos-titlebar-drag-region'), {
+      button: 0,
+    })
+
+    await waitFor(() => expect(startDragging).toHaveBeenCalledTimes(1))
+    disableTauri()
+  })
+
   test('shows right spacer in Tauri runtime on Windows', () => {
     mockUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
     enableTauri()

--- a/wework/src/components/topnav/ChromeTitlebar.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.tsx
@@ -122,7 +122,7 @@ export function ChromeTitlebar({
       {isTauri && <TitlebarExtensionSlot />}
       <div
         data-testid="titlebar-right-workspace-zone"
-        className="pointer-events-none absolute right-0 top-[3px] z-chrome flex h-[calc(100%-3px)] items-center"
+        className="pointer-events-none absolute right-0 top-0 z-chrome flex h-full items-center"
         style={{
           width: 'var(--right-workspace-titlebar-width, auto)',
         }}
@@ -130,8 +130,14 @@ export function ChromeTitlebar({
         <div
           id={TITLEBAR_RIGHT_PANEL_PORTAL_ID}
           data-testid="titlebar-right-panel"
-          className="pointer-events-auto flex min-w-0 flex-1 items-center"
-        />
+          className="pointer-events-auto relative flex min-w-0 flex-1 self-stretch items-center"
+        >
+          {isTauri ? (
+            <div data-testid="titlebar-right-panel-drag-region" className="absolute inset-0 z-0">
+              <MacOSTitleBarDragRegion className="h-full w-full" />
+            </div>
+          ) : null}
+        </div>
         <div
           id={TITLEBAR_ACTIONS_PORTAL_ID}
           data-testid="titlebar-actions"

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -724,6 +724,9 @@ export function WorkbenchProvider({
   const stableSendRuntimePaneMessage = useStableEvent(runtimeMessaging.sendRuntimePaneMessage)
   const stableCancelRuntimePaneTask = useStableEvent(runtimeMessaging.cancelRuntimePaneTask)
   const stableSendCurrentInput = useStableEvent(runtimeMessaging.sendCurrentInput)
+  const stableCreateTemporaryRuntimeTask = useStableEvent(
+    runtimeMessaging.createTemporaryRuntimeTask
+  )
   const stableRetryFailedMessage = useStableEvent(runtimeMessaging.retryFailedMessage)
   const stablePauseCurrentResponse = useStableEvent(runtimeMessaging.pauseCurrentResponse)
   const stableLoadTurnFileChangesDiff = useStableEvent(runtimeMessaging.loadTurnFileChangesDiff)
@@ -954,6 +957,7 @@ export function WorkbenchProvider({
     sendRuntimePaneMessage: runtimeMessaging.sendRuntimePaneMessage,
     cancelRuntimePaneTask: runtimeMessaging.cancelRuntimePaneTask,
     sendCurrentInput: runtimeMessaging.sendCurrentInput,
+    createTemporaryRuntimeTask: runtimeMessaging.createTemporaryRuntimeTask,
     retryFailedMessage: runtimeMessaging.retryFailedMessage,
     pauseCurrentResponse: runtimeMessaging.pauseCurrentResponse,
     loadTurnFileChangesDiff: runtimeMessaging.loadTurnFileChangesDiff,
@@ -1023,6 +1027,7 @@ export function WorkbenchProvider({
       sendRuntimePaneMessage: stableSendRuntimePaneMessage,
       cancelRuntimePaneTask: stableCancelRuntimePaneTask,
       sendCurrentInput: stableSendCurrentInput,
+      createTemporaryRuntimeTask: stableCreateTemporaryRuntimeTask,
       retryFailedMessage: stableRetryFailedMessage,
       pauseCurrentResponse: stablePauseCurrentResponse,
       loadTurnFileChangesDiff: stableLoadTurnFileChangesDiff,
@@ -1047,6 +1052,7 @@ export function WorkbenchProvider({
       stableCreateEnvironmentBranch,
       stableCreateGitWorkspaceProject,
       stableCreateProject,
+      stableCreateTemporaryRuntimeTask,
       stableDeleteDeviceWorkspace,
       stableForkCurrentRuntimeTask,
       stableGetDeviceHomeDirectory,

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -26,6 +26,7 @@ import type {
   ChatSendPayload,
   RuntimeTaskSummary,
   ModelOptions,
+  ProjectWithTasks,
   RuntimeDeviceWorkspace,
   RuntimeSendRequest,
   RuntimeTaskAddress,
@@ -36,7 +37,11 @@ import type {
 } from '@/types/api'
 import type { WorkbenchMessage, WorkbenchState } from '@/types/workbench'
 import { normalizeTurnFileChanges } from './turnFileChanges'
-import type { RuntimePaneActionOptions, SendCurrentInputOptions } from './workbenchContextTypes'
+import type {
+  CreateTemporaryRuntimeTaskOptions,
+  RuntimePaneActionOptions,
+  SendCurrentInputOptions,
+} from './workbenchContextTypes'
 import { DEVICE_STATUS_LABELS, normalizeGuidanceError } from './workbenchProviderHelpers'
 import type { WorkbenchAction } from './workbenchReducer'
 import {
@@ -109,6 +114,13 @@ function isLocalDeviceTarget(
   if (!deviceId) return false
   const device = findWorkbenchDevice(devices, deviceId)
   return device?.device_type === 'local'
+}
+
+function runtimeThreadId(address?: RuntimeTaskAddress | null): string | null {
+  const handle = address?.runtimeHandle
+  if (!isRecord(handle)) return null
+  const threadId = handle.sessionId ?? handle.session_id ?? handle.threadId ?? handle.thread_id
+  return typeof threadId === 'string' && threadId.trim() ? threadId : null
 }
 
 export function useWorkbenchRuntimeMessaging({
@@ -193,10 +205,11 @@ export function useWorkbenchRuntimeMessaging({
   const buildSendPayload = useCallback(
     (
       message: string,
-      sourceAttachments?: Attachment[]
+      sourceAttachments?: Attachment[],
+      projectOverride?: ProjectWithTasks | null
     ): { payload: ChatSendPayload; activeDeviceId?: string } | null => {
       if (!state.defaultTeam) return null
-      const activeProject = state.currentProject
+      const activeProject = projectOverride === undefined ? state.currentProject : projectOverride
       const selectedProjectWorkspace = findProjectDeviceWorkspace(
         state.runtimeWork,
         activeProject?.id,
@@ -304,7 +317,12 @@ export function useWorkbenchRuntimeMessaging({
       options?: Pick<
         SendCurrentInputOptions,
         'initialGoal' | 'onError' | 'onRuntimeTaskOptimisticOpen'
-      >
+      > & {
+        ephemeral?: boolean
+        openInMainPane?: boolean
+        refreshWorkListsOnResolve?: boolean
+        sideSource?: RuntimeTaskAddress | null
+      }
     ): Promise<RuntimeTaskAddress | false> => {
       const projectId = payload.project_id && payload.project_id > 0 ? payload.project_id : null
       const selectedModel =
@@ -324,7 +342,13 @@ export function useWorkbenchRuntimeMessaging({
         'projectId' | 'deviceWorkspaceId' | 'deviceId' | 'workspacePath'
       >
       let optimisticDeviceId: string
-      if (projectId) {
+      if (options?.sideSource?.deviceId && options.sideSource.workspacePath) {
+        optimisticDeviceId = options.sideSource.deviceId
+        runtimeTaskTarget = {
+          deviceId: options.sideSource.deviceId,
+          workspacePath: options.sideSource.workspacePath,
+        }
+      } else if (projectId) {
         if (!selectedProjectWorkspace) {
           reportSendBlocked('请选择任务运行位置', undefined, options)
           return false
@@ -392,6 +416,8 @@ export function useWorkbenchRuntimeMessaging({
         attachmentIds: payload.attachment_ids ?? [],
         attachments: payload.attachments ?? [],
         execution: payload.execution,
+        ...(options?.ephemeral ? { ephemeral: true } : {}),
+        ...(options?.sideSource ? { sideSource: options.sideSource } : {}),
         ...(options?.initialGoal ? { initialGoal: options.initialGoal } : {}),
       }
       debugRuntimeCreateFlow('create-request-built', {
@@ -434,7 +460,9 @@ export function useWorkbenchRuntimeMessaging({
         optimisticWorkspacePath: optimisticWorkspacePath ?? null,
       })
       options?.onRuntimeTaskOptimisticOpen?.(optimisticAddress)
-      runtimeTasks.openRuntimeTaskView(optimisticAddress, runtimeProject, { navigate: true })
+      if (options?.openInMainPane !== false) {
+        runtimeTasks.openRuntimeTaskView(optimisticAddress, runtimeProject, { navigate: true })
+      }
       attachmentSelection.resetAttachments()
 
       try {
@@ -462,7 +490,7 @@ export function useWorkbenchRuntimeMessaging({
           responseHasTaskId: Boolean(response.taskId),
         })
         const resolvedWorkspacePath = address.workspacePath ?? optimisticWorkspacePath
-        if (resolvedWorkspacePath) {
+        if (resolvedWorkspacePath && !options?.ephemeral) {
           dispatch({
             type: 'runtime_task_optimistic_upserted',
             project: runtimeProject,
@@ -492,11 +520,17 @@ export function useWorkbenchRuntimeMessaging({
           options?.onRuntimeTaskOptimisticOpen?.(address, {
             previousAddress: optimisticAddress,
           })
-          runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
+          if (options?.openInMainPane !== false) {
+            runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
+          }
         }
-        await refreshWorkLists()
-        runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
-        dispatch({ type: 'blank_chat_committed' })
+        if (options?.refreshWorkListsOnResolve !== false) {
+          await refreshWorkLists()
+        }
+        if (options?.openInMainPane !== false) {
+          runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
+          dispatch({ type: 'blank_chat_committed' })
+        }
         return address
       } catch (error) {
         dispatch({ type: 'runtime_task_optimistic_removed', address: optimisticAddress })
@@ -748,6 +782,62 @@ export function useWorkbenchRuntimeMessaging({
     ]
   )
 
+  const createTemporaryRuntimeTask = useCallback(
+    async (
+      input: string,
+      options?: CreateTemporaryRuntimeTaskOptions
+    ): Promise<RuntimeTaskAddress | false> => {
+      const message = input.trim()
+      if (!message) {
+        reportSendBlocked('请输入内容后再发送', undefined, options)
+        return false
+      }
+      if (!options?.source || !runtimeThreadId(options.source)) {
+        reportSendBlocked('请先打开一个已有对话后再开始临时聊天', undefined, options)
+        return false
+      }
+
+      const prepared = buildSendPayload(message, undefined, options?.project)
+      if (!prepared) {
+        reportSendBlocked(
+          'Wework default team is not configured',
+          { hasDefaultTeam: Boolean(state.defaultTeam) },
+          options
+        )
+        return false
+      }
+
+      const selectedModel =
+        modelSelection.getSelectedModel?.() ??
+        modelSelection.selectedModel ??
+        resolveAutomaticModel(modelSelection.models)
+      if (
+        prepared.activeDeviceId &&
+        isConfiguredLocalModel(selectedModel) &&
+        !isLocalDeviceTarget(state.devices, prepared.activeDeviceId)
+      ) {
+        reportSendBlocked(i18n.t('workbench.local_model_cloud_device_blocked'), undefined, options)
+        return false
+      }
+
+      return sendPreparedRuntimeMessage(message, prepared.payload, prepared.activeDeviceId, {
+        onError: options?.onError,
+        ephemeral: true,
+        sideSource: options?.source,
+        openInMainPane: false,
+        refreshWorkListsOnResolve: false,
+      })
+    },
+    [
+      buildSendPayload,
+      modelSelection,
+      reportSendBlocked,
+      sendPreparedRuntimeMessage,
+      state.defaultTeam,
+      state.devices,
+    ]
+  )
+
   const loadTurnFileChangesDiff = useCallback(
     async (subtaskId: string, messagesOverride?: WorkbenchMessage[]) => {
       const messageSource = messagesOverride ?? []
@@ -880,6 +970,7 @@ export function useWorkbenchRuntimeMessaging({
     sendRuntimePaneMessage,
     cancelRuntimePaneTask,
     sendCurrentInput,
+    createTemporaryRuntimeTask,
     retryFailedMessage,
     pauseCurrentResponse,
     loadTurnFileChangesDiff,

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -72,6 +72,12 @@ export interface SendCurrentInputOptions {
   ) => void
 }
 
+export interface CreateTemporaryRuntimeTaskOptions {
+  project?: ProjectWithTasks | null
+  source?: RuntimeTaskAddress | null
+  onError?: (error: string) => void
+}
+
 export interface RuntimePaneActionOptions {
   onError?: (error: string) => void
 }
@@ -232,6 +238,10 @@ export interface WorkbenchContextValue {
     inputOverride?: string,
     options?: SendCurrentInputOptions
   ) => Promise<boolean | RuntimeTaskAddress>
+  createTemporaryRuntimeTask: (
+    input: string,
+    options?: CreateTemporaryRuntimeTaskOptions
+  ) => Promise<RuntimeTaskAddress | false>
   retryFailedMessage: (messageId: string, messagesOverride?: WorkbenchMessage[]) => Promise<void>
   pauseCurrentResponse: (messagesOverride?: WorkbenchMessage[]) => Promise<void>
   loadTurnFileChangesDiff: (

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -17,6 +17,8 @@ import { getRuntimeTaskWorkspacePath } from './workbenchRuntimeHelpers'
 
 type WorkbenchDeviceStatus = DeviceInfo['status']
 
+const OPTIMISTIC_TASK_PRESERVE_MS = 2 * 60 * 1000
+
 export const initialWorkbenchState: WorkbenchState = {
   user: null,
   defaultTeam: null,
@@ -288,7 +290,7 @@ function mergeRuntimeTasks(
       const nextTask = nextById.get(task.taskId)
       if (nextTask) return nextTask
       if (
-        isOptimisticRuntimeTask(task) &&
+        isFreshOptimisticRuntimeTask(task) &&
         !resolvedTaskKeys.has(runtimeTaskKey(deviceId, task)) &&
         !nextTasks.some(nextTask => isResolvedOptimisticRuntimeTask(task, nextTask))
       ) {
@@ -308,6 +310,13 @@ function mergeRuntimeTasks(
 
 function isOptimisticRuntimeTask(task: RuntimeTaskSummary): boolean {
   return task.status === 'creating'
+}
+
+function isFreshOptimisticRuntimeTask(task: RuntimeTaskSummary): boolean {
+  if (!isOptimisticRuntimeTask(task)) return false
+  const rawTimestamp = task.updatedAt ?? task.createdAt
+  const timestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.parse(rawTimestamp ?? '')
+  return Number.isNaN(timestamp) || Date.now() - timestamp < OPTIMISTIC_TASK_PRESERVE_MS
 }
 
 function isResolvedOptimisticRuntimeTask(
@@ -354,7 +363,7 @@ function optimisticWorkspaceOnly(
 ): RuntimeDeviceWorkspace | null {
   const tasks = workspace.tasks.filter(
     task =>
-      isOptimisticRuntimeTask(task) &&
+      isFreshOptimisticRuntimeTask(task) &&
       !resolvedTaskKeys.has(runtimeTaskKey(workspace.deviceId, task))
   )
   return tasks.length > 0 ? { ...workspace, tasks } : null

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -115,6 +115,7 @@
     "workspace_tab_open_file": "Open file",
     "workspace_tab_review": "Review",
     "workspace_tab_files": "Files",
+    "workspace_tab_chat": "Temporary chat",
     "workspace_tab_new": "Open new tab",
     "create_project": "Create project",
     "close_dialog": "Close",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -115,6 +115,7 @@
     "workspace_tab_open_file": "打开文件",
     "workspace_tab_review": "审查",
     "workspace_tab_files": "文件",
+    "workspace_tab_chat": "临时聊天",
     "workspace_tab_new": "打开新标签页",
     "create_project": "创建项目",
     "close_dialog": "关闭",

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -472,6 +472,7 @@ export interface RuntimeTranscriptRequest extends RuntimeTaskAddress {
 export interface RuntimeSendRequest {
   address: RuntimeTaskAddress
   message: string
+  ephemeral?: boolean
   modelId?: string
   modelType?: ModelType | null
   modelOptions?: ModelOptions
@@ -741,6 +742,8 @@ export interface RuntimeTaskCreateRequest {
   attachments?: Attachment[]
   execution?: ChatSendPayload['execution']
   initialGoal?: RuntimeGoalCreateInput | null
+  ephemeral?: boolean
+  sideSource?: RuntimeTaskAddress | null
 }
 
 export interface RuntimeTaskCreateResponse {


### PR DESCRIPTION
## Summary

- Add the right-workspace Temporary chat tab with multi-tab support, compact launcher styling, shortcuts, and titlebar drag-region fixes.
- Route temporary chat creation through ephemeral runtime tasks that use the active Codex thread as `sideSource` and stay hidden from the left task list.
- Continue temporary chat follow-ups on the loaded Codex thread via `direct_thread_id` instead of the normal rollout-backed resume path.
- Document the temporary chat state source and executor continuation rules in the Wework chat state guide.

## Validation

- `pnpm --filter wework typecheck`
- `pnpm --filter wework test -- DesktopWorkbenchLayout.test.tsx ChromeTitlebar.test.tsx --run`
- `cargo test runtime_tasks_ --quiet`
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- pre-push hook: Wework ESLint, TypeScript, unit tests; executor cargo fmt, cargo test --all-features --lib, cargo clippy

## Notes

The pre-push documentation gate was satisfied by updating `docs/zh/developer-guide/wework-chat-state-sources.md` and `docs/en/developer-guide/wework-chat-state-sources.md`; `docs/*/concepts/architecture.md` does not exist in this repository.