### PR TITLE
test(wework): cover sidebar attachment isolation

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -109,8 +109,11 @@ The right workspace **Temporary chat** feature starts a short side conversation 
 - The first message calls `createTemporaryRuntimeTask`, creating an `ephemeral` runtime task with the current main thread as `sideSource`. This task does not enter the left task list and does not navigate the main pane.
 - Follow-up messages must continue the already loaded temporary thread. The Codex app-server path uses `direct_thread_id` and calls `turn/start` directly; it must not use the normal `resume_thread_id` / `thread/resume` path, because temporary threads do not have rollout mappings and would otherwise fail with `no rollout found`.
 - Temporary chats reuse only the current workspace and current thread context. If no main thread source is available, sending should be blocked and the user should be asked to open an existing conversation first.
+- After a runtime-work refresh, the reducer must hydrate the current task address with the authoritative `threadId/runtimeHandle` from the same device and task. Keeping an optimistic address without its thread merely because the device is still online prevents the temporary chat from establishing `sideSource`.
 
 Maintenance rule: do not add UI fallbacks that insert temporary chats into the left task list, and do not fabricate rollout records for temporary threads in the executor. The primary path is `ephemeral + sideSource + direct_thread_id`.
+
+After changing this path, run `pnpm --dir wework e2e:desktop:side-chat-attachment`. The scenario creates a real main thread, asserts an approximately `420px` side panel, uploads and sends an attachment from the side chat, and verifies that the main composer never inherits that attachment. It writes screenshots for each critical stage to `wework/test-results/desktop-e2e/<run-id>/`.
 
 ## Top-Level Page Transitions
 

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -107,8 +107,11 @@ Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React st
 - 首条消息通过 `createTemporaryRuntimeTask` 创建 `ephemeral` runtime task，并携带当前主线程的 `sideSource`。该任务不写入左侧任务列表，也不触发主 pane 导航。
 - 后续消息必须继续使用已加载的临时线程。Codex app-server 路径使用 `direct_thread_id` 直接 `turn/start`，不能走普通 `resume_thread_id` 的 `thread/resume` 路径，否则会因为临时线程没有 rollout 映射而出现 `no rollout found`。
 - 临时聊天只复用当前工作区和当前线程上下文；如果没有可用的主线程 source，应阻止发送并提示用户先打开已有对话。
+- runtime work 列表刷新后，reducer 必须用同一设备、同一任务的权威 `threadId/runtimeHandle` 水合当前任务地址；不能因为设备仍在线就保留缺少 thread 的 optimistic address，否则右侧临时聊天无法建立 `sideSource`。
 
 维护规则：不要用 fallback 在 UI 里把临时聊天补进左侧任务列表，也不要在 executor 中为临时线程伪造 rollout。临时聊天的主路径是 `ephemeral + sideSource + direct_thread_id`。
