### PR TITLE
fix(codex): upgrade bundled runtime to 0.144.2

### DIFF
--- a/docs/en/developer-guide/architecture.md
+++ b/docs/en/developer-guide/architecture.md
@@ -366,6 +366,8 @@ EXECUTOR_IMAGE: wegent-executor:latest # Executor image
 
 Rust executor is the only executor runtime implementation. Backend Chat shell work may still use an in-process path, while other tasks run through standalone/local executor. In Wework packaged App local-first mode, the app does not start a local Backend; it calls the executor sidecar directly over Tauri app IPC. Codex runtime control uses `codex app-server --stdio` JSON-RPC to create, continue, read, archive, and rename threads. The executor stores only the local task index and the required `localTaskId -> threadId` mapping.
 
+When Codex uses a shared app-server thread, cancelling an active turn must await acknowledgement of `turn/interrupt` before reporting cancellation to the caller. A retry can then start only after the previous turn has stopped, preventing an interrupt and a new request from interleaving and replaying cancelled input or dropping the retry message.
+
 **Core Features**:
 - 🔒 Fully isolated execution environment
 - 💼 Independent workspace

--- a/docs/zh/developer-guide/architecture.md
+++ b/docs/zh/developer-guide/architecture.md
@@ -366,6 +366,8 @@ EXECUTOR_IMAGE: wegent-executor:latest # 执行器镜像
 
 Rust executor 是唯一的 executor 运行时实现。Backend 的 Chat shell 仍可走进程内路径，其他任务由 standalone/local executor 执行；Wework 打包 App 的 local-first 模式不启动本地 Backend，而是通过 Tauri app IPC 直接调用 executor。Codex 运行时通过 `codex app-server --stdio` 的 JSON-RPC 协议创建、继续、读取、归档和重命名线程，executor 只保存必要的本地任务索引和 `localTaskId -> threadId` 关联。
 
+Codex 使用共享 app-server 线程时，取消活动轮次必须先等待 `turn/interrupt` 的确认，再向调用方报告已取消。这样重试会在前一轮真正停止后创建，避免上一轮的中断和新轮请求交错，从而恢复已取消的输入或丢失重试消息。
+
 **核心特性**：
 - 🔒 完全隔离的执行环境
 - 💼 独立的工作空间

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -1229,11 +1229,16 @@ async fn read_shared_turn_notifications(
                 _ = cancel_rx => {
                     options.cancellation = None;
                     if let Some(turn_id) = options.active_turn_id.as_deref() {
-                        interrupt_shared_turn_detached(
-                            client.clone(),
-                            thread_id.to_owned(),
-                            turn_id.to_owned(),
-                        );
+                        if let Err(error) = interrupt_shared_turn(client, thread_id, turn_id).await {
+                            log_executor_event(
+                                "codex shared turn interrupt failed",
+                                &[
+                                    ("thread_id", thread_id.to_owned()),
+                                    ("turn_id", turn_id.to_owned()),
+                                    ("error", error),
+                                ],
+                            );
+                        }
                     }
                     return Err(CODEX_APP_SERVER_TURN_CANCELLED.to_owned());
                 }
@@ -1344,25 +1349,6 @@ async fn interrupt_shared_turn(
         )
         .await
         .map(|_| ())
-}
-
-fn interrupt_shared_turn_detached(
-    client: CodexAppServerClient,
-    thread_id: String,
-    turn_id: String,
-) {
-    tokio::spawn(async move {
-        if let Err(error) = interrupt_shared_turn(&client, &thread_id, &turn_id).await {
-            log_executor_event(
-                "codex shared turn interrupt failed",
-                &[
-                    ("thread_id", thread_id),
-                    ("turn_id", turn_id),
-                    ("error", error),
-                ],
-            );
-        }
-    });
 }
 
 async fn answer_shared_request_user_input(

--- a/wework/codex-binaries.lock.json
+++ b/wework/codex-binaries.lock.json
@@ -1,40 +1,40 @@
 {
-  "codexVersion": "0.144.1",
+  "codexVersion": "0.144.2",
   "registry": "https://registry.npmjs.org",
   "targets": {
     "aarch64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "sha256": "365a5685170f66bad58dd1dabb0462dfb824f82a870bcc8d9af2eb0a41cf2e18",
+      "version": "0.144.2-darwin-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-arm64.tgz",
+      "integrity": "sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==",
       "binaryPath": "vendor/aarch64-apple-darwin/bin/codex"
     },
     "x86_64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "sha256": "03e708c91834be795559a377b81cc12881e6d852ffa428693726f2a47e6132e0",
+      "version": "0.144.2-darwin-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-x64.tgz",
+      "integrity": "sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==",
       "binaryPath": "vendor/x86_64-apple-darwin/bin/codex"
     },
     "x86_64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "sha256": "e2a64d421c10aaf0b7e3c0e8bd71b71e497d75823003318b674a278d71add0c7",
+      "version": "0.144.2-linux-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-x64.tgz",
+      "integrity": "sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==",
       "binaryPath": "vendor/x86_64-unknown-linux-musl/bin/codex"
     },
     "aarch64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "sha256": "25c66d4451c4f57df6b427173ed7d3d7e29c129d61dc58498dbdb946787b7655",
