### PR TITLE
fix(wework): add runtime sidebar diagnostics

### DIFF
--- a/docs/en/wework/troubleshooting.md
+++ b/docs/en/wework/troubleshooting.md
@@ -11,6 +11,16 @@ sidebar_position: 10
 - Restart Codex when prompted after changing a proxy.
 - For task or terminal failures, check whether the device is online, busy, or requires an update.
 
+### A new task is missing from the sidebar
+
+For development diagnostics, run the following command in the Wework Web Inspector console, then reproduce the issue:
+
+```js
+localStorage.setItem("wework:debug-runtime", "1");
+```
+
+`[Wework] Runtime sidebar state` entries in the frontend log record the executor list result, the merged state, and the task IDs left visible or hidden by sidebar sorting and truncation. If the selected task belongs to the project task list but is outside the visible region, Wework also records `[Wework] Runtime sidebar selected task is hidden`. Run `localStorage.removeItem('wework:debug-runtime')` after diagnosis to disable detailed logging.
+
 ## Projects and Git
 
 - Confirm that a local folder exists and is writable.

--- a/docs/zh/wework/troubleshooting.md
+++ b/docs/zh/wework/troubleshooting.md
@@ -18,12 +18,12 @@ sidebar_position: 10
 
 ## Git 克隆失败
 
-| 提示 | 检查内容 |
-| --- | --- |
-| Authentication failed | Git Token 是否有效、是否有仓库权限 |
-| Repository not found | 仓库地址和当前账号权限 |
-| Remote branch not found | 默认分支是否存在 |
-| Could not resolve host / timeout | 执行设备的网络和代理 |
+| 提示                             | 检查内容                           |
+| -------------------------------- | ---------------------------------- |
+| Authentication failed            | Git Token 是否有效、是否有仓库权限 |
+| Repository not found             | 仓库地址和当前账号权限             |
+| Remote branch not found          | 默认分支是否存在                   |
+| Could not resolve host / timeout | 执行设备的网络和代理               |
 
 ## 任务或终端无法运行
 
@@ -31,6 +31,16 @@ sidebar_position: 10
 - 设备提示升级时，先完成升级。
 - 切换任务后，确认终端对应的是当前项目或 Worktree。
 - 重新打开应用后仍失败，可完全退出 Wework 再启动。
+
+### 新任务未出现在侧边栏
+
+开发调试时，可在 Wework Web Inspector 的控制台执行以下命令后复现：
+
+```js
+localStorage.setItem("wework:debug-runtime", "1");
+```
+
+前端日志中的 `[Wework] Runtime sidebar state` 会依次记录 executor 列表结果、状态合并结果，以及侧边栏排序和截断后的任务 ID。当前选中的任务存在于项目任务列表但未进入可见区域时，还会记录 `[Wework] Runtime sidebar selected task is hidden`。诊断完成后执行 `localStorage.removeItem('wework:debug-runtime')` 关闭详细日志。
 
 ## 无法审核或撤销变更
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -124,6 +124,10 @@ import {
   isRuntimeWorktreeTask,
   RUNTIME_PROJECT_TASK_PREVIEW_LIMIT,
 } from './runtimeTaskSidebarHelpers'
+import {
+  debugRuntimeSidebarState,
+  warnRuntimeSidebarMismatch,
+} from '@/features/workbench/runtimeSidebarDiagnostics'
 import { formatRelativeSidebarTime, useSidebarRelativeTimeRefresh } from './runtimeSidebarTime'
 import { useResizableSidebar } from './useResizableSidebar'
 
