### PR TITLE
fix(wework): support font size shortcuts

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -151,7 +151,8 @@ from `8px` through `24px`, in whole-pixel steps. Changing UI size scales every
 UI and heading token by `configuredSize / 14` and rounds each result to the
 nearest pixel. Code size is independent and applies directly to code blocks,
 diffs, editors, and terminals. The increase/decrease-font-size shortcuts step
-both configured values together while respecting their separate limits.
+both configured values together while respecting their separate limits. The
+reset-font-size shortcut restores the default `14px` UI and `12px` code sizes.
 
 Product code must consume the semantic Tailwind sizes, `heading-*` classes,
 `text-chat`, `text-code`, or the corresponding CSS variables. Arbitrary font

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -42,6 +42,7 @@ import {
   GO_FORWARD_COMMAND,
   INCREASE_FONT_SIZE_COMMAND,
   DECREASE_FONT_SIZE_COMMAND,
+  RESET_FONT_SIZE_COMMAND,
   OPEN_SETTINGS_COMMAND,
   OPEN_TERMINAL_COMMAND,
   TOGGLE_SIDEBAR_COMMAND,
@@ -55,6 +56,7 @@ import {
   dispatchToggleSidePanelShortcut,
   dispatchToggleModelSelectorShortcut,
   dispatchStepFontSizeShortcut,
+  dispatchResetFontSizeShortcut,
   isEditableShortcutTarget,
   keybindingFromKeyboardEvent,
   mergeKeybindings,
@@ -283,7 +285,6 @@ function AppShell() {
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return
       const terminalKey = activeBindings[OPEN_TERMINAL_COMMAND]
       const settingsKey = activeBindings[OPEN_SETTINGS_COMMAND]
       const goBackKey = activeBindings[GO_BACK_COMMAND]
@@ -293,7 +294,15 @@ function AppShell() {
       const modelSelectorKey = activeBindings[TOGGLE_MODEL_SELECTOR_COMMAND]
       const increaseFontSizeKey = activeBindings[INCREASE_FONT_SIZE_COMMAND]
       const decreaseFontSizeKey = activeBindings[DECREASE_FONT_SIZE_COMMAND]
+      const resetFontSizeKey = activeBindings[RESET_FONT_SIZE_COMMAND]
       const eventKey = keybindingFromKeyboardEvent(event)
+      const matchesFontSizeShortcut =
+        eventKey === increaseFontSizeKey ||
+        eventKey === decreaseFontSizeKey ||
+        eventKey === resetFontSizeKey
+      // The page zoom guard prevents WebView zoom before this window-level
+      // handler runs. Keep application font-size shortcuts actionable.
+      if (event.defaultPrevented && !matchesFontSizeShortcut) return
       const matchesRegisteredShortcut = [
         terminalKey,
         settingsKey,
@@ -304,6 +313,7 @@ function AppShell() {
         modelSelectorKey,
         increaseFontSizeKey,
         decreaseFontSizeKey,
+        resetFontSizeKey,
       ].some(key => key && key === eventKey)
       if (!matchesRegisteredShortcut && isEditableShortcutTarget(event.target)) return
 
@@ -345,6 +355,11 @@ function AppShell() {
       if (decreaseFontSizeKey && eventKey === decreaseFontSizeKey) {
         event.preventDefault()
         dispatchStepFontSizeShortcut(-1)
+        return
+      }
+      if (resetFontSizeKey && eventKey === resetFontSizeKey) {
+        event.preventDefault()
+        dispatchResetFontSizeShortcut()
         return
       }
       if (!terminalKey || eventKey !== terminalKey) return

--- a/wework/src/components/settings/KeyboardShortcutsSettingsPage.test.tsx
+++ b/wework/src/components/settings/KeyboardShortcutsSettingsPage.test.tsx
@@ -31,5 +31,6 @@ describe('KeyboardShortcutsSettingsPage', () => {
     )
     expect(screen.getByTestId('keyboard-shortcut-row-increaseFontSize')).toHaveTextContent('⌘ +')
     expect(screen.getByTestId('keyboard-shortcut-row-decreaseFontSize')).toHaveTextContent('⌘ −')
+    expect(screen.getByTestId('keyboard-shortcut-row-resetFontSize')).toHaveTextContent('⌘ 0')
   })
 })

--- a/wework/src/components/settings/KeyboardShortcutsSettingsPage.tsx
+++ b/wework/src/components/settings/KeyboardShortcutsSettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   GO_FORWARD_COMMAND,
   INCREASE_FONT_SIZE_COMMAND,
   DECREASE_FONT_SIZE_COMMAND,
+  RESET_FONT_SIZE_COMMAND,
   KEYBINDINGS_CHANGED_EVENT,
   OPEN_SETTINGS_COMMAND,
   OPEN_TERMINAL_COMMAND,
@@ -59,6 +60,10 @@ const COMMAND_LABELS: Record<string, { label: string; description: string }> = {
     label: 'keyboard_shortcuts_decrease_font_size',
     description: 'keyboard_shortcuts_decrease_font_size_description',
   },
+  [RESET_FONT_SIZE_COMMAND]: {
+    label: 'keyboard_shortcuts_reset_font_size',
+    description: 'keyboard_shortcuts_reset_font_size_description',
+  },
 }
 
 function commandFallback(command: string): string {
@@ -70,6 +75,7 @@ function commandFallback(command: string): string {
   if (command === TOGGLE_MODEL_SELECTOR_COMMAND) return '选择模型'
   if (command === INCREASE_FONT_SIZE_COMMAND) return '增大字号'
   if (command === DECREASE_FONT_SIZE_COMMAND) return '减小字号'
+  if (command === RESET_FONT_SIZE_COMMAND) return '重置字号'
   return command === OPEN_TERMINAL_COMMAND ? '切换底部面板' : command
 }
 
@@ -82,6 +88,7 @@ function commandDescriptionFallback(command: string): string {
   if (command === TOGGLE_MODEL_SELECTOR_COMMAND) return '打开或关闭当前输入区的模型选择器'
   if (command === INCREASE_FONT_SIZE_COMMAND) return '同时增大 UI 和代码字号'
   if (command === DECREASE_FONT_SIZE_COMMAND) return '同时减小 UI 和代码字号'
+  if (command === RESET_FONT_SIZE_COMMAND) return '将 UI 和代码字号恢复为默认值'
   return command === OPEN_TERMINAL_COMMAND ? '显示或隐藏底部面板' : ''
 }
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -19,6 +19,7 @@ import {
 import { saveLocalUserPreferences } from '@/api/local/localSession'
 import { desktopControlExtension } from '@extensions/desktop-control'
 import type { DesktopControlCommand } from '@/extensions/desktop-control-contract'
+import { parseDesktopControlKey } from './desktop-control-keyboard'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -557,9 +558,11 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       const element = findDesktopControlElements(command.selector)[0]
       if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
       element.focus()
-      const key = command.key ?? ''
+      const keyboardEvent = parseDesktopControlKey(command.key ?? '')
       for (const type of ['keydown', 'keyup']) {
-        element.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true, cancelable: true }))
+        element.dispatchEvent(
+          new KeyboardEvent(type, { ...keyboardEvent, bubbles: true, cancelable: true })
+        )
       }
       return element.textContent?.trim() ?? ''
     }