+
+修改该链路后运行 `pnpm --dir wework e2e:desktop:side-chat-attachment`。该场景会建立真实主线程，断言右栏约为 `420px`，在右栏上传并发送附件，并确认主 composer 始终没有继承右栏附件；关键阶段截图写入 `wework/test-results/desktop-e2e/<run-id>/`。
 
 ## 顶层页面切换
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1889,10 +1889,17 @@ class DesktopE2EServer {
   }
 
   async awaitScenarioRequestCount(scenario, count) {
-    while ((this.scenarioRequests.get(scenario)?.length ?? 0) < count) {
-      await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
-    }
-    return this.scenarioRequests.get(scenario).at(-1)
+    const waitForCount = (async () => {
+      while ((this.scenarioRequests.get(scenario)?.length ?? 0) < count) {
+        await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
+      }
+      return this.scenarioRequests.get(scenario).at(-1)
+    })()
+    return withTimeout(
+      this.guard(waitForCount),
+      UI_TIMEOUT_MS,
+      `Timed out waiting for ${count} ${scenario} scenario requests`
+    )
   }
 
   releaseInitialToolExecution() {

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -83,6 +83,9 @@ const FRESH_CHAT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_FRESH_CHAT_COMPLETE'
 const COMPOSER_PROJECT_NAME = 'Composer Flow Project'
 const ATTACHMENT_ONLY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_ATTACHMENT_ONLY_COMPLETE'
 const ATTACHMENT_ONLY_FILENAME = 'same-name-attachment.png'
+const SIDE_CHAT_PROMPT = 'WEWORK_DESKTOP_E2E_SIDE_CHAT: verify isolated attachments.'
+const SIDE_CHAT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_SIDE_CHAT_COMPLETE'
+const SIDE_CHAT_FILENAME = 'side-chat-only.png'
 const CLOUD_TASK_PROMPT =
   'WEWORK_DESKTOP_E2E_CLOUD_TASK: create the requested cloud verification file.'
 const CLOUD_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CLOUD_COMPLETE'
@@ -102,6 +105,7 @@ const REQUEST_INPUT_ONLY = process.env.WEWORK_DESKTOP_E2E_REQUEST_INPUT_ONLY ===
 const RECONNECT_ONLY = process.argv.includes('--reconnect-only')
 const VIEW_IMAGE_ONLY = process.argv.includes('--view-image-only')
 const ATTACHMENT_ONLY_SIDEBAR = process.argv.includes('--attachment-only-sidebar')
+const SIDE_CHAT_ATTACHMENT_ONLY = process.argv.includes('--side-chat-attachment-only')
 const CLOUD_ONLY = process.argv.includes('--cloud-only')
 const PLUGINS_ONLY = process.argv.includes('--plugins-only')
 const MEMORY_ONLY = process.argv.includes('--memory-only')
@@ -986,6 +990,124 @@ async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSel
   }
 }
 
