### PR TITLE
[codex] fix Wework browser bounds sync timers

### DIFF
--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -495,6 +495,7 @@ export function WorkspaceBrowserPanel({
   const handledOpenRequestIdRef = useRef<number | null>(null)
   const syncBoundsTimerRef = useRef<number | null>(null)
   const syncBoundsAnimationFrameRef = useRef<number | null>(null)
+  const postOpenSyncTimerRefs = useRef<number[]>([])
   const annotationEmptyPollLogCountRef = useRef(0)
   const [debugPanelExpanded, setDebugPanelExpanded] = useState(false)
   const [address, setAddress] = useState('')
@@ -608,13 +609,28 @@ export function WorkspaceBrowserPanel({
     }
   }, [annotationMode, codeCommentCount, exitAnnotationMode])
 
+  const clearScheduledBoundsSync = useCallback(() => {
+    if (syncBoundsAnimationFrameRef.current !== null) {
+      window.cancelAnimationFrame(syncBoundsAnimationFrameRef.current)
+      syncBoundsAnimationFrameRef.current = null
+    }
+    if (syncBoundsTimerRef.current !== null) {
+      window.clearTimeout(syncBoundsTimerRef.current)
+      syncBoundsTimerRef.current = null
+    }
+    postOpenSyncTimerRefs.current.forEach(timer => window.clearTimeout(timer))
+    postOpenSyncTimerRefs.current = []
+  }, [])
+
   const scheduleEmbeddedBrowserBoundsSync = useCallback(
     (visible = active) => {
       if (syncBoundsAnimationFrameRef.current !== null) {
         window.cancelAnimationFrame(syncBoundsAnimationFrameRef.current)
+        syncBoundsAnimationFrameRef.current = null
       }
       if (syncBoundsTimerRef.current !== null) {
         window.clearTimeout(syncBoundsTimerRef.current)
+        syncBoundsTimerRef.current = null
       }
 
       syncBoundsAnimationFrameRef.current = window.requestAnimationFrame(() => {
@@ -636,13 +652,19 @@ export function WorkspaceBrowserPanel({
   const schedulePostOpenBoundsSync = useCallback(
     (visible = active) => {
       EMBEDDED_BROWSER_POST_OPEN_SYNC_DELAYS_MS.forEach(delay => {
-        window.setTimeout(() => {
+        const timer = window.setTimeout(() => {
+          postOpenSyncTimerRefs.current = postOpenSyncTimerRefs.current.filter(
+            pendingTimer => pendingTimer !== timer
+          )
           scheduleEmbeddedBrowserBoundsSync(visible)
         }, delay)
+        postOpenSyncTimerRefs.current.push(timer)
       })
     },
     [active, scheduleEmbeddedBrowserBoundsSync]
   )
+
+  useEffect(() => clearScheduledBoundsSync, [clearScheduledBoundsSync])
 
   const refreshPageState = useCallback(async () => {
     if (!embeddedBrowserAvailable || !nativeBrowserOpenRef.current) return
@@ -790,15 +812,11 @@ export function WorkspaceBrowserPanel({
       observer.disconnect()
       window.removeEventListener('resize', handleBoundsChange)
       window.visualViewport?.removeEventListener('resize', handleBoundsChange)
-      if (syncBoundsAnimationFrameRef.current !== null) {
-        window.cancelAnimationFrame(syncBoundsAnimationFrameRef.current)
-      }
-      if (syncBoundsTimerRef.current !== null) {
-        window.clearTimeout(syncBoundsTimerRef.current)
-      }
+      clearScheduledBoundsSync()
     }
   }, [
     active,
+    clearScheduledBoundsSync,
     currentUrl,
     embeddedBrowserAvailable,
     scheduleEmbeddedBrowserBoundsSync,


### PR DESCRIPTION
## Summary
- Track post-open embedded browser bounds sync timers in `WorkspaceBrowserPanel`.
- Clear pending animation frames, debounce timers, and post-open retry timers during cleanup.

## Root cause
The Wework test job failed because post-open bounds sync timers could outlive the jsdom test environment. After teardown, a pending timer called `window.clearTimeout` or `window.requestAnimationFrame`, causing `ReferenceError: window is not defined`.

## Validation
- `pnpm --dir wework exec vitest run src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx --coverage --passWithNoTests`
- `pnpm --dir wework exec vitest run --coverage --passWithNoTests`
- Pre-push Wework gate: ESLint, TypeScript, unit tests passed

Docs were checked; this is an internal lifecycle cleanup with no user-facing behavior, API, or setup documentation change.