### PR TITLE
feat(wework): label debug app instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ Wegent is an open-source AI-native operating system for defining, organizing, an
 - English version: [`docs/en/developer-guide/wework-performance-diagnostics.md`](docs/en/developer-guide/wework-performance-diagnostics.md)
 - Wework E2E automation: [`docs/zh/developer-guide/wework-e2e-automation.md`](docs/zh/developer-guide/wework-e2e-automation.md)
 - English version: [`docs/en/developer-guide/wework-e2e-automation.md`](docs/en/developer-guide/wework-e2e-automation.md)
+- Wework debug instance labels: [`docs/zh/developer-guide/wework-debug-instance-context.md`](docs/zh/developer-guide/wework-debug-instance-context.md)
+- English version: [`docs/en/developer-guide/wework-debug-instance-context.md`](docs/en/developer-guide/wework-debug-instance-context.md)
 - Wework chat state sources: [`docs/zh/developer-guide/wework-chat-state-sources.md`](docs/zh/developer-guide/wework-chat-state-sources.md)
 - English version: [`docs/en/developer-guide/wework-chat-state-sources.md`](docs/en/developer-guide/wework-chat-state-sources.md)
 - Wework Codex plugin runtime: [`docs/zh/developer-guide/wework-codex-plugins.md`](docs/zh/developer-guide/wework-codex-plugins.md)

--- a/docs/en/developer-guide/wework-debug-instance-context.md
+++ b/docs/en/developer-guide/wework-debug-instance-context.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 35
+---
+
+# Debug Instance Labels
+
+Wework can launch a debug Wework instance from the built-in Terminal of another running Wework window. To keep multiple worktrees and dev apps distinguishable, Wework passes the parent window context into the Terminal, and `wework/scripts/dev-mac-app.sh` forwards it to the debug instance.
+
+## Terminal Environment Variables
+
+When Wework creates a local built-in Terminal PTY, it injects:
+
+- `WEWORK_PARENT_TITLE`: the current runtime task title.
+- `WEWORK_PARENT_PROJECT`: the current project name.
+- `WEWORK_PARENT_WORKSPACE`: the current workspace path.
+
+These values are written only when the Terminal session is created. Existing Terminal sessions do not update after task switches or frontend hot reloads; close and reopen the Terminal to receive fresh context.
+
+## Dev Script Variables
+
+`wework/scripts/dev-mac-app.sh` reads the parent variables and generates debug instance variables:
+
+- `WEWORK_DEV_TITLE`: the short debug instance label. It uses `WEWORK_PARENT_TITLE` first, then the Git branch, then the worktree directory name.
+- `WEWORK_DEV_PORT`: the current Vite/Tauri dev server port.
+- `WEWORK_DEV_WORKTREE`: the current worktree root path.
+- `WEWORK_DEV_BRANCH`: the current Git branch, or empty when running on a detached HEAD.
+
+The script also exports these values as `VITE_WEWORK_*` so the frontend can display them at runtime.
+
+## Frontend Display
+
+Debug instances show a `Debug Wework` badge in the bottom-right corner. The badge shows the short label; hover or focus expands a details panel where each item can be copied individually.
+
+If the variables are missing, first check that:
+
+- The built-in Terminal was opened after the change.
+- The debug app was started from that Terminal with `wework/scripts/dev-mac-app.sh`.
+- The Terminal is checking `WEWORK_*` variables, not another prefix.

