### PR TITLE
fix(wework): simplify runtime task unread reminders

### DIFF
--- a/wework/src/features/workbench/runtimeTaskReminders.test.ts
+++ b/wework/src/features/workbench/runtimeTaskReminders.test.ts
@@ -49,12 +49,10 @@ describe('runtimeTaskReminders', () => {
 
     const snapshot = buildRuntimeTaskReminderSnapshot({
       runtimeWork: runtimeWork([completedTask]),
-      currentRuntimeTask: null,
       previousRunningTaskKeys: new Set([key]),
-      storedUnreadTaskKeys: new Set(),
+      currentRuntimeTask: null,
     })
 
-    expect(snapshot.unreadTaskKeys.has(key)).toBe(true)
     expect(snapshot.completedUnreadItems.map(item => item.key)).toEqual([key])
   })
 
@@ -64,12 +62,10 @@ describe('runtimeTaskReminders', () => {
 
     const snapshot = buildRuntimeTaskReminderSnapshot({
       runtimeWork: runtimeWork([completedTask]),
-      currentRuntimeTask: null,
       previousRunningTaskKeys: new Set([key]),
-      storedUnreadTaskKeys: new Set(),
+      currentRuntimeTask: null,
     })
 
-    expect(snapshot.unreadTaskKeys.has(key)).toBe(true)
     expect(snapshot.completedUnreadItems.map(item => item.key)).toEqual([key])
   })
 
@@ -79,89 +75,51 @@ describe('runtimeTaskReminders', () => {
 
     const snapshot = buildRuntimeTaskReminderSnapshot({
       runtimeWork: runtimeWork([activeTask]),
-      currentRuntimeTask: null,
       previousRunningTaskKeys: new Set(),
-      storedUnreadTaskKeys: new Set(),
+      currentRuntimeTask: null,
     })
 
     expect(snapshot.runningTaskKeys.has(key)).toBe(true)
     expect(snapshot.completedUnreadItems).toEqual([])
   })
 
