### PR TITLE
feat(wework): add Windows release artifacts

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -241,6 +241,10 @@ jobs:
             echo "Wework macOS DMG build."
             echo ""
             echo "This build is ad-hoc signed and not Apple notarized. On first launch, click Done if macOS shows a Move to Trash warning, then force-open it from System Settings > Privacy & Security > Open Anyway."
+            echo ""
+            echo "## Windows Distribution Notes"
+            echo ""
+            echo "Wework Windows x64 NSIS installer."
           } > "$release_notes"
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -491,7 +495,7 @@ jobs:
 
           artifact_dir="$RUNNER_TEMP/wework-macos-${{ matrix.arch }}"
           mkdir -p "$artifact_dir"
-          dmg_path="$artifact_dir/WeWork_${{ needs.prepare-release.outputs.version }}_macos_${{ matrix.arch }}_unsigned-adhoc.dmg"
+          dmg_path="$artifact_dir/WeWork_${{ needs.prepare-release.outputs.version }}_macos_${{ matrix.arch }}.dmg"
           archive_path="$artifact_dir/WeWork_${{ needs.prepare-release.outputs.version }}_macos_${{ matrix.arch }}.app.tar.gz"
           signature_path="$archive_path.sig"
           cp "$dmg_source" "$dmg_path"
@@ -556,6 +560,149 @@ jobs:
             ${{ steps.package.outputs.signature_path }}
           if-no-files-found: error
 
+  build-windows:
+    name: Build Windows x64
+    runs-on: windows-latest
+    timeout-minutes: 45
+    needs: prepare-release
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            executor/target
+            wework/src-tauri/target
+          key: ${{ runner.os }}-wework-app-x86_64-pc-windows-msvc-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wework-app-x86_64-pc-windows-msvc-
+
+      - name: Build local executor sidecar
+        shell: pwsh
+        working-directory: executor
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $env:RUSTFLAGS = '-C target-feature=+crt-static'
+          cargo build --release --locked --target x86_64-pc-windows-msvc
+          New-Item -ItemType Directory -Force ../wework/src-tauri/binaries | Out-Null
+          Copy-Item target/x86_64-pc-windows-msvc/release/wegent-executor.exe ../wework/src-tauri/binaries/wegent-executor-x86_64-pc-windows-msvc.exe
+          & ../wework/src-tauri/binaries/wegent-executor-x86_64-pc-windows-msvc.exe --version
+
+      - name: Prepare bundled Codex
+        working-directory: wework
+        env:
+          WEWORK_CODEX_TARGET: x86_64-pc-windows-msvc
+        run: pnpm run prepare:codex
+
+      - name: Build Wework app bundle
+        shell: pwsh
+        working-directory: wework
+        env:
+          GH_REPO: ${{ github.repository }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
+          VITE_API_BASE_URL: https://api.wecode.ai/api
+          VITE_SOCKET_BASE_URL: https://api.wecode.ai
+          VITE_WEGENT_BACKEND_URL: http://localhost:8000
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $env:TAURI_SIGNING_PRIVATE_KEY) { throw 'Missing GitHub secret: TAURI_SIGNING_PRIVATE_KEY' }
+          if (-not $env:TAURI_UPDATER_PUBKEY) { throw 'Missing GitHub secret: TAURI_UPDATER_PUBKEY' }
+
+          $package = Get-Content package.json -Raw | ConvertFrom-Json
+          $package.version = $env:RELEASE_VERSION
+          $package | ConvertTo-Json -Depth 100 | Set-Content package.json -Encoding utf8
+
+          $configPath = Join-Path $env:RUNNER_TEMP 'tauri-windows-ci.json'
+          @{
+            version = $env:RELEASE_VERSION
+            bundle = @{ createUpdaterArtifacts = $true }
+            plugins = @{
+              updater = @{
+                endpoints = @("https://github.com/$env:GH_REPO/releases/latest/download/latest.json")
+                pubkey = $env:TAURI_UPDATER_PUBKEY
+              }
+            }
+          } | ConvertTo-Json -Depth 10 | Set-Content $configPath -Encoding utf8
+
+          pnpm exec tauri build --target x86_64-pc-windows-msvc --bundles nsis --config $configPath
+
+      - name: Verify and collect release assets
+        id: package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundleDir = 'wework/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis'
+          $installer = Get-ChildItem $bundleDir -Filter '*.exe' | Sort-Object LastWriteTime | Select-Object -Last 1
+          if (-not $installer) { throw 'No Windows NSIS installer found' }
+          $signature = Get-Item "$($installer.FullName).sig" -ErrorAction Stop
+
+          $artifactDir = Join-Path $env:RUNNER_TEMP 'wework-windows-x64'
+          New-Item -ItemType Directory -Force $artifactDir | Out-Null
+          $installerPath = Join-Path $artifactDir 'WeWork_${{ needs.prepare-release.outputs.version }}_windows_x64-setup.exe'
+          $signaturePath = "$installerPath.sig"
+          Copy-Item $installer.FullName $installerPath
+          Copy-Item $signature.FullName $signaturePath
+          Get-FileHash $installerPath -Algorithm SHA256
+
+          "installer_path=$installerPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "signature_path=$signaturePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Create release app token
+        if: needs.prepare-release.outputs.publish_release == 'true'
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Upload Windows assets to GitHub Release
+        if: needs.prepare-release.outputs.publish_release == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+        run: gh release upload $env:RELEASE_TAG '${{ steps.package.outputs.installer_path }}' '${{ steps.package.outputs.signature_path }}' --clobber
+
+      - name: Upload Windows test artifacts
+        if: needs.prepare-release.outputs.publish_release != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-${{ needs.prepare-release.outputs.version }}-windows-x64
+          path: |
+            ${{ steps.package.outputs.installer_path }}
+            ${{ steps.package.outputs.signature_path }}
+          if-no-files-found: error
+
   publish-updater-manifest:
     name: Publish updater manifest
     runs-on: ubuntu-latest
