### PR TITLE
fix(wework): eliminate compiler warnings

### DIFF
--- a/wework/src-tauri/src/embedded_browser.rs
+++ b/wework/src-tauri/src/embedded_browser.rs
@@ -5,7 +5,7 @@ use std::{
     env,
     io::{Read, Write},
     net::{TcpListener, TcpStream},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Condvar, Mutex,
@@ -265,7 +265,7 @@ fn browser_data_directory(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 #[cfg(desktop)]
 fn browser_download_destination(
     app: &tauri::AppHandle,
-    suggested_destination: &PathBuf,
+    suggested_destination: &Path,
 ) -> Result<(PathBuf, String, bool), String> {
     let preferences = crate::read_app_preferences_impl(app);
     let suggested_name = suggested_destination
@@ -424,7 +424,7 @@ fn eval_json(
     let result = receiver
         .recv_timeout(Duration::from_millis(timeout_ms))
         .map_err(|_| "Timed out waiting for embedded browser evaluation".to_string())?;
-    serde_json::from_str(&result).or_else(|_| Ok(Value::String(result)))
+    serde_json::from_str(&result).or(Ok(Value::String(result)))
 }
 
 async fn eval_json_nonblocking(
@@ -449,7 +449,7 @@ async fn eval_json_nonblocking(
     })
     .await
     .map_err(|error| format!("Failed to join embedded browser evaluation task: {error}"))??;
-    serde_json::from_str(&result).or_else(|_| Ok(Value::String(result)))
+    serde_json::from_str(&result).or(Ok(Value::String(result)))
 }
 
 fn json_string(value: &str) -> String {

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -92,13 +92,13 @@ async fn pick_workspace_paths(
             ));
         })
         .map_err(|error| format!("Failed to open the workspace picker: {error}"))?;
