### PR TITLE
fix(wework): sanitize shell tool output

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -197,6 +197,32 @@ describe('ToolBlockItem', () => {
     expect(screen.getByText('cwd: /Users/crystal/project')).toBeInTheDocument()
   })
 
+  test('renders terminal control sequences as stable plain shell output', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'cmd-ansi',
+          subtaskId: 1,
+          type: 'tool',
+          toolName: 'exec_command',
+          toolInput: { cmd: 'npm install' },
+          toolOutput:
+            '\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0Kadded 703 packages\n\u001b[32msuccess\u001b[0m',
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /展开工具详情/ }))
+
+    expect(screen.getByText(/added 703 packages/)).toHaveTextContent('added 703 packages success')
+    expect(screen.queryByText(/⠙|⠹/)).not.toBeInTheDocument()
+    expect(document.body.textContent).not.toContain('\u001b')
+  })
+
   test('renders unknown tool as a non-expandable activity row', () => {
     render(
       <ToolBlockItem

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -223,6 +223,37 @@ describe('ToolBlockItem', () => {
     expect(document.body.textContent).not.toContain('\u001b')
   })
 
+  test('keeps the latest shell output lines in terminal-style scrollback', async () => {
+    const user = userEvent.setup()
+    const toolOutput = Array.from({ length: 201 }, (_, index) => `line ${index}`).join('\n')
+    const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(400)
+
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'cmd-scrollback',
+          subtaskId: 1,
+          type: 'tool',
+          toolName: 'exec_command',
+          toolInput: { cmd: 'long-running-command' },
+          toolOutput,
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /展开工具详情/ }))
+
+    const outputElement = screen.getByTestId('shell-tool-output')
+    const renderedOutput = outputElement.textContent
+    expect(renderedOutput).not.toContain('line 0\n')
+    expect(renderedOutput).toContain('line 1\n')
+    expect(renderedOutput).toContain('line 200')
+    expect(outputElement.scrollTop).toBe(400)
+    scrollHeight.mockRestore()
+  })
+
   test('renders unknown tool as a non-expandable activity row', () => {
     render(
       <ToolBlockItem

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { ChevronDown, Clock3, Copy, CopyCheck, FileDiff, Search, Wrench } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 import { useTranslation } from '@/hooks/useTranslation'
+import { terminalOutputToText } from '@/lib/terminal-text'
 import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { AssistantPlanCard, type AssistantPlanOpenRequest } from '../AssistantPlanCard'
@@ -1150,8 +1151,9 @@ function BashBlockDetail({
   const command = getInputField(block, 'command', 'cmd', 'commandLine')
   const cwd = getInputField(block, 'cwd', 'workdir', 'workingDirectory')
   const output = block.toolOutput
-  const outputText =
+  const rawOutputText =
     typeof output === 'string' ? output : output ? JSON.stringify(output, null, 2) : ''
+  const outputText = terminalOutputToText(rawOutputText)
   const isDone = block.status === 'done'
   const isError = block.status === 'error'
   const [copied, setCopied] = useState(false)

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { ChevronDown, Clock3, Copy, CopyCheck, FileDiff, Search, Wrench } from 'lucide-react'
 import { Streamdown } from 'streamdown'
@@ -1151,12 +1151,20 @@ function BashBlockDetail({
   const command = getInputField(block, 'command', 'cmd', 'commandLine')
   const cwd = getInputField(block, 'cwd', 'workdir', 'workingDirectory')
   const output = block.toolOutput
-  const rawOutputText =
-    typeof output === 'string' ? output : output ? JSON.stringify(output, null, 2) : ''
-  const outputText = terminalOutputToText(rawOutputText)
+  const rawOutputText = useMemo(
+    () => (typeof output === 'string' ? output : output ? JSON.stringify(output, null, 2) : ''),
+    [output]
+  )
+  const outputText = useMemo(() => terminalOutputToText(rawOutputText), [rawOutputText])
+  const outputRef = useRef<HTMLPreElement>(null)
   const isDone = block.status === 'done'
   const isError = block.status === 'error'
   const [copied, setCopied] = useState(false)
+
+  useLayoutEffect(() => {
+    const outputElement = outputRef.current
+    if (outputElement) outputElement.scrollTop = outputElement.scrollHeight
+  }, [outputText])
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(command ?? '')
@@ -1237,8 +1245,12 @@ function BashBlockDetail({
               ) : null}
             </div>
           ) : null}
-          <pre className="mt-1 max-h-48 max-w-full overflow-auto font-mono text-xs leading-5 text-text-secondary">
-            {outputText.length > 2000 ? outputText.substring(0, 2000) + '...' : outputText}
+          <pre
+            ref={outputRef}
+            className="mt-1 max-h-48 max-w-full overflow-auto font-mono text-xs leading-5 text-text-secondary"
+            data-testid="shell-tool-output"
+          >
+            {outputText}
           </pre>
         </>
       )}

--- a/wework/src/lib/terminal-text.test.ts
+++ b/wework/src/lib/terminal-text.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+import { terminalOutputToText } from './terminal-text'
+
+describe('terminalOutputToText', () => {
+  test('collapses spinner frames that return to and clear the current line', () => {
+    const output = '\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0Kadded 703 packages\n'
+
+    expect(terminalOutputToText(output)).toBe('added 703 packages\n')
+  })
+
+  test('applies carriage returns and cursor-relative overwrites', () => {
+    expect(terminalOutputToText('progress 10%\rprogress 20%\u001b[2D5')).toBe('progress 25%')
+  })
+
+  test('removes color and terminal-title sequences', () => {
+    const output = '\u001b]0;npm install\u0007\u001b[32msuccess\u001b[0m'
+
+    expect(terminalOutputToText(output)).toBe('success')
+  })
+
+  test('keeps the cursor position when the whole line is erased', () => {
+    expect(terminalOutputToText('abc\u001b[2Kx')).toBe('   x')
+  })
+})

--- a/wework/src/lib/terminal-text.test.ts
+++ b/wework/src/lib/terminal-text.test.ts
@@ -21,4 +21,34 @@ describe('terminalOutputToText', () => {
   test('keeps the cursor position when the whole line is erased', () => {
     expect(terminalOutputToText('abc\u001b[2Kx')).toBe('   x')
   })
+
+  test('applies vertical cursor movement while preserving the column', () => {
+    expect(terminalOutputToText('old\nnew\u001b[1A\rNEW')).toBe('NEW\nnew')
+  })
+
+  test('bounds cursor-controlled padding', () => {
+    const output = terminalOutputToText('\u001b[999999999Cx')
+
+    expect(output).toHaveLength(4_096)
+    expect(output.endsWith('x')).toBe(true)
+  })
+
+  test('bounds total rendered cells across lines', () => {
+    const input = Array.from({ length: 200 }, () => '\u001b[999999999Gx').join('\n')
+
+    expect(terminalOutputToText(input).length).toBeLessThanOrEqual(32_768 + 199)
+  })
+
+  test('bounds a large uninterrupted output line', () => {
+    expect(terminalOutputToText('x'.repeat(1_000_000))).toHaveLength(4_096)
+  })
+
+  test('keeps the latest terminal scrollback lines', () => {
+    const input = Array.from({ length: 201 }, (_, index) => `line ${index}`).join('\n')
+    const lines = terminalOutputToText(input).split('\n')
+
+    expect(lines).toHaveLength(200)
+    expect(lines[0]).toBe('line 1')
+    expect(lines.at(-1)).toBe('line 200')
+  })
 })

--- a/wework/src/lib/terminal-text.ts
+++ b/wework/src/lib/terminal-text.ts
@@ -1,0 +1,84 @@
+function parameterValue(parameters: string, fallback: number): number {
+  const value = Number.parseInt(parameters.split(';')[0] ?? '', 10)
+  return Number.isFinite(value) ? value : fallback
+}
+
+/** Convert terminal-oriented output into stable plain text for non-terminal views. */
+export function terminalOutputToText(value: string): string {
+  const lines: string[][] = [[]]
+  let row = 0
+  let column = 0
+
+  const currentLine = () => lines[row]
+  const moveToRow = (nextRow: number) => {
+    row = Math.max(0, nextRow)
+    while (lines.length <= row) lines.push([])
+    column = Math.min(column, currentLine().length)
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]
+
+    if (character === '\n') {
+      moveToRow(row + 1)
+      column = 0
+      continue
+    }
+    if (character === '\r') {
+      column = 0
+      continue
+    }
+    if (character === '\b') {
+      column = Math.max(0, column - 1)
+      continue
+    }
+    if (character !== '\u001b') {
+      if (character >= ' ' || character === '\t') {
+        const line = currentLine()
+        while (line.length < column) line.push(' ')
+        line[column] = character
+        column += 1
+      }
+      continue
+    }
+
+    if (value[index + 1] === ']') {
+      const bellEnd = value.indexOf('\u0007', index + 2)
+      const stringEnd = value.indexOf('\u001b\\', index + 2)
+      const end =
+        bellEnd === -1 ? stringEnd : stringEnd === -1 ? bellEnd : Math.min(bellEnd, stringEnd)
+      if (end === -1) break
+      index = end + (value[end] === '\u001b' ? 1 : 0)
+      continue
+    }
+
+    if (value[index + 1] !== '[') {
+      index += 1
+      continue
+    }
+
+    let finalIndex = index + 2
+    while (finalIndex < value.length && !/[\x40-\x7e]/.test(value[finalIndex])) {
+      finalIndex += 1
+    }
+    if (finalIndex >= value.length) break
+
+    const parameters = value.slice(index + 2, finalIndex)
+    const command = value[finalIndex]
+    const amount = parameterValue(parameters, 1)
+    if (command === 'G' || command === '`') column = Math.max(0, amount - 1)
+    else if (command === 'C') column += amount
+    else if (command === 'D') column = Math.max(0, column - amount)
+    else if (command === 'K') {
+      const mode = parameterValue(parameters, 0)
+      const line = currentLine()
+      if (mode === 0) line.splice(column)
+      else if (mode === 1)
+        line.splice(0, Math.min(column + 1, line.length), ...Array(column + 1).fill(' '))
+      else if (mode === 2) line.length = 0
+    }
+    index = finalIndex
+  }
+
+  return lines.map(line => line.join('').trimEnd()).join('\n')
+}

--- a/wework/src/lib/terminal-text.ts
+++ b/wework/src/lib/terminal-text.ts
@@ -1,27 +1,80 @@
+const MAX_TERMINAL_ROWS = 200
+const MAX_TERMINAL_COLUMNS = 4_096
+const MAX_RENDERED_CELLS = 32_768
+
 function parameterValue(parameters: string, fallback: number): number {
   const value = Number.parseInt(parameters.split(';')[0] ?? '', 10)
   return Number.isFinite(value) ? value : fallback
 }
 
-/** Convert terminal-oriented output into stable plain text for non-terminal views. */
+/** Convert terminal-oriented output into a bounded plain-text scrollback snapshot. */
 export function terminalOutputToText(value: string): string {
-  const lines: string[][] = [[]]
+  const lines = ['']
   let row = 0
   let column = 0
+  let renderedCells = 0
 
-  const currentLine = () => lines[row]
-  const moveToRow = (nextRow: number) => {
-    row = Math.max(0, nextRow)
-    while (lines.length <= row) lines.push([])
-    column = Math.min(column, currentLine().length)
+  const moveToRow = (nextRow: number, preserveColumn = false) => {
+    const previousColumn = column
+    row = Math.max(0, Math.min(nextRow, MAX_TERMINAL_ROWS - 1))
+    while (lines.length <= row) lines.push('')
+    column = preserveColumn
+      ? Math.min(previousColumn, MAX_TERMINAL_COLUMNS)
+      : Math.min(column, lines[row].length)
+  }
+
+  const replaceLine = (nextLine: string) => {
+    renderedCells += nextLine.length - lines[row].length
+    lines[row] = nextLine
+  }
+
+  const writeText = (text: string) => {
+    if (!text || column >= MAX_TERMINAL_COLUMNS) return
+
+    const line = lines[row]
+    const availableCells = MAX_RENDERED_CELLS - renderedCells
+    const maxEnd = Math.min(MAX_TERMINAL_COLUMNS, line.length + availableCells)
+    const writableLength = Math.min(text.length, MAX_TERMINAL_COLUMNS - column, maxEnd - column)
+    if (writableLength <= 0) return
+
+    const nextColumn = column + writableLength
+    const prefix = line.slice(0, column).padEnd(column, ' ')
+    const suffix = line.slice(nextColumn)
+    replaceLine(prefix + text.slice(0, writableLength) + suffix)
+    column = nextColumn
+  }
+
+  const lineFeed = () => {
+    if (row < MAX_TERMINAL_ROWS - 1) {
+      moveToRow(row + 1)
+    } else {
+      const removedLine = lines.shift()
+      renderedCells -= removedLine?.length ?? 0
+      lines.push('')
+    }
+    column = 0
+  }
+
+  const eraseInLine = (parameters: string) => {
+    const mode = parameterValue(parameters, 0)
+    const line = lines[row]
+    if (mode === 0) {
+      replaceLine(line.slice(0, column))
+    } else if (mode === 1) {
+      const targetLength = Math.min(column + 1, MAX_TERMINAL_COLUMNS)
+      const availableCells = MAX_RENDERED_CELLS - renderedCells
+      const eraseEnd = Math.min(targetLength, line.length + availableCells)
+      replaceLine(' '.repeat(eraseEnd) + line.slice(eraseEnd))
+    } else if (mode === 2) {
+      replaceLine('')
+    }
   }
 
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index]
 
     if (character === '\n') {
-      moveToRow(row + 1)
-      column = 0
+      lineFeed()
       continue
     }
     if (character === '\r') {
@@ -32,12 +85,16 @@ export function terminalOutputToText(value: string): string {
       column = Math.max(0, column - 1)
       continue
     }
+    if (character === '\t') {
+      writeText(' '.repeat(8 - (column % 8)))
+      continue
+    }
     if (character !== '\u001b') {
-      if (character >= ' ' || character === '\t') {
-        const line = currentLine()
-        while (line.length < column) line.push(' ')
-        line[column] = character
-        column += 1
+      if (character >= ' ') {
+        let end = index + 1
+        while (end < value.length && value[end] >= ' ' && value[end] !== '\u001b') end += 1
+        writeText(value.slice(index, Math.min(end, index + MAX_TERMINAL_COLUMNS)))
+        index = end - 1
       }
       continue
     }
@@ -63,22 +120,18 @@ export function terminalOutputToText(value: string): string {
     }
     if (finalIndex >= value.length) break
 
-    const parameters = value.slice(index + 2, finalIndex)
+    const parameters = value.slice(index + 2, Math.min(finalIndex, index + 66))
     const command = value[finalIndex]
     const amount = parameterValue(parameters, 1)
-    if (command === 'G' || command === '`') column = Math.max(0, amount - 1)
-    else if (command === 'C') column += amount
+    if (command === 'A') moveToRow(row - amount, true)
+    else if (command === 'B') moveToRow(row + amount, true)
+    else if (command === 'G' || command === '`')
+      column = Math.max(0, Math.min(amount - 1, MAX_TERMINAL_COLUMNS - 1))
+    else if (command === 'C') column = Math.min(column + amount, MAX_TERMINAL_COLUMNS - 1)
     else if (command === 'D') column = Math.max(0, column - amount)
-    else if (command === 'K') {
-      const mode = parameterValue(parameters, 0)
-      const line = currentLine()
-      if (mode === 0) line.splice(column)
-      else if (mode === 1)
-        line.splice(0, Math.min(column + 1, line.length), ...Array(column + 1).fill(' '))
-      else if (mode === 2) line.length = 0
-    }
+    else if (command === 'K') eraseInLine(parameters)
     index = finalIndex
   }
 
-  return lines.map(line => line.join('').trimEnd()).join('\n')
+  return lines.map(line => line.trimEnd()).join('\n')
 }


### PR DESCRIPTION
## What changed

- render shell tool output as stable plain text in non-terminal chat views
- apply cursor return, horizontal movement, and line erasure semantics so progress spinners collapse to their final visible state
- preserve vertical cursor movement and the latest 200 lines in a terminal-style auto-scrolling view
- bound snapshots to 4096 columns and 32768 rendered cells, using compact line strings instead of per-character arrays
- remove ANSI styling and terminal-title control sequences
- add parser-level and `ToolBlockItem` regression coverage

## Why

Shell commands such as `npm install` emit ANSI cursor-control sequences for progress spinners. The chat tool detail view rendered the raw output inside a `<pre>` element, so sequences such as `ESC[1G ESC[0K` appeared as garbled text instead of being consumed by a terminal.

## User impact

Expanded shell tool details now preserve the final useful command output without exposing spinner frames or ANSI escape sequences.

## Validation

- `pnpm --filter wework test` (200 files, 1984 tests)
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- pre-push Wework ESLint, TypeScript, and unit-test gates
- isolated real-Tauri flow: created local projects, ran npm-style spinner/color output, then ran 201 output lines plus a final ANSI status; verified the expanded shell detail removed control sequences and automatically showed the latest scrollback lines
