### PR TITLE
fix(executor): preserve Claude subagent model selection

### DIFF
--- a/executor/src/agents/claude_code.rs
+++ b/executor/src/agents/claude_code.rs
@@ -36,7 +36,11 @@ use crate::{
 const FILE_EDIT_HOOK_COMMAND_ENV: &str = "WEGENT_FILE_EDIT_HOOK_COMMAND";
 const CLAUDE_FILE_EDIT_HOOK_MATCHER: &str = "Write|Edit|MultiEdit|NotebookEdit";
 const SKILL_MANIFEST_FILE: &str = ".wegent-skills.json";
-const DEFAULT_HAIKU_MODEL_ENV: &str = "ANTHROPIC_DEFAULT_HAIKU_MODEL";
+const DEFAULT_CLAUDE_MODEL_ENV: &[&str] = &[
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+];
 const DEFAULT_CLAUDE_SETTINGS_ENV: &[&str] = &[
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY",
@@ -463,32 +467,34 @@ fn apply_model_environment(mut spec: CommandSpec, request: &ExecutionRequest) ->
         }
     }
 
-    spec = apply_default_haiku_model_environment(spec, request);
+    spec = apply_default_model_environment(spec, request);
 
     spec
 }
 
-fn apply_default_haiku_model_environment(
+fn apply_default_model_environment(
     mut spec: CommandSpec,
     request: &ExecutionRequest,
 ) -> CommandSpec {
-    if spec.envs().contains_key(DEFAULT_HAIKU_MODEL_ENV) {
-        return spec;
-    }
+    for key in DEFAULT_CLAUDE_MODEL_ENV {
+        if spec.envs().contains_key(*key) {
+            continue;
+        }
 
-    let value = model_string(request, DEFAULT_HAIKU_MODEL_ENV)
-        .or_else(process_default_haiku_model)
-        .or_else(|| model_id(request));
+        let value = model_string(request, key)
+            .or_else(|| process_model_environment(key))
+            .or_else(|| model_id(request));
 
-    if let Some(value) = value {
-        spec = spec.env(DEFAULT_HAIKU_MODEL_ENV, value);
+        if let Some(value) = value {
+            spec = spec.env(*key, value);
+        }
     }
 
     spec
 }
 
-fn process_default_haiku_model() -> Option<String> {
-    env::var(DEFAULT_HAIKU_MODEL_ENV)
+fn process_model_environment(key: &str) -> Option<String> {
+    env::var(key)
         .ok()
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())

--- a/executor/src/agents/runtime_capabilities.rs
+++ b/executor/src/agents/runtime_capabilities.rs
@@ -1388,10 +1388,17 @@ fn subagent_file(bot: &Value) -> Option<(String, String)> {
         .get("system_prompt")
         .and_then(Value::as_str)
         .unwrap_or("");
+    let model = bot
+        .pointer("/agent_config/env/model_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "inherit".to_owned()))
+        .unwrap_or_else(|| "inherit".to_owned());
     Some((
         name.clone(),
         format!(
-            "---\nname: {name}\ndescription: \"{description}\"\nmodel: inherit\n---\n\n{system_prompt}\n"
+            "---\nname: {name}\ndescription: \"{description}\"\nmodel: {model}\n---\n\n{system_prompt}\n"
         ),
     ))
 }
@@ -1847,6 +1854,39 @@ mod tests {
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
     };
+
+    #[test]
+    fn coordinate_subagent_uses_its_resolved_model() {
+        let bot = json!({
+            "id": 106,
+            "name": "glm",
+            "description": "GLM worker",
+            "system_prompt": "You are the GLM worker.",
+            "agent_config": {
+                "env": {
+                    "model_id": "weibo-glm5.2"
+                }
+            }
+        });
+
+        let (name, content) = subagent_file(&bot).unwrap();
+
+        assert_eq!(name, "glm-106");
+        assert!(content.contains("model: \"weibo-glm5.2\""));
+    }
+
+    #[test]
+    fn coordinate_subagent_inherits_when_model_is_unconfigured() {
+        let bot = json!({
+            "id": 103,
+            "name": "worker",
+            "system_prompt": "You are a worker."
+        });
+
+        let (_, content) = subagent_file(&bot).unwrap();
+
+        assert!(content.contains("model: inherit"));
+    }
 
     struct EnvGuard {
         key: &'static str,

--- a/executor/tests/agent_command_contract.rs
+++ b/executor/tests/agent_command_contract.rs
@@ -150,15 +150,20 @@ fn claude_command_maps_nested_model_env_to_process_environment() {
 }
 
 #[test]
-fn claude_command_uses_model_config_default_haiku_model_when_set() {
+fn claude_command_uses_explicit_default_models_when_set() {
     let _lock = env_lock();
     let _default_haiku = EnvGuard::set("ANTHROPIC_DEFAULT_HAIKU_MODEL", "process-haiku");
+    let _default_sonnet = EnvGuard::set("ANTHROPIC_DEFAULT_SONNET_MODEL", "process-sonnet");
+    let _default_opus = EnvGuard::set("ANTHROPIC_DEFAULT_OPUS_MODEL", "process-opus");
     let request = ExecutionRequest {
         prompt: json!("run locally"),
         model_config: json!({
             "model": "anthropic",
             "model_id": "claude-sonnet-4",
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-custom"
+            "CLAUDE_CODE_SUBAGENT_MODEL": "claude-subagent-custom",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-custom",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-custom",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-custom"
         }),
         ..ExecutionRequest::default()
     };
@@ -166,15 +171,29 @@ fn claude_command_uses_model_config_default_haiku_model_when_set() {
     let spec = build_claude_command(&request, "claude");
 
     assert_eq!(
+        spec.envs().get("CLAUDE_CODE_SUBAGENT_MODEL").unwrap(),
+        "claude-subagent-custom"
+    );
+    assert_eq!(
         spec.envs().get("ANTHROPIC_DEFAULT_HAIKU_MODEL").unwrap(),
         "claude-haiku-custom"
+    );
+    assert_eq!(
+        spec.envs().get("ANTHROPIC_DEFAULT_SONNET_MODEL").unwrap(),
+        "claude-sonnet-custom"
+    );
+    assert_eq!(
+        spec.envs().get("ANTHROPIC_DEFAULT_OPUS_MODEL").unwrap(),
+        "claude-opus-custom"
     );
 }
 
 #[test]
-fn claude_command_defaults_haiku_model_to_model_id() {
+fn claude_command_defaults_all_model_tiers_to_model_id() {
     let _lock = env_lock();
     let _default_haiku = EnvGuard::remove("ANTHROPIC_DEFAULT_HAIKU_MODEL");
+    let _default_sonnet = EnvGuard::remove("ANTHROPIC_DEFAULT_SONNET_MODEL");
+    let _default_opus = EnvGuard::remove("ANTHROPIC_DEFAULT_OPUS_MODEL");
     let request = ExecutionRequest {
         prompt: json!("run locally"),
         model_config: json!({"model": "anthropic", "model_id": "claude-sonnet-4"}),
@@ -183,8 +202,17 @@ fn claude_command_defaults_haiku_model_to_model_id() {
 
     let spec = build_claude_command(&request, "claude");
 
+    assert!(!spec.envs().contains_key("CLAUDE_CODE_SUBAGENT_MODEL"));
     assert_eq!(
         spec.envs().get("ANTHROPIC_DEFAULT_HAIKU_MODEL").unwrap(),
+        "claude-sonnet-4"
+    );
+    assert_eq!(
+        spec.envs().get("ANTHROPIC_DEFAULT_SONNET_MODEL").unwrap(),
+        "claude-sonnet-4"
+    );
+    assert_eq!(
+        spec.envs().get("ANTHROPIC_DEFAULT_OPUS_MODEL").unwrap(),
         "claude-sonnet-4"
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring default Claude models across Haiku, Sonnet, and Opus tiers.
  * Subagent configurations now use the specified model when available, with inheritance as a fallback.

* **Bug Fixes**
  * Improved model selection fallback behavior when tier-specific defaults are not configured.
  * Ensured configured model settings are consistently applied to generated subagents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->