### PR TITLE
test(wework): cover cloud project desktop flow

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -118,6 +118,7 @@ jobs:
             libwebkit2gtk-4.1-dev \
             imagemagick \
             librsvg2-dev \
+            redis-server \
             xvfb
 
       - name: Set up Rust
@@ -132,6 +133,14 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -159,6 +168,7 @@ jobs:
         run: |
           test -x "$CODEX_BIN"
           xvfb-run -a --server-args="-screen 0 1280x720x24" pnpm --filter wework e2e:desktop
+          xvfb-run -a --server-args="-screen 0 1280x720x24" pnpm --filter wework e2e:desktop:cloud
 
       - name: Upload Wework desktop E2E diagnostics
         if: always()

--- a/docs/en/developer-guide/wework-e2e-automation.md
+++ b/docs/en/developer-guide/wework-e2e-automation.md
@@ -26,6 +26,12 @@ Run the real desktop task-flow E2E:
 pnpm --filter wework e2e:desktop
 ```
 
+Run only the cloud-project desktop E2E:
+
+```bash
+pnpm --filter wework e2e:desktop:cloud
+```
+
 The command starts a test-only Vite server through `wework/playwright.config.ts`:
 
 ```bash
@@ -68,6 +74,8 @@ CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
 ```
 
 Optional `WEWORK_E2E_EXECUTOR_BIN` and `WEWORK_E2E_APP_BIN` reuse already-built real Executor and Tauri application binaries. A supplied application must be built with the desktop E2E Vite environment variables. The lifecycle scenarios share one application launch to control CI duration. Test artifacts, captured model requests, and failure diagnostics are stored in `wework/test-results/desktop-e2e/`.
+
+The cloud-project scenario starts a real Backend, Redis, and a real Executor registered as a remote device. It exercises real authentication, device RPC, task persistence, and project deletion while covering project creation, task execution, conversation restoration, follow-up, and project removal. Only the model Responses API used by Codex is simulated; Backend HTTP and WebSocket APIs must not be mocked. Python 3.11, `uv`, and `redis-server` are required to run this scenario.
 
 ## Responses API Mock
 
@@ -139,6 +147,7 @@ Desktop task-flow E2E requires a Linux runner with a graphical session, for exam
 ```bash
 pnpm --filter wework prepare:codex
 xvfb-run -a pnpm --filter wework e2e:desktop
+xvfb-run -a pnpm --filter wework e2e:desktop:cloud
 ```
 
 The repository includes a basic workflow at `.github/workflows/wework-e2e.yml`. It runs when Wework, `packages/chat-core`, the pnpm lockfile, or the workflow itself changes.

--- a/docs/zh/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/developer-guide/wework-e2e-automation.md
@@ -26,6 +26,12 @@ pnpm --filter wework e2e
 pnpm --filter wework e2e:desktop
 ```
 
+仅运行云端项目桌面 E2E：
+
+```bash
+pnpm --filter wework e2e:desktop:cloud
+```
+
 该命令会通过 `wework/playwright.config.ts` 启动测试专用 Vite 服务：
 
 ```bash
@@ -68,6 +74,8 @@ CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
 ```
 
 可选的 `WEWORK_E2E_EXECUTOR_BIN` 和 `WEWORK_E2E_APP_BIN` 分别允许复用已经构建的真实 Executor 和真实 Tauri 应用。传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。各生命周期场景复用一次应用启动以控制 CI 时长；测试过程、捕获的模型请求和失败诊断会保存在 `wework/test-results/desktop-e2e/`。
+
+云端项目场景会启动真实 Backend、Redis 和一个注册为远端设备的真实 Executor，通过真实鉴权、设备 RPC、任务持久化和项目删除接口完成创建项目、执行任务、恢复会话、连续追问与删除项目验证。测试只模拟 Codex 使用的模型 Responses API；不得模拟 Backend HTTP 或 WebSocket 接口。运行该场景需要 Python 3.11、`uv` 和 `redis-server`。
 
 ## Responses API Mock
 
