### PR TITLE
[codex] Fix Wework executor shutdown on app exit

### DIFF
--- a/wework/src-tauri/Cargo.lock
+++ b/wework/src-tauri/Cargo.lock
@@ -79,6 +79,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "ctrlc",
  "libc",
  "log",
  "objc2-app-kit",
@@ -784,6 +785,17 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "darling"
@@ -2453,6 +2465,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,7 +3008,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.25.1",
  "serial",
  "shared_library",
  "shell-words",

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 libc = "0.2"
+ctrlc = { version = "3.4", features = ["termination"] }
 tauri = { version = "2.11.2", features = ["protocol-asset", "tray-icon", "unstable"] }
 tauri-plugin-log = "2"
 tauri-plugin-http = "2"

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -993,9 +993,23 @@ fn open_task_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>, task_id: &s
 
 #[cfg(desktop)]
 fn quit_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    shutdown_local_executor_for_app(app);
+    app.exit(0);
+}
+
+#[cfg(desktop)]
+fn shutdown_local_executor_for_app<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     let state = app.state::<local_executor::LocalExecutorState>();
     local_executor::shutdown_local_executor(&state);
-    app.exit(0);
+}
+
+#[cfg(desktop)]
+fn install_shutdown_signal_handler(app: tauri::AppHandle) -> Result<(), String> {
+    ctrlc::set_handler(move || {
+        shutdown_local_executor_for_app(&app);
+        app.exit(130);
+    })
+    .map_err(|error| format!("Failed to install shutdown signal handler: {error}"))
 }
 
 #[derive(serde::Deserialize)]
@@ -1355,7 +1369,7 @@ mod tests {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
@@ -1405,6 +1419,9 @@ pub fn run() {
             #[cfg(desktop)]
             setup_system_tray(app)?;
             #[cfg(desktop)]
+            install_shutdown_signal_handler(app.handle().clone())
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?;
+            #[cfg(desktop)]
             if env_flag_enabled(WEBVIEW_DEVTOOLS_ENV) {
                 if let Err(error) = open_main_webview_devtools_impl(app.handle()) {
                     log::warn!("Failed to open Web Inspector from {WEBVIEW_DEVTOOLS_ENV}: {error}");
@@ -1446,6 +1463,16 @@ pub fn run() {
             local_terminal::start_local_terminal,
             local_terminal::write_local_terminal
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        #[cfg(desktop)]
+        if matches!(
+            event,
+            tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
+        ) {
+            shutdown_local_executor_for_app(app_handle);
+        }
+    });
 }


### PR DESCRIPTION
## Summary
- Shut down the Wework-managed local executor when the Tauri app receives app-exit events.
- Install a process signal handler so terminal Ctrl+C/SIGINT and termination signals clean up the executor sidecar before the app exits.
- Add the ctrlc dependency with termination support for the desktop Tauri app.

## Root Cause
The dev launcher starts the executor sidecar from inside the Tauri app, and configured sidecars run in their own process group. Pressing Ctrl+C in the shell stops the Tauri dev process group, but it did not reliably trigger the existing window-destroyed cleanup path, leaving the executor supervisor and executor process orphaned.

## Validation
- cargo check --manifest-path wework/src-tauri/Cargo.toml --no-default-features
- cargo test --manifest-path wework/src-tauri/Cargo.toml --no-default-features configured_sidecar_kill_stops_grandchild_process_group
- Manual repro: started WEWORK_PORT=1421 ./wework/scripts/dev-mac-app.sh, confirmed app=49986 executor-dev=50334 executor=50520, sent Ctrl+C, and verified the app/executor processes and socket ownership were gone.
- Pre-push hook passed: frontend, Wework, backend syntax/format checks, settings check, knowledge syntax checks, executor fmt/test/clippy, executor-manager syntax, and Alembic multi-head check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app shutdown so background work is closed cleanly when quitting from the tray, exiting the app, or receiving an interrupt signal.
  * Added support for handling OS shutdown/interrupt events more consistently, reducing the chance of lingering processes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->