### PR TITLE
fix(wework): hide git controls for non-git workspaces

### DIFF
--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -22,12 +22,12 @@ describe('parseGitShortStat', () => {
     })
   })
 
-  test('detects a non-git workspace from stderr when a generic error is present', async () => {
+  test('detects a non-git workspace without depending on localized stderr', async () => {
     const executeCommand = vi.fn().mockResolvedValue({
       success: false,
       stdout: '',
       error: 'Command failed',
-      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+      stderr: 'fatal: 不是 git 仓库（或者任何父目录）：.git',
     })
 
     const info = await loadProjectEnvironment(
@@ -55,6 +55,13 @@ describe('parseGitShortStat', () => {
       workspacePath: '/workspace/plain-cloud-workspace',
     })
     expect(info.error).toBeUndefined()
+    expect(executeCommand).toHaveBeenCalledWith('device-456', {
+      command_key: 'git_is_worktree',
+      path: '/workspace/plain-cloud-workspace',
+      args: ['/workspace/plain-cloud-workspace'],
+      timeout_seconds: 10,
+      max_output_bytes: 4096,
+    })
   })
 
   test('defaults missing additions and deletions to zero', () => {
@@ -411,6 +418,56 @@ describe('loadProjectEnvironment', () => {
       deviceId: 'device-123',
       workspacePath: '/workspace/plain-workspace',
     })
+  })
+
+  test('preserves git command errors when the workspace is a repository', async () => {
+    const executeCommand = vi.fn((_: string, data: { command_key: string }) => {
+      if (data.command_key === 'git_branch') {
+        return Promise.resolve({
+          success: false,
+          stdout: '',
+          stderr: 'fatal: failed to read git metadata',
+        })
+      }
+      if (data.command_key === 'git_is_worktree') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'true\n',
+          stderr: '',
+        })
+      }
+      return Promise.resolve({
+        success: true,
+        stdout: '',
+        stderr: '',
+      })
+    })
+
+    const info = await loadProjectEnvironment(
+      { executeCommand },
+      {
+        id: 5,
+        name: 'broken-repository',
+        config: {
+          mode: 'workspace',
+          execution: {
+            targetType: 'local',
+            deviceId: 'device-123',
+          },
+          workspace: {
+            source: 'local_path',
+            localPath: '/workspace/broken-repository',
+          },
+        },
+      }
+    )
+
+    expect(info).toMatchObject({
+      deviceId: 'device-123',
+      workspacePath: '/workspace/broken-repository',
+      error: 'fatal: failed to read git metadata',
+    })
+    expect(info.isGitRepository).toBeUndefined()
   })
 
   test('deduplicates repeated environment loads for the same project briefly', async () => {

--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -22,6 +22,41 @@ describe('parseGitShortStat', () => {
     })
   })
 
+  test('detects a non-git workspace from stderr when a generic error is present', async () => {
+    const executeCommand = vi.fn().mockResolvedValue({
+      success: false,
+      stdout: '',
+      error: 'Command failed',
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+    })
+
+    const info = await loadProjectEnvironment(
+      { executeCommand },
+      {
+        id: 4,
+        name: 'plain-cloud-workspace',
+        config: {
+          mode: 'workspace',
+          execution: {
+            targetType: 'cloud',
+            deviceId: 'device-456',
+          },
+          workspace: {
+            source: 'local_path',
+            localPath: '/workspace/plain-cloud-workspace',
+          },
+        },
+      }
+    )
+
+    expect(info).toMatchObject({
+      isGitRepository: false,
+      deviceId: 'device-456',
+      workspacePath: '/workspace/plain-cloud-workspace',
+    })
+    expect(info.error).toBeUndefined()
+  })
+
   test('defaults missing additions and deletions to zero', () => {
     expect(parseGitShortStat('')).toEqual({ additions: '+0', deletions: '-0' })
   })
