### PR TITLE
fix(wework): keep guidance context expanded

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1340,6 +1340,50 @@ describe('MessageList', () => {
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
   })
 
+  test('keeps processing expanded for the assistant segment before runtime guidance', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'process-1',
+        subtaskId: 11,
+        type: 'text',
+        content: '我正在检查项目结构。',
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+      {
+        id: 'tool-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'Bash',
+        toolInput: { command: 'pwd' },
+        toolOutput: '/workspace/project\n',
+        status: 'done',
+        createdAt: 1770000001000,
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-before-guidance',
+            role: 'assistant',
+            content: '先看一下当前目录。',
+            status: 'done',
+            blocks,
+            runtimeGuidanceSplitBefore: true,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    const collapseContent = screen.getByTestId('processing-collapse-content')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getByText('我正在检查项目结构。')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
+  })
+
   test('renders final answer web search sources as a Codex-style source chip', async () => {
     const user = userEvent.setup()
     const openWindowMock = vi.fn()
@@ -3053,6 +3097,28 @@ describe('MessageList', () => {
             role: 'user',
             content: '短消息',
             status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByTestId('toggle-user-message-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('user-message-content')).not.toHaveClass('max-h-44')
+  })
+
+  test('does not collapse long runtime guidance messages', () => {
+    const content = Array.from({ length: 12 }, (_, index) => `第 ${index + 1} 行引导`).join('\n')
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'guidance-user',
+            role: 'user',
+            content,
+            status: 'done',
+            runtimeGuidance: true,
             createdAt: '2026-05-25T15:08:00.000+08:00',
           },
         ]}

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -611,8 +611,9 @@ function UserMessage({
   const hasImagePreviews = imagePreviewAttachments.length > 0
   const hasMultipleImagePreviews = imagePreviewAttachments.length > 1
   const shouldCollapse =
-    displayContent.length > USER_MESSAGE_COLLAPSE_CHARACTERS ||
-    displayContent.split('\n').length > USER_MESSAGE_COLLAPSE_LINES
+    message.runtimeGuidance !== true &&
+    (displayContent.length > USER_MESSAGE_COLLAPSE_CHARACTERS ||
+      displayContent.split('\n').length > USER_MESSAGE_COLLAPSE_LINES)
   const showSourceBadge = isIMSource(message.source)
   const showGoalRequestBadge = message.runtimeGoalRequest === true
   const codeCommentCount = message.codeComments?.length ?? 0
@@ -1486,7 +1487,7 @@ function AssistantMessage({
               blocks={displayBlocks}
               isStreaming={isStreaming}
               startedAt={getProcessingSummaryStartMs(message, displayBlocks, isStreaming)}
-              forceExpanded={isCancelled}
+              forceExpanded={isCancelled || message.runtimeGuidanceSplitBefore === true}
               hasFinalContent={hasVisibleContent}
               showSummary={!isCancelled}
               stateKey={getMessageDisplayStateKey(conversationKey, message)}

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1000,6 +1000,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         id: queuedMessage.id,
         createdAt: queuedMessage.createdAt,
         runtimeGoalRequest: queuedMessage.runtimeGoalRequest,
+        runtimeGuidance: true,
       })
 
       try {
@@ -1664,6 +1665,7 @@ interface CreateLocalUserMessageOptions {
   id?: string
   createdAt?: string
   runtimeGoalRequest?: boolean
+  runtimeGuidance?: boolean
   codeComments?: CodeCommentContext[]
 }
 
@@ -1680,6 +1682,7 @@ function createLocalUserMessage(
     status: 'done',
     createdAt: options.createdAt ?? new Date().toISOString(),
     runtimeGoalRequest: options.runtimeGoalRequest ? true : undefined,
+    runtimeGuidance: options.runtimeGuidance ? true : undefined,
     codeComments: options.codeComments?.length ? options.codeComments : undefined,
   }
 }
@@ -1712,6 +1715,7 @@ function splitActiveAssistantForGuidance(
     runtimeStatus: 'done',
     streamTextOffset: undefined,
     completedAt: guidanceMessage.createdAt,
+    runtimeGuidanceSplitBefore: true,
     blocks: freezeGuidanceAssistantBlocks(assistantMessage.blocks),
   }
 

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -71,6 +71,8 @@ export type WorkbenchMessage = Omit<
   completedAt?: string | number | null
   stoppedNotice?: boolean | null
   runtimeGoalRequest?: boolean | null
+  runtimeGuidance?: boolean | null
+  runtimeGuidanceSplitBefore?: boolean | null
   codeComments?: CodeCommentContext[] | null
   references?: CodexReference[] | null
   memoryCitations?: CodexMemoryCitation[] | null


### PR DESCRIPTION
## What changed

- Mark runtime guidance user messages so long guidance text stays fully visible instead of using the normal long-user-message collapse behavior.
- Mark assistant segments split by runtime guidance so the pre-guidance processing context remains expanded after the guidance is submitted.
- Add MessageList coverage for both guidance-specific display paths.

## Why

Submitting guidance while a runtime turn is active splits the streaming assistant message into a completed pre-guidance segment and a continuation. The pre-guidance segment then followed the normal completed-assistant behavior and collapsed its processing context, hiding the earlier content the user still needs to see.

## Impact

Users can submit guidance without losing visibility into the prior assistant work or the guidance text itself. Normal long user messages and completed assistant turns still keep their existing collapse behavior.

## Validation

- `pnpm --dir wework test -- src/components/chat/MessageList.test.tsx`
- `pnpm --dir wework typecheck`
- Pre-push Wework checks: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how long guidance and assistant messages are displayed so they stay readable and don’t collapse unexpectedly.
  * Preserved expanded processing details when guidance splits a conversation, making it easier to review in-progress assistant actions.
  * Hidden the collapse/toggle control for guidance-style messages, preventing confusing message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->