### PR TITLE
fix(wework): preserve pane resources with Activity

### DIFF
--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -60,7 +60,8 @@ Do not append the user message to the bottom after guidance succeeds, and do not
 The right workspace **Temporary chat** feature starts a short side conversation next to the current local Codex thread. It is not a fork and it is not a normal runtime task shown in the left task list:
 
 - Each temporary chat tab has an independent `chat:<id>` instance id, so the right workspace can hold multiple temporary chats at the same time.
-- UI state lives inside `TemporaryChatPanel`, using the instance id as the `conversationKey` before a runtime thread exists. Hidden temporary chat tabs stay mounted so local messages and input state are not lost when switching tabs.
+- UI state lives inside `TemporaryChatPanel`, using the instance id as the `conversationKey` before a runtime thread exists. Switching tabs must not lose local messages or input state.
+- Temporary chat runtime stream subscriptions are owned by the tab lifecycle, not by `TemporaryChatPanel` React effect cleanup. Activity pauses effects for inactive panes or tabs, but the temporary chat's AI reply must keep flowing into that tab's message reducer; release the subscription only when the temporary chat tab closes.
 - The first message calls `createTemporaryRuntimeTask`, creating an `ephemeral` runtime task with the current main thread as `sideSource`. This task does not enter the left task list and does not navigate the main pane.
 - Follow-up messages must continue the already loaded temporary thread. The Codex app-server path uses `direct_thread_id` and calls `turn/start` directly; it must not use the normal `resume_thread_id` / `thread/resume` path, because temporary threads do not have rollout mappings and would otherwise fail with `no rollout found`.
 - Temporary chats reuse only the current workspace and current thread context. If no main thread source is available, sending should be blocked and the user should be asked to open an existing conversation first.

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -60,7 +60,8 @@ sidebar_position: 18
 右侧工作区的“临时聊天”用于在当前 Codex 本地线程旁边发起一次短对话。它不是 fork，也不是左侧任务列表中的普通 runtime task：
 
 - 每个临时聊天 tab 都有独立的 `chat:<id>` 实例标识，允许在右侧工作区同时打开多个临时聊天。
-- UI 状态保存在 `TemporaryChatPanel` 内部，并以实例标识作为未创建 runtime 线程前的 `conversationKey`；切换 tab 时面板保持挂载，避免丢失本地消息和输入状态。
+- UI 状态保存在 `TemporaryChatPanel` 内部，并以实例标识作为未创建 runtime 线程前的 `conversationKey`；切换 tab 时不能丢失本地消息和输入状态。
+- 临时聊天的 runtime stream 订阅归 tab 生命周期管理，不能绑定到 `TemporaryChatPanel` 的 React effect cleanup。Activity 隐藏 inactive pane 或 tab 时会暂停组件 effect，但临时聊天的 AI 回复仍必须继续进入对应 tab 的消息 reducer；只有关闭临时聊天 tab 时才释放订阅。
 - 首条消息通过 `createTemporaryRuntimeTask` 创建 `ephemeral` runtime task，并携带当前主线程的 `sideSource`。该任务不写入左侧任务列表，也不触发主 pane 导航。
 - 后续消息必须继续使用已加载的临时线程。Codex app-server 路径使用 `direct_thread_id` 直接 `turn/start`，不能走普通 `resume_thread_id` 的 `thread/resume` 路径，否则会因为临时线程没有 rollout 映射而出现 `no rollout found`。
 - 临时聊天只复用当前工作区和当前线程上下文；如果没有可用的主线程 source，应阻止发送并提示用户先打开已有对话。

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -22,11 +22,12 @@ import type { EnvironmentDiffMode } from '@/api/environment'
 import type { WorkspaceFileOpenRequest, WorkspaceTarget } from '@/types/workspace-files'
 import { cn } from '@/lib/utils'
 import { BottomWorkspacePanel } from './workspace-panels/BottomWorkspacePanel'
+import { RightWorkspacePanel } from './workspace-panels/RightWorkspacePanel'
 import {
-  RightWorkspacePanel,
+  isRightWorkspaceChatTab,
   type RightWorkspacePanelTab,
   type RightWorkspacePanelView,
-} from './workspace-panels/RightWorkspacePanel'
+} from './workspace-panels/rightWorkspacePanelTypes'
 import { WorkspacePanelActions } from './workspace-panels/WorkspacePanelActions'
 import { useResizableRightSplitChat } from './workspace-panels/useResizableWorkspacePanel'
 import { ConversationDeviceOfflineBanner } from './ConversationDeviceOfflineBanner'
@@ -39,10 +40,14 @@ import { DESKTOP_TOP_BAR_BUTTON_CLASS, DesktopTopBar } from './DesktopTopBar'
 import { DesktopWindowControls } from './DesktopWindowControls'
 import { MacOSTitleBarDragRegion } from './MacOSTitleBarDragRegion'
 import { isTauriRuntime } from '@/lib/runtime-environment'
+import { closeLocalTerminal } from '@/lib/local-terminal'
+import { clearTerminalOutput } from './workspace-panels/terminalOutputBuffer'
 import {
+  closeEmbeddedBrowser,
   listenEmbeddedBrowserOpenRequests,
   markEmbeddedBrowserLabelTransferred,
   relabelEmbeddedBrowser,
+  setEmbeddedBrowserBounds,
   type EmbeddedBrowserOpenRequest,
 } from '@/lib/embedded-browser'
 import { TaskForkDialog } from './TaskForkDialog'