@@ -202,6 +237,7 @@ describe('loadProjectEnvironment', () => {
       executionTarget: 'cloud',
       deviceId: 'device-123',
       workspacePath: '/workspace/Wegent',
+      isGitRepository: true,
       branchName: 'human/narwhal-20260528-073440',
       additions: '+8',
       deletions: '-3',
@@ -371,6 +407,7 @@ describe('loadProjectEnvironment', () => {
       additions: '+0',
       deletions: '-0',
       executionTarget: 'local',
+      isGitRepository: false,
       deviceId: 'device-123',
       workspacePath: '/workspace/plain-workspace',
     })

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -297,7 +297,9 @@ async function runGitCommand(
   const response = await api.executeCommand(deviceId, request)
 
   if (!response.success) {
-    throw new Error(response.error || response.stderr || `${commandKey} failed`)
+    throw new Error(
+      [response.error, response.stderr].filter(Boolean).join('\n') || `${commandKey} failed`
+    )
   }
 
   return outputAsString(response.stdout).trim()
@@ -455,12 +457,16 @@ async function loadProjectEnvironmentUncached(
     return {
       ...environmentWorkspaceInfo,
       ...diff,
+      isGitRepository: true,
       branchName,
       createPullRequestUrl: buildPullRequestUrl(remoteUrl, branchName),
     }
   } catch (error) {
     if (isNotGitRepositoryError(error)) {
-      return environmentWorkspaceInfo
+      return {
+        ...environmentWorkspaceInfo,
+        isGitRepository: false,
+      }
     }
 
     return {

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -104,10 +104,6 @@ function cloneEnvironmentInfo(info: EnvironmentInfo): EnvironmentInfo {
   return { ...info }
 }
 
-function isNotGitRepositoryError(error: unknown): boolean {
-  return error instanceof Error && /not a git repository/i.test(error.message)
-}
-
 function getEnvironmentInfoCache(api: DeviceCommandApi): Map<string, EnvironmentInfoCacheEntry> {
   let cache = environmentInfoCaches.get(api)
   if (!cache) {
@@ -305,6 +301,22 @@ async function runGitCommand(
   return outputAsString(response.stdout).trim()
 }
 
+async function probeGitRepository(
+  api: DeviceCommandApi,
+  deviceId: string,
+  path: string
+): Promise<boolean> {
+  const response = await api.executeCommand(deviceId, {
+    command_key: 'git_is_worktree',
+    path,
+    args: [path],
+    timeout_seconds: 10,
+    max_output_bytes: 4096,
+  })
+
+  return response.success && outputAsString(response.stdout).trim() === 'true'
+}
+
 async function generateCommitMessage(
   api: DeviceCommandApi,
   deviceId: string,
@@ -462,7 +474,8 @@ async function loadProjectEnvironmentUncached(
       createPullRequestUrl: buildPullRequestUrl(remoteUrl, branchName),
     }
   } catch (error) {
-    if (isNotGitRepositoryError(error)) {
+    const isGitRepository = await probeGitRepository(api, deviceId, path).catch(() => undefined)
+    if (isGitRepository === false) {
       return {
         ...environmentWorkspaceInfo,
         isGitRepository: false,

--- a/wework/src/components/layout/EnvironmentInfoPopover.test.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.test.tsx
@@ -82,4 +82,32 @@ describe('EnvironmentInfoPopover', () => {
     expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument()
     expect(localStorage.getItem('wework.desktop.environmentInfo.open')).toBeNull()
   })
+
+  test('hides git controls and diff stats for a non-git workspace', () => {
+    const popoverContainer = document.createElement('div')
+    document.body.appendChild(popoverContainer)
+    portalContainers.push(popoverContainer)
+
+    render(
+      <EnvironmentInfoPopover
+        info={{
+          additions: '+0',
+          deletions: '-0',
+          executionTarget: 'local',
+          isGitRepository: false,
+          workspacePath: '/workspace/plain-project',
+        }}
+        popoverContainer={popoverContainer}
+        open
+        onOpenChange={vi.fn()}
+        onListBranches={vi.fn().mockResolvedValue([])}
+        onCheckoutBranch={vi.fn().mockResolvedValue(undefined)}
+        onOpenChangesReview={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('environment-git-section')).not.toBeInTheDocument()
+    expect(screen.queryByText('+0')).not.toBeInTheDocument()
+    expect(screen.queryByText('-0')).not.toBeInTheDocument()
+  })
 })

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -109,9 +109,12 @@ export function EnvironmentInfoPopover({
           t('workbench.current_device', '当前设备'),
       })
     : info.error
-  const hasGitInfo = Boolean(info.branchName?.trim())
-  const canShowBranchSelector = Boolean(onListBranches && onCheckoutBranch)
-  const hasDiffStats = Boolean(info.additions || info.deletions)
+  const gitRepositoryAvailable = info.isGitRepository !== false
+  const hasGitInfo = gitRepositoryAvailable && Boolean(info.branchName?.trim())
+  const canShowBranchSelector = Boolean(
+    gitRepositoryAvailable && onListBranches && onCheckoutBranch
+  )
+  const hasDiffStats = gitRepositoryAvailable && Boolean(info.additions || info.deletions)
   const showChangesSection = hasDiffStats || hasGitInfo || canShowBranchSelector
   const taskSummaryToggleLabel = t('workbench.task_summary_toggle', '切换摘要')
   function handleCreatePullRequest() {

--- a/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
+++ b/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
@@ -57,8 +57,8 @@ export function useWorkbenchPaneEnvironment({
     createEnvironmentBranch,
   } = useWorkbenchPaneContext()
   const [environmentInfo, setEnvironmentInfo] = useState<EnvironmentInfo>({
-    additions: '+0',
-    deletions: '-0',
+    additions: '',
+    deletions: '',
     executionTarget: 'local',
   })
   const [workspaceTarget, setWorkspaceTarget] = useState<WorkspaceTarget | null>(null)
@@ -128,7 +128,7 @@ export function useWorkbenchPaneEnvironment({
     environmentInfo.deviceId === activeWorkspaceTarget.deviceId
   )
   const isGitProject = environmentMatchesActiveWorkspace
-    ? !environmentInfo.error && environmentInfo.branchName !== undefined
+    ? environmentInfo.isGitRepository !== false
     : Boolean(workspaceProject && isGitWorkspaceProject(workspaceProject))
   const workspaceProjectKey = workspaceProject ? String(workspaceProject.id) : ''
   const activeConversationProjectKey = activeConversationProject
@@ -142,6 +142,8 @@ export function useWorkbenchPaneEnvironment({
   const environmentContextRef = useRef({ workspaceProject, activeWorkspaceTarget })
   const hasEnvironmentProject = Boolean(workspaceProject)
   const environmentWorkspaceReady = !hasEnvironmentProject || Boolean(activeWorkspaceTarget)
+  const gitActionsAvailable =
+    !environmentMatchesActiveWorkspace || environmentInfo.isGitRepository !== false
 
   useEffect(() => {
     environmentContextRef.current = { workspaceProject, activeWorkspaceTarget }
@@ -234,7 +236,19 @@ export function useWorkbenchPaneEnvironment({
       }
 
       if (showLoading) {
-        setEnvironmentInfo(info => ({ ...info, loading: true }))
+        setEnvironmentInfo(info =>
+          info.workspacePath === activeWorkspaceTarget?.path &&
+          info.deviceId === activeWorkspaceTarget?.deviceId
+            ? { ...info, loading: true }
+            : {
+                additions: '',
+                deletions: '',
+                executionTarget: info.executionTarget,
+                deviceId: activeWorkspaceTarget?.deviceId,
+                workspacePath: activeWorkspaceTarget?.path,
+                loading: true,
+              }
+        )
       }
       try {
         const {
@@ -272,6 +286,8 @@ export function useWorkbenchPaneEnvironment({
       }
     },
     [
+      activeWorkspaceTarget?.deviceId,
+      activeWorkspaceTarget?.path,
       environmentWorkspaceReady,
       loadEnvironmentInfo,
       state.devices,
@@ -398,17 +414,19 @@ export function useWorkbenchPaneEnvironment({
       branchName: environmentInfo.branchName,
       branchLoading: environmentInfo.loading,
       onRefreshBranch: undefined,
-      onListBranches: activeWorkspaceTarget ? listPaneEnvironmentBranches : undefined,
-      onCheckoutBranch: checkoutPaneEnvironmentBranch,
-      onCreateBranch: createPaneEnvironmentBranch,
+      onListBranches:
+        activeWorkspaceTarget && gitActionsAvailable ? listPaneEnvironmentBranches : undefined,
+      onCheckoutBranch: gitActionsAvailable ? checkoutPaneEnvironmentBranch : undefined,
+      onCreateBranch: gitActionsAvailable ? createPaneEnvironmentBranch : undefined,
     },
     refreshEnvironmentInfo,
     commitEnvironmentChanges: commitPaneEnvironmentChanges,
     commitAndPushEnvironmentChanges: commitAndPushPaneEnvironmentChanges,
     pushEnvironmentChanges: pushPaneEnvironmentChanges,
-    loadEnvironmentDiff: activeWorkspaceTarget
-      ? (target, mode) => loadEnvironmentDiff(workspaceProject, target, mode)
-      : undefined,
+    loadEnvironmentDiff:
+      activeWorkspaceTarget && gitActionsAvailable
+        ? (target, mode) => loadEnvironmentDiff(workspaceProject, target, mode)
+        : undefined,
     listEnvironmentBranches: listPaneEnvironmentBranches,
     checkoutEnvironmentBranch: checkoutPaneEnvironmentBranch,
     createEnvironmentBranch: createPaneEnvironmentBranch,

--- a/wework/src/types/environment.ts
+++ b/wework/src/types/environment.ts
@@ -2,6 +2,7 @@ export interface EnvironmentInfo {
   additions: string
   deletions: string
   executionTarget: 'local' | 'cloud'
+  isGitRepository?: boolean
   deviceId?: string
   workspacePath?: string
   branchName?: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git repository status is now detected and displayed accurately for each workspace.
  * Git actions, branch controls, and diff statistics are hidden when unavailable.
  * Workspace loading states now update more accurately when switching environments.

* **Bug Fixes**
  * Improved handling and display of Git command failures.
  * Non-Git workspaces no longer show irrelevant Git information or controls.

* **Tests**
  * Added coverage for Git detection, command failures, non-Git workspaces, and related UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->