### PR TITLE
fix(wework): preserve renamed file summaries

### DIFF
--- a/wework/src/features/workbench/turnFileChanges.test.ts
+++ b/wework/src/features/workbench/turnFileChanges.test.ts
@@ -83,4 +83,42 @@ describe('mergeTurnFileChanges', () => {
       files: [summary.files[0], second.files[0]],
     })
   })
+
+  test('preserves a rename when the renamed file is modified later', () => {
+    const renamed = {
+      ...summary,
+      files: [
+        {
+          ...summary.files[0],
+          old_path: 'src/old.ts',
+          path: 'src/new.ts',
+          change_type: 'renamed' as const,
+        },
+      ],
+    }
+    const modified = {
+      ...summary,
+      additions: 2,
+      deletions: 1,
+      files: [
+        {
+          ...summary.files[0],
+          path: 'src/new.ts',
+          change_type: 'modified' as const,
+          additions: 2,
+          deletions: 1,
+        },
+      ],
+    }
+
+    expect(mergeTurnFileChanges([renamed, modified])?.files).toEqual([
+      expect.objectContaining({
+        old_path: 'src/old.ts',
+        path: 'src/new.ts',
+        change_type: 'renamed',
+        additions: 6,
+        deletions: 3,
+      }),
+    ])
+  })
 })

--- a/wework/src/features/workbench/turnFileChanges.ts
+++ b/wework/src/features/workbench/turnFileChanges.ts
@@ -141,8 +141,9 @@ function mergeFileChange(
     ...next,
     old_path: next.old_path ?? existing.old_path,
     change_type:
-      existing.change_type === 'created' && next.change_type === 'modified'
-        ? 'created'
+      (existing.change_type === 'created' || existing.change_type === 'renamed') &&
+      next.change_type === 'modified'
+        ? existing.change_type
         : next.change_type,
     additions: existing.additions + next.additions,
     deletions: existing.deletions + next.deletions,


### PR DESCRIPTION
## Summary

Follow-up to #2022 and its CodeRabbit review. When streamed summaries report a rename followed by a modification of the destination path, preserve the final change type as `renamed` instead of degrading it to `modified`.

## Verification

- `pnpm --dir wework exec vitest run src/features/workbench/turnFileChanges.test.ts src/features/workbench/runtimePaneMessages.test.ts` (29 tests)
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- pre-commit and pre-push checks

The real-Tauri primary-path screenshot and verification remain attached to #2022; this follow-up changes only the merge semantics for the rename-then-modify boundary.