### PR TITLE
fix(wework): release inactive pane graphics memory

### DIFF
--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -44,6 +44,12 @@ Run the desktop streaming-memory regression on macOS:
 pnpm --filter wework e2e:desktop:memory
 ```
 
+Run the whole-process memory regression with 10 concurrently executing tasks:
+
+```bash
+pnpm --filter wework e2e:desktop:concurrent-memory
+```
+
 The command starts a test-only Vite server through `wework/playwright.config.ts`:
 
 ```bash
@@ -101,6 +107,8 @@ The cloud-project scenario starts a real Backend, Redis, and a real Executor reg
 The plugin scenario dynamically creates an isolated local Codex marketplace and a plugin with a Skill under the test-results directory. It then uses the real Tauri WebView, Executor, and Codex app-server to verify marketplace discovery, installation, insertion of the plugin reference into the chat composer, and uninstallation. It neither reads the user's Codex home nor mocks plugin APIs; marketplace data, plugin cache, and installation state remain inside the isolated test directory. Screenshots are retained for all four critical stages, with application, Executor, and UI snapshot diagnostics retained on failure.
 
 The memory scenario is macOS-only. It executes a development task through a real Codex tool call, then streams a long response containing Markdown, tables, and TypeScript code into the real Tauri WebView. Every 500 milliseconds it samples the aggregate physical footprint of all associated WebKit Web Content processes, writing the samples, DOM node counts, and summary metrics to `memory-growth.json`; the gate does not include the main Wework process. The default gates limit peak growth to 512 MiB, settled growth after completion to 256 MiB, and continued growth during the settled window to 32 MiB. The first two limits can be adjusted with `WEWORK_E2E_MEMORY_MAX_PEAK_GROWTH_KIB` and `WEWORK_E2E_MEMORY_MAX_SETTLED_GROWTH_KIB`.
+
+The concurrent-memory scenario is also macOS-only. It creates and holds 10 Responses streams at the same time, samples the process-group physical footprint for the Wework main process, WebKit Web Content/GPU/Networking processes, Executor processes, and the Codex app-server, and writes the evidence to `concurrent-memory.json`. The gate requires the whole process group to stay below an 800 MiB peak. The scenario also switches between the first and last tasks to confirm that inactive panes leave layout and compositing while task content and running state remain intact.
 
 ## Responses API Mock
 

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -44,6 +44,12 @@ pnpm --filter wework e2e:desktop:plugins
 pnpm --filter wework e2e:desktop:memory
 ```
 
+运行 10 个任务同时执行的整机内存回归：
+
+```bash
+pnpm --filter wework e2e:desktop:concurrent-memory
+```
+
 该命令会通过 `wework/playwright.config.ts` 启动测试专用 Vite 服务：
 
 ```bash
@@ -101,6 +107,8 @@ CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
 插件场景会在测试结果目录动态创建隔离的本地 Codex marketplace 和带 Skill 的插件，然后通过真实 Tauri WebView、Executor 与 Codex app-server 验证市场展示、安装、在对话编辑器中插入插件引用及卸载。场景不访问个人 Codex home，也不 mock 插件 API；市场、插件缓存和安装状态都随测试结果目录清理。四个关键阶段会保留截图，失败时同时保留应用、Executor 和 UI 快照诊断。
 
 内存场景仅支持 macOS。它会通过真实 Codex 工具调用执行一个开发任务，再向真实 Tauri WebView 流式发送包含 Markdown、表格和 TypeScript 代码的长回复。测试每 500 毫秒采集 Wework 关联的全部 WebKit Web Content 进程的聚合 physical footprint，并将采样、DOM 节点数和汇总指标写入 `memory-growth.json`；门禁不包含 Wework 主进程。默认门禁为峰值增长不超过 512 MiB、完成后的稳定态增长不超过 256 MiB、稳定期继续增长不超过 32 MiB；前两个阈值可分别通过 `WEWORK_E2E_MEMORY_MAX_PEAK_GROWTH_KIB` 和 `WEWORK_E2E_MEMORY_MAX_SETTLED_GROWTH_KIB` 调整。
+
+并发内存场景同样仅支持 macOS。它会创建并同时保持 10 个 Responses 流，采集 Wework 主进程、WebKit Web Content/GPU/Networking、Executor 和 Codex app-server 的进程组 physical footprint，并将证据写入 `concurrent-memory.json`。门禁要求整个进程组峰值低于 800 MiB；场景还会在首尾任务之间切换，确认未激活 pane 退出布局和合成的同时，任务内容与运行状态仍被保留。
 
 ## Responses API Mock
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -46,6 +46,10 @@ const RECONNECT_PROMPT = 'WEWORK_DESKTOP_E2E_RECONNECT: recover after the stream
 const RECONNECT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RECONNECT_COMPLETE'
 const MEMORY_PROMPT = 'WEWORK_DESKTOP_E2E_MEMORY: run a tool and stream the report.'
 const MEMORY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_MEMORY_COMPLETE'
