### PR TITLE
fix(ci): use release app token for wework publishing

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -34,10 +34,19 @@ jobs:
       publish_release: ${{ steps.version.outputs.publish_release }}
 
     steps:
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Resolve Wework release version
         id: version
@@ -102,6 +111,7 @@ jobs:
         env:
           PUBLISH_RELEASE: ${{ steps.version.outputs.publish_release }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -179,8 +189,9 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          app_user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          git config user.name "${{ steps.release-app-token.outputs.app-slug }}[bot]"
+          git config user.email "${app_user_id}+${{ steps.release-app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git add wework/package.json wework/src-tauri/tauri.conf.json wework/src-tauri/Cargo.toml wework/src-tauri/Cargo.lock
           git commit -m "chore(wework): bump app version to ${RELEASE_VERSION}"
           git push origin "HEAD:${GITHUB_REF_NAME}"
@@ -190,7 +201,7 @@ jobs:
         if: steps.version.outputs.publish_release == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
           RELEASE_SHA: ${{ steps.version-files.outputs.release_sha }}
@@ -504,11 +515,20 @@ jobs:
             echo "signature_path=$signature_path"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Create release app token
+        if: needs.prepare-release.outputs.publish_release == 'true'
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Upload macOS assets to GitHub Release
         if: needs.prepare-release.outputs.publish_release == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |
@@ -544,10 +564,18 @@ jobs:
       - build-macos
 
     steps:
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Generate latest.json
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
@@ -619,10 +647,18 @@ jobs:
       - publish-updater-manifest
 
     steps:
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Publish GitHub Release
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |


### PR DESCRIPTION
## What changed

- Add `actions/create-github-app-token@v3` to the Wework App workflow.
- Use the release GitHub App token for checkout, version-file commits, branch pushes, release creation, asset upload, updater manifest upload, and release publishing.
- Commit Wework version bumps as the configured app bot instead of `github-actions[bot]`.

## Why

The Wework release workflow failed when pushing version-file changes to `main` because repository rules require changes to go through a pull request. A dedicated GitHub App can be added to the ruleset bypass list and used only for release automation.

## Impact

Repository admins need to configure:

- Repository variable: `RELEASE_APP_ID`
- Repository secret: `RELEASE_APP_PRIVATE_KEY`
- Ruleset bypass actor: the installed release GitHub App

The app installation needs `Contents: Read and write` on `wecode-ai/Wegent`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wework-app.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/wework-app.yml`
- `actionlint .github/workflows/wework-app.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by using a dedicated GitHub App token for release-related steps.
  * Reduced the chance of authentication issues when updating version files, uploading macOS assets, generating updater metadata, and publishing final releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->