### PR TITLE
fix(wework): preserve chat draft across settings

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2507,7 +2507,20 @@ describe('DesktopWorkbenchLayout', () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 
     expect(screen.getByTestId('wework-settings-page')).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: '我们该做什么？' })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '我们该做什么？', hidden: true })).not.toBeVisible()
+  })
+
+  test('preserves the composer while visiting settings', async () => {
+    render(<DesktopWorkbenchLayout {...baseProps} />)
+    const composerHeading = screen.getByRole('heading', { name: '我们该做什么？' })
+
+    await userEvent.click(screen.getByTestId('settings-button'))
+    await userEvent.click(screen.getByTestId('settings-menu-button'))
+    expect(composerHeading).not.toBeVisible()
+    await userEvent.click(screen.getByTestId('settings-back-button'))
+
+    expect(screen.getByRole('heading', { name: '我们该做什么？' })).toBe(composerHeading)
+    expect(composerHeading).toBeVisible()
   })
 
   test('closes the settings menu when clicking outside it', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -602,7 +602,7 @@ export function DesktopWorkbenchLayout() {
           </div>
         </>
       )}
-      {settingsOpen ? (
+      {settingsOpen && (
         <ConnectionsSettingsPage
           autoOpenAddCloudDeviceDialog={autoOpenAddCloudDeviceDialog}
           onBack={() => {
@@ -611,7 +611,8 @@ export function DesktopWorkbenchLayout() {
             navigateTo('/')
           }}
         />
-      ) : (
+      )}
+      <div style={{ display: settingsOpen ? 'none' : 'contents' }} aria-hidden={settingsOpen}>
         <DesktopWorkbenchMain
           sidebarCollapsed={effectiveSidebarCollapsed}
           sidebarResizing={sidebarResizing}
@@ -622,7 +623,7 @@ export function DesktopWorkbenchLayout() {
             standaloneChatKey: state.standaloneChatKey,
           }}
         />
-      )}
+      </div>
       <StandaloneBlankProjectDialog
         open={blankProjectDialogOpen}
         devices={state.devices}


### PR DESCRIPTION
## What changed

- Keep the desktop workbench mounted while the settings page is open.
- Hide the workbench with a layout-neutral `display: contents` wrapper rather than replacing it.
- Add regression coverage that verifies the composer remains the same mounted instance after returning from settings.

## Why

Opening settings previously unmounted `DesktopWorkbenchMain`. Recreating the composer and pane session could clear unsent input. An initial wrapper also changed the absolute-positioning layout and made the main workspace disappear; the final wrapper preserves the original layout.

## Impact

Unsent Wework chat text now remains available after opening settings and returning to the workbench, without affecting the desktop workspace layout.

## Validation

- Wework ESLint passed
- Wework TypeScript checks passed
- Wework unit tests passed
- `DesktopWorkbenchLayout.test.tsx`: 120 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the main workbench state when opening the settings page.
  - The composer is hidden while viewing settings and becomes visible again when returning, retaining its content and state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->