### PR TITLE
fix(wework): overlay mode pill cancel icon

### DIFF
--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -52,6 +52,12 @@ The goal bar's running presentation must be constrained by the current runtime t
 - This derivation affects only Wework presentation and elapsed-time calculation; it does not automatically call the goal pause API. Persisting `paused` remains an explicit user action through **Pause goal**.
 - When the task reports `running: true` again, the goal uses the original status returned by the runtime goal API.
 
+## Composer Mode Indicators
+
+When the composer is in plan mode or goal-draft mode, its bottom mode pill must show a semantic icon to the left of its label: a checklist for plan mode and a target for goal draft. Desktop and compact layouts must reuse the same mode-pill implementation so the state is expressed consistently.
+
+The mode pill's cancel button appears only on hover and is absolutely positioned over the left icon while that icon fades out. Do not expand the cancel button or add spacing that changes the pill width, because that causes the label to shift horizontally.
+
 ## Long Output Memory Boundary
 
 The Wework chat UI must not keep complete long-running output in React state. `WorkbenchMessage.content`, thinking/text/plan block `content`, and tool block `toolOutput` must enter `messages` through the shared preview-window path:

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -52,6 +52,12 @@ Goal 条的运行态必须受当前 runtime task 的执行快照约束：当 App
 - 此派生只影响 Wework 的展示与计时，不会自动调用 goal 暂停接口。用户点击“暂停目标”才会持久化 `paused` 状态。
 - 任务重新处于 `running: true` 时，goal 继续使用 runtime goal API 返回的原始状态。
 
