### PR TITLE
fix(wework): update empty conversation copy

### DIFF
--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -710,7 +710,7 @@ function ScrollableMessagePaneContent({
                 <p className="mt-2 max-w-sm text-xs leading-5 text-text-muted">
                   {t(
                     'workbench.empty_conversation_description',
-                    '在下方输入问题、粘贴上下文或添加附件，Codex 会在这里展示回复。'
+                    '在下方输入问题、粘贴上下文或添加附件，WeWork 会在这里展示回复。'
                   )}
                 </p>
               </div>

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -502,7 +502,7 @@
     "load_older_messages": "Load older messages",
     "loading_older_messages": "Loading...",
     "empty_conversation_title": "Start a new conversation",
-    "empty_conversation_description": "Ask a question, paste context, or add attachments below. Codex responses will appear here.",
+    "empty_conversation_description": "Ask a question, paste context, or add attachments below. WeWork responses will appear here.",
     "account_fallback": "Current account",
     "personal_account": "Personal account",
     "remaining_usage": "Remaining usage",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -502,7 +502,7 @@
     "load_older_messages": "加载更早记录",
     "loading_older_messages": "正在加载...",
     "empty_conversation_title": "开始新的对话",
-    "empty_conversation_description": "在下方输入问题、粘贴上下文或添加附件，Codex 会在这里展示回复。",
+    "empty_conversation_description": "在下方输入问题、粘贴上下文或添加附件，WeWork 会在这里展示回复。",
     "account_fallback": "当前账号",
     "personal_account": "个人账户",
     "remaining_usage": "剩余用量",


### PR DESCRIPTION
## Summary
- Change the Wework empty conversation copy from Codex to WeWork in zh-CN and en locales
- Update the component fallback text to match the locale copy

## Tests
- pnpm --filter wework test -- ScrollableMessageArea.test.tsx
- pre-push Wework checks: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the empty-conversation message to consistently reference WeWork instead of Codex.
  - Applied the wording correction in both English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->