### PR TITLE
fix(wework): adjust title and terminal tab styling

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2055,10 +2055,15 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     expect(screen.getByTestId('workbench-topbar')).toHaveClass('pl-[14rem]')
-    expect(screen.getByTestId('workbench-topbar-left-actions')).toHaveClass(
-      'max-w-[calc(100%-22rem)]'
+    expect(screen.queryByTestId('workbench-topbar-left-actions')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workbench-pane-task-title')).toHaveClass(
+      'absolute',
+      'left-0',
+      'top-0',
+      'h-11',
+      'pl-[14rem]',
+      'truncate'
     )
-    expect(screen.getByTestId('workbench-pane-task-title')).toHaveClass('truncate')
     expect(screen.getByTestId('workbench-pane-task-title')).toHaveTextContent(
       'wework的聊天链路现在代码逻辑比较混乱'
     )
@@ -5728,6 +5733,25 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
     await waitFor(() => expect(startTerminalSessionMock).toHaveBeenCalledWith(12))
+
+    expect(screen.getByTestId('bottom-workspace-panel')).not.toHaveClass('rounded-t-xl')
+    expect(screen.getByTestId('bottom-workspace-tabbar')).toHaveClass('bg-background')
+    expect(screen.getByTestId('bottom-workspace-tabbar')).not.toHaveClass('border-b')
+    const initialTab = screen.getByTestId('bottom-workspace-terminal-tab')
+    expect(initialTab).toHaveClass('bg-muted', 'text-text-primary')
+    expect(initialTab).not.toHaveClass('border', 'border-border', 'shadow-sm')
+    expect(initialTab).not.toHaveTextContent('终端')
+    await waitFor(() => expect(initialTab).toHaveTextContent('project'))
+    expect(initialTab).toHaveAttribute('title', 'project')
+    expect(initialTab).toHaveClass('max-w-[200px]', 'pr-7')
+    expect(initialTab).not.toHaveClass('hover:max-w-none')
+    const initialCloseButton = within(initialTab).getByTestId('close-bottom-workspace-tab-button')
+    expect(initialCloseButton).toHaveClass(
+      'group-hover:bg-border/70',
+      'hover:!bg-text-secondary',
+      'hover:text-background'
+    )
+    expect(initialCloseButton).not.toHaveClass('hover:bg-black/70', 'hover:text-white')
 
     await userEvent.click(screen.getByTestId('workspace-terminal-new-tab-button'))
 

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -92,7 +92,6 @@ const RIGHT_PANEL_HANDLE_TRANSITION_CLASS =
   'transition-[left] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[left]'
 const MAX_CACHED_DESKTOP_WORKBENCH_TABS = 10
 const RIGHT_WORKSPACE_TITLEBAR_WIDTH_VAR = '--right-workspace-titlebar-width'
-const TAURI_TITLEBAR_ACTIONS_CLEARANCE_CLASS = 'max-w-[calc(100%-22rem)]'
 
 function getRuntimeWorkbenchPaneKeys(
   runtimeWork: RuntimeWorkListResponse | null | undefined
@@ -795,10 +794,15 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const paneTaskTitle = runtimeTaskTitle ? (
     <div
       data-testid="workbench-pane-task-title"
-      className="min-w-0 max-w-[min(52rem,calc(100vw-28rem))] truncate text-[13px] font-medium leading-none text-text-primary"
+      className={cn(
+        'pointer-events-none absolute left-0 top-0 z-chrome flex h-11 min-w-0 truncate items-center pr-7 text-[13px] font-medium leading-none text-text-primary',
+        sidebarCollapsed ? 'pl-[14rem]' : 'pl-4',
+        rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+      )}
+      style={{ width: chatColumnWidth }}
       title={runtimeTaskTitle}
     >
-      {runtimeTaskTitle}
+      <span className="block w-full min-w-0 truncate">{runtimeTaskTitle}</span>
     </div>
   ) : undefined
   const topBarLeftActions = !isTauri ? (
@@ -815,14 +819,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       />
     )
   ) : undefined
-  const topBarLeftContent =
-    topBarLeftActions || paneTaskTitle ? (
-      <>
-        {topBarLeftActions}
-        {paneTaskTitle}
-      </>
-    ) : undefined
-  const showPageTopBar = !isTauri || Boolean(topBarLeftContent)
+  const topBarLeftContent = topBarLeftActions ? <>{topBarLeftActions}</> : undefined
+  const showPageTopBar = !isTauri || Boolean(topBarLeftContent) || Boolean(paneTaskTitle)
   const hasSubagentStatuses = (paneSession.subagentStatuses?.length ?? 0) > 0
   const canForkCurrentRuntimeTask = Boolean(currentRuntimeTask && forkCurrentRuntimeTask)
   const forkTaskButton = canForkCurrentRuntimeTask ? (
@@ -956,12 +954,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             )}
             style={{ width: chatColumnWidth }}
             left={topBarLeftContent}
