### PR TITLE
fix(wework): keep environment info action visible

### DIFF
--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -66,7 +66,7 @@ describe('WorkspacePanelActions', () => {
     openExternalUrlMock.mockResolvedValue(true)
   })
 
-  test('shows environment info while loading and keeps it when environment context is available', () => {
+  test('keeps environment info action visible after environment refresh resolves empty context', () => {
     const { rerender } = render(<WorkspacePanelActions {...baseProps} />)
 
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
@@ -83,7 +83,7 @@ describe('WorkspacePanelActions', () => {
       />
     )
 
-    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
 
     rerender(
       <WorkspacePanelActions

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -62,13 +62,6 @@ export function WorkspacePanelActions({
   const [ideError, setIdeError] = useState<string | null>(null)
   const showEnvironmentInfo = mode !== 'panel-toggles'
   const showPanelToggles = mode !== 'environment'
-  const hasEnvironmentContext = Boolean(
-    environmentInfo.branchName?.trim() ||
-    environmentInfo.deviceId?.trim() ||
-    environmentInfo.workspacePath?.trim() ||
-    environmentInfo.error?.trim()
-  )
-  const canShowEnvironmentInfo = environmentInfo.loading !== false || hasEnvironmentContext
   const codeServerProjectDeviceId = workspaceTarget?.deviceId ?? getProjectDeviceId(currentProject)
   const canOpenCodeServer = Boolean(currentProject && codeServerProjectDeviceId)
   const codeServerDevice = codeServerProjectDeviceId
@@ -148,7 +141,7 @@ export function WorkspacePanelActions({
 
   return (
     <>
-      {showEnvironmentInfo && canShowEnvironmentInfo && (
+      {showEnvironmentInfo && (
         <EnvironmentInfoPopover
           info={environmentInfo}
           devices={devices}


### PR DESCRIPTION
## What changed

- Keep the Wework titlebar environment info action mounted whenever environment actions are enabled.
- Update the workspace panel action test to cover the empty refreshed environment context case.

## Why

Clicking the environment info icon triggers a refresh. When that refresh resolved with no branch, device, workspace path, or error, the previous render condition removed the icon from the titlebar. The action should stay available so users can reopen the popover and retry refreshes.

## Validation

- `pnpm --filter wework test -- WorkspacePanelActions.test.tsx`
- Pre-push hook: ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment information now remains visible after a refresh even when the refreshed data is empty or missing.
  * Improved consistency of the workspace panel so the environment info action no longer disappears unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->