### PR TITLE
fix(wework): open local HTML links in browser

### DIFF
--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -8,12 +8,15 @@ import {
   classifyMarkdownLink,
   getAuthenticatedImageFetchUrl,
   isAuthenticatedAttachmentImageSrc,
+  isHtmlFilePath,
+  localHtmlBrowserUrl,
   resolveDirectMarkdownImageSrc,
   type MarkdownLinkTarget,
 } from './assistantMarkdownLinks'
 import { MarkdownCodeBlock } from './MarkdownCodeBlock'
 import { useBufferedStreamingText } from './useBufferedStreamingText'
 import { openExternalUrl } from '@/lib/external-links'
+import { requestEmbeddedBrowserOpen } from '@/lib/embedded-browser'
 import type { WorkspaceFileOpenOptions } from '@/types/workspace-files'
 
 const ASSISTANT_MARKDOWN_LINK_CLASS = [
@@ -304,6 +307,10 @@ function AssistantMarkdownLink({
         className={`${ASSISTANT_MARKDOWN_LINK_CLASS} group/file-link relative`}
         data-testid="assistant-markdown-link"
         onClick={() => {
+          if (isHtmlFilePath(filePath)) {
+            const browserUrl = localHtmlBrowserUrl(filePath)
+            if (browserUrl && requestEmbeddedBrowserOpen(browserUrl)) return
+          }
           if (openOptions) {
             onOpenFile?.(filePath, openOptions)
             return

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -12,11 +12,15 @@ const tauriCoreMock = vi.hoisted(() => ({
   isTauri: vi.fn(() => false),
 }))
 const openExternalUrlMock = vi.hoisted(() => vi.fn().mockResolvedValue(true))
+const requestEmbeddedBrowserOpenMock = vi.hoisted(() => vi.fn(() => true))
 
 vi.mock('@tauri-apps/api/core', () => tauriCoreMock)
 vi.mock('@/lib/external-links', async importOriginal => ({
   ...(await importOriginal<typeof import('@/lib/external-links')>()),
   openExternalUrl: openExternalUrlMock,
+}))
+vi.mock('@/lib/embedded-browser', () => ({
+  requestEmbeddedBrowserOpen: requestEmbeddedBrowserOpenMock,
 }))
 
 describe('MessageList', () => {
@@ -2073,6 +2077,75 @@ describe('MessageList', () => {
     expect(screen.queryByRole('link', { name: /managing-tasks\.md/ })).not.toBeInTheDocument()
     fireEvent.click(screen.getByTestId('assistant-markdown-link'))
     expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/dev/repo/docs/zh/managing-tasks.md')
+  })
+
+  test('opens local HTML file links in the Wework built-in browser', () => {
+    const onOpenWorkspaceFile = vi.fn()
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'assistant-html-file-link',
+            role: 'assistant',
+            content: '[trend.html](/Users/dev/workspace/trend.html)',
+            status: 'done',
+            createdAt: '2026-07-22T08:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
+
+    expect(requestEmbeddedBrowserOpenMock).toHaveBeenCalledWith(
+      'asset://localhost/Users/dev/workspace/trend.html'
+    )
+    expect(onOpenWorkspaceFile).not.toHaveBeenCalled()
+  })
+
+  test('treats local filesystem paths encoded as Tauri URLs as file links', () => {
+    const onOpenWorkspaceFile = vi.fn()
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'assistant-tauri-file-link',
+            role: 'assistant',
+            content: '[report](tauri://localhost/Users/dev/workspace/report.md)',
+            status: 'done',
+            createdAt: '2026-07-22T08:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
+
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/dev/workspace/report.md')
+  })
+
+  test('opens Tauri-encoded local HTML paths in the Wework built-in browser', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-tauri-html-file-link',
+            role: 'assistant',
+            content: '[trend](tauri://localhost/Users/dev/workspace/trend.html)',
+            status: 'done',
+            createdAt: '2026-07-22T08:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
+
+    expect(requestEmbeddedBrowserOpenMock).toHaveBeenCalledWith(
+      'asset://localhost/Users/dev/workspace/trend.html'
+    )
   })
 
   test('removes angle brackets from assistant file link destinations', () => {

--- a/wework/src/components/chat/assistantMarkdownLinks.ts
+++ b/wework/src/components/chat/assistantMarkdownLinks.ts
@@ -8,6 +8,9 @@ export type MarkdownLinkTarget =
   | { kind: 'none' }
   | { kind: 'file'; path: string; lineStart?: number; lineEnd?: number }
 
+const HTML_FILE_PATTERN = /\.(?:html?|xhtml)$/i
+const LOCAL_TAURI_PATH_PREFIXES = ['/Users/', '/Volumes/', '/private/', '/tmp/', '/var/']
+
 // Assistant responses frequently reference repository files with relative or
 // absolute filesystem paths. Rendering those as plain anchors makes the browser
 // navigate the SPA to a broken `http://localhost/...` URL, so file links are
@@ -21,11 +24,29 @@ export function classifyMarkdownLink(href?: string): MarkdownLinkTarget {
   if (!value) return { kind: 'none' }
   if (/^(https?|mailto|tel):/i.test(value)) return { kind: 'external' }
   if (value.startsWith('#')) return { kind: 'none' }
+  const localTauriPath = localPathFromTauriUrl(value)
+  if (localTauriPath) {
+    return { kind: 'file', ...splitMarkdownFileLineSuffix(localTauriPath) }
+  }
   if (value.startsWith('file://')) {
     return { kind: 'file', ...splitMarkdownFileLineSuffix(localPathFromMarkdownImageSrc(value)) }
   }
   if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return { kind: 'external' }
   return { kind: 'file', ...splitMarkdownFileLineSuffix(value) }
+}
+
+export function isHtmlFilePath(path: string): boolean {
+  return HTML_FILE_PATTERN.test(path.split(/[?#]/, 1)[0])
+}
+
+export function localHtmlBrowserUrl(path: string): string | null {
+  if (!isHtmlFilePath(path) || typeof convertFileSrc !== 'function') return null
+
+  try {
+    return convertFileSrc(path)
+  } catch {
+    return null
+  }
 }
 
 export function splitMarkdownFileLineSuffix(path: string): {
@@ -69,6 +90,21 @@ export function localPathFromMarkdownImageSrc(src: string): string {
     return pathname.match(/^\/[a-zA-Z]:\//) ? pathname.slice(1) : pathname
   } catch {
     return src
+  }
+}
+
+function localPathFromTauriUrl(value: string): string | null {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'tauri:' || url.hostname !== 'localhost') return null
+
+    const pathname = decodeURIComponent(url.pathname)
+    if (LOCAL_TAURI_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix))) {
+      return pathname
+    }
+    return /^\/[a-zA-Z]:\//.test(pathname) ? pathname.slice(1) : null
+  } catch {
+    return null
   }
 }
 

--- a/wework/src/lib/browser-url.test.ts
+++ b/wework/src/lib/browser-url.test.ts
@@ -24,4 +24,11 @@ describe('browser URL helpers', () => {
       normalizeBrowserUrl('custom://localhost/extension-page.html', 'tauri://localhost/')
     ).toBe(null)
   })
+
+  test('allows local asset protocol URLs for browser previews', () => {
+    expect(normalizeBrowserUrl('asset://localhost/Users/me/workspace/chart.html')).toBe(
+      'asset://localhost/Users/me/workspace/chart.html'
+    )
+    expect(normalizeBrowserUrl('asset://other-host/Users/me/workspace/chart.html')).toBeNull()
+  })
 })

--- a/wework/src/lib/browser-url.ts
+++ b/wework/src/lib/browser-url.ts
@@ -9,6 +9,10 @@ function matchesTauriAppOrigin(url: URL, appUrl: string | undefined): boolean {
   }
 }
 
+function isLocalAssetUrl(url: URL): boolean {
+  return url.protocol === 'asset:' && url.hostname === 'localhost'
+}
+
 export function normalizeBrowserUrl(value: string, appUrl?: string): string | null {
   const trimmed = value.trim()
   if (!trimmed) return null
@@ -20,6 +24,7 @@ export function normalizeBrowserUrl(value: string, appUrl?: string): string | nu
     if (
       url.protocol !== 'http:' &&
       url.protocol !== 'https:' &&
+      !isLocalAssetUrl(url) &&
       !matchesTauriAppOrigin(url, appUrl)
     ) {
       return null

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -76,8 +76,13 @@ describe('embedded-browser', () => {
       label: 'workspace-browser',
       url: 'http://localhost:3000/',
     })
+    expect(requestEmbeddedBrowserOpen('asset://localhost/Users/me/workspace/trend.html')).toBe(true)
+    expect(handler).toHaveBeenCalledWith({
+      label: 'workspace-browser',
+      url: 'asset://localhost/Users/me/workspace/trend.html',
+    })
     expect(requestEmbeddedBrowserOpen('ftp://localhost/resource')).toBe(false)
-    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledTimes(2)
 
     const release = await unlisten
     release?.()


### PR DESCRIPTION
## Summary

- Route local HTML file links in assistant messages to the Wework built-in browser.
- Convert local HTML paths to the Tauri asset protocol so the native browser can load the file and its relative resources.
- Recover local filesystem paths accidentally rendered as `tauri://localhost/Users/...` links while preserving real Wework internal Tauri pages.

## Root cause

Markdown treated every local path as a workspace-file link. Generated HTML therefore opened the file panel instead of the native browser. Tauri-encoded local paths were considered unsupported external URLs and silently failed to open.

## Validation

- `pnpm --filter wework exec vitest run src/components/chat/MessageList.test.tsx --reporter=dot -t 'local HTML file links|local filesystem paths encoded as Tauri URLs|Tauri-encoded local HTML paths'`
- `pnpm --filter wework exec vitest run src/lib/browser-url.test.ts src/lib/embedded-browser.test.ts --reporter=dot`
- `pnpm --filter wework typecheck`
- Pre-push Wework lint and test suite

## Desktop verification

Started an isolated Tauri Wework session, opened the right work panel and Browser tab, and captured the flow. The session had no active task pane, so its browser-open listener correctly rejected the synthetic bridge request; the automated browser's Enter action also does not submit native forms. The routing behavior itself is covered by the focused unit tests above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML file links in chat can now open directly in the built-in browser.
  * Supports local HTML paths, including encoded local links and links with line ranges.
  * Local asset URLs are now supported for browser previews.

* **Bug Fixes**
  * Improved link routing so HTML pages open in the browser instead of the workspace file viewer when appropriate.

* **Tests**
  * Added coverage for local HTML links, encoded paths, asset URLs, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->