### PR TITLE
fix(wiki): require auth and repo access for project detail

### DIFF
--- a/backend/app/api/endpoints/wiki.py
+++ b/backend/app/api/endpoints/wiki.py
@@ -298,18 +298,32 @@ def get_wiki_projects(
 
 
 @router.get("/projects/{project_id}", response_model=WikiProjectDetail)
-def get_wiki_project(project_id: int, db: Session = Depends(get_wiki_db)):
+def get_wiki_project(
+    project_id: int,
+    current_user: User = Depends(security.get_current_user),
+    wiki_db: Session = Depends(get_wiki_db),
+    main_db: Session = Depends(get_db),
+):
     """Get wiki project detail.
 
+    Requires authentication and verifies the current user has read access to the
+    underlying repository, matching the filtering applied by the list endpoint.
     Returns project details with recent generations from system-bound user.
     When WIKI_DEFAULT_USER_ID = 0, returns all users' generations (legacy behavior).
     """
-    project = wiki_service.get_project_detail(db=db, project_id=project_id)
+    project = wiki_service.get_project_detail(db=wiki_db, project_id=project_id)
+
+    # Enforce the same repository-access check used by the project list endpoint.
+    # Get user from main_db to ensure we have the latest git_info.
+    user = main_db.query(User).filter(User.id == current_user.id).first()
+    if not wiki_service.check_user_project_access(project, user):
+        # Use 404 to avoid leaking the existence of inaccessible projects.
+        raise HTTPException(status_code=404, detail="Project not found")
 
     # Get recent generations for this project using system-bound user ID
     # When WIKI_DEFAULT_USER_ID = 0, returns all users' generations (legacy behavior)
     generations, _ = wiki_service.get_generations(
-        db=db,
+        db=wiki_db,
         user_id=wiki_settings.DEFAULT_USER_ID,  # Use system-bound user ID
         project_id=project_id,
         skip=0,

--- a/backend/app/schemas/wiki.py
+++ b/backend/app/schemas/wiki.py
@@ -5,7 +5,27 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+def _strip_sensitive_ext(value: Any) -> Any:
+    """Remove the internal content-write token from generation ext on serialization.
+
+    Historically the wiki flow stored the internal write token in ext under
+    ``wiki_env`` and ``content_write.auth_token``. These must never be returned by
+    the API. Stripping here covers every response carrying generation ext without
+    mutating the underlying ORM object.
+    """
+    if not isinstance(value, dict):
+        return value
+
+    cleaned = {k: v for k, v in value.items() if k != "wiki_env"}
+    content_write = cleaned.get("content_write")
+    if isinstance(content_write, dict) and "auth_token" in content_write:
+        cleaned["content_write"] = {
+            k: v for k, v in content_write.items() if k != "auth_token"
+        }
+    return cleaned
 
 
 # ========== Project Schemas ==========
@@ -100,6 +120,8 @@ class WikiGenerationInDB(BaseModel):
     created_at: datetime
     updated_at: datetime
     completed_at: Optional[datetime]
+
+    _strip_ext = field_validator("ext", mode="before")(_strip_sensitive_ext)
 
     class Config:
         from_attributes = True

--- a/backend/app/services/wiki_service.py
+++ b/backend/app/services/wiki_service.py
@@ -34,8 +34,6 @@ from shared.utils.url_util import domains_match
 
 logger = logging.getLogger(__name__)
 
-INTERNAL_CONTENT_WRITE_TOKEN = wiki_settings.INTERNAL_API_TOKEN
-
 
 class WikiService:
     """Wiki document service"""
@@ -76,9 +74,12 @@ class WikiService:
                 "content_endpoint_url": f"{base_url}{endpoint_path}",
                 "default_section_types": wiki_settings.DEFAULT_SECTION_TYPES,
                 "generation_id": generation.id,
-                "auth_token": INTERNAL_CONTENT_WRITE_TOKEN,
             }
         )
+        # Do not persist the internal write token in ext: the wiki_submit skill
+        # authenticates via the task JWT (TASK_INFO.auth_token), and anything stored
+        # here leaks through the generation/project API responses.
+        content_meta.pop("auth_token", None)
         ext["content_write"] = content_meta
         return ext
 
@@ -291,13 +292,6 @@ class WikiService:
                 section_types=content_meta.get("default_section_types"),
                 language=obj_in.language,
             )
-            # Store wiki environment variables in generation ext for executor to use
-            wiki_env = {
-                "WIKI_ENDPOINT": content_meta.get("content_endpoint_url", ""),
-                "WIKI_TOKEN": content_meta.get("auth_token", ""),
-                "WIKI_GENERATION_ID": str(generation.id),
-            }
-            generation.ext["wiki_env"] = wiki_env
 
             # Note: model_id is not passed - wiki uses the team's bound model
             # The team's bot should have a model configured (bind_model or custom config)
