### PR TITLE
fix(wework): show streamed file change summary

### DIFF
--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -406,6 +406,106 @@ describe('createRuntimeTaskStreamHandlers', () => {
     ).toBeUndefined()
   })
 
+  test('builds the completed turn file changes summary from streamed blocks', () => {
+    const actions: RuntimePaneMessageAction[] = []
+    const handlers = createRuntimeTaskStreamHandlers(
+      { deviceId: 'device-1', taskId: 'runtime-task-1' },
+      { onMessageAction: action => actions.push(action) }
+    )
+    const summary = {
+      version: 1 as const,
+      status: 'active' as const,
+      artifact_id: 'artifact-1',
+      device_id: 'device-1',
+      workspace_path: '/workspace/project',
+      file_count: 1,
+      additions: 2,
+      deletions: 1,
+      files: [
+        {
+          path: 'src/main.ts',
+          change_type: 'modified' as const,
+          additions: 2,
+          deletions: 1,
+          binary: false,
+        },
+      ],
+    }
+
+    handlers.onChatDone?.({
+      taskId: 'runtime-task-1',
+      subtaskId: 'subtask-9',
+      deviceId: 'device-1',
+      result: {
+        value: 'Done',
+        blocks: [
+          {
+            id: 'file-changes-1',
+            type: 'file_changes',
+            status: 'done',
+            fileChanges: summary,
+          },
+        ],
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      type: 'assistant_done',
+      fileChanges: summary,
+    })
+  })
+
+  test('keeps file change blocks until a later completion event', () => {
+    const actions: RuntimePaneMessageAction[] = []
+    const handlers = createRuntimeTaskStreamHandlers(
+      { deviceId: 'device-1', taskId: 'runtime-task-1' },
+      { onMessageAction: action => actions.push(action) }
+    )
+    const fileChanges = {
+      version: 1 as const,
+      status: 'active' as const,
+      artifact_id: 'artifact-1',
+      device_id: 'device-1',
+      workspace_path: '/workspace/project',
+      file_count: 1,
+      additions: 1,
+      deletions: 0,
+      files: [
+        {
+          path: 'qa.txt',
+          change_type: 'created' as const,
+          additions: 1,
+          deletions: 0,
+          binary: false,
+        },
+      ],
+    }
+
+    handlers.onBlockCreated?.({
+      taskId: 'runtime-task-1',
+      subtaskId: 'subtask-9',
+      deviceId: 'device-1',
+      block: {
+        id: 'file-changes-1',
+        type: 'file_changes',
+        status: 'streaming',
+        file_changes: fileChanges,
+      },
+    })
+    handlers.onChatDone?.({
+      taskId: 'runtime-task-1',
+      subtaskId: 'subtask-9',
+      deviceId: 'device-1',
+      result: { value: 'Done' },
+    })
+
+    expect(actions[1]).toMatchObject({
+      type: 'assistant_done',
+      fileChanges,
+    })
+  })
+
   test('treats interrupted runtime errors as cancellation events', () => {
     const address: RuntimeTaskAddress = {
       deviceId: 'device-1',

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -20,7 +20,7 @@ import type {
 } from '@/types/api'
 import type { MessageSource, ProcessingBlock, WorkbenchMessage } from '@/types/workbench'
 import { stripCodexUiDirectives } from '@/lib/codex-directives'
-import { normalizeTurnFileChanges } from './turnFileChanges'
+import { mergeTurnFileChanges, normalizeTurnFileChanges } from './turnFileChanges'
 import { normalizeWorkbenchBlockStatus, type WorkbenchMessageAction } from '@wegent/chat-core'
 
 export type RuntimePaneMessageAction = WorkbenchMessageAction<Attachment, TurnFileChangesSummary>
@@ -44,6 +44,8 @@ export function createRuntimeTaskStreamHandlers(
   address: RuntimeTaskAddress,
   handlers: RuntimeTaskStreamHandlers
 ): ChatStreamHandlers {
+  const streamedFileChanges = new Map<string, Map<string, TurnFileChangesSummary>>()
+
   return {
     scope: {
       deviceId: address.deviceId,
@@ -118,9 +120,15 @@ export function createRuntimeTaskStreamHandlers(
         warnAndDropRuntimeStreamEvent('chat:done', address, payload)
         return
       }
+      const blocks = getResultBlocks(identity.subtaskId, payload.result)
+      const fileChanges =
+        normalizeTurnFileChanges(payload.result.fileChanges) ??
+        fileChangesFromBlocks(blocks) ??
+        mergeTurnFileChanges([...(streamedFileChanges.get(identity.subtaskId)?.values() ?? [])])
+      streamedFileChanges.delete(identity.subtaskId)
       debugRuntimeStreamEvent('chat:done', address, payload, true, {
-        hasFileChanges: Boolean(normalizeTurnFileChanges(payload.result.fileChanges)),
-        blockCount: getResultBlocks(identity.subtaskId, payload.result)?.length ?? 0,
+        hasFileChanges: Boolean(fileChanges),
+        blockCount: blocks?.length ?? 0,
       })
       handlers.onAssistantSettled?.()
       if (payload.result.contextUsage) {
@@ -130,8 +138,8 @@ export function createRuntimeTaskStreamHandlers(
         type: 'assistant_done',
         subtaskId: identity.subtaskId,
         content: doneContent(payload.result),
-        blocks: getResultBlocks(identity.subtaskId, payload.result),
-        fileChanges: normalizeTurnFileChanges(payload.result.fileChanges),
+        blocks,
+        fileChanges,
       })
       handlers.onRefreshWorkLists?.()
     },
@@ -162,6 +170,7 @@ export function createRuntimeTaskStreamHandlers(
           errorType: payload.type,
         })
       }
+      streamedFileChanges.delete(identity.subtaskId)
       handlers.onRefreshWorkLists?.()
     },
     onBlockCreated: payload => {
@@ -179,6 +188,14 @@ export function createRuntimeTaskStreamHandlers(
         normalizedBlockType: block?.type ?? null,
       })
       if (!block) return
+      if (block.type === 'file_changes') {
+        rememberStreamedFileChanges(
+          streamedFileChanges,
+          identity.subtaskId,
+          block.id,
+          block.fileChanges
+        )
+      }
       handlers.onMessageAction({
         type: 'block_created',
         subtaskId: identity.subtaskId,
@@ -215,6 +232,15 @@ export function createRuntimeTaskStreamHandlers(
         hasRenderPayload: payload.renderPayload !== undefined,
         hasFileChanges: payload.fileChanges !== undefined,
       })
+      const fileChanges = normalizeTurnFileChanges(payload.fileChanges)
+      if (fileChanges) {
+        rememberStreamedFileChanges(
+          streamedFileChanges,
+          identity.subtaskId,
+          payload.blockId,
+          fileChanges
+        )
+      }
       handlers.onMessageAction({
         type: 'block_updated',
         subtaskId: identity.subtaskId,
@@ -835,6 +861,28 @@ function getResultBlocks(subtaskId: string, result: unknown): ProcessingBlock[] 
   if (!isRecord(result) || !Array.isArray(result.blocks)) return undefined
   const blocks = normalizeProcessingBlocks(subtaskId, result.blocks)
   return blocks.length > 0 ? blocks : undefined
+}
+
+function fileChangesFromBlocks(
+  blocks: ProcessingBlock[] | undefined
+): TurnFileChangesSummary | undefined {
+  return mergeTurnFileChanges(
+    (blocks ?? []).flatMap(block => (block.type === 'file_changes' ? [block.fileChanges] : []))
+  )
+}
+
+function rememberStreamedFileChanges(
+  summaries: Map<string, Map<string, TurnFileChangesSummary>>,
+  subtaskId: string,
+  blockId: string,
+  fileChanges: TurnFileChangesSummary
+) {
+  let blocks = summaries.get(subtaskId)
+  if (!blocks) {
+    blocks = new Map()
+    summaries.set(subtaskId, blocks)
+  }
+  blocks.set(blockId, fileChanges)
 }
 
 function doneContent(result: unknown): string | undefined {

--- a/wework/src/features/workbench/turnFileChanges.test.ts
+++ b/wework/src/features/workbench/turnFileChanges.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { normalizeTurnFileChanges } from './turnFileChanges'
+import { mergeTurnFileChanges, normalizeTurnFileChanges } from './turnFileChanges'
 
 const summary = {
-  version: 1,
-  status: 'active',
+  version: 1 as const,
+  status: 'active' as const,
   artifact_id: 'turn-8-21',
   device_id: 'device-1',
   workspace_path: '/workspace/project',
@@ -13,7 +13,7 @@ const summary = {
   files: [
     {
       path: 'src/main.ts',
-      change_type: 'modified',
+      change_type: 'modified' as const,
       additions: 4,
       deletions: 2,
       binary: false,
@@ -53,5 +53,34 @@ describe('normalizeTurnFileChanges', () => {
         files: [{ ...summary.files[0], additions: -1 }],
       })
     ).toBeUndefined()
+  })
+})
+
+describe('mergeTurnFileChanges', () => {
+  test('combines file change blocks into one turn summary', () => {
+    const second = {
+      ...summary,
+      artifact_id: 'artifact-2',
+      file_count: 1,
+      additions: 2,
+      deletions: 0,
+      files: [
+        {
+          path: 'src/second.ts',
+          change_type: 'created' as const,
+          additions: 2,
+          deletions: 0,
+          binary: false,
+        },
+      ],
+    }
+
+    expect(mergeTurnFileChanges([summary, second])).toMatchObject({
+      artifact_id: summary.artifact_id,
+      file_count: 2,
+      additions: 6,
+      deletions: 2,
+      files: [summary.files[0], second.files[0]],
+    })
   })
 })

--- a/wework/src/features/workbench/turnFileChanges.ts
+++ b/wework/src/features/workbench/turnFileChanges.ts
@@ -98,3 +98,53 @@ export function normalizeTurnFileChanges(value: unknown): TurnFileChangesSummary
     revertible: typeof value.revertible === 'boolean' ? value.revertible : undefined,
   }
 }
+
+export function mergeTurnFileChanges(
+  summaries: TurnFileChangesSummary[]
+): TurnFileChangesSummary | undefined {
+  const first = summaries[0]
+  if (!first) return undefined
+
+  const files = new Map<string, TurnFileChangeItem>()
+  const diffs: string[] = []
+  summaries.forEach(summary => {
+    summary.files.forEach(file => {
+      const existing = files.get(file.path)
+      files.set(file.path, existing ? mergeFileChange(existing, file) : file)
+    })
+    if (summary.diff?.trim()) diffs.push(summary.diff)
+  })
+
+  const mergedFiles = [...files.values()]
+  const latest = summaries[summaries.length - 1]
+  return {
+    ...first,
+    status: latest.status,
+    device_id: latest.device_id,
+    workspace_path: latest.workspace_path,
+    file_count: mergedFiles.length,
+    additions: mergedFiles.reduce((total, file) => total + file.additions, 0),
+    deletions: mergedFiles.reduce((total, file) => total + file.deletions, 0),
+    files: mergedFiles,
+    reverted_at: latest.reverted_at,
+    revertible: latest.revertible,
+    ...(diffs.length > 0 ? { diff: diffs.join('\n') } : {}),
+  }
+}
+
+function mergeFileChange(
+  existing: TurnFileChangeItem,
+  next: TurnFileChangeItem
+): TurnFileChangeItem {
+  return {
+    ...existing,
+    ...next,
+    old_path: next.old_path ?? existing.old_path,
+    change_type:
+      existing.change_type === 'created' && next.change_type === 'modified'
+        ? 'created'
+        : next.change_type,
+    additions: existing.additions + next.additions,
+    deletions: existing.deletions + next.deletions,
+  }
+}


### PR DESCRIPTION
## Summary

- retain normalized file-change blocks for each active runtime subtask
- merge streamed file-change summaries when the terminal event does not include one
- keep explicit terminal summaries authoritative and clear retained state on completion/error

## Verification

- `pnpm --filter wework test` (179 files, 1757 tests)
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- isolated real-Tauri verification with a fresh local project: asked Codex to create two files, waited for the streaming response to settle, and confirmed the final card immediately showed 2 edited files with +2/-0 without reloading

## QA plan result

- Primary path: PASS — the completed live turn displays the change summary card immediately
- Multiple files: PASS — both `first.txt` and `second.txt` are listed with individual +1/-0 stats
- Historical path: preserved by existing transcript normalization tests
- Cleanup: isolated Tauri session stopped successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-change reporting for streamed workbench tasks.
  * File changes received across multiple streamed updates are now retained and included in completion messages.
  * Combined file-change summaries now accurately aggregate file counts, additions, deletions, paths, and diffs.

* **Tests**
  * Added coverage for streamed file-change handling and merging multiple file-change summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->