### PR TITLE
fix(wework): hide embedded browser under overlays

### DIFF
--- a/wework/src/components/layout/workspace-panels/WorkspaceAddMenu.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceAddMenu.tsx
@@ -8,10 +8,12 @@ import {
   type ComponentType,
   type MouseEvent,
 } from 'react'
+import { setEmbeddedBrowserOcclusion } from '@/lib/embedded-browser'
 
 const MENU_GAP = 8
 const VIEWPORT_PADDING = 8
 const MENU_WIDTH = 240
+const EMBEDDED_BROWSER_OCCLUSION_ID = 'workspace-add-menu'
 
 export interface WorkspaceAddMenuItem {
   id: string
@@ -92,6 +94,7 @@ export function WorkspaceAddMenu({
   useEffect(() => {
     if (!open) return
 
+    setEmbeddedBrowserOcclusion(EMBEDDED_BROWSER_OCCLUSION_ID, true)
     const handlePointerDown = (event: globalThis.PointerEvent) => {
       const target = event.target as Node
       if (buttonRef.current?.contains(target) || menuRef.current?.contains(target)) {
@@ -110,6 +113,7 @@ export function WorkspaceAddMenu({
     document.addEventListener('pointerdown', handlePointerDown, true)
     document.addEventListener('keydown', handleKeyDown)
     return () => {
+      setEmbeddedBrowserOcclusion(EMBEDDED_BROWSER_OCCLUSION_ID, false)
       document.removeEventListener('pointerdown', handlePointerDown, true)
       document.removeEventListener('keydown', handleKeyDown)
     }

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -17,6 +17,7 @@ const embeddedBrowserMocks = vi.hoisted(() => ({
   reloadEmbeddedBrowser: vi.fn(),
   setEmbeddedBrowserBounds: vi.fn(),
   EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT: 'wework:debug-panel-visibility-change',
+  EMBEDDED_BROWSER_OCCLUSION_EVENT: 'wework:embedded-browser-occlusion-change',
 }))
 
 vi.mock('@/lib/embedded-browser', () => embeddedBrowserMocks)
@@ -192,6 +193,59 @@ describe('WorkspaceBrowserPanel', () => {
           height: 1,
         },
         false,
+        'workspace-browser'
+      )
+    })
+  })
+
+  test('hides the native browser while a main webview overlay occludes it', async () => {
+    mockBrowserHostRect()
+    render(<WorkspaceBrowserPanel active />)
+
+    const input = screen.getByTestId('workspace-browser-url-input')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalled()
+    })
+
+    embeddedBrowserMocks.setEmbeddedBrowserBounds.mockClear()
+    window.dispatchEvent(
+      new CustomEvent('wework:embedded-browser-occlusion-change', {
+        detail: { id: 'workspace-add-menu', occluded: true },
+      })
+    )
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenCalledWith(
+        {
+          x: 500,
+          y: 120,
+          width: 400,
+          height: 300,
+        },
+        false,
+        'workspace-browser'
+      )
+    })
+
+    embeddedBrowserMocks.setEmbeddedBrowserBounds.mockClear()
+    window.dispatchEvent(
+      new CustomEvent('wework:embedded-browser-occlusion-change', {
+        detail: { id: 'workspace-add-menu', occluded: false },
+      })
+    )
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenCalledWith(
+        {
+          x: 500,
+          y: 120,
+          width: 400,
+          height: 300,
+        },
+        true,
         'workspace-browser'
       )
     })

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -16,6 +16,7 @@ import {
   closeEmbeddedBrowser,
   consumeEmbeddedBrowserLabelTransfer,
   EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT,
+  EMBEDDED_BROWSER_OCCLUSION_EVENT,
   evalEmbeddedBrowser,
   evalEmbeddedBrowserJson,
   goBackEmbeddedBrowser,
@@ -26,6 +27,7 @@ import {
   reloadEmbeddedBrowser,
   setEmbeddedBrowserBounds,
   type EmbeddedBrowserBounds,
+  type EmbeddedBrowserOcclusionChange,
   type EmbeddedBrowserOpenRequest,
 } from '@/lib/embedded-browser'
 import { openExternalUrl } from '@/lib/external-links'
@@ -497,7 +499,7 @@ export function WorkspaceBrowserPanel({
   const syncBoundsAnimationFrameRef = useRef<number | null>(null)
   const postOpenSyncTimerRefs = useRef<number[]>([])
   const annotationEmptyPollLogCountRef = useRef(0)
-  const [debugPanelExpanded, setDebugPanelExpanded] = useState(false)
+  const [occludingOverlayIds, setOccludingOverlayIds] = useState<Set<string>>(() => new Set())
   const [address, setAddress] = useState('')
   const [currentUrl, setCurrentUrl] = useState<string | null>(null)
   const [pageUrl, setPageUrl] = useState<string | null>(null)
@@ -507,6 +509,7 @@ export function WorkspaceBrowserPanel({
   const [annotations, setAnnotations] = useState<BrowserAnnotation[]>([])
   const embeddedBrowserAvailable = canUseEmbeddedBrowser()
   const activePageUrl = pageUrl ?? currentUrl
+  const embeddedBrowserOccluded = occludingOverlayIds.size > 0
 
   const updatePageUrl = useCallback(
     (url: string | null) => {
@@ -541,9 +544,9 @@ export function WorkspaceBrowserPanel({
         }
         return
       }
-      await setEmbeddedBrowserBounds(bounds, visible && !debugPanelExpanded, label)
+      await setEmbeddedBrowserBounds(bounds, visible && !embeddedBrowserOccluded, label)
     },
-    [active, debugPanelExpanded, embeddedBrowserAvailable, label]
+    [active, embeddedBrowserAvailable, embeddedBrowserOccluded, label]
   )
 
   const hideEmbeddedBrowser = useCallback(async () => {
@@ -929,26 +932,51 @@ export function WorkspaceBrowserPanel({
   useEffect(() => {
     const handleDebugPanelVisibility = (event: Event) => {
       const expanded = Boolean((event as CustomEvent<{ expanded?: boolean }>).detail?.expanded)
-      setDebugPanelExpanded(expanded)
+      setOccludingOverlayIds(current => {
+        const next = new Set(current)
+        if (expanded) {
+          next.add('debug-panel')
+        } else {
+          next.delete('debug-panel')
+        }
+        return next
+      })
+    }
+
+    const handleBrowserOcclusion = (event: Event) => {
+      const detail = (event as CustomEvent<EmbeddedBrowserOcclusionChange>).detail
+      if (!detail?.id) return
+
+      setOccludingOverlayIds(current => {
+        const next = new Set(current)
+        if (detail.occluded) {
+          next.add(detail.id)
+        } else {
+          next.delete(detail.id)
+        }
+        return next
+      })
     }
 
     window.addEventListener(
       EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT,
       handleDebugPanelVisibility
     )
+    window.addEventListener(EMBEDDED_BROWSER_OCCLUSION_EVENT, handleBrowserOcclusion)
     return () => {
       window.removeEventListener(
         EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT,
         handleDebugPanelVisibility
       )
+      window.removeEventListener(EMBEDDED_BROWSER_OCCLUSION_EVENT, handleBrowserOcclusion)
     }
   }, [])
 
   useEffect(() => {
     void syncEmbeddedBrowserBounds(active).catch(error => {
-      console.error('Failed to sync embedded browser debug panel visibility:', error)
+      console.error('Failed to sync embedded browser occlusion visibility:', error)
     })
-  }, [active, debugPanelExpanded, syncEmbeddedBrowserBounds])
+  }, [active, embeddedBrowserOccluded, syncEmbeddedBrowserBounds])
 
   const runBrowserCommand = useCallback(
     async (command: () => Promise<void>) => {

--- a/wework/src/lib/developerCommandMenu.ts
+++ b/wework/src/lib/developerCommandMenu.ts
@@ -15,6 +15,7 @@ import {
   setPerformanceDiagnosticsEnabled,
 } from './performanceDiagnostics'
 import { isTauriRuntime } from './runtime-environment'
+import { setEmbeddedBrowserOcclusion } from './embedded-browser'
 
 const MENU_ID = 'wework-developer-command-menu'
 const DEBUG_PANEL_ID = 'wework-debug-panel'
@@ -23,6 +24,8 @@ const INSPECTOR_COMMAND = 'open_main_webview_devtools'
 const OPEN_LOG_DIRECTORY_COMMAND = 'open_app_log_directory'
 const CODEX_STREAM_DEBUG_GET_METHOD = 'runtime.codex.stream_debug.get'
 const CODEX_STREAM_DEBUG_SET_METHOD = 'runtime.codex.stream_debug.set'
+const DEVELOPER_COMMAND_MENU_OCCLUSION_ID = 'developer-command-menu'
+const DEBUG_PANEL_OCCLUSION_ID = 'debug-panel'
 
 interface DeveloperCommand {
   id: string
@@ -54,6 +57,7 @@ export function installDeveloperCommandMenu() {
 
 function openDeveloperCommandMenu() {
   closeDeveloperCommandMenu()
+  setEmbeddedBrowserOcclusion(DEVELOPER_COMMAND_MENU_OCCLUSION_ID, true)
 
   const overlay = document.createElement('div')
   overlay.id = MENU_ID
@@ -93,6 +97,7 @@ function openDeveloperCommandMenu() {
 
 function closeDeveloperCommandMenu() {
   document.getElementById(MENU_ID)?.remove()
+  setEmbeddedBrowserOcclusion(DEVELOPER_COMMAND_MENU_OCCLUSION_ID, false)
 }
 
 function handleMenuKeyDown(event: KeyboardEvent) {
@@ -346,6 +351,7 @@ function renderDebugPanelShell(root: HTMLElement, expanded: boolean) {
 }
 
 function emitDebugPanelVisibility(expanded: boolean) {
+  setEmbeddedBrowserOcclusion(DEBUG_PANEL_OCCLUSION_ID, expanded)
   window.dispatchEvent(
     new CustomEvent(DEBUG_PANEL_VISIBILITY_EVENT, {
       detail: { expanded },

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -10,6 +10,12 @@ let embeddedBrowserOpenRequestUnlisten: UnlistenFn | null = null
 let embeddedBrowserOpenRequestReleaseTimer: ReturnType<typeof setTimeout> | null = null
 export const EMBEDDED_BROWSER_OPEN_REQUEST_EVENT = 'wework:embedded-browser-open-request'
 export const EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT = 'wework:debug-panel-visibility-change'
+export const EMBEDDED_BROWSER_OCCLUSION_EVENT = 'wework:embedded-browser-occlusion-change'
+
+export interface EmbeddedBrowserOcclusionChange {
+  id: string
+  occluded: boolean
+}
 
 export interface EmbeddedBrowserBounds {
   x: number
@@ -36,6 +42,14 @@ interface EmbeddedBrowserEvalResult {
 
 export function canUseEmbeddedBrowser(): boolean {
   return isTauriRuntime()
+}
+
+export function setEmbeddedBrowserOcclusion(id: string, occluded: boolean): void {
+  window.dispatchEvent(
+    new CustomEvent<EmbeddedBrowserOcclusionChange>(EMBEDDED_BROWSER_OCCLUSION_EVENT, {
+      detail: { id, occluded },
+    })
+  )
 }
 
 function browserArgs(label = DEFAULT_BROWSER_LABEL) {


### PR DESCRIPTION
## What changed

- Added a shared embedded-browser occlusion event so main WebView overlays can temporarily hide the native browser child WebView.
- Updated the Wework browser panel to track multiple occluding overlay sources and restore the browser only when all are gone.
- Wired the right workspace add menu, developer command menu, and debug panel into the same occlusion path.
- Added coverage for hiding and restoring the native browser during overlay occlusion.

## Why

The embedded browser is a Tauri child WebView. On macOS/WebKit it is composited outside the React DOM stacking context, so DOM `z-index` cannot reliably place Wework menus or dialogs above it. Hiding the native WebView while a main-WebView overlay is active avoids browser content covering Wework UI.

## Validation

- `pnpm --filter wework test -- WorkspaceBrowserPanel.test.tsx`
- `pnpm --filter wework typecheck`
- Pre-push gate: ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The embedded browser now better adapts when overlay panels are open, helping keep content visible and correctly sized.
  * Added coordinated visibility handling for the Developer Command menu and Debug Panel.

* **Bug Fixes**
  * Improved embedded browser bounds updates so visibility changes are reflected more reliably when overlays appear or close.
  * Fixed occlusion handling across multiple UI panels to reduce display overlap issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->