### PR TITLE
fix(executor): buffer partial Claude stdout JSON

### DIFF
--- a/executor/src/process/mod.rs
+++ b/executor/src/process/mod.rs
@@ -34,7 +34,8 @@ use crate::{
     runner::{AgentEngine, EventSink, ExecutionOutcome},
     stream::{
         collect_claude_stream_summary, extract_claude_tool_results, extract_claude_tool_uses,
-        extract_reasoning, extract_text, ClaudeToolUse,
+        extract_reasoning, extract_text, ClaudeStdoutJsonBuffer, ClaudeStdoutJsonError,
+        ClaudeToolUse,
     },
 };
 
@@ -562,6 +563,14 @@ enum CommandOutcome {
     },
 }
 
+enum StreamingStdoutOutcome {
+    Success(String),
+    InvalidJson {
+        stdout: String,
+        error: ClaudeStdoutJsonError,
+    },
+}
+
 async fn run_command_output(spec: CommandSpec, timeout_seconds: u64) -> CommandOutcome {
     let mut command = Command::new(&spec.program);
     command.args(&spec.args).envs(&spec.env);
@@ -701,13 +710,15 @@ where
     });
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
+    let stdout_task_id = task_id.clone();
+    let stdout_subtask_id = subtask_id.clone();
     let stdout_task = stdout.map(|stdout| {
         tokio::spawn(read_streaming_stdout(
             stdout,
             sink,
             builder,
-            task_id,
-            subtask_id,
+            stdout_task_id,
+            stdout_subtask_id,
             debug_stdout_path,
         ))
     });
@@ -725,8 +736,27 @@ where
             }
         }
     }
-    let stdout = join_output(stdout_task).await;
+    let stdout = join_streaming_stdout(stdout_task).await;
     let stderr = join_output(stderr_task).await;
+
+    let stdout = match stdout {
+        StreamingStdoutOutcome::Success(stdout) => stdout,
+        StreamingStdoutOutcome::InvalidJson { stdout, error } => {
+            let fields = vec![
+                ("task_id", task_id.to_string()),
+                ("subtask_id", subtask_id.to_string()),
+                ("line_number", error.line_number.to_string()),
+                ("error", error.message.clone()),
+                ("preview", error.preview.clone()),
+            ];
+            log_executor_event("invalid claude stdout json", &fields);
+            return CommandOutcome::Failure {
+                stderr: error.failure_message(),
+                stdout,
+                exit_code: status.ok().and_then(|status| status.code()),
+            };
+        }
+    };
 
     match status {
         Ok(status) if status.success() => CommandOutcome::Success { stdout },
@@ -750,7 +780,7 @@ async fn read_streaming_stdout<R, S>(
     task_id: String,
     subtask_id: String,
     debug_stdout_path: Option<PathBuf>,
-) -> String
+) -> StreamingStdoutOutcome
 where
     R: AsyncRead + Unpin,
     S: EventSink,
@@ -761,13 +791,24 @@ where
     let mut offset = 0usize;
     let mut tool_uses: HashMap<String, ClaudeToolUse> = HashMap::new();
     let mut lines = BufReader::new(stdout).lines();
+    let mut line_number = 0usize;
+    let mut json_buffer = ClaudeStdoutJsonBuffer::default();
     while let Ok(Some(line)) = lines.next_line().await {
+        line_number += 1;
         output.push_str(&line);
         output.push('\n');
         if let Some(file) = debug_stdout_file.as_mut() {
             let _ = writeln!(file, "{}", debug_claude_stdout_line(&line));
         }
-        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+        let Some(value) = (match json_buffer.push_line(&line, line_number) {
+            Ok(value) => value,
+            Err(error) => {
+                return StreamingStdoutOutcome::InvalidJson {
+                    stdout: output,
+                    error,
+                };
+            }
+        }) else {
             continue;
         };
         if let Some(reasoning) = extract_reasoning(&value) {
@@ -814,7 +855,7 @@ where
         ];
         log_executor_event("streaming text chunks emitted", &fields);
     }
