### PR TITLE
fix(backend): support custom LLM proxy headers

### DIFF
--- a/backend/app/services/llm_proxy_service.py
+++ b/backend/app/services/llm_proxy_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
 from app.models.user import User
-from app.services.chat.config.model_resolver import _extract_model_config
+from app.services.chat.config.model_resolver import extract_and_process_model_config
 from app.services.group_permission import get_user_groups
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,80 @@ logger = logging.getLogger(__name__)
 MODEL_TYPE_HEADER = "x-wegent-model-type"
 MODEL_NAMESPACE_HEADER = "x-wegent-model-namespace"
 MODEL_USER_ID_HEADER = "x-wegent-model-user-id"
+UPSTREAM_HEADER_PREFIX = "x-wegent-upstream-header-"
 SUPPORTED_MODEL_TYPES = {"public", "user", "group"}
+PROTECTED_UPSTREAM_HEADERS = {
+    "accept",
+    "authorization",
+    "connection",
+    "content-length",
+    "content-type",
+    "cookie",
+    "host",
+    "proxy-authorization",
+    "set-cookie",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    MODEL_TYPE_HEADER,
+    MODEL_NAMESPACE_HEADER,
+    MODEL_USER_ID_HEADER,
+}
+PROTECTED_UPSTREAM_HEADER_MARKERS = (
+    "api-key",
+    "apikey",
+    "credential",
+    "secret",
+    "token",
+)
+
+
+def _is_protected_upstream_header(name: str) -> bool:
+    normalized = name.strip().lower().replace("_", "-")
+    parts = normalized.split("-")
+    return (
+        normalized in PROTECTED_UPSTREAM_HEADERS
+        or "auth" in parts
+        or "authentication" in parts
+        or any(marker in normalized for marker in PROTECTED_UPSTREAM_HEADER_MARKERS)
+    )
+
+
+def _extract_custom_upstream_headers(request: Request) -> dict[str, str]:
+    custom_headers: dict[str, str] = {}
+    for header_name, value in request.headers.items():
+        if not header_name.lower().startswith(UPSTREAM_HEADER_PREFIX):
+            continue
+        target_name = header_name[len(UPSTREAM_HEADER_PREFIX) :].strip()
+        if not target_name or target_name.startswith("-"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid custom upstream header name",
+            )
+        if _is_protected_upstream_header(target_name):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Custom upstream header is protected: {target_name}",
+            )
+        custom_headers[target_name] = value
+    return custom_headers
+
+
+def _merge_headers_case_insensitive(
+    *header_sources: dict[str, str],
+) -> dict[str, str]:
+    merged: dict[str, str] = {}
+    names_by_lowercase: dict[str, str] = {}
+    for headers in header_sources:
+        for name, value in headers.items():
+            normalized = name.lower()
+            previous_name = names_by_lowercase.get(normalized)
+            if previous_name is not None:
+                merged.pop(previous_name, None)
+            merged[name] = value
+            names_by_lowercase[normalized] = name
+    return merged
 
 
 def _required_header(request: Request, name: str) -> str:
@@ -120,7 +193,11 @@ def resolve_llm_proxy_model_config(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Cloud model not found",
         )
-    return _extract_model_config(kind.json.get("spec", {}))
+    return extract_and_process_model_config(
+        model_spec=kind.json.get("spec", {}),
+        user_id=current_user.id,
+        user_name=current_user.user_name or "",
+    )
 
 
 def _parse_request_body(body_bytes: bytes) -> tuple[dict[str, Any], str]:
