### PR TITLE
fix(wework): keep local task creation off cloud routes

### DIFF
--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -778,6 +778,39 @@ describe('createHybridWorkbenchServices', () => {
     )
   })
 
+  it('discovers a local device before routing task creation', async () => {
+    mocks.localListDevices.mockResolvedValue([
+      {
+        id: 0,
+        device_id: 'runtime-local-device',
+        name: 'Local Executor',
+        status: 'online',
+        is_default: true,
+        device_type: 'local',
+        bind_shell: 'claudecode',
+      },
+    ])
+    mocks.localCreateRuntimeTask.mockResolvedValue({
+      accepted: true,
+      deviceId: 'runtime-local-device',
+      taskId: 'local-task',
+      workspacePath: '/tmp/local',
+    })
+    const services = createServices()
+
+    await services.runtimeWorkApi?.createRuntimeTask({
+      deviceId: 'runtime-local-device',
+      workspacePath: '/tmp/local',
+      teamId: 1,
+      runtime: 'codex',
+      message: 'local',
+    })
+
+    expect(mocks.localListDevices).toHaveBeenCalledTimes(1)
+    expect(mocks.localCreateRuntimeTask).toHaveBeenCalledTimes(1)
+    expect(mocks.cloudRuntimeIpcRequest).not.toHaveBeenCalled()
+  })
+
   it('routes cloud runtime IPC through socket_device_id when provided', async () => {
     mocks.cloudListDevices.mockResolvedValue([
       {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -372,6 +372,19 @@ export function createHybridWorkbenchServices(
   }
   const isLocalDeviceId = (deviceId?: string | null) =>
     Boolean(deviceId && localDeviceIds.has(deviceId))
+  const isKnownCloudDeviceId = (deviceId?: string | null) =>
+    Boolean(deviceId && rememberedCloudDevices.some(device => device.device_id === deviceId))
+  const runtimeApiForCreate = async (deviceId?: string | null) => {
+    if (isLocalDeviceId(deviceId)) return localServices.runtimeWorkApi!
+
+    // Device discovery and task creation race during bootstrap. An unknown route must
+    // not default to cloud because that makes a local task wait on an unavailable
+    // cloud connection. Refresh the authoritative local device identities first.
+    if (!isKnownCloudDeviceId(deviceId)) {
+      await listLocalDevices()
+    }
+    return runtimeApi(deviceId)
+  }
   const invalidateCloudArchiveCache = () => {
     rememberedCloudArchives.clear()
     cloudArchiveFetchedAt.clear()
@@ -842,8 +855,8 @@ export function createHybridWorkbenchServices(
     cancelRuntimeTask(address: RuntimeTaskAddress) {
       return routeByAddress(address).cancelRuntimeTask(address)
     },
-    createRuntimeTask(data: RuntimeTaskCreateRequest) {
-      return runtimeApi(data.deviceId).createRuntimeTask(data)
+    async createRuntimeTask(data: RuntimeTaskCreateRequest) {
+      return (await runtimeApiForCreate(data.deviceId)).createRuntimeTask(data)
     },
     forkRuntimeTask(data: RuntimeTaskForkRequest) {
       return runtimeApi(data.target.deviceId).forkRuntimeTask(data)

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -124,6 +124,7 @@ export function useWorkbenchDataRefresh({
       if (backgroundApi?.listRuntimeWork) activeChecks.push('runtimeWork')
 
       if (activeChecks.length === 0) return
+      if (cloudRuntimeStateRef.current.inFlightRevision != null) return
 
       const startedState = startCloudRuntimeSync(
         cloudRuntimeStateRef.current,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hybrid runtime task routing to correctly identify local devices during startup.
  * Prevented unnecessary cloud requests when a task targets a discovered local device.
  * Prevented overlapping cloud runtime synchronization requests during refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->