### PR TITLE
[codex] Set release repo for Wework gh CLI steps

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -57,6 +57,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
         run: |
@@ -248,6 +249,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |
           set -euo pipefail
@@ -270,6 +272,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Set `GH_REPO` for Wework App release creation, DMG upload, and final publish steps.
- Make `gh release` commands independent of whether the current job has a checked-out `.git` directory.

## Root Cause
The `publish-release` job runs on Ubuntu without checking out the repository. `gh release edit "$RELEASE_TAG"` tried to infer the repository from the current directory and failed with `fatal: not a git repository`. Providing `GH_REPO: ${{ github.repository }}` gives GitHub CLI the repository context directly.

## Validation
- `git diff --check`
- Parsed `.github/workflows/wework-app.yml` with Ruby YAML loading
- Pre-push quality checks passed during `git push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release pipeline so build artifacts and release updates are published more reliably.
  * Helps ensure desktop app downloads are attached and released as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->