@@ -168,7 +245,7 @@ async def proxy_llm_responses(
     provider_api_key = str(model_config.get("api_key") or "").strip()
     provider_model_id = str(model_config.get("model_id") or "").strip()
     default_headers = model_config.get("default_headers") or {}
-    if not provider_base_url or not provider_api_key or not provider_model_id:
+    if not provider_base_url or not provider_model_id:
         logger.error(
             "LLM proxy model configuration incomplete for user %s model %s",
             current_user.id,
@@ -183,18 +260,29 @@ async def proxy_llm_responses(
     body_bytes = json.dumps(body_json).encode("utf-8")
     upstream_url = f"{provider_base_url.rstrip('/')}/responses"
 
-    provider_headers = (
+    configured_headers = (
         {str(key): str(value) for key, value in default_headers.items()}
         if isinstance(default_headers, dict)
         else {}
     )
-    provider_headers["Authorization"] = f"Bearer {provider_api_key}"
+    custom_headers = _extract_custom_upstream_headers(request)
+    provider_headers = _merge_headers_case_insensitive(
+        configured_headers,
+        custom_headers,
+    )
+    protocol_headers: dict[str, str] = {}
+    if provider_api_key:
+        protocol_headers["Authorization"] = f"Bearer {provider_api_key}"
     content_type = request.headers.get("content-type")
     if content_type:
-        provider_headers["Content-Type"] = content_type
+        protocol_headers["Content-Type"] = content_type
     accept = request.headers.get("accept")
     if accept:
-        provider_headers["Accept"] = accept
+        protocol_headers["Accept"] = accept
+    provider_headers = _merge_headers_case_insensitive(
+        provider_headers,
+        protocol_headers,
+    )
 
     client = httpx.AsyncClient(timeout=httpx.Timeout(600.0))
     try:

--- a/backend/tests/services/test_llm_proxy_service.py
+++ b/backend/tests/services/test_llm_proxy_service.py
@@ -23,7 +23,19 @@ def _model_kind(
     name: str = "deepseek-v4-flash",
     namespace: str = "default",
     model_id: str = "gpt-4-turbo",
+    api_key: str = "sk-test-key",
+    default_headers: dict[str, str] | None = None,
 ) -> Kind:
+    model_config: dict[str, object] = {
+        "env": {
+            "model_id": model_id,
+            "base_url": "https://api.example.com/v1",
+            "api_key": api_key,
+        }
+    }
+    if default_headers is not None:
+        model_config["DEFAULT_HEADERS"] = default_headers
+
     return Kind(
         user_id=user_id,
         kind="Model",
@@ -35,13 +47,7 @@ def _model_kind(
             "metadata": {"name": name, "namespace": namespace},
             "spec": {
                 "provider": "openai",
-                "modelConfig": {
-                    "env": {
-                        "model_id": model_id,
-                        "base_url": "https://api.example.com/v1",
-                        "api_key": "sk-test-key",
-                    }
-                },
+                "modelConfig": model_config,
                 "protocol": "openai-responses",
             },
         },
@@ -51,7 +57,10 @@ def _model_kind(
 
 @pytest.fixture
 def test_model_kind(test_db, test_user: User) -> Kind:
-    model = _model_kind(test_user.id)
+    model = _model_kind(
+        test_user.id,
+        default_headers={"user": "${task_data.user.name}"},
+    )
     test_db.add(model)
     test_db.commit()
     test_db.refresh(model)
@@ -106,6 +115,36 @@ def test_resolve_llm_proxy_model_config_rejects_spoofed_personal_owner(
     assert exc_info.value.status_code == 403
 
 
+def test_resolve_llm_proxy_model_config_processes_custom_header_placeholders(
+    test_db, test_user: User
+):
+    model = _model_kind(
+        test_user.id,
+        name="custom-header-model",
+        default_headers={
+            "user": "${task_data.user.name}",
+            "x-custom-static": "static-value",
+            "wegent-agent-name": "${task_data.team.name}",
+        },
+    )
+    test_db.add(model)
+    test_db.commit()
+
+    config = resolve_llm_proxy_model_config(
+        test_db,
+        test_user,
+        model_name=model.name,
+        model_type="user",
+        namespace="default",
+        resource_user_id=test_user.id,
+    )
+
+    assert config["default_headers"] == {
+        "user": test_user.user_name,
+        "x-custom-static": "static-value",
+    }
+
+
 async def test_proxy_llm_responses_forwards_to_provider(
     test_db, test_user: User, test_model_kind: Kind
 ):
@@ -136,7 +175,8 @@ async def test_proxy_llm_responses_forwards_to_provider(
     client_mock.aclose = AsyncMock()
 
     with patch(
-        "app.services.llm_proxy_service.httpx.AsyncClient", return_value=client_mock
+        "app.services.llm_proxy_service.httpx.AsyncClient",
+        return_value=client_mock,
     ):
         response = await proxy_llm_responses(request_mock, test_db, test_user)
 
@@ -150,10 +190,102 @@ async def test_proxy_llm_responses_forwards_to_provider(
     assert sent_request.headers["Authorization"] == "Bearer sk-test-key"
     assert sent_request.headers["Content-Type"] == "application/json"
     assert sent_request.headers["Accept"] == "text/event-stream"
+    assert sent_request.headers["user"] == test_user.user_name
     assert b'"model": "gpt-4-turbo"' in sent_request.content
     assert b'"input": "hello"' in sent_request.content
     assert "x-wegent-model-type" not in sent_request.headers
     client_mock.aclose.assert_awaited_once()
+
+
+async def test_proxy_llm_responses_omits_authorization_when_api_key_is_empty(
+    test_db, test_user: User
+):
+    model = _model_kind(
+        test_user.id,
+        name="custom-header-auth-model",
+        api_key="",
+        default_headers={
+            "wecode-user": "${task_data.user.name}",
+            "Wecode-Executor": "chat",
+            "wecode-action": "wegent",
+        },
+    )
+    test_db.add(model)
+    test_db.commit()
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.body = AsyncMock(
+        return_value=b'{"model":"custom-header-auth-model","input":"hello"}'
+    )
+    request_mock.headers = Headers(
+        {
+            "content-type": "application/json",
+            "accept": "text/event-stream",
+            "x-wegent-model-type": "user",
+            "x-wegent-model-namespace": "default",
+            "x-wegent-model-user-id": str(test_user.id),
+            "authorization": "Bearer wegent-login-token",
+            "x-wegent-upstream-header-wecode-executor": "codex",
+            "x-wegent-upstream-header-wecode-action": "custom-action",
+        }
+    )
+
+    upstream_response_mock = MagicMock()
+    upstream_response_mock.status_code = 200
+    upstream_response_mock.headers = {"content-type": "text/event-stream"}
+
+    async def fake_aiter_raw():
+        yield b"data: ok\n\n"
+
+    upstream_response_mock.aiter_raw = fake_aiter_raw
+    client_mock = AsyncMock()
+    client_mock.send = AsyncMock(return_value=upstream_response_mock)
+    client_mock.aclose = AsyncMock()
+
+    with patch(
+        "app.services.llm_proxy_service.httpx.AsyncClient",
+        return_value=client_mock,
+    ):
+        response = await proxy_llm_responses(request_mock, test_db, test_user)
+
+    body = b"".join([chunk async for chunk in response.body_iterator])
+    sent_request = client_mock.send.call_args[0][0]
+
+    assert response.status_code == 200
+    assert body == b"data: ok\n\n"
+    assert "Authorization" not in sent_request.headers
+    assert sent_request.headers["wecode-user"] == test_user.user_name
+    assert sent_request.headers["wecode-executor"] == "codex"
+    assert sent_request.headers["wecode-action"] == "custom-action"
+    assert (
+        sum(name == "wecode-executor" for name, _ in sent_request.headers.multi_items())
+        == 1
+    )
+    client_mock.aclose.assert_awaited_once()
+
+
+async def test_proxy_llm_responses_rejects_protected_custom_upstream_header(
+    test_db, test_user: User, test_model_kind: Kind
+):
+    request_mock = MagicMock(spec=Request)
+    request_mock.body = AsyncMock(
+        return_value=b'{"model":"deepseek-v4-flash","input":"hello"}'
+    )
+    request_mock.headers = Headers(
+        {
+            "content-type": "application/json",
+            "x-wegent-model-type": "user",
+            "x-wegent-model-namespace": "default",
+            "x-wegent-model-user-id": str(test_user.id),
+            "x-wegent-upstream-header-authorization": "Bearer caller-token",
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await proxy_llm_responses(request_mock, test_db, test_user)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Custom upstream header is protected: authorization"
 
 
 async def test_proxy_llm_responses_requires_model_identity_headers(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom upstream headers on LLM proxy requests.
  * Custom header values can include dynamic user and team information.
  * Models without an API key can now be used when other required connection details are available.

* **Bug Fixes**
  * Protected authentication headers are rejected to prevent unauthorized overrides.
  * Authorization is omitted when no API key is configured.
  * Header handling is now case-insensitive and preserves supported request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->