### PR TITLE
test(wework): expand desktop lifecycle e2e

### DIFF
--- a/docs/en/developer-guide/wework-e2e-automation.md
+++ b/docs/en/developer-guide/wework-e2e-automation.md
@@ -49,12 +49,15 @@ Tests do not mock backend APIs. When Backend is not running, the login-page smok
 
 ## Desktop Task-Flow E2E
 
-`wework/e2e/desktop/task-flow.e2e.mjs` covers the real task execution path in a local workspace:
+`wework/e2e/desktop/task-flow.e2e.mjs` covers the real task lifecycle in a local workspace:
 
 1. Builds and starts the real Tauri Wework application, opening an isolated workspace with `--open-workspace`.
 2. Starts the real `wegent-executor` sidecar, which starts a real `codex app-server`.
 3. Fills in a task and clicks send in the native WebView, then waits for the real conversation to render.
 4. Verifies the request issued by Codex to the model service, the workspace file written by a real Codex tool call, and the final UI response.
+5. Sends a follow-up in the same conversation and verifies its request and rendered response.
+6. Starts a streaming response, cancels it through the desktop UI, and verifies the stopped state and closed model stream.
+7. Forces one model failure, clicks retry in the rendered error card, and verifies the retried request and final response.
 
 The test does not simulate Wework, Executor, or Codex. To keep regression results deterministic and avoid requiring a real account, it starts only a loopback OpenAI Responses-compatible service as a custom Codex model provider. That service returns deterministic tool calls and final text; the tool call is still executed by real Codex in the isolated workspace.
 
@@ -64,7 +67,7 @@ The environment needs Rust, Tauri build dependencies, and a real Codex binary. T
 CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
 ```
 
-Optional `WEWORK_E2E_EXECUTOR_BIN` and `WEWORK_E2E_APP_BIN` reuse already-built real Executor and Tauri application binaries. A supplied application must be built with the desktop E2E Vite environment variables. Test artifacts and failure diagnostics are stored in `wework/test-results/desktop-e2e/`.
+Optional `WEWORK_E2E_EXECUTOR_BIN` and `WEWORK_E2E_APP_BIN` reuse already-built real Executor and Tauri application binaries. A supplied application must be built with the desktop E2E Vite environment variables. The lifecycle scenarios share one application launch to control CI duration. Test artifacts, captured model requests, and failure diagnostics are stored in `wework/test-results/desktop-e2e/`.
 
 ## Responses API Mock
 

--- a/docs/zh/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/developer-guide/wework-e2e-automation.md
@@ -49,12 +49,15 @@ node e2e/utils/mock-response-api-server.mjs
 
 ## 桌面端任务全链路 E2E
 
-`wework/e2e/desktop/task-flow.e2e.mjs` 覆盖本机工作区中的真实任务执行链路：
+`wework/e2e/desktop/task-flow.e2e.mjs` 覆盖本机工作区中的真实任务生命周期：
 
 1. 构建并启动真实 Tauri Wework 应用，使用 `--open-workspace` 打开隔离工作区。
 2. 启动真实 `wegent-executor` sidecar，并由它启动真实 `codex app-server`。
 3. 在原生 WebView 中填入任务、点击发送，并等待真实会话渲染完成。
 4. 校验 Codex 向模型服务发出的请求、Codex 实际工具调用写入的工作区文件，以及页面中的最终回复。
+5. 在同一会话中发送连续追问，并校验对应请求和页面回复。
+6. 启动流式回复后通过桌面端 UI 取消，校验已停止状态和已关闭的模型流。
+7. 让模型首次请求确定性失败，点击错误卡中的重试，并校验重试请求和最终回复。
 
 测试不模拟 Wework、Executor 或 Codex。为了让回归结果确定且不需要真实账号，测试只在 loopback 地址启动一个 OpenAI Responses 兼容服务，作为 Codex 的自定义模型 provider。该服务会返回确定性的工具调用和最终文本；工具调用仍由真实 Codex 在隔离工作区内执行。
 
@@ -64,7 +67,7 @@ node e2e/utils/mock-response-api-server.mjs
 CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
 ```
 
