### PR TITLE
fix(wework): improve model menu layout and grouping

### DIFF
--- a/docs/en/wework/settings.md
+++ b/docs/en/wework/settings.md
@@ -22,6 +22,8 @@ Common macOS shortcuts include:
 
 In **Settings → Models**, click **Add model** and choose a provider first. For Kimi Coding, Wework discovers the provider's models. K3 automatically uses the built-in Codex Catalog profile with a 256K context window and `low` default reasoning effort.
 
+Each custom model has an optional **Group** field that controls how it appears in the model picker. Kimi Coding defaults this field to **Kimi**, but users can edit or clear it. Models without a group appear under **Custom models**.
+
 Choose **Custom** to configure an OpenAI Responses, Chat Completions, or Anthropic Messages-compatible endpoint. Model capabilities use structured controls instead of raw Catalog JSON:
 
 - One context-window field drives both runtime and Catalog configuration.

--- a/docs/zh/wework/settings.md
+++ b/docs/zh/wework/settings.md
@@ -34,6 +34,8 @@ Windows 和 Linux 使用界面中显示的对应组合键。
 
 在“设置 → 模型”中点击“添加模型”后，先选择提供商。选择 Kimi Coding 时，Wework 从服务端读取模型列表；K3 会自动使用内置的 Codex Catalog profile，包括 256K 上下文和默认 `low` 推理等级。
 
+每个自定义模型都可以设置可选的“分组”，模型选择器会使用该名称组织模型。Kimi Coding 默认填写“Kimi”，用户可以修改或清空；未设置分组的模型统一显示在“自定义模型”下。
+
 选择“完全自定义”可以配置兼容 OpenAI Responses、Chat Completions 或 Anthropic Messages 的接口。模型能力使用结构化表单维护，不需要编辑 Catalog JSON：
 
 - 最大上下文同时用于运行时和 Catalog，不需要重复填写。

