### PR TITLE
fix(wework): reuse executor dev builds across worktrees

### DIFF
--- a/executor/src/bin/wegent-executor-dev.rs
+++ b/executor/src/bin/wegent-executor-dev.rs
@@ -29,7 +29,7 @@ fn main() {
 }
 
 fn run() -> Result<(), String> {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = executor_source_dir();
     let manifest_path = manifest_dir.join("Cargo.toml");
     let executor_args = env::args().skip(1).collect::<Vec<_>>();
     let (tx, rx) = mpsc::channel::<DevEvent>();
@@ -76,6 +76,13 @@ fn run() -> Result<(), String> {
             restart_requested = true;
         }
     }
+}
+
+fn executor_source_dir() -> PathBuf {
+    env::var_os("WEGENT_EXECUTOR_SOURCE_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
 }
 
 fn watch_executor_sources(
@@ -303,6 +310,15 @@ mod tests {
                 .join("debug")
                 .join(executable_name())
         );
+    }
+
+    #[test]
+    fn executor_source_dir_uses_runtime_override() {
+        let _guard = env_lock();
+        let source_dir = PathBuf::from("/tmp/wegent-executor-source");
+        let _env = EnvVarGuard::set("WEGENT_EXECUTOR_SOURCE_DIR", &source_dir);
+
+        assert_eq!(executor_source_dir(), source_dir);
     }
 
     fn executable_name() -> &'static str {

--- a/executor/tests/build_entrypoint_contract.rs
+++ b/executor/tests/build_entrypoint_contract.rs
@@ -70,6 +70,8 @@ fn executor_build_entrypoints_use_rust_binary_build() {
     assert!(dev_sidecar.contains("--bin wegent-executor-dev"));
     assert!(dev_sidecar.contains("cargo build"));
     assert!(dev_sidecar.contains("configure_wegent_cargo_target_dir \"$PROJECT_DIR\" \"executor\""));
+    assert!(dev_sidecar.contains("executor-dev/$(executor_source_cache_key)"));
+    assert!(dev_sidecar.contains("WEGENT_EXECUTOR_SOURCE_DIR"));
     assert!(dev_sidecar
         .contains("cargo_target_binary_path \"$EXECUTOR_DIR\" debug wegent-executor-dev"));
     assert!(!dev_sidecar.contains("exec cargo run"));

--- a/wework/scripts/dev-executor-sidecar.sh
+++ b/wework/scripts/dev-executor-sidecar.sh
@@ -14,7 +14,38 @@ if [ "${WEGENT_CARGO_TARGET_DIR_AUTO:-0}" = "1" ]; then
   unset CARGO_TARGET_DIR
   unset WEGENT_CARGO_TARGET_DIR_AUTO
 fi
-configure_wegent_cargo_target_dir "$PROJECT_DIR" "executor"
+
+executor_source_cache_key() {
+  (
+    cd "$EXECUTOR_DIR"
+    {
+      shasum Cargo.toml Cargo.lock
+      find src -type f -exec shasum {} + | LC_ALL=C sort
+    } | shasum | awk '{print $1}'
+  )
+}
+
+configure_executor_dev_target_dir() {
+  if [ "${WEGENT_DISABLE_SHARED_CARGO_TARGET:-0}" = "1" ] || [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    configure_wegent_cargo_target_dir "$PROJECT_DIR" "executor"
+    return 0
+  fi
+
+  local cache_root
+  cache_root="$(wegent_cargo_cache_root)"
+  if [ -z "$cache_root" ]; then
+    configure_wegent_cargo_target_dir "$PROJECT_DIR" "executor"
+    return 0
+  fi
+
+  export CARGO_TARGET_DIR="$cache_root/executor-dev/$(executor_source_cache_key)"
+  export WEGENT_CARGO_TARGET_DIR_AUTO=1
+  mkdir -p "$CARGO_TARGET_DIR"
+  configure_wegent_sccache "$PROJECT_DIR" "$CARGO_TARGET_DIR"
+}
+
+configure_executor_dev_target_dir
+export WEGENT_EXECUTOR_SOURCE_DIR="$EXECUTOR_DIR"
 
 if [ "${WEGENT_EXECUTOR_DEV_RELOAD:-1}" != "0" ] && [ -z "${WEGENT_EXECUTOR_BINARY:-}" ]; then
   cargo build \


### PR DESCRIPTION
## What changed

- Partition the executor hot-reload Cargo target by executor source snapshot.
- Keep sccache enabled for cross-worktree Rust compilation reuse.
- Resolve the executor source directory at runtime so the shared dev launcher watches the active worktree.

## Why

A single shared executor target accumulated incompatible worktree artifacts and repeatedly rebuilt large dependency sets during Wework debugging.

## Validation

- `bash scripts/tests/cargo-cache.test.sh`
- `cargo test --manifest-path executor/Cargo.toml --features dev-reload --bin wegent-executor-dev`
- `cargo test --manifest-path executor/Cargo.toml --test build_entrypoint_contract`
- `cargo fmt --manifest-path executor/Cargo.toml --check`
- `bash -n wework/scripts/dev-executor-sidecar.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development executor setup to reliably locate source files at runtime.
  * Enhanced build caching so changes to executor sources and configuration correctly produce refreshed builds.
  * Added safeguards for existing or shared build directory configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->