### PR TITLE
feat(token-issuer): add generic extra-claims seam to token issuance

### DIFF
--- a/backend/app/api/endpoints/token_issuers.py
+++ b/backend/app/api/endpoints/token_issuers.py
@@ -33,7 +33,7 @@ async def issue_outbound_token(
             db,
             issuer_id=issuer_id,
             user=current_user,
-            expires_in=request.expires_in,
+            request=request,
         )
     except TokenIssuerNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/schemas/token_issuer.py
+++ b/backend/app/schemas/token_issuer.py
@@ -7,7 +7,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.schemas.kind import ObjectMeta, Status
 
@@ -183,7 +183,14 @@ class TokenIssuerListResponse(BaseModel):
 
 
 class TokenIssueRequest(BaseModel):
-    """Public issue request."""
+    """Public issue request.
+
+    Allows unknown fields so downstream deployments can carry extra opt-in
+    options (consumed by ``OutboundTokenService._collect_extra_claims``)
+    without the open-source core needing to know about them.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     expires_in: Optional[int] = Field(default=None, ge=60, le=86400)
 

--- a/backend/app/services/auth/outbound_token_service.py
+++ b/backend/app/services/auth/outbound_token_service.py
@@ -22,6 +22,7 @@ from app.schemas.token_issuer import (
     SigningKeyKind,
     SigningKeyResponse,
     TokenIssuerCreateRequest,
+    TokenIssueRequest,
     TokenIssueResponse,
     TokenIssuerKind,
     TokenIssuerResponse,
@@ -340,6 +341,7 @@ class OutboundTokenService:
         issuer_id: int,
         user: User,
         expires_in: Optional[int] = None,
+        request: Optional[TokenIssueRequest] = None,
     ) -> TokenIssueResponse:
         issuer_row = self._get_kind_or_raise(
             db, TOKEN_ISSUER_KIND, issuer_id, TokenIssuerNotFoundError
@@ -348,7 +350,14 @@ class OutboundTokenService:
         if not issuer.spec.enabled or not issuer_row.is_active:
             raise OutboundTokenValidationError("Token issuer is disabled")
 
-        ttl = issuer.spec.defaultTtlSeconds if expires_in is None else expires_in
+        effective_expires_in = expires_in
+        if request is not None and request.expires_in is not None:
+            effective_expires_in = request.expires_in
+        ttl = (
+            issuer.spec.defaultTtlSeconds
+            if effective_expires_in is None
+            else effective_expires_in
+        )
         if ttl <= 0:
             raise OutboundTokenValidationError("Requested TTL must be positive")
         if ttl > issuer.spec.maxTtlSeconds:
@@ -370,6 +379,12 @@ class OutboundTokenService:
             "user_name": user.user_name,
             "issuer_id": issuer_row.id,
         }
+        extra_claims = self._collect_extra_claims(
+            db, user=user, issuer=issuer, request=request
+        )
+        for key, value in extra_claims.items():
+            if key not in claims:  # standard reserved claims are never overridden
+                claims[key] = value
         token = jwt.encode(
             claims,
             signing_key.private_key_pem,
@@ -393,6 +408,23 @@ class OutboundTokenService:
             issued_at=claims["iat"],
             expires_at=claims["exp"],
         )
+
+    def _collect_extra_claims(
+        self,
+        db: Session,
+        *,
+        user: User,
+        issuer: TokenIssuerKind,
+        request: Optional[TokenIssueRequest] = None,
+    ) -> dict:
+        """Extension point for deployment-specific extra JWT claims.
+
+        Open-source core contributes none. Deployments may patch this to
+        inject additional claims (e.g. an employee id). The caller merges the
+        returned mapping into the token but never lets it override standard
+        reserved claims.
+        """
+        return {}
 
     def _to_signing_key_response(self, row: Kind) -> SigningKeyResponse:
         resource = SigningKeyKind.model_validate(row.json)

--- a/backend/tests/api/endpoints/test_token_issuers_api.py
+++ b/backend/tests/api/endpoints/test_token_issuers_api.py
@@ -161,3 +161,51 @@ def test_issue_endpoint_openapi_declares_oauth2_and_api_key_security(
 
     assert {"OAuth2PasswordBearer": []} in operation["security"]
     assert {"APIKeyHeader": []} in operation["security"]
+
+
+def test_issue_endpoint_accepts_unknown_fields_and_core_ignores_them(
+    test_client: TestClient,
+    test_admin_token: str,
+    test_token: str,
+):
+    admin_headers = {"Authorization": f"Bearer {test_admin_token}"}
+
+    signing_key = test_client.post(
+        "/api/admin/signing-keys",
+        headers=admin_headers,
+        json={"name": "extra-fields-key"},
+    ).json()
+
+    issuer = test_client.post(
+        "/api/admin/token-issuers",
+        headers=admin_headers,
+        json={
+            "name": "extra-fields-issuer",
+            "signing_key_id": signing_key["id"],
+            "issuer": "wegent",
+            "audience": "vip_sql_platform",
+            "default_ttl_seconds": 600,
+            "max_ttl_seconds": 900,
+            "enabled": True,
+        },
+    ).json()
+
+    issue_response = test_client.post(
+        f"/api/v1/token-issuers/{issuer['id']}/issue",
+        headers={"Authorization": f"Bearer {test_token}"},
+        json={"expires_in": 300, "include_employee_id": True, "bogus": "x"},
+    )
+    # extra="allow" means the unknown fields pass FastAPI validation (no 422)
+    assert issue_response.status_code == 200
+    claims = jwt.decode(
+        issue_response.json()["access_token"],
+        signing_key["public_key_pem"],
+        algorithms=["RS256"],
+        audience="vip_sql_platform",
+        issuer="wegent",
+    )
+    # open-source core contributes no extra claims
+    assert "employee_id" not in claims
+    assert "include_employee_id" not in claims
+    assert "bogus" not in claims
+    assert claims["sub"] == "user:" + str(claims["user_id"])

--- a/backend/tests/services/auth/test_outbound_token_service.py
+++ b/backend/tests/services/auth/test_outbound_token_service.py
@@ -8,7 +8,11 @@ import jwt
 import pytest
 from sqlalchemy.orm import Session
 
-from app.schemas.token_issuer import SigningKeyCreateRequest, TokenIssuerCreateRequest
+from app.schemas.token_issuer import (
+    SigningKeyCreateRequest,
+    TokenIssuerCreateRequest,
+    TokenIssueRequest,
+)
 from app.services.auth.outbound_token_service import (
     OutboundTokenValidationError,
     outbound_token_service,
@@ -207,3 +211,69 @@ def test_issue_outbound_token_rejects_non_positive_ttl(
         )
 
     assert "must be positive" in str(exc_info.value)
+
+
+def _new_issuer(test_db, name):
+    signing_key = outbound_token_service.create_signing_key(
+        test_db, SigningKeyCreateRequest(name=f"{name}-key")
+    )
+    issuer = outbound_token_service.create_token_issuer(
+        test_db,
+        TokenIssuerCreateRequest(
+            name=f"{name}-issuer",
+            signing_key_id=signing_key.id,
+            issuer="wegent",
+            audience="aud",
+            default_ttl_seconds=600,
+            max_ttl_seconds=900,
+            enabled=True,
+        ),
+    )
+    return signing_key, issuer
+
+
+def test_extra_claims_hook_merges_without_overriding_reserved(
+    test_db, test_user, monkeypatch
+):
+    signing_key, issuer = _new_issuer(test_db, "hook")
+
+    def fake_extra(self, db, *, user, issuer, request=None):
+        return {"custom_claim": "ok", "sub": "hacked"}
+
+    monkeypatch.setattr(
+        type(outbound_token_service), "_collect_extra_claims", fake_extra
+    )
+
+    issued = outbound_token_service.issue_token(
+        test_db,
+        issuer_id=issuer.id,
+        user=test_user,
+        request=TokenIssueRequest(expires_in=300),
+    )
+    claims = jwt.decode(
+        issued.access_token,
+        signing_key.public_key_pem,
+        algorithms=["RS256"],
+        audience="aud",
+        issuer="wegent",
+    )
+    assert claims["custom_claim"] == "ok"
+    assert claims["sub"] == f"user:{test_user.id}"  # reserved 不被覆盖
+
+
+def test_issue_request_ignores_unknown_fields_in_core(test_db, test_user):
+    signing_key, issuer = _new_issuer(test_db, "unknown")
+    req = TokenIssueRequest.model_validate(
+        {"expires_in": 300, "include_employee_id": True}
+    )
+    issued = outbound_token_service.issue_token(
+        test_db, issuer_id=issuer.id, user=test_user, request=req
+    )
+    claims = jwt.decode(
+        issued.access_token,
+        signing_key.public_key_pem,
+        algorithms=["RS256"],
+        audience="aud",
+        issuer="wegent",
+    )
+    assert "employee_id" not in claims  # core 无扩展


### PR DESCRIPTION
Open-source core exposes _collect_extra_claims (default empty) and lets TokenIssueRequest carry unknown fields, so downstream deployments can inject extra JWT claims without overriding reserved standard claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token issuance now accepts a richer request payload, including support for extra (previously unknown) options.
  * Added the ability to include additional custom JWT claims during issuance, while protecting standard reserved claims.
* **Bug Fixes**
  * Token expiration is now derived consistently from the full issuance request, with the same existing TTL validation and issuer policy checks.
* **Tests**
  * Expanded coverage for extra fields, custom claims, and reserved-claim protection via service and API tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->