### PR TITLE
fix(wework): fully release abandoned terminal selection

### DIFF
--- a/wework/src/components/layout/workspace-panels/xtermSelectionGuard.test.ts
+++ b/wework/src/components/layout/workspace-panels/xtermSelectionGuard.test.ts
@@ -60,20 +60,44 @@ describe('installXtermSelectionGuard', () => {
     guard.dispose()
   })
 
-  test('clears abandoned drag selection when the window loses focus', () => {
+  test('releases and clears abandoned drag selection when the window loses focus', () => {
     const container = document.createElement('div')
     const clearSelection = vi.fn()
+    const mouseUpListener = vi.fn()
     const guard = installXtermSelectionGuard({
       container,
       terminal: { clearSelection },
     })
+    container.addEventListener('mouseup', mouseUpListener)
 
     dispatchMouseEvent(container, 'mousedown', { button: 0, buttons: 1 })
     window.dispatchEvent(new Event('blur'))
 
+    expect(mouseUpListener).toHaveBeenCalledTimes(1)
     expect(clearSelection).toHaveBeenCalledTimes(1)
 
     guard.dispose()
+  })
+
+  test('releases and clears abandoned drag selection when the document becomes hidden', () => {
+    const container = document.createElement('div')
+    const clearSelection = vi.fn()
+    const mouseUpListener = vi.fn()
+    const visibilityState = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    const guard = installXtermSelectionGuard({
+      container,
+      terminal: { clearSelection },
+    })
+    container.addEventListener('mouseup', mouseUpListener)
+
+    dispatchMouseEvent(container, 'mousedown', { button: 0, buttons: 1 })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(mouseUpListener).toHaveBeenCalledTimes(1)
+    expect(clearSelection).toHaveBeenCalledTimes(1)
+
+    guard.dispose()
+    visibilityState.mockRestore()
   })
 
   test('detaches listeners on dispose', () => {

--- a/wework/src/components/layout/workspace-panels/xtermSelectionGuard.ts
+++ b/wework/src/components/layout/workspace-panels/xtermSelectionGuard.ts
@@ -46,23 +46,26 @@ export function installXtermSelectionGuard({
     dispatchTerminalMouseUp(event)
   }
 
-  const clearAbandonedSelection = () => {
+  const releaseAbandonedSelection = () => {
     if (!mouseDownInTerminal) return
 
     endDrag()
+    // clearSelection only removes the highlight. xterm's drag listeners and
+    // auto-scroll loop remain active until they receive a mouseup event.
+    dispatchTerminalMouseUp(new MouseEvent('mouseup'))
     terminal.clearSelection()
   }
 
   const handleVisibilityChange = () => {
     if (document.visibilityState === 'hidden') {
-      clearAbandonedSelection()
+      releaseAbandonedSelection()
     }
   }
 
   container.addEventListener('mousedown', handleMouseDown, true)
   window.addEventListener('mouseup', endDrag, true)
   window.addEventListener('mousemove', handleMouseMove, true)
-  window.addEventListener('blur', clearAbandonedSelection)
+  window.addEventListener('blur', releaseAbandonedSelection)
   document.addEventListener('visibilitychange', handleVisibilityChange)
 
   return {
@@ -70,7 +73,7 @@ export function installXtermSelectionGuard({
       container.removeEventListener('mousedown', handleMouseDown, true)
       window.removeEventListener('mouseup', endDrag, true)
       window.removeEventListener('mousemove', handleMouseMove, true)
-      window.removeEventListener('blur', clearAbandonedSelection)
+      window.removeEventListener('blur', releaseAbandonedSelection)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     },
   }


### PR DESCRIPTION
## What changed

- release xterm's active drag lifecycle before clearing an abandoned selection
- cover window blur and document visibility changes with regression tests

## Root cause

The existing guard called `clearSelection()` when Wework lost focus. That removed the visible highlight, but xterm's document-level drag listeners and auto-scroll loop remained active until a `mouseup` event arrived. When WebKit lost that event outside the WebView, selection could continue expanding and make the terminal appear frozen.

## Impact

Terminal drag selection now ends cleanly when Wework loses focus or becomes hidden. Normal selection behavior is unchanged.

## Validation

- isolated real-Tauri flow: opened a local terminal, started drag selection, simulated window blur, confirmed selection release and terminal responsiveness
- `pnpm --filter wework exec vitest run src/components/layout/workspace-panels/xtermSelectionGuard.test.ts`
- `pnpm --filter wework exec prettier --check src/components/layout/workspace-panels/xtermSelectionGuard.ts src/components/layout/workspace-panels/xtermSelectionGuard.test.ts`
- `pnpm --filter wework exec eslint src/components/layout/workspace-panels/xtermSelectionGuard.ts src/components/layout/workspace-panels/xtermSelectionGuard.test.ts`
- pre-push ESLint, TypeScript and Wework unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text selection handling when the browser window loses focus or becomes hidden.
  * Abandoned drag selections are now properly released and cleared, preventing selections from remaining stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->