### PR TITLE
fix(wework): resume blocked goals

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -2400,7 +2400,36 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('pause-goal-button')).toBeInTheDocument()
   })
 
-  test.each(['blocked', 'usageLimited', 'budgetLimited'] as const)(
+  test('offers the resume action for a blocked goal', async () => {
+    const onResumeGoal = vi.fn()
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        goal={{
+          threadId: 'thread-1',
+          objective: 'Resolve the issue',
+          status: 'blocked',
+          tokenBudget: null,
+          tokensUsed: 0,
+          timeUsedSeconds: 0,
+          createdAt: 1780000000000,
+          updatedAt: 1780000000000,
+        }}
+        onResumeGoal={onResumeGoal}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('resume-goal-button'))
+
+    expect(onResumeGoal).toHaveBeenCalledTimes(1)
+  })
+
+  test.each(['usageLimited', 'budgetLimited'] as const)(
     'does not offer the pause action for a %s goal',
     status => {
       render(

--- a/wework/src/components/chat/composer/GoalStatusBar.tsx
+++ b/wework/src/components/chat/composer/GoalStatusBar.tsx
@@ -40,13 +40,13 @@ export function GoalStatusBar({
     [goal, timerKey, timerState]
   )
   const elapsed = formatGoalElapsed(elapsedSeconds)
-  const paused = goal.status === 'paused'
-  const canToggle = goal.status === 'active' || paused
-  const ToggleIcon = paused ? Play : Pause
-  const toggleLabel = paused
+  const resumable = goal.status === 'paused' || goal.status === 'blocked'
+  const canToggle = goal.status === 'active' || resumable
+  const ToggleIcon = resumable ? Play : Pause
+  const toggleLabel = resumable
     ? t('workbench.goal_resume', '继续目标')
     : t('workbench.goal_pause', '暂停目标')
-  const toggleAction = paused ? onResumeGoal : onPauseGoal
+  const toggleAction = resumable ? onResumeGoal : onPauseGoal
 
   useEffect(() => {
     if (goal.status !== 'active') return
@@ -87,7 +87,7 @@ export function GoalStatusBar({
       {canToggle && (
         <button
           type="button"
-          data-testid={paused ? 'resume-goal-button' : 'pause-goal-button'}
+          data-testid={resumable ? 'resume-goal-button' : 'pause-goal-button'}
           onClick={toggleAction}
           disabled={!toggleAction}
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-text-secondary hover:bg-surface hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"


### PR DESCRIPTION
## Summary
- allow blocked runtime goals to show the existing resume control
- retain pause restrictions for usage- and budget-limited goals
- add coverage for resuming a blocked goal

## Root cause
The goal status bar treated only paused goals as resumable, even though the local runtime can reactivate a blocked goal.

## Validation
- `pnpm --filter wework exec vitest run src/components/chat/ChatInput.test.tsx --reporter=dot`
- Prettier, ESLint, TypeScript, and unit tests in the pre-push gate
- Isolated Tauri: created a local goal, observed it enter blocked state, clicked Continue goal, and verified it became Goal continuing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resume control for blocked goals.
  * Blocked goals can now be resumed directly from the goal status bar.

* **Bug Fixes**
  * Updated goal status controls to display the correct resume action and behavior for blocked goals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->