### PR TITLE
fix(wework): remove composer execution device icon

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -24,9 +24,6 @@ vi.mock('@/hooks/useTranslation', () => ({
       if (key === 'workbench.project_work_trigger_device_aria') {
         return `${options?.action ?? ''}，当前设备 ${options?.device ?? ''}`
       }
-      if (key === 'workbench.composer_execution_device_label') {
-        return `运行于${options?.location ?? ''} · ${options?.device ?? ''}`
-      }
       if (key === 'workbench.environment_cloud_device') return '云设备'
       if (key === 'workbench.environment_local') return '本机'
       if (key === 'workbench.remove_code_comments') {
@@ -3286,81 +3283,6 @@ describe('ChatInput', () => {
     expect(
       screen.queryByTestId('standalone-device-selected-icon-cloud-online')
     ).not.toBeInTheDocument()
-  })
-
-  test('shows a subtle cloud-device control and opens device selection for a new task', async () => {
-    const devices: DeviceInfo[] = [
-      {
-        id: 1,
-        device_id: 'cloud-online',
-        name: 'Cloud Online',
-        status: 'online',
-        is_default: false,
-        device_type: 'cloud',
-      },
-    ]
-
-    render(
-      <ChatInput
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        disabled={false}
-        variant="desktop"
-        projectWork={projectWorkControls({
-          devices,
-          currentStandaloneDeviceId: 'cloud-online',
-        })}
-      />
-    )
-
-    const deviceButton = screen.getByTestId('composer-execution-device-button')
-    expect(deviceButton).toHaveAccessibleName('运行于云设备 · Cloud Online')
-    expect(deviceButton).toBeEnabled()
-
-    await userEvent.click(deviceButton)
-    expect(screen.getByTestId('project-work-menu')).toBeInTheDocument()
-  })
-
-  test('shows the actual runtime device without allowing an active task to switch it', () => {
-    const devices: DeviceInfo[] = [
-      {
-        id: 1,
-        device_id: 'local-online',
-        name: 'Local Online',
-        status: 'online',
-        is_default: false,
-        device_type: 'local',
-      },
-      {
-        id: 2,
-        device_id: 'cloud-online',
-        name: 'Cloud Online',
-        status: 'online',
-        is_default: false,
-        device_type: 'cloud',
-      },
-    ]
-
-    render(
-      <ChatInput
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        disabled={false}
-        variant="desktop"
-        showProjectWorkBar={false}
-        projectWork={projectWorkControls({
-          devices,
-          currentStandaloneDeviceId: 'local-online',
-          currentRuntimeDeviceId: 'cloud-online',
-        })}
-      />
-    )
-
-    const deviceButton = screen.getByTestId('composer-execution-device-button')
-    expect(deviceButton).toHaveAccessibleName('运行于云设备 · Cloud Online')
-    expect(deviceButton).toHaveAttribute('aria-disabled', 'true')
   })
 
   test('uses the project work action as the standalone trigger accessible name', () => {

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -1,13 +1,4 @@
-import {
-  ArrowUp,
-  ChevronDown,
-  ClipboardList,
-  Clock3,
-  Cloud,
-  CornerDownRight,
-  Laptop,
-  Zap,
-} from 'lucide-react'
+import { ArrowUp, ChevronDown, ClipboardList, Clock3, CornerDownRight, Zap } from 'lucide-react'
 import { useLayoutEffect, useRef, useState } from 'react'
 import { ActionMenu } from '@/components/common/ActionMenu'
 import type { ComposerSubmitOptions } from './ComposerTextarea'
@@ -45,12 +36,6 @@ interface ComposerToolbarProps {
   onPause?: () => void
   onQuickPhraseSelect: (phrase: QuickPhrase) => void
   onSubmit: (options?: ComposerSubmitOptions) => void
-  executionDevice?: {
-    kind: 'cloud' | 'local'
-    label: string
-    selectable: boolean
-    onSelect?: () => void
-  }
 }
 
 const COMPACT_TOOLBAR_WIDTH = 475
@@ -81,7 +66,6 @@ export function ComposerToolbar({
   onPause,
   onQuickPhraseSelect,
   onSubmit,
-  executionDevice,
 }: ComposerToolbarProps) {
   const { t } = useTranslation('common')
   const toolbarRef = useRef<HTMLDivElement>(null)
@@ -131,23 +115,6 @@ export function ComposerToolbar({
         ) : null}
       </div>
       <div className="flex min-w-0 items-center gap-1.5">
-        {executionDevice && (
-          <button
-            type="button"
-            data-testid="composer-execution-device-button"
-            onClick={executionDevice.onSelect}
-            aria-disabled={!executionDevice.selectable}
-            title={executionDevice.label}
-            aria-label={executionDevice.label}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30 aria-disabled:cursor-default aria-disabled:hover:bg-transparent aria-disabled:hover:text-text-muted"
-          >
-            {executionDevice.kind === 'cloud' ? (
-              <Cloud className="h-4 w-4" aria-hidden="true" />
-            ) : (
-              <Laptop className="h-4 w-4" aria-hidden="true" />
-            )}
-          </button>
-        )}
         <ContextUsageIndicator
           usage={contextUsage}
           disabled={disabled}

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -8,12 +8,8 @@ import type {
 } from '@/types/api'
 import type { CodeCommentContext, WorkspaceFileApi, WorkspaceTarget } from '@/types/workspace-files'
 import type { DragEventHandler } from 'react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { cn } from '@/lib/utils'
-import { isCloudDevice } from '@/lib/device-selection'
-import { findWorkbenchDevice, getProjectDeviceId } from '@/lib/workbench-device'
-import { findProjectDeviceWorkspace } from '@/features/workbench/workbenchRuntimeHelpers'
-import { useTranslation } from '@/hooks/useTranslation'
 import type { ProjectWorkControls } from '../ChatInput'
 import { AttachmentBadges } from './AttachmentBadges'
 import { ComposerToolbar } from './ComposerToolbar'
@@ -113,45 +109,12 @@ export function ProjectChatComposer({
   isStreaming = false,
   onPause,
 }: ProjectChatComposerProps) {
-  const { t } = useTranslation('common')
   const [isDraggingFiles, setIsDraggingFiles] = useState(false)
-  const [deviceMenuOpenSignal, setDeviceMenuOpenSignal] = useState(0)
   const textareaRef = useAutoResizeTextarea(value, 168)
   const canSend =
     (value.trim().length > 0 || attachments.length > 0 || codeComments.length > 0) &&
     !disabled &&
     !submitDisabled
-  const executionDevice = useMemo(() => {
-    const selectedProjectWorkspace = findProjectDeviceWorkspace(
-      projectWork.runtimeWork,
-      projectWork.currentProject?.id,
-      projectWork.selectedDeviceWorkspaceId
-    )
-    const deviceId =
-      projectWork.currentRuntimeDeviceId ??
-      selectedProjectWorkspace?.deviceId ??
-      getProjectDeviceId(projectWork.currentProject) ??
-      projectWork.currentStandaloneDeviceId
-    const device = findWorkbenchDevice(projectWork.devices, deviceId)
-    if (!deviceId || !device) return undefined
-    const cloud = isCloudDevice(device)
-    const location = cloud
-      ? t('workbench.environment_cloud_device', '云设备')
-      : t('workbench.environment_local', '本机')
-    const deviceName = device.name?.trim() || device.device_id
-    return {
-      kind: cloud ? ('cloud' as const) : ('local' as const),
-      label: t('workbench.composer_execution_device_label', {
-        location,
-        device: deviceName,
-      }),
-      selectable: showProjectWorkBar && !projectWork.currentRuntimeDeviceId,
-      onSelect:
-        showProjectWorkBar && !projectWork.currentRuntimeDeviceId
-          ? () => setDeviceMenuOpenSignal(signal => signal + 1)
-          : undefined,
-    }
-  }, [projectWork, showProjectWorkBar, t])
   const handleDragOver: DragEventHandler<HTMLFormElement> = event => {
     if (!hasDraggedFiles(event.dataTransfer)) return
 
@@ -222,7 +185,6 @@ export function ProjectChatComposer({
           worktreeBranch={projectWork.worktreeBranch}
           onWorktreeBranchChange={projectWork.onWorktreeBranchChange}
           projectMenuOpenSignal={projectWork.projectMenuOpenSignal}
-          externalMenuOpenSignal={deviceMenuOpenSignal}
           projectMenuAnchorElement={projectWork.projectMenuAnchorElement}
           className="min-h-10 rounded-t-[26px] bg-surface px-4"
           buttonClassName="text-sm leading-[18px] text-text-secondary hover:bg-background/70 hover:text-text-primary"
@@ -325,7 +287,6 @@ export function ProjectChatComposer({
           onPause={onPause}
           onQuickPhraseSelect={handleQuickPhraseSelect}
           onSubmit={options => onSubmit(value, options)}
-          executionDevice={executionDevice}
         />
       </form>
     </div>

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -515,7 +515,6 @@
     "environment_local": "Local",
     "environment_cloud": "Cloud",
     "environment_cloud_device": "Cloud device",
-    "composer_execution_device_label": "Runs on {{location}} · {{device}}",
     "environment_execution_target": "Location",
     "environment_device": "Device",
     "environment_device_unknown": "Unknown device",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -515,7 +515,6 @@
     "environment_local": "本地",
     "environment_cloud": "云端",
     "environment_cloud_device": "云设备",
-    "composer_execution_device_label": "运行于{{location}} · {{device}}",
     "environment_execution_target": "位置",
     "environment_device": "设备",
     "environment_device_unknown": "未知设备",


### PR DESCRIPTION
## What changed

- remove the execution-device icon/button from the Wework composer toolbar
- remove the now-unused device-label calculation and translations
- remove tests that covered the deleted control

## Why

The execution target is already available through the project/work selector. Showing a second laptop/cloud icon in the composer adds redundant visual chrome and an overlapping device-selection entry point.

## Impact

The composer is simpler and no longer shows the laptop/cloud execution-device icon. The existing project/work selector remains available for choosing the execution target.

## Validation

- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework test -- src/components/chat/ChatInput.test.tsx`
- pre-push Wework ESLint, TypeScript, and unit-test suite
- isolated Tauri verification confirming the composer renders without `composer-execution-device-button`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer environment labels for local and cloud workspaces.
  - Added detailed environment information, including execution target, device, workspace path, and code review status.

- **Changes**
  - Removed the execution-device control from the chat composer toolbar.
  - Updated project-work controls to display the selected project more clearly.

- **Tests**
  - Updated chat composer coverage for the revised project-work button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->