### PR TITLE
fix(wework): show actual tool durations

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -4018,7 +4018,7 @@ describe('MessageList', () => {
     expect(processText.compareDocumentPosition(runningTool)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
-  test('ends the preceding live tool preview when process text starts', () => {
+  test('keeps thinking in the preceding tool preview when process text starts', () => {
     const completedBlock: ProcessingBlock = {
       id: 'call-1',
       subtaskId: 1,
@@ -4052,7 +4052,8 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-block-thinking')).toHaveTextContent('正在思考')
     expect(screen.getByTestId('process-text-block')).toHaveTextContent('负载均值明显偏高。')
   })
 

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1679,6 +1679,11 @@ function AssistantMessage({
                 ? 'intermediate'
                 : getProcessingPhase(processingSegments, index, hasVisibleContent)
           }
+          showInterToolThinking={
+            isStreaming &&
+            segment.kind === 'tool' &&
+            !processingSegments.slice(index + 1).some(candidate => candidate.kind === 'tool')
+          }
           showSummary={segment.kind === 'tool'}
           stateKey={`${processingStateKey}:${index}`}
           onOpenWorkspaceFile={onOpenWorkspaceFile}

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -819,7 +819,7 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('1 分 0 秒')).toBeInTheDocument()
   })
 
-  test('keeps ticking while streaming even when all tool blocks are done', () => {
+  test('keeps the segment ticking but shows thinking after all tool blocks are done', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-05T00:00:00.000Z'))
 
@@ -838,10 +838,11 @@ describe('ToolBlocksDisplay', () => {
     })
 
     expect(screen.getByText('5 秒')).toBeInTheDocument()
-    expect(screen.getByText('5.0s')).toBeInTheDocument()
+    expect(screen.queryByText('5.0s')).not.toBeInTheDocument()
+    expect(screen.getByTestId('tool-block-thinking')).toHaveTextContent('正在思考')
   })
 
-  test('keeps the last row ticking after that tool finishes while the segment stays live', () => {
+  test('stops the tool duration and shows thinking while waiting for the next tool', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-05T00:00:00.000Z'))
 
@@ -865,7 +866,9 @@ describe('ToolBlocksDisplay', () => {
     act(() => vi.advanceTimersByTime(2300))
 
     expect(screen.getByText('3 秒')).toBeInTheDocument()
-    expect(screen.getByText('3.5s')).toBeInTheDocument()
+    expect(screen.getByText('1.2s')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-block-thinking')).toHaveTextContent('正在思考')
+    expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
   })
 
   test('stops ticking once a streaming tool segment becomes intermediate', () => {
@@ -893,6 +896,20 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.queryByText('7 秒')).not.toBeInTheDocument()
   })
 
+  test('keeps thinking inside the latest tool block when a narrative segment follows', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[completedCommandBlock]}
+        isStreaming={true}
+        processingPhase="intermediate"
+        showInterToolThinking
+      />
+    )
+
+    expect(screen.getByTestId('processing-live-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-block-thinking')).toHaveTextContent('正在思考')
+  })
+
   test('uses the sum of concrete tool durations for the segment duration', () => {
     const firstBlock: ProcessingBlock = {
       ...completedCommandBlock,
@@ -918,6 +935,27 @@ describe('ToolBlocksDisplay', () => {
     fireEvent.click(screen.getByTestId('processing-summary-toggle'))
     expect(screen.getByText('1.2s')).toBeInTheDocument()
     expect(screen.getByText('2.3s')).toBeInTheDocument()
+  })
+
+  test('does not include the gap before the next tool in the previous tool duration', () => {
+    const firstBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      completedAt: completedCommandBlock.createdAt + 1200,
+    }
+    const secondBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      id: 'call-2',
+      createdAt: completedCommandBlock.createdAt + 5000,
+      completedAt: completedCommandBlock.createdAt + 7300,
+      toolInput: { command: 'git status' },
+    }
+
+    render(<ToolBlocksDisplay blocks={[firstBlock, secondBlock]} isStreaming={false} />)
+    fireEvent.click(screen.getByTestId('processing-summary-toggle'))
+
+    expect(screen.getByText('1.2s')).toBeInTheDocument()
+    expect(screen.getByText('2.3s')).toBeInTheDocument()
+    expect(screen.queryByText('5.0s')).not.toBeInTheDocument()
   })
 
   test('keeps a compact live preview with full processing details collapsed', async () => {
@@ -1052,7 +1090,7 @@ describe('ToolBlocksDisplay', () => {
     )
   })
 
-  test('shimmers only the latest completed row in a live tool segment', () => {
+  test('shimmers the thinking row instead of a completed tool in a live segment', () => {
     const latestBlock: ProcessingBlock = {
       ...completedCommandBlock,
       id: 'call-2',
@@ -1063,7 +1101,8 @@ describe('ToolBlocksDisplay', () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock, latestBlock]} isStreaming={true} />)
 
     expect(screen.getByText('运行 pwd')).not.toHaveClass('tool-activity-shimmer')
-    expect(screen.getByText('运行 git status --short')).toHaveClass('tool-activity-shimmer')
+    expect(screen.getByText('运行 git status --short')).not.toHaveClass('tool-activity-shimmer')
+    expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
   })
 
   test('keeps all live rows in a scroll area sized for three rows', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -64,6 +64,7 @@ interface ToolBlocksDisplayProps {
   startedAt?: number
   forceExpanded?: boolean
   processingPhase?: 'live' | 'intermediate' | 'final'
+  showInterToolThinking?: boolean
   showSummary?: boolean
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
@@ -82,6 +83,7 @@ export function ToolBlocksDisplay({
   startedAt,
   forceExpanded = false,
   processingPhase = 'live',
+  showInterToolThinking = false,
   showSummary = true,
   stateKey,
   onOpenWorkspaceFile,
@@ -95,7 +97,8 @@ export function ToolBlocksDisplay({
 }: ToolBlocksDisplayProps) {
   const { t } = useTranslation('chat')
   const hasRunningBlock = blocks.some(b => b.status !== 'done' && b.status !== 'error')
-  const isRunning = (isStreaming && processingPhase === 'live') || hasRunningBlock
+  const isRunning =
+    (isStreaming && (processingPhase === 'live' || showInterToolThinking)) || hasRunningBlock
   const [userExpanded, setUserExpanded] = usePersistentProcessingExpansion(
     stateKey ? `${stateKey}:processing` : undefined
   )
@@ -198,7 +201,10 @@ export function ToolBlocksDisplay({
   const canToggleSummary =
     showSummary && !isLockedOpen && !hasRunningToolActivity && rows.length > 0
   const hasLivePreview =
-    isRunning && (!hasClosedToolSegment || hasRunningToolActivity) && !expanded && rows.length > 0
+    isRunning &&
+    (!hasClosedToolSegment || hasRunningToolActivity || showInterToolThinking) &&
+    !expanded &&
+    rows.length > 0
   const previewRows = useMemo(
     () =>
       !expanded &&
@@ -335,11 +341,12 @@ export function ToolBlocksDisplay({
       {previewRows.length > 0 ? (
         <LiveProcessingPreview
           rows={previewRows}
-          highlightLatest={processingPhase === 'live'}
-          startedAt={turnStartedAt}
-          completedAt={completedAt}
-          now={now}
-          running={isRunning}
+          showThinking={
+            isStreaming &&
+            hasToolActivity &&
+            !hasRunningToolActivity &&
+            (processingPhase === 'live' || showInterToolThinking)
+          }
           onOpenWorkspaceFile={onOpenWorkspaceFile}
         />
       ) : null}
@@ -467,21 +474,14 @@ function ToolActivityStats({
 
 function LiveProcessingPreview({
   rows,
-  highlightLatest,
-  startedAt,
-  completedAt,
-  now,
-  running,
+  showThinking,
   onOpenWorkspaceFile,
 }: {
   rows: ProcessingDisplayRow[]
-  highlightLatest: boolean
-  startedAt: number
-  completedAt: number | null
-  now: number
-  running: boolean
+  showThinking: boolean
   onOpenWorkspaceFile?: (path: string) => void
 }) {
+  const { t } = useTranslation('chat')
   const scrollRef = useRef<HTMLDivElement>(null)
   const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
   const hasExpandedDetail = rows.some(row => expandedRowIds.has(row.id))
@@ -523,18 +523,16 @@ function LiveProcessingPreview({
           <LiveProcessingPreviewRow
             key={row.id}
             row={row}
-            shimmer={highlightLatest && index === rows.length - 1}
-            durationStartedAt={index === 0 ? startedAt : getProcessingRowStartedAt(row)}
-            durationEndAt={
-              getProcessingRowStartedAt(rows[index + 1]) ??
-              (running ? now : row.type === 'block' ? row.block.completedAt : undefined) ??
-              completedAt ??
-              getProcessingRowStartedAt(row)
-            }
+            shimmer={isProcessingRowRunning(row) && index === rows.length - 1}
             onOpenWorkspaceFile={onOpenWorkspaceFile}
             onExpandedChange={updateExpandedRow}
           />
         ))}
+        {showThinking ? (
+          <div className="flex min-h-8 items-center py-1 text-sm" data-testid="tool-block-thinking">
+            <span className="waiting-thinking-text">{t('thinking.running')}</span>
+          </div>
+        ) : null}
       </div>
     </div>
   )
@@ -601,9 +599,11 @@ function LiveProcessingPreviewRow({
   )
 }
 
-function getProcessingRowStartedAt(row: ProcessingDisplayRow | undefined): number | undefined {
-  if (!row) return undefined
-  return row.type === 'activity_group' ? row.blocks[0]?.createdAt : row.block.createdAt
+function isProcessingRowRunning(row: ProcessingDisplayRow): boolean {
+  if (row.type === 'activity_group') {
+    return row.blocks.some(block => block.status !== 'done' && block.status !== 'error')
+  }
+  return row.block.status !== 'done' && row.block.status !== 'error'
 }
 
 function countProcessingActivityKinds(rows: ProcessingDisplayRow[]) {


### PR DESCRIPTION
## What changed

- show each tool row's own `createdAt` → `completedAt` duration instead of extending it to the next tool
- render a shimmering “正在思考” / “Thinking” row inside the latest tool block while the model is between tool calls
- keep the thinking row in the tool block even when streaming reasoning text creates a separate narrative segment
- add regression coverage at both the tool block and message timeline levels

## Root cause

The live preview inferred a tool's end from the next processing row (or the still-running turn clock). That mixed model reasoning time into the preceding tool duration. Once reasoning text created another processing segment, the generic thinking state also moved outside the tool block.

## Impact

Tool durations now represent actual execution time. Between completed and upcoming tool calls, users see an explicit shimmering thinking state in the tool block instead of a completed tool timer that continues to grow.

## Validation

- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- 176 focused MessageList / ToolBlocksDisplay / ToolBlockItem tests
- full pre-push Wework ESLint, TypeScript, and 1817 unit tests
- isolated real-Tauri flow with two independent 10-second terminal calls; verified running, between-tool thinking, and final duration states by screenshot
