### PR TITLE
feat(wework): add AI verification sessions

### DIFF
--- a/docs/en/developer-guide/wework-ai-verification.md
+++ b/docs/en/developer-guide/wework-ai-verification.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 39
+---
+
+# AI Verification Sessions
+
+Wework can start an isolated development verification session so an AI can operate and assert against the real Tauri application. It reuses the desktop E2E WebView control channel, never drives an external Chrome window, and does not attach to a developer's everyday Wework window.
+
+## Start a session
+
+```bash
+pnpm --filter wework ai:verify start
+```
+
+The command prints a session file path and a local control URL. It creates separate Executor and diagnostic directories, then starts the real `dev-mac-app.sh`. Logs are stored in `wework/test-results/ai-verify/<run-id>/`.
+
+## Operate and assert
+
+Pass the session path returned by `start` to every later command. Prefer stable `data-testid` selectors.
+
+```bash
+pnpm --filter wework ai:verify snapshot --session /path/to/session.json
+pnpm --filter wework ai:verify fill --session /path/to/session.json \
+  --selector '[data-testid="chat-message-input"]' --value 'verification text'
+pnpm --filter wework ai:verify click --session /path/to/session.json \
+  --selector '[data-testid="send-message-button"]'
+pnpm --filter wework ai:verify wait-for --session /path/to/session.json \
+  --selector '[data-testid="message-assistant"]' --text 'Complete'
+pnpm --filter wework ai:verify stop --session /path/to/session.json
+```
+
+Supported operations are `snapshot`, `text`, `click`, `fill`, `press`, `wait-for`, `status`, and `stop`. Commands return structured JSON and exit non-zero when the WebView is unavailable, an element is missing, or an assertion times out.
+
+## Security boundary
+
+The controller listens only on `127.0.0.1` and creates a single-use Bearer token per session. The Vite environment enables the channel only for the development instance started by `ai:verify start`; normal development and production builds do not expose it. The session file contains the token, so treat it as short-lived local credential and never commit or share it.
+
+## AI workflow
+
+An AI should start with `snapshot` to confirm the route and available `data-testid` values, make the smallest required interaction, and use `wait-for` plus `snapshot` or `text` to verify the result. Always call `stop` when finished. On failure, keep the session directory and inspect `app.log`.

--- a/docs/zh/developer-guide/wework-ai-verification.md
+++ b/docs/zh/developer-guide/wework-ai-verification.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 39
+---
+
+# AI 自验证会话
+
+Wework 支持启动隔离的开发验证会话，让 AI 在真实 Tauri 应用中完成 UI 操作和断言。该机制复用桌面端 E2E 的 WebView 控制通道，不会操作外部 Chrome，也不会连接开发者日常使用的 Wework 窗口。
+
+## 启动会话
+
+```bash
+pnpm --filter wework ai:verify start
+```
+
+命令会输出 session 文件路径和本地控制地址。它会创建独立的 Executor 目录和诊断目录，并启动真实的 `dev-mac-app.sh`。所有日志位于 `wework/test-results/ai-verify/<run-id>/`。
+
+## 操作与断言
+
+后续命令都传入启动命令返回的 session 路径。优先使用稳定的 `data-testid` 选择器。
+
+```bash
+pnpm --filter wework ai:verify snapshot --session /path/to/session.json
+pnpm --filter wework ai:verify fill --session /path/to/session.json \
+  --selector '[data-testid="chat-message-input"]' --value '验证内容'
+pnpm --filter wework ai:verify click --session /path/to/session.json \
+  --selector '[data-testid="send-message-button"]'
+pnpm --filter wework ai:verify wait-for --session /path/to/session.json \
+  --selector '[data-testid="message-assistant"]' --text '完成'
+pnpm --filter wework ai:verify stop --session /path/to/session.json
+```
+
+可用操作包括 `snapshot`、`text`、`click`、`fill`、`press`、`wait-for`、`status` 和 `stop`。命令返回结构化 JSON；WebView 不可用、元素不存在或断言超时时，命令以非零状态退出。
+
+## 安全边界
+
+控制器只监听 `127.0.0.1`，并为每个会话生成一次性 Bearer token。该通道只有在 `ai:verify start` 启动的开发实例中通过 Vite 环境变量启用；普通开发与生产构建不会暴露控制接口。session 文件包含 token，应视为短期本地凭据，不应提交或共享。
+
+## AI 验证流程
+
+AI 应先执行 `snapshot` 确认路由和可用的 `data-testid`，再进行最小必要操作，并以 `wait-for` 加 `snapshot` 或 `text` 验证结果。结束时必须执行 `stop`；若失败，保留该会话目录中的 `app.log` 以便诊断。

