### PR TITLE
fix(wework): force app sidecar onto stdio

### DIFF
--- a/executor/src/app/mod.rs
+++ b/executor/src/app/mod.rs
@@ -128,6 +128,9 @@ pub async fn run(args: CliArgs) -> Result<(), AppError> {
         return run_upgrade(config.update, args.yes).await;
     }
 
+    if app_ipc_enabled() {
+        reserve_executor_stdout_for_protocol();
+    }
     init_executor_logging(&DeviceConfig::default());
     let config = load_device_config(args.config_path.as_deref())?;
     init_executor_logging(&config);
@@ -218,9 +221,7 @@ fn startup_plan_for_config(
     }
 
     let backend_enabled = !config.connection.backend_url.trim().is_empty();
-    let app_ipc_enabled = env::var("WEGENT_APP_IPC_DEVICE_ID")
-        .ok()
-        .is_some_and(|value| !value.trim().is_empty());
+    let app_ipc_enabled = app_ipc_enabled();
     Ok(StartupPlan {
         http_server: Some(HttpServerPlan {
             host: "127.0.0.1".to_owned(),
@@ -236,4 +237,10 @@ fn startup_plan_for_config(
             },
         }),
     })
+}
+
+fn app_ipc_enabled() -> bool {
+    env::var("WEGENT_APP_IPC_DEVICE_ID")
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty())
 }

--- a/executor/src/local/session_gateway.rs
+++ b/executor/src/local/session_gateway.rs
@@ -42,6 +42,7 @@ use crate::{
 
 const DEFAULT_GATEWAY_HOST: &str = "0.0.0.0";
 const DEFAULT_GATEWAY_PORT: u16 = 17888;
+const PUBLIC_BASE_URL_ENV: &str = "DEVICE_PUBLIC_BASE_URL";
 const MAX_PROXY_BODY_BYTES: usize = 64 * 1024 * 1024;
 const SESSION_PROBE_QUERY_KEY: &str = "__wegent_probe";
 
@@ -90,12 +91,16 @@ pub async fn start_session_gateway(
                 .and_then(|url| url.port())
         })
         .unwrap_or(DEFAULT_GATEWAY_PORT);
+    let uses_dynamic_public_url = port == 0 && !has_explicit_public_base_url();
     let listener = TcpListener::bind((host.as_str(), port))
         .await
         .map_err(|error| format!("Failed to bind session gateway on {host}:{port}: {error}"))?;
     let local_addr = listener
         .local_addr()
         .map_err(|error| format!("Failed to read session gateway address: {error}"))?;
+    if uses_dynamic_public_url {
+        update_dynamic_public_base_url(&session_handler, local_addr.port())?;
+    }
     let client = reqwest::Client::builder()
         .redirect(Policy::none())
         .build()
@@ -121,6 +126,28 @@ pub async fn start_session_gateway(
         &[("address", local_addr.to_string())],
     ));
     Ok(Some(SessionGatewayHandle { local_addr, task }))
