### PR TITLE
fix(wework): clear stale runtime truncation state

### DIFF
--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -39,6 +39,27 @@ describe('reduceWorkbenchMessages', () => {
     expect(done[0].contentTruncated).toBe(true)
   })
 
+  test('clears stale stream truncation metadata when done supplies short content', () => {
+    const streamed = reduceWorkbenchMessages([], {
+      type: 'assistant_chunk',
+      subtaskId: 'short-final-content',
+      content: 'partial response',
+      offset: 20_000
+    })
+    const done = reduceWorkbenchMessages(streamed, {
+      type: 'assistant_done',
+      subtaskId: 'short-final-content',
+      content: 'final response'
+    })
+
+    expect(done[0]).toMatchObject({
+      content: 'final response',
+      contentTruncated: undefined,
+      contentOriginalChars: undefined,
+      contentLoadRef: undefined
+    })
+  })
+
   test('keeps growing assistant original length after content is unloaded', () => {
     const truncated = reduceWorkbenchMessages([], {
       type: 'assistant_chunk',

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -328,6 +328,13 @@ export function reduceWorkbenchMessages<
               ...clearMessageError(message),
               content: action.content ?? message.content,
               streamTextOffset: undefined,
+              // A completed response is authoritative. Do not retain a stream
+              // offset or truncation metadata from a superseded partial response.
+              ...(action.content !== undefined && {
+                contentTruncated: undefined,
+                contentOriginalChars: undefined,
+                contentLoadRef: undefined
+              }),
               status: 'done' as const,
               blocks: finalizeProcessingBlocks(
                 action.blocks ?? message.blocks,
@@ -367,6 +374,11 @@ export function reduceWorkbenchMessages<
           ? limitWorkbenchMessage({
               ...clearMessageError(message),
               content: action.content ?? message.content,
+              ...(action.content !== undefined && {
+                contentTruncated: undefined,
+                contentOriginalChars: undefined,
+                contentLoadRef: undefined
+              }),
               status: 'done' as const,
               runtimeStatus: 'cancelled' as const,
               completedAt,

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -614,6 +614,41 @@ describe('runtimeMessagesToWorkbenchMessages', () => {
     )
   })
 
+  test('ignores invalid short-content truncation markers from a runtime transcript', () => {
+    const messages = runtimeMessagesToWorkbenchMessages([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '这是一段完整的短回复。',
+        content_truncated: true,
+        content_original_chars: 11,
+      },
+    ])
+
+    expect(messages[0]).toMatchObject({
+      content: '这是一段完整的短回复。',
+      contentTruncated: undefined,
+      contentOriginalChars: undefined,
+    })
+  })
+
+  test('keeps valid runtime content truncation markers so full content can be loaded', () => {
+    const messages = runtimeMessagesToWorkbenchMessages([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '回复末尾预览',
+        contentTruncated: true,
+        contentOriginalChars: 200_001,
+      },
+    ])
+
+    expect(messages[0]).toMatchObject({
+      contentTruncated: true,
+      contentOriginalChars: 200_001,
+    })
+  })
+
   test('keeps user-authored Codex directive text unchanged', () => {
     const messages = runtimeMessagesToWorkbenchMessages([
       {

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -410,19 +410,14 @@ function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): Wo
     typeof subtaskId === 'string'
       ? normalizeProcessingBlocks(subtaskId, message.blocks, messageCreatedAtMs)
       : []
+  const contentTruncated = hasTruncatedRuntimeContent(message)
   return {
     id: message.id,
     role,
     subtaskId,
     content: role === 'assistant' ? stripCodexUiDirectives(message.content) : message.content,
-    contentTruncated:
-      message.contentTruncated === true || message.content_truncated === true ? true : undefined,
-    contentOriginalChars:
-      typeof message.contentOriginalChars === 'number'
-        ? message.contentOriginalChars
-        : typeof message.content_original_chars === 'number'
-          ? message.content_original_chars
-          : undefined,
+    contentTruncated: contentTruncated || undefined,
+    contentOriginalChars: contentTruncated ? runtimeMessageOriginalChars(message) : undefined,
     runtimeMessageIndex,
     status,
     runtimeStatus,
@@ -437,6 +432,32 @@ function runtimeMessageToWorkbenchMessage(message: NormalizedRuntimeMessage): Wo
     completedAt,
     stoppedNotice,
   }
+}
+
+function hasTruncatedRuntimeContent(message: NormalizedRuntimeMessage): boolean {
+  if (message.contentTruncated !== true && message.content_truncated !== true) return false
+
+  const originalChars = runtimeMessageOriginalChars(message)
+  return (
+    originalChars !== undefined && originalChars > runtimeContentCharacterCount(message.content)
+  )
+}
+
+function runtimeMessageOriginalChars(message: NormalizedRuntimeMessage): number | undefined {
+  const originalChars =
+    typeof message.contentOriginalChars === 'number'
+      ? message.contentOriginalChars
+      : typeof message.content_original_chars === 'number'
+        ? message.content_original_chars
+        : undefined
+
+  return originalChars !== undefined && Number.isFinite(originalChars) && originalChars >= 0
+    ? originalChars
+    : undefined
+}
+
+function runtimeContentCharacterCount(content: string): number {
+  return Array.from(content).length
 }
 
 function warnAndDropRuntimeStreamEvent(


### PR DESCRIPTION
## 变更内容

- 在流式回复完成时清除被最终正文替代的截断元数据。
- 恢复运行时转录时忽略短内容的无效截断标记。
- 增加有效及无效截断状态的回归测试。

## 根因

`chat:done` 以较短最终正文覆盖流式内容时，旧的累计字符数被保留，导致短消息被误标为已截断并在消息末尾显示卸载提示。

## 验证

- `pnpm --filter @wegent/chat-core test -- workbench-message-reducer.test.ts`
- `pnpm --filter wework exec vitest run src/features/workbench/runtimePaneMessages.test.ts`
- `pnpm --filter wework typecheck`
- pre-push：ESLint、TypeScript、Wework 单测