### PR TITLE
fix(executor): separate goal and task running state

### DIFF
--- a/docs/en/developer-guide/local-device-architecture.md
+++ b/docs/en/developer-guide/local-device-architecture.md
@@ -59,6 +59,12 @@ Tauri first connects to `~/.wegent-executor/app-ipc.sock`. If the local executor
 
 Backend connectivity is optional, not a required dependency for the local app. When login, model/capability sync, cloud projects, or web control of the local computer are needed, the executor can register as a local device over the Backend WebSocket channel. The same executor sidecar reuses one command handler and one runtime work handler while serving Wework App over the local socket and Backend over WebSocket. This design does not introduce a local HTTP gateway and does not require Wework App to start Backend itself.
 
+### Runtime Task and Goal State
+
+The runtime task `running` field represents only whether a model turn is currently executing. After a turn completes, fails, or is cancelled, the executor must settle that field to `false`. Wework uses it to decide whether to render the stop control and running indicator, and whether a new message can be sent directly.
+
+Goals have an independent lifecycle. An `active` goal means that its objective can continue in later turns; it does not mean that a model turn is currently executing. Keeping an active goal while a task is idle must not mark the task as running again. A user's next message creates a new turn directly instead of being sent as guidance to an in-progress turn.
+
 ### Backend Device Chat Task REST Entrypoint
 
 The web device chat page still sends messages through WebSocket. For external systems or curl-based callers that need to create the same kind of task, Backend exposes a REST entrypoint:

--- a/docs/zh/developer-guide/local-device-architecture.md
+++ b/docs/zh/developer-guide/local-device-architecture.md
@@ -59,6 +59,12 @@ Tauri 会先连接 `~/.wegent-executor/app-ipc.sock`；如果本地 executor sid
 
 Backend 是可选能力，而不是本地 app 的必需依赖。需要登录、模型/能力同步、云端项目或网页版控制本机时，executor 可以使用 Backend WebSocket 通道注册为本地设备；同一个 executor sidecar 会复用同一个 command handler 和 runtime work handler，一边通过本机 socket 服务 Wework App，一边通过 WebSocket 服务 Backend。这个设计不引入本机 HTTP gateway，也不要求 Wework App 自己启动 Backend。
 
+### 运行时任务与目标状态
+
+运行时任务的 `running` 字段只表示当前是否存在正在执行的模型回合。回合完成、失败或取消后，executor 必须把该字段收敛为 `false`，供 Wework 决定是否显示停止按钮、运行中图标，以及新消息能否直接发送。
+
+目标（goal）有独立的生命周期。目标为 `active` 表示其目标仍可在后续回合继续推进，不表示当前存在模型回合。因此，任务空闲时保留 active goal 不会将任务重新标记为运行中；用户发送下一条消息会直接创建新回合，而不是把消息作为对运行中回合的引导。
+
 ### 后端设备对话任务 REST 入口
 
 网页版设备对话页仍然通过 WebSocket 发送消息。对于需要从外部系统或 curl 创建同类任务的场景，Backend 提供 REST 入口：

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -3776,7 +3776,7 @@ impl RuntimeWorkRpcHandler {
             runtime_handle.insert("threadPath".to_owned(), Value::String(path));
             link.runtime_handle = Value::Object(runtime_handle);
         }
