### PR TITLE
fix(wework): refine environment info defaults

### DIFF
--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -343,6 +343,41 @@ describe('loadProjectEnvironment', () => {
     })
   })
 
+  test('does not surface an error when the workspace is not a git repository', async () => {
+    const executeCommand = vi.fn().mockResolvedValue({
+      success: false,
+      stdout: '',
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+    })
+
+    const info = await loadProjectEnvironment(
+      { executeCommand },
+      {
+        id: 3,
+        name: 'plain-workspace',
+        config: {
+          mode: 'workspace',
+          execution: {
+            targetType: 'local',
+            deviceId: 'device-123',
+          },
+          workspace: {
+            source: 'local_path',
+            localPath: '/workspace/plain-workspace',
+          },
+        },
+      }
+    )
+
+    expect(info).toEqual({
+      additions: '+0',
+      deletions: '-0',
+      executionTarget: 'local',
+      deviceId: 'device-123',
+      workspacePath: '/workspace/plain-workspace',
+    })
+  })
+
   test('deduplicates repeated environment loads for the same project briefly', async () => {
     const executeCommand = vi
       .fn()

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -100,6 +100,10 @@ function cloneEnvironmentInfo(info: EnvironmentInfo): EnvironmentInfo {
   return { ...info }
 }
 
+function isNotGitRepositoryError(error: unknown): boolean {
+  return error instanceof Error && /not a git repository/i.test(error.message)
+}
+
 function getEnvironmentInfoCache(api: DeviceCommandApi): Map<string, EnvironmentInfoCacheEntry> {
   let cache = environmentInfoCaches.get(api)
   if (!cache) {
@@ -453,6 +457,10 @@ async function loadProjectEnvironmentUncached(
       createPullRequestUrl: buildPullRequestUrl(remoteUrl, branchName),
     }
   } catch (error) {
+    if (isNotGitRepositoryError(error)) {
+      return environmentWorkspaceInfo
+    }
+
     return {
       ...environmentWorkspaceInfo,
       error: error instanceof Error ? error.message : 'Failed to load environment info',

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -37,6 +37,7 @@ interface EnvironmentInfoPopoverProps {
   info: EnvironmentInfo
   popoverContainer: HTMLElement | null
   docked?: boolean
+  defaultOpen?: boolean
   floatingFooter?: ReactNode
   devices?: DeviceInfo[]
   onRefresh?: () => Promise<void>
@@ -59,6 +60,7 @@ export function EnvironmentInfoPopover({
   info,
   popoverContainer,
   docked = true,
+  defaultOpen = false,
   floatingFooter,
   devices = [],
   onRefresh,
@@ -71,7 +73,7 @@ export function EnvironmentInfoPopover({
   onOpenChangesReview,
 }: EnvironmentInfoPopoverProps) {
   const { t } = useTranslation('common')
-  const [open, setOpen] = useState(docked)
+  const [open, setOpen] = useState(docked && defaultOpen)
   const [workspacePathCopied, setWorkspacePathCopied] = useState(false)
   const [commitFormOpen, setCommitFormOpen] = useState(false)
   const [commitMessage, setCommitMessage] = useState('')

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -146,10 +146,25 @@ describe('WorkspacePanelActions', () => {
     expect(screen.getByTestId('toggle-right-workspace-panel-button')).toBeInTheDocument()
   })
 
-  test('opens environment info by default when the workspace is wide', () => {
+  test('keeps environment info collapsed by default in a conversation', () => {
     setWindowWidth(1280)
 
     render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+
+    expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+  })
+
+  test('opens environment info by default in a project', () => {
+    setWindowWidth(1280)
+
+    render(
+      <WorkspacePanelActions
+        {...baseProps}
+        mode="environment"
+        currentProject={{ id: 7, name: 'project38', config: {}, tasks: [] }}
+      />
+    )
 
     expect(screen.getByTestId('environment-info-button')).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
@@ -168,7 +183,7 @@ describe('WorkspacePanelActions', () => {
     expect(screen.getByTestId('environment-info-popover')).toHaveClass('fixed', 'z-system')
   })
 
-  test('renders environment info in its dedicated right-side container', () => {
+  test('renders environment info in its dedicated right-side container', async () => {
     setWindowWidth(1280)
     const workspaceContainer = document.createElement('main')
     document.body.append(workspaceContainer)
@@ -181,6 +196,8 @@ describe('WorkspacePanelActions', () => {
           environmentInfoPopoverContainer={workspaceContainer}
         />
       )
+
+      await userEvent.click(screen.getByTestId('environment-info-button'))
 
       const popover = screen.getByTestId('environment-info-popover')
       expect(workspaceContainer).toContainElement(popover)
@@ -200,8 +217,12 @@ describe('WorkspacePanelActions', () => {
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
   })
 
-  test('closes environment info when the dock becomes unavailable', () => {
+  test('closes environment info when the dock becomes unavailable', async () => {
     const { rerender } = render(<WorkspacePanelActions {...baseProps} mode="environment" />)
+
+    expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('environment-info-button'))
 
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
 

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -170,6 +170,7 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
           info={environmentInfo}
           popoverContainer={environmentInfoPopoverContainer}
           docked={environmentInfoDocked}
+          defaultOpen={Boolean(currentProject)}
           floatingFooter={environmentInfoFloatingFooter}
           devices={devices}
           onRefresh={onRefreshEnvironmentInfo}


### PR DESCRIPTION
## Summary

- Keep environment information collapsed by default in conversations and expanded in projects.
- Suppress the raw Git error when a workspace is not a Git repository.
- Cover both context defaults and non-Git environment loading.

## Why

The conversation UI exposed a Git command failure for non-Git folders and opened environment details unexpectedly.

## Validation

- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework test` (1,477 tests)
- `git diff --check`