### PR TITLE
fix(dev): normalize sccache paths across worktrees

### DIFF
--- a/docs/en/developer-guide/setup.md
+++ b/docs/en/developer-guide/setup.md
@@ -258,7 +258,7 @@ pnpm --filter wecode-ai-assistant run start
 The Wework macOS development scripts isolate Cargo targets by Git worktree. This prevents Cargo's path-sensitive fingerprints and unhashed binaries from overwriting each other during parallel debugging. On the first `pnpm --dir wework run dev:mac`, the script installs `sccache` with Homebrew when it is missing, then reuses matching dependency and source compilation outputs across worktrees.
 
 - `pnpm --dir wework run dev:mac`, `pnpm --dir wework run build:mac`, the development executor sidecar, and `executor/local.sh build` use `$XDG_CACHE_HOME/wegent/cargo-target/<component>/worktrees/<worktree>`, or `~/.cache/wegent/cargo-target/...` when `XDG_CACHE_HOME` is not set.
-- When `sccache` is available, the scripts set `RUSTC_WRAPPER` automatically and disable Cargo incremental compilation, which is incompatible with shared compiler caching.
+- When `sccache` is available, the scripts set `RUSTC_WRAPPER` and `SCCACHE_BASEDIRS` automatically, normalize source and target paths across worktrees, and disable Cargo incremental compilation, which is incompatible with shared compiler caching.
 - Set `WEGENT_CARGO_TARGET_ROOT=/path/to/cache` to choose another target cache root.
 - Set `WEGENT_DISABLE_SHARED_CARGO_TARGET=1` to use Cargo's repository-local default `target/`.
 - Set `WEGENT_DISABLE_SCCACHE=1` to skip automatic installation and disable `sccache`.

--- a/docs/zh/developer-guide/setup.md
+++ b/docs/zh/developer-guide/setup.md
@@ -258,7 +258,7 @@ pnpm --dir frontend run start
 Wework macOS 开发脚本会隔离各 Git worktree 的 Cargo target，避免 Cargo 的路径相关 fingerprint 和未哈希二进制在并行调试时互相覆盖。首次运行 `pnpm --dir wework run dev:mac` 时，如果本机缺少 `sccache`，脚本会通过 Homebrew 自动安装；随后通过共享编译缓存复用不同 worktree 中相同的依赖和源码产物。
 
 - `pnpm --dir wework run dev:mac`、`pnpm --dir wework run build:mac`、开发模式 executor sidecar 和 `executor/local.sh build` 都使用 `$XDG_CACHE_HOME/wegent/cargo-target/<组件>/worktrees/<worktree>`；未设置 `XDG_CACHE_HOME` 时使用 `~/.cache/wegent/cargo-target/...`。
-- 脚本检测到 `sccache` 后会自动设置 `RUSTC_WRAPPER`，并关闭与共享编译缓存不兼容的 Cargo incremental。
+- 脚本检测到 `sccache` 后会自动设置 `RUSTC_WRAPPER` 和 `SCCACHE_BASEDIRS`，归一化不同 worktree 的源码及 target 绝对路径，并关闭与共享编译缓存不兼容的 Cargo incremental。
 - 如需指定其他 target 缓存根目录，设置 `WEGENT_CARGO_TARGET_ROOT=/path/to/cache`。
 - 如需使用仓库内 Cargo 默认的 `target/`，设置 `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`。
 - 如需跳过自动安装并禁用 `sccache`，设置 `WEGENT_DISABLE_SCCACHE=1`。

--- a/scripts/lib/cargo-cache.sh
+++ b/scripts/lib/cargo-cache.sh
@@ -29,15 +29,28 @@ wegent_worktree_cache_key() {
 }
 
 configure_wegent_sccache() {
-  if [ "${WEGENT_DISABLE_SCCACHE:-0}" = "1" ] || [ -n "${RUSTC_WRAPPER:-}" ]; then
+  local project_dir="$1"
+  local target_dir="$2"
+  local canonical_project_dir=""
+
+  if [ "${WEGENT_DISABLE_SCCACHE:-0}" = "1" ]; then
+    return 0
+  fi
+
+  if [ -n "${RUSTC_WRAPPER:-}" ] && [ "${WEGENT_SCCACHE_AUTO:-0}" != "1" ]; then
     return 0
   fi
 
   if command -v sccache >/dev/null 2>&1; then
+    canonical_project_dir="$(cd "$project_dir" 2>/dev/null && pwd -P)" || return 1
     RUSTC_WRAPPER="$(command -v sccache)"
     export RUSTC_WRAPPER
     export CARGO_INCREMENTAL=0
     export WEGENT_SCCACHE_AUTO=1
+    if [ -z "${SCCACHE_BASEDIRS:-}" ] || [ "${WEGENT_SCCACHE_BASEDIRS_AUTO:-0}" = "1" ]; then
+      export SCCACHE_BASEDIRS="$canonical_project_dir:$target_dir"
+      export WEGENT_SCCACHE_BASEDIRS_AUTO=1
+    fi
   fi
 }
 
