### PR TITLE
fix(wework): restore offline remote projects and task summaries

### DIFF
--- a/docs/en/developer-guide/wework-codex-sidebar.md
+++ b/docs/en/developer-guide/wework-codex-sidebar.md
@@ -4,17 +4,17 @@ sidebar_position: 24
 
 # Codex sidebar state parity
 
-The Wework desktop app follows the Codex App sidebar state model. Project and task content still comes from the Codex app-server, while sidebar metadata comes from `.codex-global-state.json` in the target device's `CODEX_HOME`.
+The Wework desktop app follows the Codex App sidebar state model. Project and live task content comes from the Codex app-server, while sidebar metadata comes from `.codex-global-state.json` in the target device's `CODEX_HOME`. While a remote device is online, Wework also stores a local task-list summary for startup recovery after that device goes offline.
 
 ## State ownership
 
-| Data | Source of truth | Notes |
-| --- | --- | --- |
-| Project names, roots, and kinds | Codex global state | Covers legacy roots, multi-root `local-projects`, and `remote-projects` |
-| Project order, pins, and appearance | Codex global state | Uses `project-order`, `pinned-project-ids`, and `project-appearances` |
-| Task title, timestamps, and runtime status | Codex app-server | Task content is not copied into global state |
-| Task grouping, order, and pins | Codex global state | Uses assignments, workspace hints, per-project thread order, and pinned thread IDs |
-| Expansion and scroll preferences | Wework localStorage | UI-only preferences that do not affect Codex |
+| Data                                       | Source of truth                                | Notes                                                                              |
+| ------------------------------------------ | ---------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Project names, roots, and kinds            | Codex global state                             | Covers legacy roots, multi-root `local-projects`, and `remote-projects`            |
+| Project order, pins, and appearance        | Codex global state                             | Uses `project-order`, `pinned-project-ids`, and `project-appearances`              |
+| Task title, timestamps, and runtime status | Codex app-server + Wework remote summary cache | Task bodies are not cached; cached runtime status is always stopped                |
+| Task grouping, order, and pins             | Codex global state                             | Uses assignments, workspace hints, per-project thread order, and pinned thread IDs |
+| Expansion and scroll preferences           | Wework localStorage                            | UI-only preferences that do not affect Codex                                       |
 
 A project UI identity combines the state-owning device with the project key. Identical paths on different devices therefore remain isolated.
 
@@ -35,6 +35,12 @@ Wework sends semantic mutations such as “move project A before B” or “pin 
 When Codex App is not running, Executor writes a same-directory temporary file, flushes it, and atomically replaces global state. While Codex App is running, mutations are appended to a JSONL oplog. Reads overlay pending mutations on disk state for immediate UI feedback. After Codex exits, Executor merges the oplog into the latest disk state. Unknown fields are preserved by every write.
 
 Local projects are mutated by the local Executor in the local `CODEX_HOME`. Remote projects are mutated by the Executor on the owning device. Backend does not persist sidebar state.
+
+## Offline remote task recovery
+
+After a cloud or remote task-list sync succeeds, Wework stores a per-user, allowlisted summary in local `localStorage`. It includes task IDs, titles, update times, workspace paths, repository and branch hints, and sidebar ordering metadata. The cache excludes conversation bodies, tool calls, runtime handles, model configuration, and parent or child task trees. Full details remain only on the remote device.
+
+At startup, the cached summary is merged as stale data with the local Codex remote-project descriptors. When the remote device is unavailable, the project, last known IP, and task summaries remain visible with a gray status dot. Task rows cannot be opened, pinned, renamed, subscribed, or archived. After the device reconnects, the live list becomes authoritative and updates or removes cached entries. A failed device discovery or task-list sync keeps the previous summary so a temporary network error does not empty the sidebar.
 
 ## Interaction boundary
 

--- a/docs/zh/developer-guide/wework-codex-sidebar.md
+++ b/docs/zh/developer-guide/wework-codex-sidebar.md
@@ -4,17 +4,17 @@ sidebar_position: 24
 
 # Codex 左侧栏状态一致性
 
-Wework 桌面端复用 Codex App 的侧栏状态语义。项目和任务内容仍由 Codex app-server 提供，侧栏元数据由设备对应 `CODEX_HOME` 下的 `.codex-global-state.json` 提供。
+Wework 桌面端复用 Codex App 的侧栏状态语义。项目和实时任务内容由 Codex app-server 提供，侧栏元数据由设备对应 `CODEX_HOME` 下的 `.codex-global-state.json` 提供。远程设备在线时，Wework 还会在本机保存任务列表摘要，用于设备离线后的启动恢复。
 
 ## 状态所有权
 
-| 数据 | 唯一来源 | 说明 |
-| --- | --- | --- |
-| 项目名称、根目录和类型 | Codex global state | 支持传统目录项目、`local-projects` 多目录项目和 `remote-projects` |
-| 项目顺序、置顶和外观 | Codex global state | 使用 `project-order`、`pinned-project-ids`、`project-appearances` |
-| 任务标题、时间和运行状态 | Codex app-server | Wework 不把任务正文复制到 global state |
-| 任务归属、顺序和置顶 | Codex global state | 使用 assignment、workspace hint、项目内 thread order 和 pinned thread IDs |
-| 展开状态和滚动偏好 | Wework localStorage | 仅保存不影响 Codex 的纯 UI 偏好 |
+| 数据                     | 唯一来源                               | 说明                                                                      |
+| ------------------------ | -------------------------------------- | ------------------------------------------------------------------------- |
+| 项目名称、根目录和类型   | Codex global state                     | 支持传统目录项目、`local-projects` 多目录项目和 `remote-projects`         |
+| 项目顺序、置顶和外观     | Codex global state                     | 使用 `project-order`、`pinned-project-ids`、`project-appearances`         |
+| 任务标题、时间和运行状态 | Codex app-server + Wework 远程摘要缓存 | Wework 不缓存任务正文；离线缓存中的运行状态始终为停止                     |
+| 任务归属、顺序和置顶     | Codex global state                     | 使用 assignment、workspace hint、项目内 thread order 和 pinned thread IDs |
+| 展开状态和滚动偏好       | Wework localStorage                    | 仅保存不影响 Codex 的纯 UI 偏好                                           |
 
 项目的 UI 标识由“状态所属设备 + project key”组成。这样，不同设备上相同路径的项目不会被错误合并。
 
@@ -35,6 +35,12 @@ Wework 只发送语义操作，例如“把项目 A 放到 B 前”“置顶 thr
 Codex App 未运行时，Executor 在同目录写临时文件、刷盘后原子替换 global state。Codex App 运行时，操作先进入 JSONL oplog；读取时将磁盘状态和待写操作叠加，因此 UI 立即可见。Codex 退出后，Executor 把操作合并到最新磁盘状态。所有写入都保留 Wework 不认识的字段。
 
 本地项目由本地 Executor 修改本机 `CODEX_HOME`；远程项目由目标设备的 Executor 修改该设备的 `CODEX_HOME`。Backend 不持久化这部分状态。
+
+## 远程任务离线恢复
+
+云端或远程设备的任务列表同步成功后，Wework 按当前用户在本机 `localStorage` 保存字段白名单内的摘要，包括任务 ID、标题、更新时间、工作区路径、仓库和分支提示以及侧栏排序信息。缓存不包含会话正文、工具调用、运行句柄、模型配置或父子任务树；完整详情仍只存在于远程设备。
+
+启动时，缓存摘要作为过期数据与本地 Codex 项目描述合并。远程设备不可用时，项目、上次记录的 IP 和任务摘要仍会显示，状态点为灰色；任务行不能打开，也不能置顶、重命名、订阅通知或归档。设备重新在线后，实时列表恢复为权威数据，并更新或清理缓存。设备发现或任务列表同步失败时保留旧摘要，避免暂时的网络错误清空侧栏。
 
 ## 交互边界
 

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -640,6 +640,16 @@ describe('createHybridWorkbenchServices', () => {
     expect(mocks.cloudRuntimeIpcRequest).not.toHaveBeenCalled()
   })
 
