### PR TITLE
fix(wework): pause stream auto-scroll on user scroll

### DIFF
--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1097,4 +1097,123 @@ describe('ScrollableMessageArea', () => {
       behavior: 'auto',
     })
   })
+
+  test('does not follow streaming content after the user scrolls upward near the bottom', () => {
+    const streamingMessage = {
+      id: 'near-bottom-stream',
+      role: 'assistant' as const,
+      content: '正在处理',
+      status: 'streaming' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea conversationKey="near-bottom-scroll" messages={[streamingMessage]} />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 400,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn()
+
+    fireEvent.scroll(scroller)
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    scroller.scrollTop = 360
+    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.scroll(scroller)
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    })
+
+    rerender(
+      <ScrollableMessageArea
+        conversationKey="near-bottom-scroll"
+        messages={[
+          {
+            ...streamingMessage,
+            content: '正在处理\n\n核心逻辑\n\n更多流式内容',
+          },
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled()
+  })
+
+  test('resumes streaming follow after the user returns to the bottom', () => {
+    const streamingMessage = {
+      id: 'resume-stream',
+      role: 'assistant' as const,
+      content: '正在处理',
+      status: 'streaming' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea conversationKey="resume-scroll" messages={[streamingMessage]} />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 360,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+
+    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.scroll(scroller)
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    scroller.scrollTop = 400
+    fireEvent.scroll(scroller)
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    })
+
+    rerender(
+      <ScrollableMessageArea
+        conversationKey="resume-scroll"
+        messages={[
+          {
+            ...streamingMessage,
+            content: '正在处理\n\n核心逻辑\n\n更多流式内容',
+          },
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 800,
+      behavior: 'auto',
+    })
+  })
 })

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -184,6 +184,7 @@ function ScrollableMessagePaneContent({
   const scrollFrameRef = useRef<number | null>(null)
   const restoringScrollKeyRef = useRef<string | null>(null)
   const applyingSavedScrollRef = useRef(false)
+  const userScrollPausedAutoFollowRef = useRef(false)
   const scheduledScrollStateSignatureRef = useRef<string | null>(null)
   const completedScrollStateSignatureRef = useRef<string | null>(null)
   const loadingTranscriptGapKeyRef = useRef<string | null>(null)
@@ -321,7 +322,13 @@ function ScrollableMessagePaneContent({
       const overflow = element.scrollHeight > element.clientHeight + 8
       const distanceToBottom = element.scrollHeight - element.clientHeight - element.scrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
+      const isScrolledToBottom = distanceToBottom <= 1
       isAtBottomRef.current = isAtBottom
+      if (isScrolledToBottom) {
+        userScrollPausedAutoFollowRef.current = false
+      } else if (options.forceSave) {
+        userScrollPausedAutoFollowRef.current = true
+      }
       if (!isAtBottom && restoringScrollKeyRef.current !== currentScrollKey) {
         clearScheduledScrolls()
       }
@@ -353,6 +360,7 @@ function ScrollableMessagePaneContent({
         saveCurrentScrollPosition(element.scrollHeight)
       }
       isAtBottomRef.current = true
+      userScrollPausedAutoFollowRef.current = false
       setShowScrollButton(false)
     },
     [saveCurrentScrollPosition]
@@ -386,7 +394,9 @@ function ScrollableMessagePaneContent({
       const overflow = element.scrollHeight > element.clientHeight + 8
       const distanceToBottom = element.scrollHeight - element.clientHeight - nextScrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
+      const isScrolledToBottom = distanceToBottom <= 1
       isAtBottomRef.current = isAtBottom
+      userScrollPausedAutoFollowRef.current = !isScrolledToBottom
       setShowScrollButton(overflow && !isAtBottom)
       setConversationScrollSnapshot(key, savedSnapshot)
 
@@ -488,7 +498,7 @@ function ScrollableMessagePaneContent({
       return
     }
 
-    if (shouldForceBottom || isAtBottomRef.current) {
+    if (shouldForceBottom || (isAtBottomRef.current && !userScrollPausedAutoFollowRef.current)) {
       setScrollToBottom('auto', { saveSnapshot: false })
       scheduleStableScrollToBottom('auto', { saveSnapshot: false })
     }
@@ -544,7 +554,7 @@ function ScrollableMessagePaneContent({
         return
       }
 
-      if (isAtBottomRef.current) {
+      if (isAtBottomRef.current && !userScrollPausedAutoFollowRef.current) {
         scrollToBottom('auto', { saveSnapshot: false })
       }
     })
@@ -562,8 +572,14 @@ function ScrollableMessagePaneContent({
   useEffect(() => clearScheduledScrolls, [clearScheduledScrolls])
 
   const handleScrollToBottom = () => {
+    userScrollPausedAutoFollowRef.current = false
     scrollToBottom('smooth', { saveSnapshot: true })
   }
+
+  const pauseAutoFollowForUserScroll = useCallback(() => {
+    userScrollPausedAutoFollowRef.current = true
+    clearScheduledScrolls()
+  }, [clearScheduledScrolls])
 
   return (
     <div className={cn('relative min-h-0 flex-1', className)}>
@@ -592,6 +608,12 @@ function ScrollableMessagePaneContent({
           (turnNavigationLoading || autoScrollSuspended) && '[overflow-anchor:none]',
           scrollerClassName
         )}
+        onWheel={event => {
+          if (event.deltaY < 0) {
+            pauseAutoFollowForUserScroll()
+          }
+        }}
+        onTouchMove={pauseAutoFollowForUserScroll}
         onScroll={() => {
           if (
             applyingSavedScrollRef.current &&


### PR DESCRIPTION
## Summary
- pause streaming auto-follow when the user scrolls upward in the Wework message area
- require the user to return to the true bottom or click the scroll-to-bottom button before resuming auto-follow
- add regression coverage for near-bottom upward scroll and resumed bottom follow

## Tests
- pnpm --dir wework exec vitest run src/components/chat/ScrollableMessageArea.test.tsx
- pnpm --dir wework exec tsc -b
- pnpm --dir wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx -t "scroll-to-bottom|scroll to bottom|scroll"
- pre-push hook: frontend eslint/typecheck/unit tests, wework eslint/typecheck/unit tests, backend black/isort/syntax, settings config, knowledge syntax checks, executor cargo fmt/test/clippy, executor-manager syntax, alembic multi-head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat auto-scroll behavior so streaming messages no longer pull the view downward after you manually scroll up.
  * Restored auto-follow when you return to the bottom of the message list or use the “scroll to bottom” action.
  * Added coverage for upward scrolling, bottom-return behavior, and streaming updates to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->