--- a/wework/src/e2e/desktop-control-keyboard.test.ts
+++ b/wework/src/e2e/desktop-control-keyboard.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+import { parseDesktopControlKey } from './desktop-control-keyboard'
+
+describe('parseDesktopControlKey', () => {
+  test.each([
+    ['Meta+Plus', { key: '+', metaKey: true }],
+    ['Meta+Minus', { key: '-', metaKey: true }],
+    ['Meta+0', { key: '0', metaKey: true }],
+    ['Control+Shift+M', { key: 'M', ctrlKey: true, shiftKey: true }],
+  ])('parses %s', (value, expected) => {
+    expect(parseDesktopControlKey(value)).toMatchObject(expected)
+  })
+})

--- a/wework/src/e2e/desktop-control-keyboard.ts
+++ b/wework/src/e2e/desktop-control-keyboard.ts
@@ -1,0 +1,17 @@
+const MODIFIER_KEYS = new Set(['Alt', 'Control', 'Meta', 'Shift'])
+
+export function parseDesktopControlKey(value: string): KeyboardEventInit {
+  if (value === '+') return { key: '+' }
+  const parts = value.split('+').filter(Boolean)
+  const keyPart = [...parts].reverse().find(part => !MODIFIER_KEYS.has(part)) ?? ''
+  const key =
+    keyPart === 'Plus' ? '+' : keyPart === 'Minus' ? '-' : keyPart === 'Space' ? ' ' : keyPart
+
+  return {
+    key,
+    altKey: parts.includes('Alt'),
+    ctrlKey: parts.includes('Control'),
+    metaKey: parts.includes('Meta'),
+    shiftKey: parts.includes('Shift'),
+  }
+}

--- a/wework/src/features/appearance/AppearanceProvider.test.tsx
+++ b/wework/src/features/appearance/AppearanceProvider.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { AppearanceProvider } from './AppearanceProvider'
 import { darkPalette, lightPalette } from './presets'
 import { useAppearance } from './useAppearance'
