### PR TITLE
fix(wework): reduce runtime memory and status overhead

### DIFF
--- a/docs/en/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/developer-guide/wework-performance-diagnostics.md
@@ -37,6 +37,23 @@ The **Debug Panel** command in the Developer Commands menu helps diagnose the cu
 
 The Debug Panel can be expanded, collapsed, refreshed, copied as a snapshot, and cleared. When collapsed, it leaves only a small status bar in the lower-right corner so it does not block the main UI.
 
+### Runtime Memory Snapshots
+
+Debug Panel snapshots include a lightweight memory summary for the active runtime pane to help investigate WebView or executor memory spikes:
+
+- Message count, role distribution, status distribution, and content-length totals.
+- Processing block count, block type distribution, and tool-output length totals.
+- Queued messages, guidance messages, code-comment context count, and transcript range state.
+- The raw `running` value from the runtime work list and the running state derived by the pane.
+
+Snapshots only include summaries. They do not copy full command output, raw Codex events, or full transcript content into the Debug Panel. When raw payloads are needed, inspect executor logs or Web Inspector samples instead of moving large text through the frontend snapshot path.
+
+## Runtime Transcript and List Payloads
+
+To reduce frontend and executor memory pressure, runtime task lists, runtime handle summaries, and transcript responses keep only fields required by the UI. Large raw payloads such as command output, streaming deltas, cached messages, and raw request/response bodies are not sent to the frontend through runtime work list payloads.
+
+Conversation rendering still uses `WorkbenchMessage` values produced from transcript loads and message actions. Task lists and status polling are for status, titles, running state, and workspace metadata. When investigating slow list refreshes or memory growth while switching tasks, first check whether raw messages or command output have been reintroduced into the runtime list, handle, or transcript metadata path.
+
 ## Local Codex Streaming Logs
 
 The local executor keeps Codex delta details enabled by default so developers can diagnose streaming order, phase classification, and final-content overwrite issues. By default, it records raw Codex delta events and run-state classification summaries.

--- a/docs/zh/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/developer-guide/wework-performance-diagnostics.md
@@ -37,6 +37,23 @@ Developer Commands 菜单中的 **Debug Panel** 用于排查 Wework 当前运行
 
 Debug 面板可以展开、收起、刷新、复制快照和清空日志。收起后只保留右下角状态条，避免遮挡主界面。
 
+### Runtime 内存快照
+
+Debug 面板的快照会附带当前 runtime pane 的轻量内存摘要，用于定位 WebView 或 executor 内存异常：
+
+- 消息数量、角色分布、状态分布和正文长度汇总。
+- processing block 数量、类型分布和工具输出长度汇总。
+- 队列消息、guidance 消息、代码评论上下文和 transcript 范围状态。
+- 当前 runtime task 在 work list 中的 `running` 原始值，以及由 pane 推导出的运行状态。
+
+快照只记录摘要，不会把完整命令输出、原始 Codex 事件或完整 transcript 内容复制到 Debug 面板。需要排查原始内容时应查看 executor 日志或 Web Inspector 采样，而不是通过前端快照搬运大文本。
+
+## Runtime transcript 与列表载荷
+
+为降低前端和 executor 的内存压力，runtime task 列表、runtime handle 摘要和 transcript 响应只保留 UI 必需字段。命令输出、streaming delta、cached message、原始请求/响应等大块原始载荷不会放进 runtime work list 发送给前端。
+
+前端显示对话时仍以 transcript/message action 生成的 `WorkbenchMessage` 为准；任务列表和状态轮询只用于状态、标题、运行态和 workspace 信息。排查“列表很慢”或“切换任务内存上涨”时，应优先确认是否又把原始消息或命令输出加入了 runtime list/handle/transcript 元数据路径。
+
 ## 本地 Codex 流式日志
 
 本地 executor 的 Codex 调试日志默认保留 delta 详情，便于定位流式输出顺序、阶段识别和最终内容覆盖问题。默认会记录 Codex 原始 delta 与运行态分类摘要。

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -6,6 +6,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     env, fs,
     future::Future,
+    io::{self, Write},
     path::{Path, PathBuf},
     pin::Pin,
     process::Stdio,
@@ -53,6 +54,9 @@ const CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE: &str =
 const CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE: &str =
     "suppress_unstable_features_warning=true";
 const DEFAULT_EXECUTOR_SERVER_PORT: u16 = 10001;
+const CODEX_RAW_LOG_PREVIEW_CHARS: usize = 1200;
+const CODEX_RAW_LOG_LARGE_STRING_CHARS: usize = 2048;
+const CODEX_RAW_LOG_STRING_PREVIEW_CHARS: usize = 240;
 const SIDE_BOUNDARY_PROMPT: &str = r#"Side conversation boundary.
 
 The messages before this boundary are inherited reference context from the main thread.
@@ -2008,8 +2012,10 @@ fn log_codex_raw_turn_message(message: &Value) {
 
     let params = message_params(message);
     let item = params.get("item").unwrap_or(params);
-    let raw = serde_json::to_string(message)
-        .unwrap_or_else(|error| format!("failed to serialize codex raw message: {error}"));
+    let raw_len = serialized_json_len(message)
+        .map(|length| length.to_string())
+        .unwrap_or_else(|error| format!("failed to measure codex raw message: {error}"));
+    let raw_preview = codex_raw_log_preview(message);
     log_executor_event(
         "codex raw turn message",
         &[
@@ -2042,10 +2048,82 @@ fn log_codex_raw_turn_message(message: &Value) {
                     "turn_id",
                 ),
             ),
-            ("raw_len", raw.len().to_string()),
-            ("raw_preview", truncate_log_text(&raw, 1200)),
+            ("raw_len", raw_len),
+            ("raw_preview", raw_preview),
         ],
     );
