### PR TITLE
fix(wework): compact environment summary row

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -554,9 +554,10 @@ focus. Disabled items use `50%` opacity and do not activate.
 
 In the narrow environment popover, execution location, device, and workspace
 path form one compact metadata row. Keep their localized labels available to
-assistive technology and tooltips instead of repeating them visually. The path
-uses the remaining width, truncates without displacing the device name, and
-retains access to its complete value through the copy action.
+assistive technology and tooltips instead of repeating them visually. Show the
+workspace directory name instead of a low-value truncated path prefix. Keep the
+complete path available through the tooltip, accessible name, and copy action;
+copy feedback must not change the row's geometry.
 
 Use a menu for commands, a popover for a compact interactive surface, and a
 dialog when a decision blocks continuation. Do not substitute one merely to get

--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -552,6 +552,12 @@ Menu items use `14px` text, an `8px` radius, `8px–10px` horizontal padding,
 Icons default to `16px` at `75%` opacity and become fully visible on hover or
 focus. Disabled items use `50%` opacity and do not activate.
 
+In the narrow environment popover, execution location, device, and workspace
+path form one compact metadata row. Keep their localized labels available to
+assistive technology and tooltips instead of repeating them visually. The path
+uses the remaining width, truncates without displacing the device name, and
+retains access to its complete value through the copy action.
+
 Use a menu for commands, a popover for a compact interactive surface, and a
 dialog when a decision blocks continuation. Do not substitute one merely to get
 a preferred shape.

--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -552,11 +552,13 @@ Menu items use `14px` text, an `8px` radius, `8px–10px` horizontal padding,
 Icons default to `16px` at `75%` opacity and become fully visible on hover or
 focus. Disabled items use `50%` opacity and do not activate.
 
-In the narrow environment popover, execution location, device, and workspace
-path form one compact metadata row. Keep their localized labels available to
-assistive technology and tooltips instead of repeating them visually. Show the
-workspace directory name instead of a low-value truncated path prefix. Keep the
-complete path available through the tooltip, accessible name, and copy action;
+In the narrow environment popover, workspace and executor metadata form one
+compact two-line item. Lead with a folder icon and the recognizable workspace
+directory name. For local execution, show the executor name beside a laptop
+icon; for cloud execution, show the device IP beside a cloud icon. Keep
+execution-location and field labels available to assistive
+technology and tooltips instead of repeating them visually. Keep the complete
+workspace path available through the tooltip, accessible name, and copy action;
 copy feedback must not change the row's geometry.
 
 Use a menu for commands, a popover for a compact interactive surface, and a

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -6038,7 +6038,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() => expect(screen.getByText('+173')).toBeInTheDocument())
     const deviceSection = screen.getByTestId('environment-device-section')
     const gitSection = screen.getByTestId('environment-git-section')
-    expect(deviceSection).toHaveClass('flex', 'h-9', 'items-center')
+    expect(deviceSection).toHaveClass('flex', 'h-8', 'items-center')
     expect(deviceSection).not.toContainElement(gitSection)
     expect(gitSection).not.toContainElement(deviceSection)
     const executionTargetRow = screen.getByTestId('environment-execution-target-row')