-可选的 `WEWORK_E2E_EXECUTOR_BIN` 和 `WEWORK_E2E_APP_BIN` 分别允许复用已经构建的真实 Executor 和真实 Tauri 应用。传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。测试过程和失败诊断会保存在 `wework/test-results/desktop-e2e/`。
+可选的 `WEWORK_E2E_EXECUTOR_BIN` 和 `WEWORK_E2E_APP_BIN` 分别允许复用已经构建的真实 Executor 和真实 Tauri 应用。传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。各生命周期场景复用一次应用启动以控制 CI 时长；测试过程、捕获的模型请求和失败诊断会保存在 `wework/test-results/desktop-e2e/`。
 
 ## Responses API Mock
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -14,6 +14,12 @@ const UI_TIMEOUT_MS = 120_000
 const PROCESS_STOP_TIMEOUT_MS = 10_000
 const TASK_PROMPT = 'WEWORK_DESKTOP_E2E_TASK: create the requested verification file.'
 const COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_COMPLETE'
+const FOLLOW_UP_PROMPT = 'WEWORK_DESKTOP_E2E_FOLLOW_UP: confirm the completed task.'
+const FOLLOW_UP_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_FOLLOW_UP_COMPLETE'
+const CANCELLATION_PROMPT = 'WEWORK_DESKTOP_E2E_CANCEL: wait until the response is cancelled.'
+const CANCELLATION_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CANCEL_COMPLETE'
+const RETRY_PROMPT = 'WEWORK_DESKTOP_E2E_RETRY: fail once and then succeed after retry.'
+const RETRY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RETRY_COMPLETE'
 const ARTIFACT_NAME = 'wework-e2e-result.txt'
 const ARTIFACT_CONTENT = 'CODEX_EXECUTED_REAL_TOOL'
 const MODEL_API_KEY = 'wework-e2e-test-key'
@@ -120,10 +126,10 @@ async function appendProcessOutput(stream, destination) {
   })
 }
 
