### PR TITLE
feat: 打包时支持设置identifier id

### DIFF
--- a/wework/branding/demo.json
+++ b/wework/branding/demo.json
@@ -1,0 +1,4 @@
+{
+  "productName": "Demo WeWork",
+  "identifier": "com.example.demo-wework"
+}

--- a/wework/scripts/build-mac-app.sh
+++ b/wework/scripts/build-mac-app.sh
@@ -11,12 +11,17 @@ ENV_FILE="$PROJECT_DIR/.env"
 source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
 # shellcheck source=lib/wework-mac-env.sh
 source "$SCRIPT_DIR/lib/wework-mac-env.sh"
+# shellcheck source=lib/wework-branding.sh
+source "$SCRIPT_DIR/lib/wework-branding.sh"
+# shellcheck source=lib/wework-macos-signing.sh
+source "$SCRIPT_DIR/lib/wework-macos-signing.sh"
 
 BUILD_PROFILE="${WEWORK_BUILD_PROFILE:-release}"
 MACOS_BUILD_TARGET="${MACOS_BUILD_TARGET:-}"
 TAURI_BUNDLES="${WEWORK_TAURI_BUNDLES:-}"
 NO_SIGN="${WEWORK_NO_SIGN:-}"
 RELEASE_DEVTOOLS="${WEWORK_RELEASE_DEVTOOLS:-}"
+BRAND_CONFIG="${WEWORK_BRAND_CONFIG:-}"
 
 usage() {
   cat <<'EOF'
@@ -27,6 +32,7 @@ Options:
   --target <target>        macOS Rust/Tauri target, e.g. aarch64-apple-darwin.
   --bundles <bundles>      Tauri bundles to package, e.g. app or app,dmg.
   --devtools               Enable Web Inspector support in release builds.
+  --brand-config <path>    Brand identity JSON used for this app bundle.
   --sign                   Allow signing in dev profile.
   --no-sign                Skip code signing.
   -h, --help               Show this help message.
@@ -36,6 +42,7 @@ Environment:
   MACOS_BUILD_TARGET       Default macOS Rust/Tauri target.
   WEWORK_TAURI_BUNDLES     Default bundle list when --bundles is not provided.
   WEWORK_RELEASE_DEVTOOLS  Set to 1 to compile Tauri devtools into release builds.
+  WEWORK_BRAND_CONFIG      Default brand identity JSON.
   WEWORK_NO_SIGN           Set to 1 to pass --no-sign.
   VITE_WEGENT_BACKEND_URL  Default Backend URL shown in Connect cloud.
 
@@ -98,6 +105,19 @@ while [ "$#" -gt 0 ]; do
       RELEASE_DEVTOOLS="1"
       shift
       ;;
+    --brand-config)
+      if [ "$#" -lt 2 ]; then
+        echo "Error: $1 requires a config path." >&2
+        usage
+        exit 1
+      fi
+      BRAND_CONFIG="$2"
+      shift 2
+      ;;
+    --brand-config=*)
+      BRAND_CONFIG="${1#*=}"
+      shift
+      ;;
     --sign)
       NO_SIGN="0"
       shift
@@ -123,6 +143,14 @@ if [ "$BUILD_PROFILE" != "dev" ] && [ "$BUILD_PROFILE" != "release" ]; then
   exit 1
 fi
 
+if [ -n "$BRAND_CONFIG" ]; then
+  if [ ! -f "$BRAND_CONFIG" ]; then
+    echo "Error: brand config not found: $BRAND_CONFIG" >&2
+    exit 1
+  fi
+  BRAND_CONFIG="$(cd "$(dirname "$BRAND_CONFIG")" && pwd)/$(basename "$BRAND_CONFIG")"
+fi
+
 if [ "$BUILD_PROFILE" = "dev" ]; then
   TAURI_BUNDLES="${TAURI_BUNDLES:-app}"
   NO_SIGN="${NO_SIGN:-1}"
@@ -142,6 +170,7 @@ echo "  BACKEND_PORT=$BACKEND_PORT"
 echo "  MACOS_BUILD_TARGET=${MACOS_BUILD_TARGET:-<native>}"
 echo "  TAURI_BUNDLES=${TAURI_BUNDLES:-<default>}"
 echo "  RELEASE_DEVTOOLS=${RELEASE_DEVTOOLS:-0}"
