### PR TITLE
feat(wework): 修复审核按钮点击后无法展示diff的问题

### DIFF
--- a/wework/src/components/chat/FileChangesCard.test.tsx
+++ b/wework/src/components/chat/FileChangesCard.test.tsx
@@ -32,7 +32,7 @@ function renderCard(
   overrides: Partial<{
     summary: TurnFileChangesSummary
     deviceOnline: boolean
-    onLoadDiff: (subtaskId: number) => Promise<string>
+    onLoadDiff: (subtaskId: number, summary?: TurnFileChangesSummary) => Promise<string>
     onRevert: (subtaskId: number) => Promise<TurnFileChangesSummary>
     onOpenReview: (request: OpenReviewRequest) => void
   }> = {}
@@ -402,7 +402,7 @@ describe('FileChangesCard', () => {
     expect(onLoadDiff).not.toHaveBeenCalled()
 
     await request.loadDiff()
-    await waitFor(() => expect(onLoadDiff).toHaveBeenCalledWith(21))
+    await waitFor(() => expect(onLoadDiff).toHaveBeenCalledWith(21, summary))
   })
 
   test('opens the shared review panel when a file row is clicked', async () => {
@@ -438,7 +438,7 @@ describe('FileChangesCard', () => {
     expect(onLoadDiff).not.toHaveBeenCalled()
 
     await request.loadDiff()
-    await waitFor(() => expect(onLoadDiff).toHaveBeenCalledWith(21))
+    await waitFor(() => expect(onLoadDiff).toHaveBeenCalledWith(21, summary))
   })
 
   test('disables review and revert while the owning device is offline', () => {

--- a/wework/src/components/chat/FileChangesCard.tsx
+++ b/wework/src/components/chat/FileChangesCard.tsx
@@ -22,7 +22,7 @@ interface FileChangesCardProps {
   subtaskId: string
   summary: TurnFileChangesSummary
   deviceOnline: boolean
-  onLoadDiff: (subtaskId: string) => Promise<string>
+  onLoadDiff: (subtaskId: string, summary?: TurnFileChangesSummary) => Promise<string>
   onRevert: (subtaskId: string) => Promise<TurnFileChangesSummary>
   onOpenReview?: (request: {
     subtaskId: string
@@ -612,7 +612,7 @@ export function FileChangesCard({
   const openReview = (focusFilePath?: string) => {
     onOpenReview?.({
       subtaskId,
-      loadDiff: () => onLoadDiff(subtaskId),
+      loadDiff: () => onLoadDiff(subtaskId, summary),
       reviewTitle: t('file_changes.previous_turn_label'),
       defaultFileTreeVisible: false,
       focusFilePath,

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1742,7 +1742,10 @@ describe('MessageList', () => {
     expect(request.defaultFileTreeVisible).toBe(false)
     expect(onLoadFileChangesDiff).not.toHaveBeenCalled()
     await request.loadDiff()
-    expect(onLoadFileChangesDiff).toHaveBeenCalledWith(42)
+    expect(onLoadFileChangesDiff).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ artifact_id: 'turn-42' })
+    )
   })
 
   test('renders Codex memory citations and one-column deduped file references', async () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -63,7 +63,7 @@ interface MessageListProps {
   devices?: DeviceInfo[]
   onRetryFailedMessage?: (message: WorkbenchMessage) => void
   onSwitchModelForFailedMessage?: (message: WorkbenchMessage) => void
-  onLoadFileChangesDiff?: (subtaskId: string) => Promise<string>
+  onLoadFileChangesDiff?: (subtaskId: string, summary?: TurnFileChangesSummary) => Promise<string>
   onRevertFileChanges?: (subtaskId: string) => Promise<TurnFileChangesSummary>
   onOpenFileChangesReview?: (request: {
     subtaskId: string
@@ -1399,7 +1399,7 @@ function AssistantMessage({
   devices: DeviceInfo[]
   onRetryFailedMessage?: (message: WorkbenchMessage) => void
   onSwitchModelForFailedMessage?: (message: WorkbenchMessage) => void
-  onLoadFileChangesDiff?: (subtaskId: string) => Promise<string>
+  onLoadFileChangesDiff?: (subtaskId: string, summary?: TurnFileChangesSummary) => Promise<string>
   onRevertFileChanges?: (subtaskId: string) => Promise<TurnFileChangesSummary>
   onOpenFileChangesReview?: (request: {
     subtaskId: string
@@ -1454,7 +1454,7 @@ function AssistantMessage({
     if (fileChangesSubtaskId && onLoadFileChangesDiff && onOpenFileChangesReview) {
       onOpenFileChangesReview({
         subtaskId: fileChangesSubtaskId,
-        loadDiff: () => onLoadFileChangesDiff(fileChangesSubtaskId),
+        loadDiff: () => onLoadFileChangesDiff(fileChangesSubtaskId, message.fileChanges),
         reviewTitle: t('file_changes.previous_turn_label'),
         defaultFileTreeVisible: false,
         focusFilePath: path,

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -56,7 +56,7 @@ interface ScrollableMessageAreaProps {
   devices?: DeviceInfo[]
   onRetryFailedMessage?: (message: WorkbenchMessage) => void
   onSwitchModelForFailedMessage?: (message: WorkbenchMessage) => void
-  onLoadFileChangesDiff?: (subtaskId: string) => Promise<string>
+  onLoadFileChangesDiff?: (subtaskId: string, summary?: TurnFileChangesSummary) => Promise<string>
   onRevertFileChanges?: (subtaskId: string) => Promise<TurnFileChangesSummary>
   onOpenFileChangesReview?: (request: {
     subtaskId: string

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -549,6 +549,24 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     defaultFileTreeVisible?: boolean
   } | null>(null)
   const paneMessages = paneSession.messages
+  const getTurnFileChangesMessages = useCallback(
+    (subtaskId: string, summary?: WorkbenchMessage['fileChanges']) => {
+      if (!summary) return paneMessages
+      return [
+        {
+          id: `file-changes:${subtaskId}`,
+          role: 'assistant' as const,
+          subtaskId,
+          content: '',
+          status: 'done' as const,
+          createdAt: new Date().toISOString(),
+          fileChanges: summary,
+        },
+        ...paneMessages,
+      ]
+    },
+    [paneMessages]
+  )
   const pendingRequestUserInput = pendingRequestUserInputPayload(
     paneMessages,
     paneSession.answeredRequestUserInputIds
@@ -874,7 +892,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             latestPreviousTurnSubtaskId !== null
               ? {
                   loadDiff: () =>
-                    loadTurnFileChangesDiff(latestPreviousTurnSubtaskId, paneMessages),
+                    loadTurnFileChangesDiff(
+                      latestPreviousTurnSubtaskId,
+                      getTurnFileChangesMessages(latestPreviousTurnSubtaskId)
+                    ),
                   defaultFileTreeVisible: false,
                 }
               : previousTurnReviewRef.current
@@ -892,9 +913,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       latestPreviousTurnSubtaskId,
       loadEnvironmentDiff,
       loadTurnFileChangesDiff,
+      getTurnFileChangesMessages,
       openEnvironmentChangesReview,
       openReviewFromDiffLoader,
-      paneMessages,
       reviewState.reviewMode,
       tChat,
       workspaceTarget,
@@ -1329,10 +1350,12 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 onSwitchModelForFailedMessage={() =>
                   setModelSelectorOpenSignal(signal => signal + 1)
                 }
-                onLoadFileChangesDiff={subtaskId =>
-                  loadTurnFileChangesDiff(subtaskId, paneMessages)
+                onLoadFileChangesDiff={(subtaskId, summary) =>
+                  loadTurnFileChangesDiff(subtaskId, getTurnFileChangesMessages(subtaskId, summary))
                 }
-                onRevertFileChanges={subtaskId => revertTurnFileChanges(subtaskId, paneMessages)}
+                onRevertFileChanges={subtaskId =>
+                  revertTurnFileChanges(subtaskId, getTurnFileChangesMessages(subtaskId))
+                }
                 onOpenFileChangesReview={({
                   loadDiff,
                   reviewTitle,

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -44,6 +44,8 @@ import { pendingRequestUserInputPayload } from './requestUserInputOverlay'
 import { SubagentStatusIndicator } from './SubagentStatusIndicator'
 import { BufferedChatInput } from './BufferedChatInput'
 import { EMPTY_RUNTIME_TASK_REMINDERS } from '@/features/workbench/runtimeTaskReminders'
+import type { TurnFileChangesSummary } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
 
 export function MobileWorkbenchLayout() {
   const { state } = useWorkbench()
@@ -123,6 +125,24 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
   const continueInIm = useRuntimeTaskContinueInIm(currentRuntimeTask)
   const activePaneProject = pane.currentProject
   const paneMessages = paneSession.messages
+  const turnFileChangesMessages = (
+    subtaskId: string,
+    summary?: TurnFileChangesSummary
+  ): WorkbenchMessage[] => {
+    if (!summary) return paneMessages
+    return [
+      {
+        id: `file-changes:${subtaskId}`,
+        role: 'assistant',
+        subtaskId,
+        content: '',
+        status: 'done',
+        createdAt: new Date().toISOString(),
+        fileChanges: summary,
+      },
+      ...paneMessages,
+    ]
+  }
   const pendingRequestUserInput = pendingRequestUserInputPayload(
     paneMessages,
     paneSession.answeredRequestUserInputIds
@@ -320,7 +340,9 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                 void retryFailedMessage(message.id, paneMessages)
               }}
               onSwitchModelForFailedMessage={() => setModelSelectorOpenSignal(signal => signal + 1)}
-              onLoadFileChangesDiff={subtaskId => loadTurnFileChangesDiff(subtaskId, paneMessages)}
+              onLoadFileChangesDiff={(subtaskId, summary) =>
+                loadTurnFileChangesDiff(subtaskId, turnFileChangesMessages(subtaskId, summary))
+              }
               onRevertFileChanges={subtaskId => revertTurnFileChanges(subtaskId, paneMessages)}
               onEditLastUserMessage={paneSession.editLastUserMessage}
               canEditLastUserMessage={canEditLastUserMessage}

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -249,7 +249,17 @@ export function findFileChangesBySubtaskId(
   messages: WorkbenchMessage[],
   subtaskId: string
 ): TurnFileChangesSummary | undefined {
-  return messages.find(message => message.subtaskId === subtaskId)?.fileChanges
+  const matchingMessages = messages.filter(message => message.subtaskId === subtaskId)
+  for (const message of matchingMessages) {
+    if (message.fileChanges) return message.fileChanges
+
+    const blockFileChanges = message.blocks?.find(
+      block => block.type === 'file_changes'
+    )?.fileChanges
+    if (blockFileChanges) return blockFileChanges
+  }
+
+  return undefined
 }
 
 export function runtimeAddressDebug(address: RuntimeTaskAddress): Record<string, unknown> {
@@ -355,6 +365,9 @@ function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): Wo
     typeof subtaskId === 'string'
       ? normalizeProcessingBlocks(subtaskId, message.blocks, messageCreatedAtMs)
       : []
+  const fileChanges =
+    normalizeTurnFileChanges(message.fileChanges ?? message.file_changes) ??
+    blocks.find(block => block.type === 'file_changes')?.fileChanges
   return {
     id: message.id,
     role,
@@ -367,7 +380,7 @@ function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): Wo
     attachments: message.attachments,
     runtimeGoalRequest: normalizeRuntimeGoalRequest(message),
     blocks: blocks.length > 0 ? blocks : undefined,
-    fileChanges: normalizeTurnFileChanges(message.fileChanges ?? message.file_changes),
+    fileChanges,
     references: normalizeRuntimeReferences(message.references),
     memoryCitations: normalizeRuntimeMemoryCitations(message),
     createdAt,

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -988,9 +988,18 @@ export function useWorkbenchRuntimeMessaging({
   const loadTurnFileChangesDiff = useCallback(
     async (subtaskId: string, messagesOverride?: WorkbenchMessage[]) => {
       const messageSource = messagesOverride ?? []
-      const runtimeFileChanges = state.currentRuntimeTask
+      let runtimeFileChanges = state.currentRuntimeTask
         ? findFileChangesBySubtaskId(messageSource, subtaskId)
         : undefined
+      if (!runtimeFileChanges && state.currentRuntimeTask) {
+        const transcript = await runtimeTasks.loadRuntimeTranscriptForPane(
+          state.currentRuntimeTask,
+          {
+            refresh: true,
+          }
+        )
+        runtimeFileChanges = findFileChangesBySubtaskId(transcript.messages, subtaskId)
+      }
       if (runtimeFileChanges?.diff) return runtimeFileChanges.diff
       if (runtimeFileChanges) {
         const response = await executorClient.commands.executeCommand(
@@ -1027,7 +1036,7 @@ export function useWorkbenchRuntimeMessaging({
       const response = await loadDiff(subtaskId)
       return response.diff
     },
-    [executorClient, services.taskApi, state.currentRuntimeTask]
+    [executorClient, runtimeTasks, services.taskApi, state.currentRuntimeTask]
   )
 
   const revertTurnFileChanges = useCallback(
@@ -1036,9 +1045,18 @@ export function useWorkbenchRuntimeMessaging({
       messagesOverride?: WorkbenchMessage[]
     ): Promise<TurnFileChangesSummary> => {
       const messageSource = messagesOverride ?? []
-      const runtimeFileChanges = state.currentRuntimeTask
+      let runtimeFileChanges = state.currentRuntimeTask
         ? findFileChangesBySubtaskId(messageSource, subtaskId)
         : undefined
+      if (!runtimeFileChanges && state.currentRuntimeTask) {
+        const transcript = await runtimeTasks.loadRuntimeTranscriptForPane(
+          state.currentRuntimeTask,
+          {
+            refresh: true,
+          }
+        )
+        runtimeFileChanges = findFileChangesBySubtaskId(transcript.messages, subtaskId)
+      }
       if (runtimeFileChanges && state.currentRuntimeTask) {
         try {
           const response = await executorClient.runtime.revertRuntimeFileChanges({
@@ -1092,7 +1110,7 @@ export function useWorkbenchRuntimeMessaging({
         throw error
       }
     },
-    [executorClient, services.taskApi, state.currentRuntimeTask]
+    [executorClient, runtimeTasks, services.taskApi, state.currentRuntimeTask]
   )
 
   const pauseCurrentResponse = useCallback(async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File diff review now opens with the relevant summary information when available, improving accuracy for review and revert actions.
  * File-change links in chat now route to the correct diff view more reliably.
  * Diff loading and revert actions are more resilient when change details are missing, helping the review panel recover and display the right content.
  * Mobile and desktop workbench views now handle turn-specific file changes consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->