### PR TITLE
fix(knowledge): 统一知识库历史跳转与文档区权限

### DIFF
--- a/backend/app/services/knowledge/folder_service.py
+++ b/backend/app/services/knowledge/folder_service.py
@@ -67,12 +67,12 @@ class KnowledgeFolderService:
     def _check_kb_write_access(
         db: Session, knowledge_base_id: int, user_id: int
     ) -> Kind:
-        """Verify user has write access to the knowledge base.
+        """Verify user can manage knowledge base folder structure.
 
         Raises ValueError if access is denied or KB not found.
         """
         kb = KnowledgeFolderService._check_kb_access(db, knowledge_base_id, user_id)
-        if not KnowledgeService.can_manage_knowledge_base_documents(
+        if not KnowledgeService.can_manage_knowledge_base(
             db, knowledge_base_id, user_id
         ):
             raise ValueError("You do not have permission to modify this knowledge base")

--- a/backend/app/services/knowledge/folder_service.py
+++ b/backend/app/services/knowledge/folder_service.py
@@ -67,12 +67,12 @@ class KnowledgeFolderService:
     def _check_kb_write_access(
         db: Session, knowledge_base_id: int, user_id: int
     ) -> Kind:
-        """Verify user can manage knowledge base folder structure.
+        """Verify user has document-area write access to the knowledge base.
 
         Raises ValueError if access is denied or KB not found.
         """
         kb = KnowledgeFolderService._check_kb_access(db, knowledge_base_id, user_id)
