### PR TITLE
fix(wework): enable settings titlebar dragging

### DIFF
--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -329,6 +329,11 @@ describe('ConnectionsSettingsPage', () => {
 
     expect(screen.getByTestId('settings-sidebar-topbar')).toHaveClass('h-[76px]', 'pt-6', 'mb-1')
     expect(screen.getByTestId('settings-back-button')).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('settings-main-titlebar-drag-region')).getByTestId(
+        'macos-titlebar-drag-region'
+      )
+    ).toHaveAttribute('data-tauri-drag-region')
   })
 
   test('keeps the cloud device creation notice visible after the create request resolves', async () => {

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -42,6 +42,7 @@ import { navigateTo } from '@/lib/navigation'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { cn } from '@/lib/utils'
 import { DesktopTopBar } from '@/components/layout/DesktopTopBar'
+import { MacOSTitleBarDragRegion } from '@/components/layout/MacOSTitleBarDragRegion'
 import { RemoteTerminal } from '@/components/layout/workspace-panels/RemoteTerminal'
 import { useResizableSidebar } from '@/components/layout/useResizableSidebar'
 import { buildVncPageUrl } from '@/lib/vnc'
@@ -1433,7 +1434,7 @@ export function ConnectionsSettingsPage({
   return (
     <div
       data-testid="wework-settings-page"
-      className="flex h-screen min-w-0 flex-1 overflow-hidden bg-background text-text-primary"
+      className="relative flex h-screen min-w-0 flex-1 overflow-hidden bg-background text-text-primary"
     >
       <aside
         className="relative flex shrink-0 flex-col border-r border-border/70 bg-[rgb(var(--color-sidebar))] px-1.5 pb-4 shadow-[inset_-1px_0_0_rgb(var(--color-border))] backdrop-blur-xl backdrop-saturate-150"
@@ -1503,6 +1504,16 @@ export function ConnectionsSettingsPage({
           aria-label={t('workbench.resize_sidebar', '调整侧边栏宽度')}
         />
       </aside>
+
+      {usesOverlayTitlebar && (
+        <div
+          data-testid="settings-main-titlebar-drag-region"
+          className="absolute right-0 top-0 z-titlebar h-[52px]"
+          style={{ left: sidebarWidth }}
+        >
+          <MacOSTitleBarDragRegion className="h-full w-full" />
+        </div>
+      )}
 
       <main className="min-w-0 flex-1 overflow-auto bg-background px-8 py-16">
         {activeNav === 'general' ? (


### PR DESCRIPTION
## Summary

Fixes the Wework settings page so the top area can be used to drag the desktop window in the Tauri app.

## Root Cause

The settings route only exposed a drag region inside the sidebar top bar. The main settings content area reserved top spacing for the overlay titlebar, but that visible top area did not contain a Tauri drag region, so dragging from most of the settings page header area did nothing.

## Changes

- Adds a transparent `MacOSTitleBarDragRegion` across the main settings titlebar area when running in Tauri.
- Positions the drag region to start after the resizable settings sidebar, preserving the back button and sidebar controls.
- Adds a regression assertion for the settings page drag region.

## Validation

- `pnpm --filter wework test -- ConnectionsSettingsPage.test.tsx`
- pre-push hook: ESLint, TypeScript, and unit tests passed