### PR TITLE
[codex] fix wework stopped notice without zero duration

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1008,7 +1008,7 @@ describe('MessageList', () => {
     expect(screen.getByText('我会继续看 lockfile。')).toBeInTheDocument()
   })
 
-  test('keeps cancelled assistant turns even when no processing blocks were persisted', () => {
+  test('shows stopped notice without duration when a cancelled assistant turn has no elapsed time', () => {
     render(
       <MessageList
         messages={[
@@ -1024,7 +1024,8 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 0s 后停止了')
+    expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('已停止')
+    expect(screen.getByTestId('assistant-stopped-notice')).not.toHaveTextContent('0s')
   })
 
   test('uses compact spacing between messages and hover actions', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -458,13 +458,14 @@ function formatCompactDuration(durationMs: number): string {
   return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
 }
 
-function getStoppedElapsedDuration(message: WorkbenchMessage): string {
+function getStoppedElapsedDuration(message: WorkbenchMessage): string | null {
   const startedAt = getTurnStartMs(message.createdAt)
-  if (startedAt === undefined) return '0s'
+  if (startedAt === undefined) return null
 
   const completedAt = getMessageTimestampMs(message.completedAt)
   if (completedAt !== undefined && completedAt >= startedAt) {
-    return formatCompactDuration(completedAt - startedAt)
+    const durationMs = completedAt - startedAt
+    return durationMs >= 1000 ? formatCompactDuration(durationMs) : null
   }
 
   const blockEndTimes =
@@ -473,7 +474,8 @@ function getStoppedElapsedDuration(message: WorkbenchMessage): string {
       .filter((createdAt): createdAt is number => Number.isFinite(createdAt)) ?? []
   const endedAt = blockEndTimes.length > 0 ? Math.max(...blockEndTimes) : startedAt
 
-  return formatCompactDuration(endedAt - startedAt)
+  const durationMs = endedAt - startedAt
+  return durationMs >= 1000 ? formatCompactDuration(durationMs) : null
 }
 
 function getProcessingSummaryStartMs(
@@ -1397,6 +1399,8 @@ function AssistantMessage({
 }) {
   const { t } = useTranslation('chat')
   const isCancelled = isCancelledAssistantMessage(message)
+  const stoppedElapsedDuration =
+    isCancelled && message.stoppedNotice !== false ? getStoppedElapsedDuration(message) : null
   const shouldShowStoppedNotice = isCancelled && message.stoppedNotice !== false
   const shouldHideContent =
     shouldHideFailedAssistantContent(message) ||
@@ -1457,9 +1461,11 @@ function AssistantMessage({
               data-testid="assistant-stopped-notice"
               className="mb-3 w-full border-b border-border pb-2 text-xs text-text-muted"
             >
-              {t('assistant_status.stopped_after', {
-                duration: getStoppedElapsedDuration(message),
-              })}
+              {stoppedElapsedDuration
+                ? t('assistant_status.stopped_after', {
+                    duration: stoppedElapsedDuration,
+                  })
+                : t('assistant_status.stopped')}
             </div>
           ) : null}
           {shouldShowProcessingSummary && (

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -16,6 +16,7 @@
     "running": "Working"
   },
   "assistant_status": {
+    "stopped": "Stopped",
     "stopped_after": "You stopped after {{duration}}"
   },
   "request_user_input": {

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -16,6 +16,7 @@
     "running": "正在处理"
   },
   "assistant_status": {
+    "stopped": "已停止",
     "stopped_after": "你在 {{duration}} 后停止了"
   },
   "request_user_input": {


### PR DESCRIPTION
## Summary

Fixes the Wework assistant stopped notice so cancelled responses still show a stopped state, but no longer render an invalid `0s` duration when the elapsed time cannot be computed or is less than one second.

## Root Cause

Cancelled assistant turns always rendered `assistant_status.stopped_after`, and the elapsed-duration helper returned `0s` when it had no meaningful end timestamp. That made newly stopped or empty cancelled turns display `你在 0s 后停止了`.

## Changes

- Return `null` for stopped durations that are missing or shorter than one second.
- Render a plain stopped label (`已停止` / `Stopped`) when no valid duration exists.
- Preserve the existing duration text for valid stopped durations.
- Update MessageList coverage for the no-duration stopped state.

## Validation

- `pnpm --filter wework test -- src/components/chat/MessageList.test.tsx`
- Pre-push hook: Wework ESLint, TypeScript, and unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped assistant messages now show a simple “Stopped/已停止” state when no timing data is available, instead of displaying a misleading “0s” duration.
  * Improved the display logic so elapsed time is only shown when it can be calculated accurately.

* **Documentation**
  * Added updated test coverage for the new stopped-message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->