### PR TITLE
fix(wework): preserve workspace state across pages

### DIFF
--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -78,6 +78,12 @@ The right workspace **Temporary chat** feature starts a short side conversation 
 
 Maintenance rule: do not add UI fallbacks that insert temporary chats into the left task list, and do not fabricate rollout records for temporary threads in the executor. The primary path is `ephemeral + sideSource + direct_thread_id`.
 
+## Top-Level Page Transitions
+
+The workbench owns live state that cannot be serialized reliably, including composer drafts, Terminal sessions, and the in-app browser. When users move from the workbench to plugins, apps, or iframe apps, `AppRoutes` must keep `WorkbenchProvider` and `WorkbenchPage` mounted and only hide the workbench surface. Returning to the workbench then reuses the original component instances. A direct visit to an auxiliary page may defer the initial workbench mount to avoid creating unused background sessions.
+
+Do not unmount the workbench during route transitions, and do not add incomplete restoration fallbacks for Terminal or browser state. New top-level pages should join the auxiliary-page rendering branch without changing the workbench lifecycle.
+
 ## Audit Result
 
 - Desktop and mobile layouts no longer scan `messages` directly to decide whether the assistant is streaming; they read `paneSession.status.isAssistantStreaming`.

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -78,6 +78,12 @@ Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React st
 
 维护规则：不要用 fallback 在 UI 里把临时聊天补进左侧任务列表，也不要在 executor 中为临时线程伪造 rollout。临时聊天的主路径是 `ephemeral + sideSource + direct_thread_id`。
 
+## 顶层页面切换
+
+工作台包含输入草稿、Terminal 会话和内置浏览器等无法可靠序列化的实时状态。用户从工作台切换到插件、应用或 iframe 应用时，`AppRoutes` 必须保持 `WorkbenchProvider` 和 `WorkbenchPage` 挂载，只隐藏工作台表面；返回后继续使用原组件实例。直接打开辅助页面时可以延迟首次挂载工作台，避免创建没有使用过的后台会话。
+
+不要通过路由切换卸载工作台，也不要为 Terminal 或浏览器增加不完整的状态恢复 fallback。新增顶层页面时，应将它纳入辅助页面渲染分支，并保持工作台生命周期不变。
+
 ## 审核结果
 
 - 桌面和移动布局不再直接扫描 `messages` 判断是否 streaming，统一读取 `paneSession.status.isAssistantStreaming`。

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -599,6 +599,23 @@ describe('App plugins route', () => {
     expect(await screen.findByTestId('plugins-workspace')).toBeInTheDocument()
   })
 
+  test('preserves the workbench composer while visiting plugins', async () => {
+    window.history.pushState({}, '', '/')
+
+    render(<App />)
+
+    const composer = await screen.findByTestId('chat-message-input')
+    fireEvent.input(composer, { target: { textContent: '保留这段草稿' } })
+    await userEvent.click(screen.getByTestId('plugins-button'))
+    expect(await screen.findByTestId('plugins-workspace')).toBeInTheDocument()
+
+    window.history.pushState({}, '', '/')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    await waitFor(() => expect(window.location.pathname).toBe('/'))
+    expect(screen.getByTestId('chat-message-input')).toBe(composer)
+  })
+
   test('renders the plugins page on direct /plugins visit', async () => {
     window.history.pushState({}, '', '/plugins')
 

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -74,6 +74,14 @@ function AppRoutes({ onWorkbenchStartupReadyChange }: AppRoutesProps = {}) {
   const path = useCurrentPath()
   const { user, isLoading } = useAuth()
   const { activeTab, isNativeApp } = useChromeTabs(path)
+  const isAuxiliaryRoute =
+    (!isNativeApp && activeTab?.mode === 'iframe' && Boolean(activeTab.url)) ||
+    path === '/plugins/manage' ||
+    path === '/plugins/create' ||
+    path === '/plugins' ||
+    path === '/apps'
+  const [hasMountedWorkbench, setHasMountedWorkbench] = useState(() => !isAuxiliaryRoute)
+  if (!isAuxiliaryRoute && !hasMountedWorkbench) setHasMountedWorkbench(true)
 
   useEffect(() => {
     if (isLoading || !user || isNativeApp || !activeTab?.url) return
@@ -92,25 +100,32 @@ function AppRoutes({ onWorkbenchStartupReadyChange }: AppRoutesProps = {}) {
     return null
   }
 
-  // iframe-based apps (Wegent, etc.)
-  if (!isNativeApp && activeTab?.mode === 'iframe' && activeTab.url) {
-    return <AppIframe src={activeTab.url} title={activeTab.label} />
-  }
-
-  // native WeWork routes
+  const auxiliaryPage =
+    !isNativeApp && activeTab?.mode === 'iframe' && activeTab.url ? (
+      <AppIframe src={activeTab.url} title={activeTab.label} />
+    ) : path === '/plugins/manage' ? (
+      <PluginManagementPage />
+    ) : path === '/plugins/create' ? (
+      <PluginCreatePage />
+    ) : path === '/plugins' ? (
+      <PluginsPage />
+    ) : path === '/apps' ? (
+      <AppsPage />
+    ) : null
+  // Keep the workbench mounted while another top-level surface is visible. The
+  // composer, terminals and in-app browser own live, non-serializable state, so
+  // reconstructing them after every route change is both lossy and expensive.
   return (
     <WorkbenchProvider user={user} onStartupReadyChange={onWorkbenchStartupReadyChange}>
-      {path === '/plugins/manage' ? (
-        <PluginManagementPage />
-      ) : path === '/plugins/create' ? (
-        <PluginCreatePage />
-      ) : path === '/plugins' ? (
-        <PluginsPage />
-      ) : path === '/apps' ? (
-        <AppsPage />
-      ) : (
-        <WorkbenchPage />
+      {(!auxiliaryPage || hasMountedWorkbench) && (
+        <div
+          className={cn('h-full', auxiliaryPage && 'hidden')}
+          aria-hidden={Boolean(auxiliaryPage)}
+        >
+          <WorkbenchPage />
+        </div>
       )}
+      {auxiliaryPage}
     </WorkbenchProvider>
   )
 }


### PR DESCRIPTION
## What changed

- keep the Wework workbench mounted while plugins, apps, or iframe apps are displayed
- defer the initial workbench mount for direct auxiliary-page visits
- add a regression test that verifies the composer DOM instance survives a plugin-page round trip
- document the top-level page lifecycle in both Chinese and English

## Why

Top-level route switches previously unmounted `WorkbenchPage`. This destroyed live, non-serializable state owned by the composer, Terminal sessions, and the in-app browser.

## Impact

Users can switch between Wework pages without losing drafts, Terminal sessions, browser state, or other live workbench content.

## Validation

- pre-push ESLint passed
- pre-push TypeScript checks passed
- pre-push Wework unit tests passed
- targeted plugin/app route tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for switching between the workbench and auxiliary pages while preserving live workbench state.
  * Returning to the workbench now retains existing composer and workspace instances.
  * Auxiliary pages, including plugins, apps, and embedded content, are displayed without disrupting workbench activity.

* **Documentation**
  * Documented top-level page transition and state-preservation behavior in English and Chinese developer guides.

* **Tests**
  * Added coverage verifying composer state persists when navigating to plugins and back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->