### PR TITLE
fix(wework): stabilize guided runtime turns

### DIFF
--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -7,7 +7,7 @@
 from datetime import datetime
 from typing import Any, Literal, Optional
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 RuntimeName = Literal["codex", "claude_code"]
 LocalTaskStatus = Literal["active", "archived"]
@@ -453,7 +453,8 @@ class RuntimeGuidanceRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     address: RuntimeTaskAddress
-    message: str = Field(..., min_length=1)
+    message: str = ""
+    attachment_ids: list[int] = Field(default_factory=list, alias="attachmentIds")
     client_guidance_id: Optional[str] = Field(
         default=None,
         alias="clientGuidanceId",
@@ -464,6 +465,12 @@ class RuntimeGuidanceRequest(BaseModel):
         alias="additionalContext",
         validation_alias=AliasChoices("additionalContext", "additional_context"),
     )
+
+    @model_validator(mode="after")
+    def require_message_or_attachment(self) -> "RuntimeGuidanceRequest":
+        if self.message.strip() or self.attachment_ids:
+            return self
+        raise ValueError("message or attachment is required")
 
 
 class RuntimeGuidanceResponse(BaseModel):

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -602,6 +602,9 @@ async def send_runtime_guidance(
         **_runtime_task_address_payload(address),
         "message": request.message,
     }
+    attachments = _runtime_attachment_payloads(db, user_id, request.attachment_ids)
+    if attachments:
+        payload["attachments"] = attachments
     if request.client_guidance_id:
         payload["clientGuidanceId"] = request.client_guidance_id
     if request.additional_context:

--- a/backend/tests/schemas/test_runtime_work_schema.py
+++ b/backend/tests/schemas/test_runtime_work_schema.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.runtime_work import RuntimeGuidanceRequest, RuntimeTaskAddress
+
+
+def test_runtime_guidance_accepts_image_attachment_without_text() -> None:
+    request = RuntimeGuidanceRequest(
+        address=RuntimeTaskAddress(deviceId="device-1", taskId="runtime-1"),
+        attachmentIds=[1],
+    )
+
+    assert request.message == ""
+    assert request.attachment_ids == [1]
+
+
+def test_runtime_guidance_requires_text_or_attachment() -> None:
+    with pytest.raises(ValidationError, match="message or attachment is required"):
+        RuntimeGuidanceRequest(
+            address=RuntimeTaskAddress(deviceId="device-1", taskId="runtime-1"),
+        )

--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -23,7 +23,10 @@ use super::{
         file_changes_update_from_patch_updated, tool_update_from_notification,
         workbench_block_from_notification,
     },
-    util::{extract_text, is_completed_plan_item, item_id, now_ms, raw_string_field, string_field},
+    util::{
+        extract_text, is_completed_plan_item, item_id, item_type, now_ms, raw_string_field,
+        string_field,
+    },
 };
 
 const MAX_TOOL_OUTPUT_DELTA_BYTES: usize = 64 * 1024;
@@ -94,6 +97,7 @@ pub(crate) struct CodexNotificationEventMapper {
     final_text_offset: usize,
     plan_blocks: BTreeMap<String, String>,
     tool_output_deltas: BTreeMap<String, String>,
+    completed_user_message_count: usize,
 }
 
 struct ProcessTextStream {
@@ -204,6 +208,9 @@ impl CodexNotificationEventMapper {
                 if self.is_subagent_delta(notification.params) {
                     self.forget_subagent_item(notification.params);
                     self.agent_message_phases.forget_item(notification.params);
+                    return;
+                }
+                if self.emit_applied_guidance(&emit_context, notification.params) {
                     return;
                 }
                 let phase = self
@@ -329,6 +336,39 @@ impl CodexNotificationEventMapper {
                 );
             }
         }
