### PR TITLE
fix(ci): reduce executor test disk usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,10 +66,18 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    env:
+      CARGO_PROFILE_TEST_DEBUG: 0
+      CARGO_TARGET_DIR: ${{ runner.temp }}/executor-target
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Free executor runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -85,10 +93,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            executor/target
-          key: ${{ runner.os }}-cargo-executor-${{ hashFiles('executor/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-executor-v2-${{ hashFiles('executor/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-executor-
+            ${{ runner.os }}-cargo-executor-v2-
 
       - name: Run executor Rust format check
         working-directory: ./executor


### PR DESCRIPTION
## Summary
- Free unused GitHub-hosted runner tool directories before the executor Rust job builds.
- Stop restoring `executor/target` from the Rust cache and move test build output to `${{ runner.temp }}`.
- Disable debug info for the Rust test profile in CI to reduce artifact size.

## Root Cause
The `Test Executor` job restored a Rust cache of about 2.5 GB that included `executor/target`, then `cargo test --all-features` exhausted the runner disk while compiling `wegent-executor` test binaries. The failing log reported `rustc-LLVM ERROR: IO failure on output stream: No space left on device`.

## Validation
- `cargo fmt --check`
- `cargo test --all-features`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the test workflow to better manage disk space during builds.
  * Updated test environment settings to help Rust tests run more reliably in CI.
  * Refined cache settings for executor test runs to speed up repeated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->