### PR TITLE
fix(wework): preserve local message order

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -86,6 +86,12 @@ The Wework chat UI must not keep complete long-running output in React state. `W
 - `MessageList` and `ToolBlocksDisplay` may only render the current preview and truncation notice; hiding complete content with CSS does not count as releasing memory.
 - Right-side temporary chats must reuse the same reducer and stream-action batching path instead of accumulating full output for temporary threads.
 
+## Transcript Merge Order
+
+When a runtime transcript page is loaded or refreshed, the server-provided `messageIndex` defines the primary order of persisted messages. The current pane may also contain local user or streaming assistant messages that do not have a `messageIndex` yet. Merge logic must anchor those messages between their nearest persisted neighbors in the existing list and preserve their relative position. It must not move every unindexed message to the end of the transcript, because that makes an earlier user message fall to the bottom after a refresh or historical-page load.
+
+When loading an older page or filling a middle gap, indexed messages remain ordered by the server index, while local messages sharing an anchor keep their stable pane order. Deduplication uses only stable message ids and must not infer identity from content, role, or subtask.
+
 ## Guidance Message Order
 
 Running Codex LocalTasks can send a queued message as native guidance. Guidance is user input inside the current turn, not a new follow-up turn, so the UI must insert the local user message inside the active assistant as soon as guidance sending starts:

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -84,6 +84,12 @@ Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React st
 - `MessageList` 和 `ToolBlocksDisplay` 只能渲染当前预览内容和截断提示；仅用 CSS 折叠隐藏完整内容不算释放内存。
 - 右侧临时聊天必须复用同一套 reducer 与 stream action 批处理，不能为临时线程单独累积完整输出。
 
+## Transcript 合并顺序
+
+分页加载或刷新 runtime transcript 时，服务端返回的 `messageIndex` 是已持久化消息的主顺序。当前 pane 中还可能存在尚未带 `messageIndex` 的本地 user 或 streaming assistant 消息；合并逻辑必须用这些消息在现有列表中的前后已持久化消息作为锚点，保留其相对位置。不能把所有无序号消息统一排到 transcript 末尾，否则先前发送的用户消息会在刷新或加载历史页后沉到对话底部。
+
+加载较早页面或补中间 gap 时，带 `messageIndex` 的消息仍按服务端序号排序；同一锚点之间的本地消息保持 pane 中已有的稳定顺序。消息去重只使用稳定 message id，不根据内容、角色或 subtask 猜测身份。
+
 ## 引导消息顺序
 
 运行中的 Codex LocalTask 支持把队列消息作为原生引导发送。引导是当前 turn 内的用户输入，不是新的 follow-up turn，所以 UI 必须在发送开始时就把本地用户消息插入到当前 assistant 中间：

--- a/wework/src/components/layout/runtimeTranscriptMessages.test.ts
+++ b/wework/src/components/layout/runtimeTranscriptMessages.test.ts
@@ -34,4 +34,60 @@ describe('mergeRuntimeTranscriptMessages', () => {
 
     expect(merged.map(item => item.id)).toEqual(['server', 'live'])
   })
+
+  test('keeps a local user message between its persisted transcript neighbors', () => {
+    const merged = mergeRuntimeTranscriptMessages(
+      [
+        message({ id: 'older', runtimeMessageIndex: 0 }),
+        message({ id: 'newer-assistant', runtimeMessageIndex: 3 }),
+      ],
+      [
+        message({ id: 'user', role: 'user', runtimeMessageIndex: 1 }),
+        message({ id: 'local-user', role: 'user', runtimeMessageIndex: undefined }),
+        message({ id: 'newer-assistant', runtimeMessageIndex: 3 }),
+      ]
+    )
+
+    expect(merged.map(item => item.id)).toEqual(['older', 'user', 'local-user', 'newer-assistant'])
+  })
+
+  test('appends messages after the last transcript anchor in their existing order', () => {
+    const merged = mergeRuntimeTranscriptMessages(
+      [message({ id: 'persisted', runtimeMessageIndex: 0 })],
+      [
+        message({ id: 'persisted', runtimeMessageIndex: 0 }),
+        message({ id: 'local-user', role: 'user', runtimeMessageIndex: undefined }),
+        message({ id: 'streaming-assistant', runtimeMessageIndex: undefined }),
+      ]
+    )
+
+    expect(merged.map(item => item.id)).toEqual(['persisted', 'local-user', 'streaming-assistant'])
+  })
+
+  test('sorts a transcript page loaded into a gap between existing pages', () => {
+    const merged = mergeRuntimeTranscriptMessages(
+      [
+        message({ id: 'middle-1', runtimeMessageIndex: 2 }),
+        message({ id: 'middle-2', runtimeMessageIndex: 3 }),
+      ],
+      [
+        message({ id: 'older', runtimeMessageIndex: 0 }),
+        message({ id: 'newer', runtimeMessageIndex: 5 }),
+      ]
+    )
+
+    expect(merged.map(item => item.id)).toEqual(['older', 'middle-1', 'middle-2', 'newer'])
+  })
+
+  test('preserves existing order when no messages have persisted indexes', () => {
+    const merged = mergeRuntimeTranscriptMessages(
+      [],
+      [
+        message({ id: 'user', role: 'user', runtimeMessageIndex: undefined }),
+        message({ id: 'assistant', runtimeMessageIndex: undefined }),
+      ]
+    )
+
+    expect(merged.map(item => item.id)).toEqual(['user', 'assistant'])
+  })
 })

--- a/wework/src/components/layout/runtimeTranscriptMessages.ts
+++ b/wework/src/components/layout/runtimeTranscriptMessages.ts
@@ -13,21 +13,62 @@ export function mergeRuntimeTranscriptMessages(
     merged.push(message)
   }
 
-  if (!merged.some(message => getRuntimeMessageIndex(message) !== null)) return merged
-
+  const sortKeys = runtimeMessageSortKeys(merged, existingMessages)
   return merged
-    .map((message, order) => ({ message, order }))
+    .map((message, order) => ({ message, order, key: sortKeys.get(message.id) }))
     .sort((left, right) => {
-      const leftIndex = getRuntimeMessageIndex(left.message)
-      const rightIndex = getRuntimeMessageIndex(right.message)
-      if (leftIndex !== null && rightIndex !== null && leftIndex !== rightIndex) {
-        return leftIndex - rightIndex
-      }
-      if (leftIndex !== null && rightIndex === null) return -1
-      if (leftIndex === null && rightIndex !== null) return 1
-      return left.order - right.order
+      if (!left.key || !right.key) return left.order - right.order
+      if (left.key.anchor !== right.key.anchor) return left.key.anchor - right.key.anchor
+      if (left.key.position !== right.key.position) return left.key.position - right.key.position
+      return left.key.order - right.key.order
     })
     .map(item => item.message)
+}
+
+interface RuntimeMessageSortKey {
+  anchor: number
+  position: -1 | 0 | 1
+  order: number
+}
+
+function runtimeMessageSortKeys(
+  mergedMessages: WorkbenchMessage[],
+  existingMessages: WorkbenchMessage[]
+): Map<string, RuntimeMessageSortKey> {
+  const keys = new Map<string, RuntimeMessageSortKey>()
+  for (const [order, message] of mergedMessages.entries()) {
+    const index = getRuntimeMessageIndex(message)
+    if (index !== null) keys.set(message.id, { anchor: index, position: 0, order })
+  }
+
+  for (const [order, message] of existingMessages.entries()) {
+    if (keys.has(message.id)) continue
+    const nextIndex = firstRuntimeMessageIndex(existingMessages.slice(order + 1))
+    if (nextIndex !== null) {
+      keys.set(message.id, { anchor: nextIndex, position: -1, order })
+      continue
+    }
+    const previousIndex = firstRuntimeMessageIndex(existingMessages.slice(0, order).reverse())
+    if (previousIndex !== null) {
+      keys.set(message.id, { anchor: previousIndex, position: 1, order })
+    }
+  }
+
+  for (const [order, message] of mergedMessages.entries()) {
+    if (!keys.has(message.id)) {
+      keys.set(message.id, { anchor: Number.POSITIVE_INFINITY, position: 0, order })
+    }
+  }
+
+  return keys
+}
+
+function firstRuntimeMessageIndex(messages: WorkbenchMessage[]): number | null {
+  for (const message of messages) {
+    const index = getRuntimeMessageIndex(message)
+    if (index !== null) return index
+  }
+  return null
 }
 
 export function getRuntimeMessageIndex(message: WorkbenchMessage): number | null {


### PR DESCRIPTION
## What changed

- preserve local user and streaming assistant messages between their persisted transcript neighbors
- keep server-indexed messages ordered when loading older pages or filling transcript gaps
- add regression coverage for anchored local messages, trailing live messages, middle-page loads, and fully local conversations
- document the transcript merge-order invariant in Chinese and English

## Why

The transcript merge previously sorted every message without a server `messageIndex` after all indexed messages. A locally inserted user message could therefore move to the bottom after a transcript refresh or historical-page load, even though it belonged to an earlier turn.

## Impact

Switching away from a Wework conversation and reopening it now preserves the visible turn order. Historical pagination continues to follow server message indexes, while unpersisted local messages keep their stable relative positions.

## Validation

- `pnpm --filter wework test` — 200 test files, 2006 tests passed
- `pnpm --filter wework exec eslint src/components/layout/runtimeTranscriptMessages.ts src/components/layout/runtimeTranscriptMessages.test.ts`
- `pnpm --filter wework exec tsc --noEmit`
- Prettier and `git diff --check`
- isolated real-Tauri flow: created a project, completed two turns, left the conversation, reopened it, and verified `first user → first assistant → second user → second assistant`
- reviewed the nine-step screenshot chain under `wework/test-results/verification-message-order/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved transcript ordering when combining persisted messages with local user and streaming assistant messages.
  * Preserved local message positions during refreshes, pagination, and historical transcript loading.
  * Maintained stable relative ordering for messages without persisted indexes.

* **Documentation**
  * Added English and Chinese guidance describing transcript merge order and stable-ID deduplication.

* **Tests**
  * Added coverage for anchored messages, pagination gaps, appended messages, and transcripts without persisted indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->