### PR TITLE
feat(wework): add text selection conversation actions

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -980,7 +980,9 @@ async fn run_codex_app_server_turn_on_shared_client(
 
     if let Some(thread_id) = subscribed_thread_id {
         client.mark_thread_idle(&thread_id).await;
-        client.unsubscribe_thread(&thread_id).await;
+        if !prepared.request.ephemeral {
+            client.unsubscribe_thread(&thread_id).await;
+        }
     }
 
     if let Err(error) = &result {

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -618,6 +618,13 @@ async fn runtime_tasks_send_ephemeral_codex_thread_uses_loaded_thread_directly()
     assert_eq!(
         calls
             .iter()
+            .filter(|call| call["method"] == "thread/unsubscribe")
+            .count(),
+        0
+    );
+    assert_eq!(
+        calls
+            .iter()
             .filter(|call| call["method"] == "turn/start")
             .count(),
         2

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -26,7 +26,7 @@ const corsHeaders = {
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
-  pnpm --filter wework ai:verify <capture|snapshot|click|close-to-tray|fill|hover|pointer-move|press|wait-for|text|status|stop> --session PATH [options]
+  pnpm --filter wework ai:verify <capture|snapshot|click|close-to-tray|fill|hover|pointer-move|press|select-text|wait-for|text|status|stop> --session PATH [options]
 
 Options:
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
@@ -320,6 +320,7 @@ async function main() {
     hover: 'hover',
     'pointer-move': 'pointerMove',
     press: 'press',
+    'select-text': 'selectText',
     'wait-for': 'waitFor',
     text: 'getText',
   }[command]

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -83,6 +83,68 @@ describe('MessageList', () => {
     expect(screen.queryByTestId('message-selection-actions')).not.toBeInTheDocument()
   })
 
+  test('reads the final selection after a mouse interaction completes', async () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-mouse-selection',
+            role: 'assistant',
+            content: 'Select this response',
+            status: 'done',
+            createdAt: '2026-07-15T10:00:00Z',
+          },
+        ]}
+        onAddSelectionToConversation={vi.fn()}
+        onAskSelectionInSidebar={vi.fn()}
+      />
+    )
+
+    const content = screen.getByTestId('assistant-message-content')
+    const range = document.createRange()
+    range.setStart(firstTextNode(content), 0)
+    range.setEnd(firstTextNode(content), 6)
+    document.getSelection()?.removeAllRanges()
+    document.getSelection()?.addRange(range)
+    fireEvent.mouseUp(content)
+
+    expect(await screen.findByTestId('message-selection-actions')).toBeInTheDocument()
+  })
+
+  test('offers selection actions when the whole message body is selected', async () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'user-before-whole-body-selection',
+            role: 'user',
+            content: 'Previous message',
+            status: 'done',
+            createdAt: '2026-07-15T09:59:59Z',
+          },
+          {
+            id: 'assistant-whole-body-selection',
+            role: 'assistant',
+            content: 'Select the whole paragraph',
+            status: 'done',
+            createdAt: '2026-07-15T10:00:00Z',
+          },
+        ]}
+        onAddSelectionToConversation={vi.fn()}
+        onAskSelectionInSidebar={vi.fn()}
+      />
+    )
+
+    const content = screen.getByTestId('assistant-message-content')
+    const nextMessage = screen.getByTestId('user-message-content')
+    const range = document.createRange()
+    range.setStart(firstTextNode(nextMessage), 0)
+    range.setEnd(firstTextNode(content), 0)
+    setDocumentSelection(range)
+
+    expect(await screen.findByTestId('message-selection-actions')).toBeInTheDocument()
+  })
+
   test('renders generated image artifacts from image generation blocks', () => {
     render(
       <MessageList

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -20,6 +20,69 @@ vi.mock('@/lib/external-links', async importOriginal => ({
 }))
 
 describe('MessageList', () => {
+  test('offers conversation actions for text selected inside one message body', async () => {
+    const onAddSelectionToConversation = vi.fn()
+    const onAskSelectionInSidebar = vi.fn()
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-selection',
+            role: 'assistant',
+            content: 'Select this response',
+            status: 'done',
+            createdAt: '2026-07-15T10:00:00Z',
+          },
+        ]}
+        onAddSelectionToConversation={onAddSelectionToConversation}
+        onAskSelectionInSidebar={onAskSelectionInSidebar}
+      />
+    )
+
+    selectText(screen.getByTestId('assistant-message-content'), 'Select this')
+
+    expect(await screen.findByTestId('message-selection-actions')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('add-selection-to-conversation-button'))
+    expect(onAddSelectionToConversation).toHaveBeenCalledWith('Select this')
+    expect(screen.queryByTestId('message-selection-actions')).not.toBeInTheDocument()
+
+    selectText(screen.getByTestId('assistant-message-content'), 'response')
+    await userEvent.click(await screen.findByTestId('ask-selection-in-sidebar-button'))
+    expect(onAskSelectionInSidebar).toHaveBeenCalledWith('response')
+  })
+
+  test('does not offer selection actions across message bodies', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'user-selection',
+            role: 'user',
+            content: 'First message',
+            status: 'done',
+            createdAt: '2026-07-15T10:00:00Z',
+          },
+          {
+            id: 'assistant-selection',
+            role: 'assistant',
+            content: 'Second message',
+            status: 'done',
+            createdAt: '2026-07-15T10:00:01Z',
+          },
+        ]}
+        onAddSelectionToConversation={vi.fn()}
+        onAskSelectionInSidebar={vi.fn()}
+      />
+    )
+
+    const range = document.createRange()
+    range.setStart(firstTextNode(screen.getByTestId('user-message-content')), 0)
+    range.setEnd(firstTextNode(screen.getByTestId('assistant-message-content')), 6)
+    setDocumentSelection(range)
+
+    expect(screen.queryByTestId('message-selection-actions')).not.toBeInTheDocument()
+  })
+
   test('renders generated image artifacts from image generation blocks', () => {
     render(
       <MessageList
@@ -4152,3 +4215,31 @@ describe('MessageList', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+function selectText(container: HTMLElement, text: string) {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+  let node = walker.nextNode()
+  while (node && !node.textContent?.includes(text)) node = walker.nextNode()
+  if (!node) throw new Error(`Could not find text: ${text}`)
+  const start = node.textContent!.indexOf(text)
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.setEnd(node, start + text.length)
+  setDocumentSelection(range)
+}
+
+function firstTextNode(container: HTMLElement): Node {
+  const node = document.createTreeWalker(container, NodeFilter.SHOW_TEXT).nextNode()
+  if (!node) throw new Error('Could not find a text node')
+  return node
+}
+
+function setDocumentSelection(range: Range) {
+  Object.defineProperty(range, 'getBoundingClientRect', {
+    value: () => ({ left: 100, top: 100, width: 80, height: 20 }),
+  })
+  const selection = window.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+  fireEvent(document, new Event('selectionchange'))
+}

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -260,9 +260,9 @@ export const MessageList = memo(function MessageList({
       setIsTextSelectionActive(!isTauri && selectionTouchesList)
       if (!onAddSelectionToConversation || !onAskSelectionInSidebar) return
 
-      const anchorText = closestSelectableMessageText(selection.anchorNode)
-      const focusText = closestSelectableMessageText(selection.focusNode)
-      if (!anchorText || anchorText !== focusText || !root.contains(anchorText)) {
+      const range = selection.getRangeAt(0)
+      const selectedMessageBodies = selectableMessageBodiesForRange(root, range)
+      if (selectedMessageBodies.length !== 1) {
         setTextSelection(null)
         return
       }
@@ -272,7 +272,7 @@ export const MessageList = memo(function MessageList({
         setTextSelection(null)
         return
       }
-      const rect = selection.getRangeAt(0).getBoundingClientRect()
+      const rect = range.getBoundingClientRect()
       setTextSelection({
         text,
         left: Math.min(Math.max(rect.left + rect.width / 2, 120), window.innerWidth - 120),
@@ -281,7 +281,7 @@ export const MessageList = memo(function MessageList({
       })
     }
 
-    const handlePointerUp = () => {
+    const scheduleSelectionUpdate = () => {
       window.requestAnimationFrame(updateSelectionState)
     }
 
@@ -289,16 +289,20 @@ export const MessageList = memo(function MessageList({
       updateSelectionState()
     }
 
-    document.addEventListener('pointerup', handlePointerUp)
-    document.addEventListener('pointercancel', handlePointerUp)
-    document.addEventListener('selectionchange', updateSelectionState)
+    document.addEventListener('pointerup', scheduleSelectionUpdate)
+    document.addEventListener('pointercancel', scheduleSelectionUpdate)
+    document.addEventListener('mouseup', scheduleSelectionUpdate)
+    document.addEventListener('keyup', scheduleSelectionUpdate)
+    document.addEventListener('selectionchange', scheduleSelectionUpdate)
     window.addEventListener('scroll', updateSelectionState, true)
     window.addEventListener('blur', handleBlur)
 
     return () => {
-      document.removeEventListener('pointerup', handlePointerUp)
-      document.removeEventListener('pointercancel', handlePointerUp)
-      document.removeEventListener('selectionchange', updateSelectionState)
+      document.removeEventListener('pointerup', scheduleSelectionUpdate)
+      document.removeEventListener('pointercancel', scheduleSelectionUpdate)
+      document.removeEventListener('mouseup', scheduleSelectionUpdate)
+      document.removeEventListener('keyup', scheduleSelectionUpdate)
+      document.removeEventListener('selectionchange', scheduleSelectionUpdate)
       window.removeEventListener('scroll', updateSelectionState, true)
       window.removeEventListener('blur', handleBlur)
     }
@@ -430,9 +434,24 @@ function getMessageContainmentStyle(estimatedHeight: number | undefined): CSSPro
   } as CSSProperties
 }
 
-function closestSelectableMessageText(node: Node | null): HTMLElement | null {
-  const element = node instanceof Element ? node : node?.parentElement
-  return element?.closest<HTMLElement>('[data-message-selectable-text]') ?? null
+function selectableMessageBodiesForRange(root: HTMLElement, range: Range): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-message-selectable-text]')).filter(
+    element => selectedTextWithinElement(range, element).trim().length > 0
+  )
+}
+
+function selectedTextWithinElement(range: Range, element: HTMLElement): string {
+  if (!range.intersectsNode(element)) return ''
+
+  const intersection = document.createRange()
+  intersection.selectNodeContents(element)
+  if (intersection.compareBoundaryPoints(Range.START_TO_START, range) < 0) {
+    intersection.setStart(range.startContainer, range.startOffset)
+  }
+  if (intersection.compareBoundaryPoints(Range.END_TO_END, range) > 0) {
+    intersection.setEnd(range.endContainer, range.endOffset)
+  }
+  return intersection.toString()
 }
 
 function isNodeInsideElement(node: Node | null, root: HTMLElement): boolean {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1,4 +1,5 @@
 import { Fragment, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
@@ -97,6 +98,8 @@ interface MessageListProps {
   loadingFullTranscript?: boolean
   hideRequestUserInputBlocks?: boolean
   hiddenRequestUserInputIds?: ReadonlySet<string>
+  onAddSelectionToConversation?: (text: string) => void
+  onAskSelectionInSidebar?: (text: string) => void
   renderGapAfterMessage?: (
     message: WorkbenchMessage,
     nextMessage: WorkbenchMessage | undefined
@@ -106,6 +109,14 @@ interface MessageListProps {
 const USER_MESSAGE_COLLAPSE_LINES = 10
 const USER_MESSAGE_COLLAPSE_CHARACTERS = 600
 const MESSAGE_LAYOUT_RESIZE_SETTLE_MS = 120
+const SELECTION_ACTION_GAP = 8
+
+interface MessageTextSelection {
+  text: string
+  left: number
+  top: number
+  conversationKey?: string | number | null
+}
 const CODEX_FILE_MENTIONS_HEADER_PATTERN = /^\s*# Files mentioned by the user:\s*/i
 const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
 const CODEX_FILE_MENTION_LINE_PATTERN = /^##\s+(.+?):\s+(.+)$/gm
@@ -149,11 +160,15 @@ export const MessageList = memo(function MessageList({
   loadingFullTranscript = false,
   hideRequestUserInputBlocks,
   hiddenRequestUserInputIds,
+  onAddSelectionToConversation,
+  onAskSelectionInSidebar,
   renderGapAfterMessage,
 }: MessageListProps) {
+  const { t } = useTranslation('common')
   const listRef = useRef<HTMLDivElement>(null)
   const layoutWidthUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isTextSelectionActive, setIsTextSelectionActive] = useState(false)
+  const [textSelection, setTextSelection] = useState<MessageTextSelection | null>(null)
   const [layoutWidth, setLayoutWidth] = useState(0)
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null)
   const [submittingEditMessageId, setSubmittingEditMessageId] = useState<string | null>(null)
@@ -228,22 +243,42 @@ export const MessageList = memo(function MessageList({
   }, [])
 
   useEffect(() => {
-    if (isTauri) {
-      return
-    }
+    if (isTauri && (!onAddSelectionToConversation || !onAskSelectionInSidebar)) return
 
     const updateSelectionState = () => {
       const selection = document.getSelection?.()
       const root = listRef.current
       if (!selection || !root || selection.isCollapsed || selection.rangeCount === 0) {
         setIsTextSelectionActive(false)
+        setTextSelection(null)
         return
       }
 
       const selectionTouchesList =
         isNodeInsideElement(selection.anchorNode, root) ||
         isNodeInsideElement(selection.focusNode, root)
-      setIsTextSelectionActive(selectionTouchesList)
+      setIsTextSelectionActive(!isTauri && selectionTouchesList)
+      if (!onAddSelectionToConversation || !onAskSelectionInSidebar) return
+
+      const anchorText = closestSelectableMessageText(selection.anchorNode)
+      const focusText = closestSelectableMessageText(selection.focusNode)
+      if (!anchorText || anchorText !== focusText || !root.contains(anchorText)) {
+        setTextSelection(null)
+        return
+      }
+
+      const text = selection.toString().trim()
+      if (!text) {
+        setTextSelection(null)
+        return
+      }
+      const rect = selection.getRangeAt(0).getBoundingClientRect()
+      setTextSelection({
+        text,
+        left: Math.min(Math.max(rect.left + rect.width / 2, 120), window.innerWidth - 120),
+        top: Math.max(rect.top - SELECTION_ACTION_GAP, 44),
+        conversationKey,
+      })
     }
 
     const handlePointerUp = () => {
@@ -257,15 +292,24 @@ export const MessageList = memo(function MessageList({
     document.addEventListener('pointerup', handlePointerUp)
     document.addEventListener('pointercancel', handlePointerUp)
     document.addEventListener('selectionchange', updateSelectionState)
+    window.addEventListener('scroll', updateSelectionState, true)
     window.addEventListener('blur', handleBlur)
 
     return () => {
       document.removeEventListener('pointerup', handlePointerUp)
       document.removeEventListener('pointercancel', handlePointerUp)
       document.removeEventListener('selectionchange', updateSelectionState)
+      window.removeEventListener('scroll', updateSelectionState, true)
       window.removeEventListener('blur', handleBlur)
     }
-  }, [isTauri])
+  }, [conversationKey, isTauri, onAddSelectionToConversation, onAskSelectionInSidebar])
+
+  const applySelectionAction = (action: (text: string) => void) => {
+    if (!textSelection) return
+    action(textSelection.text)
+    document.getSelection()?.removeAllRanges()
+    setTextSelection(null)
+  }
 
   if (visibleMessages.length === 0 && !shouldShowWaitingIndicator) {
     return null
@@ -273,6 +317,34 @@ export const MessageList = memo(function MessageList({
 
   return (
     <div ref={listRef} className={cn(listLayoutClass, className)}>
+      {textSelection &&
+        textSelection.conversationKey === conversationKey &&
+        createPortal(
+          <div
+            data-testid="message-selection-actions"
+            className="fixed z-critical flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-lg border border-border bg-base p-1 shadow-lg"
+            style={{ left: textSelection.left, top: textSelection.top }}
+            onPointerDown={event => event.preventDefault()}
+          >
+            <button
+              type="button"
+              data-testid="add-selection-to-conversation-button"
+              className="h-8 rounded-md px-2.5 text-xs text-text-secondary hover:bg-muted hover:text-text-primary"
+              onClick={() => applySelectionAction(onAddSelectionToConversation!)}
+            >
+              {t('workbench.add_selection_to_conversation')}
+            </button>
+            <button
+              type="button"
+              data-testid="ask-selection-in-sidebar-button"
+              className="h-8 rounded-md px-2.5 text-xs text-text-secondary hover:bg-muted hover:text-text-primary"
+              onClick={() => applySelectionAction(onAskSelectionInSidebar!)}
+            >
+              {t('workbench.ask_selection_in_sidebar')}
+            </button>
+          </div>,
+          document.body
+        )}
       {visibleMessages.map((message, index) => {
         const nextMessage = visibleMessages[index + 1]
         return (
@@ -358,6 +430,11 @@ function getMessageContainmentStyle(estimatedHeight: number | undefined): CSSPro
   } as CSSProperties
 }
 
+function closestSelectableMessageText(node: Node | null): HTMLElement | null {
+  const element = node instanceof Element ? node : node?.parentElement
+  return element?.closest<HTMLElement>('[data-message-selectable-text]') ?? null
+}
+
 function isNodeInsideElement(node: Node | null, root: HTMLElement): boolean {
   if (!node) return false
 
@@ -411,6 +488,12 @@ function areMessageListPropsEqual(previous: MessageListProps, next: MessageListP
       : null,
     previous.hiddenRequestUserInputIds !== next.hiddenRequestUserInputIds
       ? 'hiddenRequestUserInputIds'
+      : null,
+    previous.onAddSelectionToConversation !== next.onAddSelectionToConversation
+      ? 'onAddSelectionToConversation'
+      : null,
+    previous.onAskSelectionInSidebar !== next.onAskSelectionInSidebar
+      ? 'onAskSelectionInSidebar'
       : null,
     previous.renderGapAfterMessage !== next.renderGapAfterMessage ? 'renderGapAfterMessage' : null,
   ].filter((key): key is string => key !== null)
@@ -756,6 +839,7 @@ function UserMessage({
           >
             <div
               data-testid="user-message-content"
+              data-message-selectable-text
               className={[
                 'relative overflow-hidden break-words whitespace-pre-wrap bg-muted px-4 py-1.5',
                 shouldCollapse && !isExpanded ? 'max-h-44' : '',
@@ -1598,11 +1682,13 @@ function AssistantMessage({
             />
           ) : null}
           {hasVisibleContent ? (
-            <AssistantMarkdown
-              content={visibleContent}
-              isStreaming={isStreaming}
-              onOpenFile={openFileFromLink}
-            />
+            <div data-message-selectable-text data-testid="assistant-message-content">
+              <AssistantMarkdown
+                content={visibleContent}
+                isStreaming={isStreaming}
+                onOpenFile={openFileFromLink}
+              />
+            </div>
           ) : null}
           {shouldShowThinking && hasVisibleContent && <AssistantThinkingIndicator />}
           {canShowFinalArtifacts && hasVisibleContent && webSearchSources.length > 0 && (

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -87,6 +87,8 @@ interface ScrollableMessageAreaProps {
   canEditLastUserMessage?: boolean
   hideRequestUserInputBlocks?: boolean
   hiddenRequestUserInputIds?: ReadonlySet<string>
+  onAddSelectionToConversation?: (text: string) => void
+  onAskSelectionInSidebar?: (text: string) => void
   autoScrollSuspended?: boolean
   onLoadMoreBefore?: () => Promise<void> | void
   onLoadFullTranscript?: () => Promise<void> | void
@@ -154,6 +156,12 @@ function areScrollableMessageAreaPropsEqual(
     previous.hiddenRequestUserInputIds !== next.hiddenRequestUserInputIds
       ? 'hiddenRequestUserInputIds'
       : null,
+    previous.onAddSelectionToConversation !== next.onAddSelectionToConversation
+      ? 'onAddSelectionToConversation'
+      : null,
+    previous.onAskSelectionInSidebar !== next.onAskSelectionInSidebar
+      ? 'onAskSelectionInSidebar'
+      : null,
     previous.autoScrollSuspended !== next.autoScrollSuspended ? 'autoScrollSuspended' : null,
     previous.onLoadMoreBefore !== next.onLoadMoreBefore ? 'onLoadMoreBefore' : null,
     previous.onLoadFullTranscript !== next.onLoadFullTranscript ? 'onLoadFullTranscript' : null,
@@ -199,6 +207,8 @@ function ScrollableMessagePaneContent({
   canEditLastUserMessage,
   hideRequestUserInputBlocks,
   hiddenRequestUserInputIds,
+  onAddSelectionToConversation,
+  onAskSelectionInSidebar,
   autoScrollSuspended = false,
   onLoadMoreBefore,
   onLoadFullTranscript,
@@ -769,6 +779,8 @@ function ScrollableMessagePaneContent({
                 loadingFullTranscript={loadingFullTranscript}
                 hideRequestUserInputBlocks={hideRequestUserInputBlocks}
                 hiddenRequestUserInputIds={hiddenRequestUserInputIds}
+                onAddSelectionToConversation={onAddSelectionToConversation}
+                onAskSelectionInSidebar={onAskSelectionInSidebar}
                 renderGapAfterMessage={renderTranscriptGapAfterMessage}
               />
             </>

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { BufferedChatInput } from './BufferedChatInput'
 
@@ -19,6 +20,25 @@ describe('BufferedChatInput', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('chat-message-input')).toHaveValue('queued message')
+    })
+  })
+
+  test('appends an insertion without replacing the buffered draft', async () => {
+    const props = {
+      value: '',
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      disabled: false,
+    }
+    const { rerender } = render(<BufferedChatInput {...props} />)
+    await userEvent.type(screen.getByTestId('chat-message-input'), 'Existing draft')
+
+    rerender(<BufferedChatInput {...props} insertion={{ id: 1, text: 'Selected response' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-message-input')).toHaveValue(
+        'Existing draft\nSelected response'
+      )
     })
   })
 })

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -1,18 +1,41 @@
-import { memo, useCallback, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { ChatInput, type ChatInputProps, type ChatSubmitOptions } from '@/components/chat/ChatInput'
 import { parseComposerMentions } from '@/components/chat/composer/composerMentions'
+
+export interface BufferedChatInputInsertion {
+  id: number
+  text: string
+}
+
+interface BufferedChatInputProps extends ChatInputProps {
+  insertion?: BufferedChatInputInsertion | null
+}
 
 export const BufferedChatInput = memo(function BufferedChatInput({
   value,
   onChange,
   onSubmit,
+  insertion,
   ...props
-}: ChatInputProps) {
+}: BufferedChatInputProps) {
   const [draftState, setDraftState] = useState(() => ({
     sourceValue: value,
     draft: value,
   }))
   const draft = draftState.sourceValue === value ? draftState.draft : value
+  const appliedInsertionIdRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!insertion || appliedInsertionIdRef.current === insertion.id) return
+    appliedInsertionIdRef.current = insertion.id
+    setDraftState(current => {
+      const currentDraft = current.sourceValue === value ? current.draft : value
+      return {
+        sourceValue: value,
+        draft: currentDraft ? `${currentDraft}\n${insertion.text}` : insertion.text,
+      }
+    })
+  }, [insertion, value])
   const setDraft = useCallback(
     (nextDraft: string) => {
       setDraftState({ sourceValue: value, draft: nextDraft })

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -29,6 +29,7 @@ import { cn } from '@/lib/utils'
 import { BottomWorkspacePanel } from './workspace-panels/BottomWorkspacePanel'
 import {
   RightWorkspacePanel,
+  type RightWorkspaceChatTab,
   type RightWorkspacePanelTab,
   type RightWorkspacePanelView,
 } from './workspace-panels/RightWorkspacePanel'
@@ -430,6 +431,11 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [embeddedBrowserOpenRequest, setEmbeddedBrowserOpenRequest] = useState<
     (EmbeddedBrowserOpenRequest & { id: number }) | null
   >(null)
+  const [conversationSelectionInsertion, setConversationSelectionInsertion] = useState<{
+    id: number
+    text: string
+  } | null>(null)
+  const temporaryChatInitialInputsRef = useRef(new Map<RightWorkspaceChatTab, string>())
   const [selectedAssistantPlan, setSelectedAssistantPlan] = useState<SelectedAssistantPlan | null>(
     null
   )
@@ -837,10 +843,39 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     },
     [setRightPanelOpen, setRightPanelView]
   )
-  const openTemporaryChatTab = useCallback(() => {
-    temporaryChatTabSequence.current += 1
-    openRightPanelTab(`chat:${Date.now()}-${temporaryChatTabSequence.current}`)
-  }, [openRightPanelTab])
+  const openTemporaryChatTab = useCallback(
+    (initialInput?: string) => {
+      temporaryChatTabSequence.current += 1
+      const tab: RightWorkspaceChatTab = `chat:${Date.now()}-${temporaryChatTabSequence.current}`
+      if (initialInput) temporaryChatInitialInputsRef.current.set(tab, initialInput)
+      openRightPanelTab(tab)
+    },
+    [openRightPanelTab]
+  )
+
+  const addSelectionToConversation = useCallback(
+    (selectedText: string) => {
+      setConversationSelectionInsertion(current => ({
+        id: (current?.id ?? 0) + 1,
+        text: selectedText,
+      }))
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document
+            .querySelector<HTMLElement>(
+              '[data-testid="desktop-floating-composer-card"] [data-testid="chat-message-input"]'
+            )
+            ?.focus()
+        })
+      })
+    },
+    [setConversationSelectionInsertion]
+  )
+
+  const askSelectionInSidebar = useCallback(
+    (selectedText: string) => openTemporaryChatTab(selectedText),
+    [openTemporaryChatTab]
+  )
   const embeddedBrowserListenerStateRef = useRef({
     embeddedBrowserLabel,
     openRightPanelTab,
@@ -885,6 +920,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   )
   const closeRightPanelTab = useCallback(
     (tab: RightWorkspacePanelTab) => {
+      if (tab.startsWith('chat:')) {
+        temporaryChatInitialInputsRef.current.delete(tab as RightWorkspaceChatTab)
+      }
       if (tab === 'files') {
         setOpenFileRequest(null)
       }
@@ -1571,6 +1609,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                           />
                         ) : (
                           <BufferedChatInput
+                            insertion={conversationSelectionInsertion}
                             value={paneSession.input}
                             onChange={paneSession.setInput}
                             onSubmit={paneSession.send}
@@ -1662,6 +1701,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 canEditLastUserMessage={canEditLastUserMessage}
                 hideRequestUserInputBlocks={Boolean(pendingRequestUserInput)}
                 hiddenRequestUserInputIds={paneSession.answeredRequestUserInputIds}
+                onAddSelectionToConversation={addSelectionToConversation}
+                onAskSelectionInSidebar={askSelectionInSidebar}
               />
             </div>
           ) : (
@@ -1802,6 +1843,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               onSelectTab={selectRightPanelTab}
               onCloseTab={closeRightPanelTab}
               onRefreshReview={reviewState.reloadDiff ? refreshReview : undefined}
+              getChatInitialInput={tab => temporaryChatInitialInputsRef.current.get(tab)}
             />
           )}
         </div>

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -104,6 +104,7 @@ interface RightWorkspacePanelProps {
   onSelectTab: (tab: RightWorkspacePanelTab) => void
   onCloseTab: (tab: RightWorkspacePanelTab) => void
   onRefreshReview?: () => void
+  getChatInitialInput?: (tab: RightWorkspaceChatTab) => string | undefined
 }
 
 export const RightWorkspacePanel = memo(function RightWorkspacePanel({
@@ -137,6 +138,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
   onSelectTab,
   onCloseTab,
   onRefreshReview,
+  getChatInitialInput,
 }: RightWorkspacePanelProps) {
   const { t } = useTranslation('common')
   const visibleTabs = canBrowseFiles ? openTabs : openTabs.filter(tab => tab !== 'files')
@@ -393,6 +395,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
               currentProject={currentProject}
               source={currentRuntimeTask}
               instanceId={tab}
+              initialInput={getChatInitialInput?.(tab)}
               testId={
                 activeView === tab
                   ? 'right-workspace-chat-panel'

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -37,6 +37,7 @@ interface TemporaryChatPanelProps {
   source: RuntimeTaskAddress | null
   instanceId: string
   testId?: string
+  initialInput?: string
 }
 
 export function TemporaryChatPanel({
@@ -44,6 +45,7 @@ export function TemporaryChatPanel({
   source,
   instanceId,
   testId = 'right-workspace-chat-panel',
+  initialInput = '',
 }: TemporaryChatPanelProps) {
   const {
     state,
@@ -56,12 +58,22 @@ export function TemporaryChatPanel({
   } = useWorkbenchPaneContext()
   const [address, setAddress] = useState<RuntimeTaskAddress | null>(null)
   const [messages, setMessages] = useState<WorkbenchMessage[]>([])
-  const [input, setInput] = useState('')
+  const [input, setInput] = useState(initialInput)
   const [error, setError] = useState<string | null>(null)
   const [sending, setSending] = useState(false)
   const [loadingFullTranscript, setLoadingFullTranscript] = useState(false)
   const pendingMessageActionsRef = useRef<RuntimePaneMessageAction[]>([])
   const messageActionFrameRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!initialInput) return
+    const frame = requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLElement>(`[data-testid="${testId}"] [data-testid="chat-message-input"]`)
+        ?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [initialInput, testId])
 
   const applyMessageActions = useCallback((actions: RuntimePaneMessageAction[]) => {
     if (actions.length === 0) return

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -26,6 +26,7 @@ type DesktopControlAction =
   | 'snapshot'
   | 'waitFor'
   | 'press'
+  | 'selectText'
 
 interface DesktopControlCommand {
   id: string
@@ -379,6 +380,26 @@ function fillDesktopControlElement(element: HTMLElement, value: string) {
   element.dispatchEvent(new Event('change', { bubbles: true }))
 }
 
+function selectDesktopControlText(selector: string, value: string): string {
+  const element = findDesktopControlElements(selector)[0]
+  if (!element) throw new Error(`Unable to find selector "${selector}"`)
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let node = walker.nextNode()
+  while (node && !node.textContent?.includes(value)) node = walker.nextNode()
+  if (!node) throw new Error(`Unable to find text "${value}" inside selector "${selector}"`)
+
+  const start = node.textContent?.indexOf(value) ?? -1
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.setEnd(node, start + value.length)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  document.dispatchEvent(new Event('selectionchange'))
+  document.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }))
+  return value
+}
+
 async function executeDesktopControlCommand(command: DesktopControlCommand): Promise<string> {
   switch (command.action) {
     case 'capture':
@@ -436,6 +457,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       }
       return element.textContent?.trim() ?? ''
     }
+    case 'selectText':
+      return selectDesktopControlText(command.selector, command.value ?? '')
   }
 }
 

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -158,6 +158,8 @@
     "workspace_tab_review": "Review",
     "workspace_tab_files": "Files",
     "workspace_tab_chat": "Temporary chat",
+    "add_selection_to_conversation": "Add to conversation",
+    "ask_selection_in_sidebar": "Ask in sidebar",
     "workspace_tab_new": "Open new tab",
     "create_project": "Create project",
     "close_dialog": "Close",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -158,6 +158,8 @@
     "workspace_tab_review": "审查",
     "workspace_tab_files": "文件",
     "workspace_tab_chat": "临时聊天",
+    "add_selection_to_conversation": "添加到对话",
+    "ask_selection_in_sidebar": "在侧边栏中提问",
     "workspace_tab_new": "打开新标签页",
     "create_project": "创建项目",
     "close_dialog": "关闭",


### PR DESCRIPTION
## What changed

- show a compact action menu after selecting text in a user or assistant message
- append selected text to the existing main conversation draft without replacing it
- open a new temporary sidebar chat with the selected text prefilled and focused
- add a `select-text` command to the isolated Tauri verification driver

## User impact

Desktop users can reuse message text without copying and pasting. They can either continue in the current conversation or prepare a separate temporary sidebar question. The sidebar action does not send automatically.

## Validation

- `pnpm --filter wework test` — 164 files, 1621 tests passed
- Wework ESLint passed
- Wework TypeScript check passed
- Prettier check passed
- isolated real-Tauri verification:
  - selecting text displayed both actions
  - “添加到对话” appended the selection to the main composer
  - “在侧边栏中提问” opened a new temporary chat and prefilled the selection without sending
  - screenshot evidence retained under `wework/test-results/ai-verify/selection-actions.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select text in chat messages to add it to the current conversation or ask about it in the sidebar.
  * Open temporary chats with selected text or other initial content prefilled.
  * Append inserted text to existing drafts without replacing them.
  * Added desktop automation support for selecting text.

* **Bug Fixes**
  * Improved cleanup behavior for ephemeral conversations.

* **Tests**
  * Added coverage for text selection, draft insertion, and ephemeral conversation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->