### PR TITLE
feat(backend): force-delete stale executors past max_inactive_hours

### DIFF
--- a/backend/app/services/adapters/executor_job.py
+++ b/backend/app/services/adapters/executor_job.py
@@ -214,16 +214,11 @@ class JobService(BaseService[Kind, None, None]):
         deleted even if workspace archiving keeps failing, so a broken archive
         cannot pin pods forever.
         """
-        if inactive_hours <= 0 or max_inactive_hours < inactive_hours * 3:
-            return self._build_cleanup_result(
-                task_id,
-                "invalid_inactive_hours",
-                details={
-                    "inactive_hours": inactive_hours,
-                    "max_inactive_hours": max_inactive_hours,
-                    "dry_run": dry_run,
-                },
-            )
+        if max_inactive_hours < inactive_hours * 3:
+            # Once idle past max_inactive_hours, the executor is force-cleaned even
+            # if archiving fails; keep it at least 3x inactive_hours (or 7 days) so
+            # that force cleanup only kicks in well after the normal stale window.
+            max_inactive_hours = max(24 * 7, inactive_hours * 3)
 
         task = await self._get_task_resource_any_state(db, task_id)
 

--- a/backend/app/services/adapters/executor_job.py
+++ b/backend/app/services/adapters/executor_job.py
@@ -199,6 +199,7 @@ class JobService(BaseService[Kind, None, None]):
         *,
         task_id: int,
         inactive_hours: int = 24,
+        max_inactive_hours: int = 24 * 7,
         dry_run: bool = False,
     ) -> Dict[str, object]:
         """Clean up executor resources for a single task after the stale window.
@@ -207,7 +208,23 @@ class JobService(BaseService[Kind, None, None]):
         intentionally not checked here — a pod stuck in RUNNING with no activity for
         24h is just as stale as a COMPLETED one, and the admin explicitly requested
         cleanup with the inactivity threshold.