-import { WEWORK_STEP_FONT_SIZE_EVENT } from '@/lib/keybindings'
+import { WEWORK_RESET_FONT_SIZE_EVENT, WEWORK_STEP_FONT_SIZE_EVENT } from '@/lib/keybindings'
 
 let mediaQueryMatches = false
 let mediaQueryListener: ((event: MediaQueryListEvent) => void) | null = null
@@ -181,6 +181,24 @@ describe('AppearanceProvider', () => {
 
     expect(screen.getByTestId('ui-font-size')).toHaveTextContent('14')
     expect(screen.getByTestId('code-font-size')).toHaveTextContent('12')
+  })
+
+  test('resets UI and code font sizes without changing other appearance settings', async () => {
+    render(
+      <AppearanceProvider>
+        <Harness />
+      </AppearanceProvider>
+    )
+
+    await userEvent.click(screen.getByTestId('set-font-sizes'))
+    act(() => {
+      window.dispatchEvent(new CustomEvent(WEWORK_RESET_FONT_SIZE_EVENT))
+    })
+
+    expect(screen.getByTestId('ui-font-size')).toHaveTextContent('14')
+    expect(screen.getByTestId('code-font-size')).toHaveTextContent('12')
+    expect(document.documentElement.style.getPropertyValue('--text-base')).toBe('14px')
+    expect(document.documentElement.style.getPropertyValue('--text-code')).toBe('12px')
   })
 
   test('keeps mobile drawer backgrounds opaque enough to hide page content', () => {

--- a/wework/src/features/appearance/AppearanceProvider.tsx
+++ b/wework/src/features/appearance/AppearanceProvider.tsx
@@ -9,7 +9,7 @@ import {
   writeStoredAppearance,
 } from './storage'
 import type { AppearanceConfig, AppearanceUpdate, ResolvedAppearanceMode } from './types'
-import { WEWORK_STEP_FONT_SIZE_EVENT } from '@/lib/keybindings'
+import { WEWORK_RESET_FONT_SIZE_EVENT, WEWORK_STEP_FONT_SIZE_EVENT } from '@/lib/keybindings'
 import { normalizeCodeFontSize, normalizeUiFontSize } from './typography'
 
 function getInitialState(): {
@@ -47,6 +47,22 @@ export function AppearanceProvider({ children }: { children: React.ReactNode }) 
 
     mediaQuery.addEventListener('change', handleChange)
     return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  useEffect(() => {
+    const handleResetFontSize = () => {
+      setState(current => {
+        const appearance = mergeAppearance({
+          ...current.appearance,
+          uiFontSize: defaultAppearance.uiFontSize,
+          codeFontSize: defaultAppearance.codeFontSize,
+        })
+        return { ...current, appearance }
+      })
+    }
+
+    window.addEventListener(WEWORK_RESET_FONT_SIZE_EVENT, handleResetFontSize)
+    return () => window.removeEventListener(WEWORK_RESET_FONT_SIZE_EVENT, handleResetFontSize)
   }, [])
 
   useEffect(() => {

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -970,6 +970,8 @@
     "keyboard_shortcuts_increase_font_size_description": "Increase both UI and code font sizes",
     "keyboard_shortcuts_decrease_font_size": "Decrease font size",
     "keyboard_shortcuts_decrease_font_size_description": "Decrease both UI and code font sizes",
+    "keyboard_shortcuts_reset_font_size": "Reset font size",
+    "keyboard_shortcuts_reset_font_size_description": "Restore the default UI and code font sizes",
     "keyboard_shortcuts_recording": "Press shortcut",
     "keyboard_shortcuts_unassigned": "Unassigned",
     "keyboard_shortcuts_reset": "Reset",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -970,6 +970,8 @@
     "keyboard_shortcuts_increase_font_size_description": "同时增大 UI 和代码字号",
     "keyboard_shortcuts_decrease_font_size": "减小字号",
     "keyboard_shortcuts_decrease_font_size_description": "同时减小 UI 和代码字号",
+    "keyboard_shortcuts_reset_font_size": "重置字号",
+    "keyboard_shortcuts_reset_font_size_description": "将 UI 和代码字号恢复为默认值",
     "keyboard_shortcuts_recording": "按下快捷键",
     "keyboard_shortcuts_unassigned": "未设置",
     "keyboard_shortcuts_reset": "恢复默认",

--- a/wework/src/lib/keybindings.test.ts
+++ b/wework/src/lib/keybindings.test.ts
@@ -17,6 +17,7 @@ import {
   MODEL_SELECTOR_BUTTON_TEST_ID,
   INCREASE_FONT_SIZE_COMMAND,
   DECREASE_FONT_SIZE_COMMAND,
+  RESET_FONT_SIZE_COMMAND,
 } from './keybindings'
 
 describe('keybindings', () => {
@@ -33,6 +34,7 @@ describe('keybindings', () => {
     expect(mergeKeybindings([])[TOGGLE_MODEL_SELECTOR_COMMAND]).toBe('Control+Shift+M')
     expect(mergeKeybindings([])[INCREASE_FONT_SIZE_COMMAND]).toBe('Command+Plus')
     expect(mergeKeybindings([])[DECREASE_FONT_SIZE_COMMAND]).toBe('Command+Minus')
+    expect(mergeKeybindings([])[RESET_FONT_SIZE_COMMAND]).toBe('Command+0')
     expect(
       mergeKeybindings([{ command: OPEN_TERMINAL_COMMAND, key: 'Control+J' }])[
         OPEN_TERMINAL_COMMAND
@@ -68,6 +70,9 @@ describe('keybindings', () => {
       keybindingFromKeyboardEvent(
         new KeyboardEvent('keydown', { key: '+', metaKey: true, shiftKey: true })
       )
+    ).toBe('Command+Plus')
+    expect(
+      keybindingFromKeyboardEvent(new KeyboardEvent('keydown', { key: '=', metaKey: true }))
     ).toBe('Command+Plus')
     expect(
       keybindingFromKeyboardEvent(new KeyboardEvent('keydown', { key: '-', metaKey: true }))

--- a/wework/src/lib/keybindings.ts
+++ b/wework/src/lib/keybindings.ts
@@ -10,8 +10,10 @@ export const TOGGLE_SIDE_PANEL_COMMAND = 'toggleSidePanel'
 export const TOGGLE_MODEL_SELECTOR_COMMAND = 'toggleModelSelector'
 export const INCREASE_FONT_SIZE_COMMAND = 'increaseFontSize'
 export const DECREASE_FONT_SIZE_COMMAND = 'decreaseFontSize'
+export const RESET_FONT_SIZE_COMMAND = 'resetFontSize'
 export const WEWORK_OPEN_TERMINAL_EVENT = 'wework:open-terminal'
 export const WEWORK_STEP_FONT_SIZE_EVENT = 'wework:step-font-size'
+export const WEWORK_RESET_FONT_SIZE_EVENT = 'wework:reset-font-size'
 export const KEYBINDINGS_CHANGED_EVENT = 'wework:keybindings-changed'
 export const ACTIVE_KEYBINDINGS_CHANGED_EVENT = 'wework:active-keybindings-changed'
 export const TOGGLE_BOTTOM_WORKSPACE_PANEL_BUTTON_TEST_ID = 'toggle-bottom-workspace-panel-button'
@@ -67,6 +69,10 @@ export const DEFAULT_KEYBINDINGS: KeybindingCommand[] = [
   {
     command: DECREASE_FONT_SIZE_COMMAND,
     defaultKey: 'Command+Minus',
+  },
+  {
+    command: RESET_FONT_SIZE_COMMAND,
+    defaultKey: 'Command+0',
   },
 ]
 
@@ -193,6 +199,10 @@ export function dispatchToggleModelSelectorShortcut() {
 
 export function dispatchStepFontSizeShortcut(delta: -1 | 1) {
   window.dispatchEvent(new CustomEvent(WEWORK_STEP_FONT_SIZE_EVENT, { detail: { delta } }))
+}
+
+export function dispatchResetFontSizeShortcut() {
+  window.dispatchEvent(new CustomEvent(WEWORK_RESET_FONT_SIZE_EVENT))
 }
 
 export function shortcutsAvailable(): boolean {


### PR DESCRIPTION
## Summary

- make Command+Plus and Command+Minus adjust Wework UI and code font sizes without being swallowed by the WebView zoom guard
- add Command+0 to restore the default 14px UI and 12px code font sizes
- show all three configurable shortcuts in settings and document reset behavior
- extend isolated desktop verification key presses with modifier support

## Root cause

The page zoom guard prevented the native WebView zoom event before the window-level application shortcut handler ran. The handler returned early for prevented events, so the registered font-size commands never executed.

## Validation

- `pnpm --filter wework test` (193 files, 1920 tests)
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- isolated real-Tauri verification with screenshots for default, increase, decrease, and reset states
- pre-push Wework ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut to reset UI and code font sizes to their defaults.
  * Added reset-font-size shortcut details to the keyboard shortcuts settings page in English and Chinese.
  * Improved keyboard shortcut handling for modifier keys and special keys.

* **Documentation**
  * Clarified the default font sizes restored by the reset shortcut.

* **Tests**
  * Added coverage for font-size resetting and keyboard shortcut parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->