### PR TITLE
fix(wework): pause goals for inactive tasks

### DIFF
--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -44,6 +44,14 @@ This document records the state sources for the Wework chat path. The goal is to
 7. `chat:done`, `chat:error`, and cancellation events settle the assistant message through the reducer and refresh the work list.
 8. If runtime work and message state disagree, do not settle it with fallback logic; fix the missing stream event, transcript data, or reducer action.
 
+## Goal and Task Execution State
+
+The goal bar's running presentation must be constrained by the current runtime task execution snapshot. When App Server explicitly reports `running: false` for the current task, an otherwise `active` goal must be derived as `paused` in the UI and its displayed elapsed time must stop. This prevents an interrupted task from showing an active, ticking goal when it is reopened.
+
+- Task execution is known only when `running` is an explicit boolean. A missing field means the state is unknown and must not pause the goal.
+- This derivation affects only Wework presentation and elapsed-time calculation; it does not automatically call the goal pause API. Persisting `paused` remains an explicit user action through **Pause goal**.
+- When the task reports `running: true` again, the goal uses the original status returned by the runtime goal API.
+
 ## Long Output Memory Boundary
 
 The Wework chat UI must not keep complete long-running output in React state. `WorkbenchMessage.content`, thinking/text/plan block `content`, and tool block `toolOutput` must enter `messages` through the shared preview-window path:

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -44,6 +44,14 @@ sidebar_position: 18
 7. `chat:done`、`chat:error`、取消事件通过 reducer 结算 assistant 消息，并触发 work list 刷新。
 8. 如果 runtime work 与消息状态不一致，不做兜底结算；必须修正缺失的 stream event、transcript 数据或 reducer action。
 
