### PR TITLE
fix(wework): sync hast lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,9 +623,6 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
-      hast:
-        specifier: ^1.0.0
-        version: 1.0.0
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
@@ -5166,10 +5163,6 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  hast@1.0.0:
-    resolution: {integrity: sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==}
-    deprecated: Renamed to rehype
 
   hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
@@ -13196,8 +13189,6 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  hast@1.0.0: {}
 
   hastscript@6.0.0:
     dependencies:


### PR DESCRIPTION
## What changed

- Remove the stale direct `hast@1.0.0` entry from the Wework lockfile importer.
- Remove the now-unreferenced package and snapshot records.

## Why

PR #1860 added `hast` to `pnpm-lock.yaml`, but `wework/package.json` does not declare it. GitHub Actions therefore rejects the lockfile during `pnpm install --frozen-lockfile` for both macOS architectures.

## Impact

Restores deterministic dependency installation for the Wework macOS release workflow without reintroducing the deprecated `hast` package.

## Validation

- `git diff --check`
- `pnpm install --frozen-lockfile`
