### PR TITLE
[codex] Highlight Wework desktop release banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ English | [简体中文](README_zh.md)
 
 </div>
 
-> **Wework Desktop is now available.** Download the latest desktop build from [Wework Releases](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true), then choose the newest Wework release and the installer package that matches your operating system.
+<div align="center">
+
+## Wework Desktop Is Now Available
+
+Download the latest desktop build and choose the installer package that matches your operating system.
+
+**[Download Wework Desktop](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true)**
+
+</div>
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,7 +18,15 @@
 
 </div>
 
-> **Wework 桌面端已发布。** 你可以从 [Wework Releases](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true) 下载最新桌面版本，并选择最新的 Wework 发布和与你的操作系统匹配的安装包。
+<div align="center">
+
+## Wework 桌面端已发布
+
+下载最新桌面版本，并选择与你的操作系统匹配的安装包。
+
+**[下载 Wework 桌面端](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true)**
+
+</div>
 
 ---
 


### PR DESCRIPTION
## What changed

- Replaced the top README Wework release notice with a centered release banner.
- Added a dedicated heading, short download copy, and bold download link in both English and Chinese READMEs.
- Kept the focused Wework release search URL: `q=Wework macOS DMG build`.

## Why

The initial notice added in #1773 was technically in the first viewport, but it was still a plain blockquote and easy to miss. This makes the Wework desktop release and download entry visibly stand out near the top of the project README.

## Validation

- Reviewed the README diff.
- No code tests run; this is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English and Chinese README announcements with clearer, more prominent headings.
  * Improved the download call-to-action wording while keeping the same release download destination.
  * Refined the presentation of the desktop availability message for a cleaner, more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->