### PR TITLE
fix(wework): make debug panel button compact and draggable

### DIFF
--- a/wework/src/lib/developerCommandMenu.test.ts
+++ b/wework/src/lib/developerCommandMenu.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent } from '@testing-library/react'
 import { installDeveloperCommandMenu } from './developerCommandMenu'
 import { APP_UPDATE_SIMULATE_EVENT } from '@/features/app-update/app-update-context'
 
@@ -126,13 +127,48 @@ describe('developerCommandMenu', () => {
     screenButton('Collapse').click()
 
     expect(screenCollapsedDebugPanel()).toBeInTheDocument()
-    expect(document.body).toHaveTextContent('Debug Panel collapsed')
+    expect(screenCollapsedDebugPanel()).toHaveClass('h-8', 'group')
+    expect(screenCollapsedDebugPanel()).toHaveTextContent('Debug')
+    expect(screenCollapsedDebugPanel()).toHaveAttribute(
+      'title',
+      expect.stringContaining('Debug Panel - taskKnown=true')
+    )
     expect(document.body).not.toHaveTextContent('Transcript vs Streaming Style')
 
     screenCollapsedDebugPanel().click()
 
     expect(document.body).toHaveTextContent('Transcript vs Streaming Style')
     expect(document.body).toHaveTextContent('Collapse')
+    expect(document.getElementById('wework-debug-panel')).not.toHaveAttribute('style')
+  })
+
+  test('drags the collapsed debug button without expanding it', () => {
+    dispatchDeveloperShortcut()
+    screenCommand('open-debug-panel').click()
+    screenButton('Collapse').click()
+
+    const root = document.getElementById('wework-debug-panel')
+    const button = screenCollapsedDebugPanel()
+    vi.spyOn(root!, 'getBoundingClientRect').mockReturnValue({
+      left: 900,
+      top: 700,
+      width: 32,
+      height: 32,
+      right: 932,
+      bottom: 732,
+      x: 900,
+      y: 700,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.pointerDown(button, { button: 0, clientX: 916, clientY: 716 })
+    fireEvent.pointerMove(window, { clientX: 816, clientY: 616 })
+    fireEvent.pointerUp(window)
+    fireEvent.click(button)
+
+    expect(root).toHaveStyle({ left: '800px', top: '600px' })
+    expect(screenCollapsedDebugPanel()).toBeInTheDocument()
+    expect(document.body).not.toHaveTextContent('Transcript vs Streaming Style')
   })
 })
 

