### PR TITLE
fix(executor): resolve user Claude CLI path

### DIFF
--- a/executor/src/agents/mod.rs
+++ b/executor/src/agents/mod.rs
@@ -50,6 +50,7 @@ const MACOS_CODEX_APP_BINARIES: [&str; 2] = [
     "/Applications/ChatGPT.app/Contents/Resources/codex",
     "/Applications/Codex.app/Contents/Resources/codex",
 ];
+const CLAUDE_USER_BINARY_SUFFIX: &str = ".local/bin/claude";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentCommandPlanner {
@@ -131,7 +132,48 @@ pub fn build_codex_app_server_command(binary: &str) -> CommandSpec {
 }
 
 fn resolve_claude_binary() -> String {
-    read_binary("CLAUDE_BINARY_PATH", "CLAUDE_BIN", "claude")
+    let binary = read_binary("CLAUDE_BINARY_PATH", "CLAUDE_BIN", "claude");
+    resolve_claude_binary_path(&binary)
+}
+
+/// Resolve a Claude Code binary name/path to an executable path.
+///
+/// GUI-launched local executors may not inherit a user's shell PATH.
+/// `~/.local/bin` is a common user-level Claude Code installation location,
+/// so check it before falling back to PATH lookup.
+pub fn resolve_claude_binary_path(value: &str) -> String {
+    let user_binary = env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join(CLAUDE_USER_BINARY_SUFFIX));
+    let search_paths = env::var_os("PATH")
+        .map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    resolve_claude_binary_path_from_candidates(value, user_binary.as_ref(), &search_paths)
+}
+
+fn resolve_claude_binary_path_from_candidates(
+    value: &str,
+    user_binary: Option<&PathBuf>,
+    search_paths: &[PathBuf],
+) -> String {
+    let trimmed = value.trim();
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return trimmed.to_owned();
+    }
+
+    if trimmed == "claude" {
+        if let Some(path) = user_binary.filter(|path| path.is_file()) {
+            return path.display().to_string();
+        }
+    }
+
+    search_paths
+        .iter()
+        .map(|path| path.join(trimmed))
+        .find(|path| path.is_file())
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| trimmed.to_owned())
 }
 
 fn read_binary(primary: &str, secondary: &str, default: &str) -> String {
@@ -418,6 +460,25 @@ mod tests {
         let resolved = resolve_codex_binary_path_from_candidates("codex", &app_candidates, &[]);
 
         assert_eq!(resolved, available_binary.display().to_string());
+    }
+
+    #[test]
+    fn claude_binary_resolver_prefers_available_user_binary() {
+        let available_binary = std::env::current_exe().expect("current test binary should exist");
+
+        let resolved =
+            resolve_claude_binary_path_from_candidates("claude", Some(&available_binary), &[]);
+
+        assert_eq!(resolved, available_binary.display().to_string());
+    }
+
+    #[test]
+    fn claude_binary_resolver_keeps_explicit_path() {
+        let explicit_path = "/custom/bin/claude";
+
+        let resolved = resolve_claude_binary_path_from_candidates(explicit_path, None, &[]);
+
+        assert_eq!(resolved, explicit_path);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Resolve the user-level Claude CLI at `~/.local/bin/claude` before searching the executor process `PATH`.
- Preserve explicitly configured Claude binary paths and add resolver coverage.

## Why

GUI-launched executors may not inherit shell PATH entries, causing Claude task startup to fail with `No such file or directory (os error 2)` even when the CLI is installed for the user.

## Validation

- `cargo fmt --check`
- `cargo test -p wegent-executor agents::tests::claude_binary_resolver --lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude command resolution by preferring an available user-installed binary.
  * Preserved explicitly provided executable paths without altering them.
  * Added fallback handling when no executable is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->