-async function fillComposerUntilSendEnabled(control, selector) {
+async function fillComposerUntilSendEnabled(control, selector, value) {
   let lastError
   for (let attempt = 0; attempt < 5; attempt += 1) {
-    await control.command('fill', selector, { value: TASK_PROMPT })
+    await control.command('fill', selector, { value })
     try {
       await control.command('waitFor', '[data-testid="send-message-button"]', {
         enabled: true,
@@ -136,6 +142,11 @@ async function fillComposerUntilSendEnabled(control, selector) {
     }
   }
   throw lastError
+}
+
+async function sendPrompt(control, selector, prompt) {
+  await fillComposerUntilSendEnabled(control, selector, prompt)
+  await control.command('click', '[data-testid="send-message-button"]')
 }
 
 function createSse(events) {
@@ -254,8 +265,13 @@ class DesktopE2EServer {
     this.commandWaiters = []
     this.commandResults = new Map()
     this.modelRequests = []
+    this.scenario = 'initial'
     this.modelStage = 'initial'
     this.toolOutput = null
+    this.scenarioRequests = new Map()
+    this.scenarioWaiters = new Map()
+    this.cancellationResponseClosed = null
+    this.cancellationResponseClosedResolver = null
   }
 
   async start() {
@@ -283,6 +299,47 @@ class DesktopE2EServer {
     return new Promise(resolvePromise => {
       this.readyResolver = resolvePromise
     })
+  }
+
+  setScenario(scenario) {
+    assert.ok(
+      ['initial', 'follow_up', 'cancellation', 'retry'].includes(scenario),
+      `Unknown desktop E2E scenario: ${scenario}`
+    )
+    this.scenario = scenario
+  }
+
+  recordScenarioRequest(scenario, request) {
+    const requests = this.scenarioRequests.get(scenario) ?? []
+    requests.push(request)
+    this.scenarioRequests.set(scenario, requests)
+    const waiter = this.scenarioWaiters.get(scenario)
+    if (waiter) {
+      this.scenarioWaiters.delete(scenario)
+      waiter(request)
+    }
+  }
+
+  awaitScenarioRequest(scenario) {
+    const request = this.scenarioRequests.get(scenario)?.at(-1)
+    if (request) return Promise.resolve(request)
+    return new Promise(resolvePromise => {
+      this.scenarioWaiters.set(scenario, resolvePromise)
+    })
+  }
+
+  awaitCancellationResponseClosed() {
+    if (this.cancellationResponseClosed) return Promise.resolve()
+    return new Promise(resolvePromise => {
+      this.cancellationResponseClosedResolver = resolvePromise
+    })
+  }
+
+  markCancellationResponseClosed() {
+    if (this.cancellationResponseClosed) return
+    this.cancellationResponseClosed = true
+    this.cancellationResponseClosedResolver?.()
+    this.cancellationResponseClosedResolver = null
   }
 
   async command(action, selector, options = {}) {
@@ -377,27 +434,37 @@ class DesktopE2EServer {
   async handleModelResponse(request, response) {
     const body = await readRequestBody(request)
     const authorization = request.headers.authorization ?? null
-    this.modelRequests.push({ authorization, body })
+    const modelRequest = { authorization, body, scenario: this.scenario }
+    this.modelRequests.push(modelRequest)
     if (authorization !== `Bearer ${MODEL_API_KEY}`) {
       json(response, 401, { error: 'The Desktop E2E model API key was not forwarded by Codex' })
       return
     }
 
     const responseId = `wework-e2e-response-${this.modelRequests.length}`
-    let events
-    if (this.modelStage === 'initial') {
+    if (this.scenario === 'initial' && this.modelStage === 'initial') {
+      this.recordScenarioRequest('initial', modelRequest)
       assert.ok(
         JSON.stringify(body).includes(TASK_PROMPT),
         'The real Codex request did not contain the UI task prompt'
       )
       const tool = selectShellTool(body, this.workspacePath)
       this.modelStage = 'awaiting_tool_output'
-      events = [
+      this.writeSse(response, [
         responseCreated(responseId),
         functionCall('wework-e2e-tool-call', tool.name, tool.arguments),
         responseCompleted(responseId),
-      ]
-    } else {
+      ])
+      return
+    }
+
+    if (this.scenario === 'initial') {
+      assert.equal(
+        this.modelStage,
+        'awaiting_tool_output',
+        `Unexpected desktop E2E model stage: ${this.modelStage}`
+      )
+      this.recordScenarioRequest('initial', modelRequest)
       assert.equal(
         requestContainsToolOutput(body),
         true,
@@ -405,13 +472,68 @@ class DesktopE2EServer {
       )
       this.toolOutput = JSON.stringify(body.input)
       this.modelStage = 'complete'
-      events = [
+      this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(COMPLETION_TEXT),
         responseCompleted(responseId),
-      ]
+      ])
+      return
     }
 
+    if (this.scenario === 'follow_up') {
+      this.recordScenarioRequest('follow_up', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(FOLLOW_UP_PROMPT),
+        'The real Codex request did not contain the follow-up prompt'
+      )
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(FOLLOW_UP_COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'cancellation') {
+      this.recordScenarioRequest('cancellation', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(CANCELLATION_PROMPT),
+        'The real Codex request did not contain the cancellation prompt'
+      )
+      response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      })
+      response.write(createSse([responseCreated(responseId)]))
+      response.once('close', () => this.markCancellationResponseClosed())
+      return
+    }
+
+    if (this.scenario === 'retry') {
+      this.recordScenarioRequest('retry', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(RETRY_PROMPT),
+        'The real Codex request did not contain the retry prompt'
+      )
+      const retryRequests = this.scenarioRequests.get('retry') ?? []
+      if (retryRequests.length === 1) {
+        json(response, 500, { error: 'WEWORK_DESKTOP_E2E_RETRY_FAILURE' })
+        return
+      }
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(RETRY_COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    throw new Error(`Unexpected desktop E2E scenario: ${this.scenario}`)
+  }
+
+  writeSse(response, events) {
     response.writeHead(200, {
       'Access-Control-Allow-Origin': '*',
       'Cache-Control': 'no-cache',
@@ -508,6 +630,7 @@ async function main() {
 
   const control = new DesktopE2EServer(workspacePath)
   let app
+  let phase = 'startup'
   try {
     await control.start()
     const codexBinary = await resolveExecutable(
@@ -567,8 +690,8 @@ async function main() {
     await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
-    await fillComposerUntilSendEnabled(control, composerSelector)
-    await control.command('click', '[data-testid="send-message-button"]')
+    phase = 'initial-task'
+    await sendPrompt(control, composerSelector, TASK_PROMPT)
     await control.command('waitFor', '[data-testid="message-assistant"]', {
       text: COMPLETION_TEXT,
       timeoutMs: UI_TIMEOUT_MS,
@@ -595,6 +718,71 @@ async function main() {
       'Codex did not report its real tool execution to the model service'
     )
 
+    phase = 'follow-up'
+    control.setScenario('follow_up')
+    await sendPrompt(control, composerSelector, FOLLOW_UP_PROMPT)
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: FOLLOW_UP_COMPLETION_TEXT,
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    const followUpRequest = await withTimeout(
+      control.awaitScenarioRequest('follow_up'),
+      UI_TIMEOUT_MS,
+      'The model service did not receive the follow-up request'
+    )
+    assert.ok(
+      JSON.stringify(followUpRequest.body).includes(FOLLOW_UP_PROMPT),
+      'The follow-up request did not preserve the user prompt'
+    )
+
+    phase = 'cancellation'
+    control.setScenario('cancellation')
+    await sendPrompt(control, composerSelector, CANCELLATION_PROMPT)
+    await withTimeout(
+      control.awaitScenarioRequest('cancellation'),
+      UI_TIMEOUT_MS,
+      'The model service did not receive the cancellation request'
+    )
+    await control.command('waitFor', '[data-testid="pause-response-button"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    await control.command('click', '[data-testid="pause-response-button"]')
+    await withTimeout(
+      control.awaitCancellationResponseClosed(),
+      UI_TIMEOUT_MS,
+      'Cancelling the task did not close the real model response stream'
+    )
+    await control.command('waitFor', '[data-testid="assistant-stopped-notice"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    await control.command('waitFor', '[data-testid="send-message-button"]', {
+      enabled: true,
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    const cancellationText = await control.command('getText', 'body')
+    assert.equal(
+      cancellationText.includes(CANCELLATION_COMPLETION_TEXT),
+      false,
+      'The cancelled task unexpectedly rendered a completion response'
+    )
+
+    phase = 'retry'
+    control.setScenario('retry')
+    await sendPrompt(control, composerSelector, RETRY_PROMPT)
+    await control.command('waitFor', '[data-testid="assistant-error-card"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    await control.command('click', '[data-testid="assistant-error-retry"]')
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: RETRY_COMPLETION_TEXT,
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    assert.equal(
+      control.scenarioRequests.get('retry')?.length,
+      2,
+      'Retry did not issue exactly one additional request for the failed user message'
+    )
+
     await writeFile(
       join(resultDir, 'model-requests.json'),
       `${JSON.stringify(control.modelRequests, null, 2)}\n`,
@@ -602,6 +790,25 @@ async function main() {
     )
     console.log(`Wework desktop task-flow E2E passed. Diagnostics: ${resultDir}`)
   } catch (error) {
+    await writeFile(
+      join(resultDir, 'scenario-state.json'),
+      `${JSON.stringify(
+        {
+          phase,
+          scenario: control.scenario,
+          modelStage: control.modelStage,
+          scenarioRequestCounts: Object.fromEntries(
+            [...control.scenarioRequests.entries()].map(([name, requests]) => [
+              name,
+              requests.length,
+            ])
+          ),
+        },
+        null,
+        2
+      )}\n`,
+      'utf8'
+    )
     try {
       const snapshot = await control.command('snapshot', 'body', { timeoutMs: 5000 })
       await writeFile(join(resultDir, 'ui-snapshot.json'), `${snapshot}\n`, 'utf8')

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -227,7 +227,14 @@ function fillDesktopControlElement(element: HTMLElement, value: string) {
     const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set
     setter?.call(element, value)
   } else {
-    element.replaceChildren(document.createTextNode(value))
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(element)
+    range.collapse(false)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    document.execCommand('selectAll', false)
+    document.execCommand('insertText', false, value)
   }
 
   element.dispatchEvent(


### PR DESCRIPTION
## Summary

- extend the real Wework desktop E2E from the initial tool call to the task lifecycle: follow-up, cancellation, and failed-message retry
- make the loopback Responses provider scenario-aware and preserve failure diagnostics
- use native WebView insertion for E2E composer input so Lexical owns the editor state
- document the expanded lifecycle coverage in English and Chinese

## Validation

- `pnpm --filter wework exec tsc -b --pretty false`
- `pnpm --filter wework e2e` (5 passed)
- pre-push hook: ESLint, TypeScript, and unit tests passed
- `node --check wework/e2e/desktop/task-flow.e2e.mjs`

## Note

The real desktop E2E was exercised while developing this change. Its initial task flow passed; a later local runner interruption prevented collecting one final complete lifecycle run after the Lexical input fix. CI will run the desktop E2E workflow on the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded desktop end-to-end coverage for follow-up conversations, streaming cancellation, stopped responses, model failures, retries, and final response validation.
  * Improved test diagnostics and artifact capture for faster investigation of failed scenarios.
  * Enhanced desktop automation when entering text into rich text controls.

* **Documentation**
  * Updated English and Chinese automation guides with the expanded task lifecycle and test artifact location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->