+}
+
+fn has_explicit_public_base_url() -> bool {
+    env::var(PUBLIC_BASE_URL_ENV)
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn update_dynamic_public_base_url(
+    session_handler: &Arc<Mutex<LocalSessionHandler>>,
+    port: u16,
+) -> Result<(), String> {
+    let mut handler = session_handler
+        .lock()
+        .map_err(|_| "Session handler lock is poisoned".to_owned())?;
+    let mut public_url = url::Url::parse(&handler.public_base_url)
+        .map_err(|error| format!("Invalid session gateway public base URL: {error}"))?;
+    public_url
+        .set_port(Some(port))
+        .map_err(|_| "Session gateway public base URL cannot contain a port".to_owned())?;
+    handler.public_base_url = public_url.as_str().trim_end_matches('/').to_owned();
+    Ok(())
 }
 
 async fn handle_gateway_request(

--- a/executor/tests/cli_contract.rs
+++ b/executor/tests/cli_contract.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    process::Command,
+    io::{BufRead, BufReader, Read},
+    process::{Command, Stdio},
     sync::{Mutex, MutexGuard, OnceLock},
 };
 use wegent_executor::app::cli::{CliArgs, CliError};
@@ -82,4 +83,53 @@ fn binary_version_exits_without_runtime_startup() {
     assert!(output.status.success());
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "7.8.9");
     assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn app_sidecar_reserves_stdout_for_jsonl_before_backend_startup() {
+    let executor_home =
+        std::env::temp_dir().join(format!("wegent-executor-cli-stdio-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&executor_home);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wegent-executor"))
+        .env_remove("EXECUTOR_MODE")
+        .env("WEGENT_EXECUTOR_HOME", &executor_home)
+        .env("WEGENT_APP_IPC_DEVICE_ID", "app-device-stdio")
+        .env("DEVICE_ID", "app-device-stdio")
+        .env("WEGENT_BACKEND_URL", "http://127.0.0.1:9")
+        .env("WEGENT_AUTH_TOKEN", "test-token")
+        .env("DEVICE_SESSION_GATEWAY_HOST", "127.0.0.1")
+        .env("DEVICE_SESSION_GATEWAY_PORT", "0")
+        .env("DEVICE_PUBLIC_BASE_URL", "")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start app stdio sidecar");
+    let mut stdout = BufReader::new(child.stdout.take().expect("capture app stdio stdout"));
+    let mut ready_line = String::new();
+    stdout
+        .read_line(&mut ready_line)
+        .expect("read app stdio ready event");
+
+    let ready: serde_json::Value = serde_json::from_str(&ready_line)
+        .expect("stdout must contain only JSONL protocol messages");
+    assert_eq!(ready["event"], "executor.ready");
+    assert_eq!(ready["payload"]["device_id"], "app-device-stdio");
+
+    drop(child.stdin.take());
+    let status = child.wait().expect("wait for app stdio sidecar");
+    assert!(status.success());
+    let mut remaining_stdout = String::new();
+    stdout
+        .read_to_string(&mut remaining_stdout)
+        .expect("read remaining app stdio output");
+    for line in remaining_stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+    {
+        serde_json::from_str::<serde_json::Value>(line)
+            .expect("all app sidecar stdout lines must be JSONL protocol messages");
+    }
+
+    let _ = std::fs::remove_dir_all(executor_home);
 }

--- a/executor/tests/local_session_handler_contract.rs
+++ b/executor/tests/local_session_handler_contract.rs
@@ -187,6 +187,7 @@ async fn running_session_gateway_proxies_http_and_websocket_to_code_server() {
     let _lock = env_lock();
     let _gateway_host = EnvGuard::set("DEVICE_SESSION_GATEWAY_HOST", "127.0.0.1");
     let _gateway_port = EnvGuard::set("DEVICE_SESSION_GATEWAY_PORT", "0");
+    let _public_base_url = EnvGuard::set("DEVICE_PUBLIC_BASE_URL", "");
     let _password = EnvGuard::set("CODE_SERVER_PASSWORD", "configured-secret");
     let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let upstream_addr = upstream_listener.local_addr().unwrap();
@@ -220,10 +221,15 @@ async fn running_session_gateway_proxies_http_and_websocket_to_code_server() {
             9999999999,
         ),
     );
-    let gateway = start_session_gateway(Arc::new(Mutex::new(handler)))
+    let handler = Arc::new(Mutex::new(handler));
+    let gateway = start_session_gateway(Arc::clone(&handler))
         .await
         .unwrap()
         .unwrap();
+    assert_eq!(
+        handler.lock().unwrap().public_base_url,
+        format!("http://127.0.0.1:{}", gateway.local_addr.port())
+    );
     let http_base = format!("http://{}", gateway.local_addr);
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -315,6 +321,7 @@ async fn running_session_gateway_supports_code_server_without_auth_cookie() {
     let _lock = env_lock();
     let _gateway_host = EnvGuard::set("DEVICE_SESSION_GATEWAY_HOST", "127.0.0.1");
     let _gateway_port = EnvGuard::set("DEVICE_SESSION_GATEWAY_PORT", "0");
+    let _public_base_url = EnvGuard::set("DEVICE_PUBLIC_BASE_URL", "");
     let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let upstream_addr = upstream_listener.local_addr().unwrap();
     let upstream = Router::new()
@@ -361,6 +368,38 @@ async fn running_session_gateway_supports_code_server_without_auth_cookie() {
 
     drop(gateway);
     upstream_task.abort();
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)] // Serializes process-wide gateway environment overrides.
+async fn dynamic_session_gateway_preserves_explicit_public_base_url() {
+    let _lock = env_lock();
+    let _gateway_host = EnvGuard::set("DEVICE_SESSION_GATEWAY_HOST", "127.0.0.1");
+    let _gateway_port = EnvGuard::set("DEVICE_SESSION_GATEWAY_PORT", "0");
+    let _public_base_url = EnvGuard::set(
+        "DEVICE_PUBLIC_BASE_URL",
+        "https://gateway.example.com/sessions",
+    );
+    let handler = Arc::new(Mutex::new(LocalSessionHandler::new(
+        "https://gateway.example.com/sessions",
+        true,
+        18080,
+        temp_root("gateway-explicit-public-url"),
+        Arc::new(RecordingPtyManager::new(Arc::new(Mutex::new(
+            RecordingTerminal::default(),
+        )))),
+    )));
+
+    let gateway = start_session_gateway(Arc::clone(&handler))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        handler.lock().unwrap().public_base_url,
+        "https://gateway.example.com/sessions"
+    );
+    drop(gateway);
 }
 
 #[test]

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -33,6 +33,10 @@ const FILE_EDIT_LOG_ENDPOINT_ENV: &str = "WEWORK_FILE_EDIT_LOG_ENDPOINT";
 const CODEX_BINARY_PATH_ENV: &str = "CODEX_BINARY_PATH";
 const CODEX_BIN_ENV: &str = "CODEX_BIN";
 const CODEX_MANAGED_PACKAGE_ROOT_ENV: &str = "CODEX_MANAGED_PACKAGE_ROOT";
