### PR TITLE
fix(wework): hide apps icon from titlebar

### DIFF
--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -162,7 +162,7 @@ describe('App center route', () => {
 
     await waitFor(() => expect(window.location.pathname).toBe('/apps'))
     expect(screen.getByTestId('chrome-tab-wework')).toHaveClass('w-8', 'min-w-0', 'px-0')
-    expect(screen.getByTestId('chrome-tab-apps')).toHaveClass('w-8', 'min-w-0', 'px-0')
+    expect(screen.queryByTestId('chrome-tab-apps')).not.toBeInTheDocument()
     expect(screen.getByTestId('titlebar-sidebar-toggle-placeholder')).toHaveClass(
       'invisible',
       'pointer-events-none'

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -10,7 +10,6 @@ import {
   FolderPlus,
   Globe2,
   GitCompareArrows,
-  Grid3X3,
   Loader2,
   MessageSquarePlus,
   Pin,
@@ -135,7 +134,6 @@ interface DesktopSidebarProps {
   onPointerLeave?: PointerEventHandler<HTMLElement>
   onToggleSidebar?: () => void
   onOpenWorkbench?: () => void
-  onOpenApps?: () => void
   onNewChat: () => void
   onOpenSearch?: () => void
   onSelectProject?: (projectId: number) => void
@@ -2450,7 +2448,6 @@ export function DesktopSidebar({
   onPointerLeave,
   onToggleSidebar,
   onOpenWorkbench,
-  onOpenApps,
 }: DesktopSidebarProps) {
   useSidebarRelativeTimeRefresh()
   const { t } = useTranslation('common')
@@ -2475,7 +2472,6 @@ export function DesktopSidebar({
         t('workbench.account_fallback', '当前账号')
       )
   const workbenchAppLabel = t('workbench.app_wework')
-  const appsAppLabel = t('workbench.apps')
   const windowFocused = useSidebarWindowFocus()
 
   const storageScope = getDesktopSidebarStorageScope(user)
@@ -2968,21 +2964,6 @@ export function DesktopSidebar({
                 <Globe2 aria-hidden="true" className="h-4 w-4 shrink-0 stroke-[1.8]" />
                 <span className="sr-only">{workbenchAppLabel}</span>
                 <span className={SIDEBAR_CHROME_TAB_TOOLTIP_CLASS}>{workbenchAppLabel}</span>
-              </button>
-              <button
-                type="button"
-                data-testid="chrome-tab-apps"
-                onClick={onOpenApps}
-                title={appsAppLabel}
-                aria-label={appsAppLabel}
-                className={cn(
-                  SIDEBAR_CHROME_TAB_BUTTON_CLASS,
-                  'text-text-secondary hover:bg-black/[0.04]'
-                )}
-              >
-                <Grid3X3 aria-hidden="true" className="h-4 w-4 shrink-0 stroke-[1.8]" />
-                <span className="sr-only">{appsAppLabel}</span>
-                <span className={SIDEBAR_CHROME_TAB_TOOLTIP_CLASS}>{appsAppLabel}</span>
               </button>
             </div>
           )}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2254,11 +2254,8 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('desktop-sidebar-chrome-controls')).toContainElement(
       screen.getByTestId('chrome-tab-wework')
     )
-    expect(screen.getByTestId('desktop-sidebar-chrome-controls')).toContainElement(
-      screen.getByTestId('chrome-tab-apps')
-    )
     expect(screen.getByTestId('chrome-tab-wework')).toHaveClass('h-8', 'w-8', 'bg-black/[0.045]')
-    expect(screen.getByTestId('chrome-tab-apps')).toHaveClass('h-8', 'w-8', 'text-text-secondary')
+    expect(screen.queryByTestId('chrome-tab-apps')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workbench-topbar')).not.toBeInTheDocument()
     expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('titlebar-actions')).toContainElement(

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -486,7 +486,6 @@ export function DesktopWorkbenchLayout() {
       onPointerLeave={onPointerLeave}
       onToggleSidebar={() => updateSidebarCollapsed(!collapsed)}
       onOpenWorkbench={() => navigateTo('/')}
-      onOpenApps={() => navigateTo('/apps')}
       onNewChat={onNewChat}
       onOpenSearch={() => setSearchOpen(true)}
       onSelectProject={onSelectProject}

--- a/wework/src/components/topnav/useChromeTabs.test.ts
+++ b/wework/src/components/topnav/useChromeTabs.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, test } from 'vitest'
 import { useChromeTabs } from './useChromeTabs'
 
 describe('useChromeTabs', () => {
-  test('shows the app center as a fixed titlebar tab', () => {
+  test('hides the app center tab without removing route resolution', () => {
     const { result } = renderHook(() => useChromeTabs('/apps'))
 
-    expect(result.current.tabs.map(tab => tab.key)).toEqual(['wework', 'apps'])
+    expect(result.current.tabs.map(tab => tab.key)).toEqual(['wework'])
     expect(result.current.activeAppKey).toBe('apps')
     expect(result.current.activeTab?.label).toBe('应用')
   })
@@ -14,7 +14,7 @@ describe('useChromeTabs', () => {
   test('hides Wegent from the titlebar without removing route resolution', () => {
     const { result } = renderHook(() => useChromeTabs('/app/wegent'))
 
-    expect(result.current.tabs.map(tab => tab.key)).toEqual(['wework', 'apps'])
+    expect(result.current.tabs.map(tab => tab.key)).toEqual(['wework'])
     expect(result.current.activeAppKey).toBe('wegent')
     expect(result.current.activeTab?.key).toBe('wegent')
   })

--- a/wework/src/config/apps.ts
+++ b/wework/src/config/apps.ts
@@ -10,7 +10,14 @@ export interface AppTab {
 
 export const APP_TABS: AppTab[] = [
   { key: 'wework', label: 'WeWork', mode: 'native', path: '/', requiresAuth: true },
-  { key: 'apps', label: '应用', mode: 'native', path: '/apps', requiresAuth: true },
+  {
+    key: 'apps',
+    label: '应用',
+    mode: 'native',
+    path: '/apps',
+    requiresAuth: true,
+    hidden: true,
+  },
   {
     key: 'wegent',
     label: 'Wegent',


### PR DESCRIPTION
## What changed

- Hide the Apps icon from the Wework desktop titlebar and sidebar chrome controls.
- Keep the `/apps` route and app center route resolution available.
- Update navigation and layout tests to assert that the Apps icon is not rendered.

## Why

The Apps entry should no longer be exposed in the top-level Wework chrome, while preserving the underlying app center for direct navigation and existing internal flows.

## Impact

Wework users no longer see the Apps icon in the top bar. No API, persistence, or route behavior changes.

## Validation

- Prettier check
- ESLint
- TypeScript
- Wework unit tests
- Focused tests: 143 passed

Real Tauri verification was attempted in an isolated session, but the local runtime remained on the startup screen and timed out before the titlebar became available. The session was stopped and cleaned up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the Apps tab from the desktop title bar.
  * Updated the WeWork tab styling and layout.
  * Apps routes continue to preserve their active application state without displaying a separate Apps tab.

* **Tests**
  * Updated route and navigation coverage to reflect the hidden Apps tab and revised title bar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->