--- a/wework/package.json
+++ b/wework/package.json
@@ -22,6 +22,7 @@
     "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:desktop": "node e2e/desktop/task-flow.e2e.mjs",
+    "ai:verify": "node scripts/ai-verify.mjs",
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -194,6 +194,9 @@ async function runServer(sessionPath, token) {
       VITE_WEWORK_E2E: 'true',
       VITE_WEWORK_DESKTOP_E2E_CONTROL_URL: controlUrl,
       VITE_WEWORK_DESKTOP_E2E_CONTROL_TOKEN: token,
+      CODEX_HOME: join(session.directory, 'executor-home', 'codex'),
+      DEVICE_ID: session.deviceId,
+      WEGENT_EXECUTOR_APP_IPC_SOCKET: join(session.directory, 'app-ipc.sock'),
       WEGENT_EXECUTOR_HOME: join(session.directory, 'executor-home'),
       WEGENT_EXECUTOR_LOG_DIR: session.directory,
     },
@@ -241,7 +244,17 @@ async function main() {
     const sessionPath = join(directory, 'session.json')
     await writeFile(
       sessionPath,
-      `${JSON.stringify({ version: 1, directory, token, status: 'starting' }, null, 2)}\n`
+      `${JSON.stringify(
+        {
+          version: 1,
+          deviceId: `ai-verify-${randomUUID()}`,
+          directory,
+          token,
+          status: 'starting',
+        },
+        null,
+        2
+      )}\n`
     )
     const child = spawn(
       process.execPath,

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -8,7 +8,7 @@
 import { createServer } from 'node:http'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { spawn } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -86,21 +86,64 @@ function authorized(request, token) {
   return request.headers.authorization === `Bearer ${token}`
 }
 
-async function stopProcessGroup(child) {
-  if (!child?.pid) return
+function execFileText(file, args) {
+  return new Promise((resolvePromise, reject) => {
+    execFile(file, args, { encoding: 'utf8' }, (error, stdout) => {
+      if (error) reject(error)
+      else resolvePromise(stdout)
+    })
+  })
+}
 
-  const signalGroup = signal => {
-    try {
-      process.kill(-child.pid, signal)
-      return true
-    } catch {
-      return false
-    }
+async function ownedSessionProcessIds(session) {
+  if (!Number.isInteger(session.launcherPid) || !session.socketPath) return []
+  const table = await execFileText('ps', ['-axo', 'pid=,ppid='])
+  const children = new Map()
+  for (const line of table.split('\n')) {
+    const [pidText, parentText] = line.trim().split(/\s+/)
+    const pid = Number(pidText)
+    const parentPid = Number(parentText)
+    if (!Number.isInteger(pid) || !Number.isInteger(parentPid)) continue
+    const values = children.get(parentPid) ?? []
+    values.push(pid)
+    children.set(parentPid, values)
   }
 
-  signalGroup('SIGTERM')
+  const candidates = []
+  const pending = [session.launcherPid]
+  while (pending.length > 0) {
+    const pid = pending.pop()
+    if (!pid || candidates.includes(pid)) continue
+    candidates.push(pid)
+    pending.push(...(children.get(pid) ?? []))
+  }
+
+  const owned = []
+  for (const pid of candidates) {
+    try {
+      const command = await execFileText('ps', ['eww', '-p', String(pid), '-o', 'command='])
+      if (command.includes(session.socketPath)) owned.push(pid)
+    } catch {
+      // The process may exit while the session is being stopped.
+    }
+  }
+  return owned
+}
+
+function signalProcesses(processIds, signal) {
+  for (const pid of processIds) {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // The process may have exited between discovery and signalling.
+    }
+  }
+}
+
+async function stopOwnedSessionProcesses(session) {
+  signalProcesses((await ownedSessionProcessIds(session)).reverse(), 'SIGTERM')
   await new Promise(resolvePromise => setTimeout(resolvePromise, 1_000))
-  if (signalGroup(0)) signalGroup('SIGKILL')
+  signalProcesses(await ownedSessionProcessIds(session), 'SIGKILL')
 }
 
 async function runServer(sessionPath, token) {
@@ -170,9 +213,10 @@ async function runServer(sessionPath, token) {
         }
       }
       if (request.method === 'POST' && url.pathname === '/shutdown') {
+        response.once('finish', () => {
+          void stopOwnedSessionProcesses(updated).finally(() => server.close(() => process.exit(0)))
+        })
         json(response, 200, { ok: true })
-        await stopProcessGroup(app)
-        server.close(() => process.exit(0))
         return
       }
       json(response, 404, { error: 'Not found' })
@@ -183,7 +227,12 @@ async function runServer(sessionPath, token) {
   )
   const address = server.address()
   const controlUrl = `http://127.0.0.1:${address.port}`
-  const updated = { ...session, controlUrl, status: 'starting' }
+  const updated = {
+    ...session,
+    controlUrl,
+    socketPath: join(session.directory, 'app-ipc.sock'),
+    status: 'starting',
+  }
   await writeFile(sessionPath, `${JSON.stringify(updated, null, 2)}\n`)
   const log = join(session.directory, 'app.log')
   app = spawn('bash', ['scripts/dev-mac-app.sh'], {
@@ -196,12 +245,13 @@ async function runServer(sessionPath, token) {
       VITE_WEWORK_DESKTOP_E2E_CONTROL_TOKEN: token,
       CODEX_HOME: join(session.directory, 'executor-home', 'codex'),
       DEVICE_ID: session.deviceId,
-      WEGENT_EXECUTOR_APP_IPC_SOCKET: join(session.directory, 'app-ipc.sock'),
+      WEGENT_EXECUTOR_APP_IPC_SOCKET: updated.socketPath,
       WEGENT_EXECUTOR_HOME: join(session.directory, 'executor-home'),
       WEGENT_EXECUTOR_LOG_DIR: session.directory,
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   })
+  await writeFile(sessionPath, `${JSON.stringify({ ...updated, launcherPid: app.pid }, null, 2)}\n`)
   for (const stream of [app.stdout, app.stderr])
     stream?.on(
       'data',

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+/**
+ * Starts and controls an isolated Wework development application for AI verification.
+ * The WebView performs the actions; this process only brokers authenticated loopback commands.
+ */
+
+import { createServer } from 'node:http'
+import { randomBytes, randomUUID } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const weworkDir = resolve(scriptDir, '..')
+const defaultTimeoutMs = 30_000
+
+function usage() {
+  console.error(`Usage:
+  pnpm --filter wework ai:verify start
+  pnpm --filter wework ai:verify <snapshot|click|fill|press|wait-for|text|status|stop> --session PATH [options]
+
+Options:
+  --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
+  --value TEXT              Replacement value for fill
+  --key KEY                 Keyboard key for press
+  --text TEXT               Expected text for wait-for
+  --timeout MS              Command timeout (default: ${defaultTimeoutMs})`)
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv
+  const options = {}
+  for (let index = 0; index < rest.length; index += 1) {
+    const value = rest[index]
+    if (!value.startsWith('--')) throw new Error(`Unexpected argument: ${value}`)
+    const key = value.slice(2)
+    const next = rest[index + 1]
+    if (!next || next.startsWith('--')) throw new Error(`Missing value for --${key}`)
+    options[key] = next
+    index += 1
+  }
+  return { command, options }
+}
+
+function json(response, status, value) {
+  response.writeHead(status, {
+    'access-control-allow-headers': 'authorization, content-type',
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-origin': '*',
+    'content-type': 'application/json; charset=utf-8',
+  })
+  response.end(`${JSON.stringify(value)}\n`)
+}
+
+function readBody(request) {
+  return new Promise((resolvePromise, reject) => {
+    let body = ''
+    request.setEncoding('utf8')
+    request.on('data', chunk => {
+      body += chunk
+    })
+    request.once('end', () => {
+      try {
+        resolvePromise(body ? JSON.parse(body) : {})
+      } catch (error) {
+        reject(error)
+      }
+    })
+    request.once('error', reject)
+  })
+}
+
+function withTimeout(promise, timeoutMs, message) {
+  let timer
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+    }),
+  ]).finally(() => clearTimeout(timer))
+}
+
+function authorized(request, token) {
+  return request.headers.authorization === `Bearer ${token}`
+}
+
+async function runServer(sessionPath, token) {
+  const session = JSON.parse(await readFile(sessionPath, 'utf8'))
+  const queue = []
+  const pending = new Map()
+  let ready = null
+  let app = null
+  const server = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+      if (request.method === 'OPTIONS') {
+        response.writeHead(204, {
+          'access-control-allow-headers': 'authorization, content-type',
+          'access-control-allow-methods': 'GET, POST, OPTIONS',
+          'access-control-allow-origin': '*',
+        })
+        return response.end()
+      }
+      if (!authorized(request, token)) return json(response, 401, { error: 'Unauthorized' })
+      if (request.method === 'POST' && url.pathname === '/ready') {
+        ready = await readBody(request)
+        return json(response, 200, { ok: true })
+      }
+      if (request.method === 'GET' && url.pathname === '/commands') {
+        const command = queue.shift()
+        if (!command) {
+          response.writeHead(204)
+          return response.end()
+        }
+        return json(response, 200, command)
+      }
+      if (request.method === 'POST' && url.pathname === '/results') {
+        const result = await readBody(request)
+        const waiter = pending.get(result.id)
+        if (!waiter) return json(response, 404, { error: `Unknown command ${result.id}` })
+        pending.delete(result.id)
+        result.ok
+          ? waiter.resolve(result.value ?? '')
+          : waiter.reject(new Error(result.error ?? 'WebView action failed'))
+        return json(response, 200, { ok: true })
+      }
+      if (request.method === 'GET' && url.pathname === '/status') {
+        return json(response, 200, {
+          ready: Boolean(ready),
+          readyInfo: ready,
+          pid: app?.pid ?? null,
+        })
+      }
+      if (request.method === 'POST' && url.pathname === '/command') {
+        if (!ready) return json(response, 409, { error: 'Wework WebView is not ready' })
+        const command = await readBody(request)
+        const id = randomUUID()
+        const timeoutMs = Number(command.timeoutMs) || defaultTimeoutMs
+        const result = new Promise((resolvePromise, reject) =>
+          pending.set(id, { resolve: resolvePromise, reject })
+        )
+        queue.push({ id, ...command })
+        try {
+          return json(response, 200, {
+            ok: true,
+            value: await withTimeout(result, timeoutMs, `Timed out running ${command.action}`),
+          })
+        } catch (error) {
+          pending.delete(id)
+          return json(response, 500, { ok: false, error: String(error.message ?? error) })
+        }
+      }
+      if (request.method === 'POST' && url.pathname === '/shutdown') {
+        json(response, 200, { ok: true })
+        if (app?.pid) {
+          try {
+            process.kill(-app.pid, 'SIGTERM')
+          } catch {
+            app.kill('SIGTERM')
+          }
+        }
+        server.close(() => process.exit(0))
+        return
+      }
+      json(response, 404, { error: 'Not found' })
+    })().catch(error => json(response, 500, { error: String(error.message ?? error) }))
+  })
+  await new Promise((resolvePromise, reject) =>
+    server.listen(0, '127.0.0.1', error => (error ? reject(error) : resolvePromise()))
+  )
+  const address = server.address()
+  const controlUrl = `http://127.0.0.1:${address.port}`
+  const updated = { ...session, controlUrl, status: 'starting' }
+  await writeFile(sessionPath, `${JSON.stringify(updated, null, 2)}\n`)
+  const log = join(session.directory, 'app.log')
+  app = spawn('bash', ['scripts/dev-mac-app.sh'], {
+    cwd: weworkDir,
+    detached: true,
+    env: {
+      ...process.env,
+      VITE_WEWORK_E2E: 'true',
+      VITE_WEWORK_DESKTOP_E2E_CONTROL_URL: controlUrl,
+      VITE_WEWORK_DESKTOP_E2E_CONTROL_TOKEN: token,
+      WEGENT_EXECUTOR_HOME: join(session.directory, 'executor-home'),
+      WEGENT_EXECUTOR_LOG_DIR: session.directory,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  for (const stream of [app.stdout, app.stderr])
+    stream?.on(
+      'data',
+      chunk => void import('node:fs/promises').then(({ appendFile }) => appendFile(log, chunk))
+    )
+  app.once('exit', code => {
+    for (const waiter of pending.values())
+      waiter.reject(new Error(`Wework exited with code ${code ?? 'unknown'}`))
+    pending.clear()
+  })
+}
+
+async function request(session, token, path, method = 'GET', body) {
+  const response = await fetch(`${session.controlUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const value = await response.json()
+  if (!response.ok || value.ok === false)
+    throw new Error(value.error ?? `Request failed with ${response.status}`)
+  return value
+}
+
+async function main() {
+  const { command, options } = parseArgs(process.argv.slice(2))
+  if (command === 'serve') return runServer(options.session, options.token)
+  if (command === 'start') {
+    const directory = join(
+      weworkDir,
+      'test-results',
+      'ai-verify',
+      `${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}`
+    )
+    await mkdir(directory, { recursive: true })
+    const token = randomBytes(32).toString('hex')
+    const sessionPath = join(directory, 'session.json')
+    await writeFile(
+      sessionPath,
+      `${JSON.stringify({ version: 1, directory, token, status: 'starting' }, null, 2)}\n`
+    )
+    const child = spawn(
+      process.execPath,
+      [fileURLToPath(import.meta.url), 'serve', '--session', sessionPath, '--token', token],
+      { detached: true, stdio: 'ignore' }
+    )
+    child.unref()
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const session = JSON.parse(await readFile(sessionPath, 'utf8'))
+      if (session.controlUrl) {
+        console.log(
+          JSON.stringify({ session: sessionPath, controlUrl: session.controlUrl }, null, 2)
+        )
+        return
+      }
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+    }
+    throw new Error('Timed out starting AI verification controller')
+  }
+  if (!options.session) throw new Error('--session is required')
+  const session = JSON.parse(await readFile(options.session, 'utf8'))
+  if (command === 'stop') {
+    await request(session, session.token, '/shutdown', 'POST')
+    return
+  }
+  if (command === 'status') {
+    console.log(JSON.stringify(await request(session, session.token, '/status'), null, 2))
+    return
+  }
+  const action = {
+    snapshot: 'snapshot',
+    click: 'click',
+    fill: 'fill',
+    press: 'press',
+    'wait-for': 'waitFor',
+    text: 'getText',
+  }[command]
+  if (!action) {
+    usage()
+    process.exitCode = 2
+    return
+  }
+  const selector =
+    options.selector ?? (command === 'snapshot' || command === 'text' ? 'body' : null)
+  if (!selector) throw new Error('--selector is required')
+  const value = await request(session, session.token, '/command', 'POST', {
+    action,
+    selector,
+    value: options.value,
+    key: options.key,
+    text: options.text,
+    timeoutMs: options.timeout ? Number(options.timeout) : undefined,
+  })
+  console.log(typeof value.value === 'string' ? value.value : JSON.stringify(value.value, null, 2))
+}
+
+main().catch(error => {
+  console.error(`ai:verify: ${error.message ?? error}`)
+  process.exitCode = 1
+})

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -86,6 +86,23 @@ function authorized(request, token) {
   return request.headers.authorization === `Bearer ${token}`
 }
 
+async function stopProcessGroup(child) {
+  if (!child?.pid) return
+
+  const signalGroup = signal => {
+    try {
+      process.kill(-child.pid, signal)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  signalGroup('SIGTERM')
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 1_000))
+  if (signalGroup(0)) signalGroup('SIGKILL')
+}
+
 async function runServer(sessionPath, token) {
   const session = JSON.parse(await readFile(sessionPath, 'utf8'))
   const queue = []
@@ -154,13 +171,7 @@ async function runServer(sessionPath, token) {
       }
       if (request.method === 'POST' && url.pathname === '/shutdown') {
         json(response, 200, { ok: true })
-        if (app?.pid) {
-          try {
-            process.kill(-app.pid, 'SIGTERM')
-          } catch {
-            app.kill('SIGTERM')
-          }
-        }
+        await stopProcessGroup(app)
         server.close(() => process.exit(0))
         return
       }

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -12,7 +12,7 @@ const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRC
 const DESKTOP_CONTROL_RETRY_DELAY_MS = 250
 const DESKTOP_CONTROL_IDLE_POLL_DELAY_MS = 50
 
-type DesktopControlAction = 'click' | 'fill' | 'getText' | 'snapshot' | 'waitFor'
+type DesktopControlAction = 'click' | 'fill' | 'getText' | 'snapshot' | 'waitFor' | 'press'
 
 interface DesktopControlCommand {
   id: string
@@ -22,6 +22,7 @@ interface DesktopControlCommand {
   text?: string
   timeoutMs?: number
   enabled?: boolean
+  key?: string
 }
 
 interface DesktopControlResult {
@@ -64,6 +65,11 @@ function isAutomationEnabled(): boolean {
 function desktopControlUrl(): string | null {
   const value = import.meta.env.VITE_WEWORK_DESKTOP_E2E_CONTROL_URL?.trim()
   return value ? value.replace(/\/+$/, '') : null
+}
+
+function desktopControlHeaders(): HeadersInit | undefined {
+  const token = import.meta.env.VITE_WEWORK_DESKTOP_E2E_CONTROL_TOKEN?.trim()
+  return token ? { Authorization: `Bearer ${token}` } : undefined
 }
 
 function normalizeAppPath(path: string): string {
@@ -278,13 +284,23 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       fillDesktopControlElement(element, command.value ?? '')
       return element.textContent?.trim() ?? ''
     }
+    case 'press': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      element.focus()
+      const key = command.key ?? ''
+      for (const type of ['keydown', 'keyup']) {
+        element.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true, cancelable: true }))
+      }
+      return element.textContent?.trim() ?? ''
+    }
   }
 }
 
 async function postDesktopControlResult(url: string, result: DesktopControlResult): Promise<void> {
   const response = await fetch(`${url}/results`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...desktopControlHeaders() },
     body: JSON.stringify(result),
   })
   if (!response.ok) {
@@ -295,13 +311,13 @@ async function postDesktopControlResult(url: string, result: DesktopControlResul
 async function runDesktopControlClient(url: string): Promise<void> {
   await fetch(`${url}/ready`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...desktopControlHeaders() },
     body: JSON.stringify({ location: window.location.href }),
   })
 
   while (true) {
     try {
-      const response = await fetch(`${url}/commands`)
+      const response = await fetch(`${url}/commands`, { headers: desktopControlHeaders() })
       if (response.status === 204) {
         await new Promise(resolve => window.setTimeout(resolve, DESKTOP_CONTROL_IDLE_POLL_DELAY_MS))
         continue


### PR DESCRIPTION
## What changed
- Added an isolated `ai:verify` CLI for driving the real Wework desktop WebView during development.
- Added authenticated loopback control, session-scoped runtime isolation, and ownership-scoped process cleanup.
- Added a Chinese and English developer guide for AI verification sessions.

## Why
AI development work could not validate Wework desktop interactions in the real app without risking a developer's active Wework runtime.

## Validation
- `pnpm --filter wework test`
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- Pre-push AI quality gate (ESLint, TypeScript, and unit tests)

## Notes
The PR is draft because the isolated send-message flow still needs a deterministic model-provider fixture before it can safely validate an assistant response end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI verification workflow for isolated Wework desktop app testing.
  * Added commands to inspect and interact with the app, including snapshots, clicks, text entry, key presses, waits, assertions, status checks, and session shutdown.
  * Commands return structured results and report failures through non-zero exit codes.
* **Documentation**
  * Added English and Chinese guides covering workflows, security considerations, session artifacts, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->