### PR TITLE
fix(wework): prevent stale updater signatures

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -12,10 +12,6 @@ on:
         type: boolean
         required: false
         default: false
-  push:
-    tags:
-      - "wework-v*"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/docs/en/developer-guide/wework-macos-release.md
+++ b/docs/en/developer-guide/wework-macos-release.md
@@ -95,7 +95,7 @@ The repository includes `.github/workflows/wework-app.yml` for producing macOS D
 https://github.com/<owner>/<repo>/releases/latest/download/latest.json
 ```
 
-The workflow creates or updates a `wework-v<version>` draft release. After both architecture builds finish, it generates `latest.json`, uploads it to the same release, and then publishes that release as GitHub latest. The client reads this manifest during automatic startup checks and when the titlebar update action is used.
+The workflow can only be started manually from GitHub Actions and does not respond to tag pushes. A formal run creates or updates a `wework-v<version>` draft release. After both architecture builds finish, it generates `latest.json`, uploads it to the same release, and then publishes that release as GitHub latest. The client reads this manifest during automatic startup checks and when the titlebar update action is used. Preventing tag-push triggers ensures that the tag created while publishing the release cannot start a second build of the same version and overwrite signed artifacts.
 
 Configure these repository secrets in GitHub Actions:
 
@@ -119,7 +119,7 @@ When downloaded from GitHub Release assets, the link points directly to the `.dm
 
 For a formal release, the workflow syncs `wework/package.json`, `wework/src-tauri/tauri.conf.json`, `wework/src-tauri/Cargo.toml`, and `wework/src-tauri/Cargo.lock` to the release version before building, then commits those files directly back to the triggering `main` branch. The macOS build jobs and GitHub Release target use that version commit, keeping the About page version, Tauri bundle version, and source version aligned.
 
-Manual workflow runs that do not publish a formal release only produce test artifacts and do not commit version files. For releases triggered by a `wework-vX.Y.Z` tag, the tag already points to an immutable commit, so the workflow does not rewrite source files; if the tagged version files do not match the tag version, the release fails and the version files must be updated before creating the tag again.
+Manual workflow runs that do not publish a formal release only produce test artifacts and do not commit version files. An existing `wework-vX.Y.Z` tag can also be selected explicitly when manually starting the workflow; the tag then points to an immutable commit, so the workflow does not rewrite source files. If the tagged version files do not match the tag version, the release fails and the version files must be updated before creating the tag again. Pushing a tag alone does not start a release.
 
 ## CI DMG Without Apple Developer
 

