### PR TITLE
fix(wework): correct file reads and Tauri capture

### DIFF
--- a/docs/en/developer-guide/wework-e2e-automation.md
+++ b/docs/en/developer-guide/wework-e2e-automation.md
@@ -105,6 +105,8 @@ The desktop E2E build additionally injects `VITE_WEWORK_DESKTOP_E2E_CONTROL_URL`
 
 The controller uses short polling: the server returns `204` when no command is available, and the frontend waits briefly before polling again. This prevents a stale long-poll connection, left behind by a WebView reload, task switch, or stream completion, from consuming later commands. When `fill` targets a Lexical editor, the controller uses the editor's exposed `value` setter so the React/Lexical state is actually committed; do not replace it with raw DOM insertion. Failure diagnostics include delivered `commandHistory` in `scenario-state.json` to aid control-channel debugging.
 
+On macOS, the desktop controller's `capture` command asks Tauri for a native WebKit `WKWebView` snapshot instead of cloning the DOM in the page. The native command is available only when `VITE_WEWORK_E2E=true` and times out after 10 seconds. Capturing `body` returns the full PNG directly; other selectors are cropped from that native snapshot using the element bounds. This keeps failure diagnostics faithful to fonts, native WebView rendering, and the real page state without depending on a hidden iframe load event.
+
 Switching models in the same conversation can cause Codex to issue an internal context-compaction request. The desktop task-flow E2E loopback Responses service identifies and responds to these requests through `client_metadata.x-codex-turn-metadata.request_kind === "compaction"`, so they are not mistaken for a user follow-up message.
 
 ## Test Helper

--- a/docs/zh/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/developer-guide/wework-e2e-automation.md
@@ -105,6 +105,8 @@ http://127.0.0.1:9998/v1
 
 控制器使用短轮询：没有待执行指令时服务端返回 `204`，前端短暂等待后再次请求。这避免了 WebView 刷新、任务切换或流结束时遗留的长轮询连接吞掉后续指令。对 Lexical 编辑器执行 `fill` 时，控制器会使用编辑器暴露的 `value` setter，以便真实提交 React/Lexical 状态；不要用原始 DOM 插入来替代它。失败诊断中的 `scenario-state.json` 会记录已投递的 `commandHistory`，用于定位控制通道问题。
 
+桌面控制器的 `capture` 指令在 macOS 上通过 Tauri 调用 WebKit 原生 `WKWebView` snapshot，而不是在页面内复制 DOM。原生层仅在 `VITE_WEWORK_E2E=true` 时开放该命令，并在 10 秒后超时；截取 `body` 时直接返回完整 PNG，截取其他选择器时由前端按照元素边界裁剪原生快照。这样失败诊断可以覆盖字体、原生 WebView 渲染和真实页面状态，也不会依赖隐藏 iframe 的加载事件。
+
 同一会话在模型切换后可能触发 Codex 的内部上下文压缩请求。桌面端任务流 E2E 的 loopback Responses 服务会通过 `client_metadata.x-codex-turn-metadata.request_kind === "compaction"` 识别并响应这类请求，使它不被误判为用户发送的后续消息。
 
 ## 测试封装

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,9 +665,6 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
-      html2canvas:
-        specifier: ^1.4.1
-        version: 1.4.1
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0

--- a/wework/package.json
+++ b/wework/package.json
@@ -94,7 +94,6 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
-    "html2canvas": "^1.4.1",
     "jsdom": "^28.1.0",
     "lint-staged": "^16.4.0",
     "postcss": "^8.5.15",

--- a/wework/src-tauri/Cargo.lock
+++ b/wework/src-tauri/Cargo.lock
@@ -79,12 +79,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.0.12"
 dependencies = [
+ "block2",
  "ctrlc",
  "libc",
  "log",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-web-kit",
  "portable-pty",
  "serde",
  "serde_json",

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -41,6 +41,8 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2.10.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6.2"
 objc2 = "0.6.3"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSOpenPanel", "NSPanel", "NSPasteboard", "NSResponder", "NSSavePanel", "NSWindow"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSDistributedNotificationCenter", "NSNotification", "NSObject", "NSString", "std"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSBitmapImageRep", "NSImage", "NSImageRep", "NSOpenPanel", "NSPanel", "NSPasteboard", "NSResponder", "NSSavePanel", "NSWindow"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSData", "NSDictionary", "NSDistributedNotificationCenter", "NSError", "NSNotification", "NSObject", "NSString", "std"] }
+objc2-web-kit = { version = "0.3.2", default-features = false, features = ["WKSnapshotConfiguration", "WKWebView", "block2", "objc2-app-kit", "std"] }