+async function verifySideChatAttachmentIsolation({ control }) {
+  const sideChatSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-chat-panel"]`
+  const rightPanelShellSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`
+  const mainComposerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-floating-composer-card"]`
+  const sideComposerSelector = `${sideChatSelector} [data-testid="chat-message-input"]`
+
+  control.setScenario('initial')
+  await sendPrompt(control, ACTIVE_COMPOSER_SELECTOR, TASK_PROMPT)
+  await control.awaitScenarioRequestCount('initial', 1)
+  control.releaseInitialToolExecution()
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    {
+      text: COMPLETION_TEXT,
+      timeoutMs: UI_TIMEOUT_MS,
+    }
+  )
+  const taskSnapshot = await waitForSnapshot(
+    control,
+    snapshot => snapshot.testIds.some(testId => testId.startsWith('runtime-local-task-row-')),
+    'The completed main conversation did not appear in the task sidebar'
+  )
+  const taskRowTestId = taskSnapshot.testIds.find(testId =>
+    testId.startsWith('runtime-local-task-row-')
+  )
+  assert.ok(taskRowTestId, 'The completed main conversation did not expose a task row')
+  await control.command('click', '[data-testid="new-chat-button"]')
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-empty-composer-frame"]`,
+    { timeoutMs: UI_TIMEOUT_MS }
+  )
+  await control.command('click', `[data-testid="${taskRowTestId}"]`)
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    {
+      text: COMPLETION_TEXT,
+      timeoutMs: UI_TIMEOUT_MS,
+    }
+  )
+  control.setScenario('side_chat_attachment')
+  await control.command('click', '[data-testid="toggle-right-workspace-panel-button"]')
+  await control.command('click', '[data-testid="right-workspace-chat-option"]')
+  await control.command('waitFor', sideComposerSelector, { timeoutMs: UI_TIMEOUT_MS })
+
+  const workbenchWidth = Number.parseFloat(
+    await control.command('getStyle', ACTIVE_WORKBENCH_SELECTOR, { value: 'width' })
+  )
+  const panelWidthStyle = await control.command('getInlineStyle', rightPanelShellSelector, {
+    value: 'width',
+  })
+  const chatWidthMatch = panelWidthStyle.match(/^calc\(100% - ([\d.]+)px\)$/)
+  assert.ok(chatWidthMatch, `Unexpected right-panel width style: ${panelWidthStyle}`)
+  const panelWidth = workbenchWidth - Number.parseFloat(chatWidthMatch[1])
+  assert.ok(
+    panelWidth >= 400 && panelWidth <= 440,
+    `The temporary-chat-only right panel was ${panelWidth}px wide instead of about 420px`
+  )
+  await captureVerificationScreenshot(control, '01-side-chat-compact-width.png')
+
+  await control.command('dropFile', sideComposerSelector, {
+    filename: SIDE_CHAT_FILENAME,
+    mimeType: 'image/png',
+    value: IMAGE_ARTIFACT_BASE64,
+  })
+  await waitForSnapshot(
+    control,
+    snapshot =>
+      snapshot.testIds.includes('attachment-badge') &&
+      !snapshot.testIds.includes('uploading-attachment-badge'),
+    'The side-chat attachment did not finish uploading',
+    UI_TIMEOUT_MS,
+    sideChatSelector
+  )
+  const mainBeforeSend = JSON.parse(await control.command('snapshot', mainComposerSelector))
+  assert.equal(
+    mainBeforeSend.testIds.includes('attachment-badge'),
+    false,
+    'Uploading in the side chat leaked an attachment into the main composer'
+  )
+  await captureVerificationScreenshot(control, '02-side-chat-attachment-isolated.png')
+
+  await control.command('fill', sideComposerSelector, { value: SIDE_CHAT_PROMPT })
+  assert.equal(
+    await control.command('getValue', sideComposerSelector),
+    SIDE_CHAT_PROMPT,
+    'The side-chat prompt did not reach the isolated composer'
+  )
+  await new Promise(resolvePromise => setTimeout(resolvePromise, COMPOSER_READY_STABILITY_MS))
+  await control.command('click', `${sideChatSelector} [data-testid="send-message-button"]`)
+  await control.awaitScenarioRequestCount('side_chat_attachment', 1)
+  await control.command('waitFor', `${sideChatSelector} [data-testid="message-assistant"]`, {
+    text: SIDE_CHAT_COMPLETION_TEXT,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  const sideAfterSend = JSON.parse(await control.command('snapshot', sideChatSelector))
+  assert.equal(
+    sideAfterSend.testIds.includes('attachment-badge'),
+    false,
+    'The sent side-chat attachment was not cleared from its composer'
+  )
+  const mainAfterSend = JSON.parse(await control.command('snapshot', mainComposerSelector))
+  assert.equal(
+    mainAfterSend.testIds.includes('attachment-badge'),
+    false,
+    'Sending the side chat leaked an attachment into the main composer'
+  )
+  await captureVerificationScreenshot(control, '03-side-chat-sent-main-clean.png')
+
+  const requests = control.scenarioRequests.get('side_chat_attachment') ?? []
+  assert.equal(requests.length, 1, 'The side chat did not send exactly one model request')
+  const requestText = JSON.stringify(requests[0].body)
+  assert.ok(requestText.includes(SIDE_CHAT_PROMPT), 'The side-chat prompt was not forwarded')
+  assert.ok(requestText.includes(SIDE_CHAT_FILENAME), 'The side-chat attachment was not forwarded')
+}
+
 async function verifyReconnectRecovery({ composerSelector, control }) {
   control.setScenario('reconnect')
   await sendPromptUntilScenarioRequest(control, composerSelector, RECONNECT_PROMPT, 'reconnect')
@@ -1736,6 +1858,7 @@ class DesktopE2EServer {
         'fresh_chat',
         'attachment_only',
         'memory',
+        'side_chat_attachment',
         'cloud_initial',
         'cloud_follow_up',
       ].includes(scenario),
@@ -2293,6 +2416,22 @@ class DesktopE2EServer {
       this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(`${ATTACHMENT_ONLY_COMPLETION_TEXT}_${requestNumber}`),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'side_chat_attachment') {
+      this.recordScenarioRequest('side_chat_attachment', modelRequest)
+      const requestText = JSON.stringify(body)
+      assert.ok(requestText.includes(SIDE_CHAT_PROMPT), 'The side-chat request lost its prompt')
+      assert.ok(
+        requestText.includes(SIDE_CHAT_FILENAME),
+        'The side-chat request lost its isolated attachment'
+      )
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(SIDE_CHAT_COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
       return
@@ -3548,6 +3687,18 @@ async function main() {
       await selectE2EModel(control)
       await verifyMemoryGrowth({ composerSelector, control })
       console.log(`Wework desktop memory E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
+    if (SIDE_CHAT_ATTACHMENT_ONLY) {
+      phase = 'side-chat-attachment-isolation'
+      await verifySideChatAttachmentIsolation({ control })
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(`Wework side-chat attachment E2E passed. Evidence: ${resultDir}`)
       return
     }
 

--- a/wework/package.json
+++ b/wework/package.json
@@ -31,6 +31,7 @@
     "e2e:desktop:lifecycle": "node e2e/desktop/task-flow.e2e.mjs --lifecycle-only",
     "e2e:desktop:reconnect": "node e2e/desktop/task-flow.e2e.mjs --reconnect-only",
     "e2e:desktop:attachment-only-sidebar": "node e2e/desktop/task-flow.e2e.mjs --attachment-only-sidebar",
+    "e2e:desktop:side-chat-attachment": "node e2e/desktop/task-flow.e2e.mjs --side-chat-attachment-only",
     "ai:verify": "node scripts/ai-verify.mjs",
     "e2e:ui": "playwright test --ui"
   },

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -557,6 +557,20 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return waitForDesktopControlElement(command)
     case 'getText':
       return desktopControlElementText(command.selector)
+    case 'getStyle': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      const property = command.value?.trim()
+      if (!property) throw new Error('getStyle requires a CSS property name')
+      return window.getComputedStyle(element).getPropertyValue(property)
+    }
+    case 'getInlineStyle': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      const property = command.value?.trim()
+      if (!property) throw new Error('getInlineStyle requires a CSS property name')
+      return element.style.getPropertyValue(property)
+    }
     case 'getValue': {
       const element = findDesktopControlElements(command.selector)[0]
       if (!element) throw new Error(`Unable to find selector "${command.selector}"`)

--- a/wework/src/features/workbench/workbenchReducer.test.ts
+++ b/wework/src/features/workbench/workbenchReducer.test.ts
@@ -620,63 +620,66 @@ describe('workbenchReducer', () => {
     expect(refreshed.devices).toEqual([device])
   })
 
-  test('reconciles legacy local-device current task to the refreshed ready task address', () => {
-    const state = {
-      ...initialWorkbenchState,
-      currentRuntimeTask: {
-        deviceId: 'local-device',
-        taskId: 'task-1',
-      },
-    }
-
-    const refreshed = workbenchReducer(state, {
-      type: 'lists_refreshed',
-      projects: [],
-      devices: [
-        {
-          id: 1,
-          device_id: 'device-uuid',
-          name: 'Local Executor',
-          status: 'online' as const,
-          is_default: true,
+  test.each(['local-device', 'device-uuid'])(
+    'reconciles %s current task to the hydrated ready task address',
+    currentDeviceId => {
+      const state = {
+        ...initialWorkbenchState,
+        currentRuntimeTask: {
+          deviceId: currentDeviceId,
+          taskId: 'task-1',
         },
-      ],
-      runtimeWork: {
+      }
+
+      const refreshed = workbenchReducer(state, {
+        type: 'lists_refreshed',
         projects: [],
-        chats: [
+        devices: [
           {
-            deviceId: 'device-uuid',
-            workspacePath: '/Users/me/chat',
-            available: true,
-            mapped: true,
-            tasks: [
-              {
-                taskId: 'task-1',
-                threadId: 'direct-thread-id',
-                workspacePath: '/Users/me/chat',
-                title: 'Chat',
-                runtime: 'codex',
-                runtimeHandle: {
-                  threadId: '019ee7f6-456a-78a1-96b1-66451afc310e',
-                },
-              },
-            ],
+            id: 1,
+            device_id: 'device-uuid',
+            name: 'Local Executor',
+            status: 'online' as const,
+            is_default: true,
           },
         ],
-        totalTasks: 1,
-      },
-    })
+        runtimeWork: {
+          projects: [],
+          chats: [
+            {
+              deviceId: 'device-uuid',
+              workspacePath: '/Users/me/chat',
+              available: true,
+              mapped: true,
+              tasks: [
+                {
+                  taskId: 'task-1',
+                  threadId: 'direct-thread-id',
+                  workspacePath: '/Users/me/chat',
+                  title: 'Chat',
+                  runtime: 'codex',
+                  runtimeHandle: {
+                    threadId: '019ee7f6-456a-78a1-96b1-66451afc310e',
+                  },
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        },
+      })
 
-    expect(refreshed.currentRuntimeTask).toEqual({
-      deviceId: 'device-uuid',
-      taskId: 'task-1',
-      threadId: 'direct-thread-id',
-      workspacePath: '/Users/me/chat',
-      runtimeHandle: {
-        threadId: '019ee7f6-456a-78a1-96b1-66451afc310e',
-      },
-    })
-  })
+      expect(refreshed.currentRuntimeTask).toEqual({
+        deviceId: 'device-uuid',
+        taskId: 'task-1',
+        threadId: 'direct-thread-id',
+        ...(currentDeviceId === 'local-device' ? { workspacePath: '/Users/me/chat' } : {}),
+        runtimeHandle: {
+          threadId: '019ee7f6-456a-78a1-96b1-66451afc310e',
+        },
+      })
+    }
+  )
 
   test('updates cached device and runtime workspace status from websocket events', () => {
     const state = workbenchReducer(initialWorkbenchState, {

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -618,7 +618,8 @@ function updateRuntimeTaskRunning(
 
 function findRuntimeTaskAddressByTaskId(
   runtimeWork: RuntimeWorkListResponse | null | undefined,
-  taskId: string
+  taskId: string,
+  deviceId?: string
 ): RuntimeTaskAddress | null {
   if (!runtimeWork) return null
 
@@ -629,6 +630,7 @@ function findRuntimeTaskAddressByTaskId(
   ]
 
   for (const workspace of workspaces) {
+    if (deviceId && workspace.deviceId !== deviceId) continue
     const task = workspace.tasks.find(task => task.taskId === taskId)
     if (!task) continue
 
@@ -655,10 +657,25 @@ function reconcileCurrentRuntimeTaskAddress(
   runtimeWork: RuntimeWorkListResponse | null | undefined
 ): RuntimeTaskAddress | null {
   if (!currentRuntimeTask) return null
+  const hydratedCurrentDeviceTask = findRuntimeTaskAddressByTaskId(
+    runtimeWork,
+    currentRuntimeTask.taskId,
+    currentRuntimeTask.deviceId
+  )
+  if (hydratedCurrentDeviceTask) {
+    return {
+      ...currentRuntimeTask,
+      ...(hydratedCurrentDeviceTask.threadId
+        ? { threadId: hydratedCurrentDeviceTask.threadId }
+        : {}),
+      ...(hydratedCurrentDeviceTask.runtimeHandle
+        ? { runtimeHandle: hydratedCurrentDeviceTask.runtimeHandle }
+        : {}),
+    }
+  }
   if (devices.some(device => device.device_id === currentRuntimeTask.deviceId)) {
     return currentRuntimeTask
   }
-
   return (
     findRuntimeTaskAddressByTaskId(runtimeWork, currentRuntimeTask.taskId) ?? currentRuntimeTask
   )


### PR DESCRIPTION
## Summary

- add a real Tauri desktop E2E flow for right-side temporary chat attachment isolation
- assert the temporary-chat-only panel resolves to the compact 420px layout
- verify the side attachment reaches the real Codex request, clears after send, and never appears in the main composer
- hydrate `threadId` and `runtimeHandle` for the active same-device task without replacing its pane workspace identity
- document the state invariant and verification command in Chinese and English

## Verification

- `pnpm --dir wework e2e:desktop:side-chat-attachment`
- `pnpm --dir wework exec vitest run src/features/workbench/workbenchReducer.test.ts src/features/workbench/WorkbenchProvider.test.tsx`
- pre-push: ESLint, TypeScript, and all 1,954 Wework unit tests passed

## E2E evidence

The passing run writes the review chain to `wework/test-results/desktop-e2e/2026-07-22T08-51-49-730Z-59069/`:

1. `01-side-chat-compact-width.png`
2. `02-side-chat-attachment-isolated.png`
3. `03-side-chat-sent-main-clean.png`

Related implementation PR: #2115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved temporary right-side chat recovery after refreshing runtime tasks by restoring the correct conversation and runtime details for the active device.
  - Prevented attachments sent in temporary side chats from appearing in the main chat composer or task.

- **Tests**
  - Added automated coverage for side-chat attachment isolation and temporary chat state reconciliation across devices.

- **Documentation**
  - Updated English and Chinese developer guidance with maintenance requirements and verification steps for temporary chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->