### PR TITLE
fix(ci): allow repository policy checks for fork PRs

### DIFF
--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -40,6 +40,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           path: policy-target
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Run repository policy check
         env:

--- a/scripts/test-repository-policy-workflow.sh
+++ b/scripts/test-repository-policy-workflow.sh
@@ -34,6 +34,7 @@ require_line "$POLICY_WORKFLOW" "contents: read" "read-only repository permissio
 require_line "$POLICY_WORKFLOW" "path: trusted-policy" "trusted script checkout path"
 require_line "$POLICY_WORKFLOW" "path: policy-target" "PR content checkout path"
 require_line "$POLICY_WORKFLOW" 'ref: refs/pull/${{ github.event.pull_request.number }}/merge' "PR merge ref checkout"
+require_line "$POLICY_WORKFLOW" "allow-unsafe-pr-checkout: true" "reviewed fork PR checkout opt-in"
 require_line "$POLICY_WORKFLOW" "REPOSITORY_POLICY_ROOT: \${{ github.workspace }}/policy-target" "target repository scan root"
 require_line "$POLICY_WORKFLOW" "trusted-policy/scripts/hooks/check-repository-policy.sh" "trusted policy script execution"
 


### PR DESCRIPTION
## Summary

- explicitly opt in to checking out fork PR merge trees in the read-only repository policy workflow
- add a regression assertion for the checkout safety setting

## Root cause

`actions/checkout@v4` now refuses fork PR checkouts from `pull_request_target` workflows unless `allow-unsafe-pr-checkout` is explicitly enabled. The policy job already isolates the untrusted tree from the trusted base-SHA scripts, grants only `contents: read`, and scans the target tree with the trusted script.

## Validation

- `git diff --check`
- `bash scripts/test-repository-policy-workflow.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository policy checks for pull request merge refs, including reviewed fork pull requests.

* **Tests**
  * Added regression coverage to verify the required checkout security setting remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->