--- a/docs/zh/developer-guide/wework-macos-release.md
+++ b/docs/zh/developer-guide/wework-macos-release.md
@@ -95,7 +95,7 @@ python3 -m http.server 8787 --directory src-tauri/target/release/local-update-se
 https://github.com/<owner>/<repo>/releases/latest/download/latest.json
 ```
 
-workflow 会创建或更新 `wework-v<version>` draft release。两个架构构建完成后，workflow 生成 `latest.json`，上传到同一个 Release，最后把 Release 发布为 GitHub latest。客户端启动后的自动检查或标题栏手动更新都会读取这个 manifest。
+workflow 只能通过 GitHub Actions 手动触发，不会响应 tag push。正式发布会创建或更新 `wework-v<version>` draft release；两个架构构建完成后，workflow 生成 `latest.json`，上传到同一个 Release，最后把 Release 发布为 GitHub latest。客户端启动后的自动检查或标题栏手动更新都会读取这个 manifest。禁止 tag push 自动触发可以避免 workflow 发布 Release 时创建的 tag 再次启动同版本构建并覆盖已签名产物。
 
 GitHub Actions 需要配置这些 repository secrets：
 
@@ -119,7 +119,7 @@ workflow 分别上传这些 Release assets：
 
 正式发布时，workflow 会在构建前把 `wework/package.json`、`wework/src-tauri/tauri.conf.json`、`wework/src-tauri/Cargo.toml` 和 `wework/src-tauri/Cargo.lock` 同步到本次 release version，并直接提交回触发 workflow 的 `main` 分支。后续 macOS 构建和 GitHub Release 都会使用这个版本提交，确保关于页版本、Tauri 包版本和源码版本一致。
 
-手动触发但未勾选正式发布时只生成测试 artifacts，不会提交版本文件。通过 `wework-vX.Y.Z` tag 触发发布时，tag 已经指向固定提交，workflow 不会改写源码；如果 tag 指向的版本文件和 tag 版本不一致，发布会失败，需要先更新版本文件并重新打 tag。
+手动触发但未勾选正式发布时只生成测试 artifacts，不会提交版本文件。也可以在 GitHub Actions 中选择已有的 `wework-vX.Y.Z` tag 后手动运行 workflow；此时 tag 已经指向固定提交，workflow 不会改写源码。如果 tag 指向的版本文件和 tag 版本不一致，发布会失败，需要先更新版本文件并重新打 tag。仅推送 tag 不会启动发布。
 
 ## 无 Apple Developer 账号的 CI DMG
 

--- a/wework/src/features/app-update/AppUpdateProvider.test.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.test.tsx
@@ -106,6 +106,46 @@ describe('AppUpdateProvider', () => {
     expect(appUpdate?.downloadProgress).toEqual({ downloadedBytes: 50, totalBytes: 100 })
   })
 
+  test('refreshes a failed update so installation can be retried without restarting', async () => {
+    let appUpdate: AppUpdateContextValue | null = null
+    const update = {
+      currentVersion: '0.0.18',
+      version: '0.0.19',
+    }
+    vi.mocked(checkForWeworkUpdate).mockResolvedValue(update)
+    vi.mocked(installPendingWeworkUpdate)
+      .mockRejectedValueOnce(new Error('The signature verification failed'))
+      .mockResolvedValueOnce()
+
+    function Probe() {
+      appUpdate = useAppUpdate()
+      return null
+    }
+
+    render(
+      <AppUpdateProvider>
+        <Probe />
+      </AppUpdateProvider>
+    )
+
+    await act(async () => {
+      await appUpdate?.checkNow()
+    })
+    await act(async () => {
+      await appUpdate?.installUpdate()
+    })
+
+    expect(checkForWeworkUpdate).toHaveBeenCalledTimes(2)
+    expect(appUpdate?.status).toBe('available')
+    expect(appUpdate?.error).toBe('The signature verification failed')
+
+    await act(async () => {
+      await appUpdate?.installUpdate()
+    })
+
+    expect(installPendingWeworkUpdate).toHaveBeenCalledTimes(2)
+  })
+
   test('simulates an update download from the developer command menu', async () => {
     let appUpdate: AppUpdateContextValue | null = null
 

--- a/wework/src/features/app-update/AppUpdateProvider.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.tsx
@@ -114,9 +114,17 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
     try {
       await installPendingWeworkUpdate(setDownloadProgress)
     } catch (caughtError) {
-      setStatus('error')
+      const installError = messageFor(caughtError)
       setDownloadProgress(null)
-      setError(messageFor(caughtError))
+      setError(installError)
+
+      try {
+        const refreshedUpdate = await checkForWeworkUpdate()
+        setAvailableUpdate(refreshedUpdate)
+        setStatus(refreshedUpdate ? 'available' : 'error')
+      } catch {
+        setStatus('error')
+      }
     }
   }, [availableUpdate, status])
 

--- a/wework/src/lib/app-updater.ts
+++ b/wework/src/lib/app-updater.ts
@@ -84,6 +84,7 @@ export async function installPendingWeworkUpdate(
     const { relaunch } = await import('@tauri-apps/plugin-process')
     await relaunch()
   } catch (error) {
+    pendingUpdate = null
     throw new Error(errorMessage(error), { cause: error })
   }
 }


### PR DESCRIPTION
## What changed

- stop tag pushes from automatically starting the Wework release workflow
- discard a failed updater object and refresh `latest.json` so users can retry without restarting
- document the manual-only release trigger in Chinese and English

## Root cause

Publishing Wework 0.0.19 created the release tag, which started the same workflow a second time. The second run overwrote updater archives before it regenerated `latest.json`, temporarily pairing the new archive with the previous signature. Clients that checked during that window cached the stale updater object and continued failing signature verification on retry.

## Impact

Each version is built and published once. If an updater manifest changes after a failed installation, Wework refreshes it and leaves the update available for another attempt without requiring a process restart.

## Verification

- verified the repaired 0.0.19 macOS arm64 archive with the updater public key embedded in Wework 0.0.18
- `actionlint .github/workflows/wework-app.yml`
- focused AppUpdateProvider tests: 5 passed
- Wework ESLint: passed
- Wework TypeScript: passed
- Wework full unit suite in pre-push: passed
- isolated real-Tauri app launched; workbench completion was blocked by the existing unavailable internal `/users/me` endpoint, and the isolated session was stopped cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed update installations now automatically re-check for available updates, allowing users to retry without restarting the app.
  * Cleared stale update information after an unsuccessful installation attempt.

* **Documentation**
  * Clarified manual release triggering, tag behavior, version validation, and test-only release runs in the macOS release guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->