@@ -563,6 +710,7 @@ jobs:
     needs:
       - prepare-release
       - build-macos
+      - build-windows
 
     steps:
       - name: Create release app token
@@ -586,10 +734,14 @@ jobs:
           gh release download "$RELEASE_TAG" \
             --pattern "WeWork_${RELEASE_VERSION}_macos_*.app.tar.gz.sig" \
             --dir "$work_dir"
+          gh release download "$RELEASE_TAG" \
+            --pattern "WeWork_${RELEASE_VERSION}_windows_x64-setup.exe.sig" \
+            --dir "$work_dir"
 
           arm64_sig_path="$work_dir/WeWork_${RELEASE_VERSION}_macos_arm64.app.tar.gz.sig"
           x64_sig_path="$work_dir/WeWork_${RELEASE_VERSION}_macos_x64.app.tar.gz.sig"
-          if [ ! -f "$arm64_sig_path" ] || [ ! -f "$x64_sig_path" ]; then
+          windows_x64_sig_path="$work_dir/WeWork_${RELEASE_VERSION}_windows_x64-setup.exe.sig"
+          if [ ! -f "$arm64_sig_path" ] || [ ! -f "$x64_sig_path" ] || [ ! -f "$windows_x64_sig_path" ]; then
             echo "Missing updater signatures for latest.json" >&2
             ls -la "$work_dir" >&2
             exit 1
@@ -600,10 +752,13 @@ jobs:
           RELEASE_NOTES="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
           export ARM64_URL="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/WeWork_${RELEASE_VERSION}_macos_arm64.app.tar.gz"
           export X64_URL="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/WeWork_${RELEASE_VERSION}_macos_x64.app.tar.gz"
+          export WINDOWS_X64_URL="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/WeWork_${RELEASE_VERSION}_windows_x64-setup.exe"
           export ARM64_SIGNATURE
           export X64_SIGNATURE
+          export WINDOWS_X64_SIGNATURE
           ARM64_SIGNATURE="$(cat "$arm64_sig_path")"
           X64_SIGNATURE="$(cat "$x64_sig_path")"
+          WINDOWS_X64_SIGNATURE="$(cat "$windows_x64_sig_path")"
           python3 - <<'PY'
           import json
           import os
@@ -621,6 +776,10 @@ jobs:
                   "darwin-x86_64": {
                       "signature": os.environ["X64_SIGNATURE"],
                       "url": os.environ["X64_URL"],
+                  },
+                  "windows-x86_64": {
+                      "signature": os.environ["WINDOWS_X64_SIGNATURE"],
+                      "url": os.environ["WINDOWS_X64_URL"],
                   },
               },
           }
@@ -645,6 +804,7 @@ jobs:
     needs:
       - prepare-release
       - build-macos
+      - build-windows
       - publish-updater-manifest
 
     steps:


### PR DESCRIPTION
## What changed

- add a Windows x64 Tauri/NSIS build to the Wework release workflow
- upload the Windows installer and updater signature to GitHub Releases
- include Windows x64 in the Tauri updater manifest
- shorten the macOS DMG filename to share the updater archive naming stem

## Why

Wework releases currently publish only macOS artifacts. This adds the Windows build to the same release flow and makes the macOS download names consistent.

## Validation

- Prettier check for the workflow
- git diff --check
- repository pre-push quality checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows x64 builds with NSIS installers to the release process.
  * Windows installers and signatures are now included in published releases and updater manifests.
  * Release notes now include Windows distribution information.

* **Bug Fixes**
  * Standardized macOS DMG filenames for released builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->