### PR TITLE
fix(executor): omit inline image data from Claude output

### DIFF
--- a/executor/src/process/mod.rs
+++ b/executor/src/process/mod.rs
@@ -39,9 +39,10 @@ use crate::{
     protocol::ExecutionRequest,
     runner::{AgentEngine, EventSink, ExecutionOutcome},
     stream::{
-        collect_claude_stream_summary, extract_claude_child_blocks, extract_claude_subagent_update,
-        extract_claude_tool_results, extract_claude_tool_uses, extract_reasoning, extract_text,
-        ClaudeAsyncTaskTracker, ClaudeStdoutJsonBuffer, ClaudeStdoutJsonError, ClaudeToolUse,
+        collect_claude_stream_summary, compact_claude_stdout_line, extract_claude_child_blocks,
+        extract_claude_subagent_update, extract_claude_tool_results, extract_claude_tool_uses,
+        extract_reasoning, extract_text, ClaudeAsyncTaskTracker, ClaudeStdoutJsonBuffer,
+        ClaudeStdoutJsonError, ClaudeToolUse,
     },
 };
 
@@ -1040,6 +1041,16 @@ where
     let dispatcher = StreamingEventDispatcher::new(sink);
     while let Ok(Some(line)) = lines.next_line().await {
         line_number += 1;
+        let line = match compact_claude_stdout_line(&line, line_number) {
+            Ok(line) => line,
+            Err(error) => {
+                dispatcher.flush().await;
+                return StreamingStdoutOutcome::InvalidJson {
+                    stdout: output,
+                    error,
+                };
+            }
+        };
         output.push_str(&line);
         output.push('\n');
         if let Some(file) = debug_stdout_file.as_mut() {

--- a/executor/src/stream/mod.rs
+++ b/executor/src/stream/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::{borrow::Cow, collections::HashSet};
 
 use serde_json::Value;
 
@@ -14,6 +14,8 @@ use crate::{
 };
 
 const CLAUDE_STDOUT_MAX_BUFFER_BYTES: usize = 1024 * 1024;
+const CLAUDE_STDOUT_MAX_RAW_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
+const OMITTED_IMAGE_DATA: &str = "[binary image data omitted]";
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClaudeStreamSummary {
@@ -112,11 +114,11 @@ impl ClaudeStdoutJsonBuffer {
         }
 
         self.buffer.push_str(line);
-        if self.buffer.len() > CLAUDE_STDOUT_MAX_BUFFER_BYTES {
+        if self.buffer.len() > CLAUDE_STDOUT_MAX_RAW_MESSAGE_BYTES {
             let error = ClaudeStdoutJsonError {
                 line_number,
                 message: format!(
-                    "JSON message exceeded maximum buffer size of {CLAUDE_STDOUT_MAX_BUFFER_BYTES} bytes"
+                    "JSON message exceeded maximum raw size of {CLAUDE_STDOUT_MAX_RAW_MESSAGE_BYTES} bytes"
                 ),
                 preview: preview_stdout_line(&self.buffer),
             };
@@ -125,12 +127,80 @@ impl ClaudeStdoutJsonBuffer {
         }
 
         match serde_json::from_str::<Value>(&self.buffer) {
-            Ok(value) => {
+            Ok(mut value) => {
+                omit_inline_image_data(&mut value);
+                let normalized_size = if self.buffer.len() > CLAUDE_STDOUT_MAX_BUFFER_BYTES {
+                    serde_json::to_vec(&value)
+                        .map(|serialized| serialized.len())
+                        .unwrap_or(self.buffer.len())
+                } else {
+                    self.buffer.len()
+                };
+                if normalized_size > CLAUDE_STDOUT_MAX_BUFFER_BYTES {
+                    let error = ClaudeStdoutJsonError {
+                        line_number,
+                        message: format!(
+                            "JSON message exceeded maximum buffer size of {CLAUDE_STDOUT_MAX_BUFFER_BYTES} bytes"
+                        ),
+                        preview: preview_stdout_line(&self.buffer),
+                    };
+                    self.buffer.clear();
+                    return Err(error);
+                }
                 self.buffer.clear();
                 Ok(Some(value))
             }
             Err(_) => Ok(None),
         }
+    }
+}
+
+pub fn compact_claude_stdout_line<'a>(
+    line: &'a str,
+    line_number: usize,
+) -> Result<Cow<'a, str>, ClaudeStdoutJsonError> {
+    if line.len() <= CLAUDE_STDOUT_MAX_BUFFER_BYTES {
+        return Ok(Cow::Borrowed(line));
+    }
+
+    let mut buffer = ClaudeStdoutJsonBuffer::default();
+    let Some(value) = buffer.push_line(line, line_number)? else {
+        return Ok(Cow::Borrowed(line));
+    };
+    serde_json::to_string(&value)
+        .map(Cow::Owned)
+        .map_err(|error| ClaudeStdoutJsonError {
+            line_number,
+            message: format!("failed to serialize normalized Claude stdout JSON: {error}"),
+            preview: preview_stdout_line(line),
+        })
+}
+
+fn omit_inline_image_data(value: &mut Value) -> bool {
+    match value {
+        Value::Array(items) => items.iter_mut().fold(false, |omitted, item| {
+            omit_inline_image_data(item) || omitted
+        }),
+        Value::Object(object) => {
+            let is_image = object.get("type").and_then(Value::as_str) == Some("image");
+            let omitted_here = if is_image {
+                object
+                    .get_mut("source")
+                    .and_then(Value::as_object_mut)
+                    .filter(|source| source.get("type").and_then(Value::as_str) == Some("base64"))
+                    .and_then(|source| source.get_mut("data"))
+                    .map(|data| {
+                        *data = Value::String(OMITTED_IMAGE_DATA.to_owned());
+                    })
+                    .is_some()
+            } else {
+                false
+            };
+            object.values_mut().fold(omitted_here, |omitted, value| {
+                omit_inline_image_data(value) || omitted
+            })
+        }
+        _ => false,
     }
 }
 

--- a/executor/src/stream/mod.rs
+++ b/executor/src/stream/mod.rs
@@ -178,9 +178,13 @@ pub fn compact_claude_stdout_line<'a>(
 
 fn omit_inline_image_data(value: &mut Value) -> bool {
     match value {
-        Value::Array(items) => items.iter_mut().fold(false, |omitted, item| {
-            omit_inline_image_data(item) || omitted
-        }),
+        Value::Array(items) => {
+            let mut omitted = false;
+            for item in items {
+                omitted = omit_inline_image_data(item) || omitted;
+            }
+            omitted
+        }
         Value::Object(object) => {
             let is_image = object.get("type").and_then(Value::as_str) == Some("image");
             let omitted_here = if is_image {

--- a/executor/tests/claude_stream_event_contract.rs
+++ b/executor/tests/claude_stream_event_contract.rs
@@ -155,6 +155,43 @@ fn claude_user_tool_result_blocks_are_extracted_for_ui_tool_events() {
 }
 
 #[test]
+fn oversized_image_tool_result_omits_base64_and_completes_tool() {
+    let image_data = "a".repeat(1024 * 1024 + 1);
+    let line = serde_json::to_string(&json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "Read_0",
+                "content": [{
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": image_data
+                    }
+                }]
+            }]
+        }
+    }))
+    .unwrap();
+
+    let mut buffer = wegent_executor::stream::ClaudeStdoutJsonBuffer::default();
+    let event = buffer.push_line(&line, 1).unwrap().unwrap();
+    let tool_results = extract_claude_tool_results(&event);
+
+    assert_eq!(tool_results.len(), 1);
+    assert_eq!(tool_results[0].tool_use_id, "Read_0");
+    assert_eq!(tool_results[0].content, None);
+    assert!(!tool_results[0].is_error);
+    assert_eq!(
+        event["message"]["content"][0]["content"][0]["source"]["data"],
+        "[binary image data omitted]"
+    );
+}
+
+#[test]
 fn claude_skill_tool_load_result_is_extracted_for_ui_tool_events() {
     let tool_use_event = json!({
         "type": "assistant",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability when processing tool results containing inline images.
  * Large embedded image data is now omitted while preserving tool result details and completion status.
  * Streaming now stops promptly and reports an invalid response when incoming data can’t be compacted or parsed.
* **Performance**
  * Added stricter size handling during streamed JSON buffering, including a normalized-size re-check.
* **Tests**
  * Added coverage for oversized inline images in tool-result NDJSON events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->