### PR TITLE
fix(wework): open local image links in file panel

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5041,6 +5041,67 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
+  test('opens a local image link on the local device while the project workspace is remote', async () => {
+    const user = userEvent.setup()
+    const workspacePanelState = createCloudWorkspacePanelState()
+    const localDevice = createLocalSkillDevice()
+    const imagePath = '/Users/me/.wegent-executor/workspace/attachments/draft/42/result.png'
+    const listWorkspaceEntries = vi.fn().mockResolvedValue({
+      path: '/Users/me/.wegent-executor/workspace/attachments/draft/42',
+      entries: [],
+    })
+    const readWorkspaceFileChunk = vi.fn().mockResolvedValue({
+      path: imagePath,
+      name: 'result.png',
+      contentBase64: 'aW1hZ2U=',
+      offset: 0,
+      size: 5,
+      eof: true,
+      modifiedAt: null,
+    })
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        workspaceFileApi={{
+          listWorkspaceEntries,
+          readWorkspaceTextFile: vi.fn(),
+          readWorkspaceFileChunk,
+        }}
+        state={{
+          ...baseProps.state,
+          ...workspacePanelState,
+          devices: [...workspacePanelState.devices, localDevice],
+        }}
+        messages={[
+          {
+            id: 'assistant-local-image-link',
+            role: 'assistant',
+            content: `[result.png](${imagePath})`,
+            status: 'done',
+            createdAt: '2026-07-18T00:00:00.000Z',
+          },
+        ]}
+        projectWork={{
+          ...baseProps.projectWork,
+          projects: workspacePanelState.projects,
+          devices: [...workspacePanelState.devices, localDevice],
+          currentProjectId: workspacePanelState.currentProject.id,
+        }}
+      />
+    )
+
+    await user.click(await screen.findByTestId('assistant-markdown-link'))
+
+    expect(await screen.findByTestId('workspace-binary-file-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
+    expect(listWorkspaceEntries).toHaveBeenCalledWith(
+      localDevice.device_id,
+      '/Users/me/.wegent-executor/workspace/attachments/draft/42'
+    )
+    expect(readWorkspaceFileChunk).toHaveBeenCalledWith(localDevice.device_id, imagePath, 0)
+  })
+
   test('opens a skill from the empty composer on the real local device', async () => {
     const user = userEvent.setup()
     const localDevice = createLocalSkillDevice()

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -13,7 +13,10 @@ import {
   getWorkbenchDeviceUnavailableDisplayName,
   isWorkbenchDeviceOnline,
 } from '@/lib/workbench-device'
-import { createLocalFileWorkspaceTarget } from '@/lib/workspace-target'
+import {
+  createLocalAttachmentWorkspaceTarget,
+  createLocalFileWorkspaceTarget,
+} from '@/lib/workspace-target'
 import {
   WEWORK_MIN_EXECUTOR_VERSION,
   isDeviceBelowWeWorkVersion,
@@ -1116,15 +1119,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     (path: string, options?: WorkspaceFileOpenOptions) => {
       const trimmedPath = path.trim()
       if (!trimmedPath) return
+      const localTarget = createLocalAttachmentWorkspaceTarget(trimmedPath, devices)
       setOpenFileRequest(current => ({
         id: (current?.id ?? 0) + 1,
         path: trimmedPath,
         lineStart: options?.lineStart,
         lineEnd: options?.lineEnd,
+        target: localTarget ?? undefined,
       }))
       openRightPanelTab('files')
     },
-    [openRightPanelTab, setOpenFileRequest]
+    [devices, openRightPanelTab, setOpenFileRequest]
   )
 
   const openLocalSkillFile = useCallback(

--- a/wework/src/lib/workspace-target.test.ts
+++ b/wework/src/lib/workspace-target.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import type { ProjectWithTasks } from '@/types/api'
 import {
+  createLocalAttachmentWorkspaceTarget,
   createLocalFileWorkspaceTarget,
   resolveProjectRuntimeWorkspaceTarget,
   resolveRuntimeWorkspaceContext,
@@ -36,6 +37,33 @@ describe('resolveWorkspaceTarget', () => {
 
   test('rejects relative local file paths', () => {
     expect(createLocalFileWorkspaceTarget('skills/gmail/SKILL.md', [])).toBeNull()
+  })
+
+  test('creates a local target only for Wework attachment paths', () => {
+    const devices = [
+      {
+        id: 1,
+        device_id: 'device-local-real',
+        name: 'Local Mac',
+        status: 'online' as const,
+        is_default: true,
+        device_type: 'local' as const,
+      },
+    ]
+
+    expect(
+      createLocalAttachmentWorkspaceTarget(
+        '/Users/me/.wegent-executor/workspace/attachments/draft/42/result.png',
+        devices
+      )
+    ).toMatchObject({
+      deviceId: 'device-local-real',
+      path: '/Users/me/.wegent-executor/workspace/attachments/draft/42',
+      workspaceSource: 'local',
+    })
+    expect(
+      createLocalAttachmentWorkspaceTarget('/workspace/project/result.png', devices)
+    ).toBeNull()
   })
 
   test('resolves relative git project paths under the executor workspace root', async () => {

--- a/wework/src/lib/workspace-target.ts
+++ b/wework/src/lib/workspace-target.ts
@@ -57,6 +57,17 @@ export function createLocalFileWorkspaceTarget(
   }
 }
 
+export function createLocalAttachmentWorkspaceTarget(
+  filePath: string,
+  devices: DeviceInfo[]
+): WorkspaceTarget | null {
+  const normalizedPath = filePath.trim().replace(/\\/g, '/')
+  const isLocalAttachment =
+    normalizedPath.includes('/.wegent-executor/workspace/attachments/') ||
+    normalizedPath.includes('/.wegent/attachments/')
+  return isLocalAttachment ? createLocalFileWorkspaceTarget(normalizedPath, devices) : null
+}
+
 async function projectWorkspaceTarget(
   project: ProjectWithTasks,
   api: ProjectWorkspaceRootApi


### PR DESCRIPTION
## Summary

- route Wework-generated local attachment links to the local workbench device
- keep remote project absolute paths on their existing workspace device
- add regression coverage for a remote project workspace opening a local PNG attachment

## Root cause

Assistant file links were always opened against the active project workspace target. When an image lived in Wework's host-local attachment directory but the project used another execution device, the right file panel attempted to read the host path from the project device and could not display it.

## User impact

Clicking an image-file link in a Wework conversation now opens the image in the right file panel, including when the active project workspace is remote.

## Validation

- `pnpm --filter wework test` — 179 files, 1776 tests passed
- Wework pre-push ESLint, TypeScript, and unit-test checks passed
- Prettier and targeted ESLint checks passed
- isolated real-Tauri verification: clicked an assistant Markdown link to a Wework local attachment, waited for `workspace-binary-file-preview`, and captured the rendered right panel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assistant links to locally stored attachment images now open the correct binary file preview, even when the active project workspace is remote.
  * The appropriate local device and attachment path are selected automatically when opening these files.
  * Non-attachment file paths continue to use existing workspace handling.

* **Tests**
  * Added coverage for local attachment detection, preview behavior, selected file tabs, and workspace file loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->