### PR TITLE
fix(wework): embed browser MCP in executor

### DIFF
--- a/docs/en/developer-guide/architecture.md
+++ b/docs/en/developer-guide/architecture.md
@@ -366,6 +366,8 @@ EXECUTOR_IMAGE: wegent-executor:latest # Executor image
 
 Rust executor is the only executor runtime implementation. Backend Chat shell work may still use an in-process path, while other tasks run through standalone/local executor. In Wework packaged App local-first mode, the app does not start a local Backend; it calls the executor sidecar directly over Tauri app IPC. Codex runtime control uses `codex app-server --stdio` JSON-RPC to create, continue, read, archive, and rename threads. The executor stores only the local task index and the required `localTaskId -> threadId` mapping.
 
+Wework's built-in browser MCP is provided by the Rust executor's `browser-mcp-server` subcommand and controls the right-side browser through a local bridge address allocated independently for each Tauri instance. The packaged app does not require Node.js or a separately deployed browser MCP server, and multiple instances do not share a fixed port.
+
 When Codex uses a shared app-server thread, cancelling an active turn must await acknowledgement of `turn/interrupt` before reporting cancellation to the caller. A retry can then start only after the previous turn has stopped, preventing an interrupt and a new request from interleaving and replaying cancelled input or dropping the retry message.
 
 **Core Features**:

--- a/docs/zh/developer-guide/architecture.md
+++ b/docs/zh/developer-guide/architecture.md
@@ -366,6 +366,8 @@ EXECUTOR_IMAGE: wegent-executor:latest # 执行器镜像
 
 Rust executor 是唯一的 executor 运行时实现。Backend 的 Chat shell 仍可走进程内路径，其他任务由 standalone/local executor 执行；Wework 打包 App 的 local-first 模式不启动本地 Backend，而是通过 Tauri app IPC 直接调用 executor。Codex 运行时通过 `codex app-server --stdio` 的 JSON-RPC 协议创建、继续、读取、归档和重命名线程，executor 只保存必要的本地任务索引和 `localTaskId -> threadId` 关联。
 
+Wework 的内置浏览器 MCP 由 Rust executor 的 `browser-mcp-server` 子命令提供，并通过每个 Tauri 实例独立分配的本地桥接地址控制右侧浏览器。打包 App 无需安装 Node.js 或单独部署 browser MCP server，多实例也不会共享固定端口。
+
 Codex 使用共享 app-server 线程时，取消活动轮次必须先等待 `turn/interrupt` 的确认，再向调用方报告已取消。这样重试会在前一轮真正停止后创建，避免上一轮的中断和新轮请求交错，从而恢复已取消的输入或丢失重试消息。
 
 **核心特性**：

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -43,7 +43,7 @@ sha2 = "0.10"
 tar = "0.4"
 tf-rust-socketio = { version = "0.8.1", features = ["async"] }
 thiserror = "2.0"
-tokio = { version = "1.48", features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.48", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 toml_edit = "0.22"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -50,6 +50,8 @@ const DEFAULT_NO_PROXY: &str = "localhost,127.0.0.1,::1,host.docker.internal";
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const WEGENT_CODEX_HOME_ENV: &str = "WEGENT_CODEX_HOME";
 const WEWORK_BROWSER_MCP_SERVER_NAME: &str = "wework_browser";
+const WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR";
+const DEFAULT_WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR: &str = "127.0.0.1:9231";
 const CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE: &str =
     "features.apply_patch_streaming_events=true";
 const CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE: &str =
@@ -3043,7 +3045,13 @@ fn global_mcp_config_overrides() -> Vec<String> {
 }
 
 fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
-    let command = executor_home().join("bin/browser-mcp-server");
+    let command =
+        env::current_exe().unwrap_or_else(|_| executor_home().join("bin/wegent-executor"));
+    let bridge_addr = env::var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR.to_owned());
+    let bridge_url = format!("http://{bridge_addr}");
     let mut overrides = vec![
         format!(
             "skills.config={}",
@@ -3064,6 +3072,11 @@ fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
             "{}={}",
             toml_key_path(&["mcp_servers", WEWORK_BROWSER_MCP_SERVER_NAME, "command"]),
             toml_value(&command.display().to_string())
+        ),
+        format!(
+            "{}={}",
+            toml_key_path(&["mcp_servers", WEWORK_BROWSER_MCP_SERVER_NAME, "args"]),
+            toml_json_value(&json!(["browser-mcp-server"]))
         ),
         format!(
             "{}={}",
@@ -3089,19 +3102,9 @@ fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
                 "mcp_servers",
                 WEWORK_BROWSER_MCP_SERVER_NAME,
                 "env",
-                "WEWORK_BROWSER_MCP_TARGET"
-            ]),
-            toml_value("embedded")
-        ),
-        format!(
-            "{}={}",
-            toml_key_path(&[
-                "mcp_servers",
-                WEWORK_BROWSER_MCP_SERVER_NAME,
-                "env",
                 "WEWORK_EMBEDDED_BROWSER_BRIDGE_URL"
             ]),
-            toml_value("http://127.0.0.1:9231")
+            toml_value(&bridge_url)
         ),
     ];
 
