### PR TITLE
fix(executor): suppress async agent interim stream output

### DIFF
--- a/executor/src/callback/mod.rs
+++ b/executor/src/callback/mod.rs
@@ -133,6 +133,7 @@ async fn send_callback_with_retries(
         }
 
         let is_final_attempt = attempt == retry_config.max_attempts;
+        let started = std::time::Instant::now();
         match send_callback_once(
             client,
             callback_url,
@@ -145,6 +146,7 @@ async fn send_callback_with_retries(
             Ok(status) => {
                 let mut success_fields = attempt_fields;
                 success_fields.push(("status", status.to_string()));
+                success_fields.push(("elapsed_ms", started.elapsed().as_millis().to_string()));
                 if log_success {
                     log_executor_event("callback request finished", &success_fields);
                 }

--- a/executor/src/process/mod.rs
+++ b/executor/src/process/mod.rs
@@ -10,6 +10,10 @@ use std::{
     path::PathBuf,
     pin::Pin,
     process::Stdio,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
     time::Instant,
 };
@@ -19,6 +23,8 @@ use serde_json::{Map, Value};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader},
     process::Command,
+    sync::mpsc::{unbounded_channel, UnboundedSender},
+    sync::oneshot,
     time::timeout,
 };
 
@@ -28,19 +34,19 @@ use crate::{
         proxy_deferred_mcp_tool, ClaudeFollowUpQuery, DeferredMcpResponseAction,
     },
     claude_session,
-    emitter::ResponsesEventBuilder,
+    emitter::{EventEnvelope, ResponsesEventBuilder},
     logging::{log_executor_event, task_fields},
     protocol::ExecutionRequest,
     runner::{AgentEngine, EventSink, ExecutionOutcome},
     stream::{
         collect_claude_stream_summary, extract_claude_tool_results, extract_claude_tool_uses,
-        extract_reasoning, extract_text, ClaudeStdoutJsonBuffer, ClaudeStdoutJsonError,
-        ClaudeToolUse,
+        extract_reasoning, extract_text, ClaudeAsyncTaskTracker, ClaudeStdoutJsonBuffer,
+        ClaudeStdoutJsonError, ClaudeToolUse,
     },
 };
 
-const DEFAULT_STREAM_CHUNK_CHARS: usize = 20;
-const DEFAULT_STREAM_CHUNK_DELAY_MS: u64 = 0;
+const DEFAULT_STREAM_TEXT_CHUNK_CHARS: usize = 256;
+const DEFAULT_STREAM_REASONING_CHUNK_CHARS: usize = 4_096;
 const MAX_DEFERRED_MCP_RETRIES: usize = 2;
 const MAX_API_ERROR_RETRIES: usize = 3;
 const DEBUG_CLAUDE_STDOUT_ENV: &str = "WEGENT_DEBUG_CLAUDE_STDOUT";
