### PR TITLE
fix(wework): stabilize runtime task visibility and ordering

### DIFF
--- a/executor/src/runtime_work/codex_global_state.rs
+++ b/executor/src/runtime_work/codex_global_state.rs
@@ -985,6 +985,9 @@ fn index_from_payload(payload: &Map<String, Value>) -> CodexGlobalProjectIndex {
         .and_then(Value::as_object)
         .into_iter()
         .flatten()
+        .filter(|(_, order)| {
+            order.get("sortKey").and_then(clean_string).as_deref() == Some("manual")
+        })
         .map(|(project_key, order)| (project_key.to_owned(), text_list(order.get("threadIds"))))
         .collect();
 
@@ -1696,7 +1699,7 @@ mod tests {
             "thread-workspace-root-hints": {"hinted": "/repo"},
             "pinned-thread-ids": ["assigned"],
             "sidebar-project-thread-orders": {
-                "multi": {"threadIds": ["nested"]}
+                "multi": {"threadIds": ["nested"], "sortKey": "manual"}
             }
         }));
 

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -2193,6 +2193,7 @@ impl RuntimeWorkRpcHandler {
                 link.status = "cancelled".to_owned();
                 link.running = false;
                 link.updated_at = now_ms();
+                link.completed_at = Some(link.updated_at);
             })
             .or_else(|| self.local_task_link(&local_task_id));
         self.resolve_pending_request_user_input_for_cancel(&local_task_id);
@@ -3421,7 +3422,10 @@ impl RuntimeWorkRpcHandler {
                 continue;
             }
 
