### PR TITLE
fix(wework): forward CLI workspace paths to running app

### DIFF
--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -507,12 +507,13 @@ ABSOLUTE_PATH="$(cd "$TARGET_PATH" && pwd -P)"
 APP_BUNDLE={app_bundle}
 WEWORK_EXECUTABLE={executable}
 
-if [ -n "$APP_BUNDLE" ] && [ -d "$APP_BUNDLE" ]; then
-  exec open "$APP_BUNDLE" --args --open-workspace "$ABSOLUTE_PATH"
+if [ -x "$WEWORK_EXECUTABLE" ]; then
+  "$WEWORK_EXECUTABLE" --open-workspace "$ABSOLUTE_PATH" >/dev/null 2>&1 &
+  exit 0
 fi
 
-if [ -x "$WEWORK_EXECUTABLE" ]; then
-  exec "$WEWORK_EXECUTABLE" --open-workspace "$ABSOLUTE_PATH"
+if [ -n "$APP_BUNDLE" ] && [ -d "$APP_BUNDLE" ]; then
+  exec open "$APP_BUNDLE" --args --open-workspace "$ABSOLUTE_PATH"
 fi
 
 echo "wework: unable to locate Wework app executable" >&2
@@ -2636,7 +2637,8 @@ mod tests {
 
         assert!(content.contains("# Wework CLI launcher"));
         assert!(content.contains("APP_BUNDLE='/Applications/WeWork.app'"));
-        assert!(content.contains("open \"$APP_BUNDLE\" --args --open-workspace"));
+        assert!(content.contains("\"$WEWORK_EXECUTABLE\" --open-workspace \"$ABSOLUTE_PATH\""));
+        assert!(content.contains("exec open \"$APP_BUNDLE\" --args --open-workspace"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update the generated macOS `wework` launcher to invoke the Wework executable directly before falling back to `open --args`
- keep the LaunchServices fallback for cases where the executable is unavailable
- update launcher generation coverage for the direct executable path

## Tests
- `cargo test wework_cli`
- `cargo test local_workspace_open`

## Manual verification
- ran `wework /tmp/wework-cli-test-1783501129`; the app received `--open-workspace /private/tmp/wework-cli-test-1783501129` and opened the workspace through `runtime.workspaces.open`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the macOS launcher flow to try launching the app directly when the executable is available, with a fallback to opening the app bundle if needed.
  * Improved workspace opening behavior so the launcher uses the most direct available path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->