### PR TITLE
fix(executor): isolate Codex from runtime IPC

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -51,6 +51,17 @@ const DEFAULT_REASONING_EFFORT: &str = "medium";
 const DEFAULT_NO_PROXY: &str = "localhost,127.0.0.1,::1,host.docker.internal";
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const WEGENT_CODEX_HOME_ENV: &str = "WEGENT_CODEX_HOME";
+const EXECUTOR_INTERNAL_ENV_KEYS: &[&str] = &[
+    "WEGENT_EXECUTOR_APP_IPC_ADDR",
+    "WEGENT_EXECUTOR_APP_IPC_ADDR_FILE",
+    "WEGENT_EXECUTOR_APP_IPC_SOCKET",
+    "WEGENT_EXECUTOR_BINARY",
+    "WEGENT_EXECUTOR_HOME",
+    "WEGENT_EXECUTOR_LOG_DIR",
+    "WEGENT_EXECUTOR_PROJECTS_DIR",
+    "WEGENT_EXECUTOR_SOURCE_DIR",
+    "WEWORK_EXECUTOR_SIDECAR",
+];
 const WEWORK_BROWSER_MCP_SERVER_NAME: &str = "wework_browser";
 const WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR";
 const DEFAULT_WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR: &str = "127.0.0.1:9231";
@@ -1603,6 +1614,9 @@ fn spawn_codex_app_server(
     let codex_home = wework_codex_home();
     prepare_wework_codex_home(&codex_home)?;
     let mut command = Command::new(&resolved_binary);
+    for key in EXECUTOR_INTERNAL_ENV_KEYS {
+        command.env_remove(key);
+    }
     for config_override in &launch_config.config_overrides {
         command.arg("-c").arg(config_override);
     }

--- a/executor/tests/local_app_ipc_contract.rs
+++ b/executor/tests/local_app_ipc_contract.rs
@@ -13,8 +13,8 @@ use serde_json::{json, Value};
 use tokio::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
 use wegent_executor::local::{
     app_ipc::{
-        app_ipc_listening_log_line, local_app_ipc_addr_file_path, read_app_ipc_addr_file,
-        AppIpcError, AppIpcServer, RuntimeWorkHandler,
+        app_ipc_listening_log_line, read_app_ipc_addr_file, AppIpcError, AppIpcServer,
+        RuntimeWorkHandler,
     },
     command::{CommandRequest, CommandResult, DeviceCommandHandler},
 };
@@ -850,6 +850,11 @@ async fn app_ipc_unknown_method_returns_protocol_error() {
 async fn app_ipc_addr_can_be_overridden() {
     let _lock = env_lock().await;
     let _addr = EnvGuard::set("WEGENT_EXECUTOR_APP_IPC_ADDR", "127.0.0.1:17490");
+    let addr_file = unique_dir("overridden-addr").join("app-ipc.addr");
+    let _addr_file = EnvGuard::set(
+        "WEGENT_EXECUTOR_APP_IPC_ADDR_FILE",
+        &addr_file.display().to_string(),
+    );
     let server = AppIpcServer::new();
     let task = tokio::spawn(async move { server.serve_forever().await });
 
@@ -863,7 +868,8 @@ async fn app_ipc_addr_can_be_overridden() {
     }
 
     task.abort();
-    let _ = std::fs::remove_file(local_app_ipc_addr_file_path());
+    let _ = std::fs::remove_file(&addr_file);
+    let _ = std::fs::remove_dir_all(addr_file.parent().unwrap());
 
     assert_eq!(addr, Some("127.0.0.1:17490".parse().unwrap()));
 }
@@ -897,6 +903,11 @@ async fn app_ipc_socket_serves_ready_event_and_responses() {
 
     let _lock = env_lock().await;
     let _addr = EnvGuard::set("WEGENT_EXECUTOR_APP_IPC_ADDR", "127.0.0.1:0");
+    let addr_file = unique_dir("socket-server").join("app-ipc.addr");
+    let _addr_file = EnvGuard::set(
+        "WEGENT_EXECUTOR_APP_IPC_ADDR_FILE",
+        &addr_file.display().to_string(),
+    );
     let server = AppIpcServer::new().with_device_id("device-1");
     let task = tokio::spawn(async move { server.serve_forever().await });
 
@@ -944,7 +955,8 @@ async fn app_ipc_socket_serves_ready_event_and_responses() {
     assert_eq!(response["error"]["code"], "unsupported_method");
 
     task.abort();
-    let _ = std::fs::remove_file(local_app_ipc_addr_file_path());
+    let _ = std::fs::remove_file(&addr_file);
+    let _ = std::fs::remove_dir_all(addr_file.parent().unwrap());
 }
 
 fn unique_dir(label: &str) -> std::path::PathBuf {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process isolation when launching Codex services by preventing executor-specific environment settings from being unintentionally inherited.
  * Reduced the risk of configuration conflicts between the executor and launched services.

* **Tests**
  * Improved test isolation by using temporary IPC address files and cleaning them up automatically after test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->