### PR TITLE
fix(wework): show thinking below streaming responses

### DIFF
--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -44,6 +44,12 @@ Run the desktop memory regression on macOS, including streaming growth and the w
 pnpm --filter wework e2e:desktop:memory
 ```
 
+Run only the regression that keeps “Thinking” below already-visible streaming assistant text and removes it after completion:
+
+```bash
+pnpm --filter wework e2e:desktop:streaming-text
+```
+
 The command starts a test-only Vite server through `wework/playwright.config.ts`:
 
 ```bash
@@ -85,6 +91,8 @@ Tests do not mock backend APIs. When Backend is not running, the login-page smok
 8. Dynamically loads a product scenario when `WEWORK_E2E_DESKTOP_SCENARIO_MODULE` is set. The public runner supplies only HTTP, WebSocket, control, and diagnostic lifecycles; it contains no concrete product protocol or assertions.
 
 The test does not simulate Wework, Executor, or Codex. To keep regression results deterministic and avoid requiring a real account, it starts only a loopback model service implementing OpenAI Responses, OpenAI Chat Completions, and Anthropic Messages. Each interface runs a send → `apply_patch` → tool result → follow-up lifecycle, while real Codex executes the tool in the isolated workspace.
+
+`e2e:desktop:streaming-text` runs an isolated streaming-message state regression through a scenario module. It uses the real Tauri WebView, Executor, and Codex app-server while a loopback Responses SSE keeps a partial reply active. The test verifies that “Thinking” appears below the visible reply and disappears after the response is released. It retains screenshots for the ready, streaming, and completed stages; its scenario-specific Codex configuration disables plugin extensions to isolate direct message streaming.
 
 Following the cc-switch conversion boundary, the mock strictly validates what reaches the model side: authentication, model ID, stream settings, message history, tool choice, shell tools, and either the `apply_patch` Lark grammar or its function wrapper. Any incorrect field returns a non-2xx response and fails the test. The desktop test stores a follow-up screenshot for each interface plus the complete `model-requests.json`; GitHub Actions uploads desktop diagnostics on both success and failure.
 

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -44,6 +44,12 @@ pnpm --filter wework e2e:desktop:plugins
 pnpm --filter wework e2e:desktop:memory
 ```
 
+仅验证助手已有流式文本时，其下方持续显示“正在思考”，并在响应完成后消失：
+
+```bash
+pnpm --filter wework e2e:desktop:streaming-text
+```
+
 该命令会通过 `wework/playwright.config.ts` 启动测试专用 Vite 服务：
 
 ```bash
@@ -85,6 +91,8 @@ node e2e/utils/mock-connector-upstream-server.mjs
 8. 如果设置了 `WEWORK_E2E_DESKTOP_SCENARIO_MODULE`，动态加载产品场景；公共 runner 只提供 HTTP、WebSocket、控制和诊断生命周期，不包含具体产品协议或断言。
 
 测试不模拟 Wework、Executor 或 Codex。为了让回归结果确定且不需要真实账号，测试只在 loopback 地址启动模型服务，分别实现 OpenAI Responses、OpenAI Chat Completions 和 Anthropic Messages。每种接口都会执行“发送 → `apply_patch` → 工具结果回传 → 追问”，工具调用仍由真实 Codex 在隔离工作区内执行。
