### PR TITLE
[codex] fix wework chat turn navigation overlap

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1317,9 +1317,9 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(screen.getByTestId('desktop-chat-scroll-content')).not.toHaveClass('justify-end')
     expect(screen.getByTestId('desktop-chat-scroll-content').firstElementChild).toHaveClass(
-      'w-[min(46rem,calc(100%_-_2rem))]',
+      'w-[min(46rem,calc(100%_-_6rem))]',
       'min-w-0',
-      'max-w-[calc(100%_-_2rem)]',
+      'max-w-[calc(100%_-_6rem)]',
       'px-0'
     )
     expect(screen.getByTestId('desktop-floating-composer-backdrop')).toHaveClass(
@@ -3669,9 +3669,9 @@ describe('DesktopWorkbenchLayout', () => {
       'max-w-[calc(100%_-_2rem)]'
     )
     expect(screen.getByTestId('desktop-chat-scroll-content').firstElementChild).toHaveClass(
-      'w-[min(46rem,calc(100%_-_2rem))]',
+      'w-[min(46rem,calc(100%_-_6rem))]',
       'min-w-0',
-      'max-w-[calc(100%_-_2rem)]',
+      'max-w-[calc(100%_-_6rem)]',
       'px-0'
     )
   })

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -77,11 +77,12 @@ import { BufferedChatInput } from './BufferedChatInput'
 const DESKTOP_CHAT_CONTENT_BASE_CLASS =
   'mx-auto min-w-0 px-0 transition-[width,max-width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'
 const DESKTOP_CHAT_CONTENT_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(46rem,calc(100%_-_2rem))] max-w-[calc(100%_-_2rem)]`
+const DESKTOP_MESSAGE_LIST_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(46rem,calc(100%_-_6rem))] max-w-[calc(100%_-_6rem)]`
 const DESKTOP_COMPOSER_FRAME_CLASS = `${DESKTOP_CHAT_CONTENT_WIDTH_CLASS} -translate-y-12`
 const DESKTOP_FLOATING_COMPOSER_CLASS =
   'pointer-events-none absolute bottom-2 left-1/2 z-chrome -translate-x-1/2'
 const DESKTOP_FLOATING_COMPOSER_LAYER_CLASS = `${DESKTOP_FLOATING_COMPOSER_CLASS} ${DESKTOP_CHAT_CONTENT_WIDTH_CLASS}`
-const DESKTOP_MESSAGE_LIST_CLASS = `${DESKTOP_CHAT_CONTENT_WIDTH_CLASS} px-0`
+const DESKTOP_MESSAGE_LIST_CLASS = `${DESKTOP_MESSAGE_LIST_WIDTH_CLASS} px-0`
 const DESKTOP_FLOATING_COMPOSER_BACKDROP_CLASS =
   'pointer-events-none absolute left-0 right-8 bottom-0 z-10 h-32 bg-gradient-to-t from-background via-background to-transparent'
 const DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS =

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -15,7 +15,7 @@ import type {
 import type { WorkbenchMessage } from '@/types/workbench'
 import { reduceWorkbenchMessages } from '@wegent/chat-core'
 
-const SIDE_CHAT_MESSAGE_LIST_CLASS = 'w-full max-w-none px-5 pb-4 pt-5'
+const SIDE_CHAT_MESSAGE_LIST_CLASS = 'w-full max-w-none px-5 pb-4 pt-5 lg:pl-14'
 
 function createUserMessage(content: string): WorkbenchMessage {
   const createdAt = new Date().toISOString()


### PR DESCRIPTION
## Summary

Fixes a narrow-width Wework chat layout issue where the left-side message turn navigation rail could overlap the transcript text.

## Root Cause

The desktop transcript column kept using the same `calc(100% - 2rem)` width as the floating composer. When the chat column was narrowed, the absolutely positioned turn navigation rail had no reserved horizontal space, so it could sit on top of message content.

## Changes

- Give the desktop message list its own width constraint with extra left-side clearance for the turn navigation rail.
- Keep the floating composer at its existing width so input sizing remains unchanged.
- Add left-side clearance for temporary chat panels when the turn navigation rail is visible.
- Update desktop layout assertions for the new message-list width constraint.

## Validation

- `pnpm --filter wework test -- DesktopWorkbenchLayout.test.tsx`
- Pre-push hook: ESLint passed, TypeScript passed, unit tests passed.

Docs were checked; this is a local UI layout fix and does not require AGENTS.md or README updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted chat and composer layout spacing on large screens for a more consistent message area.
  * Fixed floating composer sizing in split-column and overlay layouts.
  * Refined side chat padding so content aligns better in the workspace panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->