### PR TITLE
fix(wework): restore macOS dock window lifecycle

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -40,6 +40,7 @@ pnpm --filter wework ai:verify click --session <session-path> --selector '[data-
 pnpm --filter wework ai:verify fill --session <session-path> --selector '[data-testid="..."]' --value '...'
 pnpm --filter wework ai:verify wait-for --session <session-path> --selector '[data-testid="..."]' --text '...'
 pnpm --filter wework ai:verify capture --session <session-path> --output <png-path>
+pnpm --filter wework ai:verify close-to-tray --session <session-path>
 pnpm --filter wework ai:verify stop --session <session-path>
 ```
 
@@ -48,6 +49,7 @@ pnpm --filter wework ai:verify stop --session <session-path>
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.
 - Execute the complete QA test plan in the isolated Tauri session, including the primary path, relevant boundary and error cases, and recovery. Document the environment, cases run, actual results, and evidence in the change handoff or pull request.
 - Use `capture` after the final assertion when a visual verification artifact is required. It renders the current WebView without macOS screen-recording permission.
+- Use `close-to-tray` only for window-lifecycle verification. It destroys the controlled WebView while leaving the isolated Tauri process running so native reopen behavior can be tested.
 - On failure, inspect `app.log`, `executor.log`, and Tauri logs under `test-results/ai-verify/`; do not silently downgrade to mocked verification.
 
 ## Local runtime boundaries

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -26,7 +26,7 @@ const corsHeaders = {
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
-  pnpm --filter wework ai:verify <capture|snapshot|click|fill|press|wait-for|text|status|stop> --session PATH [options]
+  pnpm --filter wework ai:verify <capture|snapshot|click|close-to-tray|fill|press|wait-for|text|status|stop> --session PATH [options]
 
 Options:
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
@@ -312,6 +312,7 @@ async function main() {
     capture: 'capture',
     snapshot: 'snapshot',
     click: 'click',
+    'close-to-tray': 'closeMainWindowToTray',
     fill: 'fill',
     press: 'press',
     'wait-for': 'waitFor',
@@ -324,7 +325,12 @@ async function main() {
   }
   const selector =
     options.selector ??
-    (command === 'capture' || command === 'snapshot' || command === 'text' ? 'body' : null)
+    (command === 'capture' ||
+    command === 'snapshot' ||
+    command === 'text' ||
+    command === 'close-to-tray'
+      ? 'body'
+      : null)
   if (!selector) throw new Error('--selector is required')
   const value = await request(session, session.token, '/command', 'POST', {
     action,

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -42,5 +42,5 @@ tauri-plugin-updater = "2.10.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.3"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSImage", "NSPasteboard"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSPasteboard"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSDistributedNotificationCenter", "NSNotification", "NSObject", "NSString", "std"] }

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -3,8 +3,6 @@ mod local_executor;
 mod local_terminal;
 mod process_environment;
 
-#[cfg(all(desktop, target_os = "macos"))]
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 #[cfg(desktop)]
 use std::sync::{
@@ -42,11 +40,6 @@ const TRAY_MENU_QUIT_ID: &str = "quit";
 #[cfg(desktop)]
 const TRAY_MENU_TASK_PREFIX: &str = "task:";
 
-#[cfg(all(desktop, target_os = "macos"))]
-thread_local! {
-    static MACOS_CACHED_DOCK_ICON: RefCell<Option<objc2::rc::Retained<objc2_app_kit::NSImage>>> =
-        const { RefCell::new(None) };
-}
 #[cfg(desktop)]
 const TRAY_ID: &str = "wework-main";
 #[cfg(desktop)]
@@ -316,10 +309,21 @@ enum MainWindowOpenAction {
 }
 
 #[cfg(desktop)]
-#[derive(Default)]
 struct MainWindowLifecycleState {
+    dock_icon_visible: AtomicBool,
     destroy_to_tray_in_progress: AtomicBool,
     pending_open_action: Mutex<Option<MainWindowOpenAction>>,
+}
+
+#[cfg(desktop)]
+impl Default for MainWindowLifecycleState {
+    fn default() -> Self {
+        Self {
+            dock_icon_visible: AtomicBool::new(true),
+            destroy_to_tray_in_progress: AtomicBool::new(false),
+            pending_open_action: Mutex::new(None),
+        }
+    }
 }
 
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
@@ -1681,74 +1685,18 @@ fn get_local_executor_device_id(expected_backend_url: Option<String>) -> Option<
 fn set_dock_icon_visible<R: tauri::Runtime>(app: &tauri::AppHandle<R>, visible: bool) {
     #[cfg(target_os = "macos")]
     {
-        if !visible {
-            cache_current_macos_dock_icon();
+        let state = app.state::<MainWindowLifecycleState>();
+        if state.dock_icon_visible.swap(visible, Ordering::SeqCst) == visible {
+            return;
         }
-        let policy = if visible {
-            tauri::ActivationPolicy::Regular
-        } else {
-            tauri::ActivationPolicy::Accessory
-        };
-        if let Err(error) = app.set_activation_policy(policy) {
-            log::warn!("Failed to update macOS activation policy: {error}");
-        }
-        if visible {
-            refresh_macos_dock_icon();
+        if let Err(error) = app.set_dock_visibility(visible) {
+            state.dock_icon_visible.store(!visible, Ordering::SeqCst);
+            log::warn!("Failed to update macOS Dock visibility: {error}");
         }
     }
 
     #[cfg(not(target_os = "macos"))]
     let _ = (app, visible);
-}
-
-#[cfg(all(desktop, target_os = "macos"))]
-fn macos_application() -> Option<objc2::rc::Retained<objc2_app_kit::NSApplication>> {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::NSApplication;
-
-    let Some(main_thread) = MainThreadMarker::new() else {
-        log::warn!("Skipped macOS Dock icon operation outside the main thread");
-        return None;
-    };
-    Some(NSApplication::sharedApplication(main_thread))
-}
-
-#[cfg(all(desktop, target_os = "macos"))]
-fn cache_current_macos_dock_icon() {
-    let Some(app) = macos_application() else {
-        return;
-    };
-    let Some(app_icon) = app.applicationIconImage() else {
-        return;
-    };
-    MACOS_CACHED_DOCK_ICON.with(|cached| {
-        *cached.borrow_mut() = Some(app_icon);
-    });
-}
-
-#[cfg(all(desktop, target_os = "macos"))]
-fn refresh_macos_dock_icon() {
-    let Some(app) = macos_application() else {
-        return;
-    };
-    MACOS_CACHED_DOCK_ICON.with(|cached| {
-        if let Some(app_icon) = cached.borrow().as_ref() {
-            unsafe {
-                app.setApplicationIconImage(Some(app_icon));
-            }
-        }
-    });
-}
-
-#[cfg(all(desktop, target_os = "macos"))]
-fn initialize_macos_dock_icon_cache() {
-    if let Some(app) = macos_application() {
-        if let Some(app_icon) = app.applicationIconImage() {
-            MACOS_CACHED_DOCK_ICON.with(|cached| {
-                *cached.borrow_mut() = Some(app_icon);
-            });
-        }
-    }
 }
 
 #[cfg(desktop)]
@@ -3263,9 +3211,16 @@ pub fn run() {
     app.run(|app_handle, event| {
         #[cfg(desktop)]
         match event {
-            tauri::RunEvent::Ready => {
-                #[cfg(target_os = "macos")]
-                initialize_macos_dock_icon_cache();
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } => {
+                if !has_visible_windows {
+                    if let Err(error) = ensure_main_window(app_handle, None) {
+                        log::warn!("Failed to reopen main window from macOS activation: {error}");
+                    }
+                }
             }
             tauri::RunEvent::ExitRequested { api, .. } => {
                 let lifecycle = app_handle.state::<MainWindowLifecycleState>();

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -6,6 +6,7 @@ import {
   type TestLocalModelConnectionResult,
 } from '@/features/model-settings/localModelConnectionTest'
 import { isTauriRuntime } from '@/lib/runtime-environment'
+import { closeMainWindowToTray } from '@/tauri/runtimeTaskCloseGuard'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -16,6 +17,7 @@ type DesktopControlAction =
   | 'capture'
   | 'click'
   | 'clickWhenEnabled'
+  | 'closeMainWindowToTray'
   | 'fill'
   | 'getText'
   | 'snapshot'
@@ -306,6 +308,13 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
   switch (command.action) {
     case 'capture':
       return captureDesktopControlScreenshot(command.selector)
+    case 'closeMainWindowToTray':
+      window.setTimeout(() => {
+        void closeMainWindowToTray().catch(error => {
+          console.error('[Wework] Failed to close the main window during E2E verification:', error)
+        })
+      }, 100)
+      return ''
     case 'waitFor':
       return waitForDesktopControlElement(command)
     case 'getText':


### PR DESCRIPTION
## Summary

- use Tauri's dedicated macOS Dock visibility API for close-to-tray lifecycle changes
- reopen and focus the main window when macOS sends `RunEvent::Reopen` without visible windows
- avoid redundant Dock visibility transitions and remove the obsolete native icon cache
- add an isolated `close-to-tray` AI verification action and document its usage

## Root cause

The close-to-tray path destroyed the main window and changed `NSApplication` activation policy. On older macOS versions that policy transition could leave the Dock icon visible. The application also did not handle the native reopen callback, so activating the remaining Dock icon could not recreate the destroyed main window.

## Impact

Closing Wework to the tray now removes its Dock icon while keeping the process running. If macOS still delivers a Dock/system reopen activation, Wework recreates and focuses the main window instead of leaving an unresponsive icon.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test` — 44 passed
- Prettier and ESLint checks for the changed verification files
- `pnpm --filter wework typecheck`
- pre-push Wework ESLint, TypeScript, and unit-test suite
- isolated real-Tauri verification: closing to tray left the process running, reduced visible app windows to zero, and changed the macOS application type to `UIElement`; subsequent native activation initialized a new WebView

The real-Tauri run used macOS 26.2. Dedicated older-macOS hardware was not available in this workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a verification command action to close the main window to the system tray.
  * On macOS, reopening the app from the Dock now restores the main window when no windows are visible.

* **Bug Fixes**
  * Improved macOS Dock icon visibility tracking and recovery to better handle failures when toggling visibility.

* **Tests**
  * Added an end-to-end desktop control action to close the main window to the system tray.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->