### PR TITLE
fix(wework): focus composer for new chats

### DIFF
--- a/wework/src/components/layout/DesktopEmptyTaskLauncher.test.tsx
+++ b/wework/src/components/layout/DesktopEmptyTaskLauncher.test.tsx
@@ -30,6 +30,21 @@ function LauncherHarness({
 }
 
 describe('DesktopEmptyTaskLauncher', () => {
+  test('focuses the composer when the new chat view opens', async () => {
+    render(<LauncherHarness />)
+
+    await waitFor(() => expect(screen.getByTestId('chat-message-input')).toHaveFocus())
+  })
+
+  test('focuses the composer when a new chat is requested', async () => {
+    render(<LauncherHarness />)
+    screen.getByTestId('empty-project-title-button').focus()
+
+    window.dispatchEvent(new Event('wework:focus-new-chat-composer'))
+
+    await waitFor(() => expect(screen.getByTestId('chat-message-input')).toHaveFocus())
+  })
+
   test('renders the project-aware heading and ordered suggestion categories', () => {
     render(<LauncherHarness />)
 

--- a/wework/src/components/layout/DesktopEmptyTaskLauncher.tsx
+++ b/wework/src/components/layout/DesktopEmptyTaskLauncher.tsx
@@ -1,6 +1,7 @@
 import { Bot, Bug, ChevronLeft, Hammer, Megaphone, RefreshCw } from 'lucide-react'
-import { useRef, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { WORKBENCH_NEW_CHAT_FOCUS_EVENT } from '@/lib/workbenchComposerFocus'
 import { cn } from '@/lib/utils'
 import styles from './DesktopEmptyTaskLauncher.module.css'
 
@@ -128,6 +129,16 @@ export function DesktopEmptyTaskLauncher({
   const selectedCategory = TASK_SUGGESTION_CATEGORIES.find(
     category => category.id === selectedCategoryId
   )
+
+  useEffect(() => {
+    const focusComposer = () => {
+      launcherRef.current?.querySelector<HTMLElement>('[data-testid="chat-message-input"]')?.focus()
+    }
+
+    focusComposer()
+    window.addEventListener(WORKBENCH_NEW_CHAT_FOCUS_EVENT, focusComposer)
+    return () => window.removeEventListener(WORKBENCH_NEW_CHAT_FOCUS_EVENT, focusComposer)
+  }, [])
 
   const selectSuggestion = (prompt: string) => {
     onSelectSuggestion(prompt)

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -3048,11 +3048,14 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
 
+    const focusRequest = vi.fn()
+    window.addEventListener('wework:focus-new-chat-composer', focusRequest, { once: true })
     await userEvent.click(screen.getByText('start new project task'))
 
     await waitFor(() =>
       expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent('none')
     )
+    await waitFor(() => expect(focusRequest).toHaveBeenCalledTimes(1))
     expect(screen.getByTestId('active-pane-key')).toHaveTextContent('project:7')
     expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('')
     expect(screen.getByTestId('pane-goal-draft-active')).toHaveTextContent('inactive')

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -6,6 +6,7 @@ import { navigateTo } from '@/lib/navigation'
 import { supportsGitWorktreeExecution } from '@/lib/projectClassification'
 import { runtimeContextUsageMetrics } from '@/lib/runtime-context-usage'
 import { resolveLocalWorkbenchDeviceId } from '@/lib/workbench-device'
+import { requestNewChatComposerFocus } from '@/lib/workbenchComposerFocus'
 import { installLocalWorkspaceOpenListener } from '@/tauri/localWorkspaceOpen'
 import { createLocalCodexPluginApi } from '@/api/local/codexPlugins'
 import type {
@@ -624,6 +625,7 @@ export function WorkbenchProvider({
       standaloneWorkspacePath: null,
     })
     navigateTo('/')
+    requestNewChatComposerFocus()
   }, [state.devices, state.standaloneDeviceId, user])
 
   const startStandaloneChat = useCallback(() => {
@@ -644,6 +646,7 @@ export function WorkbenchProvider({
     (projectId: number) => {
       const deviceWorkspaceId = getSingleProjectDeviceWorkspaceId(state.runtimeWork, projectId)
       selectProjectWorkspace(projectId, deviceWorkspaceId)
+      requestNewChatComposerFocus()
     },
     [selectProjectWorkspace, state.runtimeWork]
   )

--- a/wework/src/lib/workbenchComposerFocus.ts
+++ b/wework/src/lib/workbenchComposerFocus.ts
@@ -1,0 +1,7 @@
+export const WORKBENCH_NEW_CHAT_FOCUS_EVENT = 'wework:focus-new-chat-composer'
+
+export function requestNewChatComposerFocus() {
+  window.requestAnimationFrame(() => {
+    window.dispatchEvent(new Event(WORKBENCH_NEW_CHAT_FOCUS_EVENT))
+  })
+}


### PR DESCRIPTION
## Summary
- Focus the desktop composer when a new chat view opens or is requested again.
- Trigger the same focus request when creating a project conversation.
- Add regression coverage for both focus paths.

## Root cause
Project conversation creation used `startNewProjectChat`, which did not request composer focus.

## Validation
- `pnpm --filter wework exec vitest run src/features/workbench/WorkbenchProvider.test.tsx src/components/layout/DesktopEmptyTaskLauncher.test.tsx`
- `pnpm --filter wework lint`
- Pre-push gate: ESLint, TypeScript, and Wework unit tests