+      "version": "0.144.2-linux-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-arm64.tgz",
+      "integrity": "sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==",
       "binaryPath": "vendor/aarch64-unknown-linux-musl/bin/codex"
     },
     "x86_64-pc-windows-msvc": {
       "package": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "sha256": "d6d1c36f4c5c921724c28500ba89e1e840fd791ec5cc8aca2de256695e1c1c17",
+      "version": "0.144.2-win32-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-x64.tgz",
+      "integrity": "sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==",
       "binaryPath": "vendor/x86_64-pc-windows-msvc/bin/codex.exe"
     }
   }

--- a/wework/scripts/prepare-codex-binary.mjs
+++ b/wework/scripts/prepare-codex-binary.mjs
@@ -77,13 +77,13 @@ async function pathExists(path) {
   }
 }
 
-async function sha256File(path) {
-  const hash = createHash('sha256')
+async function integrityFile(path) {
+  const hash = createHash('sha512')
   const input = await import('node:fs').then(fs => fs.createReadStream(path))
   for await (const chunk of input) {
     hash.update(chunk)
   }
-  return hash.digest('hex')
+  return `sha512-${hash.digest('base64')}`
 }
 
 async function download(url, destination) {
@@ -126,11 +126,11 @@ async function prepareTarget(target, entry) {
     await download(entry.tarball, tarballPath)
   }
 
-  const actualSha = await sha256File(tarballPath)
-  if (actualSha !== entry.sha256) {
+  const actualIntegrity = await integrityFile(tarballPath)
+  if (actualIntegrity !== entry.integrity) {
     await rm(tarballPath, { force: true })
     throw new Error(
-      `Codex tarball sha256 mismatch for ${target}: expected ${entry.sha256}, got ${actualSha}`
+      `Codex tarball integrity mismatch for ${target}: expected ${entry.integrity}, got ${actualIntegrity}`
     )
   }
 
@@ -149,7 +149,7 @@ async function prepareTarget(target, entry) {
         codexVersion: entry.version,
         binaryPath: entry.binaryPath,
         tarball: entry.tarball,
-        sha256: entry.sha256,
+        integrity: entry.integrity,
       },
       null,
       2


### PR DESCRIPTION
## 变更内容

- 将 Wework 随包 Codex 更新到 0.144.2，并使用 npm SHA-512 integrity 校验安装包。
- 在共享 Codex app-server 线程中等待 `turn/interrupt` 完成后再报告取消，避免取消与重试请求交错。
- 补充中英文架构文档说明取消顺序约束。

## 原因与影响

Codex 0.144.2 下，异步中断可能与重试交错，导致已取消输入被恢复或重试消息丢失。同步等待中断确认后，Wework 的取消和重试流程保持一致。

## 验证

- `pnpm --filter wework test`（1,534 tests）
- `cargo test --manifest-path executor/Cargo.toml --all-features --lib`（257 tests）
- `cargo clippy --manifest-path executor/Cargo.toml --all-targets --all-features -- -D warnings`
- 真实隔离 Tauri AI 验证及桌面端到端测试（使用随包 Codex 0.144.2）
- pre-push 门禁（Wework lint/typecheck/tests、Executor fmt/test/clippy）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the bundled Codex runtime to version 0.144.2 across supported platforms.
  * Improved download integrity verification using stronger SHA-512 validation.

* **Bug Fixes**
  * Improved cancellation and retry handling for shared Codex sessions.
  * Ensured retries wait for cancellation to complete, preventing interrupted requests from being replayed or lost.
  * Added clearer reporting when cancellation cannot be completed successfully.

* **Documentation**
  * Documented shared-session cancellation and retry behavior in English and Chinese architecture guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->