### PR TITLE
feat: 设置部分实验性功能

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -15,7 +15,12 @@ import {
   type AppUpdateContextValue,
 } from '@/features/app-update/app-update-context'
 import { openLocalWorkspace } from '@/lib/local-terminal'
-import { APP_PREFERENCES_CHANGED_EVENT, defaultAppPreferences } from '@/tauri/appPreferences'
+
+const experimentalFeatures = vi.hoisted(() => ({ enabled: true }))
+
+vi.mock('@/features/experimental-features/useExperimentalFeaturesEnabled', () => ({
+  useExperimentalFeaturesEnabled: () => experimentalFeatures.enabled,
+}))
 
 vi.mock('@/lib/local-terminal', () => ({
   openLocalWorkspace: vi.fn(),
@@ -136,6 +141,7 @@ function enableTauri() {
 
 describe('DesktopSidebar', () => {
   beforeEach(() => {
+    experimentalFeatures.enabled = true
     localStorage.clear()
     enableTauri()
     Element.prototype.scrollIntoView = vi.fn()
@@ -942,19 +948,16 @@ describe('DesktopSidebar', () => {
   })
 
   test('shows Sites only while experimental features are enabled', async () => {
-    renderSidebar()
+    experimentalFeatures.enabled = false
+    const { unmount } = renderSidebar()
 
     expect(screen.queryByTestId('sites-button')).not.toBeInTheDocument()
 
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent(APP_PREFERENCES_CHANGED_EVENT, {
-          detail: { ...defaultAppPreferences, experimentalFeaturesEnabled: true },
-        })
-      )
-    })
+    unmount()
+    experimentalFeatures.enabled = true
+    renderSidebar()
 
-    expect(await screen.findByTestId('sites-button')).toBeInTheDocument()
+    expect(screen.getByTestId('sites-button')).toBeInTheDocument()
   })
 
   test('renders chat runtime tasks as conversations instead of workspace groups', async () => {
@@ -2642,6 +2645,14 @@ describe('DesktopSidebar', () => {
     await user.click(screen.getByTestId('sidebar-global-im-notification-primary-button'))
 
     expect(onToggleGlobalImNotification).toHaveBeenCalledTimes(1)
+  })
+
+  test('hides global IM notifications while experimental features are disabled', () => {
+    experimentalFeatures.enabled = false
+
+    renderSidebar({ onToggleGlobalImNotification: vi.fn() })
+
+    expect(screen.queryByTestId('sidebar-global-im-notification-button')).not.toBeInTheDocument()
   })
 
   test('anchors the away reminder menu to the full-width account area', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1470,6 +1470,7 @@ function RuntimeTaskRow({
   ) => Promise<void> | void
 }) {
   const { t } = useTranslation('common')
+  const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled()
   const [optimisticMarked, setOptimisticMarked] = useState<{
     base: boolean
     value: boolean
@@ -1679,7 +1680,8 @@ function RuntimeTaskRow({
                   aria-label="Worktree"
                 />
               )}
-              {notificationsSubscribed &&
+              {experimentalFeaturesEnabled &&
+                notificationsSubscribed &&
                 renderNotificationButton(
                   `runtime-local-task-notify-${task.taskId}`,
                   `runtime-local-task-notify-icon-${task.taskId}`
@@ -1720,14 +1722,15 @@ function RuntimeTaskRow({
               data-testid={`runtime-local-task-hover-actions-${task.taskId}`}
               className="pointer-events-none absolute right-0 top-1/2 z-[70] flex w-[72px] -translate-y-1/2 items-center justify-end gap-1 opacity-0 transition-opacity group-hover/task:pointer-events-auto group-hover/task:opacity-100 hover:pointer-events-auto hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
             >
-              {renderNotificationButton(
-                notificationsSubscribed
-                  ? `runtime-local-task-notify-hover-${task.taskId}`
-                  : `runtime-local-task-notify-${task.taskId}`,
-                notificationsSubscribed
-                  ? `runtime-local-task-notify-hover-icon-${task.taskId}`
-                  : `runtime-local-task-notify-icon-${task.taskId}`
-              )}
+              {experimentalFeaturesEnabled &&
+                renderNotificationButton(
+                  notificationsSubscribed
+                    ? `runtime-local-task-notify-hover-${task.taskId}`
+                    : `runtime-local-task-notify-${task.taskId}`,
+                  notificationsSubscribed
+                    ? `runtime-local-task-notify-hover-icon-${task.taskId}`
+                    : `runtime-local-task-notify-icon-${task.taskId}`
+                )}
               <button
                 type="button"
                 data-testid={`runtime-local-task-mark-${task.taskId}`}
@@ -1792,13 +1795,18 @@ function RuntimeTaskRow({
             disabled: !workspace.available || !onRenameRuntimeTask,
             onSelect: () => setRenameOpen(true),
           },
-          {
-            label: notificationActionLabel,
-            icon: NotificationIcon,
-            testId: `runtime-local-task-menu-notify-${task.taskId}`,
-            disabled: notificationsDisabled,
-            onSelect: () => onToggleRuntimeTaskNotification?.(taskAddress, notificationsSubscribed),
-          },
+          ...(experimentalFeaturesEnabled
+            ? [
+                {
+                  label: notificationActionLabel,
+                  icon: NotificationIcon,
+                  testId: `runtime-local-task-menu-notify-${task.taskId}`,
+                  disabled: notificationsDisabled,
+                  onSelect: () =>
+                    onToggleRuntimeTaskNotification?.(taskAddress, notificationsSubscribed),
+                },
+              ]
+            : []),
           {
             label: t('workbench.archive_runtime_task', '归档'),
             icon: Archive,
@@ -3598,27 +3606,29 @@ export function DesktopSidebar({
                     />
                   </div>
                 )}
-                <GlobalImNotificationBell
-                  devices={devices}
-                  imNotificationSettings={imNotificationSettings}
-                  menuOpen={imNotificationMenuOpen}
-                  menuContainerRef={settingsMenuRef}
-                  onMenuOpenChange={open => {
-                    if (open) setSettingsMenuOpen(false)
-                    setImNotificationMenuOpen(open)
-                  }}
-                  onToggleGlobalImNotification={onToggleGlobalImNotification}
-                  onOpenGlobalImNotificationSettings={onOpenGlobalImNotificationSettings}
-                  onOpenSettings={() => onOpenSettings()}
-                  onAddCloudDevice={() => {
-                    if (onOpenStandaloneFolderProject) {
-                      onOpenStandaloneFolderProject('remote', 'add-device')
-                    } else {
-                      setStandaloneRemoteDialogIntent('add-device')
-                      setStandaloneWorkspaceDialogMode('remote')
-                    }
-                  }}
-                />
+                {experimentalFeaturesEnabled && (
+                  <GlobalImNotificationBell
+                    devices={devices}
+                    imNotificationSettings={imNotificationSettings}
+                    menuOpen={imNotificationMenuOpen}
+                    menuContainerRef={settingsMenuRef}
+                    onMenuOpenChange={open => {
+                      if (open) setSettingsMenuOpen(false)
+                      setImNotificationMenuOpen(open)
+                    }}
+                    onToggleGlobalImNotification={onToggleGlobalImNotification}
+                    onOpenGlobalImNotificationSettings={onOpenGlobalImNotificationSettings}
+                    onOpenSettings={() => onOpenSettings()}
+                    onAddCloudDevice={() => {
+                      if (onOpenStandaloneFolderProject) {
+                        onOpenStandaloneFolderProject('remote', 'add-device')
+                      } else {
+                        setStandaloneRemoteDialogIntent('add-device')
+                        setStandaloneWorkspaceDialogMode('remote')
+                      }
+                    }}
+                  />
+                )}
               </div>
               {settingsMenuOpen && (
                 <DesktopSettingsMenu

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -39,6 +39,11 @@ import { FileWorkspacePanel } from './workspace-panels/FileWorkspacePanel'
 const paneSessionMockRef = vi.hoisted(() => ({
   current: undefined as unknown,
 }))
+const experimentalFeatures = vi.hoisted(() => ({ enabled: true }))
+
+vi.mock('@/features/experimental-features/useExperimentalFeaturesEnabled', () => ({
+  useExperimentalFeaturesEnabled: () => experimentalFeatures.enabled,
+}))
 
 vi.mock('./useWorkbenchPaneSession', () => ({
   useWorkbenchPaneSession: () => paneSessionMockRef.current,
@@ -478,6 +483,7 @@ describe('DesktopWorkbenchLayout', () => {
   }
 
   beforeEach(() => {
+    experimentalFeatures.enabled = true
     vi.clearAllMocks()
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -1739,6 +1745,27 @@ describe('DesktopWorkbenchLayout', () => {
     expect(onListImPrivateSessions).toHaveBeenCalledTimes(1)
     expect(await screen.findByRole('dialog')).toBeInTheDocument()
     expect(await screen.findByTestId('continue-im-session-session-1')).toHaveTextContent('Alice')
+  })
+
+  test('hides task fork and IM actions while experimental features are disabled', () => {
+    experimentalFeatures.enabled = false
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          currentRuntimeTask: {
+            deviceId: 'device-1',
+            workspacePath: '/workspace/project-alpha',
+            taskId: 'runtime-1',
+          },
+        }}
+      />
+    )
+
+    expect(screen.queryByTestId('fork-runtime-task-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('continue-in-im-button')).not.toBeInTheDocument()
   })
 
   test('keeps continue-in-im action with workspace panel actions on web', () => {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -4,6 +4,7 @@ import type { ProjectChatControls } from '@/components/chat/ChatInput'
 import type { AssistantPlanOpenRequest } from '@/components/chat/AssistantPlanCard'
 import { RequestUserInputCard } from '@/components/chat/RequestUserInputCard'
 import { ScrollableMessageArea } from '@/components/chat/ScrollableMessageArea'
+import { useExperimentalFeaturesEnabled } from '@/features/experimental-features/useExperimentalFeaturesEnabled'
 import { useWorkbench, useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
 import type { WorkspaceSessionApi } from '@/features/workbench/workbenchServices'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -350,6 +351,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   onTerminalPanePinned: (paneKey: string) => void
   onTerminalPaneUnpinned: (paneKey: string) => void
 }) {
+  const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled()
   const appearanceContext = useOptionalAppearance()
   const appearance = appearanceContext?.appearance ?? defaultAppearance
   const background = getWorkbenchBackground(appearance, appearanceContext?.resolvedMode ?? 'light')
@@ -1360,7 +1362,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const topBarLeftContent = topBarLeftActions ? <>{topBarLeftActions}</> : undefined
   const showPageTopBar = !isTauri && (Boolean(topBarLeftContent) || Boolean(paneTaskTitle))
   const hasSubagentStatuses = (paneSession.subagentStatuses?.length ?? 0) > 0
-  const canForkCurrentRuntimeTask = Boolean(currentRuntimeTask && forkCurrentRuntimeTask)
+  const canForkCurrentRuntimeTask = Boolean(
+    experimentalFeaturesEnabled && currentRuntimeTask && forkCurrentRuntimeTask
+  )
   const forkTaskButton = canForkCurrentRuntimeTask ? (
     <button
       type="button"
@@ -1373,7 +1377,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       <ArrowLeftRight />
     </button>
   ) : undefined
-  const canContinueInIm = Boolean(currentRuntimeTask)
+  const canContinueInIm = experimentalFeaturesEnabled && Boolean(currentRuntimeTask)
   const continueInImButton = canContinueInIm ? (
     <button
       type="button"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experimental features can now control access to task-related actions, including forking runtime tasks and continuing conversations in IM.
  * Runtime-task notification controls and the global IM notification bell are now shown only when experimental features are enabled.
  * The Sites navigation entry is hidden when experimental features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->