@@ -6056,7 +6056,8 @@ describe('DesktopWorkbenchLayout', () => {
     expect(deviceButton).toHaveAttribute('title', '设备 · yunpeng7-executor-0bb4')
     const workspacePathButton = screen.getByTestId('environment-workspace-path-button')
     expect(deviceSection).toContainElement(workspacePathButton)
-    expect(workspacePathButton).toHaveTextContent('/workspace/projects/github_wegent')
+    expect(screen.getByTestId('environment-workspace-path')).toHaveTextContent('github_wegent')
+    expect(workspacePathButton).toHaveAccessibleName('路径 · /workspace/projects/github_wegent')
     expect(workspacePathButton).toContainElement(
       screen.getByTestId('environment-workspace-path-copy-icon')
     )
@@ -6077,6 +6078,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(navigator.clipboard.writeText).toHaveBeenLastCalledWith(
       '/workspace/projects/github_wegent'
     )
+    expect(screen.getByText('已复制')).toHaveAttribute('role', 'status')
 
     await userEvent.click(document.body)
 
@@ -6573,8 +6575,9 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     await waitFor(() => expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument())
-    expect(screen.getByTestId('environment-workspace-path')).toHaveTextContent(
-      '/workspace/plain-folder'
+    expect(screen.getByTestId('environment-workspace-path')).toHaveTextContent('plain-folder')
+    expect(screen.getByTestId('environment-workspace-path-button')).toHaveAccessibleName(
+      '路径 · /workspace/plain-folder'
     )
     const gitSection = screen.getByTestId('environment-git-section')
     expect(gitSection).toHaveTextContent('变更')

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -6038,6 +6038,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() => expect(screen.getByText('+173')).toBeInTheDocument())
     const deviceSection = screen.getByTestId('environment-device-section')
     const gitSection = screen.getByTestId('environment-git-section')
+    expect(deviceSection).toHaveClass('flex', 'h-9', 'items-center')
     expect(deviceSection).not.toContainElement(gitSection)
     expect(gitSection).not.toContainElement(deviceSection)
     const executionTargetRow = screen.getByTestId('environment-execution-target-row')
@@ -6981,6 +6982,7 @@ describe('DesktopWorkbenchLayout', () => {
         onLoadEnvironmentInfo={onLoadEnvironmentInfo}
         state={{
           ...baseProps.state,
+          devices: structuredClone(baseProps.state.devices),
           currentProject: workspaceProject,
           devices: structuredClone(baseProps.state.devices),
           runtimeWork: structuredClone(runtimeWork),

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5995,6 +5995,7 @@ describe('DesktopWorkbenchLayout', () => {
               is_default: false,
               device_type: 'cloud',
               bind_shell: 'claudecode',
+              client_ip: '10.23.45.67',
             },
           ],
         }}
@@ -6038,7 +6039,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() => expect(screen.getByText('+173')).toBeInTheDocument())
     const deviceSection = screen.getByTestId('environment-device-section')
     const gitSection = screen.getByTestId('environment-git-section')
-    expect(deviceSection).toHaveClass('flex', 'h-8', 'items-center')
+    expect(deviceSection).toHaveClass('flex', 'flex-col', 'gap-1')
     expect(deviceSection).not.toContainElement(gitSection)
     expect(gitSection).not.toContainElement(deviceSection)
     const executionTargetRow = screen.getByTestId('environment-execution-target-row')
@@ -6048,12 +6049,15 @@ describe('DesktopWorkbenchLayout', () => {
     const deviceButton = await screen.findByTestId('environment-device-button')
     expect(deviceSection).toContainElement(deviceButton)
     expect(deviceButton).toHaveTextContent('设备')
-    expect(deviceButton).toHaveTextContent('yunpeng7-executor-0bb4')
+    expect(deviceButton).toHaveTextContent('10.23.45.67')
     expect(deviceButton).not.toHaveTextContent('云设备')
     expect(deviceButton).not.toHaveTextContent('e13e1a10')
     expect(deviceButton).not.toHaveTextContent('8ef4')
     expect(screen.queryByTestId('environment-device-id')).not.toBeInTheDocument()
-    expect(deviceButton).toHaveAttribute('title', '设备 · yunpeng7-executor-0bb4')
+    expect(executionTargetRow).toHaveAttribute(
+      'title',
+      '位置 · 云设备; 设备 · yunpeng7-executor-0bb4'
+    )
     const workspacePathButton = screen.getByTestId('environment-workspace-path-button')
     expect(deviceSection).toContainElement(workspacePathButton)
     expect(screen.getByTestId('environment-workspace-path')).toHaveTextContent('github_wegent')
@@ -6560,7 +6564,20 @@ describe('DesktopWorkbenchLayout', () => {
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
-        state={{ ...activeProjectState, currentRuntimeTask: activeProjectRuntimeTask }}
+        state={{
+          ...activeProjectState,
+          currentRuntimeTask: activeProjectRuntimeTask,
+          devices: [
+            {
+              id: 1,
+              device_id: 'device-1',
+              name: 'Local Executor',
+              status: 'online',
+              is_default: true,
+              device_type: 'local',
+            },
+          ],
+        }}
         onLoadEnvironmentInfo={vi.fn().mockResolvedValue({
           additions: '+55',
           deletions: '-8',
@@ -6579,6 +6596,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('environment-workspace-path-button')).toHaveAccessibleName(
       '路径 · /workspace/plain-folder'
     )
+    expect(screen.getByTestId('environment-device-button')).toHaveTextContent('Local Executor')
     const gitSection = screen.getByTestId('environment-git-section')
     expect(gitSection).toHaveTextContent('变更')
     expect(gitSection).toHaveTextContent('+55')

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -26,6 +26,7 @@ import {
 import { createPortal } from 'react-dom'
 import { BranchSelector } from '@/components/common/BranchSelector'
 import { useTranslation } from '@/hooks/useTranslation'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { openExternalUrl } from '@/lib/external-links'
 import { cn } from '@/lib/utils'
 import {
@@ -136,7 +137,7 @@ export function EnvironmentInfoPopover({
       return
     }
 
-    await navigator.clipboard?.writeText(info.workspacePath)
+    await copyTextToClipboard(info.workspacePath)
     setWorkspacePathCopied(true)
     window.setTimeout(() => setWorkspacePathCopied(false), 1200)
   }
@@ -282,31 +283,33 @@ export function EnvironmentInfoPopover({
             </h2>
 
             <div className="space-y-3">
-              <section data-testid="environment-device-section" className="space-y-0.5">
+              <section
+                data-testid="environment-device-section"
+                className="flex h-9 w-full items-center gap-2 text-sm text-text-primary"
+              >
                 <div
                   data-testid="environment-execution-target-row"
-                  className="flex h-9 w-full items-center gap-3 rounded-md text-left text-sm text-text-primary"
+                  title={`${executionTargetLabel} · ${executionLabel}`}
+                  className="flex min-w-0 shrink-0 items-center gap-1.5"
                 >
-                  <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
-                    <MapPin className="h-[18px] w-[18px]" />
+                  <span className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary">
+                    <MapPin className="h-4 w-4" />
                   </span>
-                  <span className="shrink-0">{executionTargetLabel}</span>
-                  <span className="ml-auto min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-right text-text-secondary">
-                    {executionLabel}
-                  </span>
+                  <span className="sr-only">{executionTargetLabel}</span>
+                  <span className="whitespace-nowrap text-text-secondary">{executionLabel}</span>
                 </div>
                 <div
                   data-testid="environment-device-button"
                   title={deviceTitle}
-                  className="flex h-9 w-full items-center gap-3 rounded-md text-left text-sm text-text-primary"
+                  className="flex min-w-0 items-center gap-1.5 border-l border-border pl-2"
                 >
-                  <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
-                    <Laptop className="h-[18px] w-[18px]" />
+                  <span className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary">
+                    <Laptop className="h-4 w-4" />
                   </span>
-                  <span className="shrink-0">{deviceLabel}</span>
+                  <span className="sr-only">{deviceLabel}</span>
                   <span
                     data-testid="environment-device-name"
-                    className="ml-auto min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-right text-text-secondary"
+                    className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-text-secondary"
                   >
                     {deviceDisplayName}
                   </span>
@@ -317,24 +320,25 @@ export function EnvironmentInfoPopover({
                     data-testid="environment-workspace-path-button"
                     onClick={handleCopyWorkspacePath}
                     title={info.workspacePath}
-                    className="flex h-9 w-full items-center gap-3 rounded-md text-left text-sm text-text-primary hover:bg-hover"
+                    aria-label={`${t('workbench.environment_workspace_path')} · ${info.workspacePath}`}
+                    className="flex min-w-0 flex-1 items-center gap-1.5 border-l border-border pl-2 text-left hover:text-text-primary"
                   >
-                    <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
-                      <FolderOpen className="h-[18px] w-[18px]" />
+                    <span className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary">
+                      <FolderOpen className="h-4 w-4" />
                     </span>
-                    <span className="shrink-0">{t('workbench.environment_workspace_path')}</span>
+                    <span className="sr-only">{t('workbench.environment_workspace_path')}</span>
                     <span
                       data-testid="environment-workspace-path"
-                      className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-right font-mono text-xs text-text-secondary"
+                      className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-xs text-text-secondary"
                     >
                       {info.workspacePath}
                     </span>
                     <span
                       data-testid="environment-workspace-path-copy-icon"
-                      className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary"
+                      className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary"
                       aria-hidden="true"
                     >
-                      <Copy className="h-[16px] w-[16px]" />
+                      <Copy className="h-3.5 w-3.5" />
                     </span>
                     {workspacePathCopied && (
                       <span className="shrink-0 text-xs text-green-500">

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -3,14 +3,11 @@ import {
   ChevronDown,
   CircleDot,
   Copy,
-  FolderOpen,
   GitCommit,
   GitBranch,
   GitPullRequest,
   Info,
-  Laptop,
   LoaderCircle,
-  MapPin,
   Square,
   Upload,
   CornerDownLeft,
@@ -61,6 +58,11 @@ type CommitPanelAction = 'commit' | 'commit-and-push' | 'push'
 const FLOATING_POPOVER_WIDTH = 300
 const FLOATING_POPOVER_GAP = 8
 const FLOATING_POPOVER_MARGIN = 16
+
+function getWorkspacePathDisplayName(path: string): string {
+  const normalizedPath = path.replace(/[\\/]+$/, '')
+  return normalizedPath.split(/[\\/]/).filter(Boolean).at(-1) || path
+}
 
 export function EnvironmentInfoPopover({
   info,
@@ -118,6 +120,9 @@ export function EnvironmentInfoPopover({
   const hasDiffStats = gitRepositoryAvailable && Boolean(info.additions || info.deletions)
   const showChangesSection = hasDiffStats || hasGitInfo || canShowBranchSelector
   const taskSummaryToggleLabel = t('workbench.task_summary_toggle', '切换摘要')
+  const workspacePathDisplayName = info.workspacePath
+    ? getWorkspacePathDisplayName(info.workspacePath)
+    : ''
   function handleCreatePullRequest() {
     if (!info.createPullRequestUrl) {
       return
@@ -285,67 +290,70 @@ export function EnvironmentInfoPopover({
             <div className="space-y-3">
               <section
                 data-testid="environment-device-section"
-                className="flex h-9 w-full items-center gap-2 text-sm text-text-primary"
+                className="flex h-8 w-full min-w-0 items-center gap-2 text-xs text-text-secondary"
               >
                 <div
                   data-testid="environment-execution-target-row"
                   title={`${executionTargetLabel} · ${executionLabel}`}
-                  className="flex min-w-0 shrink-0 items-center gap-1.5"
+                  className="shrink-0 whitespace-nowrap"
                 >
-                  <span className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary">
-                    <MapPin className="h-4 w-4" />
-                  </span>
                   <span className="sr-only">{executionTargetLabel}</span>
-                  <span className="whitespace-nowrap text-text-secondary">{executionLabel}</span>
+                  <span>{executionLabel}</span>
                 </div>
+                <span aria-hidden="true" className="text-text-muted">
+                  ·
+                </span>
                 <div
                   data-testid="environment-device-button"
                   title={deviceTitle}
-                  className="flex min-w-0 items-center gap-1.5 border-l border-border pl-2"
+                  className="min-w-0 max-w-28 truncate"
                 >
-                  <span className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary">
-                    <Laptop className="h-4 w-4" />
-                  </span>
                   <span className="sr-only">{deviceLabel}</span>
-                  <span
-                    data-testid="environment-device-name"
-                    className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-text-secondary"
-                  >
+                  <span data-testid="environment-device-name" className="whitespace-nowrap">
                     {deviceDisplayName}
                   </span>
                 </div>
                 {info.workspacePath && (
-                  <button
-                    type="button"
-                    data-testid="environment-workspace-path-button"
-                    onClick={handleCopyWorkspacePath}
-                    title={info.workspacePath}
-                    aria-label={`${t('workbench.environment_workspace_path')} · ${info.workspacePath}`}
-                    className="flex min-w-0 flex-1 items-center gap-1.5 border-l border-border pl-2 text-left hover:text-text-primary"
-                  >
-                    <span className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary">
-                      <FolderOpen className="h-4 w-4" />
+                  <>
+                    <span aria-hidden="true" className="text-text-muted">
+                      ·
                     </span>
-                    <span className="sr-only">{t('workbench.environment_workspace_path')}</span>
-                    <span
-                      data-testid="environment-workspace-path"
-                      className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-xs text-text-secondary"
+                    <button
+                      type="button"
+                      data-testid="environment-workspace-path-button"
+                      onClick={handleCopyWorkspacePath}
+                      title={info.workspacePath}
+                      aria-label={`${t('workbench.environment_workspace_path')} · ${info.workspacePath}`}
+                      className="flex min-w-0 flex-1 items-center gap-1 rounded px-1 py-1 text-left hover:bg-hover hover:text-text-primary"
                     >
-                      {info.workspacePath}
-                    </span>
-                    <span
-                      data-testid="environment-workspace-path-copy-icon"
-                      className="flex h-4 w-4 shrink-0 items-center justify-center text-text-secondary"
-                      aria-hidden="true"
-                    >
-                      <Copy className="h-3.5 w-3.5" />
-                    </span>
-                    {workspacePathCopied && (
-                      <span className="shrink-0 text-xs text-green-500">
-                        {t('workbench.environment_copied')}
+                      <span className="sr-only">{t('workbench.environment_workspace_path')}</span>
+                      <span
+                        data-testid="environment-workspace-path"
+                        className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono"
+                      >
+                        {workspacePathDisplayName}
                       </span>
-                    )}
-                  </button>
+                      <span
+                        data-testid="environment-workspace-path-copy-icon"
+                        className={cn(
+                          'flex h-3.5 w-3.5 shrink-0 items-center justify-center',
+                          workspacePathCopied ? 'text-green-500' : 'text-text-muted'
+                        )}
+                        aria-hidden="true"
+                      >
+                        {workspacePathCopied ? (
+                          <Check className="h-3.5 w-3.5" />
+                        ) : (
+                          <Copy className="h-3.5 w-3.5" />
+                        )}
+                      </span>
+                      {workspacePathCopied && (
+                        <span role="status" className="sr-only">
+                          {t('workbench.environment_copied')}
+                        </span>
+                      )}
+                    </button>
+                  </>
                 )}
               </section>
 

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -2,11 +2,14 @@ import {
   Check,
   ChevronDown,
   CircleDot,
+  Cloud,
   Copy,
+  FolderOpen,
   GitCommit,
   GitBranch,
   GitPullRequest,
   Info,
+  Laptop,
   LoaderCircle,
   Square,
   Upload,
@@ -102,6 +105,11 @@ export function EnvironmentInfoPopover({
   const executionTargetLabel = t('workbench.environment_execution_target')
   const deviceLabel = t('workbench.environment_device')
   const deviceDisplayName = deviceName || t('workbench.environment_device_unknown')
+  const executorDisplayName =
+    info.executionTarget === 'cloud'
+      ? getWorkbenchDeviceUnavailableDisplayName(device ?? null) || deviceDisplayName
+      : deviceDisplayName
+  const ExecutorIcon = info.executionTarget === 'cloud' ? Cloud : Laptop
   const deviceTitle = [deviceLabel, deviceDisplayName].filter(Boolean).join(' · ')
   const offlineDeviceId = getExecutorOfflineDeviceId(info.error)
   const offlineDevice = offlineDeviceId ? findWorkbenchDevice(devices, offlineDeviceId) : null
@@ -144,7 +152,7 @@ export function EnvironmentInfoPopover({
 
     await copyTextToClipboard(info.workspacePath)
     setWorkspacePathCopied(true)
-    window.setTimeout(() => setWorkspacePathCopied(false), 1200)
+    window.setTimeout(() => setWorkspacePathCopied(false), 2000)
   }
 
   function getCommitErrorMessage(error: unknown) {
@@ -290,46 +298,23 @@ export function EnvironmentInfoPopover({
             <div className="space-y-3">
               <section
                 data-testid="environment-device-section"
-                className="flex h-8 w-full min-w-0 items-center gap-2 text-xs text-text-secondary"
+                className="flex w-full min-w-0 flex-col gap-1"
               >
-                <div
-                  data-testid="environment-execution-target-row"
-                  title={`${executionTargetLabel} · ${executionLabel}`}
-                  className="shrink-0 whitespace-nowrap"
-                >
-                  <span className="sr-only">{executionTargetLabel}</span>
-                  <span>{executionLabel}</span>
-                </div>
-                <span aria-hidden="true" className="text-text-muted">
-                  ·
-                </span>
-                <div
-                  data-testid="environment-device-button"
-                  title={deviceTitle}
-                  className="min-w-0 max-w-28 truncate"
-                >
-                  <span className="sr-only">{deviceLabel}</span>
-                  <span data-testid="environment-device-name" className="whitespace-nowrap">
-                    {deviceDisplayName}
-                  </span>
-                </div>
                 {info.workspacePath && (
-                  <>
-                    <span aria-hidden="true" className="text-text-muted">
-                      ·
-                    </span>
+                  <div className="flex h-7 min-w-0 items-center gap-2">
+                    <FolderOpen className="h-4 w-4 shrink-0 text-text-muted" aria-hidden="true" />
                     <button
                       type="button"
                       data-testid="environment-workspace-path-button"
                       onClick={handleCopyWorkspacePath}
                       title={info.workspacePath}
                       aria-label={`${t('workbench.environment_workspace_path')} · ${info.workspacePath}`}
-                      className="flex min-w-0 flex-1 items-center gap-1 rounded px-1 py-1 text-left hover:bg-hover hover:text-text-primary"
+                      className="flex min-w-0 flex-1 items-center gap-1 rounded py-1 text-left hover:text-text-primary"
                     >
                       <span className="sr-only">{t('workbench.environment_workspace_path')}</span>
                       <span
                         data-testid="environment-workspace-path"
-                        className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono"
+                        className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-text-primary"
                       >
                         {workspacePathDisplayName}
                       </span>
@@ -353,8 +338,24 @@ export function EnvironmentInfoPopover({
                         </span>
                       )}
                     </button>
-                  </>
+                  </div>
                 )}
+                <div
+                  data-testid="environment-execution-target-row"
+                  title={`${executionTargetLabel} · ${executionLabel}; ${deviceTitle}`}
+                  className="flex h-7 min-w-0 items-center gap-2 text-xs text-text-secondary"
+                >
+                  <ExecutorIcon className="h-4 w-4 shrink-0 text-text-muted" aria-hidden="true" />
+                  <span className="sr-only">
+                    {executionTargetLabel} · {executionLabel} ·{' '}
+                  </span>
+                  <div data-testid="environment-device-button" className="min-w-0 truncate">
+                    <span className="sr-only">{deviceLabel}</span>
+                    <span data-testid="environment-device-name" className="whitespace-nowrap">
+                      {executorDisplayName}
+                    </span>
+                  </div>
+                </div>
               </section>
 
               {showChangesSection && (


### PR DESCRIPTION
## What changed

- Combine workspace and executor metadata into one compact two-line environment item.
- Lead with a folder icon and recognizable workspace directory name; show `Local Executor` beside a laptop icon locally, or the device IP beside a cloud icon remotely.
- Preserve the full workspace path in the tooltip, accessible name, and copy action.
- Use the shared native-compatible clipboard helper so workspace path copy feedback works in the macOS WebView.
- Prevent equivalent device polling updates from retriggering visible environment loading and making the branch row jump.
- Document the compact environment popover pattern in `wework/DESIGN.md`.

## Why

The environment summary used three full rows in a 300px popover. In addition, the environment loader depended on the identity of the polled device array, so equivalent device updates could retrigger a visible loading state and make the branch row appear unstable.

## User impact

The environment summary now has a clear primary/secondary hierarchy instead of flattening unrelated metadata into one sentence. The workspace name is the primary identity; the executor or cloud IP is secondary. The full path remains discoverable and copyable, copy feedback works in the real desktop WebView, and background device polling no longer causes branch-row flicker.

## Validation

- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework test` — 200 files, 1995 tests passed on latest `origin/main`
- Pre-push ESLint, TypeScript, and unit-test checks passed
- Isolated real-Tauri flow: created a local project and task, opened the environment panel, verified the two-line hierarchy and local executor icon, then copied the workspace path and verified stable success feedback
- Captures taken before and after the 5-second refresh interval were byte-identical, confirming the branch row remained stable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the environment information popover with a more compact two-line layout.
  * Workspace paths now display the folder name while keeping the full path available through tooltips, accessibility labels, and copy actions.
  * Execution details now use laptop or cloud icons and show the appropriate executor name or device IP.
  * Added clearer copy confirmation without shifting the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->