### PR TITLE
docs(wework): fix e2e mock URL formatting

### DIFF
--- a/docs/en/developer-guide/wework-e2e-automation.md
+++ b/docs/en/developer-guide/wework-e2e-automation.md
@@ -37,7 +37,7 @@ Default configuration:
 - `VITE_WEWORK_E2E=true`
 - `VITE_WEWORK_RUNTIME_MODE=backend`
 - `VITE_LOGIN_MODE=password`
-- `WEWORK_RESPONSE_API_MOCK_URL=http://127.0.0.1:9998`
+- `WEWORK_RESPONSE_API_MOCK_URL`: `http://127.0.0.1:9998`
 
 Tests do not mock backend APIs. When Backend is not running, the login-page smoke test only verifies that the frontend renders the login entrypoint. Business flows after login must start a real Backend and required services in CI.
 

--- a/docs/zh/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/developer-guide/wework-e2e-automation.md
@@ -37,7 +37,7 @@ node e2e/utils/mock-response-api-server.mjs
 - `VITE_WEWORK_E2E=true`
 - `VITE_WEWORK_RUNTIME_MODE=backend`
 - `VITE_LOGIN_MODE=password`
-- `WEWORK_RESPONSE_API_MOCK_URL=http://127.0.0.1:9998`
+- `WEWORK_RESPONSE_API_MOCK_URL`: `http://127.0.0.1:9998`
 
 测试不 mock 后端 API。没有启动 Backend 时，登录页 smoke 测试只验证前端能渲染登录入口；需要登录后的业务流程时，CI 必须先启动真实 Backend 和依赖服务。
 


### PR DESCRIPTION
## Summary
- split the Wework E2E mock URL value into separate inline code spans in English and Chinese docs
- avoid the docs repository MDX compatibility script corrupting the URL during sync/build

## Verification
- Ran the wegent-docs local sync script against this worktree
- Ran `npm run build` in the synced wegent-docs clone; Docusaurus build completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the display of the default `WEWORK_RESPONSE_API_MOCK_URL` setting in the E2E automation and test-running guides.
  * Updated the environment variable example to a clearer key-value format in both English and Chinese docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->