### PR TITLE
fix(wework): open bottom panel directly in terminal

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -653,6 +653,11 @@ semantics for all three.
 - Back returns to the previous meaningful context; Close dismisses a layer.
 - Opening or closing sidebars, previews, terminals, and settings preserves the
   active task and unsent composer input.
+- Opening the bottom workspace panel starts or restores its Terminal directly;
+  it must not show an IDE launcher or require an intermediate tool choice.
+- Workspace IDEs and native editors launch only from the titlebar “Open
+  location” control, including its local-editor picker and remote code-server
+  behavior.
 - Resizable panes keep useful minimum sizes and preserve user-owned allocation
   where the feature supports it.
 - External URLs, applications, and windows must be clear before activation.

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -405,10 +405,30 @@ async function captureTotalMemorySample(control, phase) {
   }
 }
 
+async function waitForNewTaskRow(control, knownTaskRows, expectedText) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < UI_TIMEOUT_MS) {
+    const snapshot = JSON.parse(await control.command('snapshot', 'body'))
+    const candidates = snapshot.testIds.filter(
+      testId => testId.startsWith('runtime-local-task-row-') && !knownTaskRows.has(testId)
+    )
+    for (const testId of candidates) {
+      const rowText = await control.command('getText', `[data-testid="${testId}"]`)
+      if (rowText.includes(expectedText)) return testId
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(`The sidebar did not expose a task row for ${expectedText}`)
+}
+
 async function verifyConcurrentTaskMemory({ composerSelector, control }) {
   assert.equal(process.platform, 'darwin', 'Concurrent memory E2E currently requires macOS')
   control.setScenario('concurrent_memory')
   const taskRows = []
+  const initialSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+  const knownTaskRows = new Set(
+    initialSnapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-'))
+  )
 
   for (let index = 1; index <= CONCURRENT_MEMORY_TASK_COUNT; index += 1) {
     if (index > 1) {
@@ -419,17 +439,8 @@ async function verifyConcurrentTaskMemory({ composerSelector, control }) {
     await control.command('fill', composerSelector, { value: prompt })
     await control.command('press', composerSelector, { key: 'Enter' })
     await control.awaitScenarioRequestCount('concurrent_memory', index)
-    const snapshot = await waitForSnapshot(
-      control,
-      currentSnapshot =>
-        currentSnapshot.testIds.some(
-          testId => testId.startsWith('runtime-local-task-row-') && !taskRows.includes(testId)
-        ),
-      `Concurrent memory task ${index} did not appear in the sidebar`
-    )
-    const rows = snapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-'))
-    const nextRow = rows.find(row => !taskRows.includes(row))
-    assert.ok(nextRow, `Concurrent memory task ${index} did not create a new sidebar row`)
+    const nextRow = await waitForNewTaskRow(control, knownTaskRows, prompt)
+    knownTaskRows.add(nextRow)
     taskRows.push(nextRow)
   }
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -339,24 +339,22 @@ async function waitForSnapshot(
   throw new Error(message)
 }
 
-async function openBottomWorkspaceLauncher(control, description) {
+async function openBottomWorkspaceTerminal(control, description) {
   await control.command('click', '[data-testid="toggle-bottom-workspace-panel-button"]')
   const snapshot = await waitForSnapshot(
     control,
-    value => value.testIds.includes('workspace-tool-launcher'),
-    `${description} did not show the workspace tool launcher`,
+    value =>
+      value.testIds.includes('workspace-terminal-window') &&
+      value.testIds.includes('remote-terminal') &&
+      !value.testIds.includes('workspace-tool-launcher'),
+    `${description} did not start the terminal directly`,
     UI_TIMEOUT_MS,
     ACTIVE_WORKBENCH_SELECTOR
   )
-  assert.ok(
-    snapshot.testIds.includes('workspace-terminal-card'),
-    `${description} did not offer Terminal`
-  )
-  assert.ok(snapshot.testIds.includes('workspace-ide-card'), `${description} did not offer IDE`)
   assert.equal(
-    snapshot.testIds.includes('workspace-terminal-window'),
+    snapshot.testIds.includes('workspace-ide-card'),
     false,
-    `${description} started a terminal before Terminal was selected`
+    `${description} exposed IDE in the bottom panel`
   )
   return snapshot
 }
@@ -3587,18 +3585,7 @@ async function verifyCloudProjectFlow(control, cloudEnvironment, workspacePath) 
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   await captureVerificationScreenshot(control, 'cloud-04-conversation-ready.png')
-  await openBottomWorkspaceLauncher(control, 'The new cloud task')
-  await control.command('click', '[data-testid="workspace-terminal-card"]')
-  await waitForSnapshot(
-    control,
-    value =>
-      value.testIds.includes('workspace-terminal-window') &&
-      value.testIds.includes('remote-terminal') &&
-      !value.testIds.includes('workspace-tool-launcher'),
-    'The new cloud task did not start its terminal after Terminal was selected',
-    UI_TIMEOUT_MS,
-    ACTIVE_WORKBENCH_SELECTOR
-  )
+  await openBottomWorkspaceTerminal(control, 'The new cloud task')
   await captureVerificationScreenshot(control, 'cloud-04b-new-task-terminal-open.png')
   await control.command('click', '[data-testid="close-bottom-workspace-tab-button"]')
   await waitForSnapshot(
@@ -3639,18 +3626,7 @@ async function verifyCloudProjectFlow(control, cloudEnvironment, workspacePath) 
   })
   await captureVerificationScreenshot(control, 'cloud-05-initial-task-completed.png')
 
-  await openBottomWorkspaceLauncher(control, 'The historical cloud task')
-  await control.command('click', '[data-testid="workspace-terminal-card"]')
-  await waitForSnapshot(
-    control,
-    value =>
-      value.testIds.includes('workspace-terminal-window') &&
-      value.testIds.includes('remote-terminal') &&
-      !value.testIds.includes('workspace-tool-launcher'),
-    'The historical cloud task did not start its terminal after Terminal was selected',
-    UI_TIMEOUT_MS,
-    ACTIVE_WORKBENCH_SELECTOR
-  )
+  await openBottomWorkspaceTerminal(control, 'The historical cloud task')
   await closeBottomWorkspacePanel(control)
   await control.command('click', '[data-testid="toggle-bottom-workspace-panel-button"]')
   await waitForSnapshot(
@@ -3670,7 +3646,11 @@ async function verifyCloudProjectFlow(control, cloudEnvironment, workspacePath) 
     'The bottom workspace add menu did not open'
   )
   assert.ok(addMenuSnapshot.testIds.includes('workspace-add-terminal-option'))
-  assert.ok(addMenuSnapshot.testIds.includes('workspace-add-ide-option'))
+  assert.equal(
+    addMenuSnapshot.testIds.includes('workspace-add-ide-option'),
+    false,
+    'The bottom workspace add menu exposed IDE'
+  )
   assert.equal(
     addMenuSnapshot.testIds.includes('workspace-add-desktop-option'),
     false,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -7064,24 +7064,26 @@ describe('DesktopWorkbenchLayout', () => {
     expect(panel).toHaveClass('transition-[height,opacity,transform]', 'duration-300')
   })
 
-  test('shows the workspace tool launcher without starting a terminal when the bottom panel opens', async () => {
+  test('starts a terminal directly when the bottom panel opens', async () => {
     renderWorkspacePanelLayout()
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
 
-    expect(screen.getByTestId('workspace-tool-launcher')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-terminal-card')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-ide-card')).toBeInTheDocument()
-    expect(startTerminalSessionMock).not.toHaveBeenCalled()
-    expect(startDeviceTerminalSessionMock).not.toHaveBeenCalled()
-    expect(screen.queryByTestId('workspace-terminal-window')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(startDeviceTerminalSessionMock).toHaveBeenCalledWith(
+        'workspace-cloud-device',
+        '/workspace/project'
+      )
+    )
+    expect(screen.queryByTestId('workspace-tool-launcher')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workspace-terminal-window')).toBeInTheDocument()
   })
 
   test('restores an explicitly opened terminal when the bottom panel reopens', async () => {
     renderWorkspacePanelLayout()
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(startDeviceTerminalSessionMock).toHaveBeenCalledWith(
@@ -7151,7 +7153,6 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
@@ -7206,7 +7207,6 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
@@ -7311,7 +7311,6 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
@@ -7339,7 +7338,6 @@ describe('DesktopWorkbenchLayout', () => {
     const { rerender } = render(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
@@ -7363,7 +7361,6 @@ describe('DesktopWorkbenchLayout', () => {
     expect(startLocalTerminalMock).toHaveBeenCalledTimes(1)
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(startLocalTerminalMock).toHaveBeenCalledWith({
@@ -7427,7 +7424,6 @@ describe('DesktopWorkbenchLayout', () => {
       }
       const suffix = task.taskId.replace('runtime-', '')
       await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-      await userEvent.click(screen.getByTestId('workspace-terminal-card'))
       await waitFor(() => {
         const terminals = visibleLocalTerminals()
         expect(terminals).toHaveLength(1)
@@ -7481,7 +7477,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     const menu = screen.getByTestId('workspace-terminal-new-tab-menu')
     expect(within(menu).getByTestId('workspace-add-terminal-option')).toBeInTheDocument()
-    expect(within(menu).getByTestId('workspace-add-ide-option')).toBeInTheDocument()
+    expect(within(menu).queryByTestId('workspace-add-ide-option')).not.toBeInTheDocument()
     expect(within(menu).queryByTestId('workspace-add-desktop-option')).not.toBeInTheDocument()
   })
 
@@ -7490,7 +7486,6 @@ describe('DesktopWorkbenchLayout', () => {
     renderWorkspacePanelLayout()
 
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
     await waitFor(() =>
       expect(startDeviceTerminalSessionMock).toHaveBeenCalledWith(
         'workspace-cloud-device',
@@ -7524,27 +7519,12 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workspace-terminal-window')).toBeInTheDocument()
     expect(screen.queryByTestId('workspace-tool-launcher')).not.toBeInTheDocument()
     expect(within(menu).getByTestId('workspace-add-terminal-option')).toHaveTextContent('终端')
-    expect(within(menu).getByTestId('workspace-add-ide-option')).toHaveTextContent('IDE')
+    expect(within(menu).queryByTestId('workspace-add-ide-option')).not.toBeInTheDocument()
     expect(within(menu).getByTestId('workspace-add-desktop-option')).toHaveTextContent('桌面')
     expect(within(menu).queryByTestId('workspace-add-review-option')).not.toBeInTheDocument()
     expect(within(menu).queryByTestId('workspace-add-browser-option')).not.toBeInTheDocument()
     expect(within(menu).queryByTestId('workspace-add-files-option')).not.toBeInTheDocument()
 
-    await userEvent.click(within(menu).getByTestId('workspace-add-ide-option'))
-
-    await waitFor(() =>
-      expect(startDeviceCodeServerSessionMock).toHaveBeenCalledWith(
-        'workspace-cloud-device',
-        '/workspace/project'
-      )
-    )
-    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/ide', {
-      target: 'system',
-    })
-    expect(screen.getByTestId('bottom-workspace-panel')).toHaveAttribute('aria-hidden', 'false')
-    expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
-
-    await userEvent.click(screen.getByTestId('workspace-terminal-new-tab-button'))
     await userEvent.click(screen.getByTestId('workspace-add-desktop-option'))
 
     await waitFor(() =>

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -1,4 +1,4 @@
-import { Code2, Monitor, SquareTerminal, X } from 'lucide-react'
+import { Monitor, SquareTerminal, X } from 'lucide-react'
 import { memo, useCallback, useMemo, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import type { WorkspaceSessionApi } from '@/features/workbench/workbenchServices'
@@ -14,7 +14,6 @@ import type { WorkspacePanelMenuActions } from './workspace-panel-tools'
 interface BottomWorkspacePanelTab {
   id: string
   title: string
-  defaultOpenTool?: 'terminal'
 }
 
 interface BottomWorkspacePanelProps {
@@ -33,11 +32,8 @@ interface BottomWorkspacePanelProps {
   onTerminalTabsEmpty?: () => void
 }
 
-function createTerminalTab(
-  index: number,
-  defaultOpenTool?: BottomWorkspacePanelTab['defaultOpenTool']
-): BottomWorkspacePanelTab {
-  return { id: `terminal-${index}`, title: `Terminal ${index}`, defaultOpenTool }
+function createTerminalTab(index: number): BottomWorkspacePanelTab {
+  return { id: `terminal-${index}`, title: `Terminal ${index}` }
 }
 
 export const BottomWorkspacePanel = memo(function BottomWorkspacePanel({
@@ -71,7 +67,7 @@ export const BottomWorkspacePanel = memo(function BottomWorkspacePanel({
   const testId = (value: string) => (testIdsEnabled ? value : undefined)
 
   const openTerminalTab = useCallback(() => {
-    const tab = createTerminalTab(terminalSequence, 'terminal')
+    const tab = createTerminalTab(terminalSequence)
     setTerminalSequence(current => current + 1)
     setTabs(current => [...current, tab])
     setActiveTabId(tab.id)
@@ -149,16 +145,6 @@ export const BottomWorkspacePanel = memo(function BottomWorkspacePanel({
         label: t('workbench.terminal', '终端'),
         disabled: activeMenuActions.terminal.disabled,
         onSelect: openTerminalTab,
-      })
-    }
-    if (activeMenuActions.ide.visible) {
-      items.push({
-        id: 'ide',
-        testId: 'workspace-add-ide-option',
-        icon: Code2,
-        label: t('workbench.ide', 'IDE'),
-        disabled: activeMenuActions.ide.disabled,
-        onSelect: activeMenuActions.ide.run,
       })
     }
     if (activeMenuActions.desktop.visible) {
@@ -309,7 +295,7 @@ function BottomWorkspaceTabContent({
         currentProject={currentProject}
         devices={devices}
         workspaceTarget={workspaceTarget}
-        defaultOpenTool={tab.defaultOpenTool}
+        defaultOpenTool="terminal"
         onRequestClose={handleRequestClose}
         hideTerminalChrome
         preferLocalTerminal={preferLocalTerminal}

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -419,6 +419,46 @@ describe('WorkspacePanelActions', () => {
     })
   })
 
+  test('reports a missing cloud IDE URL from the titlebar action', async () => {
+    startProjectCodeServerMock.mockResolvedValueOnce({
+      session_id: 'ide-1',
+      project_id: 7,
+      device_id: 'device-1',
+      type: 'code_server',
+      url: '',
+      path: '/workspace/project',
+    })
+    render(
+      <WorkspacePanelActions
+        {...baseProps}
+        currentProject={{
+          id: 7,
+          name: 'project38',
+          config: { execution: { targetType: 'cloud', deviceId: 'device-1' } },
+          tasks: [],
+        }}
+        devices={[
+          {
+            id: 1,
+            device_id: 'device-1',
+            name: 'Cloud Device',
+            status: 'online',
+            is_default: false,
+            device_type: 'cloud',
+            bind_shell: 'claudecode',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('open-code-server-titlebar-button'))
+
+    expect(await screen.findByTestId('code-server-error-dialog')).toHaveTextContent(
+      'IDE session URL is missing'
+    )
+    expect(openExternalUrlMock).not.toHaveBeenCalled()
+  })
+
   test('opens remote runtime workspaces through the device IDE session and exact path', async () => {
     isLocalTerminalAvailableMock.mockReturnValue(true)
     render(
@@ -467,6 +507,53 @@ describe('WorkspacePanelActions', () => {
     )
     expect(startProjectCodeServerMock).not.toHaveBeenCalled()
     expect(openLocalWorkspaceMock).not.toHaveBeenCalled()
+    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/device-ide', {
+      target: 'system',
+    })
+  })
+
+  test('opens routed remote workspaces from the titlebar location action', async () => {
+    render(
+      <WorkspacePanelActions
+        {...baseProps}
+        currentProject={{ id: 7, name: 'project38', config: {}, tasks: [] }}
+        workspaceTarget={{
+          deviceId: 'cloud-device',
+          path: '/home/ubuntu/project38',
+          source: 'runtime',
+          workspaceSource: 'remote',
+        }}
+        devices={[
+          {
+            id: 31,
+            device_id: 'local-device',
+            name: 'Local Executor',
+            status: 'online',
+            is_default: true,
+            device_type: 'local',
+            bind_shell: 'claudecode',
+            runtime_routes: [
+              {
+                kind: 'cloud-relay',
+                device_id: 'cloud-device',
+                runtime_device_id: 'cloud-device',
+                device_type: 'cloud',
+                status: 'online',
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('open-code-server-titlebar-button'))
+
+    await waitFor(() =>
+      expect(startDeviceCodeServerMock).toHaveBeenCalledWith(
+        'cloud-device',
+        '/home/ubuntu/project38'
+      )
+    )
     expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/device-ide', {
       target: 'system',
     })

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/lib/local-workspace-openers'
 import { isLocalTerminalAvailable, openLocalWorkspace } from '@/lib/local-terminal'
 import { configuredWorkspacePath } from '@/lib/project-workspace'
-import { getProjectDeviceId } from '@/lib/workbench-device'
+import { findWorkbenchDevice, getProjectDeviceId } from '@/lib/workbench-device'
 import { EnvironmentInfoPopover } from '../EnvironmentInfoPopover'
 import { DESKTOP_TOP_BAR_BUTTON_CLASS } from '../DesktopTopBar'
 import { TitlebarTooltip } from '@/components/topnav/TitlebarTooltip'
@@ -98,18 +98,20 @@ export const WorkspacePanelActions = memo(function WorkspacePanelActions({
     codeServerProjectDeviceId && (currentProject || workspaceTarget)
   )
   const codeServerDevice = codeServerProjectDeviceId
-    ? devices.find(device => device.device_id === codeServerProjectDeviceId)
+    ? findWorkbenchDevice(devices, codeServerProjectDeviceId)
     : undefined
   const remoteWorkspaceSession = Boolean(
     workspaceTarget?.workspaceSource === 'remote' ||
     (codeServerDevice &&
-      (supportsCloudSessions(codeServerDevice) || supportsRemoteSessions(codeServerDevice)))
+      (supportsCloudSessions(codeServerDevice, codeServerProjectDeviceId) ||
+        supportsRemoteSessions(codeServerDevice, codeServerProjectDeviceId)))
   )
   const useDeviceCodeServerSession = Boolean(remoteWorkspaceSession && workspaceTarget)
   const codeServerEnabled = Boolean(
     workspaceSessionApi &&
     codeServerDevice &&
-    (supportsCloudSessions(codeServerDevice) || supportsRemoteSessions(codeServerDevice))
+    (supportsCloudSessions(codeServerDevice, codeServerProjectDeviceId) ||
+      supportsRemoteSessions(codeServerDevice, codeServerProjectDeviceId))
   )
   const localWorkspacePath =
     workspaceTarget?.path ?? (currentProject ? configuredWorkspacePath(currentProject) : undefined)

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -3,13 +3,11 @@ import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { WorkspaceSessionApi } from '@/features/workbench/workbenchServices'
-import { openExternalUrl } from '@/lib/external-links'
 import {
   closeLocalTerminal,
   getLocalExecutorDeviceId,
   isLocalTerminalAvailable,
   localPathExists,
-  openLocalWorkspace,
   startLocalTerminal,
 } from '@/lib/local-terminal'
 import { WorkspacePanelCards as ActualWorkspacePanelCards } from './WorkspacePanelCards'
@@ -91,12 +89,7 @@ vi.mock('@/lib/local-terminal', () => ({
   getLocalExecutorDeviceId: vi.fn(),
   isLocalTerminalAvailable: vi.fn(),
   localPathExists: vi.fn(),
-  openLocalWorkspace: vi.fn(),
   startLocalTerminal: vi.fn(),
-}))
-
-vi.mock('@/lib/external-links', () => ({
-  openExternalUrl: vi.fn(),
 }))
 
 vi.mock('./EmbeddedLocalTerminal', () => ({
@@ -150,25 +143,20 @@ vi.mock('./RemoteTerminal', () => ({
 }))
 
 const closeLocalTerminalMock = vi.mocked(closeLocalTerminal)
-const openExternalUrlMock = vi.mocked(openExternalUrl)
 const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const localPathExistsMock = vi.mocked(localPathExists)
-const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startLocalTerminalMock = vi.mocked(startLocalTerminal)
 const startProjectTerminalMock = vi.fn()
-const startProjectCodeServerMock = vi.fn()
 const startDeviceTerminalMock = vi.fn()
-const startDeviceCodeServerMock = vi.fn()
 const createRemoteTerminalClientMock = vi.fn()
 const workspaceSessionApi: WorkspaceSessionApi = {
   startProjectTerminal: startProjectTerminalMock,
-  startProjectCodeServer: startProjectCodeServerMock,
+  startProjectCodeServer: vi.fn(),
   startDeviceTerminal: startDeviceTerminalMock,
-  startDeviceCodeServer: startDeviceCodeServerMock,
+  startDeviceCodeServer: vi.fn(),
   createRemoteTerminalClient: createRemoteTerminalClientMock,
 }
-const fetchMock = vi.fn()
 
 function WorkspacePanelCards(props: ComponentProps<typeof ActualWorkspacePanelCards>) {
   return <ActualWorkspacePanelCards workspaceSessionApi={workspaceSessionApi} {...props} />
@@ -254,8 +242,6 @@ function createDeferred<T>() {
 describe('WorkspacePanelCards', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubGlobal('fetch', fetchMock)
-    fetchMock.mockResolvedValue(new Response(null, { status: 204 }))
     vi.spyOn(window, 'open').mockImplementation(() => null)
     window.localStorage.setItem('auth_token', 'token-1')
     cloudDesktopExtensionMock.available = true
@@ -263,8 +249,6 @@ describe('WorkspacePanelCards', () => {
     isLocalTerminalAvailableMock.mockReturnValue(true)
     getLocalExecutorDeviceIdMock.mockResolvedValue('device-1')
     localPathExistsMock.mockResolvedValue(true)
-    openLocalWorkspaceMock.mockResolvedValue(undefined)
-    openExternalUrlMock.mockResolvedValue(true)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
     let terminalSessionCount = 0
@@ -280,14 +264,6 @@ describe('WorkspacePanelCards', () => {
         path: '/workspace/projects/project38',
       }
     })
-    startProjectCodeServerMock.mockResolvedValue({
-      session_id: 'ide-1',
-      project_id: 7,
-      device_id: 'device-1',
-      type: 'code_server',
-      url: 'http://localhost/ide',
-      path: '/workspace/projects/project38',
-    })
     startDeviceTerminalMock.mockResolvedValue({
       session_id: 'device-terminal-1',
       url: '',
@@ -296,20 +272,12 @@ describe('WorkspacePanelCards', () => {
       type: 'terminal',
       path: '/workspace/worktrees/9/project38',
     })
-    startDeviceCodeServerMock.mockResolvedValue({
-      session_id: 'device-ide-1',
-      url: 'http://localhost/device-ide',
-      device_id: 'device-2',
-      type: 'code_server',
-      path: '/workspace/worktrees/9/project38',
-    })
   })
 
-  test('renders terminal, IDE, and desktop project tools', () => {
+  test('renders terminal and desktop project tools', () => {
     render(<WorkspacePanelCards currentProject={cloudProject} devices={cloudDevices} />)
 
     expect(screen.getByTestId('workspace-terminal-card')).toHaveTextContent('终端')
-    expect(screen.getByTestId('workspace-ide-card')).toHaveTextContent('IDE')
     expect(screen.getByTestId('workspace-desktop-card')).toHaveTextContent('桌面')
   })
 
@@ -409,26 +377,6 @@ describe('WorkspacePanelCards', () => {
     expect(screen.getByTestId('workspace-tool-launcher')).toBeInTheDocument()
   })
 
-  test('opens the project IDE in a new page without a preflight probe', async () => {
-    const onRequestClose = vi.fn()
-    render(
-      <WorkspacePanelCards
-        currentProject={cloudProject}
-        devices={cloudDevices}
-        onRequestClose={onRequestClose}
-      />
-    )
-
-    await userEvent.click(screen.getByTestId('workspace-ide-card'))
-
-    await waitFor(() => expect(startProjectCodeServerMock).toHaveBeenCalledWith(7))
-    expect(fetchMock).not.toHaveBeenCalled()
-    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/ide', {
-      target: 'system',
-    })
-    expect(onRequestClose).toHaveBeenCalledTimes(1)
-  })
-
   test('opens the project desktop through the cloud extension', async () => {
     const onRequestClose = vi.fn()
     render(
@@ -461,20 +409,11 @@ describe('WorkspacePanelCards', () => {
     const actions = onMenuActionsChange.mock.lastCall?.[0]
     expect(actions).toMatchObject({
       terminal: { visible: true, disabled: false },
-      ide: { visible: true, disabled: false },
       desktop: { visible: true, disabled: false },
     })
 
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
     await waitFor(() => expect(screen.getByTestId('remote-terminal')).toBeInTheDocument())
-
-    await act(async () => actions.ide.run())
-
-    expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
-    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/ide', {
-      target: 'system',
-    })
-    expect(onRequestClose).not.toHaveBeenCalled()
 
     await act(async () => actions.desktop.run())
 
@@ -483,35 +422,11 @@ describe('WorkspacePanelCards', () => {
     expect(onRequestClose).not.toHaveBeenCalled()
   })
 
-  test('shows menu action errors without replacing the active terminal', async () => {
-    startProjectCodeServerMock.mockRejectedValueOnce(new Error('IDE unavailable'))
-    const onMenuActionsChange = vi.fn()
-    render(
-      <WorkspacePanelCards
-        currentProject={cloudProject}
-        devices={cloudDevices}
-        onMenuActionsChange={onMenuActionsChange}
-      />
-    )
-
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
-    await waitFor(() => expect(screen.getByTestId('remote-terminal')).toBeInTheDocument())
-    const actions = onMenuActionsChange.mock.lastCall?.[0]
-
-    await act(async () => actions.ide.run())
-
-    await waitFor(() =>
-      expect(screen.getByTestId('workspace-tool-error')).toHaveTextContent('启动失败')
-    )
-    expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
-  })
-
   test('hides the desktop card when the cloud desktop extension is unavailable', () => {
     cloudDesktopExtensionMock.available = false
 
     render(<WorkspacePanelCards currentProject={cloudProject} devices={cloudDevices} />)
 
-    expect(screen.getByTestId('workspace-ide-card')).toBeInTheDocument()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
   })
 
@@ -545,44 +460,6 @@ describe('WorkspacePanelCards', () => {
     expect(window.open).not.toHaveBeenCalled()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
-  })
-
-  test('opens local project IDEs from the default VS Code card action', async () => {
-    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
-
-    await userEvent.click(await screen.findByTestId('workspace-ide-primary-button'))
-
-    await waitFor(() =>
-      expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
-        opener: 'vscode',
-        path: '/workspace/projects/project38',
-      })
-    )
-    expect(startProjectCodeServerMock).not.toHaveBeenCalled()
-    expect(window.open).not.toHaveBeenCalled()
-  })
-
-  test('opens local project IDEs from the picker menu', async () => {
-    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
-
-    await userEvent.click(await screen.findByTestId('workspace-ide-picker-button'))
-
-    expect(screen.getByTestId('workspace-ide-picker-menu')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-ide-option-android-studio')).toHaveTextContent(
-      'Android Studio'
-    )
-    expect(screen.getByTestId('workspace-ide-option-intellij-idea')).toHaveTextContent(
-      'IntelliJ IDEA'
-    )
-
-    await userEvent.click(screen.getByTestId('workspace-ide-option-cursor'))
-
-    await waitFor(() =>
-      expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
-        opener: 'cursor',
-        path: '/workspace/projects/project38',
-      })
-    )
   })
 
   test('launches the native terminal for local projects without requiring a device list match', async () => {
@@ -865,48 +742,6 @@ describe('WorkspacePanelCards', () => {
     expect(startProjectTerminalMock).not.toHaveBeenCalled()
   })
 
-  test('starts remote IDE on the active runtime workspace device and path', async () => {
-    isLocalTerminalAvailableMock.mockReturnValue(false)
-
-    render(
-      <WorkspacePanelCards
-        currentProject={project}
-        devices={[
-          ...localDevices,
-          {
-            id: 22,
-            device_id: 'device-2',
-            name: 'Remote Device',
-            status: 'online',
-            is_default: false,
-            device_type: 'remote',
-            bind_shell: 'claudecode',
-          },
-        ]}
-        workspaceTarget={{
-          deviceId: 'device-2',
-          path: '/workspace/worktrees/9/project38',
-          source: 'runtime',
-          workspaceSource: 'remote',
-        }}
-      />
-    )
-
-    await userEvent.click(await screen.findByTestId('workspace-ide-card'))
-
-    await waitFor(() =>
-      expect(startDeviceCodeServerMock).toHaveBeenCalledWith(
-        'device-2',
-        '/workspace/worktrees/9/project38'
-      )
-    )
-    expect(startProjectCodeServerMock).not.toHaveBeenCalled()
-    expect(openLocalWorkspaceMock).not.toHaveBeenCalled()
-    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/device-ide', {
-      target: 'system',
-    })
-  })
-
   test('launches the native terminal when the executor id differs but the local path exists', async () => {
     getLocalExecutorDeviceIdMock.mockResolvedValue('another-device')
 
@@ -946,7 +781,6 @@ describe('WorkspacePanelCards', () => {
     render(<WorkspacePanelCards currentProject={cloudProject} devices={openClawCloudDevices} />)
 
     expect(screen.queryByTestId('workspace-terminal-card')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
     expect(screen.getByTestId('workspace-local-device-limited-tools')).toBeInTheDocument()
   })
@@ -955,7 +789,6 @@ describe('WorkspacePanelCards', () => {
     render(<WorkspacePanelCards currentProject={project} devices={[]} />)
 
     expect(screen.getByTestId('workspace-terminal-card')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-ide-card')).toBeInTheDocument()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
   })
@@ -972,41 +805,7 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     expect(startProjectTerminalMock).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('workspace-ide-card')).not.toBeDisabled()
     expect(screen.getByTestId('workspace-desktop-card')).not.toBeDisabled()
-  })
-
-  test('opens IDE even when browser preflight probing would be blocked', async () => {
-    fetchMock.mockRejectedValueOnce(new TypeError('Mixed content blocked'))
-    render(<WorkspacePanelCards currentProject={cloudProject} devices={cloudDevices} />)
-
-    await userEvent.click(screen.getByTestId('workspace-ide-card'))
-
-    await waitFor(() => expect(startProjectCodeServerMock).toHaveBeenCalledWith(7))
-    expect(fetchMock).not.toHaveBeenCalled()
-    expect(startProjectCodeServerMock).toHaveBeenCalledTimes(1)
-    expect(openExternalUrlMock).toHaveBeenCalledWith('http://localhost/ide', {
-      target: 'system',
-    })
-  })
-
-  test('marks IDE as unavailable when the returned session URL is missing', async () => {
-    startProjectCodeServerMock.mockResolvedValueOnce({
-      session_id: 'ide-1',
-      project_id: 7,
-      device_id: 'device-1',
-      type: 'code_server',
-      path: '/workspace/projects/project38',
-      url: '',
-    })
-    render(<WorkspacePanelCards currentProject={cloudProject} devices={cloudDevices} />)
-
-    await userEvent.click(screen.getByTestId('workspace-ide-card'))
-
-    await waitFor(() => expect(screen.getByTestId('workspace-ide-card')).toBeDisabled())
-    expect(window.open).not.toHaveBeenCalled()
-    expect(startProjectCodeServerMock).toHaveBeenCalledTimes(1)
-    expect(screen.getByRole('alert')).toHaveTextContent('启动失败')
   })
 
   test('resets unavailable tools when the project changes', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -6,29 +6,20 @@ import type { CloudDesktopLaunchAction } from '@/extensions/cloud-desktop-contra
 import type { WorkspaceSessionApi } from '@/features/workbench/workbenchServices'
 import { useTranslation } from '@/hooks/useTranslation'
 import {
-  DEFAULT_LOCAL_WORKSPACE_OPENER_ID,
-  type LocalWorkspaceOpenerId,
-} from '@/lib/local-workspace-openers'
-import {
   supportsCloudSessions,
   supportsLocalTerminalLaunch,
-  supportsRemoteSessions,
   supportsRemoteTerminalSessions,
 } from '@/lib/device-capabilities'
-import { openExternalUrl } from '@/lib/external-links'
 import {
   closeLocalTerminal,
   getLocalExecutorDeviceId,
   isLocalTerminalAvailable,
   localPathExists,
-  openLocalWorkspace,
   startLocalTerminal,
 } from '@/lib/local-terminal'
 import { findWorkbenchDevice } from '@/lib/workbench-device'
-import type { DeviceInfo, ProjectDeviceSessionResponse, ProjectWithTasks } from '@/types/api'
-import type { DeviceSessionResponse } from '@/types/devices'
+import type { DeviceInfo, ProjectWithTasks } from '@/types/api'
 import type { WorkspaceTarget } from '@/types/workspace-files'
-import { LocalWorkspaceOpenerIcon, LocalWorkspaceOpenerPicker } from './LocalWorkspaceOpenerMenu'
 import type { WorkspaceAddMenuItem } from './WorkspaceAddMenu'
 import { WorkspaceTerminalWindow } from './WorkspaceTerminalWindow'
 import {
@@ -89,7 +80,6 @@ interface LocalTerminalCheckState {
 function createAvailableTools(): WorkspaceToolAvailability {
   return {
     terminal: true,
-    ide: true,
   }
 }
 
@@ -146,14 +136,8 @@ export function WorkspacePanelCards({
   const remoteTerminalAvailable = Boolean(
     projectDevice && supportsRemoteTerminalSessions(projectDevice, activeWorkspaceDeviceId)
   )
-  const remoteIdeAvailable = Boolean(
-    projectDevice &&
-    (supportsCloudSessions(projectDevice, activeWorkspaceDeviceId) ||
-      supportsRemoteSessions(projectDevice, activeWorkspaceDeviceId) ||
-      remoteTerminalAvailable)
-  )
   const remoteWorkspaceSession = Boolean(
-    workspaceTarget?.workspaceSource === 'remote' || remoteIdeAvailable
+    workspaceTarget?.workspaceSource === 'remote' || cloudToolsAvailable || remoteTerminalAvailable
   )
   const localProjectConfigTerminal =
     workspaceSource !== 'runtime' && (preferLocalTerminal || usesLocalProjectConfig(currentProject))
@@ -204,25 +188,16 @@ export function WorkspacePanelCards({
   )
   const localTerminalLaunchable = Boolean(localTerminalSupported && localTerminalRuntimeAvailable)
   const useDeviceTerminalSession = Boolean(remoteWorkspaceSession && workspaceTarget)
-  const useDeviceCodeServerSession = Boolean(remoteWorkspaceSession && workspaceTarget)
-  const localIdeLaunchable = Boolean(
-    !remoteWorkspaceSession &&
-    localTerminalLaunchable &&
-    activeWorkspacePath?.trim() &&
-    localTerminalSupported
-  )
   const projectTerminalAvailable =
     localTerminalLaunchable ||
     (!localTerminalSupported &&
       (Boolean(currentProject) || Boolean(workspaceSource === 'runtime' && activeWorkspacePath)) &&
       remoteTerminalAvailable)
-  const projectIdeAvailable = remoteIdeAvailable || localIdeLaunchable
   const hasLimitedProjectTools = Boolean(
     hasWorkspaceContext &&
     !cloudToolsAvailable &&
     !localTerminalCheckPending &&
-    !projectTerminalAvailable &&
-    !projectIdeAvailable
+    !projectTerminalAvailable
   )
   const projectKey = hasWorkspaceContext
     ? [
@@ -579,83 +554,6 @@ export function WorkspacePanelCards({
     }
   }
 
-  const handleIdeClick = useCallback(
-    async (
-      opener: LocalWorkspaceOpenerId = DEFAULT_LOCAL_WORKSPACE_OPENER_ID,
-      closePanelOnSuccess = true
-    ) => {
-      if (loadingTool || !availableTools.ide) return
-      setLoadingToolState({ tool: 'ide', projectKey })
-      setProjectError(null)
-      let opened = false
-      try {
-        if (localIdeLaunchable) {
-          if (!activeWorkspacePath) {
-            throw new Error('Local workspace path is missing')
-          }
-          await openLocalWorkspace({
-            opener,
-            path: activeWorkspacePath,
-          })
-          opened = true
-          return
-        }
-
-        if (!workspaceSessionApi) {
-          throw new Error('Remote workspace session service is unavailable')
-        }
-        let session: ProjectDeviceSessionResponse | DeviceSessionResponse | null
-        if (useDeviceCodeServerSession) {
-          if (!activeWorkspaceDeviceId || !activeWorkspacePath) {
-            throw new Error('Remote workspace target is missing')
-          }
-          session = await workspaceSessionApi.startDeviceCodeServer(
-            activeWorkspaceDeviceId,
-            activeWorkspacePath
-          )
-        } else {
-          session = currentProject
-            ? await workspaceSessionApi.startProjectCodeServer(currentProject.id)
-            : null
-        }
-        if (!session) {
-          throw new Error('IDE session target is missing')
-        }
-        if (!session.url) {
-          throw new Error('IDE session URL is missing')
-        }
-        await openExternalUrl(session.url, { target: 'system' })
-        opened = true
-      } catch (e) {
-        console.error('Failed to start project IDE:', e)
-        markToolUnavailable('ide')
-        setProjectError(getSessionStartErrorMessage())
-      } finally {
-        setLoadingToolState(current =>
-          current?.tool === 'ide' && current.projectKey === projectKey ? null : current
-        )
-        if (opened && closePanelOnSuccess) {
-          onRequestClose?.()
-        }
-      }
-    },
-    [
-      activeWorkspaceDeviceId,
-      activeWorkspacePath,
-      availableTools.ide,
-      currentProject,
-      getSessionStartErrorMessage,
-      loadingTool,
-      localIdeLaunchable,
-      markToolUnavailable,
-      onRequestClose,
-      projectKey,
-      setProjectError,
-      useDeviceCodeServerSession,
-      workspaceSessionApi,
-    ]
-  )
-
   const handleDesktopBusyChange = useCallback(
     (busy: boolean) => {
       setLoadingToolState(current => {
@@ -681,11 +579,6 @@ export function WorkspacePanelCards({
         disabled: toolsDisabled || !availableTools.terminal,
         run: startTerminalSession,
       },
-      ide: {
-        visible: projectIdeAvailable,
-        disabled: toolsDisabled || !availableTools.ide,
-        run: () => handleIdeClick(DEFAULT_LOCAL_WORKSPACE_OPENER_ID, false),
-      },
       desktop: {
         visible: Boolean(
           cloudToolsAvailable && cloudDesktopExtension.available && activeWorkspaceDeviceId
@@ -698,12 +591,9 @@ export function WorkspacePanelCards({
     }),
     [
       activeWorkspaceDeviceId,
-      availableTools.ide,
       availableTools.terminal,
       cloudToolsAvailable,
-      handleIdeClick,
       projectDevice?.status,
-      projectIdeAvailable,
       projectTerminalAvailable,
       startTerminalSession,
       toolsDisabled,
@@ -855,91 +745,20 @@ export function WorkspacePanelCards({
                       : t('workbench.project_tool_unavailable', '暂不可用')}
                   </span>
                 </button>
-                {projectIdeAvailable && (
-                  <>
-                    {localIdeLaunchable ? (
-                      <div
-                        data-testid={testId('workspace-ide-card')}
-                        className="relative min-h-[132px] rounded-lg bg-surface text-center hover:bg-muted"
-                      >
-                        <button
-                          type="button"
-                          data-testid={testId('workspace-ide-primary-button')}
-                          onClick={() => void handleIdeClick()}
-                          disabled={toolsDisabled || !availableTools.ide}
-                          className="flex h-full min-h-[132px] w-full flex-col items-center justify-center rounded-lg px-4 text-center disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                          {loadingTool === 'ide' ? (
-                            <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                          ) : (
-                            <LocalWorkspaceOpenerIcon
-                              opener="vscode"
-                              className="mb-5 h-7 w-7 rounded-lg"
-                            />
-                          )}
-                          <span className="text-sm font-semibold text-text-primary">
-                            {t('workbench.ide', 'IDE')}
-                          </span>
-                          <span className="mt-2 text-sm leading-[18px] text-text-secondary">
-                            {availableTools.ide
-                              ? t('workbench.open_project_ide_with', {
-                                  opener: 'VS Code',
-                                })
-                              : t('workbench.project_tool_unavailable', '暂不可用')}
-                          </span>
-                        </button>
-                        <LocalWorkspaceOpenerPicker
-                          ariaLabel={t('workbench.choose_project_ide')}
-                          buttonTestId={testId('workspace-ide-picker-button')}
-                          menuTestId={testId('workspace-ide-picker-menu')}
-                          optionTestIdPrefix={testId('workspace-ide-option')}
-                          disabled={toolsDisabled || !availableTools.ide}
-                          buttonClassName="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-muted hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                          onSelect={handleIdeClick}
-                        />
-                      </div>
-                    ) : (
-                      <button
-                        type="button"
-                        data-testid={testId('workspace-ide-card')}
-                        onClick={() => void handleIdeClick()}
-                        disabled={toolsDisabled || !currentProject || !availableTools.ide}
-                        className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {loadingTool === 'ide' ? (
-                          <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                        ) : (
-                          <LocalWorkspaceOpenerIcon
-                            opener="vscode"
-                            className="mb-5 h-7 w-7 rounded-lg"
-                          />
-                        )}
-                        <span className="text-sm font-semibold text-text-primary">
-                          {t('workbench.ide', 'IDE')}
-                        </span>
-                        <span className="mt-2 text-sm leading-[18px] text-text-secondary">
-                          {availableTools.ide
-                            ? t('workbench.open_project_ide', '打开项目 IDE')
-                            : t('workbench.project_tool_unavailable', '暂不可用')}
-                        </span>
-                      </button>
-                    )}
-                    {cloudToolsAvailable &&
-                      cloudDesktopExtension.available &&
-                      activeWorkspaceDeviceId && (
-                        <cloudDesktopExtension.WorkspaceAction
-                          contextKey={projectKey}
-                          deviceId={activeWorkspaceDeviceId}
-                          disabled={toolsDisabled || projectDevice?.status !== 'online'}
-                          onBusyChange={handleDesktopBusyChange}
-                          onErrorChange={setProjectError}
-                          onLaunchActionChange={handleDesktopLaunchActionChange}
-                          onOpened={handleDesktopOpened}
-                          testIdsEnabled={testIdsEnabled}
-                        />
-                      )}
-                  </>
-                )}
+                {cloudToolsAvailable &&
+                  cloudDesktopExtension.available &&
+                  activeWorkspaceDeviceId && (
+                    <cloudDesktopExtension.WorkspaceAction
+                      contextKey={projectKey}
+                      deviceId={activeWorkspaceDeviceId}
+                      disabled={toolsDisabled || projectDevice?.status !== 'online'}
+                      onBusyChange={handleDesktopBusyChange}
+                      onErrorChange={setProjectError}
+                      onLaunchActionChange={handleDesktopLaunchActionChange}
+                      onOpened={handleDesktopOpened}
+                      testIdsEnabled={testIdsEnabled}
+                    />
+                  )}
               </div>
             )}
           </div>

--- a/wework/src/components/layout/workspace-panels/workspace-panel-tools.ts
+++ b/wework/src/components/layout/workspace-panels/workspace-panel-tools.ts
@@ -2,7 +2,7 @@ import { configuredWorkspacePath } from '@/lib/project-workspace'
 import type { RemoteTerminalClientFactory } from '@/lib/remote-terminal-socket'
 import type { ProjectDeviceSessionResponse, ProjectWithTasks } from '@/types/api'
 
-export type WorkspaceTool = 'terminal' | 'ide'
+export type WorkspaceTool = 'terminal'
 
 export type WorkspacePanelMenuTool = WorkspaceTool | 'desktop'
 


### PR DESCRIPTION
## Summary

- open the bottom workspace panel directly in Terminal and restore existing Terminal sessions
- remove IDE cards and IDE actions from the bottom panel, keeping IDE launch behavior in the titlebar Open location control
- support routed cloud and remote workspace targets from Open location by resolving runtime route aliases
- update unit and real-Tauri E2E coverage, and document the entry-point contract

## Root cause

The first bottom-panel tab did not request Terminal by default, so it rendered a generic tool launcher containing both Terminal and IDE. IDE startup logic was duplicated between that launcher and the titlebar action, and the titlebar copy did not resolve runtime route aliases.

## User impact

Opening the bottom panel now immediately starts or restores Terminal. IDEs and native editors are opened only from the top-right Open location control, including routed remote workspaces.

## Validation

- `pnpm --filter wework test` — 200 files, 1997 tests passed
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `pnpm --filter wework e2e:desktop:cloud` — real Tauri cloud-project flow passed
- pre-push ESLint, TypeScript, and unit-test checks passed
- reviewed the complete 9-screenshot Tauri verification chain at 2560×1440


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Opening the bottom workspace panel now starts/restores the Terminal directly, without showing the workspace launcher/cards.
  - IDEs and native editors are launched only from the titlebar **Open location** control, including local-editor and remote code-server behaviors.
  - Remote code-server sessions now use the correct routed device.
  - Added a clearer IDE error dialog when an IDE session URL is missing.

- **Bug Fixes**
  - Prevented IDE options from appearing in bottom workspace panel “add” menus and tab flows.
  - Improved reliability of concurrent task sidebar verification and terminal flow validation in end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->