### PR TITLE
fix(wework): open terminal links externally

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,6 +507,9 @@ importers:
       "@xterm/addon-fit":
         specifier: ^0.11.0
         version: 0.11.0
+      "@xterm/addon-web-links":
+        specifier: ^0.12.0
+        version: 0.12.0
       "@xterm/xterm":
         specifier: ^6.0.0
         version: 6.0.0
@@ -5102,6 +5105,12 @@ packages:
     resolution:
       {
         integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==,
+      }
+
+  "@xterm/addon-web-links@0.12.0":
+    resolution:
+      {
+        integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==,
       }
 
   "@xterm/xterm@6.0.0":
@@ -15590,6 +15599,8 @@ snapshots:
       tinyrainbow: 3.1.0
 
   "@xterm/addon-fit@0.11.0": {}
+
+  "@xterm/addon-web-links@0.12.0": {}
 
   "@xterm/xterm@6.0.0": {}
 

--- a/wework/package.json
+++ b/wework/package.json
@@ -40,6 +40,7 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@wegent/chat-core": "workspace:*",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -15,6 +15,7 @@ import {
   observeTerminalTheme,
 } from '@/lib/xterm-theme'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
+import { createXtermWebLinksAddon } from './xtermLinks'
 
 interface EmbeddedLocalTerminalProps {
   sessionId: string
@@ -65,6 +66,7 @@ export function EmbeddedLocalTerminal({
       theme: getTerminalTheme(),
     })
     const fitAddon = new FitAddon()
+    const webLinksAddon = createXtermWebLinksAddon()
     let inputFallback: XtermInputFallbackController = {
       noteData: () => undefined,
       dispose: () => undefined,
@@ -80,6 +82,7 @@ export function EmbeddedLocalTerminal({
     const unlisteners: Array<() => void> = []
 
     terminal.loadAddon(fitAddon)
+    terminal.loadAddon(webLinksAddon)
     terminal.open(container)
     inputFallback = installXtermInputFallback({
       terminal,

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { openExternalUrl } from '@/lib/external-links'
 import { createRemoteTerminalClient } from '@/lib/remote-terminal-socket'
 import { RemoteTerminal } from './RemoteTerminal'
 
@@ -18,6 +19,11 @@ const testState = vi.hoisted(() => ({
     focus: ReturnType<typeof vi.fn>
     options: { theme?: unknown }
   }>,
+  webLinksAddonInstances: [] as Array<{
+    activate: ReturnType<typeof vi.fn>
+    dispose: ReturnType<typeof vi.fn>
+    openUri: (uri: string) => void
+  }>,
   resizeObserverInstances: [] as Array<{
     trigger: () => void
     observe: ReturnType<typeof vi.fn>
@@ -30,6 +36,20 @@ vi.mock('@xterm/addon-fit', () => ({
     return {
       fit: vi.fn(),
     }
+  }),
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn().mockImplementation(function WebLinksAddonMock(
+    handler: (_event: MouseEvent, uri: string) => void
+  ) {
+    const addon = {
+      activate: vi.fn(),
+      dispose: vi.fn(),
+      openUri: (uri: string) => handler(new MouseEvent('click'), uri),
+    }
+    testState.webLinksAddonInstances.push(addon)
+    return addon
   }),
 }))
 
@@ -62,7 +82,12 @@ vi.mock('@/lib/remote-terminal-socket', () => ({
   createRemoteTerminalClient: vi.fn(),
 }))
 
+vi.mock('@/lib/external-links', () => ({
+  openExternalUrl: vi.fn().mockResolvedValue(true),
+}))
+
 const createRemoteTerminalClientMock = vi.mocked(createRemoteTerminalClient)
+const openExternalUrlMock = vi.mocked(openExternalUrl)
 
 function createClient(overrides: Partial<ReturnType<typeof createRemoteTerminalClient>> = {}) {
   return {
@@ -97,6 +122,7 @@ describe('RemoteTerminal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     testState.terminalInstances.length = 0
+    testState.webLinksAddonInstances.length = 0
     testState.resizeObserverInstances.length = 0
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
     requestAnimationFrameSpy = vi
@@ -198,5 +224,20 @@ describe('RemoteTerminal', () => {
       )
     })
     expect(requestAnimationFrameSpy).toHaveBeenCalled()
+  })
+
+  test('loads web links addon and opens terminal urls through the external link handler', () => {
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
+    })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    render(<RemoteTerminal sessionId="terminal-1" active={false} />)
+    const terminal = testState.terminalInstances[0]
+    const webLinksAddon = testState.webLinksAddonInstances[0]
+
+    expect(terminal.loadAddon).toHaveBeenCalledWith(webLinksAddon)
+    webLinksAddon.openUri('https://example.com/docs')
+    expect(openExternalUrlMock).toHaveBeenCalledWith('https://example.com/docs')
   })
 })

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -9,6 +9,7 @@ import {
   getTerminalTheme,
   observeTerminalTheme,
 } from '@/lib/xterm-theme'
+import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
 
 interface RemoteTerminalProps {
@@ -61,6 +62,7 @@ export function RemoteTerminal({
       theme: getTerminalTheme(),
     })
     const fitAddon = new FitAddon()
+    const webLinksAddon = createXtermWebLinksAddon()
     const client = createRemoteTerminalClient(sessionId)
     let disposed = false
     let scheduleThemeSync: () => void = () => undefined
@@ -93,6 +95,7 @@ export function RemoteTerminal({
     })
 
     terminal.loadAddon(fitAddon)
+    terminal.loadAddon(webLinksAddon)
     terminal.open(container)
     inputFallback = installXtermInputFallback({
       terminal,

--- a/wework/src/components/layout/workspace-panels/xtermLinks.ts
+++ b/wework/src/components/layout/workspace-panels/xtermLinks.ts
@@ -1,0 +1,10 @@
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { openExternalUrl } from '@/lib/external-links'
+
+export function createXtermWebLinksAddon(): WebLinksAddon {
+  return new WebLinksAddon((_event, uri) => {
+    void openExternalUrl(uri).catch(error => {
+      console.error('Failed to open terminal URL:', error)
+    })
+  })
+}


### PR DESCRIPTION
## Summary

- Enable clickable http/https links in Wework embedded terminals using the official xterm web links addon.
- Route terminal link activation through the existing external URL opener so Tauri opens links in the system browser.
- Cover the remote terminal path with a unit test.

## Root Cause

The Wework xterm instances only loaded the fit addon, so terminal output was rendered as plain text and URL clicks had no link handler.

## Impact

Users can click links printed by local and remote Wework terminals and open them directly in the browser.

## Validation

- pnpm --filter wework exec vitest run src/components/layout/workspace-panels/RemoteTerminal.test.tsx
- pnpm --filter wework lint
- pnpm --filter wework typecheck
- pre-push Wework ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal output now supports clickable web links in both local and remote terminal panels.
  * Link clicks open in your browser or default external app.
* **Bug Fixes**
  * Improved handling for terminal URLs so failures are safely handled instead of disrupting the terminal experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->