### PR TITLE
fix(wework): handle wework_browser tools for non-GPT models

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -29,7 +29,7 @@ use crate::{
     attachments::{process_prompt, AttachmentPromptProcessor, AttachmentRecord},
     codex_phase::{codex_phase_is_process, CodexAgentMessagePhaseTracker},
     image_preprocessor::prepare_image_bytes_for_model,
-    logging::{log_executor_event, task_fields, wework_debug_log},
+    logging::{log_executor_event, task_fields},
     process_environment,
     protocol::ExecutionRequest,
     runner::{AgentEngine, ExecutionOutcome},
@@ -2194,18 +2194,6 @@ impl JsonRpcConnection {
         let mut line = serde_json::to_vec(&message)
             .map_err(|error| format!("failed to encode codex JSON-RPC message: {error}"))?;
         line.push(b'\n');
-        let preview = serde_json::to_string(&message).unwrap_or_default();
-        let preview = if preview.len() > 2048 {
-            format!("{}...", &preview[..2048])
-        } else {
-            preview
-        };
-        wework_debug_log(&format!(
-            "codex rpc send id={:?} method={:?} body={}",
-            message.get("id"),
-            message.get("method"),
-            preview
-        ));
         self.stdin
             .write_all(&line)
             .await
@@ -2228,17 +2216,6 @@ impl JsonRpcConnection {
         }
         let message: Value = serde_json::from_str(&line)
             .map_err(|error| format!("failed to parse codex JSON-RPC message: {error}"))?;
-        let preview = if line.len() > 2048 {
-            format!("{}...", &line[..2048])
-        } else {
-            line.clone()
-        };
-        wework_debug_log(&format!(
-            "codex rpc recv id={:?} method={:?} body={}",
-            message.get("id"),
-            message.get("method"),
-            preview.trim()
-        ));
         Ok(message)
     }
 }
@@ -2902,47 +2879,7 @@ fn build_codex_launch_config(request: &ExecutionRequest) -> CodexLaunchConfig {
         .config_overrides
         .extend(runtime_capabilities::request_mcp_config_overrides(request));
 
-    let base_url = non_empty_config(&request.model_config, "base_url");
-    let api_key_present = api_key(&request.model_config).is_some();
-    let use_user_config = use_user_runtime_config(&request.model_config);
-    let provider_id = explicit_model_provider(&request.model_config)
-        .unwrap_or_else(|| DEFAULT_PROVIDER_ID.to_owned());
-    wework_debug_log(&format!(
-        "build_codex_launch_config model_id={:?} base_url={:?} api_key_present={} \
-         use_user_config={} model_provider={} config_overrides={} model_config_keys={:?}",
-        model_id(request),
-        base_url,
-        api_key_present,
-        use_user_config,
-        provider_id,
-        launch_config.config_overrides.len(),
-        request
-            .model_config
-            .as_object()
-            .map(|object| object.keys().cloned().collect::<Vec<_>>())
-            .unwrap_or_default()
-    ));
-    #[cfg(target_os = "windows")]
-    wework_debug_log(&format!(
-        "windows_launch_config config_overrides={} thread_config_keys={:?} full_config={}",
-        launch_config.config_overrides.len(),
-        launch_config.thread_config.keys().collect::<Vec<_>>(),
-        serde_json::to_string(&launch_config_to_debug_value(&launch_config))
-            .unwrap_or_else(|_| "<serialize-error>".to_owned())
-    ));
     launch_config
-}
-
-#[cfg(target_os = "windows")]
-fn launch_config_to_debug_value(launch_config: &CodexLaunchConfig) -> Value {
-    json!({
-        "config_overrides": launch_config.config_overrides,
-        "thread_config": launch_config.thread_config,
-        "model_provider": launch_config.model_provider,
-        "env_keys": launch_config.env.keys().collect::<Vec<_>>(),
-        "effort": launch_config.effort,
-        "summary": launch_config.summary,
-    })
 }
 
 fn shell_path_config_override() -> String {
@@ -4150,14 +4087,7 @@ fn thread_start_params(request: &ExecutionRequest, launch_config: &CodexLaunchCo
     if request.ephemeral {
         params.insert("ephemeral".to_owned(), Value::Bool(true));
     }
-    let params = Value::Object(params);
-    #[cfg(target_os = "windows")]
-    wework_debug_log(&format!(
-        "windows_thread_start_params model_id={:?} params={}",
-        model_id(request),
-        serde_json::to_string(&params).unwrap_or_else(|_| "<serialize-error>".to_owned())
-    ));
-    params
+    Value::Object(params)
 }
 
 fn thread_fork_params(

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2922,7 +2922,27 @@ fn build_codex_launch_config(request: &ExecutionRequest) -> CodexLaunchConfig {
             .map(|object| object.keys().cloned().collect::<Vec<_>>())
             .unwrap_or_default()
     ));
+    #[cfg(target_os = "windows")]
+    wework_debug_log(&format!(
+        "windows_launch_config config_overrides={} thread_config_keys={:?} full_config={}",
+        launch_config.config_overrides.len(),
+        launch_config.thread_config.keys().collect::<Vec<_>>(),
+        serde_json::to_string(&launch_config_to_debug_value(&launch_config))
+            .unwrap_or_else(|_| "<serialize-error>".to_owned())
+    ));
     launch_config
+}
+
+#[cfg(target_os = "windows")]
+fn launch_config_to_debug_value(launch_config: &CodexLaunchConfig) -> Value {
+    json!({
+        "config_overrides": launch_config.config_overrides,
+        "thread_config": launch_config.thread_config,
+        "model_provider": launch_config.model_provider,
+        "env_keys": launch_config.env.keys().collect::<Vec<_>>(),
+        "effort": launch_config.effort,
+        "summary": launch_config.summary,
+    })
 }
 
 fn shell_path_config_override() -> String {
@@ -4130,7 +4150,14 @@ fn thread_start_params(request: &ExecutionRequest, launch_config: &CodexLaunchCo
     if request.ephemeral {
         params.insert("ephemeral".to_owned(), Value::Bool(true));
     }
-    Value::Object(params)
+    let params = Value::Object(params);
+    #[cfg(target_os = "windows")]
+    wework_debug_log(&format!(
+        "windows_thread_start_params model_id={:?} params={}",
+        model_id(request),
+        serde_json::to_string(&params).unwrap_or_else(|_| "<serialize-error>".to_owned())
+    ));
+    params
 }
 
 fn thread_fork_params(

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -3401,6 +3401,11 @@ fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
         "features.non_prefixed_mcp_tool_names=true".to_owned(),
         format!(
             "{}={}",
+            toml_key_path(&["features", "code_mode", "direct_only_tool_namespaces",]),
+            toml_json_value(&json!([WEWORK_BROWSER_MCP_SERVER_NAME]))
+        ),
+        format!(
+            "{}={}",
             toml_key_path(&["mcp_servers", WEWORK_BROWSER_MCP_SERVER_NAME, "command"]),
             toml_value(&command.display().to_string())
         ),
@@ -5829,6 +5834,10 @@ mod tests {
             ])
         );
         assert_eq!(config["features.non_prefixed_mcp_tool_names"], true);