+
+`e2e:desktop:streaming-text` 通过场景模块运行独立的流式消息状态回归。它使用真实 Tauri WebView、Executor 和 Codex app-server，通过 loopback Responses SSE 保持部分回复处于运行状态，验证“正在思考”位于可见回复下方，并在释放响应后消失。该场景会保存就绪、流式和完成三个阶段的截图；场景专用 Codex 配置会关闭插件扩展，以隔离验证消息直出链路。
 
 mock 会按 cc-switch 的转换边界严格校验模型侧收到的请求，包括鉴权、模型 ID、stream 参数、消息历史、tool choice、shell 工具，以及 `apply_patch` 的 Lark grammar 或 function wrapper。任何字段错误都会返回非 2xx 并使测试失败。桌面测试同时保存三种接口的追问截图和完整 `model-requests.json`；GitHub Actions 无论成功或失败都会上传桌面诊断产物。
 

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const ACTIVE_WORKBENCH_SELECTOR =
+  '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
+const COMPOSER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="chat-message-input"][contenteditable="true"]`
+const PROMPT = 'WEWORK_DESKTOP_E2E_STREAMING_TEXT: keep the partial response active until released.'
+const MARKER = 'WEWORK_DESKTOP_E2E_STREAMING_TEXT_PARTIAL'
+const PARTIAL_TEXT = `${MARKER}: response remains active while final checks continue.`
+const COMPLETION_TEXT = `${PARTIAL_TEXT} COMPLETE`
+
+function sse(events) {
+  return events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
+}
+
+function responseCreated(id) {
+  return { type: 'response.created', response: { id } }
+}
+
+function responseCompleted(id) {
+  return {
+    type: 'response.completed',
+    response: {
+      id,
+      usage: {
+        input_tokens: 0,
+        input_tokens_details: null,
+        output_tokens: 0,
+        output_tokens_details: null,
+        total_tokens: 0,
+      },
+    },
+  }
+}
+
+function streamingEvents(id) {
+  const itemId = `${id}-message`
+  return {
+    itemId,
+    start: [
+      responseCreated(id),
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: {
+          id: itemId,
+          type: 'message',
+          status: 'in_progress',
+          role: 'assistant',
+          content: [],
+        },
+      },
+      {
+        type: 'response.content_part.added',
+        item_id: itemId,
+        output_index: 0,
+        content_index: 0,
+        part: { type: 'output_text', text: '', annotations: [] },
+      },
+    ],
+    finish: [
+      {
+        type: 'response.output_text.done',
+        item_id: itemId,
+        output_index: 0,
+        content_index: 0,
+        text: COMPLETION_TEXT,
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: itemId,
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: COMPLETION_TEXT, annotations: [] }],
+        },
+      },
+      responseCompleted(id),
+    ],
+  }
+}
+
+async function readJson(request) {
+  const chunks = []
+  for await (const chunk of request) chunks.push(chunk)
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+async function capture(control, resultDir, name) {
+  const dataUrl = await control.command('capture', ACTIVE_WORKBENCH_SELECTOR, {
+    timeoutMs: 30_000,
+  })
+  const prefix = 'data:image/png;base64,'
+  assert.ok(dataUrl.startsWith(prefix), 'Desktop screenshot did not return PNG data')
+  await writeFile(join(resultDir, name), Buffer.from(dataUrl.slice(prefix.length), 'base64'))
+}
+
+function requestContainsPrompt(body) {
+  return JSON.stringify(body.input ?? []).includes(PROMPT)
+}
+
+export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
+  let releaseResponse
+  let resolveRequest
+  let targetRequest
+  const responseRelease = new Promise(resolve => {
+    releaseResponse = resolve
+  })
+  const requestReceived = new Promise(resolve => {
+    resolveRequest = resolve
+  })
+
+  return {
+    codexConfigToml: '\n[features]\nplugins = false\n',
+
+    async handleHttp(request, response, url) {
+      if (request.method !== 'POST' || !['/v1/responses', '/responses'].includes(url.pathname)) {
+        return false
+      }
+
+      const body = await readJson(request)
+      const responseId = `wework-streaming-text-${Date.now()}`
+      if (!requestContainsPrompt(body)) {
+        response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
+        response.end(sse([responseCreated(responseId), responseCompleted(responseId)]))
+        return true
+      }
+
+      targetRequest = body
+      resolveRequest()
+      const stream = streamingEvents(responseId)
+      response.writeHead(200, {
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      })
+      response.flushHeaders()
+      response.write(sse(stream.start))
+      response.write(
+        sse([
+          {
+            type: 'response.output_text.delta',
+            item_id: stream.itemId,
+            output_index: 0,
+            content_index: 0,
+            delta: PARTIAL_TEXT,
+            offset: 0,
+          },
+        ])
+      )
+      await responseRelease
+      response.end(sse(stream.finish))
+      return true
+    },
+
+    async verify(control) {
+      await capture(control, resultDir, 'streaming-text-00-ready-to-send.png')
+      await control.command('fill', COMPOSER_SELECTOR, { value: PROMPT })
+      await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
+      await Promise.race([
+        requestReceived,
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error('The streaming-text model request was not received')),
+            uiTimeoutMs
+          )
+        ),
+      ])
+      assert.ok(
+        requestContainsPrompt(targetRequest),
+        'The real Codex request omitted the test prompt'
+      )
+      await control.command(
+        'waitFor',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="assistant-message-content"]`,
+        { text: MARKER, stableMs: 750, timeoutMs: uiTimeoutMs }
+      )
+      await control.command(
+        'waitFor',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="thinking-indicator"]`,
+        { text: '正在思考', timeoutMs: uiTimeoutMs }
+      )
+      const streamingSnapshot = JSON.parse(
+        await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
+      )
+      assert.ok(
+        streamingSnapshot.text.indexOf(MARKER) < streamingSnapshot.text.lastIndexOf('正在思考'),
+        'The thinking indicator was not rendered below the partial assistant response'
+      )
+      await capture(control, resultDir, 'streaming-text-01-thinking-below-partial-response.png')
+
+      releaseResponse()
+      await control.command(
+        'waitFor',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="send-message-button"]`,
+        { stableMs: 750, timeoutMs: uiTimeoutMs }
+      )
+      const completedSnapshot = JSON.parse(
+        await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
+      )
+      assert.ok(
+        completedSnapshot.text.includes(MARKER),
+        'The completed response lost its streamed text'
+      )
+      assert.ok(
+        !completedSnapshot.testIds.includes('thinking-indicator'),
+        'The thinking indicator remained after completion'
+      )
+      assert.ok(
+        !completedSnapshot.testIds.includes('pause-response-button'),
+        'The pause button remained after completion'
+      )
+      await capture(control, resultDir, 'streaming-text-02-response-completed.png')
+    },
+
+    diagnostics() {
+      return { receivedTargetRequest: Boolean(targetRequest) }
+    },
+  }
+}

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -3362,11 +3362,11 @@ class DesktopE2EServer {
   }
 }
 
