### PR TITLE
fix(wework): clear task plan on new chat

### DIFF
--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -56,7 +56,7 @@ import type {
 } from '@/types/workbench'
 import type { CodeCommentContext } from '@/types/workspace-files'
 import { reduceWorkbenchMessages } from '@wegent/chat-core'
-import { getCachedRuntimeTaskPlan, getLatestRuntimeTaskPlan } from '@/stream/responseApiStream'
+import { getCachedRuntimeTaskPlan } from '@/stream/responseApiStream'
 import { useWorkbenchPaneActive } from './workbenchPaneStack'
 
 interface WorkbenchPaneSessionOptions {
@@ -329,7 +329,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     const syncCachedPlan = () => {
       const cachedPlan = currentRuntimeTaskLoadTarget
         ? getCachedRuntimeTaskPlan(currentRuntimeTaskLoadTarget.address)
-        : getLatestRuntimeTaskPlan()
+        : null
       if (import.meta.env.DEV) {
         console.warn('[Wework] Runtime task plan cache sync', {
           currentRuntimeTaskId: currentRuntimeTaskLoadTarget?.address ?? null,
@@ -337,7 +337,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           stepCount: cachedPlan?.plan.length ?? 0,
         })
       }
-      if (cachedPlan) setTaskPlan(cachedPlan)
+      setTaskPlan(cachedPlan?.plan.length ? cachedPlan : null)
     }
 
     syncCachedPlan()

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -11,10 +11,12 @@ import {
 import { WorkbenchProvider, type WorkbenchServices } from './WorkbenchProvider'
 import { useWorkbench } from './useWorkbench'
 import { MessageList } from '@/components/chat/MessageList'
+import { TaskPlanProgress } from '@/components/chat/composer/TaskPlanProgress'
 import { useWorkbenchPaneSession } from '@/components/layout/useWorkbenchPaneSession'
 import { buildRuntimeTaskRoute, parseRuntimeTaskRoute } from '@/lib/navigation'
 import { findRuntimeTask } from './workbenchRuntimeHelpers'
 import { modelSelectionFromRuntimeHandle } from './runtimeContextUsage'
+import { createResponseApiStreamState, emitResponseApiEvent } from '@/stream/responseApiStream'
 import type { ChatStreamHandlers } from '@/stream/chatStream'
 import {
   CachedWorkbenchPaneStack,
@@ -837,6 +839,30 @@ function RuntimePaneSessionIdentityProbe() {
         }
       >
         rebuild same runtime address
+      </button>
+    </div>
+  )
+}
+
+function RuntimePlanScopeProbe() {
+  const { workbench, paneSession } = useWorkbenchProbeSession()
+  const runtimeTask = {
+    deviceId: 'device-1',
+    workspacePath: '/workspace/project-alpha',
+    taskId: 'runtime-plan-scope',
+  }
+
+  return (
+    <div>
+      <span data-testid="runtime-plan-scope-task">
+        {workbench.state.currentRuntimeTask?.taskId ?? 'none'}
+      </span>
+      <TaskPlanProgress plan={paneSession.taskPlan} />
+      <button type="button" onClick={() => void workbench.openRuntimeTask(runtimeTask)}>
+        open runtime plan scope
+      </button>
+      <button type="button" onClick={workbench.startNewChat}>
+        start new plan scope chat
       </button>
     </div>
   )
@@ -4690,6 +4716,40 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     expect(runtimeSubscribeCount()).toBe(1)
     expect(runtimeCleanup).not.toHaveBeenCalled()
+  })
+
+  test('clears the task plan progress when starting a new chat', async () => {
+    renderWorkbench(<RuntimePlanScopeProbe />)
+
+    await userEvent.click(await screen.findByText('open runtime plan scope'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-plan-scope-task')).toHaveTextContent('runtime-plan-scope')
+    )
+
+    await act(async () => {
+      emitResponseApiEvent(
+        {},
+        'runtime.plan.updated',
+        {
+          taskId: 'runtime-plan-scope',
+          deviceId: 'device-1',
+          data: {
+            plan: [{ step: 'Implement the fix', status: 'inProgress' }],
+          },
+        },
+        createResponseApiStreamState()
+      )
+      globalThis.dispatchEvent(new Event('wework-runtime-plan-updated'))
+    })
+
+    await waitFor(() => expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('start new plan scope chat'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('runtime-plan-scope-task')).toHaveTextContent('none')
+      expect(screen.queryByTestId('runtime-plan-progress-button')).not.toBeInTheDocument()
+    })
   })
 
   test('reuses the current runtime task address for follow-up messages', async () => {

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -59,7 +59,6 @@ export interface ResponseApiStreamState {
 }
 
 const runtimeTaskPlans = new Map<string, RuntimePlanEventPayload>()
-let latestRuntimeTaskPlan: RuntimePlanEventPayload | null = null
 
 function runtimeTaskPlanKey(
   payload: Pick<RuntimePlanEventPayload, 'deviceId' | 'taskId'>
@@ -73,10 +72,6 @@ export function getCachedRuntimeTaskPlan(
 ): RuntimePlanEventPayload | null {
   const key = runtimeTaskPlanKey(address)
   return key ? (runtimeTaskPlans.get(key) ?? null) : null
-}
-
-export function getLatestRuntimeTaskPlan(): RuntimePlanEventPayload | null {
-  return latestRuntimeTaskPlan
 }
 
 export function createResponseApiStreamState(): ResponseApiStreamState {
@@ -738,7 +733,6 @@ export function emitResponseApiEvent(
     }
     const planKey = runtimeTaskPlanKey(payload)
     if (planKey) runtimeTaskPlans.set(planKey, payload)
-    latestRuntimeTaskPlan = payload
     handlers.onRuntimePlanUpdated?.(payload)
     return
   }


### PR DESCRIPTION
## Summary

- Scope runtime task-plan progress strictly to the active task.
- Clear the composer progress indicator when a new blank chat is opened.
- Add a regression test covering the visible progress indicator.

## Root cause

Blank conversations read a global most-recent task plan, so they could render progress from a previously selected runtime conversation.

## Validation

- `vitest run src/features/workbench/WorkbenchProvider.test.tsx`
- `vitest run src/stream/responseApiStream.test.ts`
- ESLint on changed files
- `tsc -b --pretty false`

The full Wework suite has 14 pre-existing DesktopWorkbenchLayout failures unrelated to this change (1,428 passing tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime task plans are now tracked independently for each task and device.
  * Starting a new plan-scope chat correctly clears the previous plan progress.
  * Empty or unavailable cached plans no longer appear as active plans.
  * Prevented stale plan information from being shown when switching runtime tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->