### PR TITLE
[codex] stream Codex command output

### DIFF
--- a/executor/src/runtime_work/codex_notifications.rs
+++ b/executor/src/runtime_work/codex_notifications.rs
@@ -75,6 +75,7 @@ pub(crate) fn debug_ignored_codex_notification(message: &Value, method: &str, pa
 
 fn wrapped_item_method(wrapper_type: &str, payload_type: &str) -> Option<&'static str> {
     match (wrapper_type, payload_type) {
+        ("eventmsg", "execcommandoutputdelta") => Some("item/commandExecution/outputDelta"),
         ("eventmsg", "agentmessage") | ("responseitem", "message") => Some("item/completed"),
         ("eventmsg", "subagentactivity") | ("responseitem", "subagentactivity") => {
             Some("subagent/activity")

--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -13,7 +13,7 @@ use super::{
     codex_notifications::{codex_notification, debug_ignored_codex_notification},
     notification_mapping::{
         log_dropped_notification, log_stream_text_mapping, log_text_mapping, map_text_chunk,
-        notification_item_id, TextChunkMapping,
+        map_tool_output_delta, notification_item_id, TextChunkMapping,
     },
     transcript::{
         completed_workbench_block_from_notification, file_changes_block_from_patch_updated,
@@ -87,6 +87,7 @@ pub(crate) struct CodexNotificationEventMapper {
     process_text_count: usize,
     final_text_offset: usize,
     plan_blocks: BTreeMap<String, String>,
+    tool_output_deltas: BTreeMap<String, String>,
 }
 
 struct ProcessTextStream {
@@ -162,6 +163,16 @@ impl CodexNotificationEventMapper {
                     request,
                     notification.params,
                     message.get("id"),
+                );
+            }
+            "item/tool/outputDelta"
+            | "item/commandExecution/outputDelta"
+            | "process/outputDelta"
+            | "command/exec/outputDelta" => {
+                self.emit_tool_output_delta(
+                    &emit_context,
+                    &notification.method,
+                    notification.params,
                 );
             }
             "item/plan/delta" => {
@@ -308,6 +319,48 @@ impl CodexNotificationEventMapper {
                 );
             }
         }
+    }
+
+    fn emit_tool_output_delta(
+        &mut self,
+        emit_context: &EventEmitContext<'_>,
+        method: &str,
+        params: &Value,
+    ) {
+        let mapping = match map_tool_output_delta(method, params) {
+            Ok(Some(mapping)) => mapping,
+            Ok(None) => return,
+            Err(reason) => {
+                log_dropped_notification(
+                    emit_context.local_task_id,
+                    &emit_context.request.task_id,
+                    &emit_context.request.subtask_id,
+                    method,
+                    params,
+                    reason,
+                );
+                return;
+            }
+        };
+        let content = self
+            .tool_output_deltas
+            .entry(mapping.tool_use_id.clone())
+            .or_default();
+        content.push_str(&mapping.delta);
+        emit_response_event(
+            emit_context.event_tx,
+            emit_context.device_id,
+            "response.block.updated",
+            emit_context.local_task_id,
+            emit_context.request,
+            json!({
+                "block_id": mapping.tool_use_id,
+                "updates": {
+                    "tool_output": content.clone(),
+                    "status": "streaming",
+                }
+            }),
+        );
     }
 
     fn emit_process_text_delta(
@@ -2513,6 +2566,67 @@ mod tests {
         assert_eq!(block["status"], "pending");
         assert_eq!(block["render_payload"]["kind"], "request_user_input");
         assert_eq!(block["render_payload"]["questions"][0]["id"], "goal");
+    }
+
+    #[test]
+    fn maps_codex_exec_output_delta_to_tool_output_update() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: "7".to_owned(),
+            subtask_id: "8".to_owned(),
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "exec_command_output_delta",
+                    "call_id": "call-1",
+                    "stream": "stdout",
+                    "chunk": "one"
+                }
+            }),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "exec_command_output_delta",
+                    "call_id": "call-1",
+                    "stream": "stdout",
+                    "chunk": " two"
+                }
+            }),
+        );
+
+        let first = event_rx
+            .try_recv()
+            .expect("first output delta should update the tool block");
+        assert_eq!(first["event"], "response.block.updated");
+        assert_eq!(first["payload"]["data"]["block_id"], "call-1");
+        assert_eq!(first["payload"]["data"]["updates"]["tool_output"], "one");
+        assert_eq!(first["payload"]["data"]["updates"]["status"], "streaming");
+
+        let second = event_rx
+            .try_recv()
+            .expect("second output delta should update the tool block");
+        assert_eq!(second["event"], "response.block.updated");
+        assert_eq!(second["payload"]["data"]["block_id"], "call-1");
+        assert_eq!(
+            second["payload"]["data"]["updates"]["tool_output"],
+            "one two"
+        );
+        assert_eq!(second["payload"]["data"]["updates"]["status"], "streaming");
     }
 
     #[test]

