### PR TITLE
ci(wework): publish github updater manifest

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -127,15 +127,13 @@ jobs:
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release edit "$RELEASE_TAG" \
               --title "$release_title" \
-              --notes-file "$release_notes" \
-              --prerelease
+              --notes-file "$release_notes"
           else
             gh release create "$RELEASE_TAG" \
               --target "$GITHUB_SHA" \
               --title "$release_title" \
               --notes-file "$release_notes" \
-              --draft \
-              --prerelease
+              --draft
           fi
 
   build-macos:
@@ -214,25 +212,50 @@ jobs:
       - name: Build Wework app bundle
         working-directory: wework
         env:
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
           VITE_API_BASE_URL: https://api.wecode.ai/api
           VITE_SOCKET_BASE_URL: https://api.wecode.ai
         run: |
           set -euo pipefail
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            echo "Missing GitHub secret: TAURI_SIGNING_PRIVATE_KEY" >&2
+            exit 1
+          fi
+          if [ -z "${TAURI_UPDATER_PUBKEY:-}" ]; then
+            echo "Missing GitHub secret: TAURI_UPDATER_PUBKEY" >&2
+            exit 1
+          fi
+
           config_override="$(mktemp "$PWD/src-tauri/tauri.ci.XXXXXX.json")"
           cleanup() {
             rm -f "$config_override"
           }
           trap cleanup EXIT
-          CONFIG_OVERRIDE="$config_override" VERSION="${{ needs.prepare-release.outputs.version }}" python3 - <<'PY'
+          CONFIG_OVERRIDE="$config_override" \
+          VERSION="${{ needs.prepare-release.outputs.version }}" \
+          UPDATER_ENDPOINT="https://github.com/${GH_REPO}/releases/latest/download/latest.json" \
+          TAURI_UPDATER_PUBKEY="$TAURI_UPDATER_PUBKEY" \
+          python3 - <<'PY'
           import json
           import os
 
           config = {
               "version": os.environ["VERSION"],
               "bundle": {
+                  "createUpdaterArtifacts": True,
                   "macOS": {
                       "signingIdentity": "-",
                       "hardenedRuntime": True,
+                  },
+              },
+              "plugins": {
+                  "updater": {
+                      "endpoints": [os.environ["UPDATER_ENDPOINT"]],
+                      "pubkey": os.environ["TAURI_UPDATER_PUBKEY"],
                   },
               },
           }
@@ -243,14 +266,25 @@ jobs:
           PY
           pnpm exec tauri build \
             --target "${{ matrix.rust_target }}" \
-            --bundles dmg \
+            --bundles app,dmg \
             --config "$config_override"
 
-      - name: Verify and collect DMG
+      - name: Verify and collect release assets
         id: package
         shell: bash
         run: |
           set -euo pipefail
+          archive_source="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/macos" -maxdepth 1 -name '*.app.tar.gz' -type f | sort | tail -1)"
+          if [ -z "$archive_source" ]; then
+            echo "No updater .app.tar.gz archive found" >&2
+            exit 1
+          fi
+          signature_source="$archive_source.sig"
+          if [ ! -f "$signature_source" ]; then
+            echo "No updater signature found: $signature_source" >&2
+            exit 1
+          fi
+
           dmg_source="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f | sort | tail -1)"
           if [ -z "$dmg_source" ]; then
             echo "No .dmg bundle found" >&2
@@ -285,21 +319,31 @@ jobs:
           artifact_dir="$RUNNER_TEMP/wework-macos-${{ matrix.arch }}"
           mkdir -p "$artifact_dir"
           dmg_path="$artifact_dir/WeWork_${{ needs.prepare-release.outputs.version }}_macos_${{ matrix.arch }}_unsigned-adhoc.dmg"
+          archive_path="$artifact_dir/WeWork_${{ needs.prepare-release.outputs.version }}_macos_${{ matrix.arch }}.app.tar.gz"
+          signature_path="$archive_path.sig"
           cp "$dmg_source" "$dmg_path"
+          cp "$archive_source" "$archive_path"
+          cp "$signature_source" "$signature_path"
           shasum -a 256 "$dmg_path"
