### PR TITLE
fix(wework): persist composer drafts across sessions

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -113,7 +113,7 @@ The right workspace **Temporary chat** feature starts a short side conversation 
 
 Maintenance rule: do not add UI fallbacks that insert temporary chats into the left task list, and do not fabricate rollout records for temporary threads in the executor. The primary path is `ephemeral + sideSource + direct_thread_id`.
 
-After changing this path, run `pnpm --dir wework e2e:desktop:side-chat-attachment`. The scenario creates a real main thread, asserts an approximately `420px` side panel, uploads and sends an attachment from the side chat, and verifies that the main composer never inherits that attachment. It writes screenshots for each critical stage to `wework/test-results/desktop-e2e/<run-id>/`.
+After changing this path, run `pnpm --dir wework e2e:desktop`. The main desktop scenario asserts an approximately `420px` side panel, uploads and sends an attachment from the side chat, and verifies that the main composer never inherits that attachment. It writes screenshots for each critical stage to `wework/test-results/desktop-e2e/<run-id>/`.
 
 ## Top-Level Page Transitions
 

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -38,16 +38,10 @@ Run only the plugin marketplace, install, chat-use, and uninstall flow:
 pnpm --filter wework e2e:desktop:plugins
 ```
 
-Run the desktop streaming-memory regression on macOS:
+Run the desktop memory regression on macOS, including streaming growth and the whole-process check with 10 concurrent tasks:
 
 ```bash
 pnpm --filter wework e2e:desktop:memory
-```
-
-Run the whole-process memory regression with 10 concurrently executing tasks:
-
-```bash
-pnpm --filter wework e2e:desktop:concurrent-memory
 ```
 
 The command starts a test-only Vite server through `wework/playwright.config.ts`:

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -111,7 +111,7 @@ Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React st
 
 维护规则：不要用 fallback 在 UI 里把临时聊天补进左侧任务列表，也不要在 executor 中为临时线程伪造 rollout。临时聊天的主路径是 `ephemeral + sideSource + direct_thread_id`。
 
-修改该链路后运行 `pnpm --dir wework e2e:desktop:side-chat-attachment`。该场景会建立真实主线程，断言右栏约为 `420px`，在右栏上传并发送附件，并确认主 composer 始终没有继承右栏附件；关键阶段截图写入 `wework/test-results/desktop-e2e/<run-id>/`。
+修改该链路后运行 `pnpm --dir wework e2e:desktop`。主桌面场景会断言右栏约为 `420px`，在右栏上传并发送附件，并确认主 composer 始终没有继承右栏附件；关键阶段截图写入 `wework/test-results/desktop-e2e/<run-id>/`。
 
 ## 顶层页面切换
 

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -38,16 +38,10 @@ pnpm --filter wework e2e:desktop:cloud
 pnpm --filter wework e2e:desktop:plugins
 ```
 