--- a/docs/zh/developer-guide/wework-debug-instance-context.md
+++ b/docs/zh/developer-guide/wework-debug-instance-context.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 35
+---
+
+# 调试实例标识
+
+Wework 支持从一个正在运行的 Wework 内置 Terminal 中启动另一个调试版 Wework。为了在多个 worktree、多个 dev app 同时打开时分清窗口来源，Wework 会把父窗口上下文传给 Terminal，再由 `wework/scripts/dev-mac-app.sh` 传给新启动的调试实例。
+
+## Terminal 环境变量
+
+本地内置 Terminal 创建 PTY 时，会注入以下变量：
+
+- `WEWORK_PARENT_TITLE`: 当前运行任务标题。
+- `WEWORK_PARENT_PROJECT`: 当前项目名称。
+- `WEWORK_PARENT_WORKSPACE`: 当前 workspace 路径。
+
+这些变量只在 Terminal session 创建时写入。已经打开的 Terminal 不会在任务切换或前端热更新后自动更新；需要关闭并重新打开 Terminal 才能获得新的上下文。
+
+## Dev 脚本变量
+
+`wework/scripts/dev-mac-app.sh` 会读取父窗口变量，并自动生成调试实例变量：
+
+- `WEWORK_DEV_TITLE`: 调试实例短标题，优先使用 `WEWORK_PARENT_TITLE`，否则使用 Git branch，最后使用 worktree 目录名。
+- `WEWORK_DEV_PORT`: 当前 Vite/Tauri dev server 端口。
+- `WEWORK_DEV_WORKTREE`: 当前 worktree 根路径。
+- `WEWORK_DEV_BRANCH`: 当前 Git branch，detached HEAD 时为空。
+
+脚本也会把这些值导出为 `VITE_WEWORK_*`，供前端在运行时显示。
+
+## 前端显示
+
+调试实例会在右下角显示 `Debug Wework` 浮标。浮标展示短标题；hover 或聚焦后展开完整信息面板，每一项都可以单独复制。
+
+如果看不到新变量，优先确认：
+
+- 使用的是新打开的内置 Terminal。
+- 调试 app 是从该 Terminal 中执行 `wework/scripts/dev-mac-app.sh` 启动的。
+- 当前 Terminal 里检查的是 `WEWORK_*` 变量，而不是其他前缀。

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -158,11 +158,53 @@ find_available_wework_port() {
   return 1
 }
 
+git_branch_name() {
+  git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || true
+}
+
+basename_or_path() {
+  local path="$1"
+
+  basename "$path" 2>/dev/null || echo "$path"
+}
+
+build_wework_dev_title() {
+  local parent_title="${WEWORK_PARENT_TITLE:-}"
+  local branch
+  local worktree_name
+
+  if [ -n "$parent_title" ]; then
+    echo "$parent_title"
+    return 0
+  fi
+
+  branch="$(git_branch_name)"
+  worktree_name="$(basename_or_path "$PROJECT_DIR")"
+  if [ -n "$branch" ]; then
+    echo "$branch"
+    return 0
+  fi
+
+  echo "$worktree_name"
+}
+
 AVAILABLE_WEWORK_PORT="$(find_available_wework_port "$WEWORK_PORT")"
 if [ "$AVAILABLE_WEWORK_PORT" != "$WEWORK_PORT" ]; then
   echo "WEWORK_PORT $WEWORK_PORT is already in use; using $AVAILABLE_WEWORK_PORT instead."
 fi
 WEWORK_PORT="$AVAILABLE_WEWORK_PORT"
+
+export WEWORK_DEV_WORKTREE="$PROJECT_DIR"
+export WEWORK_DEV_BRANCH="$(git_branch_name)"
+export WEWORK_DEV_PORT="$WEWORK_PORT"
+export WEWORK_DEV_TITLE="$(build_wework_dev_title)"
+export VITE_WEWORK_DEV_TITLE="$WEWORK_DEV_TITLE"
+export VITE_WEWORK_DEV_PORT="$WEWORK_DEV_PORT"
+export VITE_WEWORK_DEV_WORKTREE="$WEWORK_DEV_WORKTREE"
+export VITE_WEWORK_DEV_BRANCH="$WEWORK_DEV_BRANCH"
+export VITE_WEWORK_PARENT_TITLE="${WEWORK_PARENT_TITLE:-}"
+export VITE_WEWORK_PARENT_PROJECT="${WEWORK_PARENT_PROJECT:-}"
+export VITE_WEWORK_PARENT_WORKSPACE="${WEWORK_PARENT_WORKSPACE:-}"
 
 export SKIP_FONT_DOWNLOAD="${SKIP_FONT_DOWNLOAD:-1}"
 export VITE_API_PROXY_TARGET="$(wework_normalize_api_proxy_target "${VITE_API_PROXY_TARGET:-$BACKEND_BASE_URL}")"