+echo "  BRAND_CONFIG=${BRAND_CONFIG:-<default>}"
 echo "  NO_SIGN=${NO_SIGN:-0}"
 echo "  VITE_API_BASE_URL=$VITE_API_BASE_URL"
 echo "  VITE_SOCKET_BASE_URL=$VITE_SOCKET_BASE_URL"
@@ -152,11 +181,36 @@ if [ "${WEWORK_DRY_RUN:-}" = "1" ]; then
   exit 0
 fi
 
+EXECUTOR_DIR="$PROJECT_DIR/executor"
+EXECUTOR_PROFILE_DIR="debug"
+EXECUTOR_BINARY_DIR="$(cargo_target_dir_for "$EXECUTOR_DIR")"
+
+if [ "$BUILD_PROFILE" = "release" ]; then
+  EXECUTOR_PROFILE_DIR="release"
+fi
+if [ -n "$MACOS_BUILD_TARGET" ]; then
+  EXECUTOR_BINARY_DIR="$EXECUTOR_BINARY_DIR/$MACOS_BUILD_TARGET"
+fi
+
+echo "Building local executor sidecar"
+cd "$EXECUTOR_DIR"
+if [ -n "$MACOS_BUILD_TARGET" ]; then
+  cargo build --profile "$BUILD_PROFILE" --locked --target "$MACOS_BUILD_TARGET"
+else
+  cargo build --profile "$BUILD_PROFILE" --locked
+fi
+mkdir -p "$EXECUTOR_DIR/dist"
+cp "$EXECUTOR_BINARY_DIR/$EXECUTOR_PROFILE_DIR/wegent-executor" \
+  "$EXECUTOR_DIR/dist/wegent-executor"
+chmod 0755 "$EXECUTOR_DIR/dist/wegent-executor"
+"$EXECUTOR_DIR/dist/wegent-executor" --version
+
 cd "$WEWORK_DIR"
 CONFIG_OVERRIDE=""
 cleanup() {
   if [ -n "$CONFIG_OVERRIDE" ]; then
     rm -f "$CONFIG_OVERRIDE"
+    rm -f "$CONFIG_OVERRIDE.namespace"
   fi
 }
 trap cleanup EXIT
@@ -165,33 +219,16 @@ TAURI_ARGS=(build)
 if [ "$BUILD_PROFILE" = "dev" ]; then
   TAURI_ARGS+=(--debug)
 fi
-if [ "$RELEASE_DEVTOOLS" = "1" ]; then
-  CONFIG_OVERRIDE="$(mktemp "$WEWORK_DIR/src-tauri/tauri.devtools.XXXXXX.json")"
-  CONFIG_OVERRIDE="$CONFIG_OVERRIDE" python3 - <<'PY'
-import json
-import os
-
-with open("src-tauri/tauri.conf.json", "r", encoding="utf-8") as handle:
-    base_config = json.load(handle)
-
-windows = base_config.get("app", {}).get("windows", [])
-config = {
-    "app": {
-        "windows": [
-            {
-                **window,
-                "devtools": True,
-            }
-            for window in windows
-        ],
-    },
-}
-
-with open(os.environ["CONFIG_OVERRIDE"], "w", encoding="utf-8") as handle:
-    json.dump(config, handle, indent=2)
-    handle.write("\n")
-PY
-  TAURI_ARGS+=(--features release-devtools)
+if [ -n "$BRAND_CONFIG" ] || [ "$RELEASE_DEVTOOLS" = "1" ]; then
+  CONFIG_OVERRIDE="$(mktemp "$WEWORK_DIR/src-tauri/tauri.build.XXXXXX.json")"
+  wework_prepare_brand_config "$WEWORK_DIR" "$BRAND_CONFIG" "${RELEASE_DEVTOOLS:-0}" "$CONFIG_OVERRIDE"
+  if [ -f "$CONFIG_OVERRIDE.namespace" ]; then
+    export WEWORK_EXECUTOR_NAMESPACE="$(<"$CONFIG_OVERRIDE.namespace")"
+    rm -f "$CONFIG_OVERRIDE.namespace"
+  fi
+  if [ "$RELEASE_DEVTOOLS" = "1" ]; then
+    TAURI_ARGS+=(--features release-devtools)
+  fi
   TAURI_ARGS+=(--config "$CONFIG_OVERRIDE")
 fi
 if [ -n "$MACOS_BUILD_TARGET" ]; then
