### PR TITLE
fix(wework): hide thinking after response content

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1023,7 +1023,7 @@ describe('MessageList', () => {
     ).toBeInTheDocument()
   })
 
-  test('shows thinking after partial streaming assistant content', () => {
+  test('hides thinking after partial streaming assistant content becomes visible', () => {
     render(
       <MessageList
         messages={[
@@ -1039,13 +1039,8 @@ describe('MessageList', () => {
     )
 
     const content = screen.getByTestId('message-assistant').querySelector('p')
-    const thinking = screen.getByTestId('thinking-indicator')
-
     expect(content).toHaveTextContent('我已经完成前面的检查，继续等最后结果。')
-    expect(thinking).toHaveTextContent('正在思考')
-    expect(content.compareDocumentPosition(thinking) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING
-    )
+    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 
   test('shows only the running block after partial content', () => {
@@ -3760,7 +3755,7 @@ describe('MessageList', () => {
 
     expect(screen.queryByTestId('message-hover-time')).not.toBeInTheDocument()
     expect(screen.queryByTestId('copy-message-button')).not.toBeInTheDocument()
-    expect(screen.getByText('正在思考')).toBeInTheDocument()
+    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
   })
 
   test('renders only thinking before the first streamed response arrives', () => {
@@ -3785,7 +3780,7 @@ describe('MessageList', () => {
     expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
   })
 
-  test('shows full-width processing status and trailing thinking once final text starts streaming', () => {
+  test('shows full-width processing status without trailing thinking once final text starts streaming', () => {
     render(
       <MessageList
         messages={[
@@ -3802,7 +3797,7 @@ describe('MessageList', () => {
 
     const status = screen.getByText('1 秒')
 
-    expect(screen.getByText('正在思考')).toBeInTheDocument()
+    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
     expect(status.parentElement).toHaveAttribute('data-testid', 'processing-summary-header')
     expect(status.parentElement).not.toHaveClass('border-b')
@@ -3974,6 +3969,7 @@ describe('MessageList', () => {
     )
 
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tool-block-thinking')).not.toBeInTheDocument()
     expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
     expect(screen.getByTestId('final-processing-toggle')).toHaveAttribute('aria-expanded', 'false')
   })

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1648,6 +1648,7 @@ function AssistantMessage({
   const shouldShowThinking = shouldShowAssistantThinkingIndicator({
     isAssistantRunning,
     hasProcessingDisplayBlock: hasProcessingDisplayBlock(displayBlocks),
+    hasVisibleContent,
   })
   const webSearchSources = isStreaming
     ? []
@@ -1681,6 +1682,7 @@ function AssistantMessage({
           }
           showInterToolThinking={
             isStreaming &&
+            !hasVisibleContent &&
             segment.kind === 'tool' &&
             !processingSegments.slice(index + 1).some(candidate => candidate.kind === 'tool')
           }
@@ -1765,7 +1767,6 @@ function AssistantMessage({
               />
             </div>
           ) : null}
-          {shouldShowThinking && hasVisibleContent && <AssistantThinkingIndicator />}
           {canShowFinalArtifacts && hasVisibleContent && webSearchSources.length > 0 && (
             <WebSearchSourcesChip sources={webSearchSources} />
           )}
@@ -1951,11 +1952,13 @@ function hasProcessingDisplayBlock(blocks: ProcessingBlock[]): boolean {
 function shouldShowAssistantThinkingIndicator({
   isAssistantRunning,
   hasProcessingDisplayBlock,
+  hasVisibleContent,
 }: {
   isAssistantRunning: boolean
   hasProcessingDisplayBlock: boolean
+  hasVisibleContent: boolean
 }): boolean {
-  return isAssistantRunning && !hasProcessingDisplayBlock
+  return isAssistantRunning && !hasProcessingDisplayBlock && !hasVisibleContent
 }
 
 function AssistantErrorCard({


### PR DESCRIPTION
## What changed

- hide the generic assistant thinking indicator as soon as streamed response content becomes visible
- stop the trailing inter-tool thinking indicator once final response text is visible
- keep the waiting indicator before the first response content arrives
- update message rendering regression coverage for content-only and tool-backed responses

## Why

The assistant message could remain marked as streaming briefly after its final text was already rendered. The UI treated that transport state as proof that the model was still thinking, so users saw “正在思考” below a completed-looking answer.

The rendering state now distinguishes “waiting for visible content” from “stream transport is still open”.

## User impact

Users still receive immediate feedback while waiting for the first assistant content. Once answer text appears, stale thinking indicators no longer remain below the answer or inside the completed tool section.

## Validation

- isolated real Tauri flow: sent a prompt that invoked `pwd`, observed the waiting state, then verified the completed answer showed `已处理 7 秒` and `验证完成。` without a trailing thinking label
- screenshot chain reviewed for waiting and completed states
- `pnpm --filter wework test` — 181 files, 1820 tests passed
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `pnpm --filter wework build`
- pre-push checks: ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated streaming chat behavior so “Thinking” indicators disappear once visible assistant content is rendered.
  * Prevented trailing thinking indicators from appearing after final text or tool output becomes visible.
  * Improved consistency across processing and tool-collapsing states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->