### PR TITLE
fix(wework): stabilize conversation archiving

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1086,7 +1086,7 @@ function ArchiveProjectConversationsProbe() {
         type="button"
         onClick={() =>
           void workbench
-            .archiveProjectsConversations(['project:7'])
+            .archiveProjectsConversations(['project:7', 'remote-project-key'])
             .then(result => setLastArchiveResult(result?.status ?? 'none'))
         }
       >
@@ -1096,11 +1096,36 @@ function ArchiveProjectConversationsProbe() {
         type="button"
         onClick={() =>
           void workbench
-            .archiveProjectsConversations(['project:7'], { force: true })
+            .archiveProjectsConversations(['project:7', 'remote-project-key'], { force: true })
             .then(result => setLastArchiveResult(result?.status ?? 'none'))
         }
       >
         force archive project conversations
+      </button>
+    </div>
+  )
+}
+
+function ArchiveRemoteRuntimeTaskProbe() {
+  const workbench = useWorkbench()
+  const taskTitles =
+    workbench.state.runtimeWork?.projects.flatMap(project =>
+      project.deviceWorkspaces.flatMap(workspace => workspace.tasks.map(task => task.title))
+    ) ?? []
+  return (
+    <div>
+      <span data-testid="archive-remote-task-titles">{taskTitles.join('|')}</span>
+      <button
+        type="button"
+        onClick={() =>
+          void workbench.archiveRuntimeTask({
+            deviceId: 'remote-device',
+            workspacePath: '/srv/Wegent',
+            taskId: 'remote-task',
+          })
+        }
+      >
+        archive remote task
       </button>
     </div>
   )
@@ -4900,8 +4925,29 @@ describe('WorkbenchProvider runtime tasks', () => {
               ],
               totalTasks: 1,
             },
+            {
+              project: { key: 'remote-project-key', name: 'Remote project' },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'remote-device',
+                  deviceName: 'Remote device',
+                  deviceStatus: 'online',
+                  workspacePath: '/srv/remote-project',
+                  available: true,
+                  tasks: [
+                    {
+                      taskId: 'remote-project-task',
+                      workspacePath: '/srv/remote-project',
+                      title: 'Remote project task',
+                      runtime: 'codex',
+                    },
+                  ],
+                },
+              ],
+              totalTasks: 1,
+            },
           ],
-          totalTasks: 1,
+          totalTasks: 2,
         })
       ),
     })
@@ -4916,13 +4962,97 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     await userEvent.click(screen.getByText('archive project conversations'))
 
-    await waitFor(() => expect(runtimeWorkApi.archiveProjectConversations).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(2))
+    expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      workspacePath: '/workspace/worktrees/9/project-alpha',
+      taskId: 'runtime-worktree',
+    })
+    expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledWith({
+      deviceId: 'remote-device',
+      workspacePath: '/srv/remote-project',
+      taskId: 'remote-project-task',
+    })
+    expect(runtimeWorkApi.archiveProjectConversations).not.toHaveBeenCalled()
     expect(runtimeWorkApi.deleteWorktree).toHaveBeenCalledWith({
       deviceId: 'device-1',
       path: '/workspace/worktrees/9/project-alpha',
       preserveSnapshot: true,
     })
     await waitFor(() => expect(screen.getByTestId('archive-result')).toHaveTextContent('archived'))
