### PR TITLE
fix(dev): share Cargo targets across worktrees

### DIFF
--- a/docs/en/developer-guide/setup.md
+++ b/docs/en/developer-guide/setup.md
@@ -255,9 +255,9 @@ pnpm --filter wecode-ai-assistant run start
 
 #### Wework and Local Rust Build Cache
 
-The Wework macOS development scripts isolate Cargo targets by Git worktree. This prevents Cargo's path-sensitive fingerprints and unhashed binaries from overwriting each other during parallel debugging. On the first `pnpm --dir wework run dev:mac`, the script installs `sccache` with Homebrew when it is missing, then reuses matching dependency and source compilation outputs across worktrees.
+The Wework macOS development scripts share Cargo targets by component across Git worktrees, so switching worktrees can reuse already compiled dependencies instead of compiling them from scratch. Cargo coordinates concurrent access to a target directory and rebuilds artifacts when their fingerprints change. On the first `pnpm --dir wework run dev:mac`, the script installs `sccache` with Homebrew when it is missing to reuse compiler outputs as well.
 
-- `pnpm --dir wework run dev:mac`, `pnpm --dir wework run build:mac`, the development executor sidecar, and `executor/local.sh build` use `$XDG_CACHE_HOME/wegent/cargo-target/<component>/worktrees/<worktree>`, or `~/.cache/wegent/cargo-target/...` when `XDG_CACHE_HOME` is not set.
+- `pnpm --dir wework run dev:mac`, `pnpm --dir wework run build:mac`, the development executor sidecar, and `executor/local.sh build` use `$XDG_CACHE_HOME/wegent/cargo-target/<component>`, or `~/.cache/wegent/cargo-target/...` when `XDG_CACHE_HOME` is not set.
 - When `sccache` is available, the scripts set `RUSTC_WRAPPER` and `SCCACHE_BASEDIRS` automatically, normalize source and target paths across worktrees, and disable Cargo incremental compilation, which is incompatible with shared compiler caching.
 - Set `WEGENT_CARGO_TARGET_ROOT=/path/to/cache` to choose another target cache root.
 - Set `WEGENT_DISABLE_SHARED_CARGO_TARGET=1` to use Cargo's repository-local default `target/`.

--- a/docs/zh/developer-guide/setup.md
+++ b/docs/zh/developer-guide/setup.md
@@ -255,9 +255,9 @@ pnpm --dir frontend run start
 
 #### Wework 与本地 Rust 构建缓存
 
-Wework macOS 开发脚本会隔离各 Git worktree 的 Cargo target，避免 Cargo 的路径相关 fingerprint 和未哈希二进制在并行调试时互相覆盖。首次运行 `pnpm --dir wework run dev:mac` 时，如果本机缺少 `sccache`，脚本会通过 Homebrew 自动安装；随后通过共享编译缓存复用不同 worktree 中相同的依赖和源码产物。
+Wework macOS 开发脚本会让 Git worktree 按组件共享 Cargo target，因此切换 worktree 时可以直接复用已编译的依赖产物，而不必再次完整编译。Cargo 会为同一 target 目录协调并发访问，并在 fingerprint 变化时重新编译失效产物。首次运行 `pnpm --dir wework run dev:mac` 时，如果本机缺少 `sccache`，脚本会通过 Homebrew 自动安装，以进一步复用编译器缓存。
 
-- `pnpm --dir wework run dev:mac`、`pnpm --dir wework run build:mac`、开发模式 executor sidecar 和 `executor/local.sh build` 都使用 `$XDG_CACHE_HOME/wegent/cargo-target/<组件>/worktrees/<worktree>`；未设置 `XDG_CACHE_HOME` 时使用 `~/.cache/wegent/cargo-target/...`。
+- `pnpm --dir wework run dev:mac`、`pnpm --dir wework run build:mac`、开发模式 executor sidecar 和 `executor/local.sh build` 都使用 `$XDG_CACHE_HOME/wegent/cargo-target/<组件>`；未设置 `XDG_CACHE_HOME` 时使用 `~/.cache/wegent/cargo-target/...`。
 - 脚本检测到 `sccache` 后会自动设置 `RUSTC_WRAPPER` 和 `SCCACHE_BASEDIRS`，归一化不同 worktree 的源码及 target 绝对路径，并关闭与共享编译缓存不兼容的 Cargo incremental。
 - 如需指定其他 target 缓存根目录，设置 `WEGENT_CARGO_TARGET_ROOT=/path/to/cache`。
 - 如需使用仓库内 Cargo 默认的 `target/`，设置 `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`。

--- a/executor/local.sh
+++ b/executor/local.sh
@@ -41,7 +41,7 @@ Environment:
   WEGENT_FILE_EDIT_HOOK_COMMAND  Default: local file edit hook collector
   WEGENT_EXECUTOR_BINARY         Default: dist/wegent-executor
   CARGO_TARGET_DIR               Explicit Cargo target directory. Overrides auto cache.
-  WEGENT_CARGO_TARGET_ROOT       Root containing worktree-isolated Cargo targets.
+  WEGENT_CARGO_TARGET_ROOT       Root containing shared Cargo targets.
   WEGENT_DISABLE_SHARED_CARGO_TARGET
                                   Set to 1 to keep Cargo's default per-worktree target.
   WEGENT_DISABLE_SCCACHE         Set to 1 to disable automatic sccache detection.

--- a/scripts/lib/cargo-cache.sh
+++ b/scripts/lib/cargo-cache.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# Cargo build caches for local worktrees.
+# Shared Cargo build caches for local worktrees.
 #
