### PR TITLE
fix(wework): default environment panel on wide screens

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5196,7 +5196,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
-      'w-[340px]',
+      'w-[300px]',
       'bg-background',
       'text-text-primary',
       'border-border',

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -628,6 +628,26 @@ describe('DesktopWorkbenchLayout', () => {
     onLogout: vi.fn(),
   }
 
+  const activeProjectState = {
+    ...baseProps.state,
+    currentProject: {
+      id: 1,
+      name: 'github_wegent',
+      tasks: [],
+      config: {
+        mode: 'workspace' as const,
+        execution: {
+          targetType: 'local' as const,
+          deviceId: 'device-1',
+        },
+        workspace: {
+          source: 'local_path' as const,
+          localPath: '/workspace/github_wegent',
+        },
+      },
+    },
+  }
+
   function createPendingRequestUserInputMessage(includeAdjustment = false): WorkbenchMessage {
     return {
       id: 'assistant-request',
@@ -2097,9 +2117,7 @@ describe('DesktopWorkbenchLayout', () => {
       screen.getByTestId('desktop-window-controls')
     )
     expect(screen.queryByTestId('workbench-topbar-right-actions')).not.toBeInTheDocument()
-    expect(screen.getByTestId('workspace-panel-floating-actions')).toContainElement(
-      screen.getByTestId('environment-info-button')
-    )
+    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('workspace-panel-floating-actions')).toContainElement(
       screen.getByTestId('toggle-bottom-workspace-panel-button')
     )
@@ -2191,9 +2209,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('chrome-tab-wework')).toHaveClass('h-8', 'w-8', 'bg-black/[0.045]')
     expect(screen.getByTestId('chrome-tab-apps')).toHaveClass('h-8', 'w-8', 'text-text-secondary')
     expect(screen.queryByTestId('workbench-topbar')).not.toBeInTheDocument()
-    expect(screen.getByTestId('titlebar-main-actions')).toContainElement(
-      screen.getByTestId('environment-info-button')
-    )
+    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('titlebar-actions')).toContainElement(
       screen.getByTestId('toggle-bottom-workspace-panel-button')
     )
@@ -2482,9 +2498,7 @@ describe('DesktopWorkbenchLayout', () => {
       'pointer-events-auto',
       'z-popover'
     )
-    expect(screen.getByTestId('workspace-panel-floating-actions')).toContainElement(
-      screen.getByTestId('environment-info-button')
-    )
+    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('workspace-panel-floating-actions')).toContainElement(
       screen.getByTestId('toggle-bottom-workspace-panel-button')
     )
@@ -5152,6 +5166,7 @@ describe('DesktopWorkbenchLayout', () => {
         {...baseProps}
         state={{
           ...baseProps.state,
+          currentProject: activeProjectState.currentProject,
           devices: [
             {
               id: 1,
@@ -5638,7 +5653,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('does not reopen the branch menu when the environment popover is reopened', async () => {
-    render(<DesktopWorkbenchLayout {...baseProps} />)
+    render(<DesktopWorkbenchLayout {...baseProps} state={activeProjectState} />)
 
     await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(screen.getByTestId('environment-branch-row'))
@@ -5658,6 +5673,7 @@ describe('DesktopWorkbenchLayout', () => {
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
+        state={activeProjectState}
         onLoadEnvironmentInfo={vi.fn().mockResolvedValue({
           additions: '+55',
           deletions: '-8',
@@ -5687,7 +5703,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('closes the branch menu when Escape is pressed', async () => {
-    render(<DesktopWorkbenchLayout {...baseProps} />)
+    render(<DesktopWorkbenchLayout {...baseProps} state={activeProjectState} />)
 
     await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(screen.getByTestId('environment-branch-row'))
@@ -5702,7 +5718,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
   })
 
-  test('loads environment info from the first workspace project when the popover opens', async () => {
+  test('does not show environment info without an active project or runtime task', async () => {
     const onLoadEnvironmentInfo = vi.fn().mockResolvedValue({
       additions: '+8',
       deletions: '-3',
@@ -5741,20 +5757,8 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
+    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
     expect(onLoadEnvironmentInfo).not.toHaveBeenCalled()
-
-    await userEvent.click(screen.getByTestId('environment-info-button'))
-
-    await waitFor(() =>
-      expect(onLoadEnvironmentInfo).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 2, name: 'workspace' }),
-        {
-          deviceId: 'device-from-fallback',
-          path: '/repo',
-          source: 'project',
-        }
-      )
-    )
   })
 
   test('loads environment info automatically from the current runtime task workspace', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5202,7 +5202,7 @@ describe('DesktopWorkbenchLayout', () => {
       screen.getByTestId('environment-info-panel-container')
     )
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
-      'w-[330px]',
+      'w-[300px]',
       'bg-background',
       'text-text-primary',
       'border-border',

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5160,7 +5160,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('workspace-file-comment-input')).not.toBeInTheDocument()
   })
 
-  test('opens the environment info popover and closes it from outside click', async () => {
+  test('keeps the environment info panel open until its icon is clicked', async () => {
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
@@ -5202,7 +5202,7 @@ describe('DesktopWorkbenchLayout', () => {
       screen.getByTestId('environment-info-panel-container')
     )
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
-      'w-[240px]',
+      'w-[330px]',
       'bg-background',
       'text-text-primary',
       'border-border',
@@ -5254,6 +5254,10 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     await userEvent.click(document.body)
+
+    expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('environment-info-button'))
 
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
   })
@@ -5666,7 +5670,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(await screen.findByTestId('environment-branch-menu')).toBeInTheDocument()
 
-    await userEvent.click(document.body)
+    await userEvent.click(screen.getByTestId('environment-info-button'))
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('environment-info-button'))

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5195,8 +5195,14 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('environment-info-button'))
 
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
+    expect(screen.getByTestId('environment-info-panel-container')).toContainElement(
+      screen.getByTestId('environment-info-popover')
+    )
+    expect(screen.getByTestId('desktop-workbench-content')).toContainElement(
+      screen.getByTestId('environment-info-panel-container')
+    )
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
-      'w-[300px]',
+      'w-[240px]',
       'bg-background',
       'text-text-primary',
       'border-border',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1545,7 +1545,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <aside
             ref={setEnvironmentInfoPanelRef}
             data-testid="environment-info-panel-container"
-            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[252px]"
+            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[342px]"
           />
         </div>
         {rightPanelOpen && (

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1545,7 +1545,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <aside
             ref={setEnvironmentInfoPanelRef}
             data-testid="environment-info-panel-container"
-            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[342px]"
+            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[312px]"
           />
         </div>
         {rightPanelOpen && (

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1054,6 +1054,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       workspaceTarget={workspaceTarget}
       environmentInfo={environmentInfo}
       environmentInfoPopoverContainer={workbenchMainElement}
+      environmentInfoVisible={Boolean(currentRuntimeTask || currentProject)}
       onRefreshEnvironmentInfo={refreshEnvironmentInfo}
       onCommitEnvironmentChanges={commitEnvironmentChanges}
       onCommitAndPushEnvironmentChanges={commitAndPushEnvironmentChanges}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -391,6 +391,11 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
   const isTauri = isTauriRuntime()
   const workbenchMainRef = useRef<HTMLElement | null>(null)
+  const [workbenchMainElement, setWorkbenchMainElement] = useState<HTMLElement | null>(null)
+  const setWorkbenchMainRef = useCallback((element: HTMLElement | null) => {
+    workbenchMainRef.current = element
+    setWorkbenchMainElement(element)
+  }, [])
   const continueInIm = useRuntimeTaskContinueInIm(currentRuntimeTask)
   const [reviewState, setReviewState] = useState<DesktopReviewState>({
     loading: false,
@@ -1048,6 +1053,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       devices={devices}
       workspaceTarget={workspaceTarget}
       environmentInfo={environmentInfo}
+      environmentInfoPopoverContainer={workbenchMainElement}
       onRefreshEnvironmentInfo={refreshEnvironmentInfo}
       onCommitEnvironmentChanges={commitEnvironmentChanges}
       onCommitAndPushEnvironmentChanges={commitAndPushEnvironmentChanges}
@@ -1241,7 +1247,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
 
   return (
     <main
-      ref={workbenchMainRef}
+      ref={setWorkbenchMainRef}
       className={cn(
         'absolute inset-x-0 bottom-0 flex min-w-0 flex-1 flex-col overflow-hidden bg-background',
         'transition-[margin] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -391,10 +391,14 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
   const isTauri = isTauriRuntime()
   const workbenchMainRef = useRef<HTMLElement | null>(null)
-  const [workbenchMainElement, setWorkbenchMainElement] = useState<HTMLElement | null>(null)
-  const setWorkbenchMainRef = useCallback((element: HTMLElement | null) => {
-    workbenchMainRef.current = element
-    setWorkbenchMainElement(element)
+  const environmentInfoPanelRef = useRef<HTMLElement | null>(null)
+  const [environmentInfoPanelElement, setEnvironmentInfoPanelElement] =
+    useState<HTMLElement | null>(null)
+  const setEnvironmentInfoPanelRef = useCallback((element: HTMLElement | null) => {
+    environmentInfoPanelRef.current = element
+  }, [])
+  useLayoutEffect(() => {
+    setEnvironmentInfoPanelElement(environmentInfoPanelRef.current)
   }, [])
   const continueInIm = useRuntimeTaskContinueInIm(currentRuntimeTask)
   const [reviewState, setReviewState] = useState<DesktopReviewState>({
@@ -1053,7 +1057,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       devices={devices}
       workspaceTarget={workspaceTarget}
       environmentInfo={environmentInfo}
-      environmentInfoPopoverContainer={workbenchMainElement}
+      environmentInfoPopoverContainer={environmentInfoPanelElement}
       environmentInfoVisible={Boolean(currentRuntimeTask || currentProject)}
       onRefreshEnvironmentInfo={refreshEnvironmentInfo}
       onCommitEnvironmentChanges={commitEnvironmentChanges}
@@ -1248,7 +1252,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
 
   return (
     <main
-      ref={setWorkbenchMainRef}
+      ref={workbenchMainRef}
       className={cn(
         'absolute inset-x-0 bottom-0 flex min-w-0 flex-1 flex-col overflow-hidden bg-background',
         'transition-[margin] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
@@ -1301,16 +1305,16 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         <div
           data-testid="desktop-workbench-content"
           className={cn(
-            'relative flex min-w-0 flex-none flex-col overflow-hidden',
+            'relative grid min-w-0 flex-none grid-cols-[minmax(0,1fr)_auto] overflow-hidden',
             rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
             showPageTopBar && 'pt-11'
           )}
           style={{ width: chatColumnWidth }}
         >
           {isBootstrapping ? (
-            <div className="flex flex-1" data-testid="desktop-workbench-loading" />
+            <div className="flex min-w-0 flex-1" data-testid="desktop-workbench-loading" />
           ) : hasConversation ? (
-            <div className="relative min-h-0 flex-1 overflow-hidden">
+            <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
               <ScrollableMessageArea
                 messages={paneMessages}
                 loading={paneSession.transcriptLoading}
@@ -1482,7 +1486,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               />
             </div>
           ) : (
-            <div className="flex flex-1 items-center justify-center px-10">
+            <div className="flex min-w-0 flex-1 items-center justify-center px-10">
               <div
                 className={cn(
                   DESKTOP_COMPOSER_FRAME_CLASS,
@@ -1538,6 +1542,11 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               </div>
             </div>
           )}
+          <aside
+            ref={setEnvironmentInfoPanelRef}
+            data-testid="environment-info-panel-container"
+            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[252px]"
+          />
         </div>
         {rightPanelOpen && (
           <div

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -16,15 +16,7 @@ import {
   Upload,
   CornerDownLeft,
 } from 'lucide-react'
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-  type FormEvent,
-} from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { BranchSelector } from '@/components/common/BranchSelector'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -50,52 +42,10 @@ interface EnvironmentInfoPopoverProps {
 
 type CommitPanelAction = 'commit' | 'commit-and-push' | 'push'
 
-const POPOVER_WIDTH = 300
-const POPOVER_GAP = 8
-const VIEWPORT_MARGIN = 16
 const AUTO_OPEN_MIN_VIEWPORT_WIDTH = 1280
-const CONVERSATION_PANEL_GAP = 16
-const CONVERSATION_CONTENT_SELECTOR = '[data-testid="desktop-floating-composer-layer"]'
 
-interface PopoverPosition {
-  left: number
-  top: number
-}
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max)
-}
-
-function getEnvironmentPopoverPosition(anchor: DOMRect, container: HTMLElement): PopoverPosition {
-  const containerRect = container.getBoundingClientRect()
-  const maxLeft = Math.max(VIEWPORT_MARGIN, containerRect.width - POPOVER_WIDTH - VIEWPORT_MARGIN)
-  return {
-    left: clamp(anchor.right - containerRect.left - POPOVER_WIDTH, VIEWPORT_MARGIN, maxLeft),
-    top: Math.max(VIEWPORT_MARGIN, anchor.bottom - containerRect.top + POPOVER_GAP),
-  }
-}
-
-function canAutoOpenEnvironmentInfo(
-  anchor: DOMRect,
-  container: HTMLElement
-): { open: boolean; position: PopoverPosition } {
-  const position = getEnvironmentPopoverPosition(anchor, container)
-  if (window.innerWidth < AUTO_OPEN_MIN_VIEWPORT_WIDTH) {
-    return { open: false, position }
-  }
-
-  const conversationContent = container.querySelector(CONVERSATION_CONTENT_SELECTOR)
-  if (!conversationContent) {
-    return { open: true, position }
-  }
-
-  const containerRect = container.getBoundingClientRect()
-  const conversationRect = conversationContent.getBoundingClientRect()
-  const panelLeft = containerRect.left + position.left
-  return {
-    open: panelLeft >= conversationRect.right + CONVERSATION_PANEL_GAP,
-    position,
-  }
+function shouldAutoOpenEnvironmentInfo() {
+  return typeof window !== 'undefined' && window.innerWidth >= AUTO_OPEN_MIN_VIEWPORT_WIDTH
 }
 
 export function EnvironmentInfoPopover({
@@ -112,14 +62,13 @@ export function EnvironmentInfoPopover({
   onOpenChangesReview,
 }: EnvironmentInfoPopoverProps) {
   const { t } = useTranslation('common')
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(shouldAutoOpenEnvironmentInfo)
   const [workspacePathCopied, setWorkspacePathCopied] = useState(false)
   const [commitFormOpen, setCommitFormOpen] = useState(false)
   const [commitMessage, setCommitMessage] = useState('')
   const [commitStatus, setCommitStatus] = useState<'idle' | 'committing' | 'success'>('idle')
   const [commitProgressLabel, setCommitProgressLabel] = useState('')
   const [commitError, setCommitError] = useState<string | null>(null)
-  const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const commitPanelRef = useRef<HTMLFormElement>(null)
@@ -232,24 +181,6 @@ export function EnvironmentInfoPopover({
     await handleCommitPanelAction('commit')
   }
 
-  const updatePopoverPosition = useCallback(() => {
-    if (!rootRef.current || !popoverContainer) return
-    setPopoverPosition(
-      getEnvironmentPopoverPosition(rootRef.current.getBoundingClientRect(), popoverContainer)
-    )
-  }, [popoverContainer])
-
-  const synchronizeAutoOpenState = useCallback(() => {
-    if (userToggledOpenRef.current || !rootRef.current || !popoverContainer) return
-
-    const next = canAutoOpenEnvironmentInfo(
-      rootRef.current.getBoundingClientRect(),
-      popoverContainer
-    )
-    setPopoverPosition(next.position)
-    setOpen(next.open)
-  }, [popoverContainer])
-
   function handleToggleOpen() {
     userToggledOpenRef.current = true
     const nextOpen = !open
@@ -259,32 +190,18 @@ export function EnvironmentInfoPopover({
     }
   }
 
-  useLayoutEffect(() => {
-    synchronizeAutoOpenState()
-  }, [synchronizeAutoOpenState])
-
   useEffect(() => {
-    if (userToggledOpenRef.current || !popoverContainer) return
+    function synchronizeAutoOpenState() {
+      if (!userToggledOpenRef.current) {
+        setOpen(shouldAutoOpenEnvironmentInfo())
+      }
+    }
 
     window.addEventListener('resize', synchronizeAutoOpenState)
-    const resizeObserver =
-      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(synchronizeAutoOpenState) : null
-    resizeObserver?.observe(popoverContainer)
-    const conversationContent = popoverContainer.querySelector(CONVERSATION_CONTENT_SELECTOR)
-    if (conversationContent instanceof HTMLElement) {
-      resizeObserver?.observe(conversationContent)
-    }
-
     return () => {
       window.removeEventListener('resize', synchronizeAutoOpenState)
-      resizeObserver?.disconnect()
     }
-  }, [popoverContainer, synchronizeAutoOpenState])
-
-  useLayoutEffect(() => {
-    if (!open || !popoverContainer) return
-    updatePopoverPosition()
-  }, [open, popoverContainer, updatePopoverPosition])
+  }, [])
 
   useEffect(() => {
     if (!open) {
@@ -304,30 +221,11 @@ export function EnvironmentInfoPopover({
     }
 
     document.addEventListener('pointerdown', handlePointerDown)
-    window.addEventListener('resize', updatePopoverPosition)
-    window.addEventListener('scroll', updatePopoverPosition, true)
-    const resizeObserver =
-      popoverContainer && typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(updatePopoverPosition)
-        : null
-    if (resizeObserver && popoverContainer) {
-      resizeObserver.observe(popoverContainer)
-    }
 
     return () => {
       document.removeEventListener('pointerdown', handlePointerDown)
-      window.removeEventListener('resize', updatePopoverPosition)
-      window.removeEventListener('scroll', updatePopoverPosition, true)
-      resizeObserver?.disconnect()
     }
-  }, [open, popoverContainer, updatePopoverPosition])
-
-  const popoverStyle: CSSProperties | undefined = popoverPosition
-    ? {
-        left: `${popoverPosition.left}px`,
-        top: `${popoverPosition.top}px`,
-      }
-    : undefined
+  }, [open])
   const branchLabel = info.branchName?.trim() || t('workbench.environment_branch_empty', '暂无分支')
 
   return (
@@ -350,8 +248,7 @@ export function EnvironmentInfoPopover({
           <div
             ref={popoverRef}
             data-testid="environment-info-popover"
-            style={popoverStyle}
-            className="absolute z-system w-[300px] max-w-[calc(100%-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            className="mt-3 w-[240px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -69,9 +69,6 @@ export function EnvironmentInfoPopover({
   const [commitStatus, setCommitStatus] = useState<'idle' | 'committing' | 'success'>('idle')
   const [commitProgressLabel, setCommitProgressLabel] = useState('')
   const [commitError, setCommitError] = useState<string | null>(null)
-  const rootRef = useRef<HTMLDivElement>(null)
-  const popoverRef = useRef<HTMLDivElement>(null)
-  const commitPanelRef = useRef<HTMLFormElement>(null)
   const userToggledOpenRef = useRef(false)
   const additions = info.additions || '+0'
   const deletions = info.deletions || '-0'
@@ -192,8 +189,13 @@ export function EnvironmentInfoPopover({
 
   useEffect(() => {
     function synchronizeAutoOpenState() {
+      if (!shouldAutoOpenEnvironmentInfo()) {
+        setOpen(false)
+        return
+      }
+
       if (!userToggledOpenRef.current) {
-        setOpen(shouldAutoOpenEnvironmentInfo())
+        setOpen(true)
       }
     }
 
@@ -203,33 +205,10 @@ export function EnvironmentInfoPopover({
     }
   }, [])
 
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    function handlePointerDown(event: PointerEvent) {
-      const target = event.target as Node
-      if (
-        !rootRef.current?.contains(target) &&
-        !popoverRef.current?.contains(target) &&
-        !commitPanelRef.current?.contains(target)
-      ) {
-        userToggledOpenRef.current = true
-        setOpen(false)
-      }
-    }
-
-    document.addEventListener('pointerdown', handlePointerDown)
-
-    return () => {
-      document.removeEventListener('pointerdown', handlePointerDown)
-    }
-  }, [open])
   const branchLabel = info.branchName?.trim() || t('workbench.environment_branch_empty', '暂无分支')
 
   return (
-    <div ref={rootRef}>
+    <div>
       <button
         type="button"
         data-testid="environment-info-button"
@@ -246,9 +225,8 @@ export function EnvironmentInfoPopover({
         popoverContainer &&
         createPortal(
           <div
-            ref={popoverRef}
             data-testid="environment-info-popover"
-            className="mt-3 w-[240px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            className="mt-3 w-[330px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">
@@ -460,7 +438,6 @@ export function EnvironmentInfoPopover({
         typeof document !== 'undefined' &&
         createPortal(
           <form
-            ref={commitPanelRef}
             data-testid="environment-commit-form"
             className="fixed left-1/2 top-[36vh] z-system-popover w-[430px] max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-xl border border-border bg-background text-text-primary shadow-[0_18px_48px_rgba(0,0,0,0.20)]"
             onSubmit={handleSubmitCommit}

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -16,7 +16,15 @@ import {
   Upload,
   CornerDownLeft,
 } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { BranchSelector } from '@/components/common/BranchSelector'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -28,6 +36,7 @@ import { DESKTOP_TOP_BAR_BUTTON_CLASS } from './DesktopTopBar'
 
 interface EnvironmentInfoPopoverProps {
   info: EnvironmentInfo
+  popoverContainer: HTMLElement | null
   devices?: DeviceInfo[]
   onRefresh?: () => Promise<void>
   onCommitChanges?: (message: string) => Promise<void>
@@ -44,6 +53,7 @@ type CommitPanelAction = 'commit' | 'commit-and-push' | 'push'
 const POPOVER_WIDTH = 340
 const POPOVER_GAP = 8
 const VIEWPORT_MARGIN = 16
+const AUTO_OPEN_MIN_VIEWPORT_WIDTH = 1280
 
 interface PopoverPosition {
   left: number
@@ -54,17 +64,22 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
 
-function getEnvironmentPopoverPosition(anchor: DOMRect): PopoverPosition {
-  const viewportWidth = window.innerWidth || document.documentElement.clientWidth
-  const maxLeft = Math.max(VIEWPORT_MARGIN, viewportWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
+function getEnvironmentPopoverPosition(anchor: DOMRect, container: HTMLElement): PopoverPosition {
+  const containerRect = container.getBoundingClientRect()
+  const maxLeft = Math.max(VIEWPORT_MARGIN, containerRect.width - POPOVER_WIDTH - VIEWPORT_MARGIN)
   return {
-    left: clamp(anchor.right - POPOVER_WIDTH, VIEWPORT_MARGIN, maxLeft),
-    top: Math.max(VIEWPORT_MARGIN, anchor.bottom + POPOVER_GAP),
+    left: clamp(anchor.right - containerRect.left - POPOVER_WIDTH, VIEWPORT_MARGIN, maxLeft),
+    top: Math.max(VIEWPORT_MARGIN, anchor.bottom - containerRect.top + POPOVER_GAP),
   }
+}
+
+function shouldAutoOpenEnvironmentInfo() {
+  return typeof window !== 'undefined' && window.innerWidth >= AUTO_OPEN_MIN_VIEWPORT_WIDTH
 }
 
 export function EnvironmentInfoPopover({
   info,
+  popoverContainer,
   devices = [],
   onRefresh,
   onCommitChanges,
@@ -76,7 +91,7 @@ export function EnvironmentInfoPopover({
   onOpenChangesReview,
 }: EnvironmentInfoPopoverProps) {
   const { t } = useTranslation('common')
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(shouldAutoOpenEnvironmentInfo)
   const [workspacePathCopied, setWorkspacePathCopied] = useState(false)
   const [commitFormOpen, setCommitFormOpen] = useState(false)
   const [commitMessage, setCommitMessage] = useState('')
@@ -194,22 +209,25 @@ export function EnvironmentInfoPopover({
     await handleCommitPanelAction('commit')
   }
 
+  const updatePopoverPosition = useCallback(() => {
+    if (!rootRef.current || !popoverContainer) return
+    setPopoverPosition(
+      getEnvironmentPopoverPosition(rootRef.current.getBoundingClientRect(), popoverContainer)
+    )
+  }, [popoverContainer])
+
   function handleToggleOpen() {
     const nextOpen = !open
-    if (nextOpen && rootRef.current) {
-      setPopoverPosition(getEnvironmentPopoverPosition(rootRef.current.getBoundingClientRect()))
-    }
     setOpen(nextOpen)
-
     if (nextOpen) {
       void onRefresh?.()
     }
   }
 
-  const updatePopoverPosition = useCallback(() => {
-    if (!rootRef.current) return
-    setPopoverPosition(getEnvironmentPopoverPosition(rootRef.current.getBoundingClientRect()))
-  }, [])
+  useLayoutEffect(() => {
+    if (!open || !popoverContainer) return
+    updatePopoverPosition()
+  }, [open, popoverContainer, updatePopoverPosition])
 
   useEffect(() => {
     if (!open) {
@@ -230,13 +248,21 @@ export function EnvironmentInfoPopover({
     document.addEventListener('pointerdown', handlePointerDown)
     window.addEventListener('resize', updatePopoverPosition)
     window.addEventListener('scroll', updatePopoverPosition, true)
+    const resizeObserver =
+      popoverContainer && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(updatePopoverPosition)
+        : null
+    if (resizeObserver && popoverContainer) {
+      resizeObserver.observe(popoverContainer)
+    }
 
     return () => {
       document.removeEventListener('pointerdown', handlePointerDown)
       window.removeEventListener('resize', updatePopoverPosition)
       window.removeEventListener('scroll', updatePopoverPosition, true)
+      resizeObserver?.disconnect()
     }
-  }, [open, updatePopoverPosition])
+  }, [open, popoverContainer, updatePopoverPosition])
 
   const popoverStyle: CSSProperties | undefined = popoverPosition
     ? {
@@ -261,13 +287,13 @@ export function EnvironmentInfoPopover({
       </button>
 
       {open &&
-        typeof document !== 'undefined' &&
+        popoverContainer &&
         createPortal(
           <div
             ref={popoverRef}
             data-testid="environment-info-popover"
             style={popoverStyle}
-            className="fixed z-system w-[340px] max-w-[calc(100vw-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            className="absolute z-system w-[340px] max-w-[calc(100%-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">
@@ -472,7 +498,7 @@ export function EnvironmentInfoPopover({
               </p>
             )}
           </div>,
-          document.body
+          popoverContainer
         )}
       {open &&
         commitFormOpen &&

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -226,7 +226,7 @@ export function EnvironmentInfoPopover({
         createPortal(
           <div
             data-testid="environment-info-popover"
-            className="mt-3 w-[330px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            className="mt-3 w-[300px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -50,10 +50,12 @@ interface EnvironmentInfoPopoverProps {
 
 type CommitPanelAction = 'commit' | 'commit-and-push' | 'push'
 
-const POPOVER_WIDTH = 340
+const POPOVER_WIDTH = 300
 const POPOVER_GAP = 8
 const VIEWPORT_MARGIN = 16
 const AUTO_OPEN_MIN_VIEWPORT_WIDTH = 1280
+const CONVERSATION_PANEL_GAP = 16
+const CONVERSATION_CONTENT_SELECTOR = '[data-testid="desktop-floating-composer-layer"]'
 
 interface PopoverPosition {
   left: number
@@ -73,8 +75,27 @@ function getEnvironmentPopoverPosition(anchor: DOMRect, container: HTMLElement):
   }
 }
 
-function shouldAutoOpenEnvironmentInfo() {
-  return typeof window !== 'undefined' && window.innerWidth >= AUTO_OPEN_MIN_VIEWPORT_WIDTH
+function canAutoOpenEnvironmentInfo(
+  anchor: DOMRect,
+  container: HTMLElement
+): { open: boolean; position: PopoverPosition } {
+  const position = getEnvironmentPopoverPosition(anchor, container)
+  if (window.innerWidth < AUTO_OPEN_MIN_VIEWPORT_WIDTH) {
+    return { open: false, position }
+  }
+
+  const conversationContent = container.querySelector(CONVERSATION_CONTENT_SELECTOR)
+  if (!conversationContent) {
+    return { open: true, position }
+  }
+
+  const containerRect = container.getBoundingClientRect()
+  const conversationRect = conversationContent.getBoundingClientRect()
+  const panelLeft = containerRect.left + position.left
+  return {
+    open: panelLeft >= conversationRect.right + CONVERSATION_PANEL_GAP,
+    position,
+  }
 }
 
 export function EnvironmentInfoPopover({
@@ -91,7 +112,7 @@ export function EnvironmentInfoPopover({
   onOpenChangesReview,
 }: EnvironmentInfoPopoverProps) {
   const { t } = useTranslation('common')
-  const [open, setOpen] = useState(shouldAutoOpenEnvironmentInfo)
+  const [open, setOpen] = useState(false)
   const [workspacePathCopied, setWorkspacePathCopied] = useState(false)
   const [commitFormOpen, setCommitFormOpen] = useState(false)
   const [commitMessage, setCommitMessage] = useState('')
@@ -102,6 +123,7 @@ export function EnvironmentInfoPopover({
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const commitPanelRef = useRef<HTMLFormElement>(null)
+  const userToggledOpenRef = useRef(false)
   const additions = info.additions || '+0'
   const deletions = info.deletions || '-0'
   const device = info.deviceId
@@ -130,6 +152,7 @@ export function EnvironmentInfoPopover({
 
   function handleOpenChangesReview() {
     onOpenChangesReview?.()
+    userToggledOpenRef.current = true
     setOpen(false)
   }
 
@@ -216,13 +239,47 @@ export function EnvironmentInfoPopover({
     )
   }, [popoverContainer])
 
+  const synchronizeAutoOpenState = useCallback(() => {
+    if (userToggledOpenRef.current || !rootRef.current || !popoverContainer) return
+
+    const next = canAutoOpenEnvironmentInfo(
+      rootRef.current.getBoundingClientRect(),
+      popoverContainer
+    )
+    setPopoverPosition(next.position)
+    setOpen(next.open)
+  }, [popoverContainer])
+
   function handleToggleOpen() {
+    userToggledOpenRef.current = true
     const nextOpen = !open
     setOpen(nextOpen)
     if (nextOpen) {
       void onRefresh?.()
     }
   }
+
+  useLayoutEffect(() => {
+    synchronizeAutoOpenState()
+  }, [synchronizeAutoOpenState])
+
+  useEffect(() => {
+    if (userToggledOpenRef.current || !popoverContainer) return
+
+    window.addEventListener('resize', synchronizeAutoOpenState)
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(synchronizeAutoOpenState) : null
+    resizeObserver?.observe(popoverContainer)
+    const conversationContent = popoverContainer.querySelector(CONVERSATION_CONTENT_SELECTOR)
+    if (conversationContent instanceof HTMLElement) {
+      resizeObserver?.observe(conversationContent)
+    }
+
+    return () => {
+      window.removeEventListener('resize', synchronizeAutoOpenState)
+      resizeObserver?.disconnect()
+    }
+  }, [popoverContainer, synchronizeAutoOpenState])
 
   useLayoutEffect(() => {
     if (!open || !popoverContainer) return
@@ -241,6 +298,7 @@ export function EnvironmentInfoPopover({
         !popoverRef.current?.contains(target) &&
         !commitPanelRef.current?.contains(target)
       ) {
+        userToggledOpenRef.current = true
         setOpen(false)
       }
     }
@@ -293,7 +351,7 @@ export function EnvironmentInfoPopover({
             ref={popoverRef}
             data-testid="environment-info-popover"
             style={popoverStyle}
-            className="absolute z-system w-[340px] max-w-[calc(100%-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            className="absolute z-system w-[300px] max-w-[calc(100%-2rem)] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -72,6 +72,7 @@ const baseProps = {
     executionTarget: 'local' as const,
   },
   environmentInfoPopoverContainer: document.body,
+  environmentInfoVisible: true,
   onRefreshEnvironmentInfo: vi.fn(),
   onCommitEnvironmentChanges: vi.fn(),
   onCommitAndPushEnvironmentChanges: vi.fn(),
@@ -151,6 +152,14 @@ describe('WorkspacePanelActions', () => {
     )
 
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
+  })
+
+  test('hides environment info when no task context is available', () => {
+    render(<WorkspacePanelActions {...baseProps} environmentInfoVisible={false} />)
+
+    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('toggle-bottom-workspace-panel-button')).toBeInTheDocument()
+    expect(screen.getByTestId('toggle-right-workspace-panel-button')).toBeInTheDocument()
   })
 
   test('opens environment info by default when the workspace is wide', () => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -41,30 +41,6 @@ function setWindowWidth(width: number) {
   })
 }
 
-function createRect({
-  left,
-  top,
-  width,
-  height,
-}: {
-  left: number
-  top: number
-  width: number
-  height: number
-}): DOMRect {
-  return {
-    x: left,
-    y: top,
-    left,
-    top,
-    width,
-    height,
-    right: left + width,
-    bottom: top + height,
-    toJSON: () => ({}),
-  } as DOMRect
-}
-
 const baseProps = {
   environmentInfo: {
     additions: '+0',
@@ -171,21 +147,10 @@ describe('WorkspacePanelActions', () => {
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
   })
 
-  test('positions environment info relative to the workspace container', () => {
+  test('renders environment info in its dedicated right-side container', () => {
     setWindowWidth(1280)
     const workspaceContainer = document.createElement('main')
     document.body.append(workspaceContainer)
-    const rectSpy = vi
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(function () {
-        if (this === workspaceContainer) {
-          return createRect({ left: 220, top: 0, width: 1280, height: 720 })
-        }
-        if (this.querySelector('[data-testid="environment-info-button"]')) {
-          return createRect({ left: 1452, top: 8, width: 32, height: 32 })
-        }
-        return createRect({ left: 0, top: 0, width: 0, height: 0 })
-      })
 
     try {
       render(
@@ -198,11 +163,9 @@ describe('WorkspacePanelActions', () => {
 
       const popover = screen.getByTestId('environment-info-popover')
       expect(workspaceContainer).toContainElement(popover)
-      expect(popover).toHaveClass('absolute')
-      expect(popover).not.toHaveClass('fixed')
-      expect(popover).toHaveStyle({ left: '964px', top: '48px' })
+      expect(popover).toHaveClass('w-[240px]')
+      expect(popover).not.toHaveClass('absolute', 'fixed')
     } finally {
-      rectSpy.mockRestore()
       workspaceContainer.remove()
     }
   })
@@ -214,79 +177,6 @@ describe('WorkspacePanelActions', () => {
 
     expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
-  })
-
-  test('keeps environment info collapsed when it would overlap the conversation content', () => {
-    setWindowWidth(1600)
-    const workspaceContainer = document.createElement('main')
-    const conversationContent = document.createElement('div')
-    conversationContent.dataset.testid = 'desktop-floating-composer-layer'
-    workspaceContainer.append(conversationContent)
-    document.body.append(workspaceContainer)
-    const rectSpy = vi
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(function () {
-        if (this === workspaceContainer) {
-          return createRect({ left: 200, top: 0, width: 1200, height: 720 })
-        }
-        if (this === conversationContent) {
-          return createRect({ left: 480, top: 100, width: 700, height: 300 })
-        }
-        if (this.querySelector('[data-testid="environment-info-button"]')) {
-          return createRect({ left: 1360, top: 8, width: 32, height: 32 })
-        }
-        return createRect({ left: 0, top: 0, width: 0, height: 0 })
-      })
-
-    try {
-      render(
-        <WorkspacePanelActions
-          {...baseProps}
-          mode="environment"
-          environmentInfoPopoverContainer={workspaceContainer}
-        />
-      )
-
-      expect(screen.getByTestId('environment-info-button')).toHaveAttribute(
-        'aria-expanded',
-        'false'
-      )
-      expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
-    } finally {
-      rectSpy.mockRestore()
-      workspaceContainer.remove()
-    }
-  })
-
-  test('positions environment info popover from the trigger instead of the viewport edge', async () => {
-    const rectSpy = vi
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(function () {
-        if (this === document.body) {
-          return createRect({
-            left: 0,
-            top: 0,
-            width: window.innerWidth,
-            height: window.innerHeight,
-          })
-        }
-        if (this.querySelector('[data-testid="environment-info-button"]')) {
-          return createRect({ left: 88, top: 8, width: 32, height: 32 })
-        }
-        return createRect({ left: 0, top: 0, width: 0, height: 0 })
-      })
-
-    try {
-      render(<WorkspacePanelActions {...baseProps} mode="environment" />)
-
-      await userEvent.click(screen.getByTestId('environment-info-button'))
-
-      const popover = await screen.findByTestId('environment-info-popover')
-      expect(popover).toHaveStyle({ left: '16px', top: '48px' })
-      expect(popover).not.toHaveClass('right-6', 'top-[76px]')
-    } finally {
-      rectSpy.mockRestore()
-    }
   })
 
   test('opens local workspaces with the default VS Code titlebar action', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -163,7 +163,7 @@ describe('WorkspacePanelActions', () => {
 
       const popover = screen.getByTestId('environment-info-popover')
       expect(workspaceContainer).toContainElement(popover)
-      expect(popover).toHaveClass('w-[330px]')
+      expect(popover).toHaveClass('w-[300px]')
       expect(popover).not.toHaveClass('absolute', 'fixed')
     } finally {
       workspaceContainer.remove()

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createProjectApi } from '@/api/projects'
 import { openExternalUrl } from '@/lib/external-links'
 import { isLocalTerminalAvailable, openLocalWorkspace } from '@/lib/local-terminal'
@@ -32,6 +32,14 @@ const openExternalUrlMock = vi.mocked(openExternalUrl)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startCodeServerSessionMock = vi.fn()
+const originalInnerWidth = window.innerWidth
+
+function setWindowWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+  })
+}
 
 function createRect({
   left,
@@ -63,6 +71,7 @@ const baseProps = {
     deletions: '-0',
     executionTarget: 'local' as const,
   },
+  environmentInfoPopoverContainer: document.body,
   onRefreshEnvironmentInfo: vi.fn(),
   onCommitEnvironmentChanges: vi.fn(),
   onCommitAndPushEnvironmentChanges: vi.fn(),
@@ -80,6 +89,7 @@ const baseProps = {
 describe('WorkspacePanelActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setWindowWidth(originalInnerWidth)
     isLocalTerminalAvailableMock.mockReturnValue(false)
     openLocalWorkspaceMock.mockResolvedValue(undefined)
     startCodeServerSessionMock.mockResolvedValue({
@@ -90,6 +100,10 @@ describe('WorkspacePanelActions', () => {
       startCodeServerSession: startCodeServerSessionMock,
     } as unknown as ReturnType<typeof createProjectApi>)
     openExternalUrlMock.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    setWindowWidth(originalInnerWidth)
   })
 
   test('keeps environment info action visible after environment refresh resolves empty context', () => {
@@ -139,10 +153,72 @@ describe('WorkspacePanelActions', () => {
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
   })
 
+  test('opens environment info by default when the workspace is wide', () => {
+    setWindowWidth(1280)
+
+    render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+
+    expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
+  })
+
+  test('positions environment info relative to the workspace container', () => {
+    setWindowWidth(1280)
+    const workspaceContainer = document.createElement('main')
+    document.body.append(workspaceContainer)
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function () {
+        if (this === workspaceContainer) {
+          return createRect({ left: 220, top: 0, width: 1280, height: 720 })
+        }
+        if (this.querySelector('[data-testid="environment-info-button"]')) {
+          return createRect({ left: 1452, top: 8, width: 32, height: 32 })
+        }
+        return createRect({ left: 0, top: 0, width: 0, height: 0 })
+      })
+
+    try {
+      render(
+        <WorkspacePanelActions
+          {...baseProps}
+          mode="environment"
+          environmentInfoPopoverContainer={workspaceContainer}
+        />
+      )
+
+      const popover = screen.getByTestId('environment-info-popover')
+      expect(workspaceContainer).toContainElement(popover)
+      expect(popover).toHaveClass('absolute')
+      expect(popover).not.toHaveClass('fixed')
+      expect(popover).toHaveStyle({ left: '924px', top: '48px' })
+    } finally {
+      rectSpy.mockRestore()
+      workspaceContainer.remove()
+    }
+  })
+
+  test('keeps environment info collapsed by default when the workspace is narrow', () => {
+    setWindowWidth(1279)
+
+    render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+
+    expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+  })
+
   test('positions environment info popover from the trigger instead of the viewport edge', async () => {
     const rectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function () {
+        if (this === document.body) {
+          return createRect({
+            left: 0,
+            top: 0,
+            width: window.innerWidth,
+            height: window.innerHeight,
+          })
+        }
         if (this.querySelector('[data-testid="environment-info-button"]')) {
           return createRect({ left: 88, top: 8, width: 32, height: 32 })
         }

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -200,7 +200,7 @@ describe('WorkspacePanelActions', () => {
       expect(workspaceContainer).toContainElement(popover)
       expect(popover).toHaveClass('absolute')
       expect(popover).not.toHaveClass('fixed')
-      expect(popover).toHaveStyle({ left: '924px', top: '48px' })
+      expect(popover).toHaveStyle({ left: '964px', top: '48px' })
     } finally {
       rectSpy.mockRestore()
       workspaceContainer.remove()
@@ -214,6 +214,48 @@ describe('WorkspacePanelActions', () => {
 
     expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+  })
+
+  test('keeps environment info collapsed when it would overlap the conversation content', () => {
+    setWindowWidth(1600)
+    const workspaceContainer = document.createElement('main')
+    const conversationContent = document.createElement('div')
+    conversationContent.dataset.testid = 'desktop-floating-composer-layer'
+    workspaceContainer.append(conversationContent)
+    document.body.append(workspaceContainer)
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function () {
+        if (this === workspaceContainer) {
+          return createRect({ left: 200, top: 0, width: 1200, height: 720 })
+        }
+        if (this === conversationContent) {
+          return createRect({ left: 480, top: 100, width: 700, height: 300 })
+        }
+        if (this.querySelector('[data-testid="environment-info-button"]')) {
+          return createRect({ left: 1360, top: 8, width: 32, height: 32 })
+        }
+        return createRect({ left: 0, top: 0, width: 0, height: 0 })
+      })
+
+    try {
+      render(
+        <WorkspacePanelActions
+          {...baseProps}
+          mode="environment"
+          environmentInfoPopoverContainer={workspaceContainer}
+        />
+      )
+
+      expect(screen.getByTestId('environment-info-button')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+      expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+    } finally {
+      rectSpy.mockRestore()
+      workspaceContainer.remove()
+    }
   })
 
   test('positions environment info popover from the trigger instead of the viewport edge', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createProjectApi } from '@/api/projects'
@@ -163,7 +163,7 @@ describe('WorkspacePanelActions', () => {
 
       const popover = screen.getByTestId('environment-info-popover')
       expect(workspaceContainer).toContainElement(popover)
-      expect(popover).toHaveClass('w-[240px]')
+      expect(popover).toHaveClass('w-[330px]')
       expect(popover).not.toHaveClass('absolute', 'fixed')
     } finally {
       workspaceContainer.remove()
@@ -176,6 +176,18 @@ describe('WorkspacePanelActions', () => {
     render(<WorkspacePanelActions {...baseProps} mode="environment" />)
 
     expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+  })
+
+  test('closes environment info when the workspace becomes narrow', () => {
+    setWindowWidth(1280)
+    render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+
+    expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
+
+    setWindowWidth(1279)
+    act(() => window.dispatchEvent(new Event('resize')))
+
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -35,6 +35,7 @@ interface WorkspacePanelActionsProps {
   workspaceTarget?: WorkspaceTarget | null
   environmentInfo: EnvironmentInfo
   environmentInfoPopoverContainer: HTMLElement | null
+  environmentInfoVisible?: boolean
   onRefreshEnvironmentInfo: () => Promise<void>
   onCommitEnvironmentChanges: (message: string) => Promise<void>
   onCommitAndPushEnvironmentChanges: (message: string) => Promise<void>
@@ -56,6 +57,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
   workspaceTarget = null,
   environmentInfo,
   environmentInfoPopoverContainer,
+  environmentInfoVisible = true,
   onRefreshEnvironmentInfo,
   onCommitEnvironmentChanges,
   onCommitAndPushEnvironmentChanges,
@@ -72,7 +74,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
   const { t } = useTranslation('common')
   const [ideLoading, setIdeLoading] = useState(false)
   const [ideError, setIdeError] = useState<string | null>(null)
-  const showEnvironmentInfo = mode === 'all' || mode === 'environment'
+  const showEnvironmentInfo = environmentInfoVisible && (mode === 'all' || mode === 'environment')
   const showPrimaryTarget = mode === 'all' || mode === 'primary-target'
   const showBottomPanelToggle =
     mode === 'all' || mode === 'panel-toggles' || mode === 'bottom-panel-toggle'

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -34,6 +34,7 @@ interface WorkspacePanelActionsProps {
   devices?: DeviceInfo[]
   workspaceTarget?: WorkspaceTarget | null
   environmentInfo: EnvironmentInfo
+  environmentInfoPopoverContainer: HTMLElement | null
   onRefreshEnvironmentInfo: () => Promise<void>
   onCommitEnvironmentChanges: (message: string) => Promise<void>
   onCommitAndPushEnvironmentChanges: (message: string) => Promise<void>
@@ -54,6 +55,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
   devices = [],
   workspaceTarget = null,
   environmentInfo,
+  environmentInfoPopoverContainer,
   onRefreshEnvironmentInfo,
   onCommitEnvironmentChanges,
   onCommitAndPushEnvironmentChanges,
@@ -158,6 +160,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
       {showEnvironmentInfo && (
         <EnvironmentInfoPopover
           info={environmentInfo}
+          popoverContainer={environmentInfoPopoverContainer}
           devices={devices}
           onRefresh={onRefreshEnvironmentInfo}
           onCommitChanges={onCommitEnvironmentChanges}


### PR DESCRIPTION
## Summary

- Default the Wework environment information panel to open on wide desktop viewports.
- Anchor the panel inside the desktop workbench instead of the viewport, and keep its position aligned as the workbench resizes.
- Hide the environment panel when there is no active project or runtime task.

## Root cause

The panel was rendered as a viewport-level fixed portal and was always available from the workbench action area, including the empty workspace state.

## Validation

- `pnpm --filter wework exec vitest run src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx`
- `pnpm --filter wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint` (one existing warning in `useWorkbenchPaneSession.ts`)
- `pnpm --filter wework test` (145 files, 1425 tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment information now appears in a dedicated side panel.
  * The panel opens automatically on wider screens and collapses on narrower screens.
  * Panel visibility and resizing behavior adapt as the workspace changes.

* **Bug Fixes**
  * Environment information is hidden when no project or runtime task is active.
  * Improved panel toggle behavior prevents unintended reopening and ensures consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->