### PR TITLE
fix(wework): reorder background appearance controls

### DIFF
--- a/wework/src/features/appearance/AppearanceSettingsPage.test.tsx
+++ b/wework/src/features/appearance/AppearanceSettingsPage.test.tsx
@@ -25,6 +25,10 @@ describe('AppearanceSettingsPage', () => {
     expect(screen.getByTestId('appearance-background-select-button')).toBeInTheDocument()
     expect(screen.getByTestId('appearance-background-visibility-slider')).toBeDisabled()
     expect(screen.getByTestId('appearance-background-blur-slider')).toBeDisabled()
+
+    const blurSlider = screen.getByTestId('appearance-background-blur-slider')
+    const areaSelector = screen.getByTestId('appearance-background-area-main')
+    expect(blurSlider.compareDocumentPosition(areaSelector)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
   test('commits UI and code font sizes on Enter or blur', async () => {

--- a/wework/src/features/appearance/AppearanceSettingsPage.tsx
+++ b/wework/src/features/appearance/AppearanceSettingsPage.tsx
@@ -343,6 +343,22 @@ export function AppearanceSettingsPage() {
                 className="w-full accent-[rgb(var(--color-text-primary))] disabled:opacity-50"
               />
             </label>
+            <label className="grid gap-2 text-sm text-text-secondary">
+              <span className="flex justify-between">
+                {t('workbench.appearance_background_blur', '背景模糊')}
+                <span>{appearance.backgroundBlur}px</span>
+              </span>
+              <input
+                data-testid="appearance-background-blur-slider"
+                type="range"
+                min="0"
+                max="20"
+                value={appearance.backgroundBlur}
+                disabled={!appearance.backgroundImagePath}
+                onChange={event => setAppearance({ backgroundBlur: Number(event.target.value) })}
+                className="w-full accent-[rgb(var(--color-text-primary))] disabled:opacity-50"
+              />
+            </label>
             <fieldset className="grid gap-2">
               <legend className="mb-1 text-sm text-text-secondary">
                 {t('workbench.appearance_background_areas', '显示区域')}
@@ -380,22 +396,6 @@ export function AppearanceSettingsPage() {
                 </label>
               ))}
             </fieldset>
-            <label className="grid gap-2 text-sm text-text-secondary">
-              <span className="flex justify-between">
-                {t('workbench.appearance_background_blur', '背景模糊')}
-                <span>{appearance.backgroundBlur}px</span>
-              </span>
-              <input
-                data-testid="appearance-background-blur-slider"
-                type="range"
-                min="0"
-                max="20"
-                value={appearance.backgroundBlur}
-                disabled={!appearance.backgroundImagePath}
-                onChange={event => setAppearance({ backgroundBlur: Number(event.target.value) })}
-                className="w-full accent-[rgb(var(--color-text-primary))] disabled:opacity-50"
-              />
-            </label>
             {backgroundError && (
               <p data-testid="appearance-background-error" className="text-sm text-red-500">
                 {backgroundError}


### PR DESCRIPTION
## What changed

- Move the background blur control directly below background visibility.
- Keep display-area checkboxes grouped after the image-effect controls.
- Add a regression assertion for the control order.

## Why

Background visibility and blur both adjust the selected image, but the display-area group previously split them. This made the blur control appear detached at the bottom of the panel.

## Impact

The workbench background settings now follow a clearer order: visibility, blur, then display areas. No persisted settings or behavior changed.

## Validation

- `pnpm --dir wework exec vitest run src/features/appearance/AppearanceSettingsPage.test.tsx`
- Prettier and ESLint on the changed files
- Pre-push Wework ESLint, TypeScript, and unit tests
- Isolated real-Tauri verification of the appearance settings page, including disabled controls without a selected image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reordered the background blur control in Appearance Settings so it appears before the visible areas options.
  * Improved the logical flow of background customization controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->