### PR TITLE
Fix/wework environment info layout

### DIFF
--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -198,9 +198,7 @@ describe('App center route', () => {
     render(<App />)
 
     await waitForStartupScreenToClose()
-    expect(screen.getByTestId('wework-dev-instance-badge')).toHaveTextContent(
-      'Debug Wework: Runtime task'
-    )
+    expect(screen.getByTestId('wework-dev-instance-badge')).toHaveTextContent('Runtime task')
     fireEvent.click(screen.getByTestId('copy-wework-dev-port-button'))
     expect(writeText).toHaveBeenCalledWith('1420')
     fireEvent.click(screen.getByTestId('copy-wework-dev-parent-title-button'))

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -379,12 +379,11 @@ function WeworkDevInstanceBadge() {
       data-testid="wework-dev-instance-badge"
       className="group pointer-events-auto fixed bottom-3 right-3 z-critical max-w-[min(460px,calc(100vw-1.5rem))]"
     >
-      <div className="ml-auto max-w-[min(360px,calc(100vw-1.5rem))] truncate rounded-md border border-border/80 bg-background/95 px-2.5 py-1.5 text-xs font-medium text-text-secondary shadow-[0_8px_24px_rgba(0,0,0,0.12)] backdrop-blur">
-        Debug Wework: <span className="text-text-primary">{info.title}</span>
+      <div className="ml-auto max-w-[min(240px,calc(100vw-1.5rem))] truncate rounded-md border border-border/80 bg-background/95 px-2.5 py-1.5 text-xs font-medium text-text-secondary shadow-[0_8px_24px_rgba(0,0,0,0.12)] backdrop-blur">
+        <span className="text-text-primary">{info.title}</span>
       </div>
       <div className="pointer-events-none absolute bottom-full right-0 w-[min(460px,calc(100vw-1.5rem))] translate-y-1 pb-2 text-xs opacity-0 transition group-focus-within:pointer-events-auto group-focus-within:translate-y-0 group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:translate-y-0 group-hover:opacity-100">
         <div className="rounded-lg border border-border/80 bg-background/98 p-2 shadow-[0_18px_48px_rgba(0,0,0,0.18)] backdrop-blur">
-          <div className="mb-1 px-2 py-1 font-semibold text-text-primary">Debug Wework</div>
           <div className="space-y-1">
             {rows.map(row => (
               <div

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -53,6 +53,7 @@ interface ScrollableMessageAreaProps {
   stickyFooterClassName?: string
   scrollButtonClassName?: string
   scrollTestId?: string
+  externalScrollRef?: RefObject<HTMLDivElement | null>
   conversationKey?: string | number | null
   devices?: DeviceInfo[]
   onRetryFailedMessage?: (message: WorkbenchMessage) => void
@@ -116,6 +117,7 @@ function areScrollableMessageAreaPropsEqual(
     previous.stickyFooterClassName !== next.stickyFooterClassName ? 'stickyFooterClassName' : null,
     previous.scrollButtonClassName !== next.scrollButtonClassName ? 'scrollButtonClassName' : null,
     previous.scrollTestId !== next.scrollTestId ? 'scrollTestId' : null,
+    previous.externalScrollRef !== next.externalScrollRef ? 'externalScrollRef' : null,
     previous.conversationKey !== next.conversationKey ? 'conversationKey' : null,
     previous.devices !== next.devices ? 'devices' : null,
     previous.onRetryFailedMessage !== next.onRetryFailedMessage ? 'onRetryFailedMessage' : null,
@@ -176,6 +178,7 @@ function ScrollableMessagePaneContent({
   stickyFooterClassName,
   scrollButtonClassName,
   scrollTestId = 'chat-message-scroll-area',
+  externalScrollRef,
   conversationKey,
   devices,
   onRetryFailedMessage,
@@ -200,7 +203,8 @@ function ScrollableMessagePaneContent({
   onLoadTranscriptGap,
 }: ScrollableMessageAreaProps) {
   const { t } = useTranslation('common')
-  const scrollRef = useRef<HTMLDivElement>(null)
+  const internalScrollRef = useRef<HTMLDivElement>(null)
+  const scrollRef = externalScrollRef ?? internalScrollRef
   const contentRef = useRef<HTMLDivElement>(null)
   const stickyFooterRef = useRef<HTMLDivElement>(null)
   const isAtBottomRef = useRef(true)
@@ -655,7 +659,7 @@ function ScrollableMessagePaneContent({
         </div>
       )}
       <div
-        ref={scrollRef}
+        ref={internalScrollRef}
         data-testid={scrollTestId}
         className={cn(
           'h-full overflow-y-auto',

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5209,6 +5209,9 @@ describe('DesktopWorkbenchLayout', () => {
       'backdrop-blur-3xl',
       'backdrop-saturate-150'
     )
+    expect(screen.getByTestId('environment-info-popover')).not.toHaveClass(
+      'shadow-[0_18px_44px_rgba(0,0,0,0.24)]'
+    )
     expect(screen.getByText('环境信息')).toBeInTheDocument()
     expect(screen.getByText('变更')).toBeInTheDocument()
     const deviceSection = screen.getByTestId('environment-device-section')

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -102,6 +102,8 @@ const RIGHT_PANEL_SHELL_TRANSITION_CLASS =
   'transition-[width,opacity] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[width,opacity]'
 const RIGHT_PANEL_HANDLE_TRANSITION_CLASS =
   'transition-[left] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[left]'
+const DOCKED_ENVIRONMENT_INFO_WIDTH = 320
+const MIN_CHAT_COLUMN_WIDTH_FOR_DOCKED_ENVIRONMENT_INFO = 680
 const MAX_CACHED_DESKTOP_WORKBENCH_TABS = 10
 const COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE = '5rem'
 const MACOS_TRAFFIC_LIGHTS_CLEARANCE_CLASS = 'pl-[92px]'
@@ -393,6 +395,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
   const isTauri = isTauriRuntime()
   const workbenchMainRef = useRef<HTMLElement | null>(null)
+  const [workbenchContentWidth, setWorkbenchContentWidth] = useState(0)
   const environmentInfoPanelRef = useRef<HTMLElement | null>(null)
   const [environmentInfoPanelElement, setEnvironmentInfoPanelElement] =
     useState<HTMLElement | null>(null)
@@ -416,6 +419,21 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     reloadDiff: undefined,
   })
   const closeRightPanel = useCallback(() => setRightPanelOpen(false), [setRightPanelOpen])
+  useLayoutEffect(() => {
+    const workbenchMain = workbenchMainRef.current
+    if (!workbenchMain) return
+
+    const updateWorkbenchContentWidth = () => {
+      setWorkbenchContentWidth(workbenchMain.getBoundingClientRect().width)
+    }
+
+    updateWorkbenchContentWidth()
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(updateWorkbenchContentWidth)
+    observer.observe(workbenchMain)
+    return () => observer.disconnect()
+  }, [])
   const {
     width: rightSplitChatWidth,
     resizing: rightSplitResizing,
@@ -425,6 +443,11 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     onCollapse: closeRightPanel,
   })
   const chatColumnWidth = rightPanelOpen ? rightSplitChatWidth : '100%'
+  const availableChatColumnWidth = rightPanelOpen ? rightSplitChatWidth : workbenchContentWidth
+  const environmentInfoDocked =
+    Boolean(currentRuntimeTask) &&
+    availableChatColumnWidth - DOCKED_ENVIRONMENT_INFO_WIDTH >=
+      MIN_CHAT_COLUMN_WIDTH_FOR_DOCKED_ENVIRONMENT_INFO
   const paneTitleWidth = rightPanelOpen ? chatColumnWidth : '100%'
   const rightPanelShellWidth = rightPanelOpen ? `calc(100% - ${rightSplitChatWidth}px)` : '0px'
   const rightPanelTitlebarWidth = rightPanelOpen
@@ -1062,7 +1085,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       workspaceTarget={workspaceTarget}
       environmentInfo={environmentInfo}
       environmentInfoPopoverContainer={environmentInfoPanelElement}
-      environmentInfoVisible={Boolean(currentRuntimeTask || currentProject)}
+      environmentInfoVisible={Boolean(currentRuntimeTask)}
+      environmentInfoDocked={environmentInfoDocked}
       onRefreshEnvironmentInfo={refreshEnvironmentInfo}
       onCommitEnvironmentChanges={commitEnvironmentChanges}
       onCommitAndPushEnvironmentChanges={commitAndPushEnvironmentChanges}
@@ -1548,7 +1572,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <aside
             ref={setEnvironmentInfoPanelRef}
             data-testid="environment-info-panel-container"
-            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[312px]"
+            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[320px]"
           />
         </div>
         {rightPanelOpen && (

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -395,6 +395,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
   const isTauri = isTauriRuntime()
   const workbenchMainRef = useRef<HTMLElement | null>(null)
+  const workbenchScrollRef = useRef<HTMLDivElement | null>(null)
   const [workbenchContentWidth, setWorkbenchContentWidth] = useState(0)
   const environmentInfoPanelRef = useRef<HTMLElement | null>(null)
   const [environmentInfoPanelElement, setEnvironmentInfoPanelElement] =
@@ -1087,6 +1088,13 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       environmentInfoPopoverContainer={environmentInfoPanelElement}
       environmentInfoVisible={Boolean(currentRuntimeTask)}
       environmentInfoDocked={environmentInfoDocked}
+      environmentInfoFloatingFooter={
+        !environmentInfoDocked && (paneSession.subagentStatuses?.length ?? 0) > 0 ? (
+          <div data-testid="workbench-subagent-status-row">
+            <SubagentStatusIndicator statuses={paneSession.subagentStatuses} />
+          </div>
+        ) : undefined
+      }
       onRefreshEnvironmentInfo={refreshEnvironmentInfo}
       onCommitEnvironmentChanges={commitEnvironmentChanges}
       onCommitAndPushEnvironmentChanges={commitAndPushEnvironmentChanges}
@@ -1312,27 +1320,13 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           />
         )}
         {paneTaskTitle}
-        {showPageTopBar && hasSubagentStatuses && (
-          <div
-            data-testid="workbench-subagent-status-row"
-            className={cn(
-              'pointer-events-none absolute right-3 top-14 z-chrome flex items-start',
-              rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
-            )}
-          >
-            <SubagentStatusIndicator
-              statuses={paneSession.subagentStatuses}
-              availableWidth={rightPanelOpen ? rightSplitChatWidth : null}
-              className="pointer-events-auto"
-            />
-          </div>
-        )}
       </WorkbenchPaneActiveOnly>
       <div className="relative flex min-h-0 flex-1 overflow-visible">
         <div
+          ref={workbenchScrollRef}
           data-testid="desktop-workbench-content"
           className={cn(
-            'relative grid min-w-0 flex-none grid-cols-[minmax(0,1fr)_auto] overflow-hidden',
+            'relative grid min-w-0 flex-none grid-cols-[minmax(0,1fr)_auto] overflow-y-auto',
             rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
             showPageTopBar && 'pt-11'
           )}
@@ -1341,7 +1335,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           {isBootstrapping ? (
             <div className="flex min-w-0 flex-1" data-testid="desktop-workbench-loading" />
           ) : hasConversation ? (
-            <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+            <div className="relative min-h-0 min-w-0 flex-1">
               <ScrollableMessageArea
                 messages={paneMessages}
                 loading={paneSession.transcriptLoading}
@@ -1361,7 +1355,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 }
                 className="h-full"
                 scrollTestId="desktop-chat-scroll"
-                scrollerClassName="scrollbar-soft"
+                externalScrollRef={workbenchScrollRef}
+                scrollerClassName="overflow-visible scrollbar-none"
                 messageListClassName={cn(
                   DESKTOP_MESSAGE_LIST_CLASS,
                   chatContentResizing && 'transition-none'
@@ -1570,10 +1565,16 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             </div>
           )}
           <aside
-            ref={setEnvironmentInfoPanelRef}
             data-testid="environment-info-panel-container"
-            className="relative z-popover h-full w-0 shrink-0 overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[>[data-testid=environment-info-popover]]:w-[320px]"
-          />
+            className="sticky top-0 z-popover flex h-full w-0 shrink-0 self-start flex-col overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[[data-testid=environment-info-popover]]:w-[320px]"
+          >
+            <div ref={setEnvironmentInfoPanelRef} className="shrink-0" />
+            {environmentInfoDocked && hasSubagentStatuses && (
+              <div data-testid="workbench-subagent-status-row" className="ml-2 mt-3 w-[300px]">
+                <SubagentStatusIndicator statuses={paneSession.subagentStatuses} />
+              </div>
+            )}
+          </aside>
         </div>
         {rightPanelOpen && (
           <div

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -16,7 +16,14 @@ import {
   Upload,
   CornerDownLeft,
 } from 'lucide-react'
-import { useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+  type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { BranchSelector } from '@/components/common/BranchSelector'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -30,6 +37,7 @@ interface EnvironmentInfoPopoverProps {
   info: EnvironmentInfo
   popoverContainer: HTMLElement | null
   docked?: boolean
+  floatingFooter?: ReactNode
   devices?: DeviceInfo[]
   onRefresh?: () => Promise<void>
   onCommitChanges?: (message: string) => Promise<void>
@@ -51,6 +59,7 @@ export function EnvironmentInfoPopover({
   info,
   popoverContainer,
   docked = true,
+  floatingFooter,
   devices = [],
   onRefresh,
   onCommitChanges,
@@ -452,6 +461,9 @@ export function EnvironmentInfoPopover({
               <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-xs text-red-600">
                 {commitError}
               </p>
+            )}
+            {!docked && floatingFooter && (
+              <div className="mt-3 border-t border-border pt-3">{floatingFooter}</div>
             )}
           </div>,
           popoverPortalContainer

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -16,7 +16,7 @@ import {
   Upload,
   CornerDownLeft,
 } from 'lucide-react'
-import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { BranchSelector } from '@/components/common/BranchSelector'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -29,6 +29,7 @@ import { DESKTOP_TOP_BAR_BUTTON_CLASS } from './DesktopTopBar'
 interface EnvironmentInfoPopoverProps {
   info: EnvironmentInfo
   popoverContainer: HTMLElement | null
+  docked?: boolean
   devices?: DeviceInfo[]
   onRefresh?: () => Promise<void>
   onCommitChanges?: (message: string) => Promise<void>
@@ -42,15 +43,14 @@ interface EnvironmentInfoPopoverProps {
 
 type CommitPanelAction = 'commit' | 'commit-and-push' | 'push'
 
-const AUTO_OPEN_MIN_VIEWPORT_WIDTH = 1280
-
-function shouldAutoOpenEnvironmentInfo() {
-  return typeof window !== 'undefined' && window.innerWidth >= AUTO_OPEN_MIN_VIEWPORT_WIDTH
-}
+const FLOATING_POPOVER_WIDTH = 300
+const FLOATING_POPOVER_GAP = 8
+const FLOATING_POPOVER_MARGIN = 16
 
 export function EnvironmentInfoPopover({
   info,
   popoverContainer,
+  docked = true,
   devices = [],
   onRefresh,
   onCommitChanges,
@@ -62,14 +62,17 @@ export function EnvironmentInfoPopover({
   onOpenChangesReview,
 }: EnvironmentInfoPopoverProps) {
   const { t } = useTranslation('common')
-  const [open, setOpen] = useState(shouldAutoOpenEnvironmentInfo)
+  const [open, setOpen] = useState(docked)
   const [workspacePathCopied, setWorkspacePathCopied] = useState(false)
   const [commitFormOpen, setCommitFormOpen] = useState(false)
   const [commitMessage, setCommitMessage] = useState('')
   const [commitStatus, setCommitStatus] = useState<'idle' | 'committing' | 'success'>('idle')
   const [commitProgressLabel, setCommitProgressLabel] = useState('')
   const [commitError, setCommitError] = useState<string | null>(null)
+  const [floatingPopoverStyle, setFloatingPopoverStyle] = useState<CSSProperties>()
   const userToggledOpenRef = useRef(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
   const additions = info.additions || '+0'
   const deletions = info.deletions || '-0'
   const device = info.deviceId
@@ -181,6 +184,9 @@ export function EnvironmentInfoPopover({
   function handleToggleOpen() {
     userToggledOpenRef.current = true
     const nextOpen = !open
+    if (nextOpen && !docked) {
+      setFloatingPopoverStyle(getFloatingPopoverPosition())
+    }
     setOpen(nextOpen)
     if (nextOpen) {
       void onRefresh?.()
@@ -188,27 +194,39 @@ export function EnvironmentInfoPopover({
   }
 
   useEffect(() => {
-    function synchronizeAutoOpenState() {
-      if (!shouldAutoOpenEnvironmentInfo()) {
+    if (!open || docked) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node
+      if (!rootRef.current?.contains(target) && !popoverRef.current?.contains(target)) {
         setOpen(false)
-        return
-      }
-
-      if (!userToggledOpenRef.current) {
-        setOpen(true)
       }
     }
 
-    window.addEventListener('resize', synchronizeAutoOpenState)
-    return () => {
-      window.removeEventListener('resize', synchronizeAutoOpenState)
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [docked, open])
+
+  function getFloatingPopoverPosition(): CSSProperties | undefined {
+    const anchor = rootRef.current?.getBoundingClientRect()
+    if (!anchor) return undefined
+
+    const maxLeft = window.innerWidth - FLOATING_POPOVER_WIDTH - FLOATING_POPOVER_MARGIN
+    return {
+      left: `${Math.max(FLOATING_POPOVER_MARGIN, Math.min(anchor.right - FLOATING_POPOVER_WIDTH, maxLeft))}px`,
+      top: `${anchor.bottom + FLOATING_POPOVER_GAP}px`,
     }
-  }, [])
+  }
 
   const branchLabel = info.branchName?.trim() || t('workbench.environment_branch_empty', '暂无分支')
+  const popoverPortalContainer = docked
+    ? popoverContainer
+    : typeof document !== 'undefined'
+      ? document.body
+      : null
 
   return (
-    <div>
+    <div ref={rootRef}>
       <button
         type="button"
         data-testid="environment-info-button"
@@ -222,11 +240,16 @@ export function EnvironmentInfoPopover({
       </button>
 
       {open &&
-        popoverContainer &&
+        popoverPortalContainer &&
         createPortal(
           <div
+            ref={popoverRef}
             data-testid="environment-info-popover"
-            className="mt-3 w-[300px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-3xl backdrop-saturate-150"
+            style={docked ? undefined : floatingPopoverStyle}
+            className={cn(
+              'w-[300px] rounded-2xl border border-border bg-background px-5 py-5 text-text-primary shadow-md backdrop-blur-3xl backdrop-saturate-150',
+              docked ? 'ml-2 mt-3' : 'fixed z-system'
+            )}
           >
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-text-primary">
@@ -431,7 +454,7 @@ export function EnvironmentInfoPopover({
               </p>
             )}
           </div>,
-          popoverContainer
+          popoverPortalContainer
         )}
       {open &&
         commitFormOpen &&

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createProjectApi } from '@/api/projects'
@@ -83,6 +83,14 @@ describe('WorkspacePanelActions', () => {
     setWindowWidth(originalInnerWidth)
   })
 
+  test('hides environment info while a task is being created', () => {
+    render(<WorkspacePanelActions {...baseProps} environmentInfoVisible={false} />)
+
+    expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('toggle-bottom-workspace-panel-button')).toBeInTheDocument()
+    expect(screen.getByTestId('toggle-right-workspace-panel-button')).toBeInTheDocument()
+  })
+
   test('keeps environment info action visible after environment refresh resolves empty context', () => {
     const { rerender } = render(<WorkspacePanelActions {...baseProps} />)
 
@@ -147,6 +155,19 @@ describe('WorkspacePanelActions', () => {
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
   })
 
+  test('opens environment info as a floating panel when the dock is collapsed', async () => {
+    setWindowWidth(1024)
+    render(
+      <WorkspacePanelActions {...baseProps} mode="environment" environmentInfoDocked={false} />
+    )
+
+    expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('environment-info-button'))
+
+    expect(screen.getByTestId('environment-info-popover')).toHaveClass('fixed', 'z-system')
+  })
+
   test('renders environment info in its dedicated right-side container', () => {
     setWindowWidth(1280)
     const workspaceContainer = document.createElement('main')
@@ -170,23 +191,23 @@ describe('WorkspacePanelActions', () => {
     }
   })
 
-  test('keeps environment info collapsed by default when the workspace is narrow', () => {
-    setWindowWidth(1279)
-
-    render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+  test('keeps environment info collapsed by default when the dock is unavailable', () => {
+    render(
+      <WorkspacePanelActions {...baseProps} mode="environment" environmentInfoDocked={false} />
+    )
 
     expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
   })
 
-  test('closes environment info when the workspace becomes narrow', () => {
-    setWindowWidth(1280)
-    render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+  test('closes environment info when the dock becomes unavailable', () => {
+    const { rerender } = render(<WorkspacePanelActions {...baseProps} mode="environment" />)
 
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
 
-    setWindowWidth(1279)
-    act(() => window.dispatchEvent(new Event('resize')))
+    rerender(
+      <WorkspacePanelActions {...baseProps} mode="environment" environmentInfoDocked={false} />
+    )
 
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
   })

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
 import { AlertCircle, Loader2, PanelBottom, PanelRight } from 'lucide-react'
 import { createHttpClient } from '@/api/http'
 import { createProjectApi } from '@/api/projects'
@@ -37,6 +38,7 @@ interface WorkspacePanelActionsProps {
   environmentInfoPopoverContainer: HTMLElement | null
   environmentInfoVisible?: boolean
   environmentInfoDocked?: boolean
+  environmentInfoFloatingFooter?: ReactNode
   onRefreshEnvironmentInfo: () => Promise<void>
   onCommitEnvironmentChanges: (message: string) => Promise<void>
   onCommitAndPushEnvironmentChanges: (message: string) => Promise<void>
@@ -60,6 +62,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
   environmentInfoPopoverContainer,
   environmentInfoVisible = true,
   environmentInfoDocked = true,
+  environmentInfoFloatingFooter,
   onRefreshEnvironmentInfo,
   onCommitEnvironmentChanges,
   onCommitAndPushEnvironmentChanges,
@@ -167,6 +170,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
           info={environmentInfo}
           popoverContainer={environmentInfoPopoverContainer}
           docked={environmentInfoDocked}
+          floatingFooter={environmentInfoFloatingFooter}
           devices={devices}
           onRefresh={onRefreshEnvironmentInfo}
           onCommitChanges={onCommitEnvironmentChanges}

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -36,6 +36,7 @@ interface WorkspacePanelActionsProps {
   environmentInfo: EnvironmentInfo
   environmentInfoPopoverContainer: HTMLElement | null
   environmentInfoVisible?: boolean
+  environmentInfoDocked?: boolean
   onRefreshEnvironmentInfo: () => Promise<void>
   onCommitEnvironmentChanges: (message: string) => Promise<void>
   onCommitAndPushEnvironmentChanges: (message: string) => Promise<void>
@@ -58,6 +59,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
   environmentInfo,
   environmentInfoPopoverContainer,
   environmentInfoVisible = true,
+  environmentInfoDocked = true,
   onRefreshEnvironmentInfo,
   onCommitEnvironmentChanges,
   onCommitAndPushEnvironmentChanges,
@@ -161,8 +163,10 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
     <>
       {showEnvironmentInfo && (
         <EnvironmentInfoPopover
+          key={environmentInfoDocked ? 'docked' : 'floating'}
           info={environmentInfo}
           popoverContainer={environmentInfoPopoverContainer}
+          docked={environmentInfoDocked}
           devices={devices}
           onRefresh={onRefreshEnvironmentInfo}
           onCommitChanges={onCommitEnvironmentChanges}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment information now intelligently docks beside the workspace when sufficient space is available.
  - When docking isn’t possible, the information panel opens as a floating popover with improved positioning and outside-click behavior.
  - Subagent status details appear in the docked environment panel or floating footer as appropriate.
  - Chat scrolling is more consistent across workspace layouts.

- **UI Improvements**
  - Environment information controls are hidden while a task is being created.
  - Development instance badges now display the configured title without an additional debug label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->