### PR TITLE
fix(ci): use release bot for contributor updates

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -14,16 +14,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Update Contributors in README
         uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
         with:
           auto_detect_branch_protection: false
           image_size: 80
@@ -36,7 +45,7 @@ jobs:
       - name: Update Contributors in Chinese README
         uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
         with:
           auto_detect_branch_protection: false
           image_size: 80


### PR DESCRIPTION
## Summary

- create a Wegent release bot installation token before contributor updates
- use that token for checkout and both contributor update actions

## Root cause

The workflow used `GITHUB_TOKEN` to push directly to the protected `main` branch. Repository rules reject that actor because only the configured release GitHub App may bypass the pull-request requirement.

## Validation

- `git diff --check`
- fetched and rebased on the latest `origin/main`