### PR TITLE
feat(frontend): improve knowledge document folder navigation view

### DIFF
--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -39,6 +39,8 @@ import { useDocuments } from '../hooks/useDocuments'
 import { useFolders } from '../hooks/useFolders'
 import { FolderTree, type SortField, type SortOrder } from './FolderTree'
 import { KnowledgeDocumentTreeGrid } from './knowledge-document-tree-grid'
+import { KnowledgeFolderBreadcrumb } from './knowledge-folder-breadcrumb'
+import { KnowledgeFolderNavView } from './knowledge-folder-nav-view'
 import { CreateFolderDialog } from './CreateFolderDialog'
 import { DeleteFolderDialog } from './DeleteFolderDialog'
 import { MoveDocumentDialog } from './MoveDocumentDialog'
@@ -47,6 +49,7 @@ import {
   useKnowledgeResourceSelection,
   shouldDisableDocumentBatchActions,
 } from '../hooks/useKnowledgeResourceSelection'
+import { useFolderNavigation } from '../hooks/useFolderNavigation'
 import { Pagination } from '@/components/ui/pagination'
 import { listDocuments } from '@/apis/knowledge'
 import { toast } from '@/hooks/use-toast'
@@ -74,6 +77,8 @@ import {
   deletedFolderAffectsActiveFolder,
   folderTreeContainsId,
 } from '../utils/resource-tree'
+
+const EXPAND_ALL_THRESHOLD = 100
 
 export { deletedFolderAffectsActiveFolder, folderTreeContainsId }
 export { shouldDisableDocumentBatchActions } from '../hooks/useKnowledgeResourceSelection'
