### PR TITLE
[codex] Announce Wework desktop release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ English | [简体中文](README_zh.md)
 
 </div>
 
+> **Wework Desktop is now available.** Download the latest desktop build from [Wework Releases](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true), then choose the newest Wework release and the installer package that matches your operating system.
+
 ---
 
 ## Why Wegent

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,6 +18,8 @@
 
 </div>
 
+> **Wework 桌面端已发布。** 你可以从 [Wework Releases](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true) 下载最新桌面版本，并选择最新的 Wework 发布和与你的操作系统匹配的安装包。
+
 ---
 
 ## 为什么选择 Wegent


### PR DESCRIPTION
## What changed

- Added a prominent centered Wework Desktop release banner near the top of the English README.
- Added the same banner to the Chinese README.
- Linked to a focused Wework GitHub Releases search using `q=Wework macOS DMG build`.

## Why

Wework desktop builds are published in the Wegent GitHub Releases page with release notes that include `Wework macOS DMG build`. The README should make the download path highly visible on first load while avoiding a fixed version URL that would go stale after the next Wework release.

## Validation

- Updated the link to `https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true`.
- Reviewed the README diff.
- No code tests run; this is a documentation-only change.