+        assert_eq!(
+            config["features.code_mode.direct_only_tool_namespaces"],
+            json!([WEWORK_BROWSER_MCP_SERVER_NAME])
+        );
         assert_eq!(
             config["mcp_servers.wework_browser.command"],
             env::current_exe().unwrap().display().to_string()

--- a/executor/src/browser_mcp.rs
+++ b/executor/src/browser_mcp.rs
@@ -39,6 +39,7 @@ async fn run_inner() -> Result<(), String> {
     let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(BRIDGE_CONNECT_TIMEOUT_SECONDS))
         .timeout(Duration::from_secs(BRIDGE_REQUEST_TIMEOUT_SECONDS))
+        .no_proxy()
         .build()
         .map_err(|error| format!("Failed to build embedded browser bridge client: {error}"))?;
     let mut lines = BufReader::new(tokio::io::stdin()).lines();

--- a/executor/src/browser_mcp.rs
+++ b/executor/src/browser_mcp.rs
@@ -11,6 +11,9 @@ use chrono::Local;
 use serde_json::{json, Map, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
+#[cfg(target_os = "windows")]
+use crate::logging::wework_debug_log;
+
 const DEFAULT_BRIDGE_URL: &str = "http://127.0.0.1:9231";
 const BRIDGE_URL_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_URL";
 const BROWSER_LABEL_ENV: &str = "WEWORK_EMBEDDED_BROWSER_LABEL";
@@ -150,7 +153,15 @@ async fn handle_request(
                 }),
             )
         }),
-        "tools/list" => id.map(|id| result_response(id, json!({ "tools": tools() }))),
+        "tools/list" => {
+            let response = result_response(id?, json!({ "tools": tools() }));
+            #[cfg(target_os = "windows")]
+            wework_debug_log(&format!(
+                "windows_browser_mcp_tools_list tools={}",
+                serde_json::to_string(&response).unwrap_or_else(|_| "<serialize-error>".to_owned())
+            ));
+            Some(response)
+        }
         "ping" => id.map(|id| result_response(id, json!({}))),
         "tools/call" => {
             let id = id?;

--- a/executor/src/browser_mcp.rs
+++ b/executor/src/browser_mcp.rs
@@ -11,9 +11,6 @@ use chrono::Local;
 use serde_json::{json, Map, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-#[cfg(target_os = "windows")]
-use crate::logging::wework_debug_log;
-
 const DEFAULT_BRIDGE_URL: &str = "http://127.0.0.1:9231";
 const BRIDGE_URL_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_URL";
 const BROWSER_LABEL_ENV: &str = "WEWORK_EMBEDDED_BROWSER_LABEL";
@@ -153,15 +150,7 @@ async fn handle_request(
                 }),
             )
         }),
