### PR TITLE
fix(wework): remove startup loading delays

### DIFF
--- a/docs/en/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/developer-guide/wework-performance-diagnostics.md
@@ -12,6 +12,12 @@ When `pnpm --filter wework dev:mac` starts a debug app, each Wework process uses
 
 Development instances share one Cargo target directory by default so executor source changes can reuse incremental build artifacts. Set `WEGENT_DISABLE_SHARED_CARGO_TARGET=1` to use the project's default target directory when investigating shared build-cache issues.
 
+## Diagnosing Startup Time
+
+The desktop startup screen waits only for the local executor to report ready; debug builds do not delay the workbench to finish an animation cycle. On a cold start, Tauri cleans up the previous executor and IPC address file, then starts a new sidecar immediately. It attempts to attach to an existing sidecar only when reconnecting after a live connection is lost.
+
+When the startup screen remains visible, align `Frontend logging initialized` in the frontend log with `app IPC listening` in the executor log. The interval primarily measures local executor cold startup. Later entries such as `runtime work list finished` identify workbench data-loading time. Do not mistake a background cloud synchronization timeout for the local startup gate.
+
 ## Enabling Diagnostics
 
 Press the hidden shortcut in the Wework window:

--- a/docs/zh/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/developer-guide/wework-performance-diagnostics.md
@@ -12,6 +12,12 @@ Wework 内置一个默认关闭的前端性能诊断开关，用于定位 releas
 
 开发环境默认让这些实例复用同一个 Cargo target 目录，以便 executor 源码变化后继续使用增量编译产物。需要排查共享构建缓存问题时，可以设置 `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`，让当前启动过程使用项目内的默认 target 目录。
 
+## 启动耗时诊断
+
+桌面端的启动页只等待本地 executor 报告 ready；debug 构建不会为了播放完整动画而延迟工作台。冷启动时，Tauri 会先清理旧 executor 和 IPC 地址文件，然后直接启动新的 sidecar。只有运行中的连接断开并进入重连路径时，才会尝试连接已有 sidecar。
+
+排查启动页长时间不消失时，对齐前端日志的 `Frontend logging initialized` 与 executor 日志的 `app IPC listening`。两者之间的时间主要反映本地 executor 冷启动；`runtime work list finished` 等后续记录用于判断工作台数据加载耗时。不要把后台云端同步的超时误判为本地启动门控。
+
 ## 开启方式
 
 在 Wework 窗口中按隐藏快捷键：

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -970,7 +970,7 @@ fn cleanup_stale_local_executor_processes() -> Result<(), String> {
     remove_stale_app_ipc_addr_file_at(&addr_file_path)
 }
 
