### PR TITLE
[codex] Allow code comment runtime follow-ups

### DIFF
--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1205,7 +1205,15 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           }
 
           if (hasCodeComments) {
-            void sendCurrentInput(submittedInput, { codeCommentContexts })
+            const sent = await sendCurrentInput(submittedInput, { codeCommentContexts })
+            if (sent) {
+              appendLocalUserMessage(
+                submittedInput || i18n.t('workbench.code_comment_fallback'),
+                currentAttachments
+              )
+              setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
+              setCodeCommentContexts([])
+            }
             return
           }
 

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -34,6 +34,7 @@ import type {
   UnifiedModel,
   User,
 } from '@/types/api'
+import type { CodeCommentContext } from '@/types/workspace-files'
 
 const localExecutorMocks = vi.hoisted(() => ({
   ensureLocalExecutorStarted: vi.fn(),
@@ -211,6 +212,20 @@ function createLocalImageAttachment(overrides: Partial<Attachment> = {}): Attach
     local_preview_url: LOCAL_IMAGE_ATTACHMENT_PATH,
     ...overrides,
   })
+}
+
+function createCodeCommentContext(overrides: Partial<CodeCommentContext> = {}): CodeCommentContext {
+  return {
+    id: 'code-comment-1',
+    filePath: '/workspace/project-alpha/src/main.ts',
+    fileName: 'main.ts',
+    startLine: 3,
+    endLine: 5,
+    selectedText: 'const value = 1',
+    comment: 'Explain this value',
+    createdAt: '2026-07-06T00:00:00.000Z',
+    ...overrides,
+  }
 }
 
 function createRuntimeWorkApiMock(overrides: Record<string, unknown> = {}) {
@@ -1038,6 +1053,7 @@ function FollowUpProbe() {
   const { workbench, paneSession, currentRuntimeTask } = useWorkbenchProbeSession()
   const imageAttachment = createImageAttachment()
   const localImageAttachment = createLocalImageAttachment()
+  const codeComment = createCodeCommentContext()
   const firstQueuedMessage = paneSession.queuedMessages[0]
   const gptModel =
     workbench.projectChat.models.find(model => model.name === 'gpt-5-2025-08-07') ?? null
@@ -1063,6 +1079,7 @@ function FollowUpProbe() {
         {paneSession.queuedMessages.map(message => message.notice ?? '').join('|')}
       </span>
       <span data-testid="runtime-attachment-count">{workbench.projectChat.attachments.length}</span>
+      <span data-testid="runtime-code-comment-count">{paneSession.codeCommentContexts.length}</span>
       <span data-testid="follow-up-current-runtime-task">
         {currentRuntimeTask
           ? `${currentRuntimeTask.deviceId}:${currentRuntimeTask.taskId}`
@@ -1127,6 +1144,9 @@ function FollowUpProbe() {
         onClick={() => workbench.projectChat.addExistingAttachment(localImageAttachment)}
       >
         add local image attachment
+      </button>
+      <button type="button" onClick={() => paneSession.addCodeComment(codeComment)}>
+        add code comment
       </button>
       <button
         type="button"
@@ -3944,6 +3964,57 @@ describe('WorkbenchProvider runtime tasks', () => {
       modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
+  })
+
+  test('sends code comment context with current runtime task follow-up messages', async () => {
+    const sendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: true,
+      taskId: 'runtime-a',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <FollowUpProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    await userEvent.click(screen.getByText('add code comment'))
+    expect(screen.getByTestId('runtime-code-comment-count')).toHaveTextContent('1')
+    await userEvent.click(screen.getByText('send follow-up'))
+
+    await waitFor(() => expect(sendRuntimeMessage).toHaveBeenCalledTimes(1))
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({
+      address: {
+        deviceId: 'device-1',
+        workspacePath: '/workspace/project-alpha',
+        taskId: 'runtime-a',
+      },
+      message: expect.stringContaining('<code_comment_context>'),
+      modelOptions: { collaborationMode: 'default' },
+    })
+    expect(sendRuntimeMessage.mock.calls[0][0].message).toMatch(/code_comment/)
+    expect(sendRuntimeMessage.mock.calls[0][0].message).toContain('src/main.ts')
+    expect(sendRuntimeMessage.mock.calls[0][0].message).toContain('Explain this value')
+    expect(screen.getByTestId('runtime-code-comment-count')).toHaveTextContent('0')
+    expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent(/代码评论|code comments/)
   })
 
   test('keeps project chat composer state scoped to each runtime pane', async () => {

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -668,10 +668,6 @@ export function useWorkbenchRuntimeMessaging({
       )
 
       if (state.currentRuntimeTask) {
-        if (hasCodeComments) {
-          reportSendBlocked('当前 LocalTask 暂不支持代码评论', undefined, options)
-          return false
-        }
         if (currentRuntimeTaskRunning) {
           reportSendBlocked(i18n.t('workbench.runtime_task_running_message'), undefined, options)
           return false


### PR DESCRIPTION
## Summary

Fixes Wework runtime follow-up submission when the composer contains only code comment context.

## Root cause

The composer already serialized code comments into the prompt via `appendCodeCommentContexts`, but the current LocalTask send path blocked any request with code comments before sending. This produced the warning `当前 LocalTask 暂不支持代码评论` even though the data could be sent as prompt context.

## Changes

- Remove the current LocalTask code-comment block in runtime messaging.
- When a code-comment follow-up sends successfully, clear the code comment chip and append a local user message using the existing fallback text for comments-only sends.
- Add a regression test that verifies a current runtime task follow-up sends `<code_comment_context>` and clears the selected comment context.

## Validation

- `pnpm --filter wework exec eslint src/features/workbench/useWorkbenchRuntimeMessaging.ts src/components/layout/useWorkbenchPaneSession.ts src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework test -- src/features/workbench/WorkbenchProvider.test.tsx`
- Pre-push Wework ESLint, TypeScript, and unit tests passed.