@@ -79,6 +84,7 @@ import { WEWORK_OPEN_TERMINAL_EVENT } from '@/lib/keybindings'
 import type { RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
 import type { WorkbenchMessage } from '@/types/workbench'
 import { BufferedChatInput } from './BufferedChatInput'
+import { disposeTemporaryChatPanel } from './workspace-panels/temporaryChatPanelLifecycle'
 
 const DESKTOP_CHAT_CONTENT_BASE_CLASS =
   'mx-auto min-w-0 px-0 transition-[width,max-width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'
@@ -210,7 +216,10 @@ interface DesktopWorkbenchMainProps {
 
 export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
   const { state } = useWorkbenchPaneContext()
+  const activePaneKey = getWorkbenchPaneKey(props.activePane)
+  const previousActivePaneKeyRef = useRef(activePaneKey)
   const [terminalPinnedPaneKeys, setTerminalPinnedPaneKeys] = useState<string[]>([])
+  const localTerminalSessionsByPaneRef = useRef(new Map<string, string[]>())
   const runtimePaneKeys = useMemo(
     () => getRuntimeWorkbenchPaneKeys(state.runtimeWork),
     [state.runtimeWork]
@@ -240,6 +249,42 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
   const unpinTerminalPane = useCallback((paneKey: string) => {
     setTerminalPinnedPaneKeys(current => current.filter(key => key !== paneKey))
   }, [])
+  const updatePaneLocalTerminalSessions = useCallback((paneKey: string, sessionIds: string[]) => {
+    if (sessionIds.length > 0) {
+      localTerminalSessionsByPaneRef.current.set(paneKey, sessionIds)
+    } else {
+      localTerminalSessionsByPaneRef.current.delete(paneKey)
+    }
+  }, [])
+  const closePrunedPaneResources = useCallback((paneKeys: string[]) => {
+    paneKeys.forEach(paneKey => {
+      void closeEmbeddedBrowser(getEmbeddedBrowserLabelForPaneKey(paneKey)).catch(() => undefined)
+    })
+  }, [])
+
+  useEffect(() => {
+    const previousPaneKey = previousActivePaneKeyRef.current
+    if (previousPaneKey === activePaneKey) return
+    previousActivePaneKeyRef.current = activePaneKey
+    void setEmbeddedBrowserBounds(
+      { x: 0, y: 0, width: 1, height: 1 },
+      false,
+      getEmbeddedBrowserLabelForPaneKey(previousPaneKey)
+    ).catch(() => undefined)
+  }, [activePaneKey])
+
+  useEffect(() => {
+    if (prunedPaneKeys.length === 0) return
+
+    prunedPaneKeys.forEach(paneKey => {
+      const sessionIds = localTerminalSessionsByPaneRef.current.get(paneKey) ?? []
+      sessionIds.forEach(sessionId => {
+        void closeLocalTerminal(sessionId)
+        clearTerminalOutput(sessionId)
+      })
+      localTerminalSessionsByPaneRef.current.delete(paneKey)
+    })
+  }, [prunedPaneKeys])
 
   return (
     <CachedWorkbenchPaneStack
@@ -248,6 +293,7 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
       pinnedKeys={pinnedPaneKeys}
       prunedKeys={prunedPaneKeys}
       activeTestId="desktop-workbench-main"
+      onPrunedKeys={closePrunedPaneResources}
       renderPane={pane => (
         <DesktopWorkbenchPane
           pane={pane}
@@ -256,6 +302,7 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
           onSidebarCollapsedChange={props.onSidebarCollapsedChange}
           onTerminalPanePinned={pinTerminalPane}
           onTerminalPaneUnpinned={unpinTerminalPane}
+          onLocalTerminalSessionsChange={updatePaneLocalTerminalSessions}
         />
       )}
     />
@@ -269,6 +316,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   onSidebarCollapsedChange,
   onTerminalPanePinned,
   onTerminalPaneUnpinned,
+  onLocalTerminalSessionsChange,
 }: {
   pane: WorkbenchPaneIdentity
   sidebarCollapsed: boolean
@@ -276,6 +324,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   onSidebarCollapsedChange: (collapsed: boolean) => void
   onTerminalPanePinned: (paneKey: string) => void
   onTerminalPaneUnpinned: (paneKey: string) => void
+  onLocalTerminalSessionsChange: (paneKey: string, sessionIds: string[]) => void
 }) {
   const {
     state,
@@ -674,6 +723,11 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   )
   const closeRightPanelTab = useCallback(
     (tab: RightWorkspacePanelTab) => {
+      if (tab === 'browser') {
+        void closeEmbeddedBrowser(embeddedBrowserLabel).catch(() => undefined)
+      } else if (isRightWorkspaceChatTab(tab)) {
+        disposeTemporaryChatPanel(tab)
+      }
       setRightPanelTabs(current => {
         const currentTabs = current.includes(tab) ? current : [...current, tab]
         const next = currentTabs.filter(openTab => openTab !== tab)
@@ -688,7 +742,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         return next
       })
     },
-    [rightPanelView, setRightPanelOpen, setRightPanelTabs, setRightPanelView]
+    [embeddedBrowserLabel, rightPanelView, setRightPanelOpen, setRightPanelTabs, setRightPanelView]
   )
 
   const openReviewFromDiffLoader = useCallback(
@@ -1502,6 +1556,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 onTerminalPaneUnpinned(paneKey)
               }
             }}
+            onLocalTerminalSessionsChange={sessionIds =>
+              onLocalTerminalSessionsChange(paneKey, sessionIds)
+            }
           />
         )
       })}
