### PR TITLE
fix(wework): preserve running state for active goals

### DIFF
--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -1277,6 +1277,12 @@ impl RuntimeWorkRpcHandler {
             .await
         {
             Ok(result) => {
+                self.sync_runtime_task_goal_status(
+                    &link.local_task_id,
+                    result
+                        .get("goal")
+                        .and_then(|goal| string_field(goal, "status")),
+                );
                 let mut response = task_action_success(&link);
                 response["goal"] = result.get("goal").cloned().unwrap_or(Value::Null);
                 Ok(response)
@@ -1312,6 +1318,12 @@ impl RuntimeWorkRpcHandler {
             .await
         {
             Ok(result) => {
+                self.sync_runtime_task_goal_status(
+                    &link.local_task_id,
+                    result
+                        .get("goal")
+                        .and_then(|goal| string_field(goal, "status")),
+                );
                 let mut response = task_action_success(&link);
                 response["goal"] = result.get("goal").cloned().unwrap_or(Value::Null);
                 Ok(response)
@@ -1331,6 +1343,7 @@ impl RuntimeWorkRpcHandler {
             .await
         {
             Ok(result) => {
+                self.sync_runtime_task_goal_status(&link.local_task_id, None);
                 let mut response = task_action_success(&link);
                 response["cleared"] = result.get("cleared").cloned().unwrap_or(Value::Bool(false));
                 Ok(response)
@@ -2265,6 +2278,8 @@ impl RuntimeWorkRpcHandler {
                 let mut event_mapper = CodexNotificationEventMapper::default();
                 let mut cache_mapper = CodexNotificationCacheMapper::default();
                 while let Some(message) = notification_rx.recv().await {
+                    mapper_handler
+                        .sync_runtime_task_goal_from_notification(&mapper_local_task_id, &message);
                     cache_mapper.map(
                         &mapper_handler.store,
                         &mapper_local_task_id,
@@ -3419,7 +3434,7 @@ impl RuntimeWorkRpcHandler {
             runtime_handle.insert("threadPath".to_owned(), Value::String(path));
             link.runtime_handle = Value::Object(runtime_handle);
         }
-        if local_active {
+        if local_active || link.has_active_goal() {
             link.status = "running".to_owned();
             link.running = true;
         }
@@ -3593,8 +3608,13 @@ impl RuntimeWorkRpcHandler {
             if thread_id.is_some() {
                 link.thread_id = thread_id;
             }
-            link.status = status.to_owned();
-            link.running = status == "running";
+            let goal_active = link.has_active_goal();
+            link.status = if goal_active {
+                "running".to_owned()
+            } else {
+                status.to_owned()
+            };
+            link.running = goal_active || status == "running";
             link.updated_at = now_ms();
             if link.thread_id.is_some() && status != "running" {
                 retain_runtime_handle_user_messages(&mut link.runtime_handle);
@@ -3609,6 +3629,40 @@ impl RuntimeWorkRpcHandler {
         }
         self.thread_list_cache.invalidate();
     }
+
+    fn sync_runtime_task_goal_from_notification(&self, local_task_id: &str, message: &Value) {
+        let notification = codex_notification(message);
+        let goal_status = match notification.method.as_str() {
+            "thread/goal/updated" => notification
+                .params
+                .get("goal")
+                .and_then(|goal| string_field(goal, "status")),
+            "thread/goal/cleared" => None,
+            _ => return,
+        };
+        self.sync_runtime_task_goal_status(local_task_id, goal_status);
+    }
+
+    fn sync_runtime_task_goal_status(&self, local_task_id: &str, goal_status: Option<String>) {
+        let active_goal = goal_status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("active"));
+        let task_active = self.is_active_local_task(local_task_id);
+        let updated = self.store.update_task(local_task_id, |link| {
+            link.goal_status = goal_status.clone();
+            if active_goal {
+                link.status = "running".to_owned();
+                link.running = true;
+            } else if !task_active {
+                link.status = goal_status.clone().unwrap_or_else(|| "active".to_owned());
+                link.running = false;
+            }
+            link.updated_at = now_ms();
+        });
+        if updated.is_some() {
+            self.thread_list_cache.invalidate();
+        }
+    }
 }
 
 fn is_unmapped_pending_codex_shadow(
@@ -3622,7 +3676,7 @@ fn is_unmapped_pending_codex_shadow(
 }
 
 fn normalize_inactive_running_codex_task(link: &mut RuntimeTaskLink) -> bool {
-    if !is_inactive_running_codex_task(link) {
+    if link.has_active_goal() || !is_inactive_running_codex_task(link) {
         return false;
     }
     link.status = "active".to_owned();

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -22,6 +22,7 @@ pub(crate) struct RuntimeTaskLink {
     pub runtime: String,
     pub status: String,
     pub running: bool,
+    pub goal_status: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
     pub runtime_handle: Value,
@@ -43,6 +44,7 @@ impl RuntimeTaskLink {
             runtime: "codex".to_owned(),
             status: "running".to_owned(),
             running: true,
+            goal_status: None,
             created_at: now_ms(),
             updated_at: now_ms(),
             runtime_handle: json!({}),
@@ -69,6 +71,7 @@ impl RuntimeTaskLink {
             runtime,
             status: "active".to_owned(),
             running: false,
+            goal_status: None,
             created_at: now_ms(),
             updated_at: now_ms(),
             runtime_handle,
@@ -92,9 +95,15 @@ impl RuntimeTaskLink {
             .as_ref()
             .and_then(|link| local_terminal_status_if_current(link, thread));
         let local_running = local_link.as_ref().is_some_and(|link| link.running);
+        let goal_active = local_link
+            .as_ref()
+            .is_some_and(RuntimeTaskLink::has_active_goal);
+        let goal_status = local_link
+            .as_ref()
+            .and_then(|link| link.goal_status.clone());
         let status = if local_archived {
             "archived".to_owned()
-        } else if local_running {
+        } else if goal_active || local_running {
             "running".to_owned()
         } else if let Some(status) = &local_terminal_status {
             status.clone()
@@ -103,7 +112,7 @@ impl RuntimeTaskLink {
         };
         let running = !local_archived
             && local_terminal_status.is_none()
-            && (local_running || normalized_running_status(&status));
+            && (goal_active || local_running || normalized_running_status(&status));
         Self {
             local_task_id: local_link
                 .as_ref()
@@ -120,6 +129,7 @@ impl RuntimeTaskLink {
             runtime: "codex".to_owned(),
             status,
             running,
+            goal_status,
             created_at: timestamp_ms_field(thread, "createdAt").unwrap_or_else(now_ms),
             updated_at: timestamp_ms_field(thread, "updatedAt").unwrap_or_else(now_ms),
             runtime_handle: local_link
@@ -142,6 +152,7 @@ impl RuntimeTaskLink {
             runtime: self.runtime.clone(),
             status: self.status.clone(),
             running: self.running,
+            goal_status: self.goal_status.clone(),
             created_at: self.created_at,
             updated_at: self.updated_at,
             runtime_handle: Value::Object(runtime_handle_list_summary_map(&self.runtime_handle)),
@@ -150,6 +161,14 @@ impl RuntimeTaskLink {
             list_order: self.list_order,
             group_workspace_path: self.group_workspace_path.clone(),
         }
+    }
+}
+
+impl RuntimeTaskLink {
+    pub fn has_active_goal(&self) -> bool {
+        self.goal_status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("active"))
     }
 }
 
@@ -180,6 +199,7 @@ impl Default for RuntimeTaskLink {
             runtime: "codex".to_owned(),
             status: "active".to_owned(),
             running: false,
+            goal_status: None,
             created_at: now_ms(),
             updated_at: now_ms(),
             runtime_handle: json!({}),
@@ -650,6 +670,31 @@ mod tests {
 
         assert_eq!(link.status, "active");
         assert!(!link.running);
+    }
+
+    #[test]
+    fn active_goal_keeps_task_running_when_thread_list_is_idle() {
+        let local_link = RuntimeTaskLink {
+            local_task_id: "task-1".to_owned(),
+            thread_id: Some("thread-1".to_owned()),
+            workspace_path: "/workspace/project".to_owned(),
+            goal_status: Some("active".to_owned()),
+            ..RuntimeTaskLink::default()
+        };
+
+        let link = RuntimeTaskLink::from_thread_metadata(
+            &json!({
+                "id": "thread-1",
+                "status": "idle",
+                "cwd": "/workspace/project",
+            }),
+            Some(local_link),
+            "/workspace/project".to_owned(),
+        );
+
+        assert_eq!(link.status, "running");
+        assert!(link.running);
+        assert_eq!(link.goal_status.as_deref(), Some("active"));
     }
 
     #[test]

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -420,6 +420,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         if (!cancelled && requestedGoalRevision === goalRevisionRef.current) {
           const loadedGoal = response.accepted ? response.goal : null
           commitThreadGoal(loadedGoal)
+          if (loadedGoal?.status === 'active') {
+            void refreshWorkListsRef.current().catch(() => undefined)
+          }
           if (loadedGoal) {
             clearRuntimePaneGoalSeed(runtimeTaskLoadTarget.address)
             setPendingGoalState(current =>
@@ -560,6 +563,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             if (requestedGoalRevision !== goalRevisionRef.current) return
             const loadedGoal = response.accepted ? response.goal : null
             commitThreadGoal(loadedGoal)
+            if (loadedGoal?.status === 'active') {
+              void refreshWorkListsRef.current().catch(() => undefined)
+            }
             if (loadedGoal) {
               clearRuntimePaneGoalSeed(address)
               const latestAddress = runtimeTaskLoadTargetRef.current?.address ?? address
@@ -586,6 +592,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       onRuntimeGoalUpdated: payload => {
         const loadedGoal = payload.goal ?? null
         commitThreadGoal(loadedGoal)
+        void refreshWorkListsRef.current().catch(() => undefined)
         if (loadedGoal?.status !== 'active') setGoalContinuation(null)
         clearRuntimePaneGoalSeed(address)
         const latestAddress = runtimeTaskLoadTargetRef.current?.address ?? address
@@ -595,6 +602,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       },
       onRuntimeGoalCleared: () => {
         commitThreadGoal(null)
+        void refreshWorkListsRef.current().catch(() => undefined)
         setGoalContinuation(null)
         clearRuntimePaneGoalSeed(address)
         const latestAddress = runtimeTaskLoadTargetRef.current?.address ?? address
@@ -604,6 +612,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       },
       onRuntimeGoalContinuation: payload => {
         setGoalContinuation(payload.status === 'started' ? payload : null)
+        void refreshWorkListsRef.current().catch(() => undefined)
       },
       onRuntimePlanUpdated: payload => {
         if (import.meta.env.DEV) {
@@ -1665,6 +1674,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         if (!response.accepted) return false
 
         commitThreadGoal(response.goal)
+        if (response.goal.status === 'active') {
+          await refreshWorkLists()
+        }
         return true
       } catch (error) {
         console.error('[Wework] Runtime goal status update failed', {
@@ -1675,7 +1687,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         return false
       }
     },
-    [currentRuntimeTask, goal, setRuntimeGoal]
+    [currentRuntimeTask, goal, refreshWorkLists, setRuntimeGoal]
   )
 
   const pauseCurrentGoal = useCallback(
@@ -1724,6 +1736,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       if (!response.accepted) return false
 
       commitThreadGoal(null)
+      await refreshWorkLists()
       return true
     } catch (error) {
       console.error('[Wework] Runtime goal clear failed', {
@@ -1732,7 +1745,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       })
       return false
     }
-  }, [clearRuntimeGoal, currentRuntimeTask, goal])
+  }, [clearRuntimeGoal, currentRuntimeTask, goal, refreshWorkLists])
 
   const cancelGuidanceMessage = useCallback(() => undefined, [])
   const goalContinuing = goal?.status === 'active' && goalContinuation?.status === 'started'


### PR DESCRIPTION
## Summary
- persist Codex goal status in the local runtime task record
- keep active goals running across automatic turn gaps
- refresh Wework task lists after goal lifecycle events

## Root cause
Task list `running` was derived from transient turn activity, so it could become false between automatic goal turns while the goal remained active. This made the sidebar and composer show a stopped task.

## Validation
- `cargo test runtime_work::response::tests --lib`
- `cargo test --test app_runtime_work_send_contract runtime_tasks_keep_shared_codex_alive_for_goal_continuation`
- `pnpm exec vitest run src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm run typecheck`
- pre-push quality gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task status accuracy when goals are active, updated, or cleared.
  * Tasks with active goals now remain marked as running, even when thread activity appears idle.
  * Goal status is synchronized in real time as updates are received.

* **Improvements**
  * Work lists now refresh automatically when runtime goals change.
  * Task summaries now include goal status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->