### PR TITLE
fix(wework): display image generation results

### DIFF
--- a/docs/en/developer-guide/runtime-local-work.md
+++ b/docs/en/developer-guide/runtime-local-work.md
@@ -224,6 +224,7 @@ The runtime owns persistence for newly created tasks:
 - Codex creation still streams over the LocalTask Responses event channel with `response.created`, text/tool deltas, and `response.completed`/`error`. Those events use the `localTaskId` returned by create, so the frontend does not need to wait for the next list refresh to show the running reply.
 - Codex app-server input supports `input_text`, `input_image`, and `localImage` prompt blocks. Backend attachment-id download and sandbox-path rewriting remain separate from local-first attachments: local App mode sends same-device attachment records through executor IPC, while cloud/Backend paths continue to use uploaded attachment ids.
 - If Codex response completion includes `file_changes` or `fileChanges`, the executor stores it on the current assistant message's `fileChanges` field, and later transcript refreshes continue to show the same file changes card.
+- Codex app-server `imageGeneration` items must not be treated as ordinary text tool output. The executor stores the complete image result in the tool block `render_payload`, together with the revised prompt and generated-file path, and Wework renders the image directly from that payload. Image data must bypass the regular tool-output truncation window or the base64 will be corrupted during live display or transcript restoration.
 
 Project-backed creation uses a runtime workspace reference:
 

--- a/docs/zh/developer-guide/runtime-local-work.md
+++ b/docs/zh/developer-guide/runtime-local-work.md
@@ -224,6 +224,7 @@ Wework 在调用 create 前先生成客户端侧 `localTaskId`，并在请求体
 - Codex 创建时仍通过 LocalTask Responses 事件通道流式返回 `response.created`、文本/tool 增量和 `response.completed`/`error`，这些事件使用 create 返回的 `localTaskId`，前端不需要等待下一次列表刷新才能显示运行中的回复。
 - Codex app-server 输入支持 `input_text`、`input_image` 和 `localImage` prompt block 映射。Backend 附件 id 下载与沙箱路径重写仍和 local-first 附件分离：本地 App 模式通过 executor IPC 发送同设备附件记录，云端/Backend 路径继续使用上传后的附件 ID。
 - Codex 回复完成时如果 Responses `response.completed` 中带有 `file_changes` 或 `fileChanges`，executor 会把它保存到当前 assistant message 的 `fileChanges` 字段，后续 transcript 刷新继续展示同一张文件变更卡片。
+- Codex app-server 的 `imageGeneration` item 不能作为普通文本工具输出处理。executor 将完整图片结果保存到 tool block 的 `render_payload`，同时保留提示词和生成文件路径；Wework 使用该载荷直接展示图片。图片数据不能经过普通工具输出的截断窗口，否则实时消息或 transcript 恢复后会得到损坏的 base64。
 
 Project 场景使用运行时 workspace 引用：
 

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -517,6 +517,7 @@ pub(crate) fn tool_update_from_notification(params: &Value) -> Option<(String, V
     });
     if let Some(object) = updates.as_object_mut() {
         insert_tool_output_fields(object, &item, TranscriptBuildOptions::truncated());
+        insert_image_generation_render_payload(object, &item);
     }
     if let Some(input) = command_input_from_output(&item) {
         if let Some(object) = updates.as_object_mut() {
@@ -1344,6 +1345,7 @@ fn command_block(item: &Value, timestamp: i64, options: TranscriptBuildOptions) 
     });
     if let Some(object) = block.as_object_mut() {
         insert_tool_output_fields(object, item, options);
+        insert_image_generation_render_payload(object, item);
     }
     block
 }
@@ -1366,6 +1368,7 @@ fn tool_block(item: &Value, timestamp: i64, options: TranscriptBuildOptions) -> 
     });
     if let Some(object) = block.as_object_mut() {
         insert_tool_output_fields(object, item, options);
+        insert_image_generation_render_payload(object, item);
     }
     block
 }