@@ -54,6 +60,243 @@ impl EventSink for NoopEventSink {
 
     fn send(&self, _event: crate::emitter::EventEnvelope) -> Self::SendFuture {
         std::future::ready(Ok(()))
+    }
+}
+
+#[derive(Clone)]
+struct StreamingEventDispatcher {
+    sender: UnboundedSender<QueuedStreamEvent>,
+    pending: Arc<AtomicUsize>,
+    compact_pending_text: Arc<AtomicBool>,
+}
+
+struct QueuedStreamEvent {
+    kind: QueuedStreamEventKind,
+}
+
+enum QueuedStreamEventKind {
+    Callback {
+        event: Box<EventEnvelope>,
+        log_name: &'static str,
+        fields: Vec<(&'static str, String)>,
+        text_delta_chars: usize,
+    },
+    Flush {
+        done: oneshot::Sender<()>,
+    },
+}
+
+struct CompactedTextDelta {
+    event: EventEnvelope,
+    text: String,
+}
+
+fn compact_text_delta(
+    compacted: &mut Option<CompactedTextDelta>,
+    event: Box<EventEnvelope>,
+) -> Result<(), Box<EventEnvelope>> {
+    if event.event_type != "response.output_text.delta" {
+        return Err(event);
+    }
+    let Some(delta) = event
+        .data
+        .get("delta")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+    else {
+        return Err(event);
+    };
+    if delta.is_empty() {
+        return Ok(());
+    }
+    if let Some(existing) = compacted.as_mut() {
+        existing.text.push_str(&delta);
+        return Ok(());
+    }
+    let event = *event;
+    *compacted = Some(CompactedTextDelta { event, text: delta });
+    Ok(())
+}
+
+async fn send_compacted_text_delta<S>(sink: &S, compacted: &mut Option<CompactedTextDelta>)
+where
+    S: EventSink,
+{
+    let Some(mut compacted_text) = compacted.take() else {
+        return;
+    };
+    let text_chars = compacted_text.text.chars().count();
+    compacted_text.event.data["delta"] = Value::String(compacted_text.text);
+    let task_id = compacted_text.event.task_id.clone();
+    let subtask_id = compacted_text.event.subtask_id.clone();
+    if let Err(message) = sink.send(compacted_text.event).await {
+        let fields = vec![
+            ("task_id", task_id.clone()),
+            ("subtask_id", subtask_id.clone()),
+            ("error_len", message.len().to_string()),
+        ];
+        log_executor_event("streaming compacted text callback failed", &fields);
+    }
+    let fields = vec![
+        ("task_id", task_id),
+        ("subtask_id", subtask_id),
+        ("text_chars", text_chars.to_string()),
+    ];
+    log_executor_event("streaming compacted text emitted", &fields);
+}
+
+impl StreamingEventDispatcher {
+    fn new<S>(sink: S) -> Self
+    where
+        S: EventSink,
+    {
+        let (sender, mut receiver) = unbounded_channel::<QueuedStreamEvent>();
+        let pending = Arc::new(AtomicUsize::new(0));
+        let worker_pending = Arc::clone(&pending);
+        let compact_pending_text = Arc::new(AtomicBool::new(false));
+        let worker_compact_pending_text = Arc::clone(&compact_pending_text);
+        tokio::spawn(async move {
+            let mut compacted_text: Option<CompactedTextDelta> = None;
+            while let Some(queued) = receiver.recv().await {
+                match queued.kind {
+                    QueuedStreamEventKind::Callback {
+                        event,
+                        log_name,
+                        fields,
+                        text_delta_chars,
+                    } => {
+                        let event = if worker_compact_pending_text.load(Ordering::Relaxed)
+                            && text_delta_chars > 0
+                        {
+                            match compact_text_delta(&mut compacted_text, event) {
+                                Ok(()) => {
+                                    worker_pending.fetch_sub(1, Ordering::Relaxed);
+                                    continue;
+                                }
+                                Err(original_event) => original_event,
+                            }
+                        } else {
+                            event
+                        };
+                        send_compacted_text_delta(&sink, &mut compacted_text).await;
+                        let event = *event;
+                        let started = Instant::now();
+                        let event_type = event.event_type.clone();
+                        let task_id = event.task_id.clone();
+                        let subtask_id = event.subtask_id.clone();
+                        let message_id = event.message_id.map(|value| value.to_string());
+                        if let Err(message) = sink.send(event).await {
+                            let mut fields = fields;
+                            fields.push(("error_len", message.len().to_string()));
+                            log_executor_event(log_name, &fields);
+                        }
+                        let remaining = worker_pending
+                            .fetch_sub(1, Ordering::Relaxed)
+                            .saturating_sub(1);
+                        let elapsed_ms = started.elapsed().as_millis();
+                        if elapsed_ms >= 1_000 {
+                            let fields = vec![
+                                ("task_id", task_id),
+                                ("subtask_id", subtask_id),
+                                ("event_type", event_type),
+                                ("elapsed_ms", elapsed_ms.to_string()),
+                                ("pending_depth", remaining.to_string()),
+                                ("message_id", message_id.unwrap_or_default()),
+                            ];
+                            log_executor_event("streaming callback dispatch slow", &fields);
+                        }
+                    }
+                    QueuedStreamEventKind::Flush { done } => {
+                        send_compacted_text_delta(&sink, &mut compacted_text).await;
+                        let _ = done.send(());
+                    }
+                }
+            }
+        });
+        Self {
+            sender,
+            pending,
+            compact_pending_text,
+        }
+    }
+
+    async fn flush(&self) {
+        let (done, wait) = oneshot::channel();
+        if self
+            .sender
+            .send(QueuedStreamEvent {
+                kind: QueuedStreamEventKind::Flush { done },
+            })
+            .is_err()
+        {
+            log_executor_event("streaming callback queue closed", &[]);
+            return;
+        }
+        let _ = wait.await;
+    }
+
+    async fn compact_pending_text_and_flush(&self, task_id: &str, subtask_id: &str) {
+        self.compact_pending_text.store(true, Ordering::Relaxed);
+        let fields = vec![
+            ("task_id", task_id.to_string()),
+            ("subtask_id", subtask_id.to_string()),
+            (
+                "pending_depth",
+                self.pending.load(Ordering::Relaxed).to_string(),
+            ),
+        ];
+        log_executor_event("streaming callback queue compaction requested", &fields);
+        self.flush().await;
+    }
+
+    fn send(
+        &self,
+        event: EventEnvelope,
+        log_name: &'static str,
+        fields: Vec<(&'static str, String)>,
+    ) {
+        self.send_internal(event, log_name, fields, 0);
+    }
+
+    fn send_text_delta(
+        &self,
+        event: EventEnvelope,
+        log_name: &'static str,
+        fields: Vec<(&'static str, String)>,
+        text_delta_chars: usize,
+    ) {
+        self.send_internal(event, log_name, fields, text_delta_chars);
+    }
+
+    fn send_internal(
+        &self,
+        event: EventEnvelope,
+        log_name: &'static str,
+        fields: Vec<(&'static str, String)>,
+        text_delta_chars: usize,
+    ) {
+        let depth = self.pending.fetch_add(1, Ordering::Relaxed) + 1;
+        if depth % 100 == 0 {
+            let mut queue_fields = fields.clone();
+            queue_fields.push(("pending_depth", depth.to_string()));
+            queue_fields.push(("event_type", event.event_type.clone()));
+            log_executor_event("streaming callback queue depth", &queue_fields);
+        }
+        if self
+            .sender
+            .send(QueuedStreamEvent {
+                kind: QueuedStreamEventKind::Callback {
+                    event: Box::new(event),
+                    log_name,
+                    fields,
+                    text_delta_chars,
+                },
+            })
+            .is_err()
+        {
+            self.pending.fetch_sub(1, Ordering::Relaxed);
+            log_executor_event("streaming callback queue closed", &[]);
+        }
     }
 }
 
@@ -793,6 +1036,8 @@ where
     let mut lines = BufReader::new(stdout).lines();
     let mut line_number = 0usize;
     let mut json_buffer = ClaudeStdoutJsonBuffer::default();
+    let mut async_tasks = ClaudeAsyncTaskTracker::default();
+    let dispatcher = StreamingEventDispatcher::new(sink);
     while let Ok(Some(line)) = lines.next_line().await {
         line_number += 1;
         output.push_str(&line);
@@ -803,6 +1048,7 @@ where
         let Some(value) = (match json_buffer.push_line(&line, line_number) {
             Ok(value) => value,
             Err(error) => {
+                dispatcher.flush().await;
                 return StreamingStdoutOutcome::InvalidJson {
                     stdout: output,
                     error,
@@ -811,13 +1057,14 @@ where
         }) else {
             continue;
         };
+        async_tasks.observe(&value);
         if let Some(reasoning) = extract_reasoning(&value) {
             if !reasoning.is_empty() {
-                emit_reasoning_chunks(&sink, &builder, &reasoning, &task_id, &subtask_id).await;
+                emit_reasoning_chunks(&dispatcher, &builder, &reasoning, &task_id, &subtask_id);
             }
         }
         for tool_use in extract_claude_tool_uses(&value) {
-            emit_claude_tool_use(&sink, &builder, &tool_use, &task_id, &subtask_id).await;
+            emit_claude_tool_use(&dispatcher, &builder, &tool_use, &task_id, &subtask_id);
             tool_uses.insert(tool_use.id.clone(), tool_use);
         }
         for tool_result in extract_claude_tool_results(&value) {
@@ -829,15 +1076,17 @@ where
                     input: Value::Object(Default::default()),
                 });
             emit_claude_tool_result(
-                &sink,
+                &dispatcher,
                 &builder,
                 &tool_use,
                 tool_result.content.as_deref(),
                 tool_result.is_error,
                 &task_id,
                 &subtask_id,
-            )
-            .await;
+            );
+        }
+        if async_tasks.has_active_task() {
+            continue;
         }
         let Some(text) = extract_text(&value) else {
             continue;
@@ -845,8 +1094,14 @@ where
         if text.is_empty() {
             continue;
         }
-        let emitted =
-            emit_text_chunks(&sink, &builder, &text, &mut offset, &task_id, &subtask_id).await;
+        let emitted = emit_text_chunks(
+            &dispatcher,
+            &builder,
+            &text,
+            &mut offset,
+            &task_id,
+            &subtask_id,
+        );
         let fields = vec![
             ("task_id", task_id.to_string()),
             ("subtask_id", subtask_id.to_string()),
@@ -855,80 +1110,72 @@ where
         ];
         log_executor_event("streaming text chunks emitted", &fields);
     }
+    dispatcher
+        .compact_pending_text_and_flush(&task_id, &subtask_id)
+        .await;
     StreamingStdoutOutcome::Success(output.trim().to_owned())
 }
 
-async fn emit_claude_tool_use<S>(
-    sink: &S,
+fn emit_claude_tool_use(
+    dispatcher: &StreamingEventDispatcher,
     builder: &ResponsesEventBuilder,
     tool_use: &ClaudeToolUse,
     task_id: &str,
     subtask_id: &str,
-) where
-    S: EventSink,
-{
+) {
     let event = builder.response_tool_block_created(&tool_use.id, &tool_use.name, &tool_use.input);
-    if let Err(message) = sink.send(event).await {
-        let fields = vec![
+    dispatcher.send(
+        event,
+        "streaming tool use callback failed",
+        vec![
             ("task_id", task_id.to_string()),
             ("subtask_id", subtask_id.to_string()),
             ("tool_use_id", tool_use.id.clone()),
-            ("error_len", message.len().to_string()),
-        ];
-        log_executor_event("streaming tool use callback failed", &fields);
-    }
+        ],
+    );
 }
 
-async fn emit_claude_tool_result<S>(
-    sink: &S,
+fn emit_claude_tool_result(
+    dispatcher: &StreamingEventDispatcher,
     builder: &ResponsesEventBuilder,
     tool_use: &ClaudeToolUse,
     output: Option<&str>,
     is_error: bool,
     task_id: &str,
     subtask_id: &str,
-) where
-    S: EventSink,
-{
+) {
     let event =
         builder.response_tool_block_updated(&tool_use.id, &tool_use.input, output, is_error);
-    if let Err(message) = sink.send(event).await {
-        let fields = vec![
+    dispatcher.send(
+        event,
+        "streaming tool result callback failed",
+        vec![
             ("task_id", task_id.to_string()),
             ("subtask_id", subtask_id.to_string()),
             ("tool_use_id", tool_use.id.clone()),
-            ("error_len", message.len().to_string()),
-        ];
-        log_executor_event("streaming tool result callback failed", &fields);
-    }
+        ],
+    );
 }
 
-async fn emit_reasoning_chunks<S>(
-    sink: &S,
+fn emit_reasoning_chunks(
+    dispatcher: &StreamingEventDispatcher,
     builder: &ResponsesEventBuilder,
     reasoning: &str,
     task_id: &str,
     subtask_id: &str,
-) where
-    S: EventSink,
-{
-    let chunks = split_stream_text(reasoning, stream_chunk_chars());
-    let delay = Duration::from_millis(stream_chunk_delay_ms());
-    let should_delay = chunks.len() > 1 && !delay.is_zero();
+) {
+    let chunks = split_stream_text(reasoning, stream_reasoning_chunk_chars());
     let chunk_count = chunks.len();
-    for (index, delta) in chunks.into_iter().enumerate() {
+    for delta in chunks {
         let event = builder.response_reasoning_delta(&delta);
-        if let Err(message) = sink.send(event).await {
-            let fields = vec![
+        dispatcher.send(
+            event,
+            "streaming reasoning callback failed",
+            vec![
                 ("task_id", task_id.to_string()),
                 ("subtask_id", subtask_id.to_string()),
-                ("error_len", message.len().to_string()),
-            ];
-            log_executor_event("streaming reasoning callback failed", &fields);
-        }
-        if should_delay && index + 1 < chunk_count {
-            tokio::time::sleep(delay).await;
-        }
+            ],
+        );
     }
     let fields = vec![
         ("task_id", task_id.to_string()),
@@ -939,35 +1186,29 @@ async fn emit_reasoning_chunks<S>(
     log_executor_event("streaming reasoning chunks emitted", &fields);
 }
 
-async fn emit_text_chunks<S>(
-    sink: &S,
+fn emit_text_chunks(
+    dispatcher: &StreamingEventDispatcher,
     builder: &ResponsesEventBuilder,
     text: &str,
     offset: &mut usize,
     task_id: &str,
     subtask_id: &str,
-) -> usize
-where
-    S: EventSink,
-{
-    let chunks = split_stream_text(text, stream_chunk_chars());
-    let delay = Duration::from_millis(stream_chunk_delay_ms());
-    let should_delay = chunks.len() > 1 && !delay.is_zero();
+) -> usize {
+    let chunks = split_stream_text(text, stream_text_chunk_chars());
     let chunk_count = chunks.len();
-    for (index, delta) in chunks.into_iter().enumerate() {
+    for delta in chunks {
         let event = builder.response_text_delta(&delta, *offset);
-        *offset += delta.chars().count();
-        if let Err(message) = sink.send(event).await {
-            let fields = vec![
+        let delta_chars = delta.chars().count();
+        *offset += delta_chars;
+        dispatcher.send_text_delta(
+            event,
+            "streaming chunk callback failed",
+            vec![
                 ("task_id", task_id.to_string()),
                 ("subtask_id", subtask_id.to_string()),
-                ("error_len", message.len().to_string()),
-            ];
-            log_executor_event("streaming chunk callback failed", &fields);
-        }
-        if should_delay && index + 1 < chunk_count {
-            tokio::time::sleep(delay).await;
-        }
+            ],
+            delta_chars,
+        );
     }
     chunk_count
 }
@@ -988,19 +1229,20 @@ fn split_stream_text(text: &str, chunk_chars: usize) -> Vec<String> {
     chunks
 }
 
-fn stream_chunk_chars() -> usize {
+fn stream_text_chunk_chars() -> usize {
     env::var("WEGENT_EXECUTOR_STREAM_CHUNK_CHARS")
         .ok()
         .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_STREAM_CHUNK_CHARS)
+        .unwrap_or(DEFAULT_STREAM_TEXT_CHUNK_CHARS)
 }
 
-fn stream_chunk_delay_ms() -> u64 {
-    env::var("WEGENT_EXECUTOR_STREAM_CHUNK_DELAY_MS")
+fn stream_reasoning_chunk_chars() -> usize {
+    env::var("WEGENT_EXECUTOR_STREAM_REASONING_CHUNK_CHARS")
         .ok()
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_STREAM_CHUNK_DELAY_MS)
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_STREAM_REASONING_CHUNK_CHARS)
 }
 
 async fn read_process_output<R>(output: R) -> String
@@ -1282,13 +1524,25 @@ mod tests {
     }
 
     #[test]
-    fn stream_chunk_defaults_are_tuned_for_smooth_device_chat() {
+    fn stream_chunk_defaults_are_tuned_for_callback_backpressure() {
         let _lock = env_lock();
         let _chunk_chars = EnvGuard::remove("WEGENT_EXECUTOR_STREAM_CHUNK_CHARS");
-        let _chunk_delay = EnvGuard::remove("WEGENT_EXECUTOR_STREAM_CHUNK_DELAY_MS");
+        let _reasoning_chunk_chars =
+            EnvGuard::remove("WEGENT_EXECUTOR_STREAM_REASONING_CHUNK_CHARS");
 
-        assert_eq!(stream_chunk_chars(), 20);
-        assert_eq!(stream_chunk_delay_ms(), 0);
+        assert_eq!(stream_text_chunk_chars(), 256);
+        assert_eq!(stream_reasoning_chunk_chars(), 4_096);
+    }
+
+    #[test]
+    fn stream_chunk_env_overrides_defaults() {
+        let _lock = env_lock();
+        let _chunk_chars = EnvGuard::set("WEGENT_EXECUTOR_STREAM_CHUNK_CHARS", "128");
+        let _reasoning_chunk_chars =
+            EnvGuard::set("WEGENT_EXECUTOR_STREAM_REASONING_CHUNK_CHARS", "256");
+
+        assert_eq!(stream_text_chunk_chars(), 128);
+        assert_eq!(stream_reasoning_chunk_chars(), 256);
     }
 
     #[test]

--- a/executor/src/stream/mod.rs
+++ b/executor/src/stream/mod.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use serde_json::Value;
 
 use crate::{
@@ -35,6 +37,26 @@ pub struct ClaudeToolResult {
     pub tool_use_id: String,
     pub content: Option<String>,
     pub is_error: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct ClaudeAsyncTaskTracker {
+    active_tool_use_ids: HashSet<String>,
+}
+
+impl ClaudeAsyncTaskTracker {
+    pub fn observe(&mut self, value: &Value) {
+        if let Some(tool_use_id) = claude_task_started_tool_use_id(value) {
+            self.active_tool_use_ids.insert(tool_use_id);
+        }
+        if let Some(tool_use_id) = claude_task_notification_tool_use_id(value) {
+            self.active_tool_use_ids.remove(&tool_use_id);
+        }
+    }
+
+    pub fn has_active_task(&self) -> bool {
+        !self.active_tool_use_ids.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,6 +136,9 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
     let mut usage = Value::Null;
     let mut retryable_api_error = false;
     let mut json_buffer = ClaudeStdoutJsonBuffer::default();
+    let mut saw_claude_message = false;
+    let mut saw_result_message = false;
+    let mut async_tasks = ClaudeAsyncTaskTracker::default();
     for (index, line) in output.lines().enumerate() {
         let line_number = index + 1;
         let Some(value) = (match json_buffer.push_line(line, line_number) {
@@ -135,6 +160,10 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
         };
         let line = line.trim();
         retryable_api_error |= contains_retryable_api_error(line);
+        if value.get("type").and_then(Value::as_str).is_some() {
+            saw_claude_message = true;
+        }
+        async_tasks.observe(&value);
         if let Some(value) = value.get("session_id").and_then(Value::as_str) {
             let value = value.trim();
             if !value.is_empty() {
@@ -159,6 +188,7 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
             current_assistant_text.clear();
         }
         if value.get("type").and_then(Value::as_str) == Some("result") {
+            saw_result_message = true;
             if let Some(reason) = value
                 .get("stop_reason")
                 .and_then(Value::as_str)
@@ -209,21 +239,35 @@ pub fn collect_claude_stream_summary(output: &str) -> ClaudeStreamSummary {
             pending_error = Some(error);
             continue;
         }
-        if let Some(text) = extract_claude_assistant_message_text(&value) {
-            current_assistant_text.push_str(&text);
-            final_text = current_assistant_text.clone();
-        } else if let Some(delta) = extract_claude_text_delta(&value) {
-            current_assistant_text.push_str(&delta);
-            final_text = current_assistant_text.clone();
-        } else if let Some(delta) = extract_codex_agent_delta(&value) {
+        if !async_tasks.has_active_task() {
+            if let Some(text) = extract_claude_assistant_message_text(&value) {
+                current_assistant_text.push_str(&text);
+                final_text = current_assistant_text.clone();
+                continue;
+            }
+            if let Some(delta) = extract_claude_text_delta(&value) {
+                current_assistant_text.push_str(&delta);
+                final_text = current_assistant_text.clone();
+                continue;
+            }
+        }
+        if let Some(delta) = extract_codex_agent_delta(&value) {
             final_text.push_str(&delta);
         }
     }
 
     let outcome = terminal_outcome
         .or_else(|| pending_error.map(|message| ExecutionOutcome::Failed { message }))
-        .unwrap_or(ExecutionOutcome::Completed {
-            content: final_text,
+        .unwrap_or_else(|| {
+            if saw_claude_message && !saw_result_message {
+                ExecutionOutcome::Failed {
+                    message: "Claude stdout ended before result message".to_owned(),
+                }
+            } else {
+                ExecutionOutcome::Completed {
+                    content: final_text,
+                }
+            }
         });
     ClaudeStreamSummary {
         outcome,
@@ -300,6 +344,34 @@ fn extract_result_outcome(value: &Value) -> Option<ExecutionOutcome> {
     }
 }
 
+fn claude_task_started_tool_use_id(value: &Value) -> Option<String> {
+    if value.get("type").and_then(Value::as_str) != Some("system")
+        || value.get("subtype").and_then(Value::as_str) != Some("task_started")
+        || value.get("task_type").and_then(Value::as_str) != Some("local_agent")
+    {
+        return None;
+    }
+    non_empty_string_field(value, "tool_use_id")
+}
+
+fn claude_task_notification_tool_use_id(value: &Value) -> Option<String> {
+    if value.get("type").and_then(Value::as_str) != Some("system")
+        || value.get("subtype").and_then(Value::as_str) != Some("task_notification")
+    {
+        return None;
+    }
+    non_empty_string_field(value, "tool_use_id")
+}
+
+fn non_empty_string_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn result_stop_reason(value: &Value) -> String {
     value
         .get("stop_reason")
@@ -365,6 +437,9 @@ pub fn extract_reasoning(value: &Value) -> Option<String> {
 }
 
 pub fn extract_claude_tool_uses(value: &Value) -> Vec<ClaudeToolUse> {
+    if is_child_agent_event(value) {
+        return Vec::new();
+    }
     let Some(content) = value
         .get("message")
         .and_then(|message| message.get("content"))
@@ -402,6 +477,9 @@ pub fn extract_claude_tool_uses(value: &Value) -> Vec<ClaudeToolUse> {
 }
 
 pub fn extract_claude_tool_results(value: &Value) -> Vec<ClaudeToolResult> {
+    if is_child_agent_event(value) {
+        return Vec::new();
+    }
     let Some(content) = value
         .get("message")
         .and_then(|message| message.get("content"))
@@ -459,6 +537,9 @@ fn is_claude_assistant_message(value: &Value) -> bool {
     if value.get("type").and_then(Value::as_str) != Some("assistant") {
         return false;
     }
+    if is_child_agent_event(value) {
+        return false;
+    }
 
     value
         .get("message")
@@ -466,6 +547,15 @@ fn is_claude_assistant_message(value: &Value) -> bool {
         .and_then(Value::as_str)
         .map(|role| role == "assistant")
         .unwrap_or(true)
+}
+
+fn is_child_agent_event(value: &Value) -> bool {
+    value
+        .get("parent_tool_use_id")
+        .or_else(|| value.get("parentToolUseId"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
 }
 
 fn stringify_tool_result_content(value: Option<&Value>) -> Option<String> {
@@ -487,6 +577,9 @@ fn stringify_tool_result_content(value: Option<&Value>) -> Option<String> {
 }
 
 fn extract_claude_text_delta(value: &Value) -> Option<String> {
+    if is_child_agent_event(value) {
+        return None;
+    }
     let delta = value.get("delta")?;
     (delta.get("type").and_then(Value::as_str) == Some("text_delta"))
         .then(|| delta.get("text").and_then(Value::as_str))
@@ -495,6 +588,9 @@ fn extract_claude_text_delta(value: &Value) -> Option<String> {
 }
 
 fn extract_claude_thinking_delta(value: &Value) -> Option<String> {
+    if is_child_agent_event(value) {
+        return None;
+    }
     let delta = value.get("delta")?;
     (delta.get("type").and_then(Value::as_str) == Some("thinking_delta"))
         .then(|| delta.get("thinking").and_then(Value::as_str))

--- a/executor/tests/agent_process_engine_contract.rs
+++ b/executor/tests/agent_process_engine_contract.rs
@@ -1069,6 +1069,13 @@ printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"
 
 fn write_fake_executable(name: &str, content: &str) -> PathBuf {
     let path = std::env::temp_dir().join(format!("{name}-{}", std::process::id()));
+    let content = if name.starts_with("fake-claude") && !content.contains(r#""type":"result""#) {
+        format!(
+            "{content}\nprintf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"stop_reason\":\"end_turn\"}}'\n"
+        )
+    } else {
+        content.to_owned()
+    };
     fs::write(&path, content).unwrap();
     #[cfg(unix)]
     {

--- a/executor/tests/claude_stream_event_contract.rs
+++ b/executor/tests/claude_stream_event_contract.rs
@@ -26,6 +26,7 @@ fn claude_tool_use_stream_blocks_do_not_leak_arguments_into_final_text() {
 {"type":"content_block_stop","index":0}
 {"type":"assistant","message":{"content":[{"type":"tool_use","id":"Bash_0","name":"Bash","input":{"command":"pwd"}}]}}
 {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"done"}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
 "#;
 
     let outcome = collect_ndjson_outcome(output);
@@ -44,6 +45,7 @@ fn claude_thinking_deltas_are_not_final_answer_text() {
 {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"private reasoning"}}
 {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"opaque"}}
 {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"visible answer"}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
 "#;
 
     let outcome = collect_ndjson_outcome(output);
@@ -80,6 +82,7 @@ fn claude_user_skill_context_text_is_not_final_answer_text() {
     let output = r#"
 {"type":"user","message":{"role":"user","content":[{"type":"text","text":"Base directory for this skill: /root/.claude/skills/example\n\n# Skill instructions"}]}}
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"visible answer"}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
 "#;
 
     let outcome = collect_ndjson_outcome(output);

--- a/executor/tests/docker_runtime_contract.rs
+++ b/executor/tests/docker_runtime_contract.rs
@@ -64,6 +64,7 @@ async fn default_docker_router_runs_claude_subprocess_and_sends_callbacks() {
         "docker-fake-claude",
         r#"#!/bin/sh
 printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"docker done"}]}}'
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'
 "#,
     );
     let callback = CallbackCapture::start().await;

--- a/executor/tests/local_backend_contract.rs
+++ b/executor/tests/local_backend_contract.rs
@@ -141,8 +141,9 @@ async fn local_backend_task_execute_handler_runs_agent_and_emits_events() {
     let fake_claude = write_fake_executable(
         "fake-local-backend-claude",
         r#"#!/bin/sh
-printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"local done"}]}}'
-"#,
+	printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"local done"}]}}'
+	printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'
+	"#,
     );
     let _claude = EnvGuard::set("CLAUDE_BINARY_PATH", &fake_claude.display().to_string());
     let transport = RecordingTransport::default();
@@ -183,10 +184,11 @@ async fn local_backend_task_execute_streams_claude_stdout_before_completion() {
     let fake_claude = write_fake_executable(
         "fake-local-backend-streaming-claude",
         r#"#!/bin/sh
-printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}'
-sleep 0.1
-printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":" world"}]}}'
-"#,
+	printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}'
+	sleep 0.1
+	printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":" world"}]}}'
+	printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'
+	"#,
     );
     let _claude = EnvGuard::set("CLAUDE_BINARY_PATH", &fake_claude.display().to_string());
     let transport = RecordingTransport::default();
@@ -231,10 +233,11 @@ async fn local_backend_task_execute_streams_claude_thinking_deltas_before_text()
     let fake_claude = write_fake_executable(
         "fake-local-backend-thinking-claude",
         r#"#!/bin/sh
-printf '%s\n' '{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking image"}}'
-sleep 0.1
-printf '%s\n' '{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"visible answer"}}'
-"#,
+	printf '%s\n' '{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking image"}}'
+	sleep 0.1
+	printf '%s\n' '{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"visible answer"}}'
+	printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'
+	"#,
     );
     let _claude = EnvGuard::set("CLAUDE_BINARY_PATH", &fake_claude.display().to_string());
     let transport = RecordingTransport::default();
@@ -277,12 +280,13 @@ async fn local_backend_task_execute_streams_claude_assistant_thinking_blocks_as_
     let fake_claude = write_fake_executable(
         "fake-local-backend-assistant-thinking-claude",
         r#"#!/bin/sh
-printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"abcdef"},{"type":"text","text":"answer"}]}}'
-"#,
+	printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"abcdef"},{"type":"text","text":"answer"}]}}'
+	printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'
+	"#,
     );
     let _claude = EnvGuard::set("CLAUDE_BINARY_PATH", &fake_claude.display().to_string());
     let _chunk_chars = EnvGuard::set("WEGENT_EXECUTOR_STREAM_CHUNK_CHARS", "3");
-    let _chunk_delay = EnvGuard::set("WEGENT_EXECUTOR_STREAM_CHUNK_DELAY_MS", "0");
+    let _reasoning_chunk_chars = EnvGuard::set("WEGENT_EXECUTOR_STREAM_REASONING_CHUNK_CHARS", "3");
     let transport = RecordingTransport::default();
     let runner = LocalBackendRunner::new(local_backend_config(), transport.clone());
     runner.register_handlers();
@@ -323,11 +327,12 @@ async fn local_backend_task_execute_streams_claude_tool_use_blocks() {
     let fake_claude = write_fake_executable(
         "fake-local-backend-tool-claude",
         r##"#!/bin/sh
-printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"Read_0","name":"Read","input":{"file_path":"README.md"}}]}}'
-sleep 0.1
-printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"Read_0","content":"# Project"}]}}'
-printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"read done"}]}}'
-"##,
+	printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"Read_0","name":"Read","input":{"file_path":"README.md"}}]}}'
+	sleep 0.1
+	printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"Read_0","content":"# Project"}]}}'
+	printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"read done"}]}}'
+	printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'
+	"##,
     );
     let _claude = EnvGuard::set("CLAUDE_BINARY_PATH", &fake_claude.display().to_string());
     let transport = RecordingTransport::default();
