### PR TITLE
fix(wework): declare hast type dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.2

--- a/wework/package.json
+++ b/wework/package.json
@@ -67,6 +67,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/hast": "^3.0.4",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## What changed

- Declare `@types/hast` as a direct Wework development dependency.
- Sync the Wework importer in `pnpm-lock.yaml`.

## Root cause

`AssistantMarkdown.tsx` imports `Element` from the `hast` type declarations. The previous fix correctly removed the deprecated runtime `hast` package, but did not declare `@types/hast` directly in the Wework workspace. pnpm therefore did not link the declaration package for Wework, causing `tsc -b` to fail with TS2307 during the release build.

## Impact

Both frozen dependency installation and the Wework production build now succeed without adding the deprecated runtime package.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter wework build`
- `pnpm --filter wework test -- --run` (145 files, 1421 tests)
- `pnpm --filter wework lint` (no errors)
- pre-push ESLint, TypeScript, and unit-test gates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added TypeScript type definitions to improve development-time support for HTML syntax tree handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->