### PR TITLE
fix(wework): ignore stale runtime unread reminders

### DIFF
--- a/wework/src/features/workbench/runtimeTaskReminders.test.ts
+++ b/wework/src/features/workbench/runtimeTaskReminders.test.ts
@@ -7,6 +7,7 @@ import type {
 import {
   buildRuntimeTaskReminderSnapshot,
   getRuntimeTaskReminderItemKey,
+  reconcileRuntimeTaskUnreadKeys,
 } from './runtimeTaskReminders'
 
 function task(overrides: Partial<RuntimeTaskSummary>): RuntimeTaskSummary {
@@ -121,5 +122,24 @@ describe('runtimeTaskReminders', () => {
     })
 
     expect(snapshot.completedUnreadItems).toEqual([])
+  })
+
+  test('drops unread keys that are no longer present in runtime work', () => {
+    const completedTask = task({ running: false, status: 'done' })
+    const taskWorkspace = workspace([completedTask])
+    const visibleKey = getRuntimeTaskReminderItemKey(taskWorkspace, completedTask)
+
+    const snapshot = buildRuntimeTaskReminderSnapshot({
+      runtimeWork: runtimeWork([completedTask]),
+      previousRunningTaskKeys: new Set(),
+      currentRuntimeTask: null,
+    })
+    const nextUnreadTaskKeys = reconcileRuntimeTaskUnreadKeys({
+      previousUnreadTaskKeys: new Set(['stale-task-key', visibleKey]),
+      visibleTaskKeys: snapshot.taskKeys,
+      completedUnreadItems: snapshot.completedUnreadItems,
+    })
+
+    expect([...nextUnreadTaskKeys]).toEqual([visibleKey])
   })
 })

--- a/wework/src/features/workbench/runtimeTaskReminders.ts
+++ b/wework/src/features/workbench/runtimeTaskReminders.ts
@@ -46,6 +46,7 @@ export const EMPTY_RUNTIME_TASK_REMINDERS: RuntimeTaskReminderState = {
 
 interface RuntimeTaskReminderSnapshot {
   runningTaskKeys: Set<string>
+  taskKeys: Set<string>
   completedUnreadItems: RuntimeTaskReminderItem[]
   items: RuntimeTaskReminderItem[]
 }
@@ -252,6 +253,7 @@ export function buildRuntimeTaskReminderSnapshot({
   currentRuntimeTask?: RuntimeTaskAddress | null | undefined
 }): RuntimeTaskReminderSnapshot {
   const items = collectRuntimeTaskReminderItems(runtimeWork)
+  const taskKeys = new Set(items.map(item => item.key))
   const runningTaskKeys = new Set(
     items.filter(item => isRuntimeTaskActive(item.task)).map(item => item.key)
   )
@@ -270,7 +272,25 @@ export function buildRuntimeTaskReminderSnapshot({
     completedUnreadItems.push(item)
   }
 
-  return { runningTaskKeys, completedUnreadItems, items }
+  return { runningTaskKeys, taskKeys, completedUnreadItems, items }
+}
+
+export function reconcileRuntimeTaskUnreadKeys({
+  previousUnreadTaskKeys,
+  visibleTaskKeys,
+  completedUnreadItems,
+}: {
+  previousUnreadTaskKeys: ReadonlySet<string>
+  visibleTaskKeys: ReadonlySet<string>
+  completedUnreadItems: RuntimeTaskReminderItem[]
+}): Set<string> {
+  const nextUnreadTaskKeys = new Set(
+    [...previousUnreadTaskKeys].filter(key => visibleTaskKeys.has(key))
+  )
+  for (const item of completedUnreadItems) {
+    nextUnreadTaskKeys.add(item.key)
+  }
+  return nextUnreadTaskKeys
 }
 
 export function useRuntimeTaskReminders({
@@ -318,17 +338,23 @@ export function useRuntimeTaskReminders({
       }),
     [currentRuntimeTask, runningTaskKeys, runtimeWork]
   )
+  const visibleUnreadTaskKeys = useMemo(
+    () => new Set([...unreadTaskKeys].filter(key => snapshot.taskKeys.has(key))),
+    [snapshot.taskKeys, unreadTaskKeys]
+  )
 
   useEffect(() => {
     if (!runtimeWork) return
 
     const previousUnreadTaskKeys = readStoredStringSet(unreadTaskKeysStorageKey)
     const previousRunningTaskKeys = readStoredStringSet(runningTaskKeysStorageKey)
-    const nextUnreadTaskKeys = new Set(previousUnreadTaskKeys)
+    const nextUnreadTaskKeys = reconcileRuntimeTaskUnreadKeys({
+      previousUnreadTaskKeys,
+      visibleTaskKeys: snapshot.taskKeys,
+      completedUnreadItems: snapshot.completedUnreadItems,
+    })
     const completedUnreadItems = snapshot.completedUnreadItems.filter(item => {
-      if (nextUnreadTaskKeys.has(item.key)) return false
-      nextUnreadTaskKeys.add(item.key)
-      return true
+      return !previousUnreadTaskKeys.has(item.key)
     })
     const unreadChanged = !sameStringSet(previousUnreadTaskKeys, nextUnreadTaskKeys)
     const runningChanged = !sameStringSet(previousRunningTaskKeys, snapshot.runningTaskKeys)
@@ -394,8 +420,8 @@ export function useRuntimeTaskReminders({
 
   return useMemo(
     () => ({
-      unreadTaskKeys,
-      unreadCount: unreadTaskKeys.size,
+      unreadTaskKeys: visibleUnreadTaskKeys,
+      unreadCount: visibleUnreadTaskKeys.size,
       hasRunningTasks: snapshot.runningTaskKeys.size > 0,
       preferences,
       items: snapshot.items,
@@ -415,6 +441,6 @@ export function useRuntimeTaskReminders({
         emitStoredStringSetChange(unreadTaskKeysStorageKey)
       },
     }),
-    [preferences, snapshot, unreadTaskKeys, unreadTaskKeysStorageKey, userId]
+    [preferences, snapshot, unreadTaskKeysStorageKey, userId, visibleUnreadTaskKeys]
   )
 }


### PR DESCRIPTION
## Summary
- Filter runtime task unread reminders to tasks that still exist in the current runtime work list
- Reconcile persisted unread reminder keys when runtime work refreshes so stale completed-task reminders do not keep the tray badge stuck
- Add coverage for dropping stale unread keys

## Tests
- pnpm --filter wework test -- runtimeTaskReminders
- pnpm --filter wework typecheck
- pre-push Wework checks: ESLint, TypeScript, unit tests