### PR TITLE
chore(wework): upgrade Codex CLI to 0.144.4

### DIFF
--- a/wework/codex-binaries.lock.json
+++ b/wework/codex-binaries.lock.json
@@ -1,40 +1,40 @@
 {
-  "codexVersion": "0.144.2",
+  "codexVersion": "0.144.4",
   "registry": "https://registry.npmjs.org",
   "targets": {
     "aarch64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.144.2-darwin-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-arm64.tgz",
-      "integrity": "sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==",
+      "version": "0.144.4-darwin-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.4-darwin-arm64.tgz",
+      "integrity": "sha512-6J3g498cM2oA7vYIJhpuGJlnIi/M5JdYmjB5BZ1Of5HQ0ziIlplFSvH801oVy9J5TQFp642ODzOu/ZEokDUXsg==",
       "binaryPath": "vendor/aarch64-apple-darwin/bin/codex"
     },
     "x86_64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.144.2-darwin-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-x64.tgz",
-      "integrity": "sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==",
+      "version": "0.144.4-darwin-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.4-darwin-x64.tgz",
+      "integrity": "sha512-k1HC8gdbAy+VmMbekYkhM+r+QE2Xfgd67n1VSp94tjz7aXVKoalHcDkdKNM/uUQ8o2tvbiwhHSUftJF8Sm9/Lw==",
       "binaryPath": "vendor/x86_64-apple-darwin/bin/codex"
     },
     "x86_64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.144.2-linux-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-x64.tgz",
-      "integrity": "sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==",
+      "version": "0.144.4-linux-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.4-linux-x64.tgz",
+      "integrity": "sha512-2jxrmV6+/7eBNdg5uhhmOEPFu2o28eYY/ClLzWhSBHH8uo3f2KA1z9JQcVtwlbToW03nEPlEzYNYfCF1UBqsVQ==",
       "binaryPath": "vendor/x86_64-unknown-linux-musl/bin/codex"
     },
     "aarch64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.144.2-linux-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-arm64.tgz",
-      "integrity": "sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==",
+      "version": "0.144.4-linux-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.4-linux-arm64.tgz",
+      "integrity": "sha512-OlKx65579OwIzech9Tt3OUH9+hFZfFrCBP1hL2MudnMIoNr1+cFZjB5YIj5MWMRoBD+K5W3wdBIpQSH855b5Sg==",
       "binaryPath": "vendor/aarch64-unknown-linux-musl/bin/codex"
     },
     "x86_64-pc-windows-msvc": {
       "package": "@openai/codex",
-      "version": "0.144.2-win32-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-x64.tgz",
-      "integrity": "sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==",
+      "version": "0.144.4-win32-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.4-win32-x64.tgz",
+      "integrity": "sha512-iL1ky0ERgdQJOKzom/Ms1fhpwkSmpsA9eVrzAqURFlYGS8z7JqwEgm33+nLGCsY7y25d8Xs/LJ91Oiqz3yXcUg==",
       "binaryPath": "vendor/x86_64-pc-windows-msvc/bin/codex.exe"
     }
   }


### PR DESCRIPTION
## Summary

- Upgrade the bundled Wework Codex CLI lockfile from 0.144.2 to 0.144.4.
- Update all packaged target tarball versions and SHA-512 integrities for macOS, Linux, and Windows.

## Compatibility notes

- Latest upstream release verified as `openai/codex` `rust-v0.144.4`.
- The bundled darwin-arm64 binary reports `codex-cli 0.144.4`.
- A real 0.144.4 `app-server` smoke probe succeeded with Wework/executor-facing methods:
  - `initialize`
  - `config/read`
  - `model/list`
  - `skills/list`
  - `plugin/list`
  - `plugin/installed`
  - `app/list`
  - `thread/start`

## Local validation

- `jq empty wework/codex-binaries.lock.json`
- `node --check wework/scripts/prepare-codex-binary.mjs`
- `pnpm --filter wework exec prettier --check codex-binaries.lock.json`
- `wework/src-tauri/binaries/codex/aarch64-apple-darwin/vendor/aarch64-apple-darwin/bin/codex --version`
- `pnpm --filter wework test` equivalent direct Vitest run: 157 files, 1570 tests passed
- `pnpm --filter wework exec tsc -b` equivalent direct TypeScript build
- `pnpm --filter wework exec vite build` equivalent direct production build
- `cargo test --manifest-path executor/Cargo.toml --test codex_app_server_contract`
- `cargo test --manifest-path executor/Cargo.toml --test local_app_ipc_contract app_ipc_routes_codex_app_server_request`
- `cargo test --manifest-path wework/src-tauri/Cargo.toml local_executor`

## Real Tauri verification

- `pnpm --filter wework ai:verify start` succeeded in an isolated Tauri session.
- The isolated app reached WebView ready at `http://localhost:1420/`.
- Tauri and Vite started successfully, and the isolated local executor started with `ai-verify-*` device ids.
- The local executor app IPC path handled `runtime.keybindings.get` successfully.
- Follow-up `ai:verify` WebView action commands (`snapshot`, `wait-for`, `text`) timed out in this local run, so no personal Wework window, external browser, Chrome runtime, or mocked substitute was used.

## CI validation

- Repository Policy Check passed.
- Lint passed, including Wework ESLint & TypeScript.
- Wework E2E passed.
- Wework Desktop E2E passed.
- E2E shards, Executor E2E, and Merge Test Reports passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Codex binary to version 0.144.4 across supported platforms.
  * Refreshed associated download metadata and integrity verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->