@@ -4928,7 +4931,9 @@ mod tests {
         let _lock = crate::test_env::lock();
         let home = env::temp_dir().join(format!("codex-browser-mcp-{}", std::process::id()));
         let old_home = env::var_os("WEGENT_EXECUTOR_HOME");
+        let old_bridge_addr = env::var_os(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV);
         env::set_var("WEGENT_EXECUTOR_HOME", &home);
+        env::set_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV, "127.0.0.1:43127");
         let request = ExecutionRequest {
             task_id: "task:123".to_owned(),
             ..ExecutionRequest::default()
@@ -4957,17 +4962,17 @@ mod tests {
         assert_eq!(config["features.non_prefixed_mcp_tool_names"], true);
         assert_eq!(
             config["mcp_servers.wework_browser.command"],
-            home.join("bin/browser-mcp-server").display().to_string()
+            env::current_exe().unwrap().display().to_string()
+        );
+        assert_eq!(
+            config["mcp_servers.wework_browser.args"],
+            json!(["browser-mcp-server"])
         );
         assert_eq!(config["mcp_servers.wework_browser.startup_timeout_sec"], 15);
         assert_eq!(config["mcp_servers.wework_browser.tool_timeout_sec"], 60);
         assert_eq!(
-            config["mcp_servers.wework_browser.env.WEWORK_BROWSER_MCP_TARGET"],
-            "embedded"
-        );
-        assert_eq!(
             config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_URL"],
-            "http://127.0.0.1:9231"
+            "http://127.0.0.1:43127"
         );
         assert_eq!(
             config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_LABEL"],
@@ -4978,6 +4983,11 @@ mod tests {
             env::set_var("WEGENT_EXECUTOR_HOME", old_home);
         } else {
             env::remove_var("WEGENT_EXECUTOR_HOME");
+        }
+        if let Some(old_bridge_addr) = old_bridge_addr {
+            env::set_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV, old_bridge_addr);
+        } else {
+            env::remove_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV);
         }
     }
 