-fn cleanup_stale_local_executor_once(state: &LocalExecutorState) -> Result<(), String> {
+fn cleanup_stale_local_executor_once(state: &LocalExecutorState) -> Result<bool, String> {
     let should_cleanup = {
         let inner = state
             .inner
@@ -979,7 +979,7 @@ fn cleanup_stale_local_executor_once(state: &LocalExecutorState) -> Result<(), S
         !inner.startup_cleanup_done && inner.child.is_none()
     };
     if !should_cleanup {
-        return Ok(());
+        return Ok(false);
     }
 
     cleanup_stale_local_executor_processes()?;
@@ -989,7 +989,7 @@ fn cleanup_stale_local_executor_once(state: &LocalExecutorState) -> Result<(), S
         .lock()
         .map_err(|_| "Failed to lock local executor state".to_string())?;
     inner.startup_cleanup_done = true;
-    Ok(())
+    Ok(true)
 }
 
 fn sidecar_source_and_path() -> (String, String) {
@@ -2195,14 +2195,22 @@ async fn start_executor_if_needed_unlocked(
         }
     }
 
-    if let Err(error) = cleanup_stale_local_executor_once(state) {
-        set_executor_error(state, error.clone());
-        return Err(error);
-    }
+    let startup_cleanup_performed = match cleanup_stale_local_executor_once(state) {
+        Ok(performed) => performed,
+        Err(error) => {
+            set_executor_error(state, error.clone());
+            return Err(error);
+        }
+    };
 
-    if connect_and_attach_sidecar_socket(app.clone(), state)
-        .await
-        .is_ok()
+    // A release cold start removes the stale address file and terminates any
+    // executor that owned it. Waiting for that file to reappear can only time
+    // out, so spawn the new executor immediately. Reconnect paths still attach
+    // first because their existing child may already be opening the socket.
+    if !startup_cleanup_performed
+        && connect_and_attach_sidecar_socket(app.clone(), state)
+            .await
+            .is_ok()
     {
         return Ok(());
     }
@@ -2701,6 +2709,14 @@ mod tests {
     use std::sync::{Mutex as TestMutex, MutexGuard, OnceLock};
     #[cfg(unix)]
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn startup_cleanup_reports_only_the_first_cold_start_pass() {
+        let state = LocalExecutorState::default();
+
+        assert!(cleanup_stale_local_executor_once(&state).unwrap());
+        assert!(!cleanup_stale_local_executor_once(&state).unwrap());
+    }
 
     fn env_lock() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<TestMutex<()>> = OnceLock::new();

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -31,7 +31,6 @@ const connectMock = vi.mocked(connectLocalExecutorToBackend)
 const disconnectMock = vi.mocked(disconnectLocalExecutorFromBackend)
 const ensureMock = vi.mocked(ensureLocalExecutorStarted)
 const readLogMock = vi.mocked(readLocalExecutorLog)
-const DEV_STARTUP_HOLD_MS = 4800
 const SLOW_STARTUP_WARNING_MS = 10000
 
 function enableTauri() {
@@ -411,9 +410,7 @@ describe('LocalRuntimeInitializer', () => {
     expect(onMount).toHaveBeenCalledTimes(1)
   })
 
-  test('keeps the startup animation visible for one cycle in dev mode', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-06-26T00:00:00Z'))
+  test('reveals the app immediately when the executor is ready in dev mode', async () => {
     vi.stubEnv('DEV', true)
     ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
 
@@ -423,18 +420,8 @@ describe('LocalRuntimeInitializer', () => {
       </LocalRuntimeInitializer>
     )
 
-    expect(screen.getByTestId('local-runtime-initializer')).toBeInTheDocument()
-    expect(screen.queryByTestId('main-app')).not.toBeInTheDocument()
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(DEV_STARTUP_HOLD_MS - 1)
-    })
-    expect(screen.getByTestId('main-app')).not.toBeVisible()
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1)
-    })
-    expect(screen.getByTestId('main-app')).toBeInTheDocument()
+    expect(await screen.findByTestId('main-app')).toBeVisible()
+    expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
   })
 
   test('shows startup error and retries initialization', async () => {

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -29,7 +29,6 @@ import {
 } from '@/tauri/localExecutor'
 
 const LOCAL_EXECUTOR_LOG_PATH = '~/.wegent-executor/logs/executor.log'
-const LOCAL_RUNTIME_ANIMATION_CYCLE_MS = 4800
 const LOCAL_RUNTIME_SLOW_STARTUP_MS = 10000
 
 type LocalRuntimePhase = 'starting' | 'ready' | 'failed'
@@ -56,7 +55,6 @@ interface LocalRuntimeDebugInfo {
   runtimeMode: string
   phase: LocalRuntimePhase
   startupReady: boolean
-  minimumDelayElapsed: boolean
   ensureCallState: string
   error: string | null
   log: LocalExecutorLog | null
@@ -83,10 +81,6 @@ function errorMessage(error: unknown, fallback: string): string {
 
 function sanitizeLocalRuntimeDebugText(text: string): string {
   return text.replace(/\btauri\b/gi, 'desktop app').replace(/\bsidecar\b/gi, 'executor process')
-}
-
-function localRuntimeMinimumReadyDelayMs(): number {
-  return import.meta.env.DEV ? LOCAL_RUNTIME_ANIMATION_CYCLE_MS : 0
 }
 
 async function resolveLocalRuntimeState(
@@ -120,7 +114,6 @@ function formatLocalRuntimeDebugInfo(info: LocalRuntimeDebugInfo): string {
     `App mode: ${info.runtimeMode}`,
     `Startup phase: ${info.phase}`,
     `Startup ready: ${info.startupReady ? 'true' : 'false'}`,
-    `Minimum delay elapsed: ${info.minimumDelayElapsed ? 'true' : 'false'}`,
     `Startup check: ${info.ensureCallState}`,
     `Error: ${info.error ?? 'none'}`,
     `Socket path: ${info.log?.socketPath ?? 'unknown'}`,
@@ -294,8 +287,6 @@ export function LocalRuntimeInitializer({
   const enabled = useMemo(() => shouldInitializeLocalRuntime(), [])
   const fallbackError = t('fallback_error')
   const initialCloudConnectionRef = useRef(initialCloudConnection)
-  const minimumReadyDelayMs = localRuntimeMinimumReadyDelayMs()
-  const [minimumDelayElapsed, setMinimumDelayElapsed] = useState(() => minimumReadyDelayMs === 0)
   const [slowStartupTimedOut, setSlowStartupTimedOut] = useState(false)
   const [startupAttempt, setStartupAttempt] = useState(0)
   const [copyDebugState, setCopyDebugState] = useState<CopyDebugState>('idle')
@@ -321,17 +312,6 @@ export function LocalRuntimeInitializer({
     }, LOCAL_RUNTIME_SLOW_STARTUP_MS)
     return () => window.clearTimeout(timer)
   }, [enabled, startupAttempt])
-
-  useEffect(() => {
-    if (minimumReadyDelayMs === 0) {
-      return undefined
-    }
-
-    const timer = window.setTimeout(() => {
-      setMinimumDelayElapsed(true)
-    }, minimumReadyDelayMs)
-    return () => window.clearTimeout(timer)
-  }, [minimumReadyDelayMs])
 
   const retryInitialize = useCallback(async () => {
     if (!enabled) return
@@ -379,7 +359,6 @@ export function LocalRuntimeInitializer({
       runtimeMode: getRuntimeConfig().runtimeMode,
       phase: state.phase,
       startupReady,
-      minimumDelayElapsed,
       ensureCallState:
         state.phase === 'starting' ? 'pending' : state.phase === 'failed' ? 'failed' : 'resolved',
       error: state.error,
@@ -393,10 +372,10 @@ export function LocalRuntimeInitializer({
     } catch {
       setCopyDebugState('failed')
     }
-  }, [minimumDelayElapsed, startupReady, state.error, state.phase, t])
+  }, [startupReady, state.error, state.phase, t])
 
   const canMountChildren = state.phase === 'ready'
-  const canRevealChildren = canMountChildren && (!enabled || minimumDelayElapsed)
+  const canRevealChildren = canMountChildren
   const shouldShowStartupScreen = !canRevealChildren
   const failed = state.phase === 'failed'
 


### PR DESCRIPTION
## Summary

- skip the guaranteed 10-second existing-executor attach timeout after release cold-start cleanup
- start the new executor sidecar immediately while preserving attach-first behavior for reconnects
- remove the debug-only 4.8-second animation hold after the executor is ready
- document startup timing diagnosis in Chinese and English

## Root cause

Release startup removed the stale IPC address file and terminated its owner, then still waited up to 10 seconds for that address file to reappear before spawning a new executor. The observed startup logs matched this fixed timeout: frontend initialization at 12:26:29 and app IPC listening at 12:26:40. Debug builds also added an unrelated forced 4.8-second animation cycle.

## Impact

Cold starts spawn the local executor immediately instead of paying a guaranteed failed attach timeout. Debug instances reveal the workbench as soon as the executor reports ready.

## Validation

- cargo test --manifest-path wework/src-tauri/Cargo.toml startup_cleanup_reports_only_the_first_cold_start_pass
- pnpm --filter wework test (176 files, 1737 tests)
- ESLint, TypeScript, and unit tests through pre-push checks
- isolated real-Tauri verification with scripts/ai-verify.mjs; executor app IPC listened without the prior 10-second wait and the workbench rendered successfully
- Prettier, ESLint, cargo fmt, and git diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved desktop startup by displaying the main app as soon as the local runtime is ready.
  * Added guidance for diagnosing startup performance and distinguishing local startup delays from later data loading or cloud synchronization.

* **Bug Fixes**
  * Improved cold-start handling for the local runtime, reducing unnecessary reconnection attempts.
  * Updated startup diagnostics to provide more relevant information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->