### PR TITLE
fix: fix buffer size

### DIFF
--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -23,9 +23,10 @@ use std::{
 
 use axum::{
     body::{Body, Bytes},
-    extract::Path,
+    extract::{DefaultBodyLimit, Path},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::Response,
+    routing::{post, MethodRouter},
 };
 use futures_util::{Stream, StreamExt};
 use serde_json::{json, Map, Value};
@@ -35,6 +36,14 @@ use crate::logging::log_executor_event;
 use super::{codex_responses_proxy_transform, HttpError};
 
 pub(crate) const ROUTE: &str = "/v1/codex-router/{token}/responses";
+const MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
+
+pub(crate) fn route<S>() -> MethodRouter<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    post(handle_routed).layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct LocalModelProxyUpstream {

--- a/executor/src/server/mod.rs
+++ b/executor/src/server/mod.rs
@@ -91,10 +91,7 @@ where
         .route("/envs", get(envd_envs))
         .route("/v1/responses", post(openai_responses::<R>))
         .route(codex_model_catalog::ROUTE, get(codex_model_catalog::handle))
-        .route(
-            local_model_proxy::ROUTE,
-            post(local_model_proxy::handle_routed),
-        )
+        .route(local_model_proxy::ROUTE, local_model_proxy::route())
         .route("/v1/attachments/sync", post(sync_attachments))
         .route("/filesystem/list-dir", get(list_workspace_directory))
         .route("/filesystem/file", get(download_workspace_file))

--- a/executor/tests/http_contract.rs
+++ b/executor/tests/http_contract.rs
@@ -114,6 +114,26 @@ async fn responses_endpoint_accepts_openai_background_requests() {
 }
 
 #[tokio::test]
+async fn codex_router_accepts_request_bodies_larger_than_axum_default() {
+    let app = create_router(AppState::new(RecordingRunner::default()));
+    let payload = vec![b'x'; 3 * 1024 * 1024];
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/v1/codex-router/unknown/responses")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn workspace_routes_list_and_download_task_files() {
     let _lock = env_lock().lock().await;
     let workspace_root = unique_dir("executor-http-workspace");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the request body limit for local model proxy requests to support payloads up to 64 MiB.
  * Ensured larger requests are processed by the routing layer instead of being rejected by the default server limit.

* **Tests**
  * Added coverage confirming that requests larger than the default limit are accepted and routed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->