+## Composer 模式提示
+
+当 composer 处于计划模式或目标草稿模式时，底部模式胶囊必须在标签左侧显示对应的语义图标：计划模式使用清单图标，目标草稿使用靶心图标。桌面和紧凑布局必须复用同一个模式胶囊实现，确保表达一致。
+
+模式胶囊的取消按钮仅在悬停时显示，并绝对定位覆盖左侧图标；原图标在同一状态下淡出。不要通过展开取消按钮或额外边距改变胶囊宽度，否则标签会发生横向跳动。
+
 ## 长输出内存边界
 
 Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React state 中。`WorkbenchMessage.content`、thinking/text/plan block 的 `content`、tool block 的 `toolOutput` 都必须通过统一的预览窗口进入 `messages`：

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -297,8 +297,10 @@ describe('ChatInput', () => {
     expect(pill).toHaveClass('h-7')
     expect(pill).toHaveClass('rounded-xl')
     expect(pill).toHaveClass('bg-muted')
-    expect(screen.getByTestId('cancel-plan-mode-button')).toHaveClass('w-0')
-    expect(screen.getByTestId('cancel-plan-mode-button')).toHaveClass('group-hover:w-5')
+    expect(screen.getByTestId('plan-mode-pill-icon')).toHaveClass('h-4')
+    expect(screen.getByTestId('cancel-plan-mode-button')).toHaveClass('absolute')
+    expect(screen.getByTestId('cancel-plan-mode-button')).toHaveClass('left-2')
+    expect(screen.getByTestId('plan-mode-pill-icon')).toHaveClass('group-hover:opacity-0')
 
     await userEvent.click(screen.getByTestId('cancel-plan-mode-button'))
 
@@ -2270,12 +2272,11 @@ describe('ChatInput', () => {
     expect(pill).toHaveClass('justify-center')
     expect(pill).toHaveClass('border')
     expect(pill).toHaveClass('bg-muted')
+    expect(screen.getByTestId('goal-draft-pill-icon')).toHaveClass('h-4')
     expect(cancelButton).toHaveClass('opacity-0')
-    expect(cancelButton).toHaveClass('w-0')
-    expect(cancelButton).toHaveClass('group-hover:w-5')
-    expect(cancelButton).toHaveClass('group-hover:mr-1.5')
+    expect(cancelButton).toHaveClass('absolute')
+    expect(cancelButton).toHaveClass('left-2')
     expect(cancelButton).toHaveClass('group-hover:opacity-100')
-    expect(cancelButton).toHaveClass('group-hover:bg-text-muted/15')
     expect(cancelButton).toHaveClass('hover:bg-text-muted/30')
 
     fireEvent.click(cancelButton)

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -179,6 +179,7 @@ export function CompactChatComposer({
       ) : planModeActive ? (
         <ComposerModePill
           label={t('workbench.plan_mode', '计划模式')}
+          icon={ClipboardList}
           testId="plan-mode-pill"
           cancelTestId="cancel-plan-mode-button"
           cancelLabel={t('workbench.disable_plan_mode', '关闭计划模式')}

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Square } from 'lucide-react'
+import { ArrowUp, ClipboardList, Square } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ModelOptions, RuntimeContextUsage, UnifiedModel } from '@/types/api'
 import { AddContextMenu } from './AddContextMenu'
@@ -71,6 +71,7 @@ export function ComposerToolbar({
         ) : planModeActive ? (
           <ComposerModePill
             label={t('workbench.plan_mode', '计划模式')}
+            icon={ClipboardList}
             testId="plan-mode-pill"
             cancelTestId="cancel-plan-mode-button"
             cancelLabel={t('workbench.disable_plan_mode', '关闭计划模式')}

--- a/wework/src/components/chat/composer/GoalDraftPill.tsx
+++ b/wework/src/components/chat/composer/GoalDraftPill.tsx
@@ -1,4 +1,5 @@
-import { CircleX } from 'lucide-react'
+import { CircleX, Target } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import type { KeyboardEvent } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 
@@ -14,6 +15,7 @@ interface ComposerModePillProps {
   disabled?: boolean
   className?: string
   title?: string
+  icon?: LucideIcon
 }
 
 export function ComposerModePill({
@@ -28,6 +30,7 @@ export function ComposerModePill({
   disabled = false,
   className = '',
   title,
+  icon: Icon,
 }: ComposerModePillProps) {
   const { t } = useTranslation('common')
   const interactive = Boolean(onClick)
@@ -54,7 +57,7 @@ export function ComposerModePill({
       }}
       onKeyDown={handleKeyDown}
       className={[
-        'group flex h-7 w-fit shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted px-2.5 text-[13px] font-semibold leading-[18px] text-text-secondary transition-[background-color,color] hover:bg-muted/80 hover:text-text-primary',
+        'group relative flex h-7 w-fit shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted px-2.5 text-[13px] font-semibold leading-[18px] text-text-secondary transition-[background-color,color] hover:bg-muted/80 hover:text-text-primary',
         interactive && !disabled ? 'cursor-pointer' : '',
         disabled ? 'cursor-not-allowed opacity-50' : '',
         className,
@@ -63,6 +66,13 @@ export function ComposerModePill({
         .join(' ')}
       title={title}
     >
+      {Icon && (
+        <Icon
+          data-testid={`${testId}-icon`}
+          className="mr-1.5 h-4 w-4 shrink-0 transition-opacity group-hover:opacity-0"
+          aria-hidden="true"
+        />
+      )}
       {onCancel && (
         <button
           type="button"
@@ -72,7 +82,7 @@ export function ComposerModePill({
             onCancel()
           }}
           disabled={disabled}
-          className="pointer-events-none flex h-5 w-0 items-center justify-center overflow-hidden rounded-full bg-text-muted/15 text-text-muted opacity-0 transition-[width,margin,opacity,background-color,color] group-hover:pointer-events-auto group-hover:mr-1.5 group-hover:w-5 group-hover:bg-text-muted/15 group-hover:opacity-100 hover:bg-text-muted/30 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-0"
+          className="pointer-events-none absolute left-2 flex h-5 w-5 items-center justify-center rounded-full bg-text-muted/15 text-text-muted opacity-0 transition-[opacity,background-color,color] group-hover:pointer-events-auto group-hover:opacity-100 hover:bg-text-muted/30 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-0"
           aria-label={resolvedCancelLabel}
         >
           <CircleX className="h-4 w-4 shrink-0" />
@@ -94,6 +104,7 @@ export function GoalDraftPill({ onCancel, className = '' }: GoalDraftPillProps) 
   return (
     <ComposerModePill
       label={t('workbench.goal_chip', '目标')}
+      icon={Target}
       testId="goal-draft-pill"
       cancelTestId="cancel-goal-draft-button"
       cancelLabel={t('workbench.cancel_goal_draft', '取消目标')}


### PR DESCRIPTION
## Summary

- Add semantic icons to the plan-mode and goal-draft composer pills.
- Overlay the hover-only cancel button on the left icon so the label does not shift.
- Document the shared mode-pill behavior for desktop and compact layouts.

## Root cause

The cancel affordance expanded within the pill, placing it next to the new mode icon and changing the pill width on hover.

## Validation

- `pnpm exec vitest run src/components/chat/ChatInput.test.tsx`
- `pnpm typecheck`
- Pre-push ESLint, TypeScript, and Wework unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear visual icons for plan mode and goal-draft mode in the chat composer.
  * Improved cancel-button behavior with hover-based icon transitions and consistent positioning.
  * Preserved composer pill dimensions to prevent layout shifts across desktop and compact layouts.

* **Documentation**
  * Documented composer mode indicator behavior in English and Chinese developer guides.

* **Tests**
  * Updated composer UI tests to validate icon sizing, positioning, and hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->