-            leftClassName={cn(
-              'min-w-0 gap-2',
-              isTauri ? TAURI_TITLEBAR_ACTIONS_CLEARANCE_CLASS : 'max-w-[calc(100%-12rem)]'
-            )}
+            leftClassName={cn('min-w-0 gap-2', isTauri ? 'contents' : 'max-w-[calc(100%-12rem)]')}
           />
         )}
+        {paneTaskTitle}
         {showPageTopBar && hasSubagentStatuses && (
           <div
             data-testid="workbench-subagent-status-row"

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -11,6 +11,7 @@ import { WorkspacePanelCards } from './WorkspacePanelCards'
 
 interface BottomWorkspacePanelTab {
   id: string
+  title: string
 }
 
 interface BottomWorkspacePanelProps {
@@ -27,7 +28,7 @@ interface BottomWorkspacePanelProps {
 }
 
 function createTerminalTab(index: number): BottomWorkspacePanelTab {
-  return { id: `terminal-${index}` }
+  return { id: `terminal-${index}`, title: `Terminal ${index}` }
 }
 
 export function BottomWorkspacePanel({
@@ -88,6 +89,18 @@ export function BottomWorkspacePanel({
     }
   }
 
+  const updateTabTitle = (tabId: string, title: string) => {
+    const normalizedTitle = title.trim()
+    if (!normalizedTitle) return
+
+    setTabs(current => {
+      const tab = current.find(item => item.id === tabId)
+      if (!tab || tab.title === normalizedTitle) return current
+
+      return current.map(item => (item.id === tabId ? { ...item, title: normalizedTitle } : item))
+    })
+  }
+
   const menuItems: WorkspaceAddMenuItem[] = [
     {
       id: 'terminal',
@@ -102,7 +115,7 @@ export function BottomWorkspacePanel({
     <section
       data-testid={testId('bottom-workspace-panel')}
       className={cn(
-        'relative flex shrink-0 flex-col overflow-hidden rounded-t-xl bg-background transition-[height,opacity,transform] duration-300 ease-out',
+        'relative flex shrink-0 flex-col overflow-hidden bg-background transition-[height,opacity,transform] duration-300 ease-out',
         open
           ? 'pointer-events-auto translate-y-0 border-t border-border opacity-100'
           : 'pointer-events-none translate-y-3 border-t border-transparent opacity-0'
@@ -130,7 +143,7 @@ export function BottomWorkspacePanel({
           <header
             data-testid={contentTestIdsEnabled ? 'bottom-workspace-tabbar' : undefined}
             role="tablist"
-            className="flex h-10 shrink-0 items-center gap-1.5 overflow-hidden border-b border-border bg-surface px-2 pr-12"
+            className="flex h-10 shrink-0 items-center gap-1.5 overflow-hidden bg-background px-2 pr-12"
           >
             <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
               {tabs.map(tab => (
@@ -138,7 +151,7 @@ export function BottomWorkspacePanel({
                   key={tab.id}
                   testIdsEnabled={contentTestIdsEnabled}
                   active={activeTab?.id === tab.id}
-                  label={currentProject?.name || t('workbench.terminal', '终端')}
+                  label={tab.title}
                   onSelect={() => setActiveTabId(tab.id)}
                   onClose={() => closeTab(tab.id)}
                 />
@@ -169,6 +182,7 @@ export function BottomWorkspacePanel({
                   preferLocalTerminal={preferLocalTerminal}
                   panelActive={panelActive}
                   testIdsEnabled={contentTestIdsEnabled}
+                  onTerminalTitleChange={title => updateTabTitle(tab.id, title)}
                 />
               </div>
             ))}
@@ -201,20 +215,20 @@ function BottomWorkspaceTitleTab({
     event.preventDefault()
     onSelect()
   }
-
   return (
     <div
       data-testid={testId('bottom-workspace-terminal-tab')}
       role="tab"
       aria-selected={active}
       tabIndex={0}
+      title={label}
       onClick={onSelect}
       onKeyDown={handleKeyDown}
       className={cn(
-        'group relative flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl py-1 pl-2 pr-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'group relative flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl py-1 pl-2 pr-7 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         active
-          ? 'border border-border bg-background text-text-primary shadow-sm'
-          : 'border border-transparent text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
+          ? 'bg-muted text-text-primary'
+          : 'bg-background text-text-secondary hover:bg-muted hover:text-text-primary'
       )}
     >
       <SquareTerminal
@@ -229,7 +243,7 @@ function BottomWorkspaceTitleTab({
           event.stopPropagation()
           onClose()
         }}
-        className="pointer-events-none absolute right-1 top-1/2 flex h-[18px] w-[18px] -translate-y-1/2 items-center justify-center rounded-full text-text-secondary opacity-0 transition-colors hover:bg-black/70 hover:text-white focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
+        className="pointer-events-none absolute right-1 top-1/2 flex h-[18px] w-[18px] -translate-y-1/2 items-center justify-center rounded-full text-text-secondary opacity-0 transition-colors hover:!bg-text-secondary hover:text-background focus-visible:pointer-events-auto focus-visible:bg-border/70 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:bg-border/70 group-hover:opacity-100"
         aria-label={t('workbench.close_terminal', '关闭终端')}
       >
         <X className="h-3 w-3" />

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -20,6 +20,7 @@ interface EmbeddedLocalTerminalProps {
   sessionId: string
   active: boolean
   onExit?: () => void
+  onTitleChange?: (title: string) => void
   testIdsEnabled?: boolean
 }
 
@@ -27,6 +28,7 @@ export function EmbeddedLocalTerminal({
   sessionId,
   active,
   onExit,
+  onTitleChange,
   testIdsEnabled = true,
 }: EmbeddedLocalTerminalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -34,6 +36,7 @@ export function EmbeddedLocalTerminal({
   const fitAddonRef = useRef<FitAddon | null>(null)
   const activeRef = useRef(active)
   const onExitRef = useRef(onExit)
+  const onTitleChangeRef = useRef(onTitleChange)
   const lastSizeRef = useRef<{ rows: number; cols: number } | null>(null)
 
   useEffect(() => {
@@ -43,6 +46,10 @@ export function EmbeddedLocalTerminal({
   useEffect(() => {
     onExitRef.current = onExit
   }, [onExit])
+
+  useEffect(() => {
+    onTitleChangeRef.current = onTitleChange
+  }, [onTitleChange])
 
   useEffect(() => {
     const container = containerRef.current
@@ -65,6 +72,9 @@ export function EmbeddedLocalTerminal({
     const dataDisposable = terminal.onData(data => {
       inputFallback.noteData(data)
       void writeLocalTerminal(sessionId, data)
+    })
+    const titleDisposable = terminal.onTitleChange(title => {
+      onTitleChangeRef.current?.(title)
     })
     let disposed = false
     const unlisteners: Array<() => void> = []
@@ -140,6 +150,7 @@ export function EmbeddedLocalTerminal({
       unobserveTheme()
       resizeObserver.disconnect()
       dataDisposable.dispose()
+      titleDisposable.dispose()
       inputFallback.dispose()
       unlisteners.forEach(unlisten => unlisten())
       terminal.dispose()

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -9,6 +9,7 @@ const testState = vi.hoisted(() => ({
     cols: number
     emitData: (data: string) => void
     onData: ReturnType<typeof vi.fn>
+    onTitleChange: ReturnType<typeof vi.fn>
     write: ReturnType<typeof vi.fn>
     writeln: ReturnType<typeof vi.fn>
     loadAddon: ReturnType<typeof vi.fn>
@@ -43,6 +44,7 @@ vi.mock('@xterm/xterm', () => ({
         dataHandlers.push(handler)
         return { dispose: vi.fn() }
       }),
+      onTitleChange: vi.fn(() => ({ dispose: vi.fn() })),
       write: vi.fn(),
       writeln: vi.fn(),
       loadAddon: vi.fn(),

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -15,6 +15,7 @@ interface RemoteTerminalProps {
   sessionId: string
   active: boolean
   onExit?: () => void
+  onTitleChange?: (title: string) => void
   testIdsEnabled?: boolean
 }
 
@@ -22,6 +23,7 @@ export function RemoteTerminal({
   sessionId,
   active,
   onExit,
+  onTitleChange,
   testIdsEnabled = true,
 }: RemoteTerminalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -30,6 +32,7 @@ export function RemoteTerminal({
   const clientRef = useRef<RemoteTerminalClient | null>(null)
   const activeRef = useRef(active)
   const onExitRef = useRef(onExit)
+  const onTitleChangeRef = useRef(onTitleChange)
   const lastSizeRef = useRef<{ rows: number; cols: number } | null>(null)
 
   useEffect(() => {
@@ -39,6 +42,10 @@ export function RemoteTerminal({
   useEffect(() => {
     onExitRef.current = onExit
   }, [onExit])
+
+  useEffect(() => {
+    onTitleChangeRef.current = onTitleChange
+  }, [onTitleChange])
 
   useEffect(() => {
     const container = containerRef.current
@@ -75,6 +82,9 @@ export function RemoteTerminal({
         terminal.write(payload.data)
         scheduleThemeSync()
       }
+    })
+    const titleDisposable = terminal.onTitleChange(title => {
+      onTitleChangeRef.current?.(title)
     })
     const unsubscribeExit = client.onExit(payload => {
       if (!disposed && payload.session_id === sessionId) {
@@ -149,6 +159,7 @@ export function RemoteTerminal({
       unobserveTheme()
       resizeObserver.disconnect()
       dataDisposable.dispose()
+      titleDisposable.dispose()
       inputFallback.dispose()
       unsubscribeOutput()
       unsubscribeExit()

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -46,6 +46,7 @@ interface WorkspacePanelCardsProps {
   preferLocalTerminal?: boolean
   panelActive?: boolean
   testIdsEnabled?: boolean
+  onTerminalTitleChange?: (title: string) => void
 }
 
 type WorkspaceTool = 'terminal' | 'ide' | 'desktop'
@@ -71,6 +72,7 @@ interface LocalTerminalCheckState {
 type WorkspaceTerminalSession = ProjectDeviceSessionResponse & {
   terminal_kind?: 'remote' | 'local'
   cwd?: string
+  title?: string
 }
 
 function createAvailableTools(): WorkspaceToolAvailability {
@@ -94,6 +96,26 @@ function usesLocalProjectConfig(project: ProjectWithTasks | null): boolean {
     project &&
     (project.config?.execution?.targetType === 'local' ||
       project.config?.workspace?.source === 'local_path')
+  )
+}
+
+function getPathBasename(path?: string | null): string {
+  const normalizedPath = path?.trim().replace(/\/+$/, '')
+  if (!normalizedPath || normalizedPath === '/') return ''
+  return normalizedPath.split('/').filter(Boolean).pop() ?? ''
+}
+
+function getTerminalSessionLabel(session: WorkspaceTerminalSession | null): string {
+  if (!session) return ''
+
+  const title = session.title?.trim()
+  if (title) return title
+
+  return (
+    getPathBasename(session.cwd) ||
+    getPathBasename(session.path) ||
+    session.device_id?.trim() ||
+    session.session_id
   )
 }
 
@@ -121,6 +143,7 @@ export function WorkspacePanelCards({
   preferLocalTerminal = false,
   panelActive = true,
   testIdsEnabled = true,
+  onTerminalTitleChange,
 }: WorkspacePanelCardsProps) {
   const { t } = useTranslation('common')
   const testId = useCallback(
@@ -232,12 +255,17 @@ export function WorkspacePanelCards({
     terminalSessions.find(session => session.session_id === activeTerminalSessionId) ??
     terminalSessions[0] ??
     null
-  const terminalTabLabel =
-    currentProject?.name ?? activeTerminalSession?.cwd ?? activeTerminalSession?.device_id ?? ''
+  const activeTerminalTitle = getTerminalSessionLabel(activeTerminalSession)
 
   useEffect(() => {
     terminalSessionsRef.current = terminalSessions
   }, [terminalSessions])
+
+  useEffect(() => {
+    if (activeTerminalTitle) {
+      onTerminalTitleChange?.(activeTerminalTitle)
+    }
+  }, [activeTerminalTitle, onTerminalTitleChange])
 
   useEffect(() => {
     return () => {
@@ -499,6 +527,19 @@ export function WorkspacePanelCards({
     removeTerminalSession(sessionId)
   }
 
+  const handleTerminalTitleChange = (sessionId: string, title: string) => {
+    const normalizedTitle = title.trim()
+    if (!normalizedTitle) return
+
+    setTerminalSessions(sessions =>
+      sessions.map(session =>
+        session.session_id === sessionId && session.title !== normalizedTitle
+          ? { ...session, title: normalizedTitle }
+          : session
+      )
+    )
+  }
+
   const removeTerminalSession = (sessionId: string) => {
     setTerminalSessions(sessions => {
       const closeIndex = sessions.findIndex(session => session.session_id === sessionId)
@@ -651,6 +692,7 @@ export function WorkspacePanelCards({
           <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
             {terminalSessions.map(session => {
               const isActive = session.session_id === activeTerminalSession.session_id
+              const sessionLabel = getTerminalSessionLabel(session)
 
               return (
                 <div
@@ -660,7 +702,7 @@ export function WorkspacePanelCards({
                       ? 'border-border bg-background text-text-primary shadow-sm'
                       : 'text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
                   }`}
-                  title={terminalTabLabel || session.device_id}
+                  title={sessionLabel}
                 >
                   <button
                     type="button"
@@ -671,7 +713,7 @@ export function WorkspacePanelCards({
                     className="flex min-w-0 flex-1 items-center gap-2 px-2.5 text-left text-[13px] leading-[18px]"
                   >
                     <SquareTerminal className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
-                    <span className="truncate">{terminalTabLabel || session.device_id}</span>
+                    <span className="truncate">{sessionLabel}</span>
                   </button>
                   <button
                     type="button"
@@ -704,6 +746,7 @@ export function WorkspacePanelCards({
             sessionId={session.session_id}
             active={panelActive && isActive}
             onExit={() => handleTerminalSessionExit(session.session_id)}
+            onTitleChange={title => handleTerminalTitleChange(session.session_id, title)}
             testIdsEnabled={testIdsEnabled}
           />
         ) : (
@@ -712,6 +755,7 @@ export function WorkspacePanelCards({
             sessionId={session.session_id}
             active={panelActive && isActive}
             onExit={() => handleTerminalSessionExit(session.session_id)}
+            onTitleChange={title => handleTerminalTitleChange(session.session_id, title)}
             testIdsEnabled={testIdsEnabled}
           />
         )


### PR DESCRIPTION
## Summary
- Adjust Wework bottom workspace terminal tab styling to match the requested titlebar treatment.
- Use terminal/session titles instead of a hardcoded terminal label.
- Keep the top workbench title width independent from right-side titlebar actions.
- Guard terminal title state updates so unchanged titles do not trigger render loops.

## Tests
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `pnpm --filter wework test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal tabs can now show the terminal’s current title, making it easier to distinguish sessions.
  * The active terminal title is updated automatically when it changes.

* **Bug Fixes**
  * Improved desktop layout behavior for the task title and top bar in collapsed/split-screen states.
  * Refined bottom panel tab behavior so the initial terminal stays selected when opening the add menu.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->