### PR TITLE
fix(ci): use release app token for wework publishing

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -38,7 +38,7 @@ jobs:
         id: release-app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
 
@@ -520,7 +520,7 @@ jobs:
         id: release-app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
 
@@ -568,7 +568,7 @@ jobs:
         id: release-app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
 
@@ -651,7 +651,7 @@ jobs:
         id: release-app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
 


### PR DESCRIPTION
## What changed

- Let the Wework App workflow read the release GitHub App ID from either repository variables or secrets.
- Accepted names now include `RELEASE_APP_ID` and `RELEASE_APP_CLIENT_ID`.

## Why

The follow-up Wework App run failed before checkout because `actions/create-github-app-token@v3` received an empty `app-id` value:

```text
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

This means the repository currently does not expose `vars.RELEASE_APP_ID` to the workflow context, or it was configured under a different name/location.

## Required repository configuration

Configure at least one of these ID values:

- Repository variable: `RELEASE_APP_ID`
- Repository secret: `RELEASE_APP_ID`
- Repository variable: `RELEASE_APP_CLIENT_ID`
- Repository secret: `RELEASE_APP_CLIENT_ID`

Also keep this secret configured:

- Repository secret: `RELEASE_APP_PRIVATE_KEY`

The installed GitHub App still needs `Contents: Read and write` and must be added to the `main` ruleset bypass list.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wework-app.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/wework-app.yml`
- `actionlint .github/workflows/wework-app.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation authentication fallback, making GitHub App access more reliable when primary app ID settings aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->