### PR TITLE
chore(wework): update release workflows

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update-contributors:
@@ -18,13 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Update Contributors in README
-        uses: akhilmhdh/contributors-readme-action@v2.3.2
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          auto_detect_branch_protection: false
           image_size: 80
           columns_per_row: 8
           readme_path: README.md
@@ -33,10 +34,11 @@ jobs:
           commit_message: 'docs: update contributors list'
 
       - name: Update Contributors in Chinese README
-        uses: akhilmhdh/contributors-readme-action@v2.3.2
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          auto_detect_branch_protection: false
           image_size: 80
           columns_per_row: 8
           readme_path: README_zh.md

--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.version.outputs.release_tag }}
+      release_sha: ${{ steps.version-files.outputs.release_sha }}
       version: ${{ steps.version.outputs.value }}
       publish_release: ${{ steps.version.outputs.publish_release }}
 
@@ -95,6 +96,96 @@ jobs:
             echo "publish_release=$publish_release"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Commit Wework version files
+        id: version-files
+        shell: bash
+        env:
+          PUBLISH_RELEASE: ${{ steps.version.outputs.publish_release }}
+          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+
+          sync_version_files() {
+            python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+
+          package_path = Path("wework/package.json")
+          package_data = json.loads(package_path.read_text(encoding="utf-8"))
+          package_data["version"] = version
+          package_path.write_text(
+              json.dumps(package_data, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          tauri_config_path = Path("wework/src-tauri/tauri.conf.json")
+          tauri_config = json.loads(tauri_config_path.read_text(encoding="utf-8"))
+          tauri_config["version"] = version
+          tauri_config_path.write_text(
+              json.dumps(tauri_config, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          cargo_toml_path = Path("wework/src-tauri/Cargo.toml")
+          cargo_toml = cargo_toml_path.read_text(encoding="utf-8")
+          cargo_toml = re.sub(
+              r'(?m)^version = "[^"]+"',
+              f'version = "{version}"',
+              cargo_toml,
+              count=1,
+          )
+          cargo_toml_path.write_text(cargo_toml, encoding="utf-8")
+
+          cargo_lock_path = Path("wework/src-tauri/Cargo.lock")
+          cargo_lock = cargo_lock_path.read_text(encoding="utf-8")
+          cargo_lock = re.sub(
+              r'(?ms)(\[\[package\]\]\nname = "app"\nversion = ")[^"]+(")',
+              rf'\g<1>{version}\2',
+              cargo_lock,
+              count=1,
+          )
+          cargo_lock_path.write_text(cargo_lock, encoding="utf-8")
+          PY
+          }
+
+          if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            sync_version_files
+            if ! git diff --quiet -- wework/package.json wework/src-tauri/tauri.conf.json wework/src-tauri/Cargo.toml wework/src-tauri/Cargo.lock; then
+              echo "Error: tag release version files do not match ${RELEASE_VERSION}. Update the files before creating the tag." >&2
+              git diff -- wework/package.json wework/src-tauri/tauri.conf.json wework/src-tauri/Cargo.toml wework/src-tauri/Cargo.lock >&2
+              exit 1
+            fi
+            echo "release_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${PUBLISH_RELEASE}" != "true" ]]; then
+            echo "release_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${GITHUB_REF_TYPE:-}" != "branch" ]]; then
+            echo "release_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          sync_version_files
+          if git diff --quiet -- wework/package.json wework/src-tauri/tauri.conf.json wework/src-tauri/Cargo.toml wework/src-tauri/Cargo.lock; then
+            echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add wework/package.json wework/src-tauri/tauri.conf.json wework/src-tauri/Cargo.toml wework/src-tauri/Cargo.lock
+          git commit -m "chore(wework): bump app version to ${RELEASE_VERSION}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Create or update GitHub Release
         if: steps.version.outputs.publish_release == 'true'
         shell: bash
