### PR TITLE
fix(wework): support IME enter in inputs

### DIFF
--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -37,6 +37,7 @@ import { openLocalFile } from '@/lib/local-terminal'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { parseChatError } from '@/lib/chat-error'
 import { isIMSource } from '@/lib/im-source'
+import { isImeEnterEvent } from '@/lib/ime'
 import { ImSourceBadge } from '@/components/common/ImSourceBadge'
 import { cn } from '@/lib/utils'
 import { AssistantMarkdown } from './AssistantMarkdown'
@@ -848,7 +849,7 @@ function UserMessageEditForm({
         disabled={submitting}
         onChange={event => setDraft(event.target.value)}
         onKeyDown={event => {
-          if (event.nativeEvent.isComposing) return
+          if (isImeEnterEvent(event)) return
           if (event.key === 'Enter' && event.shiftKey) return
           if (event.key === 'Enter') {
             event.preventDefault()

--- a/wework/src/components/chat/RequestUserInputCard.tsx
+++ b/wework/src/components/chat/RequestUserInputCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type { FormEvent, KeyboardEvent } from 'react'
 import { ChevronDown, CornerDownLeft, MessageCircleQuestion, Pencil } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { isImeEnterEvent } from '@/lib/ime'
 import { cn } from '@/lib/utils'
 import type { RequestUserInputResponse } from '@/types/api'
 import { hasImplementationPlanText } from './requestUserInputMessages'
@@ -118,6 +119,8 @@ export function RequestUserInputCard({
       onIgnore?.()
       return
     }
+
+    if (isImeEnterEvent(event)) return
 
     if (event.key !== 'Enter' || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
       return

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -2,6 +2,7 @@ import { ClipboardList, Cpu, Package, Target } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode, RefObject } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { isImeComposingEvent, isImeEnterEvent } from '@/lib/ime'
 import { getModelCompatibilityFamily, inferModelFamily } from '@/lib/model-ui'
 import type { LocalDeviceSkill, ModelOptions, UnifiedModel } from '@/types/api'
 import type { ComposerTextTrigger, SlashCommand } from './composerAutocomplete'
@@ -854,7 +855,7 @@ export function ComposerTextarea({
       })
     }
 
-    if (event.key === 'Enter' && (isComposing || event.nativeEvent.isComposing)) {
+    if (isImeEnterEvent(event) || (event.key === 'Enter' && isComposing)) {
       suppressEnterUntilKeyUpRef.current = true
       debugComposerEvent('keydown-enter-ignored-composition', {
         stateIsComposing: isComposing,
@@ -875,7 +876,7 @@ export function ComposerTextarea({
       return
     }
 
-    if (isComposing || event.nativeEvent.isComposing) {
+    if (isComposing || isImeComposingEvent(event)) {
       return
     }
 

--- a/wework/src/components/chat/composer/SlashModelMenu.tsx
+++ b/wework/src/components/chat/composer/SlashModelMenu.tsx
@@ -1,6 +1,7 @@
 import { Check, Search } from 'lucide-react'
 import type { KeyboardEvent } from 'react'
 import { useCallback, useMemo } from 'react'
+import { isImeEnterEvent } from '@/lib/ime'
 import { getModelDisplayLabel, getModelUiMetadata, groupModelsByFamily } from '@/lib/model-ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ModelOptions, UnifiedModel } from '@/types/api'
@@ -126,6 +127,7 @@ export function SlashModelMenu({
       onSelectedIndexChange(Math.max(selectedIndex - 1, 0))
       return
     }
+    if (isImeEnterEvent(event)) return
     if (event.key === 'Enter' && filteredModels[selectedIndex]) {
       event.preventDefault()
       handleSelect(filteredModels[selectedIndex])

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -15,6 +15,7 @@ import { useMemo, useRef, useState } from 'react'
 import { ProjectCreateDialog } from '@/components/projects/ProjectCreateDialog'
 import { useTranslation } from '@/hooks/useTranslation'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
+import { isImeEnterEvent } from '@/lib/ime'
 import { cn } from '@/lib/utils'
 import { getRuntimeTaskReminderItemKey } from '@/features/workbench/runtimeTaskReminders'
 import { runtimeProjectUiId } from '@/lib/runtime-project'
@@ -466,6 +467,7 @@ export function MobileDrawer({
                           onChange={event => setRenameValue(event.target.value)}
                           onBlur={() => void submitProjectRename(project.id)}
                           onKeyDown={event => {
+                            if (isImeEnterEvent(event)) return
                             if (event.key === 'Enter') {
                               event.preventDefault()
                               void submitProjectRename(project.id)

--- a/wework/src/components/layout/WorkbenchSearchDialog.tsx
+++ b/wework/src/components/layout/WorkbenchSearchDialog.tsx
@@ -1,6 +1,7 @@
 import { Loader2, Search, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { isImeEnterEvent } from '@/lib/ime'
 import { cn } from '@/lib/utils'
 import type {
   RuntimeTaskAddress,
@@ -160,6 +161,7 @@ function WorkbenchSearchDialogPanel({
                 setSelectedIndex(index => Math.max(index - 1, 0))
                 return
               }
+              if (isImeEnterEvent(event)) return
               if (event.key === 'Enter') {
                 event.preventDefault()
                 openItem(selectedItem)

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -359,7 +359,7 @@ function browserAnnotationInjectionScript() {
       publish();
     });
     input.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' && !event.isComposing) {
+      if (event.key === 'Enter' && !event.isComposing && event.keyCode !== 229) {
         event.preventDefault();
         event.stopPropagation();
         publish();

--- a/wework/src/components/projects/DeviceFolderPicker.tsx
+++ b/wework/src/components/projects/DeviceFolderPicker.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronLeft, Folder, FolderPlus, Loader2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { isImeEnterEvent } from '@/lib/ime'
 import type { DeviceInfo } from '@/types/api'
 import {
   directoryMatchesQuery,
@@ -266,6 +267,7 @@ export function DeviceFolderPicker({
             }}
             onBlur={confirmPathInput}
             onKeyDown={event => {
+              if (isImeEnterEvent(event)) return
               if (event.key === 'Enter') {
                 event.preventDefault()
                 confirmPathInput()
@@ -314,6 +316,7 @@ export function DeviceFolderPicker({
               setError(null)
             }}
             onKeyDown={event => {
+              if (isImeEnterEvent(event)) return
               if (event.key === 'Enter') {
                 event.preventDefault()
                 void handleConfirm()

--- a/wework/src/components/projects/StandaloneProjectDialogs.tsx
+++ b/wework/src/components/projects/StandaloneProjectDialogs.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from '@/hooks/useTranslation'
+import { isImeEnterEvent } from '@/lib/ime'
 import { openNativeProjectDirectoryPicker } from '@/lib/native-directory-picker'
 import {
   canUseForProjectCreation,
@@ -243,6 +244,7 @@ export function StandaloneBlankProjectDialog({
             setError(null)
           }}
           onKeyDown={event => {
+            if (isImeEnterEvent(event)) return
             if (event.key === 'Enter') {
               event.preventDefault()
               void submit()

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -38,6 +38,7 @@ import { CloudConnectionDialog } from '@/features/cloud-connection/CloudConnecti
 import { useOptionalCloudConnection } from '@/features/cloud-connection/useCloudConnection'
 import { useTranslation } from '@/hooks/useTranslation'
 import { openExternalUrl } from '@/lib/external-links'
+import { isImeEnterEvent } from '@/lib/ime'
 import { navigateTo } from '@/lib/navigation'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { cn } from '@/lib/utils'
@@ -802,6 +803,7 @@ function DeviceCard({ device, onChanged }: { device: DeviceInfo; onChanged: () =
                   value={editName}
                   onChange={e => setEditName(e.target.value)}
                   onKeyDown={e => {
+                    if (isImeEnterEvent(e)) return
                     if (e.key === 'Enter') handleSaveEdit()
                     if (e.key === 'Escape') handleCancelEdit()
                   }}

--- a/wework/src/lib/ime.test.ts
+++ b/wework/src/lib/ime.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest'
+import { isImeComposingEvent, isImeEnterEvent } from './ime'
+
+describe('IME keyboard helpers', () => {
+  test('detects React native composing state', () => {
+    expect(
+      isImeEnterEvent({
+        key: 'Enter',
+        nativeEvent: { isComposing: true },
+      })
+    ).toBe(true)
+  })
+
+  test('detects process key events used by IME confirmation', () => {
+    expect(isImeEnterEvent({ key: 'Enter', keyCode: 229 })).toBe(true)
+    expect(isImeComposingEvent({ nativeEvent: { which: 229 } })).toBe(true)
+  })
+
+  test('allows ordinary Enter events', () => {
+    expect(isImeEnterEvent({ key: 'Enter' })).toBe(false)
+    expect(isImeComposingEvent({ key: 'Enter' })).toBe(false)
+  })
+})

--- a/wework/src/lib/ime.ts
+++ b/wework/src/lib/ime.ts
@@ -1,0 +1,29 @@
+interface ImeKeyboardEventLike {
+  key?: string
+  isComposing?: boolean
+  keyCode?: number
+  which?: number
+  nativeEvent?: {
+    isComposing?: boolean
+    keyCode?: number
+    which?: number
+  }
+}
+
+const IME_PROCESS_KEY_CODE = 229
+
+export function isImeComposingEvent(event: ImeKeyboardEventLike): boolean {
+  const nativeEvent = event.nativeEvent
+  return Boolean(
+    event.isComposing ||
+    nativeEvent?.isComposing ||
+    event.keyCode === IME_PROCESS_KEY_CODE ||
+    event.which === IME_PROCESS_KEY_CODE ||
+    nativeEvent?.keyCode === IME_PROCESS_KEY_CODE ||
+    nativeEvent?.which === IME_PROCESS_KEY_CODE
+  )
+}
+
+export function isImeEnterEvent(event: ImeKeyboardEventLike): boolean {
+  return event.key === 'Enter' && isImeComposingEvent(event)
+}


### PR DESCRIPTION
## Summary

Fix Wework text inputs that submitted, confirmed, or selected items when Enter was used to confirm Chinese IME composition.

## Changes

- Add shared IME keyboard helpers that check React and native composing state, including process-key code 229.
- Reuse the helper in the main composer and other Enter-driven text inputs, including search, rename, project/folder dialogs, request-user-input, message editing, model search, and browser annotation input.
- Add unit coverage for the shared helper.

## Impact

Chinese IME users can press Enter to confirm candidate text without accidentally sending messages, saving dialogs, selecting search results, or submitting custom responses.

## Validation

- `pnpm --dir wework test -- src/lib/ime.test.ts`
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`
- Pre-push Wework ESLint, TypeScript, and unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard handling across chat, search, project, and settings inputs for better IME support.
* **Bug Fixes**
  * Prevented Enter from accidentally submitting, selecting, publishing, renaming, or opening items when typing with an IME.
  * Made composing-state detection more reliable in text inputs, reducing unintended actions during multilingual text entry.
  * Added coverage for IME keyboard behavior to help keep these fixes stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->