--- a/executor/src/bin/wegent-executor.rs
+++ b/executor/src/bin/wegent-executor.rs
@@ -4,6 +4,13 @@
 
 #[tokio::main]
 async fn main() {
+    if wegent_executor::browser_mcp::is_browser_mcp_command() {
+        if let Err(error) = wegent_executor::browser_mcp::run().await {
+            eprintln!("browser MCP server failed: {error}");
+            std::process::exit(1);
+        }
+        return;
+    }
     if let Err(error) = wegent_executor::app::run_from_env().await {
         wegent_executor::logging::write_executor_error_line(&error.to_string());
         std::process::exit(error.exit_code());

--- a/executor/src/browser_mcp.rs
+++ b/executor/src/browser_mcp.rs
@@ -1,0 +1,404 @@
+use std::env;
+
+use serde_json::{json, Map, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+const DEFAULT_BRIDGE_URL: &str = "http://127.0.0.1:9231";
+const BRIDGE_URL_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_URL";
+const BROWSER_LABEL_ENV: &str = "WEWORK_EMBEDDED_BROWSER_LABEL";
+
+pub fn is_browser_mcp_command() -> bool {
+    env::args().nth(1).as_deref() == Some("browser-mcp-server")
+}
+
+pub async fn run() -> Result<(), String> {
+    let client = reqwest::Client::new();
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut stdout = tokio::io::stdout();
+
+    while let Some(line) = lines.next_line().await.map_err(|error| error.to_string())? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Value>(&line) {
+            Ok(request) => handle_request(&client, &request).await,
+            Err(error) => Some(error_response(Value::Null, -32700, error.to_string())),
+        };
+        if let Some(response) = response {
+            let mut encoded = serde_json::to_vec(&response).map_err(|error| error.to_string())?;
+            encoded.push(b'\n');
+            stdout
+                .write_all(&encoded)
+                .await
+                .map_err(|error| error.to_string())?;
+            stdout.flush().await.map_err(|error| error.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+async fn handle_request(client: &reqwest::Client, request: &Value) -> Option<Value> {
+    let id = request.get("id").cloned();
+    let method = request
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    match method {
+        "notifications/initialized" => None,
+        "initialize" => id.map(|id| {
+            result_response(
+                id,
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": { "tools": { "listChanged": false } },
+                    "serverInfo": { "name": "wegent-embedded-browser", "version": env!("CARGO_PKG_VERSION") }
+                }),
+            )
+        }),
+        "tools/list" => id.map(|id| result_response(id, json!({ "tools": tools() }))),
+        "ping" => id.map(|id| result_response(id, json!({}))),
+        "tools/call" => {
+            let id = id?;
+            let Some(name) = request.pointer("/params/name").and_then(Value::as_str) else {
+                return Some(error_response(id, -32602, "tools/call requires params.name"));
+            };
+            let arguments = request.pointer("/params/arguments").cloned().unwrap_or_else(|| json!({}));
+            Some(result_response(id, execute_tool(client, name, &arguments).await))
+        }
+        _ => id.map(|id| error_response(id, -32601, format!("Unknown method: {method}"))),
+    }
+}
+
+async fn execute_tool(client: &reqwest::Client, name: &str, arguments: &Value) -> Value {
+    let bridge_payload = match name {
+        "browser_navigate" | "browser_tab_new" => {
+            json!({ "action": "navigate", "url": string_arg(arguments, "url") })
+        }
+        "browser_snapshot" => json!({
+            "action": "evaluate",
+            "expression": "({ title: document.title, url: location.href, text: document.body?.innerText?.slice(0, 12000) || '' })"
+        }),
+        "browser_evaluate" => json!({
+            "action": "evaluate",
+            "expression": evaluate_expression(arguments)
+        }),
+        "browser_take_screenshot" => json!({ "action": "screenshot" }),
+        "browser_tab_list" => json!({ "action": "pageState" }),
+        "browser_tab_select" => {
+            return text_result(json!({ "ok": true, "targetId": "embedded" }), false)
+        }
+        "browser_tab_close" => {
+            return text_result(
+                "Embedded browser tabs are managed by the Wework right panel.",
+                true,
+            )
+        }
+        "browser_click" => json!({ "action": "click", "selector": selector_arg(arguments) }),
+        "browser_click_coordinates" => json!({
+            "action": "click",
+            "x": number_arg(arguments, "x"),
+            "y": number_arg(arguments, "y")
+        }),
+        "browser_type" => json!({
+            "action": "typeText",
+            "selector": selector_arg(arguments),
+            "text": string_arg(arguments, "text")
+        }),
+        "browser_press_key" => json!({ "action": "press", "key": string_arg(arguments, "key") }),
+        "browser_wait_for" => json!({
+            "action": "waitFor",
+            "text": optional_string_arg(arguments, "text"),
+            "selector": optional_string_arg(arguments, "selector"),
+            "url": optional_string_arg(arguments, "url"),
+            "expression": optional_string_arg(arguments, "fn"),
+            "timeoutMs": optional_number_arg(arguments, "timeoutMs")
+        }),
+        "browser_resize" => {
+            return text_result(
+                "Embedded browser size follows the Wework right panel bounds.",
+                false,
+            )
+        }
+        "browser_hover" => evaluate_payload(
+            arguments,
+            "element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })); true",
+        ),
+        "browser_scroll_into_view" => evaluate_payload(
+            arguments,
+            "element.scrollIntoView({ block: 'center', inline: 'center' }); true",
+        ),
+        "browser_scroll" => json!({
+            "action": "evaluate",
+            "expression": format!(
+                "window.scrollBy(0, {} * {}), true",
+                if string_arg(arguments, "direction") == "up" { -1 } else { 1 },
+                optional_number_arg(arguments, "amount").unwrap_or(500.0)
+            )
+        }),
+        "browser_select_option" => select_payload(arguments),
+        "browser_fill_form" => fill_form_payload(arguments),
+        "browser_drag" => drag_payload(arguments),
+        _ => return text_result(format!("Unknown tool: {name}"), true),
+    };
+
+    match call_bridge(client, bridge_payload).await {
+        Ok(value) => text_result(value, false),
+        Err(error) => text_result(error, true),
+    }
+}
+
+async fn call_bridge(client: &reqwest::Client, mut payload: Value) -> Result<Value, String> {
+    if let (Some(label), Some(object)) = (env::var(BROWSER_LABEL_ENV).ok(), payload.as_object_mut())
+    {
+        if !label.trim().is_empty() {
+            object.insert("label".to_owned(), Value::String(label));
+        }
+    }
+    let base_url = env::var(BRIDGE_URL_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_BRIDGE_URL.to_owned());
+    let response = client
+        .post(format!("{}/browser", base_url.trim_end_matches('/')))
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|error| {
+            format!("Embedded browser bridge is unavailable at {base_url}: {error}")
+        })?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Embedded browser bridge returned HTTP {}",
+            response.status()
+        ));
+    }
+    let body: Value = response.json().await.map_err(|error| error.to_string())?;
+    if body.get("ok").and_then(Value::as_bool) == Some(false) {
+        return Err(body
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("Embedded browser tool failed")
+            .to_owned());
+    }
+    Ok(body
+        .get("data")
+        .cloned()
+        .unwrap_or_else(|| json!({ "ok": true })))
+}
+
+fn tools() -> Vec<Value> {
+    vec![
+        tool(
+            "browser_navigate",
+            "Navigate the Wework built-in browser to a URL.",
+            &["url"],
+        ),
+        tool(
+            "browser_snapshot",
+            "Capture a text snapshot of the current page.",
+            &[],
+        ),
+        tool(
+            "browser_click",
+            "Click an element by CSS selector or snapshot ref.",
+            &[],
+        ),
+        tool(
+            "browser_click_coordinates",
+            "Click viewport coordinates.",
+            &["x", "y"],
+        ),
+        tool("browser_type", "Type text into an element.", &["text"]),
+        tool(
+            "browser_fill_form",
+            "Fill multiple form fields.",
+            &["fields"],
+        ),
+        tool("browser_press_key", "Press a keyboard key.", &["key"]),
+        tool("browser_hover", "Hover an element.", &[]),
+        tool("browser_scroll", "Scroll the current page.", &[]),
+        tool(
+            "browser_scroll_into_view",
+            "Scroll an element into view.",
+            &[],
+        ),
+        tool("browser_select_option", "Select option values.", &[]),
+        tool("browser_drag", "Drag between two elements.", &[]),
+        tool("browser_wait_for", "Wait for page state.", &[]),
+        tool(
+            "browser_resize",
+            "Resize the embedded browser viewport.",
+            &[],
+        ),
+        tool("browser_take_screenshot", "Capture a page screenshot.", &[]),
+        tool("browser_evaluate", "Evaluate JavaScript in the page.", &[]),
+        tool(
+            "browser_tab_list",
+            "List Wework built-in browser tabs.",
+            &[],
+        ),
+        tool(
+            "browser_tab_new",
+            "Open a URL in the browser tab.",
+            &["url"],
+        ),
+        tool("browser_tab_select", "Focus the embedded browser tab.", &[]),
+        tool("browser_tab_close", "Close an embedded browser tab.", &[]),
+    ]
+}
+
+fn tool(name: &str, description: &str, required: &[&str]) -> Value {
+    let mut properties = Map::new();
+    for key in [
+        "url",
+        "ref",
+        "element",
+        "text",
+        "key",
+        "selector",
+        "expression",
+        "function",
+        "fn",
+        "direction",
+        "startRef",
+        "endRef",
+    ] {
+        properties.insert(key.to_owned(), json!({ "type": "string" }));
+    }
+    for key in [
+        "x",
+        "y",
+        "amount",
+        "time",
+        "timeMs",
+        "timeoutMs",
+        "width",
+        "height",
+        "index",
+    ] {
+        properties.insert(key.to_owned(), json!({ "type": "number" }));
+    }
+    properties.insert("fields".to_owned(), json!({ "type": "array" }));
+    properties.insert(
+        "values".to_owned(),
+        json!({ "type": "array", "items": { "type": "string" } }),
+    );
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": true
+        }
+    })
+}
+
+fn result_response(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error_response(id: Value, code: i64, message: impl Into<String>) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message.into() } })
+}
+
+fn text_result(data: impl Into<Value>, is_error: bool) -> Value {
+    let data = data.into();
+    let text = data
+        .as_str()
+        .map(str::to_owned)
+        .unwrap_or_else(|| serde_json::to_string_pretty(&data).unwrap_or_default());
+    json!({ "content": [{ "type": "text", "text": text }], "isError": is_error })
+}
+
+fn string_arg(value: &Value, key: &str) -> String {
+    optional_string_arg(value, key).unwrap_or_default()
+}
+
+fn optional_string_arg(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(str::to_owned)
+}
+
+fn number_arg(value: &Value, key: &str) -> f64 {
+    optional_number_arg(value, key).unwrap_or(0.0)
+}
+
+fn optional_number_arg(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
+fn selector_arg(value: &Value) -> String {
+    let selector = optional_string_arg(value, "ref")
+        .or_else(|| optional_string_arg(value, "element"))
+        .or_else(|| optional_string_arg(value, "selector"))
+        .unwrap_or_default();
+    selector
+        .strip_prefix("css=")
+        .unwrap_or(&selector)
+        .to_owned()
+}
+
+fn evaluate_expression(value: &Value) -> String {
+    optional_string_arg(value, "expression")
+        .or_else(|| optional_string_arg(value, "function"))
+        .or_else(|| optional_string_arg(value, "fn"))
+        .unwrap_or_default()
+}
+
+fn evaluate_payload(value: &Value, action: &str) -> Value {
+    let selector =
+        serde_json::to_string(&selector_arg(value)).unwrap_or_else(|_| "\"\"".to_owned());
+    json!({
+        "action": "evaluate",
+        "expression": format!("(() => {{ const element = document.querySelector({selector}); if (!element) return false; {action} }})()")
+    })
+}
+
+fn select_payload(value: &Value) -> Value {
+    let selector =
+        serde_json::to_string(&selector_arg(value)).unwrap_or_else(|_| "\"\"".to_owned());
+    let values = value.get("values").cloned().unwrap_or_else(|| json!([]));
+    json!({ "action": "evaluate", "expression": format!("(() => {{ const element = document.querySelector({selector}); const values = {values}; for (const option of element?.options || []) option.selected = values.includes(option.value); element?.dispatchEvent(new Event('change', {{ bubbles: true }})); return true; }})()") })
+}
+
+fn fill_form_payload(value: &Value) -> Value {
+    let fields = value.get("fields").cloned().unwrap_or_else(|| json!([]));
+    json!({ "action": "evaluate", "expression": format!("(() => {{ for (const field of {fields}) {{ const selector = String(field.ref || '').replace(/^css=/, ''); const element = document.querySelector(selector); if (element) {{ element.value = field.value; element.dispatchEvent(new Event('input', {{ bubbles: true }})); }} }} return true; }})()") })
+}
+
+fn drag_payload(value: &Value) -> Value {
+    let start =
+        serde_json::to_string(&string_arg(value, "startRef")).unwrap_or_else(|_| "\"\"".to_owned());
+    let end =
+        serde_json::to_string(&string_arg(value, "endRef")).unwrap_or_else(|_| "\"\"".to_owned());
+    json!({ "action": "evaluate", "expression": format!("(() => {{ const source = document.querySelector({start}.replace(/^css=/, '')); const target = document.querySelector({end}.replace(/^css=/, '')); if (!source || !target) return false; source.dispatchEvent(new DragEvent('dragstart', {{ bubbles: true }})); target.dispatchEvent(new DragEvent('drop', {{ bubbles: true }})); source.dispatchEvent(new DragEvent('dragend', {{ bubbles: true }})); return true; }})()") })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn exposes_expected_browser_tools() {
+        let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+        let response = handle_request(&reqwest::Client::new(), &request)
+            .await
+            .unwrap();
+        let names = response["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"browser_navigate"));
+        assert!(names.contains(&"browser_evaluate"));
+        assert!(names.contains(&"browser_take_screenshot"));
+        assert_eq!(names.len(), 20);
+    }
+
+    #[test]
+    fn strips_css_ref_prefix() {
+        assert_eq!(selector_arg(&json!({ "ref": "css=#submit" })), "#submit");
+    }
+}

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod agents;
 pub mod app;
 pub mod attachments;
+pub mod browser_mcp;
 pub mod callback;
 mod claude_session;
 mod codex_phase;

--- a/wework/src-tauri/src/embedded_browser.rs
+++ b/wework/src-tauri/src/embedded_browser.rs
@@ -18,7 +18,7 @@ use tauri::{
 
 const MAIN_WINDOW_LABEL: &str = "main";
 const BROWSER_WEBVIEW_LABEL: &str = "workspace-browser";
-const EMBEDDED_BROWSER_BRIDGE_ADDR: &str = "127.0.0.1:9231";
+const EMBEDDED_BROWSER_BRIDGE_ADDR: &str = "127.0.0.1:0";
 const EMBEDDED_BROWSER_BRIDGE_ADDR_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR";
 const BRIDGE_READ_TIMEOUT_MS: u64 = 5_000;
 const BRIDGE_EVAL_TIMEOUT_MS: u64 = 10_000;
@@ -671,6 +671,7 @@ pub fn start_embedded_browser_bridge(app: tauri::AppHandle) -> Result<(), String
     let listening_addr = listener
         .local_addr()
         .map_err(|error| format!("Failed to read embedded browser bridge address: {error}"))?;
+    env::set_var(EMBEDDED_BROWSER_BRIDGE_ADDR_ENV, listening_addr.to_string());
     let state = app.state::<EmbeddedBrowserState>().inner().clone();
     let app_handle = app.clone();
     std::thread::Builder::new()


### PR DESCRIPTION
## What changed

- Embed the Wework browser MCP server in the Rust executor as the `browser-mcp-server` subcommand.
- Configure Codex to launch the current executor binary instead of a separately installed Node package.
- Allocate an independent embedded-browser bridge port for each Tauri instance and pass it to the executor.
- Document the packaged-app browser MCP architecture in Chinese and English.

## Root cause

Fresh Wework installations depended on a separately installed `browser-mcp-server` Node package that was not guaranteed to exist. The Tauri bridge also used the fixed port `9231`, so multiple Wework instances could connect browser tools to the wrong application instance.

## Impact

AI-generated webpages can now be opened and inspected in the Wework right-side browser without requiring Node.js or an additional MCP server installation. Multiple Wework instances use isolated bridge addresses.

## Validation

- Real isolated Tauri verification: Codex created and served a webpage, `browser_navigate` opened it in the right-side browser, and `browser_evaluate` returned `RUST_BROWSER_MCP_OK`.
- `cargo test --manifest-path executor/Cargo.toml browser_mcp --lib`
- `cargo check --manifest-path wework/src-tauri/Cargo.toml`
- Pre-push ESLint, TypeScript, Wework unit tests, Executor lib tests, `cargo fmt`, and `cargo clippy` all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in browser MCP support for the packaged app.
  * Enabled browser automation actions including navigation, interaction, tab management, form filling, and screenshots.
  * Browser bridge connections now use a unique dynamically assigned local address for each app instance.

* **Documentation**
  * Updated English and Chinese architecture guides with browser MCP setup and runtime details.
  * Clarified that Node.js and a separately deployed browser MCP server are not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->