### PR TITLE
[codex] Publish macOS DMG release assets

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -16,13 +16,78 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      version: ${{ steps.version.outputs.value }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          input_version="${{ github.event.inputs.version }}"
+          if [ -n "$input_version" ]; then
+            version="${input_version#v}"
+          elif [[ "${GITHUB_REF:-}" == refs/tags/wework-v* ]]; then
+            version="${GITHUB_REF_NAME#wework-v}"
+          else
+            version="$(node -p "require('./wework/package.json').version")-${GITHUB_SHA::7}"
+          fi
+
+          if [[ "${GITHUB_REF:-}" == refs/tags/wework-v* ]]; then
+            release_tag="$GITHUB_REF_NAME"
+          else
+            release_tag="wework-v$version"
+          fi
+
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          release_title="Wework $RELEASE_VERSION"
+          release_notes="$(mktemp)"
+          cat > "$release_notes" <<EOF
+          Wework macOS DMG build.
+
+          This build is ad-hoc signed and not Apple notarized. On first launch, click Done if macOS shows a Move to Trash warning, then force-open it from System Settings > Privacy & Security > Open Anyway.
+          EOF
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "$release_title" \
+              --notes-file "$release_notes" \
+              --prerelease
+          else
+            gh release create "$RELEASE_TAG" \
+              --target "$GITHUB_SHA" \
+              --title "$release_title" \
+              --notes-file "$release_notes" \
+              --draft \
+              --prerelease
+          fi
+
   build-macos:
     name: Build macOS ${{ matrix.arch }}
     runs-on: macos-14
     timeout-minutes: 45
+    needs: prepare-release
 
     strategy:
       fail-fast: false
@@ -36,21 +101,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Resolve artifact version
-        id: version
-        shell: bash
-        run: |
-          set -euo pipefail
-          input_version="${{ github.event.inputs.version }}"
-          if [ -n "$input_version" ]; then
-            version="${input_version#v}"
-          elif [[ "${GITHUB_REF:-}" == refs/tags/wework-v* ]]; then
-            version="${GITHUB_REF_NAME#wework-v}"
-          else
-            version="$(node -p "require('./wework/package.json').version")-${GITHUB_SHA::7}"
-          fi
-          echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install Rosetta 2
         if: matrix.arch == 'x64'
@@ -92,7 +142,7 @@ jobs:
       - name: Build local executor sidecar
         working-directory: executor
         env:
-          APP_VERSION: ${{ steps.version.outputs.value }}
+          APP_VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           set -euo pipefail
           cargo build --release --locked --target "${{ matrix.rust_target }}"
@@ -120,7 +170,7 @@ jobs:
             rm -f "$config_override"
           }
           trap cleanup EXIT
-          CONFIG_OVERRIDE="$config_override" VERSION="${{ steps.version.outputs.value }}" python3 - <<'PY'
+          CONFIG_OVERRIDE="$config_override" VERSION="${{ needs.prepare-release.outputs.version }}" python3 - <<'PY'
           import json
           import os
 
@@ -129,6 +179,7 @@ jobs:
               "bundle": {
                   "macOS": {
                       "signingIdentity": "-",
+                      "hardenedRuntime": True,
                   },
               },
           }
@@ -139,10 +190,10 @@ jobs:
           PY
           pnpm exec tauri build \
             --target "${{ matrix.rust_target }}" \
-            --bundles app \
+            --bundles dmg \
             --config "$config_override"
 
-      - name: Ad-hoc sign app bundle
+      - name: Verify and collect DMG
         id: package
         shell: bash
         run: |
@@ -152,46 +203,67 @@ jobs:
             echo "No .app bundle found" >&2
             exit 1
           fi
-
-          codesign --force --deep --options runtime --sign - "$app_path"
           codesign --verify --deep --strict --verbose=2 "$app_path"
-          spctl --assess --type execute --verbose "$app_path" || true
+          codesign --display --verbose=4 "$app_path"
+          if spctl --assess --type execute --verbose "$app_path"; then
+            echo "Gatekeeper accepted the app bundle."
+          else
+            echo "::warning::Gatekeeper rejected this ad-hoc signed, non-notarized build. Users must click Done if macOS shows Move to Trash, then force-open it from System Settings > Privacy & Security > Open Anyway."
+          fi
+
+          dmg_source="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f | sort | tail -1)"
+          if [ -z "$dmg_source" ]; then
+            echo "No .dmg bundle found" >&2
+            exit 1
+          fi
+          hdiutil verify "$dmg_source"
 
           artifact_dir="$RUNNER_TEMP/wework-macos-${{ matrix.arch }}"
           mkdir -p "$artifact_dir"
