### PR TITLE
fix(wework): stabilize image preview during streaming

### DIFF
--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import '@/i18n'
+import { WorkspaceFilePreview } from './WorkspaceFilePreview'
+
+const fileViewerMocks = vi.hoisted(() => ({
+  render: vi.fn(),
+}))
+
+vi.mock('@file-viewer/react', () => ({
+  default: (props: { filename: string }) => {
+    fileViewerMocks.render(props)
+    return <div data-testid="file-viewer">{props.filename}</div>
+  },
+}))
+
+vi.mock('@file-viewer/preset-engineering', () => ({ default: {} }))
+vi.mock('@file-viewer/preset-office', () => ({ default: {} }))
+vi.mock('@file-viewer/preset-lite', () => ({ default: {} }))
+
+beforeEach(() => {
+  fileViewerMocks.render.mockClear()
+})
+
+test('does not rebuild a binary image preview when its parent rerenders', () => {
+  const binaryFile = {
+    path: '/workspace/project/diagram.png',
+    name: 'diagram.png',
+    size: 5,
+    file: new File(['image'], 'diagram.png', { type: 'image/png' }),
+  }
+  const { rerender } = render(
+    <WorkspaceFilePreview
+      file={null}
+      binaryFile={binaryFile}
+      loading={false}
+      onRetry={vi.fn()}
+      onAddCodeComment={vi.fn()}
+    />
+  )
+
+  rerender(
+    <WorkspaceFilePreview
+      file={null}
+      binaryFile={binaryFile}
+      loading={false}
+      onRetry={vi.fn()}
+      onAddCodeComment={vi.fn()}
+    />
+  )
+
+  expect(fileViewerMocks.render).toHaveBeenCalledTimes(1)
+})

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
@@ -5,7 +5,7 @@ import engineeringRenderers from '@file-viewer/preset-engineering'
 import officeRenderers from '@file-viewer/preset-office'
 import liteRenderers from '@file-viewer/preset-lite'
 import { MessageSquare } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { CodeCommentContext, WorkspaceTextFileResponse } from '@/types/workspace-files'
 import { WorkspaceXMindPreview } from './WorkspaceXMindPreview'
@@ -120,7 +120,13 @@ function fileViewerTypeFromMime(mimeType: string): string | undefined {
   return FILE_VIEWER_TYPE_BY_MIME[mimeType.split(';', 1)[0].trim().toLowerCase()]
 }
 
-function WorkspaceBinaryFilePreview({
+const WORKSPACE_FILE_VIEWER_OPTIONS = {
+  preset: [officeRenderers, liteRenderers, engineeringRenderers],
+  spreadsheet: { worker: false },
+  theme: 'light' as const,
+}
+
+const WorkspaceBinaryFilePreview = memo(function WorkspaceBinaryFilePreview({
   file,
 }: {
   file: NonNullable<WorkspaceFilePreviewProps['binaryFile']>
@@ -143,15 +149,11 @@ function WorkspaceBinaryFilePreview({
         type={fileViewerTypeFromMime(file.file.type)}
         size={file.size}
         className="h-full w-full"
-        options={{
-          preset: [officeRenderers, liteRenderers, engineeringRenderers],
-          spreadsheet: { worker: false },
-          theme: 'light',
-        }}
+        options={WORKSPACE_FILE_VIEWER_OPTIONS}
       />
     </section>
   )
-}
+})
 
 interface SelectionState {
   filePath: string


### PR DESCRIPTION
## Summary

- memoize the binary workspace preview so streaming chat updates do not rebuild an unchanged image viewer
- reuse a stable file viewer options object to avoid unnecessary internal reloads
- add regression coverage for parent rerenders with the same binary image

## Testing

- `pnpm --dir wework exec vitest run src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx`
- `pnpm --dir wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx -t "workspace file preview stays mounted when equivalent dependencies get new references"`
- pre-push: ESLint, TypeScript, and Wework unit tests

## Desktop verification

- started and captured an isolated real Tauri session successfully
- the isolated session had no cloud login or task data, so the combined image-preview plus live-stream path could not be exercised manually; the rerender behavior is covered by the regression test