### PR TITLE
feat(wework): 过滤非v1/responses的模型

### DIFF
--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -218,6 +218,24 @@ const codexModel = {
   isActive: true,
 }
 
+const chatCompletionsModel = {
+  name: 'chat-completions-model',
+  type: 'public',
+  displayName: 'Chat Completions Model',
+  config: { protocol: 'openai-chat-completions' },
+  runtime: { family: 'openai.openai-chat-completions' },
+  isActive: true,
+}
+
+const responsesModel = {
+  name: 'responses-model',
+  type: 'public',
+  displayName: 'Responses Model',
+  config: { wire_api: 'responses' },
+  runtime: { family: 'openai' },
+  isActive: true,
+}
+
 function createServices() {
   return createHybridWorkbenchServices({
     apiBaseUrl: 'https://cloud.example.com/api',
@@ -324,6 +342,22 @@ describe('createHybridWorkbenchServices', () => {
       'gpt-5.5',
       'gpt-5.5',
     ])
+  })
+
+  it('only displays Backend models that explicitly support the Responses API', async () => {
+    mocks.localListModels.mockResolvedValue({ data: [chatCompletionsModel] })
+    mocks.cloudListModels.mockResolvedValue({
+      data: [chatCompletionsModel, responsesModel],
+    })
+    const services = createServices()
+
+    const response = await services.modelApi.listModels()
+
+    expect(response.data.map(model => model.name)).toEqual([
+      'local:public:chat-completions-model',
+      'responses-model',
+    ])
+    expect(getModelExecutionOverride(response.data[1])?.source).toBe('cloud')
   })
 
   it('keeps default team and skills on the local services', async () => {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -12,6 +12,7 @@ import {
   mergeRuntimeWorkLists as mergeRuntimeWorkPair,
 } from '@/features/workbench/workbenchCloudStatus'
 import {
+  supportsResponsesApi,
   withModelExecutionOverride,
   type HybridModelSource,
 } from '@/features/cloud-connection/modelExecution'
@@ -152,7 +153,7 @@ function annotateLocalModels(models: UnifiedModel[]): UnifiedModel[] {
 }
 
 function annotateCloudModels(models: UnifiedModel[]): UnifiedModel[] {
-  return models.map(model => {
+  return models.filter(supportsResponsesApi).map(model => {
     if (!isRuntimeCodexModel(model)) {
       return withModelExecutionOverride(model, {
         source: 'cloud',

--- a/wework/src/features/cloud-connection/modelExecution.ts
+++ b/wework/src/features/cloud-connection/modelExecution.ts
@@ -1,6 +1,9 @@
 import type { ModelType, UnifiedModel } from '@/types/api'
 
 const MODEL_EXECUTION_CONFIG_KEY = 'weworkExecution'
+const OPENAI_RESPONSES_RUNTIME_FAMILY = 'openai.openai-responses'
+const OPENAI_RESPONSES_PROTOCOL = 'openai-responses'
+const RESPONSES_API_FORMAT = 'responses'
 
 export type HybridModelSource = 'local' | 'cloud'
 
@@ -16,6 +19,21 @@ function recordValue(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null
+}
+
+function normalizedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+export function supportsResponsesApi(model: UnifiedModel): boolean {
+  const config = recordValue(model.config)
+  return (
+    normalizedString(model.runtime?.family) === OPENAI_RESPONSES_RUNTIME_FAMILY ||
+    normalizedString(config?.protocol) === OPENAI_RESPONSES_PROTOCOL ||
+    normalizedString(config?.apiFormat) === RESPONSES_API_FORMAT ||
+    normalizedString(config?.api_format) === RESPONSES_API_FORMAT ||
+    normalizedString(config?.wire_api) === RESPONSES_API_FORMAT
+  )
 }
 
 export function withModelExecutionOverride(

--- a/wework/src/features/workbench/runtimeModelSelection.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.ts
@@ -1,9 +1,8 @@
-import { resolveModelExecutionSelection } from '@/features/cloud-connection/modelExecution'
 import {
-  getDefaultModelOptions,
-  getModelCompatibilityFamily,
-  normalizeModelOptionAliases,
-} from '@/lib/model-ui'
+  resolveModelExecutionSelection,
+  supportsResponsesApi,
+} from '@/features/cloud-connection/modelExecution'
+import { getDefaultModelOptions, normalizeModelOptionAliases } from '@/lib/model-ui'
 import type {
   ModelOptions,
   ModelSelectionConfig,
@@ -11,9 +10,6 @@ import type {
   UnifiedModel,
 } from '@/types/api'
 
-const OPENAI_RESPONSES_RUNTIME_FAMILY = 'openai.openai-responses'
-const OPENAI_RESPONSES_PROTOCOL = 'openai-responses'
-const RESPONSES_API_FORMAT = 'responses'
 const MODEL_EXECUTION_CONFIG_KEY = 'weworkExecution'
 export const CLOUD_MODEL_NAMESPACE_OPTION = 'weworkCloudModelNamespace'
 export const CLOUD_MODEL_RESOURCE_USER_ID_OPTION = 'weworkCloudModelResourceUserId'
@@ -85,12 +81,7 @@ function selectionForModel(model: UnifiedModel): ModelSelectionConfig {
 }
 
 function isCodexCompatibleModel(model: UnifiedModel): boolean {
-  return (
-    getModelCompatibilityFamily(model) === OPENAI_RESPONSES_RUNTIME_FAMILY ||
-    getStringConfigValue(model.config, 'protocol') === OPENAI_RESPONSES_PROTOCOL ||
-    getStringConfigValue(model.config, 'apiFormat') === RESPONSES_API_FORMAT ||
-    getStringConfigValue(model.config, 'api_format') === RESPONSES_API_FORMAT
-  )
+  return supportsResponsesApi(model)
 }
 
 export function resolveAutomaticModel(models: UnifiedModel[]): UnifiedModel | null {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identifying models compatible with the OpenAI Responses API across supported configuration formats.
  - Cloud model listings now include only models that support the Responses API.
  - Improved model selection for Codex-compatible runtimes.

- **Bug Fixes**
  - Corrected model-listing and execution routing to distinguish Responses API models from chat-completions models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->