### PR TITLE
fix(wework): show app update download progress

### DIFF
--- a/wework/src/components/layout/DesktopSettingsMenu.test.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.test.tsx
@@ -11,6 +11,7 @@ const runtimeModeMock = vi.hoisted(() => ({
 let mockUpdateState = {
   availableUpdate: null as null | { currentVersion: string; version: string },
   status: 'idle',
+  downloadProgress: null as null | { downloadedBytes: number; totalBytes: number | null },
   error: null as string | null,
   checkNow: mockCheckNow,
   installUpdate: mockInstallUpdate,
@@ -57,6 +58,7 @@ describe('DesktopSettingsMenu', () => {
     mockUpdateState = {
       availableUpdate: null,
       status: 'idle',
+      downloadProgress: null,
       error: null,
       checkNow: mockCheckNow,
       installUpdate: mockInstallUpdate,
@@ -109,6 +111,29 @@ describe('DesktopSettingsMenu', () => {
 
     await userEvent.click(updateButton)
     expect(mockInstallUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  test('shows download progress in the update icon and menu item', () => {
+    mockUpdateState = {
+      ...mockUpdateState,
+      availableUpdate: {
+        currentVersion: '0.1.0',
+        version: '0.1.1',
+      },
+      status: 'installing',
+      downloadProgress: {
+        downloadedBytes: 50,
+        totalBytes: 100,
+      },
+    }
+
+    renderMenu()
+
+    expect(screen.getByTestId('app-update-download-icon-progress')).toHaveAttribute(
+      'aria-label',
+      '50%'
+    )
+    expect(screen.getByTestId('app-update-download-progress')).toHaveTextContent('正在下载更新 50%')
   })
 
   test('shows usage reset times in the expanded usage panel', async () => {

--- a/wework/src/components/layout/DesktopSettingsMenu.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.tsx
@@ -18,6 +18,29 @@ function formatVersionTemplate(template: string, version: string): string {
   return template.replace('{{version}}', version)
 }
 
+function calculateDownloadPercent(
+  downloadedBytes: number,
+  totalBytes: number | null
+): number | null {
+  if (!totalBytes || totalBytes <= 0) return null
+  return Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))
+}
+
+function UpdateDownloadProgressIcon({ progress }: { progress: number }) {
+  return (
+    <span
+      data-testid="app-update-download-icon-progress"
+      aria-label={`${progress}%`}
+      className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+      style={{
+        background: `conic-gradient(rgb(var(--color-primary)) ${progress}%, rgb(var(--color-border)) 0)`,
+      }}
+    >
+      <span className="h-2 w-2 rounded-full bg-popover" />
+    </span>
+  )
+}
+
 interface DesktopSettingsMenuProps {
   user: UserProfile | null
   onOpenSettings: () => void
@@ -34,6 +57,7 @@ export function DesktopSettingsMenu({ onOpenSettings, onLogout }: DesktopSetting
   const appUpdate = useOptionalAppUpdate()
   const availableUpdate = appUpdate?.availableUpdate ?? null
   const updateStatus = appUpdate?.status ?? 'idle'
+  const downloadProgress = appUpdate?.downloadProgress ?? null
   const updateError = appUpdate?.error ?? null
   const checkNow = appUpdate?.checkNow
   const installUpdate = appUpdate?.installUpdate
@@ -85,18 +109,33 @@ export function DesktopSettingsMenu({ onOpenSettings, onLogout }: DesktopSetting
       )
     : t('workbench.app_update_check', { defaultValue: '检查更新' })
   const isUpdateBusy = updateStatus === 'checking' || updateStatus === 'installing'
-  const updateMessage = availableUpdate
-    ? formatVersionTemplate(
-        t('workbench.app_update_available', {
-          defaultValue: '发现新版本 {{version}}',
-          version: availableUpdate.version,
-        }),
-        availableUpdate.version
-      )
-    : updateStatus === 'upToDate'
-      ? t('workbench.app_update_up_to_date', {
-          defaultValue: '已是最新版本',
-        })
+  const downloadPercent = downloadProgress
+    ? calculateDownloadPercent(downloadProgress.downloadedBytes, downloadProgress.totalBytes)
+    : null
+  const updateMessage =
+    updateStatus === 'installing'
+      ? null
+      : availableUpdate
+        ? formatVersionTemplate(
+            t('workbench.app_update_available', {
+              defaultValue: '发现新版本 {{version}}',
+              version: availableUpdate.version,
+            }),
+            availableUpdate.version
+          )
+        : updateStatus === 'upToDate'
+          ? t('workbench.app_update_up_to_date', {
+              defaultValue: '已是最新版本',
+            })
+          : null
+  const downloadMessage =
+    updateStatus === 'installing'
+      ? downloadPercent === null
+        ? t('workbench.app_update_downloading', { defaultValue: '正在下载更新' })
+        : t('workbench.app_update_downloading_progress', {
+            defaultValue: '正在下载更新 {{progress}}%',
+            progress: downloadPercent,
+          }).replace('{{progress}}', String(downloadPercent))
       : null
 
   return (
@@ -114,7 +153,9 @@ export function DesktopSettingsMenu({ onOpenSettings, onLogout }: DesktopSetting
       <SettingsMenuItem
         testId="check-app-update-button"
         icon={
-          isUpdateBusy ? (
+          updateStatus === 'installing' && downloadPercent !== null ? (
+            <UpdateDownloadProgressIcon progress={downloadPercent} />
+          ) : isUpdateBusy ? (
             <Loader2 className="h-4 w-4 shrink-0 animate-spin text-text-secondary" />
           ) : (
             <Download className="h-4 w-4 shrink-0 text-text-secondary" />
@@ -125,6 +166,24 @@ export function DesktopSettingsMenu({ onOpenSettings, onLogout }: DesktopSetting
         disabled={isUpdateBusy}
         active={Boolean(updateError)}
       />
+      {downloadMessage ? (
+        <div
+          data-testid="app-update-download-progress"
+          className="space-y-1.5 px-4 pb-2 pl-[44px] pr-5 text-xs font-medium leading-[18px] text-text-secondary"
+        >
+          <div className="h-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className={
+                downloadPercent === null
+                  ? 'h-full w-1/3 animate-pulse rounded-full bg-primary'
+                  : 'h-full rounded-full bg-primary transition-[width] duration-200'
+              }
+              style={downloadPercent === null ? undefined : { width: `${downloadPercent}%` }}
+            />
+          </div>
+          <span>{downloadMessage}</span>
+        </div>
+      ) : null}
       {updateMessage || updateError ? (
         <div
           data-testid="app-update-status"

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -99,6 +99,7 @@ function renderSidebar(
     const value: AppUpdateContextValue = {
       availableUpdate: null,
       status: 'idle',
+      downloadProgress: null,
       message: null,
       error: null,
       checkNow: vi.fn().mockResolvedValue(null),
@@ -203,6 +204,21 @@ describe('DesktopSidebar', () => {
     expect(screen.queryByTestId('sidebar-app-update-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('sidebar-app-update-action')).not.toBeInTheDocument()
     expect(screen.getByTestId('settings-button')).toHaveClass('pr-10')
+  })
+
+  test('shows download progress in the account-row update icon', () => {
+    renderSidebar({}, undefined, {
+      availableUpdate: { currentVersion: '0.1.0', version: '0.1.1' },
+      status: 'installing',
+      downloadProgress: { downloadedBytes: 40, totalBytes: 100 },
+    })
+
+    const progress = screen.getByTestId('sidebar-app-update-download-progress')
+    expect(progress).toHaveAttribute('aria-valuenow', '40')
+    expect(screen.getByTestId('sidebar-app-update-button')).toHaveAttribute(
+      'title',
+      '正在下载更新 40%'
+    )
   })
 
   test('keeps the resize handle hit area on the sidebar edge', () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1050,8 +1050,15 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
   } | null>(null)
   const availableUpdate = appUpdate?.availableUpdate ?? null
   const status = appUpdate?.status ?? 'idle'
+  const downloadProgress = appUpdate?.downloadProgress ?? null
   const error = appUpdate?.error ?? null
   const busy = status === 'checking' || status === 'installing'
+  const downloadPercent = downloadProgress
+    ? calculateSidebarUpdateDownloadPercent(
+        downloadProgress.downloadedBytes,
+        downloadProgress.totalBytes
+      )
+    : null
 
   const showErrorTooltip = () => {
     if (!error || !buttonRef.current) return
@@ -1073,6 +1080,16 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
         { version: availableUpdate.version }
       )
     : t('workbench.app_update_check', '检查更新')
+  const downloadTitle =
+    downloadPercent === null
+      ? t('workbench.app_update_downloading', { defaultValue: '正在下载更新' })
+      : formatSidebarTemplate(
+          t('workbench.app_update_downloading_progress', {
+            defaultValue: '正在下载更新 {{progress}}%',
+            progress: downloadPercent,
+          }),
+          { progress: String(downloadPercent) }
+        )
 
   return (
     <div
@@ -1095,8 +1112,8 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
           }
           void appUpdate.checkNow()
         }}
-        title={error ?? title}
-        aria-label={error ?? title}
+        title={error ?? (status === 'installing' ? downloadTitle : title)}
+        aria-label={error ?? (status === 'installing' ? downloadTitle : title)}
         className={cn(
           'group relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-60',
           error
@@ -1104,12 +1121,14 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
             : 'text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]'
         )}
       >
-        {busy ? (
+        {status === 'installing' && downloadPercent !== null ? (
+          <SidebarUpdateDownloadProgress progress={downloadPercent} />
+        ) : busy ? (
           <Loader2 className="h-4 w-4 animate-spin" />
         ) : (
           <Download className="sidebar-update-download-icon h-4 w-4" />
         )}
-        {availableUpdate && (
+        {availableUpdate && !busy && (
           <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary ring-2 ring-[rgb(var(--color-sidebar-hover))]" />
         )}
         {error && (
@@ -1129,6 +1148,33 @@ function SidebarAppUpdateButton({ onBeforeInstall }: { onBeforeInstall?: () => v
           )
         : null}
     </div>
+  )
+}
+
+function calculateSidebarUpdateDownloadPercent(
+  downloadedBytes: number,
+  totalBytes: number | null
+): number | null {
+  if (!totalBytes || totalBytes <= 0) return null
+  return Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))
+}
+
+function SidebarUpdateDownloadProgress({ progress }: { progress: number }) {
+  return (
+    <span
+      data-testid="sidebar-app-update-download-progress"
+      role="progressbar"
+      aria-label={`Update download ${progress}%`}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={progress}
+      className="flex h-4 w-4 items-center justify-center rounded-full"
+      style={{
+        background: `conic-gradient(rgb(var(--color-primary)) ${progress}%, rgb(var(--color-sidebar-hover)) 0)`,
+      }}
+    >
+      <span className="h-2 w-2 rounded-full bg-[rgb(var(--color-sidebar))]" />
+    </span>
   )
 }
 

--- a/wework/src/components/settings/AboutSettingsPage.tsx
+++ b/wework/src/components/settings/AboutSettingsPage.tsx
@@ -12,6 +12,14 @@ function formatVersionTemplate(template: string, version: string): string {
   return template.replace('{{version}}', version)
 }
 
+function calculateDownloadPercent(
+  downloadedBytes: number,
+  totalBytes: number | null
+): number | null {
+  if (!totalBytes || totalBytes <= 0) return null
+  return Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))
+}
+
 function formatUpdateError(message: string | null, t: ReturnType<typeof useTranslation>['t']) {
   if (!message) return null
   if (message.toLowerCase().includes('updater does not have any endpoints set')) {
@@ -70,9 +78,13 @@ export function AboutSettingsPage() {
   const appUpdate = useOptionalAppUpdate()
   const availableUpdate = appUpdate?.availableUpdate ?? null
   const updateStatus = appUpdate?.status ?? 'idle'
+  const downloadProgress = appUpdate?.downloadProgress ?? null
   const updateError = appUpdate?.error ?? null
   const formattedUpdateError = formatUpdateError(updateError, t)
   const isUpdateBusy = updateStatus === 'checking' || updateStatus === 'installing'
+  const downloadPercent = downloadProgress
+    ? calculateDownloadPercent(downloadProgress.downloadedBytes, downloadProgress.totalBytes)
+    : null
   const updateButtonLabel = availableUpdate
     ? formatVersionTemplate(
         t('workbench.app_update_install', {
@@ -135,6 +147,37 @@ export function AboutSettingsPage() {
           >
             {formattedUpdateError ?? updateMessage}
           </span>
+        ) : null}
+        {updateStatus === 'installing' ? (
+          <div data-testid="about-update-download-progress" className="w-[240px] space-y-1.5">
+            <div
+              role="progressbar"
+              aria-label={t('workbench.app_update_downloading', {
+                defaultValue: '正在下载更新',
+              })}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              {...(downloadPercent !== null ? { 'aria-valuenow': downloadPercent } : {})}
+              className="h-1.5 overflow-hidden rounded-full bg-muted"
+            >
+              <div
+                className={
+                  downloadPercent === null
+                    ? 'h-full w-1/3 animate-pulse rounded-full bg-primary'
+                    : 'h-full rounded-full bg-primary transition-[width] duration-200'
+                }
+                style={downloadPercent === null ? undefined : { width: `${downloadPercent}%` }}
+              />
+            </div>
+            <span className="block text-xs leading-5 text-text-secondary">
+              {downloadPercent === null
+                ? t('workbench.app_update_downloading', { defaultValue: '正在下载更新' })
+                : t('workbench.app_update_downloading_progress', {
+                    defaultValue: '正在下载更新 {{progress}}%',
+                    progress: downloadPercent,
+                  })}
+            </span>
+          </div>
         ) : null}
       </div>
 

--- a/wework/src/features/app-update/AppUpdateProvider.test.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.test.tsx
@@ -1,13 +1,15 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
+import { useAppUpdate, type AppUpdateContextValue } from './app-update-context'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   APP_UPDATE_AUTO_CHECK_MIN_AGE_MS,
   APP_UPDATE_INITIAL_CHECK_DELAY_MS,
   APP_UPDATE_LAST_AUTO_CHECK_KEY,
+  APP_UPDATE_SIMULATE_EVENT,
   APP_UPDATE_TIMER_INTERVAL_MS,
 } from './app-update-context'
 import { AppUpdateProvider } from './AppUpdateProvider'
-import { checkForWeworkUpdate } from '@/lib/app-updater'
+import { checkForWeworkUpdate, installPendingWeworkUpdate } from '@/lib/app-updater'
 
 vi.mock('@/lib/app-updater', () => ({
   checkForWeworkUpdate: vi.fn(),
@@ -70,5 +72,66 @@ describe('AppUpdateProvider', () => {
     await vi.advanceTimersByTimeAsync(APP_UPDATE_TIMER_INTERVAL_MS)
 
     expect(checkForWeworkUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  test('exposes download progress while installing an available update', async () => {
+    let appUpdate: AppUpdateContextValue | null = null
+    vi.mocked(checkForWeworkUpdate).mockResolvedValue({
+      currentVersion: '0.0.8',
+      version: '0.0.9',
+    })
+    vi.mocked(installPendingWeworkUpdate).mockImplementation(async onProgress => {
+      onProgress({ downloadedBytes: 50, totalBytes: 100 })
+    })
+
+    function Probe() {
+      appUpdate = useAppUpdate()
+      return null
+    }
+
+    render(
+      <AppUpdateProvider>
+        <Probe />
+      </AppUpdateProvider>
+    )
+
+    await act(async () => {
+      await appUpdate?.checkNow()
+    })
+    await act(async () => {
+      await appUpdate?.installUpdate()
+    })
+
+    expect(appUpdate?.status).toBe('installing')
+    expect(appUpdate?.downloadProgress).toEqual({ downloadedBytes: 50, totalBytes: 100 })
+  })
+
+  test('simulates an update download from the developer command menu', async () => {
+    let appUpdate: AppUpdateContextValue | null = null
+
+    function Probe() {
+      appUpdate = useAppUpdate()
+      return null
+    }
+
+    render(
+      <AppUpdateProvider>
+        <Probe />
+      </AppUpdateProvider>
+    )
+
+    await act(async () => {
+      window.dispatchEvent(new Event(APP_UPDATE_SIMULATE_EVENT))
+    })
+
+    expect(appUpdate?.status).toBe('installing')
+    expect(appUpdate?.downloadProgress).toEqual({ downloadedBytes: 0, totalBytes: 10_000_000 })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500)
+    })
+
+    expect(appUpdate?.availableUpdate).toBeNull()
+    expect(appUpdate?.status).toBe('upToDate')
   })
 })

--- a/wework/src/features/app-update/AppUpdateProvider.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import {
   checkForWeworkUpdate,
   installPendingWeworkUpdate,
+  type WeworkUpdateDownloadProgress,
   type WeworkUpdateInfo,
 } from '@/lib/app-updater'
 import { isTauriRuntime } from '@/lib/runtime-environment'
@@ -9,11 +10,17 @@ import {
   APP_UPDATE_AUTO_CHECK_MIN_AGE_MS,
   APP_UPDATE_INITIAL_CHECK_DELAY_MS,
   APP_UPDATE_LAST_AUTO_CHECK_KEY,
+  APP_UPDATE_SIMULATE_EVENT,
   APP_UPDATE_TIMER_INTERVAL_MS,
   AppUpdateContext,
   type AppUpdateContextValue,
   type AppUpdateStatus,
 } from './app-update-context'
+
+const SIMULATED_UPDATE_VERSION = 'debug-simulation'
+const SIMULATED_DOWNLOAD_TOTAL_BYTES = 10_000_000
+const SIMULATED_DOWNLOAD_STEP_BYTES = 1_000_000
+const SIMULATED_DOWNLOAD_INTERVAL_MS = 250
 
 function readLastAutoCheckAt(): number {
   const raw = window.localStorage.getItem(APP_UPDATE_LAST_AUTO_CHECK_KEY)
@@ -38,9 +45,19 @@ function messageFor(error: unknown): string {
 export function AppUpdateProvider({ children }: { children: ReactNode }) {
   const [availableUpdate, setAvailableUpdate] = useState<WeworkUpdateInfo | null>(null)
   const [status, setStatus] = useState<AppUpdateStatus>('idle')
+  const [downloadProgress, setDownloadProgress] = useState<WeworkUpdateDownloadProgress | null>(
+    null
+  )
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const checkInFlightRef = useRef(false)
+  const simulationTimerRef = useRef<number | null>(null)
+
+  const clearSimulationTimer = useCallback(() => {
+    if (simulationTimerRef.current === null) return
+    window.clearInterval(simulationTimerRef.current)
+    simulationTimerRef.current = null
+  }, [])
 
   const runCheck = useCallback(
     async ({ silent }: { silent: boolean }): Promise<WeworkUpdateInfo | null> => {
@@ -90,16 +107,53 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
     if (!availableUpdate || status === 'installing') return
 
     setStatus('installing')
+    setDownloadProgress({ downloadedBytes: 0, totalBytes: null })
     setMessage(null)
     setError(null)
 
     try {
-      await installPendingWeworkUpdate()
+      await installPendingWeworkUpdate(setDownloadProgress)
     } catch (caughtError) {
       setStatus('error')
+      setDownloadProgress(null)
       setError(messageFor(caughtError))
     }
   }, [availableUpdate, status])
+
+  const simulateUpdate = useCallback(() => {
+    clearSimulationTimer()
+    setAvailableUpdate({
+      currentVersion: __WEWORK_APP_VERSION__,
+      version: SIMULATED_UPDATE_VERSION,
+    })
+    setStatus('installing')
+    setDownloadProgress({ downloadedBytes: 0, totalBytes: SIMULATED_DOWNLOAD_TOTAL_BYTES })
+    setMessage(null)
+    setError(null)
+
+    let downloadedBytes = 0
+    simulationTimerRef.current = window.setInterval(() => {
+      downloadedBytes = Math.min(
+        downloadedBytes + SIMULATED_DOWNLOAD_STEP_BYTES,
+        SIMULATED_DOWNLOAD_TOTAL_BYTES
+      )
+      setDownloadProgress({ downloadedBytes, totalBytes: SIMULATED_DOWNLOAD_TOTAL_BYTES })
+
+      if (downloadedBytes === SIMULATED_DOWNLOAD_TOTAL_BYTES) {
+        clearSimulationTimer()
+        setAvailableUpdate(null)
+        setStatus('upToDate')
+        setMessage('upToDate')
+      }
+    }, SIMULATED_DOWNLOAD_INTERVAL_MS)
+  }, [clearSimulationTimer])
+
+  useEffect(() => {
+    window.addEventListener(APP_UPDATE_SIMULATE_EVENT, simulateUpdate)
+    return () => window.removeEventListener(APP_UPDATE_SIMULATE_EVENT, simulateUpdate)
+  }, [simulateUpdate])
+
+  useEffect(() => clearSimulationTimer, [clearSimulationTimer])
 
   useEffect(() => {
     if (!isTauriRuntime()) return
@@ -125,12 +179,13 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
     () => ({
       availableUpdate,
       status,
+      downloadProgress,
       message,
       error,
       checkNow,
       installUpdate,
     }),
-    [availableUpdate, checkNow, error, installUpdate, message, status]
+    [availableUpdate, checkNow, downloadProgress, error, installUpdate, message, status]
   )
 
   return <AppUpdateContext.Provider value={value}>{children}</AppUpdateContext.Provider>

--- a/wework/src/features/app-update/app-update-context.ts
+++ b/wework/src/features/app-update/app-update-context.ts
@@ -1,10 +1,11 @@
 import { createContext, useContext } from 'react'
-import type { WeworkUpdateInfo } from '@/lib/app-updater'
+import type { WeworkUpdateDownloadProgress, WeworkUpdateInfo } from '@/lib/app-updater'
 
 export const APP_UPDATE_LAST_AUTO_CHECK_KEY = 'wework:lastAutoUpdateCheckAt'
 export const APP_UPDATE_INITIAL_CHECK_DELAY_MS = 5_000
 export const APP_UPDATE_TIMER_INTERVAL_MS = 60 * 60 * 1000
 export const APP_UPDATE_AUTO_CHECK_MIN_AGE_MS = 24 * 60 * 60 * 1000
+export const APP_UPDATE_SIMULATE_EVENT = 'wework:simulate-app-update'
 
 export type AppUpdateStatus =
   | 'idle'
@@ -17,6 +18,7 @@ export type AppUpdateStatus =
 export interface AppUpdateContextValue {
   availableUpdate: WeworkUpdateInfo | null
   status: AppUpdateStatus
+  downloadProgress: WeworkUpdateDownloadProgress | null
   message: string | null
   error: string | null
   checkNow: () => Promise<WeworkUpdateInfo | null>

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -303,6 +303,8 @@
     "app_update_available": "Version {{version}} is available",
     "app_update_install": "Update to {{version}}",
     "app_update_installing": "Installing update...",
+    "app_update_downloading": "Downloading update",
+    "app_update_downloading_progress": "Downloading update {{progress}}%",
     "app_update_installing_short": "Updating",
     "app_update_titlebar_button": "Update",
     "app_update_up_to_date": "Already up to date",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -303,6 +303,8 @@
     "app_update_available": "发现新版本 {{version}}",
     "app_update_install": "更新到 {{version}}",
     "app_update_installing": "正在安装更新...",
+    "app_update_downloading": "正在下载更新",
+    "app_update_downloading_progress": "正在下载更新 {{progress}}%",
     "app_update_installing_short": "更新中",
     "app_update_titlebar_button": "更新",
     "app_update_up_to_date": "已是最新版本",

--- a/wework/src/lib/app-updater.ts
+++ b/wework/src/lib/app-updater.ts
@@ -6,11 +6,18 @@ export interface WeworkUpdateInfo {
   body?: string
 }
 
+export interface WeworkUpdateDownloadProgress {
+  downloadedBytes: number
+  totalBytes: number | null
+}
+
 interface PendingUpdate {
   version: string
   currentVersion: string
   body?: string
-  downloadAndInstall: () => Promise<void>
+  downloadAndInstall: (
+    onProgress: (progress: WeworkUpdateDownloadProgress) => void
+  ) => Promise<void>
 }
 
 let pendingUpdate: PendingUpdate | null = null
@@ -38,7 +45,20 @@ export async function checkForWeworkUpdate(): Promise<WeworkUpdateInfo | null> {
       version: update.version,
       currentVersion: update.currentVersion,
       body: update.body,
-      downloadAndInstall: () => update.downloadAndInstall(),
+      downloadAndInstall: onProgress => {
+        let downloadedBytes = 0
+        let totalBytes: number | null = null
+
+        return update.downloadAndInstall(event => {
+          if (event.event === 'Started') {
+            totalBytes = event.data.contentLength ?? null
+          } else if (event.event === 'Progress') {
+            downloadedBytes += event.data.chunkLength
+          }
+
+          onProgress({ downloadedBytes, totalBytes })
+        })
+      },
     }
 
     return {
@@ -52,13 +72,15 @@ export async function checkForWeworkUpdate(): Promise<WeworkUpdateInfo | null> {
   }
 }
 
-export async function installPendingWeworkUpdate(): Promise<void> {
+export async function installPendingWeworkUpdate(
+  onProgress: (progress: WeworkUpdateDownloadProgress) => void
+): Promise<void> {
   if (!pendingUpdate) {
     throw new Error('No pending Wework update is available.')
   }
 
   try {
-    await pendingUpdate.downloadAndInstall()
+    await pendingUpdate.downloadAndInstall(onProgress)
     const { relaunch } = await import('@tauri-apps/plugin-process')
     await relaunch()
   } catch (error) {

--- a/wework/src/lib/developerCommandMenu.test.ts
+++ b/wework/src/lib/developerCommandMenu.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import { installDeveloperCommandMenu } from './developerCommandMenu'
+import { APP_UPDATE_SIMULATE_EVENT } from '@/features/app-update/app-update-context'
 
 const invokeMock = vi.hoisted(() => vi.fn())
 const requestLocalExecutorMock = vi.hoisted(() => vi.fn())
@@ -48,6 +49,7 @@ describe('developerCommandMenu', () => {
 
     expect(screenCommand('reload')).toBeInTheDocument()
     expect(screenCommand('open-debug-panel')).toBeInTheDocument()
+    expect(screenCommand('simulate-app-update')).toBeInTheDocument()
     expect(screenCommand('toggle-performance-diagnostics')).toBeInTheDocument()
     expect(screenCommand('toggle-stream-logs')).toBeInTheDocument()
     expect(screenCommand('print-performance-snapshot')).toBeInTheDocument()
@@ -70,6 +72,17 @@ describe('developerCommandMenu', () => {
       enabled: true,
     })
     expect(localStorage.getItem('wework:debug-local-chat-stream')).toBe('1')
+  })
+
+  test('dispatches an event to simulate an app update', () => {
+    const listener = vi.fn()
+    window.addEventListener(APP_UPDATE_SIMULATE_EVENT, listener)
+    dispatchDeveloperShortcut()
+
+    screenCommand('simulate-app-update').click()
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    window.removeEventListener(APP_UPDATE_SIMULATE_EVENT, listener)
   })
 
   test('opens the app log directory through Tauri', () => {

--- a/wework/src/lib/developerCommandMenu.ts
+++ b/wework/src/lib/developerCommandMenu.ts
@@ -16,6 +16,7 @@ import {
 } from './performanceDiagnostics'
 import { isTauriRuntime } from './runtime-environment'
 import { setEmbeddedBrowserOcclusion } from './embedded-browser'
+import { APP_UPDATE_SIMULATE_EVENT } from '@/features/app-update/app-update-context'
 
 const MENU_ID = 'wework-developer-command-menu'
 const DEBUG_PANEL_ID = 'wework-debug-panel'
@@ -151,6 +152,12 @@ function getDeveloperCommands(): DeveloperCommand[] {
       label: 'Debug Panel',
       description: 'Inspect the active runtime task state and recent console.debug logs.',
       run: () => openDebugPanel(),
+    },
+    {
+      id: 'simulate-app-update',
+      label: 'Simulate App Update',
+      description: 'Simulate an update download and installation without changing the app.',
+      run: () => window.dispatchEvent(new Event(APP_UPDATE_SIMULATE_EVENT)),
     },
     {
       id: 'reload',


### PR DESCRIPTION
## Summary

- Report native updater download progress through the shared Wework update state.
- Show determinate progress in the About page and lower-left settings menu.
- Keep the account-row update icon synchronized as a circular progress indicator, regardless of where an update is initiated.
- Add a developer command that simulates an update download without installing or restarting the app.

## Why

The updater previously exposed only a busy state, so users could not tell whether a download was progressing. The account-row update control, which is the persistent update entry point, now reflects the same shared progress state as the other update surfaces.

## Validation

- `pnpm --filter wework test` — 145 files, 1426 tests passed
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