@@ -205,4 +242,9 @@ if [ "$NO_SIGN" = "1" ]; then
 fi
 
 WEWORK_CODEX_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:codex
+wework_sign_prepared_codex_macos_binaries \
+  "$WEWORK_DIR" \
+  "$MACOS_BUILD_TARGET" \
+  "${APPLE_SIGNING_IDENTITY:-}" \
+  "$NO_SIGN"
 exec pnpm exec tauri "${TAURI_ARGS[@]}"

--- a/wework/scripts/build-windows-app.sh
+++ b/wework/scripts/build-windows-app.sh
@@ -11,11 +11,14 @@ ENV_FILE="$PROJECT_DIR/.env"
 source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
 # shellcheck source=lib/wework-mac-env.sh
 source "$SCRIPT_DIR/lib/wework-mac-env.sh"
+# shellcheck source=lib/wework-branding.sh
+source "$SCRIPT_DIR/lib/wework-branding.sh"
 
 BUILD_PROFILE="${WEWORK_BUILD_PROFILE:-release}"
 WINDOWS_BUILD_TARGET="${WINDOWS_BUILD_TARGET:-x86_64-pc-windows-msvc}"
 TAURI_BUNDLES="${WEWORK_TAURI_BUNDLES:-nsis}"
 RELEASE_DEVTOOLS="${WEWORK_RELEASE_DEVTOOLS:-}"
+BRAND_CONFIG="${WEWORK_BRAND_CONFIG:-}"
 
 usage() {
   cat <<'EOF'
@@ -26,6 +29,7 @@ Options:
   --target <target>        Windows Rust/Tauri target, e.g. x86_64-pc-windows-msvc.
   --bundles <bundles>      Tauri bundles to package, e.g. nsis or nsis,msi.
   --devtools               Enable Web Inspector support in release builds.
+  --brand-config <path>    Brand identity JSON used for this app bundle.
   -h, --help               Show this help message.
 
 Environment:
@@ -33,6 +37,7 @@ Environment:
   WINDOWS_BUILD_TARGET      Default Windows Rust/Tauri target.
   WEWORK_TAURI_BUNDLES      Default bundle list when --bundles is not provided.
   WEWORK_RELEASE_DEVTOOLS   Set to 1 to compile Tauri devtools into release builds.
+  WEWORK_BRAND_CONFIG       Default brand identity JSON.
 
 Examples:
   bash wework/scripts/build-windows-app.sh --profile dev
@@ -93,6 +98,19 @@ while [ "$#" -gt 0 ]; do
       RELEASE_DEVTOOLS="1"
       shift
       ;;
+    --brand-config)
+      if [ "$#" -lt 2 ]; then
+        echo "Error: $1 requires a config path." >&2
+        usage
+        exit 1
+      fi
+      BRAND_CONFIG="$2"
+      shift 2
+      ;;
+    --brand-config=*)
+      BRAND_CONFIG="${1#*=}"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -110,6 +128,14 @@ if [ "$BUILD_PROFILE" != "dev" ] && [ "$BUILD_PROFILE" != "release" ]; then
   exit 1
 fi
 
+if [ -n "$BRAND_CONFIG" ]; then
+  if [ ! -f "$BRAND_CONFIG" ]; then
+    echo "Error: brand config not found: $BRAND_CONFIG" >&2
+    exit 1
+  fi
+  BRAND_CONFIG="$(cd "$(dirname "$BRAND_CONFIG")" && pwd)/$(basename "$BRAND_CONFIG")"
+fi
+
 BACKEND_BASE_URL="$(wework_resolve_backend_base_url)"
 BACKEND_PORT="${BACKEND_PORT:-9100}"
 DEFAULT_SOCKET_BASE_URL="${WEGENT_SOCKET_URL:-$BACKEND_BASE_URL}"
@@ -124,6 +150,7 @@ echo "  BACKEND_PORT=$BACKEND_PORT"
 echo "  WINDOWS_BUILD_TARGET=$WINDOWS_BUILD_TARGET"
 echo "  TAURI_BUNDLES=${TAURI_BUNDLES:-<default>}"
 echo "  RELEASE_DEVTOOLS=${RELEASE_DEVTOOLS:-0}"
+echo "  BRAND_CONFIG=${BRAND_CONFIG:-<default>}"
 echo "  VITE_API_BASE_URL=$VITE_API_BASE_URL"
 echo "  VITE_SOCKET_BASE_URL=$VITE_SOCKET_BASE_URL"
 echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-<cargo default>}"
