### PR TITLE
fix(wework): enlarge generated image previews

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -194,6 +194,13 @@ describe('MessageList', () => {
       'alt',
       'Minimal dashboard concept'
     )
+
+    await userEvent.click(screen.getByTestId('attachment-image-zoom-in'))
+    expect(screen.getByTestId('attachment-image-zoom-value')).toHaveTextContent('125%')
+
+    fireEvent.pointerEnter(screen.getByTestId('message-hover-region'))
+
+    expect(screen.getByTestId('attachment-image-zoom-value')).toHaveTextContent('125%')
   })
 
   test('marks message rows for offscreen rendering containment with intrinsic sizes', () => {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -145,7 +145,7 @@ describe('MessageList', () => {
     expect(await screen.findByTestId('message-selection-actions')).toBeInTheDocument()
   })
 
-  test('renders generated image artifacts from image generation blocks', () => {
+  test('renders generated image artifacts and opens an enlarged preview', async () => {
     render(
       <MessageList
         messages={[
@@ -163,7 +163,8 @@ describe('MessageList', () => {
                 toolName: 'image_generation',
                 renderPayload: {
                   kind: 'image_generation',
-                  imageBase64: 'aW1hZ2U=',
+                  imageBase64:
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XwY7WQAAAABJRU5ErkJggg==',
                   revisedPrompt: 'Minimal dashboard concept',
                 },
                 status: 'done',
@@ -175,9 +176,24 @@ describe('MessageList', () => {
       />
     )
 
-    const image = screen.getByTestId('generated-image')
-    expect(image).toHaveAttribute('src', 'data:image/png;base64,aW1hZ2U=')
+    const image = await screen.findByTestId('generated-image')
+    expect(image).toHaveAttribute(
+      'src',
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XwY7WQAAAABJRU5ErkJggg=='
+    )
     expect(image).toHaveAttribute('alt', 'Minimal dashboard concept')
+
+    await userEvent.click(screen.getByTestId('generated-image-preview-button'))
+
+    expect(await screen.findByTestId('attachment-image-lightbox')).toBeInTheDocument()
+    expect(await screen.findByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+      'src',
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XwY7WQAAAABJRU5ErkJggg=='
+    )
+    expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+      'alt',
+      'Minimal dashboard concept'
+    )
   })
 
   test('marks message rows for offscreen rendering containment with intrinsic sizes', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1623,7 +1623,10 @@ function AssistantMessage({
   const visibleContent = shouldHideContent ? '' : message.content
   const hiddenErrorContent =
     message.status === 'failed' && shouldHideContent ? message.content.trim() : undefined
-  const displayBlocks = getDisplayProcessingBlocks(message.blocks, isCancelled)
+  const displayBlocks = useMemo(
+    () => getDisplayProcessingBlocks(message.blocks, isCancelled),
+    [isCancelled, message.blocks]
+  )
   const processingSegments = splitProcessingBlocks(displayBlocks)
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
@@ -1654,7 +1657,7 @@ function AssistantMessage({
     ? []
     : getWebSearchSourceItems(getWebSearchToolBlocks(displayBlocks))
   const memoryCitations = message.memoryCitations ?? []
-  const generatedImages = getGeneratedImages(displayBlocks)
+  const generatedImages = useMemo(() => getGeneratedImages(displayBlocks), [displayBlocks])
   const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
 
   const openFileFromLink = (path: string, options?: WorkspaceFileOpenOptions) => {
@@ -1858,7 +1861,7 @@ function getGeneratedImages(blocks: ProcessingBlock[]): GeneratedImageArtifact[]
 }
 
 function GeneratedImageGallery({ images }: { images: GeneratedImageArtifact[] }) {
-  const attachments = images.map(generatedImageAttachment)
+  const attachments = useMemo(() => images.map(generatedImageAttachment), [images])
 
   return (
     <div
@@ -1866,31 +1869,20 @@ function GeneratedImageGallery({ images }: { images: GeneratedImageArtifact[] })
       data-testid="generated-image-gallery"
     >
       {images.map((image, index) => (
-        <GeneratedImagePreview
-          key={image.id}
-          image={image}
-          index={index}
-          galleryAttachments={attachments}
-        />
+        <GeneratedImagePreview key={image.id} index={index} galleryAttachments={attachments} />
       ))}
     </div>
   )
 }
 
 function GeneratedImagePreview({
-  image,
   index,
   galleryAttachments,
 }: {
-  image: GeneratedImageArtifact
   index: number
   galleryAttachments: Attachment[]
 }) {
-  const { id, src, alt } = image
-  const attachment = useMemo(
-    () => generatedImageAttachment({ id, src, alt }, index),
-    [alt, id, index, src]
-  )
+  const attachment = galleryAttachments[index]
 
   return (
     <AttachmentImagePreview

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1823,6 +1823,19 @@ interface GeneratedImageArtifact {
   alt: string
 }
 
+function generatedImageAttachment(image: GeneratedImageArtifact, index: number): Attachment {
+  return {
+    id: index + 1,
+    filename: image.alt,
+    file_size: 0,
+    mime_type: 'image/png',
+    status: 'ready',
+    file_extension: '.png',
+    created_at: '',
+    local_preview_url: image.src,
+  }
+}
+
 function getGeneratedImages(blocks: ProcessingBlock[]): GeneratedImageArtifact[] {
   return blocks.flatMap(block => {
     if (block.type !== 'tool' || block.toolName !== 'image_generation') return []
@@ -1845,21 +1858,53 @@ function getGeneratedImages(blocks: ProcessingBlock[]): GeneratedImageArtifact[]
 }
 
 function GeneratedImageGallery({ images }: { images: GeneratedImageArtifact[] }) {
+  const attachments = images.map(generatedImageAttachment)
+
   return (
     <div
       className="mb-3 grid max-w-3xl grid-cols-1 gap-3 sm:grid-cols-2"
       data-testid="generated-image-gallery"
     >
-      {images.map(image => (
-        <img
+      {images.map((image, index) => (
+        <GeneratedImagePreview
           key={image.id}
-          src={image.src}
-          alt={image.alt}
-          className="h-auto w-full rounded-lg border border-border bg-surface object-contain"
-          data-testid="generated-image"
+          image={image}
+          index={index}
+          galleryAttachments={attachments}
         />
       ))}
     </div>
+  )
+}
+
+function GeneratedImagePreview({
+  image,
+  index,
+  galleryAttachments,
+}: {
+  image: GeneratedImageArtifact
+  index: number
+  galleryAttachments: Attachment[]
+}) {
+  const { id, src, alt } = image
+  const attachment = useMemo(
+    () => generatedImageAttachment({ id, src, alt }, index),
+    [alt, id, index, src]
+  )
+
+  return (
+    <AttachmentImagePreview
+      attachment={attachment}
+      galleryAttachments={galleryAttachments}
+      galleryIndex={index}
+      buttonTestId="generated-image-preview-button"
+      imageTestId="generated-image"
+      loadingTestId="generated-image-loading"
+      errorTestId="generated-image-error"
+      imageClassName="h-auto w-full rounded-lg border border-border bg-surface object-contain"
+      placeholderClassName="flex min-h-40 w-full items-center justify-center rounded-lg border border-border bg-surface text-text-muted"
+      buttonClassName="block w-full cursor-zoom-in p-0 text-left"
+    />
   )
 }
 


### PR DESCRIPTION
## What changed

- make `image_generation` result previews clickable
- reuse the existing attachment lightbox with zoom, download, close, and gallery navigation
- add regression coverage for opening generated images in the lightbox

## Why

Generated image results were rendered as plain images, so users could not inspect them at full size.

## Validation

- `pnpm --filter wework test` (189 files, 1888 tests)
- `pnpm --filter wework typecheck`
- ESLint and typography checks via pre-commit/pre-push hooks
- isolated real-Tauri verification: generated preview, open lightbox, zoom to 125%, close and restore conversation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated images now support an enlarged preview experience when selected, including preview zoom interactions.
  * Image previews within chat attachments now use a more consistent gallery presentation and behavior across generated-image artifacts.

* **Bug Fixes**
  * Improved rendering of assistant-generated image artifacts in chat messages, with more reliable preview display.

* **Tests**
  * Expanded automated coverage for generated image preview/lightbox behavior and zoom interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->