--- a/executor/src/runtime_work/notification_mapping.rs
+++ b/executor/src/runtime_work/notification_mapping.rs
@@ -4,6 +4,7 @@
 
 use std::{env, sync::OnceLock};
 
+use base64::{engine::general_purpose, Engine as _};
 use serde_json::Value;
 
 use crate::{
@@ -31,6 +32,12 @@ pub(crate) enum TextChunkMapping {
         text: String,
     },
     FinalCompleted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolOutputDeltaMapping {
+    pub(crate) tool_use_id: String,
+    pub(crate) delta: String,
 }
 
 pub(crate) fn map_text_chunk(
@@ -87,6 +94,37 @@ pub(crate) fn map_text_chunk(
     }
 }
 
+pub(crate) fn map_tool_output_delta(
+    method: &str,
+    params: &Value,
+) -> Result<Option<ToolOutputDeltaMapping>, &'static str> {
+    if method != "item/tool/outputDelta"
+        && method != "item/commandExecution/outputDelta"
+        && method != "process/outputDelta"
+        && method != "command/exec/outputDelta"
+    {
+        return Ok(None);
+    }
+
+    let tool_use_id = string_field(params, "call_id")
+        .or_else(|| string_field(params, "callId"))
+        .or_else(|| string_field(params, "itemId"))
+        .or_else(|| string_field(params, "item_id"))
+        .or_else(|| string_field(params, "processId"))
+        .or_else(|| string_field(params, "process_id"))
+        .or_else(|| string_field(params, "processHandle"))
+        .or_else(|| string_field(params, "process_handle"))
+        .ok_or("missing_tool_output_delta_id")?;
+    let delta = raw_string_field(params, "chunk")
+        .or_else(|| raw_string_field(params, "delta"))
+        .or_else(|| decoded_base64_field(params, "deltaBase64"))
+        .or_else(|| decoded_base64_field(params, "delta_base64"))
+        .filter(|delta| !delta.is_empty())
+        .ok_or("missing_tool_output_delta")?;
+
+    Ok(Some(ToolOutputDeltaMapping { tool_use_id, delta }))
+}
+
 pub(crate) fn notification_item_id(params: &Value) -> Option<String> {
     params
         .get("item")
@@ -94,6 +132,12 @@ pub(crate) fn notification_item_id(params: &Value) -> Option<String> {
         .or_else(|| string_field(params, "itemId"))
         .or_else(|| string_field(params, "item_id"))
         .or_else(|| codex_item_id(params))
+}
+
+fn decoded_base64_field(value: &Value, key: &str) -> Option<String> {
+    let encoded = raw_string_field(value, key)?;
+    let bytes = general_purpose::STANDARD.decode(encoded).ok()?;
+    Some(String::from_utf8_lossy(&bytes).to_string())
 }
 
 pub(crate) fn log_dropped_notification(

--- a/executor/src/runtime_work/runtime_handle_messages.rs
+++ b/executor/src/runtime_work/runtime_handle_messages.rs
@@ -12,7 +12,7 @@ use super::{
     codex_notifications::{codex_notification, debug_ignored_codex_notification},
     notification_mapping::{
         log_dropped_notification, log_stream_text_mapping, log_text_mapping, map_text_chunk,
-        notification_item_id, TextChunkMapping,
+        map_tool_output_delta, notification_item_id, TextChunkMapping,
     },
     response::RuntimeTaskLink,
     store::RuntimeWorkStore,
@@ -108,6 +108,29 @@ impl CodexNotificationCacheMapper {
                     params,
                     phase.as_deref(),
                 );
+            }
+            "item/tool/outputDelta"
+            | "item/commandExecution/outputDelta"
+            | "process/outputDelta"
+            | "command/exec/outputDelta" => {
+                match map_tool_output_delta(&notification.method, params) {
+                    Ok(Some(mapping)) => append_runtime_assistant_tool_output_delta(
+                        store,
+                        local_task_id,
+                        request,
+                        &mapping.tool_use_id,
+                        mapping.delta,
+                    ),
+                    Ok(None) => {}
+                    Err(reason) => log_dropped_notification(
+                        local_task_id,
+                        &request.task_id,
+                        &request.subtask_id,
+                        &notification.method,
+                        params,
+                        reason,
+                    ),
+                }
             }
             "item/plan/delta" => {
                 if let Some(delta) =
@@ -521,6 +544,18 @@ fn update_runtime_assistant_block(
     });
 }
 
+fn append_runtime_assistant_tool_output_delta(
+    store: &RuntimeWorkStore,
+    local_task_id: &str,
+    request: &ExecutionRequest,
+    tool_use_id: &str,
+    delta: String,
+) {
+    mutate_cached_assistant_blocks(store, local_task_id, request, |blocks| {
+        append_tool_output_delta(blocks, tool_use_id, delta);
+    });
+}
+
 fn append_runtime_assistant_process_delta(
     store: &RuntimeWorkStore,
     local_task_id: &str,
@@ -881,6 +916,26 @@ fn update_cached_block(blocks: &mut [Value], block_id: &str, updates: Value) {
     }
 }
 
+fn append_tool_output_delta(blocks: &mut [Value], tool_use_id: &str, delta: String) {
+    let Some(block) = blocks.iter_mut().rev().find(|block| {
+        block_identity(block).as_deref() == Some(tool_use_id)
+            || string_field(block, "tool_use_id").as_deref() == Some(tool_use_id)
+    }) else {
+        return;
+    };
+    let Some(object) = block.as_object_mut() else {
+        return;
+    };
+    let mut output = object
+        .get("tool_output")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    output.push_str(&delta);
+    object.insert("tool_output".to_owned(), Value::String(output));
+    object.insert("status".to_owned(), Value::String("streaming".to_owned()));
+}
+
 fn block_identity(block: &Value) -> Option<String> {
     string_field(block, "id").or_else(|| string_field(block, "tool_use_id"))
 }
@@ -1230,6 +1285,78 @@ mod tests {
         assert_eq!(messages[0]["blocks"][0]["type"], "tool");
         assert_eq!(messages[0]["blocks"][0]["tool_name"], "context_compaction");
         assert_eq!(messages[0]["blocks"][0]["status"], "done");
+
+        let _ = fs::remove_file(index_path);
+    }
+
+    #[test]
+    fn cache_codex_notification_appends_exec_output_delta_to_tool_block() {
+        let index_path = temp_index_path("exec-output-delta-cache");
+        let store = RuntimeWorkStore::new(index_path.clone());
+        let local_task_id = "runtime-cache";
+        store.upsert_task(RuntimeTaskLink::new_pending(
+            local_task_id.to_owned(),
+            "/tmp/project".to_owned(),
+            "Runtime cache".to_owned(),
+        ));
+        let request = ExecutionRequest {
+            task_id: "1".to_owned(),
+            subtask_id: "42".to_owned(),
+            ..ExecutionRequest::default()
+        };
+
+        cache_codex_notification(
+            &store,
+            local_task_id,
+            &request,
+            &json!({
+                "type": "response_item",
+                "payload": {
+                    "id": "call-1",
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"printf hello\"}"
+                }
+            }),
+        );
+        cache_codex_notification(
+            &store,
+            local_task_id,
+            &request,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "exec_command_output_delta",
+                    "call_id": "call-1",
+                    "stream": "stdout",
+                    "chunk": "hello"
+                }
+            }),
+        );
+        cache_codex_notification(
+            &store,
+            local_task_id,
+            &request,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "exec_command_output_delta",
+                    "call_id": "call-1",
+                    "stream": "stdout",
+                    "chunk": "\n"
+                }
+            }),
+        );
+
+        let link = store
+            .get_task(local_task_id)
+            .expect("runtime task should exist");
+        let messages = cached_messages(&link);
+        let block = &messages[0]["blocks"][0];
+        assert_eq!(block["tool_name"], "exec_command");
+        assert_eq!(block["tool_output"], "hello\n");
+        assert_eq!(block["status"], "streaming");
 
         let _ = fs::remove_file(index_path);
     }