+  })
+
+  test('does not restore an archived remote task from the previous cloud snapshot', async () => {
+    const remoteRuntimeWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { key: 'remote-project', name: 'Remote Wegent' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: '10.201.3.200',
+              deviceStatus: 'online',
+              available: true,
+              workspacePath: '/srv/Wegent',
+              workspaceSource: 'remote',
+              remoteHostId: 'remote-device',
+              tasks: [
+                {
+                  taskId: 'remote-task',
+                  workspacePath: '/srv/Wegent',
+                  title: 'Remote task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        },
+      ],
+      chats: [],
+      totalTasks: 1,
+    }
+    const postArchiveCloudWork = deferred<RuntimeWorkListResponse>()
+    const cloudListRuntimeWork = vi
+      .fn()
+      .mockResolvedValueOnce(remoteRuntimeWork)
+      .mockReturnValue(postArchiveCloudWork.promise)
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue({ projects: [], chats: [], totalTasks: 0 }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([
+          createDevice({
+            id: 2,
+            device_id: 'remote-device',
+            name: '10.201.3.200',
+            status: 'online',
+            is_default: false,
+            device_type: 'remote',
+          }),
+        ]),
+        listRuntimeWork: cloudListRuntimeWork,
+      },
+    })
+
+    renderWorkbench(<ArchiveRemoteRuntimeTaskProbe />, services)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('Remote task')
+    )
+    await userEvent.click(screen.getByText('archive remote task'))
+
+    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(cloudListRuntimeWork).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
+
+    postArchiveCloudWork.resolve({ projects: [], chats: [], totalTasks: 0 })
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
+    )
   })
 
   test('renders streaming runtime task chunks when the socket connects after chat start', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -458,14 +458,19 @@ export function WorkbenchProvider({
     deleteAttachment: resolvedServices.attachmentApi?.deleteAttachment,
     scopeKey: projectChatScopeKey,
   })
-  const { cloudWorkStatus, refreshWorkLists, refreshDevices, getRemoteDeviceStartupCommand } =
-    useWorkbenchDataRefresh({
-      user,
-      state,
-      dispatch,
-      executorClient,
-      services: resolvedServices,
-    })
+  const {
+    cloudWorkStatus,
+    markRuntimeTasksArchived,
+    refreshWorkLists,
+    refreshDevices,
+    getRemoteDeviceStartupCommand,
+  } = useWorkbenchDataRefresh({
+    user,
+    state,
+    dispatch,
+    executorClient,
+    services: resolvedServices,
+  })
 
   const localRuntimeStateDeviceId = useMemo(
     () => getLocalRuntimeStateDeviceId(state.devices),
@@ -930,6 +935,7 @@ export function WorkbenchProvider({
     dispatch,
     executorClient,
     services: resolvedServices,
+    markRuntimeTasksArchived,
     refreshWorkLists,
   })
 

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Dispatch } from 'react'
 import type { ExecutorClient } from '@/api/executorAccess'
 import { getPreferredStandaloneDeviceId } from '@/lib/device-selection'
-import type { DeviceInfo, ProjectWithTasks, RuntimeWorkListResponse, User } from '@/types/api'
+import type {
+  DeviceInfo,
+  ProjectWithTasks,
+  RuntimeTaskAddress,
+  RuntimeWorkListResponse,
+  User,
+} from '@/types/api'
 import type { DockerRemoteDeviceCommandResponse } from '@/types/devices'
 import type { CloudRuntimeState, CloudWorkCheckKey, WorkbenchState } from '@/types/workbench'
 import {
@@ -10,6 +16,7 @@ import {
   EMPTY_RUNTIME_WORK,
   filterDisconnectedRemoteRuntimeWork,
   finishCloudRuntimeSync,
+  mergeRuntimeWorkLists,
   nowMs,
   readCachedDeviceList,
   resolveDeviceListWithCache,
@@ -20,7 +27,12 @@ import {
   timedWorkbenchBootstrapRequest,
 } from './workbenchCloudStatus'
 import type { WorkbenchAction } from './workbenchReducer'
-import { getRememberedStandaloneDeviceId } from './workbenchRuntimeHelpers'
+import {
+  getRememberedStandaloneDeviceId,
+  getRuntimeTaskRouteKey,
+  removeRuntimeTasks,
+  runtimeWorkContainsTask,
+} from './workbenchRuntimeHelpers'
 import type { WorkbenchServices } from './workbenchServices'
 import {
   readCachedRemoteRuntimeWork,
@@ -61,6 +73,36 @@ function createCloudRuntimeStateWithCache(runtimeWork: RuntimeWorkListResponse):
   }
 }
 
+function removeRuntimeTasksFromCloudState(
+  state: CloudRuntimeState,
+  addresses: RuntimeTaskAddress[]
+): CloudRuntimeState {
+  const removeFromSnapshot = (snapshot: CloudRuntimeState['current']) =>
+    snapshot
+      ? {
+          ...snapshot,
+          runtimeWork: removeRuntimeTasks(snapshot.runtimeWork, addresses),
+        }
+      : null
+  return {
+    ...state,
+    availability:
+      state.inFlightRevision == null ? state.availability : state.lastGood ? 'stale' : 'idle',
+    current: removeFromSnapshot(state.current),
+    lastGood: removeFromSnapshot(state.lastGood),
+    inFlightRevision: null,
+  }
+}
+
+function mergeRuntimeTaskAddresses(
+  current: RuntimeTaskAddress[],
+  incoming: RuntimeTaskAddress[]
+): RuntimeTaskAddress[] {
+  const addresses = new Map(current.map(address => [getRuntimeTaskRouteKey(address), address]))
+  incoming.forEach(address => addresses.set(getRuntimeTaskRouteKey(address), address))
+  return [...addresses.values()]
+}
+
 export function useWorkbenchDataRefresh({
   user,
   state,
@@ -86,6 +128,7 @@ export function useWorkbenchDataRefresh({
   const cloudBackgroundApiRef = useRef(services.cloudBackgroundApi)
   const runtimeWorkRef = useRef(state.runtimeWork)
   const devicesRef = useRef(state.devices)
+  const archivedRuntimeTaskAddressesRef = useRef<RuntimeTaskAddress[]>([])
   const cloudWorkStatus = useMemo(
     () => selectCloudWorkStatus(cloudRuntimeState),
     [cloudRuntimeState]
@@ -107,6 +150,7 @@ export function useWorkbenchDataRefresh({
       userId: user.id,
       runtimeWork: initialCachedRemoteRuntimeWork,
     }
+    archivedRuntimeTaskAddressesRef.current = []
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Cached runtime work must switch atomically with the authenticated user.
     updateCloudRuntimeState(
       hasCloudBackgroundApi
@@ -132,6 +176,37 @@ export function useWorkbenchDataRefresh({
     }
   }, [dispatch, hasCloudBackgroundApi, updateCloudRuntimeState])
 
+  const markRuntimeTasksArchived = useCallback(
+    (addresses: RuntimeTaskAddress[]) => {
+      if (addresses.length === 0) return
+      const archivedAddresses = mergeRuntimeTaskAddresses(
+        archivedRuntimeTaskAddressesRef.current,
+        addresses
+      )
+      archivedRuntimeTaskAddressesRef.current = archivedAddresses
+      const runtimeWork = writeCachedRemoteRuntimeWork(
+        user.id,
+        removeRuntimeTasks(cachedRemoteRuntimeWorkRef.current.runtimeWork, archivedAddresses),
+        devicesRef.current
+      )
+      cachedRemoteRuntimeWorkRef.current = { userId: user.id, runtimeWork }
+      updateCloudRuntimeState(
+        removeRuntimeTasksFromCloudState(cloudRuntimeStateRef.current, archivedAddresses)
+      )
+      dispatch({ type: 'runtime_tasks_archived', addresses: archivedAddresses })
+    },
+    [dispatch, updateCloudRuntimeState, user.id]
+  )
+
+  const releaseConfirmedArchivedRuntimeTasks = useCallback(
+    (runtimeWork: RuntimeWorkListResponse) => {
+      archivedRuntimeTaskAddressesRef.current = archivedRuntimeTaskAddressesRef.current.filter(
+        address => runtimeWorkContainsTask(runtimeWork, address)
+      )
+    },
+    []
+  )
+
   const selectVisibleRuntimeWork = useCallback(
     (
       localRuntimeWork: RuntimeWorkListResponse,
@@ -139,7 +214,10 @@ export function useWorkbenchDataRefresh({
       devices?: DeviceInfo[]
     ) => {
       const runtimeWork = selectRuntimeWorkView(localRuntimeWork, nextCloudState, devices)
-      return hasCloudBackgroundApi ? runtimeWork : filterDisconnectedRemoteRuntimeWork(runtimeWork)
+      const visibleRuntimeWork = hasCloudBackgroundApi
+        ? runtimeWork
+        : filterDisconnectedRemoteRuntimeWork(runtimeWork)
+      return removeRuntimeTasks(visibleRuntimeWork, archivedRuntimeTaskAddressesRef.current)
     },
     [hasCloudBackgroundApi]
   )
@@ -187,9 +265,21 @@ export function useWorkbenchDataRefresh({
       if (
         options?.isCancelled?.() ||
         revision == null ||
+        cloudRuntimeStateRef.current.inFlightRevision !== revision ||
         cloudBackgroundApiRef.current !== backgroundApi
       ) {
         return
+      }
+
+      if (runtimeWorkResult?.status === 'fulfilled') {
+        releaseConfirmedArchivedRuntimeTasks(
+          mergeRuntimeWorkLists(baseRuntimeWork, runtimeWorkResult.value, {
+            devices: [
+              ...baseDevices,
+              ...(devicesResult?.status === 'fulfilled' ? devicesResult.value : []),
+            ],
+          })
+        )
       }
 
       const reconciledRuntimeWorkResult =
@@ -198,7 +288,10 @@ export function useWorkbenchDataRefresh({
               status: 'fulfilled' as const,
               value: reconcileCachedRemoteRuntimeWork(
                 cachedRemoteRuntimeWorkRef.current.runtimeWork,
-                runtimeWorkResult.value,
+                removeRuntimeTasks(
+                  runtimeWorkResult.value,
+                  archivedRuntimeTaskAddressesRef.current
+                ),
                 devicesResult?.status === 'fulfilled' ? devicesResult.value : undefined
               ),
             }
@@ -239,6 +332,7 @@ export function useWorkbenchDataRefresh({
       dispatch,
       selectVisibleRuntimeWork,
       services.cloudBackgroundApi,
+      releaseConfirmedArchivedRuntimeTasks,
       updateCloudRuntimeState,
       user.id,
     ]
@@ -350,6 +444,9 @@ export function useWorkbenchDataRefresh({
       selectVisibleDevices(devices, cloudRuntimeStateRef.current)
     )
     const localRuntimeWork = runtimeWorkResult ?? state.runtimeWork ?? EMPTY_RUNTIME_WORK
+    if (runtimeWorkResult && !services.cloudBackgroundApi?.listRuntimeWork) {
+      releaseConfirmedArchivedRuntimeTasks(runtimeWorkResult)
+    }
     const runtimeWork = runtimeWorkResult
       ? selectVisibleRuntimeWork(localRuntimeWork, cloudRuntimeStateRef.current, visibleDevices)
       : hasCloudBackgroundApi
@@ -372,7 +469,9 @@ export function useWorkbenchDataRefresh({
     executorClient,
     refreshCloudBackgroundData,
     hasCloudBackgroundApi,
+    releaseConfirmedArchivedRuntimeTasks,
     selectVisibleRuntimeWork,
+    services.cloudBackgroundApi,
     state.projects,
     state.runtimeWork,
     state.standaloneDeviceId,
@@ -432,6 +531,7 @@ export function useWorkbenchDataRefresh({
 
   return {
     cloudWorkStatus,
+    markRuntimeTasksArchived,
     refreshWorkLists,
     refreshDevices,
     getRemoteDeviceStartupCommand,

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -48,6 +48,7 @@ interface UseWorkbenchRuntimeTasksOptions {
   dispatch: Dispatch<WorkbenchAction>
   executorClient: ExecutorClient
   services: WorkbenchServices
+  markRuntimeTasksArchived: (addresses: RuntimeTaskAddress[]) => void
   refreshWorkLists: () => Promise<void>
 }
 
@@ -59,6 +60,7 @@ export function useWorkbenchRuntimeTasks({
   dispatch,
   executorClient,
   services,
+  markRuntimeTasksArchived,
   refreshWorkLists,
 }: UseWorkbenchRuntimeTasksOptions) {
   const { t } = useTranslation('common')
@@ -232,44 +234,71 @@ export function useWorkbenchRuntimeTasks({
     [dispatch, services.runtimeWorkApi, t]
   )
 
-  const archiveRuntimeTask = useCallback(
+  const archiveRuntimeConversations = useCallback(
     async (
-      address: RuntimeTaskAddress,
-      options: ArchiveRuntimeTaskOptions = {}
-    ): Promise<ArchiveRuntimeTaskResult> => {
-      const worktreeTarget = findRuntimeTaskWorktree(state.runtimeWork, address)
-      const worktreeTargets = worktreeTarget ? [worktreeTarget] : []
-      console.debug('[Wework] Runtime archive task start', {
-        address: runtimeAddressDebug(address),
-        worktreeTargets: worktreeTargets.length,
-        force: Boolean(options.force),
-      })
-      const response = await executorClient.runtime.archiveConversation(address)
-      console.debug('[Wework] Runtime archive task response', {
-        address: runtimeAddressDebug(address),
-        accepted: response.accepted,
-        error: response.error ?? null,
-      })
-      if (!response.accepted) {
-        dispatch({ type: 'error_set', error: response.error || 'Failed to archive runtime task' })
-        return { status: 'failed' }
+      addresses: RuntimeTaskAddress[],
+      fallbackError: string
+    ): Promise<ArchiveRuntimeConversationsResult> => {
+      const archiveTargets = uniqueRuntimeTaskAddresses(addresses)
+      if (archiveTargets.length === 0) return { status: 'archived' }
+      const results = await Promise.all(
+        archiveTargets.map(async address => {
+          try {
+            return { address, response: await executorClient.runtime.archiveConversation(address) }
+          } catch (error) {
+            return { address, error }
+          }
+        })
+      )
+      const archivedAddresses = results.flatMap(result =>
+        result.response?.accepted ? [result.address] : []
+      )
+      if (archivedAddresses.length > 0) {
+        markRuntimeTasksArchived(archivedAddresses)
+        await removeArchivedWorktrees(
+          findRuntimeTaskWorktrees(state.runtimeWork, archivedAddresses)
+        )
+        clearCurrentRuntimeTaskIfArchived(archivedAddresses)
+        await refreshWorkLists()
       }
-      await removeArchivedWorktrees(worktreeTargets)
-      clearCurrentRuntimeTaskIfArchived([address])
-      await refreshWorkLists()
-      console.debug('[Wework] Runtime archive task finished', {
-        address: runtimeAddressDebug(address),
+      const failedResult = results.find(result => !result.response?.accepted)
+      if (!failedResult) return { status: 'archived' }
+      dispatch({
+        type: 'error_set',
+        error:
+          failedResult.response?.error ||
+          (failedResult.error instanceof Error ? failedResult.error.message : fallbackError),
       })
-      return { status: 'archived' }
+      return { status: 'failed' }
     },
     [
       clearCurrentRuntimeTaskIfArchived,
       dispatch,
       executorClient,
+      markRuntimeTasksArchived,
       refreshWorkLists,
       removeArchivedWorktrees,
       state.runtimeWork,
     ]
+  )
+
+  const archiveRuntimeTask = useCallback(
+    async (
+      address: RuntimeTaskAddress,
+      options: ArchiveRuntimeTaskOptions = {}
+    ): Promise<ArchiveRuntimeTaskResult> => {
+      console.debug('[Wework] Runtime archive task start', {
+        address: runtimeAddressDebug(address),
+        force: Boolean(options.force),
+      })
+      const result = await archiveRuntimeConversations([address], 'Failed to archive runtime task')
+      console.debug('[Wework] Runtime archive task finished', {
+        address: runtimeAddressDebug(address),
+        status: result.status,
+      })
+      return result
+    },
+    [archiveRuntimeConversations]
   )
 
   const renameRuntimeTask = useCallback(
@@ -290,44 +319,20 @@ export function useWorkbenchRuntimeTasks({
       options: ArchiveRuntimeTaskOptions = {}
     ): Promise<ArchiveRuntimeConversationsResult> => {
       const addresses = projectTaskAddresses(state.runtimeWork, [runtimeProjectKey])
-      const worktreeTargets = findRuntimeTaskWorktrees(state.runtimeWork, addresses)
       console.debug('[Wework] Runtime archive project start', {
         runtimeProjectKey,
         addresses: addresses.map(runtimeAddressDebug),
-        worktreeTargets: worktreeTargets.length,
         force: Boolean(options.force),
       })
-      const response = await executorClient.runtime.archiveProjectConversations({
-        runtimeProjectKey,
-      })
-      console.debug('[Wework] Runtime archive project response', {
-        runtimeProjectKey,
-        accepted: response.accepted,
-        requestedCount: response.requestedCount,
-        acceptedCount: response.acceptedCount,
-        error: response.error ?? null,
-      })
-      if (!response.accepted) {
-        dispatch({ type: 'error_set', error: response.error || 'Failed to archive project' })
-        return { status: 'failed' }
-      }
-      await removeArchivedWorktrees(worktreeTargets)
-      clearCurrentRuntimeTaskIfArchived(addresses)
-      await refreshWorkLists()
+      const result = await archiveRuntimeConversations(addresses, 'Failed to archive project')
       console.debug('[Wework] Runtime archive project finished', {
         runtimeProjectKey,
+        status: result.status,
         archivedAddresses: addresses.length,
       })
-      return { status: 'archived' }
+      return result
     },
-    [
-      clearCurrentRuntimeTaskIfArchived,
-      dispatch,
-      executorClient,
-      refreshWorkLists,
-      removeArchivedWorktrees,
-      state.runtimeWork,
-    ]
+    [archiveRuntimeConversations, state.runtimeWork]
   )
 
   const archiveProjectsConversations = useCallback(
@@ -339,53 +344,23 @@ export function useWorkbenchRuntimeTasks({
       if (uniqueProjectKeys.length === 0) return { status: 'archived' }
 
       const archivedAddresses = projectTaskAddresses(state.runtimeWork, uniqueProjectKeys)
-      const worktreeTargets = findRuntimeTaskWorktrees(state.runtimeWork, archivedAddresses)
       console.debug('[Wework] Runtime archive projects start', {
         runtimeProjectKeys: uniqueProjectKeys,
         addresses: archivedAddresses.map(runtimeAddressDebug),
-        worktreeTargets: worktreeTargets.length,
         force: Boolean(options.force),
       })
-      const responses = await Promise.all(
-        uniqueProjectKeys.map(runtimeProjectKey =>
-          executorClient.runtime.archiveProjectConversations({ runtimeProjectKey })
-        )
+      const result = await archiveRuntimeConversations(
+        archivedAddresses,
+        'Failed to archive project conversations'
       )
-      console.debug('[Wework] Runtime archive projects response', {
-        responses: responses.map((response, index) => ({
-          runtimeProjectKey: uniqueProjectKeys[index],
-          accepted: response.accepted,
-          requestedCount: response.requestedCount,
-          acceptedCount: response.acceptedCount,
-          error: response.error ?? null,
-        })),
-      })
-      const failedResponse = responses.find(response => !response.accepted)
-      if (failedResponse) {
-        dispatch({
-          type: 'error_set',
-          error: failedResponse.error || 'Failed to archive project conversations',
-        })
-        return { status: 'failed' }
-      }
-
-      await removeArchivedWorktrees(worktreeTargets)
-      clearCurrentRuntimeTaskIfArchived(archivedAddresses)
-      await refreshWorkLists()
       console.debug('[Wework] Runtime archive projects finished', {
         runtimeProjectKeys: uniqueProjectKeys,
+        status: result.status,
         archivedAddresses: archivedAddresses.length,
       })
-      return { status: 'archived' }
+      return result
     },
-    [
-      clearCurrentRuntimeTaskIfArchived,
-      dispatch,
-      executorClient,
-      refreshWorkLists,
-      removeArchivedWorktrees,
-      state.runtimeWork,
-    ]
+    [archiveRuntimeConversations, state.runtimeWork]
   )
 
   const archiveChatConversations = useCallback(
@@ -395,47 +370,21 @@ export function useWorkbenchRuntimeTasks({
     ): Promise<ArchiveRuntimeConversationsResult> => {
       if (addresses.length === 0) return { status: 'archived' }
 
-      const worktreeTargets = findRuntimeTaskWorktrees(state.runtimeWork, addresses)
       console.debug('[Wework] Runtime archive chats start', {
         addresses: addresses.map(runtimeAddressDebug),
-        worktreeTargets: worktreeTargets.length,
         force: Boolean(options.force),
       })
-      const responses = await Promise.all(
-        addresses.map(address => executorClient.runtime.archiveConversation(address))
+      const result = await archiveRuntimeConversations(
+        addresses,
+        'Failed to archive chat conversations'
       )
-      console.debug('[Wework] Runtime archive chats response', {
-        responses: responses.map((response, index) => ({
-          address: runtimeAddressDebug(addresses[index]),
-          accepted: response.accepted,
-          error: response.error ?? null,
-        })),
-      })
-      const failedResponse = responses.find(response => !response.accepted)
-      if (failedResponse) {
-        dispatch({
-          type: 'error_set',
-          error: failedResponse.error || 'Failed to archive chat conversations',
-        })
-        return { status: 'failed' }
-      }
-
-      await removeArchivedWorktrees(worktreeTargets)
-      clearCurrentRuntimeTaskIfArchived(addresses)
-      await refreshWorkLists()
       console.debug('[Wework] Runtime archive chats finished', {
+        status: result.status,
         archivedAddresses: addresses.length,
       })
-      return { status: 'archived' }
+      return result
     },
-    [
-      clearCurrentRuntimeTaskIfArchived,
-      dispatch,
-      executorClient,
-      refreshWorkLists,
-      removeArchivedWorktrees,
-      state.runtimeWork,
-    ]
+    [archiveRuntimeConversations]
   )
 
   const searchRuntimeWork = useCallback(
@@ -519,6 +468,13 @@ export function useWorkbenchRuntimeTasks({
 }
 
 type RuntimeTaskWorktreeTarget = { workspace: RuntimeDeviceWorkspace; task: RuntimeTaskSummary }
+
+function uniqueRuntimeTaskAddresses(addresses: RuntimeTaskAddress[]): RuntimeTaskAddress[] {
+  const uniqueAddresses = new Map(
+    addresses.map(address => [getRuntimeTaskRouteKey(address), address])
+  )
+  return [...uniqueAddresses.values()]
+}
 
 function findRuntimeTaskWorktree(
   runtimeWork: WorkbenchState['runtimeWork'],

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -19,7 +19,7 @@ import {
   standaloneRuntimeProjectKey,
 } from '@/lib/runtime-project'
 import { workbenchDeviceMatchesId } from '@/lib/workbench-device'
-import { getRuntimeTaskWorkspacePath } from './workbenchRuntimeHelpers'
+import { getRuntimeTaskWorkspacePath, removeRuntimeTasks } from './workbenchRuntimeHelpers'
 
 type WorkbenchDeviceStatus = DeviceInfo['status']
 
@@ -119,6 +119,7 @@ export type WorkbenchAction =
       type: 'runtime_task_optimistic_removed'
       address: RuntimeTaskAddress
     }
+  | { type: 'runtime_tasks_archived'; addresses: RuntimeTaskAddress[] }
   | { type: 'runtime_task_started'; address: RuntimeTaskAddress }
   | { type: 'runtime_task_settled'; address: RuntimeTaskAddress }
   | { type: 'current_task_cleared' }
@@ -1129,6 +1130,13 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
       return {
         ...state,
         runtimeWork: removeOptimisticRuntimeTask(state.runtimeWork, action.address),
+      }
+    case 'runtime_tasks_archived':
+      return {
+        ...state,
+        runtimeWork: state.runtimeWork
+          ? removeRuntimeTasks(state.runtimeWork, action.addresses)
+          : null,
       }
     case 'runtime_task_started':
       return {

--- a/wework/src/features/workbench/workbenchRuntimeHelpers.ts
+++ b/wework/src/features/workbench/workbenchRuntimeHelpers.ts
@@ -154,6 +154,64 @@ export function projectTaskAddresses(
   )
 }
 
+export function removeRuntimeTasks(
+  runtimeWork: RuntimeWorkListResponse,
+  addresses: RuntimeTaskAddress[]
+): RuntimeWorkListResponse {
+  if (addresses.length === 0) return runtimeWork
+
+  const removeFromWorkspace = (workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace => ({
+    ...workspace,
+    tasks: workspace.tasks.filter(task => {
+      const taskAddress = runtimeTaskAddressFromWorkspace(workspace, task)
+      return !addresses.some(address => runtimeTaskMatchesArchivedAddress(taskAddress, address))
+    }),
+  })
+  const projects = runtimeWork.projects.map(project => {
+    const deviceWorkspaces = project.deviceWorkspaces.map(removeFromWorkspace)
+    return {
+      ...project,
+      deviceWorkspaces,
+      totalTasks: deviceWorkspaces.reduce((total, workspace) => total + workspace.tasks.length, 0),
+    }
+  })
+  const chats = runtimeWork.chats.map(removeFromWorkspace)
+
+  return {
+    ...runtimeWork,
+    projects,
+    chats,
+    totalTasks:
+      projects.reduce((total, project) => total + (project.totalTasks ?? 0), 0) +
+      chats.reduce((total, workspace) => total + workspace.tasks.length, 0),
+  }
+}
+
+export function runtimeWorkContainsTask(
+  runtimeWork: RuntimeWorkListResponse,
+  address: RuntimeTaskAddress
+): boolean {
+  const workspaces = [
+    ...runtimeWork.projects.flatMap(project => project.deviceWorkspaces),
+    ...runtimeWork.chats,
+  ]
+  return workspaces.some(workspace =>
+    workspace.tasks.some(task =>
+      runtimeTaskMatchesArchivedAddress(runtimeTaskAddressFromWorkspace(workspace, task), address)
+    )
+  )
+}
+
+function runtimeTaskMatchesArchivedAddress(
+  taskAddress: RuntimeTaskAddress,
+  archivedAddress: RuntimeTaskAddress
+): boolean {
+  if (taskAddress.taskId !== archivedAddress.taskId) return false
+  const archivedPath = archivedAddress.workspacePath?.trim()
+  if (!archivedPath) return taskAddress.deviceId === archivedAddress.deviceId
+  return taskAddress.workspacePath?.trim() === archivedPath
+}
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }


### PR DESCRIPTION
## Summary

- archive project conversations through their resolved runtime task addresses instead of routing by merged UI project keys
- suppress successfully archived tasks from current state, persisted remote cache, and stale cloud snapshots
- cancel pre-archive cloud refresh revisions so an older response cannot restore an archived task
- keep partial bulk-archive success consistent by hiding and cleaning up accepted tasks while reporting failures

## Root cause

Project-level archive used project keys after local and remote project state had been merged. Those UI-facing keys were not always recognized by the owning runtime, so the request could succeed while archiving zero conversations.

Single-conversation archive immediately refreshed the work list. That refresh first merged the local result with the previous cloud snapshot, which still contained the archived task, and only later replaced it with the new cloud result. The task therefore disappeared, reappeared briefly, and disappeared again. This was an action-triggered refresh race, not periodic runtime-work polling.

## Task

- `A3HTja9Nvb` — 修复Wework任务归档状态竞态

## Validation

- `pnpm --filter wework test -- src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --filter wework test -- src/components/layout/DesktopSidebar.test.tsx`
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks for all changed files
- repository pre-push quality gate: Frontend and Wework ESLint/TypeScript/unit tests, Backend syntax and formatting, Executor tests and Clippy, Alembic multi-head check

## Manual verification

Real Wework desktop verification was not run at the user's request. The user will manually verify single-task archive stability and project-section archive-all behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived remote runtime tasks are now removed from the workbench immediately.
  * Archived tasks no longer reappear after cloud or cached worklist refreshes.
  * Project conversation archiving now correctly handles both local and remote tasks.
  * Task counts and visible worklists stay synchronized after archiving.
* **Tests**
  * Added coverage for remote task archiving and persistence across refreshed data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->