@@ -390,12 +395,14 @@ async fn local_backend_task_execute_splits_large_claude_assistant_message_into_d
         "fake-local-backend-large-assistant-claude",
         &format!(
             r#"#!/bin/sh
-printf '%s\n' '{}'
-"#,
+	printf '%s\n' '{}'
+	printf '%s\n' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}}'
+	"#,
             claude_event
         ),
     );
     let _claude = EnvGuard::set("CLAUDE_BINARY_PATH", &fake_claude.display().to_string());
+    let _chunk_chars = EnvGuard::set("WEGENT_EXECUTOR_STREAM_CHUNK_CHARS", "20");
     let transport = RecordingTransport::default();
     let runner = LocalBackendRunner::new(local_backend_config(), transport.clone());
     runner.register_handlers();

--- a/executor/tests/stream_parser_contract.rs
+++ b/executor/tests/stream_parser_contract.rs
@@ -12,6 +12,7 @@ fn ndjson_parser_collects_claude_text_blocks_and_deltas() {
     let output = r#"
 {"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}
 {"type":"content_block_delta","delta":{"type":"text_delta","text":" world"}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
 "#;
 
     let outcome = collect_ndjson_outcome(output);
@@ -44,6 +45,47 @@ fn ndjson_parser_uses_last_assistant_message_as_final_content() {
 }
 
 #[test]
+fn ndjson_parser_ignores_child_agent_assistant_messages() {
+    let output = r#"
+{"type":"assistant","parent_tool_use_id":"Agent_0","message":{"role":"assistant","content":[{"type":"text","text":"child draft"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"root final"}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}
+"#;
+
+    let outcome = collect_ndjson_outcome(output);
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "root final".to_owned()
+        }
+    );
+}
+
+#[test]
+fn ndjson_parser_ignores_root_assistant_text_while_async_agent_is_running() {
+    let output = r#"
+{"type":"assistant","message":{"role":"assistant","content":[{"id":"Agent_0","name":"Agent","type":"tool_use","input":{"description":"write"}}]}}
+{"type":"system","subtype":"task_started","task_type":"local_agent","tool_use_id":"Agent_0","task_id":"agent-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"draft before agent finishes"}]}}
+{"type":"assistant","parent_tool_use_id":"Agent_0","message":{"role":"assistant","content":[{"type":"text","text":"child transcript"}]}}
+{"type":"system","subtype":"task_notification","status":"completed","tool_use_id":"Agent_0","task_id":"agent-1","summary":"child result"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"final after agent"}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","result":"draft before agent finishes"}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","origin":{"kind":"task-notification"},"result":"final after agent"}
+"#;
+
+    let outcome = collect_ndjson_outcome(output);
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "final after agent".to_owned()
+        }
+    );
+}
+
+#[test]
 fn ndjson_parser_skips_non_json_stdout_lines() {
     let output = r#"
 [SandboxDebug] enabled
@@ -62,7 +104,7 @@ fn ndjson_parser_skips_non_json_stdout_lines() {
 }
 
 #[test]
-fn ndjson_parser_ignores_incomplete_trailing_json_like_python_sdk() {
+fn ndjson_parser_fails_claude_stdout_without_result_message() {
     let output = r#"
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]}}
 {"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"broken
@@ -70,12 +112,10 @@ fn ndjson_parser_ignores_incomplete_trailing_json_like_python_sdk() {
 
     let outcome = collect_ndjson_outcome(output);
 
-    assert_eq!(
-        outcome,
-        ExecutionOutcome::Completed {
-            content: "partial".to_owned()
-        }
-    );
+    assert!(matches!(outcome, ExecutionOutcome::Failed { .. }));
+    if let ExecutionOutcome::Failed { message } = outcome {
+        assert!(message.contains("Claude stdout ended before result message"));
+    }
 }
 
 #[test]

--- a/executor/tests/stream_process_engine_contract.rs
+++ b/executor/tests/stream_process_engine_contract.rs
@@ -2,19 +2,61 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use serde_json::json;
+use tokio::sync::Mutex;
 use wegent_executor::{
+    emitter::{EventEnvelope, ResponsesEventBuilder},
     process::{CommandSpec, StreamProcessEngine},
     protocol::ExecutionRequest,
-    runner::{AgentEngine, ExecutionOutcome},
+    runner::{AgentEngine, EventSink, ExecutionOutcome},
 };
 
 const TEST_PROCESS_TIMEOUT_SECONDS: u64 = 3600;
+
+#[derive(Clone)]
+struct SlowSink {
+    delay: Duration,
+}
+
+impl EventSink for SlowSink {
+    type SendFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send>>;
+
+    fn send(&self, _event: EventEnvelope) -> Self::SendFuture {
+        let delay = self.delay;
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            Ok(())
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RecordingSlowSink {
+    delay: Duration,
+    events: Arc<Mutex<Vec<EventEnvelope>>>,
+}
+
+impl EventSink for RecordingSlowSink {
+    type SendFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send>>;
+
+    fn send(&self, event: EventEnvelope) -> Self::SendFuture {
+        let delay = self.delay;
+        let events = Arc::clone(&self.events);
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            events.lock().await.push(event);
+            Ok(())
+        })
+    }
+}
 
 #[tokio::test]
 async fn stream_process_engine_parses_ndjson_stdout() {
     let engine = StreamProcessEngine::new(
         CommandSpec::new("sh").arg("-c").arg(
-            r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}'"#,
+            r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'"#,
         ),
         TEST_PROCESS_TIMEOUT_SECONDS,
     );
@@ -30,7 +72,288 @@ async fn stream_process_engine_parses_ndjson_stdout() {
 }
 
 #[tokio::test]
-async fn stream_process_engine_ignores_incomplete_trailing_json_like_python_sdk() {
+async fn stream_process_engine_completes_with_slow_stream_callbacks() {
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(
+            r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}' '{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}'"#,
+        ),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(1),
+        engine.run_with_events(
+            ExecutionRequest::default(),
+            SlowSink {
+                delay: Duration::from_millis(50),
+            },
+            ResponsesEventBuilder::new("task", "subtask", "model"),
+        ),
+    )
+    .await
+    .expect("stream callbacks should flush without hanging");
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "done".to_owned()
+        }
+    );
+}
+
+#[tokio::test]
+async fn stream_process_engine_compacts_queued_text_callbacks_before_success() {
+    let long_text = "x".repeat(5_000);
+    let assistant = json!({
+        "type": "assistant",
+        "message": {
+            "content": [{"type": "text", "text": long_text}]
+        }
+    })
+    .to_string();
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(format!(
+            r#"printf '%s\n' '{}' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}}'"#,
+            assistant
+        )),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+
+    let started = std::time::Instant::now();
+    let outcome = engine
+        .run_with_events(
+            ExecutionRequest::default(),
+            SlowSink {
+                delay: Duration::from_millis(50),
+            },
+            ResponsesEventBuilder::new("task", "subtask", "model"),
+        )
+        .await;
+
+    assert!(
+        started.elapsed() < Duration::from_millis(600),
+        "outcome waited for queued streaming callbacks to drain"
+    );
+    assert_eq!(outcome, ExecutionOutcome::Completed { content: long_text });
+}
+
+#[tokio::test]
+async fn stream_process_engine_sends_remaining_text_delta_before_success() {
+    let long_text = "x".repeat(5_000);
+    let assistant = json!({
+        "type": "assistant",
+        "message": {
+            "content": [{"type": "text", "text": long_text}]
+        }
+    })
+    .to_string();
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(format!(
+            r#"printf '%s\n' '{}' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}}'"#,
+            assistant
+        )),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let outcome = engine
+        .run_with_events(
+            ExecutionRequest::default(),
+            RecordingSlowSink {
+                delay: Duration::from_millis(50),
+                events: Arc::clone(&events),
+            },
+            ResponsesEventBuilder::new("task", "subtask", "model"),
+        )
+        .await;
+
+    let events = events.lock().await;
+    let streamed_text: String = events
+        .iter()
+        .filter(|event| event.event_type == "response.output_text.delta")
+        .filter_map(|event| event.data.get("delta").and_then(|value| value.as_str()))
+        .collect();
+    assert_eq!(streamed_text, long_text);
+    assert_eq!(outcome, ExecutionOutcome::Completed { content: long_text });
+}
+
+#[tokio::test]
+async fn stream_process_engine_preserves_queued_non_text_events_before_success() {
+    let long_text = "x".repeat(5_000);
+    let assistant = json!({
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "id": "tool-1", "name": "Read", "input": {"path": "a.txt"}},
+                {"type": "text", "text": long_text}
+            ]
+        }
+    })
+    .to_string();
+    let tool_result = json!({
+        "type": "user",
+        "message": {
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tool-1", "content": "ok"}
+            ]
+        }
+    })
+    .to_string();
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(format!(
+            r#"printf '%s\n' '{}' '{}' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}}'"#,
+            assistant, tool_result
+        )),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let outcome = engine
+        .run_with_events(
+            ExecutionRequest::default(),
+            RecordingSlowSink {
+                delay: Duration::from_millis(50),
+                events: Arc::clone(&events),
+            },
+            ResponsesEventBuilder::new("task", "subtask", "model"),
+        )
+        .await;
+
+    let events = events.lock().await;
+    assert!(events.iter().any(|event| {
+        event.event_type == "response.block.updated"
+            && event.data["block_id"] == "tool-1"
+            && event.data["updates"]["tool_output"] == "ok"
+    }));
+    assert_eq!(outcome, ExecutionOutcome::Completed { content: long_text });
+}
+
+#[tokio::test]
+async fn stream_process_engine_ignores_child_agent_assistant_text() {
+    let child = json!({
+        "type": "assistant",
+        "parent_tool_use_id": "Agent_0",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "child draft"}]
+        }
+    })
+    .to_string();
+    let root = json!({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "root final"}]
+        }
+    })
+    .to_string();
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(format!(
+            r#"printf '%s\n' '{}' '{}' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn"}}'"#,
+            child, root
+        )),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let outcome = engine
+        .run_with_events(
+            ExecutionRequest::default(),
+            RecordingSlowSink {
+                delay: Duration::from_millis(1),
+                events: Arc::clone(&events),
+            },
+            ResponsesEventBuilder::new("task", "subtask", "model"),
+        )
+        .await;
+
+    let events = events.lock().await;
+    let streamed_text: String = events
+        .iter()
+        .filter(|event| event.event_type == "response.output_text.delta")
+        .filter_map(|event| event.data.get("delta").and_then(|value| value.as_str()))
+        .collect();
+    assert_eq!(streamed_text, "root final");
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "root final".to_owned()
+        }
+    );
+}
+
+#[tokio::test]
+async fn stream_process_engine_ignores_root_text_while_async_agent_is_running() {
+    let task_started = json!({
+        "type": "system",
+        "subtype": "task_started",
+        "task_type": "local_agent",
+        "tool_use_id": "Agent_0",
+        "task_id": "agent-1"
+    })
+    .to_string();
+    let draft = json!({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "draft before agent finishes"}]
+        }
+    })
+    .to_string();
+    let task_notification = json!({
+        "type": "system",
+        "subtype": "task_notification",
+        "status": "completed",
+        "tool_use_id": "Agent_0",
+        "task_id": "agent-1",
+        "summary": "child result"
+    })
+    .to_string();
+    let final_message = json!({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "final after agent"}]
+        }
+    })
+    .to_string();
+    let engine = StreamProcessEngine::new(
+        CommandSpec::new("sh").arg("-c").arg(format!(
+            r#"printf '%s\n' '{}' '{}' '{}' '{}' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","result":"draft before agent finishes"}}' '{{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","origin":{{"kind":"task-notification"}},"result":"final after agent"}}'"#,
+            task_started, draft, task_notification, final_message
+        )),
+        TEST_PROCESS_TIMEOUT_SECONDS,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let outcome = engine
+        .run_with_events(
+            ExecutionRequest::default(),
+            RecordingSlowSink {
+                delay: Duration::from_millis(1),
+                events: Arc::clone(&events),
+            },
+            ResponsesEventBuilder::new("task", "subtask", "model"),
+        )
+        .await;
+
+    let events = events.lock().await;
+    let streamed_text: String = events
+        .iter()
+        .filter(|event| event.event_type == "response.output_text.delta")
+        .filter_map(|event| event.data.get("delta").and_then(|value| value.as_str()))
+        .collect();
+    assert_eq!(streamed_text, "final after agent");
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "final after agent".to_owned()
+        }
+    );
+}
+
+#[tokio::test]
+async fn stream_process_engine_fails_when_claude_stdout_ends_without_result() {
     let engine = StreamProcessEngine::new(
         CommandSpec::new("sh").arg("-c").arg(
             r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}'; printf '%s' '{"type":"user","message":{"content":[{"type":"tool_result","content":"broken"}'"#,
@@ -40,12 +363,10 @@ async fn stream_process_engine_ignores_incomplete_trailing_json_like_python_sdk(
 
     let outcome = engine.run(ExecutionRequest::default()).await;
 
-    assert_eq!(
-        outcome,
-        ExecutionOutcome::Completed {
-            content: "partial".to_owned()
-        }
-    );
+    assert!(matches!(outcome, ExecutionOutcome::Failed { .. }));
+    if let ExecutionOutcome::Failed { message } = outcome {
+        assert!(message.contains("Claude stdout ended before result message"));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Separate environment-based tuning for streaming text vs reasoning chunk sizes.
* **Bug Fixes**
  * Streaming output now queues and compacts text updates for cleaner ordering.
  * Nested child-agent assistant text is excluded from the main response.
  * Streaming sessions now fail clearly if output ends before a final result is received.
  * Improved reliability with delayed callbacks—tool and reasoning updates are preserved and emitted correctly.
* **Chores**
  * Updated the Codex CLI package version in build/deploy artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->