-在 macOS 上运行桌面流式输出内存回归：
+在 macOS 上运行桌面内存回归，包括流式输出增长和 10 个并发任务的整机内存检查：
 
 ```bash
 pnpm --filter wework e2e:desktop:memory
-```
-
-运行 10 个任务同时执行的整机内存回归：
-
-```bash
-pnpm --filter wework e2e:desktop:concurrent-memory
 ```
 
 该命令会通过 `wework/playwright.config.ts` 启动测试专用 Vite 服务：

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -116,16 +116,11 @@ const ACTIVE_COMPOSER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="cha
 const ACTIVE_SEND_BUTTON_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="send-message-button"]`
 const MACOS_LAUNCH_SERVICES_REGISTER =
   '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister'
-const LIFECYCLE_ONLY = process.argv.includes('--lifecycle-only')
 const REQUEST_INPUT_ONLY = process.env.WEWORK_DESKTOP_E2E_REQUEST_INPUT_ONLY === '1'
-const RECONNECT_ONLY = process.argv.includes('--reconnect-only')
 const VIEW_IMAGE_ONLY = process.argv.includes('--view-image-only')
-const ATTACHMENT_ONLY_SIDEBAR = process.argv.includes('--attachment-only-sidebar')
-const SIDE_CHAT_ATTACHMENT_ONLY = process.argv.includes('--side-chat-attachment-only')
 const CLOUD_ONLY = process.argv.includes('--cloud-only')
 const PLUGINS_ONLY = process.argv.includes('--plugins-only')
 const MEMORY_ONLY = process.argv.includes('--memory-only')
-const CONCURRENT_MEMORY_ONLY = process.argv.includes('--concurrent-memory-only')
 const DESKTOP_SCENARIO_ONLY = process.env.WEWORK_E2E_DESKTOP_SCENARIO_ONLY === 'true'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -626,6 +621,25 @@ async function waitForControlValue(control, selector, expected, message) {
   throw new Error(message)
 }
 
+async function waitForControlSelectionOffset(control, selector, expected, message) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < UI_TIMEOUT_MS) {
+    if (Number(await control.command('getSelectionOffset', selector)) === expected) return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(message)
+}
+
+async function waitForPersistedComposerInput(control, expected, message) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < UI_TIMEOUT_MS) {
+    const snapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    if (snapshot.workbench?.composer?.currentInputLength === expected.length) return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(message)
+}
+
 async function captureVerificationScreenshot(control, name, selector = 'body') {
   if (
     process.env.WEWORK_E2E_SCREENSHOTS === 'final' &&
@@ -904,7 +918,7 @@ async function verifyBackgroundTaskWindowLifecycle({
   executorLogPath,
   setPhase,
 }) {
-  const lifecycleScreenshotName = name => (LIFECYCLE_ONLY ? name : `window-lifecycle-${name}`)
+  const lifecycleScreenshotName = name => `window-lifecycle-${name}`
   setPhase('background-streaming-task')
   control.setScenario('window_lifecycle')
   await control.command('click', '[data-testid="new-chat-button"]')
@@ -1174,6 +1188,11 @@ async function attachAndSendOnlyFile(control, composerSelector) {
 
 async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSelector, control }) {
   control.setScenario('attachment_only')
+  const rowsBeforeAttachmentOnly = new Set(
+    JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
+      testId.startsWith('runtime-local-task-row-')
+    )
+  )
 
   await attachAndSendOnlyFile(control, composerSelector)
   await captureVerificationScreenshot(control, '01-attachment-only-first-submitted.png')
@@ -1185,14 +1204,16 @@ async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSel
   const firstSnapshot = await waitForSnapshot(
     control,
     snapshot =>
-      snapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-')).length >= 1,
+      snapshot.testIds.some(
+        testId =>
+          testId.startsWith('runtime-local-task-row-') && !rowsBeforeAttachmentOnly.has(testId)
+      ),
     'The first attachment-only task did not appear in the sidebar'
   )
-  const firstRows = firstSnapshot.testIds.filter(testId =>
-    testId.startsWith('runtime-local-task-row-')
+  const firstTaskRow = firstSnapshot.testIds.find(
+    testId => testId.startsWith('runtime-local-task-row-') && !rowsBeforeAttachmentOnly.has(testId)
   )
-  const firstTaskRowTestId = firstRows.at(-1)
-  assert.ok(firstTaskRowTestId, 'The first attachment-only task did not expose a task row')
+  assert.ok(firstTaskRow, 'The first attachment-only task row was not found')
   await captureVerificationScreenshot(control, '02-attachment-only-first-completed.png')
 
   await control.command('click', '[data-testid="new-chat-button"]')
@@ -1207,17 +1228,24 @@ async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSel
 
   const twoTaskSnapshot = await waitForSnapshot(
     control,
-    snapshot => {
-      const rows = snapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-'))
-      return firstRows.every(testId => rows.includes(testId)) && rows.length >= firstRows.length + 1
-    },
+    snapshot =>
+      snapshot.testIds.includes(firstTaskRow) &&
+      snapshot.testIds.some(
+        testId =>
+          testId.startsWith('runtime-local-task-row-') &&
+          testId !== firstTaskRow &&
+          !rowsBeforeAttachmentOnly.has(testId)
+      ),
     'A same-title attachment-only task disappeared after the authoritative sidebar refresh'
   )
-  const expectedRows = twoTaskSnapshot.testIds.filter(testId =>
-    testId.startsWith('runtime-local-task-row-')
+  const secondTaskRow = twoTaskSnapshot.testIds.find(
+    testId =>
+      testId.startsWith('runtime-local-task-row-') &&
+      testId !== firstTaskRow &&
+      !rowsBeforeAttachmentOnly.has(testId)
   )
-  const secondTaskRowTestId = expectedRows.find(testId => !firstRows.includes(testId))
-  assert.ok(secondTaskRowTestId, 'The second attachment-only task did not expose a task row')
+  assert.ok(secondTaskRow, 'The second attachment-only task row was not found')
+  const expectedRows = [firstTaskRow, secondTaskRow]
   await captureVerificationScreenshot(control, '04-attachment-only-two-tasks-after-refresh.png')
 
   if (process.platform === 'darwin') {
@@ -1239,7 +1267,7 @@ async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSel
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
   }
-  await control.command('clickWhenEnabled', `[data-testid="${secondTaskRowTestId}"]`, {
+  await control.command('clickWhenEnabled', `[data-testid="${secondTaskRow}"]`, {
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
@@ -1255,7 +1283,7 @@ async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSel
   await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
   await captureVerificationScreenshot(control, '05-attachment-only-current-image-after-reopen.png')
 
-  await control.command('clickWhenEnabled', `[data-testid="${firstTaskRowTestId}"]`, {
+  await control.command('clickWhenEnabled', `[data-testid="${firstTaskRow}"]`, {
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
@@ -1282,33 +1310,12 @@ async function verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSel
   }
 }
 
-async function verifySideChatAttachmentIsolation({ control }) {
+async function verifySideChatAttachmentIsolation({ control, taskRowTestId }) {
   const sideChatSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-chat-panel"]`
   const rightPanelShellSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`
   const mainComposerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-floating-composer-card"]`
   const sideComposerSelector = `${sideChatSelector} [data-testid="chat-message-input"]`
 
