### PR TITLE
fix(wework): anchor environment popover to trigger

### DIFF
--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -9,7 +9,7 @@ import {
   MapPin,
   Settings,
 } from 'lucide-react'
-import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { BranchSelector } from '@/components/common/BranchSelector'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -30,6 +30,28 @@ interface EnvironmentInfoPopoverProps {
   onOpenChangesReview?: () => void
 }
 
+const POPOVER_WIDTH = 340
+const POPOVER_GAP = 8
+const VIEWPORT_MARGIN = 16
+
+interface PopoverPosition {
+  left: number
+  top: number
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function getEnvironmentPopoverPosition(anchor: DOMRect): PopoverPosition {
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth
+  const maxLeft = Math.max(VIEWPORT_MARGIN, viewportWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
+  return {
+    left: clamp(anchor.right - POPOVER_WIDTH, VIEWPORT_MARGIN, maxLeft),
+    top: Math.max(VIEWPORT_MARGIN, anchor.bottom + POPOVER_GAP),
+  }
+}
+
 export function EnvironmentInfoPopover({
   info,
   devices = [],
@@ -47,6 +69,7 @@ export function EnvironmentInfoPopover({
   const [commitMessage, setCommitMessage] = useState('')
   const [commitStatus, setCommitStatus] = useState<'idle' | 'committing' | 'success'>('idle')
   const [commitError, setCommitError] = useState<string | null>(null)
+  const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const additions = info.additions || '+0'
@@ -117,12 +140,20 @@ export function EnvironmentInfoPopover({
 
   function handleToggleOpen() {
     const nextOpen = !open
+    if (nextOpen && rootRef.current) {
+      setPopoverPosition(getEnvironmentPopoverPosition(rootRef.current.getBoundingClientRect()))
+    }
     setOpen(nextOpen)
 
     if (nextOpen) {
       void onRefresh?.()
     }
   }
+
+  const updatePopoverPosition = useCallback(() => {
+    if (!rootRef.current) return
+    setPopoverPosition(getEnvironmentPopoverPosition(rootRef.current.getBoundingClientRect()))
+  }, [])
 
   useEffect(() => {
     if (!open) {
@@ -137,8 +168,22 @@ export function EnvironmentInfoPopover({
     }
 
     document.addEventListener('pointerdown', handlePointerDown)
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
+    window.addEventListener('resize', updatePopoverPosition)
+    window.addEventListener('scroll', updatePopoverPosition, true)
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      window.removeEventListener('resize', updatePopoverPosition)
+      window.removeEventListener('scroll', updatePopoverPosition, true)
+    }
+  }, [open, updatePopoverPosition])
+
+  const popoverStyle: CSSProperties | undefined = popoverPosition
+    ? {
+        left: `${popoverPosition.left}px`,
+        top: `${popoverPosition.top}px`,
+      }
+    : undefined
 
   return (
     <div ref={rootRef}>
@@ -160,7 +205,8 @@ export function EnvironmentInfoPopover({
           <div
             ref={popoverRef}
             data-testid="environment-info-popover"
-            className="fixed right-6 top-[76px] z-system w-[340px] max-w-[calc(100vw-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            style={popoverStyle}
+            className="fixed z-system w-[340px] max-w-[calc(100vw-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -33,6 +33,30 @@ const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startCodeServerSessionMock = vi.fn()
 
+function createRect({
+  left,
+  top,
+  width,
+  height,
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+}): DOMRect {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
 const baseProps = {
   environmentInfo: {
     additions: '+0',
@@ -111,6 +135,29 @@ describe('WorkspacePanelActions', () => {
     )
 
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
+  })
+
+  test('positions environment info popover from the trigger instead of the viewport edge', async () => {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function () {
+        if (this.querySelector('[data-testid="environment-info-button"]')) {
+          return createRect({ left: 88, top: 8, width: 32, height: 32 })
+        }
+        return createRect({ left: 0, top: 0, width: 0, height: 0 })
+      })
+
+    try {
+      render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+
+      await userEvent.click(screen.getByTestId('environment-info-button'))
+
+      const popover = await screen.findByTestId('environment-info-popover')
+      expect(popover).toHaveStyle({ left: '16px', top: '48px' })
+      expect(popover).not.toHaveClass('right-6', 'top-[76px]')
+    } finally {
+      rectSpy.mockRestore()
+    }
   })
 
   test('opens local workspaces with the default VS Code titlebar action', async () => {


### PR DESCRIPTION
## Summary

- Anchor the Wework environment info popover to the clicked trigger instead of a fixed viewport position.
- Recompute the popover position on resize and scroll while it is open.
- Add coverage to prevent the popover from regressing to the hard-coded right/top placement.

## Root Cause

The environment info popover was rendered through a portal with fixed `right-6 top-[76px]` classes, so clicking the environment button from a different toolbar area still opened the popover near the viewport edge.

## Validation

- `pnpm --filter wework exec eslint src/components/layout/EnvironmentInfoPopover.tsx src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx`
- `pnpm --filter wework test -- WorkspacePanelActions.test.tsx`
- pre-push hook: Wework ESLint, TypeScript, and unit tests passed

Docs were checked and are not needed for this UI bugfix because it does not change API, configuration, or documented workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The environment info popover now opens in a position that better matches the trigger button and stays within the visible screen area.
  * The popover updates its placement when the window is resized or scrolled, helping keep it visible and aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->