-        "tools/list" => {
-            let response = result_response(id?, json!({ "tools": tools() }));
-            #[cfg(target_os = "windows")]
-            wework_debug_log(&format!(
-                "windows_browser_mcp_tools_list tools={}",
-                serde_json::to_string(&response).unwrap_or_else(|_| "<serialize-error>".to_owned())
-            ));
-            Some(response)
-        }
+        "tools/list" => id.map(|id| result_response(id, json!({ "tools": tools() }))),
         "ping" => id.map(|id| result_response(id, json!({}))),
         "tools/call" => {
             let id = id?;

--- a/executor/src/logging.rs
+++ b/executor/src/logging.rs
@@ -18,7 +18,6 @@ use crate::config::device::DeviceConfig;
 
 const DEFAULT_LOG_FILE_NAME: &str = "executor.log";
 const BYTES_PER_MIB: u64 = 1024 * 1024;
-const WEWORK_DEBUG_LOG_PATH: &str = "/tmp/wework-debug-1";
 
 static ROLLING_LOGGER: OnceLock<Mutex<Option<RollingLogFile>>> = OnceLock::new();
 static STDOUT_RESERVED_FOR_PROTOCOL: AtomicBool = AtomicBool::new(false);
@@ -121,11 +120,29 @@ pub fn write_executor_error_line(line: &str) {
 pub fn wework_debug_log(message: &str) {
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S.%3f");
     let line = format!("{timestamp} [executor] {message}");
-    let _ = std::fs::OpenOptions::new()
+    let path = wework_debug_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(WEWORK_DEBUG_LOG_PATH)
+        .open(&path)
         .and_then(|mut file| writeln!(file, "{line}"));
+}
+
+fn wework_debug_log_path() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("tmp")
+            .join("wework-debug-1.txt")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        PathBuf::from("/tmp/wework-debug-1")
+    }
 }
 
 pub fn init_executor_logging(config: &DeviceConfig) {

--- a/executor/src/logging.rs
+++ b/executor/src/logging.rs
@@ -117,34 +117,6 @@ pub fn write_executor_error_line(line: &str) {
     write_rolling_log_line(line);
 }
 
-pub fn wework_debug_log(message: &str) {
-    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S.%3f");
-    let line = format!("{timestamp} [executor] {message}");
-    let path = wework_debug_log_path();
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-    let _ = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .and_then(|mut file| writeln!(file, "{line}"));
-}
-
-fn wework_debug_log_path() -> PathBuf {
-    #[cfg(target_os = "windows")]
-    {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("tmp")
-            .join("wework-debug-1.txt")
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        PathBuf::from("/tmp/wework-debug-1")
-    }
-}
-
 pub fn init_executor_logging(config: &DeviceConfig) {
     let log_config = rolling_log_config_from_device(config);
     match create_rolling_log_file(log_config, &config.executor_home) {

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -29,7 +29,7 @@ use crate::{
         CODEX_APP_SERVER_TURN_CANCELLED,
     },
     local::app_ipc::{AppIpcError, RuntimeWorkHandler},
-    logging::{log_executor_event, wework_debug_log},
+    logging::{log_executor_event},
     protocol::ExecutionRequest,
     runner::ExecutionOutcome,
 };
@@ -562,15 +562,7 @@ impl RuntimeWorkRpcHandler {
 
                 let result = tokio::task::spawn_blocking(move || worktrees.prune(&tasks)).await;
                 match result {
-                    Ok(Err(error)) => {
-                        wework_debug_log(&format!("background worktree cleanup failed: {error}"));
-                    }
-                    Err(error) => {
-                        wework_debug_log(&format!(
-                            "background worktree cleanup task failed: {error}"
-                        ));
-                    }
-                    Ok(Ok(_)) => {}
+                    Ok(Err(_)) | Err(_) | Ok(Ok(_)) => {}
                 }
                 return;
             }
@@ -1736,7 +1728,6 @@ impl RuntimeWorkRpcHandler {
         let mut request = execution_request(&payload)
             .ok_or_else(|| AppIpcError::new("bad_request", "executionRequest is required"))?;
         apply_runtime_payload_metadata(&mut request, &payload);
-        Self::log_execution_request_summary("runtime.tasks.create", &request);
         let workspace_path = payload_workspace_path
             .or_else(|| request.cwd().map(str::to_owned))
             .or_else(|| standalone_chat_workspace_path(&local_task_id, &request))
@@ -1787,39 +1778,6 @@ impl RuntimeWorkRpcHandler {
         }))
     }
 