-  control.setScenario('initial')
-  await sendPrompt(control, ACTIVE_COMPOSER_SELECTOR, TASK_PROMPT)
-  await control.awaitScenarioRequestCount('initial', 1)
-  control.releaseInitialToolExecution()
-  await control.command(
-    'waitFor',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
-    {
-      text: COMPLETION_TEXT,
-      timeoutMs: UI_TIMEOUT_MS,
-    }
-  )
-  const taskSnapshot = await waitForSnapshot(
-    control,
-    snapshot => snapshot.testIds.some(testId => testId.startsWith('runtime-local-task-row-')),
-    'The completed main conversation did not appear in the task sidebar'
-  )
-  const taskRowTestId = taskSnapshot.testIds.find(testId =>
-    testId.startsWith('runtime-local-task-row-')
-  )
-  assert.ok(taskRowTestId, 'The completed main conversation did not expose a task row')
   await control.command('click', '[data-testid="new-chat-button"]')
   await control.command(
     'waitFor',
@@ -1392,6 +1399,7 @@ async function verifySideChatAttachmentIsolation({ control }) {
     'Sending the side chat leaked an attachment into the main composer'
   )
   await captureVerificationScreenshot(control, '03-side-chat-sent-main-clean.png')
+  await control.command('click', '[data-testid="toggle-right-workspace-panel-button"]')
 
   const requests = control.scenarioRequests.get('side_chat_attachment') ?? []
   assert.equal(requests.length, 1, 'The side chat did not send exactly one model request')
@@ -4019,58 +4027,15 @@ async function main() {
       timeoutMs: UI_TIMEOUT_MS,
     })
 
-    if (ATTACHMENT_ONLY_SIDEBAR) {
-      phase = 'attachment-only-sidebar'
-      await verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSelector, control })
-      console.log(`Wework attachment-only sidebar E2E passed. Evidence: ${resultDir}`)
-      return
-    }
-
-    if (CONCURRENT_MEMORY_ONLY) {
-      phase = 'concurrent-memory'
-      await selectE2EModel(control)
-      await verifyConcurrentTaskMemory({ composerSelector, control })
-      console.log(`Wework concurrent memory E2E passed. Evidence: ${resultDir}`)
-      return
-    }
-
     if (MEMORY_ONLY) {
       phase = 'memory-growth'
       await selectE2EModel(control)
       await verifyMemoryGrowth({ composerSelector, control })
+      phase = 'concurrent-memory'
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', composerSelector, { timeoutMs: UI_TIMEOUT_MS })
+      await verifyConcurrentTaskMemory({ composerSelector, control })
       console.log(`Wework desktop memory E2E passed. Evidence: ${resultDir}`)
-      return
-    }
-
-    if (SIDE_CHAT_ATTACHMENT_ONLY) {
-      phase = 'side-chat-attachment-isolation'
-      await verifySideChatAttachmentIsolation({ control })
-      await writeFile(
-        join(resultDir, 'model-requests.json'),
-        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-        'utf8'
-      )
-      console.log(`Wework side-chat attachment E2E passed. Evidence: ${resultDir}`)
-      return
-    }
-
-    if (LIFECYCLE_ONLY) {
-      await verifyBackgroundTaskWindowLifecycle({
-        app,
-        appIdentifier,
-        composerSelector,
-        control,
-        executorLogPath,
-        setPhase: value => {
-          phase = value
-        },
-      })
-      await writeFile(
-        join(resultDir, 'model-requests.json'),
-        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-        'utf8'
-      )
-      console.log(`Wework desktop lifecycle E2E passed. Diagnostics: ${resultDir}`)
       return
     }
 