+
+        The max_inactive_hours parameter (default 7 days) is an upper bound on
+        retries: once an executor has been idle longer than it, the executor is
+        deleted even if workspace archiving keeps failing, so a broken archive
+        cannot pin pods forever.
         """
+        if inactive_hours <= 0 or max_inactive_hours < inactive_hours * 3:
+            return self._build_cleanup_result(
+                task_id,
+                "invalid_inactive_hours",
+                details={
+                    "inactive_hours": inactive_hours,
+                    "max_inactive_hours": max_inactive_hours,
+                    "dry_run": dry_run,
+                },
+            )
+
         task = await self._get_task_resource_any_state(db, task_id)
 
         subtasks = await self._get_cleanup_subtasks_for_task(db, task_id)
@@ -250,8 +267,10 @@ class JobService(BaseService[Kind, None, None]):
             task_id=task_id,
             task=task,
             subtasks=subtasks,
+            max_inactive_hours=max_inactive_hours,
         )
         result["inactive_hours"] = inactive_hours
+        result["max_inactive_hours"] = max_inactive_hours
         result["dry_run"] = dry_run
         return result
 
@@ -818,10 +837,12 @@ class JobService(BaseService[Kind, None, None]):
         task_id: int,
         task: TaskResource,
         subtasks: List[Subtask],
+        max_inactive_hours: int = 24 * 7,
     ) -> Dict[str, object]:
         """Delete deduplicated executors and mark the related subtasks as deleted."""
         executor_subtask_ids: Dict[Tuple[str, str], List[int]] = {}
         executor_subtasks: Dict[Tuple[str, str], Subtask] = {}
+        subtasks_executor_updated_at: Dict[Tuple[str, str], datetime | None] = {}
 
         for subtask in subtasks:
             if not subtask.executor_name:
@@ -829,14 +850,28 @@ class JobService(BaseService[Kind, None, None]):
             key = (subtask.executor_namespace, subtask.executor_name)
             executor_subtask_ids.setdefault(key, []).append(subtask.id)
             executor_subtasks.setdefault(key, subtask)
+            subtasks_executor_updated_at[key] = self._latest_datetime(
+                subtasks_executor_updated_at.get(key), subtask.updated_at
+            )
 
         if not executor_subtasks:
             return self._build_cleanup_result(task_id, "executor_not_found")
 
+        task_updated_at = task.updated_at
         task_crd = Task.model_validate(task.json)
         task_type = self._get_task_type(task_crd)
         self._detach_loaded_instance(db, task)
         await self._release_cleanup_read_transaction(db)
+
+        # Groups idle past max_inactive_hours are force-deleted even when archiving
+        # fails, so a persistently broken archive cannot pin the pods forever.
+        force_cutoff = datetime.now() - timedelta(hours=max_inactive_hours)
+        force_delete_groups: Dict[Tuple[str, str], bool] = {}
+        for key, subtask_updated_at in subtasks_executor_updated_at.items():
+            last_active_at = self._latest_datetime(subtask_updated_at, task_updated_at)
+            force_delete_groups[key] = (
+                last_active_at is not None and last_active_at <= force_cutoff
+            )
 
         deleted_executors: List[Dict[str, str]] = []
         archive_failed_executors: List[Dict[str, str]] = []
@@ -854,14 +889,21 @@ class JobService(BaseService[Kind, None, None]):
                 executor_name=name,
                 executor_namespace=namespace,
             ):
+                if not force_delete_groups[(namespace, name)]:
+                    logger.warning(
+                        f"[executor_job] Skipping executor deletion after archive "
+                        f"failure task_id={task.id} ns={namespace} name={name}"
+                    )
+                    archive_failed_executors.append(
+                        {"executor_name": name, "executor_namespace": namespace}
+                    )
+                    continue
+
                 logger.warning(
-                    f"[executor_job] Skipping executor deletion after archive "
-                    f"failure task_id={task.id} ns={namespace} name={name}"
+                    f"[executor_job] Archive failed but executor idle over "
+                    f"{max_inactive_hours}h, force deleting task_id={task.id} "
+                    f"ns={namespace} name={name}"
                 )
-                archive_failed_executors.append(
-                    {"executor_name": name, "executor_namespace": namespace}
-                )
-                continue
 
             logger.info(
                 f"[executor_job] Scheduled deleting executor task "

--- a/executor_manager/routers/sandbox.py
+++ b/executor_manager/routers/sandbox.py
@@ -66,6 +66,7 @@ class CleanupSandboxByTaskRequest(BaseModel):
     task_id: int = Field(ge=1)
     dry_run: bool = False
     archive_before_delete: bool = True
+    delete_on_archive_failure: bool = False
 
 
 @router.post("", response_model=CreateSandboxResponse)
@@ -165,10 +166,11 @@ async def cleanup_sandbox_by_task_id(
     client_ip = http_request.client.host if http_request.client else "unknown"
     logger.info(
         "[SandboxAPI] Cleanup sandbox by task: task_id=%s dry_run=%s "
-        "archive_before_delete=%s from %s",
+        "archive_before_delete=%s delete_on_archive_failure=%s from %s",
         request.task_id,
         request.dry_run,
         request.archive_before_delete,
+        request.delete_on_archive_failure,
         client_ip,
     )
 
@@ -177,6 +179,7 @@ async def cleanup_sandbox_by_task_id(
         task_id=request.task_id,
         dry_run=request.dry_run,
         archive_before_delete=request.archive_before_delete,
+        delete_on_archive_failure=request.delete_on_archive_failure,
     )
 
 

--- a/executor_manager/services/sandbox/manager.py
+++ b/executor_manager/services/sandbox/manager.py
@@ -594,6 +594,7 @@ class SandboxManager(metaclass=SingletonMeta):
         task_id: int,
         dry_run: bool = False,
         archive_before_delete: bool = True,
+        delete_on_archive_failure: bool = False,
     ) -> Dict[str, Any]:
         """Clean up one sandbox runtime by task ID without an age threshold."""
         sandbox_id = str(task_id)
@@ -604,6 +605,7 @@ class SandboxManager(metaclass=SingletonMeta):
             "sandbox_id": sandbox_id,
             "dry_run": dry_run,
             "archive_before_delete": archive_before_delete,
+            "delete_on_archive_failure": delete_on_archive_failure,
             "sandbox_found": sandbox is not None,
             "deleted": False,
             "redis_cleared": False,
@@ -620,6 +622,13 @@ class SandboxManager(metaclass=SingletonMeta):
 
         if sandbox is not None and archive_before_delete:
             result["archived"] = await self._archive_sandbox_before_cleanup(sandbox)
+            if not result["archived"] and not delete_on_archive_failure:
+                logger.warning(
+                    "[SandboxManager] Skipping sandbox deletion after archive "
+                    "failure: task_id=%s",
+                    task_id,
+                )
+                return {**result, "skipped": True, "reason": "archive_failed"}
 
         try:
             executor = ExecutorDispatcher.get_executor(EXECUTOR_DISPATCHER_MODE)

--- a/executor_manager/tests/routers/test_sandbox_cleanup_routes.py
+++ b/executor_manager/tests/routers/test_sandbox_cleanup_routes.py
@@ -76,4 +76,5 @@ async def test_cleanup_sandbox_by_task_id_calls_manager(mocker):
         task_id=1967,
         dry_run=False,
         archive_before_delete=False,
+        delete_on_archive_failure=False,
     )


### PR DESCRIPTION
## Summary

### backend — `cleanup_stale_task_executor`
- 新增 `max_inactive_hours`（默认 7 天）。当workspace 归档持续失败时，只要该 executor 空闲已超过 `max_inactive_hours`，仍会执行 `delete_executor_task_async`，避免坏归档永久占住 pod。
- 空闲判定按每个 executor 分组（namespace+name）内所有 subtask 的最新 `updated_at` 与 `task.updated_at` 取最新，保守判断，避免误删仍活跃的 executor。
- 当 `max_inactive_hours < inactive_hours * 3` 时，钳制为 `max(7天, inactive_hours*3)`，因此大 `inactive_hours` 调用不受影响。
- 未超过阈值时，保持原有"归档失败则跳过删除"的行为不变。

### executor_manager — `cleanup_sandbox_by_task_id`
- 新增请求参数 `delete_on_archive_failure`（默认 `false`）。归档失败后默认**保留** sandbox（`skipped=true, reason=archive_failed`）；置为 `true` 时即便归档失败也继续删除。
- 注意：改动前该接口无论归档成功与否都会删除（存在风险）；现在默认行为改为归档失败时跳过删除。调用方可以在调用前，判断空闲时间是否超过max_inactive_hours，如果超过最大空闲阀值，设置delete_on_archive_failure为true，这样即便sandbox归档失败，也会进行删除。

## Test plan
- [ ] `cd backend && uv run pytest tests/services/test_runtime_cleanup.py tests/services/test_preserve_executor.py`
- [ ] `cd executor_manager && uv run pytest tests/routers/test_sandbox_cleanup_routes.py tests/services/test_sandbox_manager.py`
- [ ] backend: 归档失败 + 空闲 > 7 天 → executor 被强制删除；空闲 < 7 天 → 保持跳过
- [ ] executor_manager: 归档失败 + `delete_on_archive_failure=false` → 保留；`=true` → 删除

🤖 Generated with [Claude Code](https://claude.com/claude-code)