-    fn log_execution_request_summary(method: &str, request: &ExecutionRequest) {
-        let model_config = &request.model_config;
-        let base_url = model_config
-            .get("base_url")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        let api_key_present = model_config
-            .get("api_key")
-            .and_then(Value::as_str)
-            .map(|value| !value.is_empty())
-            .unwrap_or(false);
-        let use_user_config = model_config
-            .get("runtime_config")
-            .and_then(Value::as_object)
-            .and_then(|config| config.get("codex"))
-            .and_then(Value::as_object)
-            .and_then(|codex| codex.get("use_user_config"))
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let model_id = model_config
-            .get("model_id")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        let keys: Vec<String> = model_config
-            .as_object()
-            .map(|object| object.keys().cloned().collect())
-            .unwrap_or_default();
-        wework_debug_log(&format!(
-            "{method} task_id={} model_id={} base_url={} api_key_present={} use_user_config={} model_config_keys={:?}",
-            request.task_id, model_id, base_url, api_key_present, use_user_config, keys
-        ));
-    }
-
     async fn send_message(&self, payload: Value) -> Result<Value, AppIpcError> {
         let local_task_id = runtime_task_id(&payload)
             .ok_or_else(|| AppIpcError::new("bad_request", "taskId is required"))?;
@@ -1862,7 +1820,6 @@ impl RuntimeWorkRpcHandler {
             .ok_or_else(|| AppIpcError::new("bad_request", "executionRequest is required"))?;
         apply_runtime_payload_metadata(&mut request, &payload);
         request.new_session = false;
-        Self::log_execution_request_summary("runtime.tasks.send", &request);
         if request.project_workspace_path.is_none() && !workspace_path.is_empty() {
             request.project_workspace_path = Some(workspace_path.clone());
         }

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -29,7 +29,7 @@ use crate::{
         CODEX_APP_SERVER_TURN_CANCELLED,
     },
     local::app_ipc::{AppIpcError, RuntimeWorkHandler},
-    logging::{log_executor_event},
+    logging::log_executor_event,
     protocol::ExecutionRequest,
     runner::ExecutionOutcome,
 };

--- a/executor/src/server/codex_responses_proxy_transform.rs
+++ b/executor/src/server/codex_responses_proxy_transform.rs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Value;
+use std::collections::HashSet;
+
+const WEWORK_BROWSER_NAMESPACE: &str = "wework_browser";
+
+/// Expands the `wework_browser` namespace tool in an OpenAI Responses API
+/// request into its inner `function` tools. Returns the set of tool names that
+/// were expanded so response rewriting can recognize them.
+pub fn expand_wework_browser_namespace_tools(request: &mut Value) -> HashSet<String> {
+    let mut expanded = HashSet::new();
+    let Some(tools) = request.get_mut("tools").and_then(Value::as_array_mut) else {
+        return expanded;
+    };
+
+    let mut new_tools = Vec::with_capacity(tools.len());
+    for tool in tools.drain(..) {
+        if is_wework_browser_namespace_tool(&tool) {
+            if let Some(inner) = tool.get("tools").and_then(Value::as_array) {
+                for inner_tool in inner {
+                    if let Some(name) = inner_tool.get("name").and_then(Value::as_str) {
+                        expanded.insert(name.to_owned());
+                        new_tools.push(inner_tool.clone());
+                    }
+                }
+            }
+        } else {
+            new_tools.push(tool);
+        }
+    }
+
+    if let Some(request_object) = request.as_object_mut() {
+        request_object.insert("tools".to_owned(), Value::Array(new_tools));
+    }
+    expanded
+}
+
+fn is_wework_browser_namespace_tool(tool: &Value) -> bool {
+    tool.get("type").and_then(Value::as_str) == Some("namespace")
+        && tool.get("name").and_then(Value::as_str) == Some(WEWORK_BROWSER_NAMESPACE)
+}
+
+/// Rewrites flat `function_call` items for tools that originated from the
+/// `wework_browser` namespace so Codex receives them as namespaced calls.
+pub fn rewrite_wework_browser_function_calls(value: &mut Value, expanded: &HashSet<String>) {
+    rewrite_value(value, expanded);
+}
+
+fn rewrite_value(value: &mut Value, expanded: &HashSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("type").and_then(Value::as_str) == Some("function_call") {
+                if let Some(name) = map.get("name").and_then(Value::as_str) {
+                    if expanded.contains(name)
+                        && map
+                            .get("namespace")
+                            .map_or(true, |namespace| namespace.is_null())
+                    {
+                        map.insert(
+                            "namespace".to_owned(),
+                            Value::String(WEWORK_BROWSER_NAMESPACE.to_owned()),
+                        );
+                    }
+                }
+            }
+            for child in map.values_mut() {
+                rewrite_value(child, expanded);
+            }
+        }
+        Value::Array(array) => {
+            for child in array.iter_mut() {
+                rewrite_value(child, expanded);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn expands_wework_browser_namespace_into_flat_functions() {
+        let mut request = json!({
+            "model": "doubao",
+            "tools": [
+                {"type": "function", "name": "exec_command"},
+                {
+                    "type": "namespace",
+                    "name": "wework_browser",
+                    "tools": [
+                        {"type": "function", "name": "browser_navigate", "parameters": {}},
+                        {"type": "function", "name": "browser_snapshot", "parameters": {}}
+                    ]
+                }
+            ]
+        });
+
+        let expanded = expand_wework_browser_namespace_tools(&mut request);
+
+        assert_eq!(
+            expanded,
+            HashSet::from(["browser_navigate".to_owned(), "browser_snapshot".to_owned()])
+        );
+        let tools = request["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 3);
+        assert_eq!(tools[0]["name"], "exec_command");
+        assert_eq!(tools[1]["name"], "browser_navigate");
+        assert_eq!(tools[2]["name"], "browser_snapshot");
+    }
+
+    #[test]
+    fn leaves_non_browser_namespace_tools_unchanged() {
+        let mut request = json!({
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "other_namespace",
+                    "tools": [{"type": "function", "name": "other_tool"}]
+                }
+            ]
+        });
+
+        let expanded = expand_wework_browser_namespace_tools(&mut request);
+
+        assert!(expanded.is_empty());
+        let tools = request["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["name"], "other_namespace");
+    }
+
+    #[test]
+    fn rewrites_flat_browser_function_calls_to_namespace() {
+        let mut response = json!({
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "browser_navigate",
+                "arguments": "{\"url\":\"https://example.com\"}"
+            }
+        });
+        let expanded = HashSet::from(["browser_navigate".to_owned()]);
+
+        rewrite_wework_browser_function_calls(&mut response, &expanded);
+
+        assert_eq!(response["item"]["namespace"], "wework_browser");
+        assert_eq!(response["item"]["name"], "browser_navigate");
+    }
+
+    #[test]
+    fn does_not_rewrite_non_browser_function_calls() {
+        let mut response = json!({
+            "output": [{
+                "type": "function_call",
+                "call_id": "call-2",
+                "name": "exec_command",
+                "arguments": "{}"
+            }]
+        });
+        let expanded = HashSet::from(["browser_navigate".to_owned()]);
+
+        rewrite_wework_browser_function_calls(&mut response, &expanded);
+
+        assert!(response["output"][0].get("namespace").is_none());
+    }
+}

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -154,6 +154,7 @@ pub(super) async fn handle(headers: HeaderMap, body: Bytes) -> Result<Response, 
     Ok(response)
 }
 