@@ -220,6 +262,9 @@ PY
 echo "Starting WeWork mac app"
 echo "  RELEASE_UI=$WEWORK_RELEASE_UI"
 echo "  WEWORK_PORT=$WEWORK_PORT"
+echo "  WEWORK_DEV_TITLE=$WEWORK_DEV_TITLE"
+echo "  WEWORK_DEV_WORKTREE=$WEWORK_DEV_WORKTREE"
+echo "  WEWORK_DEV_BRANCH=${WEWORK_DEV_BRANCH:-<detached>}"
 echo "  MACOS_BUILD_TARGET=${MACOS_BUILD_TARGET:-<native>}"
 echo "  VITE_API_BASE_URL=$VITE_API_BASE_URL"
 echo "  VITE_SOCKET_BASE_URL=$VITE_SOCKET_BASE_URL"

--- a/wework/src-tauri/src/local_terminal.rs
+++ b/wework/src-tauri/src/local_terminal.rs
@@ -77,6 +77,20 @@ fn normalized_cwd(cwd: Option<String>) -> Result<Option<String>, String> {
     Ok(Some(cwd.to_string()))
 }
 
+fn normalized_extra_env(env: Option<HashMap<String, String>>) -> HashMap<String, String> {
+    env.unwrap_or_default()
+        .into_iter()
+        .filter_map(|(key, value)| {
+            let key = key.trim();
+            if key.is_empty() || key.contains('=') || key.contains('\0') || value.contains('\0') {
+                return None;
+            }
+
+            Some((key.to_string(), value))
+        })
+        .collect()
+}
+
 fn decode_pty_output_chunk(pending: &mut Vec<u8>, chunk: &[u8]) -> String {
     let mut bytes = std::mem::take(pending);
     bytes.extend_from_slice(chunk);
@@ -143,6 +157,15 @@ fn configure_terminal_environment(command: &mut CommandBuilder) {
     );
 }
 
