### PR TITLE
fix(wework): sync plan panel streaming content

### DIFF
--- a/wework/src/components/chat/AssistantPlanCard.tsx
+++ b/wework/src/components/chat/AssistantPlanCard.tsx
@@ -9,8 +9,14 @@ import { AssistantMarkdown } from './AssistantMarkdown'
 
 interface AssistantPlanCardProps {
   content: string
-  onOpenPlan?: (content: string) => void
+  onOpenPlan?: () => void
   isStreaming?: boolean
+}
+
+export interface AssistantPlanOpenRequest {
+  blockId: string
+  subtaskId: string
+  content: string
 }
 
 export function AssistantPlanCard({
@@ -33,7 +39,7 @@ export function AssistantPlanCard({
   }
 
   const openPlan = () => {
-    onOpenPlan?.(content)
+    onOpenPlan?.()
   }
 
   const handleCardClick = (event: ReactMouseEvent<HTMLElement>) => {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -634,13 +634,17 @@ describe('MessageList', () => {
     expect(await screen.findByTestId('assistant-plan-copy-success')).toHaveTextContent('已复制')
     expect(onOpenAssistantPlan).not.toHaveBeenCalled()
     await user.click(planCard)
-    expect(onOpenAssistantPlan).toHaveBeenCalledWith(
-      expect.stringContaining('Wegent 代码质量与前端一致性巡检计划')
-    )
+    expect(onOpenAssistantPlan).toHaveBeenCalledWith({
+      blockId: 'plan-1',
+      subtaskId: '11',
+      content: expect.stringContaining('Wegent 代码质量与前端一致性巡检计划'),
+    })
     await user.click(screen.getByTestId('assistant-plan-expand-button'))
-    expect(onOpenAssistantPlan).toHaveBeenLastCalledWith(
-      expect.stringContaining('Wegent 代码质量与前端一致性巡检计划')
-    )
+    expect(onOpenAssistantPlan).toHaveBeenLastCalledWith({
+      blockId: 'plan-1',
+      subtaskId: '11',
+      content: expect.stringContaining('Wegent 代码质量与前端一致性巡检计划'),
+    })
     expect(onOpenAssistantPlan).toHaveBeenCalledTimes(2)
     expect(screen.queryByTestId('assistant-plan-reading-panel')).not.toBeInTheDocument()
   })

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -52,6 +52,7 @@ import { CodexMemoryCitations, CodexReferenceList } from './CodexTurnArtifacts'
 import { getAssistantReferences } from './codexReferences'
 import { FileChangesCard } from './FileChangesCard'
 import { getMessagePretextIntrinsicHeight } from './messagePretextLayout'
+import type { AssistantPlanOpenRequest } from './AssistantPlanCard'
 
 interface MessageListProps {
   messages: WorkbenchMessage[]
@@ -74,7 +75,7 @@ interface MessageListProps {
   onOpenWorkspaceFile?: (path: string) => void
   onRequestUserInputSubmit?: (response: RequestUserInputResponse) => void
   onRequestUserInputIgnore?: (payload: RequestUserInputPayload) => void
-  onOpenAssistantPlan?: (content: string) => void
+  onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
   onEditLastUserMessage?: (
     message: WorkbenchMessage,
     content: string
@@ -1407,7 +1408,7 @@ function AssistantMessage({
   onOpenWorkspaceFile?: (path: string) => void
   onRequestUserInputSubmit?: (response: RequestUserInputResponse) => void
   onRequestUserInputIgnore?: (payload: RequestUserInputPayload) => void
-  onOpenAssistantPlan?: (content: string) => void
+  onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
   hideRequestUserInputBlocks?: boolean
   hiddenRequestUserInputIds?: ReadonlySet<string>
 }) {

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -13,6 +13,7 @@ import type { WorkbenchMessage } from '@/types/workbench'
 import { MessageList } from './MessageList'
 import { MessageTurnNavigation } from './MessageTurnNavigation'
 import type { RequestUserInputPayload } from './RequestUserInputCard'
+import type { AssistantPlanOpenRequest } from './AssistantPlanCard'
 
 const BOTTOM_THRESHOLD = 48
 const STABLE_SCROLL_DELAYS = [0, 50]
@@ -64,7 +65,7 @@ interface ScrollableMessageAreaProps {
   onOpenWorkspaceFile?: (path: string) => void
   onRequestUserInputSubmit?: (response: RequestUserInputResponse) => void
   onRequestUserInputIgnore?: (payload: RequestUserInputPayload) => void
-  onOpenAssistantPlan?: (content: string) => void
+  onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
   onEditLastUserMessage?: (
     message: WorkbenchMessage,
     content: string

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -5,7 +5,7 @@ import { Streamdown } from 'streamdown'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
-import { AssistantPlanCard } from '../AssistantPlanCard'
+import { AssistantPlanCard, type AssistantPlanOpenRequest } from '../AssistantPlanCard'
 import { MarkdownCodeBlock } from '../MarkdownCodeBlock'
 import { parseUnifiedDiff } from '../parseUnifiedDiff'
 import { isWebSearchToolName } from './toolBlockActivity'
@@ -30,7 +30,7 @@ interface ToolBlockItemProps {
   forceExpanded?: boolean
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
-  onOpenAssistantPlan?: (content: string) => void
+  onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
 }
 
 export function ToolBlockItem({
@@ -121,17 +121,21 @@ function PlanBlockItem({
   onOpenAssistantPlan,
 }: {
   block: Extract<ProcessingBlock, { type: 'plan' }>
-  onOpenAssistantPlan?: (content: string) => void
+  onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
 }) {
   if (!block.content.trim()) return null
 
   const isStreaming = block.status !== 'done' && block.status !== 'error'
+  const openPlan = () => {
+    onOpenAssistantPlan?.({
+      blockId: block.id,
+      subtaskId: String(block.subtaskId),
+      content: block.content,
+    })
+  }
+
   return (
-    <AssistantPlanCard
-      content={block.content}
-      isStreaming={isStreaming}
-      onOpenPlan={onOpenAssistantPlan}
-    />
+    <AssistantPlanCard content={block.content} isStreaming={isStreaming} onOpenPlan={openPlan} />
   )
 }
 

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -23,6 +23,7 @@ import {
   RequestUserInputSummary,
   type RequestUserInputPayload,
 } from '../RequestUserInputCard'
+import type { AssistantPlanOpenRequest } from '../AssistantPlanCard'
 import {
   buildProcessingDisplayRows,
   getToolActivityFilePaths,
@@ -65,7 +66,7 @@ interface ToolBlocksDisplayProps {
   onOpenWorkspaceFile?: (path: string) => void
   onRequestUserInputSubmit?: (response: RequestUserInputResponse) => void
   onRequestUserInputIgnore?: (payload: RequestUserInputPayload) => void
-  onOpenAssistantPlan?: (content: string) => void
+  onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
   hideRequestUserInputBlocks?: boolean
   hiddenRequestUserInputIds?: ReadonlySet<string>
 }

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1295,6 +1295,109 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workspace-plan-panel')).toHaveTextContent('运行相关前端测试')
   })
 
+  test('keeps the right workspace plan panel synced with the opened streaming plan block', async () => {
+    const initialMessages: WorkbenchMessage[] = [
+      {
+        id: 'assistant-plan-block',
+        role: 'assistant',
+        content: '',
+        status: 'streaming',
+        createdAt: '2026-06-30T00:00:01.000Z',
+        blocks: [
+          {
+            id: 'plan-1',
+            subtaskId: '1',
+            type: 'plan',
+            content: '# Wegent 体验计划\n\n## Summary\n- 正在生成第一步。',
+            status: 'streaming',
+            createdAt: Date.parse('2026-06-30T00:00:01.000Z'),
+          },
+        ],
+      },
+    ]
+    const { rerender } = render(
+      <DesktopWorkbenchLayout {...baseProps} messages={initialMessages} />
+    )
+
+    await userEvent.click(screen.getByTestId('assistant-plan-expand-button'))
+
+    expect(screen.getByTestId('workspace-plan-panel')).toHaveTextContent('正在生成第一步')
+
+    rerender(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        messages={[
+          {
+            ...initialMessages[0],
+            blocks: [
+              {
+                ...initialMessages[0].blocks![0],
+                content:
+                  '# Wegent 体验计划\n\n## Summary\n- 正在生成第一步。\n- 已流式补充第二步。',
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('workspace-plan-panel')).toHaveTextContent('已流式补充第二步')
+  })
+
+  test('does not replace the opened right workspace plan when a newer plan block appears', async () => {
+    const openedPlanMessage: WorkbenchMessage = {
+      id: 'assistant-plan-block',
+      role: 'assistant',
+      content: '',
+      status: 'done',
+      createdAt: '2026-06-30T00:00:01.000Z',
+      blocks: [
+        {
+          id: 'plan-1',
+          subtaskId: '1',
+          type: 'plan',
+          content: '# 已打开的计划\n\n- 保持当前内容。',
+          status: 'done',
+          createdAt: Date.parse('2026-06-30T00:00:01.000Z'),
+        },
+      ],
+    }
+    const { rerender } = render(
+      <DesktopWorkbenchLayout {...baseProps} messages={[openedPlanMessage]} />
+    )
+
+    await userEvent.click(screen.getByTestId('assistant-plan-expand-button'))
+
+    rerender(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        messages={[
+          openedPlanMessage,
+          {
+            id: 'assistant-newer-plan-block',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            createdAt: '2026-06-30T00:01:01.000Z',
+            blocks: [
+              {
+                id: 'plan-2',
+                subtaskId: '2',
+                type: 'plan',
+                content: '# 新生成的计划\n\n- 不应抢占右侧面板。',
+                status: 'streaming',
+                createdAt: Date.parse('2026-06-30T00:01:01.000Z'),
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('workspace-plan-panel')).toHaveTextContent('已打开的计划')
+    expect(screen.getByTestId('workspace-plan-panel')).not.toHaveTextContent('新生成的计划')
+  })
+
   test('renders project-specific empty prompt after selecting a project', () => {
     render(
       <DesktopWorkbenchLayout

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import type { CSSProperties } from 'react'
 import { ArrowLeftRight, MessageCircle } from 'lucide-react'
 import type { ProjectChatControls } from '@/components/chat/ChatInput'
+import type { AssistantPlanOpenRequest } from '@/components/chat/AssistantPlanCard'
 import { RequestUserInputCard } from '@/components/chat/RequestUserInputCard'
 import { ScrollableMessageArea } from '@/components/chat/ScrollableMessageArea'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
@@ -77,6 +78,7 @@ import { requestOpenCloudDeviceSettings } from './workbenchShellEvents'
 import { SubagentStatusIndicator } from './SubagentStatusIndicator'
 import { WEWORK_OPEN_TERMINAL_EVENT } from '@/lib/keybindings'
 import type { RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
 import { BufferedChatInput } from './BufferedChatInput'
 
 const DESKTOP_CHAT_CONTENT_BASE_CLASS =
@@ -107,6 +109,12 @@ const COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE = '5rem'
 const MACOS_TRAFFIC_LIGHTS_CLEARANCE_CLASS = 'pl-[92px]'
 const BLANK_BROWSER_MIGRATION_TTL_MS = 2 * 60 * 1000
 
+interface SelectedAssistantPlan {
+  blockId: string
+  subtaskId: string
+  fallbackContent: string
+}
+
 interface PendingBlankBrowserMigration {
   sourcePaneKey: string
   browserLabel: string
@@ -117,6 +125,25 @@ interface PendingBlankBrowserMigration {
 }
 
 let latestBlankBrowserMigration: PendingBlankBrowserMigration | null = null
+
+function findSelectedAssistantPlanContent(
+  messages: WorkbenchMessage[],
+  selectedPlan: SelectedAssistantPlan | null
+): string | null {
+  if (!selectedPlan) return null
+
+  for (const message of messages) {
+    const planBlock = message.blocks?.find(
+      block =>
+        block.type === 'plan' &&
+        block.id === selectedPlan.blockId &&
+        String(block.subtaskId) === selectedPlan.subtaskId
+    )
+    if (planBlock?.type === 'plan') return planBlock.content
+  }
+
+  return null
+}
 
 function consumeLatestBlankBrowserMigration(): PendingBlankBrowserMigration | null {
   if (!latestBlankBrowserMigration) return null
@@ -321,7 +348,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [embeddedBrowserOpenRequest, setEmbeddedBrowserOpenRequest] = useState<
     (EmbeddedBrowserOpenRequest & { id: number }) | null
   >(null)
-  const [rightPanelPlanContent, setRightPanelPlanContent] = useState<string | null>(null)
+  const [selectedAssistantPlan, setSelectedAssistantPlan] = useState<SelectedAssistantPlan | null>(
+    null
+  )
   const [bottomPanelOpenByKey, setBottomPanelOpenByKey] = useState<Record<string, boolean>>({})
   const [bottomPanelContexts, setBottomPanelContexts] = useState<BottomPanelRenderContext[]>([])
   const [openFileRequest, setOpenFileRequest] = useState<WorkspaceFileOpenRequest | null>(null)
@@ -537,6 +566,12 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     paneMessages,
     paneSession.answeredRequestUserInputIds
   )
+  const selectedAssistantPlanContent = useMemo(
+    () => findSelectedAssistantPlanContent(paneMessages, selectedAssistantPlan),
+    [paneMessages, selectedAssistantPlan]
+  )
+  const rightPanelPlanContent =
+    selectedAssistantPlanContent ?? selectedAssistantPlan?.fallbackContent ?? null
   const paneQueuedMessages = paneSession.queuedMessages
   const paneGuidanceMessages = paneSession.guidanceMessages
   const paneIsResponseStreaming = paneSession.status.isAssistantStreaming
@@ -641,11 +676,15 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     }
   }, [embeddedBrowserLabel, openRightPanelTab])
   const openAssistantPlan = useCallback(
-    (content: string) => {
-      setRightPanelPlanContent(content)
+    (request: AssistantPlanOpenRequest) => {
+      setSelectedAssistantPlan({
+        blockId: request.blockId,
+        subtaskId: request.subtaskId,
+        fallbackContent: request.content,
+      })
       openRightPanelTab('plan')
     },
-    [openRightPanelTab, setRightPanelPlanContent]
+    [openRightPanelTab, setSelectedAssistantPlan]
   )
   const closeRightPanelTab = useCallback(
     (tab: RightWorkspacePanelTab) => {
@@ -1093,7 +1132,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     setHasPreviousTurnReview(false)
     setRightPanelView('launcher')
     setRightPanelTabs([])
-    setRightPanelPlanContent(null)
+    setSelectedAssistantPlan(null)
     setReviewState({
       loading: false,
       diff: '',


### PR DESCRIPTION
## Summary
- Bind the right workspace plan panel to the opened assistant plan block instead of a one-time content snapshot.
- Keep the panel content synced while that plan block streams updates.
- Preserve the currently opened plan when newer plan blocks appear.

## Root Cause
The right panel stored the plan content captured at expand time, while streaming updates only changed the message block in `paneMessages`.

## Validation
- `pnpm --filter wework test -- MessageList DesktopWorkbenchLayout`
- `pnpm --filter wework exec tsc --noEmit --pretty false`
- `pnpm --filter wework lint`
- pre-push Wework checks: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan panels now open with structured plan details, helping keep the right-side panel in sync with the selected plan block.
  * The workspace now preserves the originally opened plan when new plan blocks arrive, instead of switching unexpectedly.

* **Bug Fixes**
  * Improved plan content lookup so the panel can continue showing the correct content even if the source block changes or is unavailable.
  * Updated chat interactions to pass richer plan metadata through the app for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->