### PR TITLE
fix(wework): hide browser while settings are open

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4070,6 +4070,20 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workspace-browser-frame')).toHaveClass('bg-background')
   })
 
+  test('deactivates the right workspace browser while settings are open', async () => {
+    renderWorkspacePanelLayout()
+
+    await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
+    await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
+    expect(screen.getByTestId('workspace-browser-panel')).not.toHaveClass('hidden')
+
+    await userEvent.click(screen.getByTestId('settings-button'))
+    await userEvent.click(screen.getByTestId('settings-menu-button'))
+
+    expect(screen.getByTestId('wework-settings-page')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-browser-panel')).toHaveClass('hidden')
+  })
+
   test('preserves the browser tab after closing and reopening the right workspace area', async () => {
     renderWorkspacePanelLayout()
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -585,6 +585,7 @@ export function DesktopWorkbenchLayout() {
       )}
       <div style={{ display: settingsOpen ? 'none' : 'contents' }} aria-hidden={settingsOpen}>
         <DesktopWorkbenchMain
+          visible={!settingsOpen}
           sidebarCollapsed={effectiveSidebarCollapsed}
           sidebarResizing={sidebarResizing}
           onSidebarCollapsedChange={updateSidebarCollapsed}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -216,6 +216,7 @@ function createBottomPanelWorkspaceKey({
 
 interface DesktopWorkbenchMainProps {
   activePane: WorkbenchPaneIdentity
+  visible?: boolean
   sidebarCollapsed: boolean
   sidebarResizing?: boolean
   onSidebarCollapsedChange: (collapsed: boolean) => void
@@ -299,6 +300,7 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
       renderPane={pane => (
         <DesktopWorkbenchPane
           pane={pane}
+          workbenchVisible={props.visible ?? true}
           sidebarCollapsed={props.sidebarCollapsed}
           sidebarResizing={props.sidebarResizing ?? false}
           onSidebarCollapsedChange={props.onSidebarCollapsedChange}
@@ -325,6 +327,7 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
 
 const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   pane,
+  workbenchVisible,
   sidebarCollapsed,
   sidebarResizing = false,
   onSidebarCollapsedChange,
@@ -332,6 +335,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   onTerminalPaneUnpinned,
 }: {
   pane: WorkbenchPaneIdentity
+  workbenchVisible: boolean
   sidebarCollapsed: boolean
   sidebarResizing?: boolean
   onSidebarCollapsedChange: (collapsed: boolean) => void
@@ -1766,7 +1770,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         >
           {shouldRenderRightPanel && (
             <RightWorkspacePanel
-              visible={paneActive && rightPanelOpen}
+              visible={workbenchVisible && paneActive && rightPanelOpen}
               activeView={rightPanelView}
               openTabs={effectiveRightPanelTabs}
               currentProject={workspaceProject}


### PR DESCRIPTION
## What changed

- propagate the desktop workbench visibility state to cached workbench panes
- deactivate the embedded browser while the settings page is open
- add regression coverage for opening settings with the right-side browser active

## Why

The settings page hid the workbench DOM with CSS, but the right-side browser is a native Tauri child WebView. Native child WebViews are not hidden by the parent DOM's `display: none`, so the webpage remained visible over settings.

## User impact

Opening Wework settings now hides the right-side webpage. Returning to the workbench restores the browser panel and its existing page state.

## Validation

- Prettier and ESLint passed
- TypeScript passed
- Wework unit tests passed (161 files, 1606 tests)
- isolated real-Tauri verification: opened GitHub in the right browser, opened settings, then returned and confirmed the browser state recovered
- pre-push quality checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The workspace browser now hides correctly when the Settings page is open.
  * Prevented the right workspace panel from remaining visible behind Settings.
* **Tests**
  * Added coverage confirming the workspace browser is deactivated while Settings is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->