### PR TITLE
fix(wework): preserve remote terminal initial prompt

### DIFF
--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { StrictMode } from 'react'
 import { openExternalUrl } from '@/lib/external-links'
 import { createRemoteTerminalClient } from '@/lib/remote-terminal-socket'
 import { RemoteTerminal } from './RemoteTerminal'
@@ -162,6 +163,38 @@ describe('RemoteTerminal', () => {
 
     await waitFor(() => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to write to remote terminal:', error)
+    })
+  })
+
+  test('keeps one terminal client during the StrictMode effect replay', async () => {
+    let outputHandler: ((payload: { session_id: string; data: string }) => void) | null = null
+    const client = createClient({
+      onOutput: vi.fn(handler => {
+        outputHandler = handler
+        return vi.fn()
+      }),
+    })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    const { unmount } = render(
+      <StrictMode>
+        <RemoteTerminal sessionId="terminal-1" clientFactory={createRemoteTerminalClient} active />
+      </StrictMode>
+    )
+
+    await waitFor(() => {
+      expect(createRemoteTerminalClientMock).toHaveBeenCalledTimes(1)
+      expect(client.attach).toHaveBeenCalledTimes(1)
+    })
+    outputHandler?.({ session_id: 'terminal-1', data: 'remote prompt$ ' })
+
+    expect(testState.terminalInstances).toHaveLength(1)
+    expect(testState.terminalInstances[0].write).toHaveBeenCalledWith('remote prompt$ ')
+
+    unmount()
+    await waitFor(() => {
+      expect(client.close).toHaveBeenCalledTimes(1)
+      expect(client.dispose).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -32,6 +32,26 @@ interface RemoteTerminalProps {
   showWorkbenchBackground?: boolean
 }
 
+interface RemoteTerminalResource {
+  sessionId: string
+  clientFactory: RemoteTerminalClientFactory
+  showWorkbenchBackground: boolean
+  dispose: () => void
+}
+
+function matchesRemoteTerminalResource(
+  resource: RemoteTerminalResource,
+  sessionId: string,
+  clientFactory: RemoteTerminalClientFactory,
+  showWorkbenchBackground: boolean
+): boolean {
+  return (
+    resource.sessionId === sessionId &&
+    resource.clientFactory === clientFactory &&
+    resource.showWorkbenchBackground === showWorkbenchBackground
+  )
+}
+
 export function RemoteTerminal({
   sessionId,
   clientFactory,
@@ -56,6 +76,8 @@ export function RemoteTerminal({
   const onTitleChangeRef = useRef(onTitleChange)
   const lastSizeRef = useRef<{ rows: number; cols: number } | null>(null)
   const appearanceRef = useRef(appearance)
+  const resourceRef = useRef<RemoteTerminalResource | null>(null)
+  const cleanupTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
     appearanceRef.current = appearance
@@ -94,6 +116,28 @@ export function RemoteTerminal({
     const container = containerRef.current
     if (!container) return
 
+    if (cleanupTimerRef.current !== null) {
+      window.clearTimeout(cleanupTimerRef.current)
+      cleanupTimerRef.current = null
+    }
+    // StrictMode replays effects in development. Keep the live socket and xterm
+    // through that replay so initial PTY output cannot land on a discarded client.
+    const currentResource = resourceRef.current
+    if (
+      currentResource &&
+      matchesRemoteTerminalResource(
+        currentResource,
+        sessionId,
+        clientFactory,
+        showWorkbenchBackground
+      )
+    ) {
+      return () => {
+        cleanupTimerRef.current = window.setTimeout(currentResource.dispose, 0)
+      }
+    }
+    currentResource?.dispose()
+
     const terminalAppearance = appearanceRef.current
     const terminal = new Terminal({
       allowTransparency: showWorkbenchBackground,
@@ -111,6 +155,22 @@ export function RemoteTerminal({
     let disposed = false
     let scheduleThemeSync: () => void = () => undefined
 
+    const writeTerminalOutput = (data: string) => {
+      if (disposed || !data) return
+      const context = contextRef.current
+      appendRuntimeTerminalContext({
+        sessionId,
+        taskId: context.taskId,
+        workspacePath: context.workspacePath,
+        cwd: context.cwd,
+        title: context.title,
+        kind: 'remote',
+        data,
+      })
+      terminal.write(data)
+      scheduleThemeSync()
+    }
+
     let inputFallback: XtermInputFallbackController = {
       noteData: () => undefined,
       dispose: () => undefined,
@@ -125,18 +185,7 @@ export function RemoteTerminal({
     })
     const unsubscribeOutput = client.onOutput(payload => {
       if (!disposed && payload.session_id === sessionId) {
-        const context = contextRef.current
-        appendRuntimeTerminalContext({
-          sessionId,
-          taskId: context.taskId,
-          workspacePath: context.workspacePath,
-          cwd: context.cwd,
-          title: context.title,
-          kind: 'remote',
-          data: payload.data,
-        })
-        terminal.write(payload.data)
-        scheduleThemeSync()
+        writeTerminalOutput(payload.data)
       }
     })
     const titleDisposable = terminal.onTitleChange(title => {
@@ -212,26 +261,40 @@ export function RemoteTerminal({
         }
       })
 
+    const resource: RemoteTerminalResource = {
+      sessionId,
+      clientFactory,
+      showWorkbenchBackground,
+      dispose: () => {
+        if (disposed) return
+        disposed = true
+        unobserveTheme()
+        resizeObserver.disconnect()
+        dataDisposable.dispose()
+        titleDisposable.dispose()
+        selectionGuard.dispose()
+        inputFallback.dispose()
+        unsubscribeOutput()
+        unsubscribeExit()
+        void client
+          .close()
+          .catch(() => undefined)
+          .finally(() => {
+            client.dispose()
+          })
+        terminal.dispose()
+        if (resourceRef.current === resource) {
+          terminalRef.current = null
+          fitAddonRef.current = null
+          clientRef.current = null
+          resourceRef.current = null
+        }
+      },
+    }
+    resourceRef.current = resource
+
     return () => {
-      disposed = true
-      unobserveTheme()
-      resizeObserver.disconnect()
-      dataDisposable.dispose()
-      titleDisposable.dispose()
-      selectionGuard.dispose()
-      inputFallback.dispose()
-      unsubscribeOutput()
-      unsubscribeExit()
-      void client
-        .close()
-        .catch(() => undefined)
-        .finally(() => {
-          client.dispose()
-        })
-      terminal.dispose()
-      terminalRef.current = null
-      fitAddonRef.current = null
-      clientRef.current = null
+      cleanupTimerRef.current = window.setTimeout(resource.dispose, 0)
     }
   }, [clientFactory, sessionId, showWorkbenchBackground])
 


### PR DESCRIPTION
## Summary

- keep the remote xterm and Socket.IO client alive across React StrictMode effect replay
- prevent duplicate `terminal:attach` calls from consuming the initial PTY prompt on a discarded client
- add regression coverage for a single attach, initial output rendering, and real unmount cleanup

## Root cause

Wework runs under React StrictMode. The remote terminal effect synchronously closed and recreated its xterm and socket resources during StrictMode's development replay. The executor correctly emitted the buffered initial shell prompt after the first attach, but that output landed on the client being discarded; the second attach had no buffered prompt left.

## Impact

Opening a remote Terminal now keeps one live client and renders the initial shell prompt immediately. Backend and Executor protocols are unchanged.

## Validation

- `pnpm --filter wework test` — 189 test files, 1891 tests passed
- `pnpm --filter wework typecheck`
- focused terminal regression suite — 43 tests passed
- Prettier, ESLint, typography, and `git diff --check`
- repository pre-push quality gate, including Frontend/Wework checks and Executor cargo test/clippy
- real Wework desktop verification remains for the reporter

## Task

- `x9hIcKuoQ7` — 修复远程终端首屏提示符缺失

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote terminal lifecycle handling during React Strict Mode effect replays.
  * Prevented duplicate terminal clients and ensured resources are cleaned up reliably.
  * Improved remote output handling with consistent terminal context and theme synchronization.
  * Ensured terminal resources, subscriptions, and connections are properly disposed when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->