@@ -149,6 +176,7 @@ CONFIG_OVERRIDE=""
 cleanup() {
   if [ -n "$CONFIG_OVERRIDE" ]; then
     rm -f "$CONFIG_OVERRIDE"
+    rm -f "$CONFIG_OVERRIDE.namespace"
   fi
 }
 trap cleanup EXIT
@@ -159,33 +187,16 @@ TAURI_ARGS+=(--target "$WINDOWS_BUILD_TARGET")
 if [ "$BUILD_PROFILE" = "dev" ]; then
   TAURI_ARGS+=(--debug)
 fi
-if [ "$RELEASE_DEVTOOLS" = "1" ]; then
-  CONFIG_OVERRIDE="$(mktemp "$WEWORK_DIR/src-tauri/tauri.devtools.XXXXXX.json")"
-  CONFIG_OVERRIDE="$CONFIG_OVERRIDE" python3 - <<'PY'
-import json
-import os
-
-with open("src-tauri/tauri.conf.json", "r", encoding="utf-8") as handle:
-    base_config = json.load(handle)
-
-windows = base_config.get("app", {}).get("windows", [])
-config = {
-    "app": {
-        "windows": [
-            {
-                **window,
-                "devtools": True,
-            }
-            for window in windows
-        ],
-    },
-}
-
-with open(os.environ["CONFIG_OVERRIDE"], "w", encoding="utf-8") as handle:
-    json.dump(config, handle, indent=2)
-    handle.write("\n")
-PY
-  TAURI_ARGS+=(--features release-devtools)
+if [ -n "$BRAND_CONFIG" ] || [ "$RELEASE_DEVTOOLS" = "1" ]; then
+  CONFIG_OVERRIDE="$(mktemp "$WEWORK_DIR/src-tauri/tauri.build.XXXXXX.json")"
+  wework_prepare_brand_config "$WEWORK_DIR" "$BRAND_CONFIG" "${RELEASE_DEVTOOLS:-0}" "$CONFIG_OVERRIDE"
+  if [ -f "$CONFIG_OVERRIDE.namespace" ]; then
+    export WEWORK_EXECUTOR_NAMESPACE="$(<"$CONFIG_OVERRIDE.namespace")"
+    rm -f "$CONFIG_OVERRIDE.namespace"
+  fi
+  if [ "$RELEASE_DEVTOOLS" = "1" ]; then
+    TAURI_ARGS+=(--features release-devtools)
+  fi
   TAURI_ARGS+=(--config "$CONFIG_OVERRIDE")
 fi
 if [ -n "$TAURI_BUNDLES" ]; then

--- a/wework/scripts/lib/wework-branding.sh
+++ b/wework/scripts/lib/wework-branding.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+wework_prepare_brand_config() {
+  local wework_dir="$1"
+  local brand_config="$2"
+  local enable_devtools="$3"
+  local output_config="$4"
+
+  BRAND_CONFIG="$brand_config" \
+  BASE_CONFIG="$wework_dir/src-tauri/tauri.conf.json" \
+  ENABLE_DEVTOOLS="$enable_devtools" \
+  OUTPUT_CONFIG="$output_config" \
+  python3 - <<'PY'
+import json
+import os
+import re
+from pathlib import Path
+
+brand_path = os.environ["BRAND_CONFIG"]
+with open(os.environ["BASE_CONFIG"], "r", encoding="utf-8") as handle:
+    base_config = json.load(handle)
+
+brand = {}
+if brand_path:
+    with open(brand_path, "r", encoding="utf-8") as handle:
+        brand = json.load(handle)
+
+product_name = brand.get("productName")
+identifier = brand.get("identifier")
+base_identifier = base_config.get("identifier")
+executor_namespace = identifier if identifier != base_identifier else None
+
+if brand:
+    required = {
+        "productName": product_name,
+        "identifier": identifier,
+    }
+    missing = [name for name, value in required.items() if not isinstance(value, str) or not value]
+    if missing:
+        raise SystemExit(f"Brand config is missing non-empty fields: {', '.join(missing)}")
+    if identifier == base_identifier:
+        raise SystemExit(
+            "A branded app must use an identifier different from the default app"
+        )
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", identifier):
+        raise SystemExit("identifier may only contain letters, numbers, '.', '_' and '-'")
+
+windows = base_config.get("app", {}).get("windows", [])
+config = {}
+if brand:
+    config.update(
+        {
+            "productName": product_name,
+            "mainBinaryName": brand.get("mainBinaryName", product_name),
+            "identifier": identifier,
+        }
+    )
+
+if brand or os.environ["ENABLE_DEVTOOLS"] == "1":
+    config["app"] = {
+        "windows": [
+            {
+                **window,
+                **({"title": product_name} if brand else {}),
+                **({"devtools": True} if os.environ["ENABLE_DEVTOOLS"] == "1" else {}),
+            }
+            for window in windows
+        ]
+    }
+
+with open(os.environ["OUTPUT_CONFIG"], "w", encoding="utf-8") as handle:
+    json.dump(config, handle, indent=2)
+    handle.write("\n")
+
+if executor_namespace:
+    Path(f"{os.environ['OUTPUT_CONFIG']}.namespace").write_text(
+        executor_namespace, encoding="utf-8"
+    )
+PY
+}

