### PR TITLE
[codex] Preserve bundled executor version

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -141,8 +141,6 @@ jobs:
 
       - name: Build local executor sidecar
         working-directory: executor
-        env:
-          APP_VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           set -euo pipefail
           cargo build --release --locked --target "${{ matrix.rust_target }}"
@@ -150,7 +148,7 @@ jobs:
           mkdir -p dist
           cp "$binary" dist/wegent-executor
           chmod 0755 dist/wegent-executor
-          WEGENT_EXECUTOR_VERSION="$APP_VERSION" dist/wegent-executor --version
+          dist/wegent-executor --version
 
       - name: Prepare bundled Codex
         working-directory: wework


### PR DESCRIPTION
## Summary
- Stop passing the Wework app release version as `APP_VERSION` while compiling the bundled local executor sidecar.
- Let the executor binary report its own Cargo version (`1.8.5`) instead of the DMG/release artifact version.
- Keep the sidecar build verification by running `dist/wegent-executor --version`.

## Root Cause
The Wework App workflow set `APP_VERSION` on the executor build step. `executor/src/version.rs` reads compile-time `APP_VERSION` before falling back to `CARGO_PKG_VERSION`, so workflow-dispatch DMG builds embedded values like `0.0.0-<sha>` into the local executor binary. Wework then compared that value with its minimum executor version `1.8.5` and reported the bundled Local Executor as too old.

## Validation
- `git diff --check origin/main..HEAD`
- Parsed `.github/workflows/wework-app.yml` with Ruby YAML loading
- Pre-push quality checks passed during `git push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS build workflow to simplify how the local executor reports its version during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->