### PR TITLE
fix(wework): preserve local model selection after cloud connection

### DIFF
--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -330,14 +330,11 @@ describe('createHybridWorkbenchServices', () => {
     })
   })
 
-  it('gives local and cloud Codex models unique UI names', async () => {
+  it('keeps local model identity while giving cloud Codex models unique UI names', async () => {
     const services = createServices()
     const response = await services.modelApi.listModels()
 
-    expect(response.data.map(model => model.name)).toEqual([
-      'local:runtime:gpt-5.5',
-      'cloud:runtime:gpt-5.5',
-    ])
+    expect(response.data.map(model => model.name)).toEqual(['gpt-5.5', 'cloud:runtime:gpt-5.5'])
     expect(response.data.map(model => getModelExecutionOverride(model)?.modelName)).toEqual([
       'gpt-5.5',
       'gpt-5.5',
@@ -354,8 +351,8 @@ describe('createHybridWorkbenchServices', () => {
     const response = await services.modelApi.listModels()
 
     expect(response.data.map(model => model.name)).toEqual([
-      'local:public:chat-completions-model',
-      'responses-model',
+      'chat-completions-model',
+      'cloud:public:responses-model',
     ])
     expect(getModelExecutionOverride(response.data[1])?.source).toBe('cloud')
   })

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -130,10 +130,32 @@ function annotateHybridModel(
 function annotateLocalModels(models: UnifiedModel[]): UnifiedModel[] {
   return models.map(model => {
     if (!isRuntimeCodexModel(model)) {
+      return withModelExecutionOverride(model, {
+        source: 'local',
+        modelName: model.name,
+        modelType: model.type,
+        modelNamespace: model.namespace,
+        resourceUserId: model.resourceUserId,
+      })
+    }
+
+    return annotateHybridModel(
+      model,
+      'local',
+      model.name,
+      model.displayName || model.modelId || model.name,
+      model.displayName || model.modelId || model.name
+    )
+  })
+}
+
+function annotateCloudModels(models: UnifiedModel[]): UnifiedModel[] {
+  return models.filter(supportsResponsesApi).map(model => {
+    if (!isRuntimeCodexModel(model)) {
       return withModelExecutionOverride(
-        { ...model, name: `local:${model.type}:${model.name}` },
+        { ...model, name: `cloud:${model.type}:${model.name}` },
         {
-          source: 'local',
+          source: 'cloud',
           modelName: model.name,
           modelType: model.type,
           modelNamespace: model.namespace,
@@ -144,32 +166,10 @@ function annotateLocalModels(models: UnifiedModel[]): UnifiedModel[] {
 
     return annotateHybridModel(
       model,
-      'local',
-      `local:${model.type}:${model.name}`,
-      `${model.displayName || model.modelId || model.name} (本机)`,
-      `${model.displayName || model.modelId || model.name} 本机`
-    )
-  })
-}
-
-function annotateCloudModels(models: UnifiedModel[]): UnifiedModel[] {
-  return models.filter(supportsResponsesApi).map(model => {
-    if (!isRuntimeCodexModel(model)) {
-      return withModelExecutionOverride(model, {
-        source: 'cloud',
-        modelName: model.name,
-        modelType: model.type,
-        modelNamespace: model.namespace,
-        resourceUserId: model.resourceUserId,
-      })
-    }
-
-    return annotateHybridModel(
-      model,
       'cloud',
       `cloud:${model.type}:${model.name}`,
-      `${model.displayName || model.modelId || model.name} (云端)`,
-      `${model.displayName || model.modelId || model.name} 云端`
+      model.displayName || model.modelId || model.name,
+      model.displayName || model.modelId || model.name
     )
   })
 }

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1105,6 +1105,19 @@ describe('ChatInput', () => {
         },
       },
     }
+    const cloudModel: UnifiedModel = {
+      ...model,
+      name: 'cloud:user:cloud-gpt-5.5',
+      displayName: '云端:gpt-5.5',
+      config: {
+        ...model.config,
+        weworkExecution: {
+          source: 'cloud',
+          modelName: 'cloud-gpt-5.5',
+          modelType: 'user',
+        },
+      },
+    }
     const setSelectedModel = vi.fn()
     render(
       <ChatInput
@@ -1114,7 +1127,7 @@ describe('ChatInput', () => {
         disabled={false}
         variant="desktop"
         projectChat={projectChatControls({
-          models: [model],
+          models: [model, cloudModel],
           selectedModel: model,
           selectedModelOptions: { reasoning: 'high', speed: 'standard' },
           setSelectedModel,
@@ -1179,6 +1192,7 @@ describe('ChatInput', () => {
     expect(modelOption).toHaveTextContent('海外:gpt-5.5')
     expect(modelOption).not.toHaveTextContent('High')
     expect(modelOption.querySelectorAll('span')).toHaveLength(1)
+    expect(screen.getByTestId('model-option-cloud:user:cloud-gpt-5.5')).toHaveAccessibleName(/云端/)
     expect(
       screen
         .getByTestId('model-control-menu-model')

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -1,7 +1,8 @@
-import { Check, ChevronRight, Search, X } from 'lucide-react'
+import { Check, ChevronRight, Cloud, Search, X } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from '@/hooks/useTranslation'
+import { getModelExecutionOverride } from '@/features/cloud-connection/modelExecution'
 import { useConfiguredKeybinding } from '@/hooks/useConfiguredKeybinding'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import {
@@ -58,6 +59,10 @@ const SUBMENU_MAX_HEIGHT = 448
 const SUBMENU_VIEWPORT_VERTICAL_GAP = 128
 const DESKTOP_HIDDEN_CONTROL_IDS = new Set(['collaborationMode'])
 type DesktopSubmenuTarget = { type: 'models' } | { type: 'control'; id: string } | { type: 'none' }
+
+function isCloudModel(model: UnifiedModel): boolean {
+  return getModelExecutionOverride(model)?.source === 'cloud'
+}
 
 export function ModelSelector({
   models,
@@ -672,11 +677,23 @@ export function ModelSelector({
                         <span className="min-w-0 flex-1">
                           <span
                             className={[
-                              'block truncate text-sm font-semibold',
+                              'flex items-center gap-1.5 truncate text-sm font-semibold',
                               modelDisabled ? 'text-text-muted' : 'text-text-primary',
                             ].join(' ')}
                           >
-                            {getModelDisplayLabel(model, selectedModelOptions, resolveControlLabel)}
+                            <span className="truncate">
+                              {getModelDisplayLabel(
+                                model,
+                                selectedModelOptions,
+                                resolveControlLabel
+                              )}
+                            </span>
+                            {isCloudModel(model) && (
+                              <Cloud
+                                aria-label={t('workbench.environment_cloud', '云端')}
+                                className="h-3.5 w-3.5 shrink-0 text-text-muted"
+                              />
+                            )}
                           </span>
                           <span className="mt-0.5 block truncate text-xs text-text-muted">
                             {disabledMessage || model.displayName || model.modelId || model.name}
@@ -937,9 +954,9 @@ export function ModelSelector({
                               : 'text-text-primary hover:bg-muted',
                           ].join(' ')}
                         >
-                          <span className="min-w-0 flex-1 truncate font-medium">
+                          <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate font-medium">
                             {disabledMessage ? (
-                              <>
+                              <span className="min-w-0 flex-1 truncate">
                                 <span className="block truncate">
                                   {getModelDisplayLabel(
                                     model,
@@ -950,9 +967,19 @@ export function ModelSelector({
                                 <span className="mt-0.5 block truncate text-xs font-normal text-text-muted">
                                   {disabledMessage}
                                 </span>
-                              </>
+                              </span>
+                            ) : isCloudModel(model) ? (
+                              <span className="min-w-0 flex-1 truncate">
+                                {getModelDisplayLabel(model, {}, resolveControlLabel)}
+                              </span>
                             ) : (
                               getModelDisplayLabel(model, {}, resolveControlLabel)
+                            )}
+                            {isCloudModel(model) && (
+                              <Cloud
+                                aria-label={t('workbench.environment_cloud', '云端')}
+                                className="h-3.5 w-3.5 shrink-0 text-text-muted"
+                              />
                             )}
                           </span>
                           {selected && <Check className="h-4 w-4 shrink-0 text-text-secondary" />}


### PR DESCRIPTION
## What changed

- preserve local model names and display labels when cloud models are added
- namespace cloud model UI identities while retaining their original execution identity
- show a cloud icon after cloud models in desktop and mobile model selectors
- add regression coverage for local model identity and cloud model indicators

## Why

Connecting Wework to the cloud rebuilt the combined model list with renamed local model identities. The persisted local selection no longer matched, so the composer fell back to the default model. Cloud connection should only add available models and must not alter local model selection behavior.

## Impact

The selected local model remains selected after connecting to the cloud. Cloud models are added to the selector and are visually identified with a cloud icon. Local execution behavior is unchanged.

## Validation

- pre-commit Wework checks
- pre-push ESLint
- pre-push TypeScript checks
- pre-push Wework unit test suite
- focused hybrid service and ChatInput tests: 104 passed
- isolated Tauri verification attempted; the isolated local executor did not complete its secondary build, so the model selector could not be reached in that session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud-hosted models are now marked with a cloud icon in the model selector on desktop and mobile.
  * Cloud model options are more clearly identified for easier selection.

* **Bug Fixes**
  * Improved model naming and labeling so local and cloud models display consistently.
  * Updated model listings to distinguish cloud-backed models without unnecessary label suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->