### PR TITLE
fix(wework): stabilize cloud sync status

### DIFF
--- a/wework/src/features/cloud-connection/CloudConnectionSidebarButton.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionSidebarButton.tsx
@@ -62,7 +62,7 @@ export function CloudConnectionSidebarButton({
     !needsAttention &&
     !cloudWorkUnavailable &&
     !cloudWorkEmpty &&
-    cloudWorkStatus?.availability !== 'available'
+    cloudWorkStatus?.availability === 'syncing'
   const cloudWorkAvailable =
     connected && !needsAttention && cloudWorkStatus?.availability === 'available'
   const hasErrorDetail = connected && (needsAttention || cloudWorkUnavailable)

--- a/wework/src/features/workbench/workbenchCloudStatus.test.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.test.ts
@@ -4,6 +4,7 @@ import {
   EMPTY_CLOUD_RUNTIME_STATE,
   finishCloudRuntimeSync,
   mergeRuntimeWorkLists,
+  selectCloudWorkStatus,
   selectProjectCreatableDevices,
   selectRuntimeWorkView,
   selectVisibleDevices,
@@ -274,6 +275,17 @@ describe('cloud runtime sync state', () => {
 
     expect(stale).toBe(second)
     expect(selectVisibleDevices([], stale)).toEqual([])
+  })
+
+  test('keeps sidebar cloud work status stable during a background refresh', () => {
+    const started = startCloudRuntimeSync(EMPTY_CLOUD_RUNTIME_STATE, 'bootstrap', ['devices'])
+    const ready = finishCloudRuntimeSync(started, started.inFlightRevision ?? 0, {
+      devices: { status: 'fulfilled', value: [device()] },
+    })
+    const refreshing = startCloudRuntimeSync(ready, 'poll', ['devices'])
+
+    expect(selectCloudWorkStatus(refreshing).availability).toBe('available')
+    expect(selectCloudWorkStatus(refreshing).checks.devices).toBe('available')
   })
 
   test('derives runtime work from last good cloud snapshot without duplicating tasks', () => {

--- a/wework/src/features/workbench/workbenchCloudStatus.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.ts
@@ -271,7 +271,10 @@ export function selectCloudRuntimeSnapshot(state: CloudRuntimeState): CloudRunti
 }
 
 export function selectCloudWorkStatus(state: CloudRuntimeState): CloudWorkStatus {
-  const snapshot = state.current ?? state.lastGood
+  const snapshot =
+    state.inFlightRevision != null && state.lastGood
+      ? state.lastGood
+      : (state.current ?? state.lastGood)
   if (!snapshot) return EMPTY_CLOUD_WORK_STATUS
   const checks = {
     teams: cloudRuntimeCheckToLegacyStatus(snapshot.checks.teams.status),


### PR DESCRIPTION
## Summary

Fixes the Wework sidebar cloud-work status flicker after connecting to cloud services.

## What changed

- Keep the sidebar cloud-work status based on the last successful cloud runtime snapshot while a background refresh is in flight.
- Only show the sidebar "Syncing"/"同步中" badge when cloud work availability is explicitly `syncing`.
- Add regression coverage for stable sidebar status during background poll refreshes.

## Root cause

Background cloud refreshes mark checks as `syncing` immediately. The sidebar consumed that transient state directly, and its own syncing predicate also treated any non-available/non-empty/non-unavailable state as syncing, causing the badge to briefly switch to "同步中".

## Validation

- `pnpm --filter wework test -- src/features/workbench/workbenchCloudStatus.test.ts src/components/layout/DesktopSidebar.test.tsx`
- Pre-push hook: Wework ESLint, TypeScript, and unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud connection status handling so the syncing indicator only appears for an explicit syncing state.
  * During background refreshes, the cloud status view now keeps showing the last verified available state instead of briefly reflecting an updating snapshot.
  * Added coverage to verify cloud status remains available while a refresh is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->