### PR TITLE
fix(wework): show Codex usage in tray

### DIFF
--- a/docs/en/developer-guide/wework-cloud-connection.md
+++ b/docs/en/developer-guide/wework-cloud-connection.md
@@ -80,6 +80,8 @@ Local Codex `auth.json` status is read through the executor's read-only `runtime
 
 It never returns plaintext contents. Wework also does not upload the local auth file by default. Auth contents enter encrypted server storage and device sync only after the user explicitly uploads the file or imports it from an online device on the cloud-connected "Model Settings" page.
 
+Wework's remaining-usage display also follows the local Codex account. The frontend first reads the local `auth.json` status; if no Codex account exists, the menu and tray show none. When a local account exists, the frontend reads the Codex app-server `account/rateLimits/read` snapshot through the local executor command `runtime.codex.rate_limits.read` and displays the remaining percentages for the 5-hour and 7-day windows. The desktop system tray refreshes these two values every 60 seconds, shows only usage percentages, does not upload auth contents, and does not substitute Backend Claude quota.
+
 ## Disconnect
 
 Disconnecting cloud only clears cloud connection storage. It does not affect:

--- a/docs/zh/developer-guide/wework-cloud-connection.md
+++ b/docs/zh/developer-guide/wework-cloud-connection.md
@@ -80,6 +80,8 @@ API Key 留空时，本地 runtime 会向 Codex provider 配置传入 `dummy` be
 
 它不会返回明文内容。Wework 也不会默认上传本机认证文件。只有用户在已连接云端的“模型设置”页面显式上传或从在线设备导入后，认证内容才进入服务端加密存储和设备同步流程。
 
+Wework 的剩余额度展示也以本机 Codex 账号为准。前端先读取本机 `auth.json` 状态；如果没有 Codex 账号，则菜单和托盘显示“无”。如果本机已有账号，前端通过本地 executor 的 `runtime.codex.rate_limits.read` 命令读取 Codex app-server 的 `account/rateLimits/read` 快照，并展示 5 小时和 7 天窗口的剩余百分比。桌面系统托盘每 60 秒刷新一次这两个数值，只显示额度百分比，不上传认证内容，也不使用 Backend 的 Claude 额度作为替代。
+
 ## 断开连接
 
 断开云端连接只清除云端连接存储，不影响：

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -326,6 +326,7 @@ impl RuntimeWorkRpcHandler {
             "runtime.keybindings.get" => self.get_keybindings().await,
             "runtime.keybindings.update" => self.update_keybindings(payload).await,
             "runtime.codex.models.list" => self.list_codex_models(payload).await,
+            "runtime.codex.rate_limits.read" => self.read_codex_rate_limits().await,
             "runtime.archived_conversations.list" => {
                 self.list_archived_conversations(payload).await
             }
@@ -455,6 +456,13 @@ impl RuntimeWorkRpcHandler {
             "data": models,
             "providers": provider_results,
         }))