--- a/wework/scripts/lib/wework-macos-signing.sh
+++ b/wework/scripts/lib/wework-macos-signing.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Shared macOS code-signing helpers for Wework build scripts.
+
+wework_resolve_developer_id_application_identity() {
+  local identity="${1:-}"
+  if [ -n "$identity" ]; then
+    printf '%s\n' "$identity"
+    return 0
+  fi
+
+  security find-identity -v -p codesigning 2>/dev/null \
+    | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' \
+    | head -n 1
+}
+
+wework_sign_prepared_codex_macos_binaries() {
+  local wework_dir="$1"
+  local build_target="$2"
+  local identity
+  local skip_sign="${4:-0}"
+
+  if [ "$skip_sign" = "1" ]; then
+    return 0
+  fi
+
+  identity="$(wework_resolve_developer_id_application_identity "${3:-}")"
+  if [ -z "$identity" ]; then
+    echo "No valid Developer ID Application identity found for Codex binaries." >&2
+    return 1
+  fi
+  export APPLE_SIGNING_IDENTITY="$identity"
+
+  local targets=()
+  case "$build_target" in
+    universal-apple-darwin)
+      targets=(aarch64-apple-darwin x86_64-apple-darwin)
+      ;;
+    aarch64-apple-darwin|x86_64-apple-darwin)
+      targets=("$build_target")
+      ;;
+    "")
+      if [ "$(uname -m)" = "arm64" ]; then
+        targets=(aarch64-apple-darwin)
+      else
+        targets=(x86_64-apple-darwin)
+      fi
+      ;;
+  esac
+
+  local target target_root binary signature
+  for target in "${targets[@]}"; do
+    target_root="$wework_dir/src-tauri/binaries/codex/$target"
+    [ -d "$target_root" ] || continue
+
+    while IFS= read -r -d '' binary; do
+      [[ "$(file -b "$binary")" == *Mach-O* ]] || continue
+      signature="$(codesign --display --verbose=4 "$binary" 2>&1 || true)"
+      if [[ "$signature" == *"Authority=Developer ID Application:"* ]] \
+        && [[ "$signature" == *"Timestamp="* ]] \
+        && [[ "$signature" == *"Runtime Version="* ]]; then
+        continue
+      fi
+
+      echo "Signing bundled Codex executable: ${binary#"$wework_dir/"}"
+      codesign --force --timestamp --options runtime --sign "$identity" "$binary"
+    done < <(find "$target_root" -type f -print0)
+  done
+}

--- a/wework/scripts/release-mac-app.sh
+++ b/wework/scripts/release-mac-app.sh
@@ -7,6 +7,8 @@ WEWORK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=lib/wework-mac-env.sh
 source "$SCRIPT_DIR/lib/wework-mac-env.sh"
+# shellcheck source=lib/wework-macos-signing.sh
+source "$SCRIPT_DIR/lib/wework-macos-signing.sh"
 
 TARGET="local"
 VERSION_OVERRIDE=""
@@ -603,6 +605,12 @@ if [ "$RELEASE_DEVTOOLS" = "1" ]; then
 fi
 TAURI_BUILD_ARGS+=(--config "$config_override")
 WEWORK_CODEX_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:codex