### PR DESCRIPTION
## What changed
- Handle Codex `item/commandExecution/outputDelta` notifications as live tool output updates.
- Map wrapped `exec_command_output_delta` events to the Codex command execution delta method.
- Accumulate streaming command output in both live response events and cached runtime work messages.
- Add regression coverage for live event mapping and cached tool output updates.

## Why
Codex app-server emits agent command stdout/stderr deltas as `item/commandExecution/outputDelta`. Wegent did not handle that event name, so command output only appeared after `item/completed` delivered `aggregatedOutput` instead of streaming while the process was running.

## Validation
- `cargo fmt --manifest-path executor/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml runtime_work --lib`
- `cargo test --manifest-path executor/Cargo.toml runtime_work --tests`
- Pre-push hook: `cargo fmt --check`, `cargo test --all-features --lib`, `cargo clippy`

## Docs
Checked runtime/local executor documentation. No documentation update is needed because this is an internal Codex notification mapping fix with no API, configuration, or user workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool execution output now streams in smaller chunks and updates progressively instead of waiting for the full result.
  * Multiple output-delta event formats are now recognized, improving compatibility across command and tool execution flows.

* **Bug Fixes**
  * Repeated tool output updates now correctly accumulate into a single live response block.
  * Streaming tool output is now marked consistently as in-progress while new chunks arrive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->