### PR TITLE
test(wework): cover composer project flow

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -2070,9 +2070,10 @@ async function main() {
       'Cancelling folder selection did not restore the workbench'
     )
 
-    phase = 'project-folder-select'
-    await control.command('click', '[data-testid="projects-create-button"]')
-    await control.command('click', '[data-testid="project-create-existing-option"]')
+    phase = 'composer-project-folder-select'
+    await control.command('click', '[data-testid="project-work-button"]')
+    await control.command('hover', '[data-testid="add-local-project-option"]')
+    await control.command('click', '[data-testid="add-local-existing-project-option"]')
     await control.command('waitFor', '[data-testid="device-folder-path-input"]', {
       timeoutMs: UI_TIMEOUT_MS,
     })
@@ -2087,7 +2088,7 @@ async function main() {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
 
-    phase = 'project-folder-remove-immediately'
+    phase = 'composer-project-visible-in-sidebar'
     const openedProjectSnapshot = await waitForSnapshot(
       control,
       snapshot => snapshot.testIds.some(testId => testId.startsWith('project-menu-')),
@@ -2098,6 +2099,30 @@ async function main() {
     )
     assert.ok(projectMenuTestId, 'The newly opened folder project was not shown in the sidebar')
     const projectId = projectMenuTestId.slice('project-menu-'.length)
+    const projectRowSelector = `[data-testid="project-row-${projectId}"]`
+    await control.command('waitFor', projectRowSelector, {
+      text: 'workspace',
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    await control.command('waitFor', '[data-testid="project-work-button"]', {
+      text: 'workspace',
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+
+    phase = 'sidebar-project-new-conversation'
+    await control.command(
+      'click',
+      `${projectRowSelector} [data-testid="project-new-conversation-button"]`
+    )
+    await control.command('waitFor', composerSelector, {
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    })
+    await control.command('waitFor', '[data-testid="project-work-button"]', {
+      text: 'workspace',
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+
+    phase = 'project-folder-remove-immediately'
     await control.command('click', `[data-testid="${projectMenuTestId}"]`)
     await control.command('click', `[data-testid="remove-project-${projectId}"]`)
     await control.command(


### PR DESCRIPTION
## What changed

- add desktop E2E coverage for creating an existing-folder project from the composer project menu
- verify the created project appears in the left sidebar
- verify starting a new conversation from that sidebar project keeps the same project selected above the composer

## Why

The composer project-management flow lacked end-to-end regression coverage connecting project creation, sidebar visibility, and project-scoped conversation creation.

## Validation

- `node --check wework/e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- pre-push Wework ESLint, TypeScript, and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the desktop task-flow validation to select a local project through the project menu.
  * Added checks confirming the project appears in the sidebar with the expected workspace.
  * Added coverage for starting a new conversation directly from the project row.
  * Preserved validation of immediate project removal after the new conversation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->