+fn configure_terminal_extra_environment(
+    command: &mut CommandBuilder,
+    env: HashMap<String, String>,
+) {
+    for (key, value) in env {
+        command.env(key, value);
+    }
+}
+
 #[tauri::command]
 pub fn start_local_terminal(
     app: tauri::AppHandle,
@@ -150,6 +173,7 @@ pub fn start_local_terminal(
     cwd: Option<String>,
     rows: Option<u16>,
     cols: Option<u16>,
+    env: Option<HashMap<String, String>>,
 ) -> Result<String, String> {
     #[cfg(target_os = "macos")]
     {
@@ -175,6 +199,7 @@ pub fn start_local_terminal(
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let mut command = CommandBuilder::new(shell);
         configure_terminal_environment(&mut command);
+        configure_terminal_extra_environment(&mut command, normalized_extra_env(env));
         if let Some(cwd) = cwd {
             command.cwd(cwd);
         }
@@ -240,6 +265,7 @@ pub fn start_local_terminal(
         let _ = cwd;
         let _ = rows;
         let _ = cols;
+        let _ = env;
         Err("Local terminal is supported only on macOS".to_string())
     }
 }

--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -140,6 +140,7 @@ describe('App center route', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
   })
 
   async function waitForStartupScreenToClose() {
@@ -180,6 +181,30 @@ describe('App center route', () => {
     await waitForStartupScreenToClose()
     expect(screen.queryByTestId('chrome-titlebar')).not.toBeInTheDocument()
     expect(screen.getByTestId('workbench-page')).toBeInTheDocument()
+  })
+
+  test('renders copyable debug instance rows', async () => {
+    window.history.pushState({}, '', '/')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: { writeText },
+    })
+    vi.stubEnv('VITE_WEWORK_DEV_TITLE', 'Runtime task')
+    vi.stubEnv('VITE_WEWORK_DEV_PORT', '1420')
+    vi.stubEnv('VITE_WEWORK_DEV_WORKTREE', '/Users/me/Wegent')
+    vi.stubEnv('VITE_WEWORK_PARENT_TITLE', 'Parent task')
+
+    render(<App />)
+
+    await waitForStartupScreenToClose()
+    expect(screen.getByTestId('wework-dev-instance-badge')).toHaveTextContent(
+      'Debug Wework: Runtime task'
+    )
+    fireEvent.click(screen.getByTestId('copy-wework-dev-port-button'))
+    expect(writeText).toHaveBeenCalledWith('1420')
+    fireEvent.click(screen.getByTestId('copy-wework-dev-parent-title-button'))
+    expect(writeText).toHaveBeenCalledWith('Parent task')
   })
 
   test('keeps the app center sidebar available on desktop app widths', async () => {

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { PanelLeft } from 'lucide-react'
+import { Check, Copy, PanelLeft } from 'lucide-react'
 import { AuthProvider } from '@/features/auth/AuthProvider'
 import { useAuth } from '@/features/auth/useAuth'
 import { WorkbenchProvider } from '@/features/workbench/WorkbenchProvider'
@@ -51,6 +51,11 @@ import {
   keybindingFromKeyboardEvent,
   mergeKeybindings,
 } from '@/lib/keybindings'
+import {
+  getWeworkDevInstanceInfo,
+  getWeworkDevInstanceRows,
+  getWeworkDocumentTitle,
+} from '@/lib/wework-dev-instance'
 
 const WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS = 6000
 
@@ -131,6 +136,10 @@ function AppRoutes({ onWorkbenchStartupReadyChange }: AppRoutesProps = {}) {
 }
 
 export default function App() {
+  useEffect(() => {
+    document.title = getWeworkDocumentTitle()
+  }, [])
+
   useEffect(() => {
     let cancelled = false
 
@@ -346,9 +355,69 @@ function AppShell() {
           >
             <AppRoutes onWorkbenchStartupReadyChange={setWorkbenchStartupReady} />
           </div>
+          <WeworkDevInstanceBadge />
         </div>
       </LocalRuntimeInitializer>
     </CodexHomeInitializer>
+  )
+}
+
+function WeworkDevInstanceBadge() {
+  const info = getWeworkDevInstanceInfo()
+  const [copiedKey, setCopiedKey] = useState<string | null>(null)
+  if (!info) return null
+
+  const rows = getWeworkDevInstanceRows(info)
+  const copyValue = async (key: string, value: string) => {
+    await navigator.clipboard?.writeText(value)
+    setCopiedKey(key)
+    window.setTimeout(() => setCopiedKey(current => (current === key ? null : current)), 1200)
+  }
+
+  return (
+    <div
+      data-testid="wework-dev-instance-badge"
+      className="group pointer-events-auto fixed bottom-3 right-3 z-critical max-w-[min(460px,calc(100vw-1.5rem))]"
+    >
+      <div className="ml-auto max-w-[min(360px,calc(100vw-1.5rem))] truncate rounded-md border border-border/80 bg-background/95 px-2.5 py-1.5 text-xs font-medium text-text-secondary shadow-[0_8px_24px_rgba(0,0,0,0.12)] backdrop-blur">
+        Debug Wework: <span className="text-text-primary">{info.title}</span>
+      </div>
+      <div className="pointer-events-none absolute bottom-full right-0 w-[min(460px,calc(100vw-1.5rem))] translate-y-1 pb-2 text-xs opacity-0 transition group-focus-within:pointer-events-auto group-focus-within:translate-y-0 group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:translate-y-0 group-hover:opacity-100">
+        <div className="rounded-lg border border-border/80 bg-background/98 p-2 shadow-[0_18px_48px_rgba(0,0,0,0.18)] backdrop-blur">
+          <div className="mb-1 px-2 py-1 font-semibold text-text-primary">Debug Wework</div>
+          <div className="space-y-1">
+            {rows.map(row => (
+              <div
+                key={row.key}
+                className="grid grid-cols-[7.5rem_minmax(0,1fr)_2rem] items-center gap-2 rounded-md px-2 py-1 hover:bg-surface"
+              >
+                <div className="text-text-muted">{row.label}</div>
+                <div
+                  className="min-w-0 truncate font-mono text-[11px] text-text-primary"
+                  title={row.value}
+                >
+                  {row.value}
+                </div>
+                <button
+                  type="button"
+                  data-testid={`copy-wework-dev-${row.key}-button`}
+                  className="flex h-7 w-7 items-center justify-center rounded-md text-text-secondary hover:bg-black/[0.04] hover:text-text-primary"
+                  title={`Copy ${row.label}`}
+                  aria-label={`Copy ${row.label}`}
+                  onClick={() => void copyValue(row.key, row.value)}
+                >
+                  {copiedKey === row.key ? (
+                    <Check className="h-3.5 w-3.5 text-primary" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -6305,6 +6305,11 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
         cwd: '/Users/me/Wegent/.worktrees/a',
+        env: {
+          WEWORK_PARENT_TITLE: 'Task A',
+          WEWORK_PARENT_PROJECT: 'Wegent',
+          WEWORK_PARENT_WORKSPACE: '/Users/me/Wegent/.worktrees/a',
+        },
       })
     )
     await waitFor(() => {
@@ -6323,6 +6328,11 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
         cwd: '/Users/me/Wegent/.worktrees/b',
+        env: {
+          WEWORK_PARENT_TITLE: 'Task B',
+          WEWORK_PARENT_PROJECT: 'Wegent',
+          WEWORK_PARENT_WORKSPACE: '/Users/me/Wegent/.worktrees/b',
+        },
       })
     )
     await waitFor(() => {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -239,6 +239,7 @@ const MemoizedBottomWorkspacePanel = memo(function MemoizedBottomWorkspacePanel(
       devices={context.devices}
       workspaceTarget={context.workspaceTarget}
       preferLocalTerminal={context.preferLocalTerminal}
+      terminalContextTitle={context.terminalContextTitle}
       onRequestClose={closePanel}
       onTerminalTabsEmpty={onTerminalTabsEmpty}
     />
@@ -365,6 +366,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const isBootstrapping = state.isBootstrapping
   const runtimeWork = state.runtimeWork
   const devices = state.devices
+  const runtimeTaskTitle = findRuntimeTask(runtimeWork, currentRuntimeTask)?.title.trim() || null
   const [rightPanelOpen, setRightPanelOpen] = useState(
     () => initialBlankBrowserMigration?.rightPanelOpen ?? false
   )
@@ -532,12 +534,14 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       devices,
       workspaceTarget: effectiveWorkspaceTarget,
       preferLocalTerminal: preferLocalWorkspaceTerminal,
+      terminalContextTitle: runtimeTaskTitle,
     }),
     [
       bottomPanelWorkspaceKey,
       devices,
       effectiveWorkspaceTarget,
       preferLocalWorkspaceTerminal,
+      runtimeTaskTitle,
       workspaceProject,
     ]
   )
@@ -1066,7 +1070,6 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const mainHeaderProjectAction = renderWorkspacePanelActions('primary-target')
   const mainHeaderEnvironmentAction = renderWorkspacePanelActions('environment')
   const panelChromeActions = renderWorkspacePanelActions('panel-toggles')
-  const runtimeTaskTitle = findRuntimeTask(runtimeWork, currentRuntimeTask)?.title.trim() || null
   const paneTaskTitle =
     runtimeTaskTitle && !isTauri ? (
       <div
@@ -1570,6 +1573,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               devices={devices}
               workspaceTarget={effectiveWorkspaceTarget}
               preferLocalTerminal={preferLocalWorkspaceTerminal}
+              terminalContextTitle={runtimeTaskTitle}
               workspaceFileApi={workspaceFileApi}
               openFileRequest={openFileRequest}
               workspaceTargetError={workspaceTargetError}

--- a/wework/src/components/layout/desktopWorkbenchPaneTypes.ts
+++ b/wework/src/components/layout/desktopWorkbenchPaneTypes.ts
@@ -34,6 +34,7 @@ export interface BottomPanelRenderContext {
   devices: DeviceInfo[]
   workspaceTarget: WorkspaceTarget | null
   preferLocalTerminal: boolean
+  terminalContextTitle?: string | null
 }
 
 export function formatEnvironmentReviewErrorMessage({

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -23,6 +23,7 @@ interface BottomWorkspacePanelProps {
   devices: DeviceInfo[]
   workspaceTarget: WorkspaceTarget | null
   preferLocalTerminal?: boolean
+  terminalContextTitle?: string | null
   onRequestClose: () => void
   onTerminalTabsEmpty?: () => void
 }
@@ -40,6 +41,7 @@ export const BottomWorkspacePanel = memo(function BottomWorkspacePanel({
   devices,
   workspaceTarget,
   preferLocalTerminal = false,
+  terminalContextTitle,
   onRequestClose,
   onTerminalTabsEmpty,
 }: BottomWorkspacePanelProps) {
@@ -180,6 +182,7 @@ export const BottomWorkspacePanel = memo(function BottomWorkspacePanel({
                   onRequestClose={() => closeTab(tab.id)}
                   hideTerminalChrome
                   preferLocalTerminal={preferLocalTerminal}
+                  terminalContextTitle={terminalContextTitle}
                   panelActive={panelActive}
                   testIdsEnabled={contentTestIdsEnabled}
                   onTerminalTitleChange={title => updateTabTitle(tab.id, title)}

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -81,6 +81,7 @@ interface RightWorkspacePanelProps {
   devices: DeviceInfo[]
   workspaceTarget: WorkspaceTarget | null
   preferLocalTerminal?: boolean
+  terminalContextTitle?: string | null
   workspaceFileApi: WorkspaceFileApi
   openFileRequest?: WorkspaceFileOpenRequest | null
   workspaceTargetError?: string | null
@@ -112,6 +113,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
   devices,
   workspaceTarget,
   preferLocalTerminal = false,
+  terminalContextTitle,
   workspaceFileApi,
   openFileRequest,
   workspaceTargetError,
@@ -342,6 +344,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
             defaultOpenTool="terminal"
             hideTerminalChrome
             preferLocalTerminal={preferLocalTerminal}
+            terminalContextTitle={terminalContextTitle}
           />
         ) : !isRightWorkspaceChatTab(activeView) && activeView === 'plan' ? (
           <PlanWorkspacePanel content={planContent ?? ''} />

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -46,6 +46,7 @@ interface WorkspacePanelCardsProps {
   preferLocalTerminal?: boolean
   panelActive?: boolean
   testIdsEnabled?: boolean
+  terminalContextTitle?: string | null
   onTerminalTitleChange?: (title: string) => void
 }
 
@@ -119,6 +120,34 @@ function getTerminalSessionLabel(session: WorkspaceTerminalSession | null): stri
   )
 }
 
+function buildLocalTerminalEnv({
+  title,
+  projectName,
+  workspacePath,
+}: {
+  title?: string | null
+  projectName?: string | null
+  workspacePath?: string | null
+}): Record<string, string> | undefined {
+  const normalizedTitle = title?.trim()
+  if (!normalizedTitle) return undefined
+
+  const env: Record<string, string> = {
+    WEWORK_PARENT_TITLE: normalizedTitle,
+  }
+  const normalizedProjectName = projectName?.trim()
+  const normalizedWorkspacePath = workspacePath?.trim()
+
+  if (normalizedProjectName) {
+    env.WEWORK_PARENT_PROJECT = normalizedProjectName
+  }
+  if (normalizedWorkspacePath) {
+    env.WEWORK_PARENT_WORKSPACE = normalizedWorkspacePath
+  }
+
+  return env
+}
+
 function createProjectSessionApi() {
   const { apiBaseUrl } = getRuntimeConfig()
   return createProjectApi(createHttpClient({ baseUrl: apiBaseUrl }))
@@ -143,6 +172,7 @@ export function WorkspacePanelCards({
   preferLocalTerminal = false,
   panelActive = true,
   testIdsEnabled = true,
+  terminalContextTitle,
   onTerminalTitleChange,
 }: WorkspacePanelCardsProps) {
   const { t } = useTranslation('common')
@@ -395,7 +425,14 @@ export function WorkspacePanelCards({
       }
 
       if (shouldUseLocalTerminal) {
-        const sessionId = await startLocalTerminal({ cwd: activeWorkspacePath })
+        const sessionId = await startLocalTerminal({
+          cwd: activeWorkspacePath,
+          env: buildLocalTerminalEnv({
+            title: terminalContextTitle,
+            projectName: currentProject?.name,
+            workspacePath: activeWorkspacePath,
+          }),
+        })
         const sessionDeviceId =
           activeWorkspaceDeviceId ?? resolvedLocalTerminalCheck.executorDeviceId ?? 'local'
         setTerminalSessions(sessions => [
@@ -477,6 +514,7 @@ export function WorkspacePanelCards({
     readLocalTerminalCheck,
     setLocalTerminalCheck,
     setProjectError,
+    terminalContextTitle,
     workspaceSource,
   ])
 

--- a/wework/src/lib/local-terminal.test.ts
+++ b/wework/src/lib/local-terminal.test.ts
@@ -168,6 +168,39 @@ describe('local-terminal', () => {
     })
   })
 
+  test('passes sanitized context env when starting an embedded local terminal', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    invokeMock.mockResolvedValue('local-terminal-1')
+
+    await expect(
+      startLocalTerminal({
+        cwd: '/Users/me/project',
+        env: {
+          WEWORK_PARENT_TITLE: 'Task A',
+          ' BAD=KEY ': 'ignored',
+          EMPTY_VALUE: null,
+        },
+      })
+    ).resolves.toBe('local-terminal-1')
+    expect(invokeMock).toHaveBeenCalledWith('start_local_terminal', {
+      cwd: '/Users/me/project',
+      rows: undefined,
+      cols: undefined,
+      env: {
+        WEWORK_PARENT_TITLE: 'Task A',
+      },
+    })
+  })
+
   test('opens a local workspace through the selected native app', async () => {
     setNavigatorValue(
       'userAgent',

--- a/wework/src/lib/local-terminal.ts
+++ b/wework/src/lib/local-terminal.ts
@@ -39,6 +39,7 @@ export interface StartLocalTerminalOptions {
   cwd?: string
   rows?: number
   cols?: number
+  env?: Record<string, string | null | undefined>
 }
 
 export interface LocalTerminalOutputPayload {
@@ -54,17 +55,42 @@ export async function startLocalTerminal({
   cwd,
   rows,
   cols,
+  env,
 }: StartLocalTerminalOptions = {}): Promise<string> {
   if (!isLocalTerminalAvailable()) {
     throw new Error('Local terminal is unavailable outside the macOS Tauri app')
   }
 
   const trimmedCwd = cwd?.trim()
-  return invoke<string>('start_local_terminal', {
+  const normalizedEnv = normalizeLocalTerminalEnv(env)
+  const payload: {
+    cwd: string | null
+    rows?: number
+    cols?: number
+    env?: Record<string, string>
+  } = {
     cwd: trimmedCwd || null,
     rows,
     cols,
+  }
+  if (normalizedEnv) {
+    payload.env = normalizedEnv
+  }
+
+  return invoke<string>('start_local_terminal', payload)
+}
+
+function normalizeLocalTerminalEnv(env?: Record<string, string | null | undefined>) {
+  if (!env) return null
+
+  const entries = Object.entries(env).flatMap(([key, value]) => {
+    const normalizedKey = key.trim()
+    if (!normalizedKey || normalizedKey.includes('=') || value == null) return []
+
+    return [[normalizedKey, value]]
   })
+
+  return entries.length > 0 ? Object.fromEntries(entries) : null
 }
 
 export interface OpenLocalWorkspaceOptions {

--- a/wework/src/lib/wework-dev-instance.ts
+++ b/wework/src/lib/wework-dev-instance.ts
@@ -1,0 +1,61 @@
+export interface WeworkDevInstanceInfo {
+  title: string
+  port?: string
+  worktree?: string
+  branch?: string
+  parentTitle?: string
+  parentProject?: string
+  parentWorkspace?: string
+}
+
+export interface WeworkDevInstanceRow {
+  key: string
+  label: string
+  value: string
+}
+
+function envValue(key: keyof ImportMetaEnv): string | undefined {
+  return import.meta.env[key]?.trim() || undefined
+}
+
+export function getWeworkDevTitle(): string | null {
+  return getWeworkDevInstanceInfo()?.title ?? null
+}
+
+export function getWeworkDevInstanceInfo(): WeworkDevInstanceInfo | null {
+  const title = envValue('VITE_WEWORK_DEV_TITLE')
+  if (!title) return null
+
+  return {
+    title,
+    port: envValue('VITE_WEWORK_DEV_PORT'),
+    worktree: envValue('VITE_WEWORK_DEV_WORKTREE'),
+    branch: envValue('VITE_WEWORK_DEV_BRANCH'),
+    parentTitle: envValue('VITE_WEWORK_PARENT_TITLE'),
+    parentProject: envValue('VITE_WEWORK_PARENT_PROJECT'),
+    parentWorkspace: envValue('VITE_WEWORK_PARENT_WORKSPACE'),
+  }
+}
+
+export function getWeworkDocumentTitle(): string {
+  const devTitle = getWeworkDevTitle()
+  return devTitle ? `WeWork - ${devTitle}` : 'WeWork'
+}
+
+export function getWeworkDevInstanceRows(info: WeworkDevInstanceInfo): WeworkDevInstanceRow[] {
+  return [
+    { key: 'title', label: 'Title', value: info.title },
+    info.port ? { key: 'port', label: 'Port', value: info.port } : null,
+    info.branch ? { key: 'branch', label: 'Branch', value: info.branch } : null,
+    info.worktree ? { key: 'worktree', label: 'Worktree', value: info.worktree } : null,
+    info.parentTitle
+      ? { key: 'parent-title', label: 'Parent task', value: info.parentTitle }
+      : null,
+    info.parentProject
+      ? { key: 'parent-project', label: 'Parent project', value: info.parentProject }
+      : null,
+    info.parentWorkspace
+      ? { key: 'parent-workspace', label: 'Parent workspace', value: info.parentWorkspace }
+      : null,
+  ].filter((row): row is WeworkDevInstanceRow => Boolean(row))
+}


### PR DESCRIPTION
## Summary

- Pass Wework runtime task context into newly opened local Terminal sessions.
- Let the macOS dev app script expose debug instance metadata to the frontend.
- Show a bottom-right Debug Wework badge with copyable instance fields.
- Add Chinese and English developer docs for the debug instance context flow.

## Validation

- pnpm --dir wework exec tsc --noEmit
- pnpm --dir wework exec vitest run src/lib/local-terminal.test.ts src/components/topnav/ChromeTitlebar.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx src/App.apps.test.tsx src/App.plugins.test.tsx
- cargo check --manifest-path wework/src-tauri/Cargo.toml
- bash -n wework/scripts/dev-mac-app.sh
- pre-push Wework ESLint, TypeScript, and unit tests passed
