### PR TITLE
fix(wework): normalize local marketplace sources

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -25,6 +25,7 @@ const ARTIFACT_CONTENT = 'CODEX_EXECUTED_REAL_TOOL'
 const MODEL_API_KEY = 'wework-e2e-test-key'
 const MODEL_PROVIDER_ID = 'wework-e2e'
 const MODEL_ID = 'gpt-5.4'
+const MODEL_LABEL = 'GPT 5.4'
 const FRESH_CHAT_PROMPT = 'WEWORK_DESKTOP_E2E_FRESH_CHAT: confirm this is a new conversation.'
 const FRESH_CHAT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_FRESH_CHAT_COMPLETE'
 
@@ -149,6 +150,22 @@ async function fillComposerUntilSendEnabled(control, selector, value) {
 async function sendPrompt(control, selector, prompt) {
   await fillComposerUntilSendEnabled(control, selector, prompt)
   await control.command('click', '[data-testid="send-message-button"]')
+}
+
+async function selectE2EModel(control) {
+  await control.command('waitFor', '[data-testid="model-selector-button"]', {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await control.command('click', '[data-testid="model-selector-button"]')
+  await control.command('click', '[data-testid="model-control-menu-model"]')
+  await control.command('waitFor', `[data-testid="model-option-${MODEL_ID}"]`, {
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('click', `[data-testid="model-option-${MODEL_ID}"]`)
+  await control.command('waitFor', '[data-testid="model-selector-button"]', {
+    text: MODEL_LABEL,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
 }
 
 function createSse(events) {
@@ -745,6 +762,7 @@ async function main() {
     await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
+    await selectE2EModel(control)
     phase = 'initial-task'
     await sendPrompt(control, composerSelector, TASK_PROMPT)
     await control.command('waitFor', '[data-testid="message-assistant"]', {

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -46,6 +46,11 @@ export interface LocalCodexMarketplace {
   path: string
 }
 
+function normalizeMarketplaceSource(source: string): string {
+  const normalized = source.trim().replace(/\\\\/g, '/')
+  return normalized.replace(/(?:\/\.agents\/plugins)?\/marketplace\.json$/i, '')
+}
+
 export interface LocalCodexPluginApi {
   codexHomeMigrationStatus(): Promise<LocalCodexHomeMigrationStatus>
   initializeCodexHome(options: {
@@ -72,11 +77,7 @@ export interface LocalCodexPluginApi {
   readInstalledPluginForTrial(id: string | number): Promise<InstalledPlugin>
   deleteMarketplace(id: string): Promise<LocalCodexPluginsState>
   reorderMarketplaces(ids: string[]): Promise<LocalCodexPluginsState>
-  upsertMarketplace(data: {
-    id?: string
-    name: string
-    path: string
-  }): Promise<LocalCodexPluginsState>
+  upsertMarketplace(data: { id?: string; path: string }): Promise<LocalCodexPluginsState>
   installAvailablePlugin(pluginId: string | number): Promise<InstalledPlugin>
   updateInstalledPlugin(
     id: string | number,
@@ -702,11 +703,21 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
       return readState()
     },
     async upsertMarketplace(data) {
+      const source = normalizeMarketplaceSource(data.path)
+      if (data.id && data.id !== '') {
+        const currentState = cachedState ?? (await readState())
+        const existing = currentState.marketplaces.find(marketplace => marketplace.id === data.id)
+        if (existing?.path === source) return currentState
+
+        await codexAppServerRequest('marketplace/remove', {
+          marketplaceName: data.id,
+        })
+      }
       const response = await codexAppServerRequest<{
         marketplaceName: string
         installedRoot: string
       }>('marketplace/add', {
-        source: data.path,
+        source,
         refName: null,
         sparsePaths: null,
       })

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -924,10 +924,39 @@ describe('PluginsWorkspace', () => {
     await userEvent.click(screen.getByTestId('plugins-add-custom-marketplace-button'))
 
     expect(screen.getByTestId('plugins-marketplace-config-dialog')).toBeInTheDocument()
-    expect(screen.getByTestId('plugins-marketplace-name-input')).toBeInTheDocument()
     expect(screen.getByTestId('plugins-marketplace-path-input')).toHaveAttribute(
       'placeholder',
       'https://github.com/org/repo'
+    )
+  })
+
+  test('normalizes a local marketplace manifest path to its source directory', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    mockCodexAppServerInvoke({
+      marketplaces: [
+        {
+          name: 'existing-market',
+          displayName: 'Existing market',
+          path: '/Users/test/existing-market',
+        },
+      ],
+    })
+    render(<PluginsWorkspace cloudMarketplaceAvailable={false} />)
+
+    await userEvent.click(await screen.findByTestId('plugins-add-marketplace-button'))
+    await userEvent.click(screen.getByTestId('plugins-add-custom-marketplace-button'))
+    fireEvent.change(screen.getByTestId('plugins-marketplace-path-input'), {
+      target: { value: '/Users/test/market/.agents/plugins/marketplace.json' },
+    })
+    await userEvent.click(screen.getByTestId('plugins-marketplace-save-button'))
+
+    await waitFor(() =>
+      expectCodexAppServerRequest('marketplace/add', {
+        source: '/Users/test/market',
+      })
     )
   })
 
@@ -1263,7 +1292,8 @@ describe('PluginsWorkspace', () => {
 
     await userEvent.click(screen.getByTestId('plugins-marketplace-edit-local-openai'))
     expect(screen.getByTestId('plugins-marketplace-config-dialog')).toBeInTheDocument()
-    expect(screen.getByTestId('plugins-marketplace-name-input')).toHaveValue('OpenAI')
+    expect(screen.getByText('编辑市场')).toBeInTheDocument()
+    expect(screen.getByText('更新 GitHub 仓库或本地市场路径。')).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: '取消' }))
     await userEvent.click(screen.getByTestId('plugins-manage-marketplaces-button'))

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -64,7 +64,6 @@ interface MarketplaceOption {
 
 interface MarketplaceFormState {
   id?: string
-  name: string
   path: string
 }
 
@@ -1833,7 +1832,7 @@ export function PluginsWorkspace({
                         onClick={() => {
                           setShowAddMarketplaceMenu(false)
                           setMarketplaceConfigError(null)
-                          setMarketplaceForm({ name: '', path: '' })
+                          setMarketplaceForm({ path: '' })
                         }}
                       >
                         <span className="text-sm font-medium text-text-primary">
@@ -1888,7 +1887,7 @@ export function PluginsWorkspace({
                   customAddLabel={t('workbench.plugins_add_custom_marketplace', '添加自定义市场')}
                   onAddCustomMarketplace={() => {
                     setMarketplaceConfigError(null)
-                    setMarketplaceForm({ name: '', path: '' })
+                    setMarketplaceForm({ path: '' })
                   }}
                   onManage={() => navigateTo('/plugins/manage')}
                 />
@@ -2160,7 +2159,6 @@ export function PluginsWorkspace({
                             setMarketplaceConfigError(null)
                             setMarketplaceForm({
                               id: marketplace.id,
-                              name: marketplace.name,
                               path: marketplace.path || '',
                             })
                           }}
@@ -2209,31 +2207,23 @@ export function PluginsWorkspace({
           >
             <div className="space-y-1">
               <h2 className="text-base font-semibold text-text-primary">
-                {t('workbench.plugins_marketplace_config_title', '添加市场')}
+                {marketplaceForm.id
+                  ? t('workbench.plugins_marketplace_edit_title', '编辑市场')
+                  : t('workbench.plugins_marketplace_config_title', '添加市场')}
               </h2>
               <p className="text-sm leading-5 text-text-secondary">
-                {t(
-                  'workbench.plugins_marketplace_config_description',
-                  '填写 GitHub 仓库地址，或本地 marketplace.json/目录。'
-                )}
+                {marketplaceForm.id
+                  ? t(
+                      'workbench.plugins_marketplace_edit_description',
+                      '更新市场地址。市场名称由 marketplace.json 决定。'
+                    )
+                  : t(
+                      'workbench.plugins_marketplace_config_description',
+                      '填写 GitHub 仓库地址，或本地 marketplace.json/目录。'
+                    )}
               </p>
             </div>
             <div className="mt-5 space-y-4">
-              <label className="block space-y-1.5">
-                <span className="text-sm font-medium text-text-primary">
-                  {t('workbench.plugins_marketplace_name', '市场名称')}
-                </span>
-                <input
-                  data-testid="plugins-marketplace-name-input"
-                  value={marketplaceForm.name}
-                  onChange={event =>
-                    setMarketplaceForm(previous =>
-                      previous ? { ...previous, name: event.target.value } : previous
-                    )
-                  }
-                  className="h-10 w-full rounded-lg border border-border bg-background px-3 text-sm text-text-primary outline-none focus:border-text-muted"
-                />
-              </label>
               <label className="block space-y-1.5">
                 <span className="text-sm font-medium text-text-primary">
                   {t('workbench.plugins_marketplace_path', '市场路径')}

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -697,6 +697,8 @@
     "plugins_marketplace_welcome_title": "Add a plugin marketplace",
     "plugins_marketplace_welcome_description": "A marketplace can come from a GitHub repository or local marketplace.json file. Add one to search, install, and manage Codex-compatible plugins.",
     "plugins_marketplace_config_title": "Add marketplace",
+    "plugins_marketplace_edit_title": "Edit marketplace",
+    "plugins_marketplace_edit_description": "Update the GitHub repository or local marketplace path.",
     "plugins_marketplace_config_description": "Enter a GitHub repository or local marketplace.json file/folder.",
     "plugins_marketplace_name": "Marketplace name",
     "plugins_marketplace_path": "Marketplace address",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -697,6 +697,8 @@
     "plugins_marketplace_welcome_title": "添加一个插件市场",
     "plugins_marketplace_welcome_description": "插件市场可以来自 GitHub 仓库或本地 marketplace.json。添加后即可搜索、安装和管理 Codex 兼容插件。",
     "plugins_marketplace_config_title": "添加市场",
+    "plugins_marketplace_edit_title": "编辑市场",
+    "plugins_marketplace_edit_description": "更新 GitHub 仓库或本地市场路径。",
     "plugins_marketplace_config_description": "填写 GitHub 仓库地址，或本地 marketplace.json/目录。",
     "plugins_marketplace_name": "市场名称",
     "plugins_marketplace_path": "市场地址",


### PR DESCRIPTION
## Summary

- Normalize local `marketplace.json` file paths to the marketplace root before calling Codex App Server.
- Make marketplace editing update the source path and clarify that the display name comes from the manifest.
- Cover manifest-path normalization with a focused component test.

## Root cause

The UI passed a local manifest file path directly to `marketplace/add`, while Codex App Server requires the source directory. The editable display-name field was not supported by the App Server API and had no effect.

## Validation

- `pnpm --filter wework test --run src/components/plugins/PluginsWorkspace.test.tsx`
- Prettier and ESLint checks for changed Wework files
- Real isolated Tauri: add from a manifest file path, then edit its source path and confirm the marketplace is replaced with the new manifest.
