### PR TITLE
fix(wework): preserve composer focus while submitting

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -192,6 +192,27 @@ describe('ChatInput', () => {
     expect(screen.queryByTestId('voice-input-button')).not.toBeInTheDocument()
   })
 
+  test('keeps the desktop editor focused while submission is temporarily disabled', async () => {
+    const props = {
+      value: 'next draft',
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      disabled: false,
+      variant: 'desktop' as const,
+    }
+    const { rerender } = render(<ChatInput {...props} submitDisabled={false} />)
+    const editor = screen.getByTestId('chat-message-input')
+
+    editor.focus()
+    await waitFor(() => expect(editor).toHaveFocus())
+
+    rerender(<ChatInput {...props} submitDisabled />)
+
+    expect(editor).toHaveAttribute('contenteditable', 'true')
+    expect(editor).toHaveFocus()
+    expect(screen.getByTestId('send-message-button')).toBeDisabled()
+  })
+
   test('does not move selection when an unfocused composer syncs its value', async () => {
     const renderComposers = (backgroundValue?: string) => (
       <>

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -723,7 +723,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('chat-message-input')).toHaveClass(
       'py-[14px]',
       'scrollbar-none',
-      'text-sm',
+      'text-chat',
       'leading-5'
     )
     expect(screen.getByTestId('send-message-button')).toHaveClass(

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -91,6 +91,7 @@ export interface ChatInputProps {
   onChange: (value: string) => void
   onSubmit: (valueOverride?: string, options?: ChatSubmitOptions) => void | Promise<void>
   disabled: boolean
+  submitDisabled?: boolean
   error?: string | null
   disabledReason?: string
   placeholder?: string
@@ -197,6 +198,7 @@ export function ChatInput({
   onChange,
   onSubmit,
   disabled,
+  submitDisabled = false,
   error,
   disabledReason,
   placeholder,
@@ -319,6 +321,7 @@ export function ChatInput({
     onChange,
     onSubmit: handleSubmit,
     disabled,
+    submitDisabled,
     disabledReason,
     placeholder: disabledReason ? '' : inputPlaceholder,
     onOpenSkillFile,

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -858,7 +858,7 @@ function UserMessage({
         ) : displayContent ? (
           <div
             className={[
-              'overflow-hidden rounded-2xl bg-muted text-sm leading-5 text-text-primary',
+              'overflow-hidden rounded-2xl bg-muted text-base leading-5 text-text-primary',
               hasImagePreviews ? 'max-w-[80%]' : 'max-w-full',
             ].join(' ')}
           >
@@ -979,7 +979,7 @@ function UserMessageEditForm({
   return (
     <div
       data-testid="edit-user-message-form"
-      className="w-[min(560px,80vw)] max-w-full rounded-2xl bg-muted px-3 py-2 text-sm leading-5 text-text-primary"
+      className="w-[min(560px,80vw)] max-w-full rounded-2xl bg-muted px-3 py-2 text-base leading-5 text-text-primary"
     >
       <textarea
         ref={textareaRef}
@@ -1000,7 +1000,7 @@ function UserMessageEditForm({
             onCancel?.()
           }
         }}
-        className="block max-h-[280px] min-h-24 w-full resize-none overflow-y-auto rounded-xl border border-border bg-base px-3 py-2 text-sm leading-5 text-text-primary outline-none focus:border-primary focus:ring-1 focus:ring-primary disabled:cursor-wait disabled:opacity-70"
+        className="block max-h-[280px] min-h-24 w-full resize-none overflow-y-auto rounded-xl border border-border bg-base px-3 py-2 text-base leading-5 text-text-primary outline-none focus:border-primary focus:ring-1 focus:ring-primary disabled:cursor-wait disabled:opacity-70"
       />
       <div className="mt-2 flex items-center justify-end gap-2">
         <button
@@ -1008,7 +1008,7 @@ function UserMessageEditForm({
           data-testid="cancel-edit-user-message-button"
           disabled={submitting}
           onClick={onCancel}
-          className="flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium text-text-secondary hover:bg-surface disabled:cursor-not-allowed disabled:opacity-60"
+          className="flex h-8 items-center justify-center rounded-md px-3 text-base font-medium text-text-secondary hover:bg-surface disabled:cursor-not-allowed disabled:opacity-60"
         >
           取消
         </button>
@@ -1017,7 +1017,7 @@ function UserMessageEditForm({
           data-testid="submit-edit-user-message-button"
           disabled={submitDisabled}
           onClick={submit}
-          className="flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-contrast hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          className="flex h-8 items-center justify-center rounded-md bg-primary px-3 text-base font-medium text-primary-contrast hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           发送
         </button>

--- a/wework/src/components/chat/composer/AddContextMenu.tsx
+++ b/wework/src/components/chat/composer/AddContextMenu.tsx
@@ -66,7 +66,7 @@ export function AddContextMenu({
             type="button"
             data-testid="attach-files-button"
             onClick={() => fileInputRef.current?.click()}
-            className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-sm font-medium leading-[18px] text-text-primary hover:bg-muted"
+            className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base font-medium leading-[18px] text-text-primary hover:bg-muted"
           >
             <Paperclip className="h-[18px] w-[18px] shrink-0 text-text-secondary" />
             <span>{t('workbench.add_photos_files', '添加照片和文件')}</span>
@@ -76,7 +76,7 @@ export function AddContextMenu({
               type="button"
               data-testid="set-plan-mode-button"
               onClick={handleSetPlanMode}
-              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-sm leading-[18px] text-text-primary hover:bg-muted"
+              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base leading-[18px] text-text-primary hover:bg-muted"
             >
               <ClipboardList className="h-[18px] w-[18px] shrink-0 text-text-secondary" />
               <span className="min-w-0 truncate">
@@ -92,7 +92,7 @@ export function AddContextMenu({
               type="button"
               data-testid="set-goal-button"
               onClick={handleSetGoal}
-              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-sm leading-[18px] text-text-primary hover:bg-muted"
+              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base leading-[18px] text-text-primary hover:bg-muted"
             >
               <Target className="h-[18px] w-[18px] shrink-0 text-text-secondary" />
               <span className="min-w-0 truncate">

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -256,7 +256,7 @@ export function CompactChatComposer({
             onOpenSkillFile={onOpenSkillFile}
             workspaceTarget={workspaceTarget}
             workspaceFileApi={workspaceFileApi}
-            className="scrollbar-none max-h-32 min-h-6 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-[14px] text-sm leading-5 text-text-secondary outline-none placeholder:text-text-muted"
+            className="scrollbar-none max-h-32 min-h-6 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-[14px] text-chat leading-5 text-text-secondary outline-none placeholder:text-text-muted"
             skillMenuClassName={[
               'left-[-1rem]',
               isStreaming && canSend ? 'right-[-5.75rem]' : 'right-[-3.5rem]',

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -38,6 +38,7 @@ interface CompactChatComposerProps {
   onChange: (value: string) => void
   onSubmit: (submittedValue?: string, options?: ComposerSubmitOptions) => void
   disabled: boolean
+  submitDisabled?: boolean
   disabledReason?: string
   placeholder: string
   attachments?: Attachment[]
@@ -73,6 +74,7 @@ export function CompactChatComposer({
   onChange,
   onSubmit,
   disabled,
+  submitDisabled = false,
   disabledReason,
   placeholder,
   attachments = [],
@@ -111,7 +113,9 @@ export function CompactChatComposer({
   const [fullscreenInputOpen, setFullscreenInputOpen] = useState(false)
   const [canExpandInput, setCanExpandInput] = useState(false)
   const canSend =
-    (value.trim().length > 0 || attachments.length > 0 || codeComments.length > 0) && !disabled
+    (value.trim().length > 0 || attachments.length > 0 || codeComments.length > 0) &&
+    !disabled &&
+    !submitDisabled
   const explicitLineCount = value.split('\n').length
   const handleShowTextAttachment = (attachment: Attachment) => {
     const text = attachment.text_content

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -29,6 +29,7 @@ interface ProjectChatComposerProps {
   onChange: (value: string) => void
   onSubmit: (submittedValue?: string, options?: ComposerSubmitOptions) => void
   disabled: boolean
+  submitDisabled?: boolean
   disabledReason?: string
   placeholder: string
   models: UnifiedModel[]
@@ -151,6 +152,7 @@ export function ProjectChatComposer({
   onChange,
   onSubmit,
   disabled,
+  submitDisabled = false,
   disabledReason,
   placeholder,
   models,
@@ -192,7 +194,9 @@ export function ProjectChatComposer({
   const onFileSelectRef = useRef(onFileSelect)
   const textareaRef = useAutoResizeTextarea(value, 168)
   const canSend =
-    (value.trim().length > 0 || attachments.length > 0 || codeComments.length > 0) && !disabled
+    (value.trim().length > 0 || attachments.length > 0 || codeComments.length > 0) &&
+    !disabled &&
+    !submitDisabled
   const handleDragOver: DragEventHandler<HTMLFormElement> = event => {
     if (!hasDraggedFiles(event.dataTransfer)) return
 

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -686,9 +686,9 @@ describe('DesktopSidebar', () => {
       expect(button).toHaveClass('font-normal', 'text-[rgb(var(--color-sidebar-text-primary))]')
     }
     expect(searchButton).toHaveClass('text-[rgb(var(--color-sidebar-text-primary))]')
-    expect(newTaskButton).toHaveClass('h-[30px]', 'rounded-[10px]', 'text-sm')
-    expect(pluginsButton).toHaveClass('h-[30px]', 'rounded-[10px]', 'text-sm')
-    expect(cloudButton).toHaveClass('h-[30px]', 'rounded-[10px]', 'text-sm')
+    expect(newTaskButton).toHaveClass('h-[30px]', 'rounded-[10px]', 'text-base')
+    expect(pluginsButton).toHaveClass('h-[30px]', 'rounded-[10px]', 'text-base')
+    expect(cloudButton).toHaveClass('h-[30px]', 'rounded-[10px]', 'text-base')
     expect(newTaskIcon).toHaveClass('text-current')
     expect(cloudIcon).toHaveClass('text-[rgb(var(--color-sidebar-text-primary))]')
     expect(projectsTitle).toHaveClass(

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -481,7 +481,7 @@ function SidebarButton({
       aria-current={selected ? 'page' : undefined}
       onClick={onClick}
       className={[
-        'flex h-[30px] w-full items-center gap-2 rounded-[10px] px-2 text-left text-sm font-normal leading-5',
+        'flex h-[30px] w-full items-center gap-2 rounded-[10px] px-2 text-left text-base font-normal leading-5',
         selected
           ? 'bg-[rgb(var(--color-sidebar-active))] text-text-primary'
           : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]',
@@ -1654,7 +1654,7 @@ function RuntimeTaskRow({
           }}
           onKeyDown={event => handleSidebarRowKeyDown(event, handleOpen)}
           className={cn(
-            'group/task relative flex h-[30px] min-w-0 items-center rounded-[10px] pr-2 text-sm leading-5',
+            'group/task relative flex h-[30px] min-w-0 items-center rounded-[10px] pr-2 text-base leading-5',
             indentClassName,
             disabled ? 'cursor-not-allowed opacity-55' : 'cursor-default',
             selected
@@ -2144,7 +2144,7 @@ function ProjectItem({
             event.stopPropagation()
             setProjectMenuPosition({ left: event.clientX, top: event.clientY })
           }}
-          className="group/project relative flex h-[30px] min-w-0 items-center gap-1 rounded-[10px] pl-2.5 pr-1 text-sm leading-5 text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]"
+          className="group/project relative flex h-[30px] min-w-0 items-center gap-1 rounded-[10px] pl-2.5 pr-1 text-base leading-5 text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]"
         >
           <button
             type="button"

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -813,10 +813,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     !activeDeviceId &&
     !devices.some(device => device.status === 'online' && isWeWorkCompatibleDevice(device))
   const composerDisabled =
-    paneSession.status.isSubmitting ||
-    activeDeviceUnavailable ||
-    activeDeviceVersionUnsupported ||
-    noStandaloneCompatibleDevice
+    activeDeviceUnavailable || activeDeviceVersionUnsupported || noStandaloneCompatibleDevice
   const composerDisabledReason = activeDeviceUnavailable
     ? t('workbench.device_status_active_unavailable', {
         device:
@@ -1674,6 +1671,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                             onChange={paneSession.setInput}
                             onSubmit={paneSession.send}
                             disabled={composerDisabled}
+                            submitDisabled={paneSession.status.isSubmitting}
                             error={paneSession.error}
                             disabledReason={inlineComposerDisabledReason}
                             placeholder={t('workbench.follow_up_placeholder', '要求后续变更')}
@@ -1791,6 +1789,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                     onChange={paneSession.setInput}
                     onSubmit={paneSession.send}
                     disabled={composerDisabled}
+                    submitDisabled={paneSession.status.isSubmitting}
                     error={paneSession.error}
                     disabledReason={inlineComposerDisabledReason}
                     placeholder={t('workbench.input_placeholder', '随心输入')}

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -198,10 +198,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
     !activeDeviceId &&
     !state.devices.some(device => device.status === 'online' && isWeWorkCompatibleDevice(device))
   const composerDisabled =
-    paneSession.status.isSubmitting ||
-    activeDeviceUnavailable ||
-    activeDeviceVersionUnsupported ||
-    noStandaloneCompatibleDevice
+    activeDeviceUnavailable || activeDeviceVersionUnsupported || noStandaloneCompatibleDevice
   const composerDisabledReason = activeDeviceUnavailable
     ? t('workbench.device_status_active_unavailable', {
         device:
@@ -417,6 +414,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                     onChange={paneSession.setInput}
                     onSubmit={paneSession.send}
                     disabled={composerDisabled}
+                    submitDisabled={paneSession.status.isSubmitting}
                     error={paneSession.error}
                     disabledReason={inlineComposerDisabledReason}
                     placeholder={t('workbench.follow_up_placeholder', '要求后续变更')}
@@ -521,6 +519,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                 onChange={paneSession.setInput}
                 onSubmit={paneSession.send}
                 disabled={composerDisabled}
+                submitDisabled={paneSession.status.isSubmitting}
                 error={paneSession.error}
                 disabledReason={inlineComposerDisabledReason}
                 placeholder={t('workbench.mobile_input_placeholder', '询问 Wework')}

--- a/wework/src/features/cloud-connection/CloudConnectionSidebarButton.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionSidebarButton.tsx
@@ -174,7 +174,7 @@ export function CloudConnectionSidebarButton({
           }}
           title={statusTitle}
           className={cn(
-            'flex h-[30px] min-w-0 flex-1 items-center gap-2 rounded-[10px] py-0 pl-0 pr-2 text-left text-sm font-normal leading-5 text-[rgb(var(--color-sidebar-text-primary))]',
+            'flex h-[30px] min-w-0 flex-1 items-center gap-2 rounded-[10px] py-0 pl-0 pr-2 text-left text-base font-normal leading-5 text-[rgb(var(--color-sidebar-text-primary))]',
             (needsAttention || cloudWorkUnavailable) && 'text-red-500'
           )}
         >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat composers now prevent duplicate submissions while keeping the editor available and focused during message submission.

* **Style**
  * Updated chat messages, composer controls, sidebar items, and menus with larger, more consistent typography.

* **Tests**
  * Added coverage for composer focus retention and submission-disabled behavior.
  * Updated styling assertions for mobile chat input and sidebar text sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->