### PR TITLE
fix(wework): expose available update action

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -162,6 +162,7 @@ describe('DesktopSidebar', () => {
     renderSidebar()
 
     expect(screen.getByTestId('settings-button')).toHaveClass('h-[60px]', 'min-w-0', 'flex-1')
+    expect(screen.getByTestId('settings-button')).toHaveClass('pr-10')
     expect(screen.getByTestId('settings-button')).not.toHaveClass('w-full', 'shrink-0')
     expect(screen.getByTestId('settings-button')).toHaveTextContent('alice')
     expect(screen.getByTestId('settings-button')).toHaveTextContent('alice@example.com')
@@ -181,41 +182,27 @@ describe('DesktopSidebar', () => {
     })
 
     const button = screen.getByTestId('sidebar-app-update-button')
+    const action = screen.getByTestId('sidebar-app-update-action')
     expect(button).toHaveClass('h-8', 'w-8')
     expect(button).toHaveAttribute('title', '更新到 0.1.1')
+    expect(action).not.toHaveClass('max-w-0', 'opacity-0', 'overflow-hidden')
+    expect(screen.getByTestId('settings-button')).toHaveClass('pr-[72px]')
 
     await userEvent.click(button)
 
     expect(installUpdate).toHaveBeenCalledTimes(1)
   })
 
-  test('keeps the account-row update icon visible in debug mode for checking updates', async () => {
-    const checkNow = vi.fn().mockResolvedValue(null)
-    renderSidebar({}, undefined, { availableUpdate: null, checkNow })
-
-    const button = screen.getByTestId('sidebar-app-update-button')
-    expect(button).toHaveAttribute('title', '检查更新')
-
-    await userEvent.click(button)
-
-    expect(checkNow).toHaveBeenCalledTimes(1)
-  })
-
-  test('shows the app update error near the account-row update icon', async () => {
+  test('does not show an update icon without an available update', () => {
     renderSidebar({}, undefined, {
       availableUpdate: null,
       status: 'error',
       error: 'updater does not have any endpoints set',
     })
 
-    const button = screen.getByTestId('sidebar-app-update-button')
-    expect(button).toHaveAttribute('title', 'updater does not have any endpoints set')
-    expect(screen.queryByTestId('sidebar-app-update-error')).not.toBeInTheDocument()
-    await userEvent.hover(button)
-
-    expect(await screen.findByTestId('sidebar-app-update-error')).toHaveTextContent(
-      'updater does not have any endpoints set'
-    )
+    expect(screen.queryByTestId('sidebar-app-update-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sidebar-app-update-action')).not.toBeInTheDocument()
+    expect(screen.getByTestId('settings-button')).toHaveClass('pr-10')
   })
 
   test('keeps the resize handle hit area on the sidebar edge', () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1052,7 +1052,6 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
   const status = appUpdate?.status ?? 'idle'
   const error = appUpdate?.error ?? null
   const busy = status === 'checking' || status === 'installing'
-  const visibleForDebug = import.meta.env.DEV
 
   const showErrorTooltip = () => {
     if (!error || !buttonRef.current) return
@@ -1063,7 +1062,7 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
     })
   }
 
-  if (!appUpdate || (!availableUpdate && !visibleForDebug)) return null
+  if (!appUpdate || !availableUpdate) return null
 
   const title = availableUpdate
     ? formatSidebarTemplate(
@@ -2006,6 +2005,7 @@ export function DesktopSidebar({
   })
   const showCloudConnectionEntry = isCloudConnectionUiAvailable()
   const usesOverlayTitlebar = isTauriRuntime()
+  const hasAvailableAppUpdate = Boolean(useOptionalAppUpdate()?.availableUpdate)
   const sidebarAccount = getSidebarAccountSummary(user, t('workbench.account_fallback', '当前账号'))
   const workbenchAppLabel = t('workbench.app_wework')
   const appsAppLabel = t('workbench.apps')
@@ -2706,7 +2706,10 @@ export function DesktopSidebar({
                   setImNotificationMenuOpen(false)
                   setSettingsMenuOpen(open => !open)
                 }}
-                className="flex h-[60px] min-w-0 flex-1 items-center gap-3 rounded-[10px] py-2 pl-1.5 pr-10 text-left text-[rgb(var(--color-sidebar-text-primary))] transition-[padding] group-hover/account:pr-[72px] group-focus-within/account:pr-[72px]"
+                className={cn(
+                  'flex h-[60px] min-w-0 flex-1 items-center gap-3 rounded-[10px] py-2 pl-1.5 text-left text-[rgb(var(--color-sidebar-text-primary))]',
+                  hasAvailableAppUpdate ? 'pr-[72px]' : 'pr-10'
+                )}
                 title={t('workbench.settings', '设置')}
                 aria-label={t('workbench.settings', '设置')}
                 aria-expanded={settingsMenuOpen}
@@ -2724,14 +2727,16 @@ export function DesktopSidebar({
                 </span>
               </button>
               <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
-                <div className="max-w-0 translate-x-1 overflow-hidden opacity-0 transition-[max-width,opacity,transform] duration-150 group-hover/account:max-w-8 group-hover/account:translate-x-0 group-hover/account:opacity-100 group-focus-within/account:max-w-8 group-focus-within/account:translate-x-0 group-focus-within/account:opacity-100">
-                  <SidebarAppUpdateButton
-                    onBeforeInstall={() => {
-                      setSettingsMenuOpen(false)
-                      setImNotificationMenuOpen(false)
-                    }}
-                  />
-                </div>
+                {hasAvailableAppUpdate && (
+                  <div data-testid="sidebar-app-update-action">
+                    <SidebarAppUpdateButton
+                      onBeforeInstall={() => {
+                        setSettingsMenuOpen(false)
+                        setImNotificationMenuOpen(false)
+                      }}
+                    />
+                  </div>
+                )}
                 <GlobalImNotificationBell
                   devices={devices}
                   imNotificationSettings={imNotificationSettings}


### PR DESCRIPTION
## Summary
- keep the sidebar update action visible whenever a newer Wework version is available
- hide the action and reclaim account-row space when no update is available, including development builds
- cover both states with DesktopSidebar tests

## Root cause
The update action was placed in a hover-only account-row container, and development builds exposed a check-for-updates icon even without an available update.

## Validation
- `pnpm --filter wework exec vitest run src/components/layout/DesktopSidebar.test.tsx --reporter=dot`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- pre-push gate: Wework ESLint, TypeScript, and full unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The sidebar now displays the app update action only when an update is available.
  * Updated the account settings layout to prevent overlap and preserve proper spacing when the update action appears.
  * Improved the sidebar’s update action visibility and transition behavior.
  * When no update is available, the update action is hidden and the settings control returns to its default layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->