### PR TITLE
fix(wework): reduce long-running task memory usage

### DIFF
--- a/docs/en/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/developer-guide/wework-performance-diagnostics.md
@@ -122,9 +122,13 @@ After Web Inspector opens, run this when the app becomes slow:
 window.__WEWORK_PERF__.snapshot();
 ```
 
-The snapshot includes the current URL, page visibility, DOM node count, memory snapshot, navigation timing, resource count, and recent events. When comparing multiple snapshots, focus on:
+The snapshot includes the current URL, page visibility, DOM node count, memory snapshot, navigation timing, resource count, recent events, and Wework process-group data. macOS reparents WebKit XPC processes to PID 1; diagnostics use LaunchServices to associate the current Wework instance with its Web Content, GPU, and Networking processes.
+
+Each process group reports both `rss_kib` and `physical_footprint_kib`. RSS includes shared mappings and reclaimable resident pages and is commonly much larger than actual memory pressure. Prefer `physical_footprint_kib` when investigating leaks or system resource usage, and treat RSS as a secondary residency metric. When comparing multiple snapshots, focus on:
 
 - Whether `memory.usedJSHeapSize` keeps growing.
+- Whether `processMemory.groups[].physical_footprint_kib` keeps growing after a task completes and cools down.
+- Whether growth belongs to `webkit-webcontent`, `codex-app-server`, `executor`, or `main`.
 - Whether `domNodeCount` keeps growing.
 - Dense `longtask` or `event-loop-lag` events.
 - Repeated `slow-react-commit` events.

--- a/docs/zh/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/developer-guide/wework-performance-diagnostics.md
@@ -122,9 +122,13 @@ Web Inspector 打开后，在卡顿后执行：
 window.__WEWORK_PERF__.snapshot();
 ```
 
-返回值包含当前 URL、页面可见性、DOM 节点数、内存快照、导航时序、resource 数量和最近事件。需要持续观察时可以多次执行，重点比较：
+返回值包含当前 URL、页面可见性、DOM 节点数、内存快照、导航时序、resource 数量、最近事件，以及 Wework 进程组快照。macOS 上 WebKit XPC 进程会被系统改挂到 PID 1；诊断会通过 LaunchServices 将当前 Wework 实例对应的 Web Content、GPU 和 Networking 进程重新关联进来。
+
+进程组同时提供 `rss_kib` 和 `physical_footprint_kib`：RSS 包含共享映射和可回收驻留页，通常明显高于真实内存压力；判断泄漏或系统资源占用时应优先比较 `physical_footprint_kib`，RSS 只作为地址空间驻留的辅助指标。需要持续观察时可以多次执行，重点比较：
 
 - `memory.usedJSHeapSize` 是否持续上涨。
+- `processMemory.groups[].physical_footprint_kib` 是否在任务结束并冷却后仍持续上涨。
+- 增长来自 `webkit-webcontent`、`codex-app-server`、`executor` 还是 `main`。
 - `domNodeCount` 是否持续上涨。
 - 是否存在密集 `longtask` 或 `event-loop-lag`。
 - 是否存在重复的 `slow-react-commit`。

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -419,6 +419,28 @@ impl CodexAppServerClient {
         self.state.lock().await.active_threads.remove(thread_id);
     }
 
