### PR TITLE
fix(wework): remove executor startup timeout

### DIFF
--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -43,7 +43,6 @@ const LOCAL_EXECUTOR_RUNTIME_DIR_NAME: &str = "app-runtime";
 const LOCAL_EXECUTOR_LOG_TAIL_BYTES: u64 = 200 * 1024;
 const LOCAL_EXECUTOR_LOG_TAIL_LINES: usize = 20;
 const LOCAL_EXECUTOR_CONNECT_RETRY_MS: u64 = 250;
-const LOCAL_EXECUTOR_CONNECT_TIMEOUT_SECS: u64 = 60;
 const LOCAL_EXECUTOR_READY_TIMEOUT_SECS: u64 = 10;
 const LOCAL_EXECUTOR_PROCESS_GROUP_GRACE_MS: u64 = 500;
 const LOCAL_EXECUTOR_PROCESS_GROUP_POLL_MS: u64 = 20;
@@ -1821,8 +1820,7 @@ async fn start_executor_if_needed_unlocked(
 
     spawn_sidecar_if_needed(app.clone(), state).await?;
 
-    let started_at = Instant::now();
-    let last_error = loop {
+    loop {
         let error = match connect_and_attach_sidecar_socket(app.clone(), state).await {
             Ok(()) => return Ok(()),
             Err(error) => error,
@@ -1834,18 +1832,8 @@ async fn start_executor_if_needed_unlocked(
             fail_pending_requests(state, message.clone());
             return Err(message);
         }
-        if started_at.elapsed() >= Duration::from_secs(LOCAL_EXECUTOR_CONNECT_TIMEOUT_SECS) {
-            break error;
-        }
         retry_connect_delay().await;
-    };
-
-    let message = format!(
-        "Timed out waiting for local executor socket after {LOCAL_EXECUTOR_CONNECT_TIMEOUT_SECS}s: {last_error}"
-    );
-    set_executor_error(state, message.clone());
-    fail_pending_requests(state, message.clone());
-    Err(message)
+    }
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

Removes the 60-second global deadline while Wework waits for its local Executor sidecar socket during startup.

## Root cause and impact

Slow Executor startup could exceed the fixed deadline and surface a startup failure even though the sidecar was still alive and would become ready. Wework now continues retrying while the sidecar remains running; an exited sidecar still fails immediately.

## Validation

- `cargo fmt --manifest-path wework/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path wework/src-tauri/Cargo.toml local_executor::tests -- --skip local_executor::tests::remove_stale_app_ipc_socket_removes_socket_files_only`

The skipped existing test cannot create a Unix socket in this isolated environment; the other 27 local Executor tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local executor startup and reconnection reliability by continuing connection attempts until successful.
  * Pending requests now fail promptly when the associated executor process is no longer running.
  * Removed premature termination caused by the previous fixed connection timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->