@@ -102,6 +193,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          RELEASE_SHA: ${{ steps.version-files.outputs.release_sha }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
@@ -111,9 +203,9 @@ jobs:
           previous_tag="$(git tag -l 'wework-v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | awk -v current="$RELEASE_TAG" '$0 != current { print; exit }')"
 
           if [ -n "$previous_tag" ]; then
-            log_range="${previous_tag}..${GITHUB_SHA}"
+            log_range="${previous_tag}..${RELEASE_SHA}"
           else
-            log_range="$GITHUB_SHA"
+            log_range="$RELEASE_SHA"
           fi
 
           git log --no-merges --pretty=format:'- %s (%h)' "$log_range" -- wework/ executor/ > "$generated_notes"
@@ -146,7 +238,7 @@ jobs:
               --notes-file "$release_notes"
           else
             gh release create "$RELEASE_TAG" \
-              --target "$GITHUB_SHA" \
+              --target "$RELEASE_SHA" \
               --title "$release_title" \
               --notes-file "$release_notes" \
               --draft
@@ -170,6 +262,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
 
       - name: Install Rosetta 2
         if: matrix.arch == 'x64'
@@ -224,6 +318,57 @@ jobs:
         env:
           WEWORK_CODEX_TARGET: ${{ matrix.rust_target }}
         run: pnpm run prepare:codex
+
+      - name: Sync Wework version files
+        working-directory: wework
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+
+          package_path = Path("package.json")
+          package_data = json.loads(package_path.read_text(encoding="utf-8"))
+          package_data["version"] = version
+          package_path.write_text(
+              json.dumps(package_data, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          tauri_config_path = Path("src-tauri/tauri.conf.json")
+          tauri_config = json.loads(tauri_config_path.read_text(encoding="utf-8"))
+          tauri_config["version"] = version
+          tauri_config_path.write_text(
+              json.dumps(tauri_config, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          cargo_toml_path = Path("src-tauri/Cargo.toml")
+          cargo_toml = cargo_toml_path.read_text(encoding="utf-8")
+          cargo_toml = re.sub(
+              r'(?m)^version = "[^"]+"',
+              f'version = "{version}"',
+              cargo_toml,
+              count=1,
+          )
+          cargo_toml_path.write_text(cargo_toml, encoding="utf-8")
+
+          cargo_lock_path = Path("src-tauri/Cargo.lock")
+          cargo_lock = cargo_lock_path.read_text(encoding="utf-8")
+          cargo_lock = re.sub(
+              r'(?ms)(\[\[package\]\]\nname = "app"\nversion = ")[^"]+(")',
+              rf'\g<1>{version}\2',
+              cargo_lock,
+              count=1,
+          )
+          cargo_lock_path.write_text(cargo_lock, encoding="utf-8")
+          PY
 
       - name: Build Wework app bundle
         working-directory: wework

--- a/docs/en/developer-guide/wework-macos-release.md
+++ b/docs/en/developer-guide/wework-macos-release.md
@@ -117,6 +117,10 @@ The workflow uploads these release assets:
 
 When downloaded from GitHub Release assets, the link points directly to the `.dmg` file and is not wrapped by an Actions artifact `.zip`. When the workflow is triggered manually without a version input, the release tag auto-increments the patch version from the latest `wework-vX.Y.Z` tag.
 
+For a formal release, the workflow syncs `wework/package.json`, `wework/src-tauri/tauri.conf.json`, `wework/src-tauri/Cargo.toml`, and `wework/src-tauri/Cargo.lock` to the release version before building, then commits those files directly back to the triggering `main` branch. The macOS build jobs and GitHub Release target use that version commit, keeping the About page version, Tauri bundle version, and source version aligned.
+
+Manual workflow runs that do not publish a formal release only produce test artifacts and do not commit version files. For releases triggered by a `wework-vX.Y.Z` tag, the tag already points to an immutable commit, so the workflow does not rewrite source files; if the tagged version files do not match the tag version, the release fails and the version files must be updated before creating the tag again.
+
 ## CI DMG Without Apple Developer
 
 The GitHub workflow applies an ad-hoc codesign signature to the `.app`, but it does not perform Apple notarization, so first launch still triggers Gatekeeper. Use this mode for internal testing and developer distribution only; do not label it as a notarized production package.

--- a/docs/zh/developer-guide/wework-macos-release.md
+++ b/docs/zh/developer-guide/wework-macos-release.md
@@ -117,6 +117,10 @@ workflow 分别上传这些 Release assets：
 
 从 GitHub Release assets 下载时，下载链接本身就是 `.dmg` 文件，不会被 Actions artifact 额外套一层 `.zip`。手动触发 workflow 且未填写版本号时，release tag 会自动基于最新的 `wework-vX.Y.Z` tag 增加 patch 版本。
 
+正式发布时，workflow 会在构建前把 `wework/package.json`、`wework/src-tauri/tauri.conf.json`、`wework/src-tauri/Cargo.toml` 和 `wework/src-tauri/Cargo.lock` 同步到本次 release version，并直接提交回触发 workflow 的 `main` 分支。后续 macOS 构建和 GitHub Release 都会使用这个版本提交，确保关于页版本、Tauri 包版本和源码版本一致。
+
+手动触发但未勾选正式发布时只生成测试 artifacts，不会提交版本文件。通过 `wework-vX.Y.Z` tag 触发发布时，tag 已经指向固定提交，workflow 不会改写源码；如果 tag 指向的版本文件和 tag 版本不一致，发布会失败，需要先更新版本文件并重新打 tag。
+
 ## 无 Apple Developer 账号的 CI DMG
 
 GitHub workflow 会对 `.app` 执行 ad-hoc codesign，但不会做 Apple notarization，因此首次打开仍会触发 Gatekeeper。这个模式适合内部测试和开发者分发，不应标记为正式已公证发布包。

--- a/wework/package.json
+++ b/wework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wework",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wework/src-tauri/Cargo.lock
+++ b/wework/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.0.5"
 dependencies = [
  "ctrlc",
  "libc",

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "0.0.5"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/wework/src-tauri/tauri.conf.json
+++ b/wework/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WeWork",
-  "version": "0.1.0",
+  "version": "0.0.5",
   "identifier": "io.wecode.wework",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Sync Wework app version files to `0.0.5` so the About page no longer builds as `v0.0.0`.
- Update the Wework macOS release workflow to commit formal release version file bumps back to `main`, use the version commit as the release/build target, and validate tag releases against checked-in version files.
- Update the README contributors workflow to commit directly to `main` instead of creating PRs.
- Document the formal release version file behavior in both Chinese and English macOS release docs.

## Root Cause

The About page version is compiled from `wework/package.json`, but GitHub release builds only overrode the Tauri config version. That let release artifacts carry a newer updater version while the frontend still displayed `v0.0.0`.

## Validation

- `pnpm --filter wework build`
- `cargo metadata --locked --manifest-path wework/src-tauri/Cargo.toml --format-version 1`
- Parsed `.github/workflows/update-contributors.yml` with Ruby YAML loader
- Pre-push Wework ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now use a consistent version snapshot across the app, installer, and release assets.
  * GitHub Releases are created from the exact commit that matches the published version.

* **Bug Fixes**
  * Improved version consistency between source, build output, and tagged releases.
  * Non-release runs no longer affect published version files.

* **Documentation**
  * Updated release guides to explain the new release and tagging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->