### PR TITLE
fix(backend): encode non-ASCII wegent-agent-* header values and broaden strip matching

### DIFF
--- a/backend/app/services/chat/config/model_resolver.py
+++ b/backend/app/services/chat/config/model_resolver.py
@@ -8,6 +8,7 @@ Model resolver for Chat Shell.
 Resolves model configuration from Bot's bound model or task-level override.
 """
 
+import base64
 import json
 import logging
 import os
@@ -224,20 +225,21 @@ def build_default_headers_with_placeholders(
     return result_headers
 
 
-# Prefix identifying the agent/team identity header group forwarded to the model
-# backend (e.g. wegent-agent-namespace, wegent-agent-name). New identity fields
-# should reuse this prefix so they share the empty-strip behavior.
-WEGENT_IDENTITY_HEADER_PREFIX = "wegent-agent-"
+# Substring marker identifying the agent/team identity header group forwarded to the
+# model backend (e.g. wegent-agent-namespace, wegent-agent-name). Any header whose
+# name *contains* this substring shares the empty-strip and encoding behaviors.
+WEGENT_IDENTITY_HEADER_MARKER = "wegent-agent-"
 
 
 def strip_empty_wegent_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
-    """Drop wegent-agent-* headers whose value is empty.
+    """Drop headers whose name contains 'wegent-agent-' and whose value is empty.
 
     Placeholder resolution yields "" when a data source is missing (e.g.
     non-Team execution paths such as wizard/correction that carry no team
-    context). Emitting blank identity headers is undesirable, so only the
-    wegent-agent-* group is removed when empty; all other headers (including
-    the legacy ``user`` header) keep their existing behavior.
+    context). Emitting blank identity headers is undesirable, so any header
+    whose name contains WEGENT_IDENTITY_HEADER_MARKER is removed when its
+    value is empty; all other headers (including the legacy ``user`` header)
+    keep their existing behavior.
 
     Args:
         headers: Default headers after placeholder replacement.
@@ -249,9 +251,53 @@ def strip_empty_wegent_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
         key: value
         for key, value in headers.items()
         if not (
-            key.lower().startswith(WEGENT_IDENTITY_HEADER_PREFIX)
+            WEGENT_IDENTITY_HEADER_MARKER in key.lower()
             and (value is None or (isinstance(value, str) and not value.strip()))
         )
+    }
+
+
+def _encode_wegent_header_value(value: str) -> str:
+    """Encode a header value that may contain non-ASCII characters.
+
+    HTTP headers must be ASCII (RFC 7230). Team names may contain non-ASCII
+    characters (e.g. Chinese). If the value is already ASCII-safe it is
+    returned unchanged; otherwise it is base64-encoded and prefixed with
+    'b64:' so the receiver can detect and decode it.
+
+    Args:
+        value: The resolved header value string.
+
+    Returns:
+        The original string if ASCII-safe, otherwise 'b64:<base64>'.
+    """
+    try:
+        value.encode("ascii")
+        return value
+    except UnicodeEncodeError:
+        return "b64:" + base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+
+def encode_wegent_header_values(headers: Dict[str, Any]) -> Dict[str, Any]:
+    """Base64-encode non-ASCII values in wegent-agent-* headers.
+
+    Applies _encode_wegent_header_value to every header whose name contains
+    WEGENT_IDENTITY_HEADER_MARKER so non-ASCII team names (e.g. Chinese)
+    are transmitted as ASCII-safe 'b64:<base64>' strings.
+
+    Args:
+        headers: Resolved headers after placeholder replacement and empty-strip.
+
+    Returns:
+        Headers with non-ASCII wegent-agent-* values base64-encoded.
+    """
+    return {
+        key: (
+            _encode_wegent_header_value(value)
+            if WEGENT_IDENTITY_HEADER_MARKER in key.lower() and isinstance(value, str)
+            else value
+        )
+        for key, value in headers.items()
     }
 
 
@@ -341,6 +387,8 @@ def _process_model_config_placeholders(
         # Drop wegent-agent-* identity headers that resolved to empty (e.g. paths
         # without Team context), so we never emit blank identity headers.
         processed_headers = strip_empty_wegent_headers(processed_headers)
+        # Encode non-ASCII values (e.g. Chinese team names) to ASCII-safe base64.
+        processed_headers = encode_wegent_header_values(processed_headers)
         model_config["default_headers"] = processed_headers
         logger.info(f"[model_resolver] Processed default_headers with placeholders")
 

--- a/backend/tests/services/chat/test_model_resolver_wegent_headers.py
+++ b/backend/tests/services/chat/test_model_resolver_wegent_headers.py
@@ -5,17 +5,20 @@
 """Tests for wegent-agent-* agent identity headers in model_resolver.
 
 Covers:
