### PR TITLE
fix(wework): keep thinking row visible in tool preview

### DIFF
--- a/docs/en/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/developer-guide/wework-chat-state-sources.md
@@ -50,6 +50,10 @@ A Codex web search may not include its query action in `item/started`; the final
 
 The Wework presentation layer accepts both Responses API snake_case action names (`open_page`, `find_in_page`) and Codex app-server camelCase names (`openPage`, `findInPage`). Normalize this naming difference at the tool-detail parsing boundary; do not mask missing completion events with UI placeholder content or status fallbacks.
 
+### Tool Activity Preview Scrolling
+
+The collapsed tool activity preview shows at most three rows and follows the latest activity while no tool detail is expanded. Auto-scroll must react both to changes in the tool row count and to the bottom “Thinking” row appearing or disappearing. When a tool completes without changing the row count, the thinking row must remain inside the inner scroll area's visible range. Expanding a detail removes the preview height limit, so forced scrolling must not override the user's reading position in that state.
+
 ## Goal and Task Execution State
 
 The goal bar's running presentation must be constrained by the current runtime task execution snapshot. When App Server explicitly reports `running: false` for the current task, an otherwise `active` goal must be derived as `paused` in the UI and its displayed elapsed time must stop. This prevents an interrupted task from showing an active, ticking goal when it is reopened.

--- a/docs/zh/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/developer-guide/wework-chat-state-sources.md
@@ -50,6 +50,10 @@ Codex 的网页搜索在 `item/started` 时可能还没有查询动作，在 `it
 
 Wework 展示层兼容 Responses API 的 snake_case 动作名（如 `open_page`、`find_in_page`）和 Codex app-server 的 camelCase 动作名（如 `openPage`、`findInPage`）。动作名差异只能在工具详情解析边界处理，不能通过 UI 占位内容或状态兜底掩盖缺失的完成事件。
 
+### 工具活动预览滚动
+
+折叠的工具活动预览最多显示三行，并在用户没有展开工具详情时跟随最新活动。自动滚动必须同时响应工具行数量变化和底部“正在思考”行的出现或消失；工具完成后即使行数不变，“正在思考”也必须保持在内层滚动区域的可见范围内。展开详情时预览解除高度限制，不能用强制滚动覆盖用户阅读位置。
+
 ## Goal 与任务执行状态
 
 Goal 条的运行态必须受当前 runtime task 的执行快照约束：当 App Server 明确返回当前任务 `running: false` 时，仍为 `active` 的 goal 在 UI 中必须派生为 `paused`，并停止累计显示的耗时。这避免在重新打开已中断任务时，goal 继续显示“进行中”并计时。

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1229,6 +1229,33 @@ describe('ToolBlocksDisplay', () => {
     expect(scrollArea.scrollTop).toBe(160)
   })
 
+  test('scrolls the live preview when the thinking row appears without a new tool row', () => {
+    const runningBlocks: ProcessingBlock[] = Array.from({ length: 4 }, (_, index) => ({
+      id: `running-${index + 1}`,
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: `command-${index + 1}` },
+      status: 'streaming',
+      createdAt: Date.now() + index,
+    }))
+
+    const { rerender } = render(<ToolBlocksDisplay blocks={runningBlocks} isStreaming={true} />)
+    const scrollArea = screen.getByTestId('processing-live-preview-scroll')
+    Object.defineProperty(scrollArea, 'scrollHeight', { configurable: true, value: 192 })
+    scrollArea.scrollTop = 0
+
+    rerender(
+      <ToolBlocksDisplay
+        blocks={runningBlocks.map(block => ({ ...block, status: 'done' }))}
+        isStreaming={true}
+      />
+    )
+
+    expect(screen.getByTestId('tool-block-thinking')).toBeInTheDocument()
+    expect(scrollArea.scrollTop).toBe(192)
+  })
+
   test('anchors the running duration to the turn start, surviving a refresh', () => {
     vi.useFakeTimers()
     // The page was refreshed 10s into a still-running turn.

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -517,7 +517,7 @@ function LiveProcessingPreview({
     const scrollArea = scrollRef.current
     if (!scrollArea) return
     scrollArea.scrollTop = scrollArea.scrollHeight
-  }, [rows.length])
+  }, [rows.length, showThinking])
 
   return (
     <div className="ml-2 min-w-0 border-l border-border pl-3" data-testid="processing-live-preview">


### PR DESCRIPTION
## What changed

- Scroll the live tool activity preview when the bottom thinking row appears or disappears, even when the tool row count is unchanged.
- Add regression coverage for the running-tool to thinking transition.
- Document the tool preview auto-scroll contract in Chinese and English.

## Root cause

The inner tool preview only synchronized `scrollTop` when `rows.length` changed. Completing a tool and rendering the thinking row can keep the same row count, so that new row was rendered below the visible viewport without updating the inner scrollbar.

## Impact

During long-running Wework tasks, the current thinking status remains visible after a tool finishes instead of being hidden below the compact three-row tool preview.

## Validation

- `pnpm --filter wework test` (183 files, 1840 tests)
- `pnpm --filter wework exec vitest run src/components/chat/blocks/ToolBlocksDisplay.test.tsx` (50 tests)
- Wework pre-push ESLint, TypeScript, and unit-test checks
- Prettier and ESLint on changed Wework files
- Isolated real-Tauri verification with 8 sequential tool calls, covering running, thinking-after-tool, stable-thinking, and completed states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live tool activity previews so scrolling keeps the current “Thinking” status visible as activity changes.
  * Preserved the reader’s scroll position when expanded tool details are viewed.

* **Tests**
  * Added coverage for scrolling when the “Thinking” row appears without additional tool activity.

* **Documentation**
  * Documented collapsed preview limits and scrolling behavior in English and Chinese developer guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->