### PR TITLE
fix(wework): count edited files separately

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1171,14 +1171,16 @@ async function main() {
     await control.command('waitFor', '[aria-label="编辑 1"], [aria-label="Edits 1"]', {
       timeoutMs: UI_TIMEOUT_MS,
     })
-    const processingSummaryScreenshot = await control.command(
-      'capture',
-      '[data-testid="processing-summary-header"]'
-    )
-    await writeFile(
-      join(resultDir, 'processing-summary.png'),
-      Buffer.from(processingSummaryScreenshot.replace(/^data:image\/png;base64,/, ''), 'base64')
-    )
+    if (process.platform === 'darwin') {
+      const processingSummaryScreenshot = await control.command(
+        'capture',
+        '[data-testid="processing-summary-header"]'
+      )
+      await writeFile(
+        join(resultDir, 'processing-summary.png'),
+        Buffer.from(processingSummaryScreenshot.replace(/^data:image\/png;base64,/, ''), 'base64')
+      )
+    }
     await control.command('waitFor', '[data-testid="environment-changes-button"]', {
       text: '+1',
       timeoutMs: UI_TIMEOUT_MS,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -288,6 +288,18 @@ function functionCall(callId, name, argumentsValue) {
   }
 }
 
+function customToolCall(callId, name, input) {
+  return {
+    type: 'response.output_item.done',
+    item: {
+      type: 'custom_tool_call',
+      call_id: callId,
+      name,
+      input,
+    },
+  }
+}
+
 function assistantMessage(text) {
   return {
     type: 'response.output_item.done',
@@ -349,7 +361,7 @@ function selectTool(request, name, argumentsValue) {
 }
 
 function selectShellTool(request, workspacePath) {
-  const command = `printf '%s\\n' '${ARTIFACT_CONTENT}' > ${ARTIFACT_NAME}`
+  const command = 'pwd'
   const tools = Array.isArray(request.tools) ? request.tools : []
   if (tools.some(tool => tool?.name === 'exec_command')) {
     return selectTool(request, 'exec_command', {
@@ -366,6 +378,23 @@ function selectShellTool(request, workspacePath) {
     })
   }
   throw new Error('Real Codex did not advertise a supported shell tool')
+}
+
+function selectApplyPatchTool(request) {
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  assert.ok(
+    tools.some(tool => tool?.name === 'apply_patch'),
+    `Real Codex did not advertise apply_patch: ${tools
+      .map(tool => tool?.name)
+      .filter(Boolean)
+      .join(', ')}`
+  )
+  return [
+    '*** Begin Patch',
+    `*** Add File: ${ARTIFACT_NAME}`,
+    `+${ARTIFACT_CONTENT}`,
+    '*** End Patch',
+  ].join('\n')
 }
 
 class DesktopE2EServer {
@@ -674,11 +703,13 @@ class DesktopE2EServer {
         'The real Codex request did not contain the UI task prompt'
       )
       const tool = selectShellTool(body, this.workspacePath)
+      const patch = selectApplyPatchTool(body)
       this.modelStage = 'awaiting_tool_output'
       await this.initialToolRelease
       this.writeSse(response, [
         responseCreated(responseId),
         functionCall('wework-e2e-tool-call', tool.name, tool.arguments),
+        customToolCall('wework-e2e-apply-patch', 'apply_patch', patch),
         responseCompleted(responseId),
       ])
       return
@@ -1124,6 +1155,30 @@ async function main() {
       text: COMPLETION_TEXT,
       timeoutMs: UI_TIMEOUT_MS,
     })
+    await control.command('click', '[data-testid="final-processing-toggle"]')
+    await control.command('waitFor', '[data-testid="processing-summary-toggle"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    const processingSummaryText = await control.command(
+      'getText',
+      '[data-testid="processing-summary-toggle"]'
+    )
+    assert.match(
+      processingSummaryText,
+      /调用 1 个工具|Called 1 tools/,
+      'The processing summary did not count edited files separately from tool calls'
+    )
+    await control.command('waitFor', '[aria-label="编辑 1"], [aria-label="Edits 1"]', {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    const processingSummaryScreenshot = await control.command(
+      'capture',
+      '[data-testid="processing-summary-header"]'
+    )
+    await writeFile(
+      join(resultDir, 'processing-summary.png'),
+      Buffer.from(processingSummaryScreenshot.replace(/^data:image\/png;base64,/, ''), 'base64')
+    )
     await control.command('waitFor', '[data-testid="environment-changes-button"]', {
       text: '+1',
       timeoutMs: UI_TIMEOUT_MS,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1165,7 +1165,7 @@ async function main() {
     )
     assert.match(
       processingSummaryText,
-      /调用 1 个工具，编辑 1 个文件|Called 1 tools, edited 1 files/,
+      /调用 1 个工具，编辑 1 个文件|Called 1 tool, edited 1 file/,
       'The processing summary did not report tool calls and edited files separately'
     )
     await control.command('waitFor', '[aria-label="编辑 1"], [aria-label="Edits 1"]', {

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1165,8 +1165,8 @@ async function main() {
     )
     assert.match(
       processingSummaryText,
-      /调用 1 个工具|Called 1 tools/,
-      'The processing summary did not count edited files separately from tool calls'
+      /调用 1 个工具，编辑 1 个文件|Called 1 tools, edited 1 files/,
+      'The processing summary did not report tool calls and edited files separately'
     )
     await control.command('waitFor', '[aria-label="编辑 1"], [aria-label="Edits 1"]', {
       timeoutMs: UI_TIMEOUT_MS,

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -476,7 +476,9 @@ describe('ToolBlocksDisplay', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /调用 1 个工具 已处理/ })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /调用 1 个工具，编辑 3 个文件 已处理/ })
+    ).toBeInTheDocument()
     expect(screen.getByLabelText('命令 1')).toBeInTheDocument()
     expect(screen.getByLabelText('编辑 3')).toBeInTheDocument()
   })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1,4 +1,4 @@
-import '@/i18n'
+import i18n from '@/i18n'
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -481,6 +481,24 @@ describe('ToolBlocksDisplay', () => {
     ).toBeInTheDocument()
     expect(screen.getByLabelText('命令 1')).toBeInTheDocument()
     expect(screen.getByLabelText('编辑 3')).toBeInTheDocument()
+  })
+
+  test('pluralizes English tool and edited file counts independently', () => {
+    const toolSummary = i18n.t('tool_activity.summary', {
+      ns: 'chat',
+      lng: 'en',
+      count: 1,
+    })
+
+    expect(toolSummary).toBe('Called 1 tool')
+    expect(
+      i18n.t('tool_activity.mixed_summary', {
+        ns: 'chat',
+        lng: 'en',
+        count: 1,
+        toolSummary,
+      })
+    ).toBe('Called 1 tool, edited 1 file')
   })
 
   test('merges consecutive file change blocks into one activity row', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -453,7 +453,7 @@ describe('ToolBlocksDisplay', () => {
     ).toBeInTheDocument()
   })
 
-  test('counts every edited file as one tool activity', () => {
+  test('counts edited files separately from tool calls', () => {
     const multiFileChangesBlock: ProcessingBlock = {
       ...completedFileChangesBlock,
       fileChanges: {
@@ -476,7 +476,7 @@ describe('ToolBlocksDisplay', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /调用 4 个工具 已处理/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /调用 1 个工具 已处理/ })).toBeInTheDocument()
     expect(screen.getByLabelText('命令 1')).toBeInTheDocument()
     expect(screen.getByLabelText('编辑 3')).toBeInTheDocument()
   })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -244,8 +244,8 @@ export function ToolBlocksDisplay({
       ? t('tool_activity.edit_summary', { count: activityStats.edit })
       : activityStats.edit > 0
         ? t('tool_activity.mixed_summary', {
-            toolCount: toolCallCount,
-            fileCount: activityStats.edit,
+            count: activityStats.edit,
+            toolSummary: t('tool_activity.summary', { count: toolCallCount }),
           })
         : t('tool_activity.summary', { count: toolCallCount })
     : t('thinking.completed')

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -238,10 +238,16 @@ export function ToolBlocksDisplay({
     activityStats.file === 0 &&
     activityStats.search === 0 &&
     activityStats.other === 0
+  const toolCallCount = countProcessingToolCalls(activityStats)
   const summaryTitle = hasToolActivity
     ? hasOnlyEditActivity
       ? t('tool_activity.edit_summary', { count: activityStats.edit })
-      : t('tool_activity.summary', { count: countProcessingToolCalls(activityStats) })
+      : activityStats.edit > 0
+        ? t('tool_activity.mixed_summary', {
+            toolCount: toolCallCount,
+            fileCount: activityStats.edit,
+          })
+        : t('tool_activity.summary', { count: toolCallCount })
     : t('thinking.completed')
   const summaryDuration = hasToolActivity
     ? getWholeSecondsDurationText(blocks, turnStartedAt, now, completedAt, isRunning)

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -241,7 +241,7 @@ export function ToolBlocksDisplay({
   const summaryTitle = hasToolActivity
     ? hasOnlyEditActivity
       ? t('tool_activity.edit_summary', { count: activityStats.edit })
-      : t('tool_activity.summary', { count: countProcessingActivities(rows) })
+      : t('tool_activity.summary', { count: countProcessingToolCalls(activityStats) })
     : t('thinking.completed')
   const summaryDuration = hasToolActivity
     ? getWholeSecondsDurationText(blocks, turnStartedAt, now, completedAt, isRunning)
@@ -629,9 +629,8 @@ function countProcessingActivityKinds(rows: ProcessingDisplayRow[]) {
   return stats
 }
 
-function countProcessingActivities(rows: ProcessingDisplayRow[]): number {
-  const stats = countProcessingActivityKinds(rows)
-  return stats.command + stats.file + stats.search + stats.edit + stats.other
+function countProcessingToolCalls(stats: ReturnType<typeof countProcessingActivityKinds>): number {
+  return stats.command + stats.file + stats.search + stats.other
 }
 
 function CollapsibleProcessingContent({

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -17,6 +17,7 @@
   },
   "tool_activity": {
     "summary": "Called {{count}} tools",
+    "mixed_summary": "Called {{toolCount}} tools, edited {{fileCount}} files",
     "edit_summary": "Edited {{count}} files",
     "command": "Commands",
     "file": "Reads",

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -16,9 +16,12 @@
     "running": "Working"
   },
   "tool_activity": {
-    "summary": "Called {{count}} tools",
-    "mixed_summary": "Called {{toolCount}} tools, edited {{fileCount}} files",
-    "edit_summary": "Edited {{count}} files",
+    "summary_one": "Called {{count}} tool",
+    "summary_other": "Called {{count}} tools",
+    "mixed_summary_one": "{{toolSummary}}, edited {{count}} file",
+    "mixed_summary_other": "{{toolSummary}}, edited {{count}} files",
+    "edit_summary_one": "Edited {{count}} file",
+    "edit_summary_other": "Edited {{count}} files",
     "command": "Commands",
     "file": "Reads",
     "search": "Searches",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -17,6 +17,7 @@
   },
   "tool_activity": {
     "summary": "调用 {{count}} 个工具",
+    "mixed_summary": "调用 {{toolCount}} 个工具，编辑 {{fileCount}} 个文件",
     "edit_summary": "编辑 {{count}} 个文件",
     "command": "命令",
     "file": "读取",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -16,9 +16,9 @@
     "running": "正在处理"
   },
   "tool_activity": {
-    "summary": "调用 {{count}} 个工具",
-    "mixed_summary": "调用 {{toolCount}} 个工具，编辑 {{fileCount}} 个文件",
-    "edit_summary": "编辑 {{count}} 个文件",
+    "summary_other": "调用 {{count}} 个工具",
+    "mixed_summary_other": "{{toolSummary}}，编辑 {{count}} 个文件",
+    "edit_summary_other": "编辑 {{count}} 个文件",
     "command": "命令",
     "file": "读取",
     "search": "搜索",


### PR DESCRIPTION
## What changed

- exclude edited files from the processing summary tool-call total
- show both counts explicitly, for example “调用 1 个工具，编辑 1 个文件”
- pluralize English tool and file counts independently
- preserve dedicated activity icons and edit-only summaries
- add unit and real-Tauri desktop regression coverage

## Root cause

Edited files were included in the tool-call total. After separating the counts, the main summary also needed to state the edited-file count explicitly.

## Validation

- focused Wework tests passed: 158 tests
- pre-push ESLint, TypeScript, and full Wework unit suite passed
- real macOS Tauri task-flow E2E passed and produced `processing-summary.png` showing “调用 1 个工具，编辑 1 个文件”
- addressed CodeRabbit feedback for English singular/plural grammar
- GitHub CI is rerunning against commit `928cd806e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processing summaries now differentiate tool invocations vs edited files, including mixed scenarios, with accurate English pluralization.

* **Bug Fixes**
  * Corrected processing-summary counting so edited files no longer inflate tool-call totals.

* **Tests**
  * Updated desktop end-to-end scenarios for patch-based tool output and enhanced processing UI validations (including a saved macOS screenshot).
  * Expanded ToolBlocksDisplay tests to verify split counts and aria-labels for both English and mixed-summary strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->