-async function writeCodexConfig(codexHome, modelServerUrl) {
+async function writeCodexConfig(codexHome, modelServerUrl, scenarioConfigToml = '') {
   await mkdir(codexHome, { recursive: true })
   await writeFile(
     join(codexHome, 'config.toml'),
-    `model_provider = "${MODEL_PROVIDER_ID}"\nmodel = "${DEFAULT_MODEL_ID}"\napproval_policy = "never"\nsandbox_mode = "danger-full-access"\n\n[model_providers.${MODEL_PROVIDER_ID}]\nname = "Wework Desktop E2E"\nbase_url = "${modelServerUrl}/v1"\nenv_key = "WEWORK_E2E_MODEL_API_KEY"\nwire_api = "responses"\n`,
+    `model_provider = "${MODEL_PROVIDER_ID}"\nmodel = "${DEFAULT_MODEL_ID}"\napproval_policy = "never"\nsandbox_mode = "danger-full-access"\n${scenarioConfigToml}\n[model_providers.${MODEL_PROVIDER_ID}]\nname = "Wework Desktop E2E"\nbase_url = "${modelServerUrl}/v1"\nenv_key = "WEWORK_E2E_MODEL_API_KEY"\nwire_api = "responses"\n`,
     'utf8'
   )
 }
@@ -3750,7 +3750,7 @@ async function main() {
 
   const desktopScenario = await loadDesktopScenario(
     process.env.WEWORK_E2E_DESKTOP_SCENARIO_MODULE,
-    { uiTimeoutMs: UI_TIMEOUT_MS }
+    { resultDir, uiTimeoutMs: UI_TIMEOUT_MS }
   )
   if (DESKTOP_SCENARIO_ONLY && !desktopScenario) {
     throw new Error('Desktop scenario-only mode requires WEWORK_E2E_DESKTOP_SCENARIO_MODULE')
@@ -3790,7 +3790,11 @@ async function main() {
     )
     const appBinary = desktopApp.binaryPath
     appBundlePath = desktopApp.appBundlePath
-    await writeCodexConfig(join(executorHome, 'codex'), control.url)
+    await writeCodexConfig(
+      join(executorHome, 'codex'),
+      control.url,
+      desktopScenario?.codexConfigToml
+    )
 
     app = spawn(appBinary, [], {
       cwd: weworkDir,

--- a/wework/package.json
+++ b/wework/package.json
@@ -29,6 +29,7 @@
     "e2e:desktop:cloud": "node e2e/desktop/task-flow.e2e.mjs --cloud-only",
     "e2e:desktop:plugins": "node e2e/desktop/task-flow.e2e.mjs --plugins-only",
     "e2e:desktop:memory": "node e2e/desktop/task-flow.e2e.mjs --memory-only",
+    "e2e:desktop:streaming-text": "WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/streaming-text.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "ai:verify": "node scripts/ai-verify.mjs",
     "e2e:ui": "playwright test --ui"
   },

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1189,7 +1189,7 @@ describe('MessageList', () => {
     ).toBeInTheDocument()
   })
 
-  test('hides thinking after partial streaming assistant content becomes visible', () => {
+  test('shows thinking after partial streaming assistant content becomes visible', () => {
     render(
       <MessageList
         messages={[
@@ -1206,7 +1206,7 @@ describe('MessageList', () => {
 
     const content = screen.getByTestId('message-assistant').querySelector('p')
     expect(content).toHaveTextContent('我已经完成前面的检查，继续等最后结果。')
-    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
   })
 
   test('shows only the running block after partial content', () => {
@@ -4026,7 +4026,7 @@ describe('MessageList', () => {
 
     expect(screen.queryByTestId('message-hover-time')).not.toBeInTheDocument()
     expect(screen.queryByTestId('copy-message-button')).not.toBeInTheDocument()
-    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
   })
 
   test('renders only thinking before the first streamed response arrives', () => {
@@ -4051,7 +4051,7 @@ describe('MessageList', () => {
     expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
   })
 
-  test('shows full-width processing status without trailing thinking once final text starts streaming', () => {
+  test('shows trailing thinking once final text starts streaming', () => {
     render(
       <MessageList
         messages={[
@@ -4068,7 +4068,7 @@ describe('MessageList', () => {
 
     const status = screen.getByText('1 秒')
 
-    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
     expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
     expect(status.parentElement).toHaveAttribute('data-testid', 'processing-summary-header')
     expect(status.parentElement).not.toHaveClass('border-b')
@@ -4213,7 +4213,7 @@ describe('MessageList', () => {
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 
-  test('collapses tool rows once final text is visible without trailing thinking', () => {
+  test('collapses tool rows and shows trailing thinking once final text is visible', () => {
     const runningBlock: ProcessingBlock = {
       id: 'call-1',
       subtaskId: 1,
@@ -4239,7 +4239,7 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
     expect(screen.queryByTestId('tool-block-thinking')).not.toBeInTheDocument()
     expect(screen.queryByTestId('processing-live-preview')).not.toBeInTheDocument()
     expect(screen.getByTestId('final-processing-toggle')).toHaveAttribute('aria-expanded', 'false')

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1734,7 +1734,7 @@ function AssistantMessage({
     !message.runtimeGuidanceSplitBefore &&
     !message.runtimeGuidanceContinuation
   const shouldShowThinking = shouldShowAssistantThinkingIndicator({
-    isAssistantRunning,
+    isStreaming,
     hasProcessingDisplayBlock: hasProcessingDisplayBlock(displayBlocks),
     hasVisibleContent,
   })
@@ -1856,6 +1856,7 @@ function AssistantMessage({
               />
             </div>
           ) : null}
+          {shouldShowThinking && hasVisibleContent && <AssistantThinkingIndicator />}
           {canShowFinalArtifacts && hasVisibleContent && webSearchSources.length > 0 && (
             <WebSearchSourcesChip sources={webSearchSources} />
           )}
@@ -2073,15 +2074,15 @@ function hasProcessingDisplayBlock(blocks: ProcessingBlock[]): boolean {
 }
 
 function shouldShowAssistantThinkingIndicator({
-  isAssistantRunning,
+  isStreaming,
   hasProcessingDisplayBlock,
   hasVisibleContent,
 }: {
-  isAssistantRunning: boolean
+  isStreaming: boolean
   hasProcessingDisplayBlock: boolean
   hasVisibleContent: boolean
 }): boolean {
-  return isAssistantRunning && !hasProcessingDisplayBlock && !hasVisibleContent
+  return isStreaming && (!hasProcessingDisplayBlock || hasVisibleContent)
 }
 
 function AssistantErrorCard({


### PR DESCRIPTION
## Summary

- keep the localized “Thinking” indicator visible below partial assistant text while a response is still streaming
- preserve existing tool-activity de-duplication and remove the indicator when streaming completes
- add a focused real-Tauri desktop E2E scenario with ready, streaming, and completed screenshots
- document the focused E2E command in Chinese and English

## Root cause

The message renderer only showed the thinking indicator before any visible assistant content existed. Once final text began streaming, the indicator was suppressed even though the response was still active.

## Validation

- `pnpm --filter wework test` — 200 files, 2002 tests passed
- Prettier, ESLint, TypeScript, typography, and pre-push quality checks passed
- `pnpm --filter wework e2e:desktop:streaming-text` passed in a real Tauri app with real Executor and Codex app-server
- reviewed the generated ready → partial response with Thinking → completed screenshot chain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a desktop streaming-text regression test scenario.
  * Added the `e2e:desktop:streaming-text` command for running the scenario.
  * Added coverage for “Thinking” appearing beneath an in-progress response and disappearing when the response completes.

* **Bug Fixes**
  * Improved the streaming message experience so the thinking indicator remains visible alongside partial assistant responses and is removed after completion.

* **Documentation**
  * Documented the new desktop streaming-text test and its validation steps in English and Chinese guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->