### PR TITLE
fix(dev): isolate Cargo caches across worktrees

### DIFF
--- a/docs/en/developer-guide/setup.md
+++ b/docs/en/developer-guide/setup.md
@@ -255,13 +255,14 @@ pnpm --filter wecode-ai-assistant run start
 
 #### Wework and Local Rust Build Cache
 
-The Wework macOS development scripts configure shared Cargo target directories for Tauri and the local executor so multiple Git worktrees do not repeatedly rebuild the same dependencies from scratch:
+The Wework macOS development scripts isolate Cargo targets by Git worktree. This prevents Cargo's path-sensitive fingerprints and unhashed binaries from overwriting each other during parallel debugging. On the first `pnpm --dir wework run dev:mac`, the script installs `sccache` with Homebrew when it is missing, then reuses matching dependency and source compilation outputs across worktrees.
 
-- `pnpm --dir wework run dev:mac` and `pnpm --dir wework run build:mac` use `$XDG_CACHE_HOME/wegent/cargo-target/wework-src-tauri` by default, or `~/.cache/wegent/cargo-target/wework-src-tauri` when `XDG_CACHE_HOME` is not set.
-- The development executor sidecar and `executor/local.sh build` use the `executor` subdirectory under the same cache root by default.
-- Set `WEGENT_CARGO_TARGET_ROOT=/path/to/cache` to choose a different shared cache root.
-- Set `WEGENT_DISABLE_SHARED_CARGO_TARGET=1` to restore Cargo's default per-worktree `target/` behavior.
-- When `CARGO_TARGET_DIR` is set explicitly, the scripts respect that value and do not choose an automatic shared directory.
+- `pnpm --dir wework run dev:mac`, `pnpm --dir wework run build:mac`, the development executor sidecar, and `executor/local.sh build` use `$XDG_CACHE_HOME/wegent/cargo-target/<component>/worktrees/<worktree>`, or `~/.cache/wegent/cargo-target/...` when `XDG_CACHE_HOME` is not set.
+- When `sccache` is available, the scripts set `RUSTC_WRAPPER` automatically and disable Cargo incremental compilation, which is incompatible with shared compiler caching.
+- Set `WEGENT_CARGO_TARGET_ROOT=/path/to/cache` to choose another target cache root.
+- Set `WEGENT_DISABLE_SHARED_CARGO_TARGET=1` to use Cargo's repository-local default `target/`.
+- Set `WEGENT_DISABLE_SCCACHE=1` to skip automatic installation and disable `sccache`.
+- Explicit `CARGO_TARGET_DIR` and `RUSTC_WRAPPER` values are always preserved.
 
 ---
 

--- a/docs/zh/developer-guide/setup.md
+++ b/docs/zh/developer-guide/setup.md
@@ -255,13 +255,14 @@ pnpm --dir frontend run start
 
 #### Wework 与本地 Rust 构建缓存
 
-Wework macOS 开发脚本会为 Tauri 和本地 executor 配置共享 Cargo target 目录，避免多个 Git worktree 反复完整编译相同依赖：
+Wework macOS 开发脚本会隔离各 Git worktree 的 Cargo target，避免 Cargo 的路径相关 fingerprint 和未哈希二进制在并行调试时互相覆盖。首次运行 `pnpm --dir wework run dev:mac` 时，如果本机缺少 `sccache`，脚本会通过 Homebrew 自动安装；随后通过共享编译缓存复用不同 worktree 中相同的依赖和源码产物。
 
