### PR TITLE
fix(wework): preserve composer selection

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { describe, expect, test, vi } from 'vitest'
@@ -187,6 +187,68 @@ describe('ChatInput', () => {
     expect(screen.queryByTestId('skill-selector-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('project-work-button')).toBeInTheDocument()
     expect(screen.queryByTestId('voice-input-button')).not.toBeInTheDocument()
+  })
+
+  test('does not move selection when an unfocused composer syncs its value', async () => {
+    const renderComposers = (backgroundValue?: string) => (
+      <>
+        <ChatInput
+          value="foreground draft"
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          disabled={false}
+          variant="desktop"
+        />
+        {backgroundValue !== undefined ? (
+          <ChatInput
+            value={backgroundValue}
+            onChange={vi.fn()}
+            onSubmit={vi.fn()}
+            disabled={false}
+            variant="desktop"
+          />
+        ) : null}
+      </>
+    )
+    const { rerender } = render(renderComposers())
+    const foregroundComposer = screen.getByTestId('chat-message-input')
+    foregroundComposer.focus()
+    await waitFor(() => {
+      expect(foregroundComposer).toHaveFocus()
+      expect(foregroundComposer.contains(window.getSelection()?.anchorNode ?? null)).toBe(true)
+    })
+
+    const textNode = document.createTreeWalker(foregroundComposer, NodeFilter.SHOW_TEXT).nextNode()
+    expect(textNode).not.toBeNull()
+    const range = document.createRange()
+    range.setStart(textNode!, 5)
+    range.collapse(true)
+    const selection = window.getSelection()!
+    act(() => {
+      selection.removeAllRanges()
+      selection.addRange(range)
+      document.dispatchEvent(new Event('selectionchange'))
+    })
+
+    expect(foregroundComposer).toHaveFocus()
+    expect(foregroundComposer.contains(window.getSelection()?.anchorNode ?? null)).toBe(true)
+    expect(window.getSelection()?.anchorOffset).toBe(5)
+
+    rerender(renderComposers('background initial value'))
+
+    await waitFor(() => {
+      expect(foregroundComposer).toHaveFocus()
+      expect(foregroundComposer.contains(window.getSelection()?.anchorNode ?? null)).toBe(true)
+      expect(window.getSelection()?.anchorOffset).toBe(5)
+    })
+
+    rerender(renderComposers('background update'))
+
+    await waitFor(() => {
+      expect(foregroundComposer).toHaveFocus()
+      expect(foregroundComposer.contains(window.getSelection()?.anchorNode ?? null)).toBe(true)
+      expect(window.getSelection()?.anchorOffset).toBe(5)
+    })
   })
 
   test('selects plan mode from the add context menu', async () => {

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -1,5 +1,5 @@
 import { ClipboardList, Cpu, Package, Plug, Target } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { KeyboardEventHandler, RefObject } from 'react'
 import type { InitialConfigType } from '@lexical/react/LexicalComposer'
 import { LexicalComposer } from '@lexical/react/LexicalComposer'
@@ -9,6 +9,7 @@ import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
 import {
+  $addUpdateTag,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
   $getSelection,
@@ -22,6 +23,7 @@ import {
   DROP_COMMAND,
   PASTE_COMMAND,
   SELECTION_CHANGE_COMMAND,
+  SKIP_DOM_SELECTION_TAG,
   type LexicalEditor,
 } from 'lexical'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -427,16 +429,20 @@ function ComposerValuePlugin({
   useEffect(() => {
     if (isComposing) return
     if (value === lastEditorValueRef.current) return
+    const editorFocused = editor.getRootElement() === document.activeElement
 
-    editor.update(() => {
-      const currentValue = $getComposerValue()
-      if (currentValue === value) {
+    editor.update(
+      () => {
+        const currentValue = $getComposerValue()
+        if (currentValue === value) {
+          lastEditorValueRef.current = value
+          return
+        }
+        $setComposerValue(value, editorFocused ? value.length : undefined)
         lastEditorValueRef.current = value
-        return
-      }
-      $setComposerValue(value, value.length)
-      lastEditorValueRef.current = value
-    })
+      },
+      editorFocused ? undefined : { tag: SKIP_DOM_SELECTION_TAG }
+    )
   }, [editor, isComposing, value])
 
   return (
@@ -730,6 +736,9 @@ export function ComposerTextarea({
   const appsSourceRef = useRef<typeof onListLocalApps>(undefined)
   const mountedRef = useRef(true)
   const editorRef = useRef<LexicalEditor | null>(null)
+  const composerElementRef = useRef<HTMLDivElement | null>(null)
+  const textareaRefRef = useRef(textareaRef)
+  const commitEditorValueRef = useRef<(value: string, cursor: number) => void>(() => {})
   const valueRef = useRef(value)
   const selectionRangeRef = useRef({ start: value.length, end: value.length })
   const activeMenuRef = useRef<ActiveComposerMenu | null>(null)
@@ -754,6 +763,10 @@ export function ComposerTextarea({
   useEffect(() => {
     valueRef.current = value
   }, [value])
+  useLayoutEffect(() => {
+    textareaRefRef.current = textareaRef
+    ;(textareaRef as { current: HTMLElement | null }).current = composerElementRef.current
+  }, [textareaRef])
 
   const dedupedSkills = useMemo(() => dedupeLocalSkills(skills), [skills])
 
@@ -1128,6 +1141,9 @@ export function ComposerTextarea({
     },
     [onChange, updateAutocompleteTrigger]
   )
+  useLayoutEffect(() => {
+    commitEditorValueRef.current = commitEditorValue
+  }, [commitEditorValue])
 
   const selectMentionCandidate = useCallback(
     (candidate: ComposerMentionCandidate, explicitTrigger?: ComposerTextTrigger | null) => {
@@ -1266,23 +1282,26 @@ export function ComposerTextarea({
     [disabled]
   )
 
-  const setComposerElementRef = useCallback(
-    (element: HTMLDivElement | null) => {
-      ;(textareaRef as { current: HTMLElement | null }).current = element
-      if (!element) return
-      element.setAttribute('placeholder', placeholder)
-      element.setAttribute('rows', String(rows))
-      Object.defineProperty(element, 'value', {
-        configurable: true,
-        get: () => valueRef.current,
-        set: nextValue => {
-          const normalizedValue = String(nextValue ?? '')
-          commitEditorValue(normalizedValue, normalizedValue.length)
-        },
-      })
-    },
-    [commitEditorValue, placeholder, rows, textareaRef]
-  )
+  const setComposerElementRef = useCallback((element: HTMLDivElement | null) => {
+    composerElementRef.current = element
+    ;(textareaRefRef.current as { current: HTMLElement | null }).current = element
+    if (!element) return
+    Object.defineProperty(element, 'value', {
+      configurable: true,
+      get: () => valueRef.current,
+      set: nextValue => {
+        const normalizedValue = String(nextValue ?? '')
+        commitEditorValueRef.current(normalizedValue, normalizedValue.length)
+      },
+    })
+  }, [])
+
+  useEffect(() => {
+    const element = composerElementRef.current
+    if (!element) return
+    element.setAttribute('placeholder', placeholder)
+    element.setAttribute('rows', String(rows))
+  }, [placeholder, rows])
 
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
@@ -1291,7 +1310,10 @@ export function ComposerTextarea({
       theme: {
         paragraph: 'm-0',
       },
-      editorState: () => $setComposerValue(value, value.length),
+      editorState: () => {
+        $addUpdateTag(SKIP_DOM_SELECTION_TAG)
+        $setComposerValue(value)
+      },
       onError(error) {
         throw error
       },
@@ -1399,10 +1421,21 @@ export function ComposerTextarea({
   const ensureEditorSelection = useCallback(() => {
     const editor = editorRef.current
     if (!editor) return
+    const rootElement = editor.getRootElement()
+    const domSelection = window.getSelection()
+    const domSelectionWithinEditor = Boolean(
+      rootElement && domSelection?.anchorNode && rootElement.contains(domSelection.anchorNode)
+    )
     editor.update(() => {
+      const latestValue = valueRef.current
+      const cursor = Math.min(selectionRangeRef.current.end, latestValue.length)
+      if ($getComposerValue() !== latestValue) {
+        $setComposerValue(latestValue, cursor)
+        return
+      }
       const selection = $getSelection()
-      if (!$isRangeSelection(selection)) {
-        $selectComposerOffset($getComposerValue().length)
+      if (!domSelectionWithinEditor || !$isRangeSelection(selection)) {
+        $selectComposerOffset(cursor)
       }
     })
   }, [])

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -12,7 +12,7 @@ import { WorkbenchProvider, type WorkbenchServices } from './WorkbenchProvider'
 import { useWorkbench } from './useWorkbench'
 import { MessageList } from '@/components/chat/MessageList'
 import { useWorkbenchPaneSession } from '@/components/layout/useWorkbenchPaneSession'
-import { parseRuntimeTaskRoute } from '@/lib/navigation'
+import { buildRuntimeTaskRoute, parseRuntimeTaskRoute } from '@/lib/navigation'
 import { findRuntimeTask } from './workbenchRuntimeHelpers'
 import { modelSelectionFromRuntimeHandle } from './runtimeContextUsage'
 import type { ChatStreamHandlers } from '@/stream/chatStream'
@@ -26,6 +26,7 @@ import type {
   DeviceInfo,
   ProjectWithTasks,
   RuntimeTaskAddress,
+  RuntimeTaskCreateResponse,
   RuntimeGoal,
   RuntimeGuidanceResponse,
   RuntimeTranscriptResponse,
@@ -700,6 +701,20 @@ function ProjectSendProbe() {
       </button>
       <button type="button" onClick={() => void paneSession.send()}>
         send
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const address = {
+            deviceId: 'device-1',
+            taskId: 'runtime-b',
+            workspacePath: '/workspace/project-alpha',
+          }
+          window.history.pushState({}, '', buildRuntimeTaskRoute(address))
+          void workbench.openRuntimeTask(address)
+        }}
+      >
+        open runtime b
       </button>
       <MessageList
         messages={paneSession.messages}
@@ -2098,6 +2113,78 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(parseRuntimeTaskRoute(window.location.pathname, window.location.search)).toEqual({
       deviceId: 'device-1',
       taskId: request.taskId,
+    })
+  })
+
+  test('does not reopen a newly created task after the user switches tasks', async () => {
+    const createResponse = deferred<RuntimeTaskCreateResponse>()
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [
+                    {
+                      taskId: 'runtime-b',
+                      workspacePath: '/workspace/project-alpha',
+                      title: 'Runtime B',
+                      runtime: 'codex',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        })
+      ),
+      createRuntimeTask: vi.fn(() => createResponse.promise),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(await screen.findByText('select project'))
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    const optimisticRequest = runtimeWorkApi.createRuntimeTask.mock.calls[0][0]
+
+    await userEvent.click(screen.getByText('open runtime b'))
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:runtime-b'
+      )
+    )
+
+    await act(async () => {
+      createResponse.resolve({
+        accepted: true,
+        deviceId: 'device-1',
+        taskId: optimisticRequest.taskId,
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'codex',
+      })
+      await createResponse.promise
+    })
+
+    expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+      'device-1:runtime-b'
+    )
+    expect(parseRuntimeTaskRoute(window.location.pathname, window.location.search)).toEqual({
+      deviceId: 'device-1',
+      taskId: 'runtime-b',
     })
   })
 

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -644,6 +644,7 @@ export function useWorkbenchRuntimeMessaging({
         })
         const resolvedWorkspacePath = address.workspacePath ?? optimisticWorkspacePath
         const resolvedSameIdentity = isSameRuntimeTaskIdentity(optimisticAddress, address)
+        const optimisticTaskStillSelected = runtimeTasks.isCurrentRuntimeTask(optimisticAddress)
         if (!resolvedSameIdentity) {
           dispatch({ type: 'runtime_task_optimistic_removed', address: optimisticAddress })
         }
@@ -683,7 +684,7 @@ export function useWorkbenchRuntimeMessaging({
           options?.onRuntimeTaskOptimisticOpen?.(address, {
             previousAddress: optimisticAddress,
           })
-          if (options?.openInMainPane !== false) {
+          if (options?.openInMainPane !== false && optimisticTaskStillSelected) {
             runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
           }
         }
@@ -691,7 +692,6 @@ export function useWorkbenchRuntimeMessaging({
           await refreshWorkLists()
         }
         if (options?.openInMainPane !== false) {
-          runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
           dispatch({ type: 'blank_chat_committed' })
         }
         return address


### PR DESCRIPTION
## Summary
- prevent background Lexical composers from changing the active DOM selection
- keep the composer root ref stable across workbench refreshes
- avoid reopening a newly created task after the user switches away

## Root cause
Cached task panes mount and update Lexical composers during runtime work refreshes. Those updates could rebind the editor root or synchronize DOM selection, moving the active caret to the beginning.

## Validation
- pnpm --dir wework run typecheck
- pnpm --dir wework exec vitest run src/components/chat/ChatInput.test.tsx src/features/workbench/WorkbenchProvider.test.tsx
- pre-push ESLint, TypeScript, and unit tests