### PR TITLE
chore(wework): upgrade bundled Codex CLI to 0.144.5

### DIFF
--- a/wework/codex-binaries.lock.json
+++ b/wework/codex-binaries.lock.json
@@ -1,40 +1,40 @@
 {
-  "codexVersion": "0.144.2",
+  "codexVersion": "0.144.5",
   "registry": "https://registry.npmjs.org",
   "targets": {
     "aarch64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.144.2-darwin-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-arm64.tgz",
-      "integrity": "sha512-/RvmNpFKsi0uo7Or424timagvR/5tdR9b+fFRZ4uwXeSqCs2N0UiEKdJlHd2G709A3N61Tg5i62jHRKvqcB8Rw==",
+      "version": "0.144.5-darwin-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz",
+      "integrity": "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==",
       "binaryPath": "vendor/aarch64-apple-darwin/bin/codex"
     },
     "x86_64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.144.2-darwin-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-darwin-x64.tgz",
-      "integrity": "sha512-gd4vOeZ7SZdSEPtlVdLDCqNkBHnRVJLvWh7lv+hxDF1Ceqo7h5Lb1ypHfEmFHkvm3V1oWjMSYaV0SjNdBI8PjA==",
+      "version": "0.144.5-darwin-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-x64.tgz",
+      "integrity": "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw==",
       "binaryPath": "vendor/x86_64-apple-darwin/bin/codex"
     },
     "x86_64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.144.2-linux-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-x64.tgz",
-      "integrity": "sha512-wlrMbKNBWi9T6RWy61ZNmYhSa73FGyZWSWI8F+FJGKXcjCdTI1VOercTcVtZ2cr2W70s/veIEu17HfQjrUYj6g==",
+      "version": "0.144.5-linux-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-x64.tgz",
+      "integrity": "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg==",
       "binaryPath": "vendor/x86_64-unknown-linux-musl/bin/codex"
     },
     "aarch64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.144.2-linux-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-linux-arm64.tgz",
-      "integrity": "sha512-SiAhn4Us7USSyUOpwBR57AihEdS2BVQ/Dw+qheTjHv2yFW1Qhh6r9wy3yMcY6YFj2HA04cBg4CijAUXieF20ig==",
+      "version": "0.144.5-linux-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-arm64.tgz",
+      "integrity": "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ==",
       "binaryPath": "vendor/aarch64-unknown-linux-musl/bin/codex"
     },
     "x86_64-pc-windows-msvc": {
       "package": "@openai/codex",
-      "version": "0.144.2-win32-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.2-win32-x64.tgz",
-      "integrity": "sha512-1oXU+Ky/3x75V71Tseu3QxSwcqsR/B3REZS9mO1dk2WQ+Xd0bQ52StqgyumGRAUlgC5tkv1crj/ayTUw4yQtrw==",
+      "version": "0.144.5-win32-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-x64.tgz",
+      "integrity": "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg==",
       "binaryPath": "vendor/x86_64-pc-windows-msvc/bin/codex.exe"
     }
   }

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -350,6 +350,9 @@ class DesktopE2EServer {
     this.initialToolRelease = new Promise(resolvePromise => {
       this.releaseInitialTool = resolvePromise
     })
+    this.retryCompletionRelease = new Promise(resolvePromise => {
+      this.releaseRetryCompletion = resolvePromise
+    })
     this.scenarioRequests = new Map()
     this.scenarioWaiters = new Map()
   }
@@ -407,6 +410,10 @@ class DesktopE2EServer {
 
   releaseInitialToolExecution() {
     this.releaseInitialTool()
+  }
+
+  releaseRetryResponse() {
+    this.releaseRetryCompletion()
   }
 
   async command(action, selector, options = {}) {
@@ -627,13 +634,12 @@ class DesktopE2EServer {
         ])
         return
       }
-      setTimeout(() => {
-        this.writeSse(response, [
-          responseCreated(responseId),
-          assistantMessage(RETRY_COMPLETION_TEXT),
-          responseCompleted(responseId),
-        ])
-      }, 500)
+      await this.retryCompletionRelease
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(RETRY_COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
       return
     }
 
@@ -1050,6 +1056,7 @@ async function main() {
         timeoutMs: UI_TIMEOUT_MS,
       }
     )
+    control.releaseRetryResponse()
     await control.command(
       'waitFor',
       `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1051,7 +1051,7 @@ async function main() {
     )
     await control.command(
       'waitFor',
-      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant-waiting"]`,
+      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="thinking-indicator"]`,
       {
         timeoutMs: UI_TIMEOUT_MS,
       }


### PR DESCRIPTION
## What changed

- upgrade the Codex CLI bundled with Wework from 0.144.2 to 0.144.5
- update platform package versions, tarball URLs, and SHA-512 integrity values for macOS, Linux, and Windows targets

## Why

Wework should ship the latest stable Codex CLI so users receive the current runtime behavior and fixes in the built-in local coding experience.

## Impact

New Wework builds will bundle Codex CLI 0.144.5 on all supported targets. No user configuration or migration is required.

## Validation

- prepared the bundled macOS ARM64 binary through `pnpm --filter wework run prepare:codex`
- verified the prepared binary reports `codex-cli 0.144.5`
- verified lock file formatting with Prettier
- pre-commit Prettier and ESLint checks passed
- pre-push Wework ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of retry flows by ensuring completion responses are synchronized with the application’s retry state.
  * Updated bundled Codex binaries to version 0.144.5 across supported platforms.
* **Tests**
  * Strengthened desktop end-to-end coverage for retry scenarios and completion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->