+  it('rejects an incomplete background runtime work refresh', async () => {
+    mocks.cloudRuntimeIpcRequest.mockRejectedValue(new Error('remote runtime unavailable'))
+
+    const services = createServices()
+
+    await expect(services.cloudBackgroundApi?.listRuntimeWork?.()).rejects.toThrow(
+      'remote runtime unavailable'
+    )
+  })
+
   it('does not request background runtime work from another route on the same runtime instance', async () => {
     mocks.localListDevices.mockResolvedValue([
       {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -456,6 +456,12 @@ export function createHybridWorkbenchServices(
     const results = await Promise.allSettled(
       runtimeDevices.map(device => cloudRuntimeApi(device.device_id).listRuntimeWork())
     )
+    const failedResult = results.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+    if (failedResult) {
+      throw failedResult.reason
+    }
     return removeCurrentAppCloudRuntimeWork(
       results.reduce(
         (merged, result) =>

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1378,8 +1378,9 @@ describe('DesktopSidebar', () => {
     expect(screen.getByTestId('runtime-local-task-row-codex-1')).toBeInTheDocument()
   })
 
-  test('hides remote-only runtime projects from the project list', () => {
+  test('keeps an unavailable remote-only project visible with its IP and gray status', () => {
     renderSidebar({
+      devices: [localDevice()],
       runtimeWork: {
         projects: [
           {
@@ -1389,8 +1390,8 @@ describe('DesktopSidebar', () => {
                 id: 91,
                 deviceId: 'remote-device',
                 deviceName: '10.201.3.200',
-                deviceStatus: 'online',
-                available: true,
+                deviceStatus: 'offline',
+                available: false,
                 workspacePath: '/home/ubuntu/workspace/Wegent',
                 workspaceSource: 'remote',
                 remoteHostId: 'remote-ssh-discovered:10.201.3.200',
@@ -1419,11 +1420,132 @@ describe('DesktopSidebar', () => {
       },
     })
 
-    expect(screen.queryByText('Remote Wegent')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('project-remote-folder-icon-7')).not.toBeInTheDocument()
+    expect(screen.getByText('Remote Wegent')).toBeInTheDocument()
+    expect(screen.getByTestId('project-remote-folder-icon-7')).toBeInTheDocument()
+    expect(screen.getByTestId('project-device-status-7')).toHaveTextContent('10.201.3.200')
+    expect(screen.getByTestId('project-device-status-7-dot')).toHaveClass(
+      'bg-[rgb(var(--color-sidebar-text-muted))]',
+      'opacity-55'
+    )
+    expect(screen.getByTestId('project-device-status-7-dot')).not.toHaveAttribute('style')
     expect(screen.getByText('Local Wegent')).toBeInTheDocument()
     expect(screen.getByTestId('project-folder-icon-8')).toBeInTheDocument()
-    expect(screen.getAllByTestId('project-item')).toHaveLength(1)
+    expect(screen.getAllByTestId('project-item')).toHaveLength(2)
+  })
+
+  test('shows cached tasks for an offline remote project without allowing them to open', async () => {
+    const onOpenRuntimeTask = vi.fn()
+    const onSetRuntimeTaskPinned = vi.fn()
+    const onRenameRuntimeTask = vi.fn()
+    const onArchiveRuntimeTask = vi.fn()
+    renderSidebar({
+      devices: [
+        localDevice(),
+        localDevice({
+          id: 2,
+          device_id: 'remote-device',
+          name: 'Remote Host',
+          status: 'offline',
+          is_default: false,
+          device_type: 'remote',
+          client_ip: '10.201.3.200',
+        }),
+      ],
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, key: 'remote-project-id', name: 'Remote Wegent' },
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'remote-device',
+                deviceName: '10.201.3.200',
+                deviceStatus: 'offline',
+                available: false,
+                workspacePath: '/home/ubuntu/workspace/Wegent',
+                workspaceSource: 'remote',
+                remoteHostId: 'remote-ssh-discovered:10.201.3.200',
+                tasks: [
+                  {
+                    taskId: 'cached-remote-task',
+                    workspacePath: '/home/ubuntu/workspace/Wegent',
+                    title: 'Cached remote task',
+                    runtime: 'codex',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+      onOpenRuntimeTask,
+      onSetRuntimeTaskPinned,
+      onRenameRuntimeTask,
+      onArchiveRuntimeTask,
+    })
+
+    await userEvent.click(screen.getByTestId('project-item-button'))
+
+    const taskRow = screen.getByTestId('runtime-local-task-row-cached-remote-task')
+    expect(taskRow).toHaveAttribute('aria-disabled', 'true')
+    expect(taskRow).toHaveAttribute('tabindex', '-1')
+    expect(screen.getByTestId('runtime-local-task-mark-cached-remote-task')).toBeDisabled()
+    expect(screen.getByTestId('runtime-local-task-archive-cached-remote-task')).toBeDisabled()
+    fireEvent.click(taskRow)
+    fireEvent.click(screen.getByTestId('runtime-local-task-mark-cached-remote-task'))
+    fireEvent.doubleClick(taskRow)
+    expect(onOpenRuntimeTask).not.toHaveBeenCalled()
+    expect(onSetRuntimeTaskPinned).not.toHaveBeenCalled()
+    expect(onRenameRuntimeTask).not.toHaveBeenCalled()
+    expect(onArchiveRuntimeTask).not.toHaveBeenCalled()
+  })
+
+  test('shows an available remote project IP with green status', () => {
+    renderSidebar({
+      devices: [
+        localDevice(),
+        localDevice({
+          id: 2,
+          device_id: 'remote-device',
+          name: 'Remote Host',
+          is_default: false,
+          device_type: 'remote',
+          client_ip: '10.201.3.200',
+        }),
+      ],
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, key: 'remote-project-id', name: 'Remote Wegent' },
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'remote-device',
+                deviceName: '10.201.3.200',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/home/ubuntu/workspace/Wegent',
+                workspaceSource: 'remote',
+                remoteHostId: 'remote-ssh-discovered:10.201.3.200',
+                tasks: [],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 0,
+      },
+    })
+
+    expect(screen.getByTestId('project-device-status-7')).toHaveTextContent('10.201.3.200')
+    expect(screen.getByTestId('project-device-status-7-dot')).toHaveStyle({
+      backgroundColor: '#1FD660',
+    })
+    expect(screen.getByTestId('project-device-status-7-dot')).not.toHaveClass(
+      'bg-[rgb(var(--color-sidebar-text-muted))]'
+    )
   })
 
   test('shows running status on running runtime tasks only', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -735,12 +735,14 @@ function getRuntimeProjectDeviceState(
 ): SidebarDeviceState | null {
   const workspace = runtimeProjectWork?.deviceWorkspaces[0]
   if (!workspace) return null
-  return (
-    getSidebarDeviceState(workspace.deviceId, devices) ?? {
-      deviceId: workspace.deviceId,
-      status: (workspace.deviceStatus ?? 'unavailable') as SidebarDeviceStatus,
-    }
-  )
+  const resolvedDevice = getSidebarDeviceState(workspace.deviceId, devices)
+  if (resolvedDevice?.device) return resolvedDevice
+  return {
+    deviceId: workspace.deviceName || workspace.remoteHostId || workspace.deviceId,
+    status: (workspace.deviceStatus ??
+      resolvedDevice?.status ??
+      'unavailable') as SidebarDeviceStatus,
+  }
 }
 
 function isRuntimeRemoteProject(runtimeProjectWork: RuntimeProjectWork | undefined): boolean {
@@ -889,19 +891,13 @@ function getProjectFinderWorkspacePath(
   return null
 }
 
-function shouldShowRuntimeProject(runtimeProjectWork: RuntimeProjectWork): boolean {
-  const workspaces = runtimeProjectWork.deviceWorkspaces
-  if (workspaces.length === 0) return true
-  return workspaces.some(
-    workspace => workspace.workspaceSource !== 'remote' || workspace.tasks.length > 0
-  )
-}
-
 function shouldShowProjectDeviceStatus(
   deviceState: SidebarDeviceState | null,
-  devices: DeviceInfo[]
+  devices: DeviceInfo[],
+  remoteProject: boolean
 ): deviceState is SidebarDeviceState {
   if (!deviceState) return false
+  if (remoteProject) return true
   if (hasCloudRuntimeRoute(deviceState.device) && deviceState.device?.device_type !== 'local') {
     return true
   }
@@ -1504,7 +1500,7 @@ function RuntimeTaskRow({
     void onOpenRuntimeTask?.(taskAddress)
   }
   const toggleTaskPinned = async () => {
-    if (!threadId || !onSetRuntimeTaskPinned) return
+    if (!workspace.available || !threadId || !onSetRuntimeTaskPinned) return
     const nextMarked = !marked
     setOptimisticMarked({ base: persistedMarked, value: nextMarked })
     try {
@@ -1726,7 +1722,7 @@ function RuntimeTaskRow({
                 type="button"
                 data-testid={`runtime-local-task-mark-${task.taskId}`}
                 onClick={handleToggleMark}
-                disabled={!threadId || !onSetRuntimeTaskPinned}
+                disabled={!workspace.available || !threadId || !onSetRuntimeTaskPinned}
                 className={cn(
                   'flex h-5 w-5 items-center justify-center text-[rgb(var(--color-sidebar-text-muted))] hover:text-[rgb(var(--color-sidebar-text-primary))]',
                   marked && 'text-[rgb(var(--color-sidebar-marked-accent))]'
@@ -1776,14 +1772,14 @@ function RuntimeTaskRow({
             label: marked ? t('workbench.unmark_runtime_task') : t('workbench.mark_runtime_task'),
             icon: Pin,
             testId: `runtime-local-task-menu-pin-${task.taskId}`,
-            disabled: !threadId || !onSetRuntimeTaskPinned,
+            disabled: !workspace.available || !threadId || !onSetRuntimeTaskPinned,
             onSelect: toggleTaskPinned,
           },
           {
             label: t('workbench.rename_chat', '重命名任务'),
             icon: Edit3,
             testId: `runtime-local-task-menu-rename-${task.taskId}`,
-            disabled: !onRenameRuntimeTask,
+            disabled: !workspace.available || !onRenameRuntimeTask,
             onSelect: () => setRenameOpen(true),
           },
           {
@@ -1813,7 +1809,9 @@ function RuntimeTaskRow({
         inputTestId={`rename-runtime-local-task-input-${task.taskId}`}
         confirmTestId={`confirm-rename-runtime-local-task-${task.taskId}`}
         onClose={() => setRenameOpen(false)}
-        onSubmit={title => onRenameRuntimeTask?.(taskAddress, title)}
+        onSubmit={title => {
+          if (workspace.available) onRenameRuntimeTask?.(taskAddress, title)
+        }}
       />
       {archiveNoticeOpen &&
         createPortal(
@@ -1960,7 +1958,11 @@ function ProjectItem({
   const projectDeviceState =
     getRuntimeProjectDeviceState(runtimeProjectWork, devices) ??
     getSidebarDeviceState(getProjectDeviceId(project), devices)
-  const showProjectDeviceStatus = shouldShowProjectDeviceStatus(projectDeviceState, devices)
+  const showProjectDeviceStatus = shouldShowProjectDeviceStatus(
+    projectDeviceState,
+    devices,
+    isRuntimeRemoteProject(runtimeProjectWork)
+  )
   const canStartProjectChat = isSidebarDeviceOnline(projectDeviceState)
   const canArchiveProjectConversations =
     Boolean(runtimeProjectWork?.project.key) &&
@@ -2566,23 +2568,23 @@ export function DesktopSidebar({
       ),
     [devices, runtimeWork, standaloneDeviceId, standaloneWorkspacePath]
   )
-  const filteredRuntimeProjects = useMemo(() => {
-    const items = (runtimeWork?.projects ?? []).filter(shouldShowRuntimeProject)
+  const sidebarRuntimeProjects = useMemo(() => {
+    const items = runtimeWork?.projects ?? []
     return standaloneProjectWork ? [standaloneProjectWork, ...items] : items
   }, [runtimeWork?.projects, standaloneProjectWork])
   const sidebarProjects = useMemo(() => {
     if (runtimeWork || standaloneProjectWork) {
-      return filteredRuntimeProjects.map(runtimeProjectToProject)
+      return sidebarRuntimeProjects.map(runtimeProjectToProject)
     }
     return projects
-  }, [filteredRuntimeProjects, projects, runtimeWork, standaloneProjectWork])
+  }, [projects, runtimeWork, sidebarRuntimeProjects, standaloneProjectWork])
   const visibleExpandedProjectIds = useMemo(
     () => pruneProjectIdSet(expandedProjectIds, sidebarProjects),
     [expandedProjectIds, sidebarProjects]
   )
   const runtimeWorkByProjectId = useMemo(() => {
-    return new Map(filteredRuntimeProjects.map(item => [runtimeProjectUiId(item.project), item]))
-  }, [filteredRuntimeProjects])
+    return new Map(sidebarRuntimeProjects.map(item => [runtimeProjectUiId(item.project), item]))
+  }, [sidebarRuntimeProjects])
   const sortableProjects = useMemo(
     () =>
       sidebarProjects.map(project => ({
@@ -2634,7 +2636,7 @@ export function DesktopSidebar({
     [chatTaskItemsWithPinState]
   )
   const pinnedTaskItems = useMemo(() => {
-    const projectTasks = filteredRuntimeProjects.flatMap(projectWork =>
+    const projectTasks = sidebarRuntimeProjects.flatMap(projectWork =>
       getRuntimeSidebarTaskItems(projectWork.deviceWorkspaces)
         .filter(({ task }) => task.pinned)
         .map(item => ({ ...item, projectWork }))
@@ -2647,7 +2649,7 @@ export function DesktopSidebar({
         (left.task.pinnedOrder ?? Number.MAX_SAFE_INTEGER) -
         (right.task.pinnedOrder ?? Number.MAX_SAFE_INTEGER)
     )
-  }, [chatTaskItemsWithPinState, filteredRuntimeProjects])
+  }, [chatTaskItemsWithPinState, sidebarRuntimeProjects])
   const setChatTaskPinned = async (data: RuntimeTaskPinRequest) => {
     if (!onSetRuntimeTaskPinned) return
     const chatTask = chatTaskItems.find(
@@ -2680,13 +2682,13 @@ export function DesktopSidebar({
     }
   }
   const projectSectionArchiveItems = useMemo(() => {
-    return filteredRuntimeProjects
+    return sidebarRuntimeProjects
       .map(projectWork => ({
         key: projectWork.project.key,
         count: getRuntimeSidebarTaskItems(projectWork.deviceWorkspaces).length,
       }))
       .filter(item => item.count > 0)
-  }, [filteredRuntimeProjects])
+  }, [sidebarRuntimeProjects])
   const projectSectionArchiveKeys = useMemo(
     () => projectSectionArchiveItems.map(item => item.key),
     [projectSectionArchiveItems]
@@ -2702,7 +2704,7 @@ export function DesktopSidebar({
   const chatSectionArchiveCount = chatSectionArchiveAddresses.length
   const selectedRuntimeProject = useMemo(() => {
     if (currentRuntimeTask) {
-      const projectWork = filteredRuntimeProjects.find(item =>
+      const projectWork = sidebarRuntimeProjects.find(item =>
         item.deviceWorkspaces.some(workspace =>
           workspace.tasks.some(task => isRuntimeTaskSelected(currentRuntimeTask, workspace, task))
         )
@@ -2721,7 +2723,7 @@ export function DesktopSidebar({
       : ''
     if (!normalizedDeviceId || !normalizedWorkspacePath) return null
 
-    const projectWork = filteredRuntimeProjects.find(item =>
+    const projectWork = sidebarRuntimeProjects.find(item =>
       item.deviceWorkspaces.some(
         workspace =>
           workspace.deviceId === normalizedDeviceId &&
@@ -2734,7 +2736,7 @@ export function DesktopSidebar({
           id: runtimeProjectUiId(projectWork.project),
         }
       : null
-  }, [currentRuntimeTask, filteredRuntimeProjects, standaloneDeviceId, standaloneWorkspacePath])
+  }, [currentRuntimeTask, sidebarRuntimeProjects, standaloneDeviceId, standaloneWorkspacePath])
   const selectedRuntimeProjectId = selectedRuntimeProject?.id ?? null
   const selectedRuntimeProjectAutoExpandKey = selectedRuntimeProject?.autoExpandKey ?? null
   const selectedRuntimeChatVisible = useMemo(() => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -17,6 +17,7 @@ import { buildRuntimeTaskRoute, parseRuntimeTaskRoute } from '@/lib/navigation'
 import { runtimeProjectUiId, standaloneRuntimeProjectKey } from '@/lib/runtime-project'
 import { findRuntimeTask, readLastProjectId, writeLastProjectId } from './workbenchRuntimeHelpers'
 import { modelSelectionFromRuntimeHandle } from './runtimeContextUsage'
+import { writeCachedRemoteRuntimeWork } from './remoteRuntimeWorkCache'
 import { createResponseApiStreamState, emitResponseApiEvent } from '@/stream/responseApiStream'
 import type { ChatStreamHandlers } from '@/stream/chatStream'
 import {
@@ -538,6 +539,21 @@ function CloudWorkStatusProbe() {
 function DeviceStatusProbe() {
   const workbench = useWorkbench()
   return <span data-testid="device-status">{workbench.state.devices[0]?.status ?? 'missing'}</span>
+}
+
+function RemoteRuntimeCacheProbe() {
+  const runtimeWork = useWorkbench().state.runtimeWork
+  const workspaces = runtimeWork?.projects.flatMap(project => project.deviceWorkspaces) ?? []
+  return (
+    <div>
+      <span data-testid="cached-runtime-task-titles">
+        {workspaces.flatMap(workspace => workspace.tasks.map(task => task.title)).join('|')}
+      </span>
+      <span data-testid="cached-runtime-workspace-availability">
+        {workspaces.map(workspace => String(workspace.available)).join('|')}
+      </span>
+    </div>
+  )
 }
 
 function ProjectSendProbe() {
@@ -1852,6 +1868,95 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     expect(screen.getByTestId('cloud-work-devices-check')).toHaveTextContent('empty')
     expect(screen.getByTestId('cloud-work-error')).toHaveTextContent('')
+  })
+
+  test('restores cached remote task summaries when the device is offline at startup', async () => {
+    writeCachedRemoteRuntimeWork(1, {
+      projects: [
+        {
+          project: { key: '/srv/Wegent', name: 'Remote Wegent' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: '10.201.3.200',
+              deviceStatus: 'online',
+              available: true,
+              workspacePath: '/srv/Wegent',
+              tasks: [
+                {
+                  taskId: 'remote-cached-task',
+                  workspacePath: '/srv/Wegent',
+                  title: 'Cached remote task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalTasks: 1,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: createRuntimeWorkApiMock({
+        listRuntimeWork: vi.fn().mockResolvedValue({
+          projects: [
+            {
+              project: {
+                key: 'remote-project-id',
+                sidebarStateKey: 'remote-project-id',
+                name: 'Remote Wegent',
+                kind: 'remote',
+                source: 'remote_project',
+                stateDeviceId: 'local-device',
+              },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'remote-device',
+                  deviceName: '10.201.3.200',
+                  deviceStatus: 'offline',
+                  available: false,
+                  workspacePath: '/srv/Wegent',
+                  workspaceSource: 'remote',
+                  remoteHostId: 'remote-device',
+                  mapped: true,
+                  tasks: [],
+                },
+              ],
+            },
+          ],
+          chats: [],
+          totalTasks: 0,
+        }),
+      }),
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([
+          createDevice({
+            id: 2,
+            device_id: 'remote-device',
+            name: '10.201.3.200',
+            status: 'offline',
+            is_default: false,
+            device_type: 'remote',
+          }),
+        ]),
+        listRuntimeWork: vi.fn().mockResolvedValue({
+          projects: [],
+          chats: [],
+          totalTasks: 0,
+        }),
+      },
+    })
+
+    renderWorkbench(<RemoteRuntimeCacheProbe />, services)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cached-runtime-task-titles')).toHaveTextContent(
+        'Cached remote task'
+      )
+    )
+    expect(screen.getByTestId('cached-runtime-workspace-availability')).toHaveTextContent('false')
   })
 
   test('applies device online events immediately when refresh falls back would be stale', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -552,6 +552,9 @@ function RemoteRuntimeCacheProbe() {
       <span data-testid="cached-runtime-workspace-availability">
         {workspaces.map(workspace => String(workspace.available)).join('|')}
       </span>
+      <span data-testid="cached-runtime-device-names">
+        {workspaces.map(workspace => workspace.deviceName).join('|')}
+      </span>
     </div>
   )
 }
@@ -1913,7 +1916,7 @@ describe('WorkbenchProvider runtime tasks', () => {
               deviceWorkspaces: [
                 {
                   deviceId: 'remote-device',
-                  deviceName: '10.201.3.200',
+                  deviceName: '127.0.0.1',
                   deviceStatus: 'offline',
                   available: false,
                   workspacePath: '/srv/Wegent',
@@ -1957,6 +1960,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       )
     )
     expect(screen.getByTestId('cached-runtime-workspace-availability')).toHaveTextContent('false')
+    expect(screen.getByTestId('cached-runtime-device-names')).toHaveTextContent('10.201.3.200')
   })
 
   test('applies device online events immediately when refresh falls back would be stale', async () => {

--- a/wework/src/features/workbench/remoteRuntimeWorkCache.test.ts
+++ b/wework/src/features/workbench/remoteRuntimeWorkCache.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import type { DeviceInfo, RuntimeDeviceWorkspace, RuntimeWorkListResponse } from '@/types/api'
+import { mergeRuntimeWorkLists } from './workbenchCloudStatus'
+import {
+  createRemoteRuntimeWorkCacheSnapshot,
+  readCachedRemoteRuntimeWork,
+  reconcileCachedRemoteRuntimeWork,
+  writeCachedRemoteRuntimeWork,
+} from './remoteRuntimeWorkCache'
+
+function workspace(
+  deviceId: string,
+  taskId: string,
+  overrides: Partial<RuntimeDeviceWorkspace> = {}
+): RuntimeDeviceWorkspace {
+  return {
+    deviceId,
+    deviceName: deviceId,
+    deviceStatus: 'online',
+    available: true,
+    workspacePath: `/srv/${deviceId}`,
+    workspaceKind: 'workspace',
+    workspaceSource: 'local',
+    mapped: true,
+    tasks: [
+      {
+        taskId,
+        threadId: `thread-${taskId}`,
+        workspacePath: `/srv/${deviceId}`,
+        title: taskId,
+        runtime: 'codex',
+        updatedAt: '2026-07-17T00:00:00Z',
+        running: true,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function runtimeWork(...workspaces: RuntimeDeviceWorkspace[]): RuntimeWorkListResponse {
+  const projects = workspaces.map((deviceWorkspace, index) => ({
+    project: {
+      key: deviceWorkspace.workspacePath,
+      name: `Remote ${index + 1}`,
+    },
+    deviceWorkspaces: [deviceWorkspace],
+    totalTasks: deviceWorkspace.tasks.length,
+  }))
+  return {
+    projects,
+    chats: [],
+    totalTasks: projects.reduce((total, project) => total + (project.totalTasks ?? 0), 0),
+  }
+}
+
+function device(
+  deviceId: string,
+  status: DeviceInfo['status'],
+  overrides: Partial<DeviceInfo> = {}
+): DeviceInfo {
+  return {
+    id: deviceId === 'remote-a' ? 1 : 2,
+    device_id: deviceId,
+    name: deviceId,
+    status,
+    is_default: false,
+    device_type: 'remote',
+    bind_shell: 'claudecode',
+    ...overrides,
+  }
+}
+
+describe('remote runtime work cache', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  test('persists only sidebar summary fields and restores them as unavailable', () => {
+    const input = runtimeWork(
+      workspace('remote-a', 'task-a', {
+        repoUrl: 'git@example.com:team/repo.git',
+        tasks: [
+          {
+            taskId: 'task-a',
+            threadId: 'thread-a',
+            workspacePath: '/srv/remote-a',
+            title: 'Cached task',
+            runtime: 'codex',
+            updatedAt: '2026-07-17T00:00:00Z',
+            running: true,
+            pinned: true,
+            gitInfo: {
+              branch: 'feature/offline-cache',
+              secret: 'must-not-persist',
+            },
+            runtimeHandle: { threadId: 'thread-a', transcript: 'full conversation' },
+            modelSelection: { modelName: 'gpt-5', options: { reasoningEffort: 'high' } },
+            parent: { taskId: 'parent' },
+            children: [{ taskId: 'child' }],
+          },
+        ],
+      })
+    )
+
+    writeCachedRemoteRuntimeWork(7, input, [
+      device('remote-a', 'online', { client_ip: '10.201.3.200' }),
+    ])
+    const restored = readCachedRemoteRuntimeWork(7)
+    const restoredWorkspace = restored.projects[0].deviceWorkspaces[0]
+    const restoredTask = restoredWorkspace.tasks[0]
+
+    expect(restoredWorkspace).toMatchObject({
+      deviceId: 'remote-a',
+      deviceName: '10.201.3.200',
+      deviceStatus: 'offline',
+      available: false,
+      workspaceSource: 'remote',
+      remoteHostId: 'remote-a',
+      repoUrl: 'git@example.com:team/repo.git',
+    })
+    expect(restoredTask).toMatchObject({
+      taskId: 'task-a',
+      threadId: 'thread-a',
+      title: 'Cached task',
+      runtime: 'codex',
+      running: false,
+      pinned: true,
+      gitInfo: { branch: 'feature/offline-cache' },
+    })
+    expect(restoredTask).not.toHaveProperty('runtimeHandle')
+    expect(restoredTask).not.toHaveProperty('modelSelection')
+    expect(restoredTask).not.toHaveProperty('parent')
+    expect(restoredTask).not.toHaveProperty('children')
+    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.7')).not.toContain(
+      'must-not-persist'
+    )
+    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.7')).not.toContain(
+      'full conversation'
+    )
+  })
+
+  test('isolates cache entries by user and ignores malformed data', () => {
+    writeCachedRemoteRuntimeWork(7, runtimeWork(workspace('remote-a', 'task-a')))
+
+    expect(readCachedRemoteRuntimeWork(8)).toEqual({
+      projects: [],
+      chats: [],
+      totalTasks: 0,
+    })
+
+    localStorage.setItem('wework.workbench.remoteRuntimeWork.v1.7', '{')
+    expect(readCachedRemoteRuntimeWork(7)).toEqual({
+      projects: [],
+      chats: [],
+      totalTasks: 0,
+    })
+  })
+
+  test('preserves offline hosts while replacing an online host with live tasks', () => {
+    const cached = createRemoteRuntimeWorkCacheSnapshot(
+      runtimeWork(workspace('remote-a', 'cached-a'), workspace('remote-b', 'stale-b'))
+    )
+    const live = runtimeWork(workspace('remote-b', 'fresh-b'))
+
+    const reconciled = reconcileCachedRemoteRuntimeWork(cached, live, [
+      device('remote-a', 'offline'),
+      device('remote-b', 'online'),
+    ])
+
+    expect(
+      reconciled.projects.flatMap(project =>
+        project.deviceWorkspaces.flatMap(deviceWorkspace =>
+          deviceWorkspace.tasks.map(task => task.taskId)
+        )
+      )
+    ).toEqual(['cached-a', 'fresh-b'])
+    expect(
+      reconciled.projects
+        .flatMap(project => project.deviceWorkspaces)
+        .find(deviceWorkspace => deviceWorkspace.deviceId === 'remote-a')
+    ).toMatchObject({ available: false, deviceStatus: 'offline' })
+    expect(
+      reconciled.projects
+        .flatMap(project => project.deviceWorkspaces)
+        .find(deviceWorkspace => deviceWorkspace.deviceId === 'remote-b')?.tasks[0]
+    ).toMatchObject({ running: true })
+  })
+
+  test('cleans tasks for online or deleted devices after a successful full refresh', () => {
+    const cached = createRemoteRuntimeWorkCacheSnapshot(
+      runtimeWork(workspace('remote-a', 'deleted-a'), workspace('remote-b', 'deleted-b'))
+    )
+
+    const reconciled = reconcileCachedRemoteRuntimeWork(cached, runtimeWork(), [
+      device('remote-b', 'online'),
+    ])
+
+    expect(reconciled).toEqual({ projects: [], chats: [], totalTasks: 0 })
+  })
+
+  test('keeps cached tasks when device discovery is unavailable', () => {
+    const cached = createRemoteRuntimeWorkCacheSnapshot(
+      runtimeWork(workspace('remote-a', 'cached-a'))
+    )
+
+    const reconciled = reconcileCachedRemoteRuntimeWork(cached, runtimeWork())
+
+    expect(reconciled.projects[0].deviceWorkspaces[0].tasks[0].taskId).toBe('cached-a')
+  })
+
+  test('groups a cached task under the locally persisted remote project descriptor', () => {
+    const localDescriptor: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: {
+            key: 'remote-project-id',
+            sidebarStateKey: 'remote-project-id',
+            name: 'Remote repository',
+            kind: 'remote',
+            source: 'remote_project',
+            stateDeviceId: 'local-device',
+          },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-a',
+              deviceName: '10.201.3.200',
+              deviceStatus: 'offline',
+              available: false,
+              workspacePath: '/srv/remote-a',
+              workspaceSource: 'remote',
+              remoteHostId: 'remote-a',
+              mapped: true,
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalTasks: 0,
+    }
+    const cached = createRemoteRuntimeWorkCacheSnapshot(
+      runtimeWork(workspace('remote-a', 'cached-a'))
+    )
+
+    const merged = mergeRuntimeWorkLists(localDescriptor, cached)
+
+    expect(merged.projects).toHaveLength(1)
+    expect(merged.projects[0].project).toMatchObject({
+      name: 'Remote repository',
+      sidebarStateKey: 'remote-project-id',
+    })
+    expect(merged.projects[0].deviceWorkspaces[0].tasks[0].taskId).toBe('cached-a')
+  })
+})

--- a/wework/src/features/workbench/remoteRuntimeWorkCache.ts
+++ b/wework/src/features/workbench/remoteRuntimeWorkCache.ts
@@ -1,0 +1,422 @@
+import { isUsableDevice } from '@/lib/device-capabilities'
+import type {
+  DeviceInfo,
+  RuntimeDeviceWorkspace,
+  RuntimeProjectRef,
+  RuntimeProjectRoot,
+  RuntimeProjectWork,
+  RuntimeTaskSummary,
+  RuntimeWorkListResponse,
+} from '@/types/api'
+import { EMPTY_RUNTIME_WORK, mergeRuntimeWorkLists } from './workbenchCloudStatus'
+
+const REMOTE_RUNTIME_WORK_CACHE_VERSION = 1
+const REMOTE_RUNTIME_WORK_CACHE_KEY_PREFIX = 'wework.workbench.remoteRuntimeWork.v1'
+
+interface RemoteRuntimeWorkCacheEnvelope {
+  version: typeof REMOTE_RUNTIME_WORK_CACHE_VERSION
+  updatedAt: number
+  runtimeWork: RuntimeWorkListResponse
+}
+
+function cacheKey(userId: number): string {
+  return `${REMOTE_RUNTIME_WORK_CACHE_KEY_PREFIX}.${userId}`
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+function nullableStringValue(value: unknown): string | null | undefined {
+  return value === null ? null : stringValue(value)
+}
+
+function finiteNumberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function nullableNumberValue(value: unknown): number | null | undefined {
+  return value === null ? null : finiteNumberValue(value)
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function sanitizeProjectRoot(value: unknown): RuntimeProjectRoot | null {
+  const root = recordValue(value)
+  const kind = stringValue(root.kind)
+  const path = stringValue(root.path)
+  if (!kind || !path) return null
+  return {
+    kind,
+    path,
+    ...(nullableStringValue(root.label) !== undefined
+      ? { label: nullableStringValue(root.label) }
+      : {}),
+  }
+}
+
+function sanitizeProjectRef(value: unknown): RuntimeProjectRef | null {
+  const project = recordValue(value)
+  const key = stringValue(project.key)
+  const name = stringValue(project.name)
+  if (!key || !name) return null
+
+  const roots = Array.isArray(project.roots)
+    ? project.roots
+        .map(sanitizeProjectRoot)
+        .filter((root): root is RuntimeProjectRoot => root !== null)
+    : undefined
+
+  return {
+    key,
+    name,
+    ...(nullableStringValue(project.sidebarStateKey) !== undefined
+      ? { sidebarStateKey: nullableStringValue(project.sidebarStateKey) }
+      : {}),
+    ...(finiteNumberValue(project.id) !== undefined ? { id: finiteNumberValue(project.id) } : {}),
+    ...(nullableStringValue(project.description) !== undefined
+      ? { description: nullableStringValue(project.description) }
+      : {}),
+    ...(nullableStringValue(project.color) !== undefined
+      ? { color: nullableStringValue(project.color) }
+      : {}),
+    ...(stringValue(project.kind) ? { kind: stringValue(project.kind) } : {}),
+    ...(stringValue(project.source) ? { source: stringValue(project.source) } : {}),
+    ...(nullableStringValue(project.stateDeviceId) !== undefined
+      ? { stateDeviceId: nullableStringValue(project.stateDeviceId) }
+      : {}),
+    ...(roots ? { roots } : {}),
+    ...(booleanValue(project.pinned) !== undefined ? { pinned: booleanValue(project.pinned) } : {}),
+    ...(nullableNumberValue(project.pinnedOrder) !== undefined
+      ? { pinnedOrder: nullableNumberValue(project.pinnedOrder) }
+      : {}),
+    ...(booleanValue(project.active) !== undefined ? { active: booleanValue(project.active) } : {}),
+  }
+}
+
+const CACHED_GIT_INFO_KEYS = [
+  'branch',
+  'branchName',
+  'branch_name',
+  'currentBranch',
+  'current_branch',
+  'originUrl',
+  'origin_url',
+  'repoUrl',
+  'repo_url',
+  'branchMismatch',
+  'branch_mismatch',
+  'isBranchOutdated',
+  'is_branch_outdated',
+] as const
+
+function sanitizeGitInfo(value: unknown): Record<string, unknown> | null | undefined {
+  if (value === null) return null
+  const input = recordValue(value)
+  const gitInfo = Object.fromEntries(
+    CACHED_GIT_INFO_KEYS.flatMap(key => {
+      const field = input[key]
+      return typeof field === 'string' || typeof field === 'boolean' ? [[key, field]] : []
+    })
+  )
+  return Object.keys(gitInfo).length > 0 ? gitInfo : undefined
+}
+
+function sanitizeTask(value: unknown, workspacePath: string): RuntimeTaskSummary | null {
+  const task = recordValue(value)
+  const taskId = stringValue(task.taskId)
+  const title = stringValue(task.title)
+  const runtime = stringValue(task.runtime)
+  if (!taskId || !title || !runtime) return null
+
+  const gitInfo = sanitizeGitInfo(task.gitInfo)
+  return {
+    taskId,
+    title,
+    runtime,
+    workspacePath: stringValue(task.workspacePath) ?? workspacePath,
+    running: false,
+    ...(nullableStringValue(task.threadId) !== undefined
+      ? { threadId: nullableStringValue(task.threadId) }
+      : {}),
+    ...(nullableStringValue(task.workspaceKind) !== undefined
+      ? { workspaceKind: nullableStringValue(task.workspaceKind) }
+      : {}),
+    ...(nullableStringValue(task.worktreeId) !== undefined
+      ? { worktreeId: nullableStringValue(task.worktreeId) }
+      : {}),
+    ...(gitInfo !== undefined ? { gitInfo } : {}),
+    ...(typeof task.createdAt === 'string' || typeof task.createdAt === 'number'
+      ? { createdAt: task.createdAt }
+      : {}),
+    ...(typeof task.updatedAt === 'string' || typeof task.updatedAt === 'number'
+      ? { updatedAt: task.updatedAt }
+      : {}),
+    ...(booleanValue(task.pinned) !== undefined ? { pinned: booleanValue(task.pinned) } : {}),
+    ...(nullableNumberValue(task.pinnedOrder) !== undefined
+      ? { pinnedOrder: nullableNumberValue(task.pinnedOrder) }
+      : {}),
+    ...(nullableNumberValue(task.sidebarOrder) !== undefined
+      ? { sidebarOrder: nullableNumberValue(task.sidebarOrder) }
+      : {}),
+    ...(nullableStringValue(task.status) !== undefined
+      ? { status: nullableStringValue(task.status) }
+      : {}),
+  }
+}
+
+function sanitizeWorkspace(value: unknown): RuntimeDeviceWorkspace | null {
+  const workspace = recordValue(value)
+  const deviceId = stringValue(workspace.deviceId)
+  const workspacePath = stringValue(workspace.workspacePath)
+  if (!deviceId || !workspacePath) return null
+
+  const tasks = Array.isArray(workspace.tasks)
+    ? workspace.tasks
+        .map(task => sanitizeTask(task, workspacePath))
+        .filter((task): task is RuntimeTaskSummary => task !== null)
+    : []
+
+  return {
+    deviceId,
+    workspacePath,
+    available: false,
+    deviceStatus: 'offline',
+    workspaceSource: 'remote',
+    remoteHostId: stringValue(workspace.remoteHostId) ?? deviceId,
+    tasks,
+    ...(nullableNumberValue(workspace.id) !== undefined
+      ? { id: nullableNumberValue(workspace.id) }
+      : {}),
+    ...(nullableNumberValue(workspace.projectId) !== undefined
+      ? { projectId: nullableNumberValue(workspace.projectId) }
+      : {}),
+    ...(nullableStringValue(workspace.deviceName) !== undefined
+      ? { deviceName: nullableStringValue(workspace.deviceName) }
+      : {}),
+    ...(nullableStringValue(workspace.workspaceKind) !== undefined
+      ? { workspaceKind: nullableStringValue(workspace.workspaceKind) }
+      : {}),
+    ...(nullableStringValue(workspace.worktreeId) !== undefined
+      ? { worktreeId: nullableStringValue(workspace.worktreeId) }
+      : {}),
+    ...(nullableStringValue(workspace.label) !== undefined
+      ? { label: nullableStringValue(workspace.label) }
+      : {}),
+    ...(nullableStringValue(workspace.repoUrl) !== undefined
+      ? { repoUrl: nullableStringValue(workspace.repoUrl) }
+      : {}),
+    ...(nullableStringValue(workspace.repoRootFingerprint) !== undefined
+      ? { repoRootFingerprint: nullableStringValue(workspace.repoRootFingerprint) }
+      : {}),
+    ...(booleanValue(workspace.mapped) !== undefined
+      ? { mapped: booleanValue(workspace.mapped) }
+      : {}),
+  }
+}
+
+function sanitizeProjectWork(value: unknown): RuntimeProjectWork | null {
+  const projectWork = recordValue(value)
+  const project = sanitizeProjectRef(projectWork.project)
+  if (!project) return null
+  const deviceWorkspaces = Array.isArray(projectWork.deviceWorkspaces)
+    ? projectWork.deviceWorkspaces
+        .map(sanitizeWorkspace)
+        .filter((workspace): workspace is RuntimeDeviceWorkspace => workspace !== null)
+    : []
+  return {
+    project,
+    deviceWorkspaces,
+    totalTasks: deviceWorkspaces.reduce((total, workspace) => total + workspace.tasks.length, 0),
+  }
+}
+
+export function createRemoteRuntimeWorkCacheSnapshot(value: unknown): RuntimeWorkListResponse {
+  const runtimeWork = recordValue(value)
+  const projects = Array.isArray(runtimeWork.projects)
+    ? runtimeWork.projects
+        .map(sanitizeProjectWork)
+        .filter((project): project is RuntimeProjectWork => project !== null)
+    : []
+  const chats = Array.isArray(runtimeWork.chats)
+    ? runtimeWork.chats
+        .map(sanitizeWorkspace)
+        .filter((workspace): workspace is RuntimeDeviceWorkspace => workspace !== null)
+    : []
+  return {
+    projects,
+    chats,
+    totalTasks:
+      projects.reduce((total, project) => total + (project.totalTasks ?? 0), 0) +
+      chats.reduce((total, workspace) => total + workspace.tasks.length, 0),
+  }
+}
+
+export function readCachedRemoteRuntimeWork(userId: number): RuntimeWorkListResponse {
+  try {
+    const raw = window.localStorage.getItem(cacheKey(userId))
+    if (!raw) return EMPTY_RUNTIME_WORK
+    const envelope = recordValue(JSON.parse(raw))
+    if (envelope.version !== REMOTE_RUNTIME_WORK_CACHE_VERSION) return EMPTY_RUNTIME_WORK
+    return createRemoteRuntimeWorkCacheSnapshot(envelope.runtimeWork)
+  } catch {
+    return EMPTY_RUNTIME_WORK
+  }
+}
+
+export function writeCachedRemoteRuntimeWork(
+  userId: number,
+  runtimeWork: RuntimeWorkListResponse,
+  devices?: DeviceInfo[]
+): RuntimeWorkListResponse {
+  const snapshot = withCachedDeviceLabels(
+    createRemoteRuntimeWorkCacheSnapshot(runtimeWork),
+    devices
+  )
+  const envelope: RemoteRuntimeWorkCacheEnvelope = {
+    version: REMOTE_RUNTIME_WORK_CACHE_VERSION,
+    updatedAt: Date.now(),
+    runtimeWork: snapshot,
+  }
+  try {
+    window.localStorage.setItem(cacheKey(userId), JSON.stringify(envelope))
+  } catch {
+    // The current runtime work remains available when persistent storage is unavailable.
+  }
+  return snapshot
+}
+
+function runtimeWorkspaces(runtimeWork: RuntimeWorkListResponse): RuntimeDeviceWorkspace[] {
+  return [
+    ...runtimeWork.projects.flatMap(project => project.deviceWorkspaces),
+    ...runtimeWork.chats,
+  ]
+}
+
+function deviceAliases(device: DeviceInfo): Set<string> {
+  return new Set(
+    [
+      device.device_id,
+      device.app_device_id,
+      device.socket_device_id,
+      device.runtime_instance_id,
+      ...(device.runtime_routes ?? []).flatMap(route => [route.device_id, route.runtime_device_id]),
+    ]
+      .map(value => value?.trim())
+      .filter((value): value is string => Boolean(value))
+  )
+}
+
+function workspaceAliases(workspace: RuntimeDeviceWorkspace): Set<string> {
+  return new Set(
+    [workspace.deviceId, workspace.remoteHostId]
+      .map(value => value?.trim())
+      .filter((value): value is string => Boolean(value))
+  )
+}
+
+function aliasesIntersect(left: Set<string>, right: Set<string>): boolean {
+  for (const value of left) {
+    if (right.has(value)) return true
+  }
+  return false
+}
+
+function networkHost(value?: string | null): string | null {
+  const label = value?.trim()
+  if (!label) return null
+  const bracketMatch = label.match(/^\[([^\]]+)\](?::\d+)?$/)
+  if (bracketMatch?.[1]) return bracketMatch[1]
+  const colonParts = label.split(':')
+  if (colonParts.length === 2 && /^\d+$/.test(colonParts[1])) {
+    return colonParts[0]
+  }
+  return label
+}
+
+function withCachedDeviceLabels(
+  runtimeWork: RuntimeWorkListResponse,
+  devices?: DeviceInfo[]
+): RuntimeWorkListResponse {
+  if (!devices) return runtimeWork
+  const deviceRecords = devices.map(device => ({
+    device,
+    aliases: deviceAliases(device),
+  }))
+  const annotateWorkspace = (workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace => {
+    const aliases = workspaceAliases(workspace)
+    const device = deviceRecords.find(record => aliasesIntersect(aliases, record.aliases))?.device
+    const deviceName =
+      networkHost(device?.client_ip) ??
+      networkHost(device?.runtime_transfer_host) ??
+      workspace.deviceName
+    return deviceName ? { ...workspace, deviceName } : workspace
+  }
+  return {
+    ...runtimeWork,
+    projects: runtimeWork.projects.map(project => ({
+      ...project,
+      deviceWorkspaces: project.deviceWorkspaces.map(annotateWorkspace),
+    })),
+    chats: runtimeWork.chats.map(annotateWorkspace),
+  }
+}
+
+function filterRuntimeWorkspaces(
+  runtimeWork: RuntimeWorkListResponse,
+  keep: (workspace: RuntimeDeviceWorkspace) => boolean
+): RuntimeWorkListResponse {
+  const projects = runtimeWork.projects
+    .map(project => {
+      const deviceWorkspaces = project.deviceWorkspaces.filter(keep)
+      return {
+        ...project,
+        deviceWorkspaces,
+        totalTasks: deviceWorkspaces.reduce(
+          (total, workspace) => total + workspace.tasks.length,
+          0
+        ),
+      }
+    })
+    .filter(project => project.deviceWorkspaces.length > 0)
+  const chats = runtimeWork.chats.filter(keep)
+  return {
+    projects,
+    chats,
+    totalTasks:
+      projects.reduce((total, project) => total + (project.totalTasks ?? 0), 0) +
+      chats.reduce((total, workspace) => total + workspace.tasks.length, 0),
+  }
+}
+
+export function reconcileCachedRemoteRuntimeWork(
+  cachedRuntimeWork: RuntimeWorkListResponse,
+  liveRuntimeWork: RuntimeWorkListResponse,
+  devices?: DeviceInfo[]
+): RuntimeWorkListResponse {
+  const cachedSnapshot = createRemoteRuntimeWorkCacheSnapshot(cachedRuntimeWork)
+  const liveWorkspaceAliases = runtimeWorkspaces(liveRuntimeWork).map(workspaceAliases)
+  const deviceRecords = devices?.map(device => ({
+    aliases: deviceAliases(device),
+    available: isUsableDevice(device),
+  }))
+
+  const preservedCache = filterRuntimeWorkspaces(cachedSnapshot, workspace => {
+    const aliases = workspaceAliases(workspace)
+    if (deviceRecords) {
+      const device = deviceRecords.find(record => aliasesIntersect(aliases, record.aliases))
+      return Boolean(device && !device.available)
+    }
+    return !liveWorkspaceAliases.some(liveAliases => aliasesIntersect(aliases, liveAliases))
+  })
+
+  return mergeRuntimeWorkLists(preservedCache, liveRuntimeWork, { devices })
+}

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -21,6 +21,11 @@ import {
 import type { WorkbenchAction } from './workbenchReducer'
 import { getRememberedStandaloneDeviceId } from './workbenchRuntimeHelpers'
 import type { WorkbenchServices } from './workbenchServices'
+import {
+  readCachedRemoteRuntimeWork,
+  reconcileCachedRemoteRuntimeWork,
+  writeCachedRemoteRuntimeWork,
+} from './remoteRuntimeWorkCache'
 
 interface UseWorkbenchDataRefreshOptions {
   user: User
@@ -30,6 +35,31 @@ interface UseWorkbenchDataRefreshOptions {
   services: WorkbenchServices
 }
 
+function createCloudRuntimeStateWithCache(runtimeWork: RuntimeWorkListResponse): CloudRuntimeState {
+  if (runtimeWork.projects.length === 0 && runtimeWork.chats.length === 0) {
+    return EMPTY_CLOUD_RUNTIME_STATE
+  }
+  return {
+    availability: 'stale',
+    current: null,
+    lastGood: {
+      revision: 0,
+      devices: [],
+      runtimeWork,
+      teams: [],
+      fetchedAt: null,
+      checks: {
+        teams: { status: 'idle', updatedAt: null, error: null },
+        devices: { status: 'idle', updatedAt: null, error: null },
+        runtimeWork: { status: 'stale', updatedAt: null, error: null },
+      },
+    },
+    inFlightRevision: null,
+    lastTrigger: null,
+    nextRevision: 1,
+  }
+}
+
 export function useWorkbenchDataRefresh({
   user,
   state,
@@ -37,9 +67,18 @@ export function useWorkbenchDataRefresh({
   executorClient,
   services,
 }: UseWorkbenchDataRefreshOptions) {
-  const [cloudRuntimeState, setCloudRuntimeState] =
-    useState<CloudRuntimeState>(EMPTY_CLOUD_RUNTIME_STATE)
-  const cloudRuntimeStateRef = useRef<CloudRuntimeState>(EMPTY_CLOUD_RUNTIME_STATE)
+  const initialCachedRemoteRuntimeWork = useMemo(
+    () => readCachedRemoteRuntimeWork(user.id),
+    [user.id]
+  )
+  const cachedRemoteRuntimeWorkRef = useRef({
+    userId: user.id,
+    runtimeWork: initialCachedRemoteRuntimeWork,
+  })
+  const [cloudRuntimeState, setCloudRuntimeState] = useState<CloudRuntimeState>(() =>
+    createCloudRuntimeStateWithCache(initialCachedRemoteRuntimeWork)
+  )
+  const cloudRuntimeStateRef = useRef<CloudRuntimeState>(cloudRuntimeState)
   const cloudWorkStatus = useMemo(
     () => selectCloudWorkStatus(cloudRuntimeState),
     [cloudRuntimeState]
@@ -50,13 +89,22 @@ export function useWorkbenchDataRefresh({
     setCloudRuntimeState(next)
   }, [])
 
-  /* eslint-disable react-hooks/set-state-in-effect -- Cloud work status mirrors service availability and must reset when the service is removed. */
+  useEffect(() => {
+    cachedRemoteRuntimeWorkRef.current = {
+      userId: user.id,
+      runtimeWork: initialCachedRemoteRuntimeWork,
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Cached runtime work must switch atomically with the authenticated user.
+    updateCloudRuntimeState(createCloudRuntimeStateWithCache(initialCachedRemoteRuntimeWork))
+  }, [initialCachedRemoteRuntimeWork, updateCloudRuntimeState, user.id])
+
   useEffect(() => {
     if (!services.cloudBackgroundApi) {
-      updateCloudRuntimeState(EMPTY_CLOUD_RUNTIME_STATE)
+      updateCloudRuntimeState(
+        createCloudRuntimeStateWithCache(cachedRemoteRuntimeWorkRef.current.runtimeWork)
+      )
     }
   }, [services.cloudBackgroundApi, updateCloudRuntimeState])
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const refreshCloudBackgroundData = useCallback(
     async (
@@ -99,10 +147,32 @@ export function useWorkbenchDataRefresh({
 
       if (options?.isCancelled?.() || revision == null) return
 
+      const reconciledRuntimeWorkResult =
+        runtimeWorkResult?.status === 'fulfilled'
+          ? {
+              status: 'fulfilled' as const,
+              value: reconcileCachedRemoteRuntimeWork(
+                cachedRemoteRuntimeWorkRef.current.runtimeWork,
+                runtimeWorkResult.value,
+                devicesResult?.status === 'fulfilled' ? devicesResult.value : undefined
+              ),
+            }
+          : runtimeWorkResult
+      if (reconciledRuntimeWorkResult?.status === 'fulfilled') {
+        cachedRemoteRuntimeWorkRef.current = {
+          userId: user.id,
+          runtimeWork: writeCachedRemoteRuntimeWork(
+            user.id,
+            reconciledRuntimeWorkResult.value,
+            devicesResult?.status === 'fulfilled' ? devicesResult.value : undefined
+          ),
+        }
+      }
+
       const nextCloudState = finishCloudRuntimeSync(cloudRuntimeStateRef.current, revision, {
         teams: teamsResult,
         devices: devicesResult,
-        runtimeWork: runtimeWorkResult,
+        runtimeWork: reconciledRuntimeWorkResult,
       })
       updateCloudRuntimeState(nextCloudState)
 
@@ -120,7 +190,7 @@ export function useWorkbenchDataRefresh({
         ),
       })
     },
-    [dispatch, services.cloudBackgroundApi, updateCloudRuntimeState]
+    [dispatch, services.cloudBackgroundApi, updateCloudRuntimeState, user.id]
   )
 
   useEffect(() => {

--- a/wework/src/features/workbench/workbenchCloudStatus.test.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.test.ts
@@ -578,4 +578,75 @@ describe('cloud runtime sync state', () => {
       }),
     ])
   })
+
+  test('keeps the cached public IP when a disconnected remote descriptor reports loopback', () => {
+    const localDescriptor: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: {
+            key: 'remote-project-id',
+            sidebarStateKey: 'remote-project-id',
+            name: 'Remote',
+            kind: 'remote',
+            source: 'remote_project',
+            stateDeviceId: 'local-device',
+          },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: '127.0.0.1',
+              deviceStatus: 'offline',
+              available: false,
+              workspacePath: '/srv/repo',
+              workspaceSource: 'remote',
+              remoteHostId: 'remote-device',
+              mapped: true,
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalTasks: 0,
+    }
+    const cachedRemoteWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { key: '/srv/repo', name: 'Remote executor project' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: '10.201.3.200',
+              deviceStatus: 'offline',
+              available: false,
+              workspacePath: '/srv/repo',
+              workspaceSource: 'remote',
+              remoteHostId: 'remote-device',
+              mapped: true,
+              tasks: [
+                {
+                  taskId: 'cached-task',
+                  workspacePath: '/srv/repo',
+                  title: 'Cached task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalTasks: 1,
+    }
+
+    const merged = mergeRuntimeWorkLists(localDescriptor, cachedRemoteWork)
+
+    expect(merged.projects).toHaveLength(1)
+    expect(merged.projects[0].deviceWorkspaces[0]).toMatchObject({
+      deviceName: '10.201.3.200',
+      deviceStatus: 'offline',
+      available: false,
+      tasks: [expect.objectContaining({ taskId: 'cached-task' })],
+    })
+  })
 })

--- a/wework/src/features/workbench/workbenchCloudStatus.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.ts
@@ -703,6 +703,10 @@ function mergeRuntimeWorkspaces(
       workspace: {
         ...canonicalWorkspace,
         ...(existing ?? {}),
+        deviceName:
+          existing?.workspaceSource === 'remote' && canonicalWorkspace.workspaceSource === 'remote'
+            ? (canonicalWorkspace.deviceName ?? existing.deviceName)
+            : (existing?.deviceName ?? canonicalWorkspace.deviceName),
         available: (existing?.available ?? false) || canonicalWorkspace.available,
         tasks,
       },


### PR DESCRIPTION
## Summary

- keep remote-only projects visible after startup even when their device is unavailable, showing the last known IP with a gray status dot
- persist an allowlisted, per-user remote task-list summary and restore it as unavailable data after restart
- disable opening and task mutations while a restored remote task is offline
- reconcile cached summaries with authoritative live data after reconnect, while retaining the previous cache when discovery or task-list sync fails
- document the offline remote-task ownership and recovery model in Chinese and English

## Root cause

The sidebar filtered out remote projects with no currently loaded tasks. Remote runtime work also existed only in the React `lastGood` snapshot, so restarting Wework lost the task list. An offline remote device then produced no live runtime work, leaving only an empty remote-project descriptor.

## Persistence boundary

The local cache contains only sidebar summary fields such as task ID, title, timestamps, workspace path, repository and branch hints, and ordering metadata. It does not persist conversation bodies, tool calls, runtime handles, model configuration, or task trees. Full task details remain on the remote device.

## Associated task

- `xytBU8ic40` — 支持离线远程项目启动恢复
- Business ID: `1022749_3#74148`

## Validation

- `pnpm --dir wework test` — 177 test files, 1747 tests passed
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`
- repository pre-push quality gate, including Wework checks and applicable workspace checks
- desktop Wework verification intentionally left for manual acceptance as requested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline recovery for remote runtime tasks using locally cached sidebar summaries.
  * Remote tasks/projects stay visible when remotes are unavailable, shown with gray device indicators; interactions are disabled and actions like pin/rename respect workspace availability.
  * Reconciles cached and live remote runtime data on refresh, updating and clearing cache as devices reconnect.
* **Bug Fixes**
  * Cloud runtime refresh failures are now surfaced instead of returning partial results.
* **Documentation**
  * Updated English and Chinese developer guides with offline remote task recovery and state ownership details.
* **Tests**
  * Added coverage for remote runtime caching, sidebar rendering states, and refresh/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->