### PR TITLE
fix(frontend): gate project directory picker by executor version

### DIFF
--- a/frontend/src/__tests__/features/projects/components/ProjectCreateDialog.test.tsx
+++ b/frontend/src/__tests__/features/projects/components/ProjectCreateDialog.test.tsx
@@ -25,8 +25,8 @@ const baseDevice: DeviceInfo = {
   slot_used: 0,
   slot_max: 1,
   running_tasks: [],
-  executor_version: 'v1.7.11',
-  latest_version: 'v1.7.11',
+  executor_version: 'v1.7.13',
+  latest_version: 'v1.7.13',
   update_available: false,
   bind_shell: 'claudecode',
 }
@@ -103,17 +103,18 @@ describe('ProjectCreateDialog', () => {
     devicesMock = []
   })
 
-  test('blocks workspace project creation when the selected device version is below v1.7.11', async () => {
+  test('blocks workspace project creation before the directory command RPC was released', async () => {
     devicesMock = [
       {
         ...baseDevice,
-        executor_version: 'v1.7.10',
+        executor_version: 'v1.7.12',
       },
     ]
 
     render(<ProjectCreateDialog open={true} onOpenChange={jest.fn()} mode="workspace" />)
 
-    expect(await screen.findByText('upgrade required from v1.7.10 to v1.7.11')).toBeInTheDocument()
+    expect(await screen.findByText('upgrade required from v1.7.12 to v1.7.13')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-directory-picker-trigger')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).toBeDisabled()
   })
 
@@ -127,16 +128,16 @@ describe('ProjectCreateDialog', () => {
 
     render(<ProjectCreateDialog open={true} onOpenChange={jest.fn()} mode="workspace" />)
 
-    expect(await screen.findByText('upgrade required from 1.0.0 to v1.7.11')).toBeInTheDocument()
+    expect(await screen.findByText('upgrade required from 1.0.0 to v1.7.13')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-directory-picker-trigger')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).toBeDisabled()
   })
 
-  test('allows directory selection when the selected device version is v1.7.11 or newer', async () => {
+  test('allows directory selection when the selected device version is v1.7.13 or newer', async () => {
     devicesMock = [
       {
         ...baseDevice,
-        executor_version: 'v1.7.11',
+        executor_version: 'v1.7.13',
       },
     ]
 
@@ -198,7 +199,7 @@ describe('ProjectCreateDialog', () => {
     devicesMock = [
       {
         ...baseDevice,
-        executor_version: 'v1.7.11',
+        executor_version: 'v1.7.13',
       },
     ]
     ;(deviceApis.executeCommand as jest.Mock).mockImplementation((_deviceId, request) => {
@@ -261,7 +262,7 @@ describe('ProjectCreateDialog', () => {
         device_id: 'cloud-device',
         name: 'Cloud Device',
         device_type: 'cloud',
-        executor_version: 'v1.7.11',
+        executor_version: 'v1.7.13',
       },
     ]
     ;(deviceApis.executeCommand as jest.Mock).mockResolvedValue({
@@ -319,7 +320,7 @@ describe('ProjectCreateDialog', () => {
         device_id: 'remote-device',
         name: 'Remote Device',
         device_type: 'remote',
-        executor_version: 'v1.7.11',
+        executor_version: 'v1.7.13',
       },
     ]
     ;(deviceApis.executeCommand as jest.Mock).mockImplementation((_deviceId, request) => {
@@ -377,7 +378,7 @@ describe('ProjectCreateDialog', () => {
     devicesMock = [
       {
         ...baseDevice,
-        executor_version: 'v1.7.11',
+        executor_version: 'v1.7.13',
       },
     ]
     ;(deviceApis.executeCommand as jest.Mock).mockImplementation((_deviceId, request) => {

--- a/frontend/src/features/projects/components/ProjectCreateDialog.tsx
+++ b/frontend/src/features/projects/components/ProjectCreateDialog.tsx
@@ -44,7 +44,7 @@ const PROJECT_COLORS = [
   { id: 'gray', value: '#6B7280' },
 ]
 
-const MIN_WORKSPACE_PROJECT_DEVICE_VERSION = 'v1.7.11'
+const MIN_WORKSPACE_PROJECT_DEVICE_VERSION = 'v1.7.13'
 type WorkspaceProjectDeviceType = 'local' | 'cloud' | 'remote'
 const WORKSPACE_PROJECT_DEVICE_TYPES = new Set<WorkspaceProjectDeviceType>([
   'local',


### PR DESCRIPTION
## Summary

- require local executor v1.7.13 or newer before enabling the frontend project directory picker
- keep older executors from sending an unsupported `device:execute_command` RPC
- update project creation tests around the v1.7.12/v1.7.13 release boundary

## Root cause

The directory command RPC was released in executor v1.7.13, but the frontend allowed v1.7.11 and v1.7.12 devices to open the picker. Those versions never registered the `device:execute_command` handler, so directory loading waited for an acknowledgement and failed after the 20-second command timeout plus the 5-second ACK grace period.

## Impact

Unsupported executors now show the existing upgrade warning and cannot open the directory picker. Supported executors continue to browse and select project directories normally.

## Validation

- `pnpm --dir frontend test -- --runInBand src/__tests__/features/projects/components/ProjectCreateDialog.test.tsx` (9 tests passed)
- pre-push Frontend ESLint passed
- pre-push TypeScript check passed
- pre-push Frontend unit tests passed
- commit hooks: Prettier, ESLint, and translation consistency passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workspace project creation requirements to require device executor version v1.7.13 or later.
  * Improved upgrade guidance when a selected device does not support workspace creation.
  * Disabled the directory picker when the selected device lacks the required support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->