### PR TITLE
feat(knowledge): expand knowledge ingestion format support

### DIFF
--- a/backend/app/api/endpoints/adapter/attachments.py
+++ b/backend/app/api/endpoints/adapter/attachments.py
@@ -311,6 +311,7 @@ def _validate_share_token_access(
 async def upload_attachment(
     file: UploadFile = File(...),
     overwrite_attachment_id: Optional[int] = None,
+    purpose: str = Query(default="chat"),
     db: Session = Depends(get_db),
     current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
     authorization: str = Header(default=""),
@@ -343,11 +344,13 @@ async def upload_attachment(
 
     logger.info(
         f"[attachments.py] upload_attachment: user_id={current_user.id}, "
-        f"filename={file.filename}, subtask_id={subtask_id}"
+        f"filename={file.filename}, subtask_id={subtask_id}, purpose={purpose}"
     )
 
     if not file.filename:
         raise HTTPException(status_code=400, detail="Filename is required")
+    if purpose not in {"chat", "knowledge"}:
+        raise HTTPException(status_code=400, detail="Invalid upload purpose")
 
     # Read file content
     try:
@@ -367,6 +370,7 @@ async def upload_attachment(
         )
 
     try:
+        parse_mode = "knowledge_raw" if purpose == "knowledge" else "chat"
         if overwrite_attachment_id is not None:
             if overwrite_attachment_id <= 0:
                 raise HTTPException(
@@ -378,6 +382,7 @@ async def upload_attachment(
                 user_id=current_user.id,
                 filename=file.filename,
                 binary_data=binary_data,
+                parse_mode=parse_mode,
             )
         else:
             context, truncation_info = context_service.upload_attachment(
@@ -386,6 +391,7 @@ async def upload_attachment(
                 filename=file.filename,
                 binary_data=binary_data,
                 subtask_id=subtask_id,
+                parse_mode=parse_mode,
             )
 
         return _build_attachment_response(context, truncation_info)

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -292,8 +292,30 @@ def get_knowledge_config():
     Returns system-level configuration for knowledge base features.
     This is used by frontend to determine which features are enabled.
     """
+    document_upload_extensions = settings.knowledge_upload_extensions(
+        include_multimodal=False
+    )
+    document_upload_extension_set = set(document_upload_extensions)
+    all_upload_extensions = settings.knowledge_upload_extensions(
+        include_multimodal=True
+    )
+    multimodal_upload_extensions = tuple(
+        extension
+        for extension in all_upload_extensions
+        if extension not in document_upload_extension_set
+    )
+
     return {
         "chunk_storage_enabled": settings.CHUNK_STORAGE_ENABLED,
+        "document_upload_accept": ",".join(
+            f".{extension}" for extension in document_upload_extensions
+        ),
+        "multimodal_upload_accept": ",".join(
+            f".{extension}" for extension in multimodal_upload_extensions
+        ),
+        "knowledge_upload_file_types_configured": bool(
+            settings.KNOWLEDGE_UPLOAD_FILE_TYPES.strip()
+        ),
     }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,6 +43,7 @@ class NoInterpolationDotEnvSettingsSource(DotEnvSettingsSource):
 
 
 VALID_RAG_RUNTIME_MODES = {"local", "remote"}
+_UPLOAD_FORMATS_ALL_MARKERS = {"*", "all", "default"}
 
 
 def _normalize_rag_runtime_mode_value(value: Any, *, label: str) -> str:
@@ -66,6 +67,16 @@ def _normalize_rag_runtime_mode_mapping(value: Mapping[Any, Any]) -> dict[str, s
             label=f"operation {normalized_key!r}",
         )
     return normalized_mapping
+
+
+def _parse_extension_csv(value: str) -> tuple[str, ...]:
+    """Parse comma-separated extensions to lower-case dotless tokens."""
+
+    return tuple(
+        token.strip().lstrip(".").lower()
+        for token in value.split(",")
+        if token.strip().lstrip(".")
+    )
 
 
 def _parse_json_object_setting(value: Any, setting_name: str) -> dict[str, Any]:
@@ -395,6 +406,9 @@ class Settings(BaseSettings):
     KNOWLEDGE_CONVERSION_ENABLED: bool = False
     # [Retained] Comma-separated file extensions requiring conversion
     KNOWLEDGE_CONVERSION_FILE_TYPES: str = ""
+    # Optional KB upload allow-list. Empty means use the knowledge format
+    # registry; configured values narrow upload/accept to registered formats.
+    KNOWLEDGE_UPLOAD_FILE_TYPES: str = ""
     # [Retained] Celery queue name for conversion tasks
     KNOWLEDGE_CONVERSION_QUEUE: str = "knowledge_conversion"
     # [Retained, value adjusted] Stale detection for CONVERTING status
@@ -734,15 +748,70 @@ class Settings(BaseSettings):
         """Check if a file extension requires conversion before indexing."""
         if not self.KNOWLEDGE_CONVERSION_ENABLED:
             return False
-        if not self.KNOWLEDGE_CONVERSION_FILE_TYPES:
-            return False
         ext = file_extension.lstrip(".").lower()
-        types = [
-            t.strip().lower()
-            for t in self.KNOWLEDGE_CONVERSION_FILE_TYPES.split(",")
-            if t.strip()
-        ]
-        return ext in types
+        types = _parse_extension_csv(self.KNOWLEDGE_CONVERSION_FILE_TYPES)
+        if types:
+            return ext in types
+
+        from knowledge_engine.conversion.formats import conversion_required
+
+        return conversion_required(ext)
+
+    def knowledge_upload_extensions(
+        self,
+        *,
+        include_multimodal: bool = True,
+    ) -> tuple[str, ...]:
+        """Return KB upload extensions after applying optional configuration."""
+
+        from knowledge_engine.conversion.formats import (
+            KnowledgeFormatPipeline,
+            get_knowledge_format,
+            list_knowledge_formats,
+        )
+
+        configured = _parse_extension_csv(self.KNOWLEDGE_UPLOAD_FILE_TYPES)
+        use_registry_default = not configured or bool(
+            set(configured) & _UPLOAD_FORMATS_ALL_MARKERS
+        )
+
+        if use_registry_default:
+            formats = list_knowledge_formats()
+        else:
+            formats = tuple(
+                fmt
+                for ext in configured
+                if (fmt := get_knowledge_format(ext)) is not None
+            )
+
+        if not include_multimodal:
+            formats = tuple(
+                fmt
+                for fmt in formats
+                if fmt.pipeline != KnowledgeFormatPipeline.MULTIMODAL
+            )
+
+        return tuple(sorted({fmt.extension for fmt in formats}))
+
+    def knowledge_upload_accept(
+        self,
+        *,
+        include_multimodal: bool = True,
+    ) -> str:
+        """Return a file input accept string for KB uploads."""
+
+        return ",".join(
+            f".{extension}"
+            for extension in self.knowledge_upload_extensions(
+                include_multimodal=include_multimodal
+            )
+        )
+
+    def is_knowledge_upload_extension_allowed(self, file_extension: str) -> bool:
+        """Return whether a KB raw upload is allowed by registry/config."""
+
+        ext = file_extension.lstrip(".").lower()
+        return ext in self.knowledge_upload_extensions(include_multimodal=True)
 
     def get_rag_runtime_mode(self, operation: str) -> str:
         """Resolve the effective RAG runtime mode for an operation."""

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -11,7 +11,7 @@ context types that can be associated with subtasks.
 
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from sqlalchemy.orm import Session
 
@@ -48,6 +48,8 @@ from shared.utils.crypto import decrypt_attachment, encrypt_attachment
 from shared.utils.multimodal_ext import multimodal_media_type
 
 logger = logging.getLogger(__name__)
+
+AttachmentParseMode = Literal["chat", "knowledge_raw"]
 
 
 def _should_encrypt() -> bool:
@@ -109,6 +111,7 @@ class ContextService:
         self,
         filename: str,
         binary_data: bytes,
+        parse_mode: AttachmentParseMode = "chat",
     ) -> Tuple[str, int, str]:
         """
         Validate attachment input and return basic metadata.
@@ -119,18 +122,48 @@ class ContextService:
         _, extension = os.path.splitext(filename)
         extension = extension.lower()
 
-        if not self.parser.is_supported_extension(extension):
-            raise ValueError(
-                f"Unsupported file type: {extension}. "
-                f"Supported types: {', '.join(self.parser.SUPPORTED_EXTENSIONS.keys())}"
-            )
-
         file_size = len(binary_data)
         if not self.parser.validate_file_size(file_size):
             max_size_mb = DocumentParser.get_max_file_size() / (1024 * 1024)
             raise ValueError(f"File size exceeds maximum limit ({max_size_mb} MB)")
 
-        mime_type = self.parser.get_mime_type(extension)
+        if parse_mode == "knowledge_raw":
+            from knowledge_engine.conversion.formats import (
+                KnowledgeFormatPipeline,
+                get_knowledge_format,
+                validate_knowledge_file,
+            )
+
+            validate_knowledge_file(binary_data, extension)
+            knowledge_format = get_knowledge_format(extension)
+            if knowledge_format is None:
+                raise ValueError(f"Unsupported knowledge file type: {extension}")
+            if not settings.is_knowledge_upload_extension_allowed(extension):
+                supported = settings.knowledge_upload_accept(include_multimodal=True)
+                raise ValueError(
+                    f"Unsupported knowledge file type: {extension}. "
+                    f"Supported types: {supported}"
+                )
+            if (
+                knowledge_format.pipeline == KnowledgeFormatPipeline.MULTIMODAL
+                and not settings.KNOWLEDGE_MULTIMODAL_ENABLED
+            ):
+                raise ValueError(
+                    "Multimodal knowledge uploads are disabled by configuration"
+                )
+            mime_type = (
+                knowledge_format.mime_types[0]
+                if knowledge_format.mime_types
+                else "application/octet-stream"
+            )
+        elif not self.parser.is_supported_extension(extension):
+            raise ValueError(
+                f"Unsupported file type: {extension}. "
+                f"Supported types: {', '.join(self.parser.SUPPORTED_EXTENSIONS.keys())}"
+            )
+        else:
+            mime_type = self.parser.get_mime_type(extension)
+
         return extension, file_size, mime_type
 
     @staticmethod
@@ -334,6 +367,7 @@ class ContextService:
         filename: str,
         binary_data: bytes,
         subtask_id: int = 0,
+        parse_mode: AttachmentParseMode = "chat",
     ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
         """
         Upload and process a file attachment.
@@ -344,6 +378,8 @@ class ContextService:
             filename: Original filename
             binary_data: File binary data
             subtask_id: Subtask ID to link to (0 means unlinked)
+            parse_mode: "chat" parses content for chat injection; "knowledge_raw"
+                stores the original file for the KB conversion/index pipeline.
 
         Returns:
             Tuple of (Created SubtaskContext record, TruncationInfo if truncated)
@@ -354,7 +390,9 @@ class ContextService:
             StorageError: If storage operation fails
         """
         extension, file_size, mime_type = self._validate_attachment_input(
-            filename, binary_data
+            filename,
+            binary_data,
+            parse_mode=parse_mode,
         )
 
         # Get the storage backend
@@ -393,20 +431,32 @@ class ContextService:
             db.rollback()
             raise
 
-        # Update status to PARSING
-        context.status = ContextStatus.PARSING.value
-        db.flush()
+        if parse_mode == "knowledge_raw":
+            context.status = ContextStatus.READY.value
+            context.extracted_text = ""
+            context.text_length = 0
+            context.image_base64 = ""
+            context.type_data = {
+                **(context.type_data or {}),
+                "is_truncated": False,
+                "parse_mode": parse_mode,
+            }
+            truncation_info = None
+        else:
+            # Update status to PARSING
+            context.status = ContextStatus.PARSING.value
+            db.flush()
 
-        # Parse document
-        try:
-            truncation_info = self._parse_and_update_context(
-                context=context,
-                binary_data=binary_data,
-                extension=extension,
-            )
-        except DocumentParseError as e:
-            db.commit()
-            raise
+            # Parse document
+            try:
+                truncation_info = self._parse_and_update_context(
+                    context=context,
+                    binary_data=binary_data,
+                    extension=extension,
+                )
+            except DocumentParseError:
+                db.commit()
+                raise
 
         db.commit()
         db.refresh(context)
@@ -427,6 +477,7 @@ class ContextService:
         user_id: int,
         filename: str,
         binary_data: bytes,
+        parse_mode: AttachmentParseMode = "chat",
     ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
         """
         Overwrite an existing attachment with owner validation.
@@ -448,7 +499,13 @@ class ContextService:
         if context.context_type != ContextType.ATTACHMENT.value:
             raise NotFoundException(f"Context {context_id} not found")
 
-        return self._overwrite_attachment_impl(db, context, filename, binary_data)
+        return self._overwrite_attachment_impl(
+            db,
+            context,
+            filename,
+            binary_data,
+            parse_mode=parse_mode,
+        )
 
     def overwrite_attachment_internal(
         self,
@@ -495,10 +552,13 @@ class ContextService:
         context: SubtaskContext,
         filename: str,
         binary_data: bytes,
+        parse_mode: AttachmentParseMode = "chat",
     ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
         """Shared implementation for attachment overwrite."""
         extension, file_size, mime_type = self._validate_attachment_input(
-            filename, binary_data
+            filename,
+            binary_data,
+            parse_mode=parse_mode,
         )
 
         storage_backend = get_storage_backend(db)
@@ -533,18 +593,30 @@ class ContextService:
             db.rollback()
             raise
 
-        context.status = ContextStatus.PARSING.value
-        db.flush()
+        if parse_mode == "knowledge_raw":
+            context.status = ContextStatus.READY.value
+            context.extracted_text = ""
+            context.text_length = 0
+            context.image_base64 = ""
+            context.type_data = {
+                **(context.type_data or {}),
+                "is_truncated": False,
+                "parse_mode": parse_mode,
+            }
+            truncation_info = None
+        else:
+            context.status = ContextStatus.PARSING.value
+            db.flush()
 
-        try:
-            truncation_info = self._parse_and_update_context(
-                context=context,
-                binary_data=binary_data,
-                extension=extension,
-            )
-        except DocumentParseError:
-            db.commit()
-            raise
+            try:
+                truncation_info = self._parse_and_update_context(
+                    context=context,
+                    binary_data=binary_data,
+                    extension=extension,
+                )
+            except DocumentParseError:
+                db.commit()
+                raise
 
         db.commit()
         db.refresh(context)

--- a/backend/app/services/knowledge/multimodal_pipeline.py
+++ b/backend/app/services/knowledge/multimodal_pipeline.py
@@ -13,7 +13,7 @@ switch; when False, files are never classified as multimodal so no
 dispatch/Gemini runs anywhere, and these helpers reduce to no-ops/mineru-only.
 
 Helpers:
-- ``conversion_pipeline``: classify a file (multimodal / mineru / None)
+- ``conversion_pipeline``: classify a file (multimodal / mineru / local_markdown / None)
 - ``resolve_dispatch_or_none``: pre-flight gate for a not-yet-created document
 - ``resolve_dispatch_for_document_or_none``: pre-flight gate for an existing document
 - ``schedule_multimodal_indexing_or_none``: enqueue the Gemini conversion task
@@ -32,6 +32,10 @@ from app.core.config import settings
 from app.models.kind import Kind
 from app.models.knowledge import DocumentIndexStatus
 from app.models.user import User
+from knowledge_engine.conversion.formats import (
+    KnowledgeFormatPipeline,
+    get_knowledge_pipeline,
+)
 from shared.utils.multimodal_ext import (
     _MULTIMODAL_EXTENSIONS,
 )
@@ -43,7 +47,8 @@ def conversion_pipeline(file_extension: Optional[str], app_settings) -> Optional
     """Return the conversion pipeline for a file type.
 
     Returns ``"multimodal"`` for video/image files (Gemini analysis), ``"mineru"``
-    for files that need MinerU conversion, or ``None`` for direct indexing.
+    or ``"local_markdown"`` for files that need document conversion, or ``None``
+    for direct indexing.
 
     The multimodal branch is gated by the global ``KNOWLEDGE_MULTIMODAL_ENABLED``
     switch — when False, video/image files are never classified as multimodal so
@@ -54,8 +59,13 @@ def conversion_pipeline(file_extension: Optional[str], app_settings) -> Optional
     ext = _normalize_file_extension(file_extension).lower()
     if ext in _MULTIMODAL_EXTENSIONS and settings.KNOWLEDGE_MULTIMODAL_ENABLED:
         return "multimodal"
-    if app_settings.needs_conversion(ext):
+    if not app_settings.needs_conversion(ext):
+        return None
+    pipeline = get_knowledge_pipeline(ext)
+    if pipeline == KnowledgeFormatPipeline.MINERU:
         return "mineru"
+    if pipeline == KnowledgeFormatPipeline.LOCAL_MARKDOWN:
+        return "local_markdown"
     return None
 
 

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1353,6 +1353,7 @@ class KnowledgeOrchestrator:
                 filename=filename,
                 binary_data=binary_data,
                 subtask_id=0,  # Unlinked attachment for knowledge base
+                parse_mode="knowledge_raw",
             )
 
             # Create document using shared helper
@@ -1387,6 +1388,7 @@ class KnowledgeOrchestrator:
             filename=filename,
             binary_data=binary_data,
             subtask_id=0,
+            parse_mode="knowledge_raw",
         )
 
         # Create document using shared helper
@@ -1904,10 +1906,10 @@ class KnowledgeOrchestrator:
                 )
                 dispatched_attachment_id = document.attachment_id
 
-            elif settings.needs_conversion(normalized_extension):
-                # File type requires conversion before indexing
-                # Task is dispatched to knowledge_doc_converter microservice
-                # via the shared Celery broker (knowledge_conversion queue)
+            elif pipeline in {"mineru", "local_markdown"}:
+                # File type requires conversion before indexing. The converter
+                # worker chooses the concrete implementation from the
+                # knowledge_engine format registry.
 
                 # Override QUEUED -> PENDING_CONVERSION: document is waiting
                 # for a conversion worker, not for direct indexing

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -78,6 +78,54 @@ class TestSettings:
         assert s.ACCESS_TOKEN_EXPIRE_MINUTES == 120
         assert s.ENABLE_API_DOCS is False
 
+    def test_needs_conversion_uses_registry_when_types_unset(self):
+        """Conversion-enabled KBs use the knowledge format registry by default."""
+        s = build_settings(
+            KNOWLEDGE_CONVERSION_ENABLED=True,
+            KNOWLEDGE_CONVERSION_FILE_TYPES="",
+        )
+
+        assert s.needs_conversion("pdf") is True
+        assert s.needs_conversion("epub") is True
+        assert s.needs_conversion("txt") is False
+
+    def test_needs_conversion_explicit_types_override_registry(self):
+        """Deployments can still narrow conversion to an explicit extension list."""
+        s = build_settings(
+            KNOWLEDGE_CONVERSION_ENABLED=True,
+            KNOWLEDGE_CONVERSION_FILE_TYPES="pdf",
+        )
+
+        assert s.needs_conversion("pdf") is True
+        assert s.needs_conversion("epub") is False
+
+    def test_knowledge_upload_extensions_use_registry_by_default(self):
+        """KB upload accept defaults to the enabled knowledge format registry."""
+        s = build_settings(KNOWLEDGE_UPLOAD_FILE_TYPES="")
+
+        assert "epub" in s.knowledge_upload_extensions()
+        assert "xmind" in s.knowledge_upload_extensions()
+        assert "key" not in s.knowledge_upload_extensions()
+        assert "jpg" in s.knowledge_upload_extensions(include_multimodal=True)
+        assert "jpg" not in s.knowledge_upload_extensions(include_multimodal=False)
+
+    def test_knowledge_upload_extensions_can_be_configured(self):
+        """Deployments can narrow KB uploads without editing frontend code."""
+        s = build_settings(KNOWLEDGE_UPLOAD_FILE_TYPES="pdf, .epub, jpg, unknown")
+
+        assert s.knowledge_upload_extensions(include_multimodal=False) == (
+            "epub",
+            "pdf",
+        )
+        assert s.knowledge_upload_extensions(include_multimodal=True) == (
+            "epub",
+            "jpg",
+            "pdf",
+        )
+        assert s.knowledge_upload_accept(include_multimodal=False) == ".epub,.pdf"
+        assert s.is_knowledge_upload_extension_allowed(".jpg") is True
+        assert s.is_knowledge_upload_extension_allowed(".unknown") is False
+
     def test_settings_database_url(self):
         """Test database URL configuration"""
         s = build_settings()

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -10,6 +10,8 @@ Uses mocks to avoid database dependencies.
 """
 
 import importlib
+import io
+import zipfile
 from unittest.mock import Mock, patch
 
 import pytest
@@ -928,6 +930,45 @@ class TestContextStatusEnum:
 
 class TestContextServiceUpload:
     """Test attachment upload functionality"""
+
+    @staticmethod
+    def _minimal_epub_bytes() -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as z:
+            z.writestr("mimetype", "application/epub+zip")
+            z.writestr("META-INF/container.xml", "<container />")
+        return buf.getvalue()
+
+    def test_knowledge_raw_validation_accepts_epub(self):
+        """Knowledge uploads use the KB format registry instead of chat parsers."""
+        from app.services.context.context_service import ContextService
+
+        service = ContextService()
+
+        extension, file_size, mime_type = service._validate_attachment_input(
+            "book.epub",
+            self._minimal_epub_bytes(),
+            parse_mode="knowledge_raw",
+        )
+
+        assert extension == ".epub"
+        assert file_size > 0
+        assert mime_type == "application/epub+zip"
+
+    def test_chat_validation_uses_plain_attachment_mime_for_epub(self):
+        """Default chat validation does not use the KB format registry."""
+        from app.services.context.context_service import ContextService
+
+        service = ContextService()
+
+        extension, file_size, mime_type = service._validate_attachment_input(
+            "book.epub",
+            self._minimal_epub_bytes(),
+        )
+
+        assert extension == ".epub"
+        assert file_size > 0
+        assert mime_type == "application/octet-stream"
 
     def test_upload_unsupported_file_type(self):
         """Test upload fails for binary files with unknown extensions via MIME detection"""

--- a/docker/knowledge_doc_converter/Dockerfile
+++ b/docker/knowledge_doc_converter/Dockerfile
@@ -8,6 +8,13 @@ FROM ghcr.io/wecode-ai/wegent-base-python3.12:latest
 
 WORKDIR /app
 
+# LibreOffice is required by the converter worker to normalize legacy Office
+# files (.doc/.xls/.ppt) before sending them to the document conversion backend.
+RUN dnf install -y \
+    libreoffice-core libreoffice-writer libreoffice-calc libreoffice-impress \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf/*
+
 # Copy and install shared module first
 COPY shared /app/shared
 RUN uv pip install --system --no-cache /app/shared

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -123,6 +123,13 @@ WEGENT_IMAGE_TAG=latest
 # Optional: explicitly override the executor image; leave unset to follow WEGENT_IMAGE_TAG
 # EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 EXECUTOR_WORKSPACE=/path/to/workspace
+
+# Knowledge document conversion (PDF/Office/EPUB/HTML/XML/EML, etc.)
+INTERNAL_SERVICE_TOKEN=replace-with-a-shared-secret
+KNOWLEDGE_CONVERSION_ENABLED=true
+KNOWLEDGE_CONVERSION_QUEUE=knowledge_conversion
+# Optional: restrict uploadable knowledge-base extensions; leave empty for the default registry
+# KNOWLEDGE_UPLOAD_FILE_TYPES=pdf,docx,epub,eml,html,xml,txt,md
 ```
 
 When `RUNTIME_WEWORK_CODE_URL` is empty, Wegent Web opens coding entry points at `/chat?agent=code` and filters to coding agents. When it is configured, the sidebar shows **WeWork** instead of **Code** and opens that runtime URL. This setting is delivered only through `/runtime-config`; there is no `NEXT_PUBLIC_*` fallback.
@@ -138,6 +145,38 @@ docker-compose ps
 
 # View logs
 docker-compose logs -f
+```
+
+Knowledge document conversion, the knowledge runtime, and Elasticsearch use the `rag` profile. To upload documents that require conversion or indexing, such as PDF, Office, EPUB, HTML, XML, or EML files, start services with:
+
+```bash
+docker compose --profile rag up -d
+```
+
+If you only want Docker for dependencies and run application services from source, start:
+
+```bash
+docker compose --profile rag up -d mysql redis elasticsearch
+```
+
+Then start the backend, frontend, `knowledge_runtime`, and `knowledge_doc_converter` from source.
+
+> `knowledge_doc_converter` must use the same shared secret as the backend. Docker Compose passes it as `BACKEND_INTERNAL_TOKEN`; when running from source, set the same value in `knowledge_doc_converter/.env`. If it does not match the backend `INTERNAL_SERVICE_TOKEN`, converter downloads and callbacks return `401 Unauthorized`, and documents remain in **Pending Conversion**.
+
+Legacy Office files (`.doc`, `.ppt`, `.xls`) require LibreOffice in the converter runtime. The Docker image includes the required components. For source-based local runs, install it manually:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libreoffice-core libreoffice-writer libreoffice-calc libreoffice-impress
+
+# macOS
+brew install --cask libreoffice
+```
+
+On macOS, you can set an explicit path in `knowledge_doc_converter/.env`:
+
+```bash
+SOFFICE_PATH=/Applications/LibreOffice.app/Contents/MacOS/soffice
 ```
 
 To test CI-published edge images, set the shared image tag:
@@ -205,6 +244,9 @@ sudo apt-get install git
 ```bash
 # Install using Homebrew
 brew install python@3.10 node@18 mysql redis git
+
+# Optional: required when running the converter from source and processing .doc/.ppt/.xls
+brew install --cask libreoffice
 ```
 
 ### Step 2: Setup Database
@@ -292,6 +334,30 @@ The repository root `pnpm-workspace.yaml` declares the dependency build-script a
 ### Step 6: Install Executor Manager
 
 [Local Development](/executor_manager/README.md)
+
+### Step 7: Start Knowledge Document Converter (Optional)
+
+When `KNOWLEDGE_CONVERSION_ENABLED=true`, run the `knowledge_doc_converter` worker to process documents waiting for conversion:
+
+```bash
+cd knowledge_doc_converter
+cp .env.example .env
+vim .env  # Set BACKEND_BASE_URL, BACKEND_INTERNAL_TOKEN, and Redis URLs
+
+./start.sh
+```
+
+`knowledge_doc_converter/.env` should include at least:
+
+```bash
+BACKEND_BASE_URL=http://localhost:8000
+BACKEND_INTERNAL_TOKEN=<same-as-backend-INTERNAL_SERVICE_TOKEN>
+CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/1
+REDIS_URL=redis://127.0.0.1:6379/0
+```
+
+When running application services from source, do not also run the Docker `knowledge_doc_converter`, otherwise two workers may consume the same `knowledge_conversion` queue.
 
 ---
 

--- a/docs/en/user-guide/knowledge/document-management.md
+++ b/docs/en/user-guide/knowledge/document-management.md
@@ -26,11 +26,20 @@ Document management is a core feature of Knowledge Base, supporting multiple doc
 3. Configure chunking settings (optional)
 4. Click **Upload**
 
-Supported formats:
-- `.txt` - Plain text files
-- `.md` - Markdown files
-- `.pdf` - PDF documents
-- `.doc`, `.docx` - Word documents
+Supported formats are delivered from the backend to the upload component. By default, Wegent supports:
+
+| Type | Formats | Processing |
+|------|---------|------------|
+| **Documents, presentations, spreadsheets** | `.pdf`, `.doc`, `.docx`, `.ppt`, `.pptx`, `.xls`, `.xlsx` | Converted to Markdown before indexing |
+| **Structured text** | `.epub`, `.eml`, `.html`, `.htm`, `.xml` | Locally converted to Markdown by the converter service |
+| **Plain text and Markdown** | `.txt`, `.md`, `.markdown`, `.csv` | Indexed directly |
+| **Code and configuration** | `.py`, `.js`, `.ts`, `.vue`, `.css`, `.java`, `.go`, `.rs`, `.cpp`, `.c`, `.swift`, `.kt`, `.kts`, `.rb`, `.php`, `.sql`, `.sh`, `.json`, `.yaml`, `.yml`, `.ini`, `.toml`, `.lock` | Indexed directly as text |
+| **Mind maps** | `.xmind` | Indexed with the built-in parser |
+| **Images and videos** | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.bmp`, `.mp4`, `.avi`, `.mov`, `.mkv`, `.webm`, `.flv`, `.wmv`, `.m4v` | Uploadable only when multimodal analysis is enabled for the knowledge base |
+
+Legacy Office files (`.doc`, `.ppt`, `.xls`) require LibreOffice in the converter runtime. Wegent converts them to `.docx`, `.pptx`, or `.xlsx` before continuing.
+
+Administrators can use `KNOWLEDGE_UPLOAD_FILE_TYPES` to narrow the upload allow-list. When it is not configured, Wegent uses the default format registry.
 
 ### Text Paste
 
@@ -81,6 +90,8 @@ Web documents support re-scraping for updates. When webpage content changes, use
 | **Converting** | Document being converted to Markdown |
 | **Indexing** | Document being indexed for RAG |
 | **Error** | Indexing failed |
+
+If a document stays in **Pending Conversion** for a long time, the conversion task is queued but the converter service is not consuming it or cannot call back to the backend. Check that the `knowledge_doc_converter` worker is running, that it uses the same Redis queue as the backend, and that `BACKEND_INTERNAL_TOKEN` matches the backend `INTERNAL_SERVICE_TOKEN`.
 
 ---
 

--- a/docs/en/user-guide/knowledge/knowledge-base-guide.md
+++ b/docs/en/user-guide/knowledge/knowledge-base-guide.md
@@ -79,10 +79,7 @@ See [Knowledge Base Types](./knowledge-base-types.md) for detailed comparison.
 
 ### Supported Formats
 
-- `.txt` - Plain text files
-- `.md` - Markdown files
-- `.pdf` - PDF documents
-- `.doc`, `.docx` - Word documents
+Wegent supports common documents, Office files, structured text, plain text, code/configuration files, XMind maps, and multimodal files when multimodal analysis is enabled. The exact upload allow-list is delivered by the backend and can be narrowed by administrators with `KNOWLEDGE_UPLOAD_FILE_TYPES`.
 
 See [Document Management](./document-management.md) for detailed guide.
 

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -123,6 +123,13 @@ WEGENT_IMAGE_TAG=latest
 # 可选：显式覆盖 executor 镜像；未设置时跟随 WEGENT_IMAGE_TAG
 # EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 EXECUTOR_WORKSPACE=/path/to/workspace
+
+# 知识库文档转换（PDF/Office/EPUB/HTML/XML/EML 等）
+INTERNAL_SERVICE_TOKEN=replace-with-a-shared-secret
+KNOWLEDGE_CONVERSION_ENABLED=true
+KNOWLEDGE_CONVERSION_QUEUE=knowledge_conversion
+# 可选：限制知识库允许上传的文件扩展名；留空时使用系统默认格式注册表
+# KNOWLEDGE_UPLOAD_FILE_TYPES=pdf,docx,epub,eml,html,xml,txt,md
 ```
 
 `RUNTIME_WEWORK_CODE_URL` 为空时，Wegent Web 的编码入口会进入 `/chat?agent=code`，并只显示编码智能体；配置后，左侧菜单显示 **WeWork** 而不是 **编码**，并打开该运行时 URL。该配置只通过 `/runtime-config` 下发，不支持 `NEXT_PUBLIC_*` 回退。
@@ -138,6 +145,38 @@ docker-compose ps
 
 # 查看日志
 docker-compose logs -f
+```
+
+知识库文档转换、知识检索运行时和 Elasticsearch 使用 `rag` profile。需要上传 PDF、Office、EPUB、HTML、XML、EML 等需要转换或索引的文档时，请使用：
+
+```bash
+docker compose --profile rag up -d
+```
+
+如果只想启动依赖容器，并在本机运行源码服务，可以先启动：
+
+```bash
+docker compose --profile rag up -d mysql redis elasticsearch
+```
+
+再分别启动后端、前端、`knowledge_runtime` 和 `knowledge_doc_converter`。
+
+> `knowledge_doc_converter` 必须与后端使用同一个 `INTERNAL_SERVICE_TOKEN`。在 Docker Compose 中由 `BACKEND_INTERNAL_TOKEN` 传给转换服务；在本机源码启动时，请在 `knowledge_doc_converter/.env` 中设置相同的 `BACKEND_INTERNAL_TOKEN`，否则转换服务调用后端内部下载和回调接口会返回 `401 Unauthorized`，文档会停留在“待转换”。
+
+旧版 Office 文件（`.doc`、`.ppt`、`.xls`）需要转换服务环境安装 LibreOffice。Docker 镜像已包含所需组件；本机源码运行时需自行安装：
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libreoffice-core libreoffice-writer libreoffice-calc libreoffice-impress
+
+# macOS
+brew install --cask libreoffice
+```
+
+macOS 如需显式指定路径，可在 `knowledge_doc_converter/.env` 中配置：
+
+```bash
+SOFFICE_PATH=/Applications/LibreOffice.app/Contents/MacOS/soffice
 ```
 
 如需测试 CI 发布的 edge 镜像，可以设置统一镜像 tag：
@@ -205,6 +244,9 @@ sudo apt-get install git
 ```bash
 # 使用 Homebrew 安装
 brew install python@3.10 node@18 mysql redis git
+
+# 可选：本机运行知识库转换服务并处理 .doc/.ppt/.xls 时需要
+brew install --cask libreoffice
 ```
 
 ### 步骤 2: 设置数据库
@@ -292,6 +334,30 @@ pnpm run dev
 ### 步骤 6: 安装 Executor Manager
 
 [本地开发](/executor_manager/README_zh.md)
+
+### 步骤 7: 启动知识库转换服务（可选）
+
+当 `KNOWLEDGE_CONVERSION_ENABLED=true` 时，需要运行 `knowledge_doc_converter` worker 才能处理待转换文档：
+
+```bash
+cd knowledge_doc_converter
+cp .env.example .env
+vim .env  # 设置 BACKEND_BASE_URL、BACKEND_INTERNAL_TOKEN 和 Redis 地址
+
+./start.sh
+```
+
+`knowledge_doc_converter/.env` 至少应包含：
+
+```bash
+BACKEND_BASE_URL=http://localhost:8000
+BACKEND_INTERNAL_TOKEN=<same-as-backend-INTERNAL_SERVICE_TOKEN>
+CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/1
+REDIS_URL=redis://127.0.0.1:6379/0
+```
+
+如果只运行本机源码服务，避免同时启动 Docker 版 `knowledge_doc_converter`，否则两个 worker 可能消费同一个 `knowledge_conversion` 队列。
 
 ---
 

--- a/docs/zh/user-guide/knowledge/document-management.md
+++ b/docs/zh/user-guide/knowledge/document-management.md
@@ -26,11 +26,20 @@ sidebar_position: 8
 3. 配置分块设置（可选）
 4. 点击 **上传**
 
-支持的格式：
-- `.txt` - 纯文本文件
-- `.md` - Markdown 文件
-- `.pdf` - PDF 文档
-- `.doc`, `.docx` - Word 文档
+支持的格式由后端配置下发到上传组件。默认支持：
+
+| 类型 | 格式 | 处理方式 |
+|------|------|----------|
+| **文档/演示/表格** | `.pdf`, `.doc`, `.docx`, `.ppt`, `.pptx`, `.xls`, `.xlsx` | 转换为 Markdown 后索引 |
+| **结构化文本** | `.epub`, `.eml`, `.html`, `.htm`, `.xml` | 在转换服务中本地转换为 Markdown |
+| **纯文本与 Markdown** | `.txt`, `.md`, `.markdown`, `.csv` | 直接索引 |
+| **代码与配置** | `.py`, `.js`, `.ts`, `.vue`, `.css`, `.java`, `.go`, `.rs`, `.cpp`, `.c`, `.swift`, `.kt`, `.kts`, `.rb`, `.php`, `.sql`, `.sh`, `.json`, `.yaml`, `.yml`, `.ini`, `.toml`, `.lock` | 按文本内容直接索引 |
+| **思维导图** | `.xmind` | 使用内置解析能力索引 |
+| **图片/视频** | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.bmp`, `.mp4`, `.avi`, `.mov`, `.mkv`, `.webm`, `.flv`, `.wmv`, `.m4v` | 仅在知识库多模态分析启用时可上传 |
+
+`.doc`、`.ppt`、`.xls` 属于旧版 Office 格式，需要转换服务所在环境安装 LibreOffice，系统会先转换为 `.docx`、`.pptx`、`.xlsx` 再继续处理。
+
+管理员可以通过 `KNOWLEDGE_UPLOAD_FILE_TYPES` 缩小允许上传的格式范围；未配置时使用系统默认格式注册表。
 
 ### 文本粘贴
 
@@ -81,6 +90,8 @@ sidebar_position: 8
 | **转换中** | 文档正在转换为 Markdown |
 | **索引中** | 文档正在进行 RAG 索引 |
 | **错误** | 索引失败 |
+
+如果文档长时间停留在 **待转换**，通常表示转换任务已排队但转换服务没有消费或回调失败。请检查 `knowledge_doc_converter` worker 是否运行、它连接的 Redis 队列是否与后端一致，并确认 `BACKEND_INTERNAL_TOKEN` 与后端的 `INTERNAL_SERVICE_TOKEN` 相同。
 
 ---
 

--- a/docs/zh/user-guide/knowledge/knowledge-base-guide.md
+++ b/docs/zh/user-guide/knowledge/knowledge-base-guide.md
@@ -330,6 +330,12 @@ AI 响应包含链接到源文档的编号引用：
 
 **解决方案：** 检查文件大小限制（通常 50MB）、转换为支持的格式、尝试重新导出文档
 
+#### 文档一直停留在待转换
+
+**可能原因：** `knowledge_doc_converter` worker 未运行、Redis 队列配置不一致，或转换服务使用的 `BACKEND_INTERNAL_TOKEN` 与后端 `INTERNAL_SERVICE_TOKEN` 不一致。
+
+**解决方案：** 检查转换服务日志，确认 worker 正在消费 `knowledge_conversion` 队列；本机源码运行时不要同时启动 Docker 版 `knowledge_doc_converter`，避免两个 worker 消费同一队列。更多状态说明见 [文档管理](./document-management.md)。
+
 ### 检索问题
 
 #### 没有返回结果

--- a/frontend/src/__tests__/hooks/useBatchAttachment.test.ts
+++ b/frontend/src/__tests__/hooks/useBatchAttachment.test.ts
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom'
 import { renderHook, act } from '@testing-library/react'
 
 import { useBatchAttachment } from '@/hooks/useBatchAttachment'
+import { uploadAttachment } from '@/apis/attachments'
 import {
   registerVideoUploader,
   getVideoUploader,
@@ -29,6 +30,7 @@ jest.mock('@/apis/attachments', () => {
 })
 
 const MB = 1024 * 1024
+const mockUploadAttachment = uploadAttachment as jest.MockedFunction<typeof uploadAttachment>
 
 function makeVideoFile(name: string, sizeMb: number): File {
   return new File([new Uint8Array(sizeMb * MB)], name, { type: 'video/mp4' })
@@ -42,6 +44,7 @@ describe('useBatchAttachment — KB video queue gate', () => {
   afterEach(() => {
     // Reset provider registry between tests for isolation.
     registerVideoUploader(null)
+    jest.clearAllMocks()
   })
 
   it('rejects a video when no provider is registered (open-source default)', () => {
@@ -139,5 +142,32 @@ describe('useBatchAttachment — KB video queue gate', () => {
 
     expect(outcome!.added).toBe(1)
     expect(result.current.state.files).toHaveLength(1)
+  })
+
+  it('passes the knowledge upload purpose for KB batch uploads', async () => {
+    mockUploadAttachment.mockResolvedValue({
+      id: 123,
+      filename: 'doc.txt',
+      file_size: 1,
+      mime_type: 'text/plain',
+      status: 'ready',
+      text_length: null,
+      error_message: null,
+      error_code: null,
+      truncation_info: null,
+    })
+
+    const { result } = renderHook(() => useBatchAttachment({ uploadPurpose: 'knowledge' }))
+
+    act(() => {
+      result.current.addFiles([makeTextFile('doc.txt', 1)])
+    })
+    await act(async () => {
+      await result.current.startUpload()
+    })
+
+    expect(mockUploadAttachment).toHaveBeenCalledWith(expect.any(File), expect.any(Function), {
+      purpose: 'knowledge',
+    })
   })
 })

--- a/frontend/src/apis/attachments.ts
+++ b/frontend/src/apis/attachments.ts
@@ -385,16 +385,24 @@ export function getAttachmentPreviewUrl(attachmentId: number, shareToken?: strin
   return baseUrl
 }
 
+export type AttachmentUploadPurpose = 'chat' | 'knowledge'
+
+export interface UploadAttachmentOptions {
+  purpose?: AttachmentUploadPurpose
+}
+
 /**
  * Upload a file attachment
  *
  * @param file - File to upload
  * @param onProgress - Optional progress callback (0-100)
+ * @param options - Optional upload behavior controls
  * @returns Attachment response
  */
 export async function uploadAttachment(
   file: File,
-  onProgress?: (progress: number) => void
+  onProgress?: (progress: number) => void,
+  options: UploadAttachmentOptions = {}
 ): Promise<AttachmentResponse> {
   const token = getToken()
 
@@ -453,7 +461,12 @@ export async function uploadAttachment(
       reject(new Error('Upload cancelled'))
     })
 
-    xhr.open('POST', `${API_BASE_URL}/api/attachments/upload`)
+    let uploadUrl = `${API_BASE_URL}/api/attachments/upload`
+    if (options.purpose) {
+      uploadUrl += `?purpose=${encodeURIComponent(options.purpose)}`
+    }
+
+    xhr.open('POST', uploadUrl)
     if (token) {
       xhr.setRequestHeader('Authorization', `Bearer ${token}`)
     }

--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -400,6 +400,9 @@ export async function resetKnowledgeBaseSummary(
  */
 export interface KnowledgeConfig {
   chunk_storage_enabled: boolean
+  document_upload_accept?: string
+  multimodal_upload_accept?: string
+  knowledge_upload_file_types_configured?: boolean
 }
 
 /**

--- a/frontend/src/features/knowledge/document/components/DocumentUpload.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentUpload.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useRef, useCallback, useState, useEffect } from 'react'
+import { useRef, useCallback, useState, useEffect, useMemo } from 'react'
 import {
   Upload,
   X,
@@ -48,10 +48,9 @@ import {
 } from '@/hooks/useBatchAttachment'
 import { MAX_FILE_SIZE } from '@/apis/attachments'
 import { SplitterSettingsSection, type SplitterConfig } from './SplitterSettingsSection'
-import { MULTIMODAL_EXTENSIONS } from '@/features/knowledge/multimodal/constants'
 import type { Attachment } from '@/types/api'
 import { cn } from '@/lib/utils'
-import { validateTableUrl } from '@/apis/knowledge'
+import { getKnowledgeConfig, validateTableUrl } from '@/apis/knowledge'
 import { DEFAULT_FLAT_CHUNK_CONFIG, DEFAULT_SPLITTER_CONFIG } from '@/types/knowledge'
 import { mapKnowledgeDocumentErrorMessage } from '../utils/error-messages'
 import {
@@ -59,7 +58,8 @@ import {
   type UploadMultimodalPrompts,
 } from '@/features/knowledge/multimodal/components/UploadMultimodalPromptSettings'
 import {
-  KB_DOCUMENT_ACCEPT,
+  DEFAULT_KB_DOCUMENT_ACCEPT,
+  DEFAULT_KB_MULTIMODAL_ACCEPT,
   isKBUnsupportedExtension,
   isVideoModelBlock,
 } from '@/features/knowledge/multimodal/utils/upload-validation'
@@ -144,7 +144,7 @@ export function DocumentUpload({
   const { t } = useTranslation('knowledge')
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { state, addFiles, removeFile, clearFiles, startUpload, retryFile, renameFile, reset } =
-    useBatchAttachment()
+    useBatchAttachment({ uploadPurpose: 'knowledge' })
   const [splitterConfig, setSplitterConfig] = useState<Partial<SplitterConfig>>(
     buildDefaultSplitterConfig
   )
@@ -154,6 +154,8 @@ export function DocumentUpload({
   // a disabled pipeline.
   const multimodalFeatureEnabled = useMultimodalFeatureEnabled()
   const multimodalAnalysisEnabled = multimodalAnalysisEnabledProp && multimodalFeatureEnabled
+  const [documentUploadAccept, setDocumentUploadAccept] = useState(DEFAULT_KB_DOCUMENT_ACCEPT)
+  const [multimodalUploadAccept, setMultimodalUploadAccept] = useState(DEFAULT_KB_MULTIMODAL_ACCEPT)
   const [isDragOver, setIsDragOver] = useState(false)
   const [validationError, setValidationError] = useState<string | null>(null)
   const [isConfirming, setIsConfirming] = useState(false)
@@ -195,6 +197,34 @@ export function DocumentUpload({
 
   // Track pending files count to auto-start upload
   const pendingCount = state.files.filter(f => f.status === 'pending').length
+  const fileInputAccept = useMemo(
+    () =>
+      [documentUploadAccept, multimodalAnalysisEnabled ? multimodalUploadAccept : '']
+        .filter(Boolean)
+        .join(','),
+    [documentUploadAccept, multimodalAnalysisEnabled, multimodalUploadAccept]
+  )
+
+  useEffect(() => {
+    if (!open) return
+
+    let cancelled = false
+    getKnowledgeConfig()
+      .then(config => {
+        if (cancelled) return
+        setDocumentUploadAccept(config.document_upload_accept || DEFAULT_KB_DOCUMENT_ACCEPT)
+        setMultimodalUploadAccept(config.multimodal_upload_accept || DEFAULT_KB_MULTIMODAL_ACCEPT)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setDocumentUploadAccept(DEFAULT_KB_DOCUMENT_ACCEPT)
+        setMultimodalUploadAccept(DEFAULT_KB_MULTIMODAL_ACCEPT)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open])
 
   // Auto-start upload when there are pending files and not currently uploading
   useEffect(() => {
@@ -829,11 +859,7 @@ export function DocumentUpload({
             type="file"
             className="hidden"
             multiple
-            accept={
-              multimodalAnalysisEnabled
-                ? `${KB_DOCUMENT_ACCEPT},${MULTIMODAL_EXTENSIONS.join(',')}`
-                : KB_DOCUMENT_ACCEPT
-            }
+            accept={fileInputAccept}
             onChange={handleFileChange}
             disabled={state.isUploading}
           />

--- a/frontend/src/features/knowledge/multimodal/utils/upload-validation.ts
+++ b/frontend/src/features/knowledge/multimodal/utils/upload-validation.ts
@@ -12,19 +12,32 @@
 import { VIDEO_EXTENSIONS } from '@/apis/attachments'
 
 /**
+ * Fallback document/code extensions selectable in the KB upload file picker.
+ * The runtime value comes from /knowledge-bases/config so backend registry and
+ * optional deployment configuration remain the source of truth.
+ */
+export const DEFAULT_KB_DOCUMENT_ACCEPT =
+  '.c,.cpp,.css,.csv,.doc,.docx,.eml,.epub,.go,.htm,.html,.ini,.java,.js,.json,.kt,.kts,.lock,.markdown,.md,.pdf,.php,.ppt,.pptx,.py,.rb,.rs,.sh,.sql,.swift,.toml,.ts,.txt,.vue,.xls,.xlsx,.xmind,.xml,.yaml,.yml'
+
+/**
+ * Fallback multimodal extensions accepted by the KB upload file picker when
+ * multimodal analysis is enabled for the current KB.
+ */
+export const DEFAULT_KB_MULTIMODAL_ACCEPT = [
+  ...VIDEO_EXTENSIONS,
+  '.bmp',
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.webp',
+].join(',')
+
+/**
  * Image extensions. Unsupported for RAG UNLESS the KB has multimodal analysis
  * enabled (video+image). When disabled, they get a friendly upload error.
  */
 export const KB_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp']
-
-/**
- * Document/code extensions selectable in the KB upload file picker.
- * Multimodal extensions (video+image) are appended conditionally when the KB
- * has multimodal analysis enabled (MULTIMODAL_EXTENSIONS from
- * @/apis/attachments — the set the upload path routes to the converter).
- */
-export const KB_DOCUMENT_ACCEPT =
-  '.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.csv,.txt,.md,.markdown,.adoc,.asciidoc,.asm,.bat,.c,.cc,.cpp,.css,.conf,.config,.dart,.env,.go,.gradle,.groovy,.h,.html,.ini,.java,.js,.json,.jsx,.kotlin,.less,.license,.log,.lua,.mjs,.php,.pl,.properties,.ps1,.py,.rb,.readme,.rst,.rust,.sass,.scala,.scss,.sh,.sql,.srt,.styl,.svg,.swift,.textile,.toml,.ts,.tsx,.tsv,.vue,.wiki,.xml,.yaml,.yml'
 
 /**
  * Check if a file extension is unsupported. Image extensions are unsupported

--- a/frontend/src/hooks/useBatchAttachment.ts
+++ b/frontend/src/hooks/useBatchAttachment.ts
@@ -15,6 +15,7 @@ import {
   isVideoFileName,
   isValidFileSize,
   getErrorMessageFromCode,
+  type AttachmentUploadPurpose,
 } from '@/apis/attachments'
 import { getVideoUploader } from '@/features/knowledge/multimodal/video-upload-registry'
 import type { Attachment } from '@/types/api'
@@ -76,13 +77,20 @@ interface UseBatchAttachmentReturn {
   getSuccessfulAttachments: () => { attachment: Attachment; file: File }[]
 }
 
+interface UseBatchAttachmentOptions {
+  uploadPurpose?: AttachmentUploadPurpose
+}
+
 /** Generate unique ID for file tracking */
 function generateFileId(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
 }
 
-export function useBatchAttachment(): UseBatchAttachmentReturn {
+export function useBatchAttachment(
+  options: UseBatchAttachmentOptions = {}
+): UseBatchAttachmentReturn {
   const { t } = useTranslation()
+  const uploadPurpose = options.uploadPurpose ?? 'chat'
   const [state, setState] = useState<BatchUploadState>({
     files: [],
     isUploading: false,
@@ -210,6 +218,8 @@ export function useBatchAttachment(): UseBatchAttachmentReturn {
             files: prev.files.map(f => (f.id === fileItem.id ? { ...f, progress } : f)),
           }))
         }
+        const uploadOptions =
+          uploadPurpose === 'knowledge' ? ({ purpose: 'knowledge' } as const) : {}
 
         const attachment = videoUploader
           ? await (async () => {
@@ -227,7 +237,7 @@ export function useBatchAttachment(): UseBatchAttachmentReturn {
                 truncation_info: null,
               }
             })()
-          : await uploadAttachment(fileItem.file, onProgress)
+          : await uploadAttachment(fileItem.file, onProgress, uploadOptions)
 
         // Check if parsing succeeded (only meaningful for the generic path;
         // video attachments are always 'ready' here).
@@ -284,7 +294,7 @@ export function useBatchAttachment(): UseBatchAttachmentReturn {
         }
       }
     },
-    [t]
+    [t, uploadPurpose]
   )
 
   const startUpload = useCallback(async () => {

--- a/knowledge_engine/knowledge_engine/conversion/__init__.py
+++ b/knowledge_engine/knowledge_engine/conversion/__init__.py
@@ -2,17 +2,39 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Document conversion module — PDF/Office to Markdown via MinerU OCR."""
+"""Document conversion module — rich documents to Markdown."""
 
 from knowledge_engine.conversion.converter import ConversionResult, convert_document
+from knowledge_engine.conversion.formats import (
+    KnowledgeFileFormat,
+    KnowledgeFormatPipeline,
+    KnowledgeFormatSupportLevel,
+    conversion_required,
+    get_knowledge_format,
+    get_knowledge_pipeline,
+    is_supported_knowledge_format,
+    list_knowledge_formats,
+    supported_knowledge_extensions,
+    validate_knowledge_file,
+)
 from knowledge_engine.conversion.mineru_client import SUPPORTED_MIME_TYPES, MinerUConfig
 from knowledge_engine.conversion.s3_uploader import S3Config, S3Uploader
 
 __all__ = [
     "convert_document",
     "ConversionResult",
+    "KnowledgeFileFormat",
+    "KnowledgeFormatPipeline",
+    "KnowledgeFormatSupportLevel",
     "MinerUConfig",
     "S3Config",
     "S3Uploader",
     "SUPPORTED_MIME_TYPES",
+    "conversion_required",
+    "get_knowledge_format",
+    "get_knowledge_pipeline",
+    "is_supported_knowledge_format",
+    "list_knowledge_formats",
+    "supported_knowledge_extensions",
+    "validate_knowledge_file",
 ]

--- a/knowledge_engine/knowledge_engine/conversion/converter.py
+++ b/knowledge_engine/knowledge_engine/conversion/converter.py
@@ -13,10 +13,19 @@ import logging
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
+from knowledge_engine.conversion.formats import (
+    KnowledgeFormatPipeline,
+    get_knowledge_pipeline,
+)
+from knowledge_engine.conversion.local_markdown import convert_local_markdown
 from knowledge_engine.conversion.mineru_client import (
     SUPPORTED_MIME_TYPES,
     MinerUConfig,
     submit_and_wait,
+)
+from knowledge_engine.conversion.office_legacy import (
+    convert_legacy_office_to_openxml,
+    is_legacy_office_extension,
 )
 from knowledge_engine.conversion.s3_uploader import S3Config, S3Uploader
 from knowledge_engine.conversion.zip_extractor import extract_markdown_from_zip
@@ -59,10 +68,22 @@ def convert_document(
         RuntimeError: If conversion fails
     """
     ext = file_extension.lstrip(".").lower()
-    if ext not in SUPPORTED_MIME_TYPES:
+    pipeline = get_knowledge_pipeline(ext)
+
+    if pipeline == KnowledgeFormatPipeline.LOCAL_MARKDOWN:
+        return ConversionResult(
+            markdown_bytes=convert_local_markdown(binary_data, ext),
+            uploaded_images=[],
+        )
+
+    if pipeline == KnowledgeFormatPipeline.MINERU and is_legacy_office_extension(ext):
+        binary_data, ext = convert_legacy_office_to_openxml(binary_data, ext)
+
+    if pipeline != KnowledgeFormatPipeline.MINERU or ext not in SUPPORTED_MIME_TYPES:
+        supported = sorted(SUPPORTED_MIME_TYPES)
         raise RuntimeError(
             f"Conversion for '{ext}' not supported. "
-            f"Supported: {', '.join(SUPPORTED_MIME_TYPES)}"
+            f"Supported: {', '.join(supported)}"
         )
 
     # Use thread executor if already in a running event loop (e.g., async tests)

--- a/knowledge_engine/knowledge_engine/conversion/formats.py
+++ b/knowledge_engine/knowledge_engine/conversion/formats.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Knowledge-base file format capabilities.
+
+This module is the backend-side source of truth for formats that can enter the
+knowledge-base ingestion pipeline. It intentionally stays lightweight: adding a
+format should mean adding one registry entry and, only when needed, a converter.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Optional
+
+import chardet
+
+
+class KnowledgeFormatPipeline(str, Enum):
+    """How a knowledge-base file is prepared for indexing."""
+
+    DIRECT = "direct"
+    MINERU = "mineru"
+    LOCAL_MARKDOWN = "local_markdown"
+    MULTIMODAL = "multimodal"
+
+
+class KnowledgeFormatSupportLevel(str, Enum):
+    """Current support status exposed to server-side callers."""
+
+    STABLE = "stable"
+    CONDITIONAL = "conditional"
+    FUTURE = "future"
+
+
+@dataclass(frozen=True)
+class KnowledgeFileFormat:
+    """A single knowledge-base file format capability."""
+
+    extension: str
+    mime_types: tuple[str, ...]
+    category: str
+    pipeline: KnowledgeFormatPipeline
+    support_level: KnowledgeFormatSupportLevel = KnowledgeFormatSupportLevel.STABLE
+    enabled: bool = True
+    notes: str = ""
+
+    @property
+    def dotted_extension(self) -> str:
+        return f".{self.extension}"
+
+
+def _fmt(
+    extension: str,
+    mime_types: Iterable[str],
+    category: str,
+    pipeline: KnowledgeFormatPipeline,
+    support_level: KnowledgeFormatSupportLevel = KnowledgeFormatSupportLevel.STABLE,
+    *,
+    enabled: bool = True,
+    notes: str = "",
+) -> KnowledgeFileFormat:
+    return KnowledgeFileFormat(
+        extension=normalize_extension(extension),
+        mime_types=tuple(mime_types),
+        category=category,
+        pipeline=pipeline,
+        support_level=support_level,
+        enabled=enabled,
+        notes=notes,
+    )
+
+
+def normalize_extension(file_extension: Optional[str]) -> str:
+    """Normalize an extension to lower-case, dot-less form."""
+
+    return (file_extension or "").strip().lstrip(".").lower()
+
+
+KNOWLEDGE_FILE_FORMATS: tuple[KnowledgeFileFormat, ...] = (
+    # Rich documents converted to Markdown before indexing.
+    _fmt("pdf", ("application/pdf",), "document", KnowledgeFormatPipeline.MINERU),
+    _fmt(
+        "docx",
+        ("application/vnd.openxmlformats-officedocument.wordprocessingml.document",),
+        "document",
+        KnowledgeFormatPipeline.MINERU,
+    ),
+    _fmt(
+        "doc",
+        ("application/msword",),
+        "document",
+        KnowledgeFormatPipeline.MINERU,
+        KnowledgeFormatSupportLevel.CONDITIONAL,
+        notes="Legacy Word documents depend on the configured conversion backend.",
+    ),
+    _fmt(
+        "pptx",
+        ("application/vnd.openxmlformats-officedocument.presentationml.presentation",),
+        "presentation",
+        KnowledgeFormatPipeline.MINERU,
+    ),
+    _fmt(
+        "ppt",
+        ("application/vnd.ms-powerpoint",),
+        "presentation",
+        KnowledgeFormatPipeline.MINERU,
+        KnowledgeFormatSupportLevel.CONDITIONAL,
+        notes="Legacy PowerPoint documents depend on the configured conversion backend.",
+    ),
+    _fmt(
+        "xlsx",
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",),
+        "spreadsheet",
+        KnowledgeFormatPipeline.MINERU,
+    ),
+    _fmt(
+        "xls",
+        ("application/vnd.ms-excel",),
+        "spreadsheet",
+        KnowledgeFormatPipeline.MINERU,
+        KnowledgeFormatSupportLevel.CONDITIONAL,
+        notes="Legacy Excel documents depend on the configured conversion backend.",
+    ),
+    # Local Markdown normalization in the converter worker.
+    _fmt(
+        "epub",
+        ("application/epub+zip",),
+        "document",
+        KnowledgeFormatPipeline.LOCAL_MARKDOWN,
+    ),
+    _fmt(
+        "eml",
+        ("message/rfc822", "text/plain"),
+        "document",
+        KnowledgeFormatPipeline.LOCAL_MARKDOWN,
+        notes="RFC822 email messages only; Outlook .msg is not supported.",
+    ),
+    _fmt("html", ("text/html",), "web", KnowledgeFormatPipeline.LOCAL_MARKDOWN),
+    _fmt("htm", ("text/html",), "web", KnowledgeFormatPipeline.LOCAL_MARKDOWN),
+    _fmt(
+        "xml",
+        ("text/xml", "application/xml"),
+        "config",
+        KnowledgeFormatPipeline.LOCAL_MARKDOWN,
+        KnowledgeFormatSupportLevel.CONDITIONAL,
+        notes="Structured XML is supported; binary or object-only XML containers are not.",
+    ),
+    # Direct text/code/config indexing.
+    _fmt("txt", ("text/plain",), "text", KnowledgeFormatPipeline.DIRECT),
+    _fmt("md", ("text/markdown", "text/plain"), "text", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "markdown",
+        ("text/markdown", "text/plain"),
+        "text",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    _fmt(
+        "csv", ("text/csv", "text/plain"), "spreadsheet", KnowledgeFormatPipeline.DIRECT
+    ),
+    _fmt("py", ("text/x-python", "text/plain"), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "js",
+        ("application/javascript", "text/plain"),
+        "code",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    _fmt(
+        "ts",
+        ("application/typescript", "text/plain"),
+        "code",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    _fmt("vue", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("css", ("text/css", "text/plain"), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "java",
+        ("text/x-java-source", "text/plain"),
+        "code",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    _fmt("go", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("rs", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "cpp", ("text/x-c++src", "text/plain"), "code", KnowledgeFormatPipeline.DIRECT
+    ),
+    _fmt("c", ("text/x-csrc", "text/plain"), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("swift", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("kt", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("kts", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("rb", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("php", ("text/x-php", "text/plain"), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt("sql", ("text/plain",), "code", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "sh",
+        ("text/x-shellscript", "text/plain"),
+        "code",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    _fmt("yaml", ("text/yaml", "text/plain"), "config", KnowledgeFormatPipeline.DIRECT),
+    _fmt("yml", ("text/yaml", "text/plain"), "config", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "json",
+        ("application/json", "text/plain"),
+        "config",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    _fmt("ini", ("text/plain",), "config", KnowledgeFormatPipeline.DIRECT),
+    _fmt("toml", ("text/plain",), "config", KnowledgeFormatPipeline.DIRECT),
+    _fmt(
+        "lock",
+        ("text/plain",),
+        "config",
+        KnowledgeFormatPipeline.DIRECT,
+        KnowledgeFormatSupportLevel.CONDITIONAL,
+        notes="Only plain-text lock files are supported.",
+    ),
+    # Existing Wegent special parser.
+    _fmt(
+        "xmind",
+        ("application/vnd.xmind.workbook",),
+        "mindmap",
+        KnowledgeFormatPipeline.DIRECT,
+    ),
+    # Multimodal formats; KB-level model configuration gates actual analysis.
+    _fmt("jpg", ("image/jpeg",), "image", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("jpeg", ("image/jpeg",), "image", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("png", ("image/png",), "image", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("gif", ("image/gif",), "image", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("webp", ("image/webp",), "image", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("bmp", ("image/bmp",), "image", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("mp4", ("video/mp4",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("avi", ("video/x-msvideo",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("mov", ("video/quicktime",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("mkv", ("video/x-matroska",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("webm", ("video/webm",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("flv", ("video/x-flv",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("wmv", ("video/x-ms-wmv",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    _fmt("m4v", ("video/x-m4v",), "video", KnowledgeFormatPipeline.MULTIMODAL),
+    # iWork is intentionally visible in the registry but disabled by default.
+    _fmt(
+        "key",
+        ("application/x-iwork-keynote-sffkey",),
+        "iwork",
+        KnowledgeFormatPipeline.LOCAL_MARKDOWN,
+        KnowledgeFormatSupportLevel.FUTURE,
+        enabled=False,
+        notes="Requires a dedicated iWork conversion provider.",
+    ),
+    _fmt(
+        "numbers",
+        ("application/x-iwork-numbers-sffnumbers",),
+        "iwork",
+        KnowledgeFormatPipeline.LOCAL_MARKDOWN,
+        KnowledgeFormatSupportLevel.FUTURE,
+        enabled=False,
+        notes="Requires a dedicated iWork conversion provider.",
+    ),
+    _fmt(
+        "pages",
+        ("application/x-iwork-pages-sffpages",),
+        "iwork",
+        KnowledgeFormatPipeline.LOCAL_MARKDOWN,
+        KnowledgeFormatSupportLevel.FUTURE,
+        enabled=False,
+        notes="Requires a dedicated iWork conversion provider.",
+    ),
+)
+
+_FORMAT_BY_EXTENSION = {fmt.extension: fmt for fmt in KNOWLEDGE_FILE_FORMATS}
+_TEXT_LIKE_CATEGORIES = frozenset({"text", "code", "config"})
+_CONVERSION_PIPELINES = frozenset(
+    {KnowledgeFormatPipeline.MINERU, KnowledgeFormatPipeline.LOCAL_MARKDOWN}
+)
+
+
+def get_knowledge_format(
+    file_extension: Optional[str],
+    *,
+    include_disabled: bool = False,
+) -> KnowledgeFileFormat | None:
+    """Return the registered format for an extension."""
+
+    fmt = _FORMAT_BY_EXTENSION.get(normalize_extension(file_extension))
+    if fmt is None:
+        return None
+    if not fmt.enabled and not include_disabled:
+        return None
+    return fmt
+
+
+def list_knowledge_formats(
+    *,
+    include_disabled: bool = False,
+) -> tuple[KnowledgeFileFormat, ...]:
+    """List known knowledge-base formats."""
+
+    if include_disabled:
+        return KNOWLEDGE_FILE_FORMATS
+    return tuple(fmt for fmt in KNOWLEDGE_FILE_FORMATS if fmt.enabled)
+
+
+def is_supported_knowledge_format(file_extension: Optional[str]) -> bool:
+    """Return True when the format is currently accepted for KB upload."""
+
+    return get_knowledge_format(file_extension) is not None
+
+
+def supported_knowledge_extensions() -> tuple[str, ...]:
+    """Return sorted dotted extensions currently accepted for KB upload."""
+
+    return tuple(sorted(fmt.dotted_extension for fmt in list_knowledge_formats()))
+
+
+def get_knowledge_pipeline(
+    file_extension: Optional[str],
+) -> KnowledgeFormatPipeline | None:
+    """Return the pipeline used by a currently enabled knowledge format."""
+
+    fmt = get_knowledge_format(file_extension)
+    if fmt is None:
+        return None
+    return fmt.pipeline
+
+
+def conversion_required(file_extension: Optional[str]) -> bool:
+    """Return True if the format must be converted before direct indexing."""
+
+    pipeline = get_knowledge_pipeline(file_extension)
+    return pipeline in _CONVERSION_PIPELINES
+
+
+def decode_text_bytes(binary_data: bytes) -> str:
+    """Decode text-like uploads with a conservative binary guard."""
+
+    if not binary_data:
+        return ""
+    if b"\x00" in binary_data[:4096]:
+        raise ValueError("File content appears to be binary, not text")
+
+    for encoding in ("utf-8-sig",):
+        try:
+            return binary_data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+
+    detected = chardet.detect(binary_data[: min(len(binary_data), 1024 * 1024)])
+    encoding = detected.get("encoding")
+    confidence = float(detected.get("confidence") or 0)
+    if encoding and confidence >= 0.5:
+        try:
+            return binary_data.decode(encoding)
+        except UnicodeDecodeError:
+            pass
+
+    raise ValueError("Unable to decode file content as text")
+
+
+def validate_knowledge_file(binary_data: bytes, file_extension: Optional[str]) -> None:
+    """Validate format-specific invariants before storing a KB raw attachment."""
+
+    fmt = get_knowledge_format(file_extension)
+    ext = normalize_extension(file_extension)
+    if fmt is None:
+        supported = ", ".join(supported_knowledge_extensions())
+        raise ValueError(
+            f"Unsupported knowledge file type: .{ext or 'unknown'}. "
+            f"Supported types: {supported}"
+        )
+
+    if (
+        fmt.pipeline == KnowledgeFormatPipeline.DIRECT
+        and fmt.category in _TEXT_LIKE_CATEGORIES
+    ):
+        decode_text_bytes(binary_data)
+        return
+
+    if ext == "csv":
+        decode_text_bytes(binary_data)
+        return
+
+    if ext in {"html", "htm", "xml", "eml"}:
+        decode_text_bytes(binary_data)
+        return
+
+    if (
+        ext == "epub"
+        and binary_data
+        and not zipfile.is_zipfile(io.BytesIO(binary_data))
+    ):
+        raise ValueError("Invalid EPUB file: expected a ZIP-based EPUB package")

--- a/knowledge_engine/knowledge_engine/conversion/local_markdown.py
+++ b/knowledge_engine/knowledge_engine/conversion/local_markdown.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local converters for structured text formats to Markdown."""
+
+from __future__ import annotations
+
+import email.policy
+import posixpath
+import zipfile
+from email.parser import BytesParser
+from html import escape
+from io import BytesIO
+from typing import Callable, Iterable
+from xml.etree import ElementTree
+
+import html2text
+from bs4 import BeautifulSoup
+
+from knowledge_engine.conversion.formats import decode_text_bytes, normalize_extension
+
+LocalMarkdownConverter = Callable[[bytes], str]
+
+
+def convert_local_markdown(binary_data: bytes, file_extension: str) -> bytes:
+    """Convert a locally supported format to UTF-8 Markdown bytes."""
+
+    ext = normalize_extension(file_extension)
+    converter = _LOCAL_MARKDOWN_CONVERTERS.get(ext)
+    if converter is None:
+        raise RuntimeError(f"Local Markdown conversion for '{ext}' is not supported")
+
+    return _ensure_trailing_newline(converter(binary_data)).encode("utf-8")
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    stripped = text.strip()
+    if not stripped:
+        raise RuntimeError("Converted Markdown is empty")
+    return f"{stripped}\n"
+
+
+def _html_to_markdown(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    for node in soup(["script", "style", "noscript"]):
+        node.decompose()
+
+    converter = html2text.HTML2Text()
+    converter.body_width = 0
+    converter.ignore_links = False
+    converter.ignore_images = False
+    converter.ignore_tables = False
+    return converter.handle(str(soup))
+
+
+def _convert_html(binary_data: bytes) -> str:
+    return _html_to_markdown(decode_text_bytes(binary_data))
+
+
+def _convert_epub(binary_data: bytes) -> str:
+    if not zipfile.is_zipfile(BytesIO(binary_data)):
+        raise RuntimeError("Invalid EPUB file: expected a ZIP package")
+
+    with zipfile.ZipFile(BytesIO(binary_data)) as archive:
+        rootfile = _find_epub_rootfile(archive)
+        if not rootfile:
+            raise RuntimeError("Invalid EPUB file: missing OPF rootfile")
+
+        opf_root = ElementTree.fromstring(archive.read(rootfile))
+        manifest = _read_epub_manifest(opf_root)
+        spine_paths = _read_epub_spine_paths(opf_root, manifest, rootfile)
+        if not spine_paths:
+            spine_paths = _read_epub_html_paths(manifest, rootfile)
+
+        sections: list[str] = []
+        for path in spine_paths:
+            try:
+                html = decode_text_bytes(archive.read(path))
+            except KeyError:
+                continue
+            markdown = _html_to_markdown(html).strip()
+            if markdown:
+                sections.append(markdown)
+
+    if not sections:
+        raise RuntimeError("Invalid EPUB file: no readable document sections found")
+    return "\n\n".join(sections)
+
+
+def _find_epub_rootfile(archive: zipfile.ZipFile) -> str | None:
+    try:
+        container = ElementTree.fromstring(archive.read("META-INF/container.xml"))
+    except (KeyError, ElementTree.ParseError):
+        return None
+
+    for element in container.iter():
+        if _tag_name(element) == "rootfile":
+            full_path = element.attrib.get("full-path", "").strip()
+            if full_path:
+                return full_path
+    return None
+
+
+def _read_epub_manifest(root: ElementTree.Element) -> dict[str, dict[str, str]]:
+    manifest: dict[str, dict[str, str]] = {}
+    for element in root.iter():
+        if _tag_name(element) != "item":
+            continue
+        item_id = element.attrib.get("id")
+        href = element.attrib.get("href")
+        if not item_id or not href:
+            continue
+        manifest[item_id] = {
+            "href": href,
+            "media_type": element.attrib.get("media-type", ""),
+        }
+    return manifest
+
+
+def _read_epub_spine_paths(
+    root: ElementTree.Element,
+    manifest: dict[str, dict[str, str]],
+    rootfile: str,
+) -> list[str]:
+    paths: list[str] = []
+    for element in root.iter():
+        if _tag_name(element) != "itemref":
+            continue
+        item = manifest.get(element.attrib.get("idref", ""))
+        if not item:
+            continue
+        paths.append(_resolve_epub_path(rootfile, item["href"]))
+    return paths
+
+
+def _read_epub_html_paths(
+    manifest: dict[str, dict[str, str]],
+    rootfile: str,
+) -> list[str]:
+    html_media_types = {
+        "application/xhtml+xml",
+        "text/html",
+    }
+    return [
+        _resolve_epub_path(rootfile, item["href"])
+        for item in manifest.values()
+        if item.get("media_type") in html_media_types
+    ]
+
+
+def _resolve_epub_path(rootfile: str, href: str) -> str:
+    base = posixpath.dirname(rootfile)
+    return posixpath.normpath(posixpath.join(base, href))
+
+
+def _convert_eml(binary_data: bytes) -> str:
+    message = BytesParser(policy=email.policy.default).parsebytes(binary_data)
+    lines: list[str] = []
+
+    subject = message.get("subject")
+    if subject:
+        lines.extend([f"# {subject}", ""])
+
+    for header in ("from", "to", "cc", "date"):
+        value = message.get(header)
+        if value:
+            lines.append(f"**{header.title()}:** {value}")
+    if lines and lines[-1] != "":
+        lines.append("")
+
+    plain_body = _first_message_part(message, "text/plain")
+    html_body = _first_message_part(message, "text/html")
+    if plain_body:
+        lines.append(plain_body.strip())
+    elif html_body:
+        lines.append(_html_to_markdown(html_body).strip())
+
+    attachments = [
+        part.get_filename()
+        for part in message.walk()
+        if part.get_content_disposition() == "attachment" and part.get_filename()
+    ]
+    if attachments:
+        lines.extend(["", "## Attachments", ""])
+        lines.extend(f"- {escape(name)}" for name in attachments)
+
+    return "\n".join(part for part in lines if part is not None)
+
+
+def _first_message_part(message, content_type: str) -> str:
+    parts = message.walk() if message.is_multipart() else [message]
+    for part in parts:
+        if part.get_content_type() != content_type:
+            continue
+        if part.get_content_disposition() == "attachment":
+            continue
+        content = part.get_content()
+        if isinstance(content, bytes):
+            return decode_text_bytes(content)
+        return str(content)
+    return ""
+
+
+def _convert_xml(binary_data: bytes) -> str:
+    xml_text = decode_text_bytes(binary_data)
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError as exc:
+        raise RuntimeError(f"Invalid XML file: {exc}") from exc
+
+    lines = ["# XML Document", ""]
+    lines.extend(_xml_element_lines(root))
+    if len(lines) <= 2:
+        raise RuntimeError("XML file has no readable text content")
+    return "\n".join(lines)
+
+
+def _xml_element_lines(element: ElementTree.Element, depth: int = 0) -> Iterable[str]:
+    tag = _tag_name(element)
+    text = " ".join((element.text or "").split())
+    children = list(element)
+    indent = "  " * min(depth, 4)
+
+    if text:
+        yield f"{indent}- **{tag}:** {text}"
+    elif children:
+        yield f"{indent}- **{tag}**"
+
+    for child in children:
+        yield from _xml_element_lines(child, depth + 1)
+
+
+def _tag_name(element: ElementTree.Element) -> str:
+    return element.tag.rsplit("}", 1)[-1]
+
+
+_LOCAL_MARKDOWN_CONVERTERS: dict[str, LocalMarkdownConverter] = {
+    "epub": _convert_epub,
+    "eml": _convert_eml,
+    "html": _convert_html,
+    "htm": _convert_html,
+    "xml": _convert_xml,
+}

--- a/knowledge_engine/knowledge_engine/conversion/mineru_client.py
+++ b/knowledge_engine/knowledge_engine/conversion/mineru_client.py
@@ -47,11 +47,8 @@ class MinerUConfig:
 SUPPORTED_MIME_TYPES = {
     "pdf": "application/pdf",
     "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "doc": "application/msword",
     "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    "ppt": "application/vnd.ms-powerpoint",
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "xls": "application/vnd.ms-excel",
 }
 
 
@@ -118,7 +115,20 @@ async def _submit_task(
     response = await client.post(
         submit_url, data=data, files=files, timeout=config.submit_timeout_seconds
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        detail = response.text[:500]
+        logger.error(
+            "[MinerU] Submit failed: status=%s, filename=%s, response=%s",
+            response.status_code,
+            filename,
+            detail,
+        )
+        raise RuntimeError(
+            f"MinerU submit failed for {filename}: "
+            f"HTTP {response.status_code}, response={detail}"
+        ) from exc
 
     result = response.json()
     task_id = result.get("task_id") if isinstance(result, dict) else result.strip('"')

--- a/knowledge_engine/knowledge_engine/conversion/office_legacy.py
+++ b/knowledge_engine/knowledge_engine/conversion/office_legacy.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Legacy Office conversion helpers.
+
+MinerU's HTTP API accepts OOXML Office files (docx/pptx/xlsx), but not the
+older OLE2 formats (doc/ppt/xls). Normalize legacy files with LibreOffice
+before handing them to MinerU.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+LEGACY_OFFICE_TARGET_EXTENSIONS = {
+    "doc": "docx",
+    "ppt": "pptx",
+    "xls": "xlsx",
+}
+
+_SOFFICE_CANDIDATES = (
+    "soffice",
+    "libreoffice",
+    "/usr/bin/soffice",
+    "/usr/local/bin/soffice",
+    "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+)
+
+
+def is_legacy_office_extension(file_extension: str) -> bool:
+    """Return whether extension needs LibreOffice normalization."""
+
+    return file_extension.strip().lstrip(".").lower() in LEGACY_OFFICE_TARGET_EXTENSIONS
+
+
+@lru_cache(maxsize=1)
+def resolve_soffice_path() -> str | None:
+    """Resolve a runnable LibreOffice/soffice binary."""
+
+    configured = os.getenv("SOFFICE_PATH") or os.getenv("LIBREOFFICE_PATH")
+    candidates = (configured,) if configured else ()
+    candidates = candidates + _SOFFICE_CANDIDATES
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+
+        resolved = shutil.which(candidate) or candidate
+        try:
+            result = subprocess.run(
+                [resolved, "--version"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            return resolved
+
+    return None
+
+
+def convert_legacy_office_to_openxml(
+    binary_data: bytes,
+    file_extension: str,
+    *,
+    timeout_seconds: int = 120,
+) -> tuple[bytes, str]:
+    """Convert doc/ppt/xls bytes to docx/pptx/xlsx bytes."""
+
+    source_ext = file_extension.strip().lstrip(".").lower()
+    target_ext = LEGACY_OFFICE_TARGET_EXTENSIONS.get(source_ext)
+    if not target_ext:
+        raise RuntimeError(f"Legacy Office conversion does not support '{source_ext}'")
+
+    soffice = resolve_soffice_path()
+    if not soffice:
+        raise RuntimeError(
+            "Legacy Office conversion requires LibreOffice/soffice. "
+            f"Cannot convert .{source_ext} to .{target_ext}."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="wegent-office-convert-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        input_path = tmp_path / f"document.{source_ext}"
+        input_path.write_bytes(binary_data)
+
+        result = subprocess.run(
+            [
+                soffice,
+                "--headless",
+                "--convert-to",
+                target_ext,
+                "--outdir",
+                tmpdir,
+                str(input_path),
+            ],
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            stdout = result.stdout.decode("utf-8", errors="replace").strip()
+            detail = stderr or stdout or "unknown error"
+            raise RuntimeError(
+                f"LibreOffice failed to convert .{source_ext} to .{target_ext}: "
+                f"{detail[:500]}"
+            )
+
+        output_path = tmp_path / f"document.{target_ext}"
+        if not output_path.exists():
+            converted_files = list(tmp_path.glob(f"*.{target_ext}"))
+            if len(converted_files) == 1:
+                output_path = converted_files[0]
+            else:
+                raise RuntimeError(
+                    f"LibreOffice did not produce a .{target_ext} output file"
+                )
+
+        converted = output_path.read_bytes()
+        logger.info(
+            "[OfficeLegacy] Converted .%s to .%s using LibreOffice: bytes=%s",
+            source_ext,
+            target_ext,
+            len(converted),
+        )
+        return converted, target_ext

--- a/knowledge_engine/knowledge_engine/embedding/factory.py
+++ b/knowledge_engine/knowledge_engine/embedding/factory.py
@@ -46,12 +46,8 @@ def _create_embedding_model_from_resolved_values(
         additional_input_modalities
     )
     if protocol == "openai":
-        if custom_headers:
-            api_url = (
-                f"{base_url.rstrip('/')}/embeddings"
-                if base_url
-                else "https://api.openai.com/v1/embeddings"
-            )
+        if base_url or custom_headers:
+            api_url = _build_openai_compatible_embedding_url(base_url)
             return _attach_runtime_capabilities(
                 CustomEmbedding(
                     api_url=api_url,
@@ -95,6 +91,18 @@ def _create_embedding_model_from_resolved_values(
     raise ValueError(
         f"Unsupported embedding protocol for model '{model_name}': {protocol}"
     )
+
+
+def _build_openai_compatible_embedding_url(base_url: str | None) -> str:
+    """Build the embeddings endpoint for OpenAI-compatible providers."""
+
+    if not base_url:
+        return "https://api.openai.com/v1/embeddings"
+
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/embeddings"):
+        return normalized
+    return f"{normalized}/embeddings"
 
 
 def _attach_runtime_capabilities(

--- a/knowledge_engine/tests/test_conversion/test_converter.py
+++ b/knowledge_engine/tests/test_conversion/test_converter.py
@@ -7,6 +7,7 @@
 import io
 import zipfile
 from unittest.mock import patch
+from xml.etree import ElementTree
 
 import pytest
 
@@ -18,6 +19,41 @@ def _make_zip_with_md(md_content: str) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as z:
         z.writestr("document.md", md_content)
+    return buf.getvalue()
+
+
+def _make_minimal_epub() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("mimetype", "application/epub+zip")
+        z.writestr(
+            "META-INF/container.xml",
+            """<?xml version="1.0"?>
+            <container version="1.0"
+              xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+              <rootfiles>
+                <rootfile full-path="OPS/content.opf"
+                  media-type="application/oebps-package+xml"/>
+              </rootfiles>
+            </container>""",
+        )
+        z.writestr(
+            "OPS/content.opf",
+            """<?xml version="1.0"?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+              <manifest>
+                <item id="chapter1" href="chapter1.xhtml"
+                  media-type="application/xhtml+xml"/>
+              </manifest>
+              <spine>
+                <itemref idref="chapter1"/>
+              </spine>
+            </package>""",
+        )
+        z.writestr(
+            "OPS/chapter1.xhtml",
+            "<html><body><h1>Chapter One</h1><p>Hello EPUB.</p></body></html>",
+        )
     return buf.getvalue()
 
 
@@ -37,8 +73,12 @@ def test_convert_document_success_pdf():
     config = MinerUConfig(api_base_url="http://mineru:8367")
     zip_bytes = _make_zip_with_md("# Converted PDF")
 
+    async def fake_submit_and_wait(*args, **kwargs):
+        return zip_bytes
+
     with patch(
-        "knowledge_engine.conversion.converter.asyncio.run", return_value=zip_bytes
+        "knowledge_engine.conversion.converter.submit_and_wait",
+        side_effect=fake_submit_and_wait,
     ):
         result = convert_document(b"pdf_bytes", "pdf", config)
 
@@ -51,12 +91,98 @@ def test_convert_document_success_with_dot_extension():
     config = MinerUConfig(api_base_url="http://mineru:8367")
     zip_bytes = _make_zip_with_md("# Converted DOCX")
 
+    async def fake_submit_and_wait(*args, **kwargs):
+        return zip_bytes
+
     with patch(
-        "knowledge_engine.conversion.converter.asyncio.run", return_value=zip_bytes
+        "knowledge_engine.conversion.converter.submit_and_wait",
+        side_effect=fake_submit_and_wait,
     ):
         result = convert_document(b"docx_bytes", ".docx", config)
 
     assert result.markdown_bytes == b"# Converted DOCX"
+
+
+def test_convert_document_converts_legacy_office_before_mineru():
+    config = MinerUConfig(api_base_url="http://mineru:8367")
+    zip_bytes = _make_zip_with_md("# Converted DOC")
+    submitted = {}
+
+    async def fake_submit_and_wait(binary_data, file_extension, mineru_config):
+        submitted["binary_data"] = binary_data
+        submitted["file_extension"] = file_extension
+        submitted["mineru_config"] = mineru_config
+        return zip_bytes
+
+    with (
+        patch(
+            "knowledge_engine.conversion.converter.convert_legacy_office_to_openxml",
+            return_value=(b"docx_bytes", "docx"),
+        ) as mock_legacy_convert,
+        patch(
+            "knowledge_engine.conversion.converter.submit_and_wait",
+            side_effect=fake_submit_and_wait,
+        ),
+    ):
+        result = convert_document(b"doc_bytes", "doc", config)
+
+    mock_legacy_convert.assert_called_once_with(b"doc_bytes", "doc")
+    assert submitted["binary_data"] == b"docx_bytes"
+    assert submitted["file_extension"] == "docx"
+    assert submitted["mineru_config"] is config
+    assert result.markdown_bytes == b"# Converted DOC"
+
+
+def test_convert_document_local_epub():
+    config = MinerUConfig(api_base_url="http://mineru:8367")
+
+    result = convert_document(_make_minimal_epub(), "epub", config)
+
+    assert b"Chapter One" in result.markdown_bytes
+    assert b"Hello EPUB" in result.markdown_bytes
+    assert result.uploaded_images == []
+
+
+def test_convert_document_local_eml():
+    config = MinerUConfig(api_base_url="http://mineru:8367")
+    eml = (
+        b"Subject: Roadmap\n"
+        b"From: alice@example.com\n"
+        b"To: bob@example.com\n"
+        b"Content-Type: text/plain; charset=utf-8\n"
+        b"\n"
+        b"Ship the parser upgrade."
+    )
+
+    result = convert_document(eml, "eml", config)
+
+    assert b"# Roadmap" in result.markdown_bytes
+    assert b"Ship the parser upgrade." in result.markdown_bytes
+
+
+def test_convert_document_local_html():
+    config = MinerUConfig(api_base_url="http://mineru:8367")
+
+    result = convert_document(
+        b"<html><body><h1>Title</h1><p>Body text.</p></body></html>",
+        "html",
+        config,
+    )
+
+    assert b"Title" in result.markdown_bytes
+    assert b"Body text" in result.markdown_bytes
+
+
+def test_convert_document_local_xml():
+    config = MinerUConfig(api_base_url="http://mineru:8367")
+    xml_bytes = ElementTree.tostring(
+        ElementTree.fromstring("<root><item>Value</item></root>")
+    )
+
+    result = convert_document(xml_bytes, "xml", config)
+
+    assert b"XML Document" in result.markdown_bytes
+    assert b"Value" in result.markdown_bytes
 
 
 def test_convert_document_result_is_frozen():
@@ -64,8 +190,12 @@ def test_convert_document_result_is_frozen():
     config = MinerUConfig(api_base_url="http://mineru:8367")
     zip_bytes = _make_zip_with_md("# Test")
 
+    async def fake_submit_and_wait(*args, **kwargs):
+        return zip_bytes
+
     with patch(
-        "knowledge_engine.conversion.converter.asyncio.run", return_value=zip_bytes
+        "knowledge_engine.conversion.converter.submit_and_wait",
+        side_effect=fake_submit_and_wait,
     ):
         result = convert_document(b"data", "pptx", config)
 

--- a/knowledge_engine/tests/test_conversion/test_formats.py
+++ b/knowledge_engine/tests/test_conversion/test_formats.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for knowledge-base format capabilities."""
+
+from knowledge_engine.conversion.formats import (
+    KnowledgeFormatPipeline,
+    get_knowledge_format,
+    get_knowledge_pipeline,
+    is_supported_knowledge_format,
+    list_knowledge_formats,
+    validate_knowledge_file,
+)
+
+
+def test_registry_contains_ap_supported_formats():
+    expected = {
+        "pdf",
+        "docx",
+        "doc",
+        "pptx",
+        "ppt",
+        "xlsx",
+        "xls",
+        "epub",
+        "eml",
+        "md",
+        "markdown",
+        "txt",
+        "csv",
+        "html",
+        "htm",
+        "jpg",
+        "jpeg",
+        "png",
+        "gif",
+        "webp",
+        "bmp",
+        "mp4",
+        "avi",
+        "mov",
+        "mkv",
+        "webm",
+        "flv",
+        "wmv",
+        "m4v",
+        "py",
+        "js",
+        "ts",
+        "vue",
+        "css",
+        "java",
+        "go",
+        "rs",
+        "cpp",
+        "c",
+        "swift",
+        "kt",
+        "kts",
+        "rb",
+        "php",
+        "sql",
+        "sh",
+        "yaml",
+        "yml",
+        "json",
+        "xml",
+        "ini",
+        "toml",
+        "lock",
+    }
+    actual = {fmt.extension for fmt in list_knowledge_formats()}
+
+    assert expected <= actual
+
+
+def test_iwork_formats_are_known_but_not_enabled():
+    assert is_supported_knowledge_format("key") is False
+    assert is_supported_knowledge_format("numbers") is False
+    assert is_supported_knowledge_format("pages") is False
+
+    key_format = get_knowledge_format("key", include_disabled=True)
+    assert key_format is not None
+    assert key_format.enabled is False
+
+
+def test_unsupported_formats_are_not_registered_as_supported():
+    assert is_supported_knowledge_format("msg") is False
+    assert is_supported_knowledge_format("azw3") is False
+    assert is_supported_knowledge_format("mobi") is False
+
+
+def test_pipeline_classification():
+    assert get_knowledge_pipeline("pdf") == KnowledgeFormatPipeline.MINERU
+    assert get_knowledge_pipeline("epub") == KnowledgeFormatPipeline.LOCAL_MARKDOWN
+    assert get_knowledge_pipeline("py") == KnowledgeFormatPipeline.DIRECT
+    assert get_knowledge_pipeline("gif") == KnowledgeFormatPipeline.MULTIMODAL
+    assert get_knowledge_pipeline("mp4") == KnowledgeFormatPipeline.MULTIMODAL
+
+
+def test_text_validation_rejects_binary_lock_file():
+    try:
+        validate_knowledge_file(b"\x00\x01\x02", "lock")
+    except ValueError as exc:
+        assert "binary" in str(exc)
+    else:
+        raise AssertionError("Expected binary lock file to be rejected")

--- a/knowledge_engine/tests/test_conversion/test_mineru_client.py
+++ b/knowledge_engine/tests/test_conversion/test_mineru_client.py
@@ -35,10 +35,11 @@ def test_is_supported_extension_docx():
 def test_is_supported_extension_unsupported():
     assert is_supported_extension("txt") is False
     assert is_supported_extension("jpg") is False
+    assert is_supported_extension("doc") is False
 
 
 def test_supported_mime_types_count():
-    assert len(SUPPORTED_MIME_TYPES) == 7
+    assert len(SUPPORTED_MIME_TYPES) == 4
 
 
 def test_mineru_config_defaults():

--- a/knowledge_engine/tests/test_embedding_factory.py
+++ b/knowledge_engine/tests/test_embedding_factory.py
@@ -65,6 +65,36 @@ def test_create_embedding_model_exposes_additional_input_modalities(mocker) -> N
     assert result._additional_input_modalities == ["image"]
 
 
+def test_openai_compatible_base_url_uses_custom_embedding(mocker) -> None:
+    embedding_instance = SimpleNamespace()
+    custom_embedding_cls = mocker.patch(
+        "knowledge_engine.embedding.factory.CustomEmbedding",
+        return_value=embedding_instance,
+    )
+
+    result = create_embedding_model_from_runtime_config(
+        RuntimeEmbeddingModelConfig(
+            model_name="bge-m3",
+            resolved_config={
+                "protocol": "openai",
+                "base_url": "https://haf.example.com/haf-compatible",
+                "model_id": "bge-m3",
+                "api_key": "token",
+                "dimensions": 1024,
+            },
+        )
+    )
+
+    custom_embedding_cls.assert_called_once_with(
+        api_url="https://haf.example.com/haf-compatible/embeddings",
+        model="bge-m3",
+        headers={},
+        api_key="token",
+        dimensions=1024,
+    )
+    assert result is embedding_instance
+
+
 @pytest.mark.asyncio
 async def test_custom_embedding_supports_async_text_embedding(mocker) -> None:
     embedding = CustomEmbedding(


### PR DESCRIPTION
Add a shared knowledge file format registry for upload validation, accept lists, and conversion routing.

Support local Markdown conversion for EPUB, EML, HTML/HTM, and XML, and normalize legacy Office DOC/PPT/XLS files to OpenXML before MinerU processing.

Store knowledge uploads as raw attachments, expose backend-driven upload accept config, sync the frontend upload purpose flow, and cover the new routing and validation behavior with tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable knowledge-base upload purposes and format allow-lists.
  * Added backend-driven file picker support, including multimodal formats.
  * Added local Markdown conversion for HTML, EPUB, email, and XML files.
  * Added legacy Office document conversion with LibreOffice support.
  * Improved knowledge-document routing, validation, and conversion status handling.
  * Improved OpenAI-compatible embedding endpoint configuration.

* **Documentation**
  * Expanded setup, supported-format, conversion, and troubleshooting guidance.

* **Tests**
  * Added coverage for upload purposes, format validation, local conversions, and embedding configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->