@@ -60,13 +73,13 @@ configure_wegent_cargo_target_dir() {
   local project_dir="$1"
   local cache_name="$2"
 
-  configure_wegent_sccache
-
   if [ "${WEGENT_DISABLE_SHARED_CARGO_TARGET:-0}" = "1" ]; then
+    configure_wegent_sccache "$project_dir" "$project_dir/target"
     return 0
   fi
 
   if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    configure_wegent_sccache "$project_dir" "$CARGO_TARGET_DIR"
     return 0
   fi
 
@@ -79,6 +92,7 @@ configure_wegent_cargo_target_dir() {
   export CARGO_TARGET_DIR="$cache_root/$cache_name/worktrees/$worktree_key"
   export WEGENT_CARGO_TARGET_DIR_AUTO=1
   mkdir -p "$CARGO_TARGET_DIR"
+  configure_wegent_sccache "$project_dir" "$CARGO_TARGET_DIR"
 }
 
 cargo_target_dir_for() {

--- a/scripts/tests/cargo-cache.test.sh
+++ b/scripts/tests/cargo-cache.test.sh
@@ -61,12 +61,15 @@ test_sccache_is_configured_when_available() {
   chmod +x "$root/bin/sccache"
 
   local actual
+  local canonical_project
+  canonical_project="$(cd "$root/project" && pwd -P)"
   actual="$(PATH="$root/bin:$PATH" HOME="$root/home" bash -c '
     source "$1"
     configure_wegent_cargo_target_dir "$2" executor
-    printf "%s|%s|%s" "$RUSTC_WRAPPER" "$CARGO_INCREMENTAL" "$WEGENT_SCCACHE_AUTO"
+    printf "%s|%s|%s|%s" "$RUSTC_WRAPPER" "$CARGO_INCREMENTAL" "$WEGENT_SCCACHE_AUTO" "$SCCACHE_BASEDIRS"
   ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$root/project")"
-  [ "$actual" = "$root/bin/sccache|0|1" ] || fail "sccache was not configured"
+  [ "$actual" = "$root/bin/sccache|0|1|$canonical_project:$root/home/.cache/wegent/cargo-target/executor/worktrees/project-$(printf '%s' "$canonical_project" | cksum | awk '{print $1}')" ] \
+    || fail "sccache was not configured with normalized paths: $actual"
 }
 
 test_sccache_is_installed_with_homebrew() {
@@ -83,6 +86,24 @@ EOF
   [ "$(cat "$root/brew-call.log")" = "install sccache" ] || fail "Homebrew was not invoked"
 }
 
+test_automatic_sccache_paths_follow_target_changes() {
+  local root="$1"
+  mkdir -p "$root/reconfigure-bin" "$root/reconfigure-project"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$root/reconfigure-bin/sccache"
+  chmod +x "$root/reconfigure-bin/sccache"
+
+  local actual
+  actual="$(PATH="$root/reconfigure-bin:$PATH" HOME="$root/home" bash -c '
+    source "$1"
+    CARGO_TARGET_DIR="$3/first"
+    configure_wegent_cargo_target_dir "$2" first
+    CARGO_TARGET_DIR="$3/second"
+    configure_wegent_cargo_target_dir "$2" second
+    printf "%s" "$SCCACHE_BASEDIRS"
+  ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$root/reconfigure-project" "$root")"
+  [[ "$actual" == *":$root/second" ]] || fail "automatic sccache paths were stale: $actual"
+}
+
 cleanup() {
   rm -rf "$TEST_ROOT"
 }
@@ -94,6 +115,7 @@ main() {
   test_explicit_target_is_preserved "$TEST_ROOT"
   test_sccache_is_configured_when_available "$TEST_ROOT"
   test_sccache_is_installed_with_homebrew "$TEST_ROOT"
+  test_automatic_sccache_paths_follow_target_changes "$TEST_ROOT"
   echo "cargo-cache tests passed"
 }
 


### PR DESCRIPTION
## What changed

- configure `SCCACHE_BASEDIRS` with normalized project and Cargo target roots
- refresh automatically managed base directories when Wework switches from the Tauri target to the executor sidecar target
- preserve explicitly configured compiler wrappers and sccache base directories
- add shell coverage for path normalization and target changes
- document the normalized cross-worktree cache behavior in Chinese and English

## Why

The worktree target isolation merged in #1864 prevents Cargo state corruption, but sccache requires absolute paths to match unless `SCCACHE_BASEDIRS` is configured. Runtime worktrees have different absolute source and target paths, so Rust compilation requests were correctly routed through sccache but recorded zero Rust cache hits.

This follow-up normalizes both path families so identical Rust inputs can be reused safely across worktrees.

## Validation

- `bash scripts/tests/cargo-cache.test.sh`
- `shellcheck -x scripts/lib/cargo-cache.sh scripts/tests/cargo-cache.test.sh`
- Wework ESLint, TypeScript, and unit tests via pre-push hook
- executor `cargo fmt --check`, `cargo test --all-features --lib`, and `cargo clippy` via pre-push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shared Rust build caching across worktrees by normalizing project and target paths.
  * Automatically updates cache paths when the Cargo target directory changes.
  * Provides more consistent `sccache` configuration while preserving existing user settings.

* **Documentation**
  * Updated English and Chinese setup guides to describe the enhanced `sccache` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->