### PR TITLE
[codex] Fix wework titlebar task title truncation

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2067,6 +2067,9 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workbench-pane-task-title')).toHaveTextContent(
       'wework的聊天链路现在代码逻辑比较混乱'
     )
+    expect(screen.getByTestId('workbench-pane-task-title')).toHaveStyle({
+      width: 'calc(100% - 17rem)',
+    })
     expect(screen.getByTestId('workbench-pane-task-title')).not.toHaveAttribute('title')
   })
 

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -92,6 +92,7 @@ const RIGHT_PANEL_HANDLE_TRANSITION_CLASS =
   'transition-[left] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[left]'
 const MAX_CACHED_DESKTOP_WORKBENCH_TABS = 10
 const RIGHT_WORKSPACE_TITLEBAR_WIDTH_VAR = '--right-workspace-titlebar-width'
+const COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE = '17rem'
 
 function getRuntimeWorkbenchPaneKeys(
   runtimeWork: RuntimeWorkListResponse | null | undefined
@@ -303,6 +304,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     onCollapse: closeRightPanel,
   })
   const chatColumnWidth = rightPanelOpen ? rightSplitChatWidth : '100%'
+  const paneTitleWidth = rightPanelOpen
+    ? chatColumnWidth
+    : `calc(100% - ${COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE})`
   const rightPanelShellWidth = rightPanelOpen ? `calc(100% - ${rightSplitChatWidth}px)` : '0px'
   const rightPanelTitlebarWidth =
     rightPanelOpen && workbenchMainWidth > rightSplitChatWidth
@@ -811,7 +815,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         sidebarCollapsed ? 'pl-[14rem]' : 'pl-4',
         rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
       )}
-      style={{ width: chatColumnWidth }}
+      style={{ width: paneTitleWidth }}
     >
       <span className="block w-full min-w-0 truncate">{runtimeTaskTitle}</span>
     </div>


### PR DESCRIPTION
## What changed

- Reserve right-side titlebar action space when the Wework right workspace panel is collapsed.
- Keep the existing chat-column title width behavior when the right workspace panel is open.
- Add a regression assertion for the collapsed-panel titlebar width.

## Why

Long runtime task titles were rendered at full workbench width while the Tauri titlebar actions live in a separate absolute portal. When the right sidebar was collapsed, the title could draw underneath the Open location and panel toggle buttons.

## Impact

Long task titles now truncate before the right-side controls instead of visually mixing with them.

## Validation

- `pnpm --filter wework test -- DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework lint`
- Pre-push Wework gate: ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop layout spacing so the task title stays clear of title bar controls when the right panel is collapsed.
  * Adjusted the title area width to better fit the available space in the workbench.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->