### PR TITLE
fix(wework): collapse file list and capture Tauri verification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0

--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -39,6 +39,7 @@ pnpm --filter wework ai:verify snapshot --session <session-path>
 pnpm --filter wework ai:verify click --session <session-path> --selector '[data-testid="..."]'
 pnpm --filter wework ai:verify fill --session <session-path> --selector '[data-testid="..."]' --value '...'
 pnpm --filter wework ai:verify wait-for --session <session-path> --selector '[data-testid="..."]' --text '...'
+pnpm --filter wework ai:verify capture --session <session-path> --output <png-path>
 pnpm --filter wework ai:verify stop --session <session-path>
 ```
 
@@ -46,6 +47,7 @@ pnpm --filter wework ai:verify stop --session <session-path>
 - Session files and credentials are secrets: never print their contents. Always stop the session; it removes the auth link and terminates the isolated process group.
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.
 - Execute the complete QA test plan in the isolated Tauri session, including the primary path, relevant boundary and error cases, and recovery. Document the environment, cases run, actual results, and evidence in the change handoff or pull request.
+- Use `capture` after the final assertion when a visual verification artifact is required. It renders the current WebView without macOS screen-recording permission.
 - On failure, inspect `app.log`, `executor.log`, and Tauri logs under `test-results/ai-verify/`; do not silently downgrade to mocked verification.
 
 ## Local runtime boundaries

--- a/wework/package.json
+++ b/wework/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "html2canvas": "^1.4.1",
     "jsdom": "^28.1.0",
     "lint-staged": "^16.4.0",
     "postcss": "^8.5.15",

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -26,12 +26,13 @@ const corsHeaders = {
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
-  pnpm --filter wework ai:verify <snapshot|click|fill|press|wait-for|text|status|stop> --session PATH [options]
+  pnpm --filter wework ai:verify <capture|snapshot|click|fill|press|wait-for|text|status|stop> --session PATH [options]
 
 Options:
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
   --value TEXT              Replacement value for fill
   --key KEY                 Keyboard key for press
+  --output PATH             PNG output path for capture
   --text TEXT               Expected text for wait-for
   --timeout MS              Command timeout (default: ${defaultTimeoutMs})`)
 }
@@ -308,6 +309,7 @@ async function main() {
     return
   }
   const action = {
+    capture: 'capture',
     snapshot: 'snapshot',
     click: 'click',
     fill: 'fill',
@@ -321,7 +323,8 @@ async function main() {
     return
   }
   const selector =
-    options.selector ?? (command === 'snapshot' || command === 'text' ? 'body' : null)
+    options.selector ??
+    (command === 'capture' || command === 'snapshot' || command === 'text' ? 'body' : null)
   if (!selector) throw new Error('--selector is required')
   const value = await request(session, session.token, '/command', 'POST', {
     action,
@@ -331,6 +334,16 @@ async function main() {
     text: options.text,
     timeoutMs: options.timeout ? Number(options.timeout) : undefined,
   })
+  if (command === 'capture') {
+    if (!options.output) throw new Error('--output is required')
+    const prefix = 'data:image/png;base64,'
+    if (!value.value?.startsWith(prefix)) throw new Error('Invalid screenshot payload')
+    const outputPath = resolve(options.output)
+    await mkdir(dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, Buffer.from(value.value.slice(prefix.length), 'base64'))
+    console.log(outputPath)
+    return
+  }
   console.log(typeof value.value === 'string' ? value.value : JSON.stringify(value.value, null, 2))
 }
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4672,6 +4672,16 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workspace-file-toggle-tree-button')).toHaveAccessibleName(
       '显示目录树'
     )