+          shasum -a 256 "$archive_path"
           {
             echo "### Wework macOS ${{ matrix.arch }} release asset"
             echo ""
             echo "- DMG: $(basename "$dmg_path")"
+            echo "- Updater archive: $(basename "$archive_path")"
             echo "- This build is ad-hoc signed and not Apple notarized."
             echo "- If the first launch dialog shows Move to Trash, click Done instead."
             echo "- Then force-open from System Settings > Privacy & Security > Open Anyway."
             echo "- If macOS keeps the quarantine flag: \`xattr -dr com.apple.quarantine /Applications/WeWork.app\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "dmg_path=$dmg_path" >> "$GITHUB_OUTPUT"
+          {
+            echo "dmg_path=$dmg_path"
+            echo "archive_path=$archive_path"
+            echo "signature_path=$signature_path"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Upload DMG to GitHub Release
+      - name: Upload macOS assets to GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -307,11 +351,88 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |
           set -euo pipefail
-          gh release upload "$RELEASE_TAG" "${{ steps.package.outputs.dmg_path }}" --clobber
+          gh release upload "$RELEASE_TAG" \
+            "${{ steps.package.outputs.dmg_path }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.signature_path }}" \
+            --clobber
           release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
           {
             echo ""
-            echo "- Direct DMG download is available from: $release_url"
+            echo "- Direct DMG and updater downloads are available from: $release_url"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-updater-manifest:
+    name: Publish updater manifest
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-release
+      - build-macos
+
+    steps:
+      - name: Generate latest.json
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          work_dir="$(mktemp -d)"
+          gh release download "$RELEASE_TAG" \
+            --pattern "WeWork_${RELEASE_VERSION}_macos_*.app.tar.gz.sig" \
+            --dir "$work_dir"
+
+          arm64_sig_path="$work_dir/WeWork_${RELEASE_VERSION}_macos_arm64.app.tar.gz.sig"
+          x64_sig_path="$work_dir/WeWork_${RELEASE_VERSION}_macos_x64.app.tar.gz.sig"
+          if [ ! -f "$arm64_sig_path" ] || [ ! -f "$x64_sig_path" ]; then
+            echo "Missing updater signatures for latest.json" >&2
+            ls -la "$work_dir" >&2
+            exit 1
+          fi
+
+          export LATEST_JSON="$work_dir/latest.json"
+          export RELEASE_NOTES
+          RELEASE_NOTES="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
+          export ARM64_URL="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/WeWork_${RELEASE_VERSION}_macos_arm64.app.tar.gz"
+          export X64_URL="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/WeWork_${RELEASE_VERSION}_macos_x64.app.tar.gz"
+          export ARM64_SIGNATURE
+          export X64_SIGNATURE
+          ARM64_SIGNATURE="$(cat "$arm64_sig_path")"
+          X64_SIGNATURE="$(cat "$x64_sig_path")"
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          data = {
+              "version": os.environ["RELEASE_VERSION"],
+              "notes": os.environ["RELEASE_NOTES"],
+              "pub_date": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "platforms": {
+                  "darwin-aarch64": {
+                      "signature": os.environ["ARM64_SIGNATURE"],
+                      "url": os.environ["ARM64_URL"],
+                  },
+                  "darwin-x86_64": {
+                      "signature": os.environ["X64_SIGNATURE"],
+                      "url": os.environ["X64_URL"],
+                  },
+              },
+          }
+
+          with open(os.environ["LATEST_JSON"], "w", encoding="utf-8") as handle:
+              json.dump(data, handle, ensure_ascii=False, indent=2)
+              handle.write("\n")
+          PY
+
+          gh release upload "$RELEASE_TAG" "$work_dir/latest.json" --clobber
+          {
+            echo "### Wework updater manifest"
+            echo ""
+            echo "- Endpoint: https://github.com/${GH_REPO}/releases/latest/download/latest.json"
+            echo "- Version: ${RELEASE_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish-release:
@@ -320,6 +441,7 @@ jobs:
     needs:
       - prepare-release
       - build-macos
+      - publish-updater-manifest
 
     steps:
       - name: Publish GitHub Release
@@ -330,6 +452,12 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |
           set -euo pipefail
-          gh release edit "$RELEASE_TAG" --draft=false --prerelease
+          release_id="$(gh release view "$RELEASE_TAG" --json databaseId --jq .databaseId)"
+          gh api \
+            --method PATCH \
+            "repos/${GH_REPO}/releases/${release_id}" \
+            --field draft=false \
+            --field prerelease=false \
+            --raw-field make_latest=true >/dev/null
           release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
-          echo "Published direct DMG downloads: $release_url" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published Wework release and updater manifest: $release_url" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/en/developer-guide/wework-macos-release.md
+++ b/docs/en/developer-guide/wework-macos-release.md
@@ -87,16 +87,39 @@ To validate local updater behavior, serve the script output directory:
 python3 -m http.server 8787 --directory src-tauri/target/release/local-update-server
 ```
 
-## CI DMG Without Apple Developer
+## GitHub Release Auto Update
 
-The repository includes `.github/workflows/wework-app.yml` for producing macOS test DMGs on GitHub Actions without the Apple Developer Program. The workflow applies an ad-hoc codesign signature to the `.app`, but it does not perform Apple notarization, so first launch still triggers Gatekeeper. Use this mode for internal testing and developer distribution only; do not label it as a notarized production package.
+The repository includes `.github/workflows/wework-app.yml` for producing macOS DMGs, Tauri updater archives, signature files, and `latest.json` on GitHub Actions. The updater endpoint embedded in the client points to the GitHub Release latest asset:
 
-The workflow does not require Apple signing secrets. It creates or updates the `wework-v<version>` GitHub prerelease and uploads two release assets:
+```text
+https://github.com/<owner>/<repo>/releases/latest/download/latest.json
+```
+
+The workflow creates or updates a `wework-v<version>` draft release. After both architecture builds finish, it generates `latest.json`, uploads it to the same release, and then publishes that release as GitHub latest. The client reads this manifest during automatic startup checks and when the titlebar update action is used.
+
+Configure these repository secrets in GitHub Actions:
+
+- `TAURI_SIGNING_PRIVATE_KEY`: Tauri updater private key.
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: private key password; leave empty if the key has no password.
+- `TAURI_UPDATER_PUBKEY`: updater public key matching the private key. It is injected into the built app.
+
+Do not rotate the updater private key unless it is acceptable for already-installed clients to stop receiving automatic updates. Tauri verifies new releases with the public key embedded in the installed client.
+
+The workflow uploads these release assets:
 
 - `WeWork_<version>_macos_arm64_unsigned-adhoc.dmg`
 - `WeWork_<version>_macos_x64_unsigned-adhoc.dmg`
+- `WeWork_<version>_macos_arm64.app.tar.gz`
+- `WeWork_<version>_macos_arm64.app.tar.gz.sig`
+- `WeWork_<version>_macos_x64.app.tar.gz`
+- `WeWork_<version>_macos_x64.app.tar.gz.sig`
+- `latest.json`
 
-When downloaded from GitHub Release assets, the link points directly to the `.dmg` file and is not wrapped by an Actions artifact `.zip`. When the workflow is triggered manually without a version input, the release tag uses `wework-v<package-version>-<short-sha>`.
+When downloaded from GitHub Release assets, the link points directly to the `.dmg` file and is not wrapped by an Actions artifact `.zip`. When the workflow is triggered manually without a version input, the release tag auto-increments the patch version from the latest `wework-vX.Y.Z` tag.
+
+## CI DMG Without Apple Developer
+
+The GitHub workflow applies an ad-hoc codesign signature to the `.app`, but it does not perform Apple notarization, so first launch still triggers Gatekeeper. Use this mode for internal testing and developer distribution only; do not label it as a notarized production package.
 
 To force-open the app on first launch. On macOS 15 and later, the warning can still include a **Move to Trash** button; as long as CI passed `codesign --verify --deep --strict`, this is usually the normal Gatekeeper block for a non-notarized app, not a damaged package:
 

--- a/docs/zh/developer-guide/wework-macos-release.md
+++ b/docs/zh/developer-guide/wework-macos-release.md
@@ -87,16 +87,39 @@ scripts/release-mac-app.sh --target local --version 0.1.99 --notes "Local verifi
 python3 -m http.server 8787 --directory src-tauri/target/release/local-update-server
 ```
 
-## 无 Apple Developer 账号的 CI DMG
+## GitHub Release 自动更新
 
-仓库提供 `.github/workflows/wework-app.yml`，用于在 GitHub Actions 上生成无需 Apple Developer Program 的 macOS 测试 DMG。该 workflow 会对 `.app` 执行 ad-hoc codesign，但不会做 Apple notarization，因此首次打开仍会触发 Gatekeeper。这个模式适合内部测试和开发者分发，不应标记为正式已公证发布包。
+仓库提供 `.github/workflows/wework-app.yml`，用于在 GitHub Actions 上生成 macOS DMG、Tauri updater archive、签名文件和 `latest.json`。客户端内置的 updater endpoint 指向 GitHub Release latest asset：
 
-workflow 不需要配置 Apple signing secrets，会创建或更新 `wework-v<version>` GitHub prerelease，并分别上传两个 Release assets：
+```text
+https://github.com/<owner>/<repo>/releases/latest/download/latest.json
+```
+
+workflow 会创建或更新 `wework-v<version>` draft release。两个架构构建完成后，workflow 生成 `latest.json`，上传到同一个 Release，最后把 Release 发布为 GitHub latest。客户端启动后的自动检查或标题栏手动更新都会读取这个 manifest。
+
+GitHub Actions 需要配置这些 repository secrets：
+
+- `TAURI_SIGNING_PRIVATE_KEY`：Tauri updater 私钥。
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`：私钥密码；如果私钥无密码可以留空。
+- `TAURI_UPDATER_PUBKEY`：与私钥匹配的 updater 公钥，会被注入到构建产物中。
+
+不要轮换 updater 私钥，除非可以接受旧客户端无法继续自动升级。Tauri 会用已安装客户端内置的公钥校验新版本签名。
+
+workflow 分别上传这些 Release assets：
 
 - `WeWork_<version>_macos_arm64_unsigned-adhoc.dmg`
 - `WeWork_<version>_macos_x64_unsigned-adhoc.dmg`
+- `WeWork_<version>_macos_arm64.app.tar.gz`
+- `WeWork_<version>_macos_arm64.app.tar.gz.sig`
+- `WeWork_<version>_macos_x64.app.tar.gz`
+- `WeWork_<version>_macos_x64.app.tar.gz.sig`
+- `latest.json`
 
-从 GitHub Release assets 下载时，下载链接本身就是 `.dmg` 文件，不会被 Actions artifact 额外套一层 `.zip`。手动触发 workflow 且未填写版本号时，release tag 会使用 `wework-v<package-version>-<short-sha>`。
+从 GitHub Release assets 下载时，下载链接本身就是 `.dmg` 文件，不会被 Actions artifact 额外套一层 `.zip`。手动触发 workflow 且未填写版本号时，release tag 会自动基于最新的 `wework-vX.Y.Z` tag 增加 patch 版本。
+
+## 无 Apple Developer 账号的 CI DMG
+
+GitHub workflow 会对 `.app` 执行 ad-hoc codesign，但不会做 Apple notarization，因此首次打开仍会触发 Gatekeeper。这个模式适合内部测试和开发者分发，不应标记为正式已公证发布包。
 
 首次打开被拦截时，可以强制打开。macOS 15 之后的提示可能仍会出现 **Move to Trash / 移到废纸篓** 按钮；只要 CI 中 `codesign --verify --deep --strict` 通过，这通常仍属于未公证 app 的 Gatekeeper 拦截，不是包损坏：
 


### PR DESCRIPTION
## Summary

- enable the Wework GitHub Actions release flow to generate Tauri updater archives and signatures
- publish `latest.json` to the GitHub Release latest asset endpoint
- document required updater signing secrets and release assets in Chinese and English

## Impact

After a GitHub Wework release is published, installed desktop clients can check the GitHub-hosted updater manifest and install the signed update package.

## Validation

- `actionlint .github/workflows/wework-app.yml`
- `git diff --check HEAD~1..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Release-based auto-update support for macOS builds, including publishing update metadata and release assets for client updater checks.
  * Release publishing now marks the latest version automatically after publication.

* **Documentation**
  * Updated macOS release guides in English and Chinese to explain the new auto-update release flow, required setup, uploaded assets, and manual release behavior.
  * Clarified the behavior of CI-built DMGs without Apple Developer signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->