-        if local_active || link.has_active_goal() {
+        if local_active {
             link.status = "running".to_owned();
             link.running = true;
         }
@@ -3950,13 +3950,8 @@ impl RuntimeWorkRpcHandler {
             if thread_id.is_some() {
                 link.thread_id = thread_id;
             }
-            let goal_active = link.has_active_goal();
-            link.status = if goal_active {
-                "running".to_owned()
-            } else {
-                status.to_owned()
-            };
-            link.running = goal_active || status == "running";
+            link.status = status.to_owned();
+            link.running = status == "running";
             link.updated_at = now_ms();
             if link.thread_id.is_some() && status != "running" {
                 retain_runtime_handle_user_messages(&mut link.runtime_handle);
@@ -3986,19 +3981,8 @@ impl RuntimeWorkRpcHandler {
     }
 
     fn sync_runtime_task_goal_status(&self, local_task_id: &str, goal_status: Option<String>) {
-        let active_goal = goal_status
-            .as_deref()
-            .is_some_and(|status| status.eq_ignore_ascii_case("active"));
-        let task_active = self.is_active_local_task(local_task_id);
         let updated = self.store.update_task(local_task_id, |link| {
             link.goal_status = goal_status.clone();
-            if active_goal {
-                link.status = "running".to_owned();
-                link.running = true;
-            } else if !task_active {
-                link.status = goal_status.clone().unwrap_or_else(|| "active".to_owned());
-                link.running = false;
-            }
             link.updated_at = now_ms();
         });
         if updated.is_some() {
@@ -4018,7 +4002,7 @@ fn is_unmapped_pending_codex_shadow(
 }
 
 fn normalize_inactive_running_codex_task(link: &mut RuntimeTaskLink) -> bool {
-    if link.has_active_goal() || !is_inactive_running_codex_task(link) {
+    if !is_inactive_running_codex_task(link) {
         return false;
     }
     link.status = "active".to_owned();
@@ -5690,6 +5674,49 @@ fn current_process_max_rss_kb() -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn finishing_an_active_goal_keeps_the_task_idle() {
+        let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+        let mut link = RuntimeTaskLink::new_pending(
+            "task-1".to_owned(),
+            "/tmp/project".to_owned(),
+            "Task".to_owned(),
+        );
+        link.goal_status = Some("active".to_owned());
+        handler.upsert_local_task(link);
+
+        handler.finish_local_task("task-1", Some("thread-1".to_owned()), "done");
+
+        let task = handler
+            .local_task_link("task-1")
+            .expect("task should remain stored");
+        assert_eq!(task.status, "done");
+        assert!(!task.running);
+        assert_eq!(task.goal_status.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn syncing_an_active_goal_does_not_start_an_idle_task() {
+        let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+        let mut link = RuntimeTaskLink::new_pending(
+            "task-1".to_owned(),
+            "/tmp/project".to_owned(),
+            "Task".to_owned(),
+        );
+        link.status = "done".to_owned();
+        link.running = false;
+        handler.upsert_local_task(link);
+
+        handler.sync_runtime_task_goal_status("task-1", Some("active".to_owned()));
+
+        let task = handler
+            .local_task_link("task-1")
+            .expect("task should remain stored");
+        assert_eq!(task.status, "done");
+        assert!(!task.running);
+        assert_eq!(task.goal_status.as_deref(), Some("active"));
+    }
 
     #[test]
     fn current_codex_model_provider_reads_configured_provider_name() {

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -116,9 +116,6 @@ impl RuntimeTaskLink {
             .as_ref()
             .and_then(|link| local_terminal_status_if_current(link, thread));
         let local_running = local_link.as_ref().is_some_and(|link| link.running);
-        let goal_active = local_link
-            .as_ref()
-            .is_some_and(RuntimeTaskLink::has_active_goal);
         let goal_status = local_link
             .as_ref()
             .and_then(|link| link.goal_status.clone());
@@ -136,7 +133,7 @@ impl RuntimeTaskLink {
         }
         let status = if local_archived {
             "archived".to_owned()
-        } else if goal_active || local_running {
+        } else if local_running {
             "running".to_owned()
         } else if let Some(status) = &local_terminal_status {
             status.clone()
@@ -145,7 +142,7 @@ impl RuntimeTaskLink {
         };
         let running = !local_archived
             && local_terminal_status.is_none()
-            && (goal_active || local_running || normalized_running_status(&status));
+            && (local_running || normalized_running_status(&status));
         Self {
             local_task_id: local_link
                 .as_ref()
@@ -202,14 +199,6 @@ impl RuntimeTaskLink {
             pinned: self.pinned,
             pinned_order: self.pinned_order,
         }
-    }
-}
-
-impl RuntimeTaskLink {
-    pub fn has_active_goal(&self) -> bool {
-        self.goal_status
-            .as_deref()
-            .is_some_and(|status| status.eq_ignore_ascii_case("active"))
     }
 }
 
@@ -839,7 +828,7 @@ mod tests {
     }
 
     #[test]
-    fn active_goal_keeps_task_running_when_thread_list_is_idle() {
+    fn active_goal_does_not_keep_task_running_when_thread_list_is_idle() {
         let local_link = RuntimeTaskLink {
             local_task_id: "task-1".to_owned(),
             thread_id: Some("thread-1".to_owned()),
@@ -858,8 +847,8 @@ mod tests {
             "/workspace/project".to_owned(),
         );
 
-        assert_eq!(link.status, "running");
-        assert!(link.running);
+        assert_eq!(link.status, "active");
+        assert!(!link.running);
         assert_eq!(link.goal_status.as_deref(), Some("active"));
     }
 


### PR DESCRIPTION
## What changed

- Keep runtime task execution state independent from the goal lifecycle.
- Set completed, failed, and cancelled turns to idle even when their goal remains active.
- Document the active-goal/idle-task interaction contract.

## Why

An active goal was incorrectly written back as a running task. Wework then kept showing a running indicator and routed the next message as guidance instead of a direct follow-up.

## Validation

- `cargo test runtime_work:: --lib` (145 passed)
- `cargo fmt --check`
- `cargo clippy --all-features --lib -- -D warnings`
- Isolated real-Tauri verification: with an active goal and an idle task, the running task indicator disappeared and the next message was inserted as a normal user message. The configured model proxy returned 502, so response completion could not be validated end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the difference between an in-progress runtime task and an active goal.
  * Documented that completed, failed, or canceled model turns become idle, while goals may remain active.

* **Bug Fixes**
  * Active goals no longer incorrectly mark idle tasks as running.
  * New messages now start a fresh turn instead of being treated as guidance for a prior turn.
  * Improved task status reporting when goals remain active after execution ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->