### PR TITLE
fix(wework): stop cloud setup blocking startup

### DIFF
--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -84,7 +84,7 @@ describe('LocalRuntimeInitializer', () => {
     expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
   })
 
-  test('applies the initial cloud connection before ensuring the executor is started', async () => {
+  test('starts the executor before applying the initial cloud connection', async () => {
     connectMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
     ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
 
@@ -105,12 +105,12 @@ describe('LocalRuntimeInitializer', () => {
       backendUrl: 'https://backend.example.com',
       authToken: 'token-a',
     })
-    expect(connectMock.mock.invocationCallOrder[0]).toBeLessThan(
-      ensureMock.mock.invocationCallOrder[0]
+    expect(ensureMock.mock.invocationCallOrder[0]).toBeLessThan(
+      connectMock.mock.invocationCallOrder[0]
     )
   })
 
-  test('applies disconnected local mode before ensuring the executor is started', async () => {
+  test('starts the executor before applying disconnected local mode', async () => {
     disconnectMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
     ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
 
@@ -127,15 +127,13 @@ describe('LocalRuntimeInitializer', () => {
 
     expect(await screen.findByTestId('main-app')).toBeInTheDocument()
     expect(disconnectMock).toHaveBeenCalledTimes(1)
-    expect(disconnectMock.mock.invocationCallOrder[0]).toBeLessThan(
-      ensureMock.mock.invocationCallOrder[0]
+    expect(ensureMock.mock.invocationCallOrder[0]).toBeLessThan(
+      disconnectMock.mock.invocationCallOrder[0]
     )
   })
 
-  test('does not start the executor until initial cloud connection setup succeeds', async () => {
-    connectMock
-      .mockRejectedValueOnce(new Error('backend setup failed'))
-      .mockResolvedValueOnce({ running: true, ready: true, deviceId: 'local-device' })
+  test('reveals the app without waiting for initial cloud connection setup', async () => {
+    connectMock.mockImplementation(() => new Promise(() => undefined))
     ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
 
     render(
@@ -150,16 +148,30 @@ describe('LocalRuntimeInitializer', () => {
       </LocalRuntimeInitializer>
     )
 
-    expect(await screen.findByTestId('local-runtime-error')).toHaveTextContent(
-      'backend setup failed'
-    )
-    expect(ensureMock).not.toHaveBeenCalled()
+    expect(await screen.findByTestId('main-app')).toBeInTheDocument()
+    expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
+    expect(connectMock).toHaveBeenCalledTimes(1)
+    expect(ensureMock).toHaveBeenCalledTimes(1)
+  })
 
-    await userEvent.click(screen.getByTestId('local-runtime-retry-button'))
+  test('keeps the app ready when initial cloud connection setup fails', async () => {
+    connectMock.mockRejectedValue(new Error('backend setup failed'))
+    ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
+
+    render(
+      <LocalRuntimeInitializer
+        initialCloudConnection={{
+          backendUrl: 'https://backend.example.com',
+          isConnected: true,
+          token: 'token-a',
+        }}
+      >
+        <div data-testid="main-app">Main app</div>
+      </LocalRuntimeInitializer>
+    )
 
     expect(await screen.findByTestId('main-app')).toBeInTheDocument()
-    expect(connectMock).toHaveBeenCalledTimes(2)
-    expect(ensureMock).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('local-runtime-error')).not.toBeInTheDocument()
   })
 
   test('reveals children once executor is ready even while app startup continues', async () => {

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -101,10 +101,12 @@ describe('LocalRuntimeInitializer', () => {
     )
 
     expect(await screen.findByTestId('main-app')).toBeInTheDocument()
-    expect(connectMock).toHaveBeenCalledWith({
-      backendUrl: 'https://backend.example.com',
-      authToken: 'token-a',
-    })
+    await waitFor(() =>
+      expect(connectMock).toHaveBeenCalledWith({
+        backendUrl: 'https://backend.example.com',
+        authToken: 'token-a',
+      })
+    )
     expect(ensureMock.mock.invocationCallOrder[0]).toBeLessThan(
       connectMock.mock.invocationCallOrder[0]
     )
@@ -126,7 +128,7 @@ describe('LocalRuntimeInitializer', () => {
     )
 
     expect(await screen.findByTestId('main-app')).toBeInTheDocument()
-    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(disconnectMock).toHaveBeenCalledTimes(1))
     expect(ensureMock.mock.invocationCallOrder[0]).toBeLessThan(
       disconnectMock.mock.invocationCallOrder[0]
     )

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -91,13 +91,9 @@ function localRuntimeMinimumReadyDelayMs(): number {
 
 async function resolveLocalRuntimeState(
   fallbackError: string,
-  errorText: LocalRuntimeErrorText,
-  initialCloudConnection?: LocalExecutorCloudConnection
+  errorText: LocalRuntimeErrorText
 ): Promise<LocalRuntimeState> {
   try {
-    if (initialCloudConnection) {
-      await applyLocalExecutorCloudConnection(initialCloudConnection)
-    }
     const status = await ensureLocalExecutorStarted()
     const statusError = localRuntimeError(status, errorText)
     if (statusError) {
@@ -343,23 +339,13 @@ export function LocalRuntimeInitializer({
     setSlowStartupTimedOut(false)
     setCopyDebugState('idle')
     setState({ phase: 'starting', error: null })
-    setState(
-      await resolveLocalRuntimeState(
-        fallbackError,
-        runtimeErrorText,
-        initialCloudConnectionRef.current
-      )
-    )
+    setState(await resolveLocalRuntimeState(fallbackError, runtimeErrorText))
   }, [enabled, fallbackError, runtimeErrorText])
 
   useEffect(() => {
     if (!enabled) return undefined
     let cancelled = false
-    void resolveLocalRuntimeState(
-      fallbackError,
-      runtimeErrorText,
-      initialCloudConnectionRef.current
-    ).then(nextState => {
+    void resolveLocalRuntimeState(fallbackError, runtimeErrorText).then(nextState => {
       if (!cancelled) {
         setState(nextState)
       }
@@ -368,6 +354,14 @@ export function LocalRuntimeInitializer({
       cancelled = true
     }
   }, [enabled, fallbackError, runtimeErrorText])
+
+  useEffect(() => {
+    if (!enabled || state.phase !== 'ready' || !initialCloudConnectionRef.current) return
+
+    void applyLocalExecutorCloudConnection(initialCloudConnectionRef.current).catch(error => {
+      console.error('[Wework] Failed to apply cloud connection to local executor:', error)
+    })
+  }, [enabled, state.phase])
 
   const handleCopyDebugInfo = useCallback(async () => {
     setCopyDebugState('copying')


### PR DESCRIPTION
## What changed

- start the local executor before applying the persisted cloud connection
- apply cloud backend configuration asynchronously after the local runtime is ready
- keep the local workbench available when cloud configuration is pending or fails
- add regression coverage for pending and failed cloud configuration

## Why

Wework startup awaited cloud backend configuration before ensuring the local executor was started. A slow or unavailable cloud connection therefore delayed the local-first startup path and could turn a cloud failure into a local runtime startup failure.

## Impact

The local workbench now becomes available as soon as the local executor is ready. Cloud connectivity remains an optional enhancement and is applied in the background without blocking startup.

## Validation

- `pnpm --filter wework exec vitest run src/features/local-runtime/LocalRuntimeInitializer.test.tsx`
- `pnpm --filter wework exec prettier --check src/features/local-runtime/LocalRuntimeInitializer.tsx src/features/local-runtime/LocalRuntimeInitializer.test.tsx`
- `pnpm --filter wework exec eslint src/features/local-runtime/LocalRuntimeInitializer.tsx src/features/local-runtime/LocalRuntimeInitializer.test.tsx`
- `pnpm --filter wework typecheck`
- full Wework unit suite through pre-push
- isolated real-Tauri verification with `desktop-workbench-main` visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The app now becomes available without waiting for cloud connection setup to complete.
  * Local runtime startup proceeds before applying the saved cloud connection.
  * Cloud connection failures no longer block access to the main app or display a local runtime error screen.
  * Retry and startup behavior now follow the updated initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->