### PR TITLE
fix(wework): preserve Codex auth during migration

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -50,6 +50,7 @@ pnpm --filter wework ai:verify stop --session <session-path>
 ```
 
 - `start` waits for the WebView, creates an isolated executor home, links local Codex authentication only for that session, and gives the app its own stdio-managed executor child.
+- Use `start --codex-home-initialization true` to verify the first-run Codex migration flow with a session-local native Codex home and synthetic authentication; it does not read or modify personal Codex credentials.
 - Session files and credentials are secrets: never print their contents. Always stop the session; it removes the auth link and terminates the isolated process group.
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.
 - Execute the complete QA test plan in the isolated Tauri session, including the primary path, relevant boundary and error cases, and recovery. Document the environment, cases run, actual results, and evidence in the change handoff or pull request.

--- a/wework/scripts/ai-verify-environment.mjs
+++ b/wework/scripts/ai-verify-environment.mjs
@@ -2,7 +2,17 @@ import { join } from 'node:path'
 
 export function buildAiVerifyEnvironment(
   processEnvironment,
-  { controlUrl, token, codexHome, deviceId, appIdentifier, executorHome, sessionDirectory }
+  {
+    controlUrl,
+    token,
+    codexHome,
+    nativeCodexHome,
+    verifyCodexHomeInitialization,
+    deviceId,
+    appIdentifier,
+    executorHome,
+    sessionDirectory,
+  }
 ) {
   return {
     ...processEnvironment,
@@ -11,6 +21,8 @@ export function buildAiVerifyEnvironment(
     VITE_WEWORK_DESKTOP_E2E_CONTROL_TOKEN: token,
     CODEX_HOME: codexHome,
     WEGENT_CODEX_HOME: codexHome,
+    ...(nativeCodexHome ? { WEWORK_E2E_NATIVE_CODEX_HOME: nativeCodexHome } : {}),
+    ...(verifyCodexHomeInitialization ? { VITE_WEWORK_E2E_CODEX_HOME_INITIALIZATION: 'true' } : {}),
     DEVICE_ID: deviceId,
     WEWORK_APP_IDENTIFIER: appIdentifier,
     DEVICE_SESSION_GATEWAY_HOST: '127.0.0.1',

--- a/wework/scripts/ai-verify-environment.test.mjs
+++ b/wework/scripts/ai-verify-environment.test.mjs
@@ -9,6 +9,8 @@ describe('buildAiVerifyEnvironment', () => {
         controlUrl: 'http://127.0.0.1:9999',
         token: 'control-token',
         codexHome: '/tmp/session/executor-home/codex',
+        nativeCodexHome: '/tmp/session/native-codex',
+        verifyCodexHomeInitialization: true,
         deviceId: 'device-1',
         appIdentifier: 'io.wecode.wework.ai-verify.test',
         executorHome: '/tmp/session/executor-home',
@@ -18,6 +20,8 @@ describe('buildAiVerifyEnvironment', () => {
 
     expect(environment.CODEX_HOME).toBe('/tmp/session/executor-home/codex')
     expect(environment.WEGENT_CODEX_HOME).toBe('/tmp/session/executor-home/codex')
+    expect(environment.WEWORK_E2E_NATIVE_CODEX_HOME).toBe('/tmp/session/native-codex')
+    expect(environment.VITE_WEWORK_E2E_CODEX_HOME_INITIALIZATION).toBe('true')
     expect(environment.WEWORK_APP_IDENTIFIER).toBe('io.wecode.wework.ai-verify.test')
     expect(environment.WEGENT_EXECUTOR_HOME).toBe('/tmp/session/executor-home')
     expect(environment.WEGENT_EXECUTOR_PROJECTS_DIR).toBe(

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -29,6 +29,8 @@ function usage() {
   pnpm --filter wework ai:verify <capture|snapshot|click|close-to-tray|drag|fill|hover|navigate|pointer-move|press|select-text|wait-for|text|status|stop> --session PATH [options]
 
 Options:
+  --codex-home-initialization true
+                            Seed and verify isolated first-run Codex migration
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
   --value TEXT              Replacement value for fill
   --target SELECTOR         Event target selector for pointer-move (default: body)
@@ -198,7 +200,15 @@ async function runServer(sessionPath, token) {
   const log = join(session.directory, 'app.log')
   const executorHome = join(session.directory, 'executor-home')
   const codexHome = join(executorHome, 'codex')
+  const nativeCodexHome = session.verifyCodexHomeInitialization
+    ? join(session.directory, 'native-codex')
+    : undefined
   await mkdir(codexHome, { recursive: true })
+  if (nativeCodexHome) {
+    await mkdir(nativeCodexHome, { recursive: true })
+    await writeFile(join(nativeCodexHome, 'auth.json'), '{"test":"isolated-auth"}\n')
+    await writeFile(join(nativeCodexHome, 'config.toml'), 'model = "gpt-5"\n')
+  }
   app = spawn('bash', ['scripts/dev-mac-app.sh'], {
     cwd: weworkDir,
     detached: true,
@@ -206,6 +216,8 @@ async function runServer(sessionPath, token) {
       controlUrl,
       token,
       codexHome,
+      nativeCodexHome,
+      verifyCodexHomeInitialization: session.verifyCodexHomeInitialization,
       deviceId: session.deviceId,
       appIdentifier: `io.wecode.wework.ai-verify.${session.deviceId.replaceAll('-', '')}`,
       executorHome,
@@ -263,6 +275,7 @@ async function main() {
           directory,
           token,
           status: 'starting',
+          verifyCodexHomeInitialization: options['codex-home-initialization'] === 'true',
         },
         null,
         2

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -28,6 +28,7 @@ const LOCAL_EXECUTOR_LOG_DIR_ENV: &str = "WEGENT_EXECUTOR_LOG_DIR";
 const LOCAL_EXECUTOR_LOG_FILE_ENV: &str = "WEGENT_EXECUTOR_LOG_FILE";
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const WEGENT_CODEX_HOME_ENV: &str = "WEGENT_CODEX_HOME";
+const WEWORK_E2E_NATIVE_CODEX_HOME_ENV: &str = "WEWORK_E2E_NATIVE_CODEX_HOME";
 const FILE_EDIT_HOOK_COMMAND_ENV: &str = "WEGENT_FILE_EDIT_HOOK_COMMAND";
 const FILE_EDIT_LOG_ENDPOINT_ENV: &str = "WEWORK_FILE_EDIT_LOG_ENDPOINT";
 const CODEX_BINARY_PATH_ENV: &str = "CODEX_BINARY_PATH";
@@ -823,6 +824,11 @@ fn wework_codex_home_path(executor_home: &str) -> Result<PathBuf, String> {
 }
 
 fn native_codex_home_path() -> Result<PathBuf, String> {
+    if std::env::var("VITE_WEWORK_E2E").as_deref() == Ok("true") {
+        if let Some(path) = non_empty_env(WEWORK_E2E_NATIVE_CODEX_HOME_ENV) {
+            return Ok(PathBuf::from(path));
+        }
+    }
     let home = dirs::home_dir().ok_or_else(|| "Home directory is not available".to_string())?;
     Ok(home.join(".codex"))
 }
@@ -1004,6 +1010,15 @@ fn write_codex_remote_apps_enabled(enabled: bool) -> Result<CodexLocalConfig, St
 fn copy_codex_initialization_entry(source: &Path, destination: &Path) -> Result<(), String> {
     if !source.exists() {
         return Ok(());
+    }
+    if destination.exists() {
+        if let (Ok(source_path), Ok(destination_path)) =
+            (fs::canonicalize(source), fs::canonicalize(destination))
+        {
+            if source_path == destination_path {
+                return Ok(());
+            }
+        }
     }
     let metadata = fs::symlink_metadata(source)
         .map_err(|error| format!("failed to inspect {}: {error}", source.display()))?;
@@ -2419,6 +2434,34 @@ command = "example"
             .file_type()
             .is_symlink());
         assert_eq!(fs::read_to_string(target).unwrap(), "native-auth");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migrating_codex_home_preserves_linked_native_auth() {
+        let root = import_test_root("codex-auth-migration");
+        let native_home = root.join("native");
+        let wework_home = root.join("wework");
+        fs::create_dir_all(&native_home).unwrap();
+        fs::write(native_home.join("auth.json"), "native-auth").unwrap();
+        fs::write(native_home.join("config.toml"), "model = \"gpt-5\"").unwrap();
+        link_native_codex_auth(&native_home, &wework_home).unwrap();
+
+        copy_codex_initialization_files(&native_home, &wework_home).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(native_home.join("auth.json")).unwrap(),
+            "native-auth"
+        );
+        assert!(fs::symlink_metadata(wework_home.join("auth.json"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_to_string(wework_home.join("config.toml")).unwrap(),
+            "model = \"gpt-5\""
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/wework/src/features/local-runtime/CodexHomeInitializer.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.tsx
@@ -5,7 +5,9 @@ import type { LocalCodexHomeMigrationStatus } from '@/api/local/codexPlugins'
 import { useTranslation } from '@/hooks/useTranslation'
 
 const CODEX_MIGRATION_DISMISSED_STORAGE_KEY = 'wework.plugins.codexMigrationDismissed'
-const SHOULD_SKIP_CODEX_HOME_INITIALIZATION = import.meta.env.VITE_WEWORK_E2E === 'true'
+const SHOULD_SKIP_CODEX_HOME_INITIALIZATION =
+  import.meta.env.VITE_WEWORK_E2E === 'true' &&
+  import.meta.env.VITE_WEWORK_E2E_CODEX_HOME_INITIALIZATION !== 'true'
 
 function CodexHomeInitializationDialog({
   status,


### PR DESCRIPTION
## What changed

- skip Codex migration copies when source and destination resolve to the same file
- add a regression test for the startup auth symlink followed by first-run migration
- add an isolated real-Tauri verification mode with synthetic Codex authentication
- document the verification mode for contributors

## Root cause

Wework linked its isolated `auth.json` to the native `~/.codex/auth.json` before showing the first-run migration dialog. Migration then called `fs::copy` from the native path to that symlink. Both paths resolved to the same file, so opening the destination truncated the source authentication file before it could be copied.

## User impact

Migrating an existing Codex installation into a fresh Wework installation no longer empties `~/.codex/auth.json`. Other Codex configuration still migrates normally.

## Validation

- `pnpm --filter wework test` — 184 files, 1878 tests passed
- `pnpm --filter wework typecheck`
- `cargo test --manifest-path wework/src-tauri/Cargo.toml` — 73 tests passed
- pre-push ESLint, TypeScript, and unit-test checks passed
- isolated real Tauri flow: migration dialog displayed; migration completed; synthetic native auth stayed byte-identical at 25 bytes; Wework auth remained a symlink; migrated config was present

## Screenshot review

Reviewed the before/after real-Tauri screenshot chain. The initialization dialog, source/target paths, migration action, and resulting workbench state rendered correctly with no visible errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an isolated verification mode for testing first-run Codex setup and migration.
  * Added support for using a session-specific Codex home during verification without accessing personal credentials.

* **Bug Fixes**
  * Preserved existing authentication links during Codex home migration.
  * Prevented redundant copying when source and destination paths are identical.

* **Documentation**
  * Added instructions for running the new Codex initialization verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->