### PR TITLE
fix(wework): keep task titlebar height stable

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4306,10 +4306,14 @@ describe('DesktopWorkbenchLayout', () => {
       await userEvent.click(screen.getByTestId('right-workspace-file-option'))
 
       const titlebarRightPanel = screen.getByTestId('titlebar-right-panel')
+      const sharedMainHeader = screen.getByTestId('workbench-main-header')
       expect(within(titlebarRightPanel).getByTestId('right-workspace-file-tab')).toBeInTheDocument()
 
       rerender(<DesktopWorkbenchLayout {...propsForTask(taskB)} />)
 
+      expect(screen.getAllByTestId('workbench-main-header')).toHaveLength(1)
+      expect(screen.getByTestId('workbench-main-header')).toBe(sharedMainHeader)
+      expect(sharedMainHeader).toHaveClass('h-[38px]', 'shrink-0')
       expect(within(titlebarRightPanel).queryByTestId('right-workspace-file-tab')).toBeNull()
     } finally {
       if (previousTauriInternals === undefined) {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -39,6 +39,8 @@ import { DeviceStatusPrompt } from './DeviceStatusPrompt'
 import {
   TITLEBAR_ACTIONS_PORTAL_ID,
   TITLEBAR_RIGHT_PANEL_PORTAL_ID,
+  WORKBENCH_MAIN_HEADER_PORTAL_ID,
+  WorkbenchMainHeaderPortal,
 } from '@/components/topnav/TitlebarActionsPortal'
 import { DESKTOP_TOP_BAR_BUTTON_CLASS, DesktopTopBar } from './DesktopTopBar'
 import { DesktopWindowControls } from './DesktopWindowControls'
@@ -254,6 +256,7 @@ const MemoizedBottomWorkspacePanel = memo(function MemoizedBottomWorkspacePanel(
 
 export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
   const { state } = useWorkbenchPaneContext()
+  const isTauri = isTauriRuntime()
   const [terminalPinnedPaneKeys, setTerminalPinnedPaneKeys] = useState<string[]>([])
   const runtimePaneKeys = useMemo(
     () => getRuntimeWorkbenchPaneKeys(state.runtimeWork),
@@ -285,7 +288,7 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
     setTerminalPinnedPaneKeys(current => current.filter(key => key !== paneKey))
   }, [])
 
-  return (
+  const paneStack = (
     <CachedWorkbenchPaneStack
       activePane={props.activePane}
       maxPanes={MAX_CACHED_DESKTOP_WORKBENCH_TABS}
@@ -303,6 +306,19 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
         />
       )}
     />
+  )
+
+  if (!isTauri) return paneStack
+
+  return (
+    <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+      <header
+        id={WORKBENCH_MAIN_HEADER_PORTAL_ID}
+        data-testid="workbench-main-header"
+        className="relative z-chrome flex h-[38px] shrink-0 items-center overflow-hidden border-b border-border/40 bg-background/95"
+      />
+      {paneStack}
+    </div>
   )
 }
 
@@ -1229,11 +1245,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       {workspacePanelActions}
     </>
   )
-  const tauriMainHeader = isTauri ? (
-    <header
-      data-testid="workbench-main-header"
-      className="relative z-chrome flex h-[38px] shrink-0 items-center overflow-hidden border-b border-border/40 bg-background/95"
-    >
+  const tauriMainHeaderContent = isTauri ? (
+    <div className="relative flex h-full min-w-0 flex-1 items-center overflow-hidden">
       <MacOSTitleBarDragRegion className="absolute inset-0 z-0 h-full w-full" />
       {sidebarCollapsed && (
         <div
@@ -1300,7 +1313,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           {topRightActions}
         </div>
       </div>
-    </header>
+    </div>
   ) : undefined
   useLayoutEffect(() => {
     if (previousRightPanelSessionKey.current === rightPanelSessionKey) {
@@ -1338,7 +1351,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         !isTauri && 'mt-1.5 rounded-xl border border-border/60 shadow-[0_3px_16px_rgba(0,0,0,0.04)]'
       )}
     >
-      {paneActive ? tauriMainHeader : null}
+      {paneActive && tauriMainHeaderContent ? (
+        <WorkbenchMainHeaderPortal>{tauriMainHeaderContent}</WorkbenchMainHeaderPortal>
+      ) : null}
       <WorkbenchPaneActiveOnly>
         {!isTauri && (
           <div

--- a/wework/src/components/topnav/TitlebarActionsPortal.tsx
+++ b/wework/src/components/topnav/TitlebarActionsPortal.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 export const TITLEBAR_ACTIONS_PORTAL_ID = 'titlebar-actions-portal'
 export const TITLEBAR_CENTER_PORTAL_ID = 'titlebar-center-portal'
 export const TITLEBAR_RIGHT_PANEL_PORTAL_ID = 'titlebar-right-panel-portal'
+export const WORKBENCH_MAIN_HEADER_PORTAL_ID = 'workbench-main-header-portal'
 
 interface TitlebarActionsPortalProps {
   children: ReactNode
@@ -29,6 +30,16 @@ export function TitlebarRightPanelPortal({ children }: TitlebarActionsPortalProp
   const portalTarget = useSyncExternalStore(
     subscribeToPortalTarget,
     () => document.getElementById(TITLEBAR_RIGHT_PANEL_PORTAL_ID),
+    () => null
+  )
+
+  return portalTarget ? createPortal(children, portalTarget) : null
+}
+
+export function WorkbenchMainHeaderPortal({ children }: TitlebarActionsPortalProps) {
+  const portalTarget = useSyncExternalStore(
+    subscribeToPortalTarget,
+    () => document.getElementById(WORKBENCH_MAIN_HEADER_PORTAL_ID),
     () => null
   )
 


### PR DESCRIPTION
## What changed

- move the Tauri workbench titlebar container outside the cached task pane stack
- portal only the active task title and actions into the shared titlebar
- keep right-workspace titlebar tabs and actions scoped to the active task
- add a regression assertion that task switches retain the same single 38px titlebar node

## Root cause

The Tauri titlebar was rendered inside each cached task pane. Switching between retained panes could therefore reveal different titlebar DOM/layout state, which made some tasks render a visibly shorter titlebar than others.

## Impact

All Tauri tasks now share one fixed-height titlebar container. Task-specific content still updates normally, while cached conversation, terminal, and right-workspace state remains preserved.

## Verification

- `pnpm --filter wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx src/components/topnav/ChromeTitlebar.test.tsx` (136 tests passed)
- `pnpm --filter wework typecheck`
- Prettier and ESLint on changed files
- pre-push Wework ESLint, TypeScript, and unit checks
- isolated real-Tauri verification: one titlebar node, 38px height, outside all cached task panes; titlebar action and right-workspace zones rendered at 37px content height


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop workbench layout when switching between runtime tasks.
  * Preserved the active file tab and prevented duplicate main headers from appearing.
  * Ensured header sizing and layout remain consistent during task changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->