### PR TITLE
fix(wework): keep branch menu above chat composer

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5464,15 +5464,15 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
-    expect(screen.getByTestId('environment-info-panel-container')).toContainElement(
-      screen.getByTestId('environment-info-popover')
-    )
-    expect(screen.getByTestId('desktop-workbench-content')).toContainElement(
-      screen.getByTestId('environment-info-panel-container')
-    )
-    expect(screen.getByTestId('environment-info-panel-container')).toHaveClass(
+    const environmentInfoPanel = screen.getByTestId('environment-info-panel-container')
+    const environmentInfoPopover = screen.getByTestId('environment-info-popover')
+    expect(environmentInfoPanel).toContainElement(environmentInfoPopover)
+    expect(environmentInfoPopover).toHaveAttribute('data-environment-info-popover')
+    expect(environmentInfoPanel.matches(':has([data-environment-info-popover])')).toBe(true)
+    expect(screen.getByTestId('desktop-workbench-content')).toContainElement(environmentInfoPanel)
+    expect(environmentInfoPanel).toHaveClass(
       'overflow-hidden',
-      'has-[[data-testid=environment-info-popover]]:overflow-visible'
+      'has-[[data-environment-info-popover]]:overflow-visible'
     )
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
       'w-[300px]',
@@ -5537,6 +5537,8 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('environment-info-button'))
 
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
+    expect(environmentInfoPanel.matches(':has([data-environment-info-popover])')).toBe(false)
+    expect(environmentInfoPanel).toHaveClass('overflow-hidden')
   })
 
   test('opens environment changes review in the right workspace panel', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5470,6 +5470,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('desktop-workbench-content')).toContainElement(
       screen.getByTestId('environment-info-panel-container')
     )
+    expect(screen.getByTestId('environment-info-panel-container')).toHaveClass(
+      'overflow-hidden',
+      'has-[[data-testid=environment-info-popover]]:overflow-visible'
+    )
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
       'w-[300px]',
       'bg-background',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1695,7 +1695,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           )}
           <aside
             data-testid="environment-info-panel-container"
-            className="sticky top-0 z-popover flex h-full w-0 shrink-0 self-start flex-col overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[[data-testid=environment-info-popover]]:w-[320px]"
+            className="sticky top-0 z-popover flex h-full w-0 shrink-0 self-start flex-col overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[[data-testid=environment-info-popover]]:w-[320px] has-[[data-testid=environment-info-popover]]:overflow-visible"
           >
             <div ref={setEnvironmentInfoPanelRef} className="shrink-0" />
             {environmentInfoDocked && hasSubagentStatuses && (

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1695,7 +1695,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           )}
           <aside
             data-testid="environment-info-panel-container"
-            className="sticky top-0 z-popover flex h-full w-0 shrink-0 self-start flex-col overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[[data-testid=environment-info-popover]]:w-[320px] has-[[data-testid=environment-info-popover]]:overflow-visible"
+            className="sticky top-0 z-popover flex h-full w-0 shrink-0 self-start flex-col overflow-hidden transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none has-[[data-environment-info-popover]]:w-[320px] has-[[data-environment-info-popover]]:overflow-visible"
           >
             <div ref={setEnvironmentInfoPanelRef} className="shrink-0" />
             {environmentInfoDocked && hasSubagentStatuses && (

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -255,6 +255,7 @@ export function EnvironmentInfoPopover({
         createPortal(
           <div
             ref={popoverRef}
+            data-environment-info-popover
             data-testid="environment-info-popover"
             style={docked ? undefined : floatingPopoverStyle}
             className={cn(


### PR DESCRIPTION
## What changed

- allow the docked environment info panel to overflow while its popover is open
- keep overflow clipping while the panel is collapsed
- add a regression assertion for the conditional overflow behavior

## Why

The environment branch menu opens toward the chat column. Its `z-system-popover` layer was still clipped by the docked panel's `overflow-hidden` ancestor, so the chat composer appeared to cover most of the branch list.

## Impact

The complete branch menu now remains visible and interactive above the chat composer without changing the collapsed panel behavior.

## Validation

- `prettier --check` on changed files
- `eslint` on changed files
- `vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx` (128 tests)
- `tsc -b`
- `vite build`
- isolated real-Tauri verification with `scripts/ai-verify.mjs`
  - loaded the actual repository branch list
  - verified the menu renders fully over the chat composer
  - verified Escape closes only the branch menu
  - verified the environment popover closes cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment information popover visibility and positioning so it can extend beyond its panel when opened.
  * Ensured the environment information panel continues to clip content appropriately when the popover is not displayed.
* **Tests**
  * Strengthened coverage to verify the panel/popup overflow behavior before and after dismissing the popover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->