+    }
+
+    async fn read_codex_rate_limits(&self) -> Result<Value, AppIpcError> {
+        self.codex_app_server
+            .request("account/rateLimits/read", Value::Null)
+            .await
+            .map_err(|error| AppIpcError::new("codex_rate_limits_unavailable", error))
     }
 
     async fn list_tasks(&self) -> Result<Value, AppIpcError> {

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -30,6 +30,24 @@ const TRAY_MENU_TASK_PREFIX: &str = "task:";
 #[cfg(desktop)]
 const TRAY_ID: &str = "wework-main";
 #[cfg(desktop)]
+const TRAY_USAGE_ICON_HEIGHT: u32 = 22;
+#[cfg(desktop)]
+const TRAY_USAGE_ICON_LEFT_PADDING: u32 = 0;
+#[cfg(desktop)]
+const TRAY_USAGE_ICON_TEXT_GAP: u32 = 2;
+#[cfg(desktop)]
+const TRAY_USAGE_ICON_SCALE: u32 = 2;
+#[cfg(desktop)]
+const TRAY_USAGE_GLYPH_WIDTH: u32 = 3;
+#[cfg(desktop)]
+const TRAY_USAGE_GLYPH_HEIGHT: u32 = 5;
+#[cfg(desktop)]
+const TRAY_USAGE_GLYPH_GAP: u32 = 1;
+#[cfg(desktop)]
+const TRAY_USAGE_SPACE_WIDTH: u32 = 1;
+#[cfg(desktop)]
+const TRAY_USAGE_LINE_GAP: u32 = 2;
+#[cfg(desktop)]
 const LOG_DIRECTORY_APP_NAME: &str = "Wework";
 #[cfg(desktop)]
 const LOG_DIRECTORY_VENDOR_NAME: &str = "Wegent";
@@ -1024,6 +1042,8 @@ struct TrayMenuTaskItem {
 #[serde(rename_all = "camelCase")]
 struct TrayMenuStatePayload {
     language: String,
+    usage_title: Option<String>,
+    usage_tooltip: Option<String>,
     running: Vec<TrayMenuTaskItem>,
     running_more: Vec<TrayMenuTaskItem>,
     pinned: Vec<TrayMenuTaskItem>,
@@ -1037,6 +1057,8 @@ impl TrayMenuStatePayload {
     fn empty(language: &str) -> Self {
         Self {
             language: language.to_string(),
+            usage_title: None,
+            usage_tooltip: None,
             running: Vec::new(),
             running_more: Vec::new(),
             pinned: Vec::new(),
@@ -1215,6 +1237,148 @@ fn normalized_menu_task_title(item: &TrayMenuTaskItem, fallback: &str) -> String
 }
 
 #[cfg(desktop)]
+fn tray_usage_glyph(character: char) -> Option<[u8; 5]> {
+    match character {
+        '0' => Some([0b111, 0b101, 0b101, 0b101, 0b111]),
+        '1' => Some([0b010, 0b110, 0b010, 0b010, 0b111]),
+        '2' => Some([0b111, 0b001, 0b111, 0b100, 0b111]),
+        '3' => Some([0b111, 0b001, 0b111, 0b001, 0b111]),
+        '4' => Some([0b101, 0b101, 0b111, 0b001, 0b001]),
+        '5' => Some([0b111, 0b100, 0b111, 0b001, 0b111]),
+        '6' => Some([0b111, 0b100, 0b111, 0b101, 0b111]),
+        '7' => Some([0b111, 0b001, 0b010, 0b010, 0b010]),
+        '8' => Some([0b111, 0b101, 0b111, 0b101, 0b111]),
+        '9' => Some([0b111, 0b101, 0b111, 0b001, 0b111]),
+        '%' => Some([0b101, 0b001, 0b010, 0b100, 0b101]),
+        '-' => Some([0b000, 0b000, 0b111, 0b000, 0b000]),
+        'd' | 'D' => Some([0b001, 0b001, 0b111, 0b101, 0b111]),
+        'h' | 'H' => Some([0b100, 0b100, 0b111, 0b101, 0b101]),
+        _ => None,
+    }
+}
+
+#[cfg(desktop)]
+fn tray_usage_line_width(line: &str) -> u32 {
+    let glyph_count = line.chars().count() as u32;
+    if glyph_count == 0 {
+        return 1;
+    }
+    line.chars()
+        .map(|character| {
+            if character == ' ' {
+                TRAY_USAGE_SPACE_WIDTH * TRAY_USAGE_ICON_SCALE
+            } else {
+                TRAY_USAGE_GLYPH_WIDTH * TRAY_USAGE_ICON_SCALE
+            }
+        })
+        .sum::<u32>()
+        + glyph_count.saturating_sub(1) * TRAY_USAGE_GLYPH_GAP * TRAY_USAGE_ICON_SCALE
+}
+
+#[cfg(desktop)]
+fn draw_tray_usage_text(buffer: &mut [u8], width: u32, x: u32, y: u32, line: &str) {
+    let mut cursor_x = x;
+    for character in line.chars() {
+        if character == ' ' {
+            cursor_x += (TRAY_USAGE_SPACE_WIDTH + TRAY_USAGE_GLYPH_GAP) * TRAY_USAGE_ICON_SCALE;
+            continue;
+        }
+        if let Some(glyph) = tray_usage_glyph(character) {
+            for (row_index, row) in glyph.iter().enumerate() {
+                for column in 0..TRAY_USAGE_GLYPH_WIDTH {
+                    if row & (1 << (TRAY_USAGE_GLYPH_WIDTH - column - 1)) == 0 {
+                        continue;
+                    }
+                    for dy in 0..TRAY_USAGE_ICON_SCALE {
+                        for dx in 0..TRAY_USAGE_ICON_SCALE {
+                            let pixel_x = cursor_x + column * TRAY_USAGE_ICON_SCALE + dx;
+                            let pixel_y = y + row_index as u32 * TRAY_USAGE_ICON_SCALE + dy;
+                            let offset = ((pixel_y * width + pixel_x) * 4) as usize;
+                            if offset + 3 < buffer.len() {
+                                buffer[offset] = 255;
+                                buffer[offset + 1] = 255;
+                                buffer[offset + 2] = 255;
+                                buffer[offset + 3] = 255;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        cursor_x += (TRAY_USAGE_GLYPH_WIDTH + TRAY_USAGE_GLYPH_GAP) * TRAY_USAGE_ICON_SCALE;
+    }
+}
+
+#[cfg(desktop)]
+fn tray_usage_icon(
+    title: &str,
+    base_icon: Option<&tauri::image::Image<'_>>,
+) -> Option<tauri::image::Image<'static>> {
+    let lines = title
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(2)
+        .collect::<Vec<_>>();
+    if lines.len() != 2 {
+        return None;
+    }
+
+    let text_height = TRAY_USAGE_GLYPH_HEIGHT * TRAY_USAGE_ICON_SCALE * 2 + TRAY_USAGE_LINE_GAP;
+    let text_width = lines
+        .iter()
+        .map(|line| tray_usage_line_width(line))
+        .max()
+        .unwrap_or(1)
+        .max(1);
+    let base_icon_size = base_icon
+        .map(|icon| icon.width().min(icon.height()).min(TRAY_USAGE_ICON_HEIGHT))
+        .unwrap_or(0);
+    let base_icon_width = if base_icon_size > 0 {
+        base_icon_size + TRAY_USAGE_ICON_TEXT_GAP
+    } else {
+        0
+    };
+    let width = base_icon_width + text_width + TRAY_USAGE_ICON_LEFT_PADDING;
+    let height = TRAY_USAGE_ICON_HEIGHT.max(text_height);
+    let mut buffer = vec![0; (width * height * 4) as usize];
+    let first_y = (height - text_height) / 2;
+    let second_y = first_y + TRAY_USAGE_GLYPH_HEIGHT * TRAY_USAGE_ICON_SCALE + TRAY_USAGE_LINE_GAP;
+
+    if let Some(icon) = base_icon {
+        let source_width = icon.width();
+        let source_height = icon.height();
+        let source_size = source_width.min(source_height);
+        if source_size > 0 && base_icon_size > 0 {
+            let source_x = (source_width - source_size) / 2;
+            let source_y = (source_height - source_size) / 2;
+            let target_y = (height - base_icon_size) / 2;
+            let rgba = icon.rgba();
+            for y in 0..base_icon_size {
+                for x in 0..base_icon_size {
+                    let sample_x = source_x + x * source_size / base_icon_size;
+                    let sample_y = source_y + y * source_size / base_icon_size;
+                    let source_offset = ((sample_y * source_width + sample_x) * 4) as usize;
+                    let target_offset = (((target_y + y) * width + x) * 4) as usize;
+                    if source_offset + 3 < rgba.len() && target_offset + 3 < buffer.len() {
+                        buffer[target_offset..target_offset + 4]
+                            .copy_from_slice(&rgba[source_offset..source_offset + 4]);
+                    }
+                }
+            }
+        }
+    }
+
+    for (line_index, line) in lines.iter().enumerate() {
+        let x = base_icon_width + TRAY_USAGE_ICON_LEFT_PADDING;
+        let y = if line_index == 0 { first_y } else { second_y };
+        draw_tray_usage_text(&mut buffer, width, x, y, line);
+    }
+
+    Some(tauri::image::Image::new_owned(buffer, width, height))
+}
+
+#[cfg(desktop)]
 fn setup_system_tray(app: &mut tauri::App) -> tauri::Result<()> {
     let menu = build_system_tray_menu(app, &TrayMenuStatePayload::empty("zh-CN"))?;
 
@@ -1253,7 +1417,31 @@ fn set_tray_menu_state(app: tauri::AppHandle, state: TrayMenuStatePayload) -> Re
         return Ok(());
     };
     tray.set_menu(Some(menu))
-        .map_err(|error| format!("Failed to update tray menu: {error}"))
+        .map_err(|error| format!("Failed to update tray menu: {error}"))?;
+    let icon_update = state
+        .usage_title
+        .as_deref()
+        .and_then(|title| tray_usage_icon(title, app.default_window_icon()))
+        .map(|icon| tray.set_icon(Some(icon)));
+    match icon_update {
+        Some(Ok(())) => {
+            if let Err(error) = tray.set_title(None::<&str>) {
+                log::warn!("Failed to clear tray title: {error}");
+            }
+        }
+        Some(Err(error)) => {
+            log::warn!("Failed to update tray usage icon: {error}");
+        }
+        None => {
+            if let Err(error) = tray.set_title(None::<&str>) {
+                log::warn!("Failed to clear tray title: {error}");
+            }
+        }
+    }
+    if let Err(error) = tray.set_tooltip(state.usage_tooltip.as_deref().or(Some("WeWork"))) {
+        log::warn!("Failed to update tray tooltip: {error}");
+    }
+    Ok(())
 }
 
 #[cfg(not(desktop))]

--- a/wework/src/api/local/codexUsage.ts
+++ b/wework/src/api/local/codexUsage.ts
@@ -1,0 +1,126 @@
+import { ensureLocalExecutorStarted, requestLocalExecutor } from '@/tauri/localExecutor'
+import { getLocalCodexAuthStatus } from './runtimeAuthStatus'
+
+export interface CodexRateLimitWindow {
+  usedPercent: number
+  windowDurationMins: number | null
+  resetsAt: number | null
+}
+
+export interface CodexRateLimitSnapshot {
+  limitId: string | null
+  limitName: string | null
+  primary: CodexRateLimitWindow | null
+  secondary: CodexRateLimitWindow | null
+}
+
+export interface CodexRateLimitsResponse {
+  rateLimits: CodexRateLimitSnapshot
+  rateLimitsByLimitId: Record<string, CodexRateLimitSnapshot | undefined> | null
+}
+
+export interface CodexUsageWindowDisplay {
+  label: '5h' | '7d'
+  title: string
+  value: string
+  percent: number | null
+  resetsAt: number | null
+}
+
+export interface CodexUsageDisplay {
+  status: 'available' | 'none'
+  fiveHour: CodexUsageWindowDisplay
+  sevenDay: CodexUsageWindowDisplay
+  trayTitle: string
+  tooltip: string
+}
+
+const EMPTY_VALUE = '无'
+const FIVE_HOUR_MINUTES = 5 * 60
+const SEVEN_DAY_MINUTES = 7 * 24 * 60
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, Math.round(value)))
+}
+
+function remainingPercent(window: CodexRateLimitWindow | null | undefined): number | null {
+  if (!window || typeof window.usedPercent !== 'number') return null
+  return clampPercent(100 - window.usedPercent)
+}
+
+function emptyWindow(label: '5h' | '7d'): CodexUsageWindowDisplay {
+  return {
+    label,
+    title: label === '5h' ? '5小时额度' : '7天额度',
+    value: EMPTY_VALUE,
+    percent: null,
+    resetsAt: null,
+  }
+}
+
+function formatWindow(
+  label: '5h' | '7d',
+  window: CodexRateLimitWindow | null | undefined
+): CodexUsageWindowDisplay {
+  const percent = remainingPercent(window)
+  if (percent === null) {
+    return emptyWindow(label)
+  }
+  return {
+    label,
+    title: label === '5h' ? '5小时额度' : '7天额度',
+    value: `${percent}%`,
+    percent,
+    resetsAt: window?.resetsAt ?? null,
+  }
+}
+
+function windowsFromSnapshot(snapshot: CodexRateLimitSnapshot | null | undefined) {
+  const windows = [snapshot?.primary, snapshot?.secondary].filter(Boolean) as CodexRateLimitWindow[]
+  return {
+    fiveHour: windows.find(window => window.windowDurationMins === FIVE_HOUR_MINUTES) ?? null,
+    sevenDay: windows.find(window => window.windowDurationMins === SEVEN_DAY_MINUTES) ?? null,
+  }
+}
+
+function codexSnapshot(response: CodexRateLimitsResponse): CodexRateLimitSnapshot | null {
+  return response.rateLimitsByLimitId?.codex ?? response.rateLimits ?? null
+}
+
+export function formatCodexUsageDisplay(
+  response: CodexRateLimitsResponse | null | undefined
+): CodexUsageDisplay {
+  const snapshot = response ? codexSnapshot(response) : null
+  const windows = windowsFromSnapshot(snapshot)
+  const fiveHour = formatWindow('5h', windows.fiveHour)
+  const sevenDay = formatWindow('7d', windows.sevenDay)
+  const status = fiveHour.percent === null && sevenDay.percent === null ? 'none' : 'available'
+  const trayFiveHourValue = fiveHour.percent === null ? '--' : fiveHour.value
+  const traySevenDayValue = sevenDay.percent === null ? '--' : sevenDay.value
+  const trayTitle = `5h ${trayFiveHourValue}\n7d ${traySevenDayValue}`
+  return {
+    status,
+    fiveHour,
+    sevenDay,
+    trayTitle,
+    tooltip: `5小时额度 ${fiveHour.value}\n7天额度 ${sevenDay.value}`,
+  }
+}
+
+export function emptyCodexUsageDisplay(): CodexUsageDisplay {
+  return formatCodexUsageDisplay(null)
+}
+
+export async function getLocalCodexUsageDisplay(): Promise<CodexUsageDisplay> {
+  const authStatus = await getLocalCodexAuthStatus()
+  if (!authStatus.exists) {
+    return emptyCodexUsageDisplay()
+  }
+
+  await ensureLocalExecutorStarted()
+  const response = await requestLocalExecutor<CodexRateLimitsResponse>(
+    'runtime.codex.rate_limits.read'
+  )
+  return formatCodexUsageDisplay(response)
+}

--- a/wework/src/components/layout/DesktopSettingsMenu.test.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.test.tsx
@@ -17,9 +17,20 @@ vi.mock('@/features/app-update/app-update-context', () => ({
   useOptionalAppUpdate: () => mockUpdateState,
 }))
 
-vi.mock('@/api/quota', () => ({
-  createQuotaApi: () => ({
-    fetchQuota: vi.fn(),
+vi.mock('@/api/local/codexUsage', () => ({
+  emptyCodexUsageDisplay: () => ({
+    status: 'none',
+    fiveHour: { label: '5h', title: '5小时额度', value: '无', percent: null, resetsAt: null },
+    sevenDay: { label: '7d', title: '7天额度', value: '无', percent: null, resetsAt: null },
+    trayTitle: '5h --\n7d --',
+    tooltip: '5小时额度 无\n7天额度 无',
+  }),
+  getLocalCodexUsageDisplay: vi.fn().mockResolvedValue({
+    status: 'available',
+    fiveHour: { label: '5h', title: '5小时额度', value: '90%', percent: 90, resetsAt: null },
+    sevenDay: { label: '7d', title: '7天额度', value: '80%', percent: 80, resetsAt: null },
+    trayTitle: '5h 90%\n7d 80%',
+    tooltip: '5小时额度 90%\n7天额度 80%',
   }),
 }))
 
@@ -55,16 +66,12 @@ describe('DesktopSettingsMenu', () => {
     expect(mockCheckNow).toHaveBeenCalledTimes(1)
   })
 
-  test('renders the account area as a non-clickable muted group', () => {
+  test('does not render the old account or quota summary row', () => {
     renderMenu()
 
-    const accountGroup = screen.getByTestId('settings-account-group')
-    const accountItem = screen.getByTestId('account-menu-button')
-
-    expect(accountGroup).toHaveTextContent('user@example.com')
-    expect(accountItem.tagName).toBe('DIV')
-    expect(accountItem).toHaveClass('cursor-default', 'text-text-secondary')
-    expect(accountItem).not.toHaveClass('hover:bg-white/[0.08]')
+    expect(screen.queryByTestId('settings-account-group')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('account-menu-button')).not.toBeInTheDocument()
+    expect(screen.queryByText('Codex 额度')).not.toBeInTheDocument()
   })
 
   test('installs a discovered app update', async () => {

--- a/wework/src/components/layout/DesktopSettingsMenu.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.tsx
@@ -1,20 +1,15 @@
-import { ChevronDown, Clock, Download, Loader2, LogOut, Settings, User } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { ChevronDown, Clock, Download, Loader2, LogOut, Settings } from 'lucide-react'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { createHttpClient } from '@/api/http'
-import { createQuotaApi } from '@/api/quota'
-import type { QuotaData } from '@/api/quota'
+import {
+  emptyCodexUsageDisplay,
+  getLocalCodexUsageDisplay,
+  type CodexUsageDisplay,
+} from '@/api/local/codexUsage'
 import { KeyboardShortcut } from '@/components/common/KeyboardShortcut'
-import { getRuntimeConfig } from '@/config/runtime'
 import { useOptionalAppUpdate } from '@/features/app-update/app-update-context'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { User as UserProfile } from '@/types/api'
-
-function getQuotaUsagePercent(quota: QuotaData): number {
-  const rawPercent = quota.usage_rate * 100
-  if (!Number.isFinite(rawPercent)) return 0
-  return Math.min(100, Math.max(0, rawPercent))
-}
 
 function formatVersionTemplate(template: string, version: string): string {
   return template.replace('{{version}}', version)
@@ -26,23 +21,10 @@ interface DesktopSettingsMenuProps {
   onLogout: () => void
 }
 
-function getAccountInitials(label: string): string {
-  const normalizedLabel = label.trim()
-  if (!normalizedLabel) return 'U'
-  const [namePart] = normalizedLabel.split('@')
-  const words = namePart.split(/[._\-\s]+/).filter(Boolean)
-  if (words.length >= 2) return `${words[0][0]}${words[1][0]}`.toUpperCase()
-  return namePart.slice(0, 2).toUpperCase()
-}
-
-export function DesktopSettingsMenu({ user, onOpenSettings, onLogout }: DesktopSettingsMenuProps) {
+export function DesktopSettingsMenu({ onOpenSettings, onLogout }: DesktopSettingsMenuProps) {
   const { t } = useTranslation('common')
-  const quotaApi = useMemo(() => {
-    const { apiBaseUrl } = getRuntimeConfig()
-    return createQuotaApi(createHttpClient({ baseUrl: apiBaseUrl }))
-  }, [])
   const [isUsageExpanded, setIsUsageExpanded] = useState(false)
-  const [quota, setQuota] = useState<QuotaData | null>(null)
+  const [codexUsage, setCodexUsage] = useState<CodexUsageDisplay>(() => emptyCodexUsageDisplay())
   const [isQuotaLoading, setIsQuotaLoading] = useState(false)
   const [quotaError, setQuotaError] = useState<string | null>(null)
   const appUpdate = useOptionalAppUpdate()
@@ -51,34 +33,17 @@ export function DesktopSettingsMenu({ user, onOpenSettings, onLogout }: DesktopS
   const updateError = appUpdate?.error ?? null
   const checkNow = appUpdate?.checkNow
   const installUpdate = appUpdate?.installUpdate
-  const accountLabel = user?.email || user?.user_name || t('workbench.account_fallback', '当前账号')
-  const quotaUsageText = quota
-    ? `${quota.usage.toFixed(2)} / ${quota.quota.toLocaleString()} ${t('workbench.quota_unit_yuan', '元')}`
-    : ''
-  const quotaRemainingText = quota
-    ? `${t('workbench.quota_remaining_label', '剩余')} ${quota.remaining.toFixed(2)} ${t('workbench.quota_unit_yuan', '元')}`
-    : ''
-  const quotaUsagePercent = quota ? getQuotaUsagePercent(quota) : 0
-  const quotaUsagePercentValue = Math.round(quotaUsagePercent)
 
-  const handleUsageClick = () => {
-    const shouldExpand = !isUsageExpanded
-    setIsUsageExpanded(shouldExpand)
-
-    if (!shouldExpand || quota || isQuotaLoading) {
+  const loadCodexUsage = () => {
+    if (isQuotaLoading) {
       return
     }
 
     setIsQuotaLoading(true)
     setQuotaError(null)
-    quotaApi
-      .fetchQuota()
+    getLocalCodexUsageDisplay()
       .then(data => {
-        if (data) {
-          setQuota(data)
-        } else {
-          setQuotaError(t('workbench.quota_load_failed', '额度信息获取失败'))
-        }
+        setCodexUsage(data)
       })
       .catch(() => {
         setQuotaError(t('workbench.quota_load_failed', '额度信息获取失败'))
@@ -86,6 +51,15 @@ export function DesktopSettingsMenu({ user, onOpenSettings, onLogout }: DesktopS
       .finally(() => {
         setIsQuotaLoading(false)
       })
+  }
+
+  const handleUsageClick = () => {
+    const shouldExpand = !isUsageExpanded
+    setIsUsageExpanded(shouldExpand)
+
+    if (shouldExpand) {
+      loadCodexUsage()
+    }
   }
 
   const handleUpdateClick = async () => {
@@ -126,22 +100,6 @@ export function DesktopSettingsMenu({ user, onOpenSettings, onLogout }: DesktopS
       data-testid="settings-menu"
       className="absolute bottom-[72px] left-1.5 right-1.5 z-30 overflow-hidden rounded-[20px] border border-border/70 bg-popover/95 py-2.5 text-text-primary shadow-[0_24px_60px_rgba(0,0,0,0.36)] ring-1 ring-border/40 backdrop-blur-xl"
     >
-      <div data-testid="settings-account-group" className="px-4 pb-1">
-        <div className="flex h-9 items-center gap-3 text-[13px] font-medium leading-[18px] text-text-secondary">
-          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border/70 text-[10px] font-medium text-text-secondary">
-            {getAccountInitials(accountLabel)}
-          </div>
-          <span className="min-w-0 flex-1 truncate">{accountLabel}</span>
-        </div>
-        <div
-          data-testid="account-menu-button"
-          className="flex h-9 cursor-default items-center gap-3 text-[13px] font-medium leading-[18px] text-text-secondary"
-        >
-          <User className="h-4 w-4 shrink-0 text-text-secondary" />
-          <span>{t('workbench.personal_account', '个人账户')}</span>
-        </div>
-      </div>
-      <div className="mx-4 my-1.5 border-t border-border/70" />
       <SettingsMenuItem
         testId="settings-menu-button"
         icon={<Settings className="h-4 w-4 shrink-0 text-text-secondary" />}
@@ -203,23 +161,15 @@ export function DesktopSettingsMenu({ user, onOpenSettings, onLogout }: DesktopS
           {quotaError ? (
             <div className="py-1 text-[13px] leading-[18px] text-text-secondary">{quotaError}</div>
           ) : null}
-          {quota ? (
+          {!quotaError ? (
             <div className="space-y-1.5 text-xs leading-5 text-text-secondary">
-              <div className="whitespace-nowrap font-semibold text-text-primary">
-                {quotaUsageText}
+              <div className="flex items-center justify-between gap-3 whitespace-nowrap">
+                <span>{codexUsage.fiveHour.title}</span>
+                <span className="font-semibold text-text-primary">{codexUsage.fiveHour.value}</span>
               </div>
-              <div className="whitespace-nowrap">{quotaRemainingText}</div>
-              <div
-                role="progressbar"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={quotaUsagePercentValue}
-                className="h-1.5 overflow-hidden rounded-full bg-white/10"
-              >
-                <div
-                  className="h-full rounded-full bg-primary"
-                  style={{ width: `${quotaUsagePercent}%` }}
-                />
+              <div className="flex items-center justify-between gap-3 whitespace-nowrap">
+                <span>{codexUsage.sevenDay.title}</span>
+                <span className="font-semibold text-text-primary">{codexUsage.sevenDay.value}</span>
               </div>
             </div>
           ) : null}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ProjectChatControls } from '@/components/chat/ChatInput'
 import { createDeviceApi } from '@/api/devices'
+import { getLocalCodexUsageDisplay } from '@/api/local/codexUsage'
 import { createProjectApi } from '@/api/projects'
-import { createQuotaApi } from '@/api/quota'
 import { AuthContext } from '@/features/auth/useAuth'
 import { WorkbenchContext, WorkbenchPaneContext } from '@/features/workbench/useWorkbench'
 import type {
@@ -160,8 +160,15 @@ vi.mock('@/api/projects', () => ({
   createProjectApi: vi.fn(),
 }))
 
-vi.mock('@/api/quota', () => ({
-  createQuotaApi: vi.fn(),
+vi.mock('@/api/local/codexUsage', () => ({
+  emptyCodexUsageDisplay: () => ({
+    status: 'none',
+    fiveHour: { label: '5h', title: '5小时额度', value: '无', percent: null, resetsAt: null },
+    sevenDay: { label: '7d', title: '7天额度', value: '无', percent: null, resetsAt: null },
+    trayTitle: '5h --\n7d --',
+    tooltip: '5小时额度 无\n7天额度 无',
+  }),
+  getLocalCodexUsageDisplay: vi.fn(),
 }))
 
 vi.mock('@/features/auth/useAuth', async importOriginal => ({
@@ -347,14 +354,13 @@ vi.mock('./workspace-panels/EmbeddedLocalTerminal', () => ({
 
 const createDeviceApiMock = vi.mocked(createDeviceApi)
 const createProjectApiMock = vi.mocked(createProjectApi)
-const createQuotaApiMock = vi.mocked(createQuotaApi)
+const getLocalCodexUsageDisplayMock = vi.mocked(getLocalCodexUsageDisplay)
 const closeLocalTerminalMock = vi.mocked(closeLocalTerminal)
 const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const localPathExistsMock = vi.mocked(localPathExists)
 const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startLocalTerminalMock = vi.mocked(startLocalTerminal)
-const fetchQuotaMock = vi.fn()
 const startTerminalSessionMock = vi.fn()
 const startCodeServerSessionMock = vi.fn()
 
@@ -483,15 +489,12 @@ describe('DesktopWorkbenchLayout', () => {
     openExternalUrlMock.mockResolvedValue(true)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
-    fetchQuotaMock.mockResolvedValue({
-      quota: 748,
-      usage: 747.74,
-      remaining: 0.26,
-      usage_rate: 0.9997,
-      user: 'yunpeng7',
-    })
-    createQuotaApiMock.mockReturnValue({
-      fetchQuota: fetchQuotaMock,
+    getLocalCodexUsageDisplayMock.mockResolvedValue({
+      status: 'available',
+      fiveHour: { label: '5h', title: '5小时额度', value: '87%', percent: 87, resetsAt: null },
+      sevenDay: { label: '7d', title: '7天额度', value: '42%', percent: 42, resetsAt: null },
+      trayTitle: '5h 87%\n7d 42%',
+      tooltip: '5小时额度 87%\n7天额度 42%',
     })
     createDeviceApiMock.mockReturnValue(createMockDeviceApi() as never)
     startCodeServerSessionMock.mockResolvedValue({
@@ -2296,7 +2299,7 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('settings-button'))
 
     expect(screen.getByTestId('settings-menu')).toBeInTheDocument()
-    expect(screen.getByText('个人账户')).toBeInTheDocument()
+    expect(screen.queryByText('Codex 额度')).not.toBeInTheDocument()
     expect(screen.getByTestId('settings-menu-button')).toHaveTextContent('设置')
     expect(screen.getByTestId('settings-menu-button')).toHaveTextContent('⌘,')
     expect(screen.getByText('剩余用量')).toBeInTheDocument()
@@ -2329,17 +2332,19 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('settings-button'))
     await userEvent.click(screen.getByTestId('usage-menu-button'))
 
-    await waitFor(() => expect(fetchQuotaMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(getLocalCodexUsageDisplayMock).toHaveBeenCalled())
 
     const usagePanel = await screen.findByTestId('usage-detail-panel')
     expect(within(usagePanel).queryByText('模型额度')).not.toBeInTheDocument()
-    expect(usagePanel).toHaveTextContent('747.74 / 748 元')
-    expect(usagePanel).toHaveTextContent('剩余 0.26 元')
+    expect(usagePanel).toHaveTextContent('5小时额度')
+    expect(usagePanel).toHaveTextContent('87%')
+    expect(usagePanel).toHaveTextContent('7天额度')
+    expect(usagePanel).toHaveTextContent('42%')
     expect(usagePanel).not.toHaveTextContent('使用率')
     expect(usagePanel).not.toHaveTextContent('总额度')
     expect(usagePanel).not.toHaveTextContent('额度与计费说明')
     expect(usagePanel).not.toHaveClass('pl-12')
-    expect(within(usagePanel).getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100')
+    expect(within(usagePanel).queryByRole('progressbar')).not.toBeInTheDocument()
   })
 
   test('opens the project create menu from the sidebar project create button', async () => {

--- a/wework/src/pages/WorkbenchPage.tsx
+++ b/wework/src/pages/WorkbenchPage.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  emptyCodexUsageDisplay,
+  getLocalCodexUsageDisplay,
+  type CodexUsageDisplay,
+} from '@/api/local/codexUsage'
 import { DesktopWorkbenchLayout } from '@/components/layout/DesktopWorkbenchLayout'
 import { MobileWorkbenchLayout } from '@/components/layout/MobileWorkbenchLayout'
 import { useWorkbench } from '@/features/workbench/useWorkbench'
@@ -12,14 +17,46 @@ export function WorkbenchPage() {
   const isMobileViewport = useIsMobile()
   const isTauri = isTauriRuntime()
   const { state } = useWorkbench()
+  const [codexUsage, setCodexUsage] = useState<CodexUsageDisplay>(() => emptyCodexUsageDisplay())
   const trayMenuTaskGroups = useMemo(
     () => buildTrayMenuTaskGroups(state.runtimeWork),
     [state.runtimeWork]
   )
 
   useEffect(() => {
-    syncTrayMenuState(trayMenuTaskGroups)
-  }, [trayMenuTaskGroups])
+    syncTrayMenuState(trayMenuTaskGroups, undefined, {
+      title: codexUsage.trayTitle,
+      tooltip: codexUsage.tooltip,
+    })
+  }, [trayMenuTaskGroups, codexUsage])
+
+  useEffect(() => {
+    if (!isTauri) {
+      return
+    }
+
+    let cancelled = false
+    const refreshUsage = () => {
+      getLocalCodexUsageDisplay()
+        .then(usage => {
+          if (!cancelled) {
+            setCodexUsage(usage)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setCodexUsage(emptyCodexUsageDisplay())
+          }
+        })
+    }
+
+    refreshUsage()
+    const interval = window.setInterval(refreshUsage, 60_000)
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [isTauri])
 
   return shouldUseMobileWorkbenchLayout({ isMobileViewport, isTauri }) ? (
     <MobileWorkbenchLayout />

--- a/wework/src/tauri/trayNavigation.test.ts
+++ b/wework/src/tauri/trayNavigation.test.ts
@@ -136,6 +136,8 @@ describe('trayNavigation', () => {
     expect(invokeMock).toHaveBeenCalledWith(SET_TRAY_MENU_STATE_COMMAND, {
       state: {
         language: 'en',
+        usageTitle: null,
+        usageTooltip: null,
         running: [],
         runningMore: [],
         pinned: [],
@@ -154,11 +156,16 @@ describe('trayNavigation', () => {
       recent: [{ id: 'task-1', title: 'Running task', projectName: 'Wegent' }],
       recentMore: [],
     }
-    syncTrayMenuState(taskGroups, 'en-US')
+    syncTrayMenuState(taskGroups, 'en-US', {
+      title: '5h 90%\n7d 80%',
+      tooltip: '5小时额度 90%\n7天额度 80%',
+    })
 
     expect(invokeMock).toHaveBeenLastCalledWith(SET_TRAY_MENU_STATE_COMMAND, {
       state: {
         language: 'en',
+        usageTitle: '5h 90%\n7d 80%',
+        usageTooltip: '5小时额度 90%\n7天额度 80%',
         ...taskGroups,
       },
     })
@@ -168,6 +175,8 @@ describe('trayNavigation', () => {
     expect(invokeMock).toHaveBeenLastCalledWith(SET_TRAY_MENU_STATE_COMMAND, {
       state: {
         language: 'zh-CN',
+        usageTitle: '5h 90%\n7d 80%',
+        usageTooltip: '5小时额度 90%\n7天额度 80%',
         ...taskGroups,
       },
     })

--- a/wework/src/tauri/trayNavigation.ts
+++ b/wework/src/tauri/trayNavigation.ts
@@ -14,6 +14,8 @@ let traySettingsNavigationListener: Promise<UnlistenFn> | null = null
 let trayTaskNavigationListener: Promise<UnlistenFn> | null = null
 let trayLanguageSyncInstalled = false
 let latestTrayTaskGroups = EMPTY_TRAY_MENU_TASK_GROUPS
+let latestUsageTitle: string | null = null
+let latestUsageTooltip: string | null = null
 
 function getTrayLanguage(language?: string): string {
   return language?.toLowerCase().startsWith('en') ? 'en' : 'zh-CN'
@@ -22,15 +24,22 @@ function getTrayLanguage(language?: string): string {
 function getTrayMenuState(language = i18n.resolvedLanguage || i18n.language) {
   return {
     language: getTrayLanguage(language),
+    usageTitle: latestUsageTitle,
+    usageTooltip: latestUsageTooltip,
     ...latestTrayTaskGroups,
   }
 }
 
 export function syncTrayMenuState(
   taskGroups: TrayMenuTaskGroups = latestTrayTaskGroups,
-  language = i18n.resolvedLanguage || i18n.language
+  language = i18n.resolvedLanguage || i18n.language,
+  usage?: { title: string | null; tooltip: string | null }
 ) {
   latestTrayTaskGroups = taskGroups
+  if (usage) {
+    latestUsageTitle = usage.title
+    latestUsageTooltip = usage.tooltip
+  }
 
   if (!isTauriRuntime()) {
     return


### PR DESCRIPTION
## Summary
- show local Codex remaining usage in the Wework system tray with compact 5h/7d percentages
- read Codex rate-limit snapshots through the local executor when a local Codex account exists, otherwise show none
- remove the Codex quota row from the settings menu and document the local usage-display behavior

## Testing
- pnpm --filter wework test -- DesktopSettingsMenu DesktopWorkbenchLayout trayNavigation
- cargo check --manifest-path wework/src-tauri/Cargo.toml
- cargo check --manifest-path executor/Cargo.toml
- pre-push: Wework ESLint, TypeScript, unit tests; executor cargo fmt, cargo test --all-features --lib, cargo clippy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local Codex usage display in the desktop settings menu and system tray.
  * Shows remaining usage for 5-hour and 7-day windows, refreshing every 60 seconds.
  * When no local account is present, the UI now shows a clear “none” state.

* **Bug Fixes**
  * Removed the old quota-style account summary and progress bar from the menu.
  * Tray labels and tooltips now stay in sync with the latest usage status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->