--- a/wework/src-tauri/src/desktop_capture.rs
+++ b/wework/src-tauri/src/desktop_capture.rs
@@ -1,0 +1,106 @@
+const SNAPSHOT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[tauri::command]
+pub async fn capture_main_webview(app: tauri::AppHandle) -> Result<String, String> {
+    if std::env::var("VITE_WEWORK_E2E").as_deref() != Ok("true") {
+        return Err(
+            "Main webview snapshots are only available during E2E verification".to_string(),
+        );
+    }
+    capture_main_webview_impl(app).await
+}
+
+#[cfg(target_os = "macos")]
+async fn capture_main_webview_impl(app: tauri::AppHandle) -> Result<String, String> {
+    use tauri::Manager;
+
+    let webview = app
+        .get_webview_window("main")
+        .ok_or_else(|| "Main webview is unavailable".to_string())?;
+    let (sender, mut receiver) = tauri::async_runtime::channel(1);
+    let timeout_sender = sender.clone();
+
+    webview
+        .with_webview(move |platform_webview| {
+            start_macos_snapshot(platform_webview, sender);
+        })
+        .map_err(|error| format!("Failed to access main webview: {error}"))?;
+
+    std::thread::spawn(move || {
+        std::thread::sleep(SNAPSHOT_TIMEOUT);
+        let _ = timeout_sender.try_send(Err("Main webview snapshot timed out".to_string()));
+    });
+
+    receiver
+        .recv()
+        .await
+        .ok_or_else(|| "Main webview snapshot was cancelled".to_string())?
+}
+
+#[cfg(target_os = "macos")]
+fn start_macos_snapshot(
+    platform_webview: tauri::webview::PlatformWebview,
+    sender: tauri::async_runtime::Sender<Result<String, String>>,
+) {
+    use block2::RcBlock;
+    use objc2_app_kit::NSImage;
+    use objc2_foundation::NSError;
+    use objc2_web_kit::WKWebView;
+
+    let completion = RcBlock::new(move |image: *mut NSImage, error: *mut NSError| {
+        let result = unsafe { encode_snapshot(image, error) };
+        let _ = sender.try_send(result);
+    });
+
+    unsafe {
+        let webview: &WKWebView = &*platform_webview.inner().cast();
+        webview.takeSnapshotWithConfiguration_completionHandler(None, &completion);
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn encode_snapshot(
+    image: *mut objc2_app_kit::NSImage,
+    error: *mut objc2_foundation::NSError,
+) -> Result<String, String> {
+    use objc2::runtime::AnyObject;
+    use objc2_app_kit::{NSBitmapImageFileType, NSBitmapImageRep};
+    use objc2_foundation::NSDictionary;
+
+    if !error.is_null() {
+        return Err((*error).localizedDescription().to_string());
+    }
+    let image = image
+        .as_ref()
+        .ok_or_else(|| "WebKit returned an empty snapshot".to_string())?;
+    let tiff = image
+        .TIFFRepresentation()
+        .ok_or_else(|| "Failed to encode WebKit snapshot as TIFF".to_string())?;
+    let bitmap = NSBitmapImageRep::imageRepWithData(&tiff)
+        .ok_or_else(|| "Failed to create bitmap from WebKit snapshot".to_string())?;
+    let properties: objc2::rc::Retained<
+        NSDictionary<objc2_app_kit::NSBitmapImageRepPropertyKey, AnyObject>,
+    > = NSDictionary::new();
+    let png = bitmap
+        .representationUsingType_properties(NSBitmapImageFileType::PNG, &properties)
+        .ok_or_else(|| "Failed to encode WebKit snapshot as PNG".to_string())?;
+    let bytes = ns_data_bytes(&png);
+    Ok(format!(
+        "data:image/png;base64,{}",
+        crate::encode_base64(&bytes)
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn ns_data_bytes(data: &objc2_foundation::NSData) -> Vec<u8> {
+    let mut bytes = vec![0; data.length()];
+    if let Some(buffer) = std::ptr::NonNull::new(bytes.as_mut_ptr().cast()) {
+        unsafe { data.getBytes_length(buffer, bytes.len()) };
+    }
+    bytes
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn capture_main_webview_impl(_app: tauri::AppHandle) -> Result<String, String> {
+    Err("Main webview snapshots are currently supported on macOS only".to_string())
+}

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod desktop_capture;
 mod embedded_browser;
 mod local_executor;
 mod local_terminal;
@@ -3485,6 +3486,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            desktop_capture::capture_main_webview,
             embedded_browser::embedded_browser_close,
             embedded_browser::embedded_browser_eval,
             embedded_browser::embedded_browser_eval_json,

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -243,7 +243,7 @@ describe('ToolBlocksDisplay', () => {
             toolName: 'bash',
             toolInput: {
               command:
-                '/bin/zsh -lc "sed -n \'1,120p\' wework/src/components/chat/blocks/toolBlockKinds.ts"',
+                "/bin/zsh -lc \"sed -n '1,120p' wework/src/components/chat/blocks/toolBlockKinds.ts\nsed -n '180,220p' wework/src/components/chat/blocks/toolBlockKinds.ts\"",
             },
             status: 'done',
             createdAt: 1770000000001,
@@ -258,6 +258,8 @@ describe('ToolBlocksDisplay', () => {
 
     expect(screen.getByText('Read toolBlockActivity.ts')).toBeInTheDocument()
     expect(screen.getByText('Read toolBlockKinds.ts')).toBeInTheDocument()
+    expect(screen.queryByText('Read sed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Read 180,220p')).not.toBeInTheDocument()
     expect(screen.queryByText(/已运行 nl -ba/)).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -129,6 +129,12 @@ describe('toolBlockActivity', () => {
         )
       )
     ).toEqual(['wework/src/components/chat/blocks/toolBlockKinds.ts'])
+
+    expect(
+      getToolActivityFilePaths(
+        tool('sed-multiline', "sed -n '1222,1245p' Cargo.toml\nsed -n '1940,1955p' Cargo.toml")
+      )
+    ).toEqual(['Cargo.toml'])
   })
 
   test('extracts code search summaries from shell search commands', () => {

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -556,7 +556,8 @@ function splitShellWords(command: string): string[] {
 
   for (const char of command) {
     if (escaped) {
-      current += char
+      // A backslash followed by a newline continues the same shell command.
+      if (char !== '\n' && char !== '\r') current += char
       escaped = false
       continue
     }
@@ -577,6 +578,12 @@ function splitShellWords(command: string): string[] {
 
     if (char === '"' || char === "'") {
       quote = char
+      continue
+    }
+
+    if (char === '\n' || char === '\r') {
+      pushCurrent()
+      if (words.at(-1) !== ';') words.push(';')
       continue
     }
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -7,6 +7,7 @@ import {
 } from '@/features/model-settings/localModelConnectionTest'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { closeMainWindowToTray } from '@/tauri/runtimeTaskCloseGuard'
+import { invoke } from '@tauri-apps/api/core'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -218,19 +219,41 @@ async function captureDesktopControlScreenshot(selector: string): Promise<string
   const element = findDesktopControlElements(selector)[0]
   if (!element) throw new Error(`Unable to find selector "${selector}"`)
 
-  const { default: html2canvas } = await import('html2canvas')
-  const canvas = await html2canvas(element, {
-    allowTaint: false,
-    backgroundColor: getComputedStyle(document.documentElement).backgroundColor,
-    height: element === document.body ? window.innerHeight : undefined,
-    logging: false,
-    scale: Math.min(window.devicePixelRatio, 2),
-    useCORS: true,
-    width: element === document.body ? window.innerWidth : undefined,
-    windowHeight: window.innerHeight,
-    windowWidth: window.innerWidth,
-  })
+  const snapshot = await invoke<string>('capture_main_webview')
+  if (element === document.body) return snapshot
+  return cropDesktopControlScreenshot(snapshot, element.getBoundingClientRect())
+}
+
+async function cropDesktopControlScreenshot(snapshot: string, rect: DOMRect): Promise<string> {
+  const image = await loadDesktopControlScreenshot(snapshot)
+  const scaleX = image.naturalWidth / window.innerWidth
+  const scaleY = image.naturalHeight / window.innerHeight
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.max(1, Math.round(rect.width * scaleX))
+  canvas.height = Math.max(1, Math.round(rect.height * scaleY))
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error('Unable to create screenshot canvas context')
+  context.drawImage(
+    image,
+    Math.round(rect.left * scaleX),
+    Math.round(rect.top * scaleY),
+    canvas.width,
+    canvas.height,
+    0,
+    0,
+    canvas.width,
+    canvas.height
+  )
   return canvas.toDataURL('image/png')
+}
+
+function loadDesktopControlScreenshot(snapshot: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Unable to decode main webview snapshot'))
+    image.src = snapshot
+  })
 }
 
 function desktopControlElementEnabled(element: HTMLElement): boolean {


### PR DESCRIPTION
## Summary

- Treat unquoted newlines in shell commands as command boundaries so later `sed` commands and ranges are not displayed as files.
- Replace `html2canvas` in desktop E2E capture with a native macOS `WKWebView` snapshot, while retaining selector cropping in the frontend.
- Restrict the native snapshot command to E2E builds and document the capture path in Chinese and English.

## Root cause

The activity parser tokenized unquoted newlines as ordinary whitespace. In multi-command tool input, arguments from later commands were therefore attached to the preceding `sed` invocation and rendered as filenames.

Separately, `html2canvas` waited for its hidden cloned iframe to load in the Tauri macOS WKWebView. That load event did not complete, so capture stalled before fonts, images, or rendering began.

## Verification

- Real Tauri macOS full-WebView screenshot and selector crop
- Wework unit tests: 156 files, 1551 tests passed
- Wework pre-push: ESLint, TypeScript, and unit tests passed
- `cargo check --manifest-path wework/src-tauri/Cargo.toml`
- `cargo fmt --manifest-path wework/src-tauri/Cargo.toml --check`
- Prettier and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved desktop automation screenshots on macOS by capturing the native WebView, including full-page and element-specific screenshots.
  * Added safeguards limiting screenshot capture to E2E environments and enforcing a 10-second timeout.

* **Bug Fixes**
  * Improved shell-command parsing for multiline file-read operations and line continuations.
  * Updated activity displays and test coverage for multiline read commands.

* **Documentation**
  * Documented macOS screenshot behavior, limitations, and troubleshooting details in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->