### PR TITLE
fix(wework): show reconnecting stream status

### DIFF
--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -35,6 +35,24 @@ use super::{
 const MAX_TOOL_OUTPUT_DELTA_BYTES: usize = 64 * 1024;
 const MAX_TOOL_OUTPUT_BUFFER_BYTES: usize = 512 * 1024;
 
+fn codex_error_will_retry(params: &Value) -> bool {
+    params
+        .get("willRetry")
+        .or_else(|| params.get("will_retry"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn codex_retry_message(params: &Value) -> String {
+    params
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .or_else(|| params.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("Reconnecting")
+        .to_owned()
+}
+
 pub(crate) fn emit_response_event(
     event_tx: &Option<broadcast::Sender<Value>>,
     device_id: &str,
@@ -163,6 +181,7 @@ pub(crate) struct CodexNotificationEventMapper {
     tool_output_deltas: BTreeMap<String, String>,
     completed_user_message_count: usize,
     goal_status: Option<String>,
+    reconnecting_block_id: Option<String>,
 }
 
 struct ProcessTextStream {
@@ -189,6 +208,9 @@ impl CodexNotificationEventMapper {
             request,
         };
         let notification = codex_notification(&message);
+        if notification.method != "error" {
+            self.clear_reconnecting(&emit_context);
+        }
         match notification.method.as_str() {
             "item/agentMessage/delta" => {
                 if self.is_subagent_delta(notification.params) {
@@ -430,6 +452,9 @@ impl CodexNotificationEventMapper {
                     }),
                 );
             }
+            "error" if codex_error_will_retry(notification.params) => {
+                self.emit_reconnecting(&emit_context, notification.params);
+            }
             _ => {
                 log_unhandled_codex_raw_message(
                     local_task_id,
@@ -449,6 +474,53 @@ impl CodexNotificationEventMapper {
 
     fn has_active_goal(&self) -> bool {
         self.goal_status.as_deref() == Some("active")
+    }
+
+    fn emit_reconnecting(&mut self, context: &EventEmitContext<'_>, params: &Value) {
+        if self.reconnecting_block_id.is_some() {
+            return;
+        }
+        let id = format!(
+            "reconnecting-{}-{}",
+            context.local_task_id, context.request.subtask_id
+        );
+        self.reconnecting_block_id = Some(id.clone());
+        emit_response_event(
+            context.event_tx,
+            context.device_id,
+            "response.block.created",
+            context.local_task_id,
+            context.request,
+            json!({
+                "block": {
+                    "id": id,
+                    "type": "tool",
+                    "tool_name": "runtime_reconnecting",
+                    "tool_input": {
+                        "message": codex_retry_message(params),
+                    },
+                    "status": "streaming",
+                    "timestamp": now_ms(),
+                }
+            }),
+        );
+    }
+
+    fn clear_reconnecting(&mut self, context: &EventEmitContext<'_>) {
+        let Some(id) = self.reconnecting_block_id.take() else {
+            return;
+        };
+        emit_response_event(
+            context.event_tx,
+            context.device_id,
+            "response.block.updated",
+            context.local_task_id,
+            context.request,
+            json!({
+                "block_id": id,
+                "updates": { "status": "done" }
+            }),
+        );
     }
 
     fn emit_applied_guidance(&mut self, context: &EventEmitContext<'_>, params: &Value) -> bool {
@@ -1681,6 +1753,61 @@ mod tests {
     use crate::protocol::ExecutionRequest;
 
     use super::*;
+
+    #[test]
+    fn emits_one_transient_block_while_codex_reconnects() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: "7".to_owned(),
+            subtask_id: "8".to_owned(),
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+        let retry = |attempt| {
+            json!({
+                "method": "error",
+                "params": {
+                    "error": { "message": format!("Reconnecting... {attempt}/5") },
+                    "willRetry": true
+                }
+            })
+        };
+
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device",
+            "task",
+            &request,
+            retry(1),
+        );
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device",
+            "task",
+            &request,
+            retry(2),
+        );
+
+        let created = event_rx.try_recv().expect("reconnecting block");
+        assert_eq!(created["event"], "response.block.created");
+        assert_eq!(
+            created["payload"]["data"]["block"]["tool_name"],
+            "runtime_reconnecting"
+        );
+        assert!(event_rx.try_recv().is_err());
+
+        mapper.map(
+            &Some(event_tx),
+            "device",
+            "task",
+            &request,
+            json!({"method": "turn/diff/updated", "params": {}}),
+        );
+
+        let cleared = event_rx.try_recv().expect("reconnecting block update");
+        assert_eq!(cleared["event"], "response.block.updated");
+        assert_eq!(cleared["payload"]["data"]["updates"]["status"], "done");
+    }
 
     #[test]
     fn emits_guidance_applied_for_second_completed_user_message() {

--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -199,6 +199,35 @@ describe('reduceWorkbenchMessages', () => {
     })
   })
 
+  test('keeps repeated optimistic user message delivery idempotent', () => {
+    const message: WorkbenchMessage = {
+      id: 'runtime-local-pane-1',
+      role: 'user',
+      content: 'inspect the latest screenshot',
+      status: 'done',
+      createdAt: '2026-05-25T00:00:00.000Z'
+    }
+
+    const optimistic = reduceWorkbenchMessages([], {
+      type: 'user_added',
+      message
+    })
+    const reconciled = reduceWorkbenchMessages(optimistic, {
+      type: 'user_added',
+      message: {
+        ...message,
+        subtaskId: 'runtime-worktree-0'
+      }
+    })
+
+    expect(reconciled).toHaveLength(1)
+    expect(reconciled[0]).toMatchObject({
+      id: 'runtime-local-pane-1',
+      content: 'inspect the latest screenshot',
+      subtaskId: 'runtime-worktree-0'
+    })
+  })
+
   test('uses chunk offsets to ignore duplicate assistant chunks', () => {
     const started = reduceWorkbenchMessages([], {
       type: 'assistant_started',

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -207,7 +207,9 @@ export function reduceWorkbenchMessages<
         limitWorkbenchMessage
       )
     case 'user_added':
-      return [...state, action.message]
+      return normalizeUniqueWorkbenchMessages([...state, action.message]).map(
+        limitWorkbenchMessage
+      )
     case 'assistant_started':
       if (
         state.some((message) => isAssistantMessageForAction(message, action))

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -24,6 +24,8 @@ const CANCELLATION_PROMPT = 'WEWORK_DESKTOP_E2E_CANCEL: wait until the response 
 const CANCELLATION_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CANCEL_COMPLETE'
 const RETRY_PROMPT = 'WEWORK_DESKTOP_E2E_RETRY: fail once and then succeed after retry.'
 const RETRY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RETRY_COMPLETE'
+const RECONNECT_PROMPT = 'WEWORK_DESKTOP_E2E_RECONNECT: recover after the stream disconnects.'
+const RECONNECT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RECONNECT_COMPLETE'
 const ARTIFACT_NAME = 'wework-e2e-result.txt'
 const ARTIFACT_CONTENT = 'CODEX_EXECUTED_REAL_TOOL'
 const GIT_SEED_NAME = 'README.md'
@@ -40,6 +42,7 @@ const ACTIVE_COMPOSER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="cha
 const MACOS_LAUNCH_SERVICES_REGISTER =
   '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister'
 const LIFECYCLE_ONLY = process.argv.includes('--lifecycle-only')
+const RECONNECT_ONLY = process.argv.includes('--reconnect-only')
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const weworkDir = resolve(scriptDir, '..', '..')
@@ -397,6 +400,61 @@ async function verifyBackgroundTaskWindowLifecycle({
   )
 }
 
+async function verifyReconnectRecovery({ composerSelector, control }) {
+  control.setScenario('reconnect')
+  await sendPromptUntilScenarioRequest(control, composerSelector, RECONNECT_PROMPT, 'reconnect')
+  await withTimeout(
+    control.awaitReconnectResponseStarted(),
+    UI_TIMEOUT_MS,
+    'The reconnect response stream did not start'
+  )
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="thinking-indicator"]`,
+    { timeoutMs: UI_TIMEOUT_MS }
+  )
+  await captureVerificationScreenshot(
+    control,
+    'reconnect-01-streaming.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+
+  control.disconnectReconnectResponse()
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="runtime-reconnecting-status"]`,
+    { timeoutMs: UI_TIMEOUT_MS }
+  )
+  await captureVerificationScreenshot(
+    control,
+    'reconnect-02-reconnecting.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+
+  await withTimeout(
+    control.awaitScenarioRequestCount('reconnect', 2),
+    UI_TIMEOUT_MS,
+    'Codex did not retry the disconnected response stream'
+  )
+  control.releaseReconnectResponse()
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    { text: RECONNECT_COMPLETION_TEXT, timeoutMs: UI_TIMEOUT_MS }
+  )
+  const recoveredSnapshot = JSON.parse(await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR))
+  assert.equal(
+    recoveredSnapshot.testIds.includes('runtime-reconnecting-status'),
+    false,
+    'The reconnecting status remained after model output recovered'
+  )
+  await captureVerificationScreenshot(
+    control,
+    'reconnect-03-recovered.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+}
+
 function createSse(events) {
   return events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
 }
@@ -597,6 +655,15 @@ class DesktopE2EServer {
     this.retryCompletionRelease = new Promise(resolvePromise => {
       this.releaseRetryCompletion = resolvePromise
     })
+    this.reconnectDisconnectRelease = new Promise(resolvePromise => {
+      this.releaseReconnectDisconnect = resolvePromise
+    })
+    this.reconnectResponseStarted = new Promise(resolvePromise => {
+      this.resolveReconnectResponseStarted = resolvePromise
+    })
+    this.reconnectCompletionRelease = new Promise(resolvePromise => {
+      this.releaseReconnectCompletion = resolvePromise
+    })
     this.windowLifecycleRelease = new Promise(resolvePromise => {
       this.releaseWindowLifecycle = resolvePromise
     })
@@ -701,9 +768,15 @@ class DesktopE2EServer {
 
   setScenario(scenario) {
     assert.ok(
-      ['initial', 'follow_up', 'window_lifecycle', 'cancellation', 'retry', 'fresh_chat'].includes(
-        scenario
-      ),
+      [
+        'initial',
+        'follow_up',
+        'window_lifecycle',
+        'cancellation',
+        'retry',
+        'reconnect',
+        'fresh_chat',
+      ].includes(scenario),
       `Unknown desktop E2E scenario: ${scenario}`
     )
     this.scenario = scenario
@@ -728,12 +801,31 @@ class DesktopE2EServer {
     })
   }
 
+  async awaitScenarioRequestCount(scenario, count) {
+    while ((this.scenarioRequests.get(scenario)?.length ?? 0) < count) {
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
+    }
+    return this.scenarioRequests.get(scenario).at(-1)
+  }
+
   releaseInitialToolExecution() {
     this.releaseInitialTool()
   }
 
   releaseRetryResponse() {
     this.releaseRetryCompletion()
+  }
+
+  awaitReconnectResponseStarted() {
+    return this.reconnectResponseStarted
+  }
+
+  disconnectReconnectResponse() {
+    this.releaseReconnectDisconnect()
+  }
+
+  releaseReconnectResponse() {
+    this.releaseReconnectCompletion()
   }
 
   awaitWindowLifecycleResponseStarted() {
@@ -1046,6 +1138,35 @@ class DesktopE2EServer {
       this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(RETRY_COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'reconnect') {
+      this.recordScenarioRequest('reconnect', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(RECONNECT_PROMPT),
+        'The real Codex request did not contain the reconnect prompt'
+      )
+      const reconnectRequests = this.scenarioRequests.get('reconnect') ?? []
+      if (reconnectRequests.length === 1) {
+        response.writeHead(200, {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'Content-Type': 'text/event-stream; charset=utf-8',
+        })
+        response.write(createSse([responseCreated(responseId)]))
+        this.resolveReconnectResponseStarted()
+        await this.reconnectDisconnectRelease
+        response.destroy()
+        return
+      }
+      await this.reconnectCompletionRelease
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(RECONNECT_COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
       return
@@ -1402,6 +1523,17 @@ async function main() {
     const initialModelLabel = await control.command('waitFor', activeModelSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
+    if (RECONNECT_ONLY) {
+      phase = 'reconnect'
+      await verifyReconnectRecovery({ composerSelector, control })
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(`Wework desktop reconnect E2E passed. Evidence: ${resultDir}`)
+      return
+    }
     phase = 'initial-task'
     await sendPrompt(control, composerSelector, TASK_PROMPT)
     await withTimeout(
@@ -1650,6 +1782,9 @@ async function main() {
       2,
       'Retry did not issue exactly one additional request for the failed user message'
     )
+
+    phase = 'reconnect'
+    await verifyReconnectRecovery({ composerSelector, control })
 
     phase = 'fresh-chat'
     control.setScenario('fresh_chat')

--- a/wework/package.json
+++ b/wework/package.json
@@ -26,6 +26,7 @@
     "e2e": "playwright test",
     "e2e:desktop": "node e2e/desktop/task-flow.e2e.mjs",
     "e2e:desktop:lifecycle": "node e2e/desktop/task-flow.e2e.mjs --lifecycle-only",
+    "e2e:desktop:reconnect": "node e2e/desktop/task-flow.e2e.mjs --reconnect-only",
     "ai:verify": "node scripts/ai-verify.mjs",
     "e2e:ui": "playwright test --ui"
   },

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -92,6 +92,20 @@ export function ToolBlockItem({
     )
   }
 
+  if (block.toolName === 'runtime_reconnecting') {
+    return (
+      <div
+        className="min-w-0 truncate py-1 text-sm text-text-muted"
+        data-testid="runtime-reconnecting-status"
+        role="status"
+      >
+        <span className="tool-activity-shimmer">
+          {t('tool_activity.reconnecting', '连接中断，正在重连…')}
+        </span>
+      </div>
+    )
+  }
+
   const { icon, label } = getBlockLabel(block, {
     waitRunning: t('tool_activity.wait_running'),
     waitDone: t('tool_activity.wait_done'),

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1185,6 +1185,31 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText(/\d+ 秒/)).toBeInTheDocument()
   })
 
+  test('shows a subtle one-line reconnecting status only while it is active', () => {
+    const reconnectingBlock: ProcessingBlock = {
+      id: 'reconnecting-1',
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'runtime_reconnecting',
+      status: 'streaming',
+      createdAt: 1770000000000,
+    }
+
+    const { rerender } = render(
+      <ToolBlocksDisplay blocks={[reconnectingBlock]} isStreaming={true} />
+    )
+
+    const status = screen.getByTestId('runtime-reconnecting-status')
+    expect(status).toHaveTextContent('连接中断，正在重连…')
+    expect(status).toHaveClass('truncate')
+    expect(status.firstElementChild).toHaveClass('tool-activity-shimmer')
+
+    rerender(
+      <ToolBlocksDisplay blocks={[{ ...reconnectingBlock, status: 'done' }]} isStreaming={true} />
+    )
+    expect(screen.queryByTestId('runtime-reconnecting-status')).not.toBeInTheDocument()
+  })
+
   test('does not duplicate the generic thinking indicator when live thinking is visible', () => {
     const thinkingBlock: ProcessingBlock = {
       id: 'thinking-1',

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -48,6 +48,7 @@ const SEARCH_TOOL_HINTS = ['search', 'grep', 'glob']
 const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag', 'ack'])
 const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'file'])
 const HIDDEN_ACTIVITY_TOOLS = new Set(['write_stdin', 'functions.write_stdin'])
+const RECONNECTING_TOOL_NAME = 'runtime_reconnecting'
 
 export function buildProcessingDisplayRows(
   blocks: ProcessingBlock[],
@@ -639,7 +640,11 @@ function isRedundantPatchApplyBlock(block: ProcessingBlock): boolean {
 }
 
 function isHiddenToolActivityBlock(block: ProcessingBlock): boolean {
-  return block.type === 'tool' && HIDDEN_ACTIVITY_TOOLS.has(block.toolName.toLowerCase())
+  return (
+    block.type === 'tool' &&
+    (HIDDEN_ACTIVITY_TOOLS.has(block.toolName.toLowerCase()) ||
+      (block.toolName === RECONNECTING_TOOL_NAME && isCompletedToolBlock(block)))
+  )
 }
 
 export function isWebSearchToolName(name: string): boolean {

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -16,6 +16,7 @@
     "running": "Working"
   },
   "tool_activity": {
+    "reconnecting": "Connection interrupted. Reconnecting…",
     "summary_one": "Called {{count}} tool",
     "summary_other": "Called {{count}} tools",
     "mixed_summary_one": "{{toolSummary}}, edited {{count}} file",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -16,6 +16,7 @@
     "running": "正在处理"
   },
   "tool_activity": {
+    "reconnecting": "连接中断，正在重连…",
     "summary_other": "调用 {{count}} 个工具",
     "mixed_summary_other": "{{toolSummary}}，编辑 {{count}} 个文件",
     "edit_summary_other": "编辑 {{count}} 个文件",


### PR DESCRIPTION
## What\n\n- surface Codex retryable stream errors as a transient Wework processing block\n- render a subtle one-line localized reconnecting status with the existing shimmer treatment\n- clear the status as soon as model events resume\n- add unit coverage and a real Tauri disconnect/reconnect recovery flow with screenshot evidence\n\n## Why\n\nRelease logs around 06:54 showed repeated upstream SSE timeout/reconnect attempts while local IPC and transcript polling remained responsive. The desktop UI had no feedback during that gap, so output appeared frozen even though Codex was retrying.\n\n## Impact\n\nUsers now see a lightweight “连接中断，正在重连…” status only while automatic reconnection is active. Normal output resumes without leaving a stale status.\n\n## Checks\n\n- real Tauri reconnect E2E: streaming → reconnecting → recovered\n- Wework ESLint\n- Wework TypeScript\n- Wework unit tests (1821 passed)\n- Executor cargo fmt\n- Executor cargo test --all-features --lib\n- Executor cargo clippy\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible reconnecting status when a connection is interrupted.
  * Automatically retries interrupted responses and hides the reconnecting status after recovery.
  * Added reconnecting messages in English and Simplified Chinese.

* **Bug Fixes**
  * Prevented duplicate optimistic messages while preserving updated metadata.
  * Ensured completed reconnecting activity does not remain visible.

* **Tests**
  * Added coverage for reconnect recovery and duplicate-message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->