### PR TITLE
test(wework): add real desktop task-flow e2e

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -7,24 +7,24 @@ on:
       - master
       - develop
     paths:
-      - '.github/workflows/wework-e2e.yml'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'packages/chat-core/**'
-      - 'wework/**'
+      - ".github/workflows/wework-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "packages/chat-core/**"
+      - "wework/**"
   pull_request:
     branches:
       - main
       - master
       - develop
     paths:
-      - '.github/workflows/wework-e2e.yml'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'packages/chat-core/**'
-      - 'wework/**'
+      - ".github/workflows/wework-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "packages/chat-core/**"
+      - "wework/**"
   workflow_dispatch:
 
 concurrency:
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -96,5 +96,74 @@ jobs:
         with:
           name: wework-playwright-traces
           path: wework/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  wework-desktop-e2e:
+    name: Wework Desktop E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            xvfb
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            executor/target
+            wework/src-tauri/target
+          key: ${{ runner.os }}-wework-desktop-e2e-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wework-desktop-e2e-
+
+      - name: Prepare real Codex binary
+        working-directory: ./wework
+        run: pnpm run prepare:codex
+
+      - name: Run Wework desktop task-flow E2E
+        env:
+          CI: true
+          CODEX_BIN: ${{ github.workspace }}/wework/src-tauri/binaries/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex
+        run: |
+          test -x "$CODEX_BIN"
+          xvfb-run -a --server-args="-screen 0 1280x720x24" pnpm --filter wework e2e:desktop
+
+      - name: Upload Wework desktop E2E diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-desktop-e2e-diagnostics
+          path: wework/test-results/desktop-e2e/
           if-no-files-found: ignore
           retention-days: 7

--- a/docs/en/developer-guide/wework-e2e-automation.md
+++ b/docs/en/developer-guide/wework-e2e-automation.md
@@ -4,7 +4,7 @@ sidebar_position: 34
 
 # E2E Automation
 
-Wework provides a dedicated Playwright E2E entrypoint and a test-only frontend automation bridge for operating the Wework Vite/React frontend in CI. The default entrypoint runs in browser mode, which covers most frontend interactions; native window behavior should be covered separately with Tauri/WebDriver tests when needed.
+Wework provides a dedicated Playwright E2E entrypoint and a test-only frontend automation bridge for operating the Wework Vite/React frontend in CI. The default entrypoint runs in browser mode, which covers most frontend interactions; the desktop task-flow E2E below covers native-window and task-execution behavior.
 
 ## Running Tests
 
@@ -18,6 +18,12 @@ Run Wework E2E:
 
 ```bash
 pnpm --filter wework e2e
+```
+
+Run the real desktop task-flow E2E:
+
+```bash
+pnpm --filter wework e2e:desktop
 ```
 
 The command starts a test-only Vite server through `wework/playwright.config.ts`:
@@ -40,6 +46,25 @@ Default configuration:
 - `WEWORK_RESPONSE_API_MOCK_URL`: `http://127.0.0.1:9998`
 
 Tests do not mock backend APIs. When Backend is not running, the login-page smoke test only verifies that the frontend renders the login entrypoint. Business flows after login must start a real Backend and required services in CI.
+
+## Desktop Task-Flow E2E
+
+`wework/e2e/desktop/task-flow.e2e.mjs` covers the real task execution path in a local workspace:
+
+1. Builds and starts the real Tauri Wework application, opening an isolated workspace with `--open-workspace`.
+2. Starts the real `wegent-executor` sidecar, which starts a real `codex app-server`.
+3. Fills in a task and clicks send in the native WebView, then waits for the real conversation to render.
+4. Verifies the request issued by Codex to the model service, the workspace file written by a real Codex tool call, and the final UI response.
+
+The test does not simulate Wework, Executor, or Codex. To keep regression results deterministic and avoid requiring a real account, it starts only a loopback OpenAI Responses-compatible service as a custom Codex model provider. That service returns deterministic tool calls and final text; the tool call is still executed by real Codex in the isolated workspace.
+
+The environment needs Rust, Tauri build dependencies, and a real Codex binary. The runner finds `codex` on `PATH` by default; an installed or `prepare:codex`-prepared real binary can also be selected explicitly:
+
+```bash
+CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
+```
+
+Optional `WEWORK_E2E_EXECUTOR_BIN` and `WEWORK_E2E_APP_BIN` reuse already-built real Executor and Tauri application binaries. A supplied application must be built with the desktop E2E Vite environment variables. Test artifacts and failure diagnostics are stored in `wework/test-results/desktop-e2e/`.
 
 ## Responses API Mock
 
@@ -73,17 +98,19 @@ Available methods:
 - `clearAuthToken()`: clears the auth token.
 - `clearStorage()`: clears local auth state and browser storage.
 
+The desktop E2E build additionally injects `VITE_WEWORK_DESKTOP_E2E_CONTROL_URL`. Only when E2E mode and this URL are both present does the frontend poll a local loopback controller for `click`, `fill`, and wait assertions; normal development and production builds have no controller endpoint. The controller drives real WebView DOM events and does not replace task, model-selection, Executor, or Codex implementations.
+
 ## Test Helper
 
 `wework/e2e/fixtures/wework-app.ts` provides a `WeworkApp` Playwright helper that wraps `window.__WEWORK_E2E__` in typed test operations:
 
 ```ts
-const app = new WeworkApp(page)
+const app = new WeworkApp(page);
 
-await app.goto("/")
-await app.waitForTestId("login-form")
-await app.navigate("/apps")
-const route = await app.route()
+await app.goto("/");
+await app.waitForTestId("login-form");
+await app.navigate("/apps");
+const route = await app.route();
 ```
 
 New E2E tests should prefer this helper and `data-testid` locators instead of unstable CSS selectors or visible copy.
@@ -96,6 +123,13 @@ CI can run Wework E2E as a separate job:
 pnpm install --frozen-lockfile
 pnpm --filter wework exec playwright install chromium
 pnpm --filter wework e2e
+```
+
+Desktop task-flow E2E requires a Linux runner with a graphical session, for example:
+
+```bash
+pnpm --filter wework prepare:codex
+xvfb-run -a pnpm --filter wework e2e:desktop
 ```
 
 The repository includes a basic workflow at `.github/workflows/wework-e2e.yml`. It runs when Wework, `packages/chat-core`, the pnpm lockfile, or the workflow itself changes.

--- a/docs/zh/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/developer-guide/wework-e2e-automation.md
@@ -4,7 +4,7 @@ sidebar_position: 34
 
 # E2E 自动化
 
-Wework 提供独立的 Playwright E2E 入口和测试专用前端自动化接口，用于在 CI 中稳定操作 Wework 的 Vite/React 前端。默认入口运行在浏览器模式，适合覆盖大多数前端交互；需要验证原生窗口能力时，再单独接入 Tauri/WebDriver 测试。
+Wework 提供独立的 Playwright E2E 入口和测试专用前端自动化接口，用于在 CI 中稳定操作 Wework 的 Vite/React 前端。默认入口运行在浏览器模式，适合覆盖大多数前端交互；原生窗口与任务执行链路由下文的桌面端全链路 E2E 覆盖。
 
 ## 运行方式
 
@@ -18,6 +18,12 @@ pnpm --filter wework exec playwright install chromium
 
 ```bash
 pnpm --filter wework e2e
+```
+
+运行真实桌面端任务全链路 E2E：
+
+```bash
+pnpm --filter wework e2e:desktop
 ```
 
 该命令会通过 `wework/playwright.config.ts` 启动测试专用 Vite 服务：
@@ -40,6 +46,25 @@ node e2e/utils/mock-response-api-server.mjs
 - `WEWORK_RESPONSE_API_MOCK_URL`: `http://127.0.0.1:9998`
 
 测试不 mock 后端 API。没有启动 Backend 时，登录页 smoke 测试只验证前端能渲染登录入口；需要登录后的业务流程时，CI 必须先启动真实 Backend 和依赖服务。
+
+## 桌面端任务全链路 E2E
+
+`wework/e2e/desktop/task-flow.e2e.mjs` 覆盖本机工作区中的真实任务执行链路：
+
+1. 构建并启动真实 Tauri Wework 应用，使用 `--open-workspace` 打开隔离工作区。
+2. 启动真实 `wegent-executor` sidecar，并由它启动真实 `codex app-server`。
+3. 在原生 WebView 中填入任务、点击发送，并等待真实会话渲染完成。
+4. 校验 Codex 向模型服务发出的请求、Codex 实际工具调用写入的工作区文件，以及页面中的最终回复。
+
+测试不模拟 Wework、Executor 或 Codex。为了让回归结果确定且不需要真实账号，测试只在 loopback 地址启动一个 OpenAI Responses 兼容服务，作为 Codex 的自定义模型 provider。该服务会返回确定性的工具调用和最终文本；工具调用仍由真实 Codex 在隔离工作区内执行。
+
+运行环境需要 Rust、Tauri 构建依赖和真实 Codex 二进制。默认从 `PATH` 查找 `codex`；也可以显式指定已安装或由 `prepare:codex` 准备的真实二进制：
+
+```bash
+CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
+```
+
+可选的 `WEWORK_E2E_EXECUTOR_BIN` 和 `WEWORK_E2E_APP_BIN` 分别允许复用已经构建的真实 Executor 和真实 Tauri 应用。传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。测试过程和失败诊断会保存在 `wework/test-results/desktop-e2e/`。
 
 ## Responses API Mock
 
@@ -73,17 +98,19 @@ http://127.0.0.1:9998/v1
 - `clearAuthToken()`：清除认证 token。
 - `clearStorage()`：清空本地认证和浏览器存储。
 
+桌面端 E2E 构建会额外注入 `VITE_WEWORK_DESKTOP_E2E_CONTROL_URL`。只有在 E2E 模式且该 URL 存在时，前端才会轮询本机 loopback 控制器来执行 `click`、`fill` 和等待断言；常规开发和生产构建不会包含控制端点。控制器只驱动真实 WebView DOM 事件，不替换任务、模型选择、Executor 或 Codex 的实现。
+
 ## 测试封装
 
 `wework/e2e/fixtures/wework-app.ts` 提供 `WeworkApp` Playwright helper，用于把 `window.__WEWORK_E2E__` 封装成类型安全的测试操作：
 
 ```ts
-const app = new WeworkApp(page)
+const app = new WeworkApp(page);
 
-await app.goto("/")
-await app.waitForTestId("login-form")
-await app.navigate("/apps")
-const route = await app.route()
+await app.goto("/");
+await app.waitForTestId("login-form");
+await app.navigate("/apps");
+const route = await app.route();
 ```
 
 新增 E2E 用例应优先使用该 helper 和 `data-testid` 定位，不要依赖易变的 CSS 选择器或可见文案。
@@ -96,6 +123,13 @@ CI 可以把 Wework E2E 作为独立 job：
 pnpm install --frozen-lockfile
 pnpm --filter wework exec playwright install chromium
 pnpm --filter wework e2e
+```
+
+桌面端全链路 E2E 需要在有图形会话的 Linux runner 上运行，例如：
+
+```bash
+pnpm --filter wework prepare:codex
+xvfb-run -a pnpm --filter wework e2e:desktop
 ```
 
 仓库内的基础 workflow 是 `.github/workflows/wework-e2e.yml`，会在 Wework、`packages/chat-core`、pnpm lockfile 或 workflow 自身变化时运行。

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -120,6 +120,24 @@ async function appendProcessOutput(stream, destination) {
   })
 }
 
+async function fillComposerUntilSendEnabled(control, selector) {
+  let lastError
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await control.command('fill', selector, { value: TASK_PROMPT })
+    try {
+      await control.command('waitFor', '[data-testid="send-message-button"]', {
+        enabled: true,
+        timeoutMs: 3_000,
+      })
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
+    }
+  }
+  throw lastError
+}
+
 function createSse(events) {
   return events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
 }
@@ -549,8 +567,7 @@ async function main() {
     await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
-    await control.command('fill', composerSelector, { value: TASK_PROMPT })
-    await control.command('waitFor', '[data-testid="send-message-button"]', { enabled: true })
+    await fillComposerUntilSendEnabled(control, composerSelector)
     await control.command('click', '[data-testid="send-message-button"]')
     await control.command('waitFor', '[data-testid="message-assistant"]', {
       text: COMPLETION_TEXT,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1,0 +1,612 @@
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { spawn, spawnSync } from 'node:child_process'
+import { createServer } from 'node:http'
+import { access, appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const DESKTOP_READY_TIMEOUT_MS = 60_000
+const WORKBENCH_READY_TIMEOUT_MS = 180_000
+const UI_TIMEOUT_MS = 120_000
+const PROCESS_STOP_TIMEOUT_MS = 10_000
+const TASK_PROMPT = 'WEWORK_DESKTOP_E2E_TASK: create the requested verification file.'
+const COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_COMPLETE'
+const ARTIFACT_NAME = 'wework-e2e-result.txt'
+const ARTIFACT_CONTENT = 'CODEX_EXECUTED_REAL_TOOL'
+const MODEL_API_KEY = 'wework-e2e-test-key'
+const MODEL_PROVIDER_ID = 'wework-e2e'
+const MODEL_ID = 'gpt-5.4'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const weworkDir = resolve(scriptDir, '..', '..')
+const repoDir = resolve(weworkDir, '..')
+const runId = `${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}`
+const resultDir = join(weworkDir, 'test-results', 'desktop-e2e', runId)
+
+function withTimeout(promise, timeoutMs, message) {
+  let timeout
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
+  })
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout))
+}
+
+async function isExecutable(path) {
+  try {
+    await access(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function commandOutput(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} exited with ${result.status}: ${result.stderr || result.stdout}`
+    )
+  }
+  return result.stdout.trim()
+}
+
+async function runChecked(command, args, options = {}) {
+  console.log(`$ ${command} ${args.join(' ')}`)
+  await new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: 'inherit',
+    })
+    child.once('error', reject)
+    child.once('exit', code => {
+      if (code === 0) {
+        resolvePromise()
+        return
+      }
+      reject(new Error(`${command} ${args.join(' ')} exited with ${code ?? 'unknown status'}`))
+    })
+  })
+}
+
+async function resolveExecutable(configuredPath, fallbackCommand, description) {
+  const candidate = configuredPath?.trim()
+  if (candidate) {
+    const absolutePath = resolve(candidate)
+    assert.equal(
+      await isExecutable(absolutePath),
+      true,
+      `${description} is not executable: ${absolutePath}`
+    )
+    return absolutePath
+  }
+
+  const resolved = commandOutput('which', [fallbackCommand])
+  assert.equal(await isExecutable(resolved), true, `${description} is not executable: ${resolved}`)
+  return resolved
+}
+
+function waitForProcessExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve()
+  return withTimeout(
+    new Promise(resolvePromise => child.once('exit', resolvePromise)),
+    timeoutMs,
+    `Timed out waiting for process ${child.pid ?? 'unknown'} to exit`
+  )
+}
+
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return
+  child.kill('SIGTERM')
+  try {
+    await waitForProcessExit(child, PROCESS_STOP_TIMEOUT_MS)
+  } catch {
+    child.kill('SIGKILL')
+    await waitForProcessExit(child, PROCESS_STOP_TIMEOUT_MS)
+  }
+}
+
+async function appendProcessOutput(stream, destination) {
+  if (!stream) return
+  stream.on('data', chunk => {
+    void appendFile(destination, chunk)
+  })
+}
+
+function createSse(events) {
+  return events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
+}
+
+function responseCreated(id) {
+  return { type: 'response.created', response: { id } }
+}
+
+function responseCompleted(id) {
+  return {
+    type: 'response.completed',
+    response: {
+      id,
+      usage: {
+        input_tokens: 0,
+        input_tokens_details: null,
+        output_tokens: 0,
+        output_tokens_details: null,
+        total_tokens: 0,
+      },
+    },
+  }
+}
+
+function functionCall(callId, name, argumentsValue) {
+  return {
+    type: 'response.output_item.done',
+    item: {
+      type: 'function_call',
+      call_id: callId,
+      name,
+      arguments: JSON.stringify(argumentsValue),
+    },
+  }
+}
+
+function assistantMessage(text) {
+  return {
+    type: 'response.output_item.done',
+    item: {
+      type: 'message',
+      role: 'assistant',
+      id: 'wework-e2e-message',
+      content: [{ type: 'output_text', text }],
+    },
+  }
+}
+
+function readRequestBody(request) {
+  return new Promise((resolvePromise, reject) => {
+    let body = ''
+    request.setEncoding('utf8')
+    request.on('data', chunk => {
+      body += chunk
+    })
+    request.once('end', () => {
+      try {
+        resolvePromise(body ? JSON.parse(body) : {})
+      } catch (error) {
+        reject(error)
+      }
+    })
+    request.once('error', reject)
+  })
+}
+
+function json(response, statusCode, value) {
+  response.writeHead(statusCode, {
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'application/json; charset=utf-8',
+  })
+  response.end(`${JSON.stringify(value)}\n`)
+}
+
+function cors(response) {
+  response.setHeader('Access-Control-Allow-Origin', '*')
+  response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+}
+
+function requestContainsToolOutput(request) {
+  return JSON.stringify(request.input ?? []).includes('function_call_output')
+}
+
+function selectShellTool(request, workspacePath) {
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  const names = new Set(tools.map(tool => tool?.name).filter(Boolean))
+  const command = `printf '%s\\n' '${ARTIFACT_CONTENT}' > ${ARTIFACT_NAME}`
+
+  if (names.has('exec_command')) {
+    return {
+      name: 'exec_command',
+      arguments: { cmd: command, workdir: workspacePath, yield_time_ms: 1000 },
+    }
+  }
+  if (names.has('shell_command')) {
+    return {
+      name: 'shell_command',
+      arguments: { command, workdir: workspacePath, timeout_ms: 10_000 },
+    }
+  }
+  throw new Error(`Real Codex did not advertise a supported shell tool: ${[...names].join(', ')}`)
+}
+
+class DesktopE2EServer {
+  constructor(workspacePath) {
+    this.workspacePath = workspacePath
+    this.server = createServer((request, response) => {
+      void this.handle(request, response)
+    })
+    this.ready = null
+    this.readyResolver = null
+    this.commandQueue = []
+    this.commandWaiters = []
+    this.commandResults = new Map()
+    this.modelRequests = []
+    this.modelStage = 'initial'
+    this.toolOutput = null
+  }
+
+  async start() {
+    await new Promise((resolvePromise, reject) => {
+      this.server.once('error', reject)
+      this.server.listen(0, '127.0.0.1', () => {
+        this.server.off('error', reject)
+        resolvePromise()
+      })
+    })
+    const address = this.server.address()
+    assert.ok(address && typeof address !== 'string', 'Desktop E2E server did not bind a TCP port')
+    this.url = `http://127.0.0.1:${address.port}`
+  }
+
+  async close() {
+    for (const waiter of this.commandWaiters.splice(0)) {
+      json(waiter, 503, { error: 'Desktop E2E server is shutting down' })
+    }
+    await new Promise(resolvePromise => this.server.close(resolvePromise))
+  }
+
+  awaitReady() {
+    if (this.ready) return Promise.resolve(this.ready)
+    return new Promise(resolvePromise => {
+      this.readyResolver = resolvePromise
+    })
+  }
+
+  async command(action, selector, options = {}) {
+    const id = randomUUID()
+    const command = { id, action, selector, ...options }
+    const result = new Promise((resolvePromise, reject) => {
+      this.commandResults.set(id, { resolve: resolvePromise, reject })
+    })
+    this.commandQueue.push(command)
+    this.flushCommandWaiter()
+    return withTimeout(
+      result,
+      options.timeoutMs ?? UI_TIMEOUT_MS,
+      `Timed out running UI action ${action}`
+    )
+  }
+
+  flushCommandWaiter() {
+    if (this.commandQueue.length === 0 || this.commandWaiters.length === 0) return
+    const command = this.commandQueue.shift()
+    const response = this.commandWaiters.shift()
+    json(response, 200, command)
+  }
+
+  async handle(request, response) {
+    cors(response)
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    const url = new URL(request.url ?? '/', this.url)
+    if (request.method === 'POST' && url.pathname === '/ready') {
+      const ready = await readRequestBody(request)
+      this.ready = ready
+      this.readyResolver?.(ready)
+      this.readyResolver = null
+      json(response, 200, { ok: true })
+      return
+    }
+
+    if (request.method === 'GET' && url.pathname === '/commands') {
+      if (this.commandQueue.length > 0) {
+        json(response, 200, this.commandQueue.shift())
+        return
+      }
+      this.commandWaiters.push(response)
+      response.once('close', () => {
+        const index = this.commandWaiters.indexOf(response)
+        if (index >= 0) this.commandWaiters.splice(index, 1)
+      })
+      return
+    }
+
+    if (request.method === 'POST' && url.pathname === '/results') {
+      const result = await readRequestBody(request)
+      const pending = this.commandResults.get(result.id)
+      if (!pending) {
+        json(response, 404, { error: `Unknown command ${result.id}` })
+        return
+      }
+      this.commandResults.delete(result.id)
+      if (result.ok) {
+        pending.resolve(result.value ?? '')
+      } else {
+        pending.reject(new Error(result.error ?? `UI action ${result.id} failed`))
+      }
+      json(response, 200, { ok: true })
+      return
+    }
+
+    if (request.method === 'GET' && (url.pathname === '/v1/models' || url.pathname === '/models')) {
+      json(response, 200, {
+        object: 'list',
+        data: [{ id: MODEL_ID, object: 'model', created: 0, owned_by: MODEL_PROVIDER_ID }],
+      })
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      (url.pathname === '/v1/responses' || url.pathname === '/responses')
+    ) {
+      await this.handleModelResponse(request, response)
+      return
+    }
+
+    json(response, 404, { error: `No Desktop E2E route for ${request.method} ${url.pathname}` })
+  }
+
+  async handleModelResponse(request, response) {
+    const body = await readRequestBody(request)
+    const authorization = request.headers.authorization ?? null
+    this.modelRequests.push({ authorization, body })
+    if (authorization !== `Bearer ${MODEL_API_KEY}`) {
+      json(response, 401, { error: 'The Desktop E2E model API key was not forwarded by Codex' })
+      return
+    }
+
+    const responseId = `wework-e2e-response-${this.modelRequests.length}`
+    let events
+    if (this.modelStage === 'initial') {
+      assert.ok(
+        JSON.stringify(body).includes(TASK_PROMPT),
+        'The real Codex request did not contain the UI task prompt'
+      )
+      const tool = selectShellTool(body, this.workspacePath)
+      this.modelStage = 'awaiting_tool_output'
+      events = [
+        responseCreated(responseId),
+        functionCall('wework-e2e-tool-call', tool.name, tool.arguments),
+        responseCompleted(responseId),
+      ]
+    } else {
+      assert.equal(
+        requestContainsToolOutput(body),
+        true,
+        'The real Codex request did not report its tool output to the model service'
+      )
+      this.toolOutput = JSON.stringify(body.input)
+      this.modelStage = 'complete'
+      events = [
+        responseCreated(responseId),
+        assistantMessage(COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ]
+    }
+
+    response.writeHead(200, {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Content-Type': 'text/event-stream; charset=utf-8',
+    })
+    response.end(createSse(events))
+  }
+}
+
+async function writeCodexConfig(codexHome, modelServerUrl) {
+  await mkdir(codexHome, { recursive: true })
+  await writeFile(
+    join(codexHome, 'config.toml'),
+    `model_provider = "${MODEL_PROVIDER_ID}"\nmodel = "${MODEL_ID}"\napproval_policy = "never"\nsandbox_mode = "workspace-write"\n\n[model_providers.${MODEL_PROVIDER_ID}]\nname = "Wework Desktop E2E"\nbase_url = "${modelServerUrl}/v1"\nenv_key = "WEWORK_E2E_MODEL_API_KEY"\nwire_api = "responses"\n`,
+    'utf8'
+  )
+}
+
+async function buildExecutor() {
+  const configured = process.env.WEWORK_E2E_EXECUTOR_BIN
+  if (configured)
+    return resolveExecutable(configured, 'wegent-executor', 'Configured Wework executor')
+
+  await runChecked('cargo', ['build', '--locked', '--bin', 'wegent-executor'], {
+    cwd: join(repoDir, 'executor'),
+  })
+  const binaryName = process.platform === 'win32' ? 'wegent-executor.exe' : 'wegent-executor'
+  const binaryPath = join(repoDir, 'executor', 'target', 'debug', binaryName)
+  assert.equal(await isExecutable(binaryPath), true, `Executor build did not produce ${binaryPath}`)
+  return binaryPath
+}
+
+async function buildDesktopApp(controlUrl, appIdentifier) {
+  const configured = process.env.WEWORK_E2E_APP_BIN
+  if (configured) return resolveExecutable(configured, 'app', 'Configured Wework desktop app')
+
+  await runChecked(
+    'pnpm',
+    [
+      'exec',
+      'tauri',
+      'build',
+      '--debug',
+      '--no-bundle',
+      '--config',
+      JSON.stringify({ identifier: appIdentifier }),
+    ],
+    {
+      cwd: weworkDir,
+      env: {
+        ...process.env,
+        VITE_WEWORK_DESKTOP_E2E_CONTROL_URL: controlUrl,
+        VITE_WEWORK_E2E: 'true',
+        VITE_WEWORK_RUNTIME_MODE: 'local-first',
+      },
+    }
+  )
+  const binaryName = process.platform === 'win32' ? 'app.exe' : 'app'
+  const candidates = [
+    join(weworkDir, 'src-tauri', 'target', 'debug', binaryName),
+    join(
+      weworkDir,
+      'src-tauri',
+      'target',
+      'debug',
+      'bundle',
+      'macos',
+      'WeWork.app',
+      'Contents',
+      'MacOS',
+      binaryName
+    ),
+  ]
+  for (const candidate of candidates) {
+    if (await isExecutable(candidate)) return candidate
+  }
+  throw new Error(
+    `Tauri build did not produce an executable app. Checked: ${candidates.join(', ')}`
+  )
+}
+
+async function main() {
+  await mkdir(resultDir, { recursive: true })
+  const workspacePath = join(resultDir, 'workspace')
+  const homePath = join(resultDir, 'home')
+  const executorHome = join(resultDir, 'executor-home')
+  const appLogPath = join(resultDir, 'app.log')
+  const executorSocketPath = join(tmpdir(), `wework-e2e-${process.pid}.sock`)
+  await Promise.all([
+    mkdir(workspacePath, { recursive: true }),
+    mkdir(homePath, { recursive: true }),
+  ])
+
+  const control = new DesktopE2EServer(workspacePath)
+  let app
+  try {
+    await control.start()
+    const codexBinary = await resolveExecutable(
+      process.env.CODEX_BIN ?? process.env.CODEX_BINARY_PATH,
+      'codex',
+      'Codex binary'
+    )
+    const codexVersion = commandOutput(codexBinary, ['--version'])
+    assert.ok(codexVersion.length > 0, 'Real Codex did not return a version')
+    console.log(`Using real Codex: ${codexVersion}`)
+
+    const appIdentifier = `io.wecode.wework.e2e.run${process.pid}`
+    const [executorBinary, appBinary] = await Promise.all([
+      buildExecutor(),
+      buildDesktopApp(control.url, appIdentifier),
+    ])
+    await writeCodexConfig(join(executorHome, 'codex'), control.url)
+
+    app = spawn(
+      appBinary,
+      ['--open-workspace', workspacePath, '--workspace-label', 'Desktop E2E'],
+      {
+        cwd: weworkDir,
+        env: {
+          ...process.env,
+          CODEX_BIN: codexBinary,
+          HOME: homePath,
+          WEGENT_CODEX_HOME: join(executorHome, 'codex'),
+          WEGENT_EXECUTOR_HOME: executorHome,
+          WEGENT_EXECUTOR_APP_IPC_SOCKET: executorSocketPath,
+          WEGENT_EXECUTOR_LOG_DIR: resultDir,
+          WEGENT_EXECUTOR_LOG_FILE: 'executor.log',
+          DEVICE_ID: `wework-e2e-device-${process.pid}`,
+          WEWORK_E2E_MODEL_API_KEY: MODEL_API_KEY,
+          WEWORK_EXECUTOR_SIDECAR: executorBinary,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    )
+    await Promise.all([
+      appendProcessOutput(app.stdout, appLogPath),
+      appendProcessOutput(app.stderr, appLogPath),
+    ])
+
+    const ready = await withTimeout(
+      control.awaitReady(),
+      DESKTOP_READY_TIMEOUT_MS,
+      'Timed out waiting for the real Tauri application to connect to the Desktop E2E controller'
+    )
+    assert.match(
+      String(ready.location ?? ''),
+      /^(tauri|http):/,
+      'The desktop controller did not connect from a webview'
+    )
+
+    await control.command('waitFor', '[data-testid="new-chat-button"]', {
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    })
+    await control.command('click', '[data-testid="new-chat-button"]')
+    await control.command('waitFor', '[data-testid="chat-message-input"]', {
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    })
+    await control.command('fill', '[data-testid="chat-message-input"]', { value: TASK_PROMPT })
+    await control.command('waitFor', '[data-testid="send-message-button"]', { enabled: true })
+    await control.command('click', '[data-testid="send-message-button"]')
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: COMPLETION_TEXT,
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+
+    assert.equal(
+      await readFile(join(workspacePath, ARTIFACT_NAME), 'utf8'),
+      `${ARTIFACT_CONTENT}\n`,
+      'The real Codex tool execution did not create the expected workspace artifact'
+    )
+    assert.equal(
+      control.modelStage,
+      'complete',
+      'The model service did not complete the Codex tool loop'
+    )
+    assert.ok(control.modelRequests.length >= 2, 'The real Codex did not make both model requests')
+    assert.ok(
+      typeof control.modelRequests[0].body.model === 'string' &&
+        control.modelRequests[0].body.model.length > 0,
+      'The real Codex request did not select a model'
+    )
+    assert.ok(
+      control.toolOutput,
+      'Codex did not report its real tool execution to the model service'
+    )
+
+    await writeFile(
+      join(resultDir, 'model-requests.json'),
+      `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+      'utf8'
+    )
+    console.log(`Wework desktop task-flow E2E passed. Diagnostics: ${resultDir}`)
+  } catch (error) {
+    try {
+      const snapshot = await control.command('snapshot', 'body', { timeoutMs: 5000 })
+      await writeFile(join(resultDir, 'ui-snapshot.json'), `${snapshot}\n`, 'utf8')
+    } catch {
+      // Preserve the original test failure when the WebView can no longer answer diagnostics.
+    }
+    await writeFile(
+      join(resultDir, 'failure.txt'),
+      `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+      'utf8'
+    )
+    throw error
+  } finally {
+    await stopProcess(app)
+    await control.close()
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? (error.stack ?? error.message) : error)
+  process.exitCode = 1
+})

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -545,14 +545,11 @@ async function main() {
       'The desktop controller did not connect from a webview'
     )
 
-    await control.command('waitFor', '[data-testid="new-chat-button"]', {
+    const composerSelector = '[data-testid="chat-message-input"][contenteditable="true"]'
+    await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
-    await control.command('click', '[data-testid="new-chat-button"]')
-    await control.command('waitFor', '[data-testid="chat-message-input"]', {
-      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
-    })
-    await control.command('fill', '[data-testid="chat-message-input"]', { value: TASK_PROMPT })
+    await control.command('fill', composerSelector, { value: TASK_PROMPT })
     await control.command('waitFor', '[data-testid="send-message-button"]', { enabled: true })
     await control.command('click', '[data-testid="send-message-button"]')
     await control.command('waitFor', '[data-testid="message-assistant"]', {

--- a/wework/eslint.config.js
+++ b/wework/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['coverage', 'dist', 'src-tauri/target']),
+  globalIgnores(['coverage', 'dist', 'src-tauri/target', 'test-results']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/wework/package.json
+++ b/wework/package.json
@@ -21,6 +21,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "e2e": "playwright test",
+    "e2e:desktop": "node e2e/desktop/task-flow.e2e.mjs",
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -648,6 +648,18 @@ describe('DesktopWorkbenchLayout', () => {
     },
   }
 
+  const activeProjectRuntimeTask = {
+    deviceId: 'device-1',
+    workspacePath: '/workspace/github_wegent',
+    taskId: 'runtime-project-1',
+  }
+  const activeProjectRuntimeTarget = {
+    deviceId: 'device-1',
+    path: '/workspace/github_wegent',
+    source: 'runtime' as const,
+    taskId: 'runtime-project-1',
+  }
+
   function createPendingRequestUserInputMessage(includeAdjustment = false): WorkbenchMessage {
     return {
       id: 'assistant-request',
@@ -1492,8 +1504,8 @@ describe('DesktopWorkbenchLayout', () => {
     expect(desktopContent.style.getPropertyValue('--desktop-floating-composer-clearance')).toBe('')
     expect(screen.getByTestId('desktop-chat-scroll')).toHaveClass(
       'h-full',
-      'overflow-y-auto',
-      'scrollbar-soft',
+      'overflow-visible',
+      'scrollbar-none',
       'flex',
       'flex-col'
     )
@@ -1536,9 +1548,11 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('renders subagent status below the top bar without shifting messages', () => {
+    mockDesktopWorkbenchMainWidth(1024)
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
+        state={{ ...baseProps.state, currentRuntimeTask: activeProjectRuntimeTask }}
         messages={[
           {
             id: 'message-1',
@@ -1564,7 +1578,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('workbench-topbar-right-actions')).not.toBeInTheDocument()
     const statusRow = screen.getByTestId('workbench-subagent-status-row')
     expect(statusRow).toContainElement(screen.getByTestId('subagent-status-toggle-button'))
-    expect(statusRow).toHaveClass('right-3', 'top-14')
+    expect(statusRow).toHaveClass('ml-2', 'mt-3', 'w-[300px]')
     expect(screen.getByTestId('desktop-workbench-content')).toHaveClass('pt-11')
   })
 
@@ -1933,7 +1947,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
-  test('positions the scroll-to-bottom button above the sticky composer footer', () => {
+  test('positions the scroll-to-bottom button above the sticky composer footer', async () => {
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
@@ -1949,7 +1963,8 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    const scroller = screen.getByTestId('desktop-chat-scroll')
+    const scrollContainer = screen.getByTestId('desktop-chat-scroll')
+    const scroller = screen.getByTestId('desktop-workbench-content')
     Object.defineProperty(scroller, 'clientHeight', {
       value: 200,
       configurable: true,
@@ -1964,9 +1979,9 @@ describe('DesktopWorkbenchLayout', () => {
       configurable: true,
     })
 
-    fireEvent.scroll(scroller)
+    fireEvent.scroll(scrollContainer)
 
-    expect(screen.getByTestId('scroll-to-bottom-button')).toHaveClass('bottom-4', 'z-popover')
+    expect(await screen.findByTestId('scroll-to-bottom-button')).toHaveClass('bottom-4', 'z-10')
   })
 
   test('keeps queued messages inside the sticky composer footer flow', () => {
@@ -5161,11 +5176,13 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('keeps the environment info panel open until its icon is clicked', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: activeProjectState.currentProject,
           devices: [
             {
@@ -5192,8 +5209,6 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
-
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
     expect(screen.getByTestId('environment-info-panel-container')).toContainElement(
       screen.getByTestId('environment-info-popover')
@@ -5214,6 +5229,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(screen.getByText('环境信息')).toBeInTheDocument()
     expect(screen.getByText('变更')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('+173')).toBeInTheDocument())
     const deviceSection = screen.getByTestId('environment-device-section')
     const gitSection = screen.getByTestId('environment-git-section')
     expect(deviceSection).not.toContainElement(gitSection)
@@ -5266,6 +5282,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('opens environment changes review in the right workspace panel', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onLoadEnvironmentDiff = vi
       .fn()
       .mockResolvedValue(
@@ -5278,6 +5295,7 @@ describe('DesktopWorkbenchLayout', () => {
         onLoadEnvironmentDiff={onLoadEnvironmentDiff}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5298,19 +5316,10 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(await screen.findByTestId('environment-changes-button'))
 
     await waitFor(() =>
-      expect(onLoadEnvironmentDiff).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1, name: 'github_wegent' }),
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        },
-        'branch'
-      )
+      expect(onLoadEnvironmentDiff).toHaveBeenCalledWith(null, activeProjectRuntimeTarget, 'branch')
     )
     expect(screen.queryByRole('dialog', { name: '本轮文件变更' })).not.toBeInTheDocument()
     expect(screen.getByTestId('right-workspace-panel')).toBeInTheDocument()
@@ -5323,6 +5332,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('submits environment commits from the popover', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onCommitEnvironmentChanges = vi.fn().mockResolvedValue(undefined)
     render(
       <DesktopWorkbenchLayout
@@ -5330,6 +5340,7 @@ describe('DesktopWorkbenchLayout', () => {
         onCommitEnvironmentChanges={onCommitEnvironmentChanges}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5350,26 +5361,22 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(await screen.findByTestId('environment-commit-button'))
     await userEvent.type(screen.getByTestId('environment-commit-message-input'), 'feat: ship')
     await userEvent.click(screen.getByTestId('environment-confirm-commit-button'))
 
     await waitFor(() =>
       expect(onCommitEnvironmentChanges).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1, name: 'github_wegent' }),
+        null,
         'feat: ship',
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        }
+        activeProjectRuntimeTarget
       )
     )
     expect(screen.getByText('已提交')).toBeInTheDocument()
   })
 
   test('submits an empty environment commit message so AI can generate it', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onCommitEnvironmentChanges = vi.fn().mockResolvedValue(undefined)
     render(
       <DesktopWorkbenchLayout
@@ -5377,6 +5384,7 @@ describe('DesktopWorkbenchLayout', () => {
         onCommitEnvironmentChanges={onCommitEnvironmentChanges}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5397,7 +5405,6 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(await screen.findByTestId('environment-commit-button'))
 
     const confirmButton = screen.getByTestId('environment-confirm-commit-button')
@@ -5405,19 +5412,12 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(confirmButton)
 
     await waitFor(() =>
-      expect(onCommitEnvironmentChanges).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1, name: 'github_wegent' }),
-        '',
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        }
-      )
+      expect(onCommitEnvironmentChanges).toHaveBeenCalledWith(null, '', activeProjectRuntimeTarget)
     )
   })
 
   test('renders the environment commit menu as the compact commit or push panel', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onCommitAndPushEnvironmentChanges = vi.fn().mockResolvedValue(undefined)
     const onPushEnvironmentChanges = vi.fn().mockResolvedValue(undefined)
 
@@ -5428,6 +5428,7 @@ describe('DesktopWorkbenchLayout', () => {
         onPushEnvironmentChanges={onPushEnvironmentChanges}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5447,8 +5448,6 @@ describe('DesktopWorkbenchLayout', () => {
         }}
       />
     )
-
-    await userEvent.click(screen.getByTestId('environment-info-button'))
 
     const popover = await screen.findByTestId('environment-info-popover')
     const commitMenuButton = await screen.findByTestId('environment-commit-button')
@@ -5471,31 +5470,21 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(scopedPanel.getByTestId('environment-commit-and-push-button'))
     await waitFor(() =>
       expect(onCommitAndPushEnvironmentChanges).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1, name: 'github_wegent' }),
+        null,
         '',
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        }
+        activeProjectRuntimeTarget
       )
     )
 
     await userEvent.click(screen.getByTestId('environment-commit-button'))
     await userEvent.click(screen.getByTestId('environment-push-button'))
     await waitFor(() =>
-      expect(onPushEnvironmentChanges).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1, name: 'github_wegent' }),
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        }
-      )
+      expect(onPushEnvironmentChanges).toHaveBeenCalledWith(null, activeProjectRuntimeTarget)
     )
   })
 
   test('shows the environment commit progress row while generating a message', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onCommitEnvironmentChanges = vi.fn(
       () =>
         new Promise<void>(() => {
@@ -5509,6 +5498,7 @@ describe('DesktopWorkbenchLayout', () => {
         onCommitEnvironmentChanges={onCommitEnvironmentChanges}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5529,7 +5519,6 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(await screen.findByTestId('environment-commit-button'))
     await userEvent.click(screen.getByTestId('environment-confirm-commit-button'))
 
@@ -5543,6 +5532,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('shows the environment push progress row while pushing', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onPushEnvironmentChanges = vi.fn(
       () =>
         new Promise<void>(() => {
@@ -5556,6 +5546,7 @@ describe('DesktopWorkbenchLayout', () => {
         onPushEnvironmentChanges={onPushEnvironmentChanges}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5576,7 +5567,6 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(await screen.findByTestId('environment-commit-button'))
     await userEvent.click(screen.getByTestId('environment-push-button'))
 
@@ -5588,6 +5578,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('switches and creates branches from the environment popover', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     const onListEnvironmentBranches = vi
       .fn()
       .mockResolvedValue(['main', 'human/chipmunk-20260603-053420', 'human/alpaca-20260603-050330'])
@@ -5602,6 +5593,7 @@ describe('DesktopWorkbenchLayout', () => {
         onCreateEnvironmentBranch={onCreateEnvironmentBranch}
         state={{
           ...baseProps.state,
+          currentRuntimeTask: activeProjectRuntimeTask,
           currentProject: {
             id: 1,
             name: 'github_wegent',
@@ -5622,7 +5614,6 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(await screen.findByTestId('environment-branch-row'))
 
     expect(await screen.findByTestId('environment-branch-menu')).toBeInTheDocument()
@@ -5637,13 +5628,9 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByText('human/alpaca-20260603-050330'))
     await waitFor(() =>
       expect(onCheckoutEnvironmentBranch).toHaveBeenCalledWith(
-        expect.anything(),
+        null,
         'human/alpaca-20260603-050330',
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        }
+        activeProjectRuntimeTarget
       )
     )
 
@@ -5654,21 +5641,22 @@ describe('DesktopWorkbenchLayout', () => {
 
     await waitFor(() =>
       expect(onCreateEnvironmentBranch).toHaveBeenCalledWith(
-        expect.anything(),
+        null,
         'human/new-branch',
-        {
-          deviceId: 'device-1',
-          path: '/workspace/github_wegent',
-          source: 'project',
-        }
+        activeProjectRuntimeTarget
       )
     )
   })
 
   test('does not reopen the branch menu when the environment popover is reopened', async () => {
-    render(<DesktopWorkbenchLayout {...baseProps} state={activeProjectState} />)
+    mockDesktopWorkbenchMainWidth(1024)
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{ ...activeProjectState, currentRuntimeTask: activeProjectRuntimeTask }}
+      />
+    )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(screen.getByTestId('environment-branch-row'))
 
     expect(await screen.findByTestId('environment-branch-menu')).toBeInTheDocument()
@@ -5683,10 +5671,11 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('keeps environment diff stats and branch row visible without a current branch', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
-        state={activeProjectState}
+        state={{ ...activeProjectState, currentRuntimeTask: activeProjectRuntimeTask }}
         onLoadEnvironmentInfo={vi.fn().mockResolvedValue({
           additions: '+55',
           deletions: '-8',
@@ -5699,8 +5688,6 @@ describe('DesktopWorkbenchLayout', () => {
         onCheckoutEnvironmentBranch={vi.fn().mockResolvedValue(undefined)}
       />
     )
-
-    await userEvent.click(screen.getByTestId('environment-info-button'))
 
     await waitFor(() => expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument())
     expect(screen.getByTestId('environment-workspace-path')).toHaveTextContent(
@@ -5716,9 +5703,14 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('closes the branch menu when Escape is pressed', async () => {
-    render(<DesktopWorkbenchLayout {...baseProps} state={activeProjectState} />)
+    mockDesktopWorkbenchMainWidth(1024)
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{ ...activeProjectState, currentRuntimeTask: activeProjectRuntimeTask }}
+      />
+    )
 
-    await userEvent.click(screen.getByTestId('environment-info-button'))
     await userEvent.click(screen.getByTestId('environment-branch-row'))
 
     expect(await screen.findByTestId('environment-branch-menu')).toBeInTheDocument()

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -9,6 +9,26 @@ import { isTauriRuntime } from '@/lib/runtime-environment'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
+const DESKTOP_CONTROL_RETRY_DELAY_MS = 250
+
+type DesktopControlAction = 'click' | 'fill' | 'getText' | 'snapshot' | 'waitFor'
+
+interface DesktopControlCommand {
+  id: string
+  action: DesktopControlAction
+  selector: string
+  value?: string
+  text?: string
+  timeoutMs?: number
+  enabled?: boolean
+}
+
+interface DesktopControlResult {
+  id: string
+  ok: boolean
+  value?: string
+  error?: string
+}
 
 export interface WeworkAutomationBridge {
   version: 1
@@ -38,6 +58,11 @@ declare global {
 
 function isAutomationEnabled(): boolean {
   return import.meta.env.MODE === 'e2e' || import.meta.env.VITE_WEWORK_E2E === 'true'
+}
+
+function desktopControlUrl(): string | null {
+  const value = import.meta.env.VITE_WEWORK_DESKTOP_E2E_CONTROL_URL?.trim()
+  return value ? value.replace(/\/+$/, '') : null
 }
 
 function normalizeAppPath(path: string): string {
@@ -138,4 +163,154 @@ export function installWeworkAutomationBridge() {
   }
 
   window.__WEWORK_E2E__ = createBridge()
+  installDesktopControlClient()
+}
+
+function findDesktopControlElements(selector: string): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(selector))
+}
+
+function desktopControlElementText(selector: string): string {
+  return findDesktopControlElements(selector)
+    .map(element => element.textContent?.trim() ?? '')
+    .filter(Boolean)
+    .join('\n')
+}
+
+function desktopControlSnapshot(): string {
+  const testIds = Array.from(document.querySelectorAll<HTMLElement>('[data-testid]'))
+    .map(element => element.dataset.testid)
+    .filter((testId): testId is string => Boolean(testId))
+
+  return JSON.stringify({
+    location: window.location.href,
+    text: document.body.innerText,
+    testIds: Array.from(new Set(testIds)).sort(),
+  })
+}
+
+function desktopControlElementEnabled(element: HTMLElement): boolean {
+  if (element.getAttribute('aria-disabled') === 'true') return false
+  return !('disabled' in element) || !(element as HTMLButtonElement).disabled
+}
+
+async function waitForDesktopControlElement(command: DesktopControlCommand): Promise<string> {
+  const timeoutMs = command.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const elements = findDesktopControlElements(command.selector)
+    const text = elements.map(element => element.textContent?.trim() ?? '').join('\n')
+    const hasExpectedText = !command.text || text.includes(command.text)
+    const isEnabled = !command.enabled || elements.some(desktopControlElementEnabled)
+    if (elements.length > 0 && hasExpectedText && isEnabled) {
+      return text
+    }
+    await new Promise(resolve => window.setTimeout(resolve, 50))
+  }
+
+  throw new Error(
+    `Timed out waiting for selector "${command.selector}"${
+      command.text ? ` containing "${command.text}"` : ''
+    }`
+  )
+}
+
+function fillDesktopControlElement(element: HTMLElement, value: string) {
+  element.focus()
+
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const prototype =
+      element instanceof HTMLInputElement
+        ? HTMLInputElement.prototype
+        : HTMLTextAreaElement.prototype
+    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set
+    setter?.call(element, value)
+  } else {
+    element.replaceChildren(document.createTextNode(value))
+  }
+
+  element.dispatchEvent(
+    new InputEvent('input', {
+      bubbles: true,
+      composed: true,
+      data: value,
+      inputType: 'insertText',
+    })
+  )
+  element.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+async function executeDesktopControlCommand(command: DesktopControlCommand): Promise<string> {
+  switch (command.action) {
+    case 'waitFor':
+      return waitForDesktopControlElement(command)
+    case 'getText':
+      return desktopControlElementText(command.selector)
+    case 'snapshot':
+      return desktopControlSnapshot()
+    case 'click': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      if (!desktopControlElementEnabled(element)) {
+        throw new Error(`Selector "${command.selector}" is disabled`)
+      }
+      element.click()
+      return element.textContent?.trim() ?? ''
+    }
+    case 'fill': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      fillDesktopControlElement(element, command.value ?? '')
+      return element.textContent?.trim() ?? ''
+    }
+  }
+}
+
+async function postDesktopControlResult(url: string, result: DesktopControlResult): Promise<void> {
+  const response = await fetch(`${url}/results`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(result),
+  })
+  if (!response.ok) {
+    throw new Error(`Desktop E2E control result failed with ${response.status}`)
+  }
+}
+
+async function runDesktopControlClient(url: string): Promise<void> {
+  await fetch(`${url}/ready`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ location: window.location.href }),
+  })
+
+  while (true) {
+    try {
+      const response = await fetch(`${url}/commands`)
+      if (!response.ok) {
+        throw new Error(`Desktop E2E control command failed with ${response.status}`)
+      }
+      const command = (await response.json()) as DesktopControlCommand
+      try {
+        const value = await executeDesktopControlCommand(command)
+        await postDesktopControlResult(url, { id: command.id, ok: true, value })
+      } catch (error) {
+        await postDesktopControlResult(url, {
+          id: command.id,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    } catch (error) {
+      console.error('[Wework] Desktop E2E control client failed:', error)
+      await new Promise(resolve => window.setTimeout(resolve, DESKTOP_CONTROL_RETRY_DELAY_MS))
+    }
+  }
+}
+
+function installDesktopControlClient() {
+  const url = desktopControlUrl()
+  if (!url) return
+  void runDesktopControlClient(url)
 }

--- a/wework/vite.config.ts
+++ b/wework/vite.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     globals: true,
-    exclude: [...configDefaults.exclude, 'e2e/**'],
+    exclude: [...configDefaults.exclude, 'e2e/**', 'test-results/**'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'json', 'lcov'],


### PR DESCRIPTION
## 改动

新增 Wework 桌面端真实全链路回归测试：启动 Tauri 应用、通过应用内自动化桥执行新建会话和发送任务，并由真实 Codex 运行工具后校验 UI、模型调用与工作区产物。

同时将该测试接入 GitHub Actions，使用 Xvfb、Tauri 系统依赖与 Linux Codex 二进制执行。

## 原因

现有浏览器 E2E 无法覆盖桌面应用、实际 Codex 执行和工作区副作用。该用例为功能开发后的真实回归验证提供闭环。模型服务仅用于确定性响应；Tauri、Codex、工具执行和 UI 交互均为真实运行。

## 验证

- `pnpm --filter wework lint`
- `pnpm --filter wework test`（146 个文件，1441 个测试）
- `CODEX_BIN=/opt/homebrew/bin/codex pnpm --filter wework e2e:desktop`
- GitHub Actions：已手动派发当前分支的 `Wework E2E`，包含 `Wework Desktop E2E` Job。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a desktop end-to-end task-flow test that validates sending a task, tool execution, completion output, and workspace artifact creation.
  - Added desktop UI automation support for clicking, filling fields, reading text, taking snapshots, and waiting for interface states.

- **Documentation**
  - Expanded English and Chinese guidance for desktop E2E testing, prerequisites, deterministic test behavior, and CI execution.

- **Tests**
  - Re-enabled and strengthened coverage for environment panels, branches, commits, scrolling, and desktop layout behavior.

- **Chores**
  - Added a command for running desktop E2E tests and improved test-result exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->