### PR TITLE
fix(wework): release stuck terminal selection

### DIFF
--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -17,6 +17,7 @@ import {
 import { appendRuntimeTerminalContext } from '@/lib/runtime-terminal-context'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
 import { createXtermWebLinksAddon } from './xtermLinks'
+import { installXtermSelectionGuard } from './xtermSelectionGuard'
 
 interface EmbeddedLocalTerminalProps {
   sessionId: string
@@ -98,6 +99,7 @@ export function EmbeddedLocalTerminal({
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(webLinksAddon)
     terminal.open(container)
+    const selectionGuard = installXtermSelectionGuard({ container, terminal })
     inputFallback = installXtermInputFallback({
       terminal,
       writeData: data => {
@@ -178,6 +180,7 @@ export function EmbeddedLocalTerminal({
       resizeObserver.disconnect()
       dataDisposable.dispose()
       titleDisposable.dispose()
+      selectionGuard.dispose()
       inputFallback.dispose()
       unlisteners.forEach(unlisten => unlisten())
       terminal.dispose()

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -12,6 +12,7 @@ import {
 import { appendRuntimeTerminalContext } from '@/lib/runtime-terminal-context'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
+import { installXtermSelectionGuard } from './xtermSelectionGuard'
 
 interface RemoteTerminalProps {
   sessionId: string
@@ -121,6 +122,7 @@ export function RemoteTerminal({
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(webLinksAddon)
     terminal.open(container)
+    const selectionGuard = installXtermSelectionGuard({ container, terminal })
     inputFallback = installXtermInputFallback({
       terminal,
       writeData: data => {
@@ -187,6 +189,7 @@ export function RemoteTerminal({
       resizeObserver.disconnect()
       dataDisposable.dispose()
       titleDisposable.dispose()
+      selectionGuard.dispose()
       inputFallback.dispose()
       unsubscribeOutput()
       unsubscribeExit()

--- a/wework/src/components/layout/workspace-panels/xtermSelectionGuard.test.ts
+++ b/wework/src/components/layout/workspace-panels/xtermSelectionGuard.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { installXtermSelectionGuard } from './xtermSelectionGuard'
+
+function dispatchMouseEvent(target: EventTarget, type: string, init: MouseEventInit = {}) {
+  target.dispatchEvent(
+    new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    })
+  )
+}
+
+describe('installXtermSelectionGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('sends mouseup to terminal when the button was released outside the WebView', () => {
+    const container = document.createElement('div')
+    const clearSelection = vi.fn()
+    const mouseUpListener = vi.fn()
+    const guard = installXtermSelectionGuard({
+      container,
+      terminal: { clearSelection },
+    })
+    container.addEventListener('mouseup', mouseUpListener)
+
+    dispatchMouseEvent(container, 'mousedown', { button: 0, buttons: 1 })
+    dispatchMouseEvent(window, 'mousemove', { buttons: 0, clientX: 12, clientY: 18 })
+
+    expect(mouseUpListener).toHaveBeenCalledTimes(1)
+    expect(mouseUpListener.mock.calls[0][0]).toMatchObject({
+      button: 0,
+      buttons: 0,
+      clientX: 12,
+      clientY: 18,
+    })
+    expect(clearSelection).not.toHaveBeenCalled()
+
+    guard.dispose()
+  })
+
+  test('does not interfere with active drag selection', () => {
+    const container = document.createElement('div')
+    const clearSelection = vi.fn()
+    const mouseUpListener = vi.fn()
+    const guard = installXtermSelectionGuard({
+      container,
+      terminal: { clearSelection },
+    })
+    container.addEventListener('mouseup', mouseUpListener)
+
+    dispatchMouseEvent(container, 'mousedown', { button: 0, buttons: 1 })
+    dispatchMouseEvent(window, 'mousemove', { buttons: 1 })
+
+    expect(mouseUpListener).not.toHaveBeenCalled()
+    expect(clearSelection).not.toHaveBeenCalled()
+
+    guard.dispose()
+  })
+
+  test('clears abandoned drag selection when the window loses focus', () => {
+    const container = document.createElement('div')
+    const clearSelection = vi.fn()
+    const guard = installXtermSelectionGuard({
+      container,
+      terminal: { clearSelection },
+    })
+
+    dispatchMouseEvent(container, 'mousedown', { button: 0, buttons: 1 })
+    window.dispatchEvent(new Event('blur'))
+
+    expect(clearSelection).toHaveBeenCalledTimes(1)
+
+    guard.dispose()
+  })
+
+  test('detaches listeners on dispose', () => {
+    const container = document.createElement('div')
+    const clearSelection = vi.fn()
+    const mouseUpListener = vi.fn()
+    const guard = installXtermSelectionGuard({
+      container,
+      terminal: { clearSelection },
+    })
+    container.addEventListener('mouseup', mouseUpListener)
+
+    dispatchMouseEvent(container, 'mousedown', { button: 0, buttons: 1 })
+    guard.dispose()
+    dispatchMouseEvent(window, 'mousemove', { buttons: 0 })
+    window.dispatchEvent(new Event('blur'))
+
+    expect(mouseUpListener).not.toHaveBeenCalled()
+    expect(clearSelection).not.toHaveBeenCalled()
+  })
+})

--- a/wework/src/components/layout/workspace-panels/xtermSelectionGuard.ts
+++ b/wework/src/components/layout/workspace-panels/xtermSelectionGuard.ts
@@ -1,0 +1,77 @@
+import type { Terminal } from '@xterm/xterm'
+
+type XtermSelectionGuardOptions = {
+  container: HTMLElement
+  terminal: Pick<Terminal, 'clearSelection'>
+}
+
+export type XtermSelectionGuardController = {
+  dispose: () => void
+}
+
+export function installXtermSelectionGuard({
+  container,
+  terminal,
+}: XtermSelectionGuardOptions): XtermSelectionGuardController {
+  let mouseDownInTerminal = false
+
+  const endDrag = () => {
+    mouseDownInTerminal = false
+  }
+
+  const dispatchTerminalMouseUp = (event: MouseEvent) => {
+    container.dispatchEvent(
+      new MouseEvent('mouseup', {
+        bubbles: true,
+        cancelable: true,
+        button: event.button,
+        buttons: 0,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+      })
+    )
+  }
+
+  const handleMouseDown = (event: MouseEvent) => {
+    if (event.button !== 0) return
+    mouseDownInTerminal = true
+  }
+
+  const handleMouseMove = (event: MouseEvent) => {
+    if (!mouseDownInTerminal || event.buttons !== 0) return
+
+    endDrag()
+    dispatchTerminalMouseUp(event)
+  }
+
+  const clearAbandonedSelection = () => {
+    if (!mouseDownInTerminal) return
+
+    endDrag()
+    terminal.clearSelection()
+  }
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      clearAbandonedSelection()
+    }
+  }
+
+  container.addEventListener('mousedown', handleMouseDown, true)
+  window.addEventListener('mouseup', endDrag, true)
+  window.addEventListener('mousemove', handleMouseMove, true)
+  window.addEventListener('blur', clearAbandonedSelection)
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+
+  return {
+    dispose: () => {
+      container.removeEventListener('mousedown', handleMouseDown, true)
+      window.removeEventListener('mouseup', endDrag, true)
+      window.removeEventListener('mousemove', handleMouseMove, true)
+      window.removeEventListener('blur', clearAbandonedSelection)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Add an xterm selection guard that ends stale drag-selection state when the mouse button has already been released outside the terminal/WebView.
- Clear abandoned terminal selection on window blur or page hide.
- Wire the guard into both embedded local and remote terminal components.

## Root Cause
The xterm selection lifecycle can remain active if a drag selection starts inside the terminal but the WebView does not receive the matching mouseup event. Subsequent mouse movement is then interpreted as continued selection.

## Validation
- pnpm --filter wework test -- xtermSelectionGuard.test.ts RemoteTerminal.test.tsx
- pnpm --filter wework exec prettier --check src/components/layout/workspace-panels/xtermSelectionGuard.ts src/components/layout/workspace-panels/xtermSelectionGuard.test.ts src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx src/components/layout/workspace-panels/RemoteTerminal.tsx
- pnpm --filter wework exec eslint src/components/layout/workspace-panels/xtermSelectionGuard.ts src/components/layout/workspace-panels/xtermSelectionGuard.test.ts src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx src/components/layout/workspace-panels/RemoteTerminal.tsx
- pnpm --filter wework ai:verify start/snapshot/stop
- Pre-push Wework checks: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal text selection when the pointer leaves the terminal area.
  - Prevented selections from remaining stuck when the window loses focus or the page is hidden.
  - Ensured terminal selection handling is properly cleaned up when terminals are closed.

- **Tests**
  - Added coverage for pointer release, active dragging, focus loss, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->