+if [ -n "$app_sign_identity" ]; then
+  wework_sign_prepared_codex_macos_binaries \
+    "$WEWORK_DIR" \
+    "$MACOS_BUILD_TARGET" \
+    "$app_sign_identity"
+fi
 pnpm exec tauri "${TAURI_BUILD_ARGS[@]}"
 
 archive_path="$(find_update_archive)"

--- a/wework/src-tauri/build.rs
+++ b/wework/src-tauri/build.rs
@@ -5,8 +5,10 @@ use std::process::Command;
 
 const SIDECAR_NAME: &str = "wegent-executor";
 const SIDECAR_ENV: &str = "WEWORK_EXECUTOR_SIDECAR";
+const EXECUTOR_NAMESPACE_ENV: &str = "WEWORK_EXECUTOR_NAMESPACE";
 
 fn main() {
+    println!("cargo:rerun-if-env-changed={EXECUTOR_NAMESPACE_ENV}");
     prepare_local_executor_sidecar();
     verify_bundled_codex_binary();
     ensure_codex_resource_glob_exists();

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -25,6 +25,7 @@ const LOCAL_EXECUTOR_ISOLATION_OVERRIDE_ENV: &str = "WEWORK_EXECUTOR_ISOLATION_O
 const LOCAL_EXECUTOR_ADDR_ENV: &str = "WEGENT_EXECUTOR_APP_IPC_ADDR";
 const LOCAL_EXECUTOR_ADDR_FILE_ENV: &str = "WEGENT_EXECUTOR_APP_IPC_ADDR_FILE";
 const LOCAL_EXECUTOR_HOME_ENV: &str = "WEGENT_EXECUTOR_HOME";
+const LOCAL_EXECUTOR_NAMESPACE: Option<&str> = option_env!("WEWORK_EXECUTOR_NAMESPACE");
 const LOCAL_EXECUTOR_SHARED_HOME_ENV: &str = "WEWORK_SHARED_EXECUTOR_HOME";
 const LOCAL_EXECUTOR_LOG_DIR_ENV: &str = "WEGENT_EXECUTOR_LOG_DIR";
 const LOCAL_EXECUTOR_LOG_FILE_ENV: &str = "WEGENT_EXECUTOR_LOG_FILE";
@@ -597,7 +598,17 @@ fn local_executor_home_path() -> Result<PathBuf, String> {
     }
 
     let home = dirs::home_dir().ok_or_else(|| "Home directory is not available".to_string())?;
-    Ok(home.join(".wegent-executor"))
+    Ok(default_local_executor_home_path(
+        &home,
+        LOCAL_EXECUTOR_NAMESPACE,
+    ))
+}
+
+fn default_local_executor_home_path(home: &Path, namespace: Option<&str>) -> PathBuf {
+    let root = home.join(".wegent-executor");
+    namespace
+        .filter(|value| !value.is_empty())
+        .map_or(root.clone(), |value| root.join("apps").join(value))
 }
 
 fn app_ipc_addr_file_path() -> Result<PathBuf, String> {
@@ -3126,6 +3137,21 @@ command = "example"
 
     #[cfg(unix)]
     #[test]
+    fn branded_executor_home_stays_under_shared_root() {
+        let home = Path::new("/tmp/wework-test-home");
+
+        assert_eq!(
+            default_local_executor_home_path(home, None),
+            PathBuf::from("/tmp/wework-test-home/.wegent-executor")
+        );
+        assert_eq!(
+            default_local_executor_home_path(home, Some("com.example.demo-wework")),
+            PathBuf::from("/tmp/wework-test-home/.wegent-executor/apps/com.example.demo-wework")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn default_runtime_paths_follow_build_mode() {
         let _guard = env_lock();
         let previous_home = std::env::var_os("HOME");
@@ -3148,7 +3174,10 @@ command = "example"
 
         assert_eq!(
             home,
-            PathBuf::from("/tmp/wework-test-home/.wegent-executor")
+            default_local_executor_home_path(
+                Path::new("/tmp/wework-test-home"),
+                LOCAL_EXECUTOR_NAMESPACE,
+            )
         );
         if cfg!(debug_assertions) {
             assert_eq!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for branded macOS and Windows builds using a product name and application identifier.
  - Branded builds can display customized application and window names.
  - Added a demo WeWork brand configuration.
  - Branded installations now use separate executor storage locations to prevent data overlap.

- **Bug Fixes**
  - Improved macOS release signing for prepared application binaries.
  - Added validation for branding configuration values and clearer build configuration reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->