--- a/wework/src/components/chat/composer/ModelSelector.test.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.test.tsx
@@ -189,16 +189,92 @@ describe('ModelSelector desktop layout', () => {
     fireEvent.click(screen.getByTestId('model-selector-button'))
     fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
 
-    expect(await screen.findByTestId('model-family-codex-official')).toBeInTheDocument()
+    expect(await screen.findByTestId('model-family-codex-official')).toHaveTextContent('我的CodeX')
     expect(screen.getByTestId('model-family-claude')).toBeInTheDocument()
+    expect(screen.getByTestId('model-selector-submenu')).not.toHaveClass('min-h-48')
     expect(screen.queryByTestId(`model-option-${SAMPLE_MODEL.name}`)).not.toBeInTheDocument()
 
     fireEvent.mouseEnter(screen.getByTestId('model-family-claude'))
 
     const familySubmenu = await screen.findByTestId('model-selector-family-submenu')
     expect(familySubmenu).toHaveTextContent('Claude')
+    expect(familySubmenu).not.toHaveClass('min-h-48')
     expect(screen.getByTestId(`model-option-${SECOND_FAMILY_MODEL.name}`)).toBeInTheDocument()
     expect(screen.queryByTestId(`model-option-${SAMPLE_MODEL.name}`)).not.toBeInTheDocument()
+  })
+
+  test('keeps the family model submenu above the viewport bottom', async () => {
+    createShellElement({ hidden: true })
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    )
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this.getAttribute('data-testid') === 'model-selector-menu') {
+        return {
+          top: 600,
+          left: 600,
+          right: 856,
+          bottom: 856,
+          width: 256,
+          height: 256,
+          x: 600,
+          y: 600,
+          toJSON: () => {},
+        } as DOMRect
+      }
+      if (this.getAttribute('data-testid') === 'model-selector-family-submenu') {
+        return {
+          top: 800,
+          left: 888,
+          right: 1176,
+          bottom: 1040,
+          width: 288,
+          height: 240,
+          x: 888,
+          y: 800,
+          toJSON: () => {},
+        } as DOMRect
+      }
+      return originalGetBoundingClientRect.call(this)
+    }
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return this.getAttribute('data-testid') === 'model-selector-family-submenu' ? 240 : 0
+      },
+    })
+
+    try {
+      render(
+        <ModelSelector
+          models={[SAMPLE_MODEL, SECOND_FAMILY_MODEL]}
+          selectedModel={SAMPLE_MODEL}
+          selectedModelOptions={{}}
+          disabled={false}
+          onSelectModel={vi.fn()}
+          onSelectModelOption={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('model-selector-button'))
+      fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
+      fireEvent.mouseEnter(await screen.findByTestId('model-family-claude'))
+
+      const familySubmenu = await screen.findByTestId('model-selector-family-submenu')
+      const wrapper = screen.getByTestId('model-selector-menu').parentElement
+      await waitFor(() => {
+        expect(
+          parseInt(wrapper!.style.top, 10) + parseInt(familySubmenu.style.top, 10) + 240
+        ).toBeLessThanOrEqual(WINDOW_INNER_HEIGHT - 16)
+      })
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+      if (originalScrollHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight)
+      }
+    }
   })
 
   test('caps the trigger width when maxClosedWidth is provided', () => {

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -95,6 +95,7 @@ export function ModelSelector({
   const desktopMenuWrapperRef = useRef<HTMLDivElement>(null)
   const menuPanelRef = useRef<HTMLDivElement>(null)
   const submenuPanelRef = useRef<HTMLDivElement>(null)
+  const familySubmenuPanelRef = useRef<HTMLDivElement>(null)
   const mobileMenuRef = useRef<HTMLDivElement>(null)
   const mobileCloseButtonRef = useRef<HTMLButtonElement>(null)
   const modelButtonRef = useRef<HTMLButtonElement>(null)
@@ -114,6 +115,7 @@ export function ModelSelector({
   )
   const [activeDesktopFamilyId, setActiveDesktopFamilyId] = useState<string | null>(null)
   const [desktopFamilyOffset, setDesktopFamilyOffset] = useState(0)
+  const [desktopFamilyTop, setDesktopFamilyTop] = useState(0)
   const [advancedOpen, setAdvancedOpen] = useState(readModelSelectorPowerViewPreference)
   const [powerSliderInteracting, setPowerSliderInteracting] = useState(false)
   const modelSelectorShortcut = useConfiguredKeybinding(TOGGLE_MODEL_SELECTOR_COMMAND)
@@ -409,6 +411,23 @@ export function ModelSelector({
       ? rightSideLeft
       : -desktopFamilySubmenuWidth
   })()
+
+  useLayoutEffect(() => {
+    if (!open || isMobile || !activeDesktopFamily) return
+
+    const familySubmenu = familySubmenuPanelRef.current
+    if (!familySubmenu) return
+
+    const submenuHeight = Math.min(
+      familySubmenu.scrollHeight || familySubmenu.getBoundingClientRect().height,
+      SUBMENU_MAX_HEIGHT,
+      Math.max(0, window.innerHeight - SUBMENU_VIEWPORT_VERTICAL_GAP)
+    )
+    const preferredTop = submenuOffset + desktopFamilyOffset
+    const minTop = DESKTOP_MENU_VIEWPORT_TOP - desktopMenuTop
+    const maxTop = window.innerHeight - VIEWPORT_MARGIN - submenuHeight - desktopMenuTop
+    setDesktopFamilyTop(Math.round(Math.max(minTop, Math.min(preferredTop, maxTop))))
+  }, [activeDesktopFamily, desktopFamilyOffset, desktopMenuTop, isMobile, open, submenuOffset])
 
   useLayoutEffect(() => {
     if (!open || isMobile) return
@@ -1011,7 +1030,7 @@ export function ModelSelector({
                 data-enter-animation="submenu"
                 style={{ top: submenuOffset, left: submenuLeft, width: submenuWidth }}
                 className={cn(
-                  'absolute max-h-[min(28rem,calc(100vh-8rem))] min-h-48 w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+                  'absolute max-h-[min(28rem,calc(100vh-8rem))] w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
                   styles.submenu
                 )}
               >
@@ -1060,11 +1079,12 @@ export function ModelSelector({
             {activeDesktopSubmenu?.type === 'models' && activeDesktopFamily ? (
               <div
                 key={`family:${activeDesktopFamily.config.id}`}
+                ref={familySubmenuPanelRef}
                 data-testid="model-selector-family-submenu"
                 data-enter-animation="submenu"
-                style={{ top: submenuOffset + desktopFamilyOffset, left: desktopFamilySubmenuLeft }}
+                style={{ top: desktopFamilyTop, left: desktopFamilySubmenuLeft }}
                 className={cn(
-                  'absolute max-h-[min(28rem,calc(100vh-8rem))] min-h-48 w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+                  'absolute max-h-[min(28rem,calc(100vh-8rem))] w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
                   styles.submenu
                 )}
               >

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -669,6 +669,10 @@ describe('ConnectionsSettingsPage', () => {
         screen.getByTestId('local-model-provider-select'),
         'kimi-coding'
       )
+      const groupInput = screen.getByTestId('local-model-group-input')
+      expect(groupInput).toHaveValue('Kimi')
+      await userEvent.clear(groupInput)
+      await userEvent.type(groupInput, '月之暗面')
       await userEvent.type(screen.getByTestId('local-model-api-key-input'), 'test-key')
       await userEvent.click(screen.getByTestId('local-model-load-provider-models-button'))
       await waitFor(() =>
@@ -679,6 +683,7 @@ describe('ConnectionsSettingsPage', () => {
       const stored = JSON.parse(localStorage.getItem('wework.localModelSettings.v1') ?? '[]')
       expect(stored[0]).toMatchObject({
         providerProfileId: 'kimi-coding',
+        group: '月之暗面',
         modelId: 'k3',
         contextWindow: 262_144,
         codexCatalogModelId: 'wework-kimi-k3',

--- a/wework/src/components/settings/ModelSettingsPage.tsx
+++ b/wework/src/components/settings/ModelSettingsPage.tsx
@@ -1230,6 +1230,19 @@ function LocalModelSettingsSection({
                     className={LOCAL_MODEL_FIELD_CLASS}
                   />
                 </label>
+                <label className="grid gap-1.5 text-xs font-medium text-text-secondary">
+                  {t('workbench.local_model_group_label', '分组（可选）')}
+                  <input
+                    data-testid="local-model-group-input"
+                    value={form.group}
+                    onChange={event => updateForm({ group: event.target.value })}
+                    placeholder={t(
+                      'workbench.local_model_group_optional_placeholder',
+                      '留空则归入自定义模型'
+                    )}
+                    className={LOCAL_MODEL_FIELD_CLASS}
+                  />
+                </label>
                 <button
                   type="button"
                   data-testid="local-model-provider-advanced-toggle"

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -1296,6 +1296,7 @@
     "local_model_display_name_label": "Display name",
     "local_model_group_label": "Group",
     "local_model_group_placeholder": "For example: Local inference",
+    "local_model_group_optional_placeholder": "Leave blank to use Custom models",
     "local_model_api_key_label": "API Key",
     "local_model_api_key_placeholder": "Optional",
     "local_model_api_key_replace_placeholder": "Leave blank to keep the saved key",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -1296,6 +1296,7 @@
     "local_model_display_name_label": "显示名",
     "local_model_group_label": "分组",
     "local_model_group_placeholder": "例如：本地推理",
+    "local_model_group_optional_placeholder": "留空则归入自定义模型",
     "local_model_api_key_label": "API Key",
     "local_model_api_key_placeholder": "可选",
     "local_model_api_key_replace_placeholder": "留空则保留现有 Key",

--- a/wework/src/lib/model-ui.test.ts
+++ b/wework/src/lib/model-ui.test.ts
@@ -180,9 +180,9 @@ describe('model-ui', () => {
       'gpt',
     ])
     expect(groups.map(group => group.config.label)).toEqual([
-      'CodeX',
+      '我的CodeX',
       'wecode openai',
-      '接口模型',
+      '自定义模型',
       'GPT',
     ])
   })

--- a/wework/src/lib/model-ui.ts
+++ b/wework/src/lib/model-ui.ts
@@ -188,9 +188,9 @@ const OPENAI_RESPONSES_CONTROLS: ModelControlConfig[] = [
 
 export const MODEL_FAMILY_CONFIGS: ModelFamilyConfig[] = [
   { id: 'claude', label: 'Claude', order: 10, controls: [] },
-  { id: 'codex-official', label: 'CodeX', order: 20, controls: OPENAI_RESPONSES_CONTROLS },
+  { id: 'codex-official', label: '我的CodeX', order: 20, controls: OPENAI_RESPONSES_CONTROLS },
   { id: 'codex-provider', label: 'Provider 模型', order: 30, controls: OPENAI_RESPONSES_CONTROLS },
-  { id: 'model-interface', label: '接口模型', order: 40, controls: OPENAI_RESPONSES_CONTROLS },
+  { id: 'model-interface', label: '自定义模型', order: 40, controls: OPENAI_RESPONSES_CONTROLS },
   {
     id: 'gpt',
     label: 'GPT',


### PR DESCRIPTION
## What changed

- keep nested model menus within the visible viewport and let short menus shrink to their content
- rename the built-in Codex group to `我的CodeX` and the ungrouped interface section to `自定义模型`
- expose the optional group field for provider presets while retaining Kimi as the Kimi Coding default
- document how custom model grouping works in Chinese and English

## Why

Nested menus near the bottom edge could extend beyond the window, and fixed minimum heights left large empty areas for short lists. Provider presets could also create a group such as Kimi without showing users where that value came from or allowing them to edit it.

## User impact

Model menus now remain visible and size to their entries. Users can see, edit, or clear the group assigned to a provider model; models without a group appear under `自定义模型`.

## Validation

- pre-push Wework ESLint, TypeScript, and full unit test suite
- focused ModelSelector, model UI, provider settings, and model settings tests
- Prettier and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional **Group** field when configuring managed custom models.
  - Model pickers now organize models by group, with ungrouped models shown under **Custom models**.
  - Added localized English and Chinese guidance for the Group field.

- **Bug Fixes**
  - Improved desktop model submenu positioning to keep it within the visible viewport.
  - Updated model family labels for clearer organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->