@@ -1980,6 +1984,34 @@ function ProjectItem({
     prioritizedRuntimeTaskItems,
     runtimeTaskVisibleLimit
   )
+  useEffect(() => {
+    const details = {
+      projectId: project.id,
+      currentTaskId: currentRuntimeTask?.taskId ?? null,
+      visibleLimit: runtimeTaskVisibleLimit,
+      allTaskIds: prioritizedRuntimeTaskItems.map(item => item.task.taskId),
+      visibleTaskIds: visibleRuntimeTaskItems.map(item => item.task.taskId),
+      hiddenTaskIds: prioritizedRuntimeTaskItems
+        .slice(visibleRuntimeTaskItems.length)
+        .map(item => item.task.taskId),
+    }
+    debugRuntimeSidebarState('project-visible-items', details)
+
+    const currentTaskId = currentRuntimeTask?.taskId
+    if (
+      currentTaskId &&
+      prioritizedRuntimeTaskItems.some(item => item.task.taskId === currentTaskId) &&
+      !visibleRuntimeTaskItems.some(item => item.task.taskId === currentTaskId)
+    ) {
+      warnRuntimeSidebarMismatch(details)
+    }
+  }, [
+    currentRuntimeTask?.taskId,
+    prioritizedRuntimeTaskItems,
+    project.id,
+    runtimeTaskVisibleLimit,
+    visibleRuntimeTaskItems,
+  ])
   const projectDeviceState =
     getRuntimeProjectDeviceState(runtimeProjectWork, devices) ??
     getSidebarDeviceState(getProjectDeviceId(project), devices)

--- a/wework/src/features/workbench/runtimeSidebarDiagnostics.ts
+++ b/wework/src/features/workbench/runtimeSidebarDiagnostics.ts
@@ -1,0 +1,29 @@
+import type { RuntimeWorkListResponse } from '@/types/api'
+
+export function debugRuntimeSidebarState(event: string, details: Record<string, unknown>): void {
+  if (globalThis.localStorage?.getItem('wework:debug-runtime') !== '1') return
+
+  console.info('[Wework] Runtime sidebar state', {
+    event,
+    ...details,
+  })
+}
+
+export function warnRuntimeSidebarMismatch(details: Record<string, unknown>): void {
+  console.warn('[Wework] Runtime sidebar selected task is hidden', details)
+}
+
+export function summarizeRuntimeWorkTaskIds(runtimeWork: RuntimeWorkListResponse | null) {
+  if (!runtimeWork) return { projects: [], chats: [] }
+
+  return {
+    projects: runtimeWork.projects.map(projectWork => ({
+      projectId: projectWork.project.id ?? null,
+      projectKey: projectWork.project.key ?? null,
+      taskIds: projectWork.deviceWorkspaces.flatMap(workspace =>
+        workspace.tasks.map(task => task.taskId)
+      ),
+    })),
+    chats: runtimeWork.chats.flatMap(workspace => workspace.tasks.map(task => task.taskId)),
+  }
+}

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -27,6 +27,7 @@ import {
   timedWorkbenchBootstrapRequest,
 } from './workbenchCloudStatus'
 import type { WorkbenchAction } from './workbenchReducer'
+import { debugRuntimeSidebarState, summarizeRuntimeWorkTaskIds } from './runtimeSidebarDiagnostics'
 import {
   getRememberedStandaloneDeviceId,
   getRuntimeTaskRouteKey,
@@ -452,6 +453,11 @@ export function useWorkbenchDataRefresh({
       : hasCloudBackgroundApi
         ? localRuntimeWork
         : filterDisconnectedRemoteRuntimeWork(localRuntimeWork)
+    debugRuntimeSidebarState('refresh-resolved', {
+      source: runtimeWorkResult ? 'executor' : 'current-state',
+      executorTaskIds: summarizeRuntimeWorkTaskIds(runtimeWorkResult ?? null),
+      visibleTaskIds: summarizeRuntimeWorkTaskIds(runtimeWork),
+    })
     dispatch({
       type: 'lists_refreshed',
       projects: state.projects,

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -20,6 +20,7 @@ import {
 } from '@/lib/runtime-project'
 import { workbenchDeviceMatchesId } from '@/lib/workbench-device'
 import { getRuntimeTaskWorkspacePath, removeRuntimeTasks } from './workbenchRuntimeHelpers'
+import { debugRuntimeSidebarState, summarizeRuntimeWorkTaskIds } from './runtimeSidebarDiagnostics'
 
 type WorkbenchDeviceStatus = DeviceInfo['status']
 
@@ -937,6 +938,11 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
             ? state.standaloneWorkspacePath
             : action.standaloneWorkspacePath,
       }
+      debugRuntimeSidebarState('reducer-lists-refreshed', {
+        incomingTaskIds: summarizeRuntimeWorkTaskIds(action.runtimeWork ?? null),
+        previousTaskIds: summarizeRuntimeWorkTaskIds(state.runtimeWork ?? null),
+        mergedTaskIds: summarizeRuntimeWorkTaskIds(runtimeWork),
+      })
       return refreshedState
     }
     case 'devices_refreshed': {
@@ -961,6 +967,11 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
     }
     case 'runtime_work_refreshed': {
       const runtimeWork = mergeRuntimeWorkPreservingTaskOrder(state.runtimeWork, action.runtimeWork)
+      debugRuntimeSidebarState('reducer-runtime-work-refreshed', {
+        incomingTaskIds: summarizeRuntimeWorkTaskIds(action.runtimeWork),
+        previousTaskIds: summarizeRuntimeWorkTaskIds(state.runtimeWork ?? null),
+        mergedTaskIds: summarizeRuntimeWorkTaskIds(runtimeWork),
+      })
       return {
         ...state,
         runtimeWork,


### PR DESCRIPTION
## What changed

- add structured runtime sidebar diagnostics for executor list results and reducer merges
- record sorted, visible, and hidden task IDs for each project sidebar
- emit a focused warning when the selected project task is unexpectedly hidden
- document how to enable and disable detailed diagnostics in Chinese and English

## Why

Executor logs confirm that newly created tasks are persisted, matched to the project, and returned by `runtime.tasks.list`, while the task can still be absent from the visible sidebar. Existing frontend logs do not expose the state between the list response, reducer merge, and sidebar truncation, so the remaining frontend failure cannot be diagnosed from evidence.

## Impact

The new logs make the next reproduction attributable to list ingestion, state reconciliation, or sidebar sorting/truncation without logging message content or credentials. Detailed tracing remains behind `wework:debug-runtime`; the selected-task-hidden warning is emitted only for the anomalous state.

## Validation

- `pnpm --filter wework exec vitest run src/features/workbench/workbenchReducer.test.ts src/components/layout/DesktopSidebar.test.tsx`
- Prettier checks for changed source and documentation files
- ESLint for changed Wework source files
- pre-push ESLint, TypeScript, and full Wework unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for tasks missing from the sidebar.
  * Included steps to enable detailed diagnostic logging, interpret relevant console messages, and disable logging afterward.
  * Improved the formatting and readability of Git clone failure troubleshooting tips.

* **Bug Fixes**
  * Added diagnostic warnings and logging to help identify cases where a selected task is hidden from the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->