+const CONCURRENT_MEMORY_TASK_COUNT = 10
+const CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB = Number(
+  process.env.WEWORK_E2E_CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB ?? 800 * 1024
+)
 const MEMORY_SAMPLE_INTERVAL_MS = 500
 const MEMORY_MAX_PEAK_GROWTH_KIB = Number(
   process.env.WEWORK_E2E_MEMORY_MAX_PEAK_GROWTH_KIB ?? 256 * 1024
@@ -121,6 +125,7 @@ const SIDE_CHAT_ATTACHMENT_ONLY = process.argv.includes('--side-chat-attachment-
 const CLOUD_ONLY = process.argv.includes('--cloud-only')
 const PLUGINS_ONLY = process.argv.includes('--plugins-only')
 const MEMORY_ONLY = process.argv.includes('--memory-only')
+const CONCURRENT_MEMORY_ONLY = process.argv.includes('--concurrent-memory-only')
 const DESKTOP_SCENARIO_ONLY = process.env.WEWORK_E2E_DESKTOP_SCENARIO_ONLY === 'true'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -390,6 +395,109 @@ async function captureMemorySample(control, phase) {
     physicalFootprintKiB: webContent.physical_footprint_kib,
     pids: webContent.pids,
   }
+}
+
+async function captureTotalMemorySample(control, phase) {
+  const snapshot = JSON.parse(await control.command('performanceSnapshot', 'body'))
+  return {
+    phase,
+    timestamp: snapshot.timestamp,
+    domNodeCount: snapshot.domNodeCount,
+    rssKiB: snapshot.processMemory.groups.reduce((total, group) => total + group.rss_kib, 0),
+    physicalFootprintKiB: snapshot.processMemory.groups.reduce(
+      (total, group) => total + group.physical_footprint_kib,
+      0
+    ),
+    groups: snapshot.processMemory.groups,
+  }
+}
+
+async function verifyConcurrentTaskMemory({ composerSelector, control }) {
+  assert.equal(process.platform, 'darwin', 'Concurrent memory E2E currently requires macOS')
+  control.setScenario('concurrent_memory')
+  const taskRows = []
+
+  for (let index = 1; index <= CONCURRENT_MEMORY_TASK_COUNT; index += 1) {
+    if (index > 1) {
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', composerSelector, { timeoutMs: UI_TIMEOUT_MS })
+    }
+    const prompt = `WEWORK_DESKTOP_E2E_CONCURRENT_MEMORY_${index}`
+    await control.command('fill', composerSelector, { value: prompt })
+    await control.command('press', composerSelector, { key: 'Enter' })
+    await control.awaitScenarioRequestCount('concurrent_memory', index)
+    const snapshot = JSON.parse(await control.command('snapshot', 'body'))
+    const rows = snapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-'))
+    const nextRow = rows.find(row => !taskRows.includes(row))
+    if (nextRow) taskRows.push(nextRow)
+  }
+
+  assert.equal(
+    control.scenarioRequests.get('concurrent_memory')?.length,
+    CONCURRENT_MEMORY_TASK_COUNT,
+    'The model service did not keep ten task requests running concurrently'
+  )
+  assert.equal(
+    control.concurrentMemoryResponses.length,
+    CONCURRENT_MEMORY_TASK_COUNT,
+    'The model service released a concurrent task stream before memory sampling'
+  )
+  assert.equal(
+    taskRows.length,
+    CONCURRENT_MEMORY_TASK_COUNT,
+    'The sidebar did not expose ten tasks'
+  )
+  await captureVerificationScreenshot(control, 'concurrent-memory-01-running.png')
+
+  const samples = []
+  for (let index = 0; index < 5; index += 1) {
+    samples.push(await captureTotalMemorySample(control, 'running'))
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 1_000))
+  }
+  const peak = samples.reduce((largest, sample) =>
+    sample.physicalFootprintKiB > largest.physicalFootprintKiB ? sample : largest
+  )
+
+  const sidebarSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+  const expandTasksButton = sidebarSnapshot.testIds.find(testId =>
+    testId.startsWith('project-runtime-tasks-expand-')
+  )
+  if (expandTasksButton) {
+    await control.command('click', `[data-testid="${expandTasksButton}"]`)
+  }
+  await control.command('waitFor', `[data-testid="${taskRows[0]}"]`, {
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('clickWhenEnabled', `[data-testid="${taskRows[0]}"]`)
+  await control.command('waitFor', ACTIVE_WORKBENCH_SELECTOR, {
+    text: 'WEWORK_DESKTOP_E2E_CONCURRENT_MEMORY_1',
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('clickWhenEnabled', `[data-testid="${taskRows.at(-1)}"]`)
+  await control.command('waitFor', ACTIVE_WORKBENCH_SELECTOR, {
+    text: `WEWORK_DESKTOP_E2E_CONCURRENT_MEMORY_${CONCURRENT_MEMORY_TASK_COUNT}`,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+
+  await writeFile(
+    join(resultDir, 'concurrent-memory.json'),
+    `${JSON.stringify(
+      {
+        taskCount: CONCURRENT_MEMORY_TASK_COUNT,
+        limitPhysicalFootprintKiB: CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB,
+        peak,
+        samples,
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  )
+  assert.ok(
+    peak.physicalFootprintKiB < CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB,
+    `Wework physical footprint reached ${peak.physicalFootprintKiB} KiB with ten concurrent tasks`
+  )
+  control.releaseConcurrentMemoryResponses()
 }
 
 async function verifyMemoryGrowth({ composerSelector, control }) {
@@ -1817,6 +1925,7 @@ class DesktopE2EServer {
     this.scenario = 'initial'
     this.modelStage = 'initial'
     this.memoryStage = 'initial'
+    this.concurrentMemoryResponses = []
     this.cloudModelStage = 'initial'
     this.toolLessPrewarmHandled = false
     this.memoryToolLessPrewarmHandled = false
@@ -1994,6 +2103,7 @@ class DesktopE2EServer {
         'fresh_chat',
         'attachment_only',
         'memory',
+        'concurrent_memory',
         'side_chat_attachment',
         'cloud_initial',
         'cloud_follow_up',
@@ -2069,6 +2179,12 @@ class DesktopE2EServer {
 
   releaseWindowLifecycleResponse() {
     this.releaseWindowLifecycle()
+  }
+
+  releaseConcurrentMemoryResponses() {
+    for (const { response, stream } of this.concurrentMemoryResponses.splice(0)) {
+      response.end(createSse(stream.finish))
+    }
   }
 
   async command(action, selector, options = {}) {
@@ -2377,6 +2493,37 @@ class DesktopE2EServer {
         assistantMessage(COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
+      return
+    }
+
+    if (this.scenario === 'concurrent_memory') {
+      const requestNumber = (this.scenarioRequests.get('concurrent_memory')?.length ?? 0) + 1
+      this.recordScenarioRequest('concurrent_memory', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(`WEWORK_DESKTOP_E2E_CONCURRENT_MEMORY_${requestNumber}`),
+        `Concurrent memory request ${requestNumber} did not contain its UI prompt`
+      )
+      const stream = streamingTextEvents(responseId, `Concurrent task ${requestNumber} completed.`)
+      response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      })
+      response.write(createSse(stream.start))
+      response.write(
+        createSse([
+          {
+            type: 'response.output_text.delta',
+            item_id: stream.itemId,
+            output_index: 0,
+            content_index: 0,
+            delta: `Concurrent task ${requestNumber} is running.`,
+            offset: 0,
+          },
+        ])
+      )
+      this.concurrentMemoryResponses.push({ response, stream })
       return
     }
 
@@ -3827,6 +3974,14 @@ async function main() {
       phase = 'attachment-only-sidebar'
       await verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSelector, control })
       console.log(`Wework attachment-only sidebar E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
+    if (CONCURRENT_MEMORY_ONLY) {
+      phase = 'concurrent-memory'
+      await selectE2EModel(control)
+      await verifyConcurrentTaskMemory({ composerSelector, control })
+      console.log(`Wework concurrent memory E2E passed. Evidence: ${resultDir}`)
       return
     }
 

--- a/wework/package.json
+++ b/wework/package.json
@@ -29,6 +29,7 @@
     "e2e:desktop:cloud": "node e2e/desktop/task-flow.e2e.mjs --cloud-only",
     "e2e:desktop:plugins": "node e2e/desktop/task-flow.e2e.mjs --plugins-only",
     "e2e:desktop:memory": "node e2e/desktop/task-flow.e2e.mjs --memory-only",
+    "e2e:desktop:concurrent-memory": "node e2e/desktop/task-flow.e2e.mjs --concurrent-memory-only",
     "e2e:desktop:lifecycle": "node e2e/desktop/task-flow.e2e.mjs --lifecycle-only",
     "e2e:desktop:reconnect": "node e2e/desktop/task-flow.e2e.mjs --reconnect-only",
     "e2e:desktop:attachment-only-sidebar": "node e2e/desktop/task-flow.e2e.mjs --attachment-only-sidebar",

--- a/wework/src/components/layout/workbenchPaneStack.test.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.test.tsx
@@ -191,6 +191,9 @@ describe('workbenchPaneStack', () => {
       const [pane, setPane] = useState<WorkbenchPaneIdentity>(runtimePane)
       return (
         <div>
+          <button type="button" onClick={() => setPane(runtimePane)}>
+            reopen runtime chat
+          </button>
           <button type="button" onClick={() => setPane(standalonePane)}>
             start new chat
           </button>
@@ -204,6 +207,7 @@ describe('workbenchPaneStack', () => {
     }
 
     render(<RuntimePaneStackProbe />)
+    const runtimeMountId = screen.getByTestId('runtime-pane-mount-id').textContent
     expect(screen.getByTestId('runtime-pane-runtime-1')).toBeVisible()
 
     await userEvent.click(screen.getByText('start new chat'))
@@ -216,9 +220,18 @@ describe('workbenchPaneStack', () => {
       .closest('[data-active-workbench-pane]')
 
     expect(standaloneWrapper).toHaveAttribute('data-active-workbench-pane', 'true')
-    expect(standaloneWrapper).toHaveClass('visible')
+    expect(standaloneWrapper).not.toHaveAttribute('hidden')
     expect(runtimeWrapper).toHaveAttribute('data-active-workbench-pane', 'false')
-    expect(runtimeWrapper).toHaveClass('invisible')
+    expect(runtimeWrapper).toHaveAttribute('hidden')
+    expect(screen.getByTestId('runtime-pane-runtime-1')).not.toBeVisible()
+
+    await userEvent.click(screen.getByText('reopen runtime chat'))
+
+    const reopenedRuntimePane = screen.getByTestId('runtime-pane-runtime-1')
+    expect(reopenedRuntimePane).toBeVisible()
+    expect(
+      reopenedRuntimePane.querySelector('[data-testid="runtime-pane-mount-id"]')
+    ).toHaveTextContent(runtimeMountId ?? '')
   })
 
   test('uses standalone chat key to create a fresh new chat pane', async () => {

--- a/wework/src/components/layout/workbenchPaneStack.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.tsx
@@ -131,9 +131,10 @@ export function CachedWorkbenchPaneStack({
               data-active-workbench-pane={active ? 'true' : 'false'}
               data-testid={active ? activeTestId : undefined}
               aria-hidden={!active}
+              hidden={!active}
               className={cn(
                 'absolute inset-0 min-w-0 overflow-hidden',
-                active ? 'visible z-10' : 'invisible pointer-events-none z-0'
+                active ? 'z-10' : 'pointer-events-none z-0'
               )}
             >
               <CachedWorkbenchPane pane={pane} renderPane={renderPane} />


### PR DESCRIPTION
## Summary

- remove inactive cached workbench panes from WebKit layout and compositing while keeping their React state mounted
- preserve terminal, built-in browser, transcript, and running-task state across task switches
- add a macOS desktop E2E gate that holds 10 tasks concurrently and requires the complete Wework process group to remain below 800 MiB
- document the new regression command and measurement scope in Chinese and English

## Root cause

Inactive cached panes used `visibility: hidden`. WebKit continued retaining their rendering layers and backing stores, so graphics memory accumulated as more task panes were opened. Using the native `hidden` attribute moves inactive panes to `display: none`, releasing layout/compositor resources without unmounting React state.

## Verification

- pre-push ESLint, TypeScript, and complete Wework unit suite passed
- focused pane/layout/terminal/browser suite: 189 tests passed
- complete Wework unit suite: 1,995 tests passed
- 10-task concurrent desktop E2E passed after rebasing on latest `main`
- full process-group peak physical footprint: 566,838 KiB (553.6 MiB), below the 800 MiB gate
- concurrent E2E switches between first and last task and verifies prompt/running state preservation

## Evidence

The E2E writes per-process-group samples and its peak record to `concurrent-memory.json`. The measured group includes Wework main, WebKit Web Content/GPU/Networking, all Executor processes, Codex app-server, and child processes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane switching so inactive runtime panes retain their content and state when hidden and reopened.
  * Preserved cached pane instances to prevent unnecessary remounting during navigation.

* **Documentation**
  * Added guidance for the macOS concurrent-memory desktop regression scenario, including execution steps, monitoring, and memory limits.

* **Tests**
  * Added a concurrent-memory end-to-end test covering 10 simultaneous tasks, process memory usage, task state, and pane behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->