### PR TITLE
fix(wework): rename interrupt send action

### DIFF
--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -464,7 +464,7 @@
     "send_after_turn": "当前回复结束后发送",
     "guide_current_turn": "引导当前回复",
     "interrupt_and_send": "打断并立即发送",
-    "interrupt_and_send_short": "打断并发送",
+    "interrupt_and_send_short": "立即发送",
     "choose_send_mode": "选择发送方式",
     "interrupting_and_sending": "正在打断并发送",
     "sending_message": "正在发送...",


### PR DESCRIPTION
## What changed

- Rename the Chinese short action label from `打断并发送` to `立即发送`.
- Keep the full action description and in-progress status unchanged so the behavior remains explicit in menus and accessibility labels.

## Why

The queued-message action should use the shorter, result-oriented label `立即发送`.

## Impact

This is a Chinese localization-only change. Runtime behavior and the English locale are unchanged.

## Validation

- `pnpm --filter wework exec prettier --check src/i18n/locales/zh-CN/common.json`
- Wework unit suite: 180 files / 1814 tests passed
- Pre-commit: Prettier, ESLint, typography checks passed
- Pre-push: ESLint, TypeScript, unit tests passed
- Isolated real-Tauri verification covered project creation, task submission, and an active long-running response; screenshots were reviewed with no layout or visual regressions found

The isolated `ai:verify` controller repeatedly timed out after a missing-element wait and blocked subsequent WebView commands, so the queued-message `立即发送` state could not be captured reliably. The localization value itself was asserted directly from `zh-CN/common.json`.