+## Goal 与任务执行状态
+
+Goal 条的运行态必须受当前 runtime task 的执行快照约束：当 App Server 明确返回当前任务 `running: false` 时，仍为 `active` 的 goal 在 UI 中必须派生为 `paused`，并停止累计显示的耗时。这避免在重新打开已中断任务时，goal 继续显示“进行中”并计时。
+
+- 仅当 `running` 是明确的布尔值时，任务执行状态才是已知状态；缺失该字段意味着状态尚不确定，不能据此暂停 goal。
+- 此派生只影响 Wework 的展示与计时，不会自动调用 goal 暂停接口。用户点击“暂停目标”才会持久化 `paused` 状态。
+- 任务重新处于 `running: true` 时，goal 继续使用 runtime goal API 返回的原始状态。
+
 ## 长输出内存边界
 
 Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React state 中。`WorkbenchMessage.content`、thinking/text/plan block 的 `content`、tool block 的 `toolOutput` 都必须通过统一的预览窗口进入 `messages`：

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -12,6 +12,7 @@ import {
   deriveRuntimePaneStatus,
   getRuntimePaneTaskExecution,
   hasSettledAssistantMessage,
+  pauseGoalForInactiveTask,
   type RuntimePaneSendPhase,
 } from '@/features/workbench/runtimePaneStatus'
 import {
@@ -281,23 +282,29 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   )
   const activeAssistantMessage = paneStatus.activeAssistantMessage
   const goal = useMemo(() => {
+    let resolvedGoal: RuntimeGoal | null
     if (!currentRuntimeTaskLoadTarget) {
       if (pendingGoalState && isUnboundPendingGoalState(pendingGoalState)) {
-        return visibleRuntimeGoal(pendingGoalState.goal)
+        resolvedGoal = visibleRuntimeGoal(pendingGoalState.goal)
+      } else {
+        resolvedGoal = null
       }
-      return null
+    } else {
+      const visibleThreadGoal = visibleRuntimeGoal(threadGoal)
+      if (visibleThreadGoal) {
+        resolvedGoal = visibleThreadGoal
+      } else if (
+        pendingGoalState &&
+        isPendingGoalVisibleForRuntimeTarget(pendingGoalState, currentRuntimeTaskLoadTarget.address)
+      ) {
+        resolvedGoal = visibleRuntimeGoal(pendingGoalState.goal)
+      } else {
+        resolvedGoal = null
+      }
     }
 
-    const visibleThreadGoal = visibleRuntimeGoal(threadGoal)
-    if (visibleThreadGoal) return visibleThreadGoal
-    if (!pendingGoalState) return null
-    if (
-      isPendingGoalVisibleForRuntimeTarget(pendingGoalState, currentRuntimeTaskLoadTarget.address)
-    ) {
-      return visibleRuntimeGoal(pendingGoalState.goal)
-    }
-    return null
-  }, [currentRuntimeTaskLoadTarget, pendingGoalState, threadGoal])
+    return pauseGoalForInactiveTask(resolvedGoal, taskExecution)
+  }, [currentRuntimeTaskLoadTarget, pendingGoalState, taskExecution, threadGoal])
 
   /* eslint-disable react-hooks/set-state-in-effect -- Runtime task changes reset pane transcript state before the async transcript load completes. */
   useEffect(() => {

--- a/wework/src/features/workbench/runtimePaneStatus.test.ts
+++ b/wework/src/features/workbench/runtimePaneStatus.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import type { RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
+import type { RuntimeGoal, RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
 import type { WorkbenchMessage } from '@/types/workbench'
-import { deriveRuntimePaneStatus, getRuntimePaneTaskExecution } from './runtimePaneStatus'
+import {
+  deriveRuntimePaneStatus,
+  getRuntimePaneTaskExecution,
+  pauseGoalForInactiveTask,
+} from './runtimePaneStatus'
 
 const runtimeAddress: RuntimeTaskAddress = {
   deviceId: 'device-1',
@@ -57,6 +61,51 @@ function runtimeWork(running: boolean, status?: string | null): RuntimeWorkListR
 }
 
 describe('runtime pane status', () => {
+  test('pauses an active goal when its known task is no longer running', () => {
+    const goal: RuntimeGoal = {
+      threadId: 'thread-1',
+      objective: 'Finish the task',
+      status: 'active',
+      tokenBudget: null,
+      tokensUsed: 12,
+      timeUsedSeconds: 30,
+      createdAt: 1770000000000,
+      updatedAt: 1770000000000,
+    }
+
+    expect(
+      pauseGoalForInactiveTask(goal, { known: true, running: false, status: 'interrupted' })
+    ).toMatchObject({ status: 'paused', timeUsedSeconds: 30 })
+  })
+
+  test('does not change an active goal before task execution is known', () => {
+    const goal: RuntimeGoal = {
+      threadId: 'thread-1',
+      objective: 'Finish the task',
+      status: 'active',
+      tokenBudget: null,
+      tokensUsed: 12,
+      timeUsedSeconds: 30,
+      createdAt: 1770000000000,
+      updatedAt: 1770000000000,
+    }
+
+    expect(pauseGoalForInactiveTask(goal, { known: false, running: false, status: null })).toBe(
+      goal
+    )
+  })
+
+  test('treats a task without a running flag as unknown', () => {
+    const runtimeWorkWithoutRunningState = runtimeWork(false)
+    runtimeWorkWithoutRunningState.chats[0].tasks[0].running = undefined
+
+    expect(getRuntimePaneTaskExecution(runtimeWorkWithoutRunningState, runtimeAddress)).toEqual({
+      known: false,
+      running: false,
+      status: null,
+    })
+  })
+
   test('derives one busy state from send phase, streaming message, and task execution', () => {
     const taskExecution = getRuntimePaneTaskExecution(runtimeWork(true), runtimeAddress)
     const status = deriveRuntimePaneStatus({

--- a/wework/src/features/workbench/runtimePaneStatus.ts
+++ b/wework/src/features/workbench/runtimePaneStatus.ts
@@ -1,4 +1,9 @@
-import type { RuntimeTaskSummary, RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
+import type {
+  RuntimeGoal,
+  RuntimeTaskSummary,
+  RuntimeTaskAddress,
+  RuntimeWorkListResponse,
+} from '@/types/api'
 import type { WorkbenchMessage } from '@/types/workbench'
 import { findRuntimeTask } from './workbenchRuntimeHelpers'
 
@@ -32,9 +37,10 @@ export function getRuntimePaneTaskExecution(
     return { known: false, running: false, status: null }
   }
 
+  const running = typeof task.running === 'boolean' ? task.running : null
   return {
-    known: true,
-    running: task.running === true,
+    known: running !== null,
+    running: running === true,
     status: normalizeTaskStatus(task),
   }
 }
@@ -76,6 +82,22 @@ export function deriveRuntimePaneStatus({
       isWaitingForAssistantMessage,
     canSendQueuedMessage: Boolean(currentRuntimeTask) && !isBusy,
   }
+}
+
+/**
+ * A goal cannot be active while its owning runtime task is idle. The runtime
+ * task list is authoritative when it contains the task; an absent task may
+ * simply mean the list has not loaded yet, so its goal is left unchanged.
+ */
+export function pauseGoalForInactiveTask(
+  goal: RuntimeGoal | null,
+  taskExecution: RuntimePaneTaskExecution
+): RuntimeGoal | null {
+  if (!goal || goal.status !== 'active' || !taskExecution.known || taskExecution.running) {
+    return goal
+  }
+
+  return { ...goal, status: 'paused' }
 }
 
 export function findActiveAssistantMessage(


### PR DESCRIPTION
## Summary
- Derive a paused goal presentation and stop goal elapsed time when App Server explicitly reports the current task as not running.
- Treat a missing `running` field as unknown, preventing incorrect state changes while data is incomplete.
- Document the goal/task execution-state precedence in Chinese and English.

## Root cause
The goal timer was driven solely by the persisted goal status. Reopening an interrupted task could therefore render an active, ticking goal even though the runtime task was idle.

## Validation
- `pnpm --dir wework test` (145 files, 1421 tests)
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`
- Pre-push quality gate (including full Wework checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal status now reflects the current task execution state in Wework.
  * Active goals are shown as paused, with elapsed time stopped, when the task is explicitly not running.
  * Goals resume their original status when task execution resumes.

* **Bug Fixes**
  * Missing task execution status no longer incorrectly pauses goals.
  * Display-only pausing does not automatically persist a paused goal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->