### PR TITLE
fix(wework): keep plan mode for adjustments

### DIFF
--- a/wework/src/components/chat/AssistantPlanCard.tsx
+++ b/wework/src/components/chat/AssistantPlanCard.tsx
@@ -10,9 +10,14 @@ import { AssistantMarkdown } from './AssistantMarkdown'
 interface AssistantPlanCardProps {
   content: string
   onOpenPlan?: (content: string) => void
+  isStreaming?: boolean
 }
 
-export function AssistantPlanCard({ content, onOpenPlan }: AssistantPlanCardProps) {
+export function AssistantPlanCard({
+  content,
+  onOpenPlan,
+  isStreaming = false,
+}: AssistantPlanCardProps) {
   const { t } = useTranslation('chat')
 
   const handleDownload = async () => {
@@ -61,6 +66,18 @@ export function AssistantPlanCard({ content, onOpenPlan }: AssistantPlanCardProp
         <div className="inline-flex min-w-0 items-center gap-2 text-sm font-medium">
           <ListChecks className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden="true" />
           <span>{t('plan_card.title')}</span>
+          {isStreaming ? (
+            <span
+              data-testid="assistant-plan-streaming-indicator"
+              className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-text-secondary"
+            >
+              <span
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary"
+                aria-hidden="true"
+              />
+              <span>{t('plan_card.generating')}</span>
+            </span>
+          ) : null}
         </div>
         <PlanCardActions content={content} onDownload={handleDownload} onExpand={openPlan} />
       </div>
@@ -72,7 +89,7 @@ export function AssistantPlanCard({ content, onOpenPlan }: AssistantPlanCardProp
           data-testid="assistant-plan-card-content"
           className="assistant-plan-card-content text-sm leading-6 text-text-primary [&_.assistant-markdown_h1]:mb-3 [&_.assistant-markdown_h1]:mt-2 [&_.assistant-markdown_h2]:mb-2 [&_.assistant-markdown_h2]:mt-3 [&_.assistant-markdown_p]:mb-2 [&_.assistant-markdown_p]:leading-5 [&_.assistant-markdown_ul]:mb-2 [&_.assistant-markdown_ul]:space-y-1 [&_.assistant-markdown_li]:leading-5"
         >
-          <AssistantMarkdown content={content} />
+          <AssistantMarkdown content={content} isStreaming={isStreaming} />
         </div>
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
       </div>

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -616,6 +616,7 @@ describe('MessageList', () => {
 
     const planCard = screen.getByTestId('assistant-plan-card')
     expect(planCard).toHaveTextContent('计划')
+    expect(screen.queryByTestId('assistant-plan-streaming-indicator')).not.toBeInTheDocument()
     expect(planCard).toHaveAttribute('role', 'button')
     expect(screen.getByTestId('assistant-plan-card-preview').className).toContain('max-h-[168px]')
     expect(screen.getByTestId('assistant-plan-card-content').className).toContain('text-sm')
@@ -709,6 +710,7 @@ describe('MessageList', () => {
 
     expect(screen.getByTestId('assistant-plan-card')).toHaveTextContent('流式计划')
     expect(screen.getByTestId('assistant-plan-card')).toHaveTextContent('正在生成第一步')
+    expect(screen.getByTestId('assistant-plan-streaming-indicator')).toHaveTextContent('正在生成')
   })
 
   test('renders untagged streaming plan-shaped markdown as regular assistant markdown', () => {

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -125,7 +125,14 @@ function PlanBlockItem({
 }) {
   if (!block.content.trim()) return null
 
-  return <AssistantPlanCard content={block.content} onOpenPlan={onOpenAssistantPlan} />
+  const isStreaming = block.status !== 'done' && block.status !== 'error'
+  return (
+    <AssistantPlanCard
+      content={block.content}
+      isStreaming={isStreaming}
+      onOpenPlan={onOpenAssistantPlan}
+    />
+  )
 }
 
 function ProcessFileChangesBlockItem({

--- a/wework/src/components/chat/requestUserInputMessages.ts
+++ b/wework/src/components/chat/requestUserInputMessages.ts
@@ -61,6 +61,20 @@ export function isImplementationPlanRequestUserInput(
   })
 }
 
+export function isImplementationPlanConfirmationResponse(
+  response: RequestUserInputResponse | null | undefined
+): boolean {
+  const answers = response?.answers
+  if (!answers || typeof answers !== 'object') return false
+
+  return Object.values(answers).some(answer => {
+    if (!answer || typeof answer !== 'object') return false
+    const values = (answer as { answers?: unknown }).answers
+    if (!Array.isArray(values)) return false
+    return values.some(value => hasImplementationPlanText(String(value)))
+  })
+}
+
 export function isRequestUserInputBlock(block: ProcessingBlock): block is RequestUserInputBlock {
   if (block.type !== 'tool') return false
   return isRequestUserInputPayload(block.renderPayload)

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -607,7 +607,7 @@ describe('DesktopWorkbenchLayout', () => {
     onLogout: vi.fn(),
   }
 
-  function createPendingRequestUserInputMessage(): WorkbenchMessage {
+  function createPendingRequestUserInputMessage(includeAdjustment = false): WorkbenchMessage {
     return {
       id: 'assistant-request',
       role: 'assistant',
@@ -629,6 +629,15 @@ describe('DesktopWorkbenchLayout', () => {
                 question: '执行此计划?',
                 options: [{ label: '是的，执行此计划' }],
               },
+              ...(includeAdjustment
+                ? [
+                    {
+                      id: 'adjustment',
+                      question: '否，请告知 WeWork 如何调整',
+                      is_other: true,
+                    },
+                  ]
+                : []),
             ],
           },
         },
@@ -1146,6 +1155,41 @@ describe('DesktopWorkbenchLayout', () => {
         },
       },
       { appendUserMessage: true, forceDefaultCollaborationMode: true }
+    )
+  })
+
+  test('keeps plan mode when submitting implementation plan adjustments', async () => {
+    const onRequestUserInputSubmit = vi.fn().mockResolvedValue(true)
+    const user = userEvent.setup()
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          currentRuntimeTask: {
+            deviceId: 'device-1',
+            workspacePath: '/workspace/project-alpha',
+            taskId: 'runtime-plan',
+          },
+        }}
+        messages={[createPendingRequestUserInputMessage(true)]}
+        onRequestUserInputSubmit={onRequestUserInputSubmit}
+      />
+    )
+
+    await user.type(screen.getByTestId('request-user-input-custom-adjustment'), '先缩小范围')
+    await user.click(screen.getByTestId('request-user-input-submit-button'))
+
+    expect(onRequestUserInputSubmit).toHaveBeenCalledWith(
+      {
+        requestId: 42,
+        itemId: undefined,
+        answers: {
+          adjustment: { answers: ['先缩小范围'] },
+        },
+      },
+      { appendUserMessage: true, forceDefaultCollaborationMode: false }
     )
   })
 

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -49,6 +49,7 @@ import { TaskForkDialog } from './TaskForkDialog'
 import { ContinueInImDialog } from '@/components/chat/ContinueInImDialog'
 import { TransientNotice } from '@/components/common/TransientNotice'
 import {
+  isImplementationPlanConfirmationResponse,
   isImplementationPlanRequestUserInput,
   requestUserInputPayloadKey,
 } from '@/components/chat/requestUserInputMessages'
@@ -1322,10 +1323,13 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                       }
                       payload={pendingRequestUserInput}
                       onSubmit={response => {
-                        const shouldImplementPlan =
+                        const isImplementationPlanRequest =
                           isImplementationPlanRequestUserInput(pendingRequestUserInput)
+                        const shouldImplementPlan =
+                          isImplementationPlanRequest &&
+                          isImplementationPlanConfirmationResponse(response)
                         return paneSession.sendRequestUserInputResponse(response, {
-                          appendUserMessage: shouldImplementPlan,
+                          appendUserMessage: isImplementationPlanRequest,
                           forceDefaultCollaborationMode: shouldImplementPlan,
                         })
                       }}

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -153,7 +153,7 @@ type LegacyMobileWorkbenchLayoutProps = {
   onRequestUserInputSubmit?: (...args: unknown[]) => Promise<boolean> | void
 }
 
-function createPendingRequestUserInputMessage(): WorkbenchMessage {
+function createPendingRequestUserInputMessage(includeAdjustment = false): WorkbenchMessage {
   return {
     id: 'assistant-request',
     role: 'assistant',
@@ -175,6 +175,15 @@ function createPendingRequestUserInputMessage(): WorkbenchMessage {
               question: '执行此计划?',
               options: [{ label: '是的，执行此计划' }],
             },
+            ...(includeAdjustment
+              ? [
+                  {
+                    id: 'adjustment',
+                    question: '否，请告知 WeWork 如何调整',
+                    is_other: true,
+                  },
+                ]
+              : []),
           ],
         },
       },
@@ -560,6 +569,41 @@ describe('MobileWorkbenchLayout', () => {
         },
       },
       { appendUserMessage: true, forceDefaultCollaborationMode: true }
+    )
+  })
+
+  test('keeps plan mode when submitting implementation plan adjustments on mobile', async () => {
+    const onRequestUserInputSubmit = vi.fn().mockResolvedValue(true)
+    const user = userEvent.setup()
+
+    renderAtMobileWidth(
+      <MobileWorkbenchLayout
+        state={{
+          ...baseState,
+          currentRuntimeTask: {
+            deviceId: 'device-1',
+            workspacePath: '/workspace/project-alpha',
+            taskId: 'runtime-plan',
+          },
+        }}
+        messages={[createPendingRequestUserInputMessage(true)]}
+        projectChat={baseProjectChat}
+        onRequestUserInputSubmit={onRequestUserInputSubmit}
+      />
+    )
+
+    await user.type(screen.getByTestId('request-user-input-custom-adjustment'), '先缩小范围')
+    await user.click(screen.getByTestId('request-user-input-submit-button'))
+
+    expect(onRequestUserInputSubmit).toHaveBeenCalledWith(
+      {
+        requestId: 42,
+        itemId: undefined,
+        answers: {
+          adjustment: { answers: ['先缩小范围'] },
+        },
+      },
+      { appendUserMessage: true, forceDefaultCollaborationMode: false }
     )
   })
 

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -26,6 +26,7 @@ import { MobileDrawer } from './MobileDrawer'
 import { ContinueInImDialog } from '@/components/chat/ContinueInImDialog'
 import { TransientNotice } from '@/components/common/TransientNotice'
 import {
+  isImplementationPlanConfirmationResponse,
   isImplementationPlanRequestUserInput,
   requestUserInputPayloadKey,
 } from '@/components/chat/requestUserInputMessages'
@@ -355,10 +356,13 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                     }
                     payload={pendingRequestUserInput}
                     onSubmit={response => {
-                      const shouldImplementPlan =
+                      const isImplementationPlanRequest =
                         isImplementationPlanRequestUserInput(pendingRequestUserInput)
+                      const shouldImplementPlan =
+                        isImplementationPlanRequest &&
+                        isImplementationPlanConfirmationResponse(response)
                       return paneSession.sendRequestUserInputResponse(response, {
-                        appendUserMessage: shouldImplementPlan,
+                        appendUserMessage: isImplementationPlanRequest,
                         forceDefaultCollaborationMode: shouldImplementPlan,
                       })
                     }}

--- a/wework/src/components/layout/requestUserInputOverlay.test.ts
+++ b/wework/src/components/layout/requestUserInputOverlay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   applyRequestUserInputResponseToMessages,
+  isImplementationPlanConfirmationResponse,
   requestUserInputPayloadKey,
   requestUserInputResponseKey,
 } from '@/components/chat/requestUserInputMessages'