+    }
+
+    fn emit_applied_guidance(&mut self, context: &EventEmitContext<'_>, params: &Value) -> bool {
+        let item = params.get("item").unwrap_or(params);
+        if item_type(item).as_str() != "usermessage" {
+            return false;
+        }
+
+        self.completed_user_message_count += 1;
+        if self.completed_user_message_count == 1 {
+            return true;
+        }
+
+        self.final_text_offset = 0;
+        self.reset_process_text();
+
+        emit_response_event(
+            context.event_tx,
+            context.device_id,
+            "response.guidance.applied",
+            context.local_task_id,
+            context.request,
+            json!({
+                "guidanceId": item_id(item, "guidance"),
+                "message": extract_text(item).unwrap_or_default(),
+                "appliedAtMs": params
+                    .get("completedAtMs")
+                    .or_else(|| params.get("completed_at_ms"))
+                    .and_then(Value::as_i64)
+                    .unwrap_or_else(now_ms),
+            }),
+        );
+        true
     }
 
     fn emit_tool_output_delta(
@@ -1438,6 +1478,56 @@ mod tests {
     use crate::protocol::ExecutionRequest;
 
     use super::*;
+
+    #[test]
+    fn emits_guidance_applied_for_second_completed_user_message() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: "7".to_owned(),
+            subtask_id: "8".to_owned(),
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+        let user_message = |id: &str, text: &str, completed_at_ms: i64| {
+            json!({
+                "method": "item/completed",
+                "params": {
+                    "completedAtMs": completed_at_ms,
+                    "item": {
+                        "id": id,
+                        "type": "userMessage",
+                        "content": [{"type": "text", "text": text}]
+                    }
+                }
+            })
+        };
+
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            user_message("user-initial", "first", 100),
+        );
+        assert!(event_rx.try_recv().is_err());
+
+        mapper.map(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            user_message("user-guidance", "also inspect memory", 200),
+        );
+
+        let event = event_rx
+            .try_recv()
+            .expect("guidance event should be emitted");
+        assert_eq!(event["event"], "response.guidance.applied");
+        assert_eq!(event["payload"]["subtaskId"], "8");
+        assert_eq!(event["payload"]["data"]["guidanceId"], "user-guidance");
+        assert_eq!(event["payload"]["data"]["message"], "also inspect memory");
+        assert_eq!(event["payload"]["data"]["appliedAtMs"], 200);
+    }
 
     #[test]
     fn maps_codex_commentary_agent_messages_to_process_text_blocks() {

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -1267,7 +1267,7 @@ impl RuntimeWorkRpcHandler {
 
     async fn get_task_goal(&self, payload: Value) -> Result<Value, AppIpcError> {
         let link = self.task_link_from_payload(&payload, false).await?;
-        let Some(thread_id) = runtime_session_id_from_link(&link) else {
+        let Some(thread_id) = codex_thread_id_from_link(&link) else {
             return Ok(task_goal_missing_session(&link));
         };
 
@@ -1286,7 +1286,7 @@ impl RuntimeWorkRpcHandler {
 
     async fn set_task_goal(&self, payload: Value) -> Result<Value, AppIpcError> {
         let link = self.task_link_from_payload(&payload, false).await?;
-        let Some(thread_id) = runtime_session_id_from_link(&link) else {
+        let Some(thread_id) = codex_thread_id_from_link(&link) else {
             return Ok(task_goal_missing_session(&link));
         };
 
@@ -1321,7 +1321,7 @@ impl RuntimeWorkRpcHandler {
 
     async fn clear_task_goal(&self, payload: Value) -> Result<Value, AppIpcError> {
         let link = self.task_link_from_payload(&payload, false).await?;
-        let Some(thread_id) = runtime_session_id_from_link(&link) else {
+        let Some(thread_id) = codex_thread_id_from_link(&link) else {
             return Ok(task_goal_missing_session(&link));
         };
 
@@ -1755,8 +1755,14 @@ impl RuntimeWorkRpcHandler {
         let message = string_field(&payload, "message")
             .or_else(|| string_field(&payload, "guidance"))
             .map(|value| value.trim().to_owned())
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| AppIpcError::new("bad_request", "message is required"))?;
+            .unwrap_or_default();
+        let steer_input = guidance_input_items(&message, payload.get("attachments"));
+        if steer_input.is_empty() {
+            return Err(AppIpcError::new(
+                "bad_request",
+                "message or image attachment is required",
+            ));
+        }
         let Some(active_turn) = self.wait_for_active_codex_turn(&local_task_id).await else {
             return Ok(json!({
                 "success": false,
@@ -1771,12 +1777,6 @@ impl RuntimeWorkRpcHandler {
         let guidance_id = string_field(&payload, "client_guidance_id")
             .or_else(|| string_field(&payload, "clientGuidanceId"))
             .unwrap_or_else(|| format!("guidance-{}", now_ms()));
-        let steer_input = json!([
-            {
-                "type": "text",
-                "text": message,
-            }
-        ]);
         let additional_context = payload
             .get("additionalContext")
             .or_else(|| payload.get("additional_context"))
@@ -1787,7 +1787,7 @@ impl RuntimeWorkRpcHandler {
             .steer_turn(
                 &active_turn.thread_id,
                 &active_turn.turn_id,
-                steer_input,
+                Value::Array(steer_input),
                 additional_context,
             )
             .await
@@ -2513,7 +2513,6 @@ impl RuntimeWorkRpcHandler {
         if self.is_active_local_task(&route.local_task_id) {
             return;
         }
-
         if let Some(started_thread_id) = codex_started_thread_id(&message) {
             self.register_codex_thread_workspace_root(&started_thread_id, &route.request);
         }
@@ -3151,9 +3150,10 @@ impl RuntimeWorkRpcHandler {
 
         let workspace_path = workspace_path(payload)
             .ok_or_else(|| AppIpcError::new("not_found", "runtime task was not found"))?;
+        // A local task ID identifies Wework's persisted task record; it is not a
+        // Codex thread ID. Keep this unresolved until a provider thread is known.
         let mut link =
             RuntimeTaskLink::new_pending(local_task_id.clone(), workspace_path, local_task_id);
-        link.thread_id = Some(link.local_task_id.clone());
         link.status = if archived { "archived" } else { "active" }.to_owned();
         link.running = false;
         log_runtime_archive_link("runtime task payload created pending link", &link, archived);
@@ -4388,6 +4388,33 @@ fn normalized_attachments(value: Option<&Value>) -> Vec<Value> {
         .collect()
 }
 
+fn guidance_image_inputs(value: Option<&Value>) -> Vec<Value> {
+    value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|attachment| {
+            let mime_type = string_field(attachment, "mime_type")
+                .or_else(|| string_field(attachment, "mimeType"))?;
+            if !mime_type.starts_with("image/") {
+                return None;
+            }
+            let path = string_field(attachment, "local_path")
+                .or_else(|| string_field(attachment, "localPath"))?;
+            Some(json!({ "type": "localImage", "path": path }))
+        })
+        .collect()
+}
+
+fn guidance_input_items(message: &str, attachments: Option<&Value>) -> Vec<Value> {
+    let mut inputs = Vec::new();
+    if !message.trim().is_empty() {
+        inputs.push(json!({ "type": "text", "text": message }));
+    }
+    inputs.extend(guidance_image_inputs(attachments));
+    inputs
+}
+
 fn copy_attachment_field(source: &Map<String, Value>, target: &mut Map<String, Value>, key: &str) {
     if let Some(value) = source.get(key).cloned() {
         target.insert(key.to_owned(), value);
@@ -4458,6 +4485,22 @@ fn runtime_session_id_from_link(link: &RuntimeTaskLink) -> Option<String> {
     link.thread_id
         .clone()
         .or_else(|| runtime_session_id_from_handle(&link.runtime_handle))
+}
+
+fn codex_thread_id_from_link(link: &RuntimeTaskLink) -> Option<String> {
+    runtime_session_id_from_link(link).filter(|thread_id| is_codex_thread_id(thread_id))
+}
+
+fn is_codex_thread_id(thread_id: &str) -> bool {
+    let thread_id = thread_id.strip_prefix("urn:uuid:").unwrap_or(thread_id);
+    thread_id.len() == 36
+        && thread_id
+            .chars()
+            .enumerate()
+            .all(|(index, character)| match index {
+                8 | 13 | 18 | 23 => character == '-',
+                _ => character.is_ascii_hexdigit(),
+            })
 }
 
 fn runtime_thread_path_from_link(link: &RuntimeTaskLink) -> Option<String> {
@@ -5211,6 +5254,28 @@ mod tests {
     }
 
     #[test]
+    fn runtime_session_ids_only_accept_codex_uuid_thread_ids() {
+        assert!(is_codex_thread_id("019f4c0d-b036-78f3-b879-7e5ed203ad61"));
+        assert!(is_codex_thread_id(
+            "urn:uuid:019f4c0d-b036-78f3-b879-7e5ed203ad61"
+        ));
+        assert!(!is_codex_thread_id("runtime-481327491"));
+        assert!(!is_codex_thread_id("thread-1"));
+
+        let mut link = RuntimeTaskLink::new_pending(
+            "runtime-481327491".to_owned(),
+            "/tmp/project".to_owned(),
+            "Task".to_owned(),
+        );
+        link.thread_id = Some(link.local_task_id.clone());
+        assert_eq!(
+            runtime_session_id_from_link(&link).as_deref(),
+            Some("runtime-481327491")
+        );
+        assert_eq!(codex_thread_id_from_link(&link), None);
+    }
+
+    #[test]
     fn plugin_app_server_method_allowlist_covers_wework_plugin_runtime_surface() {
         for method in [
             "marketplace/add",
@@ -5889,6 +5954,39 @@ mod tests {
         assert!(target_paths.contains(
             &"/Users/me/.wegent-executor/workspace/attachments/draft/1/photo.png".to_owned()
         ));
+    }
+
+    #[test]
+    fn guidance_inputs_include_only_local_images() {
+        let attachments = json!([
+            {
+                "mime_type": "image/png",
+                "local_path": "/tmp/screenshot.png"
+            },
+            {
+                "mime_type": "text/plain",
+                "local_path": "/tmp/notes.txt"
+            },
+            {
+                "mime_type": "image/jpeg"
+            }
+        ]);
+
+        assert_eq!(
+            guidance_image_inputs(Some(&attachments)),
+            vec![json!({
+                "type": "localImage",
+                "path": "/tmp/screenshot.png"
+            })]
+        );
+        assert_eq!(
+            guidance_input_items("", Some(&attachments)),
+            vec![json!({
+                "type": "localImage",
+                "path": "/tmp/screenshot.png"
+            })]
+        );
+        assert!(guidance_input_items("", None).is_empty());
     }
 
     #[test]

--- a/wework/src/api/local/localChatStream.ts
+++ b/wework/src/api/local/localChatStream.ts
@@ -153,7 +153,8 @@ function hasLocalExecutorResponseHandlers(handlers: ChatStreamHandlers): boolean
     handlers.onBlockUpdated ||
     handlers.onSubagentActivity ||
     handlers.onRuntimeGoalUpdated ||
-    handlers.onRuntimeGoalCleared
+    handlers.onRuntimeGoalCleared ||
+    handlers.onGuidanceApplied
   )
 }
 

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -1567,6 +1567,8 @@ export function createRuntimeWorkApiFromIpc(
           taskId: normalizedAddress.taskId,
           address: normalizedAddress,
           message: data.message,
+          ...(data.attachmentIds ? { attachmentIds: data.attachmentIds } : {}),
+          ...(data.attachments ? { attachments: data.attachments } : {}),
           ...(data.clientGuidanceId ? { clientGuidanceId: data.clientGuidanceId } : {}),
           ...(data.client_guidance_id ? { client_guidance_id: data.client_guidance_id } : {}),
           ...(data.additionalContext ? { additionalContext: data.additionalContext } : {}),

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -549,6 +549,38 @@ describe('MessageList', () => {
     expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 9m 18s 后停止了')
   })
 
+  test('keeps late cancelled output without rendering it as active thinking', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-cancelled-late-output',
+            subtaskId: 21,
+            role: 'assistant',
+            content: '取消后仍收到的模型输出。',
+            status: 'streaming',
+            runtimeStatus: 'cancelled',
+            createdAt: '2026-06-11T10:00:00Z',
+            blocks: [
+              {
+                id: 'late-process',
+                subtaskId: 21,
+                type: 'text',
+                content: '补充分析。',
+                status: 'streaming',
+                createdAt: Date.parse('2026-06-11T10:00:10Z'),
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('取消后仍收到的模型输出。')).toBeInTheDocument()
+    expect(screen.getByText('补充分析。')).toBeInTheDocument()
+    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+  })
+
   test('renders tagged proposed plan content as regular assistant markdown', () => {
     render(
       <MessageList
@@ -1469,6 +1501,40 @@ describe('MessageList', () => {
     expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
     expect(screen.getByText('我正在检查项目结构。')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
+  })
+
+  test('keeps processing expanded for the assistant continuation after runtime guidance', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-after-guidance',
+            role: 'assistant',
+            content: '继续处理。',
+            status: 'done',
+            runtimeGuidanceContinuation: true,
+            blocks: [
+              {
+                id: 'guidance-1',
+                subtaskId: 12,
+                type: 'tool',
+                toolName: 'conversation_guidance',
+                toolInput: { message: '也看看内存' },
+                status: 'done',
+                createdAt: 1770000002000,
+              },
+            ],
+            createdAt: '2026-06-24T08:00:02.000Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    )
+    expect(screen.getByText('已引导对话')).toBeInTheDocument()
   })
 
   test('renders final answer web search sources as a Codex-style source chip', async () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1398,14 +1398,23 @@ function shouldHideFailedAssistantContent(message: WorkbenchMessage) {
   return RAW_FAILED_MESSAGE_PATTERNS.some(pattern => pattern.test(content))
 }
 
-function getDisplayProcessingBlocks(blocks: ProcessingBlock[] | undefined): ProcessingBlock[] {
+function getDisplayProcessingBlocks(
+  blocks: ProcessingBlock[] | undefined,
+  settleForCancelledTurn = false
+): ProcessingBlock[] {
   if (!blocks?.length) return []
 
-  return blocks.filter(block => {
-    if (block.type !== 'text') return true
+  return blocks
+    .filter(block => {
+      if (block.type !== 'text') return true
 
-    return Boolean(block.content.trim())
-  })
+      return Boolean(block.content.trim())
+    })
+    .map(block =>
+      settleForCancelledTurn && block.status !== 'done' && block.status !== 'error'
+        ? { ...block, status: 'done' as const }
+        : block
+    )
 }
 
 function getWebSearchToolBlocks(blocks: ProcessingBlock[]) {
@@ -1475,10 +1484,10 @@ function AssistantMessage({
   const visibleContent = shouldHideContent ? '' : message.content
   const hiddenErrorContent =
     message.status === 'failed' && shouldHideContent ? message.content.trim() : undefined
-  const displayBlocks = getDisplayProcessingBlocks(message.blocks)
+  const displayBlocks = getDisplayProcessingBlocks(message.blocks, isCancelled)
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
-  const isStreaming = message.status === 'streaming'
+  const isStreaming = !isCancelled && message.status === 'streaming'
   const hasRunningBlocks = hasRunningProcessingBlocks(displayBlocks)
   const isAssistantRunning = isStreaming || hasRunningBlocks
   const canShowFinalArtifacts = !isAssistantRunning
@@ -1530,7 +1539,11 @@ function AssistantMessage({
               blocks={displayBlocks}
               isStreaming={isStreaming}
               startedAt={getProcessingSummaryStartMs(message, displayBlocks, isStreaming)}
-              forceExpanded={isCancelled || message.runtimeGuidanceSplitBefore === true}
+              forceExpanded={
+                isCancelled ||
+                message.runtimeGuidanceSplitBefore === true ||
+                message.runtimeGuidanceContinuation === true
+              }
               hasFinalContent={hasVisibleContent}
               showSummary={!isCancelled}
               stateKey={getMessageDisplayStateKey(conversationKey, message)}

--- a/wework/src/components/chat/composer/GoalStatusBar.tsx
+++ b/wework/src/components/chat/composer/GoalStatusBar.tsx
@@ -58,7 +58,7 @@ export function GoalStatusBar({
   return (
     <div
       data-testid="goal-status-bar"
-      className="mb-1 flex h-11 w-[calc(100%-2rem)] max-w-[54rem] items-center gap-2 rounded-t-[26px] border border-border/45 border-b-0 bg-background px-4 text-[13px] leading-[18px] text-text-secondary shadow-[0_8px_28px_rgba(0,0,0,0.06)]"
+      className="mb-2 flex h-11 w-full items-center gap-2 rounded-2xl border border-border/45 bg-background px-4 text-[13px] leading-[18px] text-text-secondary shadow-[0_8px_24px_rgba(15,23,42,0.05)]"
     >
       <Target className="h-4 w-4 shrink-0 text-text-muted" />
       <div className="min-w-0 flex-1 truncate">

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -166,6 +166,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   const messagesRef = useRef<WorkbenchMessage[]>([])
   const loadedTranscriptRangesRef = useRef<LoadedTranscriptRange[]>([])
   const guidanceSplitBoundariesRef = useRef(new Map<string, GuidanceSplitBoundary>())
+  const pendingAppliedGuidancesRef = useRef(new Map<string, RuntimePaneQueuedMessage>())
   const pendingMessageActionsRef = useRef<RuntimePaneMessageAction[]>([])
   const messageActionFrameRef = useRef<number | null>(null)
   const currentRuntimeTaskLoadTarget = useMemo(
@@ -238,6 +239,30 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       })
     },
     [applyMessageActions, flushPendingMessageActions]
+  )
+  const appendGuidanceLocalUserMessage = useCallback(
+    (content: string, attachments?: Attachment[], options?: CreateLocalUserMessageOptions) => {
+      const guidanceMessage = createLocalUserMessage(content, attachments, options)
+      setMessages(currentMessages => {
+        const nextMessages = splitActiveAssistantForGuidance(
+          currentMessages,
+          guidanceMessage,
+          guidanceSplitBoundariesRef.current
+        )
+        const activeRuntimeTask = currentRuntimeTaskRef.current
+        if (activeRuntimeTask) {
+          snapshotRuntimePaneMessages(activeRuntimeTask, nextMessages)
+          debugRuntimePaneMessageFlow('guidance-message-inserted', {
+            address: runtimeAddressDebug(activeRuntimeTask),
+            previousCount: currentMessages.length,
+            nextCount: nextMessages.length,
+            nextMessages: summarizeWorkbenchMessages(nextMessages),
+          })
+        }
+        return nextMessages
+      })
+    },
+    []
   )
   const runtimeTaskStatusAddress = runtimeTaskLoadTarget?.address ?? currentRuntimeTask
   const taskExecution = useMemo(
@@ -525,9 +550,24 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           current && isPendingGoalVisibleForRuntimeTarget(current, latestAddress) ? null : current
         )
       },
+      onGuidanceApplied: payload => {
+        const pendingEntry = [...pendingAppliedGuidancesRef.current.entries()].find(
+          ([, message]) => !payload.message || message.content === payload.message
+        )
+        if (!pendingEntry) return
+        const [guidanceId, guidanceMessage] = pendingEntry
+        pendingAppliedGuidancesRef.current.delete(guidanceId)
+        appendGuidanceLocalUserMessage(guidanceMessage.content, guidanceMessage.attachments, {
+          id: guidanceMessage.id,
+          createdAt: new Date(payload.appliedAtMs).toISOString(),
+          runtimeGoalRequest: guidanceMessage.runtimeGoalRequest,
+          runtimeGuidance: true,
+        })
+        setQueuedMessages(messages => messages.filter(message => message.id !== guidanceId))
+      },
     })
     return unsubscribe
-  }, [dispatchMessages, runtimeTaskStreamTargetKey])
+  }, [appendGuidanceLocalUserMessage, dispatchMessages, runtimeTaskStreamTargetKey])
 
   const loadMoreTranscriptBefore = useCallback(async () => {
     if (
@@ -709,30 +749,6 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       })
     },
     [dispatchMessages]
-  )
-
-  const appendGuidanceLocalUserMessage = useCallback(
-    (content: string, attachments?: Attachment[], options?: CreateLocalUserMessageOptions) => {
-      const guidanceMessage = createLocalUserMessage(content, attachments, options)
-      setMessages(currentMessages => {
-        const nextMessages = splitActiveAssistantForGuidance(
-          currentMessages,
-          guidanceMessage,
-          guidanceSplitBoundariesRef.current
-        )
-        if (currentRuntimeTask) {
-          snapshotRuntimePaneMessages(currentRuntimeTask, nextMessages)
-          debugRuntimePaneMessageFlow('guidance-message-inserted', {
-            address: runtimeAddressDebug(currentRuntimeTask),
-            previousCount: currentMessages.length,
-            nextCount: nextMessages.length,
-            nextMessages: summarizeWorkbenchMessages(nextMessages),
-          })
-        }
-        return nextMessages
-      })
-    },
-    [currentRuntimeTask]
   )
 
   const applyLocalRequestUserInputResponse = useCallback(
@@ -1029,6 +1045,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
 
       if (queuedMessage.status === 'sending') return
 
+      setError(null)
       if (!paneStatus.isBusy) {
         setQueuedMessages(messages =>
           messages.map(message =>
@@ -1077,23 +1094,24 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         )
       )
 
-      appendGuidanceLocalUserMessage(queuedMessage.content, queuedMessage.attachments, {
-        id: queuedMessage.id,
-        createdAt: queuedMessage.createdAt,
-        runtimeGoalRequest: queuedMessage.runtimeGoalRequest,
-        runtimeGuidance: true,
-      })
+      pendingAppliedGuidancesRef.current.set(id, queuedMessage)
 
       try {
         const additionalContext = readRuntimeTerminalAdditionalContext(currentRuntimeTask)
+        const messageAttachments = queuedMessage.attachments ?? []
+        const attachmentIds = remoteAttachmentIds(messageAttachments)
+        const attachments = localRuntimeAttachments(messageAttachments)
         const result = await sendRuntimePaneGuidance({
           address: currentRuntimeTask,
           message: queuedMessage.content,
           clientGuidanceId: id,
+          ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
+          ...(attachments.length > 0 ? { attachments } : {}),
           ...(additionalContext ? { additionalContext } : {}),
         })
         if (!result.sent && result.code === 'no_active_turn') {
-          const sent = await sendRuntimeMessage(queuedMessage, { appendLocalMessage: false })
+          pendingAppliedGuidancesRef.current.delete(id)
+          const sent = await sendRuntimeMessage(queuedMessage)
           setQueuedMessages(messages =>
             sent
               ? messages.filter(message => message.id !== id)
@@ -1105,16 +1123,18 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           )
           return
         }
-        setQueuedMessages(messages =>
-          result.sent
-            ? messages.filter(message => message.id !== id)
-            : messages.map(message =>
-                message.id === id
-                  ? { ...message, status: 'failed', notice: undefined, error: '引导发送失败' }
-                  : message
-              )
-        )
+        if (!result.sent) {
+          pendingAppliedGuidancesRef.current.delete(id)
+          setQueuedMessages(messages =>
+            messages.map(message =>
+              message.id === id
+                ? { ...message, status: 'failed', notice: undefined, error: '引导发送失败' }
+                : message
+            )
+          )
+        }
       } catch (error) {
+        pendingAppliedGuidancesRef.current.delete(id)
         console.error('[Wework] Queued guidance send failed', {
           id,
           error,
@@ -1128,13 +1148,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         )
       }
     },
-    [
-      appendGuidanceLocalUserMessage,
-      currentRuntimeTask,
-      paneStatus.isBusy,
-      sendRuntimeMessage,
-      sendRuntimePaneGuidance,
-    ]
+    [currentRuntimeTask, paneStatus.isBusy, sendRuntimeMessage, sendRuntimePaneGuidance]
   )
 
   const send: (inputOverride?: string, options?: RuntimePaneSendOptions) => Promise<void> =
@@ -1167,6 +1181,8 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             return
           }
 
+          // Errors belong to the previous action; a new goal submission starts fresh.
+          setError(null)
           setInput('')
           setSendPhase('submitting')
           try {
@@ -1195,6 +1211,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
               projectChat.resetAttachments()
               if (paneStatus.isBusy) {
                 setQueuedMessages(messages => [...messages, queuedMessage])
+                if (options.guideWhenBusy) {
+                  await sendQueuedMessageAsGuidance(queuedMessage)
+                }
                 return
               }
 
@@ -1309,6 +1328,8 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           return
         }
 
+        // Do not keep an earlier action error visible once the user sends a new message.
+        setError(null)
         setInput('')
         setSendPhase('submitting')
         try {
@@ -1504,19 +1525,6 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     [queuedMessages, sendQueuedMessageAsGuidance]
   )
 
-  const pauseCurrentResponse = useCallback(async () => {
-    if (!currentRuntimeTask) return
-
-    const cancelled = await cancelRuntimePaneTask(currentRuntimeTask)
-    if (!cancelled) return
-
-    if (!activeAssistantMessage) return
-
-    dispatchMessages({
-      type: 'assistant_cancelled',
-    })
-  }, [activeAssistantMessage, cancelRuntimePaneTask, currentRuntimeTask, dispatchMessages])
-
   const compactContext = useCallback(async () => {
     if (!currentRuntimeTask) {
       setError('当前对话还没有可压缩的 Codex 线程')
@@ -1599,6 +1607,30 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     () => updateCurrentGoalStatus('active'),
     [updateCurrentGoalStatus]
   )
+
+  const pauseCurrentResponse = useCallback(async () => {
+    if (!currentRuntimeTask) return
+
+    const cancelled = await cancelRuntimePaneTask(currentRuntimeTask)
+    if (!cancelled) return
+
+    if (goal?.status === 'active') {
+      await updateCurrentGoalStatus('paused')
+    }
+
+    if (!activeAssistantMessage) return
+
+    dispatchMessages({
+      type: 'assistant_cancelled',
+    })
+  }, [
+    activeAssistantMessage,
+    cancelRuntimePaneTask,
+    currentRuntimeTask,
+    dispatchMessages,
+    goal?.status,
+    updateCurrentGoalStatus,
+  ])
 
   const clearCurrentGoal = useCallback(async () => {
     if (!goal) return false
@@ -1894,8 +1926,6 @@ function createGuidanceContinuationAssistantMessage(
   assistantMessage: WorkbenchMessage & { subtaskId: string },
   guidanceMessage: WorkbenchMessage
 ): WorkbenchMessage {
-  const subtaskId = assistantMessage.subtaskId
-  const guidanceCreatedAt = getMessageCreatedAtMs(guidanceMessage.createdAt)
   return {
     ...assistantMessage,
     id: `${assistantMessage.id}-after-guidance-${guidanceMessage.id}`,
@@ -1906,14 +1936,17 @@ function createGuidanceContinuationAssistantMessage(
     blocks: [
       {
         id: `${guidanceMessage.id}-guidance`,
-        subtaskId,
+        subtaskId: assistantMessage.subtaskId,
         type: 'tool',
         toolName: 'conversation_guidance',
         toolInput: { message: guidanceMessage.content },
         status: 'done',
-        createdAt: guidanceCreatedAt,
+        createdAt: getMessageCreatedAtMs(guidanceMessage.createdAt),
       },
     ],
+    runtimeGuidanceContinuation: true,
+    contentTruncated: undefined,
+    contentOriginalChars: undefined,
     completedAt: undefined,
     stoppedNotice: false,
   }
@@ -1930,10 +1963,7 @@ function transformRuntimePaneActionForGuidanceSplits(
 
   switch (action.type) {
     case 'assistant_chunk':
-      return {
-        ...action,
-        content: trimGuidanceSplitPrefix(boundary.prefix, action.content, action.offset),
-      }
+      return action
     case 'assistant_done': {
       splitBoundaries.delete(action.subtaskId)
       return {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1011,6 +1011,13 @@ function RuntimeOpenProbe() {
       <span data-testid="runtime-message-statuses">
         {paneSession.messages.map(message => `${message.role}:${message.status}`).join('|')}
       </span>
+      <span data-testid="runtime-content-truncation">
+        {paneSession.messages
+          .map(
+            message => `${message.id}:${message.contentTruncated === true ? 'truncated' : 'full'}`
+          )
+          .join('|')}
+      </span>
       <span data-testid="runtime-transcript-loading">
         {paneSession.transcriptLoading ? 'loading' : 'idle'}
       </span>
@@ -6082,7 +6089,6 @@ describe('WorkbenchProvider runtime tasks', () => {
     await userEvent.click(screen.getByText('set follow-up'))
     await userEvent.click(screen.getByText('send follow-up'))
     const queuedMessageId = screen.getByTestId('queued-message-ids').textContent
-    const queuedMessageCreatedAt = screen.getByTestId('queued-message-created-at').textContent
     await userEvent.click(screen.getByText('guide first queued'))
 
     await waitFor(() => expect(guideRuntimeTask).toHaveBeenCalledTimes(1))
@@ -6099,31 +6105,12 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(sendRuntimeMessage).not.toHaveBeenCalled()
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('sending:继续修')
     expect(screen.getByTestId('runtime-open-messages').textContent).toBe(
-      'first message|working|before |继续修|'
+      'first message|working|before '
     )
-    expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent(
+    expect(screen.getByTestId('runtime-open-blocks')).not.toHaveTextContent(
       'tool:conversation_guidance:done'
     )
-    expect(screen.getByTestId('runtime-open-message-ids')).toHaveTextContent(queuedMessageId ?? '')
-    expect(screen.getByTestId('runtime-open-message-created-at')).toHaveTextContent(
-      queuedMessageCreatedAt ?? ''
-    )
     expect(screen.getByTestId('guidance-messages')).toHaveTextContent('')
-
-    await act(async () => {
-      streamHandlers.onChatChunk?.({
-        taskId: 'runtime-a',
-        subtaskId: '101',
-        content: 'after',
-        offset: 7,
-        deviceId: 'device-1',
-      })
-    })
-    await waitFor(() =>
-      expect(screen.getByTestId('runtime-open-messages').textContent).toBe(
-        'first message|working|before |继续修|after'
-      )
-    )
 
     await act(async () => {
       guidanceResult.resolve({
@@ -6131,15 +6118,42 @@ describe('WorkbenchProvider runtime tasks', () => {
         success: true,
         taskId: 'runtime-a',
         guidanceId: 'queued-runtime-guidance',
+        turnId: '019f4c02-df59-71c3-ac19-f1e7cec46069',
       })
-      streamHandlers.onChatDone?.({
+    })
+    expect(screen.getByTestId('queued-messages')).toHaveTextContent('sending:继续修')
+    expect(screen.getByTestId('runtime-open-blocks')).not.toHaveTextContent(
+      'tool:conversation_guidance:done'
+    )
+
+    await act(async () => {
+      streamHandlers.onGuidanceApplied?.({
         taskId: 'runtime-a',
         subtaskId: '101',
         deviceId: 'device-1',
-        result: { value: 'before after' },
+        guidanceId: 'raw-guidance-item',
+        message: '继续修',
+        appliedAtMs: Date.now(),
       })
     })
+    await waitFor(() => expect(screen.getByTestId('queued-messages')).toHaveTextContent(''))
+    expect(screen.getByTestId('runtime-open-messages').textContent).toBe(
+      'first message|working|before |继续修|'
+    )
+    expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent(
+      'tool:conversation_guidance:done'
+    )
+    expect(screen.getByTestId('runtime-open-message-ids')).toHaveTextContent(queuedMessageId ?? '')
 
+    await act(async () => {
+      streamHandlers.onChatChunk?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        content: 'after',
+        offset: 0,
+        deviceId: 'device-1',
+      })
+    })
     await waitFor(() =>
       expect(screen.getByTestId('runtime-open-messages').textContent).toBe(
         'first message|working|before |继续修|after'
@@ -6148,9 +6162,40 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent(
       'tool:conversation_guidance:done'
     )
+    await act(async () => {
+      streamHandlers.onChatChunk?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        content: ' more',
+        offset: 5,
+        deviceId: 'device-1',
+      })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('after more')
+    )
+    expect(screen.getByTestId('runtime-content-truncation')).not.toHaveTextContent('truncated')
+
+    await act(async () => {
+      streamHandlers.onChatDone?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        deviceId: 'device-1',
+        result: { value: 'before after more' },
+      })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages').textContent).toBe(
+        'first message|working|before |继续修|after more'
+      )
+    )
+    expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent(
+      'tool:conversation_guidance:done'
+    )
   })
 
-  test('sends busy follow-up directly as guidance when requested by submit options', async () => {
+  test('sends a busy goal message as guidance when requested by submit options', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
       if (hasRuntimeStreamHandler(handlers)) streamHandlers = handlers
@@ -6165,6 +6210,10 @@ describe('WorkbenchProvider runtime tasks', () => {
       success: true,
       taskId: 'runtime-a',
       guidanceId: 'shortcut-runtime-guidance',
+    })
+    const setRuntimeGoal = vi.fn().mockResolvedValue({
+      accepted: true,
+      goal: createRuntimeGoal({ objective: '继续修', status: 'active' }),
     })
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(
@@ -6214,6 +6263,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       }),
       sendRuntimeMessage,
       guideRuntimeTask,
+      setRuntimeGoal,
     })
     const services = createWorkbenchServices({
       runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
@@ -6242,13 +6292,46 @@ describe('WorkbenchProvider runtime tasks', () => {
         deviceId: 'device-1',
       })
     })
+    await userEvent.click(screen.getByText('set follow-up goal'))
     await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('add local image attachment'))
     await userEvent.click(screen.getByText('send follow-up as guidance'))
 
     await waitFor(() => expect(guideRuntimeTask).toHaveBeenCalledTimes(1))
+    expect(setRuntimeGoal).toHaveBeenCalledWith({
+      address: {
+        deviceId: 'device-1',
+        workspacePath: '/workspace/project-alpha',
+        taskId: 'runtime-a',
+      },
+      objective: '继续修',
+      status: 'active',
+    })
+    await act(async () => {
+      streamHandlers.onGuidanceApplied?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        deviceId: 'device-1',
+        guidanceId: 'raw-guidance-item',
+        message: '继续修',
+        appliedAtMs: Date.now(),
+      })
+    })
+    expect(guideRuntimeTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '继续修',
+        attachments: [
+          expect.objectContaining({
+            local_path: LOCAL_IMAGE_ATTACHMENT_PATH,
+            mime_type: 'image/png',
+          }),
+        ],
+      })
+    )
     expect(sendRuntimeMessage).not.toHaveBeenCalled()
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('')
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
+    expect(screen.getByTestId('runtime-open-goal-flags')).toHaveTextContent('goal:继续修')
     expect(screen.getByTestId('runtime-open-message-ids')).toHaveTextContent('queued-runtime-pane-')
   })
 
@@ -6512,7 +6595,7 @@ describe('WorkbenchProvider runtime tasks', () => {
                   taskId: 'runtime-a',
                   workspacePath: '/workspace/project-alpha',
                   title: 'Runtime A',
-                  runtime: 'claude_code',
+                  runtime: 'codex',
                   running: true,
                 },
               ],
@@ -6541,7 +6624,7 @@ describe('WorkbenchProvider runtime tasks', () => {
                   taskId: 'runtime-a',
                   workspacePath: '/workspace/project-alpha',
                   title: 'Runtime A',
-                  runtime: 'claude_code',
+                  runtime: 'codex',
                   running: false,
                   status: 'cancelled',
                 },
@@ -6565,6 +6648,10 @@ describe('WorkbenchProvider runtime tasks', () => {
         taskId: 'runtime-a',
       })
     })
+    const setRuntimeGoal = vi.fn().mockResolvedValue({
+      accepted: true,
+      goal: createRuntimeGoal({ status: 'paused' }),
+    })
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork,
       getRuntimeTranscript: vi.fn().mockResolvedValue({
@@ -6582,6 +6669,11 @@ describe('WorkbenchProvider runtime tasks', () => {
         ],
       }),
       cancelRuntimeTask,
+      getRuntimeGoal: vi.fn().mockResolvedValue({
+        accepted: true,
+        goal: createRuntimeGoal({ status: 'active' }),
+      }),
+      setRuntimeGoal,
     })
     const services = createWorkbenchServices({
       runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
@@ -6610,6 +6702,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         deviceId: 'device-1',
       })
     })
+    await waitFor(() => expect(runtimeWorkApi.getRuntimeGoal).toHaveBeenCalledTimes(1))
     const listCallsBeforeCancel = listRuntimeWork.mock.calls.length
     await userEvent.click(screen.getByText('stop current response'))
 
@@ -6619,6 +6712,16 @@ describe('WorkbenchProvider runtime tasks', () => {
       workspacePath: '/workspace/project-alpha',
       taskId: 'runtime-a',
     })
+    await waitFor(() =>
+      expect(setRuntimeGoal).toHaveBeenCalledWith({
+        address: {
+          deviceId: 'device-1',
+          workspacePath: '/workspace/project-alpha',
+          taskId: 'runtime-a',
+        },
+        status: 'paused',
+      })
+    )
     await waitFor(() => expect(listRuntimeWork).toHaveBeenCalledTimes(listCallsBeforeCancel + 1))
     await waitFor(() =>
       expect(screen.getByTestId('current-runtime-task-running')).toHaveTextContent('idle')
@@ -6732,6 +6835,16 @@ describe('WorkbenchProvider runtime tasks', () => {
       },
       message: '执行ls',
       clientGuidanceId: expect.stringMatching(/^queued-runtime-pane-/),
+    })
+    await act(async () => {
+      streamHandlers.onGuidanceApplied?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        deviceId: 'device-1',
+        guidanceId: 'raw-guidance-item',
+        message: '执行ls',
+        appliedAtMs: Date.now(),
+      })
     })
     expect(cancelRuntimeTask).not.toHaveBeenCalled()
     expect(sendRuntimeMessage).not.toHaveBeenCalled()

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -10,6 +10,7 @@ import type {
   ChatBlockUpdatedPayload,
   RuntimeContextUsage,
   RuntimeGoalEventPayload,
+  RuntimeGuidanceAppliedPayload,
   RuntimeSubagentActivityPayload,
   NormalizedRuntimeMessage,
   RuntimeTaskAddress,
@@ -31,6 +32,7 @@ export interface RuntimeTaskStreamHandlers {
   onSubagentActivity?: (payload: RuntimeSubagentActivityPayload) => void
   onRuntimeGoalUpdated?: (payload: RuntimeGoalEventPayload) => void
   onRuntimeGoalCleared?: (payload: RuntimeGoalEventPayload) => void
+  onGuidanceApplied?: (payload: RuntimeGuidanceAppliedPayload) => void
 }
 
 export function createRuntimeTaskStreamHandlers(
@@ -244,6 +246,10 @@ export function createRuntimeTaskStreamHandlers(
     onRuntimeGoalCleared: payload => {
       if (!isRuntimeTaskStreamPayload(address, payload)) return
       handlers.onRuntimeGoalCleared?.(payload)
+    },
+    onGuidanceApplied: payload => {
+      if (!isRuntimeTaskStreamPayload(address, payload)) return
+      handlers.onGuidanceApplied?.(payload)
     },
   }
 }

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -248,15 +248,18 @@ export function useWorkbenchRuntimeMessaging({
             error: response.error || '引导发送失败',
           }
         }
-        try {
-          await refreshWorkLists()
-        } catch (error) {
+        void refreshWorkLists().catch(error => {
           console.warn('[Wework] Runtime guidance accepted but work list refresh failed', {
             taskId: response.taskId ?? response.task_id ?? request.address.taskId,
             error: error instanceof Error ? error.message : String(error),
           })
+        })
+        return {
+          sent: true,
+          turnId: response.turnId ?? response.turn_id,
+          code: response.code,
+          error: response.error,
         }
-        return { sent: true, code: response.code, error: response.error }
       } catch (error) {
         console.warn('[Wework] Runtime guidance failed', {
           taskId: request.address.taskId,

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -90,6 +90,7 @@ export interface RuntimePaneActionOptions {
 
 export interface RuntimePaneGuidanceResult {
   sent: boolean
+  turnId?: string
   code?: string | null
   error?: string | null
 }

--- a/wework/src/stream/chatStream.ts
+++ b/wework/src/stream/chatStream.ts
@@ -6,6 +6,7 @@ import type {
   ChatErrorPayload,
   ChatStartPayload,
   RuntimeGoalEventPayload,
+  RuntimeGuidanceAppliedPayload,
   RuntimeSubagentActivityPayload,
 } from '@/types/api'
 import type { DeviceSlotUpdatePayload, DeviceUpgradeStatusPayload } from '@/types/device-events'
@@ -34,6 +35,7 @@ export interface ChatStreamHandlers {
   onSubagentActivity?: (payload: RuntimeSubagentActivityPayload) => void
   onRuntimeGoalUpdated?: (payload: RuntimeGoalEventPayload) => void
   onRuntimeGoalCleared?: (payload: RuntimeGoalEventPayload) => void
+  onGuidanceApplied?: (payload: RuntimeGuidanceAppliedPayload) => void
   onDeviceOnline?: (payload: unknown) => void
   onDeviceOffline?: (payload: unknown) => void
   onDeviceStatus?: (payload: unknown) => void

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -43,6 +43,7 @@ export const RESPONSE_API_STREAM_EVENTS = [
   'response.block.created',
   'response.block.updated',
   'response.subagent.activity',
+  'response.guidance.applied',
   'runtime.goal.updated',
   'runtime.goal.cleared',
   'thread/tokenUsage/updated',
@@ -653,6 +654,19 @@ export function emitResponseApiEvent(
 
   if (eventName === 'response.subagent.activity') {
     emitSubagentActivity(handlers, base, data)
+    return
+  }
+
+  if (eventName === 'response.guidance.applied') {
+    handlers.onGuidanceApplied?.({
+      ...base,
+      guidanceId: stringField(data, 'guidanceId') ?? stringField(data, 'guidance_id') ?? 'guidance',
+      message: stringField(data, 'message') ?? '',
+      appliedAtMs:
+        optionalNumberField(data, 'appliedAtMs') ??
+        optionalNumberField(data, 'applied_at_ms') ??
+        Date.now(),
+    })
     return
   }
 

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -549,6 +549,8 @@ export interface RuntimeSendResponse {
 export interface RuntimeGuidanceRequest {
   address: RuntimeTaskAddress
   message: string
+  attachmentIds?: number[]
+  attachments?: Attachment[]
   clientGuidanceId?: string
   client_guidance_id?: string
   additionalContext?: RuntimeAdditionalContext
@@ -1767,6 +1769,15 @@ export interface RuntimeGoalEventPayload {
   deviceId?: string
   threadId?: string
   goal?: RuntimeGoal | null
+}
+
+export interface RuntimeGuidanceAppliedPayload {
+  taskId?: string
+  subtaskId?: string
+  deviceId?: string
+  guidanceId: string
+  message: string
+  appliedAtMs: number
 }
 
 export interface ChatGuidanceQueuedPayload {

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -74,6 +74,7 @@ export type WorkbenchMessage = Omit<
   runtimeGoalRequest?: boolean | null
   runtimeGuidance?: boolean | null
   runtimeGuidanceSplitBefore?: boolean | null
+  runtimeGuidanceContinuation?: boolean | null
   codeComments?: CodeCommentContext[] | null
   references?: CodexReference[] | null
   memoryCitations?: CodexMemoryCitation[] | null


### PR DESCRIPTION
## Summary
- preserve image attachments in runtime guidance and support image-only guidance
- create guidance boundaries from raw Codex user-message events to keep message order and turn state correct
- align Goal pause/clear behavior with manual stop and correct Goal bar presentation
- prevent cancelled turns with late output from showing as still thinking

## Root cause
Guidance was previously represented optimistically and did not have a raw stream boundary. In addition, local task IDs could be used as Codex thread IDs and image-only guidance was rejected as missing text.

## Validation
- `pnpm --filter wework test`
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- `uv run pytest tests/schemas/test_runtime_work_schema.py`
- `cargo test --all-features --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- pre-push quality gate (AI verified; docs checked and no update required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime guidance can now include image attachments.
  * Guidance application events are surfaced in real time, allowing queued guidance to appear when applied.
  * Guidance responses now provide additional status information.
* **Bug Fixes**
  * Improved handling of cancelled responses so late content remains visible without a misleading thinking indicator.
  * Guidance continuation messages remain expanded for clearer context.
  * Pausing a response now pauses the active goal before stopping generation.
* **Style**
  * Updated goal status bar layout and visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->