### PR TITLE
fix(executor): retain Codex thread subscriptions until archive

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -455,7 +455,7 @@ impl CodexAppServerClient {
         self.state.lock().await.active_threads.remove(thread_id);
     }
 
-    async fn unsubscribe_thread(&self, thread_id: &str) {
+    pub(crate) async fn unsubscribe_thread(&self, thread_id: &str) {
         let result: Result<(), String> = async {
             let (request_id, handle, response_rx) = self.prepare_existing_request().await?;
             let message = json!({
@@ -923,13 +923,11 @@ async fn run_codex_app_server_turn_on_shared_client(
                 .await?;
         }
 
-        let mut goal_run_active = false;
         if !request.ephemeral {
             if let Some(goal) = initial_thread_goal.as_ref() {
                 let goal_params = thread_goal_set_params(&thread_id, goal)?;
                 let goal_response = client.request("thread/goal/set", goal_params).await?;
                 if goal_response_goal_is_active(&goal_response) {
-                    goal_run_active = true;
                     state.set_goal_status("active");
                 }
             } else if resuming_thread {
@@ -938,7 +936,6 @@ async fn run_codex_app_server_turn_on_shared_client(
                     .await
                 {
                     if goal_response_goal_is_active(&goal_response) {
-                        goal_run_active = true;
                         state.set_goal_status("active");
                     }
                 }
@@ -1011,7 +1008,6 @@ async fn run_codex_app_server_turn_on_shared_client(
                 notifications,
                 cancellation,
                 request_user_input_answers,
-                goal_run_active,
                 active_turn_started,
                 active_turn_finished,
             },
@@ -1030,9 +1026,6 @@ async fn run_codex_app_server_turn_on_shared_client(
 
     if let Some(thread_id) = subscribed_thread_id {
         client.mark_thread_idle(&thread_id).await;
-        if !prepared.request.ephemeral {
-            client.unsubscribe_thread(&thread_id).await;
-        }
     }
 
     if let Err(error) = &result {
@@ -1294,7 +1287,6 @@ struct SharedTurnNotificationOptions {
     notifications: Option<CodexNotificationSender>,
     cancellation: Option<oneshot::Receiver<()>>,
     request_user_input_answers: Option<CodexRequestUserInputReceiver>,
-    goal_run_active: bool,
     active_turn_started: Option<CodexActiveTurnCallback>,
     active_turn_finished: Option<CodexActiveTurnFinishedCallback>,
 }
@@ -1424,16 +1416,17 @@ async fn read_shared_turn_notifications(
             if let Some(callback) = options.active_turn_finished.as_ref() {
                 callback();
             }
-            if !matches!(outcome, ExecutionOutcome::Completed { .. }) {
-                return Ok(outcome);
-            }
-            if !options.goal_run_active || !state.goal_is_active() {
+            if !should_wait_for_goal_continuation(&outcome, state) {
                 return Ok(outcome);
             }
             last_outcome = Some(outcome);
             state.reset_turn_output();
         }
     }
+}
+
+fn should_wait_for_goal_continuation(outcome: &ExecutionOutcome, state: &CodexRunState) -> bool {
+    matches!(outcome, ExecutionOutcome::Completed { .. }) && state.goal_is_active()
 }
 
 async fn recover_stalled_shared_turn(
@@ -5196,6 +5189,32 @@ mod tests {
                 content: String::new()
             }
         );
+    }
+
+    #[test]
+    fn goal_created_during_turn_keeps_notification_reader_alive() {
+        let mut state = CodexRunState::default();
+
+        assert!(state
+            .handle_message(&json!({
+                "method": "thread/goal/updated",
+                "params": {
+                    "threadId": "thread-1",
+                    "goal": { "status": "active" }
+                }
+            }))
+            .is_none());
+        let outcome = state
+            .handle_message(&json!({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-1",
+                    "turn": { "status": "completed" }
+                }
+            }))
+            .expect("turn completion should produce an outcome");
+
+        assert!(should_wait_for_goal_continuation(&outcome, &state));
     }
 
     #[test]

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -1289,6 +1289,8 @@ impl RuntimeWorkRpcHandler {
                     ("thread_id", thread_id.to_owned()),
                 ],
             );
+            self.codex_app_server.unsubscribe_thread(thread_id).await;
+            self.remove_thread_event_route(thread_id);
         } else {
             log_executor_event(
                 "runtime task archive skipped codex",
@@ -3104,6 +3106,13 @@ impl RuntimeWorkRpcHandler {
         {
             route.active = false;
         }
+    }
+
+    fn remove_thread_event_route(&self, thread_id: &str) {
+        self.thread_event_routes
+            .lock()
+            .expect("thread event route lock should not be poisoned")
+            .remove(thread_id);
     }
 
     fn mark_thread_event_routes_idle_for_local_task(&self, local_task_id: &str) {

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -614,7 +614,7 @@ async fn runtime_tasks_send_ephemeral_codex_thread_uses_loaded_thread_directly()
 }
 
 #[tokio::test]
-async fn runtime_tasks_reuse_one_codex_process_across_follow_up_turns() {
+async fn runtime_tasks_keep_thread_subscription_until_archive() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
         "WEGENT_EXECUTOR_HOME",
@@ -713,8 +713,21 @@ async fn runtime_tasks_reuse_one_codex_process_across_follow_up_turns() {
             .iter()
             .filter(|call| call["method"] == "thread/unsubscribe")
             .count(),
-        2
+        0
     );
+
+    let archived = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.archive",
+            "payload": {
+                "taskId": "local-task-persistent",
+                "workspacePath": "/tmp/project"
+            }
+        }))
+        .await
+        .expect("archive should succeed");
+    assert_eq!(archived["success"], true);
+    wait_for_method_count(&log_path, "thread/unsubscribe", 1).await;
 }
 
 #[tokio::test]
@@ -2011,6 +2024,9 @@ while IFS= read -r line; do
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"goal":null}}}}'
       ;;
     *'"method":"thread/name/set"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{}}}}'
+      ;;
+    *'"method":"thread/archive"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{}}}}'
       ;;
     *'"method":"turn/start"'*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved continuation handling for active goals during Codex task execution.
  * Preserved notification monitoring when a goal becomes active during a turn.
  * Ensured archived tasks are fully unsubscribed from thread notifications and event routing.

* **Tests**
  * Added coverage confirming persistent task subscriptions remain active until explicit archival.
  * Added validation for continued notification monitoring during active goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->