+
+    await user.click(screen.getByTestId('workspace-file-toggle-tree-button'))
+
+    expect(screen.getByTestId('workspace-file-tree-container')).toHaveClass(
+      'w-[240px]',
+      'opacity-100'
+    )
+    expect(screen.getByTestId('workspace-file-toggle-tree-button')).toHaveAccessibleName(
+      '隐藏目录树'
+    )
     expect(readWorkspaceTextFile).toHaveBeenCalledWith(
       'workspace-cloud-device',
       '/workspace/project/README.md'

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4664,6 +4664,14 @@ describe('DesktopWorkbenchLayout', () => {
     expect(await screen.findByTestId('workspace-file-preview-code-view')).toBeInTheDocument()
     await waitFor(() => expect(getWorkspaceCodeViewText()).toContain('opened from tool block'))
     expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('workspace-file-tree-container')).toHaveClass(
+      'pointer-events-none',
+      'w-0',
+      'opacity-0'
+    )
+    expect(screen.getByTestId('workspace-file-toggle-tree-button')).toHaveAccessibleName(
+      '显示目录树'
+    )
     expect(readWorkspaceTextFile).toHaveBeenCalledWith(
       'workspace-cloud-device',
       '/workspace/project/README.md'

--- a/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
@@ -388,6 +388,7 @@ export function FileWorkspacePanel({
     let cancelled = false
     void Promise.resolve().then(() => {
       if (!cancelled) {
+        setDirectoryTreeVisible(false)
         openFilePath(openFileRequest.path, {
           lineStart: openFileRequest.lineStart,
           lineEnd: openFileRequest.lineEnd,

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -12,7 +12,14 @@ const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRC
 const DESKTOP_CONTROL_RETRY_DELAY_MS = 250
 const DESKTOP_CONTROL_IDLE_POLL_DELAY_MS = 50
 
-type DesktopControlAction = 'click' | 'fill' | 'getText' | 'snapshot' | 'waitFor' | 'press'
+type DesktopControlAction =
+  | 'capture'
+  | 'click'
+  | 'fill'
+  | 'getText'
+  | 'snapshot'
+  | 'waitFor'
+  | 'press'
 
 interface DesktopControlCommand {
   id: string
@@ -196,6 +203,25 @@ function desktopControlSnapshot(): string {
   })
 }
 
+async function captureDesktopControlScreenshot(selector: string): Promise<string> {
+  const element = findDesktopControlElements(selector)[0]
+  if (!element) throw new Error(`Unable to find selector "${selector}"`)
+
+  const { default: html2canvas } = await import('html2canvas')
+  const canvas = await html2canvas(element, {
+    allowTaint: false,
+    backgroundColor: getComputedStyle(document.documentElement).backgroundColor,
+    height: element === document.body ? window.innerHeight : undefined,
+    logging: false,
+    scale: Math.min(window.devicePixelRatio, 2),
+    useCORS: true,
+    width: element === document.body ? window.innerWidth : undefined,
+    windowHeight: window.innerHeight,
+    windowWidth: window.innerWidth,
+  })
+  return canvas.toDataURL('image/png')
+}
+
 function desktopControlElementEnabled(element: HTMLElement): boolean {
   if (element.getAttribute('aria-disabled') === 'true') return false
   return !('disabled' in element) || !(element as HTMLButtonElement).disabled
@@ -263,6 +289,8 @@ function fillDesktopControlElement(element: HTMLElement, value: string) {
 
 async function executeDesktopControlCommand(command: DesktopControlCommand): Promise<string> {
   switch (command.action) {
+    case 'capture':
+      return captureDesktopControlScreenshot(command.selector)
     case 'waitFor':
       return waitForDesktopControlElement(command)
     case 'getText':


### PR DESCRIPTION
## Summary

- Collapse the workspace file list by default when a concrete file link opens the right panel.
- Keep the file list expanded when users open the Files tab directly, and allow restoring it with the existing toggle.
- Add `ai:verify capture` so isolated Tauri verification can save a PNG without macOS screen-recording permission.

## Root cause

The file workspace panel always initialized its directory tree as visible. File-open requests selected the requested preview but did not distinguish that focused preview flow from browsing the Files tab directly.

## User and developer impact

Opening a file from a conversation now prioritizes the preview area while preserving manual file-list navigation. Contributors can also retain visual evidence from the real isolated Tauri WebView.

## Validation

- `pnpm --filter wework test` — 154 files, 1535 tests passed.
- `pnpm --filter wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx` — 125 tests passed.
- TypeScript, ESLint, Prettier, and `git diff --check` passed.
- Pre-push Wework quality checks passed.
- Isolated Tauri QA:
  - Direct Files-tab browsing kept the file list visible.
  - Clicking a real `verify.txt` conversation link opened the preview with the tree container at width zero.
  - The toggle exposed the accessible name `显示目录树`, and the automated recovery path restored the 240px file list.
  - `ai:verify capture` produced a 1200×720 PNG from the Tauri WebView.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added desktop verification support for capturing selected interface areas as PNG images.
  - Added a command-line capture option with configurable output paths and clear success feedback.

- **Bug Fixes**
  - Opening a requested workspace file now automatically collapses the directory tree for a cleaner view.

- **Documentation**
  - Updated verification guidance to include capturing a final visual result after assertions.

- **Tests**
  - Added coverage for directory tree collapsed and expanded states, including accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->