@@ -1386,6 +1389,7 @@ fn merge_tool_output(
         if let Some(object) = block.as_object_mut() {
             merge_tool_input(object, command_input_from_output(item));
             insert_tool_output_fields(object, item, options);
+            insert_image_generation_render_payload(object, item);
             object.insert("status".to_owned(), Value::String(tool_status(item)));
         }
         return;
@@ -1400,6 +1404,7 @@ fn merge_tool_output(
     });
     if let Some(object) = block.as_object_mut() {
         insert_tool_output_fields(object, item, options);
+        insert_image_generation_render_payload(object, item);
     }
     if let Some(input) = command_input_from_output(item) {
         if let Some(object) = block.as_object_mut() {
@@ -1426,6 +1431,29 @@ fn insert_tool_output_fields(
         object.remove("tool_output_truncated");
         object.remove("tool_output_original_bytes");
     }
+}
+
+fn insert_image_generation_render_payload(object: &mut Map<String, Value>, item: &Value) {
+    if item_type(item) != "imagegeneration" {
+        return;
+    }
+    let mut payload = Map::from_iter([(
+        "kind".to_owned(),
+        Value::String("image_generation".to_owned()),
+    )]);
+    if let Some(result) = raw_string_field(item, "result").filter(|result| !result.is_empty()) {
+        payload.insert("imageBase64".to_owned(), Value::String(result));
+    }
+    if let Some(prompt) =
+        string_field(item, "revisedPrompt").or_else(|| string_field(item, "revised_prompt"))
+    {
+        payload.insert("revisedPrompt".to_owned(), Value::String(prompt));
+    }
+    if let Some(path) = string_field(item, "savedPath").or_else(|| string_field(item, "saved_path"))
+    {
+        payload.insert("savedPath".to_owned(), Value::String(path));
+    }
+    object.insert("render_payload".to_owned(), Value::Object(payload));
 }
 
 fn command_input(item: &Value) -> Value {
@@ -2472,6 +2500,36 @@ mod tests {
             assert_eq!(updates["status"], "done");
             assert_eq!(updates["tool_input"], action);
         }
+    }
+
+    #[test]
+    fn image_generation_blocks_preserve_renderable_image_data() {
+        let item = json!({
+            "id": "ig-1",
+            "type": "imageGeneration",
+            "status": "completed",
+            "result": "aW1hZ2U=",
+            "revisedPrompt": "A minimal blue circle",
+            "savedPath": "/tmp/ig-1.png"
+        });
+
+        let block = workbench_block_from_codex_item(
+            &item,
+            "turn-1",
+            "device-1",
+            "/tmp",
+            1,
+            TranscriptBuildOptions::truncated(),
+        )
+        .expect("image generation should produce a workbench block");
+
+        assert_eq!(block["tool_name"], "image_generation");
+        assert_eq!(block["render_payload"]["kind"], "image_generation");
+        assert_eq!(block["render_payload"]["imageBase64"], "aW1hZ2U=");
+        assert_eq!(
+            block["render_payload"]["revisedPrompt"],
+            "A minimal blue circle"
+        );
     }
 
     #[test]

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -310,7 +310,6 @@ pub(crate) fn is_codex_tool_output_item_type(item_type: &str) -> bool {
 pub(crate) fn is_likely_codex_tool_item_type(item_type: &str) -> bool {
     is_codex_tool_item_type(item_type)
         || is_codex_tool_output_item_type(item_type)
-        || item_type == "imagegeneration"
         || item_type.contains("tool")
         || item_type.contains("command")
         || item_type.contains("exec")

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -310,6 +310,7 @@ pub(crate) fn is_codex_tool_output_item_type(item_type: &str) -> bool {
 pub(crate) fn is_likely_codex_tool_item_type(item_type: &str) -> bool {
     is_codex_tool_item_type(item_type)
         || is_codex_tool_output_item_type(item_type)
+        || item_type == "imagegeneration"
         || item_type.contains("tool")
         || item_type.contains("command")
         || item_type.contains("exec")

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -15,6 +15,41 @@ const tauriCoreMock = vi.hoisted(() => ({
 vi.mock('@tauri-apps/api/core', () => tauriCoreMock)
 
 describe('MessageList', () => {
+  test('renders generated image artifacts from image generation blocks', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-image',
+            role: 'assistant',
+            content: 'Choose a direction.',
+            status: 'done',
+            createdAt: '2026-06-11T10:00:01Z',
+            blocks: [
+              {
+                id: 'ig-1',
+                subtaskId: '1',
+                type: 'tool',
+                toolName: 'image_generation',
+                renderPayload: {
+                  kind: 'image_generation',
+                  imageBase64: 'aW1hZ2U=',
+                  revisedPrompt: 'Minimal dashboard concept',
+                },
+                status: 'done',
+                createdAt: Date.now(),
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    const image = screen.getByTestId('generated-image')
+    expect(image).toHaveAttribute('src', 'data:image/png;base64,aW1hZ2U=')
+    expect(image).toHaveAttribute('alt', 'Minimal dashboard concept')
+  })
+
   test('marks message rows for offscreen rendering containment with intrinsic sizes', () => {
     render(
       <MessageList

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1532,6 +1532,7 @@ function AssistantMessage({
     ? []
     : getWebSearchSourceItems(getWebSearchToolBlocks(displayBlocks))
   const memoryCitations = message.memoryCitations ?? []
+  const generatedImages = getGeneratedImages(displayBlocks)
   const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
 
   const openFileFromLink = (path: string, options?: WorkspaceFileOpenOptions) => {
@@ -1588,6 +1589,7 @@ function AssistantMessage({
             />
           )}
           {shouldShowThinking && !hasVisibleContent && <AssistantThinkingIndicator />}
+          {generatedImages.length > 0 ? <GeneratedImageGallery images={generatedImages} /> : null}
           {message.contentTruncated ? (
             <ContentTruncatedNotice
               originalChars={message.contentOriginalChars}
@@ -1649,6 +1651,52 @@ function AssistantMessage({
             <MessageHoverActions message={message} align="left" visible={areHoverActionsVisible} />
           )}
       </div>
+    </div>
+  )
+}
+
+interface GeneratedImageArtifact {
+  id: string
+  src: string
+  alt: string
+}
+
+function getGeneratedImages(blocks: ProcessingBlock[]): GeneratedImageArtifact[] {
+  return blocks.flatMap(block => {
+    if (block.type !== 'tool' || block.toolName !== 'image_generation') return []
+    const payload = block.renderPayload
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return []
+    const imageBase64 = Reflect.get(payload, 'imageBase64')
+    if (typeof imageBase64 !== 'string' || !imageBase64.trim()) return []
+    const revisedPrompt = Reflect.get(payload, 'revisedPrompt')
+    return [
+      {
+        id: block.id,
+        src: imageBase64.startsWith('data:') ? imageBase64 : `data:image/png;base64,${imageBase64}`,
+        alt:
+          typeof revisedPrompt === 'string' && revisedPrompt.trim()
+            ? revisedPrompt
+            : 'Generated image',
+      },
+    ]
+  })
+}
+
+function GeneratedImageGallery({ images }: { images: GeneratedImageArtifact[] }) {
+  return (
+    <div
+      className="mb-3 grid max-w-3xl grid-cols-1 gap-3 sm:grid-cols-2"
+      data-testid="generated-image-gallery"
+    >
+      {images.map(image => (
+        <img
+          key={image.id}
+          src={image.src}
+          alt={image.alt}
+          className="h-auto w-full rounded-lg border border-border bg-surface object-contain"
+          data-testid="generated-image"
+        />
+      ))}
     </div>
   )
 }

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -211,6 +211,7 @@ export function createRuntimeTaskStreamHandlers(
         hasToolOutput: payload.toolOutput !== undefined,
         hasToolOutputDelta: payload.toolOutputDelta !== undefined,
         hasToolOutputTruncated: payload.toolOutputTruncated !== undefined,
+        hasRenderPayload: payload.renderPayload !== undefined,
         hasFileChanges: payload.fileChanges !== undefined,
       })
       handlers.onMessageAction({
@@ -226,6 +227,9 @@ export function createRuntimeTaskStreamHandlers(
           }),
           ...(payload.toolOutputTruncated !== undefined && {
             toolOutputTruncated: payload.toolOutputTruncated,
+          }),
+          ...(payload.renderPayload !== undefined && {
+            renderPayload: payload.renderPayload,
           }),
           ...(payload.fileChanges !== undefined && {
             fileChanges: normalizeTurnFileChanges(payload.fileChanges),
@@ -659,6 +663,25 @@ function normalizeProcessingBlock(
             ? block.tool_output_original_bytes
             : undefined,
       renderPayload: normalizeToolRenderPayload(block),
+      status,
+      createdAt: timestamp,
+    }
+  }
+
+  if (block.type === 'image_generation_call') {
+    const id = typeof block.id === 'string' ? block.id : null
+    if (!id) return warnAndDropRuntimeTranscriptBlock(subtaskId, block, index)
+    return {
+      id,
+      subtaskId,
+      type: 'tool',
+      toolName: 'image_generation',
+      renderPayload: {
+        kind: 'image_generation',
+        ...(typeof block.result === 'string' && { imageBase64: block.result }),
+        ...(typeof block.revised_prompt === 'string' && { revisedPrompt: block.revised_prompt }),
+        ...(typeof block.saved_path === 'string' && { savedPath: block.saved_path }),
+      },
       status,
       createdAt: timestamp,
     }

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -444,4 +444,81 @@ describe('emitResponseApiEvent', () => {
       toolOutput: { exit_code: 2, message: 'tool failed' },
     })
   })
+
+  test('maps image generation lifecycle events to renderable tool blocks', () => {
+    const onBlockCreated = vi.fn()
+    const onBlockUpdated = vi.fn()
+    const state = createResponseApiStreamState()
+
+    emitResponseApiEvent(
+      { onBlockCreated, onBlockUpdated },
+      'response.output_item.added',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          item: { id: 'ig-1', type: 'image_generation_call', status: 'in_progress' },
+        },
+      },
+      state
+    )
+    emitResponseApiEvent(
+      { onBlockCreated, onBlockUpdated },
+      'image_generation.partial_image',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: { item_id: 'ig-1', partial_image_b64: 'cGFydGlhbA==' },
+      },
+      state
+    )
+    emitResponseApiEvent(
+      { onBlockCreated, onBlockUpdated },
+      'response.output_item.done',
+      {
+        taskId: 'task-1',
+        subtaskId: '2',
+        data: {
+          item: {
+            id: 'ig-1',
+            type: 'image_generation_call',
+            status: 'completed',
+            revised_prompt: 'A finished image',
+            result: 'ZmluYWw=',
+          },
+        },
+      },
+      state
+    )
+
+    expect(onBlockCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        block: expect.objectContaining({
+          id: 'ig-1',
+          type: 'tool',
+          tool_name: 'image_generation',
+        }),
+      })
+    )
+    expect(onBlockUpdated).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        blockId: 'ig-1',
+        status: 'streaming',
+        renderPayload: { kind: 'image_generation', imageBase64: 'cGFydGlhbA==' },
+      })
+    )
+    expect(onBlockUpdated).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        blockId: 'ig-1',
+        status: 'done',
+        renderPayload: {
+          kind: 'image_generation',
+          imageBase64: 'ZmluYWw=',
+          revisedPrompt: 'A finished image',
+        },
+      })
+    )
+  })
 })

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -483,8 +483,10 @@ describe('emitResponseApiEvent', () => {
             id: 'ig-1',
             type: 'image_generation_call',
             status: 'completed',
-            revised_prompt: 'A finished image',
+            revisedPrompt: 'A finished image',
             result: 'ZmluYWw=',
+            partial_image_b64: 'cGFydGlhbA==',
+            savedPath: '/tmp/generated.png',
           },
         },
       },
@@ -517,6 +519,7 @@ describe('emitResponseApiEvent', () => {
           kind: 'image_generation',
           imageBase64: 'ZmluYWw=',
           revisedPrompt: 'A finished image',
+          savedPath: '/tmp/generated.png',
         },
       })
     )

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -503,13 +503,15 @@ function emitToolDone(
 function imageGenerationRenderPayload(item: Record<string, unknown>): Record<string, unknown> {
   const result = stringField(item, 'result')
   const partialImage = stringField(item, 'partial_image_b64')
+  const imageBase64 = result ?? partialImage
+  const revisedPrompt = stringField(item, 'revised_prompt') ?? stringField(item, 'revisedPrompt')
+  const savedPath = stringField(item, 'saved_path') ?? stringField(item, 'savedPath')
+
   return {
     kind: 'image_generation',
-    ...(result && { imageBase64: result }),
-    ...(partialImage && { imageBase64: partialImage }),
-    ...(stringField(item, 'revised_prompt') && {
-      revisedPrompt: stringField(item, 'revised_prompt'),
-    }),
+    ...(imageBase64 && { imageBase64 }),
+    ...(revisedPrompt && { revisedPrompt }),
+    ...(savedPath && { savedPath }),
   }
 }
 

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -60,6 +60,8 @@ export interface ResponseApiStreamState {
   toolContexts: Map<string, { name?: string; input?: Record<string, unknown> }>
 }
 
+const IMAGE_GENERATION_TOOL_NAME = 'image_generation'
+
 const runtimeTaskPlans = new Map<string, RuntimePlanEventPayload>()
 
 function runtimeTaskPlanKey(
@@ -363,7 +365,9 @@ function responseToolItem(data: Record<string, unknown>): Record<string, unknown
 }
 
 function isToolItem(item: Record<string, unknown>): boolean {
-  return ['function_call', 'mcp_call', 'shell_call'].includes(stringField(item, 'type') ?? '')
+  return ['function_call', 'mcp_call', 'shell_call', 'image_generation_call'].includes(
+    stringField(item, 'type') ?? ''
+  )
 }
 
 function isCommandToolItem(item: Record<string, unknown>): boolean {
@@ -398,7 +402,8 @@ function emitBlockCreated(
   }
 
   const toolInput = toolInputFrom(data, item)
-  const toolName = normalizeToolName(item)
+  const isImageGeneration = item.type === 'image_generation_call'
+  const toolName = isImageGeneration ? IMAGE_GENERATION_TOOL_NAME : normalizeToolName(item)
   state.toolContexts.set(callId, { name: toolName, input: toolInput })
 
   handlers.onBlockCreated?.({
@@ -409,6 +414,9 @@ function emitBlockCreated(
       tool_use_id: callId,
       tool_name: toolName,
       tool_input: toolInput,
+      ...(isImageGeneration && {
+        renderPayload: imageGenerationRenderPayload(item),
+      }),
       status: data.argument_status === 'streaming' ? 'generating_arguments' : 'pending',
       timestamp: Date.now(),
     },
@@ -429,6 +437,7 @@ function emitBlockUpdated(
     toolOutputOriginalBytes?: number
     content?: string
     fileChanges?: ChatBlock['fileChanges']
+    renderPayload?: unknown
   }
 ): void {
   if (!blockId) {
@@ -483,9 +492,42 @@ function emitToolDone(
     status,
     ...(nextInput && { toolInput: nextInput }),
     ...(toolOutput !== undefined && { toolOutput }),
+    ...(item.type === 'image_generation_call' && {
+      renderPayload: imageGenerationRenderPayload(item),
+    }),
   })
 
   state.toolContexts.delete(callId)
+}
+
+function imageGenerationRenderPayload(item: Record<string, unknown>): Record<string, unknown> {
+  const result = stringField(item, 'result')
+  const partialImage = stringField(item, 'partial_image_b64')
+  return {
+    kind: 'image_generation',
+    ...(result && { imageBase64: result }),
+    ...(partialImage && { imageBase64: partialImage }),
+    ...(stringField(item, 'revised_prompt') && {
+      revisedPrompt: stringField(item, 'revised_prompt'),
+    }),
+  }
+}
+
+function emitImageGenerationPartial(
+  handlers: ChatStreamHandlers,
+  base: ReturnType<typeof eventBase>,
+  data: Record<string, unknown>
+): void {
+  const blockId = callIdFromData(data) ?? stringField(data, 'id')
+  const partialImage = stringField(data, 'partial_image_b64')
+  if (!blockId || !partialImage) {
+    warnDroppedResponseBlock('image_generation.partial_image', 'missing_image_data', base, data)
+    return
+  }
+  emitBlockUpdated(handlers, 'image_generation.partial_image', base, blockId, {
+    status: 'streaming',
+    renderPayload: imageGenerationRenderPayload(data),
+  })
 }
 
 function emitResponseBlockCreated(
@@ -511,6 +553,7 @@ function emitResponseBlockUpdated(
 ): void {
   const updates = recordField(data, 'updates')
   const toolInput = parseRecord(updates.toolInput ?? updates.tool_input)
+  const renderPayload = updates.renderPayload ?? updates.render_payload
   const fileChanges = parseRecord(updates.fileChanges ?? updates.file_changes)
   const toolOutputDelta = updates.toolOutputDelta ?? updates.tool_output_delta
   const toolOutputTruncated = updates.toolOutputTruncated ?? updates.tool_output_truncated
@@ -536,6 +579,7 @@ function emitResponseBlockUpdated(
         toolOutputOriginalBytes,
       }),
       ...(toolInput && { toolInput }),
+      ...(renderPayload !== undefined && { renderPayload }),
       ...(fileChanges && { fileChanges: fileChanges as unknown as ChatBlock['fileChanges'] }),
       ...(typeof updates.status === 'string' && {
         status: updates.status as ChatBlock['status'],
@@ -769,6 +813,11 @@ export function emitResponseApiEvent(
 
   if (eventName === 'response.output_item.added') {
     emitBlockCreated(handlers, base, data, state)
+    return
+  }
+
+  if (eventName === 'image_generation.partial_image') {
+    emitImageGenerationPartial(handlers, base, data)
     return
   }
 

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -1895,6 +1895,7 @@ export interface ChatBlockUpdatedPayload {
   tool_output_truncated?: boolean
   tool_output_original_bytes?: number
   toolInput?: Record<string, unknown>
+  renderPayload?: unknown
   fileChanges?: TurnFileChangesSummary
   status?: ChatBlock['status'] | 'running'
   deviceId?: string


### PR DESCRIPTION
## What changed

- map Codex app-server `imageGeneration` items into persistent Wework tool blocks
- preserve complete image data in a dedicated render payload instead of the truncated text output field
- handle Responses API image generation start, partial image, and completion events
- render generated images inline in assistant messages and restore them from transcripts
- document the local runtime image-generation message contract in Chinese and English

## Root cause

Wework subscribed to image-generation events but did not map them into renderable message blocks. The local executor also classified app-server `imageGeneration` items as non-tool items. As a result, the model completed image generation but only its surrounding text reached the chat UI.

## User impact

Generated image previews now appear directly in the Wework conversation, including after transcript restoration, instead of leaving an empty area above text that refers to missing方案 images.

## Validation

- Wework unit suite: 157 files, 1564 tests passed
- pre-push Wework ESLint, TypeScript, and unit checks passed
- pre-push Executor `cargo fmt`, `cargo test --all-features --lib`, and clippy passed
- focused Executor image-generation transcript test passed
- isolated real-Tauri QA generated a blue circular icon and asserted `generated-image` plus `generated-image-gallery` were visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying generated images directly in chat messages.
  - Generated images now appear progressively as they are created, with revised prompts and saved file paths when available.
  - Image results remain available when restoring conversation transcripts.

- **Bug Fixes**
  - Prevented image data from being truncated or corrupted during live updates and transcript restoration.

- **Documentation**
  - Documented handling requirements for image-generation results in the English and Chinese developer guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->