-- `pnpm --dir wework run dev:mac` 和 `pnpm --dir wework run build:mac` 默认使用 `$XDG_CACHE_HOME/wegent/cargo-target/wework-src-tauri`，未设置 `XDG_CACHE_HOME` 时使用 `~/.cache/wegent/cargo-target/wework-src-tauri`。
-- 开发模式的 executor sidecar 和 `executor/local.sh build` 默认使用同一缓存根下的 `executor` 子目录。
-- 如需指定其他缓存根目录，设置 `WEGENT_CARGO_TARGET_ROOT=/path/to/cache`。
-- 如需恢复 Cargo 默认的每个 worktree 独立 `target/`，设置 `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`。
-- 显式设置 `CARGO_TARGET_DIR` 时，脚本会尊重该值，不再自动选择共享目录。
+- `pnpm --dir wework run dev:mac`、`pnpm --dir wework run build:mac`、开发模式 executor sidecar 和 `executor/local.sh build` 都使用 `$XDG_CACHE_HOME/wegent/cargo-target/<组件>/worktrees/<worktree>`；未设置 `XDG_CACHE_HOME` 时使用 `~/.cache/wegent/cargo-target/...`。
+- 脚本检测到 `sccache` 后会自动设置 `RUSTC_WRAPPER`，并关闭与共享编译缓存不兼容的 Cargo incremental。
+- 如需指定其他 target 缓存根目录，设置 `WEGENT_CARGO_TARGET_ROOT=/path/to/cache`。
+- 如需使用仓库内 Cargo 默认的 `target/`，设置 `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`。
+- 如需跳过自动安装并禁用 `sccache`，设置 `WEGENT_DISABLE_SCCACHE=1`。
+- 显式设置 `CARGO_TARGET_DIR` 或 `RUSTC_WRAPPER` 时，脚本会尊重该值。
 
 ---
 

--- a/executor/local.sh
+++ b/executor/local.sh
@@ -41,9 +41,10 @@ Environment:
   WEGENT_FILE_EDIT_HOOK_COMMAND  Default: local file edit hook collector
   WEGENT_EXECUTOR_BINARY         Default: dist/wegent-executor
   CARGO_TARGET_DIR               Explicit Cargo target directory. Overrides auto cache.
-  WEGENT_CARGO_TARGET_ROOT       Shared Cargo target root for Wegent local builds.
+  WEGENT_CARGO_TARGET_ROOT       Root containing worktree-isolated Cargo targets.
   WEGENT_DISABLE_SHARED_CARGO_TARGET
                                   Set to 1 to keep Cargo's default per-worktree target.
+  WEGENT_DISABLE_SCCACHE         Set to 1 to disable automatic sccache detection.
 
 Examples:
   ./local.sh all

--- a/scripts/lib/cargo-cache.sh
+++ b/scripts/lib/cargo-cache.sh
@@ -1,13 +1,66 @@
 #!/usr/bin/env bash
 
-# Shared Cargo target directories for local worktrees.
+# Cargo build caches for local worktrees.
 #
