### PR TITLE
[codex] Verify Wework app inside generated DMG

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -198,9 +198,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          app_path="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/macos" -maxdepth 1 -name '*.app' -type d | sort | tail -1)"
+          dmg_source="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f | sort | tail -1)"
+          if [ -z "$dmg_source" ]; then
+            echo "No .dmg bundle found" >&2
+            exit 1
+          fi
+          hdiutil verify "$dmg_source"
+
+          mount_dir="$RUNNER_TEMP/wework-dmg-${{ matrix.arch }}"
+          rm -rf "$mount_dir"
+          mkdir -p "$mount_dir"
+          cleanup_mount() {
+            hdiutil detach "$mount_dir" -quiet || true
+          }
+          trap cleanup_mount EXIT
+
+          hdiutil attach "$dmg_source" -mountpoint "$mount_dir" -nobrowse -readonly
+          app_path="$(find "$mount_dir" -maxdepth 1 -name '*.app' -type d | sort | tail -1)"
           if [ -z "$app_path" ]; then
-            echo "No .app bundle found" >&2
+            echo "No .app bundle found inside DMG" >&2
             exit 1
           fi
           codesign --verify --deep --strict --verbose=2 "$app_path"
@@ -210,13 +226,8 @@ jobs:
           else
             echo "::warning::Gatekeeper rejected this ad-hoc signed, non-notarized build. Users must click Done if macOS shows Move to Trash, then force-open it from System Settings > Privacy & Security > Open Anyway."
           fi
-
-          dmg_source="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f | sort | tail -1)"
-          if [ -z "$dmg_source" ]; then
-            echo "No .dmg bundle found" >&2
-            exit 1
-          fi
-          hdiutil verify "$dmg_source"
+          cleanup_mount
+          trap - EXIT
 
           artifact_dir="$RUNNER_TEMP/wework-macos-${{ matrix.arch }}"
           mkdir -p "$artifact_dir"


### PR DESCRIPTION
## Summary

- Fix the Wework App workflow verification step after switching to `tauri build --bundles dmg`.
- Verify the generated DMG first, then mount it and run `codesign`/`spctl` against the `.app` inside the mounted image.
- Keep the ad-hoc, non-notarized warning behavior for Gatekeeper while avoiding a hard failure when Tauri cleans `bundle/macos/WeWork.app` after DMG creation.

## Root Cause

Tauri removes the intermediate `bundle/macos/WeWork.app` after creating a DMG-only bundle. The workflow still tried to verify that cleaned path, so both macOS jobs failed with `No .app bundle found`.

## Validation

- `git diff --check origin/main..HEAD`
- Parsed `.github/workflows/wework-app.yml` with Ruby YAML loading
- Pre-push hook quality checks passed during `git push`

## Notes

The failing run was `28787457067`, job `85357597414`. This PR fixes the missing `.app` verification path; the full Wework App workflow still needs to be rerun on GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS packaging checks to inspect the app inside the generated disk image, helping ensure the distributed app is the one being validated.
  * Added stricter verification during packaging, including validation of the selected disk image and the packaged app’s signing and Gatekeeper status.
  * Cleaned up temporary mount handling after validation to reduce leftover artifacts during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->