### PR TITLE
fix(wework): link Codex auth for local executor

### DIFF
--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -7,9 +7,9 @@
 
 import { createServer } from 'node:http'
 import { randomBytes, randomUUID } from 'node:crypto'
-import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { execFile, spawn } from 'node:child_process'
-import { homedir, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -199,7 +199,6 @@ async function runServer(sessionPath, token) {
   const executorHome = join(session.directory, 'executor-home')
   const codexHome = join(executorHome, 'codex')
   await mkdir(codexHome, { recursive: true })
-  await symlink(join(homedir(), '.codex', 'auth.json'), join(codexHome, 'auth.json'))
   app = spawn('bash', ['scripts/dev-mac-app.sh'], {
     cwd: weworkDir,
     detached: true,

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -1030,6 +1030,60 @@ fn native_codex_home_path() -> Result<PathBuf, String> {
     Ok(home.join(".codex"))
 }
 
+fn link_native_codex_auth(
+    native_codex_home: &Path,
+    wework_codex_home: &Path,
+) -> Result<(), String> {
+    let source = native_codex_home.join("auth.json");
+    let target = wework_codex_home.join("auth.json");
+    if source == target || !source.is_file() {
+        return Ok(());
+    }
+
+    if let Ok(metadata) = fs::symlink_metadata(&target) {
+        if metadata.file_type().is_symlink() && !target.exists() {
+            fs::remove_file(&target).map_err(|error| {
+                format!(
+                    "failed to remove stale Codex auth link {}: {error}",
+                    target.display()
+                )
+            })?;
+        } else {
+            return Ok(());
+        }
+    }
+
+    fs::create_dir_all(wework_codex_home)
+        .map_err(|error| format!("failed to create {}: {error}", wework_codex_home.display()))?;
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&source, &target).map_err(|error| {
+        format!(
+            "failed to link Codex auth {} -> {}: {error}",
+            target.display(),
+            source.display()
+        )
+    })?;
+    #[cfg(not(unix))]
+    fs::copy(&source, &target).map_err(|error| {
+        format!(
+            "failed to copy Codex auth {} to {}: {error}",
+            source.display(),
+            target.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn prepare_local_executor_codex_auth(envs: &[(String, String)]) -> Result<(), String> {
+    let Some(codex_home) = envs
+        .iter()
+        .find_map(|(key, value)| (key == CODEX_HOME_ENV).then_some(PathBuf::from(value)))
+    else {
+        return Ok(());
+    };
+    link_native_codex_auth(&native_codex_home_path()?, &codex_home)
+}
+
 fn codex_home_migration_status() -> Result<CodexHomeMigrationStatus, String> {
     let executor_home = local_executor_home_path()?;
     let wework_codex_home = wework_codex_home_path(&executor_home.display().to_string())?;
@@ -1817,6 +1871,7 @@ async fn spawn_sidecar_if_needed(
         }
         local_executor_sidecar_env(&inner, &app)
     };
+    prepare_local_executor_codex_auth(&envs)?;
 
     if let Some(path) = configured_sidecar_path() {
         let child = spawn_configured_sidecar(path, &envs)?;
@@ -2501,7 +2556,10 @@ mod tests {
 
         let result = import_external_content_from_paths("codex", &home, &destination).unwrap();
 
-        assert_eq!(fs::read_to_string(destination.join("config.toml")).unwrap(), "model = \"gpt-5\"");
+        assert_eq!(
+            fs::read_to_string(destination.join("config.toml")).unwrap(),
+            "model = \"gpt-5\""
+        );
         assert!(destination.join("skills/example/SKILL.md").is_file());
         assert_eq!(result.imported_entries, vec!["config.toml", "skills"]);
         fs::remove_dir_all(root).unwrap();
@@ -2519,7 +2577,10 @@ mod tests {
         let result =
             import_external_content_from_paths("claude-code", &home, &destination).unwrap();
 
-        assert_eq!(fs::read_to_string(destination.join("AGENTS.md")).unwrap(), "Claude instructions");
+        assert_eq!(
+            fs::read_to_string(destination.join("AGENTS.md")).unwrap(),
+            "Claude instructions"
+        );
         assert!(destination.join("skills/example/SKILL.md").is_file());
         assert_eq!(result.imported_entries, vec!["CLAUDE.md", "skills"]);
         fs::remove_dir_all(root).unwrap();
@@ -2590,6 +2651,80 @@ command = "example"
 
         assert_eq!(source, "bundled");
         assert_eq!(path, "wegent-executor");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn links_native_codex_auth_into_isolated_home() {
+        let root = import_test_root("codex-auth-link");
+        let native_home = root.join("native");
+        let wework_home = root.join("wework");
+        fs::create_dir_all(&native_home).unwrap();
+        fs::write(native_home.join("auth.json"), "native-auth").unwrap();
+
+        link_native_codex_auth(&native_home, &wework_home).unwrap();
+
+        let target = wework_home.join("auth.json");
+        assert!(fs::symlink_metadata(&target)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read_to_string(target).unwrap(), "native-auth");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replaces_stale_isolated_codex_auth_link() {
+        let root = import_test_root("codex-auth-stale-link");
+        let native_home = root.join("native");
+        let wework_home = root.join("wework");
+        fs::create_dir_all(&native_home).unwrap();
+        fs::create_dir_all(&wework_home).unwrap();
+        fs::write(native_home.join("auth.json"), "current-auth").unwrap();
+        std::os::unix::fs::symlink(
+            root.join("missing-auth.json"),
+            wework_home.join("auth.json"),
+        )
+        .unwrap();
+
+        link_native_codex_auth(&native_home, &wework_home).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(wework_home.join("auth.json")).unwrap(),
+            "current-auth"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn preserves_existing_isolated_codex_auth_file() {
+        let root = import_test_root("codex-auth-existing");
+        let native_home = root.join("native");
+        let wework_home = root.join("wework");
+        fs::create_dir_all(&native_home).unwrap();
+        fs::create_dir_all(&wework_home).unwrap();
+        fs::write(native_home.join("auth.json"), "native-auth").unwrap();
+        fs::write(wework_home.join("auth.json"), "isolated-auth").unwrap();
+
+        link_native_codex_auth(&native_home, &wework_home).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(wework_home.join("auth.json")).unwrap(),
+            "isolated-auth"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn skips_codex_auth_link_when_native_auth_is_missing() {
+        let root = import_test_root("codex-auth-missing");
+        let native_home = root.join("native");
+        let wework_home = root.join("wework");
+
+        link_native_codex_auth(&native_home, &wework_home).unwrap();
+
+        assert!(!wework_home.join("auth.json").exists());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Link the native `~/.codex/auth.json` into each isolated Wework local-executor Codex home during startup.
- Preserve an existing valid auth file or symlink and replace only stale symlinks.
- Remove the AI verifier's manual auth-link setup so verification exercises the production startup path.

## Why

`dev:mac` launches the local executor with an isolated `CODEX_HOME`. The executor then searched that isolated directory as its auth source, so Codex requests were sent without authentication and returned 401.

## Validation

- `cargo test --manifest-path wework/src-tauri/Cargo.toml codex_auth`
- Wework pre-push ESLint, TypeScript, and unit tests
- Verified a newly created runtime links its auth path to the native Codex auth file without reading or logging credential contents


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex authentication availability when starting isolated Wework sessions.
  * Existing authentication files are preserved, while outdated links are refreshed automatically.
  * Sessions continue to start smoothly when no native Codex authentication file is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->