@@ -139,6 +147,7 @@ pnpm --filter wework e2e
 ```bash
 pnpm --filter wework prepare:codex
 xvfb-run -a pnpm --filter wework e2e:desktop
+xvfb-run -a pnpm --filter wework e2e:desktop:cloud
 ```
 
 仓库内的基础 workflow 是 `.github/workflows/wework-e2e.yml`，会在 Wework、`packages/chat-core`、pnpm lockfile 或 workflow 自身变化时运行。

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -943,7 +943,47 @@ class RealCloudEnvironment {
     throw new Error('The real cloud backend still returned the removed project')
   }
 
+  async cancelRunningTasks() {
+    if (!this.backendUrl || !this.authToken) return
+    const work = await fetchJson(`${this.backendUrl}/api/runtime-work`, {
+      headers: { Authorization: `Bearer ${this.authToken}` },
+    })
+    const workspaces = [
+      ...(work.projects ?? []).flatMap(project => project.deviceWorkspaces ?? []),
+      ...(work.chats ?? []),
+    ]
+    const runningTasks = workspaces.flatMap(workspace =>
+      (workspace.tasks ?? [])
+        .filter(task => task.running)
+        .map(task => ({
+          deviceId: workspace.deviceId,
+          taskId: task.taskId,
+          workspacePath: task.workspacePath,
+        }))
+    )
+    await Promise.all(
+      runningTasks.map(address =>
+        fetchJson(`${this.backendUrl}/api/runtime-work/cancel`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.authToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(address),
+        })
+      )
+    )
+  }
+
   async stop() {
+    try {
+      await this.cancelRunningTasks()
+    } catch (error) {
+      await appendFile(
+        this.remoteExecutorLogPath,
+        `Cloud E2E cleanup could not cancel running tasks: ${String(error)}\n`
+      )
+    }
     await stopProcess(this.remoteExecutor)
     await stopProcess(this.backend)
     await stopProcess(this.redis)
@@ -1408,7 +1448,7 @@ class DesktopE2EServer {
       this.cloudModelStage = 'awaiting_tool_output'
       this.writeSse(response, [
         responseCreated(responseId),
-        functionCall('wework-cloud-e2e-tool-call', tool.name, tool.arguments),
+        ...functionCall('wework-cloud-e2e-tool-call', tool.name, tool.arguments),
         customToolCall('wework-cloud-e2e-apply-patch', 'apply_patch', patch),
         responseCompleted(responseId),
       ])
@@ -1765,10 +1805,18 @@ async function verifyCloudProjectFlow(control, cloudEnvironment, workspacePath) 
   assert.ok(deviceStatusTestId, 'The cloud project did not expose its remote device status')
   const projectId = deviceStatusTestId.slice('project-device-status-'.length)
   await control.command('click', `[data-testid="project-row-${projectId}"]`)
+  await control.command('waitFor', '[data-testid="project-work-button"]', {
+    text: 'workspace',
+    timeoutMs: UI_TIMEOUT_MS,
+  })
   await control.command(
     'clickWhenEnabled',
     `[data-testid="project-row-${projectId}"] [data-testid="project-new-conversation-button"]`
   )
+  await control.command('waitFor', '[data-testid="project-work-button"]', {
+    text: 'workspace',
+    timeoutMs: UI_TIMEOUT_MS,
+  })
   await control.command('waitFor', composerSelector, { timeoutMs: WORKBENCH_READY_TIMEOUT_MS })
 
   control.setScenario('cloud_initial')
@@ -2506,6 +2554,7 @@ async function main() {
           phase,
           scenario: control.scenario,
           modelStage: control.modelStage,
+          cloudModelStage: control.cloudModelStage,
           scenarioRequestCounts: Object.fromEntries(
             [...control.scenarioRequests.entries()].map(([name, requests]) => [
               name,
@@ -2517,6 +2566,11 @@ async function main() {
         null,
         2
       )}\n`,
+      'utf8'
+    )
+    await writeFile(
+      join(resultDir, 'model-requests.json'),
+      `${JSON.stringify(control.modelRequests, null, 2)}\n`,
       'utf8'
     )
     try {
@@ -2532,8 +2586,8 @@ async function main() {
     )
     throw error
   } finally {
-    await stopProcess(app)
     await cloudEnvironment?.stop()
+    await stopProcess(app)
     await control.close()
     if (appBundlePath) {
       spawnSync(MACOS_LAUNCH_SERVICES_REGISTER, ['-u', appBundlePath])

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -42,6 +42,15 @@ const FRESH_CHAT_PROMPT = 'WEWORK_DESKTOP_E2E_FRESH_CHAT: confirm this is a new 
 const FRESH_CHAT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_FRESH_CHAT_COMPLETE'
 const ATTACHMENT_ONLY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_ATTACHMENT_ONLY_COMPLETE'
 const ATTACHMENT_ONLY_FILENAME = 'same-name-attachment.png'
+const CLOUD_DEVICE_ID = 'wework-e2e-cloud-device'
+const CLOUD_TASK_PROMPT =
+  'WEWORK_DESKTOP_E2E_CLOUD_TASK: create the requested cloud verification file.'
+const CLOUD_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CLOUD_COMPLETE'
+const CLOUD_FOLLOW_UP_PROMPT =
+  'WEWORK_DESKTOP_E2E_CLOUD_FOLLOW_UP: confirm the cloud task remains available.'
+const CLOUD_FOLLOW_UP_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CLOUD_FOLLOW_UP_COMPLETE'
+const CLOUD_ARTIFACT_NAME = 'wework-cloud-e2e-result.txt'
+const CLOUD_ARTIFACT_CONTENT = 'CODEX_EXECUTED_REAL_CLOUD_TOOL'
 const ACTIVE_WORKBENCH_SELECTOR = '[data-testid="desktop-workbench-main"]'
 const ACTIVE_COMPOSER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="chat-message-input"][contenteditable="true"]`
 const MACOS_LAUNCH_SERVICES_REGISTER =
@@ -50,6 +59,7 @@ const LIFECYCLE_ONLY = process.argv.includes('--lifecycle-only')
 const RECONNECT_ONLY = process.argv.includes('--reconnect-only')
 const VIEW_IMAGE_ONLY = process.argv.includes('--view-image-only')
 const ATTACHMENT_ONLY_SIDEBAR = process.argv.includes('--attachment-only-sidebar')
+const CLOUD_ONLY = process.argv.includes('--cloud-only')
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const weworkDir = resolve(scriptDir, '..', '..')
@@ -105,6 +115,43 @@ async function runChecked(command, args, options = {}) {
       reject(new Error(`${command} ${args.join(' ')} exited with ${code ?? 'unknown status'}`))
     })
   })
+}
+
+async function reservePort() {
+  const server = createServer()
+  await new Promise((resolvePromise, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolvePromise)
+  })
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string', 'Unable to reserve an E2E port')
+  await new Promise(resolvePromise => server.close(resolvePromise))
+  return address.port
+}
+
+async function waitForUrl(url, message, timeoutMs = WORKBENCH_READY_TIMEOUT_MS) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+    } catch {
+      // The real service is still starting.
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
+  }
+  throw new Error(message)
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options)
+  const body = await response.json()
+  assert.equal(
+    response.ok,
+    true,
+    `${options.method ?? 'GET'} ${url} failed: ${JSON.stringify(body)}`
+  )
+  return body
 }
 
 async function resolveExecutable(configuredPath, fallbackCommand, description) {
@@ -166,6 +213,15 @@ async function waitForSnapshot(control, predicate, message, timeoutMs = UI_TIMEO
   while (Date.now() - startedAt < timeoutMs) {
     const snapshot = JSON.parse(await control.command('snapshot', 'body'))
     if (predicate(snapshot)) return snapshot
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(message)
+}
+
+async function waitForControlValue(control, selector, expected, message) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < UI_TIMEOUT_MS) {
+    if ((await control.command('getValue', selector)) === expected) return
     await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
   }
   throw new Error(message)
@@ -678,7 +734,8 @@ function cors(response) {
 }
 
 function requestContainsToolOutput(request) {
-  return JSON.stringify(request.input ?? []).includes('function_call_output')
+  const input = JSON.stringify(request.input ?? [])
+  return input.includes('function_call_output') || input.includes('custom_tool_call_output')
 }
 
 function requestAdvertisesShellTool(request) {
@@ -730,15 +787,173 @@ function selectApplyPatchTool(request) {
   ].join('\n')
 }
 
+function selectCloudApplyPatchTool(request) {
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  assert.ok(
+    tools.some(tool => tool?.name === 'apply_patch'),
+    'Real cloud Codex did not advertise apply_patch'
+  )
+  return [
+    '*** Begin Patch',
+    `*** Add File: ${CLOUD_ARTIFACT_NAME}`,
+    `+${CLOUD_ARTIFACT_CONTENT}`,
+    '*** End Patch',
+  ].join('\n')
+}
+
 function selectViewImageTool(request, workspacePath) {
   return selectTool(request, 'view_image', {
     path: join(workspacePath, IMAGE_ARTIFACT_NAME),
   })
 }
 
-class DesktopE2EServer {
-  constructor(workspacePath) {
+class RealCloudEnvironment {
+  constructor({ codexBinary, executorBinary, modelServerUrl, workspacePath }) {
+    this.codexBinary = codexBinary
+    this.executorBinary = executorBinary
+    this.modelServerUrl = modelServerUrl
     this.workspacePath = workspacePath
+  }
+
+  async start() {
+    this.redisPort = await reservePort()
+    this.backendPort = await reservePort()
+    this.backendUrl = `http://127.0.0.1:${this.backendPort}`
+    this.databasePath = join(resultDir, 'cloud-backend.sqlite3')
+    this.backendLogPath = join(resultDir, 'cloud-backend.log')
+    this.redisLogPath = join(resultDir, 'cloud-redis.log')
+    this.remoteExecutorLogPath = join(resultDir, 'cloud-executor.log')
+
+    this.redis = spawn(
+      'redis-server',
+      ['--port', String(this.redisPort), '--save', '', '--appendonly', 'no'],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+    await Promise.all([
+      appendProcessOutput(this.redis.stdout, this.redisLogPath),
+      appendProcessOutput(this.redis.stderr, this.redisLogPath),
+    ])
+
+    const backendEnv = {
+      ...process.env,
+      DATABASE_URL: `sqlite:///${this.databasePath}`,
+      REDIS_URL: `redis://127.0.0.1:${this.redisPort}/0`,
+      SECRET_KEY: `wework-desktop-e2e-${process.pid}`,
+      INTERNAL_SERVICE_TOKEN: `wework-desktop-e2e-internal-${process.pid}`,
+      DB_AUTO_MIGRATE: 'false',
+      INIT_DATA_ENABLED: 'true',
+    }
+    await runChecked('uv', ['run', 'alembic', 'upgrade', 'head'], {
+      cwd: join(repoDir, 'backend'),
+      env: backendEnv,
+    })
+    this.backend = spawn(
+      'uv',
+      ['run', 'uvicorn', 'app.main:app', '--host', '127.0.0.1', '--port', String(this.backendPort)],
+      {
+        cwd: join(repoDir, 'backend'),
+        env: backendEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    )
+    await Promise.all([
+      appendProcessOutput(this.backend.stdout, this.backendLogPath),
+      appendProcessOutput(this.backend.stderr, this.backendLogPath),
+    ])
+    await waitForUrl(
+      `${this.backendUrl}/api/docs`,
+      `Real cloud backend did not start; see ${this.backendLogPath}`
+    )
+
+    const password = `wework-desktop-e2e-${process.pid}`
+    const setup = await fetchJson(`${this.backendUrl}/api/auth/admin-password/setup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    })
+    this.authToken = setup.access_token
+    assert.ok(this.authToken, 'Real cloud backend did not return an authentication token')
+
+    const remoteHome = join(resultDir, 'cloud-executor-home')
+    const remoteCodexHome = join(remoteHome, 'codex')
+    await writeCodexConfig(remoteCodexHome, this.modelServerUrl)
+    const remoteEnv = {
+      ...process.env,
+      CODEX_BIN: this.codexBinary,
+      CODEX_HOME: remoteCodexHome,
+      HOME: remoteHome,
+      WEGENT_CODEX_HOME: remoteCodexHome,
+      WEGENT_EXECUTOR_HOME: remoteHome,
+      WEGENT_EXECUTOR_LOG_DIR: resultDir,
+      WEGENT_EXECUTOR_LOG_FILE: 'cloud-executor-runtime.log',
+      EXECUTOR_MODE: 'local',
+      WEGENT_BACKEND_URL: this.backendUrl,
+      WEGENT_AUTH_TOKEN: this.authToken,
+      DEVICE_ID: CLOUD_DEVICE_ID,
+      DEVICE_NAME: 'Wework E2E Cloud Device',
+      DEVICE_TYPE: 'remote',
+      BIND_SHELL: 'claudecode',
+      LOCAL_WORKSPACE_ROOT: dirname(this.workspacePath),
+      WEWORK_E2E_MODEL_API_KEY: MODEL_API_KEY,
+    }
+    delete remoteEnv.WEGENT_APP_IPC_DEVICE_ID
+    this.remoteExecutor = spawn(this.executorBinary, [], {
+      cwd: weworkDir,
+      env: remoteEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    await Promise.all([
+      appendProcessOutput(this.remoteExecutor.stdout, this.remoteExecutorLogPath),
+      appendProcessOutput(this.remoteExecutor.stderr, this.remoteExecutorLogPath),
+    ])
+    await this.waitForDevice()
+  }
+
+  async waitForDevice() {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < WORKBENCH_READY_TIMEOUT_MS) {
+      const response = await fetch(`${this.backendUrl}/api/devices`, {
+        headers: { Authorization: `Bearer ${this.authToken}` },
+      })
+      if (response.ok) {
+        const devices = await response.json()
+        const device = devices.items?.find(item => item.device_id === CLOUD_DEVICE_ID)
+        if (device?.status === 'online') return
+      }
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
+    }
+    throw new Error(`Real cloud executor did not register; see ${this.remoteExecutorLogPath}`)
+  }
+
+  async waitForWorkspaceRemoved(workspacePath) {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < UI_TIMEOUT_MS) {
+      const response = await fetch(`${this.backendUrl}/api/runtime-work`, {
+        headers: { Authorization: `Bearer ${this.authToken}` },
+      })
+      if (response.ok) {
+        const work = await response.json()
+        const stillPresent = work.workspaces?.some(
+          workspace => workspace.workspacePath === workspacePath
+        )
+        if (!stillPresent) return
+      }
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
+    }
+    throw new Error('The real cloud backend still returned the removed project')
+  }
+
+  async stop() {
+    await stopProcess(this.remoteExecutor)
+    await stopProcess(this.backend)
+    await stopProcess(this.redis)
+  }
+}
+
+class DesktopE2EServer {
+  constructor(workspacePath, cloudWorkspacePath = workspacePath) {
+    this.workspacePath = workspacePath
+    this.cloudWorkspacePath = cloudWorkspacePath
     this.server = createServer((request, response) => {
       void this.handle(request, response)
     })
@@ -761,7 +976,9 @@ class DesktopE2EServer {
     this.failedCloudModelWaiter = null
     this.scenario = 'initial'
     this.modelStage = 'initial'
+    this.cloudModelStage = 'initial'
     this.toolLessPrewarmHandled = false
+    this.cloudToolLessPrewarmHandled = false
     this.toolOutput = null
     this.initialToolRelease = new Promise(resolvePromise => {
       this.releaseInitialTool = resolvePromise
@@ -891,6 +1108,8 @@ class DesktopE2EServer {
         'reconnect',
         'fresh_chat',
         'attachment_only',
+        'cloud_initial',
+        'cloud_follow_up',
       ].includes(scenario),
       `Unknown desktop E2E scenario: ${scenario}`
     )
@@ -1124,6 +1343,17 @@ class DesktopE2EServer {
       return
     }
 
+    if (
+      this.scenario === 'cloud_initial' &&
+      this.cloudModelStage === 'initial' &&
+      !this.cloudToolLessPrewarmHandled &&
+      !requestAdvertisesShellTool(body)
+    ) {
+      this.cloudToolLessPrewarmHandled = true
+      this.writeSse(response, [responseCreated(responseId), responseCompleted(responseId)])
+      return
+    }
+
     if (this.scenario === 'initial' && this.modelStage === 'initial') {
       this.recordScenarioRequest('initial', modelRequest)
       assert.ok(
@@ -1162,6 +1392,54 @@ class DesktopE2EServer {
       this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'cloud_initial' && this.cloudModelStage === 'initial') {
+      this.recordScenarioRequest('cloud_initial', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(CLOUD_TASK_PROMPT),
+        'The real cloud Codex request did not contain the UI task prompt'
+      )
+      const tool = selectShellTool(body, this.cloudWorkspacePath)
+      const patch = selectCloudApplyPatchTool(body)
+      this.cloudModelStage = 'awaiting_tool_output'
+      this.writeSse(response, [
+        responseCreated(responseId),
+        functionCall('wework-cloud-e2e-tool-call', tool.name, tool.arguments),
+        customToolCall('wework-cloud-e2e-apply-patch', 'apply_patch', patch),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'cloud_initial') {
+      this.recordScenarioRequest('cloud_initial', modelRequest)
+      assert.equal(
+        requestContainsToolOutput(body),
+        true,
+        'The real cloud Codex request did not report its tool output to the model service'
+      )
+      this.cloudModelStage = 'complete'
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(CLOUD_COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'cloud_follow_up') {
+      this.recordScenarioRequest('cloud_follow_up', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(CLOUD_FOLLOW_UP_PROMPT),
+        'The real cloud Codex request did not contain the follow-up prompt'
+      )
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(CLOUD_FOLLOW_UP_COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
       return
@@ -1385,7 +1663,7 @@ async function wrapMacDesktopApp(binaryPath, binaryName, appIdentifier) {
   return { binaryPath: bundledBinaryPath, appBundlePath }
 }
 
-async function buildDesktopApp(controlUrl, cloudBackendUrl, appIdentifier) {
+async function buildDesktopApp(controlUrl, cloudBackendUrl, cloudToken, appIdentifier) {
   const configured = process.env.WEWORK_E2E_APP_BIN
   if (configured) {
     const binaryPath = await resolveExecutable(configured, 'app', 'Configured Wework desktop app')
@@ -1409,6 +1687,7 @@ async function buildDesktopApp(controlUrl, cloudBackendUrl, appIdentifier) {
         ...process.env,
         VITE_WEWORK_DESKTOP_E2E_CONTROL_URL: controlUrl,
         VITE_WEWORK_E2E_CLOUD_BACKEND_URL: cloudBackendUrl,
+        VITE_WEWORK_E2E_CLOUD_TOKEN: cloudToken,
         VITE_WEWORK_E2E: 'true',
         VITE_WEWORK_RUNTIME_MODE: 'local-first',
       },
@@ -1441,6 +1720,113 @@ async function buildDesktopApp(controlUrl, cloudBackendUrl, appIdentifier) {
   )
 }
 
+async function verifyCloudProjectFlow(control, cloudEnvironment, workspacePath) {
+  const composerSelector = ACTIVE_COMPOSER_SELECTOR
+  await control.command('waitFor', '[data-testid="projects-create-button"]', {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+
+  await control.command('click', '[data-testid="projects-create-button"]')
+  await control.command('click', '[data-testid="project-create-remote-option"]')
+  await control.command('waitFor', '[data-testid="standalone-remote-device-select"]', {
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('fill', '[data-testid="standalone-remote-device-select"]', {
+    value: CLOUD_DEVICE_ID,
+  })
+  await waitForControlValue(
+    control,
+    '[data-testid="device-folder-path-input"]',
+    join(resultDir, 'cloud-executor-home'),
+    'The remote folder picker did not load the real executor home directory'
+  )
+  await control.command('waitFor', '[data-testid="device-folder-path-input"]', {
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('fill', '[data-testid="device-folder-path-input"]', {
+    value: workspacePath,
+  })
+  await control.command('press', '[data-testid="device-folder-path-input"]', { key: 'Enter' })
+  await waitForControlValue(
+    control,
+    '[data-testid="device-folder-path-input"]',
+    workspacePath,
+    'The remote folder picker did not retain the selected cloud workspace path'
+  )
+  await control.command('clickWhenEnabled', '[data-testid="confirm-device-folder-picker-button"]')
+  const projectSnapshot = await waitForSnapshot(
+    control,
+    value => value.testIds.some(testId => testId.startsWith('project-device-status-')),
+    'The real cloud project was not shown with its remote device status'
+  )
+  const deviceStatusTestId = projectSnapshot.testIds.find(testId =>
+    testId.startsWith('project-device-status-')
+  )
+  assert.ok(deviceStatusTestId, 'The cloud project did not expose its remote device status')
+  const projectId = deviceStatusTestId.slice('project-device-status-'.length)
+  await control.command('click', `[data-testid="project-row-${projectId}"]`)
+  await control.command(
+    'clickWhenEnabled',
+    `[data-testid="project-row-${projectId}"] [data-testid="project-new-conversation-button"]`
+  )
+  await control.command('waitFor', composerSelector, { timeoutMs: WORKBENCH_READY_TIMEOUT_MS })
+
+  control.setScenario('cloud_initial')
+  await sendPrompt(control, composerSelector, CLOUD_TASK_PROMPT)
+  await withTimeout(
+    control.awaitScenarioRequestCount('cloud_initial', 2),
+    UI_TIMEOUT_MS,
+    'The real cloud executor did not complete its model tool loop'
+  )
+  assert.equal(
+    (await readFile(join(workspacePath, CLOUD_ARTIFACT_NAME), 'utf8')).trim(),
+    CLOUD_ARTIFACT_CONTENT,
+    'The real cloud executor did not create the verification artifact'
+  )
+  const taskSnapshot = await waitForSnapshot(
+    control,
+    value => value.testIds.some(testId => testId.startsWith('runtime-local-task-row-')),
+    'The completed cloud task was not persisted in the sidebar'
+  )
+  const taskRowTestId = taskSnapshot.testIds.find(testId =>
+    testId.startsWith('runtime-local-task-row-')
+  )
+  assert.ok(taskRowTestId, 'The completed cloud task row was not available')
+  await control.command('click', `[data-testid="${taskRowTestId}"]`)
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: CLOUD_COMPLETION_TEXT,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await captureVerificationScreenshot(control, 'cloud-project-task-completed.png')
+
+  control.setScenario('cloud_follow_up')
+  await sendPrompt(control, composerSelector, CLOUD_FOLLOW_UP_PROMPT)
+  await withTimeout(
+    control.awaitScenarioRequest('cloud_follow_up'),
+    UI_TIMEOUT_MS,
+    'The real cloud executor did not send the follow-up model request'
+  )
+  await control.command('click', `[data-testid="${taskRowTestId}"]`)
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: CLOUD_FOLLOW_UP_COMPLETION_TEXT,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+
+  const projectMenuTestId = `project-menu-${projectId}`
+  await waitForSnapshot(
+    control,
+    value => value.testIds.includes(projectMenuTestId),
+    'The cloud project was not shown in the sidebar'
+  )
+  await control.command('click', `[data-testid="${projectMenuTestId}"]`)
+  await control.command('click', `[data-testid="remove-project-${projectId}"]`)
+  await control.command(
+    'clickWhenEnabled',
+    `[data-testid="remove-project-dialog-${projectId}-confirm-button"]`
+  )
+  await cloudEnvironment.waitForWorkspaceRemoved(workspacePath)
+}
+
 async function main() {
   await mkdir(resultDir, { recursive: true })
   const workspacePath = join(resultDir, 'workspace')
@@ -1470,9 +1856,10 @@ async function main() {
     cwd: workspacePath,
   })
 
-  const control = new DesktopE2EServer(workspacePath)
+  const control = new DesktopE2EServer(workspacePath, workspacePath)
   let app
   let appBundlePath
+  let cloudEnvironment
   let phase = 'startup'
   try {
     await control.start()
@@ -1486,10 +1873,22 @@ async function main() {
     console.log(`Using real Codex: ${codexVersion}`)
 
     const appIdentifier = `io.wecode.wework.e2e.run${process.pid}`
-    const [executorBinary, desktopApp] = await Promise.all([
-      buildExecutor(),
-      buildDesktopApp(control.controlUrl, control.url, appIdentifier),
-    ])
+    const executorBinary = await buildExecutor()
+    if (CLOUD_ONLY) {
+      cloudEnvironment = new RealCloudEnvironment({
+        codexBinary,
+        executorBinary,
+        modelServerUrl: control.url,
+        workspacePath,
+      })
+      await cloudEnvironment.start()
+    }
+    const desktopApp = await buildDesktopApp(
+      control.controlUrl,
+      cloudEnvironment?.backendUrl ?? control.url,
+      cloudEnvironment?.authToken ?? 'wework-desktop-e2e-cloud-token',
+      appIdentifier
+    )
     const appBinary = desktopApp.binaryPath
     appBundlePath = desktopApp.appBundlePath
     await writeCodexConfig(join(executorHome, 'codex'), control.url)
@@ -1530,6 +1929,18 @@ async function main() {
       /^(tauri|http):/,
       'The desktop controller did not connect from a webview'
     )
+
+    if (CLOUD_ONLY) {
+      phase = 'cloud-project-flow'
+      await verifyCloudProjectFlow(control, cloudEnvironment, workspacePath)
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(`Wework desktop cloud-project E2E passed. Diagnostics: ${resultDir}`)
+      return
+    }
 
     phase = 'cloud-request-non-blocking'
     await withTimeout(
@@ -2122,6 +2533,7 @@ async function main() {
     throw error
   } finally {
     await stopProcess(app)
+    await cloudEnvironment?.stop()
     await control.close()
     if (appBundlePath) {
       spawnSync(MACOS_LAUNCH_SERVICES_REGISTER, ['-u', appBundlePath])

--- a/wework/package.json
+++ b/wework/package.json
@@ -25,6 +25,7 @@
     "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:desktop": "node e2e/desktop/task-flow.e2e.mjs",
+    "e2e:desktop:cloud": "node e2e/desktop/task-flow.e2e.mjs --cloud-only",
     "e2e:desktop:lifecycle": "node e2e/desktop/task-flow.e2e.mjs --lifecycle-only",
     "e2e:desktop:reconnect": "node e2e/desktop/task-flow.e2e.mjs --reconnect-only",
     "e2e:desktop:attachment-only-sidebar": "node e2e/desktop/task-flow.e2e.mjs --attachment-only-sidebar",

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -34,6 +34,7 @@ type DesktopControlAction =
   | 'dropFile'
   | 'fill'
   | 'getText'
+  | 'getValue'
   | 'hover'
   | 'navigate'
   | 'pointerMove'
@@ -208,11 +209,13 @@ function createBridge(): WeworkAutomationBridge {
 function seedDesktopE2ECloudConnection() {
   const backendUrl = import.meta.env.VITE_WEWORK_E2E_CLOUD_BACKEND_URL?.trim()
   if (!backendUrl) return
+  const token =
+    import.meta.env.VITE_WEWORK_E2E_CLOUD_TOKEN?.trim() || 'wework-desktop-e2e-cloud-token'
 
   const config = normalizeCloudBackendUrl(backendUrl)
   saveStoredCloudConnection({
     ...config,
-    token: 'wework-desktop-e2e-cloud-token',
+    token,
     tokenExpiresAt: null,
     user: {
       id: 9001,
@@ -523,6 +526,14 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return waitForDesktopControlElement(command)
     case 'getText':
       return desktopControlElementText(command.selector)
+    case 'getValue': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      if (element instanceof HTMLInputElement || element instanceof HTMLSelectElement) {
+        return element.value
+      }
+      return element.textContent?.trim() ?? ''
+    }
     case 'snapshot':
       return desktopControlSnapshot()
     case 'scrollIntoView': {


### PR DESCRIPTION
## Summary

- add a complete cloud-project desktop E2E flow covering remote project creation, task execution, persisted conversation restoration, follow-up, and project removal
- run real Backend, Redis, authentication, device RPC, remote Executor, and Codex; mock only the model Responses API
- add the cloud scenario to the Wework E2E GitHub Actions job and document local/CI usage in Chinese and English

## Verification

- `pnpm --filter wework e2e:desktop:cloud`
- `pnpm --filter wework e2e:desktop`
- `pnpm --filter wework test`
- `VITE_API_PROXY_TARGET=http://127.0.0.1:9 pnpm --filter wework e2e`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- pre-push quality checks (ESLint, TypeScript, unit tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a cloud-project desktop end-to-end testing scenario covering authentication, remote device connectivity, task execution, persistence, and project deletion.
  - Added a dedicated command to run cloud desktop tests.
  - Enhanced desktop E2E controls to support retrieving values from inputs and selecting values reliably.

- **Documentation**
  - Updated English and Chinese developer guidance with cloud-project desktop E2E run commands, prerequisites, and CI examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->