### PR TITLE
fix(wework): prevent duplicate pasted messages across chats

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -614,6 +614,8 @@ semantics for all three.
 - Keep useful content visible during refresh, reconnect, and long-running work.
 - Prevent duplicate submissions while pending.
 - Preserve unsent input and valid form values after recoverable failure.
+- Scope buffered composer drafts to their conversation. Reusing a composer for
+  another task or a new chat must never carry over hidden draft state.
 - Never convert a failed cloud or local-runtime action into apparent success.
 - Use optimistic updates only when failure is clearly reversible.
 - Put status next to the affected object whenever possible; use a toast for a

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -30,6 +30,7 @@ import { TaskPlanProgress } from './composer/TaskPlanProgress'
 export type ProjectCreateMode = 'scratch' | 'existing' | 'git'
 
 export interface ProjectChatControls {
+  scopeKey?: string
   models: UnifiedModel[]
   skills: UnifiedSkill[]
   selectedModel: UnifiedModel | null

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { BufferedChatInput } from './BufferedChatInput'
@@ -40,5 +40,59 @@ describe('BufferedChatInput', () => {
         'Existing draft\nSelected response'
       )
     })
+  })
+
+  test('discards the previous buffered draft when the chat scope changes', async () => {
+    const onSubmit = vi.fn()
+    const baseProjectChat = {
+      models: [],
+      skills: [],
+      selectedModel: null,
+      selectedModelOptions: {},
+      selectedSkills: [],
+      attachments: [],
+      uploadingFiles: new Map(),
+      errors: new Map(),
+      isOptionsLocked: false,
+      setSelectedModel: vi.fn(),
+      setSelectedModelOption: vi.fn(),
+      toggleSkill: vi.fn(),
+      handleFileSelect: vi.fn(),
+      removeAttachment: vi.fn(),
+      listLocalSkills: vi.fn(),
+    }
+    const { rerender } = render(
+      <BufferedChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        disabled={false}
+        projectChat={{ ...baseProjectChat, scopeKey: 'chat-1' }}
+      />
+    )
+    await userEvent.type(screen.getByTestId('chat-message-input'), 'previous message')
+
+    rerender(
+      <BufferedChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        disabled={false}
+        projectChat={{ ...baseProjectChat, scopeKey: 'chat-2' }}
+      />
+    )
+    const input = screen.getByTestId('chat-message-input')
+    input.focus()
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => (type === 'text/plain' ? 'previous message' : ''),
+        types: ['text/plain'],
+      },
+    })
+    await userEvent.keyboard('{Enter}')
+
+    expect(onSubmit).toHaveBeenCalledOnce()
+    expect(onSubmit).toHaveBeenCalledWith('previous message')
   })
 })

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -18,32 +18,37 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   insertion,
   ...props
 }: BufferedChatInputProps) {
+  const scopeKey = props.projectChat?.scopeKey
   const [draftState, setDraftState] = useState(() => ({
+    scopeKey,
     sourceValue: value,
     draft: value,
   }))
-  const draft = draftState.sourceValue === value ? draftState.draft : value
+  const draft =
+    draftState.scopeKey === scopeKey && draftState.sourceValue === value ? draftState.draft : value
   const appliedInsertionIdRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (!insertion || appliedInsertionIdRef.current === insertion.id) return
     appliedInsertionIdRef.current = insertion.id
     setDraftState(current => {
-      const currentDraft = current.sourceValue === value ? current.draft : value
+      const currentDraft =
+        current.scopeKey === scopeKey && current.sourceValue === value ? current.draft : value
       return {
+        scopeKey,
         sourceValue: value,
         draft: currentDraft ? `${currentDraft}\n${insertion.text}` : insertion.text,
       }
     })
-  }, [insertion, value])
+  }, [insertion, scopeKey, value])
   const setDraft = useCallback(
     (nextDraft: string) => {
-      setDraftState({ sourceValue: value, draft: nextDraft })
+      setDraftState({ scopeKey, sourceValue: value, draft: nextDraft })
       if (parseComposerMentions(nextDraft).length > 0) {
         onChange(nextDraft)
       }
     },
-    [onChange, value]
+    [onChange, scopeKey, value]
   )
 
   const handleSubmit = useCallback(
@@ -55,10 +60,10 @@ export const BufferedChatInput = memo(function BufferedChatInput({
         void onSubmit(submittedDraft, options)
       }
       if (submittedDraft.trim()) {
-        setDraftState({ sourceValue: value, draft: '' })
+        setDraftState({ scopeKey, sourceValue: value, draft: '' })
       }
     },
-    [draft, onSubmit, value]
+    [draft, onSubmit, scopeKey, value]
   )
 
   return <ChatInput {...props} value={draft} onChange={setDraft} onSubmit={handleSubmit} />

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1252,6 +1252,7 @@ export function WorkbenchProvider({
   )
   const projectChatValue = useMemo(
     () => ({
+      scopeKey: projectChatScopeKey,
       models: modelSelection.models,
       skills: skillSelection.skills,
       selectedModel: modelSelection.selectedModel,
@@ -1291,6 +1292,7 @@ export function WorkbenchProvider({
       attachmentSelection.removeAttachment,
       attachmentSelection.resetAttachments,
       attachmentSelection.uploadingFiles,
+      projectChatScopeKey,
       draftInput,
       trialTemplates,
       handleBlockedModelSelect,
@@ -1316,6 +1318,7 @@ export function WorkbenchProvider({
   )
   const paneProjectChatValue = useMemo(
     () => ({
+      scopeKey: projectChatScopeKey,
       models: modelSelection.models,
       skills: skillSelection.skills,
       selectedModel: modelSelection.selectedModel,
@@ -1355,6 +1358,7 @@ export function WorkbenchProvider({
       attachmentSelection.removeAttachment,
       attachmentSelection.resetAttachments,
       attachmentSelection.uploadingFiles,
+      projectChatScopeKey,
       draftInput,
       trialTemplates,
       handleBlockedModelSelect,


### PR DESCRIPTION
## What

- scope buffered composer drafts to the active chat/task
- discard stale buffered text when a reused composer switches conversations
- add a regression test for switching chats, pasting the previous text, and pressing Enter
- document the scoped-draft interaction invariant

## Why

The buffered composer previously treated an unchanged external value as proof that its local draft still belonged to the current chat. After stopping a task and opening a new chat, both external values could be empty while the component instance was reused, so pasting the previous text could combine with stale hidden draft state and submit duplicate content.

## Verification

- `pnpm --filter wework test` (180 files / 1820 tests passed)
- `pnpm --filter wework exec vitest run src/components/layout/BufferedChatInput.test.tsx`
- `pnpm --filter wework exec tsc --noEmit`
- Wework pre-push ESLint, TypeScript, and unit test checks
- isolated Wework flow: send → stop → new chat → paste the same text → Enter; one submitted copy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Buffered chat drafts are now isolated to their current conversation or task.
  * Switching chats no longer carries over hidden composer text or stale draft content.
  * Draft insertions and submissions now respect the active conversation context.

* **Documentation**
  * Updated interaction-state guidance to document conversation-scoped composer drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->