-  test('marks the current completed task unread when the window is not focused', () => {
+  test('does not mark the currently selected completed task unread', () => {
     const completedTask = task({ running: false })
     const taskWorkspace = workspace([completedTask])
     const key = getRuntimeTaskReminderItemKey(taskWorkspace, completedTask)
 
     const snapshot = buildRuntimeTaskReminderSnapshot({
       runtimeWork: runtimeWork([completedTask]),
-      currentRuntimeTask: { deviceId: 'local-device', taskId: 'task-1' },
       previousRunningTaskKeys: new Set([key]),
-      storedUnreadTaskKeys: new Set(),
-      currentRuntimeTaskVisible: false,
+      currentRuntimeTask: {
+        deviceId: taskWorkspace.deviceId,
+        workspacePath: taskWorkspace.workspacePath,
+        taskId: completedTask.taskId,
+      },
     })
 
-    expect(snapshot.unreadTaskKeys.has(key)).toBe(true)
-    expect(snapshot.completedUnreadItems.map(item => item.key)).toEqual([key])
-  })
-
-  test('treats the focused current task as read when it completes', () => {
-    const completedTask = task({ running: false })
-    const taskWorkspace = workspace([completedTask])
-    const key = getRuntimeTaskReminderItemKey(taskWorkspace, completedTask)
-
-    const snapshot = buildRuntimeTaskReminderSnapshot({
-      runtimeWork: runtimeWork([completedTask]),
-      currentRuntimeTask: { deviceId: 'local-device', taskId: 'task-1' },
-      previousRunningTaskKeys: new Set([key]),
-      storedUnreadTaskKeys: new Set(),
-      currentRuntimeTaskVisible: true,
-    })
-
-    expect(snapshot.unreadTaskKeys.has(key)).toBe(false)
     expect(snapshot.completedUnreadItems).toEqual([])
   })
 
-  test('clears stored unread for the focused current task', () => {
-    const completedTask = task({ running: false })
-    const taskWorkspace = workspace([completedTask])
-    const key = getRuntimeTaskReminderItemKey(taskWorkspace, completedTask)
+  test('does not complete unread items when the current task changes', () => {
+    const currentTask = task({ running: true })
+    const previousCompletedTask = task({
+      taskId: 'task-2',
+      title: 'Previous completed task',
+      running: false,
+    })
+    const taskWorkspace = workspace([currentTask, previousCompletedTask])
 
     const snapshot = buildRuntimeTaskReminderSnapshot({
-      runtimeWork: runtimeWork([completedTask]),
-      currentRuntimeTask: { deviceId: 'local-device', taskId: 'task-1' },
+      runtimeWork: runtimeWork([currentTask, previousCompletedTask]),
       previousRunningTaskKeys: new Set(),
-      storedUnreadTaskKeys: new Set([key]),
-      currentRuntimeTaskVisible: true,
+      currentRuntimeTask: {
+        deviceId: taskWorkspace.deviceId,
+        workspacePath: taskWorkspace.workspacePath,
+        taskId: currentTask.taskId,
+      },
     })
 
-    expect(snapshot.unreadTaskKeys.has(key)).toBe(false)
-  })
-
-  test('keeps stored unread for the current task when the window is not focused', () => {
-    const completedTask = task({ running: false })
-    const taskWorkspace = workspace([completedTask])
-    const key = getRuntimeTaskReminderItemKey(taskWorkspace, completedTask)
-
-    const snapshot = buildRuntimeTaskReminderSnapshot({
-      runtimeWork: runtimeWork([completedTask]),
-      currentRuntimeTask: { deviceId: 'local-device', taskId: 'task-1' },
-      previousRunningTaskKeys: new Set(),
-      storedUnreadTaskKeys: new Set([key]),
-      currentRuntimeTaskVisible: false,
-    })
-
-    expect(snapshot.unreadTaskKeys.has(key)).toBe(true)
-  })
-
-  test('keeps unread keys for tasks that are temporarily missing from runtime work', () => {
-    const snapshot = buildRuntimeTaskReminderSnapshot({
-      runtimeWork: runtimeWork([]),
-      currentRuntimeTask: null,
-      previousRunningTaskKeys: new Set(),
-      storedUnreadTaskKeys: new Set(['local-device\0archived-task']),
-    })
-
-    expect(snapshot.unreadTaskKeys).toEqual(new Set(['local-device\0archived-task']))
+    expect(snapshot.completedUnreadItems).toEqual([])
   })
 })

--- a/wework/src/features/workbench/runtimeTaskReminders.ts
+++ b/wework/src/features/workbench/runtimeTaskReminders.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import {
   APP_PREFERENCES_CHANGED_EVENT,
   defaultAppPreferences,
@@ -45,13 +45,15 @@ export const EMPTY_RUNTIME_TASK_REMINDERS: RuntimeTaskReminderState = {
 }
 
 interface RuntimeTaskReminderSnapshot {
-  unreadTaskKeys: Set<string>
   runningTaskKeys: Set<string>
   completedUnreadItems: RuntimeTaskReminderItem[]
   items: RuntimeTaskReminderItem[]
 }
 
 const REMINDER_STORAGE_VERSION = 1
+const MAX_STORED_REMINDER_KEYS = 200
+const EMPTY_STORAGE_SNAPSHOT = '[]'
+const reminderStorageListeners = new Map<string, Set<() => void>>()
 const TERMINAL_RUNTIME_TASK_STATUSES = new Set([
   'done',
   'complete',
@@ -74,10 +76,25 @@ function getReminderStorageKey(
 }
 
 function readStoredStringSet(key: string): Set<string> {
-  if (typeof window === 'undefined') return new Set()
+  return parseStoredStringSetSnapshot(readStoredStringSetSnapshot(key))
+}
+
+function readStoredStringSetSnapshot(key: string): string {
+  if (typeof window === 'undefined') return EMPTY_STORAGE_SNAPSHOT
   try {
     const parsed = JSON.parse(window.localStorage.getItem(key) ?? '[]')
-    return new Set(Array.isArray(parsed) ? parsed.filter(item => typeof item === 'string') : [])
+    const values = Array.isArray(parsed) ? parsed.filter(item => typeof item === 'string') : []
+    return JSON.stringify(values.slice(Math.max(0, values.length - MAX_STORED_REMINDER_KEYS)))
+  } catch {
+    return EMPTY_STORAGE_SNAPSHOT
+  }
+}
+
+function parseStoredStringSetSnapshot(snapshot: string): Set<string> {
+  try {
+    const parsed = JSON.parse(snapshot)
+    const values = Array.isArray(parsed) ? parsed.filter(item => typeof item === 'string') : []
+    return new Set(values)
   } catch {
     return new Set()
   }
@@ -86,6 +103,44 @@ function readStoredStringSet(key: string): Set<string> {
 function writeStoredStringSet(key: string, values: ReadonlySet<string>) {
   if (typeof window === 'undefined') return
   window.localStorage.setItem(key, JSON.stringify([...values]))
+}
+
+function limitStringSet(
+  values: ReadonlySet<string>,
+  limit = MAX_STORED_REMINDER_KEYS
+): Set<string> {
+  const entries = [...values]
+  return new Set(entries.slice(Math.max(0, entries.length - limit)))
+}
+
+function writeLimitedStoredStringSet(key: string, values: ReadonlySet<string>) {
+  writeStoredStringSet(key, limitStringSet(values))
+}
+
+function subscribeStoredStringSet(key: string, listener: () => void): () => void {
+  const listeners = reminderStorageListeners.get(key) ?? new Set<() => void>()
+  listeners.add(listener)
+  reminderStorageListeners.set(key, listeners)
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) {
+      reminderStorageListeners.delete(key)
+    }
+  }
+}
+
+function emitStoredStringSetChange(key: string) {
+  reminderStorageListeners.get(key)?.forEach(listener => listener())
+}
+
+function useStoredStringSet(key: string): Set<string> {
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeStoredStringSet(key, listener),
+    [key]
+  )
+  const getSnapshot = useCallback(() => readStoredStringSetSnapshot(key), [key])
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_STORAGE_SNAPSHOT)
+  return useMemo(() => parseStoredStringSetSnapshot(snapshot), [snapshot])
 }
 
 function debugReminderKey(key: string): string {
@@ -177,49 +232,33 @@ function collectRuntimeTaskReminderItems(
 
 export function buildRuntimeTaskReminderSnapshot({
   runtimeWork,
-  currentRuntimeTask,
   previousRunningTaskKeys,
-  storedUnreadTaskKeys,
-  currentRuntimeTaskVisible = false,
+  currentRuntimeTask,
 }: {
   runtimeWork: RuntimeWorkListResponse | null | undefined
-  currentRuntimeTask: RuntimeTaskAddress | null | undefined
   previousRunningTaskKeys: ReadonlySet<string>
-  storedUnreadTaskKeys: ReadonlySet<string>
-  currentRuntimeTaskVisible?: boolean
+  currentRuntimeTask?: RuntimeTaskAddress | null | undefined
 }): RuntimeTaskReminderSnapshot {
   const items = collectRuntimeTaskReminderItems(runtimeWork)
-  const currentRuntimeTaskKey = currentRuntimeTask
-    ? getRuntimeTaskReminderKey(currentRuntimeTask)
-    : null
   const runningTaskKeys = new Set(
     items.filter(item => isRuntimeTaskActive(item.task)).map(item => item.key)
   )
-  const unreadTaskKeys = new Set(storedUnreadTaskKeys)
+  const currentRuntimeTaskKey = currentRuntimeTask
+    ? getRuntimeTaskReminderKey(currentRuntimeTask)
+    : null
   const completedUnreadItems: RuntimeTaskReminderItem[] = []
-  if (currentRuntimeTaskVisible && currentRuntimeTaskKey) {
-    unreadTaskKeys.delete(currentRuntimeTaskKey)
-  }
 
   for (const item of items) {
     if (!isRuntimeTaskTerminal(item.task) || !previousRunningTaskKeys.has(item.key)) {
       continue
     }
-    if (currentRuntimeTaskVisible && item.key === currentRuntimeTaskKey) {
+    if (item.key === currentRuntimeTaskKey) {
       continue
     }
-    if (!unreadTaskKeys.has(item.key)) {
-      completedUnreadItems.push(item)
-    }
-    unreadTaskKeys.add(item.key)
+    completedUnreadItems.push(item)
   }
 
-  return { unreadTaskKeys, runningTaskKeys, completedUnreadItems, items }
-}
-
-function getWindowFocused(): boolean {
-  if (typeof document === 'undefined') return false
-  return document.visibilityState === 'visible' && document.hasFocus()
+  return { runningTaskKeys, completedUnreadItems, items }
 }
 
 export function useRuntimeTaskReminders({
@@ -231,12 +270,12 @@ export function useRuntimeTaskReminders({
   runtimeWork: RuntimeWorkListResponse | null | undefined
   currentRuntimeTask: RuntimeTaskAddress | null | undefined
 }): RuntimeTaskReminderState {
-  const [preferences, setPreferences] = useState<AppPreferences>(defaultAppPreferences)
-  const [storageVersion, setStorageVersion] = useState(0)
-  const [windowFocused, setWindowFocused] = useState(getWindowFocused)
-  const notifiedTaskKeysRef = useRef<Set<string>>(new Set())
   const runningTaskKeysStorageKey = getReminderStorageKey(userId, 'runningTaskKeys')
   const unreadTaskKeysStorageKey = getReminderStorageKey(userId, 'unreadTaskKeys')
+  const [preferences, setPreferences] = useState<AppPreferences>(defaultAppPreferences)
+  const runningTaskKeys = useStoredStringSet(runningTaskKeysStorageKey)
+  const unreadTaskKeys = useStoredStringSet(unreadTaskKeysStorageKey)
+  const notifiedTaskKeysRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
     let cancelled = false
@@ -258,39 +297,14 @@ export function useRuntimeTaskReminders({
     }
   }, [])
 
-  useEffect(() => {
-    const refreshFocused = () => setWindowFocused(getWindowFocused())
-    window.addEventListener('focus', refreshFocused)
-    window.addEventListener('blur', refreshFocused)
-    document.addEventListener('visibilitychange', refreshFocused)
-    refreshFocused()
-    return () => {
-      window.removeEventListener('focus', refreshFocused)
-      window.removeEventListener('blur', refreshFocused)
-      document.removeEventListener('visibilitychange', refreshFocused)
-    }
-  }, [])
-
-  const storedUnreadTaskKeys = useMemo(() => {
-    void storageVersion
-    return readStoredStringSet(unreadTaskKeysStorageKey)
-  }, [storageVersion, unreadTaskKeysStorageKey])
   const snapshot = useMemo(
     () =>
       buildRuntimeTaskReminderSnapshot({
         runtimeWork,
+        previousRunningTaskKeys: runningTaskKeys,
         currentRuntimeTask,
-        previousRunningTaskKeys: readStoredStringSet(runningTaskKeysStorageKey),
-        storedUnreadTaskKeys,
-        currentRuntimeTaskVisible: windowFocused,
       }),
-    [
-      currentRuntimeTask,
-      runningTaskKeysStorageKey,
-      runtimeWork,
-      storedUnreadTaskKeys,
-      windowFocused,
-    ]
+    [currentRuntimeTask, runningTaskKeys, runtimeWork]
   )
 
   useEffect(() => {
@@ -298,9 +312,15 @@ export function useRuntimeTaskReminders({
 
     const previousUnreadTaskKeys = readStoredStringSet(unreadTaskKeysStorageKey)
     const previousRunningTaskKeys = readStoredStringSet(runningTaskKeysStorageKey)
-    const unreadChanged = !sameStringSet(previousUnreadTaskKeys, snapshot.unreadTaskKeys)
+    const nextUnreadTaskKeys = new Set(previousUnreadTaskKeys)
+    const completedUnreadItems = snapshot.completedUnreadItems.filter(item => {
+      if (nextUnreadTaskKeys.has(item.key)) return false
+      nextUnreadTaskKeys.add(item.key)
+      return true
+    })
+    const unreadChanged = !sameStringSet(previousUnreadTaskKeys, nextUnreadTaskKeys)
     const runningChanged = !sameStringSet(previousRunningTaskKeys, snapshot.runningTaskKeys)
-    if (unreadChanged || runningChanged || snapshot.completedUnreadItems.length > 0) {
+    if (unreadChanged || runningChanged) {
       logRuntimeTaskReminderState('persist', {
         userId,
         currentRuntimeTask: currentRuntimeTask
@@ -310,13 +330,12 @@ export function useRuntimeTaskReminders({
               workspacePath: currentRuntimeTask.workspacePath ?? null,
             }
           : null,
-        currentRuntimeTaskVisible: windowFocused,
         taskCompletionNotificationsEnabled: preferences.taskCompletionNotificationsEnabled,
         previousUnreadTaskKeys: debugReminderKeys(previousUnreadTaskKeys),
-        nextUnreadTaskKeys: debugReminderKeys(snapshot.unreadTaskKeys),
+        nextUnreadTaskKeys: debugReminderKeys(nextUnreadTaskKeys),
         previousRunningTaskKeys: debugReminderKeys(previousRunningTaskKeys),
         nextRunningTaskKeys: debugReminderKeys(snapshot.runningTaskKeys),
-        completedUnreadItems: snapshot.completedUnreadItems.map(item => ({
+        completedUnreadItems: completedUnreadItems.map(item => ({
           key: debugReminderKey(item.key),
           taskId: item.task.taskId,
           title: item.task.title,
@@ -329,11 +348,18 @@ export function useRuntimeTaskReminders({
       })
     }
 
-    writeStoredStringSet(unreadTaskKeysStorageKey, snapshot.unreadTaskKeys)
-    writeStoredStringSet(runningTaskKeysStorageKey, snapshot.runningTaskKeys)
+    if (unreadChanged) {
+      writeLimitedStoredStringSet(unreadTaskKeysStorageKey, nextUnreadTaskKeys)
+      emitStoredStringSetChange(unreadTaskKeysStorageKey)
+    }
+    if (runningChanged) {
+      const nextRunningTaskKeys = limitStringSet(snapshot.runningTaskKeys)
+      writeStoredStringSet(runningTaskKeysStorageKey, nextRunningTaskKeys)
+      emitStoredStringSetChange(runningTaskKeysStorageKey)
+    }
 
     if (!preferences.taskCompletionNotificationsEnabled) return
-    for (const item of snapshot.completedUnreadItems) {
+    for (const item of completedUnreadItems) {
       if (notifiedTaskKeysRef.current.has(item.key)) continue
       notifiedTaskKeysRef.current.add(item.key)
       logRuntimeTaskReminderState('system-notification-send', {
@@ -351,14 +377,13 @@ export function useRuntimeTaskReminders({
     runningTaskKeysStorageKey,
     snapshot,
     unreadTaskKeysStorageKey,
-    windowFocused,
     userId,
   ])
 
   return useMemo(
     () => ({
-      unreadTaskKeys: snapshot.unreadTaskKeys,
-      unreadCount: snapshot.unreadTaskKeys.size,
+      unreadTaskKeys,
+      unreadCount: unreadTaskKeys.size,
       hasRunningTasks: snapshot.runningTaskKeys.size > 0,
       preferences,
       items: snapshot.items,
@@ -374,10 +399,10 @@ export function useRuntimeTaskReminders({
           nextUnreadTaskKeys: debugReminderKeys(nextKeys),
           address,
         })
-        writeStoredStringSet(unreadTaskKeysStorageKey, nextKeys)
-        setStorageVersion(version => version + 1)
+        writeLimitedStoredStringSet(unreadTaskKeysStorageKey, nextKeys)
+        emitStoredStringSetChange(unreadTaskKeysStorageKey)
       },
     }),
-    [preferences, snapshot, unreadTaskKeysStorageKey, userId]
+    [preferences, snapshot, unreadTaskKeys, unreadTaskKeysStorageKey, userId]
   )
 }


### PR DESCRIPTION
## Summary

Simplifies Wework runtime task unread reminders so unread state is driven by persisted task keys instead of transient in-memory unread state.

## Root Cause

The previous reminder flow mixed current task visibility/focus handling with stored unread state. That made unrelated tasks lose their unread marker when another task became active or sent messages.

## Changes

- Track `running -> terminal` transitions and persist only the completed task key as unread.
- Clear unread by deleting only the clicked task key from persisted storage.
- Cap persisted unread/running key storage to avoid unbounded growth.
- Remove window-focus/current-task batch clearing behavior from reminder snapshots.
- Add/update tests for the simplified single-task unread behavior.

## Validation

- `pnpm --filter wework typecheck`
- `pnpm --filter wework test -- runtimeTaskReminders`
- pre-commit Wework checks
- pre-push Wework ESLint, TypeScript, and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime task reminders now update more instantly when items are marked as read or completed.
  * Reminder counts and unread items stay in sync across the app without needing a manual refresh.

* **Bug Fixes**
  * Fixed cases where completed tasks could be incorrectly shown as unread.
  * Improved handling so the currently active task is not mistakenly added to completed unread reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->