### PR TITLE
fix(wework): defer worktree cleanup

### DIFF
--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -8,7 +8,10 @@ use std::{
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
     time::{Duration, Instant},
 };
 
@@ -76,6 +79,7 @@ const SEARCH_SNIPPET_CONTEXT_CHARS: usize = 80;
 const SEARCH_SNIPPET_MAX_CHARS: usize = 240;
 const ARCHIVED_BACKGROUND_THREAD_DELETE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const ARCHIVED_BACKGROUND_DELETE_INTERVAL: Duration = Duration::from_millis(250);
+const WORKTREE_AUTO_CLEANUP_IDLE_DELAY: Duration = Duration::from_secs(5 * 60);
 const CODEX_OFFICIAL_PROVIDER_ID: &str = "openai";
 const CODEX_OFFICIAL_PROVIDER_NAME: &str = "CodeX";
 
@@ -250,6 +254,7 @@ pub struct RuntimeWorkRpcHandler {
     transcript_cache: TranscriptCache,
     thread_list_cache: CodexThreadListCache,
     worktrees: WorktreeManager,
+    worktree_cleanup_generation: Arc<AtomicU64>,
 }
 
 struct ActiveTurnCancellation {
@@ -307,6 +312,7 @@ impl RuntimeWorkRpcHandler {
             transcript_cache: TranscriptCache::default(),
             thread_list_cache: CodexThreadListCache::default(),
             worktrees: WorktreeManager::from_env(),
+            worktree_cleanup_generation: Arc::new(AtomicU64::new(0)),
         };
         handler.spawn_archived_delete_worker(archived_delete_rx);
         handler
@@ -421,13 +427,50 @@ impl RuntimeWorkRpcHandler {
             .worktrees
             .prepare(Path::new(&source_path), &worktree_id, git_ref.as_deref())
             .map_err(|error| AppIpcError::new("worktree_prepare_failed", error))?;
-        let _ = self.worktrees.prune(&self.store.list_task_summaries(true));
+        self.schedule_worktree_prune();
         Ok(json!({
             "success": true,
             "deviceId": self.device_id,
             "worktree": record,
             "path": record.path,
         }))
+    }
+
+    fn schedule_worktree_prune(&self) {
+        let generation = self
+            .worktree_cleanup_generation
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
+        let cleanup_generation = self.worktree_cleanup_generation.clone();
+        let worktrees = self.worktrees.clone();
+        let store = self.store.clone();
+        tokio::spawn(async move {
+            loop {
+                sleep(WORKTREE_AUTO_CLEANUP_IDLE_DELAY).await;
+                if cleanup_generation.load(Ordering::SeqCst) != generation {
+                    return;
+                }
+
+                let tasks = store.list_task_summaries(true);
+                if tasks.iter().any(|task| task.running) {
+                    continue;
+                }
+
+                let result = tokio::task::spawn_blocking(move || worktrees.prune(&tasks)).await;
+                match result {
+                    Ok(Err(error)) => {
+                        wework_debug_log(&format!("background worktree cleanup failed: {error}"));
+                    }
+                    Err(error) => {
+                        wework_debug_log(&format!(
+                            "background worktree cleanup task failed: {error}"
+                        ));
+                    }
+                    Ok(Ok(_)) => {}
+                }
+                return;
+            }
+        });
     }
 
     async fn list_worktrees(&self) -> Result<Value, AppIpcError> {
@@ -1712,6 +1755,7 @@ impl RuntimeWorkRpcHandler {
         }
         let runtime_handle = runtime_handle_json(&link);
         self.upsert_local_task(link);
+        self.schedule_worktree_prune();
         let initial_thread_goal = initial_thread_goal_from_payload(&payload);
         let mut side_source = side_source_thread(&payload);
         if let Some(source) = &mut side_source {
@@ -1868,6 +1912,7 @@ impl RuntimeWorkRpcHandler {
             &request,
             &payload,
         );
+        self.schedule_worktree_prune();
         let link_for_send = existing_link.as_ref().or(recovered_link.as_ref());
         let ephemeral = request.ephemeral || link_for_send.is_some_and(|link| link.ephemeral);
         let direct_thread_id = ephemeral.then(|| thread_id.clone());

--- a/executor/src/runtime_work/worktrees.rs
+++ b/executor/src/runtime_work/worktrees.rs
@@ -342,8 +342,8 @@ impl WorktreeManager {
         let mut active = self
             .list(tasks)?
             .into_iter()
+            .filter(|(record, linked_tasks)| is_auto_prune_candidate(record, linked_tasks))
             .map(|(record, _)| record)
-            .filter(|record| record.state == "active")
             .collect::<Vec<_>>();
         active.sort_by_key(|record| std::cmp::Reverse(record.updated_at));
         let mut removed = Vec::new();
@@ -683,6 +683,10 @@ fn same_path(left: &str, right: &str) -> bool {
     normalized_path_key(Path::new(left)) == normalized_path_key(Path::new(right))
 }
 
+fn is_auto_prune_candidate(record: &ManagedWorktree, linked_tasks: &[RuntimeTaskLink]) -> bool {
+    record.state == "active" && linked_tasks.iter().all(|task| task.status == "archived")
+}
+
 fn now_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -693,6 +697,7 @@ fn now_ms() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
 
     #[test]
     fn default_settings_match_codex() {
@@ -758,6 +763,19 @@ mod tests {
     }
 
     #[test]
+    fn auto_prune_only_selects_archived_or_unlinked_worktrees() {
+        let record = ManagedWorktree::default();
+        let mut active_task = task_link("active");
+        active_task.status = "active".to_owned();
+        let mut archived_task = task_link("archived");
+        archived_task.status = "archived".to_owned();
+
+        assert!(!is_auto_prune_candidate(&record, &[active_task]));
+        assert!(is_auto_prune_candidate(&record, &[archived_task]));
+        assert!(is_auto_prune_candidate(&record, &[]));
+    }
+
+    #[test]
     fn discovered_worktree_includes_source_repository_path() {
         let root = env::temp_dir().join(format!("wegent-worktree-discovery-test-{}", now_ms()));
         let source = root.join("source");
@@ -817,5 +835,25 @@ mod tests {
             "{}",
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn task_link(id: &str) -> RuntimeTaskLink {
+        RuntimeTaskLink {
+            local_task_id: id.to_owned(),
+            thread_id: None,
+            workspace_path: format!("/tmp/{id}"),
+            title: id.to_owned(),
+            runtime: "codex".to_owned(),
+            status: "active".to_owned(),
+            running: false,
+            goal_status: None,
+            created_at: 0,
+            updated_at: 0,
+            runtime_handle: Value::Null,
+            parent: None,
+            ephemeral: false,
+            list_order: None,
+            group_workspace_path: None,
+        }
     }
 }


### PR DESCRIPTION
## Summary
- defer automatic worktree cleanup until five minutes after the most recent worktree or task activity
- keep postponing cleanup while runtime tasks are running
- limit automatic cleanup candidates to archived or unlinked worktrees, preserving active conversations

## Why
Creating a worktree synchronously triggered Git worktree deletion. Large worktrees could make that cleanup exceed the local executor timeout and cause message sends to fail.

## Validation
- `cargo test -p wegent-executor runtime_work::worktrees::tests --lib`
- `cargo check -p wegent-executor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic background cleanup for inactive worktrees.
  * Cleanup now runs after a period of inactivity and avoids interfering with active tasks.

* **Bug Fixes**
  * Improved worktree cleanup safety by retaining worktrees linked to non-archived tasks.
  * Prevented overlapping cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->