-        return tauri::async_runtime::spawn_blocking(move || {
+        tauri::async_runtime::spawn_blocking(move || {
             receiver
                 .recv()
                 .map_err(|_| "Workspace picker closed unexpectedly".to_string())?
         })
         .await
-        .map_err(|error| format!("Failed to join workspace picker task: {error}"))?;
+        .map_err(|error| format!("Failed to join workspace picker task: {error}"))?
     }
 
     #[cfg(not(all(desktop, target_os = "macos")))]
@@ -280,7 +280,7 @@ fn create_log_plugin(
         .target(
             tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
                 path: log_directory.clone(),
-                file_name: Some(rust_log_file_name.into()),
+                file_name: Some(rust_log_file_name),
             })
             .filter(|metadata| {
                 !metadata
@@ -291,7 +291,7 @@ fn create_log_plugin(
         .target(
             tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
                 path: log_directory,
-                file_name: Some(webview_log_file_name.into()),
+                file_name: Some(webview_log_file_name),
             })
             .filter(|metadata| {
                 metadata
@@ -1607,7 +1607,7 @@ fn reveal_local_file(path: String) -> Result<(), String> {
         if !status.success() {
             return Err("Failed to reveal local file".to_string());
         }
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -2431,6 +2431,15 @@ struct TrayMenuLabels {
 }
 
 #[cfg(desktop)]
+struct TrayTaskSection<'a> {
+    title: &'a str,
+    empty_text: &'a str,
+    items: &'a [TrayMenuTaskItem],
+    more_items: &'a [TrayMenuTaskItem],
+    always_visible: bool,
+}
+
+#[cfg(desktop)]
 fn build_system_tray_menu<M: Manager<tauri::Wry>>(
     manager: &M,
     state: &TrayMenuStatePayload,
@@ -2441,46 +2450,54 @@ fn build_system_tray_menu<M: Manager<tauri::Wry>>(
     builder = append_tray_task_section(
         builder,
         manager,
-        labels.unread_completed,
         labels.untitled_task,
-        "",
         labels.more,
-        &state.unread,
-        &state.unread_more,
-        false,
+        TrayTaskSection {
+            title: labels.unread_completed,
+            empty_text: "",
+            items: &state.unread,
+            more_items: &state.unread_more,
+            always_visible: false,
+        },
     )?;
     builder = append_tray_task_section(
         builder,
         manager,
-        labels.running,
         labels.untitled_task,
-        "",
         labels.more,
-        &state.running,
-        &state.running_more,
-        false,
+        TrayTaskSection {
+            title: labels.running,
+            empty_text: "",
+            items: &state.running,
+            more_items: &state.running_more,
+            always_visible: false,
+        },
     )?;
     builder = append_tray_task_section(
         builder,
         manager,
-        labels.pinned,
         labels.untitled_task,
-        labels.no_pinned_tasks,
         labels.more,
-        &state.pinned,
-        &state.pinned_more,
-        true,
+        TrayTaskSection {
+            title: labels.pinned,
+            empty_text: labels.no_pinned_tasks,
+            items: &state.pinned,
+            more_items: &state.pinned_more,
+            always_visible: true,
+        },
     )?;
     builder = append_tray_task_section(
         builder,
         manager,
-        labels.tasks,
         labels.untitled_task,
-        labels.no_tasks,
         labels.more,
-        &state.recent,
-        &state.recent_more,
-        true,
+        TrayTaskSection {
+            title: labels.tasks,
+            empty_text: labels.no_tasks,
+            items: &state.recent,
+            more_items: &state.recent_more,
+            always_visible: true,
+        },
     )?;
 
     builder
@@ -2496,32 +2513,28 @@ fn build_system_tray_menu<M: Manager<tauri::Wry>>(
 fn append_tray_task_section<'m, M: Manager<tauri::Wry>>(
     mut builder: MenuBuilder<'m, tauri::Wry, M>,
     manager: &M,
-    title: &str,
     untitled_task: &str,
-    empty_text: &str,
     more: &str,
-    items: &[TrayMenuTaskItem],
-    more_items: &[TrayMenuTaskItem],
-    always_visible: bool,
+    section: TrayTaskSection<'_>,
 ) -> tauri::Result<MenuBuilder<'m, tauri::Wry, M>> {
-    if items.is_empty() && more_items.is_empty() && !always_visible {
+    if section.items.is_empty() && section.more_items.is_empty() && !section.always_visible {
         return Ok(builder);
     }
 
-    let heading = MenuItem::new(manager, title, false, None::<&str>)?;
+    let heading = MenuItem::new(manager, section.title, false, None::<&str>)?;
     builder = builder.item(&heading);
 
-    if items.is_empty() && more_items.is_empty() {
-        let empty_item = MenuItem::new(manager, empty_text, false, None::<&str>)?;
+    if section.items.is_empty() && section.more_items.is_empty() {
+        let empty_item = MenuItem::new(manager, section.empty_text, false, None::<&str>)?;
         builder = builder.item(&empty_item);
     } else {
-        for item in items {
+        for item in section.items {
             let title = normalized_menu_task_title(item, untitled_task);
             builder = builder.text(format!("{TRAY_MENU_TASK_PREFIX}{}", item.id), title);
         }
-        if !more_items.is_empty() {
+        if !section.more_items.is_empty() {
             let mut submenu = SubmenuBuilder::new(manager, more);
-            for item in more_items {
+            for item in section.more_items {
                 let title = normalized_menu_task_title(item, untitled_task);
                 submenu = submenu.text(format!("{TRAY_MENU_TASK_PREFIX}{}", item.id), title);
             }
@@ -2710,12 +2723,12 @@ fn draw_tray_text_scaled(
     buffer: &mut [u8],
     width: u32,
     height: u32,
-    x: u32,
-    y: u32,
+    origin: (u32, u32),
     text: &str,
     scale: (u32, u32),
     rgba: [u8; 4],
 ) {
+    let (x, y) = origin;
     let (numerator, denominator) = scale;
     let mut source_cursor_x = 0;
     for character in text.chars() {
@@ -2894,8 +2907,7 @@ fn draw_tray_unread_badge(
         buffer,
         width,
         height,
-        text_x,
-        text_y,
+        (text_x, text_y),
         &text,
         (3, 2),
         if cfg!(target_os = "macos") {
@@ -3196,6 +3208,7 @@ fn set_tray_menu_state(_state: TrayMenuStatePayload) -> Result<(), String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
         can_replace_wework_cli_path, executor_home_attachment_root, install_wework_cli_impl,
@@ -3660,10 +3673,8 @@ pub fn run() {
             }
 
             #[cfg(desktop)]
-            app.handle().plugin(
-                create_log_plugin(app.handle())
-                    .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?,
-            )?;
+            app.handle()
+                .plugin(create_log_plugin(app.handle()).map_err(std::io::Error::other)?)?;
 
             #[cfg(desktop)]
             println!(
@@ -3701,8 +3712,7 @@ pub fn run() {
                 maybe_show_main_window_on_launch(app.handle());
             }
             #[cfg(desktop)]
-            install_shutdown_signal_handler(app.handle().clone())
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?;
+            install_shutdown_signal_handler(app.handle().clone()).map_err(std::io::Error::other)?;
             #[cfg(desktop)]
             if let Err(error) =
                 embedded_browser::start_embedded_browser_bridge(app.handle().clone())
@@ -3789,13 +3799,11 @@ pub fn run() {
         match event {
             #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen {
-                has_visible_windows,
+                has_visible_windows: false,
                 ..
             } => {
-                if !has_visible_windows {
-                    if let Err(error) = ensure_main_window(app_handle, None) {
-                        log::warn!("Failed to reopen main window from macOS activation: {error}");
-                    }
+                if let Err(error) = ensure_main_window(app_handle, None) {
+                    log::warn!("Failed to reopen main window from macOS activation: {error}");
                 }
             }
             tauri::RunEvent::ExitRequested { api, .. } => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -29,6 +29,7 @@ import type {
   ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import { ActionMenu } from '@/components/common/ActionMenu'
 import { TextInputDialog } from '@/components/common/TextInputDialog'
 import { ProjectFolderIcon } from '@/components/projects/ProjectFolderIcon'
@@ -498,8 +499,8 @@ function useSidebarWindowFocus(): boolean {
     let disposed = false
     let unlisten: (() => void) | undefined
     let browserFallbackActive = false
-    void import('@tauri-apps/api/window')
-      .then(async ({ getCurrentWindow }) => {
+    void Promise.resolve()
+      .then(async () => {
         const currentWindow = getCurrentWindow()
         if (
           typeof currentWindow?.isFocused !== 'function' ||

--- a/wework/src/lib/cloud-authorization-window.ts
+++ b/wework/src/lib/cloud-authorization-window.ts
@@ -1,4 +1,5 @@
 import type { UnlistenFn } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import type { CloudAuthorizationHandle } from '@/features/cloud-connection/CloudConnectionContext'
 import { isHttpUrl, openExternalUrl } from './external-links'
 import { isTauriRuntime } from './runtime-environment'
@@ -69,7 +70,6 @@ function formatTauriError(payload: unknown): string {
 
 async function getAuthorizationWindowPosition(): Promise<AuthorizationWindowPosition> {
   try {
-    const { getCurrentWindow } = await import('@tauri-apps/api/window')
     const currentWindow = getCurrentWindow()
     const [position, size, scaleFactor] = await Promise.all([
       currentWindow.outerPosition(),

--- a/wework/src/lib/native-workspace-path-picker.ts
+++ b/wework/src/lib/native-workspace-path-picker.ts
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core'
 import { isTauriRuntime } from './runtime-environment'
 
 export interface NativeWorkspacePath {
@@ -21,7 +22,6 @@ export async function openNativeWorkspacePathPicker(
 ): Promise<NativeWorkspacePath[]> {
   if (!isTauriRuntime()) return []
 
-  const { invoke } = await import('@tauri-apps/api/core')
   const selected = await invoke<NativeWorkspacePath[]>('pick_workspace_paths', {
     initialDirectory: initialDirectory?.trim() || null,
     directoriesOnly: options.directoriesOnly ?? false,

--- a/wework/vite.config.ts
+++ b/wework/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs'
-import { defineConfig } from 'vite'
+import { createLogger, defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { fileViewerRenderers } from '@file-viewer/vite-plugin'
 import { configDefaults } from 'vitest/config'
@@ -20,9 +20,20 @@ const internalExtensionsDir = path.resolve(__dirname, './wecode/extensions')
 const extensionsDir = fs.existsSync(path.join(internalExtensionsDir, 'apps.tsx'))
   ? internalExtensionsDir
   : path.resolve(__dirname, './src/extensions')
+const logger = createLogger()
+const defaultWarn = logger.warn.bind(logger)
+const browserExternalPackages = ['/avsc/', '/ag-psd/', '/jszip/', '/@ljheee/xmind-parser/']
+
+logger.warn = (message, options) => {
+  const isKnownBrowserExternal =
+    message.includes('has been externalized for browser compatibility') &&
+    browserExternalPackages.some(packagePath => message.includes(packagePath))
+  if (!isKnownBrowserExternal) defaultWarn(message, options)
+}
 
 export default defineConfig({
   base: appBasePath,
+  customLogger: logger,
   plugins: [
     react(),
     fileViewerRenderers({
@@ -34,6 +45,11 @@ export default defineConfig({
   ],
   define: {
     __WEWORK_APP_VERSION__: JSON.stringify(packageJson.version ?? '0.0.0'),
+  },
+  build: {
+    // File-viewer renderers are split into dedicated chunks; the desktop shell
+    // intentionally remains a single entry bundle.
+    chunkSizeWarningLimit: 5_000,
   },
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
## What changed

- clean up Wework Tauri Clippy warnings in embedded browser, workspace picker, logging, tray menu, and lifecycle code
- replace ineffective dynamic Tauri API imports with static imports
- suppress known browser-external noise emitted by file-viewer dependencies and set an intentional desktop entry chunk threshold

## Why

The Wework build emitted compiler and bundler warnings even though compilation succeeded. The Rust warnings came from lint violations in application code, while the Vite warnings came from ineffective dynamic imports, expected browser shims in file-viewer dependencies, and the intentionally large desktop entry bundle.

This keeps strict warning checks clean and makes real regressions easier to spot in local and CI build output. There is no user-facing behavior or public API change.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` in `executor`
- `cargo clippy --all-targets --all-features -- -D warnings` in `wework/src-tauri`
- `cargo test --all-features` in `wework/src-tauri` (52 passed)
- `pnpm test` in `wework` (164 files, 1618 tests passed)
- `pnpm build` in `wework`
- pre-push ESLint, TypeScript, and unit-test checks

The executor full unit run had one shared-state test fail once; the exact failed test passed when rerun in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when selecting workspace folders on macOS, including clearer handling when the picker closes unexpectedly.
  * Improved desktop window focus behavior and cloud authorization window positioning.
  * Improved embedded browser handling of text results returned from evaluations.
  * Enhanced system tray task menu consistency and unread badge rendering.
* **Improvements**
  * Reduced unnecessary build warnings and increased the allowed chunk size for large application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->