### PR TITLE
fix(chat-shell): pass disallowed_special=() to encoding.encode in tool output guard

### DIFF
--- a/chat_shell/chat_shell/guard/tool_output.py
+++ b/chat_shell/chat_shell/guard/tool_output.py
@@ -177,7 +177,7 @@ def _truncate_body(
         ``(rendered_body, total_input_tokens, truncated_flag, header_fields)``.
     """
     if policy.kind == "tokens":
-        ids = counter.encoding.encode(body)
+        ids = counter.encoding.encode(body, disallowed_special=())
         total_tokens = len(ids)
         if total_tokens <= policy.limit:
             return (

--- a/chat_shell/tests/test_tool_output_adapter.py
+++ b/chat_shell/tests/test_tool_output_adapter.py
@@ -21,7 +21,7 @@ from chat_shell.guard.types import TruncationPolicy
 def _make_tokens(n: int, counter: TokenCounter) -> str:
     """Generate text with exactly *n* tokens using cl100k encoding."""
     base = "The quick brown fox jumps over the lazy dog. " * ((n // 10) + 1)
-    ids = counter.encoding.encode(base)
+    ids = counter.encoding.encode(base, disallowed_special=())
     return counter.encoding.decode(ids[:n])
 
 
@@ -457,3 +457,49 @@ class TestRecognition:
 
         assert adapter.should_bypass_source_compaction(message) is False
         assert adapter.should_bypass_request_compaction(message) is False
+
+    def test_body_containing_tiktoken_special_token_does_not_raise(self):
+        """Tool output that contains '<|endoftext|>' or other tiktoken special
+        tokens must not raise during token counting or truncation.
+
+        Regression: _truncate_body() called encoding.encode(body) without
+        disallowed_special=(), which caused tiktoken to raise when web-search
+        results (or any user-facing content) contained GPT special tokens.
+        """
+        counter = TokenCounter("gpt-4")
+        adapter = ToolOutputGuardAdapter(
+            token_counter=counter,
+            default_policy=TruncationPolicy(kind="tokens", limit=200),
+        )
+        policy = TruncationPolicy(kind="tokens", limit=200)
+
+        # Content containing a tiktoken special token — must not raise
+        body_with_special = (
+            "Here is an example: tokenizer.register_special_tokens("
+            '{"<|endoftext|>": 50256})'
+        )
+        output = adapter.to_model_visible({"text": body_with_special}, policy)
+
+        assert output.startswith(HEADER_PREFIX)
+        assert "truncated=false" in output.split("\n")[0]
+        assert body_with_special in output
+
+    def test_body_containing_tiktoken_special_token_truncated_does_not_raise(self):
+        """Same as above but with truncation — ensures encode inside truncation
+        path also handles special tokens correctly."""
+        counter = TokenCounter("gpt-4")
+        adapter = ToolOutputGuardAdapter(
+            token_counter=counter,
+            default_policy=TruncationPolicy(kind="tokens", limit=5),
+        )
+        policy = TruncationPolicy(kind="tokens", limit=5)
+
+        # Large body with a special token embedded, exceeds the 5-token limit
+        body_with_special = (
+            "Some prefix text. " * 20 + "<|endoftext|>" + " Some suffix text. " * 20
+        )
+        # Must not raise
+        output = adapter.to_model_visible({"text": body_with_special}, policy)
+
+        assert output.startswith(HEADER_PREFIX)
+        assert "truncated=true" in output.split("\n")[0]


### PR DESCRIPTION
## Summary

- **Root cause**: `_truncate_body()` in `ToolOutputGuardAdapter` called `counter.encoding.encode(body)` without `disallowed_special=()`, causing tiktoken to raise a `ValueError` when tool output contained GPT special token strings such as `<|endoftext|>`.
- **Trigger**: A user asked about BPE tokenizer training datasets; the web-search tool returned code snippets containing `<|endoftext|>` as a literal string. The token-counting step in the tool output guard crashed, terminating the chat session with `error_type: generic_error`.
- **Fix**: Add `disallowed_special=()` to the one remaining `encoding.encode()` call site in `tool_output.py:180`. All other encode call sites in the codebase already carry this parameter — this was the sole missed spot from a prior partial fix.
- **Consistency**: Also aligned the `_make_tokens` test helper in `test_tool_output_adapter.py` which used `encoding.encode(base)` without the parameter (safe there due to hardcoded ASCII input, but now consistent with the rest of the codebase).

## Test plan

- [ ] `test_body_containing_tiktoken_special_token_does_not_raise` — verifies that body content with `<|endoftext|>` does not raise during token counting (under-budget path)
- [ ] `test_body_containing_tiktoken_special_token_truncated_does_not_raise` — verifies the same for the truncation path (over-budget)
- [ ] All 26 existing tests in `test_tool_output_adapter.py` continue to pass
- [ ] Run: `cd chat_shell && uv run pytest tests/test_tool_output_adapter.py -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special token strings during tool output processing, preventing errors when text contains token-like values.
  * Ensured truncation decisions work consistently when special tokens are present.

* **Tests**
  * Added regression coverage for tool output rendering with special tokens.
  * Verified both normal and truncated outputs are returned without errors and preserve the original text where expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->