### PR TITLE
fix(wework): stabilize native folder selection

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -721,27 +721,23 @@ async function main() {
     ])
     await writeCodexConfig(join(executorHome, 'codex'), control.url)
 
-    app = spawn(
-      appBinary,
-      ['--open-workspace', workspacePath, '--workspace-label', 'Desktop E2E'],
-      {
-        cwd: weworkDir,
-        env: {
-          ...process.env,
-          CODEX_BIN: codexBinary,
-          HOME: homePath,
-          WEGENT_CODEX_HOME: join(executorHome, 'codex'),
-          WEGENT_EXECUTOR_HOME: executorHome,
-          WEGENT_EXECUTOR_APP_IPC_SOCKET: executorSocketPath,
-          WEGENT_EXECUTOR_LOG_DIR: resultDir,
-          WEGENT_EXECUTOR_LOG_FILE: 'executor.log',
-          DEVICE_ID: `wework-e2e-device-${process.pid}`,
-          WEWORK_E2E_MODEL_API_KEY: MODEL_API_KEY,
-          WEWORK_EXECUTOR_SIDECAR: executorBinary,
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }
-    )
+    app = spawn(appBinary, [], {
+      cwd: weworkDir,
+      env: {
+        ...process.env,
+        CODEX_BIN: codexBinary,
+        HOME: homePath,
+        WEGENT_CODEX_HOME: join(executorHome, 'codex'),
+        WEGENT_EXECUTOR_HOME: executorHome,
+        WEGENT_EXECUTOR_APP_IPC_SOCKET: executorSocketPath,
+        WEGENT_EXECUTOR_LOG_DIR: resultDir,
+        WEGENT_EXECUTOR_LOG_FILE: 'executor.log',
+        DEVICE_ID: `wework-e2e-device-${process.pid}`,
+        WEWORK_E2E_MODEL_API_KEY: MODEL_API_KEY,
+        WEWORK_EXECUTOR_SIDECAR: executorBinary,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
     await Promise.all([
       appendProcessOutput(app.stdout, appLogPath),
       appendProcessOutput(app.stderr, appLogPath),
@@ -757,6 +753,35 @@ async function main() {
       /^(tauri|http):/,
       'The desktop controller did not connect from a webview'
     )
+
+    phase = 'project-folder-cancel'
+    await control.command('waitFor', '[data-testid="projects-create-button"]', {
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    })
+    await control.command('click', '[data-testid="projects-create-button"]')
+    await control.command('click', '[data-testid="project-create-existing-option"]')
+    await control.command('waitFor', '[data-testid="standalone-folder-project-dialog"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    await control.command('click', '[data-testid="cancel-device-folder-picker-button"]')
+    const cancelledFolderPickerSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+    assert.equal(
+      cancelledFolderPickerSnapshot.testIds.includes('standalone-folder-project-dialog'),
+      false,
+      'Cancelling folder selection did not restore the workbench'
+    )
+
+    phase = 'project-folder-select'
+    await control.command('click', '[data-testid="projects-create-button"]')
+    await control.command('click', '[data-testid="project-create-existing-option"]')
+    await control.command('waitFor', '[data-testid="device-folder-path-input"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    await control.command('fill', '[data-testid="device-folder-path-input"]', {
+      value: workspacePath,
+    })
+    await control.command('press', '[data-testid="device-folder-path-input"]', { key: 'Enter' })
+    await control.command('click', '[data-testid="confirm-device-folder-picker-button"]')
 
     const composerSelector = '[data-testid="chat-message-input"][contenteditable="true"]'
     await control.command('waitFor', composerSelector, {

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -12,6 +12,7 @@ const DESKTOP_READY_TIMEOUT_MS = 60_000
 const WORKBENCH_READY_TIMEOUT_MS = 180_000
 const UI_TIMEOUT_MS = 120_000
 const PROCESS_STOP_TIMEOUT_MS = 10_000
+const COMPOSER_READY_STABILITY_MS = 750
 const TASK_PROMPT = 'WEWORK_DESKTOP_E2E_TASK: create the requested verification file.'
 const COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_COMPLETE'
 const FOLLOW_UP_PROMPT = 'WEWORK_DESKTOP_E2E_FOLLOW_UP: confirm the completed task.'
@@ -129,35 +130,26 @@ async function appendProcessOutput(stream, destination) {
   })
 }
 
-async function fillComposerUntilSendEnabled(control, selector, value) {
-  let lastError
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    await control.command('fill', selector, { value })
-    try {
-      await control.command('waitFor', '[data-testid="send-message-button"]', {
-        enabled: true,
-        timeoutMs: 3_000,
-      })
-      return
-    } catch (error) {
-      lastError = error
-      await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
-    }
-  }
-  throw lastError
-}
-
 async function sendPrompt(control, selector, prompt) {
-  await fillComposerUntilSendEnabled(control, selector, prompt)
-  await control.command('click', '[data-testid="send-message-button"]')
+  await control.command('fill', selector, { value: prompt })
+  await control.command('clickWhenEnabled', '[data-testid="send-message-button"]', {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
 }
 
 async function selectE2EModel(control) {
   await control.command('waitFor', '[data-testid="model-selector-button"]', {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
-  await control.command('click', '[data-testid="model-selector-button"]')
-  await control.command('click', '[data-testid="model-control-menu-model"]')
+  await control.command('clickWhenEnabled', '[data-testid="model-selector-button"]', {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('clickWhenEnabled', '[data-testid="model-control-menu-model"]', {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
   await control.command('waitFor', `[data-testid="model-option-${MODEL_ID}"]`, {
     timeoutMs: UI_TIMEOUT_MS,
   })
@@ -860,7 +852,10 @@ async function main() {
     await control.command('waitFor', '[data-testid="assistant-error-card"]', {
       timeoutMs: UI_TIMEOUT_MS,
     })
-    await control.command('click', '[data-testid="assistant-error-retry"]')
+    await control.command('clickWhenEnabled', '[data-testid="assistant-error-retry"]', {
+      stableMs: COMPOSER_READY_STABILITY_MS,
+      timeoutMs: UI_TIMEOUT_MS,
+    })
     await control.command('waitFor', '[data-testid="message-assistant"]', {
       text: RETRY_COMPLETION_TEXT,
       timeoutMs: UI_TIMEOUT_MS,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -85,11 +85,11 @@ const nativeDirectoryPickerMocks = vi.hoisted(() => ({
 }))
 
 const automationMocks = vi.hoisted(() => ({
-  enabled: false,
+  useNativeDirectoryPicker: true,
 }))
 
 vi.mock('@/e2e/automation', () => ({
-  isWeworkAutomationEnabled: () => automationMocks.enabled,
+  shouldUseNativeProjectDirectoryPicker: () => automationMocks.useNativeDirectoryPicker,
 }))
 
 vi.mock('@/lib/native-directory-picker', () => ({
@@ -506,7 +506,7 @@ describe('DesktopWorkbenchLayout', () => {
     localPathExistsMock.mockResolvedValue(false)
     openLocalWorkspaceMock.mockResolvedValue(undefined)
     nativeDirectoryPickerMocks.openNativeProjectDirectoryPicker.mockResolvedValue(null)
-    automationMocks.enabled = false
+    automationMocks.useNativeDirectoryPicker = true
     openExternalUrlMock.mockResolvedValue(true)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
@@ -3190,7 +3190,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('uses the controllable folder dialog during desktop E2E verification', async () => {
-    automationMocks.enabled = true
+    automationMocks.useNativeDirectoryPicker = false
     const onGetDeviceHomeDirectory = vi.fn().mockResolvedValue('/Users/alice')
     const onListDeviceDirectories = vi.fn().mockResolvedValue(['repo'])
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -84,6 +84,14 @@ const nativeDirectoryPickerMocks = vi.hoisted(() => ({
   openNativeProjectDirectoryPicker: vi.fn(),
 }))
 
+const automationMocks = vi.hoisted(() => ({
+  enabled: false,
+}))
+
+vi.mock('@/e2e/automation', () => ({
+  isWeworkAutomationEnabled: () => automationMocks.enabled,
+}))
+
 vi.mock('@/lib/native-directory-picker', () => ({
   openNativeProjectDirectoryPicker: nativeDirectoryPickerMocks.openNativeProjectDirectoryPicker,
 }))
@@ -498,6 +506,7 @@ describe('DesktopWorkbenchLayout', () => {
     localPathExistsMock.mockResolvedValue(false)
     openLocalWorkspaceMock.mockResolvedValue(undefined)
     nativeDirectoryPickerMocks.openNativeProjectDirectoryPicker.mockResolvedValue(null)
+    automationMocks.enabled = false
     openExternalUrlMock.mockResolvedValue(true)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
@@ -3105,9 +3114,10 @@ describe('DesktopWorkbenchLayout', () => {
 
   test('opens a standalone Codex workspace from an existing local folder selected in Finder', async () => {
     const onOpenStandaloneWorkspace = vi.fn()
-    nativeDirectoryPickerMocks.openNativeProjectDirectoryPicker.mockResolvedValue(
-      '/Users/alice/repo'
-    )
+    nativeDirectoryPickerMocks.openNativeProjectDirectoryPicker.mockImplementation(async () => {
+      expect(screen.queryByTestId('projects-create-button-menu')).not.toBeInTheDocument()
+      return '/Users/alice/repo'
+    })
 
     render(
       <DesktopWorkbenchLayout
@@ -3177,6 +3187,42 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(onOpenStandaloneWorkspace).not.toHaveBeenCalled()
     expect(screen.queryByTestId('standalone-folder-project-dialog')).not.toBeInTheDocument()
+  })
+
+  test('uses the controllable folder dialog during desktop E2E verification', async () => {
+    automationMocks.enabled = true
+    const onGetDeviceHomeDirectory = vi.fn().mockResolvedValue('/Users/alice')
+    const onListDeviceDirectories = vi.fn().mockResolvedValue(['repo'])
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
+        onListDeviceDirectories={onListDeviceDirectories}
+        state={{
+          ...baseProps.state,
+          devices: [
+            {
+              id: 1,
+              device_id: 'device-1',
+              name: 'sifang-executor',
+              status: 'online',
+              is_default: true,
+              bind_shell: 'claudecode',
+              device_type: 'local',
+              executor_version: '1.8.5',
+            },
+          ],
+        }}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('projects-create-button'))
+    await userEvent.click(screen.getByTestId('project-create-existing-option'))
+
+    expect(await screen.findByTestId('standalone-folder-project-dialog')).toBeInTheDocument()
+    await waitFor(() => expect(onGetDeviceHomeDirectory).toHaveBeenCalledWith('device-1'))
+    expect(nativeDirectoryPickerMocks.openNativeProjectDirectoryPicker).not.toHaveBeenCalled()
   })
 
   test('falls back to the remote-style folder dialog when existing folder targets a remote device', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -4,21 +4,14 @@ import type { ProjectCreateMode } from '@/components/chat/ChatInput'
 import { useWorkbench } from '@/features/workbench/useWorkbench'
 import { useAuth } from '@/features/auth/useAuth'
 import type {
-  DeviceInfo,
   IMPrivateSession,
   ProjectWithTasks,
   RuntimeTaskAddress,
   RuntimeIMNotificationSettingsResponse,
 } from '@/types/api'
 import { stripAppBasePath } from '@/config/runtime'
-import {
-  canUseForProjectCreation,
-  isCloudDevice,
-  isClaudeCodeDevice,
-  isRemoteDevice,
-} from '@/lib/device-capabilities'
 import { isSettingsRoute, navigateTo } from '@/lib/navigation'
-import { openNativeProjectDirectoryPicker } from '@/lib/native-directory-picker'
+import { isWeworkAutomationEnabled } from '@/e2e/automation'
 import { cn } from '@/lib/utils'
 import { DesktopSidebar } from './DesktopSidebar'
 import { ProjectCreateDialog } from '@/components/projects/ProjectCreateDialog'
@@ -44,28 +37,6 @@ import { EMPTY_RUNTIME_TASK_REMINDERS } from '@/features/workbench/runtimeTaskRe
 type ImNotificationDialogMode = { type: 'global' } | { type: 'task'; address: RuntimeTaskAddress }
 
 const SIDEBAR_AUTO_COLLAPSE_WINDOW_WIDTH = 960
-
-function isLocalStandaloneDevice(device: DeviceInfo): boolean {
-  return !isCloudDevice(device) && !isRemoteDevice(device)
-}
-
-function getPreferredLocalStandaloneDevice(
-  devices: DeviceInfo[],
-  preferredDeviceId: string | null | undefined
-): DeviceInfo | null {
-  const usableDevices = devices.filter(
-    device =>
-      isLocalStandaloneDevice(device) &&
-      isClaudeCodeDevice(device) &&
-      canUseForProjectCreation(device)
-  )
-  return (
-    usableDevices.find(device => device.device_id === preferredDeviceId) ??
-    usableDevices.find(device => device.is_default) ??
-    usableDevices[0] ??
-    null
-  )
-}
 
 export function DesktopWorkbenchLayout() {
   const { t } = useTranslation('common')
@@ -198,28 +169,11 @@ export function DesktopWorkbenchLayout() {
       setStandaloneRemoteDialogIntent(intent)
 
       if (mode === 'existing') {
-        const preferredDeviceId =
-          state.standaloneDeviceId ?? state.user?.preferences?.default_execution_target
-        const localDevice = getPreferredLocalStandaloneDevice(state.devices, preferredDeviceId)
-
-        if (localDevice) {
-          try {
-            const selectedPath = await openNativeProjectDirectoryPicker()
-            if (selectedPath) {
-              await onOpenStandaloneWorkspace?.(localDevice.device_id, selectedPath)
-              setStandaloneWorkspaceDialogMode(null)
-              setStandalonePreferNativeLocalPicker(true)
-              return
-            }
-            setStandaloneWorkspaceDialogMode(null)
-            setStandalonePreferNativeLocalPicker(true)
-            return
-          } catch (error) {
-            console.error('[Wework project] native picker failed in layout', error)
-          }
-        }
-
-        setStandalonePreferNativeLocalPicker(false)
+        // Mount the dialog before opening the native picker so the triggering menu and
+        // pointer event are fully dismissed before macOS starts its modal event loop.
+        // Desktop automation uses the equivalent in-app picker because native OS dialogs
+        // cannot be driven or observed through the isolated WebView controller.
+        setStandalonePreferNativeLocalPicker(!isWeworkAutomationEnabled())
         setStandaloneWorkspaceDialogMode('existing')
         void onRefreshDevices?.().catch(() => undefined)
         return
@@ -229,13 +183,7 @@ export function DesktopWorkbenchLayout() {
       setStandaloneWorkspaceDialogMode(mode)
       void onRefreshDevices?.().catch(() => undefined)
     },
-    [
-      onOpenStandaloneWorkspace,
-      onRefreshDevices,
-      state.devices,
-      state.standaloneDeviceId,
-      state.user?.preferences?.default_execution_target,
-    ]
+    [onRefreshDevices]
   )
 
   const openProjectFromWorkMenu = useCallback(

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@/types/api'
 import { stripAppBasePath } from '@/config/runtime'
 import { isSettingsRoute, navigateTo } from '@/lib/navigation'
-import { isWeworkAutomationEnabled } from '@/e2e/automation'
+import { shouldUseNativeProjectDirectoryPicker } from '@/e2e/automation'
 import { cn } from '@/lib/utils'
 import { DesktopSidebar } from './DesktopSidebar'
 import { ProjectCreateDialog } from '@/components/projects/ProjectCreateDialog'
@@ -171,9 +171,10 @@ export function DesktopWorkbenchLayout() {
       if (mode === 'existing') {
         // Mount the dialog before opening the native picker so the triggering menu and
         // pointer event are fully dismissed before macOS starts its modal event loop.
-        // Desktop automation uses the equivalent in-app picker because native OS dialogs
-        // cannot be driven or observed through the isolated WebView controller.
-        setStandalonePreferNativeLocalPicker(!isWeworkAutomationEnabled())
+        // Desktop automation uses the equivalent in-app picker by default because native OS
+        // dialogs cannot be driven through the isolated WebView controller. An explicit E2E
+        // override keeps the controller active for real native-picker verification.
+        setStandalonePreferNativeLocalPicker(shouldUseNativeProjectDirectoryPicker())
         setStandaloneWorkspaceDialogMode('existing')
         void onRefreshDevices?.().catch(() => undefined)
         return

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -15,6 +15,7 @@ const DESKTOP_CONTROL_IDLE_POLL_DELAY_MS = 50
 type DesktopControlAction =
   | 'capture'
   | 'click'
+  | 'clickWhenEnabled'
   | 'fill'
   | 'getText'
   | 'snapshot'
@@ -29,6 +30,7 @@ interface DesktopControlCommand {
   text?: string
   timeoutMs?: number
   enabled?: boolean
+  stableMs?: number
   key?: string
 }
 
@@ -230,6 +232,7 @@ function desktopControlElementEnabled(element: HTMLElement): boolean {
 async function waitForDesktopControlElement(command: DesktopControlCommand): Promise<string> {
   const timeoutMs = command.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
   const startedAt = Date.now()
+  let matchedAt: number | null = null
 
   while (Date.now() - startedAt < timeoutMs) {
     const elements = findDesktopControlElements(command.selector)
@@ -237,7 +240,12 @@ async function waitForDesktopControlElement(command: DesktopControlCommand): Pro
     const hasExpectedText = !command.text || text.includes(command.text)
     const isEnabled = !command.enabled || elements.some(desktopControlElementEnabled)
     if (elements.length > 0 && hasExpectedText && isEnabled) {
-      return text
+      matchedAt ??= Date.now()
+      if (Date.now() - matchedAt >= (command.stableMs ?? 0)) {
+        return text
+      }
+    } else {
+      matchedAt = null
     }
     await new Promise(resolve => window.setTimeout(resolve, 50))
   }
@@ -302,6 +310,17 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
       if (!desktopControlElementEnabled(element)) {
         throw new Error(`Selector "${command.selector}" is disabled`)
+      }
+      element.click()
+      return element.textContent?.trim() ?? ''
+    }
+    case 'clickWhenEnabled': {
+      await waitForDesktopControlElement({ ...command, enabled: true })
+      const element = findDesktopControlElements(command.selector).find(
+        desktopControlElementEnabled
+      )
+      if (!element) {
+        throw new Error(`Selector "${command.selector}" became disabled before click`)
       }
       element.click()
       return element.textContent?.trim() ?? ''

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -65,7 +65,7 @@ declare global {
   }
 }
 
-function isAutomationEnabled(): boolean {
+export function isWeworkAutomationEnabled(): boolean {
   return import.meta.env.MODE === 'e2e' || import.meta.env.VITE_WEWORK_E2E === 'true'
 }
 
@@ -172,7 +172,7 @@ function createBridge(): WeworkAutomationBridge {
 }
 
 export function installWeworkAutomationBridge() {
-  if (!isAutomationEnabled() || typeof window === 'undefined') {
+  if (!isWeworkAutomationEnabled() || typeof window === 'undefined') {
     return
   }
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -71,6 +71,13 @@ export function isWeworkAutomationEnabled(): boolean {
   return import.meta.env.MODE === 'e2e' || import.meta.env.VITE_WEWORK_E2E === 'true'
 }
 
+export function shouldUseNativeProjectDirectoryPicker(): boolean {
+  return (
+    !isWeworkAutomationEnabled() ||
+    import.meta.env.VITE_WEWORK_E2E_NATIVE_DIRECTORY_PICKER === 'true'
+  )
+}
+
 function desktopControlUrl(): string | null {
   const value = import.meta.env.VITE_WEWORK_DESKTOP_E2E_CONTROL_URL?.trim()
   return value ? value.replace(/\/+$/, '') : null


### PR DESCRIPTION
## What changed

- defer the macOS native directory picker until the project dialog has mounted and the triggering menu event has fully completed
- use the existing in-app directory browser during deterministic desktop E2E, while providing an explicit verification-only override that keeps the isolated controller active with the real native picker
- extend the real desktop E2E task flow to cover folder-picker cancellation, reopening, path selection, workspace registration, and the Codex task/retry lifecycle
- make desktop control actions wait for a continuously stable enabled state and click atomically, fixing state-propagation races found by the first PR CI run

## Root cause

The local-folder menu handler opened `NSOpenPanel` before React had committed the menu close. Starting the macOS modal loop from the active menu pointer event could leave the native picker stuck. Unit tests mocked the picker at the handler boundary, and desktop E2E bypassed folder selection with `--open-workspace`, so neither suite covered this ordering.

Production still uses the Finder picker, but it now opens from the mounted dialog effect after the originating menu is gone. Default isolated automation uses the equivalent in-app browser backed by the real executor because an OS-owned modal cannot be driven through the WebView controller. `VITE_WEWORK_E2E_NATIVE_DIRECTORY_PICKER=true` explicitly restores the native picker in an isolated verification build without disabling the controller.

## QA test plan and results

Environment and preconditions:

- macOS real Tauri development application, not a browser-only run
- isolated executor HOME, device ID, IPC socket, Codex auth link, and application process group created by `ai:verify`
- local runtime online with a usable local Codex device
- temporary workspace `/tmp/wework-folder-picker-qa-1925-rebase`
- branch rebased onto current `origin/main` (`1a5e21c5c`)

| Case | Steps | Expected result | Actual result / evidence |
| --- | --- | --- | --- |
| QA-NATIVE-01 native panel ordering and responsiveness | Start isolated Tauri with `VITE_WEWORK_E2E_NATIVE_DIRECTORY_PICKER=true`; open Projects → Use existing folder; issue a WebView snapshot with a 3s timeout while the native panel is open | project menu is already unmounted before the native call; Finder panel opens; the application event loop and controller remain responsive | Passed. Unit assertion observes the menu absent inside the native-picker invocation. In real Tauri, the in-app dialog was absent, the native app became frontmost, and the controller returned the snapshot within 3s. The previous hang did not reproduce. |
| QA-NEG-01 cancel and recover | Start normal isolated Tauri verification; open Use existing folder; capture the dialog; click Cancel; wait for Projects create control | dialog closes, no project is added, workbench remains interactive | Passed. `folder-dialog-open.png` and `folder-dialog-cancelled.png` retained in the isolated session evidence directory. |
| QA-RECOVERY-01 reopen after cancel | From the recovered workbench, open Use existing folder again | picker opens again with a usable path input and directory listing | Passed. `device-folder-path-input` became available and accepted input. |
| QA-HAPPY-01 select a real directory | Enter the temporary path, confirm selection, wait for the editable composer and project name, capture final UI | selected project appears, composer is editable, no modal remains | Passed. Body contained `wework-folder-picker-qa-1925-rebase`; `folder-selected.png` was inspected and shows the selected project and ready composer. |
| QA-E2E-01 core desktop lifecycle | Launch the built Tauri binary from an empty workbench; cancel and reopen folder selection; select the E2E workspace; run real Codex tool execution, follow-up, cancellation, retry, and fresh chat | every stage reaches its asserted UI/runtime state and Codex creates the expected workspace artifact | Passed locally after the latest rebase. Diagnostics: `wework/test-results/desktop-e2e/2026-07-13T11-50-02-842Z-70747`. |
| QA-CLEANUP-01 isolation cleanup | stop both `ai:verify` sessions and delete temporary workspaces | process groups terminate, auth links and IPC sockets are removed, temporary test data is deleted | Passed. |

The host has not granted `osascript` Accessibility permission, so the OS-owned Finder buttons were not falsely claimed as script-driven. Native opening/order/responsiveness is covered by QA-NATIVE-01; cancel, positive selection, recovery, and end-to-end behavior are covered in the real Tauri application through the controllable executor-backed picker.

## Automated regression coverage

- native picker is invoked only after the project menu has unmounted
- native cancel closes the mounted dialog without opening the in-app fallback
- automation mode uses the controllable local folder browser
- desktop E2E starts without `--open-workspace` and covers cancel → reopen → select → register workspace before task execution
- stable atomic control actions prevent transient enabled states from racing send, model selection, cancellation, and retry

## Validation

- changed-file Prettier and ESLint — passed
- `pnpm --filter wework typecheck` — passed
- focused `DesktopWorkbenchLayout` suite — 126 tests passed
- full Wework unit suite in pre-push — passed
- `pnpm --filter wework e2e:desktop` — passed with built Tauri, real executor, and real Codex binary after rebasing latest main
- isolated `ai:verify` native-panel run — passed ordering/responsiveness check
- isolated `ai:verify` cancel/reopen/select run — passed with inspected screenshots
- pre-push Frontend/Wework lint, TypeScript, unit tests, Backend formatting/syntax, settings, and Alembic checks — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved desktop project-folder selection experience, including a clearer existing-folder path with cancel/reopen, then final confirm.
  * When native directory picking is disabled, desktop now uses the in-app standalone folder dialog with device-home resolution.

* **Bug Fixes**
  * Desktop workspace setup dialog behavior is more consistent, preserving/restoring the folder dialog state during interruption flows.
  * Enhanced desktop UI automation reliability by waiting for elements to become enabled/stable before interacting, reducing flaky retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->