### PR TITLE
fix(wework): unify tool processing display

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ If the command is not in your current `PATH`, use `~/.local/bin/wegent-standalon
 
 Download Wework and open a local project to start AI coding. Wework includes local execution and can also connect to a team deployment of Wegent from Settings.
 
+While a task runs, Wework keeps the latest tool activity visible. The tool list shows about 3.5 rows by default and remains scrollable, while command output, search details, and file changes can be expanded individually. Once the final answer starts, the processing timeline collapses into a separated processed row and expands back into the same tool list.
+
 **[Download Wework Desktop](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true)**
 
 ### Wegent Web Deployment Options

--- a/README_zh.md
+++ b/README_zh.md
@@ -82,6 +82,8 @@ wegent-standalone stop
 
 下载并安装 Wework，打开一个本地项目即可开始 AI Coding。Wework 自带本地执行能力，也可以在设置中连接团队部署的 Wegent。
 
+任务执行期间，Wework 会持续展示最新工具调用；工具列表默认显示约 3.5 行并可滚动，命令输出、搜索详情和文件变更可逐项展开。最终回答开始后，处理过程会收起为带分隔线的“已处理”条目，展开后仍使用相同的工具列表。
+
 **[下载 Wework Desktop](https://github.com/wecode-ai/Wegent/releases?q=Wework+macOS+DMG+build&expanded=true)**
 
 ### Wegent Web 部署方式

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1625,18 +1625,19 @@ describe('MessageList', () => {
       processStatus.compareDocumentPosition(screen.getByText('最终建议放在 PR flow 里。')) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
-    const collapseContent = screen.getAllByTestId('processing-collapse-content')[1]
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
-    expect(collapseContent).toHaveClass('opacity-0')
-    expect(collapseContent).toHaveStyle({ maxHeight: '0px' })
+    expect(screen.getAllByTestId('processing-collapse-content')).toHaveLength(1)
 
     fireEvent.click(processStatus)
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getAllByTestId('processing-collapse-content')[1]).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
     expect(screen.getByText('已搜索代码')).toBeInTheDocument()
     expect(screen.queryByTestId('processing-activity-group-toggle')).not.toBeInTheDocument()
   })
 
-  test('collapses streaming processing as soon as final answer appears', () => {
+  test('keeps a running tool visible when streamed answer text appears', () => {
     const blocks: ProcessingBlock[] = [
       {
         id: 'tool-1',
@@ -1667,21 +1668,21 @@ describe('MessageList', () => {
 
     const finalAnswer = screen.getByTestId('message-assistant').querySelector('p')
     expect(finalAnswer).toHaveTextContent('这是正在流式输出的最终答案。')
-    const processStatus = screen.getByRole('button', { name: /已处理/ })
+    const processStatus = screen.getByTestId('processing-summary-header')
     const collapseContent = screen.getByTestId('processing-collapse-content')
 
     expect(
       processStatus.compareDocumentPosition(finalAnswer) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
-    expect(processStatus).toHaveAttribute('aria-expanded', 'false')
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
-
-    fireEvent.click(processStatus)
-
-    expect(processStatus).toHaveAttribute('aria-expanded', 'true')
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.queryByTestId('processing-summary-toggle')).not.toBeInTheDocument()
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
     expect(screen.getByText('正在运行 pwd')).toBeInTheDocument()
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '展开工具详情' }))
+
+    expect(screen.getByText('/workspace/project')).toBeInTheDocument()
   })
 
   test('keeps narrative visible but collapses tools before runtime guidance', () => {
@@ -1723,9 +1724,8 @@ describe('MessageList', () => {
     )
 
     const collapseContents = screen.getAllByTestId('processing-collapse-content')
-    expect(collapseContents).toHaveLength(2)
+    expect(collapseContents).toHaveLength(1)
     expect(collapseContents[0]).toHaveAttribute('aria-hidden', 'false')
-    expect(collapseContents[1]).toHaveAttribute('aria-hidden', 'true')
     expect(screen.getByText('我正在检查项目结构。')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /已调用 1 个工具 已处理/ })).toHaveAttribute(
       'aria-expanded',
@@ -1866,25 +1866,19 @@ describe('MessageList', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
-    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
-      'aria-hidden',
-      'false'
-    )
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
 
     rerender(
       <MessageList conversationKey="conversation-b" messages={[buildMessage('assistant-b')]} />
     )
 
-    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
 
     rerender(
       <MessageList conversationKey="conversation-a" messages={[buildMessage('assistant-a')]} />
     )
 
-    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
-      'aria-hidden',
-      'false'
-    )
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
   })
 
   test('reserves enough marker gutter for multi-digit ordered lists', () => {
@@ -3920,7 +3914,7 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getByText('运行命令')).toBeInTheDocument()
+    expect(screen.getByText('已运行 pwd')).toBeInTheDocument()
     expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
   })
 
@@ -3960,7 +3954,7 @@ describe('MessageList', () => {
       type: 'tool',
       toolName: 'Bash',
       toolInput: { command: 'rg -n "foo" src' },
-      status: 'streaming',
+      status: 'done',
       createdAt: 1770000000000,
     }
 
@@ -4022,9 +4016,47 @@ describe('MessageList', () => {
     )
 
     const processText = screen.getByTestId('process-text-block')
-    const runningTool = screen.getByText('搜索代码')
+    const runningTool = screen.getByText('正在搜索代码')
 
     expect(processText.compareDocumentPosition(runningTool)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  test('ends the preceding live tool preview when process text starts', () => {
+    const completedBlock: ProcessingBlock = {
+      id: 'call-1',
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'Bash',
+      toolInput: { command: 'uptime' },
+      status: 'done',
+      createdAt: 1770000000000,
+    }
+    const processBlock: ProcessingBlock = {
+      id: 'text-1',
+      subtaskId: 1,
+      type: 'text',
+      content: '负载均值明显偏高。',
+      status: 'streaming',
+      createdAt: 1770000000001,
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+            blocks: [completedBlock, processBlock],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('process-text-block')).toHaveTextContent('负载均值明显偏高。')
   })
 
   test('keeps context compaction visible between separate tool groups', () => {
@@ -4066,7 +4098,7 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByText('上下文已自动压缩')).toBeInTheDocument()
-    expect(screen.getAllByTestId('processing-summary-toggle')).toHaveLength(2)
+    expect(screen.getAllByTestId('processing-summary-toggle')).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /已调用 1 个工具 已处理/ })).toHaveLength(2)
   })
 
@@ -4169,6 +4201,7 @@ describe('MessageList', () => {
     const editSummary = screen.getByRole('button', { name: /已编辑 3 个文件 已处理/ })
 
     expect(screen.getByText('已引导对话')).toBeInTheDocument()
+    fireEvent.click(toolSummary)
     expect(screen.getByLabelText('搜索 1')).toBeInTheDocument()
     expect(screen.getByLabelText('读取 3')).toBeInTheDocument()
     expect(screen.getByLabelText('编辑 3')).toBeInTheDocument()
@@ -4182,7 +4215,6 @@ describe('MessageList', () => {
       Node.DOCUMENT_POSITION_FOLLOWING
     )
 
-    fireEvent.click(toolSummary)
     expect(screen.getByText('已读取 file-1.ts')).toBeInTheDocument()
     expect(screen.getByText('已读取 file-2.ts')).toBeInTheDocument()
     expect(screen.getByText('已读取 file-3.ts')).toBeInTheDocument()

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1681,7 +1681,12 @@ function AssistantMessage({
                   isStreaming={isStreaming}
                   startedAt={getProcessingSummaryStartMs(message, segment.blocks, isStreaming)}
                   forceExpanded={segment.kind === 'narrative'}
-                  hasFinalContent={hasVisibleContent}
+                  hasFinalContent={
+                    hasVisibleContent ||
+                    processingSegments
+                      .slice(index + 1)
+                      .some(laterSegment => laterSegment.kind === 'narrative')
+                  }
                   showSummary={segment.kind === 'tool'}
                   stateKey={`${getMessageDisplayStateKey(conversationKey, message)}:${index}`}
                   onOpenWorkspaceFile={onOpenWorkspaceFile}

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -31,25 +31,35 @@ const INLINE_DIFF_MAX_LINES = 96
 
 interface ToolBlockItemProps {
   block: ProcessingBlock
+  compact?: boolean
   forceExpanded?: boolean
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
   onOpenAssistantPlan?: (request: AssistantPlanOpenRequest) => void
   onLoadFullTranscript?: () => Promise<void> | void
   loadingFullTranscript?: boolean
+  onExpandedChange?: (expanded: boolean) => void
 }
 
 export function ToolBlockItem({
   block,
+  compact = false,
   forceExpanded = false,
   onOpenWorkspaceFile,
   onOpenAssistantPlan,
   onLoadFullTranscript,
   loadingFullTranscript = false,
+  onExpandedChange,
 }: ToolBlockItemProps) {
   const { t } = useTranslation('chat')
   const [userExpanded, setUserExpanded] = useState(false)
   const isRunning = block.status !== 'done' && block.status !== 'error'
+  const hasDetail = block.type === 'tool' && hasBlockDetail(block)
+  const expanded = hasDetail && (forceExpanded || userExpanded)
+
+  useLayoutEffect(() => {
+    if (block.type === 'tool') onExpandedChange?.(expanded)
+  }, [block.type, expanded, onExpandedChange])
 
   if (block.type === 'thinking') {
     return <ThinkingBlockItem block={block} isRunning={isRunning} />
@@ -61,7 +71,7 @@ export function ToolBlockItem({
     return <PlanBlockItem block={block} onOpenAssistantPlan={onOpenAssistantPlan} />
   }
   if (block.type === 'file_changes') {
-    return <ProcessFileChangesBlockItem block={block} />
+    return <ProcessFileChangesBlockItem block={block} onExpandedChange={onExpandedChange} />
   }
 
   const { icon, label } = getBlockLabel(block, {
@@ -78,8 +88,6 @@ export function ToolBlockItem({
     searchError: t('tool_activity.search_error'),
   })
   const workspaceFilePath = getWorkspaceFilePath(block)
-  const hasDetail = hasBlockDetail(block)
-  const expanded = hasDetail && (forceExpanded || userExpanded)
   const labelContent = (
     <>
       {icon}
@@ -89,8 +97,10 @@ export function ToolBlockItem({
   )
 
   return (
-    <div className="min-w-0 overflow-x-hidden text-sm" data-processing-block-id={block.id}>
-      <div className="flex max-w-full items-center gap-1.5 text-text-secondary">
+    <div className="min-w-0 overflow-x-clip text-sm" data-processing-block-id={block.id}>
+      <div
+        className={`flex max-w-full items-center gap-1.5 text-text-secondary ${compact ? 'min-h-8' : ''}`}
+      >
         {workspaceFilePath && onOpenWorkspaceFile ? (
           <button
             type="button"
@@ -102,6 +112,8 @@ export function ToolBlockItem({
         ) : hasDetail ? (
           <button
             type="button"
+            data-tool-detail-toggle
+            aria-expanded={expanded}
             onClick={() => setUserExpanded(value => !value)}
             className="flex min-w-0 items-center gap-1.5 hover:text-text-primary"
           >
@@ -113,6 +125,7 @@ export function ToolBlockItem({
         {hasDetail ? (
           <button
             type="button"
+            data-tool-detail-toggle
             onClick={() => setUserExpanded(value => !value)}
             className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-secondary hover:bg-muted hover:text-text-primary"
             aria-label={expanded ? '收起工具详情' : '展开工具详情'}
@@ -131,7 +144,7 @@ export function ToolBlockItem({
         ) : null}
       </div>
       {expanded ? (
-        <div className="mt-2 min-w-0 overflow-x-hidden">
+        <div className="mt-2 min-w-0 overflow-x-clip">
           {renderBlockDetail(block, { onLoadFullTranscript, loadingFullTranscript })}
         </div>
       ) : null}
@@ -166,13 +179,19 @@ function PlanBlockItem({
 
 function ProcessFileChangesBlockItem({
   block,
+  onExpandedChange,
 }: {
   block: Extract<ProcessingBlock, { type: 'file_changes' }>
+  onExpandedChange?: (expanded: boolean) => void
 }) {
   const { t } = useTranslation('chat')
   const summary = block.fileChanges
   const isRunning = block.status !== 'done' && block.status !== 'error'
   const [expandedFilePath, setExpandedFilePath] = useState<string | null>(null)
+
+  useLayoutEffect(() => {
+    onExpandedChange?.(expandedFilePath !== null)
+  }, [expandedFilePath, onExpandedChange])
 
   if (!summary.files.length) return null
 

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1,6 +1,6 @@
 import '@/i18n'
 
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { ToolBlocksDisplay } from './ToolBlocksDisplay'
 import type { ProcessingBlock } from '@/types/workbench'
@@ -693,39 +693,28 @@ describe('ToolBlocksDisplay', () => {
       />
     )
 
-    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
-      'aria-hidden',
-      'false'
-    )
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
     expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('已编辑 env')
     expect(screen.queryByTestId('process-file-change-diff')).not.toBeInTheDocument()
   })
 
-  test('opens completed processing details with a short content transition', () => {
+  test('uses the same tool list for completed and streaming processing', () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={false} />)
 
     const toggle = screen.getByRole('button', { name: /已处理/ })
     const collapseContent = screen.getByTestId('processing-collapse-content')
-    expect(toggle).toHaveClass('inline-flex')
-    expect(toggle).not.toHaveClass('w-full')
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
-    expect(collapseContent).toHaveClass(
-      'transition-[max-height,opacity]',
-      'duration-[260ms]',
-      'opacity-0',
-      'pointer-events-none'
-    )
-    expect(collapseContent).toHaveStyle({ maxHeight: '0px' })
-    expect(toggle.querySelector('svg')).toHaveClass('-rotate-90')
-
-    fireEvent.click(toggle.parentElement as HTMLElement)
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
 
     fireEvent.click(toggle)
 
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
-    expect(collapseContent).toHaveClass('opacity-100')
-    expect(toggle.querySelector('svg')).not.toHaveClass('-rotate-90')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.getByTestId('processing-live-preview')).toHaveTextContent('已运行 pwd')
+    expect(screen.getByTestId('processing-live-preview-scroll')).toHaveStyle({
+      maxHeight: '7rem',
+      overflowY: 'auto',
+    })
   })
 
   test('keeps live duration when the run finishes', async () => {
@@ -812,16 +801,55 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('已处理 5 秒')).toBeInTheDocument()
   })
 
-  test('keeps a compact live preview with full processing details collapsed', () => {
+  test('keeps a compact live preview with full processing details collapsed', async () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={true} />)
 
     const collapseContent = screen.getByTestId('processing-collapse-content')
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
-    expect(screen.getByRole('button', { name: /已处理/ })).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
-    expect(screen.getByText('运行命令')).toBeInTheDocument()
-    expect(screen.queryByText('已运行 pwd')).not.toBeInTheDocument()
+    const toggle = screen.getByRole('button', { name: /已处理/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const preview = screen.getByTestId('processing-live-preview')
+    expect(preview).toBeInTheDocument()
+    expect(preview.querySelector('.bg-gradient-to-b')).toBeNull()
+    expect(preview).toHaveClass('ml-2', 'border-l', 'border-border', 'pl-3')
+    expect(screen.getByText('已运行 pwd')).toBeInTheDocument()
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
+    expect(screen.getByTestId('processing-live-preview-scroll')).toHaveStyle({
+      maxHeight: '7rem',
+      overflowY: 'auto',
+    })
+    fireEvent.click(screen.getByRole('button', { name: '展开工具详情' }))
+    expect(screen.getByText('/workspace/project')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('processing-live-preview-scroll')).toHaveStyle({
+        maxHeight: 'none',
+        overflowY: 'visible',
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: '收起工具详情' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('processing-live-preview-scroll')).toHaveStyle({
+        maxHeight: '7rem',
+        overflowY: 'auto',
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: '展开工具详情' }))
+    const initialRow = preview.querySelector('[data-processing-block-id="call-1"]')
+    expect(initialRow).not.toBeNull()
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
+    expect(initialRow?.isConnected).toBe(false)
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const remountedPreview = screen.getByTestId('processing-live-preview')
+    const remountedRow = remountedPreview.querySelector('[data-processing-block-id="call-1"]')
+    expect(remountedRow).not.toBe(initialRow)
+    expect(remountedRow?.isConnected).toBe(true)
   })
 
   test('leaves generic thinking placeholders to the message list', () => {
@@ -842,16 +870,27 @@ describe('ToolBlocksDisplay', () => {
     )
 
     const toggle = screen.getByRole('button', { name: /已处理/ })
-    const collapseContent = screen.getByTestId('processing-collapse-content')
 
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.queryByTestId('processing-collapse-content')).not.toBeInTheDocument()
 
     fireEvent.click(toggle)
 
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
-    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
-    expect(screen.getByText('已运行 pwd')).toBeInTheDocument()
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.getByTestId('processing-live-preview')).toHaveTextContent('已运行 pwd')
+  })
+
+  test('keeps active tools expanded when streamed text is visible', () => {
+    const runningBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      status: 'streaming',
+    }
+
+    render(<ToolBlocksDisplay blocks={[runningBlock]} isStreaming={true} hasFinalContent={true} />)
+
+    expect(screen.getByTestId('processing-live-preview')).toHaveTextContent('正在运行 pwd')
+    expect(screen.queryByTestId('processing-summary-toggle')).not.toBeInTheDocument()
   })
 
   test('keeps completed and running tools as flat preview rows', () => {
@@ -882,23 +921,20 @@ describe('ToolBlocksDisplay', () => {
     )
 
     const preview = screen.getByTestId('processing-live-preview')
-    expect(preview).toHaveTextContent('运行命令')
-    expect(preview).toHaveTextContent('搜索代码')
-    expect(preview).toHaveTextContent('运行命令')
+    expect(preview).toHaveTextContent('已运行 pwd')
+    expect(preview).toHaveTextContent('已搜索代码')
+    expect(preview).toHaveTextContent('正在运行 bin/paas-context --help')
     expect(screen.getByLabelText('命令 2')).toBeInTheDocument()
     expect(screen.getByLabelText('搜索 1')).toBeInTheDocument()
     expect(screen.queryByText(/已运行 \/bin\/zsh/)).not.toBeInTheDocument()
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /已调用 3 个工具 已处理/ }))
-
     expect(screen.queryByTestId('processing-activity-group-toggle')).not.toBeInTheDocument()
-    expect(screen.getByText('已运行 pwd')).toBeInTheDocument()
-    expect(screen.getByText('已搜索代码')).toBeInTheDocument()
-    expect(screen.getByText('正在运行 bin/paas-context --help')).toBeInTheDocument()
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
+    expect(screen.queryByTestId('processing-summary-toggle')).not.toBeInTheDocument()
   })
 
-  test('limits the collapsed live preview to the latest three processing rows', () => {
+  test('keeps all live rows in a scroll area sized for three rows', () => {
     const runningBlocks: ProcessingBlock[] = Array.from({ length: 4 }, (_, index) => ({
       id: `running-${index + 1}`,
       subtaskId: 1,
@@ -909,13 +945,35 @@ describe('ToolBlocksDisplay', () => {
       createdAt: Date.now() + index,
     }))
 
-    render(<ToolBlocksDisplay blocks={runningBlocks} isStreaming={true} />)
+    const { rerender } = render(<ToolBlocksDisplay blocks={runningBlocks} isStreaming={true} />)
 
     const preview = screen.getByTestId('processing-live-preview')
-    expect(preview.querySelector('[data-processing-block-id="running-1"]')).toBeNull()
+    const scrollArea = screen.getByTestId('processing-live-preview-scroll')
+    expect(scrollArea).toHaveStyle({ maxHeight: '7rem', overflowY: 'auto' })
+    expect(preview.querySelector('[data-processing-block-id="running-1"]')).not.toBeNull()
     expect(preview.querySelector('[data-processing-block-id="running-2"]')).not.toBeNull()
     expect(preview.querySelector('[data-processing-block-id="running-3"]')).not.toBeNull()
     expect(preview.querySelector('[data-processing-block-id="running-4"]')).not.toBeNull()
+    preview.querySelectorAll('[data-processing-block-id]').forEach(row => {
+      expect(row).toHaveClass('overflow-x-clip')
+      expect(row).not.toHaveClass('overflow-x-hidden', 'overflow-y-auto')
+    })
+
+    Object.defineProperty(scrollArea, 'scrollHeight', { configurable: true, value: 160 })
+    rerender(
+      <ToolBlocksDisplay
+        blocks={[
+          ...runningBlocks,
+          {
+            ...runningBlocks[0],
+            id: 'running-5',
+            toolInput: { command: 'command-5' },
+          },
+        ]}
+        isStreaming={true}
+      />
+    )
+    expect(scrollArea.scrollTop).toBe(160)
   })
 
   test('anchors the running duration to the turn start, surviving a refresh', () => {
@@ -944,7 +1002,7 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('已处理 10 秒')).toBeInTheDocument()
   })
 
-  test('renders the running header as an expandable summary', () => {
+  test('renders the running header as a non-collapsible summary', () => {
     const runningBlock: ProcessingBlock = {
       ...completedCommandBlock,
       status: 'streaming',
@@ -952,10 +1010,7 @@ describe('ToolBlocksDisplay', () => {
 
     render(<ToolBlocksDisplay blocks={[runningBlock]} isStreaming={true} />)
 
-    expect(screen.getByRole('button', { name: /已调用 1 个工具 已处理 .* 秒/ })).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    )
+    expect(screen.queryByTestId('processing-summary-toggle')).not.toBeInTheDocument()
     expect(screen.getByText(/已处理 .* 秒/)).toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode, TransitionEvent } from 'react'
 import {
   Archive,
@@ -44,8 +44,6 @@ import { WebSearchActivityRows } from './WebSearchSources'
 import { getWebSearchActivityItems } from './webSearchActivity'
 
 const EMPTY_HIDDEN_REQUEST_USER_INPUT_IDS = new Set<string>()
-const LIVE_PREVIEW_ROW_LIMIT = 3
-
 type ProcessingDisplayItem =
   | ProcessingDisplayRow
   | {
@@ -98,6 +96,10 @@ export function ToolBlocksDisplay({
   const isRunning = isStreaming || blocks.some(b => b.status !== 'done' && b.status !== 'error')
   const [userExpanded, setUserExpanded] = usePersistentProcessingExpansion(
     stateKey ? `${stateKey}:processing` : undefined
+  )
+  const [livePreviewCollapsed, setLivePreviewCollapsed] = useState(false)
+  const [finalContentExpanded, setFinalContentExpanded] = usePersistentProcessingExpansion(
+    stateKey ? `${stateKey}:final-processing` : undefined
   )
   const [mountedAt] = useState(() => Date.now())
   const turnStartedAt = startedAt ?? mountedAt
@@ -184,12 +186,45 @@ export function ToolBlocksDisplay({
     hasPlanResponse ||
     hasRequestUserInput ||
     hasActiveContextCompaction
-  const expanded = isLockedOpen || userExpanded
-  const canToggleSummary = showSummary && !isLockedOpen && rows.length > 0
-  const previewRows = useMemo(
-    () => (isRunning && !hasFinalContent && !expanded ? rows.slice(-LIVE_PREVIEW_ROW_LIMIT) : []),
-    [expanded, hasFinalContent, isRunning, rows]
+  const hasRunningToolActivity = rows.some(row =>
+    row.type === 'activity_group'
+      ? row.blocks.some(block => block.status !== 'done' && block.status !== 'error')
+      : (row.block.type === 'tool' || row.block.type === 'file_changes') &&
+        row.block.status !== 'done' &&
+        row.block.status !== 'error'
   )
+  const usesUnifiedToolList = showSummary && !isLockedOpen
+  const expanded = isLockedOpen || (userExpanded && !usesUnifiedToolList)
+  const canToggleSummary =
+    showSummary && !isLockedOpen && !hasRunningToolActivity && rows.length > 0
+  const hasLivePreview =
+    isRunning && (!hasFinalContent || hasRunningToolActivity) && !expanded && rows.length > 0
+  const previewRows = useMemo(
+    () =>
+      !expanded &&
+      (hasRunningToolActivity ||
+        (hasLivePreview && !livePreviewCollapsed) ||
+        (usesUnifiedToolList && userExpanded))
+        ? rows
+        : [],
+    [
+      expanded,
+      hasLivePreview,
+      hasRunningToolActivity,
+      livePreviewCollapsed,
+      rows,
+      userExpanded,
+      usesUnifiedToolList,
+    ]
+  )
+  const summaryExpanded = expanded || previewRows.length > 0
+  const toggleSummary = () => {
+    if (hasLivePreview) {
+      setLivePreviewCollapsed(value => !value)
+      return
+    }
+    setUserExpanded(value => !value)
+  }
   const hasToolActivity = rows.some(
     row =>
       row.type === 'activity_group' ||
@@ -264,16 +299,16 @@ export function ToolBlocksDisplay({
 
   if (blocks.length === 0 && !isStreaming) return null
 
-  return (
-    <div className="mb-3 min-w-0 w-full">
+  const processingBody = (
+    <>
       {showSummary ? (
         <ProcessingSummaryHeader
           canToggle={canToggleSummary}
           duration={duration}
-          expanded={expanded}
+          expanded={summaryExpanded}
           isRunning={isRunning && !hasFinalContent}
           rows={rows}
-          onToggle={() => setUserExpanded(value => !value)}
+          onToggle={toggleSummary}
           title={summaryTitle}
           labels={{
             command: t('tool_activity.command'),
@@ -288,22 +323,41 @@ export function ToolBlocksDisplay({
         {processingContent}
       </CollapsibleProcessingContent>
       {previewRows.length > 0 ? (
-        <LiveProcessingPreview
-          rows={previewRows}
-          now={now}
-          onOpenWorkspaceFile={onOpenWorkspaceFile}
-          labels={{
-            command: t('tool_activity.command_action'),
-            file: t('tool_activity.file_action'),
-            search: t('tool_activity.search_action'),
-            edit: t('tool_activity.edit_action'),
-            create: t('tool_activity.create_action'),
-            other: t('tool_activity.other_action'),
-          }}
-        />
+        <LiveProcessingPreview rows={previewRows} onOpenWorkspaceFile={onOpenWorkspaceFile} />
       ) : null}
-    </div>
+    </>
   )
+  const usesFinalContentShell =
+    showSummary && hasFinalContent && !hasRunningToolActivity && rows.length > 0
+
+  if (usesFinalContentShell) {
+    return (
+      <div className="mb-3 min-w-0 w-full border-b border-border pb-2">
+        <button
+          type="button"
+          data-testid="final-processing-toggle"
+          aria-expanded={finalContentExpanded}
+          aria-label={duration ? `${summaryTitle} ${duration}` : `${summaryTitle} 已处理`}
+          className="flex min-h-8 items-center gap-1 text-sm text-text-muted hover:text-text-secondary"
+          onClick={() => {
+            const nextExpanded = !finalContentExpanded
+            setFinalContentExpanded(nextExpanded)
+            if (nextExpanded) setUserExpanded(true)
+          }}
+        >
+          <span>{duration || '已处理'}</span>
+          <ChevronDown
+            className={`h-4 w-4 transition-transform ${finalContentExpanded ? '' : '-rotate-90'}`}
+            strokeWidth={2}
+            aria-hidden="true"
+          />
+        </button>
+        {finalContentExpanded ? <div className="mt-1">{processingBody}</div> : null}
+      </div>
+    )
+  }
+
+  return <div className="mb-3 min-w-0 w-full">{processingBody}</div>
 }
 
 type ToolActivityLabels = {
@@ -313,8 +367,6 @@ type ToolActivityLabels = {
   edit: string
   other: string
 }
-
-type ToolActionLabels = ToolActivityLabels & { create: string }
 
 function ProcessingSummaryHeader({
   canToggle,
@@ -424,29 +476,54 @@ function ToolActivityStats({
 
 function LiveProcessingPreview({
   rows,
-  now,
   onOpenWorkspaceFile,
-  labels,
 }: {
   rows: ProcessingDisplayRow[]
-  now: number
   onOpenWorkspaceFile?: (path: string) => void
-  labels: ToolActionLabels
 }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
+  const hasExpandedDetail = rows.some(row => expandedRowIds.has(row.id))
+
+  const updateExpandedRow = useCallback((rowId: string, expanded: boolean) => {
+    setExpandedRowIds(current => {
+      if (current.has(rowId) === expanded) return current
+      const next = new Set(current)
+      if (expanded) next.add(rowId)
+      else next.delete(rowId)
+      return next
+    })
+    if (!expanded) {
+      requestAnimationFrame(() => {
+        const scrollArea = scrollRef.current
+        if (scrollArea) scrollArea.scrollTop = scrollArea.scrollHeight
+      })
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    const scrollArea = scrollRef.current
+    if (!scrollArea) return
+    scrollArea.scrollTop = scrollArea.scrollHeight
+  }, [rows.length])
+
   return (
-    <div className="relative min-w-0" data-testid="processing-live-preview">
+    <div className="ml-2 min-w-0 border-l border-border pl-3" data-testid="processing-live-preview">
       <div
-        className="pointer-events-none absolute inset-x-4 top-0 z-10 h-6 bg-gradient-to-b from-background to-transparent"
-        aria-hidden="true"
-      />
-      <div className="flex min-w-0 flex-col">
+        ref={scrollRef}
+        className="scrollbar-soft flex min-w-0 flex-col"
+        data-testid="processing-live-preview-scroll"
+        style={{
+          maxHeight: hasExpandedDetail ? 'none' : '7rem',
+          overflowY: hasExpandedDetail ? 'visible' : 'auto',
+        }}
+      >
         {rows.map(row => (
           <LiveProcessingPreviewRow
             key={row.id}
             row={row}
-            now={now}
             onOpenWorkspaceFile={onOpenWorkspaceFile}
-            labels={labels}
+            onExpandedChange={updateExpandedRow}
           />
         ))}
       </div>
@@ -456,60 +533,46 @@ function LiveProcessingPreview({
 
 function LiveProcessingPreviewRow({
   row,
-  now,
   onOpenWorkspaceFile,
-  labels,
+  onExpandedChange,
 }: {
   row: ProcessingDisplayRow
-  now: number
   onOpenWorkspaceFile?: (path: string) => void
-  labels: ToolActionLabels
+  onExpandedChange: (rowId: string, expanded: boolean) => void
 }) {
+  const handleExpandedChange = useCallback(
+    (expanded: boolean) => onExpandedChange(row.id, expanded),
+    [onExpandedChange, row.id]
+  )
+
   if (row.type === 'activity_group') {
     return (
-      <div className="flex h-8 min-w-0 items-center gap-1.5 pl-5 text-sm text-text-muted">
-        {renderActivityGroupIcon(row.blocks)}
-        <span className="min-w-0 truncate">{row.label}</span>
+      <div className="min-h-8 min-w-0 py-1">
+        <ToolActivityGroup
+          row={row}
+          initialExpanded={false}
+          onOpenWorkspaceFile={onOpenWorkspaceFile}
+        />
       </div>
     )
   }
 
-  if (row.block.type !== 'tool') {
-    return <ToolBlockItem block={row.block} />
+  if (row.block.type === 'tool') {
+    if (isContextCompactionToolBlock(row.block)) {
+      return <ContextCompactionIndicator block={row.block} />
+    }
+
+    return (
+      <ToolBlockItem
+        block={row.block}
+        compact
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        onExpandedChange={handleExpandedChange}
+      />
+    )
   }
 
-  const block = row.block
-  const isActive = block.status !== 'done' && block.status !== 'error'
-  const elapsed = isActive ? formatPreviewElapsed(now - block.createdAt) : null
-  const workspacePath = getToolActivityFilePaths(block)[0]
-  const label = `${getToolActionLabel(block, labels)}${workspacePath ? ` ${basename(workspacePath)}` : ''}`
-  const labelContent = (
-    <span className={`min-w-0 truncate ${isActive ? 'tool-activity-shimmer' : ''}`}>{label}</span>
-  )
-
-  return (
-    <div
-      className="flex h-8 min-w-0 items-center gap-1.5 pl-5 text-sm text-text-muted"
-      data-processing-block-id={block.id}
-    >
-      {renderActivityGroupIcon([block])}
-      {workspacePath && onOpenWorkspaceFile ? (
-        <button
-          type="button"
-          data-testid="processing-live-file-button"
-          className="min-w-0 text-left hover:text-text-secondary"
-          onClick={() => onOpenWorkspaceFile(workspacePath)}
-        >
-          {labelContent}
-        </button>
-      ) : (
-        labelContent
-      )}
-      {elapsed ? (
-        <span className="tool-activity-shimmer ml-auto shrink-0 font-mono text-xs">{elapsed}</span>
-      ) : null}
-    </div>
-  )
+  return <ToolBlockItem block={row.block} onExpandedChange={handleExpandedChange} />
 }
 
 function countProcessingActivityKinds(rows: ProcessingDisplayRow[]) {
@@ -544,20 +607,6 @@ function countProcessingActivityKinds(rows: ProcessingDisplayRow[]) {
 function countProcessingActivities(rows: ProcessingDisplayRow[]): number {
   const stats = countProcessingActivityKinds(rows)
   return stats.command + stats.file + stats.search + stats.edit + stats.other
-}
-
-function getToolActionLabel(block: ToolBlock, labels: ToolActionLabels): string {
-  const kind = getToolActivityKind(block)
-  if (kind === 'command') return labels.command
-  if (kind === 'file') return labels.file
-  if (kind === 'search') return labels.search
-  if (kind === 'edit') return labels.edit
-  if (kind === 'create') return labels.create
-  return labels.other
-}
-
-function formatPreviewElapsed(durationMs: number): string {
-  return `${Math.max(0, Math.floor(durationMs / 1000))}s`
 }
 
 function CollapsibleProcessingContent({
@@ -649,12 +698,14 @@ function CollapsibleProcessingContent({
 
 function ToolActivityGroup({
   row,
+  initialExpanded = true,
   onOpenWorkspaceFile,
 }: {
   row: Extract<ProcessingDisplayRow, { type: 'activity_group' }>
+  initialExpanded?: boolean
   onOpenWorkspaceFile?: (path: string) => void
 }) {
-  const [expanded, setExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(initialExpanded)
   const isWebSearchGroup = isWebSearchActivityGroup(row.blocks)
   const isGuidanceGroup = isGuidanceActivityGroup(row.blocks)
   const icon = renderActivityGroupIcon(row.blocks)
@@ -672,10 +723,11 @@ function ToolActivityGroup({
   }
 
   return (
-    <div className="min-w-0 overflow-x-hidden text-sm">
+    <div className="min-w-0 overflow-x-clip text-sm">
       <button
         type="button"
         data-testid="processing-activity-group-toggle"
+        data-tool-detail-toggle
         aria-expanded={expanded}
         onClick={() => setExpanded(value => !value)}
         className="flex max-w-full items-center gap-1.5 text-text-muted hover:text-text-secondary"

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -182,6 +182,17 @@ describe('toolBlockActivity', () => {
     ).toBe('已引导对话')
   })
 
+  test('keeps disk usage commands out of file-read activity groups', () => {
+    const rows = buildProcessingDisplayRows([
+      tool('read-1', 'cat package.json'),
+      tool('disk-usage-1', 'du -sh "$HOME/.bun" "$HOME/.cargo"'),
+    ])
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({ type: 'activity_group', label: '已读取 1 个文件' })
+    expect(rows[1]).toMatchObject({ type: 'activity_group', label: '已运行 1 条命令' })
+  })
+
   test('hides internal stdin polling tools from activity rows', () => {
     const rows = buildProcessingDisplayRows([
       {

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -46,7 +46,7 @@ interface ActivityStats {
 
 const SEARCH_TOOL_HINTS = ['search', 'grep', 'glob']
 const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag', 'ack'])
-const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'du', 'file'])
+const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'file'])
 const HIDDEN_ACTIVITY_TOOLS = new Set(['write_stdin', 'functions.write_stdin'])
 
 export function buildProcessingDisplayRows(

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5012,7 +5012,7 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /编辑文件 README\.md/ }))
+    await user.click(screen.getByRole('button', { name: /正在编辑 README\.md/ }))
 
     expect(await screen.findByTestId('workspace-file-preview-code-view')).toBeInTheDocument()
     await waitFor(() => expect(getWorkspaceCodeViewText()).toContain('opened from tool block'))


### PR DESCRIPTION
## Summary

- separate the final-content processing fold from the inner tool-list fold
- use one tool-row renderer for streaming and completed activity, with a 3.5-row scroll area anchored to the latest tool
- keep running tools visible, unmount collapsed content, and expand the outer list for command/search/file details
- fix command classification so `du` is not presented as a multi-file read
- document the Wework processing timeline behavior in Chinese and English

## Verification

- `pnpm --filter wework test` (179 files, 1782 tests)
- `pnpm --filter wework typecheck`
- Wework pre-push ESLint, TypeScript, and unit-test checks
- isolated Tauri verification for final fold, divider, unified tool list, scrolling, and detail expansion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tool-activity previews during task execution, keeping recent activity visible while allowing details, command output, searches, and file changes to be expanded.
  * Processing summaries now clearly transition to completed status when the final answer begins.
  * Added clearer controls and accessibility indicators for expanding tool and file-change details.

* **Bug Fixes**
  * Improved activity grouping and live-preview behavior during streaming.
  * Corrected classification of file-reading and disk-usage commands.
* **Documentation**
  * Updated English and Chinese usage guides with the latest activity-display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->