-          app_name="$(basename "$app_path")"
-          zip_path="$artifact_dir/WeWork_${{ steps.version.outputs.value }}_macos_${{ matrix.arch }}_unsigned-adhoc.app.zip"
-          dmg_path="$artifact_dir/WeWork_${{ steps.version.outputs.value }}_macos_${{ matrix.arch }}_unsigned-adhoc.dmg"
+          dmg_path="$artifact_dir/WeWork_${{ needs.prepare-release.outputs.version }}_macos_${{ matrix.arch }}_unsigned-adhoc.dmg"
+          cp "$dmg_source" "$dmg_path"
+          shasum -a 256 "$dmg_path"
+          {
+            echo "### Wework macOS ${{ matrix.arch }} release asset"
+            echo ""
+            echo "- DMG: $(basename "$dmg_path")"
+            echo "- This build is ad-hoc signed and not Apple notarized."
+            echo "- If the first launch dialog shows Move to Trash, click Done instead."
+            echo "- Then force-open from System Settings > Privacy & Security > Open Anyway."
+            echo "- If macOS keeps the quarantine flag: \`xattr -dr com.apple.quarantine /Applications/WeWork.app\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          ditto -c -k --keepParent "$app_path" "$zip_path"
-          hdiutil create \
-            -volname "WeWork" \
-            -srcfolder "$app_path" \
-            -ov \
-            -format UDZO \
-            "$dmg_path"
+          echo "dmg_path=$dmg_path" >> "$GITHUB_OUTPUT"
 
-          echo "artifact_dir=$artifact_dir" >> "$GITHUB_OUTPUT"
-          echo "app_name=$app_name" >> "$GITHUB_OUTPUT"
-
-      - name: Write install note
+      - name: Upload DMG to GitHub Release
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |
-          cat > "${{ steps.package.outputs.artifact_dir }}/README-macos-unsigned.txt" <<'EOF'
-          This macOS build is ad-hoc signed but not Apple notarized.
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" "${{ steps.package.outputs.dmg_path }}" --clobber
+          release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
+          {
+            echo ""
+            echo "- Direct DMG download is available from: $release_url"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          First launch may require:
-          1. Open System Settings > Privacy & Security.
-          2. Click Open Anyway for WeWork.
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-release
+      - build-macos
 
-          If macOS keeps the download quarantine flag, run:
-            xattr -dr com.apple.quarantine /Applications/WeWork.app
-          EOF
-
-      - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wework-macos-${{ matrix.arch }}-unsigned-adhoc
-          path: ${{ steps.package.outputs.artifact_dir }}/*
-          if-no-files-found: error
-          retention-days: 14
+    steps:
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$RELEASE_TAG" --draft=false --prerelease
+          release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
+          echo "Published direct DMG downloads: $release_url" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/en/developer-guide/wework-macos-release.md
+++ b/docs/en/developer-guide/wework-macos-release.md
@@ -87,26 +87,28 @@ To validate local updater behavior, serve the script output directory:
 python3 -m http.server 8787 --directory src-tauri/target/release/local-update-server
 ```
 
-## CI Builds Without Apple Developer
+## CI DMG Without Apple Developer
 
-The repository includes `.github/workflows/wework-app.yml` for producing macOS artifacts on GitHub Actions. This workflow does not require an Apple Developer account and builds:
+The repository includes `.github/workflows/wework-app.yml` for producing macOS test DMGs on GitHub Actions without the Apple Developer Program. The workflow applies an ad-hoc codesign signature to the `.app`, but it does not perform Apple notarization, so first launch still triggers Gatekeeper. Use this mode for internal testing and developer distribution only; do not label it as a notarized production package.
 
-- `wework-macos-arm64-unsigned-adhoc`
-- `wework-macos-x64-unsigned-adhoc`
+The workflow does not require Apple signing secrets. It creates or updates the `wework-v<version>` GitHub prerelease and uploads two release assets:
 
-Each artifact contains `.app.zip`, `.dmg`, and `README-macos-unsigned.txt`. The workflow applies an ad-hoc signature to the `.app`:
+- `WeWork_<version>_macos_arm64_unsigned-adhoc.dmg`
+- `WeWork_<version>_macos_x64_unsigned-adhoc.dmg`
 
-```bash
-codesign --force --deep --options runtime --sign - WeWork.app
-```
+When downloaded from GitHub Release assets, the link points directly to the `.dmg` file and is not wrapped by an Actions artifact `.zip`. When the workflow is triggered manually without a version input, the release tag uses `wework-v<package-version>-<short-sha>`.
 
-This build is not Apple notarized, so first launch still triggers Gatekeeper. Users can force-open it from **Open Anyway** in macOS Privacy & Security settings. If the download keeps the quarantine flag, they can also run:
+To force-open the app on first launch. On macOS 15 and later, the warning can still include a **Move to Trash** button; as long as CI passed `codesign --verify --deep --strict`, this is usually the normal Gatekeeper block for a non-notarized app, not a damaged package:
+
+1. Open the DMG and drag `WeWork.app` to `/Applications`.
+2. If the first launch shows an unidentified developer or **Move to Trash** warning, click Done. Do not click Move to Trash.
+3. Open **System Settings > Privacy & Security**, then click **Open Anyway** in the Security section.
+
+If macOS still keeps the quarantine flag, run this after confirming the source is trusted:
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/WeWork.app
 ```
-
-Use this mode for internal testing and developer distribution only. Do not label it as a notarized production package. Public distribution for ordinary users should still use a Developer ID Application certificate and Apple notarization.
 
 ## Production Release
 

--- a/docs/zh/developer-guide/wework-macos-release.md
+++ b/docs/zh/developer-guide/wework-macos-release.md
@@ -87,26 +87,28 @@ scripts/release-mac-app.sh --target local --version 0.1.99 --notes "Local verifi
 python3 -m http.server 8787 --directory src-tauri/target/release/local-update-server
 ```
 
-## 无 Apple Developer 账号的 CI 包
+## 无 Apple Developer 账号的 CI DMG
 
-仓库提供 `.github/workflows/wework-app.yml`，用于在 GitHub Actions 上生成 macOS artifact。该 workflow 不需要 Apple Developer 账号，会分别构建：
+仓库提供 `.github/workflows/wework-app.yml`，用于在 GitHub Actions 上生成无需 Apple Developer Program 的 macOS 测试 DMG。该 workflow 会对 `.app` 执行 ad-hoc codesign，但不会做 Apple notarization，因此首次打开仍会触发 Gatekeeper。这个模式适合内部测试和开发者分发，不应标记为正式已公证发布包。
 
-- `wework-macos-arm64-unsigned-adhoc`
-- `wework-macos-x64-unsigned-adhoc`
+workflow 不需要配置 Apple signing secrets，会创建或更新 `wework-v<version>` GitHub prerelease，并分别上传两个 Release assets：
 
-每个 artifact 包含 `.app.zip`、`.dmg` 和 `README-macos-unsigned.txt`。构建流程会对 `.app` 执行 ad-hoc codesign：
+- `WeWork_<version>_macos_arm64_unsigned-adhoc.dmg`
+- `WeWork_<version>_macos_x64_unsigned-adhoc.dmg`
 
-```bash
-codesign --force --deep --options runtime --sign - WeWork.app
-```
+从 GitHub Release assets 下载时，下载链接本身就是 `.dmg` 文件，不会被 Actions artifact 额外套一层 `.zip`。手动触发 workflow 且未填写版本号时，release tag 会使用 `wework-v<package-version>-<short-sha>`。
 
-这种包没有 Apple notarization，因此首次打开仍会触发 Gatekeeper。用户可以通过系统隐私设置中的 **Open Anyway** 强行打开；如果下载带有 quarantine 标记，也可以执行：
+首次打开被拦截时，可以强制打开。macOS 15 之后的提示可能仍会出现 **Move to Trash / 移到废纸篓** 按钮；只要 CI 中 `codesign --verify --deep --strict` 通过，这通常仍属于未公证 app 的 Gatekeeper 拦截，不是包损坏：
+
+1. 双击打开 DMG，把 `WeWork.app` 拖到 `/Applications`。
+2. 第一次打开如果看到“无法验证开发者”或 **Move to Trash / 移到废纸篓** 提示，点“完成”，不要点“移到废纸篓”。
+3. 打开 **System Settings > Privacy & Security**，在 Security 区域点击 **Open Anyway**。
+
+如果 macOS 仍保留 quarantine 标记，也可以在确认来源可信后执行：
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/WeWork.app
 ```
-
-该模式适合内部测试和开发者分发，不应标记为正式已公证发布包。面向普通用户的公开分发仍应使用 Developer ID Application 证书和 Apple notarization。
 
 ## 生产发布
 


### PR DESCRIPTION
## Summary

- Publish Wework macOS DMGs as GitHub Release assets so the download target is a direct `.dmg` instead of an Actions artifact zip.
- Keep the no-Apple-Developer-account path by using Tauri ad-hoc signing and Tauri-generated DMG bundles.
- Add CI verification and release notes that explain the non-notarized force-open flow.
- Update Chinese and English macOS release docs with the Release asset download model and Gatekeeper guidance.

## Root Cause

The previous Actions artifact flow uploaded a directory through `actions/upload-artifact`, so GitHub always wrapped the DMG in an outer artifact `.zip`. The app was also distributed as an ad-hoc, non-notarized build, so the user-facing opening instructions needed to match Gatekeeper behavior for valid-but-unnotarized builds.

## Validation

- `git diff --check`
- Parsed `.github/workflows/wework-app.yml` with Ruby YAML loading
- Pre-push hook quality checks passed during `git push`

## Notes

This remains an ad-hoc signed, non-notarized macOS build. Users may still need to force-open it from System Settings > Privacy & Security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS releases now publish DMG files directly to GitHub Releases, with versioned prerelease metadata created automatically.
  * The macOS build flow now produces signed DMGs and publishes the final release once ready.

* **Documentation**
  * Updated macOS release guides in English and Chinese to match the new DMG-based release process.
  * Added clearer download, versioning, and first-launch instructions for macOS 15+ users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->