@@ -8,6 +9,26 @@ import type { WorkbenchMessage } from '@/types/workbench'
 import { pendingRequestUserInputPayload } from './requestUserInputOverlay'
 
 describe('pendingRequestUserInputPayload', () => {
+  test('detects only explicit implementation plan confirmation responses', () => {
+    expect(
+      isImplementationPlanConfirmationResponse({
+        answers: {
+          implement: { answers: ['是的，执行此计划'] },
+        },
+      })
+    ).toBe(true)
+
+    expect(
+      isImplementationPlanConfirmationResponse({
+        answers: {
+          adjustment: { answers: ['先缩小范围'] },
+        },
+      })
+    ).toBe(false)
+
+    expect(isImplementationPlanConfirmationResponse({ answers: {} })).toBe(false)
+  })
+
   test('returns the latest pending request_user_input payload', () => {
     const messages = [
       {

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -27,6 +27,7 @@
   },
   "plan_card": {
     "title": "Plan",
+    "generating": "Generating",
     "download": "Download plan",
     "copy": "Copy plan",
     "copy_success": "Copied",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -27,6 +27,7 @@
   },
   "plan_card": {
     "title": "计划",
+    "generating": "正在生成",
     "download": "下载计划",
     "copy": "复制计划",
     "copy_success": "已复制",


### PR DESCRIPTION
## Summary
- keep Wework plan mode active when users submit plan adjustment text instead of confirming execution
- send generated-plan adjustment responses as normal user messages to avoid stale request_user_input pending checks
- add a subtle streaming indicator for plan cards while plans are still being generated

## Root Cause
The generated plan confirmation UI was deciding execution from the request shape instead of the submitted answer. Adjustment text could either force default mode or be sent as a structured request_user_input response even when the runtime had no pending request.

## Validation
- pnpm --filter wework test -- DesktopWorkbenchLayout.test.tsx MobileWorkbenchLayout.test.tsx requestUserInputOverlay.test.ts MessageList.test.tsx
- pre-push Wework ESLint, TypeScript, and unit tests passed

## Docs
No documentation update needed: this is a Wework UI bug fix with no public API, setup, or user-guide contract changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streaming “Generating” state for plan cards while content is being produced.
  * Improved plan-related input handling so the app can distinguish plan confirmations from adjustment responses.
* **Bug Fixes**
  * Plan mode now stays consistent when users submit adjustments, instead of switching behavior too early.
  * Mobile and desktop chat flows now handle implementation plan responses more accurately.
* **Tests**
  * Expanded coverage for streaming indicators and plan confirmation/adjustment submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->