### PR TITLE
fix(wework): improve task archive undo flow

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1037,12 +1037,12 @@ describe('DesktopSidebar', () => {
     ).not.toBeInTheDocument()
   })
 
-  test('shows hover actions and an undo notice before archiving project runtime tasks', async () => {
+  test('optimistically archives project runtime tasks with an undo notice', async () => {
     const user = userEvent.setup()
     const onArchiveRuntimeTask = vi.fn().mockResolvedValue(undefined)
     const originalSetTimeout = window.setTimeout
     const originalClearTimeout = window.clearTimeout
-    const archiveTimerId = 2200
+    const archiveTimerId = 3000
     let archiveTimerCallback: (() => void) | null = null
     const setTimeoutSpy = vi
       .spyOn(window, 'setTimeout')
@@ -1129,6 +1129,7 @@ describe('DesktopSidebar', () => {
       await user.click(screen.getByTestId('runtime-local-task-archive-codex-1'))
 
       expect(onArchiveRuntimeTask).not.toHaveBeenCalled()
+      expect(taskRow).toHaveClass('hidden')
       expect(screen.getByTestId('runtime-local-task-archive-toast-codex-1')).toHaveTextContent(
         '撤销'
       )
@@ -1136,15 +1137,10 @@ describe('DesktopSidebar', () => {
       await user.click(screen.getByTestId('runtime-local-task-archive-undo-codex-1'))
 
       expect(onArchiveRuntimeTask).not.toHaveBeenCalled()
+      expect(taskRow).not.toHaveClass('hidden')
       expect(archiveTimerCallback).toBeNull()
-      expect(
-        screen.queryByTestId('runtime-local-task-archive-toast-codex-1')
-      ).not.toBeInTheDocument()
 
       await user.click(screen.getByTestId('runtime-local-task-archive-codex-1'))
-      expect(screen.getByTestId('runtime-local-task-archive-toast-codex-1')).toBeInTheDocument()
-      expect(archiveTimerCallback).toBeTypeOf('function')
-
       const runArchiveTimer = archiveTimerCallback
       await act(async () => {
         runArchiveTimer?.()
@@ -1158,9 +1154,6 @@ describe('DesktopSidebar', () => {
           taskId: 'codex-1',
         })
       )
-      expect(
-        screen.queryByTestId('runtime-local-task-archive-toast-codex-1')
-      ).not.toBeInTheDocument()
     } finally {
       setTimeoutSpy.mockRestore()
       clearTimeoutSpy.mockRestore()
@@ -1174,8 +1167,7 @@ describe('DesktopSidebar', () => {
       .mockResolvedValueOnce({ status: 'dirty_worktree' })
       .mockResolvedValueOnce({ status: 'archived' })
     const originalSetTimeout = window.setTimeout
-    const originalClearTimeout = window.clearTimeout
-    const archiveTimerId = 2200
+    const archiveTimerId = 3000
     let archiveTimerCallback: (() => void) | null = null
     const setTimeoutSpy = vi
       .spyOn(window, 'setTimeout')
@@ -1186,13 +1178,6 @@ describe('DesktopSidebar', () => {
         }
         return originalSetTimeout(handler, timeout)
       })
-    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout').mockImplementation((id?: number) => {
-      if (id === archiveTimerId) {
-        archiveTimerCallback = null
-        return
-      }
-      originalClearTimeout(id)
-    })
 
     try {
       renderSidebar({
@@ -1235,7 +1220,6 @@ describe('DesktopSidebar', () => {
       await user.click(screen.getByTestId('project-item-button'))
       await user.click(screen.getByTestId('runtime-local-task-archive-codex-1'))
       const runArchiveTimer = archiveTimerCallback
-
       await act(async () => {
         runArchiveTimer?.()
         await Promise.resolve()
@@ -1270,7 +1254,6 @@ describe('DesktopSidebar', () => {
       ).not.toBeInTheDocument()
     } finally {
       setTimeoutSpy.mockRestore()
-      clearTimeoutSpy.mockRestore()
     }
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -194,7 +194,7 @@ interface ArchiveConversationsConfirmDialogProps {
 
 const PROJECT_CREATE_MENU_WIDTH = 248
 const PROJECT_CREATE_MENU_MARGIN = 8
-const RUNTIME_ARCHIVE_UNDO_DELAY_MS = 2200
+const RUNTIME_ARCHIVE_UNDO_DELAY_MS = 3000
 const MACOS_WINDOW_CONTROLS_SAFE_AREA_CLASS = 'left-[92px]'
 const SIDEBAR_CHROME_TAB_BUTTON_CLASS =
   'group relative flex h-8 w-8 min-w-0 items-center justify-center rounded-lg px-0 text-center text-[13px] font-medium leading-none transition-colors'
@@ -1406,7 +1406,8 @@ function RuntimeTaskRow({
             ? 'bg-[rgb(var(--color-sidebar-active))] text-text-primary'
             : marked
               ? 'bg-[rgb(var(--color-sidebar-marked))] text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-marked-hover))]'
-              : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'
+              : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]',
+          (archivePending || archiving) && 'hidden'
         )}
       >
         <span title={task.title} className="min-w-0 flex-1 truncate">

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -954,6 +954,21 @@ function ArchiveRuntimeTaskProbe() {
     <div>
       <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
       <span data-testid="archive-result">{lastArchiveResult}</span>
+      <span data-testid="current-runtime-task">
+        {workbench.state.currentRuntimeTask?.taskId ?? ''}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          void workbench.openRuntimeTask({
+            deviceId: 'device-1',
+            workspacePath: '/workspace/project-alpha',
+            taskId: 'runtime-b',
+          })
+        }
+      >
+        open runtime b
+      </button>
       <button
         type="button"
         onClick={() =>
@@ -3786,6 +3801,43 @@ describe('WorkbenchProvider runtime tasks', () => {
       'device-1',
       expect.objectContaining({ command_key: 'git_worktree_remove' })
     )
+  })
+
+  test('keeps a newly opened task selected when a different task finishes archiving', async () => {
+    const archiveRequest = deferred<{
+      accepted: boolean
+      taskId: string
+      workspacePath: string
+      runtime: 'codex'
+    }>()
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(createRuntimeWork()),
+      archiveConversation: vi.fn().mockReturnValue(archiveRequest.promise),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ArchiveRuntimeTaskProbe />, services)
+
+    await waitFor(() => expect(screen.getByText('archive worktree task')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('archive worktree task'))
+    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
+
+    await userEvent.click(screen.getByText('open runtime b'))
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task')).toHaveTextContent('runtime-b')
+    )
+
+    archiveRequest.resolve({
+      accepted: true,
+      taskId: 'runtime-worktree',
+      workspacePath: '/workspace/worktrees/9/project-alpha',
+      runtime: 'codex',
+    })
+
+    await waitFor(() => expect(screen.getByTestId('archive-result')).toHaveTextContent('archived'))
+    expect(screen.getByTestId('current-runtime-task')).toHaveTextContent('runtime-b')
   })
 
   test('force archives and removes a dirty worktree task', async () => {

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -290,9 +290,7 @@ export function useWorkbenchRuntimeTasks({
         return { status: 'failed' }
       }
       await removeArchivedWorktrees(worktreeTargets)
-      if (isSameRuntimeTaskAddress(state.currentRuntimeTask, address)) {
-        clearCurrentRuntimeTaskView()
-      }
+      clearCurrentRuntimeTaskIfArchived([address])
       await refreshWorkLists()
       console.debug('[Wework] Runtime archive task finished', {
         address: runtimeAddressDebug(address),
@@ -300,13 +298,12 @@ export function useWorkbenchRuntimeTasks({
       return { status: 'archived' }
     },
     [
-      clearCurrentRuntimeTaskView,
+      clearCurrentRuntimeTaskIfArchived,
       dispatch,
       executorClient,
       prepareWorktreeArchive,
       refreshWorkLists,
       removeArchivedWorktrees,
-      state.currentRuntimeTask,
       state.runtimeWork,
     ]
   )


### PR DESCRIPTION
## What changed

- Make task archiving optimistic in the sidebar and show a 3-second undo capsule before the archive request is sent.
- Keep the active task view unchanged when a different task finishes archiving.
- Add regression coverage for undo timing and archive/view switching races.

## Why

The prior flow delayed visual feedback and could navigate away from the task currently being viewed when another task completed archiving.

## Validation

- `pnpm --dir wework test --run src/components/layout/DesktopSidebar.test.tsx src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --dir wework typecheck`
- Pre-push quality gate (ESLint, TypeScript, and Wework unit tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the undo period after archiving a runtime task to 3 seconds.
  * Improved archiving behavior when switching between runtime tasks during an in-progress archive.
  * Ensured archiving one task no longer unexpectedly changes the task currently being viewed.
  * The open task view is now cleared appropriately when its associated task is archived.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->