### PR TITLE
fix(wework): separate tool activity types

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -307,12 +307,13 @@ describe('ToolBlocksDisplay', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
 
-    const activityToggle = screen.getByRole('button', {
-      name: /已搜索代码 已运行 1 条命令/,
-    })
+    const activityToggles = screen.getAllByTestId('processing-activity-group-toggle')
+    expect(activityToggles).toHaveLength(2)
+    expect(activityToggles[0]).toHaveTextContent('已搜索代码')
+    expect(activityToggles[1]).toHaveTextContent('已运行 1 条命令')
     expect(screen.getByTestId('processing-activity-search-icon')).toBeInTheDocument()
 
-    fireEvent.click(activityToggle)
+    activityToggles.forEach(toggle => fireEvent.click(toggle))
 
     expect(screen.getByText('已运行 git diff --name-only')).toBeInTheDocument()
     expect(
@@ -358,12 +359,17 @@ describe('ToolBlocksDisplay', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
-    fireEvent.click(screen.getByRole('button', { name: /已读取 1 个文件 已搜索代码/ }))
+    const activityToggles = screen.getAllByTestId('processing-activity-group-toggle')
+    expect(activityToggles).toHaveLength(2)
+    expect(activityToggles[0]).toHaveTextContent('已搜索代码')
+    expect(activityToggles[1]).toHaveTextContent('已读取 1 个文件')
+    activityToggles.forEach(toggle => fireEvent.click(toggle))
 
-    const activityContent = screen.getByTestId('processing-activity-group-content')
-      .firstElementChild?.firstElementChild as HTMLElement
-    expect(activityContent).toHaveClass('mt-1.5', 'gap-1.5')
-    expect(activityContent).not.toHaveClass('border-l', 'pl-4', 'gap-3')
+    screen.getAllByTestId('processing-activity-group-content').forEach(content => {
+      const activityContent = content.firstElementChild?.firstElementChild as HTMLElement
+      expect(activityContent).toHaveClass('mt-1.5', 'gap-1.5')
+      expect(activityContent).not.toHaveClass('border-l', 'pl-4', 'gap-3')
+    })
     expect(screen.getByText('Searched for toolBlock in blocks')).toBeInTheDocument()
     expect(screen.getByText('Read toolBlockActivity.ts')).toBeInTheDocument()
     expect(screen.queryByText(/已运行 sed -n/)).not.toBeInTheDocument()
@@ -859,11 +865,12 @@ describe('ToolBlocksDisplay', () => {
       />
     )
 
-    const activityToggle = screen.getByRole('button', {
-      name: /已搜索代码 已运行 1 条命令/,
-    })
+    const activityToggles = screen.getAllByTestId('processing-activity-group-toggle')
 
-    expect(activityToggle).toHaveAttribute('aria-expanded', 'false')
+    expect(activityToggles).toHaveLength(2)
+    expect(activityToggles[0]).toHaveTextContent('已运行 1 条命令')
+    expect(activityToggles[1]).toHaveTextContent('已搜索代码')
+    activityToggles.forEach(toggle => expect(toggle).toHaveAttribute('aria-expanded', 'false'))
     expect(screen.queryByText(/已运行 \/bin\/zsh/)).not.toBeInTheDocument()
     expect(screen.getByText('正在运行 bin/paas-context --help')).toBeInTheDocument()
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -61,6 +61,22 @@ function fileChangesBlock(
 }
 
 describe('toolBlockActivity', () => {
+  test('groups consecutive completed tools by activity type', () => {
+    const rows = buildProcessingDisplayRows([
+      tool('read-1', "sed -n '1,5p' first.ts"),
+      tool('read-2', 'cat second.ts'),
+      tool('search-1', 'rg session_meta .'),
+      tool('cmd-1', 'node inspect.js'),
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows.map(row => (row.type === 'activity_group' ? row.label : ''))).toEqual([
+      '已读取 2 个文件',
+      '已搜索代码',
+      '已运行 1 条命令',
+    ])
+  })
+
   test('summarizes completed file, search, command, and failed command blocks', () => {
     expect(
       summarizeToolBlocks([

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -70,6 +70,17 @@ export function buildProcessingDisplayRows(
     completedTools = []
   }
 
+  const appendCompletedTool = (block: ToolBlock) => {
+    const previousBlock = completedTools.at(-1)
+    if (
+      previousBlock &&
+      getToolActivityGroupKey(previousBlock) !== getToolActivityGroupKey(block)
+    ) {
+      flushCompletedTools()
+    }
+    completedTools.push(block)
+  }
+
   const flushFileChanges = () => {
     if (consecutiveFileChanges.length === 0) return
     const block =
@@ -104,7 +115,7 @@ export function buildProcessingDisplayRows(
 
     if (groupCompletedTools && block.type === 'tool' && isCompletedToolBlock(block)) {
       flushFileChanges()
-      completedTools.push(block)
+      appendCompletedTool(block)
       continue
     }
 
@@ -116,6 +127,12 @@ export function buildProcessingDisplayRows(
   flushCompletedTools()
   flushFileChanges()
   return rows
+}
+
+function getToolActivityGroupKey(block: ToolBlock): string {
+  const name = block.toolName.toLowerCase()
+  if (isWebSearchToolName(name)) return 'web-search'
+  return getToolActivityKind(block)
 }
 
 function mergeConsecutiveFileChanges(blocks: FileChangesBlock[]): FileChangesBlock {


### PR DESCRIPTION
## What changed

- split completed Wework tool activities into separate rows when their activity types differ
- keep adjacent tools of the same activity type aggregated with a count
- keep web search activity separate from code search activity
- update activity rendering tests and add grouping coverage

## Why

Previously, file reads, code searches, and command executions could be combined into one summary row. This made different kinds of work harder to scan and caused the row icon to represent a mixed group.

## Impact

Wework now presents each tool activity type on its own row while preserving compact aggregation for consecutive tools of the same type.

## Validation

- Wework ESLint
- Wework TypeScript typecheck
- Wework unit tests
- focused tool activity tests: 46 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity grouping so consecutive completed actions are grouped by activity type.
  * Web searches now consistently appear in their own activity groups.
  * Updated activity controls and labels to accurately reflect separate groups.
  * Improved visual indicators and expanded/collapsed behavior for grouped activities.

* **Tests**
  * Added coverage for mixed activity sequences, grouping labels, icons, styling, and collapsed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->