-# Cargo target directories contain path-sensitive fingerprints and unhashed
-# binaries. Keep them isolated per worktree, while sccache (when installed)
-# shares compiler outputs safely across worktrees.
+# Keep one target directory per component so Cargo can reuse dependency
+# artifacts between worktrees. Cargo serializes concurrent access to a target
+# directory and invalidates artifacts when its fingerprints change.
 
 wegent_cargo_cache_root() {
   if [ -n "${WEGENT_CARGO_TARGET_ROOT:-}" ]; then
@@ -14,18 +14,6 @@ wegent_cargo_cache_root() {
   elif [ -n "${HOME:-}" ]; then
     printf '%s\n' "$HOME/.cache/wegent/cargo-target"
   fi
-}
-
-wegent_worktree_cache_key() {
-  local project_dir="$1"
-  local canonical_dir=""
-  local directory_name=""
-  local checksum=""
-
-  canonical_dir="$(cd "$project_dir" 2>/dev/null && pwd -P)" || return 1
-  directory_name="$(basename "$canonical_dir" | tr -c '[:alnum:]._-\n' '_')"
-  checksum="$(printf '%s' "$canonical_dir" | cksum | awk '{print $1}')"
-  printf '%s-%s\n' "$directory_name" "$checksum"
 }
 
 configure_wegent_sccache() {
@@ -84,12 +72,10 @@ configure_wegent_cargo_target_dir() {
   fi
 
   local cache_root=""
-  local worktree_key=""
   cache_root="$(wegent_cargo_cache_root)"
   [ -n "$cache_root" ] || return 0
-  worktree_key="$(wegent_worktree_cache_key "$project_dir")" || return 0
 
-  export CARGO_TARGET_DIR="$cache_root/$cache_name/worktrees/$worktree_key"
+  export CARGO_TARGET_DIR="$cache_root/$cache_name"
   export WEGENT_CARGO_TARGET_DIR_AUTO=1
   mkdir -p "$CARGO_TARGET_DIR"
   configure_wegent_sccache "$project_dir" "$CARGO_TARGET_DIR"

--- a/scripts/tests/cargo-cache.test.sh
+++ b/scripts/tests/cargo-cache.test.sh
@@ -20,7 +20,7 @@ fail() {
   exit 1
 }
 
-test_worktree_target_isolation() {
+test_worktrees_share_component_target() {
   local root="$1"
   local first="$root/first/Wegent"
   local second="$root/second/Wegent"
@@ -39,8 +39,8 @@ test_worktree_target_isolation() {
     printf "%s" "$CARGO_TARGET_DIR"
   ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$second")"
 
-  [ "$first_target" != "$second_target" ] || fail "worktrees share a target directory"
-  [[ "$first_target" == "$root/cache/executor/worktrees/"* ]] || fail "unexpected target path"
+  [ "$first_target" = "$second_target" ] || fail "worktrees use different target directories"
+  [ "$first_target" = "$root/cache/executor" ] || fail "unexpected target path: $first_target"
 }
 
 test_explicit_target_is_preserved() {
@@ -68,7 +68,7 @@ test_sccache_is_configured_when_available() {
     configure_wegent_cargo_target_dir "$2" executor
     printf "%s|%s|%s|%s" "$RUSTC_WRAPPER" "$CARGO_INCREMENTAL" "$WEGENT_SCCACHE_AUTO" "$SCCACHE_BASEDIRS"
   ' _ "$PROJECT_DIR/scripts/lib/cargo-cache.sh" "$root/project")"
-  [ "$actual" = "$root/bin/sccache|0|1|$canonical_project:$root/home/.cache/wegent/cargo-target/executor/worktrees/project-$(printf '%s' "$canonical_project" | cksum | awk '{print $1}')" ] \
+  [ "$actual" = "$root/bin/sccache|0|1|$canonical_project:$root/home/.cache/wegent/cargo-target/executor" ] \
     || fail "sccache was not configured with normalized paths: $actual"
 }
 
@@ -111,7 +111,7 @@ cleanup() {
 main() {
   TEST_ROOT="$(mktemp -d)"
   trap cleanup EXIT
-  test_worktree_target_isolation "$TEST_ROOT"
+  test_worktrees_share_component_target "$TEST_ROOT"
   test_explicit_target_is_preserved "$TEST_ROOT"
   test_sccache_is_configured_when_available "$TEST_ROOT"
   test_sccache_is_installed_with_homebrew "$TEST_ROOT"

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -32,7 +32,7 @@ Environment:
   BACKEND_PORT          Backend port used when proxy targets are not set.
   CARGO_TARGET_DIR      Explicit Cargo target directory. Overrides auto cache.
   WEGENT_CARGO_TARGET_ROOT
-                        Root containing worktree-isolated Cargo targets.
+                        Root containing shared Cargo targets.
   WEGENT_DISABLE_SHARED_CARGO_TARGET
                         Set to 1 to keep Cargo's default per-worktree target.
   WEGENT_DISABLE_SCCACHE


### PR DESCRIPTION
## What changed

- Share Cargo target directories by component across Git worktrees.
- Keep explicit cache overrides and the local-target opt-out.
- Update cache coverage and Chinese/English setup guidance.

## Why

Worktrees previously used isolated Cargo target directories, so each worktree rebuilt the same Rust dependencies on first Wework development run.

## Validation

- `bash scripts/tests/cargo-cache.test.sh`
- Wework `dev:mac` and `build:mac` dry-run checks
- Repository pre-push quality gate (lint, typecheck, and tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated English and Chinese setup guides to explain shared Cargo build caches across Git worktrees.
  - Documented the revised component-level cache locations and artifact reuse behavior.
  - Clarified environment variable help text for shared Cargo targets.

- **Bug Fixes**
  - Local Rust builds now reuse compiled artifacts across worktrees, reducing unnecessary recompilation.
  - Updated cache validation and sccache path handling to match the shared-target layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->