-        if not KnowledgeService.can_manage_knowledge_base(
+        if not KnowledgeService.can_manage_knowledge_base_documents(
             db, knowledge_base_id, user_id
         ):
             raise ValueError("You do not have permission to modify this knowledge base")

--- a/backend/app/services/knowledge/permission_policy.py
+++ b/backend/app/services/knowledge/permission_policy.py
@@ -149,17 +149,9 @@ def can_manage_accessible_knowledge_document(
     user_id: int,
     document_owner_id: int,
 ) -> bool:
-    """Return whether merged KB access allows document management."""
-    if not has_access:
-        return False
-
-    if is_creator:
-        return True
-
-    if role is None:
-        return False
-
-    if has_permission(role, BaseRole.Maintainer):
-        return True
-
-    return role == BaseRole.Developer and document_owner_id == user_id
+    """Return whether merged KB access allows document-area management."""
+    return can_manage_accessible_knowledge_base_documents(
+        has_access=has_access,
+        role=role,
+        is_creator=is_creator,
+    )

--- a/backend/tests/services/knowledge/test_namespace_knowledge_permissions.py
+++ b/backend/tests/services/knowledge/test_namespace_knowledge_permissions.py
@@ -444,7 +444,7 @@ def test_developer_can_add_document_to_someone_elses_namespace_kb(
 
 
 @pytest.mark.unit
-def test_developer_cannot_delete_someone_elses_namespace_document(
+def test_namespace_developer_can_manage_shared_kb_documents(
     test_db: Session,
 ) -> None:
     owner = _create_user(test_db, "owner-delete-other-doc")
@@ -470,8 +470,10 @@ def test_developer_cannot_delete_someone_elses_namespace_document(
         ),
     )
 
-    with pytest.raises(ValueError, match="permission"):
-        KnowledgeService.delete_document(test_db, owner_document.id, developer.id)
+    result = KnowledgeService.delete_document(test_db, owner_document.id, developer.id)
+
+    assert result.success is True
+    assert result.kb_id == knowledge_base_id
 
 
 @pytest.mark.unit
@@ -631,7 +633,7 @@ def test_explicit_kb_developer_can_add_document_to_shared_kb(test_db: Session) -
 
 
 @pytest.mark.unit
-def test_explicit_kb_developer_can_delete_own_document_but_not_others(
+def test_explicit_kb_developer_can_manage_shared_kb_documents(
     test_db: Session,
 ) -> None:
     owner = _create_user(test_db, "owner-kb-dev-doc-delete")
@@ -675,8 +677,11 @@ def test_explicit_kb_developer_can_delete_own_document_but_not_others(
         ),
     )
 
-    with pytest.raises(ValueError, match="permission"):
-        KnowledgeService.delete_document(test_db, owner_document.id, collaborator.id)
+    owner_delete_result = KnowledgeService.delete_document(
+        test_db, owner_document.id, collaborator.id
+    )
+    assert owner_delete_result.success is True
+    assert owner_delete_result.kb_id == knowledge_base_id
 
     result = KnowledgeService.delete_document(
         test_db, collaborator_document.id, collaborator.id
@@ -751,7 +756,7 @@ def test_admin_can_manage_organization_knowledge_base_without_namespace_membersh
 
 
 @pytest.mark.unit
-def test_developer_can_manage_own_documents_but_not_folder_structure(
+def test_developer_can_manage_document_area_but_not_kb_settings(
     test_db: Session,
 ) -> None:
     owner = _create_user(test_db, "owner-folder-structure")
@@ -776,19 +781,25 @@ def test_developer_can_manage_own_documents_but_not_folder_structure(
     assert not KnowledgeService.can_manage_knowledge_base(
         test_db, knowledge_base_id, developer.id
     )
+    assert KnowledgeService.can_manage_knowledge_document(
+        test_db, knowledge_base_id, developer.id, owner.id
+    )
 
-    developer_document = KnowledgeService.create_document(
+    owner_document = KnowledgeService.create_document(
         test_db,
         knowledge_base_id,
-        developer.id,
+        owner.id,
         KnowledgeDocumentCreate(
-            name="developer-owned-doc",
+            name="owner-owned-doc",
             file_extension="md",
             file_size=12,
             source_type=DocumentSourceType.TEXT,
         ),
     )
-    assert developer_document.user_id == developer.id
+    delete_result = KnowledgeService.delete_document(
+        test_db, owner_document.id, developer.id
+    )
+    assert delete_result.success is True
 
     owner_folder = KnowledgeFolderService.create_folder(
         test_db,
@@ -797,30 +808,22 @@ def test_developer_can_manage_own_documents_but_not_folder_structure(
         KnowledgeFolderCreate(name="owner-folder", parent_id=0),
     )
 
-    with pytest.raises(ValueError, match="permission to modify"):
-        KnowledgeFolderService.create_folder(
-            test_db,
-            knowledge_base_id,
-            developer.id,
-            KnowledgeFolderCreate(name="developer-folder", parent_id=0),
-        )
+    updated_folder = KnowledgeFolderService.update_folder(
+        test_db,
+        owner_folder.id,
+        developer.id,
+        KnowledgeFolderUpdate(name="renamed-by-developer"),
+        knowledge_base_id=knowledge_base_id,
+    )
+    assert updated_folder.name == "renamed-by-developer"
 
-    with pytest.raises(ValueError, match="permission to modify"):
-        KnowledgeFolderService.update_folder(
-            test_db,
-            owner_folder.id,
-            developer.id,
-            KnowledgeFolderUpdate(name="renamed-by-developer"),
-            knowledge_base_id=knowledge_base_id,
-        )
-
-    with pytest.raises(ValueError, match="permission to modify"):
-        KnowledgeFolderService.delete_folder(
-            test_db,
-            owner_folder.id,
-            developer.id,
-            knowledge_base_id=knowledge_base_id,
-        )
+    folder_delete_result = KnowledgeFolderService.delete_folder(
+        test_db,
+        owner_folder.id,
+        developer.id,
+        knowledge_base_id=knowledge_base_id,
+    )
+    assert folder_delete_result["deleted_folder_count"] == 1
 
 
 @pytest.mark.unit

--- a/backend/tests/services/knowledge/test_namespace_knowledge_permissions.py
+++ b/backend/tests/services/knowledge/test_namespace_knowledge_permissions.py
@@ -751,6 +751,79 @@ def test_admin_can_manage_organization_knowledge_base_without_namespace_membersh
 
 
 @pytest.mark.unit
+def test_developer_can_manage_own_documents_but_not_folder_structure(
+    test_db: Session,
+) -> None:
+    owner = _create_user(test_db, "owner-folder-structure")
+    developer = _create_user(test_db, "developer-folder-structure")
+
+    knowledge_base_id = KnowledgeService.create_knowledge_base(
+        test_db,
+        owner.id,
+        KnowledgeBaseCreate(name="folder-structure-kb", namespace="default"),
+    )
+    _add_kb_member(
+        test_db,
+        knowledge_base_id,
+        developer,
+        ResourceRole.Developer,
+        owner.id,
+    )
+
+    assert KnowledgeService.can_manage_knowledge_base_documents(
+        test_db, knowledge_base_id, developer.id
+    )
+    assert not KnowledgeService.can_manage_knowledge_base(
+        test_db, knowledge_base_id, developer.id
+    )
+
+    developer_document = KnowledgeService.create_document(
+        test_db,
+        knowledge_base_id,
+        developer.id,
+        KnowledgeDocumentCreate(
+            name="developer-owned-doc",
+            file_extension="md",
+            file_size=12,
+            source_type=DocumentSourceType.TEXT,
+        ),
+    )
+    assert developer_document.user_id == developer.id
+
+    owner_folder = KnowledgeFolderService.create_folder(
+        test_db,
+        knowledge_base_id,
+        owner.id,
+        KnowledgeFolderCreate(name="owner-folder", parent_id=0),
+    )
+
+    with pytest.raises(ValueError, match="permission to modify"):
+        KnowledgeFolderService.create_folder(
+            test_db,
+            knowledge_base_id,
+            developer.id,
+            KnowledgeFolderCreate(name="developer-folder", parent_id=0),
+        )
+
+    with pytest.raises(ValueError, match="permission to modify"):
+        KnowledgeFolderService.update_folder(
+            test_db,
+            owner_folder.id,
+            developer.id,
+            KnowledgeFolderUpdate(name="renamed-by-developer"),
+            knowledge_base_id=knowledge_base_id,
+        )
+
+    with pytest.raises(ValueError, match="permission to modify"):
+        KnowledgeFolderService.delete_folder(
+            test_db,
+            owner_folder.id,
+            developer.id,
+            knowledge_base_id=knowledge_base_id,
+        )
+
+
+@pytest.mark.unit
 def test_org_admin_share_permission_matches_manage_permission(
     test_db: Session,
 ) -> None:

--- a/backend/tests/services/knowledge/test_permission_policy.py
+++ b/backend/tests/services/knowledge/test_permission_policy.py
@@ -250,7 +250,7 @@ def test_explicit_kb_developer_can_manage_documents_but_not_kb_settings() -> Non
 
 
 @pytest.mark.unit
-def test_explicit_kb_developer_can_manage_only_owned_document() -> None:
+def test_explicit_kb_developer_can_manage_accessible_documents() -> None:
     assert can_manage_accessible_knowledge_document(
         has_access=True,
         role=BaseRole.Developer,
@@ -258,7 +258,7 @@ def test_explicit_kb_developer_can_manage_only_owned_document() -> None:
         user_id=2,
         document_owner_id=2,
     )
-    assert not can_manage_accessible_knowledge_document(
+    assert can_manage_accessible_knowledge_document(
         has_access=True,
         role=BaseRole.Developer,
         is_creator=False,

--- a/frontend/src/__tests__/features/knowledge/document/document-list-summary.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/document-list-summary.test.tsx
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import { DocumentList } from '@/features/knowledge/document/components/DocumentList'
-import type { KnowledgeBase } from '@/types/knowledge'
+import type { KnowledgeBase, KnowledgeDocument } from '@/types/knowledge'
+
+let mockDocuments: KnowledgeDocument[] = []
 
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
@@ -32,15 +34,23 @@ jest.mock('@/features/common/UserContext', () => ({
 
 jest.mock('@/features/knowledge/document/hooks/useDocuments', () => ({
   useDocuments: () => ({
-    documents: [],
+    documents: mockDocuments,
     loading: false,
     error: null,
     create: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
     batchDelete: jest.fn(),
+    transfer: jest.fn(),
     refresh: jest.fn(),
     fetchWithFolder: jest.fn(),
+    page: 1,
+    pageSize: 20,
+    totalCount: mockDocuments.length,
+    totalPages: 1,
+    hasMore: false,
+    setPage: jest.fn(),
+    setPageSize: jest.fn(),
   }),
 }))
 
@@ -52,6 +62,8 @@ jest.mock('@/features/knowledge/document/hooks/useFolders', () => ({
     updateFolder: jest.fn(),
     deleteFolder: jest.fn(),
     fetchFolders: jest.fn(),
+    moveDocument: jest.fn(),
+    batchMove: jest.fn(),
   }),
 }))
 
@@ -81,6 +93,33 @@ jest.mock('@/features/knowledge/document/components/RetrievalTestDialog', () => 
 }))
 jest.mock('@/features/knowledge/document/components/FolderTree', () => ({
   FolderTree: () => null,
+}))
+jest.mock('@/features/knowledge/document/components/knowledge-document-tree-grid', () => ({
+  KnowledgeDocumentTreeGrid: ({
+    documents,
+    showSelectionColumn,
+    canSelect,
+    onSelect,
+  }: {
+    documents: KnowledgeDocument[]
+    showSelectionColumn: boolean
+    canSelect?: (document: KnowledgeDocument) => boolean
+    onSelect?: (document: KnowledgeDocument, selected: boolean) => void
+  }) => (
+    <div>
+      {documents.map(document => (
+        <button
+          key={document.id}
+          type="button"
+          data-testid={`select-document-${document.id}`}
+          disabled={!showSelectionColumn || !canSelect?.(document)}
+          onClick={() => onSelect?.(document, true)}
+        >
+          {document.name}
+        </button>
+      ))}
+    </div>
+  ),
 }))
 jest.mock('@/features/knowledge/document/components/CreateFolderDialog', () => ({
   CreateFolderDialog: () => null,
@@ -120,7 +159,34 @@ function createKnowledgeBase(overrides?: Partial<KnowledgeBase>): KnowledgeBase 
   }
 }
 
+function createDocument(overrides?: Partial<KnowledgeDocument>): KnowledgeDocument {
+  return {
+    id: 10,
+    kind_id: 1,
+    user_id: 1,
+    name: 'doc.txt',
+    file_extension: 'txt',
+    file_size: 128,
+    status: 'enabled',
+    is_active: true,
+    index_status: 'success',
+    index_generation: 1,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    folder_id: 0,
+    source_type: 'file',
+    source_config: {},
+    attachment_id: null,
+    created_by: 'alice',
+    ...overrides,
+  }
+}
+
 describe('DocumentList summary header', () => {
+  beforeEach(() => {
+    mockDocuments = []
+  })
+
   it('shows inline summary edit button when manual summary exists after AI failure', () => {
     render(<DocumentList knowledgeBase={createKnowledgeBase()} canManageAllDocuments={true} />)
 
@@ -153,5 +219,22 @@ describe('DocumentList summary header', () => {
     )
 
     expect(screen.queryByText('chatPage.summaryRetry')).not.toBeInTheDocument()
+  })
+
+  it('shows batch actions for document-area editors without knowledge-base manage permission', () => {
+    mockDocuments = [createDocument()]
+
+    render(
+      <DocumentList
+        knowledgeBase={createKnowledgeBase({ document_count: 1 })}
+        canUpload={true}
+        canManageAllDocuments={false}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('select-document-10'))
+
+    expect(screen.getByTestId('batch-move-button')).toBeInTheDocument()
+    expect(screen.getByTestId('batch-transfer-button')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/features/knowledge/document/document-list-summary.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/document-list-summary.test.tsx
@@ -221,6 +221,19 @@ describe('DocumentList summary header', () => {
     expect(screen.queryByText('chatPage.summaryRetry')).not.toBeInTheDocument()
   })
 
+  it('shows create-folder action for folder managers without upload permission', () => {
+    render(
+      <DocumentList
+        knowledgeBase={createKnowledgeBase()}
+        canUpload={false}
+        canManageAllDocuments={true}
+      />
+    )
+
+    expect(screen.getByText('document.folder.create')).toBeInTheDocument()
+    expect(screen.queryByText('document.document.upload')).not.toBeInTheDocument()
+  })
+
   it('shows batch actions for document-area editors without knowledge-base manage permission', () => {
     mockDocuments = [createDocument()]
 

--- a/frontend/src/__tests__/features/knowledge/document/knowledge-view-mode.test.ts
+++ b/frontend/src/__tests__/features/knowledge/document/knowledge-view-mode.test.ts
@@ -57,6 +57,26 @@ describe('useKnowledgeViewMode', () => {
     expect(result.current.currentView).toBe('documents')
   })
 
+  it('opens notebook view for knowledge task history URLs even when kb_type is classic', () => {
+    setBrowserUrl('/knowledge/default/my-kb?taskId=123')
+
+    const { result } = renderHook(() => useKnowledgeViewMode('classic'))
+
+    expect(result.current.defaultView).toBe('documents')
+    expect(result.current.currentView).toBe('notebook')
+  })
+
+  it('keeps explicit documents view ahead of task history defaults', async () => {
+    setBrowserUrl('/knowledge/default/my-kb?view=documents&taskId=123')
+
+    const { result } = renderHook(() => useKnowledgeViewMode('classic'))
+
+    expect(result.current.currentView).toBe('documents')
+    await waitFor(() => {
+      expect(window.location.search).toBe('?view=documents')
+    })
+  })
+
   it('falls back to kb_type when URL view is invalid', () => {
     setBrowserUrl('/knowledge/default/my-kb?view=classic')
 

--- a/frontend/src/__tests__/features/knowledge/document/namespace-permissions.test.ts
+++ b/frontend/src/__tests__/features/knowledge/document/namespace-permissions.test.ts
@@ -196,7 +196,7 @@ describe('namespace permissions', () => {
       ).toBe(true)
     })
 
-    it('allows developer to manage only their own document', () => {
+    it('allows developer to manage accessible documents', () => {
       expect(
         canManageKnowledgeDocument({
           currentUserId: 2,
@@ -213,7 +213,7 @@ describe('namespace permissions', () => {
           knowledgeBase: { namespace: 'engineering', user_id: 1 },
           documentOwnerId: 1,
         })
-      ).toBe(false)
+      ).toBe(true)
     })
 
     it('allows knowledge-base manager when document owner is missing', () => {

--- a/frontend/src/__tests__/features/tasks/components/sidebar/TaskListSection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/sidebar/TaskListSection.test.tsx
@@ -209,4 +209,14 @@ describe('TaskListSection', () => {
 
     expect(mockPush).toHaveBeenCalledWith('/chat?taskId=8')
   })
+
+  it('opens knowledge tasks in the notebook route with task context', () => {
+    const task = createTask(9, { task_type: 'knowledge', knowledge_base_id: 88 })
+
+    render(<TaskListSection tasks={[task]} title="History" />)
+
+    fireEvent.click(screen.getAllByText('Conversation 9')[0].closest('.cursor-pointer')!)
+
+    expect(mockPush).toHaveBeenCalledWith('/knowledge/document/88?taskId=9')
+  })
 })

--- a/frontend/src/__tests__/utils/taskRouting.test.ts
+++ b/frontend/src/__tests__/utils/taskRouting.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getTaskTargetHref, getTaskTargetPath } from '@/utils/taskRouting'
+
+describe('taskRouting', () => {
+  it('routes knowledge tasks with knowledge base context to the notebook entry', () => {
+    expect(
+      getTaskTargetHref({
+        id: 12,
+        task_type: 'knowledge',
+        knowledge_base_id: 34,
+      })
+    ).toBe('/knowledge/document/34?taskId=12')
+  })
+
+  it('keeps knowledge tasks without knowledge base context in the knowledge area', () => {
+    expect(
+      getTaskTargetHref({
+        id: 12,
+        task_type: 'knowledge',
+      })
+    ).toBe('/knowledge?taskId=12')
+  })
+
+  it('routes non-knowledge tasks to their owning work surfaces', () => {
+    expect(getTaskTargetPath({ id: 1, task_type: 'task' })).toBe('/devices/chat')
+    expect(getTaskTargetPath({ id: 2, task_type: 'video' })).toBe('/generate')
+    expect(getTaskTargetPath({ id: 3, task_type: 'image' })).toBe('/generate')
+    expect(getTaskTargetPath({ id: 4, task_type: 'chat' })).toBe('/chat')
+    expect(getTaskTargetPath({ id: 5, task_type: 'code' })).toBe('/chat')
+  })
+})

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -58,7 +58,6 @@ import type {
   KbGroupInfo,
 } from '@/types/knowledge'
 import { useTranslation } from '@/hooks/useTranslation'
-import { useUser } from '@/features/common/UserContext'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { EditKnowledgeBaseSummaryDialog } from './EditKnowledgeBaseSummaryDialog'
 import { useKnowledgeBaseSummaryEditor } from '../hooks/useKnowledgeBaseSummaryEditor'
@@ -253,7 +252,6 @@ export function DocumentList({
   paginationEnabled = true,
 }: DocumentListProps) {
   const { t } = useTranslation('knowledge')
-  const { user } = useUser()
   const [searchQuery, setSearchQuery] = useState('')
   const [sortField, setSortField] = useState<SortField>('createdAt')
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc')
@@ -498,10 +496,9 @@ export function DocumentList({
   }, [folders, activeFolderId, resetSelection])
 
   const canManageAnyDocuments = canUpload || canManageAllDocuments
-  const canManageFolderStructure = canManageAllDocuments
+  const canManageDocumentArea = canManageAnyDocuments
 
-  const canManageDocument = (document: KnowledgeDocument) =>
-    canManageAllDocuments || (canUpload && user?.id === document.user_id)
+  const canManageDocument = (_document: KnowledgeDocument) => canManageDocumentArea
 
   const canSelectDocument = (document: KnowledgeDocument) =>
     Boolean(onSelectionChange) || (canManageAllDocuments && canManageDocument(document))
@@ -1236,10 +1233,10 @@ export function DocumentList({
                 includedInFolderScope={isDocumentIncludedInFolderScope}
                 onSelect={handleSelectDoc}
                 ragConfigured={ragConfigured}
-                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
-                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
-                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
-                canManageFolders={canManageFolderStructure}
+                onCreateFolder={canManageDocumentArea ? handleCreateFolder : undefined}
+                onRenameFolder={canManageDocumentArea ? handleRenameFolder : undefined}
+                onDeleteFolder={canManageDocumentArea ? handleDeleteFolderClick : undefined}
+                canManageFolders={canManageDocumentArea}
                 canSelectFolders={canManageAllDocuments && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}
@@ -1296,10 +1293,10 @@ export function DocumentList({
                 includedInFolderScope={isDocumentIncludedInFolderScope}
                 onSelect={canManageAllDocuments ? handleSelectDoc : undefined}
                 ragConfigured={ragConfigured}
-                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
-                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
-                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
-                canManageFolders={canManageFolderStructure}
+                onCreateFolder={canManageDocumentArea ? handleCreateFolder : undefined}
+                onRenameFolder={canManageDocumentArea ? handleRenameFolder : undefined}
+                onDeleteFolder={canManageDocumentArea ? handleDeleteFolderClick : undefined}
+                canManageFolders={canManageDocumentArea}
                 canSelectFolders={canManageAllDocuments && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -497,6 +497,7 @@ export function DocumentList({
 
   const canManageAnyDocuments = canUpload || canManageAllDocuments
   const canManageDocumentArea = canManageAnyDocuments
+  const canManageFolderStructure = canManageDocumentArea
 
   const canManageDocument = (_document: KnowledgeDocument) => canManageDocumentArea
 
@@ -1075,7 +1076,7 @@ export function DocumentList({
         </TooltipProvider>
 
         {/* Create folder button */}
-        {canUpload && (
+        {canManageFolderStructure && (
           <Button
             variant="outline"
             className="h-11 min-w-[44px]"
@@ -1233,11 +1234,11 @@ export function DocumentList({
                 includedInFolderScope={isDocumentIncludedInFolderScope}
                 onSelect={handleSelectDoc}
                 ragConfigured={ragConfigured}
-                onCreateFolder={canManageDocumentArea ? handleCreateFolder : undefined}
-                onRenameFolder={canManageDocumentArea ? handleRenameFolder : undefined}
-                onDeleteFolder={canManageDocumentArea ? handleDeleteFolderClick : undefined}
-                canManageFolders={canManageDocumentArea}
-                canSelectFolders={canManageDocumentArea && !onSelectionChange}
+                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                canManageFolders={canManageFolderStructure}
+                canSelectFolders={canManageFolderStructure && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}
                 activeFolderId={activeFolderId}
@@ -1293,11 +1294,11 @@ export function DocumentList({
                 includedInFolderScope={isDocumentIncludedInFolderScope}
                 onSelect={canManageDocumentArea ? handleSelectDoc : undefined}
                 ragConfigured={ragConfigured}
-                onCreateFolder={canManageDocumentArea ? handleCreateFolder : undefined}
-                onRenameFolder={canManageDocumentArea ? handleRenameFolder : undefined}
-                onDeleteFolder={canManageDocumentArea ? handleDeleteFolderClick : undefined}
-                canManageFolders={canManageDocumentArea}
-                canSelectFolders={canManageDocumentArea && !onSelectionChange}
+                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                canManageFolders={canManageFolderStructure}
+                canSelectFolders={canManageFolderStructure && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}
                 activeFolderId={activeFolderId}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -501,7 +501,7 @@ export function DocumentList({
   const canManageDocument = (_document: KnowledgeDocument) => canManageDocumentArea
 
   const canSelectDocument = (document: KnowledgeDocument) =>
-    Boolean(onSelectionChange) || (canManageAllDocuments && canManageDocument(document))
+    Boolean(onSelectionChange) || canManageDocument(document)
 
   const folderSelectionBlocksDocumentBatchActions = selectionSummary.hasFolderScopeSelection
   const documentBatchActionsDisabled = shouldDisableDocumentBatchActions({
@@ -1110,7 +1110,7 @@ export function DocumentList({
       ) : documents.length > 0 || folders.length > 0 ? (
         <>
           {/* Batch action bar - shown when items are selected (not in notebook mode where selection is for context injection) */}
-          {canManageAllDocuments && selectionSummary.canTransfer && !onSelectionChange && (
+          {canManageDocumentArea && selectionSummary.canTransfer && !onSelectionChange && (
             <div
               className={`flex items-center gap-3 ${compact ? 'px-2 py-2' : 'px-4 py-2.5'} bg-primary/5 border border-primary/20 rounded-lg`}
             >
@@ -1237,7 +1237,7 @@ export function DocumentList({
                 onRenameFolder={canManageDocumentArea ? handleRenameFolder : undefined}
                 onDeleteFolder={canManageDocumentArea ? handleDeleteFolderClick : undefined}
                 canManageFolders={canManageDocumentArea}
-                canSelectFolders={canManageAllDocuments && !onSelectionChange}
+                canSelectFolders={canManageDocumentArea && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}
                 activeFolderId={activeFolderId}
@@ -1263,7 +1263,7 @@ export function DocumentList({
                 treeIndex={resourceTree.index}
                 folders={folders}
                 documents={documents}
-                showSelectionColumn={canManageAllDocuments}
+                showSelectionColumn={canManageDocumentArea}
                 showActionsColumn={canManageAnyDocuments}
                 sortField={sortField}
                 sortOrder={sortOrder}
@@ -1288,16 +1288,16 @@ export function DocumentList({
                 refreshingDocId={refreshingDocId}
                 reindexingDocId={reindexingDocId}
                 canManage={canManageDocument}
-                canSelect={doc => canSelectDocument(doc) && canManageAllDocuments}
+                canSelect={canSelectDocument}
                 selectedDocumentIds={selectedDocumentIds}
                 includedInFolderScope={isDocumentIncludedInFolderScope}
-                onSelect={canManageAllDocuments ? handleSelectDoc : undefined}
+                onSelect={canManageDocumentArea ? handleSelectDoc : undefined}
                 ragConfigured={ragConfigured}
                 onCreateFolder={canManageDocumentArea ? handleCreateFolder : undefined}
                 onRenameFolder={canManageDocumentArea ? handleRenameFolder : undefined}
                 onDeleteFolder={canManageDocumentArea ? handleDeleteFolderClick : undefined}
                 canManageFolders={canManageDocumentArea}
-                canSelectFolders={canManageAllDocuments && !onSelectionChange}
+                canSelectFolders={canManageDocumentArea && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}
                 activeFolderId={activeFolderId}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -498,6 +498,7 @@ export function DocumentList({
   }, [folders, activeFolderId, resetSelection])
 
   const canManageAnyDocuments = canUpload || canManageAllDocuments
+  const canManageFolderStructure = canManageAllDocuments
 
   const canManageDocument = (document: KnowledgeDocument) =>
     canManageAllDocuments || (canUpload && user?.id === document.user_id)
@@ -1235,10 +1236,10 @@ export function DocumentList({
                 includedInFolderScope={isDocumentIncludedInFolderScope}
                 onSelect={handleSelectDoc}
                 ragConfigured={ragConfigured}
-                onCreateFolder={canUpload ? handleCreateFolder : undefined}
-                onRenameFolder={canUpload ? handleRenameFolder : undefined}
-                onDeleteFolder={canUpload ? handleDeleteFolderClick : undefined}
-                canManageFolders={canUpload}
+                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                canManageFolders={canManageFolderStructure}
                 canSelectFolders={canManageAllDocuments && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}
@@ -1295,10 +1296,10 @@ export function DocumentList({
                 includedInFolderScope={isDocumentIncludedInFolderScope}
                 onSelect={canManageAllDocuments ? handleSelectDoc : undefined}
                 ragConfigured={ragConfigured}
-                onCreateFolder={canUpload ? handleCreateFolder : undefined}
-                onRenameFolder={canUpload ? handleRenameFolder : undefined}
-                onDeleteFolder={canUpload ? handleDeleteFolderClick : undefined}
-                canManageFolders={canUpload}
+                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                canManageFolders={canManageFolderStructure}
                 canSelectFolders={canManageAllDocuments && !onSelectionChange}
                 selectedFolderIds={selectedFolderIds}
                 onSelectFolder={handleSelectFolder}

--- a/frontend/src/features/knowledge/document/hooks/useKnowledgeViewMode.ts
+++ b/frontend/src/features/knowledge/document/hooks/useKnowledgeViewMode.ts
@@ -27,6 +27,26 @@ function readBrowserView(): string | null {
   return new URLSearchParams(window.location.search).get('view')
 }
 
+function readBrowserTaskParam(): string | null {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  for (const key of TASK_QUERY_KEYS) {
+    const value = params.get(key)
+    if (value) return value
+  }
+  return null
+}
+
+function readTaskParam(searchParams: URLSearchParams): string | null {
+  const browserValue = readBrowserTaskParam()
+  if (browserValue) return browserValue
+  for (const key of TASK_QUERY_KEYS) {
+    const value = searchParams.get(key)
+    if (value) return value
+  }
+  return null
+}
+
 function removeTaskParams(url: URL): boolean {
   let removed = false
   for (const key of TASK_QUERY_KEYS) {
@@ -63,7 +83,8 @@ export function useKnowledgeViewMode(kbType?: KnowledgeBaseType | null, resetKey
   const resolvedView = useMemo(() => {
     void resetKey
     const viewParam = readBrowserView() ?? searchParams.get('view')
-    return isKnowledgeView(viewParam) ? viewParam : defaultView
+    if (isKnowledgeView(viewParam)) return viewParam
+    return readTaskParam(searchParams) ? 'notebook' : defaultView
   }, [searchParams, defaultView, resetKey])
 
   const [currentView, setCurrentViewState] = useState<KnowledgeView>(resolvedView)

--- a/frontend/src/features/tasks/components/sidebar/HistoryManageDialog.tsx
+++ b/frontend/src/features/tasks/components/sidebar/HistoryManageDialog.tsx
@@ -248,7 +248,9 @@ export default function HistoryManageDialog({ open, onOpenChange }: HistoryManag
   const handleTaskClick = (task: Task) => {
     onOpenChange(false)
     let targetPath = paths.chat.getHref() // default to chat
-    if (task.task_type === 'code') {
+    if (task.task_type === 'knowledge' && task.knowledge_base_id) {
+      targetPath = `/knowledge/document/${task.knowledge_base_id}`
+    } else if (task.task_type === 'code') {
       targetPath = paths.chat.getHref()
     } else if (task.task_type === 'video' || task.task_type === 'image') {
       targetPath = paths.generate.getHref()

--- a/frontend/src/features/tasks/components/sidebar/HistoryManageDialog.tsx
+++ b/frontend/src/features/tasks/components/sidebar/HistoryManageDialog.tsx
@@ -27,8 +27,8 @@ import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useTaskSession } from '@/features/tasks/session/TaskSession'
 import { Task } from '@/types/api'
-import { paths } from '@/config/paths'
 import { taskApis } from '@/apis/tasks'
+import { getTaskTargetHref } from '@/utils/taskRouting'
 
 // History filter type: online (chat), offline (code), flow
 export type HistoryFilterType = 'online' | 'offline' | 'flow'
@@ -247,15 +247,7 @@ export default function HistoryManageDialog({ open, onOpenChange }: HistoryManag
   // Handle task click (navigate to task)
   const handleTaskClick = (task: Task) => {
     onOpenChange(false)
-    let targetPath = paths.chat.getHref() // default to chat
-    if (task.task_type === 'knowledge' && task.knowledge_base_id) {
-      targetPath = `/knowledge/document/${task.knowledge_base_id}`
-    } else if (task.task_type === 'code') {
-      targetPath = paths.chat.getHref()
-    } else if (task.task_type === 'video' || task.task_type === 'image') {
-      targetPath = paths.generate.getHref()
-    }
-    router.push(`${targetPath}?taskId=${task.id}`)
+    router.push(getTaskTargetHref(task))
   }
 
   // Format time ago

--- a/frontend/src/features/tasks/components/sidebar/SearchDialog.tsx
+++ b/frontend/src/features/tasks/components/sidebar/SearchDialog.tsx
@@ -25,6 +25,7 @@ import { useTaskSession } from '@/features/tasks/session/TaskSession'
 import { Task } from '@/types/api'
 import { taskApis } from '@/apis/tasks'
 import { paths } from '@/config/paths'
+import { getTaskTargetHref } from '@/utils/taskRouting'
 
 interface SearchDialogProps {
   open: boolean
@@ -121,14 +122,7 @@ export default function SearchDialog({
   // Handle task click in dialog
   const handleDialogTaskClick = (task: Task) => {
     handleCloseSearchDialog()
-    // Navigate to task with taskId parameter
-    let targetPath = paths.chat.getHref() // default to chat
-    if (task.task_type === 'code') {
-      targetPath = paths.chat.getHref()
-    } else if (task.task_type === 'video' || task.task_type === 'image') {
-      targetPath = paths.generate.getHref()
-    }
-    router.push(`${targetPath}?taskId=${task.id}`)
+    router.push(getTaskTargetHref(task))
   }
 
   // Handle new conversation click

--- a/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
@@ -43,6 +43,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { toast } from 'sonner'
+import { getTaskTargetHref } from '@/utils/taskRouting'
 
 interface TaskListSectionProps {
   tasks: Task[]
@@ -58,7 +59,6 @@ interface TaskListSectionProps {
 }
 
 import { useRouter } from 'next/navigation'
-import { paths } from '@/config/paths'
 
 // Draggable task item wrapper component
 function DraggableTaskItem({
@@ -166,38 +166,7 @@ export default function TaskListSection({
 
   const navigateToTask = (task: Task) => {
     if (typeof window !== 'undefined') {
-      const params = new URLSearchParams()
-      params.set('taskId', String(task.id))
-
-      // Navigate to the appropriate page based on task task_type
-      // If task_type is not set, infer from git information
-      let targetPath = paths.chat.getHref() // default to chat
-
-      if (task.task_type === 'knowledge' && task.knowledge_base_id) {
-        // Knowledge type tasks navigate to the dedicated KB chat page
-        // This ensures full task functionality (follow-up questions, link sharing, etc.)
-        targetPath = `/knowledge/document/${task.knowledge_base_id}`
-      } else if (task.task_type === 'task') {
-        // Task type tasks navigate to device chat page
-        targetPath = '/devices/chat'
-      } else if (task.task_type === 'code') {
-        targetPath = paths.chat.getHref()
-      } else if (task.task_type === 'video' || task.task_type === 'image') {
-        // Video and image generation tasks navigate to generate page
-        targetPath = paths.generate.getHref()
-      } else if (task.task_type === 'chat') {
-        targetPath = paths.chat.getHref()
-      } else {
-        // For backward compatibility: infer type from git information
-        // If task has git repo info, assume it's a code task
-        if (task.git_repo && task.git_repo.trim() !== '') {
-          targetPath = paths.chat.getHref()
-        } else {
-          targetPath = paths.chat.getHref()
-        }
-      }
-
-      router.push(`${targetPath}?${params.toString()}`)
+      router.push(getTaskTargetHref(task))
 
       // Call the onTaskClick callback if provided (to close mobile sidebar)
       if (onTaskClick) {

--- a/frontend/src/features/tasks/session/taskPuller.ts
+++ b/frontend/src/features/tasks/session/taskPuller.ts
@@ -424,7 +424,7 @@ export function useTaskPuller(): TaskPuller {
         const isFailed = currentStatus === 'FAILED'
 
         if (wasRunning && (isCompleted || isFailed)) {
-          notifyTaskCompletion(task.id, task.title, isCompleted, task.task_type)
+          notifyTaskCompletion(task, task.title, isCompleted)
         }
       }
 

--- a/frontend/src/utils/namespace-permissions.ts
+++ b/frontend/src/utils/namespace-permissions.ts
@@ -86,35 +86,14 @@ export function canManageKnowledgeDocument({
   knowledgeBase,
   knowledgeRole,
   namespaceRole,
-  documentOwnerId,
+  documentOwnerId: _documentOwnerId,
 }: KnowledgeAccessOptions & { documentOwnerId: number | null | undefined }): boolean {
-  if (!currentUserId) {
-    return false
-  }
-
-  if (
-    canManageKnowledgeBase({
-      currentUserId,
-      knowledgeBase,
-      knowledgeRole,
-      namespaceRole,
-    })
-  ) {
-    return true
-  }
-
-  if (documentOwnerId == null) {
-    return false
-  }
-
-  return (
-    canManageKnowledgeBaseDocuments({
-      currentUserId,
-      knowledgeBase,
-      knowledgeRole,
-      namespaceRole,
-    }) && documentOwnerId === currentUserId
-  )
+  return canManageKnowledgeBaseDocuments({
+    currentUserId,
+    knowledgeBase,
+    knowledgeRole,
+    namespaceRole,
+  })
 }
 
 export function canManageKnowledgeBasePermissions({

--- a/frontend/src/utils/notification.ts
+++ b/frontend/src/utils/notification.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { TaskType } from '@/types/api'
+import { getTaskTargetHref, type TaskRouteTarget } from '@/utils/taskRouting'
 
 /**
  * Browser notification utility
@@ -123,27 +123,14 @@ export async function sendNotification(
  * Send task completion notification
  */
 export function notifyTaskCompletion(
-  taskId: number,
+  task: TaskRouteTarget,
   taskTitle: string,
-  success: boolean,
-  taskType?: TaskType
+  success: boolean
 ): void {
   const title = success ? '✅ Task Completed' : '❌ Task Failed'
   const body = taskTitle.length > 100 ? `${taskTitle.substring(0, 100)}...` : taskTitle
 
-  // Build target URL based on task type
-  let targetUrl: string
-  if (taskType === 'code') {
-    targetUrl = `${window.location.origin}/chat?taskId=${taskId}`
-  } else if (taskType === 'knowledge') {
-    targetUrl = `${window.location.origin}/knowledge?taskId=${taskId}`
-  } else if (taskType === 'task') {
-    targetUrl = `${window.location.origin}/devices/chat?taskId=${taskId}`
-  } else if (taskType === 'video') {
-    targetUrl = `${window.location.origin}/generate?taskId=${taskId}`
-  } else {
-    targetUrl = `${window.location.origin}/chat?taskId=${taskId}`
-  }
+  const targetUrl = new URL(getTaskTargetHref(task), window.location.origin).toString()
 
   sendNotification(
     title,

--- a/frontend/src/utils/taskRouting.ts
+++ b/frontend/src/utils/taskRouting.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { paths } from '@/config/paths'
+import type { TaskType } from '@/types/api'
+
+export interface TaskRouteTarget {
+  id: number
+  task_type?: TaskType
+  knowledge_base_id?: number | null
+  git_repo?: string | null
+}
+
+export function getTaskTargetPath(task: TaskRouteTarget): string {
+  if (task.task_type === 'knowledge') {
+    return task.knowledge_base_id
+      ? `/knowledge/document/${task.knowledge_base_id}`
+      : paths.wiki.getHref()
+  }
+
+  if (task.task_type === 'task') {
+    return '/devices/chat'
+  }
+
+  if (task.task_type === 'video' || task.task_type === 'image') {
+    return paths.generate.getHref()
+  }
+
+  return paths.chat.getHref()
+}
+
+export function getTaskTargetHref(task: TaskRouteTarget): string {
+  const params = new URLSearchParams()
+  params.set('taskId', String(task.id))
+  return `${getTaskTargetPath(task)}?${params.toString()}`
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified task navigation targets across history, task lists, search, and task completion notifications, including consistent knowledge document/notebook routing.
* **Bug Fixes**
  * Fixed knowledge view initialization to respect the `view` query parameter while correctly deriving notebook view from task identifiers; improved URL query handling during async updates.
  * Updated document and folder permission logic so authorized users can manage accessible shared documents and related folder operations.
* **Tests**
  * Added/expanded test coverage for task routing, knowledge view mode behavior, navigation, and knowledge permission outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->