### PR TITLE
fix(hooks): require docs review before push checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,10 +181,10 @@ When pushing code, pre-commit automatically runs quality checks:
 - Documentation update reminders
 
 ```bash
-# Push to remote (triggers quality checks)
+# First push: inspect documentation reminders without running quality checks
 git push origin feature/your-feature-name
 
-# If documentation reminders shown, verify and push
+# Ask the AI to complete documentation, then run quality checks and push
 AI_VERIFIED=1 git push origin feature/your-feature-name
 
 # Skip checks if needed (not recommended)

--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -7,11 +7,11 @@
 # - Runs all quality checks (lint, type, test, build)
 # - Generates a comprehensive report
 # - Blocks push if critical checks fail
-# - Documentation reminders require verification with AI_VERIFIED=1
+# - Shows documentation reminders before requiring AI_VERIFIED=1
 #
 # Usage:
-#   git push                    (runs all checks)
-#   AI_VERIFIED=1 git push      (confirm docs checked and no updates needed)
+#   git push                    (shows documentation work without running checks)
+#   AI_VERIFIED=1 git push      (runs checks after the AI updates documentation)
 #   AI_PUSH_FULL_TESTS=1 git push  (also run full Python and Rust test suites)
 # =============================================================================
 
@@ -285,6 +285,14 @@ else
     done
 fi
 echo ""
+
+if [ "${AI_VERIFIED:-0}" != "1" ]; then
+    echo -e "${YELLOW}${BOLD}Ask the AI to review and complete documentation for these changes.${NC}"
+    echo -e "${YELLOW}After documentation is complete, run:${NC}"
+    echo -e "${GREEN}${BOLD}AI_VERIFIED=1 git push${NC}"
+    echo ""
+    exit 1
+fi
 
 # -----------------------------------------------------------------------------
 # Run Quality Checks
@@ -814,58 +822,6 @@ if [ ${#WARNINGS[@]} -gt 0 ]; then
     for warning in "${WARNINGS[@]}"; do
         echo -e "      ${YELLOW}- $warning${NC}"
     done
-    echo ""
-fi
-
-# -----------------------------------------------------------------------------
-# Check AI_VERIFIED for documentation reminders
-# -----------------------------------------------------------------------------
-if [ ${#DOC_REMINDERS[@]} -gt 0 ] && [ "$AI_VERIFIED" != "1" ]; then
-    echo -e "${CYAN}══════════════════════════════════════════════════════════${NC}"
-    echo ""
-    echo -e "${RED}${BOLD}🚫 PUSH BLOCKED - Documentation Update Required${NC}"
-    echo ""
-    echo -e "${RED}${BOLD}⚠️  CRITICAL: THIS IS YOUR ONLY CHANCE TO UPDATE DOCUMENTATION${NC}"
-    echo ""
-    echo -e "${YELLOW}${BOLD}Your code changes require documentation updates.${NC}"
-    echo -e "${YELLOW}After this push, there will be NO further opportunity to update docs.${NC}"
-    echo -e "${YELLOW}The documentation must be complete and accurate IN THIS COMMIT.${NC}"
-    echo ""
-    echo -e "${BLUE}Documentation reminders:${NC}"
-    for reminder in "${DOC_REMINDERS[@]}"; do
-        echo -e "   ${YELLOW}• $reminder${NC}"
-    done
-    echo ""
-    echo -e "${BOLD}You MUST either:${NC}"
-    echo ""
-    echo -e "  ${GREEN}1. Update the relevant documentation NOW${NC}"
-    echo -e "     Add doc changes to this commit, then push again."
-    echo -e "     ${CYAN}This is the recommended approach.${NC}"
-    echo ""
-    echo -e "  ${YELLOW}2. ONLY if you have THOROUGHLY VERIFIED that your changes${NC}"
-    echo -e "     ${YELLOW}do NOT require ANY documentation updates:${NC}"
-    echo ""
-    echo -e "     ${GREEN}${BOLD}AI_VERIFIED=1 git push${NC}"
-    echo -e "     ${CYAN}(This confirms you have checked all relevant docs and no updates are needed)${NC}"
-    echo ""
-    echo -e "${RED}${BOLD}════════════════════════════════════════════════════════════${NC}"
-    echo -e "${RED}${BOLD}⚠️  WARNING: INCOMPLETE DOCUMENTATION IS NOT ACCEPTABLE${NC}"
-    echo -e "${RED}${BOLD}════════════════════════════════════════════════════════════${NC}"
-    echo -e "${RED}   • Users depend on accurate documentation${NC}"
-    echo -e "${RED}   • Outdated docs cause confusion and support burden${NC}"
-    echo -e "${RED}   • You will NOT get another chance to update docs for this change${NC}"
-    echo -e "${RED}   • AI_VERIFIED=1 means you CONFIRM docs are already up-to-date${NC}"
-    echo ""
-    echo -e "${CYAN}══════════════════════════════════════════════════════════${NC}"
-    echo ""
-    exit 1
-fi
-
-# If AI_VERIFIED=1 or no doc reminders, proceed
-if [ "$AI_VERIFIED" = "1" ]; then
-    echo -e "${GREEN}══════════════════════════════════════════════════════════${NC}"
-    echo -e "${GREEN}✅ AI Verified - Proceeding with push${NC}"
-    echo -e "${GREEN}══════════════════════════════════════════════════════════${NC}"
     echo ""
 fi
 

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -51,6 +51,45 @@ done
 
 export CALL_LOG
 
+# This historical range changes only backend Python files. It exercises the
+# Python module branch without pulling frontend or executor checks into the
+# regression test.
+REMOTE_SHA="32219870e7b781dfaa4b0046db9e4ac5aeb02aa4"
+LOCAL_SHA="6342ce3b9624f3ce05f831d52b2b3b56edf2c36c"
+
+if PATH="$TMP_DIR/bin:$PATH" \
+    bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" >"$TMP_DIR/unverified-test.out" 2>&1 <<EOF; then
+refs/heads/topic $LOCAL_SHA refs/heads/topic $REMOTE_SHA
+EOF
+    echo "Expected a push without AI_VERIFIED=1 to be blocked."
+    exit 1
+fi
+
+if [ -s "$CALL_LOG" ]; then
+    echo "Expected a push without AI_VERIFIED=1 to skip every pre-push check."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+if ! grep -q 'AI_VERIFIED=1 git push' "$TMP_DIR/unverified-test.out"; then
+    echo "Expected an unverified push to print the verified push command."
+    cat "$TMP_DIR/unverified-test.out"
+    exit 1
+fi
+
+if ! grep -q 'Documentation reminders' "$TMP_DIR/unverified-test.out"; then
+    echo "Expected an unverified push to show documentation reminders."
+    cat "$TMP_DIR/unverified-test.out"
+    exit 1
+fi
+
+if grep -q 'Running Quality Checks' "$TMP_DIR/unverified-test.out"; then
+    echo "Expected an unverified push to stop before quality checks."
+    cat "$TMP_DIR/unverified-test.out"
+    exit 1
+fi
+
 ensure_wework_node_modules() {
     if [ ! -d "$PROJECT_ROOT/node_modules" ]; then
         mkdir "$PROJECT_ROOT/node_modules"
@@ -74,12 +113,6 @@ ensure_frontend_node_modules() {
         FRONTEND_NODE_MODULES_CREATED=1
     fi
 }
-
-# This historical range changes only backend Python files. It exercises the
-# Python module branch without pulling frontend or executor checks into the
-# regression test.
-REMOTE_SHA="32219870e7b781dfaa4b0046db9e4ac5aeb02aa4"
-LOCAL_SHA="6342ce3b9624f3ce05f831d52b2b3b56edf2c36c"
 
 AI_VERIFIED=1 \
 PATH="$TMP_DIR/bin:$PATH" \


### PR DESCRIPTION
## What changed

- stop an unverified push after changed-file and documentation analysis, before quality checks run
- prompt the AI to review and complete documentation, then retry with `AI_VERIFIED=1`
- let the verified push run the existing module-aware quality checks without a second documentation block
- add regression coverage proving the unverified path invokes no quality-check commands

## Why

The previous flow ran expensive checks before asking the AI to confirm documentation. The intended workflow is two-stage: documentation review first, then quality checks and issue fixing on the verified push.

## Validation

- `git diff --check origin/main...HEAD`
- `bash -n scripts/hooks/ai-push-gate.sh scripts/hooks/test-ai-push-gate.sh`
- `bash scripts/hooks/test-ai-push-gate.sh`
- direct invocation of `frontend/.husky/pre-push` for both unverified and `AI_VERIFIED=1` paths