--- a/wework/src/lib/developerCommandMenu.ts
+++ b/wework/src/lib/developerCommandMenu.ts
@@ -41,6 +41,7 @@ interface CodexStreamDebugState {
 
 let codexStreamDebugEnabled: boolean | null = null
 let codexStreamDebugLoad: Promise<void> | null = null
+let collapsedDebugPanelPosition: { left: number; top: number } | null = null
 
 export function installDeveloperCommandMenu() {
   window.addEventListener(
@@ -297,15 +298,19 @@ function renderDebugPanelShell(root: HTMLElement, expanded: boolean) {
   emitDebugPanelVisibility(expanded)
   const snapshot = getWorkbenchDebugSnapshot()
   root.innerHTML = ''
+  if (expanded) root.removeAttribute('style')
   root.className = expanded
     ? 'fixed inset-0 z-[2147483647] flex items-stretch justify-center bg-black/30 p-4'
-    : 'fixed bottom-4 right-4 z-[2147483647]'
+    : 'fixed z-[2147483647]'
   root.setAttribute('role', 'presentation')
 
   if (!expanded) {
+    applyCollapsedDebugPanelPosition(root)
     root.onclick = null
     root.onkeydown = null
-    root.appendChild(createCollapsedDebugPanel(snapshot, () => renderDebugPanelShell(root, true)))
+    root.appendChild(
+      createCollapsedDebugPanel(root, snapshot, () => renderDebugPanelShell(root, true))
+    )
     return
   }
 
@@ -382,14 +387,33 @@ function renderDebugPanelBody(container: HTMLElement, snapshot: WorkbenchDebugSn
   )
 }
 
-function createCollapsedDebugPanel(snapshot: WorkbenchDebugSnapshot, onExpand: () => void) {
+function applyCollapsedDebugPanelPosition(root: HTMLElement) {
+  if (collapsedDebugPanelPosition) {
+    root.style.left = `${collapsedDebugPanelPosition.left}px`
+    root.style.top = `${collapsedDebugPanelPosition.top}px`
+    root.style.right = 'auto'
+    root.style.bottom = 'auto'
+    return
+  }
+
+  root.style.left = 'auto'
+  root.style.top = 'auto'
+  root.style.right = '16px'
+  root.style.bottom = '16px'
+}
+
+function createCollapsedDebugPanel(
+  root: HTMLElement,
+  snapshot: WorkbenchDebugSnapshot,
+  onExpand: () => void
+) {
   const button = document.createElement('button')
   button.type = 'button'
   button.dataset.testid = 'debug-panel-collapsed'
   button.className =
-    'flex max-w-[min(420px,calc(100vw-2rem))] items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-left text-xs text-text-primary shadow-2xl hover:bg-muted focus:bg-muted focus:outline-none'
+    'group flex h-8 max-w-[calc(100vw-2rem)] cursor-grab items-center overflow-hidden rounded-md border border-border bg-background px-[11px] text-xs font-medium text-text-primary shadow-2xl transition-[width,background-color] hover:bg-muted focus:bg-muted focus:outline-none active:cursor-grabbing'
   button.setAttribute('aria-label', 'Expand debug panel')
-  button.addEventListener('click', onExpand)
+  button.title = `Debug Panel - ${formatRunningStateLabel(snapshot)}`
 
   const dot = document.createElement('span')
   dot.className = snapshot.workbench?.runningState.activeTaskRunning
@@ -397,14 +421,48 @@ function createCollapsedDebugPanel(snapshot: WorkbenchDebugSnapshot, onExpand: (
     : 'h-2 w-2 shrink-0 rounded-full bg-border'
 
   const text = document.createElement('span')
-  text.className = 'min-w-0 truncate'
-  text.textContent = `Debug Panel collapsed - ${formatRunningStateLabel(snapshot)}`
+  text.className =
+    'max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-[max-width,margin,opacity] group-hover:ml-2 group-hover:max-w-20 group-hover:opacity-100 group-focus-visible:ml-2 group-focus-visible:max-w-20 group-focus-visible:opacity-100'
+  text.textContent = 'Debug'
 
-  const hint = document.createElement('span')
-  hint.className = 'shrink-0 text-text-muted'
-  hint.textContent = 'Expand'
+  let dragged = false
+  button.addEventListener('click', event => {
+    if (dragged) {
+      event.preventDefault()
+      dragged = false
+      return
+    }
+    onExpand()
+  })
+  button.addEventListener('pointerdown', event => {
+    if (event.button !== 0) return
+    const startX = event.clientX
+    const startY = event.clientY
+    const startRect = root.getBoundingClientRect()
 
-  button.append(dot, text, hint)
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const deltaX = moveEvent.clientX - startX
+      const deltaY = moveEvent.clientY - startY
+      if (!dragged && Math.hypot(deltaX, deltaY) < 4) return
+      dragged = true
+      const maxLeft = Math.max(0, window.innerWidth - startRect.width)
+      const maxTop = Math.max(0, window.innerHeight - startRect.height)
+      collapsedDebugPanelPosition = {
+        left: Math.min(maxLeft, Math.max(0, startRect.left + deltaX)),
+        top: Math.min(maxTop, Math.max(0, startRect.top + deltaY)),
+      }
+      applyCollapsedDebugPanelPosition(root)
+    }
+    const handlePointerUp = () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+  })
+
+  button.append(dot, text)
   return button
 }
 


### PR DESCRIPTION
## What changed

- replace the long collapsed debug panel title with a compact 32px status button
- reveal the concise Debug label on hover or keyboard focus
- allow the collapsed button to be dragged within the viewport without triggering the panel
- retain the full runtime state in the button tooltip

## Why

The collapsed debug panel rendered the complete runtime state at the bottom-right of the workbench. Long task state frequently covered nearby controls. A compact, movable control keeps debug access available without obstructing the workspace.

## Validation

- Wework ESLint
- Wework TypeScript checks
- Wework unit tests
- focused `developerCommandMenu` tests (8/8)
- Prettier and `git diff --check`

An isolated Tauri session was started, but its local runtime remained on the startup timeout screen, so the debug panel could not be reached for real-app visual interaction verification. The isolated session was stopped cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop repositioning for the collapsed debug panel.
  * Preserved the panel’s position while moving it and prevented accidental expansion after dragging.
  * Maintained the default bottom-right placement when no custom position is set.

* **Bug Fixes**
  * Improved collapsed-panel behavior by hiding transcript content and restoring it correctly when expanded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->