### PR TITLE
fix(wework): keep streaming conversations pinned at bottom

### DIFF
--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1126,6 +1126,68 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('keeps streaming content pinned within the bottom pixel tolerance', () => {
+    const streamingMessage = {
+      id: 'fractional-bottom-stream',
+      role: 'assistant' as const,
+      content: '正在处理',
+      status: 'streaming' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea
+        conversationKey="fractional-bottom-scroll"
+        messages={[streamingMessage]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 396,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+
+    fireEvent.scroll(scroller)
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    })
+
+    rerender(
+      <ScrollableMessageArea
+        conversationKey="fractional-bottom-scroll"
+        messages={[
+          {
+            ...streamingMessage,
+            content: '正在处理\n\n核心逻辑\n\n更多流式内容',
+          },
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 800,
+      behavior: 'auto',
+    })
+    expect(screen.queryByTestId('scroll-to-bottom-button')).not.toBeInTheDocument()
+  })
+
   test('does not follow streaming content after the user scrolls upward near the bottom', () => {
     const streamingMessage = {
       id: 'near-bottom-stream',

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -18,6 +18,7 @@ import type { RequestUserInputPayload } from './RequestUserInputCard'
 import type { AssistantPlanOpenRequest } from './AssistantPlanCard'
 
 const BOTTOM_THRESHOLD = 48
+const SCROLLED_TO_BOTTOM_THRESHOLD = 8
 const STABLE_SCROLL_DELAYS = [0, 50]
 const MAX_SCROLL_SNAPSHOTS = 50
 const MESSAGE_ANCHOR_SELECTOR = '[data-message-id]'
@@ -362,7 +363,7 @@ function ScrollableMessagePaneContent({
       const overflow = element.scrollHeight > element.clientHeight + 8
       const distanceToBottom = element.scrollHeight - element.clientHeight - element.scrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
-      const isScrolledToBottom = distanceToBottom <= 1
+      const isScrolledToBottom = distanceToBottom <= SCROLLED_TO_BOTTOM_THRESHOLD
       isAtBottomRef.current = isAtBottom
       if (isScrolledToBottom) {
         userScrollPausedAutoFollowRef.current = false
@@ -434,7 +435,7 @@ function ScrollableMessagePaneContent({
       const overflow = element.scrollHeight > element.clientHeight + 8
       const distanceToBottom = element.scrollHeight - element.clientHeight - nextScrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
-      const isScrolledToBottom = distanceToBottom <= 1
+      const isScrolledToBottom = distanceToBottom <= SCROLLED_TO_BOTTOM_THRESHOLD
       isAtBottomRef.current = isAtBottom
       userScrollPausedAutoFollowRef.current = !isScrolledToBottom
       setShowScrollButton(overflow && !isAtBottom)


### PR DESCRIPTION
## What changed

- Allow a small pixel tolerance when deciding whether the conversation has truly reached the bottom.
- Add regression coverage for streaming updates when the scroll position is a few pixels above the calculated maximum.

## Why

The scroll-to-bottom button used a 48px near-bottom threshold, while streaming auto-follow only resumed within 1px of the exact bottom. Fractional layout pixels, zoom, or font reflow could leave a small residual distance, causing auto-follow to remain paused and the down-arrow button to reappear after streaming output grew.

## Impact

Conversations that are visually at the bottom continue following streaming output without showing a stale down-arrow button. Explicit upward scrolling still pauses auto-follow.

## Validation

- `pnpm --filter wework test` (157 files, 1567 tests)
- `pnpm --filter wework exec vitest run src/components/chat/ScrollableMessageArea.test.tsx` (25 tests, after rebase)
- Pre-push ESLint, TypeScript, and unit tests
- Isolated real-Tauri verification: long streaming response stayed at the bottom without the button; PageUp showed the button; clicking it returned to the bottom and hid it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling behavior when users are near the bottom of a conversation.
  * Streaming messages now continue to auto-follow appropriately within a small bottom margin.
  * The scroll-to-bottom button is less likely to appear unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->