+    async fn unsubscribe_thread(&self, thread_id: &str) {
+        let result: Result<(), String> = async {
+            let (request_id, handle, response_rx) = self.prepare_existing_request().await?;
+            let message = json!({
+                "method": "thread/unsubscribe",
+                "id": request_id,
+                "params": {"threadId": thread_id},
+            });
+            let write_result = handle.write_message(message).await;
+            handle.remove_pending(request_id).await;
+            drop(response_rx);
+            write_result
+        }
+        .await;
+        if let Err(error) = result {
+            log_executor_event(
+                "codex shared thread unsubscribe failed",
+                &[("thread_id", thread_id.to_owned()), ("error", error)],
+            );
+        }
+    }
+
     async fn unscoped_notification_belongs_to_thread(&self, thread_id: &str) -> bool {
         let state = self.state.lock().await;
         state.active_threads.len() == 1 && state.active_threads.contains(thread_id)
@@ -780,6 +802,7 @@ async fn run_codex_app_server_turn_on_shared_client(
     }
     log_executor_event("codex shared app-server turn starting", &fields);
 
+    let mut subscribed_thread_id = None;
     let result: Result<CodexAppServerTurn, String> = async {
         let request = &prepared.request;
         let mut notification_rx = client
@@ -836,6 +859,7 @@ async fn run_codex_app_server_turn_on_shared_client(
             log_executor_event("codex shared thread request finished", &thread_fields);
             thread_id
         };
+        subscribed_thread_id = Some(thread_id.clone());
         if let Some(callback) = thread_started {
             callback(thread_id.clone());
         }
@@ -915,7 +939,6 @@ async fn run_codex_app_server_turn_on_shared_client(
         {
             Ok(turn) => turn,
             Err(error) => {
-                client.mark_thread_idle(&thread_id).await;
                 return Err(error);
             }
         };
@@ -941,7 +964,6 @@ async fn run_codex_app_server_turn_on_shared_client(
             },
         )
         .await;
-        client.mark_thread_idle(&thread_id).await;
         let outcome = outcome_result?;
         turn_fields.push(("outcome", codex_outcome_name(&outcome).to_owned()));
         if let ExecutionOutcome::Failed { message } = &outcome {
@@ -952,6 +974,11 @@ async fn run_codex_app_server_turn_on_shared_client(
         Ok(CodexAppServerTurn { thread_id, outcome })
     }
     .await;
+
+    if let Some(thread_id) = subscribed_thread_id {
+        client.mark_thread_idle(&thread_id).await;
+        client.unsubscribe_thread(&thread_id).await;
+    }
 
     if let Err(error) = &result {
         let mut failed_fields = fields.clone();

--- a/executor/src/runtime_work/transcript_cache.rs
+++ b/executor/src/runtime_work/transcript_cache.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     fs::{self, File},
     io::{Read, Seek, SeekFrom},
     sync::{Arc, Mutex},
@@ -16,10 +16,17 @@ use super::util::now_ms;
 
 const RUNNING_TRANSCRIPT_CACHE_TTL_MS: i64 = 1_200;
 const COMPLETED_TRANSCRIPT_CACHE_TTL_MS: i64 = 60_000;
+const MAX_TRANSCRIPT_CACHE_ENTRIES: usize = 8;
 
 #[derive(Clone, Default)]
 pub(crate) struct TranscriptCache {
-    entries: Arc<Mutex<HashMap<String, CachedTranscript>>>,
+    state: Arc<Mutex<TranscriptCacheState>>,
+}
+
+#[derive(Default)]
+struct TranscriptCacheState {
+    entries: HashMap<String, CachedTranscript>,
+    lru: VecDeque<String>,
 }
 
 #[derive(Clone)]
@@ -112,18 +119,21 @@ impl TranscriptCache {
         running_hint: bool,
         require_current_source: bool,
     ) -> Option<CachedTranscript> {
-        let mut entries = self.entries.lock().ok()?;
-        let entry = entries.get(key)?;
+        let mut state = self.state.lock().ok()?;
+        remove_expired_entries(&mut state);
+        let entry = state.entries.get(key)?;
         if require_current_source {
             let is_current = entry
                 .source_signature
                 .as_ref()
                 .is_some_and(TranscriptSourceSignature::is_current);
             if !is_current {
-                entries.remove(key);
+                remove_entry(&mut state, key);
                 return None;
             }
-            return Some(entry.clone());
+            let entry = entry.clone();
+            touch_entry(&mut state, key);
+            return Some(entry);
         }
         let ttl = if running_hint || entry.running {
             RUNNING_TRANSCRIPT_CACHE_TTL_MS
@@ -131,28 +141,71 @@ impl TranscriptCache {
             COMPLETED_TRANSCRIPT_CACHE_TTL_MS
         };
         if now_ms().saturating_sub(entry.cached_at) > ttl {
-            entries.remove(key);
+            remove_entry(&mut state, key);
             return None;
         }
-        Some(entry.clone())
+        let entry = entry.clone();
+        touch_entry(&mut state, key);
+        Some(entry)
     }
 
     pub fn peek(&self, key: &str) -> Option<CachedTranscript> {
-        let entries = self.entries.lock().ok()?;
-        entries.get(key).cloned()
+        let mut state = self.state.lock().ok()?;
+        remove_expired_entries(&mut state);
+        let entry = state.entries.get(key)?.clone();
+        touch_entry(&mut state, key);
+        Some(entry)
     }
 
     pub fn insert(&self, key: impl Into<String>, transcript: CachedTranscript) {
-        if let Ok(mut entries) = self.entries.lock() {
-            entries.insert(key.into(), transcript);
+        if let Ok(mut state) = self.state.lock() {
+            remove_expired_entries(&mut state);
+            let key = key.into();
+            state.entries.insert(key.clone(), transcript);
+            touch_entry(&mut state, &key);
+            while state.entries.len() > MAX_TRANSCRIPT_CACHE_ENTRIES {
+                let Some(oldest_key) = state.lru.pop_front() else {
+                    break;
+                };
+                state.entries.remove(&oldest_key);
+            }
         }
     }
 
     pub fn invalidate(&self, key: &str) {
-        if let Ok(mut entries) = self.entries.lock() {
-            entries.remove(key);
+        if let Ok(mut state) = self.state.lock() {
+            remove_entry(&mut state, key);
         }
     }
+}
+
+fn remove_expired_entries(state: &mut TranscriptCacheState) {
+    let timestamp = now_ms();
+    let expired = state
+        .entries
+        .iter()
+        .filter_map(|(key, entry)| {
+            let ttl = if entry.running {
+                RUNNING_TRANSCRIPT_CACHE_TTL_MS
+            } else {
+                COMPLETED_TRANSCRIPT_CACHE_TTL_MS
+            };
+            (timestamp.saturating_sub(entry.cached_at) > ttl).then(|| key.clone())
+        })
+        .collect::<Vec<_>>();
+    for key in expired {
+        remove_entry(state, &key);
+    }
+}
+
+fn touch_entry(state: &mut TranscriptCacheState, key: &str) {
+    state.lru.retain(|candidate| candidate != key);
+    state.lru.push_back(key.to_owned());
+}
+
+fn remove_entry(state: &mut TranscriptCacheState, key: &str) {
+    state.entries.remove(key);
+    state.lru.retain(|candidate| candidate != key);
 }
 
 fn path_has_complete_tail(path: &str, len: u64) -> Option<bool> {
@@ -208,6 +261,34 @@ mod tests {
 
         assert!(cache.get("thread-1", true, true).is_none());
         assert!(cache.peek("thread-1").is_none());
+    }
+
+    #[test]
+    fn cache_evicts_least_recently_used_entries() {
+        let cache = TranscriptCache::default();
+        for index in 0..MAX_TRANSCRIPT_CACHE_ENTRIES {
+            cache.insert(
+                format!("thread-{index}"),
+                cached_transcript(format!("message-{index}")),
+            );
+        }
+        assert!(cache.get("thread-0", false, false).is_some());
+
+        cache.insert("thread-new", cached_transcript("new".to_owned()));
+
+        assert!(cache.peek("thread-0").is_some());
+        assert!(cache.peek("thread-1").is_none());
+        assert!(cache.peek("thread-new").is_some());
+    }
+
+    fn cached_transcript(message: String) -> CachedTranscript {
+        CachedTranscript::new(
+            "/tmp/project".to_owned(),
+            "codex".to_owned(),
+            vec![Value::String(message)],
+            false,
+            None,
+        )
     }
 
     fn temp_path(label: &str) -> std::path::PathBuf {

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -719,6 +719,13 @@ async fn runtime_tasks_reuse_one_codex_process_across_follow_up_turns() {
             .count(),
         1
     );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call["method"] == "thread/unsubscribe")
+            .count(),
+        2
+    );
 }
 
 #[tokio::test]

--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -118,7 +118,7 @@ describe('reduceWorkbenchMessages', () => {
     const output =
       state[0].blocks?.[0]?.type === 'tool' ? state[0].blocks[0].toolOutput : ''
     expect(typeof output).toBe('string')
-    expect((output as string).length).toBe(120_000)
+    expect((output as string).length).toBe(64 * 1024)
     expect((output as string).endsWith('tail')).toBe(true)
   })
 
@@ -161,7 +161,7 @@ describe('reduceWorkbenchMessages', () => {
     expect(block?.type).toBe('tool')
     if (block?.type !== 'tool') return
     expect(block.toolOutputOriginalChars).toBe(120_018)
-    expect(String(block.toolOutput).length).toBe(120_000)
+    expect(String(block.toolOutput).length).toBe(64 * 1024)
     expect(String(block.toolOutput).endsWith('tailnext')).toBe(true)
   })
 

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -117,7 +117,7 @@ type ProcessingBlockUpdate = {
 
 const MAX_LIVE_MESSAGE_CONTENT_CHARS = 200_000
 const MAX_LIVE_BLOCK_CONTENT_CHARS = 120_000
-const MAX_LIVE_TOOL_OUTPUT_CHARS = 120_000
+const MAX_LIVE_TOOL_OUTPUT_CHARS = 64 * 1024
 
 export type WorkbenchMessageAction<
   TAttachment = unknown,

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -773,6 +773,7 @@ struct ProcessDiagnosticsProcess {
     ppid: u32,
     group: String,
     rss_kib: u64,
+    physical_footprint_kib: u64,
     cpu_percent: f64,
     command: String,
 }
@@ -782,6 +783,7 @@ struct ProcessDiagnosticsGroup {
     group: String,
     process_count: usize,
     rss_kib: u64,
+    physical_footprint_kib: u64,
     cpu_percent: f64,
     pids: Vec<u32>,
 }
@@ -846,6 +848,116 @@ fn collect_descendant_pids(processes: &[RawProcessInfo], roots: &[u32]) -> HashS
     descendants
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Debug, PartialEq, Eq)]
+struct LaunchServicesProcess {
+    display_name: String,
+    bundle_id: Option<String>,
+    pid: u32,
+}
+
+#[cfg(target_os = "macos")]
+fn parse_launch_services_processes(output: &str) -> Vec<LaunchServicesProcess> {
+    let mut processes = Vec::new();
+    let mut display_name = None;
+    let mut bundle_id = None;
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if let Some((_, value)) = trimmed.split_once(") \"") {
+            if let Some((name, _)) = value.split_once("\" ASN:") {
+                display_name = Some(name.to_owned());
+                bundle_id = None;
+                continue;
+            }
+        }
+        if let Some(value) = trimmed.strip_prefix("bundleID=\"") {
+            bundle_id = value.strip_suffix('"').map(str::to_owned);
+            continue;
+        }
+        let Some(value) = trimmed.strip_prefix("pid = ") else {
+            continue;
+        };
+        let Some(pid) = value
+            .split_whitespace()
+            .next()
+            .and_then(|candidate| candidate.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if let Some(display_name) = display_name.take() {
+            processes.push(LaunchServicesProcess {
+                display_name,
+                bundle_id: bundle_id.take(),
+                pid,
+            });
+        }
+    }
+    processes
+}
+
+#[cfg(target_os = "macos")]
+fn collect_macos_webkit_process_ids(main_pid: u32) -> Result<HashSet<u32>, String> {
+    let output = std::process::Command::new("lsappinfo")
+        .arg("list")
+        .output()
+        .map_err(|error| format!("Failed to run lsappinfo: {error}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+
+    related_macos_webkit_process_ids(
+        &parse_launch_services_processes(&String::from_utf8_lossy(&output.stdout)),
+        main_pid,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn related_macos_webkit_process_ids(
+    processes: &[LaunchServicesProcess],
+    main_pid: u32,
+) -> Result<HashSet<u32>, String> {
+    let (main_index, display_name) = processes
+        .iter()
+        .enumerate()
+        .find(|(_, process)| process.pid == main_pid)
+        .map(|(index, process)| (index, process.display_name.as_str()))
+        .ok_or_else(|| format!("LaunchServices entry missing for Wework pid {main_pid}"))?;
+    let expected_processes = [
+        ("Web Content", "com.apple.WebKit.WebContent"),
+        ("Networking", "com.apple.WebKit.Networking"),
+        ("Graphics and Media", "com.apple.WebKit.GPU"),
+    ];
+    let instance_end = processes[main_index + 1..]
+        .iter()
+        .position(|process| process.display_name == display_name)
+        .map_or(processes.len(), |offset| main_index + 1 + offset);
+    let instance_processes = &processes[main_index + 1..instance_end];
+
+    Ok(expected_processes
+        .into_iter()
+        .filter_map(|(suffix, bundle_id)| {
+            let expected_name = format!("{display_name} {suffix}");
+            instance_processes
+                .iter()
+                .find(|process| {
+                    process.display_name == expected_name
+                        && process.bundle_id.as_deref() == Some(bundle_id)
+                })
+                .map(|process| process.pid)
+        })
+        .collect())
+}
+
+#[cfg(target_os = "macos")]
+fn process_physical_footprint_kib(pid: u32) -> Option<u64> {
+    let mut usage = unsafe { std::mem::zeroed::<libc::rusage_info_v2>() };
+    let usage_pointer = (&mut usage as *mut libc::rusage_info_v2).cast::<libc::rusage_info_t>();
+    // SAFETY: proc_pid_rusage writes a rusage_info_v2 into the initialized buffer for V2 flavor.
+    let result =
+        unsafe { libc::proc_pid_rusage(pid as libc::c_int, libc::RUSAGE_INFO_V2, usage_pointer) };
+    (result == 0).then_some(usage.ri_phys_footprint / 1024)
+}
+
 fn classify_process(
     process: &RawProcessInfo,
     main_pid: u32,
@@ -858,6 +970,12 @@ fn classify_process(
     if terminal_process_ids.contains(&process.pid) || terminal_descendant_ids.contains(&process.pid)
     {
         return Some("terminal".to_string());
+    }
+    if process.command.contains("wegent-executor") {
+        return Some("executor".to_string());
+    }
+    if process.command.contains("codex") && process.command.contains("app-server") {
+        return Some("codex-app-server".to_string());
     }
     if process.command.contains("com.apple.WebKit.WebContent") {
         return Some("webkit-webcontent".to_string());
@@ -894,7 +1012,8 @@ fn get_wework_process_snapshot(
         .collect::<Vec<_>>();
     let main_pid = std::process::id();
     let terminal_roots = local_terminal_state.active_process_ids()?;
-    let app_process_ids = collect_descendant_pids(&processes, &[main_pid]);
+    let mut app_process_ids = collect_descendant_pids(&processes, &[main_pid]);
+    app_process_ids.extend(collect_macos_webkit_process_ids(main_pid)?);
     let terminal_process_ids = terminal_roots.iter().copied().collect::<HashSet<_>>();
     let terminal_descendant_ids = collect_descendant_pids(&processes, &terminal_roots);
 
@@ -913,12 +1032,17 @@ fn get_wework_process_snapshot(
                 ppid: process.ppid,
                 group,
                 rss_kib: process.rss_kib,
+                physical_footprint_kib: process_physical_footprint_kib(process.pid).unwrap_or(0),
                 cpu_percent: process.cpu_percent,
                 command: process.command.clone(),
             })
         })
         .collect::<Vec<_>>();
-    related_processes.sort_by(|left, right| right.rss_kib.cmp(&left.rss_kib));
+    related_processes.sort_by(|left, right| {
+        right
+            .physical_footprint_kib
+            .cmp(&left.physical_footprint_kib)
+    });
 
     let mut groups_by_name = HashMap::<String, ProcessDiagnosticsGroup>::new();
     for process in &related_processes {
@@ -928,17 +1052,23 @@ fn get_wework_process_snapshot(
                 group: process.group.clone(),
                 process_count: 0,
                 rss_kib: 0,
+                physical_footprint_kib: 0,
                 cpu_percent: 0.0,
                 pids: Vec::new(),
             });
         group.process_count += 1;
         group.rss_kib += process.rss_kib;
+        group.physical_footprint_kib += process.physical_footprint_kib;
         group.cpu_percent += process.cpu_percent;
         group.pids.push(process.pid);
     }
 
     let mut groups = groups_by_name.into_values().collect::<Vec<_>>();
-    groups.sort_by(|left, right| right.rss_kib.cmp(&left.rss_kib));
+    groups.sort_by(|left, right| {
+        right
+            .physical_footprint_kib
+            .cmp(&left.physical_footprint_kib)
+    });
 
     Ok(ProcessDiagnosticsSnapshot {
         timestamp_ms: std::time::SystemTime::now()
@@ -2846,6 +2976,11 @@ mod tests {
         parse_local_workspace_open_request, parse_process_snapshot_line, tray_template_pixel,
         tray_usage_icon, wework_cli_launcher_content, RawProcessInfo,
     };
+    #[cfg(target_os = "macos")]
+    use super::{
+        parse_launch_services_processes, process_physical_footprint_kib,
+        related_macos_webkit_process_ids, LaunchServicesProcess,
+    };
     use std::collections::HashSet;
 
     fn test_temp_dir(name: &str) -> std::path::PathBuf {
@@ -3040,6 +3175,95 @@ mod tests {
         assert!(!descendants.contains(&4));
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parses_launch_services_webkit_processes() {
+        let output = r#"
+192) "app" ASN:0x0-0x3f38f35:
+    bundleID=[ NULL ]
+    pid = 40739 type="Foreground"
+193) "app Networking" ASN:0x0-0x3f39f36:
+    bundleID="com.apple.WebKit.Networking"
+    pid = 41055 type="UIElement"
+194) "app Graphics and Media" ASN:0x0-0x3f3af37:
+    bundleID="com.apple.WebKit.GPU"
+    pid = 41054 type="UIElement"
+195) "app Web Content" ASN:0x0-0x3f3bf38:
+    bundleID="com.apple.WebKit.WebContent"
+    pid = 41056 type="UIElement"
+"#;
+
+        assert_eq!(
+            parse_launch_services_processes(output),
+            vec![
+                LaunchServicesProcess {
+                    display_name: "app".to_owned(),
+                    bundle_id: None,
+                    pid: 40739,
+                },
+                LaunchServicesProcess {
+                    display_name: "app Networking".to_owned(),
+                    bundle_id: Some("com.apple.WebKit.Networking".to_owned()),
+                    pid: 41055,
+                },
+                LaunchServicesProcess {
+                    display_name: "app Graphics and Media".to_owned(),
+                    bundle_id: Some("com.apple.WebKit.GPU".to_owned()),
+                    pid: 41054,
+                },
+                LaunchServicesProcess {
+                    display_name: "app Web Content".to_owned(),
+                    bundle_id: Some("com.apple.WebKit.WebContent".to_owned()),
+                    pid: 41056,
+                },
+            ]
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn associates_webkit_processes_with_the_nearest_matching_app_instance() {
+        let processes = parse_launch_services_processes(
+            r#"
+1) "app" ASN:1:
+    bundleID=[ NULL ]
+    pid = 100 type="Foreground"
+2) "app Networking" ASN:2:
+    bundleID="com.apple.WebKit.Networking"
+    pid = 101 type="UIElement"
+3) "app Graphics and Media" ASN:3:
+    bundleID="com.apple.WebKit.GPU"
+    pid = 102 type="UIElement"
+4) "app Web Content" ASN:4:
+    bundleID="com.apple.WebKit.WebContent"
+    pid = 103 type="UIElement"
+5) "app" ASN:5:
+    bundleID=[ NULL ]
+    pid = 200 type="Foreground"
+6) "app Networking" ASN:6:
+    bundleID="com.apple.WebKit.Networking"
+    pid = 201 type="UIElement"
+7) "app Graphics and Media" ASN:7:
+    bundleID="com.apple.WebKit.GPU"
+    pid = 202 type="UIElement"
+8) "app Web Content" ASN:8:
+    bundleID="com.apple.WebKit.WebContent"
+    pid = 203 type="UIElement"
+"#,
+        );
+
+        assert_eq!(
+            related_macos_webkit_process_ids(&processes, 200),
+            Ok(HashSet::from([201, 202, 203]))
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn reads_current_process_physical_footprint() {
+        assert!(process_physical_footprint_kib(std::process::id()).is_some_and(|value| value > 0));
+    }
+
     #[test]
     fn classifies_wework_process_groups() {
         let terminal_roots = HashSet::from([3]);
@@ -3071,6 +3295,24 @@ mod tests {
                 &terminal_descendants
             ),
             Some("terminal".to_string())
+        );
+        assert_eq!(
+            classify_process(
+                &raw_process(5, 1, "/Applications/Wework.app/wegent-executor"),
+                1,
+                &terminal_roots,
+                &terminal_descendants
+            ),
+            Some("executor".to_string())
+        );
+        assert_eq!(
+            classify_process(
+                &raw_process(6, 5, "/Applications/Wework.app/codex app-server"),
+                1,
+                &terminal_roots,
+                &terminal_descendants
+            ),
+            Some("codex-app-server".to_string())
         );
     }
 

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -18,6 +18,7 @@ import {
   resolveAutomaticModel,
   selectedModelExecutionFields,
 } from '@/features/workbench/runtimeModelSelection'
+import { persistAttachmentReferences } from '@/lib/attachments'
 import { localRuntimeAttachments, remoteAttachmentIds } from '@/lib/runtime-attachments'
 import {
   applyRequestUserInputResponseToMessages,
@@ -1296,7 +1297,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
                 content: submittedInput,
                 status: 'queued',
                 createdAt: new Date().toISOString(),
-                attachments: currentAttachments,
+                attachments: persistAttachmentReferences(currentAttachments),
                 runtimeGoalRequest: true,
                 ...getRuntimeModelFields(),
               }
@@ -1520,7 +1521,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
               codeComments: codeCommentContexts,
               status: 'queued',
               createdAt: new Date().toISOString(),
-              attachments: currentAttachments,
+              attachments: persistAttachmentReferences(currentAttachments),
               ...getRuntimeModelFields(),
             }
 
@@ -1544,7 +1545,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             content: submittedInput,
             status: 'queued',
             createdAt: new Date().toISOString(),
-            attachments: currentAttachments,
+            attachments: persistAttachmentReferences(currentAttachments),
             ...getRuntimeModelFields(),
           }
 
@@ -2039,7 +2040,7 @@ function createLocalUserMessage(
     id: options.id ?? `runtime-local-pane-${Date.now()}`,
     role: 'user',
     content,
-    attachments,
+    attachments: attachments ? persistAttachmentReferences(attachments) : undefined,
     status: 'done',
     createdAt: options.createdAt ?? new Date().toISOString(),
     runtimeGoalRequest: options.runtimeGoalRequest ? true : undefined,

--- a/wework/src/features/workbench/useWorkbenchAttachments.ts
+++ b/wework/src/features/workbench/useWorkbenchAttachments.ts
@@ -5,7 +5,7 @@ import {
   isValidFileSize,
   uploadAttachment as defaultUploadAttachment,
 } from '@/api/attachments'
-import { readTextAttachmentMetadata } from '@/lib/attachments'
+import { readTextAttachmentMetadata, releaseAttachmentPreview } from '@/lib/attachments'
 
 interface UseWorkbenchAttachmentsOptions {
   uploadAttachment?: (file: File, onProgress?: (progress: number) => void) => Promise<Attachment>
@@ -133,23 +133,26 @@ export function useWorkbenchAttachments(options: UseWorkbenchAttachmentsOptions 
 
   const removeAttachment = useCallback(
     async (attachmentId: number) => {
+      const attachment = state.attachments.find(item => item.id === attachmentId)
+      if (attachment) releaseAttachmentPreview(attachment)
       updateScopeState(current => ({
         ...current,
         attachments: current.attachments.filter(attachment => attachment.id !== attachmentId),
       }))
       await deleteAttachment(attachmentId)
     },
-    [deleteAttachment, updateScopeState]
+    [deleteAttachment, state.attachments, updateScopeState]
   )
 
   const resetAttachments = useCallback(() => {
+    state.attachments.forEach(releaseAttachmentPreview)
     updateScopeState(current => ({
       ...current,
       attachments: [],
       uploadingFiles: new Map(),
       errors: new Map(),
     }))
-  }, [updateScopeState])
+  }, [state.attachments, updateScopeState])
 
   return {
     state,

--- a/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
+++ b/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
@@ -556,6 +556,38 @@ describe('workbench project chat hooks', () => {
     expect(result.current.attachments).toEqual([])
   })
 
+  test('releases temporary image previews when attachments leave the composer', async () => {
+    const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const firstAttachment: Attachment = {
+      id: 44,
+      filename: 'first.png',
+      file_size: 1200,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-05-27T00:00:00.000Z',
+      local_preview_url: 'blob:first-preview',
+    }
+    const secondAttachment: Attachment = {
+      ...firstAttachment,
+      id: 45,
+      filename: 'second.png',
+      local_preview_url: 'blob:second-preview',
+    }
+    const remove = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useWorkbenchAttachments({ deleteAttachment: remove }))
+
+    act(() => {
+      result.current.addExistingAttachment(firstAttachment)
+      result.current.addExistingAttachment(secondAttachment)
+    })
+    await act(async () => result.current.removeAttachment(firstAttachment.id))
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:first-preview')
+
+    act(() => result.current.resetAttachments())
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:second-preview')
+  })
+
   test('uploads attachments without restricting file extensions', async () => {
     const attachment: Attachment = {
       id: 43,

--- a/wework/src/lib/attachments.test.ts
+++ b/wework/src/lib/attachments.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+import type { Attachment } from '@/types/api'
+import { persistAttachmentReferences } from './attachments'
+
+describe('attachment helpers', () => {
+  test('removes transient object URLs from persisted message attachments', () => {
+    const attachment: Attachment = {
+      id: 7,
+      filename: 'image.png',
+      file_size: 1200,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-05-27T00:00:00.000Z',
+      local_preview_url: 'blob:composer-preview',
+    }
+
+    expect(persistAttachmentReferences([attachment])).toEqual([
+      { ...attachment, local_preview_url: undefined },
+    ])
+    expect(attachment.local_preview_url).toBe('blob:composer-preview')
+  })
+
+  test('preserves local filesystem previews', () => {
+    const attachment: Attachment = {
+      id: -1,
+      filename: 'image.png',
+      file_size: 1200,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-05-27T00:00:00.000Z',
+      local_preview_url: '/tmp/image.png',
+    }
+
+    expect(persistAttachmentReferences([attachment])).toEqual([attachment])
+  })
+})

--- a/wework/src/lib/attachments.ts
+++ b/wework/src/lib/attachments.ts
@@ -18,6 +18,29 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   '.yml',
 ])
 
+function isObjectUrl(value: string | undefined): value is string {
+  return value?.startsWith('blob:') ?? false
+}
+
+export function releaseAttachmentPreview(attachment: Attachment): void {
+  if (
+    !isObjectUrl(attachment.local_preview_url) ||
+    typeof URL === 'undefined' ||
+    typeof URL.revokeObjectURL !== 'function'
+  ) {
+    return
+  }
+  URL.revokeObjectURL(attachment.local_preview_url)
+}
+
+export function persistAttachmentReferences(attachments: Attachment[]): Attachment[] {
+  return attachments.map(attachment =>
+    isObjectUrl(attachment.local_preview_url)
+      ? { ...attachment, local_preview_url: undefined }
+      : attachment
+  )
+}
+
 export function isImageAttachment(attachment: Attachment): boolean {
   return (
     attachment.mime_type.toLowerCase().startsWith('image/') ||

--- a/wework/src/lib/performanceDiagnostics.ts
+++ b/wework/src/lib/performanceDiagnostics.ts
@@ -30,6 +30,7 @@ interface ProcessDiagnosticsProcess {
   ppid: number
   group: string
   rss_kib: number
+  physical_footprint_kib: number
   cpu_percent: number
   command: string
 }
@@ -38,6 +39,7 @@ interface ProcessDiagnosticsGroup {
   group: string
   process_count: number
   rss_kib: number
+  physical_footprint_kib: number
   cpu_percent: number
   pids: number[]
 }


### PR DESCRIPTION
## What changed

- bound the executor transcript cache to an eight-entry LRU and remove expired entries proactively
- unsubscribe Codex app-server threads after each shared-server turn
- cap live tool output retained by the workbench at 64 KiB
- revoke transient attachment object URLs and avoid persisting blob references in messages
- associate macOS WebKit helper processes with the correct Wework instance and report physical footprint alongside RSS
- document how to interpret Wework process memory in Chinese and English

## Why

After long-running tasks, Activity Monitor could show 700–800 MB across the Wework process family. Stress testing showed that RSS substantially overstated current physical pressure: after cooldown, Codex used about 21 MB of physical footprint despite roughly 147 MB RSS, while WebContent remained the largest consumer. The implementation also had concrete retention risks from an unbounded transcript cache, lingering thread subscriptions, retained live tool output, and unreleased Blob URLs.

## Impact

Long sessions now retain less transcript, tool-output, subscription, and attachment-preview state. Performance diagnostics correctly include macOS WebKit helpers and expose physical footprint so high RSS can be distinguished from real memory pressure.

## Validation

- Wework: 1538 unit tests passed
- chat-core: 115 tests passed
- executor library: 260 tests passed
- Tauri library: 47 tests passed
- app runtime work send contract: 21 tests passed
- TypeScript, ESLint, Prettier, Rust fmt, Clippy, and git diff checks passed
- real Tauri long-task stress run completed and diagnostics were verified
- repository pre-push quality checks passed after syncing with latest origin/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced macOS performance diagnostics with physical memory footprint reporting and improved WebKit process attribution.
  - Added clearer guidance for interpreting memory snapshots and identifying resource growth.

- **Bug Fixes**
  - Improved attachment handling by preventing temporary preview URLs from persisting and releasing them when attachments are removed.
  - Improved reliability across follow-up runtime interactions.

- **Improvements**
  - Reduced retained live tool-output previews to improve memory usage.
  - Improved transcript caching behavior for consistency and bounded resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->