+#[allow(clippy::type_complexity)]
 fn prepare_request(
     api_format: &str,
     body: &[u8],
@@ -164,8 +165,8 @@ fn prepare_request(
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Invalid Codex Responses request: {error}"),
             })?;
-        let expanded_browser_tools = codex_responses_proxy_transform
-            ::expand_wework_browser_namespace_tools(
+        let expanded_browser_tools =
+            codex_responses_proxy_transform::expand_wework_browser_namespace_tools(
                 &mut request_value,
             );
         let body = serde_json::to_vec(&request_value).map_err(|error| HttpError {
@@ -279,16 +280,13 @@ where
                         let normalized = if state.expanded_browser_tools.is_empty() {
                             normalize_responses_event(&event)
                         } else {
-                            let rewritten = rewrite_responses_event(
-                                &event,
-                                &state.expanded_browser_tools,
-                            );
+                            let rewritten =
+                                rewrite_responses_event(&event, &state.expanded_browser_tools);
                             normalize_responses_event(&rewritten)
                         };
-                        state.output.push_back(Ok(Bytes::from(format!(
-                            "{}\n\n",
-                            normalized
-                        ))));
+                        state
+                            .output
+                            .push_back(Ok(Bytes::from(format!("{}\n\n", normalized))));
                     }
                 }
                 Some(Err(error)) => {

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -27,6 +27,8 @@ use futures_util::{Stream, StreamExt};
 use serde_json::{Map, Value};
 
 use crate::logging::log_executor_event;
+#[cfg(target_os = "windows")]
+use crate::logging::wework_debug_log;
 
 use super::{codex_responses_proxy_transform, HttpError};
 
@@ -84,6 +86,23 @@ pub(super) async fn handle(headers: HeaderMap, body: Bytes) -> Result<Response, 
         .unwrap_or_else(|| format!("{}/responses", upstream.base_url.trim_end_matches('/')));
     let (request_body, conversion, expanded_browser_tools) =
         prepare_request(&upstream.api_format, &body)?;
+    #[cfg(target_os = "windows")]
+    {
+        let debug_request_id = format!(
+            "req-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let original_body = String::from_utf8_lossy(&body);
+        let modified_body = String::from_utf8_lossy(&request_body);
+        wework_debug_log(&format!(
+            "windows_codex_proxy_request request_id={debug_request_id} api_format={} expanded_tools={:?} original_body={original_body} modified_body={modified_body}",
+            upstream.api_format, expanded_browser_tools
+        ));
+    }
     log_executor_event(
         "local model proxy request started",
         &[
@@ -346,6 +365,16 @@ fn rewrite_responses_event(event: &str, expanded: &HashSet<String>) -> String {
             codex_responses_proxy_transform::rewrite_wework_browser_function_calls(
                 &mut value, expanded,
             );
+            #[cfg(target_os = "windows")]
+            if value != original {
+                let rewritten = format!(
+                    "data: {}",
+                    serde_json::to_string(&value).unwrap_or_else(|_| data.to_owned())
+                );
+                wework_debug_log(&format!(
+                    "windows_codex_proxy_response_rewrite original={line} rewritten={rewritten}"
+                ));
+            }
             if value == original {
                 return line.to_owned();
             }

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -27,8 +27,6 @@ use futures_util::{Stream, StreamExt};
 use serde_json::{Map, Value};
 
 use crate::logging::log_executor_event;
-#[cfg(target_os = "windows")]
-use crate::logging::wework_debug_log;
 
 use super::{codex_responses_proxy_transform, HttpError};
 
@@ -86,23 +84,6 @@ pub(super) async fn handle(headers: HeaderMap, body: Bytes) -> Result<Response, 
         .unwrap_or_else(|| format!("{}/responses", upstream.base_url.trim_end_matches('/')));
     let (request_body, conversion, expanded_browser_tools) =
         prepare_request(&upstream.api_format, &body)?;
-    #[cfg(target_os = "windows")]
-    {
-        let debug_request_id = format!(
-            "req-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
-        let original_body = String::from_utf8_lossy(&body);
-        let modified_body = String::from_utf8_lossy(&request_body);
-        wework_debug_log(&format!(
-            "windows_codex_proxy_request request_id={debug_request_id} api_format={} expanded_tools={:?} original_body={original_body} modified_body={modified_body}",
-            upstream.api_format, expanded_browser_tools
-        ));
-    }
     log_executor_event(
         "local model proxy request started",
         &[
@@ -365,16 +346,6 @@ fn rewrite_responses_event(event: &str, expanded: &HashSet<String>) -> String {
             codex_responses_proxy_transform::rewrite_wework_browser_function_calls(
                 &mut value, expanded,
             );
-            #[cfg(target_os = "windows")]
-            if value != original {
-                let rewritten = format!(
-                    "data: {}",
-                    serde_json::to_string(&value).unwrap_or_else(|_| data.to_owned())
-                );
-                wework_debug_log(&format!(
-                    "windows_codex_proxy_response_rewrite original={line} rewritten={rewritten}"
-                ));
-            }
             if value == original {
                 return line.to_owned();
             }

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -13,7 +13,7 @@ mod anthropic;
 mod chat;
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     pin::Pin,
     sync::{Mutex, OnceLock},
 };
@@ -28,7 +28,7 @@ use serde_json::{Map, Value};
 
 use crate::logging::log_executor_event;
 
-use super::HttpError;
+use super::{codex_responses_proxy_transform, HttpError};
 
 pub(crate) const ROUTE: &str = "/v1/codex-responses-proxy/responses";
 
@@ -82,13 +82,18 @@ pub(super) async fn handle(headers: HeaderMap, body: Bytes) -> Result<Response, 
         .request_url
         .clone()
         .unwrap_or_else(|| format!("{}/responses", upstream.base_url.trim_end_matches('/')));
-    let (request_body, conversion) = prepare_request(&upstream.api_format, &body)?;
+    let (request_body, conversion, expanded_browser_tools) =
+        prepare_request(&upstream.api_format, &body)?;
     log_executor_event(
         "local model proxy request started",
         &[
             ("api_format", upstream.api_format.clone()),
             ("upstream", safe_url(&request_url)),
             ("body_bytes", request_body.len().to_string()),
+            (
+                "expanded_browser_tools",
+                expanded_browser_tools.len().to_string(),
+            ),
         ],
     );
 
@@ -134,6 +139,7 @@ pub(super) async fn handle(headers: HeaderMap, body: Bytes) -> Result<Response, 
         )),
         None => Response::new(Body::from_stream(normalize_responses_stream(
             upstream_response.bytes_stream(),
+            expanded_browser_tools,
         ))),
     };
     *response.status_mut() = status;
@@ -151,9 +157,22 @@ pub(super) async fn handle(headers: HeaderMap, body: Bytes) -> Result<Response, 
 fn prepare_request(
     api_format: &str,
     body: &[u8],
-) -> Result<(Vec<u8>, Option<Conversion>), HttpError> {
+) -> Result<(Vec<u8>, Option<Conversion>, HashSet<String>), HttpError> {
     if api_format == "openai-responses" {
-        return Ok((body.to_vec(), None));
+        let mut request_value =
+            serde_json::from_slice::<Value>(body).map_err(|error| HttpError {
+                status: StatusCode::BAD_REQUEST,
+                detail: format!("Invalid Codex Responses request: {error}"),
+            })?;
+        let expanded_browser_tools = codex_responses_proxy_transform
+            ::expand_wework_browser_namespace_tools(
+                &mut request_value,
+            );
+        let body = serde_json::to_vec(&request_value).map_err(|error| HttpError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: format!("Failed to serialize local model request: {error}"),
+        })?;
+        return Ok((body, None, expanded_browser_tools));
     }
     let responses_body = serde_json::from_slice::<Value>(body).map_err(|error| HttpError {
         status: StatusCode::BAD_REQUEST,
@@ -164,7 +183,7 @@ fn prepare_request(
             .map(|(body, context)| (body, Conversion::Chat(context))),
         "anthropic-messages" => anthropic::responses_to_anthropic(&responses_body)
             .map(|(body, context)| (body, Conversion::Anthropic(context))),
-        _ => return Ok((body.to_vec(), None)),
+        _ => return Ok((body.to_vec(), None, HashSet::new())),
     }
     .map_err(|error| HttpError {
         status: StatusCode::BAD_REQUEST,
@@ -174,7 +193,7 @@ fn prepare_request(
         status: StatusCode::INTERNAL_SERVER_ERROR,
         detail: format!("Failed to serialize local model request: {error}"),
     })?;
-    Ok((body, Some(context)))
+    Ok((body, Some(context), HashSet::new()))
 }
 
 #[derive(Debug)]
@@ -230,9 +249,13 @@ struct ResponsesStreamState<S> {
     stream: Pin<Box<S>>,
     pending: String,
     output: VecDeque<Result<Bytes, std::io::Error>>,
+    expanded_browser_tools: HashSet<String>,
 }
 
-fn normalize_responses_stream<S>(stream: S) -> impl Stream<Item = Result<Bytes, std::io::Error>>
+fn normalize_responses_stream<S>(
+    stream: S,
+    expanded_browser_tools: HashSet<String>,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>>
 where
     S: Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 {
@@ -240,6 +263,7 @@ where
         stream: Box::pin(stream),
         pending: String::new(),
         output: VecDeque::new(),
+        expanded_browser_tools,
     };
     futures_util::stream::unfold(state, |mut state| async move {
         loop {
@@ -252,9 +276,18 @@ where
                     while let Some(index) = state.pending.find("\n\n") {
                         let event = state.pending[..index].to_owned();
                         state.pending.drain(..index + 2);
+                        let normalized = if state.expanded_browser_tools.is_empty() {
+                            normalize_responses_event(&event)
+                        } else {
+                            let rewritten = rewrite_responses_event(
+                                &event,
+                                &state.expanded_browser_tools,
+                            );
+                            normalize_responses_event(&rewritten)
+                        };
                         state.output.push_back(Ok(Bytes::from(format!(
                             "{}\n\n",
-                            normalize_responses_event(&event)
+                            normalized
                         ))));
                     }
                 }
@@ -289,6 +322,45 @@ fn normalize_responses_event(event: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn rewrite_responses_event(event: &str, expanded: &HashSet<String>) -> String {
+    if expanded.is_empty() {
+        return event.to_owned();
+    }
+    let mut changed = false;
+    let lines = event
+        .lines()
+        .map(|line| {
+            let Some(data) = line.strip_prefix("data:") else {
+                return line.to_owned();
+            };
+            let data = data.trim_start();
+            if data == "[DONE]" {
+                return line.to_owned();
+            }
+            let Ok(mut value) = serde_json::from_str::<Value>(data) else {
+                return line.to_owned();
+            };
+            let original = value.clone();
+            codex_responses_proxy_transform::rewrite_wework_browser_function_calls(
+                &mut value, expanded,
+            );
+            if value == original {
+                return line.to_owned();
+            }
+            changed = true;
+            format!(
+                "data: {}",
+                serde_json::to_string(&value).unwrap_or_else(|_| data.to_owned())
+            )
+        })
+        .collect::<Vec<_>>();
+    if changed {
+        lines.join("\n")
+    } else {
+        event.to_owned()
+    }
 }
 
 fn normalize_completed_usage(value: &mut Value) {
@@ -443,5 +515,67 @@ mod tests {
             "WEWORK_MODEL_TOOL_OK"
         );
         assert!(String::from_utf8_lossy(&output.stdout).contains("complete"));
+    }
+
+    #[test]
+    fn rewrite_responses_event_adds_namespace_to_browser_calls() {
+        let event = concat!(
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"browser_navigate\",\"arguments\":\"{\\\"url\\\":\\\"https://example.com\\\"}\"}}"
+        );
+        let expanded = HashSet::from(["browser_navigate".to_owned()]);
+
+        let rewritten = rewrite_responses_event(event, &expanded);
+        let data = rewritten
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .expect("rewritten event should contain data");
+        let value = serde_json::from_str::<Value>(data).unwrap();
+
+        assert_eq!(value["item"]["namespace"], "wework_browser");
+        assert_eq!(value["item"]["name"], "browser_navigate");
+    }
+
+    #[test]
+    fn rewrite_responses_event_leaves_non_browser_calls_unchanged() {
+        let event =
+            "data: {\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{}\"}";
+        let expanded = HashSet::from(["browser_navigate".to_owned()]);
+
+        assert_eq!(rewrite_responses_event(event, &expanded), event);
+    }
+
+    #[test]
+    fn rewrite_responses_event_combines_with_completed_usage_normalization() {
+        let event = concat!(
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[{\"type\":\"function_call\",\"name\":\"browser_snapshot\",\"arguments\":\"{}\"}],\"usage\":{\"input_tokens\":1,\"input_tokens_details\":{},\"output_tokens\":2,\"output_tokens_details\":{},\"total_tokens\":3}}}"
+        );
+        let expanded = HashSet::from(["browser_snapshot".to_owned()]);
+
+        let normalized = if expanded.is_empty() {
+            normalize_responses_event(event)
+        } else {
+            let rewritten = rewrite_responses_event(event, &expanded);
+            normalize_responses_event(&rewritten)
+        };
+        let data = normalized
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .expect("normalized event should contain data");
+        let value = serde_json::from_str::<Value>(data).unwrap();
+
+        assert_eq!(
+            value["response"]["output"][0]["namespace"],
+            "wework_browser"
+        );
+        assert_eq!(
+            value["response"]["usage"]["input_tokens_details"]["cached_tokens"],
+            json!(0)
+        );
+        assert_eq!(
+            value["response"]["usage"]["output_tokens_details"]["reasoning_tokens"],
+            json!(0)
+        );
     }
 }

--- a/executor/src/server/mod.rs
+++ b/executor/src/server/mod.rs
@@ -14,6 +14,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+mod codex_responses_proxy_transform;
 mod config;
 pub(crate) mod local_model_proxy;
 

--- a/frontend/e2e/tests/tasks/agent-conversation-regression.spec.ts
+++ b/frontend/e2e/tests/tasks/agent-conversation-regression.spec.ts
@@ -763,18 +763,25 @@ test.describe('Agent conversation regression', () => {
     await expect
       .poll(
         async () => {
-          const response = await request.get(`${API_BASE_URL}/api/tasks/${taskId}/runtime-check`, {
-            headers: authHeaders(),
-          })
-          if (response.status() !== 200) {
-            return `HTTP_${response.status()}`
-          }
+          try {
+            const response = await request.get(
+              `${API_BASE_URL}/api/tasks/${taskId}/runtime-check`,
+              {
+                headers: authHeaders(),
+              }
+            )
+            if (response.status() !== 200) {
+              return `HTTP_${response.status()}`
+            }
 
-          const runtime = (await response.json()) as RuntimeCheckResponse
-          const status = String(runtime.task_status || '').toUpperCase()
-          return ['COMPLETED', 'COMPLETED_SILENT', 'FAILED', 'CANCELLED'].includes(status)
-            ? status
-            : 'RUNNING'
+            const runtime = (await response.json()) as RuntimeCheckResponse
+            const status = String(runtime.task_status || '').toUpperCase()
+            return ['COMPLETED', 'COMPLETED_SILENT', 'FAILED', 'CANCELLED'].includes(status)
+              ? status
+              : 'RUNNING'
+          } catch (error) {
+            return `NETWORK_ERROR_${error instanceof Error ? error.message : String(error)}`
+          }
         },
         {
           message: `Task ${taskId} should reach a terminal status`,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -506,15 +506,25 @@ function responseFailed(id, message) {
 }
 
 function functionCall(callId, name, argumentsValue) {
-  return {
-    type: 'response.output_item.done',
-    item: {
-      type: 'function_call',
-      call_id: callId,
-      name,
-      arguments: JSON.stringify(argumentsValue),
+  return [
+    {
+      type: 'response.output_item.added',
+      item: {
+        type: 'function_call',
+        call_id: callId,
+        name,
+      },
     },
-  }
+    {
+      type: 'response.output_item.done',
+      item: {
+        type: 'function_call',
+        call_id: callId,
+        name,
+        arguments: JSON.stringify(argumentsValue),
+      },
+    },
+  ]
 }
 
 function customToolCall(callId, name, input) {
@@ -1032,8 +1042,8 @@ class DesktopE2EServer {
       await this.initialToolRelease
       this.writeSse(response, [
         responseCreated(responseId),
-        functionCall('wework-e2e-tool-call', tool.name, tool.arguments),
-        functionCall('wework-e2e-view-image', image.name, image.arguments),
+        ...functionCall('wework-e2e-tool-call', tool.name, tool.arguments),
+        ...functionCall('wework-e2e-view-image', image.name, image.arguments),
         customToolCall('wework-e2e-apply-patch', 'apply_patch', patch),
         responseCompleted(responseId),
       ])

--- a/wework/scripts/build-windows-app.sh
+++ b/wework/scripts/build-windows-app.sh
@@ -171,6 +171,11 @@ RUSTFLAGS="-C target-feature=+crt-static" cargo xwin build --"$BUILD_PROFILE" --
 mkdir -p "$SIDE_CAR_DIR"
 cp "$CARGO_TARGET_DIR/$WINDOWS_BUILD_TARGET/$BUILD_PROFILE/$EXECUTOR_BINARY_NAME" "$SIDE_CAR_DIR/$SIDE_CAR_NAME"
 
+# Tauri's build.rs looks for the sidecar in executor/dist/ before falling back
+# to wework/src-tauri/binaries/, so keep the two locations in sync.
+mkdir -p "$EXECUTOR_DIR/dist"
+cp "$CARGO_TARGET_DIR/$WINDOWS_BUILD_TARGET/$BUILD_PROFILE/$EXECUTOR_BINARY_NAME" "$EXECUTOR_DIR/dist/$EXECUTOR_BINARY_NAME"
+
 cd "$WEWORK_DIR"
 CONFIG_OVERRIDE=""
 cleanup() {


### PR DESCRIPTION
## Summary

Non-GPT models (e.g. Claude) do not understand the `wework_browser` namespace tool type that Codex uses for embedded browser operations. This change flattens the namespace into plain `function` tools when proxying local model requests, and rewrites the corresponding `function_call` items in Responses streams back to the namespaced form so Codex receives them correctly.

- Add `codex_responses_proxy_transform` module to expand/rewrite `wework_browser` namespace tools.
- Update `local_model_proxy` to flatten namespace tools for the `openai-responses` format and rewrite response events.
- Add Windows debug logging for embedded browser tools and clean it up afterwards.
- Sync the Windows executor sidecar to `executor/dist/` so Tauri's `build.rs` finds it before falling back to `wework/src-tauri/binaries/`.

## Test plan

- [ ] Run executor unit tests: `cd executor && cargo test --all-features --lib`
- [ ] Run executor clippy: `cd executor && cargo clippy --all-features --lib -- -D warnings`
- [ ] Build wework Windows installer: `cd wework && pnpm run build:windows`
- [ ] Verify non-GPT model task can use browser navigate/click tools end-to-end
- [ ] Verify Codex/GPT model path remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved compatibility for browser tools in OpenAI Responses API requests and streamed responses by expanding namespace tools and rewriting matching function calls.
  * Codex tool calls now emit paired “added” and “done” SSE events to better reflect tool lifecycle.

* **Bug Fixes**
  * Browser bridge HTTP requests now bypass proxies to improve connectivity.
  * Reduced noisy debug logging by removing temporary debug log file output and suppressing background prune failure logging.
  * E2E polling now handles transient network errors more gracefully during runtime checks.

* **Chores**
  * Windows builds now copy the executor sidecar to additional locations to keep packaging and launch behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->