@@ -1546,4 +1603,14 @@ function sanitizeEmbeddedBrowserLabelSegment(value: string) {
     .split('')
     .map(character => (/^[a-zA-Z0-9_-]$/.test(character) ? character : '-'))
     .join('')
+}
+
+function getEmbeddedBrowserLabelForPaneKey(paneKey: string): string {
+  if (paneKey.startsWith('runtime:')) {
+    const [, , ...taskIdParts] = paneKey.split(':')
+    const taskId = taskIdParts.join(':') || paneKey
+    return `workspace-browser-${sanitizeEmbeddedBrowserLabelSegment(taskId)}`
+  }
+
+  return `workspace-browser-${sanitizeEmbeddedBrowserLabelSegment(paneKey)}`
 }

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import i18n from '@/i18n'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
+import type { WorkbenchPaneContextValue } from '@/features/workbench/workbenchContextTypes'
 import {
   compareMessageStyles,
   summarizeRuntimePaneMemory,
@@ -103,6 +104,14 @@ interface GuidanceSplitBoundary {
 const runtimePaneMessageSeeds = new Map<string, WorkbenchMessage[]>()
 const runtimePaneMessageSnapshots = new Map<string, WorkbenchMessage[]>()
 const runtimePaneGoalSeeds = new Map<string, PendingRuntimeGoalState>()
+type RuntimeTaskStreamSubscriber = WorkbenchPaneContextValue['subscribeRuntimeTaskStream']
+const runtimePaneStreamSubscriptions = new Map<
+  string,
+  {
+    subscribe: RuntimeTaskStreamSubscriber
+    unsubscribe: () => void
+  }
+>()
 const RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
 const MAX_CACHED_RUNTIME_PANE_MESSAGES = 3
 const MAX_CACHED_RUNTIME_PANE_GOALS = 3
@@ -465,8 +474,18 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       return
     }
 
-    const { address } = target
-    const unsubscribe = subscribeRuntimeTaskStreamRef.current(address, {
+    const { address, identityKey } = target
+    const subscribeRuntimeTaskStream = subscribeRuntimeTaskStreamRef.current
+    const existingSubscription = runtimePaneStreamSubscriptions.get(identityKey)
+    if (existingSubscription?.subscribe === subscribeRuntimeTaskStream) {
+      return
+    }
+    if (existingSubscription) {
+      existingSubscription.unsubscribe()
+      runtimePaneStreamSubscriptions.delete(identityKey)
+    }
+
+    const unsubscribe = subscribeRuntimeTaskStream(address, {
       onMessageAction: dispatchMessages,
       onAssistantStart: () => setSendPhase('idle'),
       onAssistantSettled: () => {
@@ -518,7 +537,10 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         )
       },
     })
-    return unsubscribe
+    runtimePaneStreamSubscriptions.set(identityKey, {
+      subscribe: subscribeRuntimeTaskStream,
+      unsubscribe,
+    })
   }, [dispatchMessages, runtimeTaskStreamTargetKey])
 
   const loadMoreTranscriptBefore = useCallback(async () => {

--- a/wework/src/components/layout/workbenchPaneStack.test.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.test.tsx
@@ -181,9 +181,9 @@ describe('workbenchPaneStack', () => {
       .closest('[data-active-workbench-pane]')
 
     expect(standaloneWrapper).toHaveAttribute('data-active-workbench-pane', 'true')
-    expect(standaloneWrapper).toHaveClass('visible')
+    expect(screen.getByTestId('runtime-pane-project')).toBeVisible()
     expect(runtimeWrapper).toHaveAttribute('data-active-workbench-pane', 'false')
-    expect(runtimeWrapper).toHaveClass('invisible')
+    expect(screen.getByTestId('runtime-pane-runtime-1')).not.toBeVisible()
   })
 
   test('uses standalone chat key to create a fresh new chat pane', async () => {

--- a/wework/src/components/layout/workbenchPaneStack.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.tsx
@@ -1,6 +1,7 @@
-/* eslint-disable react-hooks/refs -- Inactive workbench panes are intentionally cached in refs so their local UI state survives pane switches. */
+/* eslint-disable react-hooks/refs -- Inactive workbench panes are intentionally cached in refs so Activity can restore their UI state. */
 /* eslint-disable react-refresh/only-export-components -- The stack exports pane identity helpers used by layout modules. */
 import {
+  Activity,
   createContext,
   memo,
   useContext,
@@ -63,6 +64,7 @@ interface CachedWorkbenchPaneStackProps {
   prunedKeys?: string[]
   className?: string
   activeTestId?: string
+  onPrunedKeys?: (keys: string[]) => void
   renderPane: (pane: WorkbenchPaneIdentity) => ReactNode
 }
 
@@ -73,6 +75,7 @@ export function CachedWorkbenchPaneStack({
   prunedKeys = [],
   className,
   activeTestId,
+  onPrunedKeys,
   renderPane,
 }: CachedWorkbenchPaneStackProps) {
   const activeKey = getWorkbenchPaneKey(activePane)
@@ -84,6 +87,7 @@ export function CachedWorkbenchPaneStack({
   const paneCacheRef = useRef<Map<string, WorkbenchPaneIdentity>>(new Map())
   const [cachedKeys, setCachedKeys] = useState<string[]>(() => [activeKey])
   const cachedKeysRef = useRef<string[]>(cachedKeys)
+  const previousCachedKeysRef = useRef<string[]>(cachedKeys)
   const recentKeysRef = useRef<string[]>([activeKey])
   cachedKeysRef.current = cachedKeys
 
@@ -118,6 +122,15 @@ export function CachedWorkbenchPaneStack({
     })
   }, [activeKey, maxPanes, pinnedKeySet, prunedKeySet])
 
+  useEffect(() => {
+    const previousKeys = previousCachedKeysRef.current
+    const removedKeys = previousKeys.filter(key => !cachedKeys.includes(key))
+    previousCachedKeysRef.current = cachedKeys
+    if (removedKeys.length > 0) {
+      onPrunedKeys?.(removedKeys)
+    }
+  }, [cachedKeys, onPrunedKeys])
+
   const renderKeys = getStableCachedPaneKeys(
     cachedKeys.filter(key => !prunedKeySet.has(key)),
     activeKey,
@@ -139,12 +152,11 @@ export function CachedWorkbenchPaneStack({
               data-active-workbench-pane={active ? 'true' : 'false'}
               data-testid={active ? activeTestId : undefined}
               aria-hidden={!active}
-              className={cn(
-                'absolute inset-0 min-w-0 overflow-hidden',
-                active ? 'visible z-10' : 'invisible pointer-events-none z-0'
-              )}
+              className={cn('absolute inset-0 min-w-0 overflow-hidden', active ? 'z-10' : 'z-0')}
             >
-              <CachedWorkbenchPane pane={pane} renderPane={renderPane} />
+              <Activity mode={active ? 'visible' : 'hidden'}>
+                <CachedWorkbenchPane pane={pane} renderPane={renderPane} />
+              </Activity>
             </div>
           </WorkbenchPaneActiveContext.Provider>
         )

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -1,5 +1,5 @@
 import { SquareTerminal, X } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
@@ -25,6 +25,7 @@ interface BottomWorkspacePanelProps {
   preferLocalTerminal?: boolean
   onRequestClose: () => void
   onTerminalTabsEmpty?: () => void
+  onLocalTerminalSessionsChange?: (sessionIds: string[]) => void
 }
 
 function createTerminalTab(index: number): BottomWorkspacePanelTab {
@@ -42,12 +43,14 @@ export function BottomWorkspacePanel({
   preferLocalTerminal = false,
   onRequestClose,
   onTerminalTabsEmpty,
+  onLocalTerminalSessionsChange,
 }: BottomWorkspacePanelProps) {
   const { t } = useTranslation('common')
   const { height, handleResizeStart } = useResizableBottomPanel()
   const terminalSequenceRef = useRef(2)
   const [tabs, setTabs] = useState<BottomWorkspacePanelTab[]>(() => [createTerminalTab(1)])
   const [activeTabId, setActiveTabId] = useState('terminal-1')
+  const localTerminalSessionsByTabRef = useRef(new Map<string, string[]>())
   const activeTab = tabs.find(tab => tab.id === activeTabId) ?? tabs[0] ?? null
   const renderContent = open || preserveContent
   const panelActive = active && open
@@ -75,6 +78,10 @@ export function BottomWorkspacePanel({
     const nextTabs = tabs.filter(tab => tab.id !== tabId)
 
     setTabs(nextTabs)
+    localTerminalSessionsByTabRef.current.delete(tabId)
+    onLocalTerminalSessionsChange?.(
+      Array.from(localTerminalSessionsByTabRef.current.values()).flat()
+    )
 
     if (nextTabs.length === 0) {
       setActiveTabId('')
@@ -100,6 +107,20 @@ export function BottomWorkspacePanel({
       return current.map(item => (item.id === tabId ? { ...item, title: normalizedTitle } : item))
     })
   }
+
+  const updateLocalTerminalSessions = useCallback(
+    (tabId: string, sessionIds: string[]) => {
+      if (sessionIds.length > 0) {
+        localTerminalSessionsByTabRef.current.set(tabId, sessionIds)
+      } else {
+        localTerminalSessionsByTabRef.current.delete(tabId)
+      }
+      onLocalTerminalSessionsChange?.(
+        Array.from(localTerminalSessionsByTabRef.current.values()).flat()
+      )
+    },
+    [onLocalTerminalSessionsChange]
+  )
 
   const menuItems: WorkspaceAddMenuItem[] = [
     {
@@ -183,6 +204,9 @@ export function BottomWorkspacePanel({
                   panelActive={panelActive}
                   testIdsEnabled={contentTestIdsEnabled}
                   onTerminalTitleChange={title => updateTabTitle(tab.id, title)}
+                  onLocalTerminalSessionsChange={sessionIds =>
+                    updateLocalTerminalSessions(tab.id, sessionIds)
+                  }
                 />
               </div>
             ))}

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/xterm-theme'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
 import { createXtermWebLinksAddon } from './xtermLinks'
+import { appendTerminalOutput, readTerminalOutput } from './terminalOutputBuffer'
 
 interface EmbeddedLocalTerminalProps {
   sessionId: string
@@ -84,6 +85,10 @@ export function EmbeddedLocalTerminal({
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(webLinksAddon)
     terminal.open(container)
+    const bufferedOutput = readTerminalOutput(sessionId)
+    if (bufferedOutput) {
+      terminal.write(bufferedOutput)
+    }
     inputFallback = installXtermInputFallback({
       terminal,
       writeData: data => {
@@ -125,6 +130,7 @@ export function EmbeddedLocalTerminal({
 
     void listenLocalTerminalOutput(payload => {
       if (!disposed && payload.session_id === sessionId) {
+        appendTerminalOutput(sessionId, payload.data)
         terminal.write(payload.data)
         scheduleThemeSync()
       }

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/xterm-theme'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
+import { appendTerminalOutput, readTerminalOutput } from './terminalOutputBuffer'
 
 interface RemoteTerminalProps {
   sessionId: string
@@ -81,6 +82,7 @@ export function RemoteTerminal({
     })
     const unsubscribeOutput = client.onOutput(payload => {
       if (!disposed && payload.session_id === sessionId) {
+        appendTerminalOutput(sessionId, payload.data)
         terminal.write(payload.data)
         scheduleThemeSync()
       }
@@ -97,6 +99,10 @@ export function RemoteTerminal({
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(webLinksAddon)
     terminal.open(container)
+    const bufferedOutput = readTerminalOutput(sessionId)
+    if (bufferedOutput) {
+      terminal.write(bufferedOutput)
+    }
     inputFallback = installXtermInputFallback({
       terminal,
       writeData: data => {

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -35,6 +35,12 @@ import { WorkspaceAddMenu, type WorkspaceAddMenuItem } from './WorkspaceAddMenu'
 import { WorkspaceBrowserPanel } from './WorkspaceBrowserPanel'
 import { WorkspacePanelCards } from './WorkspacePanelCards'
 import { TemporaryChatPanel } from './TemporaryChatPanel'
+import {
+  getRightWorkspaceChatTabSuffix,
+  isRightWorkspaceChatTab,
+  type RightWorkspacePanelTab,
+  type RightWorkspacePanelView,
+} from './rightWorkspacePanelTypes'
 
 const RIGHT_WORKSPACE_SHORTCUTS = {
   review: '⌥⌘R',
@@ -42,24 +48,6 @@ const RIGHT_WORKSPACE_SHORTCUTS = {
   chat: '⌥⌘S',
   files: '⌥⌘F',
 } as const
-
-export type RightWorkspaceChatTab = `chat:${string}`
-export type RightWorkspacePanelTab =
-  | 'review'
-  | 'terminal'
-  | 'browser'
-  | 'files'
-  | 'plan'
-  | RightWorkspaceChatTab
-export type RightWorkspacePanelView = 'launcher' | RightWorkspacePanelTab
-
-function isRightWorkspaceChatTab(tab: RightWorkspacePanelView): tab is RightWorkspaceChatTab {
-  return tab.startsWith('chat:')
-}
-
-function getRightWorkspaceChatTabSuffix(tab: RightWorkspaceChatTab) {
-  return tab.slice('chat:'.length)
-}
 
 interface RightWorkspaceReviewState {
   loading: boolean

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { WorkbenchPaneContextValue } from '@/features/workbench/workbenchContextTypes'
+import type { RuntimeTaskAddress } from '@/types/api'
+import { TemporaryChatPanel } from './TemporaryChatPanel'
+import { disposeTemporaryChatPanel } from './temporaryChatPanelLifecycle'
+
+const workbenchPaneContextMock = vi.hoisted(() => ({
+  value: null as WorkbenchPaneContextValue | null,
+}))
+
+vi.mock('@/features/workbench/useWorkbench', () => ({
+  useWorkbenchPaneContext: () => {
+    if (!workbenchPaneContextMock.value) {
+      throw new Error('Missing workbench pane context mock')
+    }
+    return workbenchPaneContextMock.value
+  },
+}))
+
+vi.mock('@/components/chat/ScrollableMessageArea', () => ({
+  ScrollableMessageArea: ({ messages }: { messages: { content: string }[] }) => (
+    <div data-testid="mock-scrollable-message-area">
+      {messages.map(message => (
+        <div key={message.content}>{message.content}</div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/layout/BufferedChatInput', () => ({
+  BufferedChatInput: ({
+    value,
+    onChange,
+    onSubmit,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    onSubmit: (value?: string) => void
+  }) => (
+    <form
+      onSubmit={event => {
+        event.preventDefault()
+        onSubmit(value)
+      }}
+    >
+      <input
+        data-testid="temporary-chat-input"
+        value={value}
+        onChange={event => onChange(event.target.value)}
+      />
+      <button data-testid="temporary-chat-submit-button" type="submit">
+        Send
+      </button>
+    </form>
+  ),
+}))
+
+function createMockContext(address: RuntimeTaskAddress, unsubscribe: () => void) {
+  return {
+    state: { devices: [] },
+    projectChat: {
+      attachments: [],
+      resetAttachments: vi.fn(),
+      selectedModel: null,
+      selectedModelOptions: {},
+    },
+    createTemporaryRuntimeTask: vi.fn().mockResolvedValue(address),
+    sendRuntimePaneMessage: vi.fn().mockResolvedValue(true),
+    cancelRuntimePaneTask: vi.fn().mockResolvedValue(true),
+    subscribeRuntimeTaskStream: vi.fn(() => unsubscribe),
+    loadRuntimeTranscriptForPane: vi.fn().mockResolvedValue({ messages: [] }),
+  } as unknown as WorkbenchPaneContextValue
+}
+
+describe('TemporaryChatPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    workbenchPaneContextMock.value = null
+    disposeTemporaryChatPanel('chat:test')
+  })
+
+  test('keeps the runtime stream subscription when the panel unmounts', async () => {
+    const unsubscribe = vi.fn()
+    const address = {
+      deviceId: 'local-device',
+      taskId: 'temporary-task',
+      workspacePath: '/tmp/workspace',
+    }
+    const context = createMockContext(address, unsubscribe)
+    workbenchPaneContextMock.value = context
+
+    const { unmount } = render(
+      <TemporaryChatPanel currentProject={null} source={address} instanceId="chat:test" />
+    )
+
+    fireEvent.change(screen.getByTestId('temporary-chat-input'), {
+      target: { value: '你好' },
+    })
+    fireEvent.click(screen.getByTestId('temporary-chat-submit-button'))
+
+    await waitFor(() => {
+      expect(context.subscribeRuntimeTaskStream).toHaveBeenCalledWith(
+        address,
+        expect.objectContaining({
+          onMessageAction: expect.any(Function),
+        })
+      )
+    })
+
+    unmount()
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    disposeTemporaryChatPanel('chat:test')
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -14,6 +14,11 @@ import type {
 } from '@/types/api'
 import type { WorkbenchMessage } from '@/types/workbench'
 import { reduceWorkbenchMessages } from '@wegent/chat-core'
+import {
+  getTemporaryChatStreamSubscription,
+  setTemporaryChatStreamSubscription,
+  temporaryChatAddressKey,
+} from './temporaryChatPanelLifecycle'
 
 const SIDE_CHAT_MESSAGE_LIST_CLASS = 'w-full max-w-none px-5 pb-4 pt-5 lg:pl-14'
 
@@ -83,12 +88,27 @@ export function TemporaryChatPanel({
 
   useEffect(() => {
     if (!address) return
-    return subscribeRuntimeTaskStream(address, {
+    const addressKey = temporaryChatAddressKey(address)
+    const existingSubscription = getTemporaryChatStreamSubscription(instanceId)
+    if (
+      existingSubscription?.addressKey === addressKey &&
+      existingSubscription.subscribe === subscribeRuntimeTaskStream
+    ) {
+      return
+    }
+    existingSubscription?.unsubscribe()
+
+    const unsubscribe = subscribeRuntimeTaskStream(address, {
       onMessageAction: dispatchMessages,
       onAssistantStart: () => setSending(true),
       onAssistantSettled: () => setSending(false),
     })
-  }, [address, dispatchMessages, subscribeRuntimeTaskStream])
+    setTemporaryChatStreamSubscription(instanceId, {
+      addressKey,
+      subscribe: subscribeRuntimeTaskStream,
+      unsubscribe,
+    })
+  }, [address, dispatchMessages, instanceId, subscribeRuntimeTaskStream])
 
   const selectedModelFields = useMemo(() => {
     const selectedModel = projectChat.getSelectedModel?.() ?? projectChat.selectedModel

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -197,6 +197,23 @@ describe('WorkspaceBrowserPanel', () => {
     })
   })
 
+  test('keeps the native browser open when the panel unmounts', async () => {
+    mockBrowserHostRect()
+    const { unmount } = render(<WorkspaceBrowserPanel active />)
+
+    const input = screen.getByTestId('workspace-browser-url-input')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalled()
+    })
+
+    unmount()
+
+    expect(embeddedBrowserMocks.closeEmbeddedBrowser).not.toHaveBeenCalled()
+  })
+
   test('creates only a code comment context from a browser annotation', async () => {
     mockBrowserHostRect()
     const onAddCodeComment = vi.fn()

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -13,8 +13,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { FormEvent, ReactNode } from 'react'
 import {
   canUseEmbeddedBrowser,
-  closeEmbeddedBrowser,
-  consumeEmbeddedBrowserLabelTransfer,
   EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT,
   evalEmbeddedBrowser,
   evalEmbeddedBrowserJson,
@@ -709,11 +707,13 @@ export function WorkspaceBrowserPanel({
         }, EMBEDDED_BROWSER_READY_TIMEOUT_MS)
 
         const pageState = await openEmbeddedBrowser(currentUrl, bounds, label)
+        nativeBrowserOpenRef.current = true
         if (disposed) {
-          await closeEmbeddedBrowser(label).catch(() => undefined)
+          await setEmbeddedBrowserBounds({ x: 0, y: 0, width: 1, height: 1 }, false, label).catch(
+            () => undefined
+          )
           return
         }
-        nativeBrowserOpenRef.current = true
         updatePageUrl(pageState.url || currentUrl)
         schedulePostOpenBoundsSync(active)
         if (readyTimer !== null) window.clearTimeout(readyTimer)
@@ -917,14 +917,6 @@ export function WorkspaceBrowserPanel({
       window.clearInterval(intervalId)
     }
   }, [active, activePageUrl, annotationMode, embeddedBrowserAvailable, label, onAddCodeComment])
-
-  useEffect(() => {
-    return () => {
-      nativeBrowserOpenRef.current = false
-      if (consumeEmbeddedBrowserLabelTransfer(label)) return
-      void closeEmbeddedBrowser(label).catch(() => undefined)
-    }
-  }, [label])
 
   useEffect(() => {
     const handleDebugPanelVisibility = (event: Event) => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -475,15 +475,25 @@ describe('WorkspacePanelCards', () => {
     expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
   })
 
-  test('closes local terminal sessions when the workspace panel unmounts', async () => {
-    const { unmount } = render(<WorkspacePanelCards currentProject={project} devices={[]} />)
+  test('reports local terminal sessions and keeps them alive when the panel unmounts', async () => {
+    const onLocalTerminalSessionsChange = vi.fn()
+    const { unmount } = render(
+      <WorkspacePanelCards
+        currentProject={project}
+        devices={[]}
+        onLocalTerminalSessionsChange={onLocalTerminalSessionsChange}
+      />
+    )
 
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
     await waitFor(() => expect(startLocalTerminalMock).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(onLocalTerminalSessionsChange).toHaveBeenLastCalledWith(['local-terminal-1'])
+    )
 
     unmount()
 
-    expect(closeLocalTerminalMock).toHaveBeenCalledWith('local-terminal-1')
+    expect(closeLocalTerminalMock).not.toHaveBeenCalledWith('local-terminal-1')
   })
 
   test('closes local terminal sessions when the workspace target changes', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -30,6 +30,7 @@ import type { WorkspaceTarget } from '@/types/workspace-files'
 import { EmbeddedLocalTerminal } from './EmbeddedLocalTerminal'
 import { LocalWorkspaceOpenerIcon, LocalWorkspaceOpenerPicker } from './LocalWorkspaceOpenerMenu'
 import { RemoteTerminal } from './RemoteTerminal'
+import { clearTerminalOutput } from './terminalOutputBuffer'
 import { WorkspaceAddMenu, type WorkspaceAddMenuItem } from './WorkspaceAddMenu'
 
 interface WorkspacePanelCardsProps {
@@ -47,6 +48,7 @@ interface WorkspacePanelCardsProps {
   panelActive?: boolean
   testIdsEnabled?: boolean
   onTerminalTitleChange?: (title: string) => void
+  onLocalTerminalSessionsChange?: (sessionIds: string[]) => void
 }
 
 type WorkspaceTool = 'terminal' | 'ide' | 'desktop'
@@ -144,6 +146,7 @@ export function WorkspacePanelCards({
   panelActive = true,
   testIdsEnabled = true,
   onTerminalTitleChange,
+  onLocalTerminalSessionsChange,
 }: WorkspacePanelCardsProps) {
   const { t } = useTranslation('common')
   const testId = useCallback(
@@ -268,14 +271,12 @@ export function WorkspacePanelCards({
   }, [activeTerminalTitle, onTerminalTitleChange])
 
   useEffect(() => {
-    return () => {
-      terminalSessionsRef.current.forEach(session => {
-        if (session.terminal_kind === 'local') {
-          void closeLocalTerminal(session.session_id)
-        }
-      })
-    }
-  }, [])
+    onLocalTerminalSessionsChange?.(
+      terminalSessions
+        .filter(session => session.terminal_kind === 'local')
+        .map(session => session.session_id)
+    )
+  }, [onLocalTerminalSessionsChange, terminalSessions])
 
   useEffect(() => {
     if (terminalProjectKeyRef.current === null) {
@@ -519,11 +520,13 @@ export function WorkspacePanelCards({
     if (session?.terminal_kind === 'local') {
       void closeLocalTerminal(sessionId)
     }
+    clearTerminalOutput(sessionId)
 
     removeTerminalSession(sessionId)
   }
 
   const handleTerminalSessionExit = (sessionId: string) => {
+    clearTerminalOutput(sessionId)
     removeTerminalSession(sessionId)
   }
 

--- a/wework/src/components/layout/workspace-panels/rightWorkspacePanelTypes.ts
+++ b/wework/src/components/layout/workspace-panels/rightWorkspacePanelTypes.ts
@@ -1,0 +1,19 @@
+export type RightWorkspaceChatTab = `chat:${string}`
+export type RightWorkspacePanelTab =
+  | 'review'
+  | 'terminal'
+  | 'browser'
+  | 'files'
+  | 'plan'
+  | RightWorkspaceChatTab
+export type RightWorkspacePanelView = 'launcher' | RightWorkspacePanelTab
+
+export function isRightWorkspaceChatTab(
+  tab: RightWorkspacePanelView
+): tab is RightWorkspaceChatTab {
+  return tab.startsWith('chat:')
+}
+
+export function getRightWorkspaceChatTabSuffix(tab: RightWorkspaceChatTab) {
+  return tab.slice('chat:'.length)
+}

--- a/wework/src/components/layout/workspace-panels/temporaryChatPanelLifecycle.ts
+++ b/wework/src/components/layout/workspace-panels/temporaryChatPanelLifecycle.ts
@@ -1,0 +1,38 @@
+import type { WorkbenchPaneContextValue } from '@/features/workbench/workbenchContextTypes'
+import type { RuntimeTaskAddress } from '@/types/api'
+
+type RuntimeTaskStreamSubscriber = WorkbenchPaneContextValue['subscribeRuntimeTaskStream']
+
+const temporaryChatStreamSubscriptions = new Map<
+  string,
+  {
+    addressKey: string
+    subscribe: RuntimeTaskStreamSubscriber
+    unsubscribe: () => void
+  }
+>()
+
+export function disposeTemporaryChatPanel(instanceId: string) {
+  const subscription = temporaryChatStreamSubscriptions.get(instanceId)
+  subscription?.unsubscribe()
+  temporaryChatStreamSubscriptions.delete(instanceId)
+}
+
+export function getTemporaryChatStreamSubscription(instanceId: string) {
+  return temporaryChatStreamSubscriptions.get(instanceId)
+}
+
+export function setTemporaryChatStreamSubscription(
+  instanceId: string,
+  subscription: {
+    addressKey: string
+    subscribe: RuntimeTaskStreamSubscriber
+    unsubscribe: () => void
+  }
+) {
+  temporaryChatStreamSubscriptions.set(instanceId, subscription)
+}
+
+export function temporaryChatAddressKey(address: RuntimeTaskAddress) {
+  return `${address.deviceId}:${address.taskId}`
+}

--- a/wework/src/components/layout/workspace-panels/terminalOutputBuffer.test.ts
+++ b/wework/src/components/layout/workspace-panels/terminalOutputBuffer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import {
+  appendTerminalOutput,
+  clearTerminalOutput,
+  readTerminalOutput,
+} from './terminalOutputBuffer'
+
+describe('terminalOutputBuffer', () => {
+  test('replays and clears terminal output by session', () => {
+    clearTerminalOutput('session-a')
+    clearTerminalOutput('session-b')
+
+    appendTerminalOutput('session-a', 'hello')
+    appendTerminalOutput('session-a', ' world')
+    appendTerminalOutput('session-b', 'other')
+
+    expect(readTerminalOutput('session-a')).toBe('hello world')
+    expect(readTerminalOutput('session-b')).toBe('other')
+
+    clearTerminalOutput('session-a')
+
+    expect(readTerminalOutput('session-a')).toBe('')
+    expect(readTerminalOutput('session-b')).toBe('other')
+  })
+})

--- a/wework/src/components/layout/workspace-panels/terminalOutputBuffer.ts
+++ b/wework/src/components/layout/workspace-panels/terminalOutputBuffer.ts
@@ -1,0 +1,19 @@
+const MAX_TERMINAL_BUFFER_CHUNKS = 500
+const terminalOutputBuffers = new Map<string, string[]>()
+
+export function appendTerminalOutput(sessionId: string, data: string) {
+  const chunks = terminalOutputBuffers.get(sessionId) ?? []
+  chunks.push(data)
+  if (chunks.length > MAX_TERMINAL_BUFFER_CHUNKS) {
+    chunks.splice(0, chunks.length - MAX_TERMINAL_BUFFER_CHUNKS)
+  }
+  terminalOutputBuffers.set(sessionId, chunks)
+}
+
+export function readTerminalOutput(sessionId: string): string {
+  return terminalOutputBuffers.get(sessionId)?.join('') ?? ''
+}
+
+export function clearTerminalOutput(sessionId: string) {
+  terminalOutputBuffers.delete(sessionId)
+}

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createContext, StrictMode, useContext, useEffect, useMemo, useState } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
@@ -710,6 +710,20 @@ function RuntimePaneSendProbe() {
       <span data-testid="runtime-local-task-titles">
         {runtimeTasks.map(task => task.title).join('|')}
       </span>
+      <button
+        type="button"
+        onClick={() => {
+          const task = runtimeTasks[0]
+          if (!task) return
+          void workbench.openRuntimeTask({
+            deviceId: 'device-1',
+            taskId: task.taskId,
+            workspacePath: task.workspacePath,
+          })
+        }}
+      >
+        open first runtime task
+      </button>
       <CachedWorkbenchPaneStack
         activePane={{
           currentRuntimeTask: workbench.state.currentRuntimeTask,
@@ -717,10 +731,15 @@ function RuntimePaneSendProbe() {
           standaloneChatKey: workbench.state.standaloneChatKey,
         }}
         maxPanes={10}
+        activeTestId="active-runtime-pane"
         renderPane={pane => <RuntimePaneStackItem pane={pane} />}
       />
     </div>
   )
+}
+
+function activeRuntimePane() {
+  return within(screen.getByTestId('active-runtime-pane'))
 }
 
 function RuntimePaneStackItem({ pane }: { pane: WorkbenchPaneIdentity }) {
@@ -2654,9 +2673,9 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbench(<RuntimePaneSendProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
-    await userEvent.click(await screen.findByText('select mapped project workspace'))
-    await userEvent.click(screen.getByText('set pane input'))
-    await userEvent.click(screen.getByText('send pane input'))
+    await userEvent.click(activeRuntimePane().getByText('select mapped project workspace'))
+    await userEvent.click(activeRuntimePane().getByText('set pane input'))
+    await userEvent.click(activeRuntimePane().getByText('send pane input'))
 
     await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
     await waitFor(() =>
@@ -2664,7 +2683,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         'device-1:runtime-created:/workspace/project-alpha'
       )
     )
-    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+    expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
     expect(screen.getByTestId('runtime-local-task-count')).toHaveTextContent('1')
     expect(screen.getByTestId('runtime-local-task-titles')).toHaveTextContent('修复 CI')
   })
@@ -2714,14 +2733,14 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderStrictWorkbench(<RuntimePaneSendProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
-    await userEvent.click(await screen.findByText('select mapped project workspace'))
-    await userEvent.click(screen.getByText('set pane goal'))
-    expect(screen.getByTestId('pane-goal-draft-active')).toHaveTextContent('active')
-    await userEvent.click(screen.getByText('set pane input'))
-    await userEvent.click(screen.getByText('send pane input'))
+    await userEvent.click(activeRuntimePane().getByText('select mapped project workspace'))
+    await userEvent.click(activeRuntimePane().getByText('set pane goal'))
+    expect(activeRuntimePane().getByTestId('pane-goal-draft-active')).toHaveTextContent('active')
+    await userEvent.click(activeRuntimePane().getByText('set pane input'))
+    await userEvent.click(activeRuntimePane().getByText('send pane input'))
 
     await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
-    expect(screen.getByTestId('pane-goal-objective')).toHaveTextContent('修复 CI')
+    expect(activeRuntimePane().getByTestId('pane-goal-objective')).toHaveTextContent('修复 CI')
 
     const request = runtimeWorkApi.createRuntimeTask.mock.calls[0][0]
     await act(async () => {
@@ -2740,7 +2759,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         `device-1:${request.taskId}:/workspace/project-alpha`
       )
     )
-    expect(screen.getByTestId('pane-goal-objective')).toHaveTextContent('修复 CI')
+    expect(activeRuntimePane().getByTestId('pane-goal-objective')).toHaveTextContent('修复 CI')
   })
 
   test('keeps the sent user message when transcript loading effects replay', async () => {
@@ -2790,16 +2809,16 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderStrictWorkbench(<RuntimePaneSendProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
-    await userEvent.click(await screen.findByText('select mapped project workspace'))
-    await userEvent.click(screen.getByText('set pane input'))
-    await userEvent.click(screen.getByText('send pane input'))
+    await userEvent.click(activeRuntimePane().getByText('select mapped project workspace'))
+    await userEvent.click(activeRuntimePane().getByText('set pane input'))
+    await userEvent.click(activeRuntimePane().getByText('send pane input'))
 
     await waitFor(() =>
       expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
         'device-1:runtime-created:/workspace/project-alpha'
       )
     )
-    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+    expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
   })
 
   test('starts a fresh project pane after creating a runtime task in the same project', async () => {
@@ -2849,25 +2868,125 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbench(<RuntimePaneSendProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
-    await userEvent.click(await screen.findByText('select mapped project workspace'))
-    await userEvent.click(screen.getByText('set pane input'))
-    await userEvent.click(screen.getByText('send pane input'))
+    await userEvent.click(activeRuntimePane().getByText('select mapped project workspace'))
+    await userEvent.click(activeRuntimePane().getByText('set pane input'))
+    await userEvent.click(activeRuntimePane().getByText('send pane input'))
 
     await waitFor(() =>
       expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
         'device-1:runtime-created:/workspace/project-alpha'
       )
     )
-    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+    expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
 
-    await userEvent.click(screen.getByText('start new project task'))
+    await userEvent.click(activeRuntimePane().getByText('start new project task'))
 
     await waitFor(() =>
       expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent('none')
     )
-    expect(screen.getByTestId('active-pane-key')).toHaveTextContent('project:7')
-    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('')
-    expect(screen.getByTestId('pane-goal-draft-active')).toHaveTextContent('inactive')
+    expect(activeRuntimePane().getByTestId('active-pane-key')).toHaveTextContent('project:7')
+    expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent('')
+    expect(activeRuntimePane().getByTestId('pane-goal-draft-active')).toHaveTextContent('inactive')
+  })
+
+  test('keeps streaming inactive runtime pane content and shows it when reopened', async () => {
+    const streamHandlers: ChatStreamHandlers[] = []
+    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
+      streamHandlers.push(handlers)
+      return vi.fn(() => {
+        const index = streamHandlers.indexOf(handlers)
+        if (index >= 0) streamHandlers.splice(index, 1)
+      })
+    })
+    const initialRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              tasks: [],
+            },
+          ],
+          totalTasks: 0,
+        },
+      ],
+      chats: [],
+      totalTasks: 0,
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(initialRuntimeWork),
+      createRuntimeTask: vi.fn().mockResolvedValue({
+        accepted: true,
+        deviceId: 'device-1',
+        taskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+      }),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      chatStream: {
+        subscribe,
+      } as unknown as WorkbenchServices['chatStream'],
+    })
+
+    renderWorkbench(<RuntimePaneSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
+    await userEvent.click(activeRuntimePane().getByText('select mapped project workspace'))
+    await userEvent.click(activeRuntimePane().getByText('set pane input'))
+    await userEvent.click(activeRuntimePane().getByText('send pane input'))
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:runtime-created:/workspace/project-alpha'
+      )
+    )
+
+    await userEvent.click(activeRuntimePane().getByText('start new project task'))
+    await waitFor(() =>
+      expect(activeRuntimePane().getByTestId('active-pane-key')).toHaveTextContent('project:7')
+    )
+    await waitFor(() => expect(streamHandlers.some(handler => handler.onChatChunk)).toBe(true))
+
+    act(() => {
+      streamHandlers.forEach(handler => {
+        handler.onChatStart?.({
+          taskId: 'runtime-created',
+          subtaskId: 'inactive-subtask',
+          timestamp: Date.now(),
+          deviceId: 'device-1',
+        })
+        handler.onChatChunk?.({
+          taskId: 'runtime-created',
+          subtaskId: 'inactive-subtask',
+          content: 'inactive streamed answer',
+          offset: 0,
+          deviceId: 'device-1',
+        })
+      })
+    })
+
+    await userEvent.click(screen.getByText('open first runtime task'))
+
+    await waitFor(() =>
+      expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent(
+        'assistant:inactive streamed answer'
+      )
+    )
   })
 
   test('keeps streamed assistant content when the resolved address adds a workspace path', async () => {
@@ -2926,9 +3045,9 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbench(<RuntimePaneSendProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
-    await userEvent.click(await screen.findByText('select mapped project workspace'))
-    await userEvent.click(screen.getByText('set pane input'))
-    await userEvent.click(screen.getByText('send pane input'))
+    await userEvent.click(activeRuntimePane().getByText('select mapped project workspace'))
+    await userEvent.click(activeRuntimePane().getByText('set pane input'))
+    await userEvent.click(activeRuntimePane().getByText('send pane input'))
 
     await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
     const request = runtimeWorkApi.createRuntimeTask.mock.calls[0][0]
@@ -2952,7 +3071,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       })
     })
     await waitFor(() =>
-      expect(screen.getByTestId('pane-message-roles')).toHaveTextContent(
+      expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent(
         'assistant:streamed answer'
       )
     )
@@ -2973,8 +3092,10 @@ describe('WorkbenchProvider runtime tasks', () => {
         `device-1:${request.taskId}:/workspace/project-alpha`
       )
     )
-    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
-    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('assistant:streamed answer')
+    expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+    expect(activeRuntimePane().getByTestId('pane-message-roles')).toHaveTextContent(
+      'assistant:streamed answer'
+    )
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Migrates cached Wework pane switching to React `Activity` while keeping pane identity and pruning explicit.
- Moves long-lived resources out of Activity cleanup paths: runtime streams, temporary chat streams, embedded browser instances, and terminal sessions.
- Replays terminal output after Activity remounts and hides native embedded browsers on pane switches without closing them.
- Documents the temporary chat stream lifecycle in the Wework chat state source guide.

## Root Cause

The previous pane switch used CSS visibility, so hidden panes kept React effects mounted. After moving to Activity, inactive pane effects are paused. Resources that were incorrectly owned by component cleanup paths could unsubscribe, close, or lose display buffers while the pane was only inactive.

## Impact

Inactive panes now stop React-side effects while terminal/browser/stream resources that must survive pane switches are owned by explicit pane or tab lifecycle boundaries. Switching panes should preserve terminal content, embedded browser state, runtime streaming updates, and right-side temporary chat replies.

## Validation

- `pnpm --filter wework exec tsc --noEmit --pretty false`
- `pnpm --filter wework lint`
- `pnpm --filter wework test -- src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx src/components/layout/workspace-panels/terminalOutputBuffer.test.ts src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx src/features/workbench/WorkbenchProvider.test.tsx src/components/layout/workbenchPaneStack.test.tsx`
- Pre-push Wework gate: ESLint, TypeScript, and unit tests passed