@@ -4078,17 +4043,6 @@ async function main() {
     const initialModelLabel = await control.command('waitFor', activeModelSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
-    if (RECONNECT_ONLY) {
-      phase = 'reconnect'
-      await verifyReconnectRecovery({ composerSelector, control })
-      await writeFile(
-        join(resultDir, 'model-requests.json'),
-        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-        'utf8'
-      )
-      console.log(`Wework desktop reconnect E2E passed. Evidence: ${resultDir}`)
-      return
-    }
     phase = 'initial-task'
     await sendPrompt(control, composerSelector, TASK_PROMPT)
     await withTimeout(
@@ -4309,22 +4263,39 @@ async function main() {
     assert.ok(taskRowTestId, 'The completed task row was not found')
 
     phase = 'blank-task-draft-restoration'
-    await control.command('click', '[data-testid="new-chat-button"]')
+    await control.command(
+      'clickWhenEnabled',
+      `${projectRowSelector} [data-testid="project-new-conversation-button"]`
+    )
     await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
     await control.command('fill', composerSelector, { value: UNSENT_BLANK_TASK_DRAFT })
+    await waitForPersistedComposerInput(
+      control,
+      UNSENT_BLANK_TASK_DRAFT,
+      'The blank task composer did not persist its draft before switching tasks'
+    )
     await control.command('click', `[data-testid="${taskRowTestId}"]`)
     await control.command('waitFor', '[data-testid="message-assistant"]', {
       text: COMPLETION_TEXT,
       timeoutMs: UI_TIMEOUT_MS,
     })
-    await control.command('click', '[data-testid="new-chat-button"]')
+    await control.command(
+      'clickWhenEnabled',
+      `${projectRowSelector} [data-testid="project-new-conversation-button"]`
+    )
     await waitForControlValue(
       control,
       composerSelector,
       UNSENT_BLANK_TASK_DRAFT,
       'The blank task lost its unsent composer draft after switching tasks'
+    )
+    await waitForControlSelectionOffset(
+      control,
+      composerSelector,
+      UNSENT_BLANK_TASK_DRAFT.length,
+      'The restored blank task draft did not place the caret at the end'
     )
     await control.command('fill', composerSelector, { value: '' })
 
@@ -4418,6 +4389,15 @@ async function main() {
       REQUEST_USER_INPUT_PROMPT,
       'request_user_input'
     )
+    const requestInputDebugSnapshot = JSON.parse(
+      await control.command('getWorkbenchDebugSnapshot', 'body')
+    )
+    const requestInputTaskId = requestInputDebugSnapshot.workbench?.currentRuntimeTask?.taskId
+    assert.ok(requestInputTaskId, 'The request-user-input task did not expose its runtime task ID')
+    const requestInputTaskRowTestId = `runtime-local-task-row-${requestInputTaskId}`
+    await control.command('waitFor', `[data-testid="${requestInputTaskRowTestId}"]`, {
+      timeoutMs: UI_TIMEOUT_MS,
+    })
     await control.command('click', '[data-testid="new-chat-button"]')
     await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
@@ -4431,7 +4411,7 @@ async function main() {
       'Timed out waiting for the request-user-input SSE response'
     )
     await control.command('press', 'body', { key: 'Escape' })
-    await control.command('click', `[data-testid="${taskRowTestId}"]`)
+    await control.command('click', `[data-testid="${requestInputTaskRowTestId}"]`)
     await control.command('waitFor', '[data-testid="request-user-input-card"]', {
       text: REQUEST_USER_INPUT_QUESTION,
       visible: true,
@@ -4560,8 +4540,18 @@ async function main() {
     )
     assert.ok(secondTaskRowTestId, 'The second task row was not found')
     await control.command('fill', composerSelector, { value: UNSENT_SECOND_TASK_DRAFT })
+    await waitForPersistedComposerInput(
+      control,
+      UNSENT_SECOND_TASK_DRAFT,
+      'The second task composer did not persist its draft before switching tasks'
+    )
     await control.command('click', `[data-testid="${taskRowTestId}"]`)
     await control.command('fill', composerSelector, { value: UNSENT_FIRST_TASK_DRAFT })
+    await waitForPersistedComposerInput(
+      control,
+      UNSENT_FIRST_TASK_DRAFT,
+      'The first task composer did not persist its draft before switching tasks'
+    )
     await control.command('click', `[data-testid="${secondTaskRowTestId}"]`)
     await waitForControlValue(
       control,
@@ -4701,6 +4691,14 @@ async function main() {
       stableMs: COMPOSER_READY_STABILITY_MS,
       timeoutMs: UI_TIMEOUT_MS,
     })
+
+    phase = 'side-chat-attachment-isolation'
+    await verifySideChatAttachmentIsolation({ control, taskRowTestId })
+
+    phase = 'attachment-only-sidebar'
+    await control.command('click', '[data-testid="new-chat-button"]')
+    await control.command('waitFor', composerSelector, { timeoutMs: WORKBENCH_READY_TIMEOUT_MS })
+    await verifyAttachmentOnlySidebarLifecycle({ appIdentifier, composerSelector, control })
 
     await writeFile(
       join(resultDir, 'model-requests.json'),

--- a/wework/package.json
+++ b/wework/package.json
@@ -29,11 +29,6 @@
     "e2e:desktop:cloud": "node e2e/desktop/task-flow.e2e.mjs --cloud-only",
     "e2e:desktop:plugins": "node e2e/desktop/task-flow.e2e.mjs --plugins-only",
     "e2e:desktop:memory": "node e2e/desktop/task-flow.e2e.mjs --memory-only",
-    "e2e:desktop:concurrent-memory": "node e2e/desktop/task-flow.e2e.mjs --concurrent-memory-only",
-    "e2e:desktop:lifecycle": "node e2e/desktop/task-flow.e2e.mjs --lifecycle-only",
-    "e2e:desktop:reconnect": "node e2e/desktop/task-flow.e2e.mjs --reconnect-only",
-    "e2e:desktop:attachment-only-sidebar": "node e2e/desktop/task-flow.e2e.mjs --attachment-only-sidebar",
-    "e2e:desktop:side-chat-attachment": "node e2e/desktop/task-flow.e2e.mjs --side-chat-attachment-only",
     "ai:verify": "node scripts/ai-verify.mjs",
     "e2e:ui": "playwright test --ui"
   },

--- a/wework/src/components/chat/composer/ComposerTextarea.test.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.test.tsx
@@ -3,6 +3,7 @@ import { createRef, useState } from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { LocalDeviceSkill } from '@/types/api'
 import type { WorkspaceFileApi, WorkspaceTarget } from '@/types/workspace-files'
+import { WORKBENCH_NEW_CHAT_FOCUS_EVENT } from '@/lib/workbenchComposerFocus'
 import { ComposerTextarea } from './ComposerTextarea'
 
 const nativeWorkspacePickerMocks = vi.hoisted(() => ({
@@ -26,6 +27,41 @@ describe('ComposerTextarea', () => {
   beforeEach(() => {
     nativeWorkspacePickerMocks.open.mockReset()
     nativeWorkspacePickerMocks.open.mockResolvedValue([])
+  })
+
+  test('places the caret at the end when returning to a restored new-chat draft', async () => {
+    const textareaRef = createRef<HTMLElement>()
+    const value = 'restored draft'
+
+    render(
+      <ComposerTextarea
+        value={value}
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        canSend
+        placeholder="Message"
+        rows={2}
+        textareaRef={textareaRef}
+        className="min-h-12"
+      />
+    )
+
+    const editor = screen.getByTestId('chat-message-input')
+    const textNode = editor.querySelector('p')?.firstChild
+    expect(textNode).not.toBeNull()
+    act(() => {
+      const range = document.createRange()
+      range.setStart(textNode!, 0)
+      range.collapse(true)
+      window.getSelection()?.removeAllRanges()
+      window.getSelection()?.addRange(range)
+      window.dispatchEvent(new Event(WORKBENCH_NEW_CHAT_FOCUS_EVENT))
+    })
+
+    await waitFor(() => {
+      expect(editor).toHaveFocus()
+      expect(window.getSelection()?.anchorOffset).toBe(value.length)
+    })
   })
 
   test('uses the interrupt send mode for Command-Shift-Enter', () => {

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { useTranslation } from '@/hooks/useTranslation'
 import { FOCUS_PLUGIN_TRIAL_COMPOSER_EVENT } from '@/features/plugins/pluginTrial'
 import { isImeComposingEvent, isImeEnterEvent } from '@/lib/ime'
+import { WORKBENCH_NEW_CHAT_FOCUS_EVENT } from '@/lib/workbenchComposerFocus'
 import {
   canOpenNativeWorkspacePathPicker,
   openNativeWorkspacePathPicker,
@@ -708,6 +709,27 @@ export function ComposerTextarea({
     window.addEventListener(FOCUS_PLUGIN_TRIAL_COMPOSER_EVENT, handleFocusRequest)
     return () => {
       window.removeEventListener(FOCUS_PLUGIN_TRIAL_COMPOSER_EVENT, handleFocusRequest)
+    }
+  }, [closeAutocompleteMenu])
+
+  useEffect(() => {
+    let focusFrame: number | null = null
+    const handleNewChatFocusRequest = () => {
+      if (focusFrame !== null) window.cancelAnimationFrame(focusFrame)
+      focusFrame = window.requestAnimationFrame(() => {
+        focusFrame = null
+        const editor = editorRef.current
+        if (!editor) return
+        editor.setValue(valueRef.current, valueRef.current.length)
+        editor.focus()
+        closeAutocompleteMenu()
+      })
+    }
+
+    window.addEventListener(WORKBENCH_NEW_CHAT_FOCUS_EVENT, handleNewChatFocusRequest)
+    return () => {
+      window.removeEventListener(WORKBENCH_NEW_CHAT_FOCUS_EVENT, handleNewChatFocusRequest)
+      if (focusFrame !== null) window.cancelAnimationFrame(focusFrame)
     }
   }, [closeAutocompleteMenu])
 

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -42,6 +42,15 @@ describe('BufferedChatInput', () => {
     })
   })
 
+  test('persists ordinary text while the composer is still mounted', async () => {
+    const onChange = vi.fn()
+    render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
+
+    await userEvent.type(screen.getByTestId('chat-message-input'), 'unfinished draft')
+
+    expect(onChange).toHaveBeenLastCalledWith('unfinished draft')
+  })
+
   test('restores a buffered draft after switching chat scopes', async () => {
     const drafts = new Map<string, string>()
     const onBlankChange = vi.fn((value: string) => drafts.set('blank', value))

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { ChatInput, type ChatInputProps, type ChatSubmitOptions } from '@/components/chat/ChatInput'
-import { parseComposerMentions } from '@/components/chat/composer/composerMentions'
 
 export interface BufferedChatInputInsertion {
   id: number
@@ -58,9 +57,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     (nextDraft: string) => {
       draftRef.current = nextDraft
       setDraftState({ scopeKey, sourceValue: value, draft: nextDraft })
-      if (parseComposerMentions(nextDraft).length > 0) {
-        onChange(nextDraft)
-      }
+      onChange(nextDraft)
     },
     [onChange, scopeKey, value]
   )

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -21,6 +21,7 @@ import { saveLocalUserPreferences } from '@/api/local/localSession'
 import { desktopControlExtension } from '@extensions/desktop-control'
 import type { DesktopControlCommand } from '@/extensions/desktop-control-contract'
 import { parseDesktopControlKey } from './desktop-control-keyboard'
+import { getWorkbenchDebugSnapshot } from '@/lib/debugPanel'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -588,6 +589,16 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       }
       return element.textContent?.trim() ?? ''
     }
+    case 'getSelectionOffset': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      const selection = window.getSelection()
+      if (!selection?.anchorNode || !element.contains(selection.anchorNode)) return '-1'
+      const range = document.createRange()
+      range.selectNodeContents(element)
+      range.setEnd(selection.anchorNode, selection.anchorOffset)
+      return String(range.toString().length)
+    }
     case 'snapshot':
       return desktopControlSnapshot(command.selector)
     case 'scrollIntoView': {
@@ -631,6 +642,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       fillDesktopControlElement(element, command.value ?? '')
       return element.textContent?.trim() ?? ''
     }
+    case 'getWorkbenchDebugSnapshot':
+      return JSON.stringify(getWorkbenchDebugSnapshot())
     case 'hover':
       return hoverDesktopControlElement(command.selector)
     case 'pointerDown':

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -650,6 +650,9 @@ function ProjectSendProbe() {
       <button type="button" onClick={() => workbench.startNewChat()}>
         start new chat
       </button>
+      <button type="button" onClick={() => workbench.startNewProjectChat(7)}>
+        start new project chat
+      </button>
       <button type="button" onClick={() => workbench.startStandaloneChat()}>
         start standalone chat
       </button>
@@ -3740,7 +3743,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
   })
 
-  test('starts a fresh project pane after creating a runtime task in the same project', async () => {
+  test('returns to the committed project pane after creating a runtime task', async () => {
     const initialRuntimeWork = createRuntimeWork({
       projects: [
         {
@@ -3813,7 +3816,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('')
     expect(screen.getByTestId('pane-goal-draft-active')).toHaveTextContent('inactive')
     expect(screen.getByTestId('runtime-pane-standalone-chat-key')).toHaveTextContent(
-      String(previousBlankChatKey + 1)
+      String(previousBlankChatKey)
     )
   })
 
@@ -6122,6 +6125,41 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('current-project-name')).toHaveTextContent('Wegent')
     expect(screen.getByTestId('composer-input')).toHaveTextContent('修复 CI')
     expect(screen.getByTestId('project-attachment-count')).toHaveTextContent('1')
+  })
+
+  test('keeps blank chat draft when starting a project chat from a runtime task', async () => {
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'message runtime-a' }],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(await screen.findByText('select project'))
+    await userEvent.click(screen.getByText('set input'))
+    expect(screen.getByTestId('composer-input')).toHaveTextContent('修复 CI')
+    const blankChatKey = screen.getByTestId('standalone-chat-key').textContent
+
+    await userEvent.click(screen.getByText('open project runtime task'))
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:runtime-a'
+      )
+    )
+    await userEvent.click(screen.getByText('start new project chat'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent('none')
+    )
+    expect(screen.getByTestId('standalone-chat-key')).toHaveTextContent(blankChatKey ?? '')
+    expect(screen.getByTestId('composer-input')).toHaveTextContent('修复 CI')
   })
 
   test('starts standalone chat with a fresh blank draft scope', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -927,7 +927,6 @@ export function WorkbenchProvider({
         type: 'project_workspace_selected',
         project,
         deviceWorkspaceId,
-        startFreshChat: true,
       })
       navigateTo('/')
       requestNewChatComposerFocus()


### PR DESCRIPTION
## Summary

- persist ordinary composer text in the scoped workbench draft state as the user types
- strengthen desktop E2E coverage by asserting the persisted draft before switching conversations
- merge lifecycle, reconnect, attachment-only, and side-chat attachment coverage into the main desktop flow
- merge streaming and concurrent memory coverage under the existing memory command

## Root cause

Ordinary text only lived in `BufferedChatInput` local state and was copied to the scoped provider state during effect cleanup. A real conversation switch could therefore replace the component before the draft became authoritative. The previous E2E only asserted the final DOM value after switching, so its synthetic fill plus cleanup path could pass without proving that the draft had already been persisted.

The project-row new-conversation action also advanced `standaloneChatKey` unconditionally. That discarded an existing unsent blank-project draft even though successful submission already advances the key through `blank_chat_committed`. The E2E now uses the project-row action for both sides of the draft round trip instead of only exercising the global new-chat button.

The request-user-input E2E also reused a stale task-row ID. It now resolves the active runtime task from the workbench debug snapshot before switching away and back.

## Validation

- latest `origin/main` fails the strengthened draft assertion with `The blank task composer did not persist its draft before switching tasks`
- fixed branch passes the same draft scenario
- project-row new-conversation draft round trip passes in the real desktop flow
- `pnpm --filter wework e2e:desktop` passes, including the merged side-chat and attachment-only scenarios
- focused `BufferedChatInput` tests pass (4/4)
- pre-push ESLint, TypeScript, and unit tests pass
- Prettier and `git diff --check` pass

## Known check result

`pnpm --filter wework e2e:desktop:memory` reached the existing streaming-memory check but failed before the newly merged concurrent phase because settled WebContent physical footprint grew by 180673 KiB, above the existing threshold. This PR does not relax the memory limit.