-            let group_path = workspace_group_path(&link.workspace_path);
+            let group_path = self
+                .worktrees
+                .source_path_for(&link.workspace_path)
+                .unwrap_or_else(|| workspace_group_path(&link.workspace_path));
             let thread_id = link.thread_id.as_deref();
             let thread_hint = thread_id.and_then(|id| project_index.thread_workspace_hint(id));
             if thread_id.is_some_and(|id| project_index.is_projectless_thread(id)) {
@@ -3866,6 +3870,9 @@ impl RuntimeWorkRpcHandler {
             link.status = status.to_owned();
             link.running = status == "running";
             link.updated_at = now_ms();
+            if status != "running" {
+                link.completed_at = Some(link.updated_at);
+            }
             if link.thread_id.is_some() && status != "running" {
                 retain_runtime_handle_user_messages(&mut link.runtime_handle);
             }

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -32,6 +32,7 @@ pub(crate) struct RuntimeTaskLink {
     pub git_info: Option<Value>,
     pub created_at: i64,
     pub updated_at: i64,
+    pub completed_at: Option<i64>,
     pub runtime_handle: Value,
     pub parent: Option<Value>,
     pub ephemeral: bool,
@@ -61,6 +62,7 @@ impl RuntimeTaskLink {
             git_info: None,
             created_at: now_ms(),
             updated_at: now_ms(),
+            completed_at: None,
             runtime_handle: json!({}),
             parent: None,
             ephemeral: false,
@@ -92,6 +94,7 @@ impl RuntimeTaskLink {
             git_info: None,
             created_at: now_ms(),
             updated_at: now_ms(),
+            completed_at: None,
             runtime_handle,
             parent: Some(parent),
             ephemeral: false,
@@ -153,6 +156,12 @@ impl RuntimeTaskLink {
             git_info,
             created_at: timestamp_ms_field(thread, "createdAt").unwrap_or_else(now_ms),
             updated_at: timestamp_ms_field(thread, "updatedAt").unwrap_or_else(now_ms),
+            completed_at: if running {
+                local_link.as_ref().and_then(|link| link.completed_at)
+            } else {
+                timestamp_ms_field(thread, "updatedAt")
+                    .or_else(|| local_link.as_ref().and_then(|link| link.completed_at))
+            },
             runtime_handle: local_link
                 .as_ref()
                 .map(|link| link.runtime_handle.clone())
@@ -180,6 +189,7 @@ impl RuntimeTaskLink {
             git_info: self.git_info.clone(),
             created_at: self.created_at,
             updated_at: self.updated_at,
+            completed_at: self.completed_at,
             runtime_handle: Value::Object(runtime_handle_list_summary_map(&self.runtime_handle)),
             parent: self.parent.clone(),
             ephemeral: self.ephemeral,
@@ -227,6 +237,7 @@ impl Default for RuntimeTaskLink {
             git_info: None,
             created_at: now_ms(),
             updated_at: now_ms(),
+            completed_at: None,
             runtime_handle: json!({}),
             parent: None,
             ephemeral: false,
@@ -412,15 +423,18 @@ fn compare_runtime_task_links(
     match (left.list_order, right.list_order) {
         (Some(left_order), Some(right_order)) => left_order
             .cmp(&right_order)
-            .then_with(|| right.updated_at.cmp(&left.updated_at))
+            .then_with(|| runtime_task_sort_time(right).cmp(&runtime_task_sort_time(left)))
             .then_with(|| left.local_task_id.cmp(&right.local_task_id)),
         (Some(_), None) => std::cmp::Ordering::Less,
         (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => right
-            .updated_at
-            .cmp(&left.updated_at)
+        (None, None) => runtime_task_sort_time(right)
+            .cmp(&runtime_task_sort_time(left))
             .then_with(|| left.local_task_id.cmp(&right.local_task_id)),
     }
+}
+
+fn runtime_task_sort_time(link: &RuntimeTaskLink) -> i64 {
+    link.completed_at.unwrap_or(link.created_at)
 }
 
 pub(crate) fn archived_conversations_response(
@@ -540,6 +554,9 @@ fn local_task_json(link: RuntimeTaskLink) -> Value {
         "updatedAt".to_owned(),
         Value::Number(link.updated_at.into()),
     );
+    if let Some(completed_at) = link.completed_at {
+        task.insert("completedAt".to_owned(), Value::Number(completed_at.into()));
+    }
     if let Some(parent) = link.parent {
         task.insert("parent".to_owned(), parent);
     }
@@ -819,6 +836,40 @@ mod tests {
 
         assert_eq!(link.status, "running");
         assert!(link.running);
+    }
+
+    #[test]
+    fn active_thread_keeps_previous_completion_time_for_sorting() {
+        let local_link = RuntimeTaskLink {
+            completed_at: Some(1_780_000_000_000),
+            ..RuntimeTaskLink::default()
+        };
+        let link = RuntimeTaskLink::from_thread_metadata(
+            &json!({
+                "id": "thread-1",
+                "status": {"type": "active", "activeFlags": []},
+                "updatedAt": 1_780_000_100_000_i64,
+            }),
+            Some(local_link),
+            "/workspace/project".to_owned(),
+        );
+
+        assert_eq!(link.completed_at, Some(1_780_000_000_000));
+    }
+
+    #[test]
+    fn completed_thread_uses_its_final_update_time_for_sorting() {
+        let link = RuntimeTaskLink::from_thread_metadata(
+            &json!({
+                "id": "thread-1",
+                "status": "idle",
+                "updatedAt": 1_780_000_100_000_i64,
+            }),
+            None,
+            "/workspace/project".to_owned(),
+        );
+
+        assert_eq!(link.completed_at, Some(1_780_000_100_000));
     }
 
     #[test]

--- a/executor/src/runtime_work/worktrees.rs
+++ b/executor/src/runtime_work/worktrees.rs
@@ -100,6 +100,14 @@ pub(crate) struct WorktreeManager {
 }
 
 impl WorktreeManager {
+    pub fn source_path_for(&self, workspace_path: &str) -> Option<String> {
+        let normalized_path = normalized_path_key(Path::new(workspace_path));
+        self.load()
+            .records
+            .get(&normalized_path)
+            .and_then(|record| record.source_path.clone())
+    }
+
     pub fn from_env() -> Self {
         Self::new(runtime_work_dir().join("worktrees.json"))
     }
@@ -875,6 +883,36 @@ mod tests {
         let _ = fs::remove_dir_all(root);
     }
 
+    #[test]
+    fn source_path_lookup_survives_missing_worktree_git_metadata() {
+        let root = test_directory("wegent-worktree-source-lookup-test");
+        let manager = WorktreeManager::new(root.join("runtime-work/worktrees.json"));
+        let worktree_path = root.join("managed/task-1/project");
+        let source_path = root.join("source/project");
+        let mut records = HashMap::new();
+        records.insert(
+            normalized_path_key(&worktree_path),
+            ManagedWorktree {
+                path: worktree_path.display().to_string(),
+                source_path: Some(source_path.display().to_string()),
+                ..ManagedWorktree::default()
+            },
+        );
+        manager
+            .save(&WorktreeState {
+                version: STATE_VERSION,
+                records,
+                ..WorktreeState::default()
+            })
+            .unwrap();
+
+        assert_eq!(
+            manager.source_path_for(&worktree_path.display().to_string()),
+            Some(source_path.display().to_string())
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
     fn test_directory(prefix: &str) -> PathBuf {
         env::temp_dir().join(format!(
             "{prefix}-{}-{}",
@@ -916,6 +954,7 @@ mod tests {
             git_info: None,
             created_at: 0,
             updated_at: 0,
+            completed_at: None,
             runtime_handle: Value::Null,
             parent: None,
             ephemeral: false,

--- a/executor/tests/app_runtime_work_workspace_contract.rs
+++ b/executor/tests/app_runtime_work_workspace_contract.rs
@@ -387,7 +387,10 @@ async fn runtime_task_list_applies_manual_order_to_projectless_chats() {
         json!({
             "projectless-thread-ids": ["thread-newer", "thread-older"],
             "sidebar-project-thread-orders": {
-                "chats": {"threadIds": ["thread-older", "thread-newer"]}
+                "chats": {
+                    "threadIds": ["thread-older", "thread-newer"],
+                    "sortKey": "manual"
+                }
             }
         }),
     );

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
@@ -23,6 +23,7 @@ describe('runtimeTaskSidebarHelpers', () => {
           title: 'Older running',
           runtime: 'codex',
           running: true,
+          completedAt: '2026-06-01T00:00:00.000Z',
           updatedAt: '2026-06-01T00:00:00.000Z',
         },
         {
@@ -31,6 +32,7 @@ describe('runtimeTaskSidebarHelpers', () => {
           title: 'Newer idle',
           runtime: 'codex',
           running: false,
+          completedAt: '2026-06-02T00:00:00.000Z',
           updatedAt: '2026-06-02T00:00:00.000Z',
         },
       ],
@@ -47,6 +49,7 @@ describe('runtimeTaskSidebarHelpers', () => {
           title: 'New worktree task',
           runtime: 'codex',
           running: true,
+          completedAt: '2026-06-03T00:00:00.000Z',
           updatedAt: '2026-06-03T00:00:00.000Z',
         },
       ],
@@ -55,6 +58,41 @@ describe('runtimeTaskSidebarHelpers', () => {
     expect(
       getRuntimeSidebarTaskItems([oldWorkspace, newWorkspace]).map(item => item.task.taskId)
     ).toEqual(['new-worktree-task', 'newer-idle', 'older-running'])
+  })
+
+  test('does not reorder a running task when streaming updates change updatedAt', () => {
+    const workspace: RuntimeDeviceWorkspace = {
+      deviceId: 'device-1',
+      workspacePath: '/workspace/repo',
+      available: true,
+      tasks: [
+        {
+          taskId: 'running',
+          workspacePath: '/workspace/repo',
+          title: 'Running',
+          runtime: 'codex',
+          running: true,
+          createdAt: '2026-06-01T00:00:00.000Z',
+          completedAt: '2026-06-02T00:00:00.000Z',
+          updatedAt: '2026-06-04T00:00:00.000Z',
+        },
+        {
+          taskId: 'completed',
+          workspacePath: '/workspace/repo',
+          title: 'Completed',
+          runtime: 'codex',
+          running: false,
+          createdAt: '2026-06-01T00:00:00.000Z',
+          completedAt: '2026-06-03T00:00:00.000Z',
+          updatedAt: '2026-06-03T00:00:00.000Z',
+        },
+      ],
+    }
+
+    expect(getRuntimeSidebarTaskItems([workspace]).map(item => item.task.taskId)).toEqual([
+      'completed',
+      'running',
+    ])
   })
 
   test('carries runtime handle into task addresses when present', () => {

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -13,10 +13,20 @@ export function getRuntimeTaskTime(task: RuntimeTaskSummary) {
   return task.updatedAt || task.createdAt || undefined
 }
 
+function getRuntimeTaskSortTime(task: RuntimeTaskSummary) {
+  return (
+    task.completedAt ||
+    (!task.running ? task.updatedAt : null) ||
+    task.createdAt ||
+    task.updatedAt ||
+    undefined
+  )
+}
+
 export function sortRuntimeTasks(tasks: RuntimeTaskSummary[] = []) {
   return [...tasks].sort((left, right) => {
-    const leftTime = new Date(getRuntimeTaskTime(left) || 0).getTime()
-    const rightTime = new Date(getRuntimeTaskTime(right) || 0).getTime()
+    const leftTime = new Date(getRuntimeTaskSortTime(left) || 0).getTime()
+    const rightTime = new Date(getRuntimeTaskSortTime(right) || 0).getTime()
     const normalizedLeftTime = Number.isNaN(leftTime) ? 0 : leftTime
     const normalizedRightTime = Number.isNaN(rightTime) ? 0 : rightTime
     return normalizedRightTime - normalizedLeftTime
@@ -45,8 +55,8 @@ export function getRuntimeChatSidebarTaskItems(
 
 export function sortRuntimeTaskItems(items: RuntimeSidebarTaskItem[]) {
   return [...items].sort((left, right) => {
-    const leftTime = new Date(getRuntimeTaskTime(left.task) || 0).getTime()
-    const rightTime = new Date(getRuntimeTaskTime(right.task) || 0).getTime()
+    const leftTime = new Date(getRuntimeTaskSortTime(left.task) || 0).getTime()
+    const rightTime = new Date(getRuntimeTaskSortTime(right.task) || 0).getTime()
     const normalizedLeftTime = Number.isNaN(leftTime) ? 0 : leftTime
     const normalizedRightTime = Number.isNaN(rightTime) ? 0 : rightTime
     return normalizedRightTime - normalizedLeftTime

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -350,6 +350,7 @@ export interface RuntimeTaskSummary {
   runtime: RuntimeName
   createdAt?: string | number | null
   updatedAt?: string | number | null
+  completedAt?: string | number | null
   running?: boolean
   pinned?: boolean
   pinnedOrder?: number | null


### PR DESCRIPTION
## What changed

- resolve managed worktree tasks through the persisted source repository path before applying project visibility filtering
- persist and expose a dedicated conversation completion timestamp
- sort runtime tasks by completion time so streaming `updatedAt` changes do not move sidebar rows
- only honor persisted thread order when the project explicitly uses manual sorting

## Root cause

The runtime task filter recomputed a worktree's project root from live `.git` metadata on every refresh. When that metadata was temporarily unavailable, the worktree path could not be mapped back to its project and the task was omitted from the response. Separately, the sidebar used provider `updatedAt` and non-manual thread order, both of which can change while chunks stream.

## Impact

Tasks remain visible across transient worktree metadata failures. In automatic sort mode, a running conversation keeps its previous position while chunks stream and moves only after the turn completes. Explicit manual ordering remains unchanged.

## Validation

- `pnpm --filter wework test` — 177 files, 1747 tests passed
- `cd executor && cargo test --quiet` — full suite passed
- `pnpm --filter wework typecheck`
- focused Prettier and ESLint checks for changed Wework files
- pre-push ESLint, TypeScript, Wework unit tests, cargo fmt, cargo test, and cargo clippy
- isolated real Tauri verification with two completed conversations, a follow-up streaming response, repeated task-list refreshes, and captured screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Runtime tasks now retain and display completion times when available.
  * Task lists use completion time for ordering, keeping finished tasks in a stable position while active tasks stream updates.
  * Workspace grouping more accurately reflects each task’s originating workspace.
  * Manual sidebar ordering is now applied consistently to project and projectless conversations.

* **Bug Fixes**
  * Cancelled and finished tasks now receive completion timestamps for more reliable status and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->