+}
+
+struct ByteCounter {
+    length: usize,
+}
+
+impl Write for ByteCounter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.length += buffer.len();
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_json_len(value: &Value) -> serde_json::Result<usize> {
+    let mut counter = ByteCounter { length: 0 };
+    serde_json::to_writer(&mut counter, value)?;
+    Ok(counter.length)
+}
+
+fn codex_raw_log_preview(value: &Value) -> String {
+    let sanitized = sanitize_codex_raw_log_value(value, None);
+    let preview = serde_json::to_string(&sanitized)
+        .unwrap_or_else(|error| format!("failed to serialize codex raw message preview: {error}"));
+    truncate_log_text(&preview, CODEX_RAW_LOG_PREVIEW_CHARS)
+}
+
+fn sanitize_codex_raw_log_value(value: &Value, key: Option<&str>) -> Value {
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        sanitize_codex_raw_log_value(value, Some(key.as_str())),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| sanitize_codex_raw_log_value(item, None))
+                .collect(),
+        ),
+        Value::String(text) if should_summarize_codex_raw_log_string(key, text) => {
+            Value::String(format!(
+                "[{} chars omitted; preview: {}]",
+                text.chars().count(),
+                truncate_log_text(text, CODEX_RAW_LOG_STRING_PREVIEW_CHARS)
+            ))
+        }
+        _ => value.clone(),
+    }
+}
+
+fn should_summarize_codex_raw_log_string(key: Option<&str>, text: &str) -> bool {
+    matches!(
+        key,
+        Some("aggregatedOutput")
+            | Some("toolOutput")
+            | Some("tool_output")
+            | Some("toolOutputDelta")
+            | Some("tool_output_delta")
+            | Some("output")
+            | Some("stdout")
+            | Some("stderr")
+    ) || text.len() > CODEX_RAW_LOG_LARGE_STRING_CHARS
 }
 
 fn json_string_field(value: &Value, key: &str) -> String {
@@ -3691,6 +3769,32 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn codex_raw_log_preview_summarizes_large_command_output() {
+        let output = "x".repeat(4096);
+        let message = json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "id": "cmd-1",
+                    "type": "commandExecution",
+                    "aggregatedOutput": output,
+                }
+            }
+        });
+
+        let preview = codex_raw_log_preview(&message);
+
+        assert!(preview.contains("4096 chars omitted"));
+        assert!(!preview.contains(&"x".repeat(512)));
+        assert_eq!(
+            serialized_json_len(&message).expect("message length should serialize"),
+            serde_json::to_string(&message)
+                .expect("message should serialize")
+                .len()
+        );
+    }
 
     #[test]
     fn codex_launch_config_enables_streaming_patch_updates() {

--- a/executor/src/runtime_work/codex_rollout.rs
+++ b/executor/src/runtime_work/codex_rollout.rs
@@ -4,7 +4,7 @@
 
 use std::{
     fs::File,
-    io::{BufRead, BufReader, Read, Seek, SeekFrom},
+    io::{BufRead, BufReader, Seek, SeekFrom},
     path::Path,
 };
 
@@ -14,8 +14,6 @@ use super::util::{
     codex_wrapped_item_payload, extract_text, integer_field, item_type, now_ms, string_field,
     timestamp_ms_field,
 };
-
-const ROLLOUT_STATUS_TAIL_BYTES: u64 = 64 * 1024;
 
 pub(crate) fn thread_with_rollout_turns(thread: &Value) -> Option<Value> {
     let Some(path) = string_field(thread, "path") else {
@@ -182,71 +180,6 @@ pub(crate) fn append_rollout_turns_from_offset(
         turns,
         changed_start,
     })
-}
-
-pub(crate) fn thread_with_rollout_running_status(thread: &Value) -> Value {
-    if !rollout_tail_is_running(thread) {
-        return thread.clone();
-    }
-
-    let mut next_thread = thread.clone();
-    if let Some(object) = next_thread.as_object_mut() {
-        object.insert("status".to_owned(), Value::String("running".to_owned()));
-    }
-    next_thread
-}
-
-fn rollout_tail_is_running(thread: &Value) -> bool {
-    let Some(path) = string_field(thread, "path") else {
-        return false;
-    };
-    let Ok(mut file) = File::open(path) else {
-        return false;
-    };
-    let Ok(metadata) = file.metadata() else {
-        return false;
-    };
-    let file_len = metadata.len();
-    let start = file_len.saturating_sub(ROLLOUT_STATUS_TAIL_BYTES);
-    if file.seek(SeekFrom::Start(start)).is_err() {
-        return false;
-    }
-
-    let mut tail_bytes = Vec::new();
-    if file.read_to_end(&mut tail_bytes).is_err() {
-        return false;
-    }
-    let tail = String::from_utf8_lossy(&tail_bytes);
-    let tail = if start > 0 {
-        tail.split_once('\n')
-            .map(|(_, rest)| rest)
-            .unwrap_or(tail.as_ref())
-    } else {
-        tail.as_ref()
-    };
-
-    let mut running = false;
-    for line in tail.lines() {
-        let Ok(item) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        if is_turn_start_item(&item) {
-            running = true;
-            continue;
-        }
-        if is_turn_completion_item(&item) {
-            running = false;
-            continue;
-        }
-        if is_final_assistant_message_item(&item) {
-            running = false;
-            continue;
-        }
-        if rollout_transcript_item(&item).is_some() || is_rollout_activity_item(&item) {
-            running = true;
-        }
-    }
-    running
 }
 
 fn rollout_path_turns(path: &Path, thread: &Value) -> Vec<Value> {
@@ -963,86 +896,6 @@ mod tests {
     }
 
     #[test]
-    fn running_status_uses_rollout_tail_without_hydrating_turns() {
-        let path = temp_rollout_path("running-status");
-        fs::write(
-            &path,
-            [
-                json!({"type":"event_msg","payload":{"type":"task_started"}}).to_string(),
-                json!({"type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"exec_command"}})
-                    .to_string(),
-            ]
-            .join("\n"),
-        )
-        .unwrap();
-
-        let thread = thread_with_path(&path);
-        let state = thread_with_rollout_running_status(&thread);
-
-        assert_eq!(state["status"], "running");
-        assert_eq!(
-            state["turns"]
-                .as_array()
-                .expect("existing turns array should be preserved")
-                .len(),
-            0
-        );
-        let _ = fs::remove_file(path);
-    }
-
-    #[test]
-    fn running_status_detects_completed_tail() {
-        let path = temp_rollout_path("running-status-complete");
-        fs::write(
-            &path,
-            [
-                json!({"type":"event_msg","payload":{"type":"task_started"}}).to_string(),
-                json!({"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}})
-                    .to_string(),
-                json!({"type":"event_msg","payload":{"type":"task_complete"}}).to_string(),
-            ]
-            .join("\n"),
-        )
-        .unwrap();
-
-        let thread = thread_with_path(&path);
-        let state = thread_with_rollout_running_status(&thread);
-
-        assert_ne!(state["status"], "running");
-        assert_eq!(
-            state["turns"]
-                .as_array()
-                .expect("existing turns array should be preserved")
-                .len(),
-            0
-        );
-        let _ = fs::remove_file(path);
-    }
-
-    #[test]
-    fn running_status_detects_final_assistant_message_tail() {
-        let path = temp_rollout_path("running-status-final-message");
-        fs::write(
-            &path,
-            [
-                json!({"type":"event_msg","payload":{"type":"task_started"}}).to_string(),
-                json!({"type":"event_msg","payload":{"type":"agent_message","message":"done"}})
-                    .to_string(),
-                json!({"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}})
-                    .to_string(),
-            ]
-            .join("\n"),
-        )
-        .unwrap();
-
-        let thread = thread_with_path(&path);
-        let state = thread_with_rollout_running_status(&thread);
-
-        assert_ne!(state["status"], "running");
-        let _ = fs::remove_file(path);
-    }
-
-    #[test]
     fn ignores_subagent_turn_completion_for_root_rollout_status() {
         let path = temp_rollout_path("subagent-complete");
         fs::write(
@@ -1091,30 +944,6 @@ mod tests {
 
         assert_eq!(items.len(), 2);
         assert_eq!(items[1]["payload"]["content"][0]["text"], "root");
-        let _ = fs::remove_file(path);
-    }
-
-    #[test]
-    fn running_status_ignores_subagent_turn_completion_tail() {
-        let path = temp_rollout_path("running-status-subagent-complete");
-        fs::write(
-            &path,
-            [
-                json!({"type":"event_msg","payload":{"type":"task_started","turn_id":"root-turn"}})
-                    .to_string(),
-                json!({"type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"spawn_agent"}})
-                    .to_string(),
-                json!({"type":"event_msg","payload":{"type":"task_complete","turn_id":"child-turn","agent_path":"/root/worker"}})
-                    .to_string(),
-            ]
-            .join("\n"),
-        )
-        .unwrap();
-
-        let thread = thread_with_path(&path);
-        let state = thread_with_rollout_running_status(&thread);
-
-        assert_eq!(state["status"], "running");
         let _ = fs::remove_file(path);
     }
 

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -37,7 +37,7 @@ use super::{
     codex_notifications::codex_notification,
     codex_rollout::{
         append_rollout_turns_from_offset, rollout_context_usage, rollout_turns,
-        thread_with_rollout_running_status, thread_with_rollout_turns, thread_with_turns,
+        thread_with_rollout_turns, thread_with_turns,
     },
     events::{emit_response_event, CodexNotificationEventMapper},
     notification_mapping::{codex_stream_debug_enabled, set_codex_stream_debug_enabled},
@@ -509,15 +509,53 @@ impl RuntimeWorkRpcHandler {
 
     async fn list_tasks(&self) -> Result<Value, AppIpcError> {
         let started_at = Instant::now();
+        log_runtime_work_list_diagnostic("started", started_at, started_at, &[]);
+        let stage_started_at = Instant::now();
         let project_index = CodexGlobalProjectIndex::load();
-        let links =
-            self.visible_links_for_projects(self.collect_links(false).await, &project_index);
+        log_runtime_work_list_diagnostic(
+            "project_index_loaded",
+            started_at,
+            stage_started_at,
+            &[
+                ("projects", project_index.projects().len().to_string()),
+                (
+                    "project_state_loaded",
+                    project_index.has_project_state().to_string(),
+                ),
+            ],
+        );
+        let stage_started_at = Instant::now();
+        let collected_links = self.collect_links(false).await;
+        log_runtime_work_list_diagnostic(
+            "links_collected",
+            started_at,
+            stage_started_at,
+            &[("links", collected_links.len().to_string())],
+        );
+        let stage_started_at = Instant::now();
+        let links = self.visible_links_for_projects(collected_links, &project_index);
+        log_runtime_work_list_diagnostic(
+            "project_filter_applied",
+            started_at,
+            stage_started_at,
+            &[("visible_links", links.len().to_string())],
+        );
+        let stage_started_at = Instant::now();
         let workspaces = workspace_response(links, codex_project_workspaces(&project_index));
         let task_count = workspaces
             .iter()
             .filter_map(|workspace| workspace.get("tasks").and_then(Value::as_array))
             .map(Vec::len)
             .sum::<usize>();
+        log_runtime_work_list_diagnostic(
+            "response_built",
+            started_at,
+            stage_started_at,
+            &[
+                ("workspaces", workspaces.len().to_string()),
+                ("tasks", task_count.to_string()),
+            ],
+        );
         log_executor_event(
             "runtime work list finished",
             &[
@@ -2415,13 +2453,25 @@ impl RuntimeWorkRpcHandler {
     }
 
     async fn collect_links(&self, archived: bool) -> Vec<RuntimeTaskLink> {
+        let started_at = Instant::now();
         let mut links = Vec::new();
         let mut discovered_thread_ids = HashSet::new();
         let mut discovered_local_task_ids = HashSet::new();
         let mut discovered_codex_task_signatures = HashSet::new();
 
-        for thread in self.codex_threads(archived).await {
+        let threads = self.codex_threads(archived).await;
+        let stage_started_at = Instant::now();
+        for thread in threads {
+            let thread_started_at = Instant::now();
+            let thread_id = string_field(&thread, "id").unwrap_or_else(|| "none".to_owned());
             if let Some(mut link) = self.link_from_thread(&thread) {
+                log_slow_runtime_collect_thread(
+                    archived,
+                    &thread_id,
+                    thread_started_at,
+                    &thread,
+                    &link,
+                );
                 if link.ephemeral {
                     continue;
                 }
@@ -2455,9 +2505,27 @@ impl RuntimeWorkRpcHandler {
                     discovered_codex_task_signatures.insert(signature);
                 }
                 links.push(link);
+            } else {
+                log_slow_runtime_collect_thread_missing(
+                    archived,
+                    &thread_id,
+                    thread_started_at,
+                    &thread,
+                );
             }
         }
+        log_runtime_collect_diagnostic(
+            "threads_linked",
+            archived,
+            started_at,
+            stage_started_at,
+            &[
+                ("links", links.len().to_string()),
+                ("threads", discovered_thread_ids.len().to_string()),
+            ],
+        );
 
+        let stage_started_at = Instant::now();
         for mut link in self.local_task_links(true) {
             if self.archived_link_is_deleted(&link) {
                 continue;
@@ -2493,6 +2561,13 @@ impl RuntimeWorkRpcHandler {
             link.list_order = Some(links.len());
             links.push(link);
         }
+        log_runtime_collect_diagnostic(
+            "local_links_merged",
+            archived,
+            started_at,
+            stage_started_at,
+            &[("links", links.len().to_string())],
+        );
 
         links
     }
@@ -2987,9 +3062,8 @@ impl RuntimeWorkRpcHandler {
         let workspace_path = string_field(thread, "cwd")
             .or_else(|| local_link.as_ref().map(|link| link.workspace_path.clone()))
             .unwrap_or_else(|| "~/.codex".to_owned());
-        let codex_thread = thread_with_rollout_running_status(thread);
-        let mut link = RuntimeTaskLink::from_thread(&codex_thread, local_link, workspace_path);
-        if let Some(path) = string_field(&codex_thread, "path") {
+        let mut link = RuntimeTaskLink::from_thread_metadata(thread, local_link, workspace_path);
+        if let Some(path) = string_field(thread, "path") {
             let mut runtime_handle = link
                 .runtime_handle
                 .as_object()
@@ -3006,7 +3080,7 @@ impl RuntimeWorkRpcHandler {
     }
 
     fn local_task_links(&self, include_archived: bool) -> Vec<RuntimeTaskLink> {
-        self.store.list_tasks(include_archived)
+        self.store.list_task_summaries(include_archived)
     }
 
     fn local_task_link(&self, local_task_id: &str) -> Option<RuntimeTaskLink> {
@@ -3058,7 +3132,7 @@ impl RuntimeWorkRpcHandler {
     }
 
     fn local_task_by_thread_id(&self, thread_id: &str) -> Option<RuntimeTaskLink> {
-        self.store.find_by_thread_id(thread_id)
+        self.store.find_summary_by_thread_id(thread_id)
     }
 
     fn upsert_local_task(&self, link: RuntimeTaskLink) {
@@ -4594,6 +4668,159 @@ impl RuntimeWorkHandler for RuntimeWorkRpcHandler {
                 .unwrap_or_else(|| json!({}));
             self.dispatch(&method, payload).await
         })
+    }
+}
+
+#[cfg(debug_assertions)]
+const SLOW_RUNTIME_COLLECT_THREAD_MS: u128 = 100;
+
+#[cfg(debug_assertions)]
+fn log_runtime_collect_diagnostic(
+    stage: &str,
+    archived: bool,
+    started_at: Instant,
+    stage_started_at: Instant,
+    fields: &[(&str, String)],
+) {
+    let mut diagnostic_fields = vec![
+        ("stage", stage.to_owned()),
+        ("archived", archived.to_string()),
+        ("elapsed_ms", elapsed_ms(started_at)),
+        ("stage_elapsed_ms", elapsed_ms(stage_started_at)),
+    ];
+    if let Some(rss_kb) = current_process_max_rss_kb() {
+        diagnostic_fields.push(("max_rss_kb", rss_kb.to_string()));
+    }
+    diagnostic_fields.extend(fields.iter().map(|(key, value)| (*key, value.clone())));
+    log_executor_event("runtime work collect diagnostic", &diagnostic_fields);
+}
+
+#[cfg(not(debug_assertions))]
+fn log_runtime_collect_diagnostic(
+    _stage: &str,
+    _archived: bool,
+    _started_at: Instant,
+    _stage_started_at: Instant,
+    _fields: &[(&str, String)],
+) {
+}
+
+#[cfg(debug_assertions)]
+fn log_slow_runtime_collect_thread(
+    archived: bool,
+    thread_id: &str,
+    started_at: Instant,
+    thread: &Value,
+    link: &RuntimeTaskLink,
+) {
+    let elapsed = started_at.elapsed().as_millis();
+    if elapsed < SLOW_RUNTIME_COLLECT_THREAD_MS {
+        return;
+    }
+    log_executor_event(
+        "runtime work collect slow thread",
+        &[
+            ("archived", archived.to_string()),
+            ("elapsed_ms", elapsed.to_string()),
+            ("thread_id", thread_id.to_owned()),
+            ("thread_json_bytes", debug_json_len(thread).to_string()),
+            ("local_task_id", link.local_task_id.clone()),
+            ("workspace_path", link.workspace_path.clone()),
+            ("status", link.status.clone()),
+        ],
+    );
+}
+
+#[cfg(not(debug_assertions))]
+fn log_slow_runtime_collect_thread(
+    _archived: bool,
+    _thread_id: &str,
+    _started_at: Instant,
+    _thread: &Value,
+    _link: &RuntimeTaskLink,
+) {
+}
+
+#[cfg(debug_assertions)]
+fn log_slow_runtime_collect_thread_missing(
+    archived: bool,
+    thread_id: &str,
+    started_at: Instant,
+    thread: &Value,
+) {
+    let elapsed = started_at.elapsed().as_millis();
+    if elapsed < SLOW_RUNTIME_COLLECT_THREAD_MS {
+        return;
+    }
+    log_executor_event(
+        "runtime work collect slow skipped thread",
+        &[
+            ("archived", archived.to_string()),
+            ("elapsed_ms", elapsed.to_string()),
+            ("thread_id", thread_id.to_owned()),
+            ("thread_json_bytes", debug_json_len(thread).to_string()),
+        ],
+    );
+}
+
+#[cfg(not(debug_assertions))]
+fn log_slow_runtime_collect_thread_missing(
+    _archived: bool,
+    _thread_id: &str,
+    _started_at: Instant,
+    _thread: &Value,
+) {
+}
+
+#[cfg(debug_assertions)]
+fn debug_json_len(value: &Value) -> usize {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .unwrap_or_default()
+}
+
+#[cfg(debug_assertions)]
+fn log_runtime_work_list_diagnostic(
+    stage: &str,
+    started_at: Instant,
+    stage_started_at: Instant,
+    fields: &[(&str, String)],
+) {
+    let mut diagnostic_fields = vec![
+        ("stage", stage.to_owned()),
+        ("elapsed_ms", elapsed_ms(started_at)),
+        ("stage_elapsed_ms", elapsed_ms(stage_started_at)),
+    ];
+    if let Some(rss_kb) = current_process_max_rss_kb() {
+        diagnostic_fields.push(("max_rss_kb", rss_kb.to_string()));
+    }
+    diagnostic_fields.extend(fields.iter().map(|(key, value)| (*key, value.clone())));
+    log_executor_event("runtime work list diagnostic", &diagnostic_fields);
+}
+
+#[cfg(not(debug_assertions))]
+fn log_runtime_work_list_diagnostic(
+    _stage: &str,
+    _started_at: Instant,
+    _stage_started_at: Instant,
+    _fields: &[(&str, String)],
+) {
+}
+
+#[cfg(debug_assertions)]
+fn current_process_max_rss_kb() -> Option<u64> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    let max_rss = unsafe { usage.assume_init().ru_maxrss };
+    #[cfg(target_os = "macos")]
+    {
+        Some((max_rss as u64).saturating_div(1024))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Some(max_rss as u64)
     }
 }
 

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -8,9 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use super::util::{
-    codex_wrapped_item_payload, infer_workspace_kind, infer_worktree_id, normalize_workspace_path,
-    now_ms, path_is_within, string_field, timestamp_ms_field, workspace_group_path,
-    workspace_label, workspace_task_path,
+    infer_workspace_kind, infer_worktree_id, normalize_workspace_path, now_ms, path_is_within,
+    string_field, timestamp_ms_field, workspace_group_path, workspace_label, workspace_task_path,
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -80,7 +79,7 @@ impl RuntimeTaskLink {
         }
     }
 
-    pub fn from_thread(
+    pub fn from_thread_metadata(
         thread: &Value,
         local_link: Option<RuntimeTaskLink>,
         workspace_path: String,
@@ -104,7 +103,7 @@ impl RuntimeTaskLink {
         };
         let running = !local_archived
             && local_terminal_status.is_none()
-            && (local_running || thread_running(thread));
+            && (local_running || normalized_running_status(&status));
         Self {
             local_task_id: local_link
                 .as_ref()
@@ -131,6 +130,25 @@ impl RuntimeTaskLink {
             ephemeral: local_link.as_ref().is_some_and(|link| link.ephemeral),
             list_order: None,
             group_workspace_path: None,
+        }
+    }
+
+    pub fn list_summary(&self) -> Self {
+        Self {
+            local_task_id: self.local_task_id.clone(),
+            thread_id: self.thread_id.clone(),
+            workspace_path: self.workspace_path.clone(),
+            title: self.title.clone(),
+            runtime: self.runtime.clone(),
+            status: self.status.clone(),
+            running: self.running,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            runtime_handle: Value::Object(runtime_handle_list_summary_map(&self.runtime_handle)),
+            parent: self.parent.clone(),
+            ephemeral: self.ephemeral,
+            list_order: self.list_order,
+            group_workspace_path: self.group_workspace_path.clone(),
         }
     }
 }
@@ -522,11 +540,7 @@ fn runtime_task_address(link: &RuntimeTaskLink, device_id: &str) -> Value {
 }
 
 fn runtime_handle_with_thread_id(link: &RuntimeTaskLink) -> Map<String, Value> {
-    let mut runtime_handle = link
-        .runtime_handle
-        .as_object()
-        .cloned()
-        .unwrap_or_else(Map::new);
+    let mut runtime_handle = runtime_handle_list_summary_map(&link.runtime_handle);
     runtime_handle.insert(
         "threadId".to_owned(),
         link.thread_id
@@ -535,6 +549,31 @@ fn runtime_handle_with_thread_id(link: &RuntimeTaskLink) -> Map<String, Value> {
             .unwrap_or(Value::Null),
     );
     runtime_handle
+}
+
+pub(crate) fn runtime_handle_list_summary_map(runtime_handle: &Value) -> Map<String, Value> {
+    runtime_handle
+        .as_object()
+        .map(|object| {
+            object
+                .iter()
+                .filter(|(key, _)| !runtime_handle_list_payload_key(key))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn runtime_handle_list_payload_key(key: &str) -> bool {
+    matches!(
+        key,
+        "message"
+            | "messages"
+            | "cachedMessage"
+            | "cachedMessages"
+            | "cached_message"
+            | "cached_messages"
+    )
 }
 
 fn thread_status(thread: &Value) -> String {
@@ -551,34 +590,98 @@ fn thread_status(thread: &Value) -> String {
     .to_owned()
 }
 
-fn thread_running(thread: &Value) -> bool {
-    string_field(thread, "status")
-        .map(|status| normalized_running_status(&status))
-        .unwrap_or(false)
-        || thread
-            .get("turns")
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-            .any(turn_or_item_running)
-}
-
-fn turn_or_item_running(value: &Value) -> bool {
-    string_field(value, "status")
-        .map(|status| normalized_running_status(&status))
-        .unwrap_or(false)
-        || codex_wrapped_item_payload(value).is_some_and(turn_or_item_running)
-        || value
-            .get("items")
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-            .any(turn_or_item_running)
-}
-
 fn normalized_running_status(status: &str) -> bool {
     matches!(
         status.replace(['_', '-'], "").to_ascii_lowercase().as_str(),
         "running" | "inprogress" | "busy" | "pending"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn workspace_response_omits_runtime_handle_messages_from_task_list() {
+        let task = RuntimeTaskLink {
+            local_task_id: "task-1".to_owned(),
+            thread_id: Some("thread-1".to_owned()),
+            workspace_path: "/tmp/project".to_owned(),
+            title: "Large output".to_owned(),
+            runtime_handle: json!({
+                "threadId": "stale-thread",
+                "modelSelection": {"model": "gpt-5.5"},
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "blocks": [
+                            {
+                                "type": "tool_use",
+                                "tool_output": "x".repeat(1024),
+                            }
+                        ],
+                    }
+                ],
+            }),
+            ..RuntimeTaskLink::default()
+        };
+
+        let workspaces = workspace_response(vec![task], Vec::new());
+        let handle = &workspaces[0]["tasks"][0]["runtimeHandle"];
+
+        assert_eq!(handle["threadId"], "thread-1");
+        assert_eq!(handle["modelSelection"]["model"], "gpt-5.5");
+        assert!(handle.get("messages").is_none());
+    }
+
+    #[test]
+    fn thread_list_running_status_does_not_drive_task_running() {
+        let link = RuntimeTaskLink::from_thread_metadata(
+            &json!({
+                "id": "thread-1",
+                "status": "running",
+                "cwd": "/workspace/project",
+            }),
+            None,
+            "/workspace/project".to_owned(),
+        );
+
+        assert_eq!(link.status, "active");
+        assert!(!link.running);
+    }
+
+    #[test]
+    fn search_result_address_omits_runtime_handle_messages() {
+        let task = RuntimeTaskLink {
+            local_task_id: "task-1".to_owned(),
+            thread_id: Some("thread-1".to_owned()),
+            workspace_path: "/tmp/project".to_owned(),
+            title: "Large output".to_owned(),
+            runtime_handle: json!({
+                "messages": [{"content": "large cached transcript"}],
+                "executorSession": {"agent": "Codex"},
+            }),
+            ..RuntimeTaskLink::default()
+        };
+
+        let item = search_result_item(
+            &task,
+            "device-1",
+            SearchResultMatch {
+                snippet: "Large".to_owned(),
+                match_start: 0,
+                match_end: 5,
+                message_id: String::new(),
+                message_role: "title".to_owned(),
+                message_created_at: Value::Null,
+            },
+        );
+        let handle = &item["address"]["runtimeHandle"];
+
+        assert_eq!(handle["threadId"], "thread-1");
+        assert_eq!(handle["executorSession"]["agent"], "Codex");
+        assert!(handle.get("messages").is_none());
+    }
 }

--- a/executor/src/runtime_work/runtime_handle_messages.rs
+++ b/executor/src/runtime_work/runtime_handle_messages.rs
@@ -27,8 +27,6 @@ use super::{
     },
 };
 
-const STREAM_DELTA_PERSIST_INTERVAL_MS: i64 = 10_000;
-
 pub(crate) fn cached_messages(link: &RuntimeTaskLink) -> Vec<Value> {
     link.runtime_handle
         .get("messages")
@@ -41,19 +39,17 @@ pub(crate) fn cached_messages(link: &RuntimeTaskLink) -> Vec<Value> {
 }
 
 pub(crate) fn set_runtime_handle_messages(runtime_handle: &mut Value, messages: Vec<Value>) {
-    let mut object = runtime_handle.as_object().cloned().unwrap_or_default();
+    if !runtime_handle.is_object() {
+        *runtime_handle = Value::Object(Map::new());
+    }
+    let object = runtime_handle
+        .as_object_mut()
+        .expect("runtime handle object was just inserted");
     object.insert("messages".to_owned(), Value::Array(messages));
-    *runtime_handle = Value::Object(object);
 }
 
 pub(crate) fn append_runtime_handle_message(runtime_handle: &mut Value, message: Value) {
-    let mut messages = runtime_handle
-        .get("messages")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    messages.push(message);
-    set_runtime_handle_messages(runtime_handle, messages);
+    runtime_handle_messages_mut(runtime_handle).push(message);
 }
 
 #[cfg(test)]
@@ -483,7 +479,7 @@ fn cache_runtime_assistant_block(
     request: &ExecutionRequest,
     block: Value,
 ) {
-    mutate_cached_assistant_blocks(store, local_task_id, request, |blocks| {
+    mutate_cached_assistant_blocks_throttled(store, local_task_id, request, |blocks| {
         complete_open_process_blocks(blocks);
         merge_cached_block(blocks, block);
     });
@@ -498,7 +494,7 @@ fn cache_runtime_assistant_plan_item(
 ) {
     let block_id = plan_block_id(params);
     let process_item_id = notification_item_id(params);
-    mutate_cached_assistant_blocks(store, local_task_id, request, |blocks| {
+    mutate_cached_assistant_blocks_throttled(store, local_task_id, request, |blocks| {
         if let Some(block) = blocks.iter_mut().find(|block| {
             block_identity(block).as_deref() == Some(block_id.as_str())
                 || process_block_accepts_delta_for_item(
@@ -541,7 +537,7 @@ fn update_runtime_assistant_block(
     block_id: &str,
     updates: Value,
 ) {
-    mutate_cached_assistant_blocks(store, local_task_id, request, |blocks| {
+    mutate_cached_assistant_blocks_throttled(store, local_task_id, request, |blocks| {
         update_cached_block(blocks, block_id, updates);
     });
 }
@@ -589,7 +585,7 @@ fn append_runtime_assistant_process_snapshot(
     process_item_id: Option<String>,
     content: String,
 ) {
-    mutate_cached_assistant_blocks(store, local_task_id, request, |blocks| {
+    mutate_cached_assistant_blocks_throttled(store, local_task_id, request, |blocks| {
         if let Some(block) = blocks.iter_mut().rev().find(|block| {
             process_block_accepts_delta_for_item(
                 block,
@@ -688,18 +684,6 @@ pub(crate) fn merge_cached_messages(
     merged
 }
 
-fn mutate_cached_assistant_blocks(
-    store: &RuntimeWorkStore,
-    local_task_id: &str,
-    request: &ExecutionRequest,
-    mutate_blocks: impl FnOnce(&mut Vec<Value>),
-) {
-    mutate_cached_assistant_message(store, local_task_id, request, |assistant| {
-        let blocks = ensure_message_blocks(assistant);
-        mutate_blocks(blocks);
-    });
-}
-
 fn mutate_cached_assistant_blocks_throttled(
     store: &RuntimeWorkStore,
     local_task_id: &str,
@@ -715,21 +699,6 @@ fn mutate_cached_assistant_blocks_throttled(
             let blocks = ensure_message_blocks(assistant);
             mutate_blocks(blocks);
         },
-    );
-}
-
-fn mutate_cached_assistant_message(
-    store: &RuntimeWorkStore,
-    local_task_id: &str,
-    request: &ExecutionRequest,
-    mutate_message: impl FnOnce(&mut Value),
-) {
-    mutate_cached_assistant_message_with_persistence(
-        store,
-        local_task_id,
-        request,
-        true,
-        mutate_message,
     );
 }
 
@@ -756,16 +725,15 @@ fn mutate_cached_assistant_message_with_persistence(
     mutate_message: impl FnOnce(&mut Value),
 ) {
     let update = |link: &mut RuntimeTaskLink| {
-        let mut messages = cached_messages(link);
-        let assistant = ensure_cached_assistant_message(&mut messages, local_task_id, request);
+        let messages = runtime_handle_messages_mut(&mut link.runtime_handle);
+        let assistant = ensure_cached_assistant_message(messages, local_task_id, request);
         mutate_message(assistant);
         link.updated_at = now_ms();
-        set_runtime_handle_messages(&mut link.runtime_handle, messages);
     };
     if persist {
         store.update_task(local_task_id, update);
     } else {
-        store.update_task_throttled(local_task_id, STREAM_DELTA_PERSIST_INTERVAL_MS, update);
+        store.update_task_in_memory(local_task_id, update);
     }
 }
 
@@ -775,14 +743,13 @@ fn mutate_existing_cached_assistant_message(
     request: &ExecutionRequest,
     mutate_message: impl FnOnce(&mut Value),
 ) {
-    store.update_task(local_task_id, |link| {
-        let mut messages = cached_messages(link);
-        let Some(index) = cached_assistant_message_index(&messages, request) else {
+    store.update_task_in_memory(local_task_id, |link| {
+        let messages = runtime_handle_messages_mut(&mut link.runtime_handle);
+        let Some(index) = cached_assistant_message_index(messages, request) else {
             return;
         };
         mutate_message(&mut messages[index]);
         link.updated_at = now_ms();
-        set_runtime_handle_messages(&mut link.runtime_handle, messages);
     });
 }
 
@@ -910,6 +877,22 @@ fn ensure_cached_assistant_message<'a>(
     messages
         .last_mut()
         .expect("assistant message was just inserted")
+}
+
+fn runtime_handle_messages_mut(runtime_handle: &mut Value) -> &mut Vec<Value> {
+    if !runtime_handle.is_object() {
+        *runtime_handle = Value::Object(Map::new());
+    }
+    let object = runtime_handle
+        .as_object_mut()
+        .expect("runtime handle object was just inserted");
+    if !object.get("messages").is_some_and(Value::is_array) {
+        object.insert("messages".to_owned(), Value::Array(Vec::new()));
+    }
+    object
+        .get_mut("messages")
+        .and_then(Value::as_array_mut)
+        .expect("messages array was just inserted")
 }
 
 fn cached_assistant_message_index(messages: &[Value], request: &ExecutionRequest) -> Option<usize> {

--- a/executor/src/runtime_work/store.rs
+++ b/executor/src/runtime_work/store.rs
@@ -24,7 +24,7 @@ const DELETED_ARCHIVED_TASK_ID_MAX_COUNT: usize = 2_000;
 pub(crate) struct RuntimeWorkStore {
     index_path: PathBuf,
     index: Arc<Mutex<RuntimeWorkIndex>>,
-    throttled_writes: Arc<Mutex<HashMap<String, i64>>>,
+    index_signature: Arc<Mutex<Option<IndexFileSignature>>>,
 }
 
 #[derive(Clone, Default, Deserialize, Serialize)]
@@ -37,13 +37,20 @@ struct RuntimeWorkIndex {
     deleted_archived_task_ids: HashMap<String, i64>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct IndexFileSignature {
+    len: u64,
+    modified_ms: u128,
+}
+
 impl RuntimeWorkStore {
     pub fn new(index_path: PathBuf) -> Self {
         let index = read_index_from_path(&index_path);
+        let index_signature = index_file_signature(&index_path);
         Self {
             index_path,
             index: Arc::new(Mutex::new(index)),
-            throttled_writes: Arc::new(Mutex::new(HashMap::new())),
+            index_signature: Arc::new(Mutex::new(index_signature)),
         }
     }
 
@@ -51,32 +58,49 @@ impl RuntimeWorkStore {
         Self::new(default_index_path())
     }
 
-    pub fn list_tasks(&self, include_archived: bool) -> Vec<RuntimeTaskLink> {
-        let mut tasks = self
-            .read_index_snapshot()
+    pub fn list_task_summaries(&self, include_archived: bool) -> Vec<RuntimeTaskLink> {
+        self.refresh_index_from_disk_if_changed();
+        let Some(index) = self.index.lock().ok() else {
+            return Vec::new();
+        };
+        let mut tasks = index
             .tasks
-            .into_values()
+            .values()
             .filter(|task| include_archived || task.status != "archived")
+            .map(RuntimeTaskLink::list_summary)
             .collect::<Vec<_>>();
         tasks.sort_by_key(|task| Reverse(task.updated_at));
         tasks
     }
 
     pub fn get_task(&self, local_task_id: &str) -> Option<RuntimeTaskLink> {
-        self.read_index_snapshot().tasks.get(local_task_id).cloned()
+        self.refresh_index_from_disk_if_changed();
+        self.index.lock().ok()?.tasks.get(local_task_id).cloned()
     }
 
-    pub fn find_by_thread_id(&self, thread_id: &str) -> Option<RuntimeTaskLink> {
-        self.read_index_snapshot()
+    pub fn find_summary_by_thread_id(&self, thread_id: &str) -> Option<RuntimeTaskLink> {
+        self.refresh_index_from_disk_if_changed();
+        self.index
+            .lock()
+            .ok()?
             .tasks
-            .into_values()
+            .values()
             .find(|link| link.thread_id.as_deref() == Some(thread_id))
+            .map(RuntimeTaskLink::list_summary)
     }
 
     pub fn is_deleted_archived_task_id(&self, task_id: &str) -> bool {
-        self.read_index_snapshot()
-            .deleted_archived_task_ids
-            .contains_key(task_id)
+        self.refresh_index_from_disk_if_changed();
+        let Some(mut index) = self.index.lock().ok() else {
+            return false;
+        };
+        let before_deleted_count = index.deleted_archived_task_ids.len();
+        prune_deleted_archived_task_ids(&mut index.deleted_archived_task_ids, current_time_ms());
+        let deleted = index.deleted_archived_task_ids.contains_key(task_id);
+        if index.deleted_archived_task_ids.len() != before_deleted_count {
+            self.write_index(&index);
+        }
+        deleted
     }
 
     pub fn mark_deleted_archived_task_ids(&self, task_ids: impl IntoIterator<Item = String>) {
@@ -109,20 +133,12 @@ impl RuntimeWorkStore {
         self.update_task_with_persistence(local_task_id, updater, true)
     }
 
-    pub fn update_task_throttled(
+    pub fn update_task_in_memory(
         &self,
         local_task_id: &str,
-        min_interval_ms: i64,
         updater: impl FnOnce(&mut RuntimeTaskLink),
     ) -> Option<RuntimeTaskLink> {
-        let mut index = self.index.lock().ok()?;
-        let task = index.tasks.get_mut(local_task_id)?;
-        updater(task);
-        let updated = task.clone();
-        if self.throttled_write_due(local_task_id, min_interval_ms) {
-            self.write_index(&index);
-        }
-        Some(updated)
+        self.update_task_with_persistence(local_task_id, updater, false)
     }
 
     fn update_task_with_persistence(
@@ -144,27 +160,8 @@ impl RuntimeWorkStore {
     pub fn delete_task(&self, local_task_id: &str) -> Option<RuntimeTaskLink> {
         let mut index = self.index.lock().ok()?;
         let removed = index.tasks.remove(local_task_id)?;
-        if let Ok(mut throttled_writes) = self.throttled_writes.lock() {
-            throttled_writes.remove(local_task_id);
-        }
         self.write_index(&index);
         Some(removed)
-    }
-
-    fn throttled_write_due(&self, local_task_id: &str, min_interval_ms: i64) -> bool {
-        let now_ms = current_time_ms();
-        let Ok(mut throttled_writes) = self.throttled_writes.lock() else {
-            return true;
-        };
-        let last_write_ms = throttled_writes
-            .get(local_task_id)
-            .copied()
-            .unwrap_or_default();
-        if now_ms - last_write_ms < min_interval_ms {
-            return false;
-        }
-        throttled_writes.insert(local_task_id.to_owned(), now_ms);
-        true
     }
 
     fn write_index(&self, index: &RuntimeWorkIndex) {
@@ -182,40 +179,40 @@ impl RuntimeWorkStore {
         });
         if let Ok(payload) = payload {
             let temp_path = temporary_index_path(&self.index_path);
-            if fs::write(&temp_path, payload).is_ok()
-                && fs::rename(&temp_path, &self.index_path).is_err()
-            {
-                let _ = fs::remove_file(temp_path);
+            if fs::write(&temp_path, payload).is_ok() {
+                if fs::rename(&temp_path, &self.index_path).is_ok() {
+                    self.update_index_signature();
+                } else {
+                    let _ = fs::remove_file(temp_path);
+                }
             }
         }
     }
 
-    fn read_index_snapshot(&self) -> RuntimeWorkIndex {
-        let mut disk_index = read_index_from_path(&self.index_path);
-        let before_deleted_count = disk_index.deleted_archived_task_ids.len();
-        prune_deleted_archived_task_ids(
-            &mut disk_index.deleted_archived_task_ids,
-            current_time_ms(),
-        );
-        let dirty_task_ids = self
-            .throttled_writes
+    fn refresh_index_from_disk_if_changed(&self) {
+        let current_signature = index_file_signature(&self.index_path);
+        let changed = self
+            .index_signature
             .lock()
             .ok()
-            .map(|writes| writes.keys().cloned().collect::<Vec<_>>())
-            .unwrap_or_default();
-        let Some(mut memory_index) = self.index.lock().ok() else {
-            return disk_index;
-        };
-        for task_id in dirty_task_ids {
-            if let Some(link) = memory_index.tasks.get(&task_id) {
-                disk_index.tasks.insert(task_id, link.clone());
-            }
+            .is_some_and(|signature| *signature != current_signature);
+        if !changed {
+            return;
         }
-        *memory_index = disk_index.clone();
-        if disk_index.deleted_archived_task_ids.len() != before_deleted_count {
-            self.write_index(&disk_index);
+
+        let disk_index = read_index_from_path(&self.index_path);
+        if let Ok(mut index) = self.index.lock() {
+            *index = disk_index;
         }
-        disk_index
+        if let Ok(mut signature) = self.index_signature.lock() {
+            *signature = current_signature;
+        }
+    }
+
+    fn update_index_signature(&self) {
+        if let Ok(mut signature) = self.index_signature.lock() {
+            *signature = index_file_signature(&self.index_path);
+        }
     }
 }
 
@@ -231,6 +228,20 @@ fn read_index_from_path(index_path: &Path) -> RuntimeWorkIndex {
         return empty_index();
     };
     serde_json::from_str::<RuntimeWorkIndex>(&content).unwrap_or_else(|_| empty_index())
+}
+
+fn index_file_signature(index_path: &Path) -> Option<IndexFileSignature> {
+    let metadata = fs::metadata(index_path).ok()?;
+    let modified_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    Some(IndexFileSignature {
+        len: metadata.len(),
+        modified_ms,
+    })
 }
 
 fn empty_index() -> RuntimeWorkIndex {
@@ -342,8 +353,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn update_task_throttled_persists_at_interval() {
-        let index_path = temp_index_path("throttled-delta");
+    fn update_task_in_memory_defers_persistence_until_next_write() {
+        let index_path = temp_index_path("in-memory-update");
         let store = RuntimeWorkStore::new(index_path.clone());
         store.upsert_task(RuntimeTaskLink::new_pending(
             "task-1".to_owned(),
@@ -351,31 +362,22 @@ mod tests {
             "Task".to_owned(),
         ));
 
-        store.update_task_throttled("task-1", 60_000, |link| {
-            link.title = "First delta".to_owned();
+        store.update_task_in_memory("task-1", |link| {
+            link.title = "Streaming delta".to_owned();
         });
-        let reloaded_after_first_write = RuntimeWorkStore::new(index_path.clone());
+        assert_eq!(store.get_task("task-1").unwrap().title, "Streaming delta");
+        let reloaded_before_persist = RuntimeWorkStore::new(index_path.clone());
         assert_eq!(
-            reloaded_after_first_write.get_task("task-1").unwrap().title,
-            "First delta"
-        );
-
-        store.update_task_throttled("task-1", 60_000, |link| {
-            link.title = "Second delta".to_owned();
-        });
-        assert_eq!(store.get_task("task-1").unwrap().title, "Second delta");
-        let reloaded_before_next_due = RuntimeWorkStore::new(index_path.clone());
-        assert_eq!(
-            reloaded_before_next_due.get_task("task-1").unwrap().title,
-            "First delta"
+            reloaded_before_persist.get_task("task-1").unwrap().title,
+            "Task"
         );
 
         store.update_task("task-1", |link| {
             link.status = "done".to_owned();
         });
-        let reloaded_after_terminal_write = RuntimeWorkStore::new(index_path.clone());
-        let task = reloaded_after_terminal_write.get_task("task-1").unwrap();
-        assert_eq!(task.title, "Second delta");
+        let reloaded_after_persist = RuntimeWorkStore::new(index_path.clone());
+        let task = reloaded_after_persist.get_task("task-1").unwrap();
+        assert_eq!(task.title, "Streaming delta");
         assert_eq!(task.status, "done");
 
         let _ = fs::remove_file(index_path);

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -10,9 +10,11 @@ use super::util::{
     bool_field, codex_wrapped_item_payload, extract_text, id_field, integer_field,
     is_codex_context_compaction_item_type, is_codex_tool_item_type, is_codex_tool_output_item_type,
     is_likely_codex_tool_item_type, is_likely_codex_tool_output_item_type, item_id, item_type,
-    normalize_workspace_path, now_ms, raw_string_field, reasoning_content, string_field,
-    timestamp_ms_field,
+    normalize_workspace_path, now_ms, raw_string_field, raw_string_field_ref, reasoning_content,
+    string_field, timestamp_ms_field,
 };
+
+const MAX_TRANSCRIPT_TOOL_OUTPUT_BYTES: usize = 64 * 1024;
 
 pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value> {
     let mut messages = Vec::new();
@@ -456,8 +458,10 @@ pub(crate) fn tool_update_from_notification(params: &Value) -> Option<(String, V
     }
     let mut updates = json!({
         "status": tool_status(&item),
-        "tool_output": tool_output(&item),
     });
+    if let Some(object) = updates.as_object_mut() {
+        insert_tool_output_fields(object, &item);
+    }
     if let Some(input) = command_input_from_output(&item) {
         if let Some(object) = updates.as_object_mut() {
             object.insert("tool_input".to_owned(), input);
@@ -1231,16 +1235,19 @@ fn synthetic_assistant_message(draft: AssistantMessageDraft<'_>) -> Value {
 }
 
 fn command_block(item: &Value, timestamp: i64) -> Value {
-    json!({
+    let mut block = json!({
         "id": item_id(item, "tool"),
         "type": "tool",
         "tool_use_id": item_id(item, "tool"),
         "tool_name": "bash",
         "tool_input": command_input(item),
-        "tool_output": command_output(item),
         "status": tool_status(item),
         "timestamp": timestamp,
-    })
+    });
+    if let Some(object) = block.as_object_mut() {
+        insert_tool_output_fields(object, item);
+    }
+    block
 }
 
 fn tool_block(item: &Value, timestamp: i64) -> Value {
@@ -1250,16 +1257,19 @@ fn tool_block(item: &Value, timestamp: i64) -> Value {
     ) {
         return command_block(item, timestamp);
     }
-    json!({
+    let mut block = json!({
         "id": tool_call_id(item),
         "type": "tool",
         "tool_use_id": tool_call_id(item),
         "tool_name": tool_name(item),
         "tool_input": tool_input(item),
-        "tool_output": tool_output(item),
         "status": tool_status(item),
         "timestamp": timestamp,
-    })
+    });
+    if let Some(object) = block.as_object_mut() {
+        insert_tool_output_fields(object, item);
+    }
+    block
 }
 
 fn merge_tool_output(blocks: &mut Vec<Value>, item: &Value, timestamp: i64) {
@@ -1272,7 +1282,7 @@ fn merge_tool_output(blocks: &mut Vec<Value>, item: &Value, timestamp: i64) {
     }) {
         if let Some(object) = block.as_object_mut() {
             merge_tool_input(object, command_input_from_output(item));
-            object.insert("tool_output".to_owned(), tool_output(item));
+            insert_tool_output_fields(object, item);
             object.insert("status".to_owned(), Value::String(tool_status(item)));
         }
         return;
@@ -1282,16 +1292,33 @@ fn merge_tool_output(blocks: &mut Vec<Value>, item: &Value, timestamp: i64) {
         "type": "tool",
         "tool_use_id": tool_call_id(item),
         "tool_name": tool_name(item),
-        "tool_output": tool_output(item),
         "status": tool_status(item),
         "timestamp": timestamp,
     });
+    if let Some(object) = block.as_object_mut() {
+        insert_tool_output_fields(object, item);
+    }
     if let Some(input) = command_input_from_output(item) {
         if let Some(object) = block.as_object_mut() {
             object.insert("tool_input".to_owned(), input);
         }
     }
     blocks.push(block);
+}
+
+fn insert_tool_output_fields(object: &mut Map<String, Value>, item: &Value) {
+    let output = limited_tool_output(item);
+    object.insert("tool_output".to_owned(), output.value);
+    if output.truncated {
+        object.insert("tool_output_truncated".to_owned(), Value::Bool(true));
+        object.insert(
+            "tool_output_original_bytes".to_owned(),
+            json!(output.original_bytes),
+        );
+    } else {
+        object.remove("tool_output_truncated");
+        object.remove("tool_output_original_bytes");
+    }
 }
 
 fn command_input(item: &Value) -> Value {
@@ -1303,11 +1330,57 @@ fn command_input(item: &Value) -> Value {
     })
 }
 
-fn command_output(item: &Value) -> String {
-    raw_string_field(item, "aggregatedOutput")
-        .or_else(|| raw_string_field(item, "aggregated_output"))
-        .or_else(|| raw_string_field(item, "output"))
-        .unwrap_or_default()
+#[derive(Debug)]
+struct LimitedToolOutput {
+    value: Value,
+    truncated: bool,
+    original_bytes: usize,
+}
+
+fn limited_tool_output(item: &Value) -> LimitedToolOutput {
+    match raw_tool_output(item) {
+        RawToolOutput::String(text) => limited_tool_output_string(text),
+        RawToolOutput::Value(value) => LimitedToolOutput {
+            value,
+            truncated: false,
+            original_bytes: 0,
+        },
+    }
+}
+
+enum RawToolOutput<'a> {
+    String(&'a str),
+    Value(Value),
+}
+
+fn limited_tool_output_string(text: &str) -> LimitedToolOutput {
+    let original_bytes = text.len();
+    if original_bytes <= MAX_TRANSCRIPT_TOOL_OUTPUT_BYTES {
+        return LimitedToolOutput {
+            value: Value::String(text.to_owned()),
+            truncated: false,
+            original_bytes,
+        };
+    }
+    LimitedToolOutput {
+        value: Value::String(tail_utf8_bytes(text, MAX_TRANSCRIPT_TOOL_OUTPUT_BYTES)),
+        truncated: true,
+        original_bytes,
+    }
+}
+
+fn tail_utf8_bytes(text: &str, max_bytes: usize) -> String {
+    let mut start = text.len().saturating_sub(max_bytes);
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    text[start..].to_owned()
+}
+
+fn command_output_ref(item: &Value) -> Option<&str> {
+    raw_string_field_ref(item, "aggregatedOutput")
+        .or_else(|| raw_string_field_ref(item, "aggregated_output"))
+        .or_else(|| raw_string_field_ref(item, "output"))
 }
 
 fn command_input_from_output(item: &Value) -> Option<Value> {
@@ -1474,57 +1547,74 @@ fn parse_json_object_string(item: &Value, key: &str) -> Option<Value> {
         .filter(Value::is_object)
 }
 
-fn tool_output(item: &Value) -> Value {
+fn raw_tool_output(item: &Value) -> RawToolOutput<'_> {
     match item_type(item).as_str() {
         "commandexecution" | "shellcall" | "localshellcall" | "execcommandend" => {
-            Value::String(command_output(item))
+            RawToolOutput::String(command_output_ref(item).unwrap_or_default())
         }
         "functioncalloutput" | "customtoolcalloutput" => output_payload_text(item)
-            .map(Value::String)
-            .unwrap_or_else(|| item.get("output").cloned().unwrap_or(Value::Null)),
-        "toolsearchoutput" => item.get("results").cloned().unwrap_or_else(|| {
-            output_payload_text(item)
-                .map(Value::String)
-                .unwrap_or(Value::Null)
-        }),
+            .map(|output| RawToolOutput::Value(Value::String(output)))
+            .unwrap_or_else(|| {
+                RawToolOutput::Value(item.get("output").cloned().unwrap_or(Value::Null))
+            }),
+        "toolsearchoutput" => item
+            .get("results")
+            .cloned()
+            .unwrap_or_else(|| {
+                output_payload_text(item)
+                    .map(Value::String)
+                    .unwrap_or(Value::Null)
+            })
+            .into(),
         "dynamictoolcall" => item
             .get("contentItems")
             .or_else(|| item.get("content_items"))
             .map(output_content_items_text)
-            .map(Value::String)
-            .unwrap_or_else(|| item.get("result").cloned().unwrap_or(Value::Null)),
-        "mcptoolcall" | "mcpcall" | "mcptoolcallend" => mcp_tool_output(item),
+            .map(|output| RawToolOutput::Value(Value::String(output)))
+            .unwrap_or_else(|| {
+                RawToolOutput::Value(item.get("result").cloned().unwrap_or(Value::Null))
+            }),
+        "mcptoolcall" | "mcpcall" | "mcptoolcallend" => RawToolOutput::Value(mcp_tool_output(item)),
         "imagegeneration" => string_field(item, "savedPath")
             .or_else(|| string_field(item, "saved_path"))
             .or_else(|| raw_string_field(item, "result"))
-            .map(Value::String)
-            .unwrap_or(Value::Null),
+            .map(|output| RawToolOutput::Value(Value::String(output)))
+            .unwrap_or(RawToolOutput::Value(Value::Null)),
         _ => default_tool_output(item),
     }
 }
 
-fn default_tool_output(item: &Value) -> Value {
+impl From<Value> for RawToolOutput<'_> {
+    fn from(value: Value) -> Self {
+        RawToolOutput::Value(value)
+    }
+}
+
+fn default_tool_output(item: &Value) -> RawToolOutput<'_> {
     if let Some(output) = output_payload_text(item) {
-        return Value::String(output);
+        return RawToolOutput::Value(Value::String(output));
     }
-    let command_output = command_output(item);
-    if !command_output.is_empty() {
-        return Value::String(command_output);
+    if let Some(command_output) = command_output_ref(item) {
+        if !command_output.is_empty() {
+            return RawToolOutput::String(command_output);
+        }
     }
-    let stdout = raw_string_field(item, "stdout").unwrap_or_default();
-    let stderr = raw_string_field(item, "stderr").unwrap_or_default();
+    let stdout = raw_string_field_ref(item, "stdout").unwrap_or_default();
+    let stderr = raw_string_field_ref(item, "stderr").unwrap_or_default();
     let combined = [stdout, stderr]
         .into_iter()
         .filter(|value| !value.is_empty())
         .collect::<Vec<_>>()
         .join("\n");
     if !combined.is_empty() {
-        return Value::String(combined);
+        return RawToolOutput::Value(limited_tool_output_string(&combined).value);
     }
-    item.get("result")
-        .or_else(|| item.get("formatted_output"))
-        .cloned()
-        .unwrap_or(Value::Null)
+    RawToolOutput::Value(
+        item.get("result")
+            .or_else(|| item.get("formatted_output"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    )
 }
 
 fn mcp_invocation_field(item: &Value, key: &str) -> Option<String> {
@@ -2810,6 +2900,51 @@ mod tests {
         assert_eq!(block["tool_input"]["cwd"], "/tmp/project");
         assert_eq!(block["tool_output"], "/tmp/project\n");
         assert_eq!(block["status"], "done");
+    }
+
+    #[test]
+    fn transcript_truncates_large_exec_command_output() {
+        let output = format!(
+            "{}tail",
+            "x".repeat(MAX_TRANSCRIPT_TOOL_OUTPUT_BYTES + 1024)
+        );
+        let thread = json!({
+            "id": "thread-1",
+            "cwd": "/tmp/project",
+            "turns": [
+                {
+                    "id": "turn-1",
+                    "startedAt": 1_780_000_000,
+                    "status": "running",
+                    "items": [
+                        {
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "exec_command_end",
+                                "call_id": "call-1",
+                                "command": ["/bin/zsh", "-lc", "cat large.log"],
+                                "cwd": "/tmp/project",
+                                "aggregated_output": output,
+                                "status": "completed",
+                                "exit_code": 0
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let messages = transcript_messages(&thread, "device-1");
+        let block = &messages[0]["blocks"][0];
+        let tool_output = block["tool_output"].as_str().unwrap();
+
+        assert_eq!(tool_output.len(), MAX_TRANSCRIPT_TOOL_OUTPUT_BYTES);
+        assert!(tool_output.ends_with("tail"));
+        assert_eq!(block["tool_output_truncated"], true);
+        assert_eq!(
+            block["tool_output_original_bytes"],
+            MAX_TRANSCRIPT_TOOL_OUTPUT_BYTES + 1028
+        );
     }
 
     #[test]

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -126,6 +126,10 @@ pub(crate) fn raw_string_field(value: &Value, key: &str) -> Option<String> {
     value.get(key).and_then(Value::as_str).map(str::to_owned)
 }
 
+pub(crate) fn raw_string_field_ref<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str)
+}
+
 pub(crate) fn integer_field(value: &Value, key: &str) -> Option<i64> {
     value.get(key).and_then(|value| {
         value

--- a/executor/tests/app_runtime_work_native_update_contract.rs
+++ b/executor/tests/app_runtime_work_native_update_contract.rs
@@ -46,7 +46,7 @@ impl Drop for EnvGuard {
 }
 
 #[tokio::test]
-async fn runtime_task_list_maps_native_running_thread_statuses() {
+async fn runtime_task_list_trusts_native_thread_status_without_rollout_probe() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
         "WEGENT_EXECUTOR_HOME",
@@ -127,7 +127,7 @@ async fn runtime_task_list_maps_native_running_thread_statuses() {
         .unwrap();
 
     assert_eq!(running_by_rollout["status"], "active");
-    assert_eq!(running_by_rollout["running"], true);
+    assert_eq!(running_by_rollout["running"], false);
     assert_eq!(idle["status"], "active");
     assert_eq!(idle["running"], false);
     assert_eq!(active_completed["status"], "active");

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -29,6 +29,8 @@ export interface WorkbenchToolBlock extends BaseWorkbenchProcessingBlock {
   toolName: string
   toolInput?: Record<string, unknown>
   toolOutput?: unknown
+  toolOutputTruncated?: boolean
+  toolOutputOriginalBytes?: number
   renderPayload?: unknown
 }
 
@@ -87,6 +89,8 @@ type ProcessingBlockUpdate = {
   toolInput?: Record<string, unknown>
   toolOutput?: unknown
   toolOutputDelta?: string
+  toolOutputTruncated?: boolean
+  toolOutputOriginalBytes?: number
   renderPayload?: unknown
   fileChanges?: unknown
   status?: WorkbenchToolBlockStatus

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -39,6 +39,8 @@ Environment:
                         Executor sidecar path. Defaults to source reload sidecar.
   WEGENT_EXECUTOR_DEV_RELOAD
                         Set to 0 to run executor source once without reload.
+  WEWORK_MALLOC_STACK_LOGGING
+                        Set to 1 to enable macOS malloc stack logging for WebKit diagnostics.
   MACOS_BUILD_TARGET    Default macOS Rust/Tauri target when --target is not provided.
 
 Examples:
@@ -223,6 +225,13 @@ echo "  VITE_API_PROXY_TARGET=$VITE_API_PROXY_TARGET"
 echo "  VITE_SOCKET_PROXY_TARGET=$VITE_SOCKET_PROXY_TARGET"
 echo "  WEWORK_EXECUTOR_SIDECAR=${WEWORK_EXECUTOR_SIDECAR:-<bundled sidecar>}"
 echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-<cargo default>}"
+
+if [ "${WEWORK_MALLOC_STACK_LOGGING:-}" = "1" ]; then
+  export MallocStackLogging=1
+  export MallocStackLoggingNoCompact=1
+  echo "  MallocStackLogging=1"
+  echo "  MallocStackLoggingNoCompact=1"
+fi
 
 if [ "${WEWORK_DRY_RUN:-}" = "1" ]; then
   echo "  TAURI_DEV_CONFIG=$TAURI_DEV_CONFIG"

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -153,8 +153,11 @@ export const MessageList = memo(function MessageList({
     editingMessageId === editableLastUserMessageId ? editingMessageId : null
   const activeSubmittingEditMessageId =
     submittingEditMessageId === editableLastUserMessageId ? submittingEditMessageId : null
+  const lastVisibleMessage = visibleMessages.at(-1)
+  const waitingForAssistantTurn = !lastVisibleMessage || lastVisibleMessage.role === 'user'
   const shouldShowWaitingIndicator =
     isWaitingForAssistant &&
+    waitingForAssistantTurn &&
     !messages.some(message => message.role === 'assistant' && message.status === 'streaming')
   const disableMessageContentVisibility =
     disableContentVisibility || isTextSelectionActive || isTauri

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -68,7 +68,7 @@ export function ToolBlockItem({
   )
 
   return (
-    <div className="min-w-0 overflow-x-hidden text-[13px]">
+    <div className="min-w-0 overflow-x-hidden text-[13px]" data-processing-block-id={block.id}>
       <div className="flex max-w-full items-center gap-1.5 text-text-secondary">
         {workspaceFilePath && onOpenWorkspaceFile ? (
           <button
@@ -135,7 +135,9 @@ function PlanBlockItem({
   }
 
   return (
-    <AssistantPlanCard content={block.content} isStreaming={isStreaming} onOpenPlan={openPlan} />
+    <div data-processing-block-id={block.id}>
+      <AssistantPlanCard content={block.content} isStreaming={isStreaming} onOpenPlan={openPlan} />
+    </div>
   )
 }
 
@@ -153,7 +155,11 @@ function ProcessFileChangesBlockItem({
   if (!summary.files.length) return null
 
   return (
-    <div className="min-w-0 overflow-visible text-[13px]" data-testid="process-file-changes-block">
+    <div
+      className="min-w-0 overflow-visible text-[13px]"
+      data-processing-block-id={block.id}
+      data-testid="process-file-changes-block"
+    >
       <button
         type="button"
         aria-expanded={expanded}
@@ -705,7 +711,7 @@ function ThinkingBlockItem({
     const preview = buildBlockPreview(block.content)
 
     return (
-      <div className="min-w-0 overflow-x-hidden text-[13px]">
+      <div className="min-w-0 overflow-x-hidden text-[13px]" data-processing-block-id={block.id}>
         <div
           className="flex max-w-full items-center gap-1.5 text-text-secondary"
           role="status"
@@ -726,7 +732,7 @@ function ThinkingBlockItem({
   const detailId = `${block.id}-thinking-detail`
 
   return (
-    <div className="min-w-0 overflow-x-hidden text-[13px]">
+    <div className="min-w-0 overflow-x-hidden text-[13px]" data-processing-block-id={block.id}>
       <button
         type="button"
         data-testid="thinking-toggle-button"
@@ -770,6 +776,7 @@ function ProcessTextBlockItem({
   return (
     <div
       className="min-w-0 overflow-x-hidden text-[13px] text-text-secondary"
+      data-processing-block-id={block.id}
       role={isRunning ? 'status' : undefined}
       aria-live={isRunning ? 'polite' : undefined}
       aria-label={isRunning ? t('process_text.running') : undefined}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -71,7 +71,7 @@ function createPaneStatus({
     isAssistantStreaming,
     isResponseActive,
     isBusy,
-    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant,
+    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant || taskRunning,
     canSendQueuedMessage: !isBusy,
   }
 }

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -51,7 +51,7 @@ function createPaneStatus({
     isAssistantStreaming,
     isResponseActive,
     isBusy,
-    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant,
+    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant || taskRunning,
     canSendQueuedMessage: !isBusy,
   }
 }

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -3,6 +3,7 @@ import i18n from '@/i18n'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
 import {
   compareMessageStyles,
+  summarizeRuntimePaneMemory,
   summarizeMessages,
   updateRuntimePaneDebugSnapshot,
 } from '@/lib/debugPanel'
@@ -83,6 +84,12 @@ interface LoadedTranscriptRange {
   end: number
 }
 
+interface RuntimeTaskLoadTarget {
+  key: string
+  identityKey: string
+  address: RuntimeTaskAddress
+}
+
 interface PendingRuntimeGoalState {
   goal: RuntimeGoal
   targetKey: string | null
@@ -151,25 +158,22 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   const getRuntimeGoalRef = useRef(getRuntimeGoal)
   const refreshWorkListsRef = useRef(refreshWorkLists)
   const currentRuntimeTaskRef = useRef(currentRuntimeTask)
-  const runtimeTaskLoadTargetRef = useRef<{
-    key: string
-    address: RuntimeTaskAddress
-  } | null>(null)
+  const runtimeTaskLoadTargetRef = useRef<RuntimeTaskLoadTarget | null>(null)
   const messagesRef = useRef<WorkbenchMessage[]>([])
   const loadedTranscriptRangesRef = useRef<LoadedTranscriptRange[]>([])
   const guidanceSplitBoundariesRef = useRef(new Map<string, GuidanceSplitBoundary>())
   const pendingMessageActionsRef = useRef<RuntimePaneMessageAction[]>([])
   const messageActionFrameRef = useRef<number | null>(null)
-  const runtimeTaskLoadTarget = useMemo(() => {
-    if (!currentRuntimeTask) return null
-    return {
-      key: runtimeTranscriptPaneKey(currentRuntimeTask),
-      address: currentRuntimeTask,
-    }
-  }, [currentRuntimeTask])
-  const runtimeTaskStreamTargetKey = runtimeTaskLoadTarget
-    ? runtimeTranscriptPaneIdentityKey(runtimeTaskLoadTarget.address)
-    : null
+  const currentRuntimeTaskLoadTarget = useMemo(
+    () => (currentRuntimeTask ? runtimeTaskLoadTargetFromAddress(currentRuntimeTask) : null),
+    [currentRuntimeTask]
+  )
+  const [retainedRuntimeTaskLoadTarget, setRetainedRuntimeTaskLoadTarget] =
+    useState<RuntimeTaskLoadTarget | null>(() =>
+      currentRuntimeTask ? runtimeTaskLoadTargetFromAddress(currentRuntimeTask) : null
+    )
+  const runtimeTaskLoadTarget = retainedRuntimeTaskLoadTarget
+  const runtimeTaskStreamTargetKey = runtimeTaskLoadTarget?.identityKey ?? null
   const [messages, setMessages] = useState<WorkbenchMessage[]>([])
   const applyMessageActions = useCallback((actions: RuntimePaneMessageAction[]) => {
     if (actions.length === 0) return
@@ -185,7 +189,8 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           actionForReduction
         )
       }
-      const activeRuntimeTask = currentRuntimeTaskRef.current
+      const activeRuntimeTask =
+        runtimeTaskLoadTargetRef.current?.address ?? currentRuntimeTaskRef.current
       if (activeRuntimeTask) {
         snapshotRuntimePaneMessages(activeRuntimeTask, nextMessages)
         debugRuntimePaneMessageFlow('message-action', {
@@ -230,9 +235,10 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     },
     [applyMessageActions, flushPendingMessageActions]
   )
+  const runtimeTaskStatusAddress = runtimeTaskLoadTarget?.address ?? currentRuntimeTask
   const taskExecution = useMemo(
-    () => getRuntimePaneTaskExecution(workbenchState.runtimeWork, currentRuntimeTask),
-    [currentRuntimeTask, workbenchState.runtimeWork]
+    () => getRuntimePaneTaskExecution(workbenchState.runtimeWork, runtimeTaskStatusAddress),
+    [runtimeTaskStatusAddress, workbenchState.runtimeWork]
   )
   const paneStatus = useMemo(
     () =>
@@ -246,25 +252,36 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   )
   const activeAssistantMessage = paneStatus.activeAssistantMessage
   const goal = useMemo(() => {
+    if (!currentRuntimeTaskLoadTarget) {
+      if (pendingGoalState && isUnboundPendingGoalState(pendingGoalState)) {
+        return visibleRuntimeGoal(pendingGoalState.goal)
+      }
+      return null
+    }
+
     const visibleThreadGoal = visibleRuntimeGoal(threadGoal)
     if (visibleThreadGoal) return visibleThreadGoal
     if (!pendingGoalState) return null
-    if (!runtimeTaskLoadTarget && isUnboundPendingGoalState(pendingGoalState)) {
-      return visibleRuntimeGoal(pendingGoalState.goal)
-    }
     if (
-      runtimeTaskLoadTarget &&
-      isPendingGoalVisibleForRuntimeTarget(pendingGoalState, runtimeTaskLoadTarget.address)
+      isPendingGoalVisibleForRuntimeTarget(pendingGoalState, currentRuntimeTaskLoadTarget.address)
     ) {
       return visibleRuntimeGoal(pendingGoalState.goal)
     }
     return null
-  }, [pendingGoalState, runtimeTaskLoadTarget, threadGoal])
+  }, [currentRuntimeTaskLoadTarget, pendingGoalState, threadGoal])
 
   /* eslint-disable react-hooks/set-state-in-effect -- Runtime task changes reset pane transcript state before the async transcript load completes. */
   useEffect(() => {
     currentRuntimeTaskRef.current = currentRuntimeTask
   }, [currentRuntimeTask])
+
+  useEffect(() => {
+    if (currentRuntimeTaskLoadTarget) {
+      setRetainedRuntimeTaskLoadTarget(current =>
+        current?.key === currentRuntimeTaskLoadTarget.key ? current : currentRuntimeTaskLoadTarget
+      )
+    }
+  }, [currentRuntimeTaskLoadTarget])
 
   useEffect(() => {
     return () => {
@@ -358,15 +375,11 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
 
   useEffect(() => {
     if (!runtimeTaskLoadTarget) {
-      loadedRuntimeTranscriptKeyRef.current = null
-      // This clears pane-local transcript state when there is no runtime target.
+      // Keep the loaded transcript key and range metadata while the pane is on a blank
+      // chat. The pane intentionally keeps the previous runtime DOM alive, so returning
+      // to the same task should not reload and reset the transcript tree.
       setTranscriptLoading(false)
-      setTranscriptHasMoreBefore(false)
-      setTranscriptBeforeCursor(null)
       setTranscriptLoadingMoreBefore(false)
-      setLoadedTranscriptRanges([])
-      setTurnNavigation([])
-      setSubagentStatuses([])
       return
     }
 
@@ -1162,12 +1175,13 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
               },
             })
             if (sent) {
-              setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
               if (!isRuntimeTaskAddress(sent)) {
+                setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
                 appendLocalUserMessage(submittedInput, currentAttachments, {
                   runtimeGoalRequest: true,
                 })
               } else {
+                setSendPhase('idle')
                 setPendingGoalState(current =>
                   current
                     ? {
@@ -1253,22 +1267,25 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
               },
             })
             if (sent) {
-              setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
               if (!isRuntimeTaskAddress(sent)) {
+                setSendPhase(current => (current === 'submitting' ? 'awaiting_assistant' : current))
                 appendLocalUserMessage(visibleSubmittedInput, currentAttachments, {
                   runtimeGoalRequest: Boolean(pendingInitialGoal),
                   codeComments: codeCommentContexts,
                 })
-              } else if (pendingInitialGoal) {
-                setPendingGoalState(current =>
-                  current
-                    ? {
-                        ...current,
-                        targetKey: runtimeTranscriptPaneKey(sent),
-                        targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
-                      }
-                    : current
-                )
+              } else {
+                setSendPhase('idle')
+                if (pendingInitialGoal) {
+                  setPendingGoalState(current =>
+                    current
+                      ? {
+                          ...current,
+                          targetKey: runtimeTranscriptPaneKey(sent),
+                          targetIdentityKey: runtimeTranscriptPaneIdentityKey(sent),
+                        }
+                      : current
+                  )
+                }
               }
               if (isRuntimeTaskAddress(sent)) {
                 dispatchMessages({ type: 'reset', messages: [] })
@@ -1390,10 +1407,12 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   )
 
   const pauseCurrentResponse = useCallback(async () => {
-    if (!currentRuntimeTask || !activeAssistantMessage) return
+    if (!currentRuntimeTask) return
 
     const cancelled = await cancelRuntimePaneTask(currentRuntimeTask)
     if (!cancelled) return
+
+    if (!activeAssistantMessage) return
 
     dispatchMessages({
       type: 'assistant_cancelled',
@@ -1498,6 +1517,11 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       status: paneStatus,
       messageSummary: summarizeMessages(messages),
       messageStyleComparison: compareMessageStyles(messages),
+      memory: summarizeRuntimePaneMemory({
+        messages,
+        currentRuntimeTask,
+        loadedRanges: loadedTranscriptRanges,
+      }),
       queuedMessages,
       guidanceMessages,
       codeCommentContextCount: codeCommentContexts.length,
@@ -1507,6 +1531,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         hasMoreBefore: transcriptHasMoreBefore,
         loadingMoreBefore: transcriptLoadingMoreBefore,
         turnNavigationCount: turnNavigation.length,
+        loadedRanges: loadedTranscriptRanges,
       },
       subagentStatuses,
       goal,
@@ -1519,6 +1544,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     goalDraftActive,
     guidanceMessages,
     input.length,
+    loadedTranscriptRanges,
     messages,
     paneActive,
     paneStatus,
@@ -1573,6 +1599,14 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
 }
 
 export type WorkbenchPaneSession = ReturnType<typeof useWorkbenchPaneSession>
+
+function runtimeTaskLoadTargetFromAddress(address: RuntimeTaskAddress): RuntimeTaskLoadTarget {
+  return {
+    key: runtimeTranscriptPaneKey(address),
+    identityKey: runtimeTranscriptPaneIdentityKey(address),
+    address,
+  }
+}
 
 function runtimeTranscriptPaneKey(address: RuntimeTaskAddress): string {
   return `${address.deviceId}:${address.taskId}:${address.workspacePath ?? ''}`

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -609,6 +609,10 @@ function ProjectSendProbe() {
       <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
       <span data-testid="pane-session-error">{paneSession.error ?? ''}</span>
       <span data-testid="sending-state">{paneSession.sending ? 'sending' : 'idle'}</span>
+      <span data-testid="pane-busy">{paneSession.status.isBusy ? 'busy' : 'idle'}</span>
+      <span data-testid="pane-waiting">
+        {paneSession.status.isWaitingForAssistantIndicator ? 'waiting' : 'idle'}
+      </span>
       <button type="button" onClick={() => workbench.selectProjectWorkspace(7, null)}>
         select project
       </button>
@@ -1193,6 +1197,10 @@ function FollowUpProbe() {
           .map(message => `${message.status}:${message.content}`)
           .join('|')}
       </span>
+      <span data-testid="follow-up-messages">
+        {paneSession.messages.map(message => `${message.role}:${message.content}`).join('|')}
+      </span>
+      <span data-testid="follow-up-pane-busy">{paneSession.status.isBusy ? 'busy' : 'idle'}</span>
       <button type="button" onClick={() => paneSession.setInput('继续修')}>
         set follow-up
       </button>
@@ -2413,6 +2421,71 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('workbench-error')).toHaveTextContent('')
   })
 
+  test('shows waiting status while creating a new runtime task from a fresh message', async () => {
+    const createResponse = deferred<{
+      accepted: boolean
+      deviceId: string
+      taskId: string
+      workspacePath: string
+      runtime: string
+    }>()
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [],
+                },
+              ],
+            },
+          ],
+          totalTasks: 0,
+        })
+      ),
+      createRuntimeTask: vi.fn().mockReturnValue(createResponse.promise),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'codex',
+        messages: [],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByText('select project')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('select project'))
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('pane-busy')).toHaveTextContent('busy')
+    expect(screen.getByTestId('pane-waiting')).toHaveTextContent('waiting')
+
+    await act(async () => {
+      createResponse.resolve({
+        accepted: true,
+        deviceId: 'device-1',
+        taskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'codex',
+      })
+      await createResponse.promise
+    })
+  })
+
   test('keeps default model options when creating a runtime task', async () => {
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(
@@ -3016,7 +3089,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(screen.getByTestId('message-roles')).toHaveTextContent('assistant'))
     expect(screen.getByTestId('message-roles')).toHaveTextContent('assistant:done answer')
-    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument())
   })
 
   test('renders image attachments immediately when creating a runtime task', async () => {
@@ -4409,6 +4482,48 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
   })
 
+  test('marks an existing runtime task running while a follow-up send is pending', async () => {
+    const sendResponse = deferred<{ accepted: boolean; taskId: string }>()
+    const sendRuntimeMessage = vi.fn().mockReturnValue(sendResponse.promise)
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <FollowUpProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    expect(screen.getByTestId('current-runtime-task-running')).toHaveTextContent('idle')
+
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+
+    await waitFor(() => expect(sendRuntimeMessage).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('current-runtime-task-running')).toHaveTextContent('running')
+
+    await act(async () => {
+      sendResponse.resolve({ accepted: true, taskId: 'runtime-a' })
+      await sendResponse.promise
+    })
+  })
+
   test('keeps project chat composer state scoped to each runtime pane', async () => {
     const runtimeWorkApi = createRuntimeWorkApiMock({
       getRuntimeTranscript: vi.fn().mockImplementation(({ taskId }) =>
@@ -4451,16 +4566,56 @@ describe('WorkbenchProvider runtime tasks', () => {
   })
 
   test('keeps blank chat draft when using sidebar new chat from a runtime task', async () => {
+    let streamHandlers: ChatStreamHandlers = {}
+    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
+      if (hasRuntimeStreamHandler(handlers)) streamHandlers = handlers
+      return vi.fn()
+    })
+    const getRuntimeTranscript = vi.fn().mockResolvedValue({
+      taskId: 'runtime-a',
+      workspacePath: '/workspace/project-alpha',
+      runtime: 'claude_code',
+      messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'message runtime-a' }],
+    })
+    const runtimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              tasks: [
+                {
+                  taskId: 'runtime-a',
+                  workspacePath: '/workspace/project-alpha',
+                  title: 'Runtime A',
+                  runtime: 'claude_code',
+                  running: true,
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        },
+      ],
+      totalTasks: 1,
+    })
     const runtimeWorkApi = createRuntimeWorkApiMock({
-      getRuntimeTranscript: vi.fn().mockResolvedValue({
-        taskId: 'runtime-a',
-        workspacePath: '/workspace/project-alpha',
-        runtime: 'claude_code',
-        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'message runtime-a' }],
-      }),
+      listRuntimeWork: vi.fn().mockResolvedValue(runtimeWork),
+      getRuntimeTranscript,
     })
     const services = createWorkbenchServices({
       runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      chatStream: {
+        subscribe,
+      } as unknown as WorkbenchServices['chatStream'],
     })
 
     renderWorkbench(<FollowUpProbe />, services)
@@ -4477,15 +4632,49 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() =>
       expect(screen.getByTestId('runtime-attachment-count')).toHaveTextContent('0')
     )
+    await waitFor(() => expect(getRuntimeTranscript).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('follow-up-messages')).toHaveTextContent('user:message runtime-a')
 
     await userEvent.click(screen.getByText('sidebar new follow-up chat'))
     await waitFor(() =>
       expect(screen.getByTestId('follow-up-current-runtime-task')).toHaveTextContent('none')
     )
     expect(screen.getByTestId('composer-input')).toHaveTextContent('继续修')
+    expect(screen.getByTestId('follow-up-messages')).toHaveTextContent('user:message runtime-a')
     await waitFor(() =>
       expect(screen.getByTestId('runtime-attachment-count')).toHaveTextContent('1')
     )
+
+    await act(async () => {
+      streamHandlers.onChatStart?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        shellType: 'Codex',
+        deviceId: 'device-1',
+      })
+      streamHandlers.onChatChunk?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        offset: 0,
+        content: 'retained stream output',
+        deviceId: 'device-1',
+      })
+    })
+
+    expect(screen.getByTestId('follow-up-current-runtime-task')).toHaveTextContent('none')
+    expect(screen.getByTestId('follow-up-pane-busy')).toHaveTextContent('busy')
+    await waitFor(() =>
+      expect(screen.getByTestId('follow-up-messages')).toHaveTextContent('retained stream output')
+    )
+
+    await userEvent.click(screen.getByText('open follow-up runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('follow-up-current-runtime-task')).toHaveTextContent(
+        'device-1:runtime-a'
+      )
+    )
+    expect(getRuntimeTranscript).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('follow-up-messages')).toHaveTextContent('user:message runtime-a')
   })
 
   test('keeps blank chat draft when selecting a project chat context', async () => {

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -195,6 +195,7 @@ export function createRuntimeTaskStreamHandlers(
         hasToolInput: payload.toolInput !== undefined,
         hasToolOutput: payload.toolOutput !== undefined,
         hasToolOutputDelta: payload.toolOutputDelta !== undefined,
+        hasToolOutputTruncated: payload.toolOutputTruncated !== undefined,
         hasFileChanges: payload.fileChanges !== undefined,
       })
       handlers.onMessageAction({
@@ -207,6 +208,9 @@ export function createRuntimeTaskStreamHandlers(
           ...(payload.toolOutput !== undefined && { toolOutput: payload.toolOutput }),
           ...(payload.toolOutputDelta !== undefined && {
             toolOutputDelta: payload.toolOutputDelta,
+          }),
+          ...(payload.toolOutputTruncated !== undefined && {
+            toolOutputTruncated: payload.toolOutputTruncated,
           }),
           ...(payload.fileChanges !== undefined && {
             fileChanges: normalizeTurnFileChanges(payload.fileChanges),
@@ -552,6 +556,18 @@ function normalizeProcessingBlock(
           ? block.tool_input
           : undefined,
       toolOutput: block.toolOutput ?? block.tool_output,
+      toolOutputTruncated:
+        typeof block.toolOutputTruncated === 'boolean'
+          ? block.toolOutputTruncated
+          : typeof block.tool_output_truncated === 'boolean'
+            ? block.tool_output_truncated
+            : undefined,
+      toolOutputOriginalBytes:
+        typeof block.toolOutputOriginalBytes === 'number'
+          ? block.toolOutputOriginalBytes
+          : typeof block.tool_output_original_bytes === 'number'
+            ? block.tool_output_original_bytes
+            : undefined,
       renderPayload: normalizeToolRenderPayload(block),
       status,
       createdAt: timestamp,

--- a/wework/src/features/workbench/runtimePaneStatus.ts
+++ b/wework/src/features/workbench/runtimePaneStatus.ts
@@ -59,6 +59,8 @@ export function deriveRuntimePaneStatus({
   const isAssistantStreaming = Boolean(activeAssistantMessage)
   const isResponseActive = isAwaitingAssistant || isAssistantStreaming
   const isBusy = isSubmitting || isResponseActive || taskExecution.running
+  const isWaitingForAssistantMessage =
+    !isAssistantStreaming && isLastMessageWaitingForAssistant(messages)
 
   return {
     sendPhase,
@@ -69,7 +71,9 @@ export function deriveRuntimePaneStatus({
     isAssistantStreaming,
     isResponseActive,
     isBusy,
-    isWaitingForAssistantIndicator: isSubmitting || isAwaitingAssistant,
+    isWaitingForAssistantIndicator:
+      (isSubmitting || isAwaitingAssistant || taskExecution.running) &&
+      isWaitingForAssistantMessage,
     canSendQueuedMessage: Boolean(currentRuntimeTask) && !isBusy,
   }
 }
@@ -90,4 +94,9 @@ export function hasSettledAssistantMessage(messages: WorkbenchMessage[]): boolea
 
 function normalizeTaskStatus(task: RuntimeTaskSummary): string | null {
   return task.status?.trim().toLowerCase() || null
+}
+
+function isLastMessageWaitingForAssistant(messages: WorkbenchMessage[]): boolean {
+  const lastMessage = [...messages].reverse().find(message => message.role !== 'system')
+  return !lastMessage || lastMessage.role === 'user'
 }

--- a/wework/src/features/workbench/runtimeTaskReminders.ts
+++ b/wework/src/features/workbench/runtimeTaskReminders.ts
@@ -160,7 +160,19 @@ function sameStringSet(left: ReadonlySet<string>, right: ReadonlySet<string>): b
 }
 
 function logRuntimeTaskReminderState(event: string, payload: Record<string, unknown>) {
+  if (globalThis.localStorage?.getItem('wework:debug-runtime') !== '1') return
+
   console.info(`[Wework] Runtime task reminder ${event}`, payload)
+}
+
+function debugRuntimeTaskAddress(address: RuntimeTaskAddress): Record<string, unknown> {
+  return {
+    deviceId: address.deviceId,
+    taskId: address.taskId,
+    workspacePath: address.workspacePath ?? null,
+    hasRuntimeHandle: Boolean(address.runtimeHandle),
+    runtimeHandleKeys: address.runtimeHandle ? Object.keys(address.runtimeHandle).sort() : [],
+  }
 }
 
 export function getRuntimeTaskReminderKey(address: RuntimeTaskAddress): string {
@@ -397,7 +409,7 @@ export function useRuntimeTaskReminders({
           hadUnread,
           previousUnreadTaskKeys: debugReminderKeys(readStoredStringSet(unreadTaskKeysStorageKey)),
           nextUnreadTaskKeys: debugReminderKeys(nextKeys),
-          address,
+          address: debugRuntimeTaskAddress(address),
         })
         writeLimitedStoredStringSet(unreadTaskKeysStorageKey, nextKeys)
         emitStoredStringSetChange(unreadTaskKeysStorageKey)

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -66,7 +66,6 @@ import {
 } from './workbenchRuntimeHelpers'
 import type { WorkbenchRuntimeTasks } from './useWorkbenchRuntimeTasks'
 import { findFileChangesBySubtaskId } from './runtimePaneMessages'
-import { findActiveAssistantMessage } from './runtimePaneStatus'
 import {
   inferRuntimeName,
   resolveAutomaticModel,
@@ -173,6 +172,7 @@ export function useWorkbenchRuntimeMessaging({
 
   const sendRuntimePaneMessage = useCallback(
     async (request: RuntimeSendRequest, options?: RuntimePaneActionOptions): Promise<boolean> => {
+      dispatch({ type: 'runtime_task_started', address: request.address })
       try {
         const response = await executorClient.runtime.sendRuntimeMessage(request)
         if (!response.accepted) {
@@ -188,6 +188,7 @@ export function useWorkbenchRuntimeMessaging({
         }
         return true
       } catch (error) {
+        dispatch({ type: 'runtime_task_settled', address: request.address })
         console.warn('[Wework] Runtime send failed', {
           taskId: request.address.taskId,
           deviceId: request.address.deviceId,
@@ -199,7 +200,7 @@ export function useWorkbenchRuntimeMessaging({
         return false
       }
     },
-    [executorClient, refreshWorkLists, reportError]
+    [dispatch, executorClient, refreshWorkLists, reportError]
   )
 
   const editLastUserMessage = useCallback(
@@ -567,6 +568,20 @@ export function useWorkbenchRuntimeMessaging({
       if (options?.openInMainPane !== false) {
         runtimeTasks.openRuntimeTaskView(optimisticAddress, runtimeProject, { navigate: true })
       }
+      if (optimisticWorkspace && optimisticWorkspacePath && !options?.ephemeral) {
+        dispatch({
+          type: 'runtime_task_optimistic_upserted',
+          project: runtimeProject,
+          workspace: optimisticWorkspace,
+          task: buildOptimisticRuntimeTask({
+            taskId: optimisticAddress.taskId,
+            workspacePath: optimisticWorkspacePath,
+            title: createRequest.title ?? buildRuntimeTaskTitle(displayMessage, payload.title),
+            runtime,
+            modelSelection: createModelSelection,
+          }),
+        })
+      }
       attachmentSelection.resetAttachments()
 
       try {
@@ -595,6 +610,10 @@ export function useWorkbenchRuntimeMessaging({
           responseHasTaskId: Boolean(response.taskId),
         })
         const resolvedWorkspacePath = address.workspacePath ?? optimisticWorkspacePath
+        const resolvedSameIdentity = isSameRuntimeTaskIdentity(optimisticAddress, address)
+        if (!resolvedSameIdentity) {
+          dispatch({ type: 'runtime_task_optimistic_removed', address: optimisticAddress })
+        }
         if (resolvedWorkspacePath && !options?.ephemeral) {
           dispatch({
             type: 'runtime_task_optimistic_upserted',
@@ -615,7 +634,7 @@ export function useWorkbenchRuntimeMessaging({
             }),
           })
         }
-        if (!isSameRuntimeTaskIdentity(optimisticAddress, address)) {
+        if (!resolvedSameIdentity) {
           modelSelection.setSelectionForScope?.(
             getRuntimeTaskChatScopeKey(address),
             selectedModel,
@@ -1076,23 +1095,19 @@ export function useWorkbenchRuntimeMessaging({
     [executorClient, services.taskApi, state.currentRuntimeTask]
   )
 
-  const pauseCurrentResponse = useCallback(
-    async (messagesOverride?: WorkbenchMessage[]) => {
-      const activeMessage = findActiveAssistantMessage(messagesOverride ?? [])
-      if (!activeMessage || !state.currentRuntimeTask) return
+  const pauseCurrentResponse = useCallback(async () => {
+    if (!state.currentRuntimeTask) return
 
-      const ack = await executorClient.runtime.cancelRuntimeTask(state.currentRuntimeTask)
-      if (!ack.accepted) {
-        dispatch({
-          type: 'error_set',
-          error: normalizeGuidanceError(ack.error ?? '取消当前回复失败'),
-        })
-        return
-      }
-      await refreshWorkLists()
-    },
-    [dispatch, executorClient, refreshWorkLists, state.currentRuntimeTask]
-  )
+    const ack = await executorClient.runtime.cancelRuntimeTask(state.currentRuntimeTask)
+    if (!ack.accepted) {
+      dispatch({
+        type: 'error_set',
+        error: normalizeGuidanceError(ack.error ?? '取消当前回复失败'),
+      })
+      return
+    }
+    await refreshWorkLists()
+  }, [dispatch, executorClient, refreshWorkLists, state.currentRuntimeTask])
 
   return {
     sendRuntimePaneMessage,

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -113,6 +113,10 @@ export type WorkbenchAction =
       address: RuntimeTaskAddress
     }
   | {
+      type: 'runtime_task_started'
+      address: RuntimeTaskAddress
+    }
+  | {
       type: 'runtime_task_settled'
       address: RuntimeTaskAddress
     }
@@ -617,6 +621,53 @@ function settleRuntimeTask(
     }
   })
   const chats = current.chats.map(settleWorkspace)
+  const nextRuntimeWork = {
+    ...current,
+    projects,
+    chats,
+  }
+  return {
+    ...nextRuntimeWork,
+    totalTasks: countRuntimeWorkTasks(nextRuntimeWork),
+  }
+}
+
+function startRuntimeTask(
+  current: RuntimeWorkListResponse | null | undefined,
+  address: RuntimeTaskAddress
+): RuntimeWorkListResponse | null {
+  if (!current) return null
+
+  const startWorkspace = (workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace => {
+    if (workspace.deviceId !== address.deviceId) return workspace
+    return {
+      ...workspace,
+      tasks: workspace.tasks.map(task => {
+        if (task.taskId !== address.taskId) return task
+        if (
+          address.workspacePath &&
+          getRuntimeTaskWorkspacePath(workspace, task) !== address.workspacePath
+        ) {
+          return task
+        }
+        return {
+          ...task,
+          running: true,
+          updatedAt: new Date().toISOString(),
+        }
+      }),
+    }
+  }
+
+  const projects = current.projects.map(project => {
+    const deviceWorkspaces = project.deviceWorkspaces.map(startWorkspace)
+    return {
+      ...project,
+      deviceWorkspaces,
+      totalTasks: countRuntimeTasks(deviceWorkspaces),
+    }
+  })
+  const chats = current.chats.map(startWorkspace)
   const nextRuntimeWork = {
     ...current,
     projects,
@@ -1155,6 +1206,11 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
       return {
         ...state,
         runtimeWork: removeOptimisticRuntimeTask(state.runtimeWork, action.address),
+      }
+    case 'runtime_task_started':
+      return {
+        ...state,
+        runtimeWork: startRuntimeTask(state.runtimeWork, action.address),
       }
     case 'runtime_task_settled':
       return {

--- a/wework/src/lib/app-logging.ts
+++ b/wework/src/lib/app-logging.ts
@@ -9,11 +9,20 @@ type TauriWindow = Window &
 
 const MAX_LOG_ARGUMENT_LENGTH = 4000
 const MAX_LOG_MESSAGE_LENGTH = 12000
+const VERBOSE_TAURI_LOG_STORAGE_KEY = 'wework:debug-tauri-console-log'
 
 let installed = false
 
 function isTauriRuntime() {
   return typeof window !== 'undefined' && Boolean((window as TauriWindow).__TAURI_INTERNALS__)
+}
+
+function shouldWriteTauriLog(level: ConsoleLevel) {
+  if (level === 'error' || level === 'warn') {
+    return true
+  }
+
+  return globalThis.localStorage?.getItem(VERBOSE_TAURI_LOG_STORAGE_KEY) === '1'
 }
 
 function serializeLogArgument(value: unknown): string {
@@ -80,7 +89,9 @@ export function installAppLogging() {
   ;(['debug', 'error', 'info', 'log', 'warn'] as const).forEach(level => {
     console[level] = (...args: unknown[]) => {
       originalConsole[level](...args)
-      writeTauriLog(level, args)
+      if (shouldWriteTauriLog(level)) {
+        writeTauriLog(level, args)
+      }
     }
   })
 

--- a/wework/src/lib/debugPanel.ts
+++ b/wework/src/lib/debugPanel.ts
@@ -1,8 +1,8 @@
 import type { RuntimePaneStatus } from '@/features/workbench/runtimePaneStatus'
 import type {
-  RuntimeTaskSummary,
   RuntimeDeviceWorkspace,
   RuntimeTaskAddress,
+  RuntimeTaskSummary,
   RuntimeWorkListResponse,
 } from '@/types/api'
 import type {
@@ -28,11 +28,11 @@ export interface WorkbenchDebugSnapshot {
     isBootstrapping: boolean
     error: string | null
     currentProject: WorkbenchState['currentProject']
-    currentRuntimeTask: RuntimeTaskAddress | null
+    currentRuntimeTask: RuntimeTaskAddressDebug | null
     currentRuntimeTaskRunning: boolean
     runningState: RuntimeTaskRunningDebugState
-    activeTask: RuntimeTaskSummary | null
-    activeWorkspace: RuntimeDeviceWorkspace | null
+    activeTask: RuntimeTaskSummaryDebug | null
+    activeWorkspace: RuntimeDeviceWorkspaceDebug | null
     runtimeWorkSummary: RuntimeWorkSummary
     devices: WorkbenchState['devices']
     standaloneDeviceId: string | null
@@ -48,10 +48,11 @@ export interface WorkbenchDebugSnapshot {
 
 export interface RuntimePaneDebugSnapshot {
   updatedAt: string
-  currentRuntimeTask: RuntimeTaskAddress | null
+  currentRuntimeTask: RuntimeTaskAddressDebug | null
   status: RuntimePaneStatus
   messageSummary: MessageSummary
   messageStyleComparison: MessageStyleComparison
+  memory: RuntimePaneMemoryDiagnostics
   queuedMessages: QueuedWorkbenchMessage[]
   guidanceMessages: GuidanceWorkbenchMessage[]
   codeCommentContextCount: number
@@ -61,10 +62,16 @@ export interface RuntimePaneDebugSnapshot {
     hasMoreBefore: boolean
     loadingMoreBefore: boolean
     turnNavigationCount: number
+    loadedRanges: RuntimePaneLoadedRange[]
   }
   subagentStatuses: RuntimeSubagentStatus[]
   goal: unknown
   goalDraftActive: boolean
+}
+
+export interface RuntimePaneLoadedRange {
+  start: number
+  end: number
 }
 
 export interface RuntimeTaskRunningDebugState {
@@ -116,6 +123,45 @@ interface RuntimeWorkSummary {
   runningTaskCount: number
 }
 
+interface RuntimeTaskAddressDebug {
+  deviceId: string
+  taskId: string
+  threadId?: string | null
+  workspacePath?: string | null
+  hasRuntimeHandle: boolean
+  runtimeHandleKeys: string[]
+  runtimeHandleApproxChars: number
+  runtimeHandleEstimateTruncated: boolean
+}
+
+interface RuntimeTaskSummaryDebug {
+  taskId: string
+  workspacePath: string
+  workspaceKind?: string | null
+  worktreeId?: string | null
+  title: string
+  runtime: string
+  createdAt?: string | number | null
+  updatedAt?: string | number | null
+  running?: boolean
+  status?: string | null
+  modelSelection?: unknown
+  hasRuntimeHandle: boolean
+  runtimeHandleKeys: string[]
+  runtimeHandleApproxChars: number
+  runtimeHandleEstimateTruncated: boolean
+}
+
+interface RuntimeDeviceWorkspaceDebug {
+  deviceId: string
+  deviceName?: string | null
+  workspacePath: string
+  workspaceKind?: string | null
+  worktreeId?: string | null
+  label?: string | null
+  tasks: RuntimeTaskSummaryDebug[]
+}
+
 interface WorkbenchComposerDebugSnapshot {
   scopeKey: string
   standaloneChatKey: number
@@ -146,7 +192,54 @@ interface MessageSummaryItem {
   memoryCitationCount: number
 }
 
+interface RuntimePaneMemoryDiagnostics {
+  messages: {
+    count: number
+    contentChars: number
+    blockCount: number
+    toolBlockCount: number
+    toolOutputApproxChars: number
+    renderPayloadApproxChars: number
+    attachmentCount: number
+    attachmentPathChars: number
+    referenceCount: number
+    memoryCitationCount: number
+    topToolOutputs: RuntimePaneToolOutputDiagnostic[]
+  }
+  currentRuntimeTask: {
+    hasRuntimeHandle: boolean
+    runtimeHandleKeys: string[]
+    runtimeHandleApproxChars: number
+    runtimeHandleEstimateTruncated: boolean
+  } | null
+  transcript: {
+    loadedRangeCount: number
+    loadedRanges: RuntimePaneLoadedRange[]
+    loadedMessageSlots: number
+  }
+  dom: {
+    messageNodes: number
+    processingBlockNodes: number
+    codeBlocks: number
+  }
+}
+
+interface RuntimePaneToolOutputDiagnostic {
+  messageId: string
+  blockId: string
+  toolName: string
+  status: string
+  approxChars: number
+  outputType: string
+}
+
 const DEBUG_LOG_LIMIT = 500
+const DEBUG_LOG_ARGUMENT_LIMIT = 2000
+const DEBUG_LOG_ENTRY_LIMIT = 8000
+const MEMORY_ESTIMATE_NODE_LIMIT = 20_000
+const TOP_TOOL_OUTPUT_LIMIT = 8
+const DEBUG_PANEL_ID = 'wework-debug-panel'
+const RUNTIME_MEMORY_DIAGNOSTICS_STORAGE_KEY = 'wework:debug-runtime-memory'
 
 let installed = false
 let debugLogSequence = 0
@@ -178,11 +271,12 @@ export function updateWorkbenchDebugSnapshot({
   composer?: WorkbenchComposerDebugSnapshot | null
 }) {
   const activeTask = findRuntimeTask(state.runtimeWork, state.currentRuntimeTask)
+  const activeWorkspace = findRuntimeWorkspace(state.runtimeWork, state.currentRuntimeTask)
   workbenchSnapshot = {
     isBootstrapping: state.isBootstrapping,
     error: state.error,
     currentProject: state.currentProject,
-    currentRuntimeTask: state.currentRuntimeTask,
+    currentRuntimeTask: sanitizeRuntimeTaskAddress(state.currentRuntimeTask),
     currentRuntimeTaskRunning,
     runningState: {
       hasCurrentRuntimeTask: Boolean(state.currentRuntimeTask),
@@ -191,8 +285,8 @@ export function updateWorkbenchDebugSnapshot({
       activeTaskStatus: activeTask?.status ?? null,
       providerRunning: currentRuntimeTaskRunning,
     },
-    activeTask,
-    activeWorkspace: findRuntimeWorkspace(state.runtimeWork, state.currentRuntimeTask),
+    activeTask: sanitizeRuntimeTaskSummary(activeTask),
+    activeWorkspace: sanitizeRuntimeWorkspace(activeWorkspace),
     runtimeWorkSummary: summarizeRuntimeWork(state.runtimeWork),
     devices: state.devices,
     standaloneDeviceId: state.standaloneDeviceId,
@@ -204,10 +298,13 @@ export function updateWorkbenchDebugSnapshot({
 }
 
 export function updateRuntimePaneDebugSnapshot(
-  snapshot: Omit<RuntimePaneDebugSnapshot, 'updatedAt'>
+  snapshot: Omit<RuntimePaneDebugSnapshot, 'updatedAt' | 'currentRuntimeTask'> & {
+    currentRuntimeTask: RuntimeTaskAddress | null
+  }
 ) {
   paneSnapshot = {
     ...snapshot,
+    currentRuntimeTask: sanitizeRuntimeTaskAddress(snapshot.currentRuntimeTask),
     updatedAt: new Date().toISOString(),
   }
 }
@@ -241,6 +338,202 @@ export function summarizeMessages(messages: WorkbenchMessage[]): MessageSummary 
       ? createMessageSummaryItem(activeAssistantMessage)
       : null,
     lastMessage: lastMessage ? createMessageSummaryItem(lastMessage) : null,
+  }
+}
+
+export function summarizeRuntimePaneMemory({
+  messages,
+  currentRuntimeTask,
+  loadedRanges,
+}: {
+  messages: WorkbenchMessage[]
+  currentRuntimeTask: RuntimeTaskAddress | null
+  loadedRanges: RuntimePaneLoadedRange[]
+}): RuntimePaneMemoryDiagnostics {
+  if (!isRuntimePaneMemoryDiagnosticsEnabled()) {
+    return emptyRuntimePaneMemoryDiagnostics()
+  }
+
+  let contentChars = 0
+  let blockCount = 0
+  let toolBlockCount = 0
+  let toolOutputApproxChars = 0
+  let renderPayloadApproxChars = 0
+  let attachmentCount = 0
+  let attachmentPathChars = 0
+  let referenceCount = 0
+  let memoryCitationCount = 0
+  const topToolOutputs: RuntimePaneToolOutputDiagnostic[] = []
+
+  for (const message of messages) {
+    contentChars += message.content.length
+    attachmentCount += message.attachments?.length ?? 0
+    attachmentPathChars +=
+      message.attachments?.reduce(
+        (total, attachment) =>
+          total +
+          String(attachment.filename ?? '').length +
+          String(attachment.local_path ?? '').length +
+          String(attachment.local_preview_url ?? '').length,
+        0
+      ) ?? 0
+    referenceCount += message.references?.length ?? 0
+    memoryCitationCount += message.memoryCitations?.length ?? 0
+
+    for (const block of message.blocks ?? []) {
+      blockCount += 1
+      if (block.type !== 'tool') continue
+
+      toolBlockCount += 1
+      const outputEstimate = estimateApproxChars(block.toolOutput)
+      const renderPayloadEstimate = estimateApproxChars(block.renderPayload)
+      toolOutputApproxChars += outputEstimate.chars
+      renderPayloadApproxChars += renderPayloadEstimate.chars
+      topToolOutputs.push({
+        messageId: message.id,
+        blockId: block.id,
+        toolName: block.toolName,
+        status: block.status,
+        approxChars: outputEstimate.chars,
+        outputType: valueType(block.toolOutput),
+      })
+    }
+  }
+
+  const runtimeHandleEstimate = estimateApproxChars(currentRuntimeTask?.runtimeHandle)
+  const normalizedRanges = loadedRanges
+    .filter(range => Number.isFinite(range.start) && Number.isFinite(range.end))
+    .map(range => ({ start: range.start, end: range.end }))
+
+  return {
+    messages: {
+      count: messages.length,
+      contentChars,
+      blockCount,
+      toolBlockCount,
+      toolOutputApproxChars,
+      renderPayloadApproxChars,
+      attachmentCount,
+      attachmentPathChars,
+      referenceCount,
+      memoryCitationCount,
+      topToolOutputs: topToolOutputs
+        .sort((left, right) => right.approxChars - left.approxChars)
+        .slice(0, TOP_TOOL_OUTPUT_LIMIT),
+    },
+    currentRuntimeTask: currentRuntimeTask
+      ? {
+          hasRuntimeHandle: Boolean(currentRuntimeTask.runtimeHandle),
+          runtimeHandleKeys: currentRuntimeTask.runtimeHandle
+            ? Object.keys(currentRuntimeTask.runtimeHandle).sort()
+            : [],
+          runtimeHandleApproxChars: runtimeHandleEstimate.chars,
+          runtimeHandleEstimateTruncated: runtimeHandleEstimate.truncated,
+        }
+      : null,
+    transcript: {
+      loadedRangeCount: normalizedRanges.length,
+      loadedRanges: normalizedRanges,
+      loadedMessageSlots: normalizedRanges.reduce(
+        (total, range) => total + Math.max(0, range.end - range.start),
+        0
+      ),
+    },
+    dom: summarizeRuntimePaneDom(),
+  }
+}
+
+function isRuntimePaneMemoryDiagnosticsEnabled(): boolean {
+  if (typeof document !== 'undefined' && document.getElementById(DEBUG_PANEL_ID)) {
+    return true
+  }
+  return globalThis.localStorage?.getItem(RUNTIME_MEMORY_DIAGNOSTICS_STORAGE_KEY) === '1'
+}
+
+function emptyRuntimePaneMemoryDiagnostics(): RuntimePaneMemoryDiagnostics {
+  return {
+    messages: {
+      count: 0,
+      contentChars: 0,
+      blockCount: 0,
+      toolBlockCount: 0,
+      toolOutputApproxChars: 0,
+      renderPayloadApproxChars: 0,
+      attachmentCount: 0,
+      attachmentPathChars: 0,
+      referenceCount: 0,
+      memoryCitationCount: 0,
+      topToolOutputs: [],
+    },
+    currentRuntimeTask: null,
+    transcript: {
+      loadedRangeCount: 0,
+      loadedRanges: [],
+      loadedMessageSlots: 0,
+    },
+    dom: {
+      messageNodes: 0,
+      processingBlockNodes: 0,
+      codeBlocks: 0,
+    },
+  }
+}
+
+function sanitizeRuntimeTaskAddress(
+  address: RuntimeTaskAddress | null
+): RuntimeTaskAddressDebug | null {
+  if (!address) return null
+  const runtimeHandleEstimate = estimateApproxChars(address.runtimeHandle)
+  return {
+    deviceId: address.deviceId,
+    taskId: address.taskId,
+    threadId: address.threadId ?? null,
+    workspacePath: address.workspacePath ?? null,
+    hasRuntimeHandle: Boolean(address.runtimeHandle),
+    runtimeHandleKeys: address.runtimeHandle ? Object.keys(address.runtimeHandle).sort() : [],
+    runtimeHandleApproxChars: runtimeHandleEstimate.chars,
+    runtimeHandleEstimateTruncated: runtimeHandleEstimate.truncated,
+  }
+}
+
+function sanitizeRuntimeTaskSummary(
+  task: RuntimeDeviceWorkspace['tasks'][number] | null
+): RuntimeTaskSummaryDebug | null {
+  if (!task) return null
+  const runtimeHandleEstimate = estimateApproxChars(task.runtimeHandle)
+  return {
+    taskId: task.taskId,
+    workspacePath: task.workspacePath,
+    workspaceKind: task.workspaceKind ?? null,
+    worktreeId: task.worktreeId ?? null,
+    title: task.title,
+    runtime: task.runtime,
+    createdAt: task.createdAt ?? null,
+    updatedAt: task.updatedAt ?? null,
+    running: task.running,
+    status: task.status ?? null,
+    modelSelection: task.modelSelection,
+    hasRuntimeHandle: Boolean(task.runtimeHandle),
+    runtimeHandleKeys: task.runtimeHandle ? Object.keys(task.runtimeHandle).sort() : [],
+    runtimeHandleApproxChars: runtimeHandleEstimate.chars,
+    runtimeHandleEstimateTruncated: runtimeHandleEstimate.truncated,
+  }
+}
+
+function sanitizeRuntimeWorkspace(
+  workspace: RuntimeDeviceWorkspace | null
+): RuntimeDeviceWorkspaceDebug | null {
+  if (!workspace) return null
+  return {
+    deviceId: workspace.deviceId,
+    deviceName: workspace.deviceName ?? null,
+    workspacePath: workspace.workspacePath,
+    workspaceKind: workspace.workspaceKind ?? null,
+    worktreeId: workspace.worktreeId ?? null,
+    label: workspace.label ?? null,
+    tasks: workspace.tasks
+      .map(task => sanitizeRuntimeTaskSummary(task))
+      .filter((task): task is RuntimeTaskSummaryDebug => task !== null),
   }
 }
 
@@ -299,10 +592,18 @@ export function compareMessageStyles(messages: WorkbenchMessage[]): MessageStyle
 }
 
 function recordDebugLog(args: unknown[]) {
+  const serializedArgs = args.map(arg =>
+    truncateDebugLogValue(serializeLogArgument(arg), DEBUG_LOG_ARGUMENT_LIMIT)
+  )
+  const entryLength = serializedArgs.reduce((total, arg) => total + arg.length, 0)
+
   debugLogs.push({
     id: ++debugLogSequence,
     timestamp: new Date().toISOString(),
-    args: args.map(serializeLogArgument),
+    args:
+      entryLength <= DEBUG_LOG_ENTRY_LIMIT
+        ? serializedArgs
+        : trimDebugLogEntry(serializedArgs, DEBUG_LOG_ENTRY_LIMIT),
   })
 
   if (debugLogs.length > DEBUG_LOG_LIMIT) {
@@ -427,6 +728,72 @@ function truncatePreview(value: string): string {
   return value.length <= 600 ? value : `${value.slice(0, 600)}...`
 }
 
+function estimateApproxChars(value: unknown): { chars: number; truncated: boolean } {
+  const seen = new WeakSet<object>()
+  let visited = 0
+  let truncated = false
+
+  const visit = (item: unknown): number => {
+    if (visited >= MEMORY_ESTIMATE_NODE_LIMIT) {
+      truncated = true
+      return 0
+    }
+    visited += 1
+
+    if (typeof item === 'string') return item.length
+    if (typeof item === 'number' || typeof item === 'boolean' || typeof item === 'bigint') {
+      return String(item).length
+    }
+    if (
+      item === null ||
+      item === undefined ||
+      typeof item === 'symbol' ||
+      typeof item === 'function'
+    ) {
+      return 0
+    }
+    if (Array.isArray(item)) {
+      if (seen.has(item)) return 0
+      seen.add(item)
+      return item.reduce((total, value) => total + visit(value), 0)
+    }
+    if (typeof item === 'object') {
+      if (seen.has(item)) return 0
+      seen.add(item)
+      let total = 0
+      for (const [key, nestedValue] of Object.entries(item as Record<string, unknown>)) {
+        total += key.length + visit(nestedValue)
+        if (visited >= MEMORY_ESTIMATE_NODE_LIMIT) {
+          truncated = true
+          break
+        }
+      }
+      return total
+    }
+    return 0
+  }
+
+  return { chars: visit(value), truncated }
+}
+
+function valueType(value: unknown): string {
+  if (Array.isArray(value)) return 'array'
+  if (value === null) return 'null'
+  return typeof value
+}
+
+function summarizeRuntimePaneDom(): RuntimePaneMemoryDiagnostics['dom'] {
+  if (typeof document === 'undefined') {
+    return { messageNodes: 0, processingBlockNodes: 0, codeBlocks: 0 }
+  }
+
+  return {
+    messageNodes: document.querySelectorAll('[data-message-id]').length,
+    processingBlockNodes: document.querySelectorAll('[data-processing-block-id]').length,
+    codeBlocks: document.querySelectorAll('pre code, pre').length,
+  }
+}
+
 function serializeLogArgument(value: unknown): string {
   if (value instanceof Error) {
     return value.stack || `${value.name}: ${value.message}`
@@ -442,6 +809,32 @@ function serializeLogArgument(value: unknown): string {
   }
 
   return String(value)
+}
+
+function truncateDebugLogValue(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  const suffix = `... [truncated ${value.length - maxLength} chars]`
+  if (maxLength <= suffix.length) return value.slice(0, maxLength)
+  return `${value.slice(0, maxLength - suffix.length)}${suffix}`
+}
+
+function trimDebugLogEntry(args: string[], maxLength: number): string[] {
+  const trimmed: string[] = []
+  let remaining = maxLength
+
+  for (const arg of args) {
+    if (remaining <= 0) break
+    const next = truncateDebugLogValue(arg, remaining)
+    trimmed.push(next)
+    remaining -= next.length
+  }
+
+  const omittedCount = args.length - trimmed.length
+  if (omittedCount > 0) {
+    trimmed.push(`[omitted ${omittedCount} debug args]`)
+  }
+
+  return trimmed
 }
 
 function summarizeRuntimeWork(runtimeWork: RuntimeWorkListResponse | null): RuntimeWorkSummary {

--- a/wework/src/lib/developerCommandMenu.test.ts
+++ b/wework/src/lib/developerCommandMenu.test.ts
@@ -95,8 +95,10 @@ describe('developerCommandMenu', () => {
 
     expect(document.getElementById('wework-debug-panel')).toBeInTheDocument()
     expect(document.body).toHaveTextContent('Active Task State (taskKnown=true')
+    expect(document.body).toHaveTextContent('Memory Diagnostics')
     expect(document.body).toHaveTextContent('Transcript vs Streaming Style')
     expect(document.body).toHaveTextContent('"taskId": "task-1"')
+    expect(document.body).toHaveTextContent('"toolOutputApproxChars": 128')
     expect(document.body).toHaveTextContent('Transcript Loaded')
     expect(document.body).toHaveTextContent('Current Streaming')
     expect(document.body).toHaveTextContent('loaded transcript response')
@@ -298,6 +300,46 @@ function createDebugSnapshot() {
         ],
         renderingRules: ['Streaming messages hide hover actions and suppress final artifacts.'],
       },
+      memory: {
+        messages: {
+          count: 2,
+          contentChars: 41,
+          blockCount: 2,
+          toolBlockCount: 1,
+          toolOutputApproxChars: 128,
+          renderPayloadApproxChars: 0,
+          attachmentCount: 0,
+          attachmentPathChars: 0,
+          referenceCount: 1,
+          memoryCitationCount: 0,
+          topToolOutputs: [
+            {
+              messageId: 'loaded-1',
+              blockId: 'tool-1',
+              toolName: 'bash',
+              status: 'done',
+              approxChars: 128,
+              outputType: 'string',
+            },
+          ],
+        },
+        currentRuntimeTask: {
+          hasRuntimeHandle: true,
+          runtimeHandleKeys: ['messages'],
+          runtimeHandleApproxChars: 256,
+          runtimeHandleEstimateTruncated: false,
+        },
+        transcript: {
+          loadedRangeCount: 1,
+          loadedRanges: [{ start: 0, end: 50 }],
+          loadedMessageSlots: 50,
+        },
+        dom: {
+          messageNodes: 2,
+          processingBlockNodes: 1,
+          codeBlocks: 1,
+        },
+      },
       queuedMessages: [],
       guidanceMessages: [],
       codeCommentContextCount: 0,
@@ -307,6 +349,7 @@ function createDebugSnapshot() {
         hasMoreBefore: false,
         loadingMoreBefore: false,
         turnNavigationCount: 0,
+        loadedRanges: [{ start: 0, end: 50 }],
       },
       subagentStatuses: [],
       goal: null,

--- a/wework/src/lib/developerCommandMenu.ts
+++ b/wework/src/lib/developerCommandMenu.ts
@@ -360,6 +360,7 @@ function renderDebugPanelBody(container: HTMLElement, snapshot: WorkbenchDebugSn
       `Active Task State (${formatRunningStateLabel(snapshot)})`,
       formatDebugJson(snapshot)
     ),
+    createDebugPanelSection('Memory Diagnostics', formatMemoryDiagnostics(snapshot)),
     createMessageStyleComparisonSection(snapshot),
     createDebugPanelSection(
       `Debug Logs (${snapshot.logs.length}/${snapshot.logLimit})`,
@@ -542,6 +543,13 @@ function formatDebugJson(snapshot: WorkbenchDebugSnapshot): string {
     null,
     2
   )
+}
+
+function formatMemoryDiagnostics(snapshot: WorkbenchDebugSnapshot): string {
+  const memory = snapshot.pane?.memory
+  if (!memory) return 'No runtime pane memory snapshot has been captured yet.'
+
+  return JSON.stringify(memory, null, 2)
 }
 
 function formatDebugLogs(snapshot: WorkbenchDebugSnapshot): string {

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -405,6 +405,7 @@ function emitBlockUpdated(
     toolOutput?: unknown
     toolOutputDelta?: string
     toolOutputTruncated?: boolean
+    toolOutputOriginalBytes?: number
     content?: string
     fileChanges?: ChatBlock['fileChanges']
   }
@@ -492,6 +493,8 @@ function emitResponseBlockUpdated(
   const fileChanges = parseRecord(updates.fileChanges ?? updates.file_changes)
   const toolOutputDelta = updates.toolOutputDelta ?? updates.tool_output_delta
   const toolOutputTruncated = updates.toolOutputTruncated ?? updates.tool_output_truncated
+  const toolOutputOriginalBytes =
+    updates.toolOutputOriginalBytes ?? updates.tool_output_original_bytes
   emitBlockUpdated(
     handlers,
     'response.block.updated',
@@ -507,6 +510,9 @@ function emitResponseBlockUpdated(
       }),
       ...(typeof toolOutputTruncated === 'boolean' && {
         toolOutputTruncated,
+      }),
+      ...(typeof toolOutputOriginalBytes === 'number' && {
+        toolOutputOriginalBytes,
       }),
       ...(toolInput && { toolInput }),
       ...(fileChanges && { fileChanges: fileChanges as unknown as ChatBlock['fileChanges'] }),

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -1615,6 +1615,8 @@ export interface ChatBlock {
   tool_name?: string
   tool_input?: Record<string, unknown>
   tool_output?: unknown
+  tool_output_truncated?: boolean
+  tool_output_original_bytes?: number
   render_payload?: unknown
   renderPayload?: unknown
   file_changes?: TurnFileChangesSummary
@@ -1640,6 +1642,9 @@ export interface ChatBlockUpdatedPayload {
   toolOutput?: unknown
   toolOutputDelta?: string
   toolOutputTruncated?: boolean
+  toolOutputOriginalBytes?: number
+  tool_output_truncated?: boolean
+  tool_output_original_bytes?: number
   toolInput?: Record<string, unknown>
   fileChanges?: TurnFileChangesSummary
   status?: ChatBlock['status'] | 'running'


### PR DESCRIPTION
## Summary

- reduce runtime work list and transcript payload memory pressure by trimming raw cached message/runtime handle data before it reaches Wework
- improve runtime pane status consistency for queued, streaming, settled, cancelled, and reminder-driven task states
- add debug-only memory/message diagnostics for runtime panes and document how to capture the new diagnostics

## Why

Switching runtime tasks and polling work lists could move more raw runtime/message data through executor and frontend paths than the UI needs. That increased WebView memory pressure, made status polling expensive, and made it harder to diagnose whether the pane state came from transcript loading, stream updates, or task list state.

## Validation

- `pnpm --dir wework run typecheck`
- `pnpm --filter wework exec vitest run src/features/workbench/WorkbenchProvider.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx src/components/layout/MobileWorkbenchLayout.test.tsx src/components/chat/MessageList.test.tsx`
- `cargo clippy --all-features --lib --manifest-path executor/Cargo.toml -- -D warnings`
- pre-push hook: ESLint, TypeScript, Wework unit tests, `cargo fmt --check`, `cargo test --all-features --lib`, and `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug panel memory diagnostics for runtime panes, including summarized message, queue, and transcript activity.
  * Added clearer runtime task and assistant waiting indicators in chat and workbench views.
  * Tool outputs and transcripts now show truncation details and original size when large content is shortened.

* **Bug Fixes**
  * Improved runtime task state handling so active/running states update more consistently.
  * Reduced memory pressure by avoiding large raw payloads in task summaries and debug snapshots.

* **Documentation**
  * Expanded performance diagnostics guidance in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->