@@ -1123,6 +1117,25 @@ class WikiService:
             raise HTTPException(status_code=404, detail="Project not found")
 
         return project
+
+    def check_user_project_access(
+        self, project: WikiProject, user: Optional[User]
+    ) -> bool:
+        """Check whether a user has read access to a single project's repository.
+
+        Reuses the same repository-access logic as the project list endpoint so
+        the detail endpoint cannot be used to bypass permission filtering.
+
+        Args:
+            project: WikiProject to check.
+            user: Current user. Access is denied when user is None.
+
+        Returns:
+            True if the user has read access to the underlying repository.
+        """
+        if user is None:
+            return False
+        return bool(self._filter_projects_by_user_access([project], user))
 
     def cancel_wiki_generation(
         self, wiki_db: Session, generation_id: int, user_id: int

--- a/backend/tests/api/test_wiki_project_auth.py
+++ b/backend/tests/api/test_wiki_project_auth.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for wiki project detail endpoint authentication and access control.
+
+Guards against a security bypass where GET /api/wiki/projects/{id} skipped
+authentication entirely and performed no repository-access filtering, allowing
+any caller to read any project by enumerating IDs.
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db.session import get_wiki_db
+from app.models.wiki import WikiProject
+
+
+def _create_project(
+    db: Session, source_url: str = "http://git.example.com/a/b.git"
+) -> WikiProject:
+    project = WikiProject(
+        project_name="acme/repo",
+        project_type="git",
+        source_type="gitlab",
+        source_url=source_url,
+        source_id="12345",
+        source_domain="git.example.com",
+        description="",
+        ext={},
+        is_active=True,
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def _use_wiki_db(test_client: TestClient, test_db: Session) -> None:
+    """Route get_wiki_db to the same in-memory test session."""
+
+    def override_get_wiki_db():
+        yield test_db
+
+    test_client.app.dependency_overrides[get_wiki_db] = override_get_wiki_db
+
+
+class TestWikiProjectDetailAuth:
+    def test_detail_no_auth_returns_401(
+        self, test_client: TestClient, test_db: Session
+    ) -> None:
+        """Without a token the detail endpoint must reject before any DB access."""
+        _use_wiki_db(test_client, test_db)
+        project = _create_project(test_db)
+
+        response = test_client.get(f"/api/wiki/projects/{project.id}")
+
+        assert response.status_code == 401
+
+    def test_detail_missing_project_no_auth_returns_401(
+        self, test_client: TestClient
+    ) -> None:
+        """A non-existent id without a token must still be 401, not 404.
+
+        A 404 here would prove auth was skipped and the DB was queried.
+        """
+        response = test_client.get("/api/wiki/projects/999999")
+
+        assert response.status_code == 401
+
+    def test_detail_without_repo_access_returns_404(
+        self, test_client: TestClient, test_db: Session, test_token: str
+    ) -> None:
+        """Authenticated user without repository access must not read the project."""
+        _use_wiki_db(test_client, test_db)
+        project = _create_project(test_db)
+
+        # test_user has git_info=None, so it has access to no repositories.
+        response = test_client.get(
+            f"/api/wiki/projects/{project.id}",
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+
+        assert response.status_code == 404

--- a/backend/tests/api/test_wiki_project_auth.py
+++ b/backend/tests/api/test_wiki_project_auth.py
@@ -9,6 +9,7 @@ authentication entirely and performed no repository-access filtering, allowing
 any caller to read any project by enumerating IDs.
 """
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -36,24 +37,30 @@ def _create_project(
     return project
 
 
-def _use_wiki_db(test_client: TestClient, test_db: Session) -> None:
-    """Route get_wiki_db to the same in-memory test session."""
+@pytest.fixture
+def wiki_client(test_client: TestClient, test_db: Session) -> TestClient:
+    """Client whose get_wiki_db is routed to the shared test session.
+
+    Clears the override on teardown so it cannot leak into other tests even if
+    test_client ever becomes broader-scoped.
+    """
 
     def override_get_wiki_db():
         yield test_db
 
     test_client.app.dependency_overrides[get_wiki_db] = override_get_wiki_db
+    yield test_client
+    test_client.app.dependency_overrides.pop(get_wiki_db, None)
 
 
 class TestWikiProjectDetailAuth:
     def test_detail_no_auth_returns_401(
-        self, test_client: TestClient, test_db: Session
+        self, wiki_client: TestClient, test_db: Session
     ) -> None:
         """Without a token the detail endpoint must reject before any DB access."""
-        _use_wiki_db(test_client, test_db)
         project = _create_project(test_db)
 
-        response = test_client.get(f"/api/wiki/projects/{project.id}")
+        response = wiki_client.get(f"/api/wiki/projects/{project.id}")
 
         assert response.status_code == 401
 
@@ -69,14 +76,13 @@ class TestWikiProjectDetailAuth:
         assert response.status_code == 401
 
     def test_detail_without_repo_access_returns_404(
-        self, test_client: TestClient, test_db: Session, test_token: str
+        self, wiki_client: TestClient, test_db: Session, test_token: str
     ) -> None:
         """Authenticated user without repository access must not read the project."""
-        _use_wiki_db(test_client, test_db)
         project = _create_project(test_db)
 
         # test_user has git_info=None, so it has access to no repositories.
-        response = test_client.get(
+        response = wiki_client.get(
             f"/api/wiki/projects/{project.id}",
             headers={"Authorization": f"Bearer {test_token}"},
         )

--- a/backend/tests/services/test_wiki_generation_ext.py
+++ b/backend/tests/services/test_wiki_generation_ext.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests ensuring wiki generation ext never carries the internal write token.
+
+Guards against re-introducing the leak where the internal content-write token was
+persisted into generation ext and returned by the generation/project APIs. Two
+layers protect against it:
+- the write path no longer stores the token (TestBuildGenerationExt)
+- the response schema strips it on serialization, covering legacy rows
+  (TestExtSerialization)
+"""
+
+from types import SimpleNamespace
+
+from app.schemas.wiki import WikiGenerationInDB
+from app.services.wiki_service import wiki_service
+
+
+class TestBuildGenerationExt:
+    def test_does_not_persist_internal_token(self) -> None:
+        generation = SimpleNamespace(id=42)
+
+        ext = wiki_service._build_generation_ext(generation=generation, base_ext=None)
+
+        assert "wiki_env" not in ext
+        assert "auth_token" not in ext.get("content_write", {})
+        # Non-secret bookkeeping metadata is still populated.
+        assert ext["content_write"]["generation_id"] == 42
+
+    def test_strips_token_supplied_via_request_ext(self) -> None:
+        generation = SimpleNamespace(id=7)
+        base_ext = {"content_write": {"auth_token": "attacker-supplied"}}
+
+        ext = wiki_service._build_generation_ext(
+            generation=generation, base_ext=base_ext
+        )
+
+        assert "auth_token" not in ext["content_write"]
+
+
+class TestExtSerialization:
+    """The response schema must strip secrets, protecting legacy rows in the DB."""
+
+    def _make(self, ext: dict) -> WikiGenerationInDB:
+        return WikiGenerationInDB(
+            id=1,
+            project_id=1,
+            user_id=1,
+            task_id=1,
+            team_id=1,
+            generation_type="full",
+            source_snapshot={},
+            status="RUNNING",
+            ext=ext,
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+            completed_at=None,
+        )
+
+    def test_removes_wiki_env_and_auth_token(self) -> None:
+        model = self._make(
+            {
+                "wiki_env": {"WIKI_TOKEN": "weki"},
+                "content_write": {"auth_token": "weki", "total_sections": 3},
+            }
+        )
+
+        assert model.ext is not None
+        assert "wiki_env" not in model.ext
+        assert "auth_token" not in model.ext["content_write"]
+        # Legitimate metadata survives.
+        assert model.ext["content_write"]["total_sections"] == 3
+
+    def test_leaves_clean_ext_untouched(self) -> None:
+        model = self._make({"content_write": {"total_sections": 1}})
+
+        assert model.ext == {"content_write": {"total_sections": 1}}


### PR DESCRIPTION
GET /api/wiki/projects/{id} skipped authentication and performed no repository-access filtering, so any caller could read any project by enumerating IDs (the list endpoint already filtered by access).

- Add auth dependency and reuse the list endpoint's repo-access check via wiki_service.check_user_project_access; return 404 when denied
- Stop persisting the internal content-write token into generation ext (auth_token / wiki_env), which leaked through generation and project API responses; the wiki_submit skill authenticates via the task JWT and nothing consumed wiki_env
- Add scrub_wiki_generation_secrets.py to strip the token from existing rows, and regression tests for auth, access control, and ext contents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Wiki project details now require authentication and repository read access.
  * Unauthorized or inaccessible projects return appropriate errors without revealing whether the project exists.
  * Internal wiki write credentials and environment details are no longer persisted in generation metadata and are stripped from API responses.

* **Tests**
  * Added regression coverage for wiki project authentication/access control behavior.
  * Added safeguards to ensure sensitive “generation ext” data is removed during building and response serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->