@@ -257,6 +262,14 @@ export function DocumentList({
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc')
   const [activeFolderId, setActiveFolderId] = useState<number | undefined>(undefined)
 
+  // Display mode: expand-all for small KBs, folder-nav for large ones.
+  // Only applies to the normal (non-compact) view.
+  const displayMode = useMemo<'expand-all' | 'folder-nav'>(() => {
+    return knowledgeBase.document_count < EXPAND_ALL_THRESHOLD ? 'expand-all' : 'folder-nav'
+  }, [knowledgeBase.document_count])
+
+  const isFolderNavMode = displayMode === 'folder-nav'
+
   // Folder state
   const {
     folders,
@@ -269,6 +282,11 @@ export function DocumentList({
   } = useFolders({ knowledgeBaseId: knowledgeBase.id })
 
   const folderResourceTree = useMemo(() => buildKnowledgeResourceTree(folders, []), [folders])
+
+  const { navFolderId, breadcrumbs, directChildFolders, navigateTo } = useFolderNavigation(
+    folders,
+    knowledgeBase.id
+  )
 
   const activeFolderScopeIds = useMemo(
     () =>
@@ -297,9 +315,12 @@ export function DocumentList({
   } = useDocuments({
     knowledgeBaseId: knowledgeBase.id,
     paginationEnabled,
-    folderId: activeFolderId,
-    includeSubfolders: activeFolderId !== undefined,
-    folderScopeIds: activeFolderScopeIds,
+    // folder-nav mode (no search): scope to current folder's direct documents only.
+    // folder-nav mode (searching): folderId=undefined → global search across all docs.
+    // expand-all / compact modes: use activeFolderId (legacy filter behavior).
+    folderId: isFolderNavMode && !searchQuery ? (navFolderId ?? 0) : activeFolderId,
+    includeSubfolders: isFolderNavMode ? false : activeFolderId !== undefined,
+    folderScopeIds: isFolderNavMode ? undefined : activeFolderScopeIds,
     keyword: searchQuery,
     sortBy: sortField,
     sortOrder,
@@ -333,10 +354,6 @@ export function DocumentList({
   const searchPlaceholder = activeFolderName
     ? t('document.document.searchInFolder', { folder: activeFolderName })
     : t('document.document.search')
-
-  const handleActivateFolder = useCallback((folderId: number) => {
-    setActiveFolderId(currentFolderId => (currentFolderId === folderId ? undefined : folderId))
-  }, [])
 
   // Only show error on page for initial load failures (when documents list is empty)
   // Operation errors are shown via toast notifications
@@ -495,6 +512,13 @@ export function DocumentList({
     }
   }, [folders, activeFolderId, resetSelection])
 
+  // In folder-nav mode, navigate back to root if the current folder was deleted
+  useEffect(() => {
+    if (isFolderNavMode && navFolderId !== null && !folderTreeContainsId(folders, navFolderId)) {
+      navigateTo(null)
+    }
+  }, [folders, isFolderNavMode, navFolderId, navigateTo])
+
   const canManageAnyDocuments = canUpload || canManageAllDocuments
   const canManageDocumentArea = canManageAnyDocuments
   const canManageFolderStructure = canManageDocumentArea
@@ -511,9 +535,9 @@ export function DocumentList({
   })
 
   const handleOpenUpload = useCallback(() => {
-    setSelectedUploadFolderId(activeFolderId ?? 0)
+    setSelectedUploadFolderId(isFolderNavMode ? (navFolderId ?? 0) : (activeFolderId ?? 0))
     setShowUpload(true)
-  }, [activeFolderId])
+  }, [activeFolderId, isFolderNavMode, navFolderId])
 
   const handleGoToPage = useCallback(
     (targetPage: number) => {
@@ -1075,12 +1099,12 @@ export function DocumentList({
           </Tooltip>
         </TooltipProvider>
 
-        {/* Create folder button */}
+        {/* Create folder button - in folder-nav mode, create inside current folder */}
         {canManageFolderStructure && (
           <Button
             variant="outline"
             className="h-11 min-w-[44px]"
-            onClick={() => handleCreateFolder(0)}
+            onClick={() => handleCreateFolder(isFolderNavMode ? (navFolderId ?? 0) : 0)}
           >
             <FolderPlus className="w-4 h-4 mr-1" />
             {t('document.folder.create')}
@@ -1189,134 +1213,241 @@ export function DocumentList({
             </div>
           )}
 
-          {/* Compact mode: Card layout */}
+          {/* Compact mode: Card layout — dual-mode same as normal mode */}
           {compact ? (
             <div className="space-y-2">
-              {/* Select all control bar for notebook mode */}
-              {onSelectionChange && documents.length > 0 && (
-                <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-text-muted">
-                  <button
-                    onClick={() => handleSelectAll(!isAllSelected)}
-                    className="flex items-center gap-1.5 hover:text-text-primary transition-colors"
-                  >
-                    {isAllSelected ? (
-                      <CheckSquare className="w-3.5 h-3.5 text-primary" />
-                    ) : (
-                      <Square className="w-3.5 h-3.5" />
-                    )}
-                    <span>
-                      {paginationEnabled
-                        ? t('document.document.batch.selectCurrentPage')
-                        : t('document.document.batch.selectAll')}
-                    </span>
-                  </button>
-                  <span className="text-text-muted">
-                    ({documents.filter(doc => selectedDocumentIds.has(doc.id)).length}/
-                    {documents.length})
-                  </span>
-                </div>
-              )}
-              <FolderTree
-                folders={folders}
-                documents={documents}
-                compact={true}
-                onViewDetail={setViewingDoc}
-                onEdit={setEditingDoc}
-                onDelete={setDeletingDoc}
-                onRefresh={handleRefreshWebDocument}
-                onReindex={handleReindexDocument}
-                onMove={handleMoveDocument}
-                refreshingDocId={refreshingDocId}
-                reindexingDocId={reindexingDocId}
-                canManage={canManageDocument}
-                canSelect={canSelectDocument}
-                selectedIds={selectedDocumentIds}
-                includedInFolderScope={isDocumentIncludedInFolderScope}
-                onSelect={handleSelectDoc}
-                ragConfigured={ragConfigured}
-                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
-                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
-                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
-                canManageFolders={canManageFolderStructure}
-                canSelectFolders={canManageFolderStructure && !onSelectionChange}
-                selectedFolderIds={selectedFolderIds}
-                onSelectFolder={handleSelectFolder}
-                activeFolderId={activeFolderId}
-                onActivateFolder={handleActivateFolder}
-              />
-              {paginationEnabled && (
-                <Pagination
-                  page={page}
-                  totalPages={totalPages}
-                  totalCount={totalCount}
-                  pageSize={pageSize}
-                  onGoToPage={handleGoToPage}
-                  onPageSizeChange={handlePageSizeChange}
-                  disabled={loading}
-                />
+              {displayMode === 'expand-all' ? (
+                /* Compact expand-all: all folders open, no pagination */
+                <>
+                  {onSelectionChange && documents.length > 0 && (
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-text-muted">
+                      <button
+                        onClick={() => handleSelectAll(!isAllSelected)}
+                        className="flex items-center gap-1.5 hover:text-text-primary transition-colors"
+                      >
+                        {isAllSelected ? (
+                          <CheckSquare className="w-3.5 h-3.5 text-primary" />
+                        ) : (
+                          <Square className="w-3.5 h-3.5" />
+                        )}
+                        <span>{t('document.document.batch.selectAll')}</span>
+                      </button>
+                      <span className="text-text-muted">
+                        ({documents.filter(doc => selectedDocumentIds.has(doc.id)).length}/
+                        {documents.length})
+                      </span>
+                    </div>
+                  )}
+                  <FolderTree
+                    folders={folders}
+                    documents={documents}
+                    compact={true}
+                    expandAll={true}
+                    onViewDetail={setViewingDoc}
+                    onEdit={setEditingDoc}
+                    onDelete={setDeletingDoc}
+                    onRefresh={handleRefreshWebDocument}
+                    onReindex={handleReindexDocument}
+                    onMove={handleMoveDocument}
+                    refreshingDocId={refreshingDocId}
+                    reindexingDocId={reindexingDocId}
+                    canManage={canManageDocument}
+                    canSelect={canSelectDocument}
+                    selectedIds={selectedDocumentIds}
+                    includedInFolderScope={isDocumentIncludedInFolderScope}
+                    onSelect={handleSelectDoc}
+                    ragConfigured={ragConfigured}
+                    onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                    onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                    onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                    canManageFolders={canManageFolderStructure}
+                    canSelectFolders={canManageFolderStructure && !onSelectionChange}
+                    selectedFolderIds={selectedFolderIds}
+                    onSelectFolder={handleSelectFolder}
+                  />
+                </>
+              ) : (
+                /* Compact folder-nav: breadcrumb + direct children only */
+                <>
+                  <KnowledgeFolderBreadcrumb breadcrumbs={breadcrumbs} onNavigate={navigateTo} />
+                  {onSelectionChange && documents.length > 0 && (
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-text-muted">
+                      <button
+                        onClick={() => handleSelectAll(!isAllSelected)}
+                        className="flex items-center gap-1.5 hover:text-text-primary transition-colors"
+                      >
+                        {isAllSelected ? (
+                          <CheckSquare className="w-3.5 h-3.5 text-primary" />
+                        ) : (
+                          <Square className="w-3.5 h-3.5" />
+                        )}
+                        <span>
+                          {paginationEnabled
+                            ? t('document.document.batch.selectCurrentPage')
+                            : t('document.document.batch.selectAll')}
+                        </span>
+                      </button>
+                      <span className="text-text-muted">
+                        ({documents.filter(doc => selectedDocumentIds.has(doc.id)).length}/
+                        {documents.length})
+                      </span>
+                    </div>
+                  )}
+                  <FolderTree
+                    folders={
+                      searchQuery ? [] : directChildFolders.map(f => ({ ...f, children: [] }))
+                    }
+                    documents={documents}
+                    compact={true}
+                    folderNavMode={true}
+                    onViewDetail={setViewingDoc}
+                    onEdit={setEditingDoc}
+                    onDelete={setDeletingDoc}
+                    onRefresh={handleRefreshWebDocument}
+                    onReindex={handleReindexDocument}
+                    onMove={handleMoveDocument}
+                    refreshingDocId={refreshingDocId}
+                    reindexingDocId={reindexingDocId}
+                    canManage={canManageDocument}
+                    canSelect={canSelectDocument}
+                    selectedIds={selectedDocumentIds}
+                    includedInFolderScope={isDocumentIncludedInFolderScope}
+                    onSelect={handleSelectDoc}
+                    ragConfigured={ragConfigured}
+                    onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                    onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                    onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                    canManageFolders={canManageFolderStructure}
+                    canSelectFolders={canManageFolderStructure && !onSelectionChange}
+                    selectedFolderIds={selectedFolderIds}
+                    onSelectFolder={handleSelectFolder}
+                    onActivateFolder={navigateTo}
+                  />
+                  {paginationEnabled && (
+                    <Pagination
+                      page={page}
+                      totalPages={totalPages}
+                      totalCount={totalCount}
+                      pageSize={pageSize}
+                      onGoToPage={handleGoToPage}
+                      onPageSizeChange={handlePageSizeChange}
+                      disabled={loading}
+                    />
+                  )}
+                </>
               )}
             </div>
           ) : (
-            /* Normal mode: Table layout with folder tree - single bordered container */
+            /* Normal mode: dual-mode based on document count */
             <div className="border border-border rounded-lg overflow-x-auto">
-              <KnowledgeDocumentTreeGrid
-                nodes={resourceTree.nodes}
-                treeIndex={resourceTree.index}
-                folders={folders}
-                documents={documents}
-                showSelectionColumn={canManageDocumentArea}
-                showActionsColumn={canManageAnyDocuments}
-                sortField={sortField}
-                sortOrder={sortOrder}
-                onSortChange={(field, order) => {
-                  setSortField(field)
-                  setSortOrder(order)
-                }}
-                isAllSelected={isAllSelected}
-                isPartialSelected={isPartialSelected}
-                onSelectAll={handleSelectAll}
-                selectAllLabel={
-                  paginationEnabled
-                    ? t('document.document.batch.selectCurrentPage')
-                    : t('document.document.batch.selectAll')
-                }
-                onViewDetail={setViewingDoc}
-                onEdit={setEditingDoc}
-                onDelete={setDeletingDoc}
-                onRefresh={handleRefreshWebDocument}
-                onReindex={handleReindexDocument}
-                onMove={handleMoveDocument}
-                refreshingDocId={refreshingDocId}
-                reindexingDocId={reindexingDocId}
-                canManage={canManageDocument}
-                canSelect={canSelectDocument}
-                selectedDocumentIds={selectedDocumentIds}
-                includedInFolderScope={isDocumentIncludedInFolderScope}
-                onSelect={canManageDocumentArea ? handleSelectDoc : undefined}
-                ragConfigured={ragConfigured}
-                onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
-                onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
-                onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
-                canManageFolders={canManageFolderStructure}
-                canSelectFolders={canManageFolderStructure && !onSelectionChange}
-                selectedFolderIds={selectedFolderIds}
-                onSelectFolder={handleSelectFolder}
-                activeFolderId={activeFolderId}
-                onActivateFolder={handleActivateFolder}
-              />
-              {/* Pagination bar for classic mode */}
-              {paginationEnabled && (
-                <div className="min-w-[880px] bg-base">
-                  <Pagination
-                    page={page}
-                    totalPages={totalPages}
-                    totalCount={totalCount}
-                    pageSize={pageSize}
-                    onGoToPage={handleGoToPage}
-                    onPageSizeChange={handlePageSizeChange}
-                    disabled={loading}
+              {displayMode === 'expand-all' ? (
+                /* Expand-all mode: all folders open, no pagination */
+                <KnowledgeDocumentTreeGrid
+                  nodes={resourceTree.nodes}
+                  treeIndex={resourceTree.index}
+                  folders={folders}
+                  documents={documents}
+                  showSelectionColumn={canManageDocumentArea}
+                  showActionsColumn={canManageAnyDocuments}
+                  sortField={sortField}
+                  sortOrder={sortOrder}
+                  onSortChange={(field, order) => {
+                    setSortField(field)
+                    setSortOrder(order)
+                  }}
+                  isAllSelected={isAllSelected}
+                  isPartialSelected={isPartialSelected}
+                  onSelectAll={handleSelectAll}
+                  selectAllLabel={t('document.document.batch.selectAll')}
+                  onViewDetail={setViewingDoc}
+                  onEdit={setEditingDoc}
+                  onDelete={setDeletingDoc}
+                  onRefresh={handleRefreshWebDocument}
+                  onReindex={handleReindexDocument}
+                  onMove={handleMoveDocument}
+                  refreshingDocId={refreshingDocId}
+                  reindexingDocId={reindexingDocId}
+                  canManage={canManageDocument}
+                  canSelect={canSelectDocument}
+                  selectedDocumentIds={selectedDocumentIds}
+                  includedInFolderScope={isDocumentIncludedInFolderScope}
+                  onSelect={canManageDocumentArea ? handleSelectDoc : undefined}
+                  ragConfigured={ragConfigured}
+                  onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                  onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                  onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                  canManageFolders={canManageFolderStructure}
+                  canSelectFolders={canManageFolderStructure && !onSelectionChange}
+                  selectedFolderIds={selectedFolderIds}
+                  onSelectFolder={handleSelectFolder}
+                  expandAll={true}
+                />
+              ) : (
+                /* Folder-nav mode: breadcrumb + flat subfolder/document list */
+                <>
+                  {searchQuery ? (
+                    <div className="flex items-center gap-2 px-4 h-9 border-b border-border bg-surface/50 text-sm text-text-secondary">
+                      <Search className="w-3.5 h-3.5 flex-shrink-0" />
+                      <span className="truncate">
+                        {t('document.nav.searchResults')}: {searchQuery}
+                      </span>
+                    </div>
+                  ) : (
+                    <KnowledgeFolderBreadcrumb breadcrumbs={breadcrumbs} onNavigate={navigateTo} />
+                  )}
+                  <KnowledgeFolderNavView
+                    subfolders={searchQuery ? [] : directChildFolders}
+                    documents={documents}
+                    onNavigateFolder={navigateTo}
+                    showSelectionColumn={canManageDocumentArea}
+                    showActionsColumn={canManageAnyDocuments}
+                    sortField={sortField}
+                    sortOrder={sortOrder}
+                    onSortChange={(field, order) => {
+                      setSortField(field)
+                      setSortOrder(order)
+                    }}
+                    isAllSelected={isAllSelected}
+                    isPartialSelected={isPartialSelected}
+                    onSelectAll={handleSelectAll}
+                    selectAllLabel={
+                      paginationEnabled
+                        ? t('document.document.batch.selectCurrentPage')
+                        : t('document.document.batch.selectAll')
+                    }
+                    onViewDetail={setViewingDoc}
+                    onEdit={setEditingDoc}
+                    onDelete={setDeletingDoc}
+                    onRefresh={handleRefreshWebDocument}
+                    onReindex={handleReindexDocument}
+                    onMove={handleMoveDocument}
+                    refreshingDocId={refreshingDocId}
+                    reindexingDocId={reindexingDocId}
+                    canManage={canManageDocument}
+                    canSelect={canSelectDocument}
+                    selectedDocumentIds={selectedDocumentIds}
+                    includedInFolderScope={isDocumentIncludedInFolderScope}
+                    onSelect={canManageDocumentArea ? handleSelectDoc : undefined}
+                    ragConfigured={ragConfigured}
+                    onCreateFolder={canManageFolderStructure ? handleCreateFolder : undefined}
+                    onRenameFolder={canManageFolderStructure ? handleRenameFolder : undefined}
+                    onDeleteFolder={canManageFolderStructure ? handleDeleteFolderClick : undefined}
+                    canManageFolders={canManageFolderStructure}
                   />
-                </div>
+                  {paginationEnabled && (
+                    <div className="min-w-[880px] bg-base">
+                      <Pagination
+                        page={page}
+                        totalPages={totalPages}
+                        totalCount={totalCount}
+                        pageSize={pageSize}
+                        onGoToPage={handleGoToPage}
+                        onPageSizeChange={handlePageSizeChange}
+                        disabled={loading}
+                      />
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -503,7 +503,7 @@ export function DocumentList({
 
   useEffect(() => {
     resetSelection()
-  }, [activeFolderId, searchQuery, sortField, sortOrder, resetSelection])
+  }, [activeFolderId, navFolderId, searchQuery, sortField, sortOrder, resetSelection])
 
   useEffect(() => {
     if (!folderTreeContainsId(folders, activeFolderId)) {

--- a/frontend/src/features/knowledge/document/components/FolderTree.tsx
+++ b/frontend/src/features/knowledge/document/components/FolderTree.tsx
@@ -292,6 +292,7 @@ function FolderRow({
             : undefined
         }
         title={node.name}
+        data-testid={canActivate ? `folder-nav-row-${node.id}` : undefined}
       >
         {folderCheckbox}
         {!folderNavMode &&
@@ -349,6 +350,7 @@ function FolderRow({
             }
           : undefined
       }
+      data-testid={canActivate ? `folder-nav-row-${node.id}` : undefined}
     >
       {folderCheckbox}
       {expanded ? (

--- a/frontend/src/features/knowledge/document/components/FolderTree.tsx
+++ b/frontend/src/features/knowledge/document/components/FolderTree.tsx
@@ -18,6 +18,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { DocumentItem } from './DocumentItem'
 import type { KnowledgeDocument, KnowledgeFolder } from '@/types/knowledge'
 import { useTranslation } from '@/hooks/useTranslation'
+import { getAllFolderKeys } from '../utils/resource-tree'
 
 /** A node in the document browser: real folder or current document result */
 interface FolderNode {
@@ -76,6 +77,10 @@ interface FolderTreeProps {
   onSelectFolder?: (folderId: number, selected: boolean) => void
   activeFolderId?: number
   onActivateFolder?: (folderId: number) => void
+  /** When true, all folders (including nested) are expanded by default */
+  expandAll?: boolean
+  /** When true, folders are navigation items only — no expand arrow, always closed icon */
+  folderNavMode?: boolean
 }
 
 export type SortField = 'name' | 'size' | 'createdAt' | 'updatedAt'
@@ -184,6 +189,8 @@ interface FolderRowProps {
   onFolderCheck?: (checked: boolean) => void
   active?: boolean
   onActivate?: (folderId: number) => void
+  /** When true, folder is a navigation item only — no expand arrow */
+  folderNavMode?: boolean
 }
 
 function FolderRow({
@@ -202,6 +209,7 @@ function FolderRow({
   onFolderCheck,
   active,
   onActivate,
+  folderNavMode = false,
 }: FolderRowProps) {
   const { t } = useTranslation('knowledge')
   const indent = depth * (compact ? 12 : 16)
@@ -286,24 +294,25 @@ function FolderRow({
         title={node.name}
       >
         {folderCheckbox}
-        {expanded ? (
-          <ChevronDown
-            className="w-3 h-3 text-text-muted flex-shrink-0"
-            onClick={e => {
-              e.stopPropagation()
-              onToggle(node.path)
-            }}
-          />
-        ) : (
-          <ChevronRight
-            className="w-3 h-3 text-text-muted flex-shrink-0"
-            onClick={e => {
-              e.stopPropagation()
-              onToggle(node.path)
-            }}
-          />
-        )}
-        {expanded ? (
+        {!folderNavMode &&
+          (expanded ? (
+            <ChevronDown
+              className="w-3 h-3 text-text-muted flex-shrink-0"
+              onClick={e => {
+                e.stopPropagation()
+                onToggle(node.path)
+              }}
+            />
+          ) : (
+            <ChevronRight
+              className="w-3 h-3 text-text-muted flex-shrink-0"
+              onClick={e => {
+                e.stopPropagation()
+                onToggle(node.path)
+              }}
+            />
+          ))}
+        {expanded && !folderNavMode ? (
           <FolderOpen className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />
         ) : (
           <Folder className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />
@@ -408,6 +417,7 @@ interface FolderTreeNodeProps {
   onSelectFolder?: (folderId: number, selected: boolean) => void
   activeFolderId?: number
   onActivateFolder?: (folderId: number) => void
+  folderNavMode?: boolean
 }
 
 function FolderTreeNode({
@@ -442,6 +452,7 @@ function FolderTreeNode({
   onSelectFolder,
   activeFolderId,
   onActivateFolder,
+  folderNavMode = false,
 }: FolderTreeNodeProps) {
   // Hooks must be called unconditionally (before any early returns)
   const handleFolderCheck = useCallback(
@@ -537,6 +548,7 @@ function FolderTreeNode({
         onFolderCheck={handleFolderCheck}
         active={activeFolderId === node.id}
         onActivate={onActivateFolder}
+        folderNavMode={folderNavMode}
       />
       {isExpanded && (
         <div>
@@ -573,6 +585,7 @@ function FolderTreeNode({
               onSelectFolder={onSelectFolder}
               activeFolderId={activeFolderId}
               onActivateFolder={onActivateFolder}
+              folderNavMode={folderNavMode}
             />
           ))}
         </div>
@@ -614,13 +627,16 @@ export function FolderTree({
   onSelectFolder,
   activeFolderId,
   onActivateFolder,
+  expandAll = false,
+  folderNavMode = false,
 }: FolderTreeProps) {
   const tree = useMemo(() => buildMergedTree(folders, documents), [folders, documents])
 
-  const defaultExpandedFolderPaths = useMemo(
-    () => folders.map(folder => `folder:${folder.id}`),
-    [folders]
-  )
+  const defaultExpandedFolderPaths = useMemo(() => {
+    if (folderNavMode) return []
+    if (expandAll) return Array.from(getAllFolderKeys(folders))
+    return folders.map(folder => `folder:${folder.id}`)
+  }, [expandAll, folderNavMode, folders])
   const activeFolderPaths = useMemo(
     () => findFolderPathIds(folders, activeFolderId).map(id => `folder:${id}`),
     [folders, activeFolderId]
@@ -717,6 +733,7 @@ export function FolderTree({
             onSelectFolder={onSelectFolder}
             activeFolderId={activeFolderId}
             onActivateFolder={onActivateFolder}
+            folderNavMode={folderNavMode}
           />
         ))}
       </div>

--- a/frontend/src/features/knowledge/document/components/knowledge-folder-breadcrumb.tsx
+++ b/frontend/src/features/knowledge/document/components/knowledge-folder-breadcrumb.tsx
@@ -32,7 +32,7 @@ export function KnowledgeFolderBreadcrumb({
 
   return (
     <nav
-      className="flex items-center gap-1 px-4 h-9 border-b border-border bg-surface/50 overflow-hidden"
+      className="flex items-center gap-1 px-4 h-11 md:h-9 border-b border-border bg-surface/50 overflow-hidden"
       aria-label="folder navigation breadcrumb"
     >
       {visibleBreadcrumbs.map((item, index) => {
@@ -52,7 +52,7 @@ export function KnowledgeFolderBreadcrumb({
             ) : (
               <button
                 onClick={() => onNavigate(item.id)}
-                className="flex items-center gap-1 text-sm text-text-secondary hover:text-primary truncate max-w-[150px] transition-colors"
+                className="flex items-center gap-1 text-sm text-text-secondary hover:text-primary truncate max-w-[150px] transition-colors min-h-[44px] md:min-h-0"
                 data-testid={`breadcrumb-${item.id ?? 'root'}`}
               >
                 {index === 0 && <Home className="h-3.5 w-3.5 flex-shrink-0" />}

--- a/frontend/src/features/knowledge/document/components/knowledge-folder-breadcrumb.tsx
+++ b/frontend/src/features/knowledge/document/components/knowledge-folder-breadcrumb.tsx
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { Fragment } from 'react'
+import { ChevronRight, Home } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { BreadcrumbItem } from '../hooks/useFolderNavigation'
+
+interface KnowledgeFolderBreadcrumbProps {
+  breadcrumbs: BreadcrumbItem[]
+  onNavigate: (folderId: number | null) => void
+}
+
+// Collapse middle items when path depth exceeds this threshold
+const MAX_VISIBLE_SEGMENTS = 4
+
+export function KnowledgeFolderBreadcrumb({
+  breadcrumbs,
+  onNavigate,
+}: KnowledgeFolderBreadcrumbProps) {
+  const { t } = useTranslation('knowledge')
+  // Root item name is translated here, not in the data hook
+  const rootLabel = t('document.nav.allDocuments')
+  const shouldCollapse = breadcrumbs.length > MAX_VISIBLE_SEGMENTS + 1
+
+  const visibleBreadcrumbs: BreadcrumbItem[] = shouldCollapse
+    ? [breadcrumbs[0], { id: -1, name: '...' }, ...breadcrumbs.slice(-(MAX_VISIBLE_SEGMENTS - 1))]
+    : breadcrumbs
+
+  return (
+    <nav
+      className="flex items-center gap-1 px-4 h-9 border-b border-border bg-surface/50 overflow-hidden"
+      aria-label="folder navigation breadcrumb"
+    >
+      {visibleBreadcrumbs.map((item, index) => {
+        const isLast = index === visibleBreadcrumbs.length - 1
+        const isEllipsis = item.id === -1
+
+        return (
+          <Fragment key={item.id ?? 'root'}>
+            {index > 0 && <ChevronRight className="h-3.5 w-3.5 text-text-muted flex-shrink-0" />}
+            {isEllipsis ? (
+              <span className="text-xs text-text-muted px-1 select-none">...</span>
+            ) : isLast ? (
+              <span className="flex items-center gap-1 text-sm font-medium text-text-primary truncate max-w-[200px]">
+                {index === 0 && <Home className="h-3.5 w-3.5 flex-shrink-0" />}
+                <span className="truncate">{index === 0 ? rootLabel : item.name}</span>
+              </span>
+            ) : (
+              <button
+                onClick={() => onNavigate(item.id)}
+                className="flex items-center gap-1 text-sm text-text-secondary hover:text-primary truncate max-w-[150px] transition-colors"
+                data-testid={`breadcrumb-${item.id ?? 'root'}`}
+              >
+                {index === 0 && <Home className="h-3.5 w-3.5 flex-shrink-0" />}
+                {index > 0 && <span className="truncate">{item.name}</span>}
+              </button>
+            )}
+          </Fragment>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/features/knowledge/document/components/knowledge-folder-nav-view.tsx
+++ b/frontend/src/features/knowledge/document/components/knowledge-folder-nav-view.tsx
@@ -203,6 +203,7 @@ export function KnowledgeFolderNavView({
               onCheckedChange={checked => onSelect?.(document, checked === true)}
               onClick={event => event.stopPropagation()}
               className="data-[state=checked]:bg-primary data-[state=checked]:border-primary disabled:opacity-60"
+              data-testid={`document-checkbox-${document.id}`}
             />
           )
         },
@@ -823,6 +824,9 @@ export function KnowledgeFolderNavView({
               : `bg-base hover:bg-surface group ${onViewDetail ? 'cursor-pointer' : ''}`
           }`}
           style={{ gridTemplateColumns }}
+          data-testid={
+            isFolder ? `folder-row-${item.folder.id}` : `document-row-${item.document.id}`
+          }
           onClick={() => {
             if (isFolder) {
               onNavigateFolder(item.folder.id)

--- a/frontend/src/features/knowledge/document/components/knowledge-folder-nav-view.tsx
+++ b/frontend/src/features/knowledge/document/components/knowledge-folder-nav-view.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import {
   flexRender,
   getCoreRowModel,
@@ -14,6 +14,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import { useState } from 'react'
 import {
   ChevronDown,
   ChevronRight,
@@ -24,7 +25,6 @@ import {
   FileText,
   Folder,
   FolderInput,
-  FolderOpen,
   FolderPlus,
   Globe,
   Pencil,
@@ -41,26 +41,15 @@ import { toast } from '@/hooks/use-toast'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { KnowledgeDocument, KnowledgeFolder } from '@/types/knowledge'
 import type { SortField, SortOrder } from './FolderTree'
-import type {
-  KnowledgeResourceNode,
-  KnowledgeResourceRow,
-  KnowledgeResourceTreeIndex,
-} from '../utils/resource-tree'
-import {
-  flattenKnowledgeResourceRows,
-  getAllFolderKeys,
-  getDefaultExpandedFolderKeys,
-  getFolderPathKeys,
-  getResultDocumentFolderKeys,
-} from '../utils/resource-tree'
 
-type SortableColumnId = SortField
+type FolderNavRow =
+  | { kind: 'folder'; folder: KnowledgeFolder }
+  | { kind: 'document'; document: KnowledgeDocument }
 
-interface KnowledgeDocumentTreeGridProps {
-  nodes: KnowledgeResourceNode[]
-  treeIndex: KnowledgeResourceTreeIndex
-  folders: KnowledgeFolder[]
+interface KnowledgeFolderNavViewProps {
+  subfolders: KnowledgeFolder[]
   documents: KnowledgeDocument[]
+  onNavigateFolder: (folderId: number) => void
   showSelectionColumn: boolean
   showActionsColumn: boolean
   sortField: SortField
@@ -70,16 +59,11 @@ interface KnowledgeDocumentTreeGridProps {
   isPartialSelected: boolean
   onSelectAll: (checked: boolean) => void
   selectAllLabel: string
-  activeFolderId?: number
-  onActivateFolder?: (folderId: number) => void
   onCreateFolder?: (parentId: number) => void
   onRenameFolder?: (folderId: number, currentName: string) => void
   onDeleteFolder?: (folderId: number, folderName: string) => void
   canManageFolders?: boolean
-  canSelectFolders?: boolean
-  selectedFolderIds: Set<number>
   selectedDocumentIds: Set<number>
-  onSelectFolder?: (folderId: number, selected: boolean) => void
   onViewDetail?: (doc: KnowledgeDocument) => void
   onEdit?: (doc: KnowledgeDocument) => void
   onDelete?: (doc: KnowledgeDocument) => void
@@ -93,8 +77,6 @@ interface KnowledgeDocumentTreeGridProps {
   includedInFolderScope?: (doc: KnowledgeDocument) => boolean
   onSelect?: (doc: KnowledgeDocument, selected: boolean) => void
   ragConfigured?: boolean
-  /** When true, all folders are expanded by default and expansion is recursive */
-  expandAll?: boolean
 }
 
 function formatFileSize(bytes: number) {
@@ -115,36 +97,13 @@ function formatDateTime(dateString?: string) {
   return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`
 }
 
-function hasSelectedDescendantDocument(
-  node: KnowledgeResourceNode,
-  selectedDocumentIds: Set<number>
-): boolean {
-  if (node.kind === 'document') {
-    return selectedDocumentIds.has(node.documentId)
-  }
-  return node.children.some(child => hasSelectedDescendantDocument(child, selectedDocumentIds))
-}
-
-function hasSelectedDescendantFolder(
-  node: KnowledgeResourceNode,
-  selectedFolderIds: Set<number>
-): boolean {
-  if (node.kind === 'document') return false
-  return node.children.some(child => {
-    if (child.kind === 'document') return false
-    return (
-      selectedFolderIds.has(child.folderId) || hasSelectedDescendantFolder(child, selectedFolderIds)
-    )
-  })
-}
-
 function getDocumentDisplayName(document: KnowledgeDocument) {
   return document.source_type === 'web' && document.name.endsWith('.md')
     ? document.name.slice(0, -3)
     : document.name
 }
 
-function isSortableColumnId(columnId: string): columnId is SortableColumnId {
+function isSortableColumnId(columnId: string): columnId is SortField {
   return ['name', 'size', 'createdAt', 'updatedAt'].includes(columnId)
 }
 
@@ -157,11 +116,10 @@ function canOpenExternalUrl(url: string) {
   }
 }
 
-export function KnowledgeDocumentTreeGrid({
-  nodes,
-  treeIndex,
-  folders,
+export function KnowledgeFolderNavView({
+  subfolders,
   documents,
+  onNavigateFolder,
   showSelectionColumn,
   showActionsColumn,
   sortField,
@@ -171,16 +129,11 @@ export function KnowledgeDocumentTreeGrid({
   isPartialSelected,
   onSelectAll,
   selectAllLabel,
-  activeFolderId,
-  onActivateFolder,
   onCreateFolder,
   onRenameFolder,
   onDeleteFolder,
   canManageFolders = false,
-  canSelectFolders = false,
-  selectedFolderIds,
   selectedDocumentIds,
-  onSelectFolder,
   onViewDetail,
   onEdit,
   onDelete,
@@ -194,67 +147,15 @@ export function KnowledgeDocumentTreeGrid({
   includedInFolderScope,
   onSelect,
   ragConfigured = true,
-  expandAll = false,
-}: KnowledgeDocumentTreeGridProps) {
+}: KnowledgeFolderNavViewProps) {
   const { t } = useTranslation('knowledge')
-  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set())
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({})
 
-  const defaultExpandedKeys = useMemo(
-    () => (expandAll ? getAllFolderKeys(folders) : getDefaultExpandedFolderKeys(folders)),
-    [expandAll, folders]
-  )
-  const activeFolderKeys = useMemo(
-    () => getFolderPathKeys(treeIndex, activeFolderId),
-    [treeIndex, activeFolderId]
-  )
-  const resultDocumentFolderKeys = useMemo(
-    () => getResultDocumentFolderKeys(treeIndex, documents),
-    [treeIndex, documents]
-  )
-
-  useEffect(() => {
-    setExpandedKeys(previous => {
-      const next = new Set(previous)
-      defaultExpandedKeys.forEach(key => next.add(key))
-      return next
-    })
-  }, [defaultExpandedKeys])
-
-  useEffect(() => {
-    if (activeFolderKeys.size === 0) return
-    setExpandedKeys(previous => {
-      const next = new Set(previous)
-      activeFolderKeys.forEach(key => next.add(key))
-      return next
-    })
-  }, [activeFolderKeys])
-
-  useEffect(() => {
-    if (resultDocumentFolderKeys.size === 0) return
-    setExpandedKeys(previous => {
-      const next = new Set(previous)
-      resultDocumentFolderKeys.forEach(key => next.add(key))
-      return next
-    })
-  }, [resultDocumentFolderKeys])
-
-  const rows = useMemo(
-    () => flattenKnowledgeResourceRows(nodes, expandedKeys),
-    [nodes, expandedKeys]
-  )
-
-  const toggleFolder = useCallback((key: string) => {
-    setExpandedKeys(previous => {
-      const next = new Set(previous)
-      if (next.has(key)) {
-        next.delete(key)
-      } else {
-        next.add(key)
-      }
-      return next
-    })
-  }, [])
+  const rows = useMemo<FolderNavRow[]>(() => {
+    const folderRows: FolderNavRow[] = subfolders.map(f => ({ kind: 'folder', folder: f }))
+    const docRows: FolderNavRow[] = documents.map(d => ({ kind: 'document', document: d }))
+    return [...folderRows, ...docRows]
+  }, [subfolders, documents])
 
   const handleDocumentDownload = useCallback(
     async (document: KnowledgeDocument) => {
@@ -262,16 +163,13 @@ export function KnowledgeDocumentTreeGrid({
       try {
         await downloadAttachment(document.attachment_id, document.name)
       } catch {
-        toast({
-          title: t('document.document.downloadFailed'),
-          variant: 'destructive',
-        })
+        toast({ title: t('document.document.downloadFailed'), variant: 'destructive' })
       }
     },
     [t]
   )
 
-  const columns = useMemo<ColumnDef<KnowledgeResourceRow>[]>(
+  const columns = useMemo<ColumnDef<FolderNavRow>[]>(
     () => [
       {
         id: 'selection',
@@ -291,161 +189,105 @@ export function KnowledgeDocumentTreeGrid({
           ) : null,
         cell: ({ row }) => {
           if (!showSelectionColumn) return null
-          const { node, parentKeys } = row.original
-          if (node.kind === 'document') {
-            const document = node.document
-            const includedByFolder = includedInFolderScope?.(document) ?? false
-            const selectable = canSelect?.(document) ?? false
-            if (!selectable && !includedByFolder) return null
-            return (
-              <Checkbox
-                checked={selectedDocumentIds.has(document.id) || includedByFolder}
-                disabled={includedByFolder}
-                onCheckedChange={checked => onSelect?.(document, checked === true)}
-                onClick={event => event.stopPropagation()}
-                className="data-[state=checked]:bg-primary data-[state=checked]:border-primary disabled:opacity-60"
-              />
-            )
-          }
-
-          if (!canSelectFolders) return null
-          const coveredByAncestor = parentKeys.some(key => {
-            const folderId = Number(key.replace('folder:', ''))
-            return selectedFolderIds.has(folderId)
-          })
-          const directlySelected = selectedFolderIds.has(node.folderId)
-          const partiallySelected =
-            !directlySelected &&
-            !coveredByAncestor &&
-            (hasSelectedDescendantDocument(node, selectedDocumentIds) ||
-              hasSelectedDescendantFolder(node, selectedFolderIds))
-          const checked: boolean | 'indeterminate' =
-            directlySelected || coveredByAncestor
-              ? true
-              : partiallySelected
-                ? 'indeterminate'
-                : false
-
+          const item = row.original
+          // No checkbox for folder rows in nav view
+          if (item.kind === 'folder') return null
+          const document = item.document
+          const includedByFolder = includedInFolderScope?.(document) ?? false
+          const selectable = canSelect?.(document) ?? false
+          if (!selectable && !includedByFolder) return null
           return (
             <Checkbox
-              checked={checked}
-              disabled={coveredByAncestor || node.documentCount === 0}
-              onCheckedChange={nextChecked => onSelectFolder?.(node.folderId, nextChecked === true)}
+              checked={selectedDocumentIds.has(document.id) || includedByFolder}
+              disabled={includedByFolder}
+              onCheckedChange={checked => onSelect?.(document, checked === true)}
               onClick={event => event.stopPropagation()}
               className="data-[state=checked]:bg-primary data-[state=checked]:border-primary disabled:opacity-60"
-              data-testid={`folder-checkbox-${node.folderId}`}
             />
           )
         },
       },
       {
         id: 'name',
-        accessorFn: row => row.node.name,
+        accessorFn: row => (row.kind === 'folder' ? row.folder.name : row.document.name),
         header: () => t('document.document.columns.name'),
         size: 280,
         minSize: 200,
         maxSize: 520,
         cell: ({ row }) => {
-          const { node, depth } = row.original
-          const indent = depth * 16
-          if (node.kind === 'document') {
-            const document = node.document
-            const isTable = document.source_type === 'table'
-            const isWeb = document.source_type === 'web'
-            const sourceUrl =
-              (isTable || isWeb) &&
-              document.source_config?.url &&
-              typeof document.source_config.url === 'string'
-                ? document.source_config.url
-                : null
-            const displayName = getDocumentDisplayName(document)
+          const item = row.original
+          if (item.kind === 'folder') {
+            const folder = item.folder
+            const totalCount = folder.total_document_count ?? folder.document_count
             return (
-              <div
-                className="flex items-center gap-2 overflow-hidden min-w-0"
-                style={indent > 0 ? { paddingLeft: `${indent}px` } : undefined}
-              >
-                {isTable ? (
-                  <Table2 className="w-4 h-4 text-primary flex-shrink-0" />
-                ) : isWeb ? (
-                  <Globe className="w-4 h-4 text-primary flex-shrink-0" />
-                ) : (
-                  <FileText className="w-4 h-4 text-primary flex-shrink-0" />
-                )}
+              <div className="flex items-center gap-2 overflow-hidden min-w-0">
+                <Folder className="h-4 w-4 flex-shrink-0 text-amber-500" />
                 <TooltipProvider>
                   <Tooltip delayDuration={300}>
                     <TooltipTrigger asChild>
-                      <span className="min-w-0 flex-1 text-sm font-medium text-text-primary truncate">
-                        {displayName}
+                      <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary">
+                        {folder.name}
                       </span>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="max-w-xs">
-                      <p className="text-xs break-all">{displayName}</p>
+                      <p className="text-xs break-all">{folder.name}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
-                {sourceUrl && (
-                  <button
-                    className="p-1 rounded-md text-primary hover:bg-primary/10 transition-colors flex-shrink-0"
-                    onClick={event => {
-                      event.stopPropagation()
-                      if (canOpenExternalUrl(sourceUrl)) {
-                        window.open(sourceUrl, '_blank', 'noopener,noreferrer')
-                      }
-                    }}
-                    title={t('document.document.openLink')}
-                    data-testid={`open-document-source-${document.id}`}
-                  >
-                    <ExternalLink className="w-3.5 h-3.5" />
-                  </button>
-                )}
+                <span className="flex-shrink-0 text-xs text-text-muted">
+                  {t('document.folder.docCount', { count: totalCount })}
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 flex-shrink-0 text-text-muted ml-auto" />
               </div>
             )
           }
 
-          const isExpanded = expandedKeys.has(node.key)
+          const document = item.document
+          const isTable = document.source_type === 'table'
+          const isWeb = document.source_type === 'web'
+          const sourceUrl =
+            (isTable || isWeb) &&
+            document.source_config?.url &&
+            typeof document.source_config.url === 'string'
+              ? document.source_config.url
+              : null
+          const displayName = getDocumentDisplayName(document)
           return (
-            <div
-              className="flex items-center gap-2 overflow-hidden min-w-0"
-              style={indent > 0 ? { paddingLeft: `${indent}px` } : undefined}
-            >
-              <button
-                type="button"
-                className="flex h-6 w-6 items-center justify-center rounded-md text-text-muted hover:bg-primary/10 hover:text-primary"
-                onClick={event => {
-                  event.stopPropagation()
-                  toggleFolder(node.key)
-                }}
-                aria-label={
-                  isExpanded ? t('document.folder.collapse') : t('document.folder.expand')
-                }
-                data-testid={`toggle-folder-${node.folderId}`}
-              >
-                {isExpanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
-              </button>
-              {isExpanded ? (
-                <FolderOpen className="h-4 w-4 flex-shrink-0 text-amber-500" />
+            <div className="flex items-center gap-2 overflow-hidden min-w-0">
+              {isTable ? (
+                <Table2 className="w-4 h-4 text-primary flex-shrink-0" />
+              ) : isWeb ? (
+                <Globe className="w-4 h-4 text-primary flex-shrink-0" />
               ) : (
-                <Folder className="h-4 w-4 flex-shrink-0 text-amber-500" />
+                <FileText className="w-4 h-4 text-primary flex-shrink-0" />
               )}
               <TooltipProvider>
                 <Tooltip delayDuration={300}>
                   <TooltipTrigger asChild>
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary">
-                      {node.name}
+                    <span className="min-w-0 flex-1 text-sm font-medium text-text-primary truncate">
+                      {displayName}
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
-                    <p className="text-xs break-all">{node.name}</p>
+                    <p className="text-xs break-all">{displayName}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-              <span className="flex-shrink-0 text-xs text-text-muted">
-                {t('document.folder.docCount', { count: node.documentCount })}
-              </span>
+              {sourceUrl && (
+                <button
+                  className="p-1 rounded-md text-primary hover:bg-primary/10 transition-colors flex-shrink-0"
+                  onClick={event => {
+                    event.stopPropagation()
+                    if (canOpenExternalUrl(sourceUrl)) {
+                      window.open(sourceUrl, '_blank', 'noopener,noreferrer')
+                    }
+                  }}
+                  title={t('document.document.openLink')}
+                  data-testid={`open-document-source-${document.id}`}
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </button>
+              )}
             </div>
           )
         },
@@ -459,39 +301,38 @@ export function KnowledgeDocumentTreeGrid({
         enableResizing: false,
         header: () => null,
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'document') {
-            const document = node.document
-            if (!onEdit || !(canManage?.(document) ?? true)) return null
-            const label = t('common:actions.edit')
+          const item = row.original
+          if (item.kind === 'folder') {
+            if (!canManageFolders || !onRenameFolder) return null
+            const label = t('document.folder.rename')
             return (
               <button
                 className="p-1 rounded-md text-primary hover:bg-primary/10 transition-colors"
-                onClick={event => {
-                  event.stopPropagation()
-                  onEdit?.(document)
-                }}
                 title={label}
                 aria-label={label}
-                data-testid={`edit-document-${document.id}`}
+                onClick={event => {
+                  event.stopPropagation()
+                  onRenameFolder(item.folder.id, item.folder.name)
+                }}
+                data-testid={`rename-folder-${item.folder.id}`}
               >
                 <Pencil className="w-3.5 h-3.5" />
               </button>
             )
           }
-
-          if (!canManageFolders || !onRenameFolder) return null
-          const label = t('document.folder.rename')
+          const document = item.document
+          if (!onEdit || !(canManage?.(document) ?? true)) return null
+          const label = t('common:actions.edit')
           return (
             <button
               className="p-1 rounded-md text-primary hover:bg-primary/10 transition-colors"
-              title={label}
-              aria-label={label}
               onClick={event => {
                 event.stopPropagation()
-                onRenameFolder(node.folderId, node.name)
+                onEdit?.(document)
               }}
-              data-testid={`rename-folder-${node.folderId}`}
+              title={label}
+              aria-label={label}
+              data-testid={`edit-document-${document.id}`}
             >
               <Pencil className="w-3.5 h-3.5" />
             </button>
@@ -505,8 +346,8 @@ export function KnowledgeDocumentTreeGrid({
         maxSize: 120,
         header: () => t('document.document.columns.type'),
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'folder') {
+          const item = row.original
+          if (item.kind === 'folder') {
             return (
               <Badge
                 variant="default"
@@ -517,7 +358,7 @@ export function KnowledgeDocumentTreeGrid({
               </Badge>
             )
           }
-          const document = node.document
+          const document = item.document
           if (document.source_type === 'table') {
             return (
               <Badge
@@ -552,9 +393,9 @@ export function KnowledgeDocumentTreeGrid({
         maxSize: 120,
         header: () => t('document.document.columns.size'),
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'folder') return <span className="text-xs text-text-muted">-</span>
-          const document = node.document
+          const item = row.original
+          if (item.kind === 'folder') return <span className="text-xs text-text-muted">-</span>
+          const document = item.document
           return (
             <span className="text-xs text-text-muted">
               {document.source_type === 'table' || document.source_type === 'web'
@@ -571,19 +412,19 @@ export function KnowledgeDocumentTreeGrid({
         maxSize: 160,
         header: () => t('document.document.columns.createdBy'),
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'folder') return <span className="text-xs text-text-muted">-</span>
+          const item = row.original
+          if (item.kind === 'folder') return <span className="text-xs text-text-muted">-</span>
           return (
             <TooltipProvider>
               <Tooltip delayDuration={300}>
                 <TooltipTrigger asChild>
                   <span className="block text-xs text-text-muted truncate">
-                    {node.document.created_by || '-'}
+                    {item.document.created_by || '-'}
                   </span>
                 </TooltipTrigger>
-                {node.document.created_by && (
+                {item.document.created_by && (
                   <TooltipContent side="top" className="max-w-xs">
-                    <p className="text-xs">{node.document.created_by}</p>
+                    <p className="text-xs">{item.document.created_by}</p>
                   </TooltipContent>
                 )}
               </Tooltip>
@@ -598,8 +439,8 @@ export function KnowledgeDocumentTreeGrid({
         maxSize: 220,
         header: () => t('document.document.columns.date'),
         cell: ({ row }) => {
-          const node = row.original.node
-          const value = node.kind === 'folder' ? node.createdAt : node.document.created_at
+          const item = row.original
+          const value = item.kind === 'folder' ? item.folder.created_at : item.document.created_at
           return <span className="text-xs text-text-muted">{formatDateTime(value)}</span>
         },
       },
@@ -610,15 +451,20 @@ export function KnowledgeDocumentTreeGrid({
         maxSize: 220,
         header: () => t('document.document.columns.updatedAt'),
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'folder') {
-            return <span className="text-xs text-text-muted">{formatDateTime(node.updatedAt)}</span>
+          const item = row.original
+          if (item.kind === 'folder') {
+            return (
+              <span className="text-xs text-text-muted">
+                {formatDateTime(item.folder.updated_at)}
+              </span>
+            )
           }
+          const document = item.document
           return (
             <span className="text-xs text-text-muted">
-              {node.document.updated_at === node.document.created_at
+              {document.updated_at === document.created_at
                 ? '-'
-                : formatDateTime(node.document.updated_at)}
+                : formatDateTime(document.updated_at)}
             </span>
           )
         },
@@ -631,9 +477,9 @@ export function KnowledgeDocumentTreeGrid({
         enableSorting: false,
         header: () => t('document.document.columns.indexStatus'),
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'folder') return <span className="text-xs text-text-muted">-</span>
-          const document = node.document
+          const item = row.original
+          if (item.kind === 'folder') return <span className="text-xs text-text-muted">-</span>
+          const document = item.document
           const isPendingConversion = document.index_status === 'pending_conversion'
           const isConverting = document.index_status === 'converting'
           const isIndexing =
@@ -680,9 +526,10 @@ export function KnowledgeDocumentTreeGrid({
         enableSorting: false,
         header: () => t('document.document.columns.actions'),
         cell: ({ row }) => {
-          const node = row.original.node
-          if (node.kind === 'folder') {
+          const item = row.original
+          if (item.kind === 'folder') {
             if (!canManageFolders) return null
+            const folder = item.folder
             return (
               <div className="flex items-center justify-center gap-1">
                 {onCreateFolder && (
@@ -692,9 +539,9 @@ export function KnowledgeDocumentTreeGrid({
                     aria-label={t('document.folder.create')}
                     onClick={event => {
                       event.stopPropagation()
-                      onCreateFolder(node.folderId)
+                      onCreateFolder(folder.id)
                     }}
-                    data-testid={`create-subfolder-${node.folderId}`}
+                    data-testid={`create-subfolder-${folder.id}`}
                   >
                     <FolderPlus className="w-3.5 h-3.5" />
                   </button>
@@ -706,9 +553,9 @@ export function KnowledgeDocumentTreeGrid({
                     aria-label={t('document.folder.delete')}
                     onClick={event => {
                       event.stopPropagation()
-                      onDeleteFolder(node.folderId, node.name)
+                      onDeleteFolder(folder.id, folder.name)
                     }}
-                    data-testid={`delete-folder-${node.folderId}`}
+                    data-testid={`delete-folder-${folder.id}`}
                   >
                     <Trash2 className="w-3.5 h-3.5" />
                   </button>
@@ -717,7 +564,7 @@ export function KnowledgeDocumentTreeGrid({
             )
           }
 
-          const document = node.document
+          const document = item.document
           if (!(canManage?.(document) ?? true)) return null
           const isWeb = document.source_type === 'web'
           const isTable = document.source_type === 'table'
@@ -835,8 +682,6 @@ export function KnowledgeDocumentTreeGrid({
       canManage,
       canManageFolders,
       canSelect,
-      canSelectFolders,
-      expandedKeys,
       handleDocumentDownload,
       includedInFolderScope,
       isAllSelected,
@@ -851,16 +696,13 @@ export function KnowledgeDocumentTreeGrid({
       onRenameFolder,
       onSelect,
       onSelectAll,
-      onSelectFolder,
       ragConfigured,
       refreshingDocId,
       reindexingDocId,
       selectAllLabel,
       selectedDocumentIds,
-      selectedFolderIds,
       showSelectionColumn,
       t,
-      toggleFolder,
     ]
   )
 
@@ -879,17 +721,15 @@ export function KnowledgeDocumentTreeGrid({
   const table = useReactTable({
     data: rows,
     columns,
-    state: {
-      sorting,
-      columnSizing,
-      columnVisibility,
-    },
+    state: { sorting, columnSizing, columnVisibility },
     manualSorting: true,
     columnResizeMode: 'onChange',
     onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(),
-    getRowId: row => row.node.key,
+    getRowId: row =>
+      row.kind === 'folder' ? `folder:${row.folder.id}` : `document:${row.document.id}`,
   })
+
   const tableRows = table.getRowModel().rows
   const visibleColumns = table.getVisibleLeafColumns()
   const gridTemplateColumns = visibleColumns.map(column => `${column.getSize()}px`).join(' ')
@@ -972,42 +812,34 @@ export function KnowledgeDocumentTreeGrid({
 
   const renderRow = useCallback(
     (row: (typeof tableRows)[number]) => {
-      const { node } = row.original
-      const canActivateFolder = node.kind === 'folder' && Boolean(onActivateFolder)
-      const canActivateDocument = node.kind === 'document' && Boolean(onViewDetail)
-      const canActivateRow = canActivateFolder || canActivateDocument
+      const item = row.original
+      const isFolder = item.kind === 'folder'
+      const canClick = isFolder ? true : Boolean(onViewDetail)
       return (
         <div
           className={`grid items-center gap-4 px-4 py-3 transition-colors border-b border-border min-w-[880px] ${
-            node.kind === 'folder'
-              ? activeFolderId === node.folderId
-                ? `bg-primary/10 text-primary ${canActivateRow ? 'cursor-pointer' : ''}`
-                : `bg-surface/50 hover:bg-surface ${canActivateRow ? 'cursor-pointer' : ''}`
+            isFolder
+              ? `bg-surface/50 hover:bg-surface cursor-pointer`
               : `bg-base hover:bg-surface group ${onViewDetail ? 'cursor-pointer' : ''}`
           }`}
           style={{ gridTemplateColumns }}
           onClick={() => {
-            if (canActivateFolder) {
-              onActivateFolder?.(node.folderId)
-            } else if (canActivateDocument) {
-              onViewDetail?.(node.document)
+            if (isFolder) {
+              onNavigateFolder(item.folder.id)
+            } else if (canClick) {
+              onViewDetail?.(item.document)
             }
           }}
-          role={canActivateRow ? 'button' : undefined}
-          tabIndex={canActivateRow ? 0 : undefined}
-          aria-pressed={
-            node.kind === 'folder' && canActivateFolder
-              ? activeFolderId === node.folderId
-              : undefined
-          }
+          role="button"
+          tabIndex={0}
           onKeyDown={event => {
-            if (!canActivateRow || event.currentTarget !== event.target) return
+            if (event.currentTarget !== event.target) return
             if (event.key === 'Enter' || event.key === ' ') {
               event.preventDefault()
-              if (canActivateFolder) {
-                onActivateFolder?.(node.folderId)
-              } else if (canActivateDocument) {
-                onViewDetail?.(node.document)
+              if (isFolder) {
+                onNavigateFolder(item.folder.id)
+              } else if (canClick) {
+                onViewDetail?.(item.document)
               }
             }
           }}
@@ -1028,7 +860,7 @@ export function KnowledgeDocumentTreeGrid({
         </div>
       )
     },
-    [activeFolderId, gridTemplateColumns, onActivateFolder, onViewDetail]
+    [gridTemplateColumns, onNavigateFolder, onViewDetail]
   )
 
   return (
@@ -1045,14 +877,9 @@ export function KnowledgeDocumentTreeGrid({
       <div
         ref={scrollParentRef}
         className="max-h-[70vh] overflow-y-auto overflow-x-hidden"
-        data-testid="knowledge-document-treegrid-virtual-scroll"
+        data-testid="knowledge-folder-nav-virtual-scroll"
       >
-        <div
-          className="relative"
-          style={{
-            height: `${totalSize}px`,
-          }}
-        >
+        <div className="relative" style={{ height: `${totalSize}px` }}>
           {renderedVirtualItems.map(virtualRow => {
             const tableRow = tableRows[virtualRow.index]
             if (!tableRow) return null

--- a/frontend/src/features/knowledge/document/hooks/useFolderNavigation.ts
+++ b/frontend/src/features/knowledge/document/hooks/useFolderNavigation.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import type { KnowledgeFolder } from '@/types/knowledge'
+import { buildKnowledgeResourceTree } from '../utils/resource-tree'
+
+export interface BreadcrumbItem {
+  id: number | null
+  name: string
+}
+
+interface UseFolderNavigationResult {
+  navFolderId: number | null
+  breadcrumbs: BreadcrumbItem[]
+  directChildFolders: KnowledgeFolder[]
+  navigateTo: (folderId: number | null) => void
+}
+
+export function useFolderNavigation(
+  allFolders: KnowledgeFolder[],
+  knowledgeBaseId: number
+): UseFolderNavigationResult {
+  const [navFolderId, setNavFolderId] = useState<number | null>(null)
+
+  // Reset to root when switching knowledge bases
+  useEffect(() => {
+    setNavFolderId(null)
+  }, [knowledgeBaseId])
+
+  const navigateTo = useCallback((folderId: number | null) => {
+    setNavFolderId(folderId)
+  }, [])
+
+  const treeData = useMemo(() => buildKnowledgeResourceTree(allFolders, []), [allFolders])
+
+  const directChildFolders = useMemo(() => {
+    if (navFolderId === null) return allFolders
+    return treeData.index.folderById.get(navFolderId)?.children ?? []
+  }, [navFolderId, allFolders, treeData])
+
+  // Root item name is intentionally left empty — KnowledgeFolderBreadcrumb
+  // handles the translation directly to avoid timing issues with i18n in hooks.
+  const breadcrumbs = useMemo<BreadcrumbItem[]>(() => {
+    const root: BreadcrumbItem = { id: null, name: '' }
+    if (navFolderId === null) return [root]
+    const pathIds = treeData.index.folderPathIds.get(navFolderId) ?? []
+    return [
+      root,
+      ...pathIds.map(id => ({
+        id,
+        name: treeData.index.folderById.get(id)?.name ?? String(id),
+      })),
+    ]
+  }, [navFolderId, treeData])
+
+  return { navFolderId, breadcrumbs, directChildFolders, navigateTo }
+}

--- a/frontend/src/features/knowledge/document/utils/resource-tree.ts
+++ b/frontend/src/features/knowledge/document/utils/resource-tree.ts
@@ -232,3 +232,15 @@ export function deletedFolderAffectsActiveFolder(
   if (activeFolderId === undefined) return false
   return collectFolderAndDescendantIds(folders, deletedFolderId).has(activeFolderId)
 }
+
+export function getAllFolderKeys(folders: KnowledgeFolder[]): Set<string> {
+  const keys = new Set<string>()
+  const collect = (list: KnowledgeFolder[]) => {
+    for (const folder of list) {
+      keys.add(`folder:${folder.id}`)
+      collect(folder.children)
+    }
+  }
+  collect(folders)
+  return keys
+}

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -275,6 +275,10 @@
       "batchMoveFailed": "Failed to move documents",
       "batchMovePartial": "Batch move completed: {{success}} succeeded, {{failed}} failed. Failed documents remain selected and highlighted for retry"
     },
+    "nav": {
+      "allDocuments": "All Documents",
+      "searchResults": "Search results"
+    },
     "document": {
       "title": "Documents",
       "upload": "Add sources",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -275,6 +275,10 @@
       "batchMoveFailed": "移动文档失败",
       "batchMovePartial": "批量移动完成：成功 {{success}} 个，失败 {{failed}} 个。失败文档仍保留选中状态，请查看高亮项后重试"
     },
+    "nav": {
+      "allDocuments": "全部文档",
+      "searchResults": "搜索结果"
+    },
     "document": {
       "title": "文档",
       "upload": "添加来源",


### PR DESCRIPTION
知识库文档数量较多时，会进行分页，因为只对所有文档分页，文件夹全部展示，文件夹和文档是混合在一棵树里渲染，所以会出现一个文件夹下的文档分在多页显示的情况。对此进行优化，当文档总数<100时，全量展示所有文件夹和文档；当文档总数>=100时，只展示根目录下文件夹，由用户手动点击一层层展开，并在顶部添加面包屑组件，便于返回到任意父层级文件夹中。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added folder-based navigation with clickable breadcrumbs and a dedicated folder/document nav view.
  * Documents are now scoped to the currently selected folder (with optional search results view).
  * Added recursive “expand all” support and configurable navigation/compact rendering behavior.
  * Creating folders and targeting uploads now use the currently navigated folder.
* **Bug Fixes**
  * If the currently selected folder becomes unavailable, navigation automatically returns to the root.
* **Localization**
  * Added English and Simplified Chinese labels for “all documents” and “search results.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->