+const APP_IPC_DEVICE_ID_ENV: &str = "WEGENT_APP_IPC_DEVICE_ID";
+const SESSION_GATEWAY_HOST_ENV: &str = "DEVICE_SESSION_GATEWAY_HOST";
+const SESSION_GATEWAY_PORT_ENV: &str = "DEVICE_SESSION_GATEWAY_PORT";
+const SESSION_GATEWAY_PUBLIC_BASE_URL_ENV: &str = "DEVICE_PUBLIC_BASE_URL";
 const DEFAULT_FILE_EDIT_LOG_ENDPOINT: &str = "http://127.0.0.1:3456/api/file-edit-log";
 const LOCAL_EXECUTOR_DEVICE_ID: &str = "local-device";
 const LOCAL_EXECUTOR_LOG_FILE_NAME: &str = "executor.log";
@@ -751,10 +755,34 @@ fn local_executor_backend_env(inner: &LocalExecutorInner) -> Vec<(String, String
     let executor_home = path_or_error(local_executor_runtime_home_path());
     let codex_home = path_or_error(wework_codex_home_path(&executor_home));
     let log_dir = path_or_error(local_executor_log_dir_path());
+    let app_ipc_device_id = inner
+        .device_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(LOCAL_EXECUTOR_DEVICE_ID)
+        .to_string();
     let mut envs = vec![
         (LOCAL_EXECUTOR_HOME_ENV.to_string(), executor_home),
         (CODEX_HOME_ENV.to_string(), codex_home),
         (LOCAL_EXECUTOR_LOG_DIR_ENV.to_string(), log_dir),
+        (APP_IPC_DEVICE_ID_ENV.to_string(), app_ipc_device_id.clone()),
+        ("DEVICE_ID".to_string(), app_ipc_device_id.clone()),
+        (
+            "DEVICE_NAME".to_string(),
+            format!("{app_ipc_device_id} app"),
+        ),
+        ("DEVICE_TYPE".to_string(), "app".to_string()),
+        ("BIND_SHELL".to_string(), "claudecode".to_string()),
+        (
+            SESSION_GATEWAY_HOST_ENV.to_string(),
+            "127.0.0.1".to_string(),
+        ),
+        (SESSION_GATEWAY_PORT_ENV.to_string(), "0".to_string()),
+        (
+            SESSION_GATEWAY_PUBLIC_BASE_URL_ENV.to_string(),
+            String::new(),
+        ),
         (
             "PATH".to_string(),
             process_environment::normalized_current_path(),
@@ -770,13 +798,6 @@ fn local_executor_backend_env(inner: &LocalExecutorInner) -> Vec<(String, String
     let Some(connection) = &inner.backend_connection else {
         return envs;
     };
-    let app_ipc_device_id = inner
-        .device_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(LOCAL_EXECUTOR_DEVICE_ID)
-        .to_string();
 
     envs.extend([
         (
@@ -787,14 +808,6 @@ fn local_executor_backend_env(inner: &LocalExecutorInner) -> Vec<(String, String
             "WEGENT_AUTH_TOKEN".to_string(),
             connection.auth_token.clone(),
         ),
-        ("DEVICE_ID".to_string(), app_ipc_device_id.clone()),
-        (
-            "DEVICE_NAME".to_string(),
-            format!("{app_ipc_device_id} app"),
-        ),
-        ("DEVICE_TYPE".to_string(), "app".to_string()),
-        ("BIND_SHELL".to_string(), "claudecode".to_string()),
-        ("WEGENT_APP_IPC_DEVICE_ID".to_string(), app_ipc_device_id),
     ]);
     envs
 }
@@ -2751,6 +2764,38 @@ command = "example"
             assert_eq!(codex_home_env, "/tmp/wework-instance-executor/codex");
             assert_eq!(log_dir_env, "/tmp/wework-instance-executor/logs");
         }
+    }
+
+    #[test]
+    fn sidecar_env_forces_stdio_and_dynamic_gateway_without_backend_connection() {
+        let _guard = env_lock();
+        let envs = local_executor_backend_env(&LocalExecutorInner::default())
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(
+            envs.get(APP_IPC_DEVICE_ID_ENV).map(String::as_str),
+            Some(LOCAL_EXECUTOR_DEVICE_ID)
+        );
+        assert_eq!(
+            envs.get("DEVICE_ID").map(String::as_str),
+            Some(LOCAL_EXECUTOR_DEVICE_ID)
+        );
+        assert_eq!(
+            envs.get(SESSION_GATEWAY_HOST_ENV).map(String::as_str),
+            Some("127.0.0.1")
+        );
+        assert_eq!(
+            envs.get(SESSION_GATEWAY_PORT_ENV).map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            envs.get(SESSION_GATEWAY_PUBLIC_BASE_URL_ENV)
+                .map(String::as_str),
+            Some("")
+        );
+        assert!(!envs.contains_key("WEGENT_BACKEND_URL"));
+        assert!(!envs.contains_key("WEGENT_AUTH_TOKEN"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- always mark Wework-owned executor children as app stdio sidecars, even before cloud connection details are available
- reserve executor stdout for JSONL before config and backend startup can emit diagnostics
- bind the Wework session gateway to an isolated loopback ephemeral port and publish the actual bound port
- preserve standalone Local Executor Socket.IO behavior and explicit remote gateway URLs

## Root cause

After #2056, `WEGENT_APP_IPC_DEVICE_ID` was only added when Wework already had a backend connection. During release startup without that connection, an existing backend config could select the standalone remote transport. Timestamped diagnostic lines such as `2026-...` were then written to stdout and parsed by Tauri as JSONL, producing:

```
invalid type: integer `2026`, expected internally tagged enum ExecutorLine
```

The same wrong startup path also tried to bind the fixed session gateway port `17888`, causing the earlier exit-code-1 failure when another executor owned that port.

## Verification

- full Executor test suite passed serially
- all 59 Wework Tauri tests passed
- added a binary contract asserting every app-sidecar stdout line is valid JSONL while backend startup runs
- added gateway contracts for ephemeral port publication and preservation of explicit remote public URLs
- isolated real Tauri startup passed:
  - app IPC ready on stdio
  - backend Socket.IO registration succeeded
  - session gateway used a separate ephemeral loopback port
  - no `invalid type: integer`, executor exit, or fixed-port bind error
- pre-push ESLint, TypeScript, unit tests, Cargo fmt/test/clippy passed

Follow-up to #2056.