-- strip_empty_wegent_headers: only wegent-agent-* empty headers are dropped.
-- _process_model_config_placeholders: nested ${task_data.team.*} resolution and
-  the empty-strip behavior for paths without Team context.
+- strip_empty_wegent_headers: headers containing 'wegent-agent-' are dropped when empty.
+- encode_wegent_header_values: non-ASCII values in wegent-agent-* headers are base64-encoded.
+- _process_model_config_placeholders: nested ${task_data.team.*} resolution,
+  empty-strip, and base64 encoding for non-ASCII team names.
 - The EXECUTOR_ENV default declares the identity header group.
 """
 
+import base64
 import json
 
 from app.core.config import Settings
 from app.services.chat.config.model_resolver import (
     _process_model_config_placeholders,
+    encode_wegent_header_values,
     strip_empty_wegent_headers,
 )
 from shared.models.execution import ExecutionRequest
@@ -56,9 +59,56 @@ class TestStripEmptyWegentHeaders:
         result = strip_empty_wegent_headers({"user": "", NAME_HEADER: ""})
         assert result == {"user": ""}
 
-    def test_prefix_match_is_case_insensitive(self):
+    def test_match_is_case_insensitive(self):
         result = strip_empty_wegent_headers({"WEGENT-Agent-Name": ""})
         assert result == {}
+
+    def test_drops_header_containing_marker_as_substring(self):
+        # A header whose name contains 'wegent-agent-' anywhere (not just prefix)
+        # is subject to the empty-strip rule.
+        result = strip_empty_wegent_headers({"x-wegent-agent-id": ""})
+        assert result == {}
+
+    def test_keeps_non_empty_header_containing_marker_as_substring(self):
+        result = strip_empty_wegent_headers({"x-wegent-agent-id": "some-value"})
+        assert result == {"x-wegent-agent-id": "some-value"}
+
+
+class TestEncodeWegentHeaderValues:
+    """Unit tests for encode_wegent_header_values."""
+
+    def test_ascii_value_unchanged(self):
+        headers = {NAME_HEADER: "my-agent", NS_HEADER: "default"}
+        assert encode_wegent_header_values(headers) == headers
+
+    def test_non_ascii_value_is_base64_encoded(self):
+        chinese_name = "我的智能体"
+        result = encode_wegent_header_values({NAME_HEADER: chinese_name})
+        expected = "b64:" + base64.b64encode(chinese_name.encode("utf-8")).decode(
+            "ascii"
+        )
+        assert result == {NAME_HEADER: expected}
+
+    def test_non_wegent_header_value_is_not_encoded(self):
+        # The legacy 'user' header is not a wegent-agent-* header and must be
+        # left unchanged even when it contains non-ASCII characters.
+        headers = {"user": "非ASCII用户"}
+        assert encode_wegent_header_values(headers) == headers
+
+    def test_non_string_value_is_not_encoded(self):
+        headers = {NAME_HEADER: 42}
+        assert encode_wegent_header_values(headers) == {NAME_HEADER: 42}
+
+    def test_empty_string_value_unchanged(self):
+        # Empty strings survive to encode; strip_empty_wegent_headers handles removal.
+        headers = {NAME_HEADER: ""}
+        assert encode_wegent_header_values(headers) == {NAME_HEADER: ""}
+
+    def test_header_containing_marker_as_substring_is_encoded(self):
+        chinese = "汉字"
+        result = encode_wegent_header_values({"x-wegent-agent-id": chinese})
+        expected = "b64:" + base64.b64encode(chinese.encode("utf-8")).decode("ascii")
+        assert result == {"x-wegent-agent-id": expected}
 
 
 class TestTeamPlaceholderResolution:
@@ -89,6 +139,24 @@ class TestTeamPlaceholderResolution:
             NS_HEADER: "default",
             NAME_HEADER: "wegent-chat",
         }
+
+    def test_chinese_team_name_is_base64_encoded(self):
+        """Non-ASCII team name -> wegent-agent-name value prefixed with 'b64:'."""
+        chinese_name = "我的智能体"
+        task_data = ExecutionRequest(
+            task_id=1,
+            team_id=2,
+            team_name=chinese_name,
+            team_namespace="default",
+            user={"id": 5, "name": "alice"},
+        )
+        headers = self._resolve(task_data)
+        expected_name = "b64:" + base64.b64encode(chinese_name.encode("utf-8")).decode(
+            "ascii"
+        )
+        assert headers[NAME_HEADER] == expected_name
+        # ASCII namespace stays untouched.
+        assert headers[NS_HEADER] == "default"
 
     def test_missing_team_context_strips_identity_headers(self):
         """No team fields -> identity headers resolve empty and are dropped."""


### PR DESCRIPTION
## Summary

- **Non-ASCII team name encoding**: When `task_data.team.name` contains Chinese or other non-ASCII characters, forwarding the value as an HTTP header raised `'ascii' codec can't encode characters`. A new `_encode_wegent_header_value()` helper base64-encodes any non-ASCII value and prefixes it with `b64:` so the header is always ASCII-safe; ASCII values pass through unchanged. `encode_wegent_header_values()` applies this to every header whose name contains `wegent-agent-` and is called immediately after `strip_empty_wegent_headers` in the resolution pipeline.

- **Substring matching for strip**: `strip_empty_wegent_headers` was using `startswith()`, so it only caught headers that literally began with `wegent-agent-`. The check is now a substring match (`WEGENT_IDENTITY_HEADER_MARKER in key.lower()`), matching any header whose name contains `wegent-agent-` regardless of position (e.g. `x-wegent-agent-id`). The constant is renamed from `WEGENT_IDENTITY_HEADER_PREFIX` to `WEGENT_IDENTITY_HEADER_MARKER` to reflect the looser semantics.

## Test plan

- [x] `TestEncodeWegentHeaderValues` (6 new cases): ASCII unchanged, Chinese `→ b64:…`, non-wegent header skipped, non-string skipped, empty unchanged, substring-matched header encoded.
- [x] `TestStripEmptyWegentHeaders` (2 new cases): empty substring-position header dropped; non-empty substring-position header kept.
- [x] `TestTeamPlaceholderResolution.test_chinese_team_name_is_base64_encoded`: end-to-end check that a Chinese team name produces a `b64:` prefixed `wegent-agent-name` header.
- [x] All 19 tests pass: `uv run pytest tests/services/chat/test_model_resolver_wegent_headers.py -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of identity headers so empty or whitespace-only values are removed more reliably.
  * Non-ASCII identity header values are now safely transmitted in an ASCII-compatible format, helping avoid issues with special characters.
  * Matching for identity headers is now more flexible and case-insensitive, reducing missed headers during processing.

* **Tests**
  * Expanded coverage for empty-value handling, header matching, and non-ASCII value encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->