### PR TITLE
[codex] update Wework README coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ English | [简体中文](README_zh.md)
 
 <div align="center">
 
-[Quick Start](#-quick-start) · [Core Scenarios](#core-scenarios) · [How It Grows](#how-it-grows) · [Documentation](https://wecode-ai.github.io/wegent-docs/) · [Development Guide](https://wecode-ai.github.io/wegent-docs/docs/category/developer-guide)
+[Quick Start](#-quick-start) · [Core Scenarios](#core-scenarios) · [Wework Desktop](#wework-desktop) · [How It Grows](#how-it-grows) · [Documentation](https://wecode-ai.github.io/wegent-docs/) · [Development Guide](https://wecode-ai.github.io/wegent-docs/docs/category/developer-guide)
 
 </div>
 
@@ -45,19 +45,19 @@ Then open http://localhost:3000 in your browser.
 
 ### Deployment Modes
 
-| Mode | Best For |
-|------|----------|
+| Mode                     | Best For                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------- |
 | **Standalone** (default) | Single container + SQLite, best for personal trials and lightweight deployments |
-| **Standard** | Multi-container + MySQL + Redis, best for teams and production |
-| **Development** | Source startup + hot reload, best for development and extensions |
+| **Standard**             | Multi-container + MySQL + Redis, best for teams and production                  |
+| **Development**          | Source startup + hot reload, best for development and extensions                |
 
 Standalone can choose where coding/execution agents run:
 
-| Standalone Executor Mode | Behavior | Best For |
-|--------------------------|----------|----------|
-| `host` | Run the executor on the host machine while Backend, Frontend, and Wework stay in Docker | macOS or any setup that needs host commands such as `open`, `osascript`, Terminal, or local CLI tools |
-| `container` | Run the executor inside the standalone container | Linux quick start and single-container deployments |
-| `hybrid` | Run both host and container executors | Keeping the container device while also using host-native capabilities |
+| Standalone Executor Mode | Behavior                                                                                | Best For                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `host`                   | Run the executor on the host machine while Backend, Frontend, and Wework stay in Docker | macOS or any setup that needs host commands such as `open`, `osascript`, Terminal, or local CLI tools |
+| `container`              | Run the executor inside the standalone container                                        | Linux quick start and single-container deployments                                                    |
+| `hybrid`                 | Run both host and container executors                                                   | Keeping the container device while also using host-native capabilities                                |
 
 Interactive macOS installs default to `host`; Linux and non-interactive installs default to `container`.
 
@@ -132,6 +132,19 @@ Upload documents, import webpages, or sync DingTalk multi-dimensional tables to 
 
 Install a local runner on your own machine and connect it securely to Wegent. Tasks can switch between cloud environments and local devices, which is useful when AI needs access to local repositories, intranet resources, or dedicated development environments.
 
+### Wework Desktop
+
+Wework brings the AI coding workspace onto your own computer. You can open a local project, start a coding conversation, let AI read and edit files, review the changes, and keep working even when you are not connected to a Wegent server. When you do connect to a server, cloud models and remote devices appear in the same workspace instead of becoming a separate product.
+
+It is designed for day-to-day coding work:
+
+- **Code where the repo already lives**: work directly against local folders, private networks, local CLIs, and machine-specific setup.
+- **Continue real coding sessions**: pick up local runtime conversations and keep context tied to the project.
+- **Review before you accept**: inspect file changes, browse project files, and use the built-in terminal from the same workbench.
+- **Use local or cloud resources together**: start locally by default, then add server models, cloud devices, and shared authentication when a team deployment is available.
+
+For developer setup and packaging commands, see [wework/README.md](wework/README.md).
+
 ### Team Tools and Existing Systems
 
 Connect Wegent agents to DingTalk, Telegram, and other IM tools, or call them from existing applications through an API.
@@ -142,12 +155,12 @@ Connect Wegent agents to DingTalk, Telegram, and other IM tools, or call them fr
 
 You do not need to learn every concept upfront. Wegent can start as a private AI workspace: choose a model, create an assistant, upload materials, and chat. As your team starts reusing these capabilities, you can turn common assistants, knowledge bases, coding tasks, and IM entrypoints into shared workflows.
 
-| Stage | How You Can Use Wegent |
-|-------|------------------------|
-| **Personal use** | Start the service and create your own AI assistants and knowledge bases |
-| **Team collaboration** | Share common assistants, model settings, knowledge bases, and coding tasks |
-| **Automated workflows** | Let AI handle work through schedules, event triggers, or IM bots |
-| **Deep integration** | Connect Wegent to existing systems through APIs, tools, and configuration files |
+| Stage                   | How You Can Use Wegent                                                          |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| **Personal use**        | Start the service and create your own AI assistants and knowledge bases         |
+| **Team collaboration**  | Share common assistants, model settings, knowledge bases, and coding tasks      |
+| **Automated workflows** | Let AI handle work through schedules, event triggers, or IM bots                |
+| **Deep integration**    | Connect Wegent to existing systems through APIs, tools, and configuration files |
 
 <details>
 <summary><b>Core concepts for customization and extension</b></summary>
@@ -177,6 +190,7 @@ Wegent can grow from a personal trial to a team deployment:
 - **Personal trial**: Standalone mode starts one container, suitable for a laptop or lightweight server.
 - **Team deployment**: Standard mode uses dedicated database, cache, and execution services for long-running use.
 - **Local devices**: Connect your own machine as a place to run tasks that need local repositories or intranet access.
+- **Desktop app**: Use Wework for a local-first coding workspace that can also connect back to a team Wegent deployment.
 - **Existing systems**: Connect Wegent to team tools through APIs or IM bots.
 
 <details>
@@ -185,8 +199,11 @@ Wegent can grow from a personal trial to a team deployment:
 ```mermaid
 graph TB
     User["User / API / IM"] --> Frontend["Next.js Web"]
+    User --> Wework["Wework Desktop<br/>Tauri + React"]
     User --> Backend["FastAPI Backend"]
     Frontend --> Backend
+    Wework --> Backend
+    Wework --> WeworkExecutor["Local Executor Sidecar<br/>Codex / Local Work"]
 
     Backend --> MySQL[("MySQL / SQLite")]
     Backend --> Redis[("Redis")]
@@ -209,6 +226,7 @@ graph TB
 - **Application integration**: Call Wegent agents from your own apps through `/api/v1/responses`.
 - **External tools**: Use MCP to let AI call existing tools and services.
 - **Reusable capabilities**: Package specialized abilities as Skills and load them only when needed.
+- **Local-first desktop runtime**: Extend Wework when teams need local repositories, terminals, device tools, and cloud-connected coding workflows in one desktop app.
 - **Flexible runtimes**: Use different runtime engines for chat, coding tasks, multi-agent work, and external app proxying.
 - **Central model management**: OpenAI, Claude, Gemini, DeepSeek, GLM, and protocol-compatible model services.
 - **Team sharing and permissions**: Groups, shared agents, shared models, shared Skills, and admin management.
@@ -218,12 +236,12 @@ graph TB
 
 ## Built-in Assistants
 
-| Assistant | Purpose |
-|-----------|---------|
-| `chat-team` | General AI assistant with Mermaid diagram support |
-| `translator` | Multi-language translation |
-| `dev-team` | Git workflow: branch, code, commit, PR |
-| `wiki-team` | Codebase Wiki documentation generation |
+| Assistant    | Purpose                                           |
+| ------------ | ------------------------------------------------- |
+| `chat-team`  | General AI assistant with Mermaid diagram support |
+| `translator` | Multi-language translation                        |
+| `dev-team`   | Git workflow: branch, code, commit, PR            |
+| `wiki-team`  | Codebase Wiki documentation generation            |
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,7 +14,7 @@
 
 <div align="center">
 
-[快速开始](#-快速开始) · [核心场景](#核心场景) · [工作方式](#工作方式) · [文档](https://wecode-ai.github.io/wegent-docs/zh/) · [开发指南](https://wecode-ai.github.io/wegent-docs/zh/docs/category/developer-guide)
+[快速开始](#-快速开始) · [核心场景](#核心场景) · [Wework 桌面端](#wework-桌面端) · [工作方式](#工作方式) · [文档](https://wecode-ai.github.io/wegent-docs/zh/) · [开发指南](https://wecode-ai.github.io/wegent-docs/zh/docs/category/developer-guide)
 
 </div>
 
@@ -45,19 +45,19 @@ curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | 
 
 ### 部署模式
 
-| 模式 | 适合场景 |
-|------|----------|
-| **Standalone**（默认） | 单容器 + SQLite，适合个人试用和轻量部署 |
-| **Standard** | 多容器 + MySQL + Redis，适合团队和生产环境 |
-| **Development** | 源码启动 + 热重载，适合开发和二次扩展 |
+| 模式                   | 适合场景                                   |
+| ---------------------- | ------------------------------------------ |
+| **Standalone**（默认） | 单容器 + SQLite，适合个人试用和轻量部署    |
+| **Standard**           | 多容器 + MySQL + Redis，适合团队和生产环境 |
+| **Development**        | 源码启动 + 热重载，适合开发和二次扩展      |
 
 Standalone 可以选择编码/执行 Agent 的运行位置：
 
-| Standalone Executor 模式 | 行为 | 适合场景 |
-|--------------------------|------|----------|
-| `host` | Backend、Frontend 和 Wework 仍在 Docker 中运行，executor 在宿主机运行 | macOS，或需要调用 `open`、`osascript`、系统 Terminal、本机 CLI 工具等宿主机能力 |
-| `container` | executor 在 standalone 容器内运行 | Linux 快速体验和单容器部署 |
-| `hybrid` | 宿主机 executor 和容器 executor 同时运行 | 保留容器设备，同时使用宿主机能力 |
+| Standalone Executor 模式 | 行为                                                                  | 适合场景                                                                        |
+| ------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `host`                   | Backend、Frontend 和 Wework 仍在 Docker 中运行，executor 在宿主机运行 | macOS，或需要调用 `open`、`osascript`、系统 Terminal、本机 CLI 工具等宿主机能力 |
+| `container`              | executor 在 standalone 容器内运行                                     | Linux 快速体验和单容器部署                                                      |
+| `hybrid`                 | 宿主机 executor 和容器 executor 同时运行                              | 保留容器设备，同时使用宿主机能力                                                |
 
 交互式 macOS 安装默认选择 `host`；Linux 和非交互安装默认选择 `container`。
 
@@ -132,6 +132,19 @@ docker compose up -d
 
 在自己的电脑上安装本地执行程序，并安全连接到 Wegent。任务可以在云端隔离环境和本地设备之间切换，适合需要访问本机仓库、内网资源或专属开发环境的场景。
 
+### Wework 桌面端
+
+Wework 把 AI 编码工作台带到你自己的电脑上。你可以打开本地项目，发起编码对话，让 AI 读取和修改文件，审查改动，并且在没有连接 Wegent 服务端时继续工作。连接服务端后，云端模型和远程设备会进入同一个工作台，而不是变成另一套割裂的产品。
+
+它面向日常编码工作：
+
+- **代码就在原处工作**：直接使用本地目录、内网资源、本机 CLI 和机器上的开发环境。
+- **延续真实编码会话**：打开已有本地运行时会话，让上下文继续留在项目里。
+- **先审查再接受**：在同一个工作台里查看文件改动、浏览项目文件、使用内置终端。
+- **本地和云端一起用**：默认从本地开始，需要团队能力时再加入服务端模型、云端设备和共享认证。
+
+开发启动和打包命令见 [wework/README.md](wework/README.md)。
+
 ### 接入团队沟通工具和已有系统
 
 把 Wegent 智能体接入钉钉、Telegram 等 IM 工具，也可以通过 API 接入已有应用，让团队在原来的工作流里直接调用 AI。
@@ -142,12 +155,12 @@ docker compose up -d
 
 你不需要一开始就理解所有概念。Wegent 可以先当作一个私有 AI 工作台使用：选模型、创建助手、上传资料、开始对话。等团队开始复用这些能力时，再逐步把常用助手、知识库、代码任务和 IM 入口沉淀下来。
 
-| 阶段 | 你可以怎么用 |
-|------|--------------|
-| **个人使用** | 快速启动服务，创建自己的 AI 助手和知识库 |
-| **团队协作** | 共享常用助手、模型配置、知识库和代码任务 |
+| 阶段             | 你可以怎么用                                       |
+| ---------------- | -------------------------------------------------- |
+| **个人使用**     | 快速启动服务，创建自己的 AI 助手和知识库           |
+| **团队协作**     | 共享常用助手、模型配置、知识库和代码任务           |
 | **自动化工作流** | 用定时任务、事件触发或 IM 机器人让 AI 主动处理工作 |
-| **深度集成** | 通过 API、工具扩展和配置文件接入已有系统 |
+| **深度集成**     | 通过 API、工具扩展和配置文件接入已有系统           |
 
 <details>
 <summary><b>核心概念（给需要自定义和扩展的人）</b></summary>
@@ -177,6 +190,7 @@ Wegent 可以从个人试用逐步扩展到团队部署：
 - **个人试用**：Standalone 模式单容器启动，适合本机或轻量服务器。
 - **团队部署**：Standard 模式使用独立数据库、缓存和执行服务，适合长期运行。
 - **本地设备**：把自己的电脑接入为执行环境，处理需要本机仓库或内网资源的任务。
+- **桌面应用**：使用 Wework 获得本地优先的编码工作台，也可以连接回团队 Wegent 部署。
 - **已有系统**：通过 API 或 IM 机器人，把 Wegent 接到团队现有工具里。
 
 <details>
@@ -185,8 +199,11 @@ Wegent 可以从个人试用逐步扩展到团队部署：
 ```mermaid
 graph TB
     User["用户 / API / IM"] --> Frontend["Next.js Web"]
+    User --> Wework["Wework Desktop<br/>Tauri + React"]
     User --> Backend["FastAPI Backend"]
     Frontend --> Backend
+    Wework --> Backend
+    Wework --> WeworkExecutor["Local Executor Sidecar<br/>Codex / Local Work"]
 
     Backend --> MySQL[("MySQL / SQLite")]
     Backend --> Redis[("Redis")]
@@ -209,6 +226,7 @@ graph TB
 - **接入自己的应用**：通过 `/api/v1/responses` 调用 Wegent 中的智能体。
 - **连接外部工具**：通过 MCP 让 AI 调用已有工具和服务。
 - **复用复杂能力**：把特定能力打包成 Skill，需要时再加载。
+- **本地优先桌面运行时**：扩展 Wework，把本地仓库、终端、设备工具和云端协同编码放进同一个桌面应用。
 - **选择适合的运行方式**：对话、代码任务、多智能体协作和外部应用代理可以分别使用不同运行引擎。
 - **统一管理模型**：支持 OpenAI、Claude、Gemini、DeepSeek、GLM 以及兼容协议的模型服务。
 - **团队共享和权限**：支持组织、共享智能体、共享模型、共享 Skills 和管理后台。
@@ -218,12 +236,12 @@ graph TB
 
 ## 预置助手
 
-| 助手 | 用途 |
-|------|------|
-| `chat-team` | 通用 AI 助手，支持 Mermaid 图表 |
-| `translator` | 多语言翻译 |
-| `dev-team` | Git 工作流：分支、编码、提交、PR |
-| `wiki-team` | 代码库 Wiki 文档生成 |
+| 助手         | 用途                             |
+| ------------ | -------------------------------- |
+| `chat-team`  | 通用 AI 助手，支持 Mermaid 图表  |
+| `translator` | 多语言翻译                       |
+| `dev-team`   | Git 工作流：分支、编码、提交、PR |
+| `wiki-team`  | 代码库 Wiki 文档生成             |
 
 ---
 

--- a/wework/README.md
+++ b/wework/README.md
@@ -1,80 +1,67 @@
-# React + TypeScript + Vite
+# Wework
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Wework is the Wegent desktop workbench for local-first AI coding and workplace workflows. It is built with Tauri v2, Vite, React, and TypeScript.
 
-Currently, two official plugins are available:
+## Capabilities
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- Run local Codex-backed tasks through a managed executor sidecar.
+- Work with local projects, runtime conversations, attachments, terminals, file previews, and code change review without Backend login.
+- Connect to a Wegent Backend when cloud models, cloud devices, remote runtime work, or encrypted Codex auth sync are needed.
+- Package macOS builds as DMG releases with bundled Codex binaries and Tauri updater metadata.
+- Build iOS simulator, device, and App Store Connect packages from the same Tauri app.
 
-## React Compiler
+## Development
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+From the repository root:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install
+pnpm --filter wework dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+For the macOS Tauri app:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm --filter wework dev:mac
 ```
 
-## iOS App (Tauri)
+Useful checks:
 
-The desktop app is built with [Tauri v2](https://v2.tauri.app/), which also targets iOS.
+```bash
+pnpm --filter wework typecheck
+pnpm --filter wework lint
+pnpm --filter wework test
+pnpm --filter wework e2e
+```
+
+## macOS Build and Release
+
+Build a local macOS app bundle or DMG:
+
+```bash
+pnpm --filter wework build:mac
+pnpm --filter wework build:mac -- --target universal-apple-darwin --bundles app,dmg
+```
+
+Release builds prepare the pinned Codex binary before Tauri packaging:
+
+```bash
+pnpm --filter wework run prepare:codex
+```
+
+The release script handles version calculation, Tauri config injection, updater signing, DMG generation, and upload:
+
+```bash
+cd wework
+scripts/release-mac-app.sh --target local --version 0.1.99 --notes "Local verification."
+scripts/release-mac-app.sh --target prod --notes "Release notes."
+```
+
+Production publishing requires updater, signing, and notarization environment variables. See [Wework macOS Release](../docs/en/developer-guide/wework-macos-release.md) for the full release model.
+
+## iOS App
+
+The Tauri app also targets iOS.
 
 ### Prerequisites
 
@@ -82,63 +69,58 @@ The desktop app is built with [Tauri v2](https://v2.tauri.app/), which also targ
 - Rust iOS targets: `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios`
 - CocoaPods (`brew install cocoapods`) and `xcodegen` (`brew install xcodegen`)
 
-### One-time setup
+### One-Time Setup
 
-The Xcode project lives in `src-tauri/gen/apple` and is **git-ignored** (regenerable, and a real build may embed your Apple Team ID into it). Generate it locally with:
+The Xcode project lives in `src-tauri/gen/apple` and is git-ignored because it is regenerable and may embed an Apple Team ID.
 
 ```bash
-pnpm run ios:init
+pnpm --filter wework run ios:init
 ```
 
-### Per-environment configuration
+### Environment Configuration
 
-iOS native builds have **no Vite dev proxy**, so the backend URLs must be absolute.
-Each environment is a file under `scripts/ios-env/<env>.env` (`dev`, `staging`, `prod`).
-Edit these to point at your real backend before building:
+iOS native builds have no Vite dev proxy, so backend URLs must be absolute. Each environment is a file under `scripts/ios-env/<env>.env` (`dev`, `staging`, `prod`):
 
 ```dotenv
 VITE_API_BASE_URL=https://wework.example.com/api
 VITE_SOCKET_BASE_URL=https://wework.example.com
-APPLE_DEVELOPMENT_TEAM=XXXXXXXXXX   # Apple Team ID for signing (device/IPA)
+APPLE_DEVELOPMENT_TEAM=XXXXXXXXXX
 ```
 
-### Dev (simulator / device)
+### Run and Package
 
 ```bash
-pnpm run dev:ios                          # env=dev (default)
-pnpm run dev:ios -- --env staging
-pnpm run dev:ios -- --device "iPhone 16 Pro"
+pnpm --filter wework dev:ios
+pnpm --filter wework dev:ios -- --env staging
+pnpm --filter wework dev:ios -- --device "iPhone 16 Pro"
+
+pnpm --filter wework build:ios -- --env prod
+pnpm --filter wework build:ios -- --env staging --target sim
+pnpm --filter wework build:ios -- --env prod --export-method app-store-connect
 ```
 
-### Build / package
+Useful flags: `--target device|sim|x86_64`, `--export-method app-store-connect|release-testing|debugging`, `--build-number N`, `--open`, `--archive-only`, `--no-sign`.
+
+Set `WEWORK_DRY_RUN=1` to print the resolved Tauri command without running it.
+
+Free or personal Apple teams can only create development profiles. Use `--export-method debugging`; the `release-testing` default requires Ad Hoc provisioning permissions. The signed device must also be registered to the team in Xcode.
+
+### Install to a Device
+
+Building does not install the app. List devices, then install the IPA:
 
 ```bash
-pnpm run build:ios -- --env prod                         # device IPA (release-testing)
-pnpm run build:ios -- --env staging --target sim         # simulator build
-pnpm run build:ios -- --env prod --export-method app-store-connect
-```
-
-Useful flags: `--target device|sim|x86_64`, `--export-method app-store-connect|release-testing|debugging`,
-`--build-number N`, `--open`, `--archive-only`, `--no-sign`.
-Set `WEWORK_DRY_RUN=1` to print the resolved `tauri` command without running it.
-
-> **Free / Personal Apple teams** can only create *development* profiles, not Ad Hoc or
-> App Store ones. Use `--export-method debugging` (the `release-testing` default fails with
-> "does not have permission to create iOS Ad Hoc provisioning profiles"). The signed device
-> must also be registered to the team — set this up once in Xcode (open `src-tauri/gen/apple`,
-> select the target → Signing & Capabilities → pick the team with Automatic signing).
-
-### Install to a device
-
-Building does not install. List devices, then install the IPA:
-
-```bash
-xcrun devicectl list devices                              # find your device UDID
+xcrun devicectl list devices
 xcrun devicectl device install app --device <UDID> \
   src-tauri/gen/apple/build/arm64/WeWork.ipa
 ```
 
-First launch: on the phone, **Settings ▸ General ▸ VPN & Device Management** → trust the
-developer certificate, otherwise iOS blocks the app as an untrusted developer.
+On first launch, trust the developer certificate in iOS Settings. The phone must be able to reach the backend URL configured in the selected environment file.
 
-The phone must reach the backend URL from `local.env` (same LAN, backend listening on `0.0.0.0`).
+## Related Documentation
+
+- [Local-First Cloud Connection](../docs/en/developer-guide/wework-cloud-connection.md)
+- [Runtime Local Work](../docs/en/developer-guide/runtime-local-work.md)
+- [Wework macOS Release](../docs/en/developer-guide/wework-macos-release.md)
+- [Wework Performance Diagnostics](../docs/en/developer-guide/wework-performance-diagnostics.md)
+- [Wework E2E Automation](../docs/en/developer-guide/wework-e2e-automation.md)


### PR DESCRIPTION
## Summary
- add user-facing Wework Desktop coverage to the root English and Chinese READMEs
- replace the Wework Vite template README with project-specific development, packaging, and related documentation links
- keep release and packaging details in the Wework subproject README instead of promoting them as root README product copy

## Validation
- pnpm --filter wework exec prettier --check ../README.md ../README_zh.md README.md
- pre-push hook: Wework ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the main guides with clearer navigation and more consistent tables.
  * Added a new desktop app section describing local-first coding, offline continuation, and cloud-connected workflows.
  * Expanded deployment and integration guidance with a desktop app option.
  * Improved technical diagrams and assistant listings for easier understanding.
  * Reworked the Wework guide with clearer setup, development, macOS release, and iOS build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->