-    output.trim().to_owned()
+    StreamingStdoutOutcome::Success(output.trim().to_owned())
 }
 
 async fn emit_claude_tool_use<S>(
@@ -979,6 +1020,24 @@ async fn join_output(handle: Option<tokio::task::JoinHandle<String>>) -> String 
     match handle {
         Some(handle) => handle.await.unwrap_or_default(),
         None => String::new(),
+    }
+}
+
+async fn join_streaming_stdout(
+    handle: Option<tokio::task::JoinHandle<StreamingStdoutOutcome>>,
+) -> StreamingStdoutOutcome {
+    match handle {
+        Some(handle) => handle
+            .await
+            .unwrap_or_else(|error| StreamingStdoutOutcome::InvalidJson {
+                stdout: String::new(),
+                error: ClaudeStdoutJsonError {
+                    line_number: 0,
+                    message: format!("stdout reader task failed: {error}"),
+                    preview: String::new(),
+                },
+            }),
+        None => StreamingStdoutOutcome::Success(String::new()),
     }
 }
 

--- a/executor/src/stream/mod.rs
+++ b/executor/src/stream/mod.rs
@@ -11,6 +11,8 @@ use crate::{
     runner::ExecutionOutcome,
 };
 
+const CLAUDE_STDOUT_MAX_BUFFER_BYTES: usize = 1024 * 1024;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClaudeStreamSummary {
     pub outcome: ExecutionOutcome,
@@ -35,12 +37,71 @@ pub struct ClaudeToolResult {
     pub is_error: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaudeStdoutJsonError {
+    pub line_number: usize,
+    pub message: String,
+    pub preview: String,
+}
+
+impl ClaudeStdoutJsonError {
+    pub fn failure_message(&self) -> String {
+        format!(
+            "invalid Claude stdout JSON at line {}: {}; preview={}",
+            self.line_number, self.message, self.preview
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ClaudeStdoutJsonBuffer {
+    buffer: String,
+}
+
+impl ClaudeStdoutJsonBuffer {
+    pub fn push_line(
+        &mut self,
+        line: &str,
+        line_number: usize,
+    ) -> Result<Option<Value>, ClaudeStdoutJsonError> {
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(None);
+        }
+        if self.buffer.is_empty() && !line.starts_with('{') {
+            return Ok(None);
+        }
+
+        self.buffer.push_str(line);
+        if self.buffer.len() > CLAUDE_STDOUT_MAX_BUFFER_BYTES {
+            let error = ClaudeStdoutJsonError {
+                line_number,
+                message: format!(
+                    "JSON message exceeded maximum buffer size of {CLAUDE_STDOUT_MAX_BUFFER_BYTES} bytes"
+                ),
+                preview: preview_stdout_line(&self.buffer),
+            };
+            self.buffer.clear();
+            return Err(error);
+        }
+
+        match serde_json::from_str::<Value>(&self.buffer) {
+            Ok(value) => {
+                self.buffer.clear();
+                Ok(Some(value))
+            }
+            Err(_) => Ok(None),
+        }
+    }
+}
+
 pub fn collect_ndjson_outcome(output: &str) -> ExecutionOutcome {
     collect_claude_stream_summary(output).outcome
 }
 
 pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
-    let mut text = String::new();
+    let mut current_assistant_text = String::new();
+    let mut final_text = String::new();
     let mut terminal_outcome = None;
     // Mid-stream `type:error` events (e.g. GLM's "Tool call preview did not
     // complete before the turn ended") are recoverable: the SDK often keeps the
@@ -52,14 +113,27 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
     let mut stop_reason = None;
     let mut usage = Value::Null;
     let mut retryable_api_error = false;
-    for line in output
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-    {
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
+    let mut json_buffer = ClaudeStdoutJsonBuffer::default();
+    for (index, line) in output.lines().enumerate() {
+        let line_number = index + 1;
+        let Some(value) = (match json_buffer.push_line(line, line_number) {
+            Ok(value) => value,
+            Err(error) => {
+                return ClaudeStreamSummary {
+                    outcome: ExecutionOutcome::Failed {
+                        message: error.failure_message(),
+                    },
+                    session_id,
+                    deferred_tool_use,
+                    stop_reason,
+                    usage,
+                    retryable_api_error,
+                };
+            }
+        }) else {
             continue;
         };
+        let line = line.trim();
         retryable_api_error |= contains_retryable_api_error(line);
         if let Some(value) = value.get("session_id").and_then(Value::as_str) {
             let value = value.trim();
@@ -80,6 +154,9 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
                 usage,
                 retryable_api_error,
             };
+        }
+        if value.get("type").and_then(Value::as_str) == Some("user") {
+            current_assistant_text.clear();
         }
         if value.get("type").and_then(Value::as_str) == Some("result") {
             if let Some(reason) = value
@@ -132,14 +209,22 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
             pending_error = Some(error);
             continue;
         }
-        if let Some(delta) = extract_text(&value) {
-            text.push_str(&delta);
+        if let Some(text) = extract_claude_assistant_message_text(&value) {
+            current_assistant_text.push_str(&text);
+            final_text = current_assistant_text.clone();
+        } else if let Some(delta) = extract_claude_text_delta(&value) {
+            current_assistant_text.push_str(&delta);
+            final_text = current_assistant_text.clone();
+        } else if let Some(delta) = extract_codex_agent_delta(&value) {
+            final_text.push_str(&delta);
         }
     }
 
     let outcome = terminal_outcome
         .or_else(|| pending_error.map(|message| ExecutionOutcome::Failed { message }))
-        .unwrap_or(ExecutionOutcome::Completed { content: text });
+        .unwrap_or(ExecutionOutcome::Completed {
+            content: final_text,
+        });
     ClaudeStreamSummary {
         outcome,
         session_id,
@@ -269,6 +354,10 @@ pub fn extract_text(value: &Value) -> Option<String> {
     extract_claude_assistant_text(value)
         .or_else(|| extract_claude_text_delta(value))
         .or_else(|| extract_codex_agent_delta(value))
+}
+
+pub fn extract_claude_assistant_message_text(value: &Value) -> Option<String> {
+    extract_claude_assistant_text(value)
 }
 
 pub fn extract_reasoning(value: &Value) -> Option<String> {
@@ -439,4 +528,15 @@ fn extract_codex_agent_delta(value: &Value) -> Option<String> {
         .then(|| value.get("params")?.get("delta")?.as_str())
         .flatten()
         .map(ToOwned::to_owned)
+}
+
+fn preview_stdout_line(value: &str) -> String {
+    let value = value.replace(['\r', '\n'], "\\n");
+    let mut chars = value.chars();
+    let preview: String = chars.by_ref().take(200).collect();
+    if chars.next().is_some() {
+        format!("{preview}...")
+    } else {
+        preview
+    }
 }

--- a/executor/tests/stream_parser_contract.rs
+++ b/executor/tests/stream_parser_contract.rs
@@ -25,6 +25,60 @@ fn ndjson_parser_collects_claude_text_blocks_and_deltas() {
 }
 
 #[test]
+fn ndjson_parser_uses_last_assistant_message_as_final_content() {
+    let output = r#"
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"working"}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"final"},{"type":"text","text":" answer"}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
+"#;
+
+    let outcome = collect_ndjson_outcome(output);
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "final answer".to_owned()
+        }
+    );
+}
+
+#[test]
+fn ndjson_parser_skips_non_json_stdout_lines() {
+    let output = r#"
+[SandboxDebug] enabled
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
+"#;
+
+    let outcome = collect_ndjson_outcome(output);
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "done".to_owned()
+        }
+    );
+}
+
+#[test]
+fn ndjson_parser_ignores_incomplete_trailing_json_like_python_sdk() {
+    let output = r#"
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"broken
+"#;
+
+    let outcome = collect_ndjson_outcome(output);
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "partial".to_owned()
+        }
+    );
+}
+
+#[test]
 fn ndjson_parser_collects_codex_agent_message_deltas() {
     let output = r#"
 {"method":"item/agentMessage/delta","params":{"delta":"codex ","phase":"final_answer"}}

--- a/executor/tests/stream_process_engine_contract.rs
+++ b/executor/tests/stream_process_engine_contract.rs
@@ -30,6 +30,25 @@ async fn stream_process_engine_parses_ndjson_stdout() {
 }
 
 #[tokio::test]
+async fn stream_process_engine_ignores_incomplete_trailing_json_like_python_sdk() {
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(
+            r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}'; printf '%s' '{"type":"user","message":{"content":[{"type":"tool_result","content":"broken"}'"#,
+        ),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+
+    let outcome = engine.run(ExecutionRequest::default()).await;
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "partial".to_owned()
+        }
+    );
+}
+
+#[tokio::test]
 async fn stream_process_engine_keeps_stderr_for_process_failures() {
     let engine = StreamProcessEngine::new(
         CommandSpec::new("sh")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming command output is now parsed more robustly, with clearer handling of malformed or truncated JSON lines.
  * Final assistant responses now consistently use the latest complete message content.

* **Bug Fixes**
  * Non-JSON debug output and incomplete trailing fragments are now ignored instead of causing failures.
  * Invalid streamed output now returns a clearer failure with preserved output details for easier troubleshooting.

* **Tests**
  * Added coverage for last-message selection, noisy output handling, and incomplete JSON fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->