-# Local scripts use a stable cache root so dependency artifacts can be reused
-# across git worktrees without committing machine-specific Cargo config.
+# Cargo target directories contain path-sensitive fingerprints and unhashed
+# binaries. Keep them isolated per worktree, while sccache (when installed)
+# shares compiler outputs safely across worktrees.
+
+wegent_cargo_cache_root() {
+  if [ -n "${WEGENT_CARGO_TARGET_ROOT:-}" ]; then
+    printf '%s\n' "${WEGENT_CARGO_TARGET_ROOT%/}"
+  elif [ -n "${XDG_CACHE_HOME:-}" ]; then
+    printf '%s\n' "${XDG_CACHE_HOME%/}/wegent/cargo-target"
+  elif [ -n "${HOME:-}" ]; then
+    printf '%s\n' "$HOME/.cache/wegent/cargo-target"
+  fi
+}
+
+wegent_worktree_cache_key() {
+  local project_dir="$1"
+  local canonical_dir=""
+  local directory_name=""
+  local checksum=""
+
+  canonical_dir="$(cd "$project_dir" 2>/dev/null && pwd -P)" || return 1
+  directory_name="$(basename "$canonical_dir" | tr -c '[:alnum:]._-\n' '_')"
+  checksum="$(printf '%s' "$canonical_dir" | cksum | awk '{print $1}')"
+  printf '%s-%s\n' "$directory_name" "$checksum"
+}
+
+configure_wegent_sccache() {
+  if [ "${WEGENT_DISABLE_SCCACHE:-0}" = "1" ] || [ -n "${RUSTC_WRAPPER:-}" ]; then
+    return 0
+  fi
+
+  if command -v sccache >/dev/null 2>&1; then
+    RUSTC_WRAPPER="$(command -v sccache)"
+    export RUSTC_WRAPPER
+    export CARGO_INCREMENTAL=0
+    export WEGENT_SCCACHE_AUTO=1
+  fi
+}
+
+install_wegent_sccache_with_homebrew() {
+  if [ "${WEGENT_DISABLE_SCCACHE:-0}" = "1" ] || command -v sccache >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Error: sccache is required for shared Rust compilation caching." >&2
+    echo "Install Homebrew or set WEGENT_DISABLE_SCCACHE=1 to continue without sccache." >&2
+    return 1
+  fi
+
+  echo "sccache is not installed; installing it with Homebrew..."
+  brew install sccache
+}
 
 configure_wegent_cargo_target_dir() {
   local project_dir="$1"
   local cache_name="$2"
+
+  configure_wegent_sccache
 
   if [ "${WEGENT_DISABLE_SHARED_CARGO_TARGET:-0}" = "1" ]; then
     return 0
@@ -18,17 +71,12 @@ configure_wegent_cargo_target_dir() {
   fi
 
   local cache_root=""
-  if [ -n "${WEGENT_CARGO_TARGET_ROOT:-}" ]; then
-    cache_root="${WEGENT_CARGO_TARGET_ROOT%/}"
-  elif [ -n "${XDG_CACHE_HOME:-}" ]; then
-    cache_root="${XDG_CACHE_HOME%/}/wegent/cargo-target"
-  elif [ -n "${HOME:-}" ]; then
-    cache_root="$HOME/.cache/wegent/cargo-target"
-  else
-    return 0
-  fi
+  local worktree_key=""
+  cache_root="$(wegent_cargo_cache_root)"
+  [ -n "$cache_root" ] || return 0
+  worktree_key="$(wegent_worktree_cache_key "$project_dir")" || return 0
 
-  export CARGO_TARGET_DIR="$cache_root/$cache_name"
+  export CARGO_TARGET_DIR="$cache_root/$cache_name/worktrees/$worktree_key"
   export WEGENT_CARGO_TARGET_DIR_AUTO=1
   mkdir -p "$CARGO_TARGET_DIR"
 }

--- a/scripts/tests/cargo-cache.test.sh
+++ b/scripts/tests/cargo-cache.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck source-path=SCRIPTDIR
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=../lib/cargo-cache.sh
+source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
+
+TEST_ROOT=""
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+test_worktree_target_isolation() {
+  local root="$1"
+  local first="$root/first/Wegent"
+  local second="$root/second/Wegent"
+  mkdir -p "$first" "$second"
+
+  local first_target
+  local second_target
+  first_target="$(HOME="$root/home" WEGENT_CARGO_TARGET_ROOT="$root/cache" bash -c '
+    source "$1"
+    configure_wegent_cargo_target_dir "$2" executor
+    printf "%s" "$CARGO_TARGET_DIR"
+  ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$first")"
+  second_target="$(HOME="$root/home" WEGENT_CARGO_TARGET_ROOT="$root/cache" bash -c '
+    source "$1"
+    configure_wegent_cargo_target_dir "$2" executor
+    printf "%s" "$CARGO_TARGET_DIR"
+  ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$second")"
+
+  [ "$first_target" != "$second_target" ] || fail "worktrees share a target directory"
+  [[ "$first_target" == "$root/cache/executor/worktrees/"* ]] || fail "unexpected target path"
+}
+
+test_explicit_target_is_preserved() {
+  local root="$1"
+  local actual
+  actual="$(CARGO_TARGET_DIR="$root/explicit" bash -c '
+    source "$1"
+    configure_wegent_cargo_target_dir "$2" executor
+    printf "%s" "$CARGO_TARGET_DIR"
+  ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$PROJECT_DIR")"
+  [ "$actual" = "$root/explicit" ] || fail "explicit CARGO_TARGET_DIR was replaced"
+}
+
+test_sccache_is_configured_when_available() {
+  local root="$1"
+  mkdir -p "$root/bin" "$root/project"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$root/bin/sccache"
+  chmod +x "$root/bin/sccache"
+
+  local actual
+  actual="$(PATH="$root/bin:$PATH" HOME="$root/home" bash -c '
+    source "$1"
+    configure_wegent_cargo_target_dir "$2" executor
+    printf "%s|%s|%s" "$RUSTC_WRAPPER" "$CARGO_INCREMENTAL" "$WEGENT_SCCACHE_AUTO"
+  ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$root/project")"
+  [ "$actual" = "$root/bin/sccache|0|1" ] || fail "sccache was not configured"
+}
+
+test_sccache_is_installed_with_homebrew() {
+  local root="$1"
+  mkdir -p "$root/brew-bin"
+  cat > "$root/brew-bin/brew" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$BREW_CALL_LOG"
+EOF
+  chmod +x "$root/brew-bin/brew"
+
+  BREW_CALL_LOG="$root/brew-call.log" PATH="$root/brew-bin:/usr/bin:/bin" \
+    install_wegent_sccache_with_homebrew >/dev/null
+  [ "$(cat "$root/brew-call.log")" = "install sccache" ] || fail "Homebrew was not invoked"
+}
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+
+main() {
+  TEST_ROOT="$(mktemp -d)"
+  trap cleanup EXIT
+  test_worktree_target_isolation "$TEST_ROOT"
+  test_explicit_target_is_preserved "$TEST_ROOT"
+  test_sccache_is_configured_when_available "$TEST_ROOT"
+  test_sccache_is_installed_with_homebrew "$TEST_ROOT"
+  echo "cargo-cache tests passed"
+}
+
+main "$@"

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -32,9 +32,11 @@ Environment:
   BACKEND_PORT          Backend port used when proxy targets are not set.
   CARGO_TARGET_DIR      Explicit Cargo target directory. Overrides auto cache.
   WEGENT_CARGO_TARGET_ROOT
-                        Shared Cargo target root for Wegent local builds.
+                        Root containing worktree-isolated Cargo targets.
   WEGENT_DISABLE_SHARED_CARGO_TARGET
                         Set to 1 to keep Cargo's default per-worktree target.
+  WEGENT_DISABLE_SCCACHE
+                        Set to 1 to disable automatic sccache detection.
   WEWORK_EXECUTOR_SIDECAR
                         Executor sidecar path. Defaults to source reload sidecar.
   WEGENT_EXECUTOR_DEV_RELOAD
@@ -181,6 +183,7 @@ else
   export VITE_SOCKET_PATH="${VITE_SOCKET_PATH:-/socket.io}"
   BEFORE_DEV_COMMAND="pnpm exec vite --host 0.0.0.0 --port $WEWORK_PORT --strictPort"
 fi
+install_wegent_sccache_with_homebrew
 configure_wegent_cargo_target_dir "$PROJECT_DIR" "wework-src-tauri"
 
 TAURI_DEV_CONFIG="$(mktemp -t wework-tauri-dev.XXXXXX.json)"


### PR DESCRIPTION
## What changed

- isolate Cargo target directories by Git worktree for Wework and executor local builds
- automatically configure shared `sccache` compiler caching across worktrees
- install `sccache` with Homebrew on the first `dev:mac` run, with an opt-out environment variable
- preserve explicit Cargo target and Rust compiler wrapper configuration
- add shell coverage for target isolation, explicit overrides, sccache setup, and Homebrew installation
- document the cache behavior in Chinese and English

## Why

Multiple runtime worktrees previously shared the same complete Cargo target directory. Cargo fingerprints include path-sensitive state, while top-level debug binaries are unhashed, so concurrent or alternating Wework debug sessions invalidated and overwrote each other's executor artifacts. This caused repeated executor compilation even when its source had not changed.

The new layout keeps Cargo state isolated per worktree while using `sccache` as the safe cross-worktree layer for identical compiler outputs.

## Validation

- `bash scripts/tests/cargo-cache.test.sh`
- `shellcheck -x scripts/lib/cargo-cache.sh scripts/tests/cargo-cache.test.sh`
- Wework ESLint, TypeScript, and unit tests via pre-push hook
- executor `cargo fmt --check`, `cargo test --all-features --lib`, and `cargo clippy` via pre-push hook
- successful Wework Tauri debug build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved local Rust build caching by isolating Cargo targets for each Git worktree.
  * Added automatic `sccache` detection and optional Homebrew installation on macOS.
  * Added environment variables to customize cache locations or disable shared caching and `sccache`.
  * Preserved explicitly configured Cargo target and compiler-wrapper settings.

* **Documentation**
  * Updated English and Chinese setup guides and command-line help with the new caching behavior and configuration options.

* **Tests**
  * Added coverage for worktree isolation, configuration overrides, and `sccache` setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->