### PR TITLE
fix(wework): correct dark startup debug panel

### DIFF
--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -249,11 +249,13 @@ describe('LocalRuntimeInitializer', () => {
     const slowStartupHelp = screen.getByTestId('local-runtime-slow-startup-help')
     expect(slowStartupHelp).toHaveTextContent('启动时间有点久')
     expect(slowStartupHelp.className).toContain('sm:flex-row')
-    expect(slowStartupHelp.className).toContain('bg-amber-50/70')
+    expect(slowStartupHelp.className).toContain('bg-amber-500/10')
     expect(
       within(slowStartupHelp).getByTestId('local-runtime-slow-startup-icon').className
-    ).toContain('bg-amber-100')
-    expect(screen.getByTestId('local-runtime-copy-debug-button').className).toContain('sm:w-auto')
+    ).toContain('dark:text-amber-300')
+    expect(screen.getByTestId('local-runtime-copy-debug-button').className).toContain(
+      'hover:bg-muted'
+    )
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('local-runtime-copy-debug-button'))

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -247,12 +247,12 @@ function SlowStartupHelp({ copyState, onCopyDebugInfo }: SlowStartupHelpProps) {
   return (
     <div
       data-testid="local-runtime-slow-startup-help"
-      className="mt-5 flex w-full max-w-[480px] flex-col items-stretch gap-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3.5 py-3 text-left sm:flex-row sm:items-center sm:px-4"
+      className="mt-5 flex w-full max-w-[480px] flex-col items-stretch gap-3 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3.5 py-3 text-left sm:flex-row sm:items-center sm:px-4"
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
         <span
           data-testid="local-runtime-slow-startup-icon"
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-amber-100 text-amber-700 sm:h-8 sm:w-8"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-amber-500/15 text-amber-700 sm:h-8 sm:w-8 dark:text-amber-300"
         >
           <AlertCircle className="h-4 w-4" />
         </span>
@@ -266,7 +266,7 @@ function SlowStartupHelp({ copyState, onCopyDebugInfo }: SlowStartupHelpProps) {
       <Button
         type="button"
         variant="outline"
-        className="h-11 min-w-[44px] border-amber-200/80 bg-base px-3 text-xs text-text-primary hover:bg-amber-50 sm:h-9 sm:w-auto"
+        className="h-11 min-w-[44px] border-border bg-base px-3 text-xs text-text-primary hover:bg-muted sm:h-9 sm:w-auto"
         onClick={onCopyDebugInfo}
         disabled={copying}
         data-testid="local-runtime-copy-debug-button"


### PR DESCRIPTION
## What changed

- replace light-only amber surfaces in the slow-startup debug panel with theme-safe translucent warning colors
- use a neutral themed copy button and improve the dark-theme warning icon contrast
- update the component regression assertions for the dark-mode styling

## Root cause

The panel used fixed `amber-50`, `amber-100`, and `amber-200` Tailwind colors. Those light palette values stayed active in dark mode, producing a washed-out block and weak text hierarchy.

## Impact

The Wework local-runtime slow-startup panel now remains visually consistent and readable in dark mode without changing its behavior or the 10-second threshold.

## Validation

- `pnpm --filter wework exec vitest run src/features/local-runtime/LocalRuntimeInitializer.test.tsx` (14/14 passed)
- `pnpm --filter wework exec prettier --check ...` passed
- `pnpm --filter wework exec eslint ...` passed
- pre-push ESLint, TypeScript, and complete unit test suite passed
- isolated real-Tauri dark-mode snapshot and capture verified; recovery to the main workbench passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the slow-startup help panel with refreshed amber-themed colors and improved dark-mode contrast.
  - Refined the copy button styling with standard border, background, and hover states.
- **Tests**
  - Updated UI checks to verify the revised panel, icon, and button styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->