### PR TITLE
fix(wework): dismiss error card when retrying

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -3813,6 +3813,7 @@ describe('MessageList', () => {
     await user.click(screen.getByTestId('assistant-error-retry'))
 
     expect(onRetryFailedMessage).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+    expect(screen.queryByTestId('assistant-error-card')).not.toBeInTheDocument()
   })
 
   test('classifies hidden raw failed content before generic task status errors', () => {
@@ -3892,11 +3893,12 @@ describe('MessageList', () => {
       />
     )
 
-    await user.click(screen.getByTestId('assistant-error-retry'))
     await user.click(screen.getByTestId('assistant-error-switch-model-retry'))
+    await user.click(screen.getByTestId('assistant-error-retry'))
 
     expect(onRetryFailedMessage).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
     expect(onSwitchModelForFailedMessage).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+    expect(screen.queryByTestId('assistant-error-card')).not.toBeInTheDocument()
   })
 
   test('uses backend error type before raw error text when rendering failed messages', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1709,6 +1709,7 @@ function AssistantErrorCard({
 }) {
   const { t } = useTranslation('chat')
   const [isDetailExpanded, setIsDetailExpanded] = useState(false)
+  const [isDismissed, setIsDismissed] = useState(false)
   const displayError = rawError || error
   const hasErrorDetails = Boolean(displayError)
   const parsedError = parseChatError(displayError ?? '', errorType)
@@ -1733,6 +1734,10 @@ function AssistantErrorCard({
             ),
           })
 
+  if (isDismissed) {
+    return null
+  }
+
   return (
     <div
       data-testid="assistant-error-card"
@@ -1756,7 +1761,10 @@ function AssistantErrorCard({
           <button
             type="button"
             data-testid="assistant-error-retry"
-            onClick={() => onRetry?.(message)}
+            onClick={() => {
+              setIsDismissed(true)
+              onRetry?.(message)
+            }}
             className="h-8 rounded-lg border border-border bg-base px-3 text-xs font-semibold text-text-secondary hover:bg-muted hover:text-text-primary"
           >
             {t('assistant_error.actions.retry', '重试')}


### PR DESCRIPTION
## 变更内容
- 点击失败消息卡片的普通“重试”后，立即隐藏当前错误卡片。
- 补充 MessageList 回归测试，覆盖重试后错误卡片消失。

## 原因与影响
失败消息会保持 failed 状态；重试只启动新的请求，旧错误卡片原本仍继续渲染。现在用户点击重试后，旧失败提示会从界面移除，避免和新一轮生成状态同时出现。

## 验证
- pnpm --filter wework test -- --run src/components/chat/MessageList.test.tsx
- pnpm --filter wework exec eslint src/components/chat/MessageList.tsx src/components/chat/MessageList.test.tsx
- git diff --check
- pre-push: ESLint / TypeScript / Unit Tests passed

## 说明
- 已在提交 PR 前拉取最新 origin/main，并 fast-forward 到 4949252f7。
- 未补文档：这是 Wework 错误卡片交互修复，不涉及 README、AGENTS、API 或用户配置文档。
- 未执行桌面 AI 验证：仓库当前没有 wework/scripts/ai-verify.mjs。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error cards now disappear immediately after users select Retry or switch models.
  * Improved retry interactions for failed assistant responses, preventing dismissed error messages from remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->