### PR TITLE
fix(executor): extend Claude Code timeout to 24h

### DIFF
--- a/docs/en/user-guide/ai-devices/local-device-support.md
+++ b/docs/en/user-guide/ai-devices/local-device-support.md
@@ -214,10 +214,10 @@ The installer and first startup create `~/.wegent-executor/device-config.json`. 
 
 #### Claude Code Execution Timeout
 
-When the local executor starts a Claude Code child process, it waits up to 1 hour by default. Long-running code generation, dependency installation, or file processing tasks can continue within that window. To tune the limit for a specific environment, set `WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS` before starting the executor. This setting only affects Claude Code child processes, not the native Codex app-server path; Codex RPC timeouts are controlled by `WEGENT_CODEX_RPC_TIMEOUT_SECONDS`.
+When the local executor starts a Claude Code child process, it waits up to 24 hours by default. Long-running code generation, dependency installation, or file processing tasks can continue within that window. To tune the limit for a specific environment, set `WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS` before starting the executor. This setting only affects Claude Code child processes, not the native Codex app-server path; Codex RPC timeouts are controlled by `WEGENT_CODEX_RPC_TIMEOUT_SECONDS`.
 
 ```bash
-export WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS=7200
+export WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS=172800
 wegent-executor
 ```
 

--- a/docs/zh/user-guide/ai-devices/local-device-support.md
+++ b/docs/zh/user-guide/ai-devices/local-device-support.md
@@ -216,10 +216,10 @@ wegent-executor
 
 #### Claude Code 执行超时
 
-本地 executor 启动 Claude Code 子进程时，默认最长等待 1 小时。长时间代码生成、依赖安装或文件处理任务可以在这个时间内继续运行。若需要为特定环境调整该限制，可在启动 executor 前设置 `WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS`。该配置只影响 Claude Code 子进程，不影响 native Codex app-server；Codex RPC 超时由 `WEGENT_CODEX_RPC_TIMEOUT_SECONDS` 控制。
+本地 executor 启动 Claude Code 子进程时，默认最长等待 24 小时。长时间代码生成、依赖安装或文件处理任务可以在这个时间内继续运行。若需要为特定环境调整该限制，可在启动 executor 前设置 `WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS`。该配置只影响 Claude Code 子进程，不影响 native Codex app-server；Codex RPC 超时由 `WEGENT_CODEX_RPC_TIMEOUT_SECONDS` 控制。
 
 ```bash
-export WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS=7200
+export WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS=172800
 wegent-executor
 ```
 

--- a/executor/src/agents/mod.rs
+++ b/executor/src/agents/mod.rs
@@ -43,7 +43,7 @@ pub use codex::{
 pub use dify::{build_dify_config, saved_dify_task_id, DifyEngine};
 pub use image_validator::ImageValidatorEngine;
 
-const DEFAULT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS: u64 = 3600;
+const DEFAULT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentCommandPlanner {
@@ -353,6 +353,6 @@ mod tests {
         let _old_timeout = EnvGuard::set("WEGENT_EXECUTOR_PROCESS_TIMEOUT_SECONDS", "1");
         let _timeout = EnvGuard::remove("WEGENT_CLAUDE_CODE_PROCESS_TIMEOUT_SECONDS");
 
-        assert_eq!(claude_code_process_timeout_seconds(), 3600);
+        assert_eq!(claude_code_process_timeout_seconds(), 86_400);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default wait time for Claude Code local execution from 1 hour to 24 hours when no valid timeout setting is provided.
  * Updated the example timeout value to match the new default behavior.

* **Documentation**
  * Revised the local device support guide in both English and Chinese to reflect the longer default timeout and updated configuration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->