### PR TITLE
feat(wework): support portable authenticated hooks

### DIFF
--- a/executor/src/hooks/codex.rs
+++ b/executor/src/hooks/codex.rs
@@ -7,10 +7,11 @@ use std::path::PathBuf;
 use serde_json::Value;
 use thiserror::Error;
 
-use super::model::{HookEventName, PostToolUseInput};
+use super::model::{HookEventName, HookUser, PostToolUseInput};
 
 #[derive(Debug, Clone)]
 pub struct CodexHookContext {
+    pub user: HookUser,
     pub session_id: String,
     pub turn_id: String,
     pub cwd: PathBuf,
@@ -50,6 +51,7 @@ pub fn post_tool_use_from_notification(
         string(params.get("agentType").or_else(|| params.get("agent_type"))).map(ToOwned::to_owned);
     let raw_item = Value::Object(item.clone());
     Ok(Some(PostToolUseInput {
+        user: context.user.clone(),
         session_id: context.session_id.clone(),
         turn_id: context.turn_id.clone(),
         agent_id,
@@ -81,6 +83,10 @@ mod tests {
 
     fn context() -> CodexHookContext {
         CodexHookContext {
+            user: HookUser {
+                id: Some("7".to_owned()),
+                name: "alice".to_owned(),
+            },
             session_id: "thread-1".to_owned(),
             turn_id: "turn-1".to_owned(),
             cwd: PathBuf::from("/workspace"),
@@ -100,6 +106,7 @@ mod tests {
         assert_eq!(input.tool_name, "apply_patch");
         assert_eq!(input.tool_use_id, "call-1");
         assert_eq!(input.session_id, "thread-1");
+        assert_eq!(input.user.name, "alice");
     }
 
     #[test]

--- a/executor/src/hooks/command.rs
+++ b/executor/src/hooks/command.rs
@@ -90,10 +90,17 @@ pub async fn execute_command_hook<T: Serialize>(
 }
 
 fn platform_command(config: &CommandHookConfig) -> &str {
+    if let Some(command) = config.commands.get(&platform_target()) {
+        return command;
+    }
     #[cfg(windows)]
     return config.command_windows.as_deref().unwrap_or(&config.command);
     #[cfg(not(windows))]
     return &config.command;
+}
+
+fn platform_target() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
 }
 
 fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
@@ -230,6 +237,7 @@ mod tests {
             handler_type: "command".to_owned(),
             command,
             command_windows: None,
+            commands: BTreeMap::new(),
             timeout: 2,
             asynchronous: false,
             status_message: None,
@@ -267,5 +275,14 @@ mod tests {
         let outcome =
             execute_command_hook(&hook, directory.path(), directory.path(), &json!({})).await;
         assert!(outcome.timed_out);
+    }
+
+    #[test]
+    fn selects_the_current_os_and_arch_command() {
+        let mut hook = config("fallback".to_owned());
+        hook.commands
+            .insert(platform_target(), "target-command".to_owned());
+
+        assert_eq!(platform_command(&hook), "target-command");
     }
 }

--- a/executor/src/hooks/host.rs
+++ b/executor/src/hooks/host.rs
@@ -16,7 +16,7 @@ use super::{
     command::execute_command_hook,
     matcher::matches_tool,
     model::{
-        HookEventName, HookHealth, HookRunStatus, HookRunSummary, PostToolUseInput,
+        HookEventName, HookHealth, HookRunStatus, HookRunSummary, HookUser, PostToolUseInput,
         ResolvedHookPluginView,
     },
     registry::HookRegistryStore,
@@ -145,6 +145,10 @@ impl HookService {
             .find(|hook| hook.handler_id == handler_id)
             .ok_or("hook handler not found")?;
         let input = PostToolUseInput {
+            user: HookUser {
+                id: None,
+                name: "anonymous".to_owned(),
+            },
             session_id: "hook-test-session".to_owned(),
             turn_id: "hook-test-turn".to_owned(),
             agent_id: None,

--- a/executor/src/hooks/model.rs
+++ b/executor/src/hooks/model.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -17,8 +17,15 @@ pub enum HookEventName {
     PostToolUse,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookUser {
+    pub id: Option<String>,
+    pub name: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PostToolUseInput {
+    pub user: HookUser,
     pub session_id: String,
     pub turn_id: String,
     pub agent_id: Option<String>,
@@ -64,6 +71,8 @@ pub struct CommandHookConfig {
     pub handler_type: String,
     pub command: String,
     pub command_windows: Option<String>,
+    #[serde(default)]
+    pub commands: BTreeMap<String, String>,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
     #[serde(rename = "async", default)]

--- a/executor/src/hooks/registry.rs
+++ b/executor/src/hooks/registry.rs
@@ -403,11 +403,7 @@ fn load_plugin(
 }
 
 fn command_health(directory: &Path, config: &CommandHookConfig) -> Option<HookHealth> {
-    let command = if cfg!(windows) {
-        config.command_windows.as_deref().unwrap_or(&config.command)
-    } else {
-        &config.command
-    };
+    let command = selected_command(config);
     let program = command.split_whitespace().next()?.trim_matches(['\'', '"']);
     let path = Path::new(program);
     if path.is_absolute() {
@@ -532,8 +528,18 @@ fn validate_hook(config: &CommandHookConfig) -> Result<(), String> {
     if config.handler_type != "command" {
         return Err(format!("unsupported hook type: {}", config.handler_type));
     }
-    if config.command.trim().is_empty() {
-        return Err("hook command is empty".to_owned());
+    if config.command.trim().is_empty() && config.commands.is_empty() {
+        return Err("hook command and platform commands are empty".to_owned());
+    }
+    for (target, command) in &config.commands {
+        if !valid_platform_target(target) {
+            return Err(format!("invalid hook platform target: {target}"));
+        }
+        if command.trim().is_empty() {
+            return Err(format!(
+                "hook command is empty for platform target: {target}"
+            ));
+        }
     }
     if !(1..=MAX_TIMEOUT_SECONDS).contains(&config.timeout) {
         return Err(format!(
@@ -543,10 +549,58 @@ fn validate_hook(config: &CommandHookConfig) -> Result<(), String> {
     Ok(())
 }
 
+fn selected_command(config: &CommandHookConfig) -> &str {
+    let target = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+    if let Some(command) = config.commands.get(&target) {
+        return command;
+    }
+    if cfg!(windows) {
+        config.command_windows.as_deref().unwrap_or(&config.command)
+    } else {
+        &config.command
+    }
+}
+
+fn valid_platform_target(target: &str) -> bool {
+    matches!(
+        target,
+        "macos-aarch64"
+            | "macos-x86_64"
+            | "linux-aarch64"
+            | "linux-x86_64"
+            | "windows-aarch64"
+            | "windows-x86_64"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn validates_supported_platform_commands() {
+        let mut hook = CommandHookConfig {
+            handler_type: "command".to_owned(),
+            command: String::new(),
+            command_windows: None,
+            commands: [("macos-aarch64".to_owned(), "./bin/reporter".to_owned())]
+                .into_iter()
+                .collect(),
+            timeout: 10,
+            asynchronous: true,
+            status_message: None,
+        };
+
+        assert!(validate_hook(&hook).is_ok());
+        hook.commands
+            .insert("freebsd-x86_64".to_owned(), "./bin/reporter".to_owned());
+        assert_eq!(
+            validate_hook(&hook).unwrap_err(),
+            "invalid hook platform target: freebsd-x86_64"
+        );
+    }
+
     #[test]
     fn discovers_duplicates_as_unhealthy() {
         let home = tempdir().unwrap();

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -31,6 +31,7 @@ use crate::{
     hooks::{
         codex::{post_tool_use_from_notification, CodexHookContext},
         host::HookService,
+        model::HookUser,
     },
     local::app_ipc::{AppIpcError, RuntimeWorkHandler},
     logging::log_executor_event,

--- a/executor/src/runtime_work/handler/turns.rs
+++ b/executor/src/runtime_work/handler/turns.rs
@@ -4,6 +4,43 @@
 
 use super::*;
 
+fn hook_user(request: &ExecutionRequest) -> HookUser {
+    let nested_user = request.extra.get("user").and_then(Value::as_object);
+    let id = request
+        .extra
+        .get("user_id")
+        .or_else(|| nested_user.and_then(|user| user.get("id")))
+        .and_then(hook_user_id);
+    let name = request
+        .user_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            nested_user.and_then(|user| {
+                ["name", "user_name", "username"]
+                    .iter()
+                    .find_map(|key| user.get(*key).and_then(Value::as_str))
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+        })
+        .unwrap_or("anonymous")
+        .to_owned();
+    HookUser { id, name }
+}
+
+fn hook_user_id(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        }
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
 impl RuntimeWorkRpcHandler {
     pub(super) fn spawn_turn(&self, turn: SpawnTurnRequest) {
         let SpawnTurnRequest {
@@ -84,7 +121,9 @@ impl RuntimeWorkRpcHandler {
                         .expect("hook turn context lock should not be poisoned")
                         .clone();
                     if let (Some(active_turn), Some(cwd)) = (active_turn, mapper_request.cwd()) {
+                        let resolved_hook_user = hook_user(&mapper_request);
                         let context = CodexHookContext {
+                            user: resolved_hook_user.clone(),
                             session_id: active_turn.thread_id,
                             turn_id: active_turn.turn_id,
                             cwd: PathBuf::from(cwd),
@@ -92,7 +131,22 @@ impl RuntimeWorkRpcHandler {
                             permission_mode: "workspace-write".to_owned(),
                         };
                         match post_tool_use_from_notification(&context, &message) {
-                            Ok(Some(input)) => mapper_handler.hook_service.dispatch(input).await,
+                            Ok(Some(input)) => {
+                                log_executor_event(
+                                    "runtime work hook identity resolved",
+                                    &[
+                                        (
+                                            "request_user_name",
+                                            mapper_request
+                                                .user_name
+                                                .clone()
+                                                .unwrap_or_else(|| "<none>".to_owned()),
+                                        ),
+                                        ("hook_user_name", resolved_hook_user.name.clone()),
+                                    ],
+                                );
+                                mapper_handler.hook_service.dispatch(input).await
+                            }
                             Ok(None) => {}
                             Err(error) => log_executor_event(
                                 "runtime work hook notification mapping failed",
@@ -315,5 +369,38 @@ impl RuntimeWorkRpcHandler {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_standard_hook_user_from_execution_request() {
+        let mut request = ExecutionRequest {
+            user_name: Some("alice".to_owned()),
+            ..ExecutionRequest::default()
+        };
+        request.extra.insert("user_id".to_owned(), json!(42));
+
+        assert_eq!(
+            hook_user(&request),
+            HookUser {
+                id: Some("42".to_owned()),
+                name: "alice".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_anonymous_hook_user_without_private_config_fallbacks() {
+        assert_eq!(
+            hook_user(&ExecutionRequest::default()),
+            HookUser {
+                id: None,
+                name: "anonymous".to_owned(),
+            }
+        );
     }
 }

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -49,6 +49,7 @@ import type {
   RuntimeWorkSearchItem,
   UnifiedModel,
   UnifiedModelListResponse,
+  User,
 } from '@/types/api'
 
 const LOCAL_DEVICE_ID = 'local-device'
@@ -59,6 +60,7 @@ export interface HybridWorkbenchServicesOptions {
   socketBaseUrl: string
   socketPath: string
   token: string
+  user?: User
 }
 
 function runtimeAddressDebug(address: RuntimeTaskAddress): Record<string, unknown> {
@@ -313,7 +315,7 @@ export function createHybridWorkbenchServices(
     baseUrl: `${options.apiBaseUrl.replace(/\/+$/, '')}/runtime-work/llm-responses-proxy`,
     apiKey: options.token,
   }
-  const localServices = createLocalAppServices({ cloudModelGateway })
+  const localServices = createLocalAppServices({ cloudModelGateway, user: options.user })
   const cloudRuntimeIpc = createCloudRuntimeIpcClient({
     socketBaseUrl: options.socketBaseUrl,
     socketPath: options.socketPath,

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -432,6 +432,7 @@ describe('createLocalAppServices', () => {
       ensure: vi.fn().mockResolvedValue({ running: true, ready: true, deviceId: 'device-uuid' }),
       request,
       subscribe: vi.fn(),
+      user: { id: 9, user_name: 'hongyu9', email: 'hongyu9@example.com' },
     })
 
     await services.runtimeWorkApi?.createRuntimeTask({
@@ -503,6 +504,14 @@ describe('createLocalAppServices', () => {
         subtask_id: expect.any(String),
         team_id: 0,
         team_name: 'local-wework',
+        user_id: 9,
+        user_name: 'hongyu9',
+        user: {
+          id: 9,
+          name: 'hongyu9',
+          user_name: 'hongyu9',
+          email: 'hongyu9@example.com',
+        },
         task_title: 'Hello',
         subtask_title: 'Hello - Assistant',
         prompt: 'hello',

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -301,6 +301,7 @@ interface LocalAppServicesDeps {
   request?: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   subscribe?: (handler: (event: LocalExecutorEvent) => void) => Promise<() => void>
   cloudModelGateway?: CloudModelGateway
+  user?: User
 }
 
 interface CloudModelGateway {
@@ -313,6 +314,7 @@ interface RuntimeWorkIpcOptions {
   normalizeDeviceRecord?: <T extends Record<string, unknown>>(data: T, deviceId: string) => T
   adaptListResponse?: (response: unknown, deviceId: string) => RuntimeWorkListResponse
   cloudModelGateway?: CloudModelGateway
+  user?: User
   transportLabel?: 'Local' | 'Cloud'
 }
 
@@ -1122,6 +1124,7 @@ interface BuildLocalRuntimeExecutionRequestInput {
   newSession: boolean
   clientMessageId?: string
   ephemeral?: boolean
+  user: User
 }
 
 function buildLocalRuntimeExecutionRequest(
@@ -1161,13 +1164,13 @@ function buildLocalRuntimeExecutionRequest(
     task_title: input.title,
     subtask_title: `${input.title} - Assistant`,
     user: {
-      id: LOCAL_USER.id,
-      name: LOCAL_USER.user_name,
-      user_name: LOCAL_USER.user_name,
-      email: LOCAL_USER.email,
+      id: input.user.id,
+      name: input.user.user_name,
+      user_name: input.user.user_name,
+      email: input.user.email,
     },
-    user_id: LOCAL_USER.id,
-    user_name: LOCAL_USER.user_name,
+    user_id: input.user.id,
+    user_name: input.user.user_name,
     bot: [],
     model_config: modelConfig,
     prompt: input.message,
@@ -1290,7 +1293,8 @@ async function createLocalRuntimeTaskPayload(
   data: RuntimeTaskCreateRequest,
   localDeviceId: string,
   requestWithLocalDevice: RequestWithLocalDevice,
-  cloudModelGateway?: CloudModelGateway
+  cloudModelGateway: CloudModelGateway | undefined,
+  user: User
 ): Promise<Record<string, unknown>> {
   const runtimeWorkspace = await prepareLocalRuntimeWorkspace(data, requestWithLocalDevice)
   const execution = executionWithWorkspace(data, runtimeWorkspace)
@@ -1329,6 +1333,7 @@ async function createLocalRuntimeTaskPayload(
       newSession: true,
       clientMessageId: normalizedData.clientMessageId,
       ephemeral: normalizedData.ephemeral,
+      user,
     }),
   } as unknown as Record<string, unknown>
 }
@@ -1336,7 +1341,8 @@ async function createLocalRuntimeTaskPayload(
 function createLocalRuntimeSendPayload(
   data: RuntimeSendRequest,
   localDeviceId: string,
-  cloudModelGateway?: CloudModelGateway
+  cloudModelGateway: CloudModelGateway | undefined,
+  user: User
 ): Record<string, unknown> {
   const turnSeed = createRuntimeTurnSeed()
   const normalizedData: RuntimeSendRequest = {
@@ -1389,6 +1395,7 @@ function createLocalRuntimeSendPayload(
         newSession: false,
         clientMessageId: normalizedData.clientMessageId,
         ephemeral: data.ephemeral,
+        user,
       }),
     } as unknown as Record<string, unknown>
   }
@@ -1419,6 +1426,7 @@ function createLocalRuntimeSendPayload(
       newSession: false,
       clientMessageId: normalizedData.clientMessageId,
       ephemeral: data.ephemeral,
+      user,
     }),
   } as unknown as Record<string, unknown>
 }
@@ -1671,6 +1679,7 @@ export function createRuntimeWorkApiFromIpc(
   options: RuntimeWorkIpcOptions = {}
 ) {
   const transportLabel = options.transportLabel ?? 'Local'
+  const user = options.user ?? LOCAL_USER
   const resolveDeviceId = options.resolveDeviceId ?? (() => getDefaultDeviceId())
   const normalizeDeviceRecord = options.normalizeDeviceRecord ?? normalizeLocalDeviceRecord
   const adaptListResponse = options.adaptListResponse ?? adaptRuntimeWorkListResponse
@@ -1773,7 +1782,12 @@ export function createRuntimeWorkApiFromIpc(
     },
     async sendRuntimeMessage(data: RuntimeSendRequest): Promise<RuntimeSendResponse> {
       const localDeviceId = await resolveDeviceId(data as unknown as Record<string, unknown>)
-      const payload = createLocalRuntimeSendPayload(data, localDeviceId, options.cloudModelGateway)
+      const payload = createLocalRuntimeSendPayload(
+        data,
+        localDeviceId,
+        options.cloudModelGateway,
+        user
+      )
       if (!payload.executionRequest) {
         console.warn('[Wework] Local runtime send payload missing executionRequest', {
           taskId: payload.taskId,
@@ -1791,7 +1805,12 @@ export function createRuntimeWorkApiFromIpc(
     },
     async rollbackRuntimeTask(data: RuntimeRollbackRequest): Promise<RuntimeSendResponse> {
       const localDeviceId = await resolveDeviceId(data as unknown as Record<string, unknown>)
-      const payload = createLocalRuntimeSendPayload(data, localDeviceId, options.cloudModelGateway)
+      const payload = createLocalRuntimeSendPayload(
+        data,
+        localDeviceId,
+        options.cloudModelGateway,
+        user
+      )
       if (!payload.executionRequest) {
         console.warn('[Wework] Local runtime rollback payload missing executionRequest', {
           taskId: payload.taskId,
@@ -1844,7 +1863,12 @@ export function createRuntimeWorkApiFromIpc(
       data: RuntimeInterruptAndSendRequest
     ): Promise<RuntimeSendResponse> {
       const localDeviceId = await resolveDeviceId(data as unknown as Record<string, unknown>)
-      const payload = createLocalRuntimeSendPayload(data, localDeviceId, options.cloudModelGateway)
+      const payload = createLocalRuntimeSendPayload(
+        data,
+        localDeviceId,
+        options.cloudModelGateway,
+        user
+      )
       if (!payload.executionRequest) {
         console.warn('[Wework] Local runtime interrupt payload missing executionRequest', {
           taskId: payload.taskId,
@@ -2004,16 +2028,22 @@ export function createRuntimeWorkApiFromIpc(
         data,
         localDeviceId,
         requestWithLocalDevice,
-        options.cloudModelGateway
+        options.cloudModelGateway,
+        user
       )
       debugLocalRuntimeCreatePayload(data, payload)
+      const executionRequest = recordValue(payload.executionRequest)
+      console.info('[Wework] Local runtime execution identity', {
+        taskId: stringValue(executionRequest.task_id),
+        userId: executionRequest.user_id ?? null,
+        userName: stringValue(executionRequest.user_name),
+      })
       const response = await request<Partial<RuntimeTaskCreateResponse>>(
         'runtime.tasks.create',
         payload,
         localDeviceId
       )
       const workspacePath = stringValue(payload.workspacePath) ?? requiredRuntimeWorkspacePath(data)
-      const executionRequest = recordValue(payload.executionRequest)
       const responseRecord = recordValue(response)
       const taskId =
         stringValue(responseRecord.taskId) ??
@@ -2266,6 +2296,7 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
     getLocalDeviceId,
     {
       cloudModelGateway: deps.cloudModelGateway,
+      user: deps.user,
     }
   ) as unknown as NonNullable<WorkbenchServices['runtimeWorkApi']>
 

--- a/wework/src/features/hooks/HookEditorDialog.tsx
+++ b/wework/src/features/hooks/HookEditorDialog.tsx
@@ -56,6 +56,7 @@ export function HookEditorDialog({
                         type: 'command',
                         command,
                         ...(commandWindows ? { commandWindows } : {}),
+                        ...(first?.config.commands ? { commands: first.config.commands } : {}),
                         timeout,
                         async: asynchronous,
                         ...(statusMessage ? { statusMessage } : {}),

--- a/wework/src/features/hooks/hooksTypes.ts
+++ b/wework/src/features/hooks/hooksTypes.ts
@@ -24,6 +24,7 @@ export interface CommandHookConfig {
   type: 'command'
   command: string
   commandWindows?: string
+  commands?: Record<string, string>
   timeout: number
   async: boolean
   statusMessage?: string

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -171,6 +171,7 @@ export function WorkbenchProvider({
         socketBaseUrl: cloudConnection.socketBaseUrl,
         socketPath: cloudConnection.socketPath,
         token: cloudConnection.token,
+        user: cloudConnection.user ?? user,
       }),
     [
       cloudConnection.apiBaseUrl,
@@ -179,7 +180,9 @@ export function WorkbenchProvider({
       cloudConnection.socketBaseUrl,
       cloudConnection.socketPath,
       cloudConnection.token,
+      cloudConnection.user,
       services,
+      user,
     ]
   )
   const executorClient = useMemo(() => {

--- a/wework/src/features/workbench/workbenchServices.ts
+++ b/wework/src/features/workbench/workbenchServices.ts
@@ -24,6 +24,7 @@ import type {
   DeviceInfo,
   ProjectDeviceSessionResponse,
   RuntimeWorkListResponse,
+  User,
 } from '@/types/api'
 import type { DeviceSessionResponse } from '@/types/devices'
 import type { WorkspaceFileApi } from '@/types/workspace-files'
@@ -94,6 +95,7 @@ interface CloudConnectionServicesSnapshot {
   socketBaseUrl?: string
   socketPath?: string
   token: string | null
+  user?: User
 }
 
 export function createExecutorClientForWorkbenchServices(
@@ -133,9 +135,10 @@ export function createDefaultWorkbenchServices(
         socketBaseUrl: cloudConnection.socketBaseUrl,
         socketPath: cloudConnection.socketPath,
         token: cloudConnection.token,
+        user: cloudConnection.user,
       })
     }
-    return createLocalAppServices()
+    return createLocalAppServices({ user: cloudConnection?.user })
   }
 
   return createBackendWorkbenchServices()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for platform-specific hook commands with validation and fallback behavior.
  * Hook and runtime requests now carry the active user’s name and identifier.
  * User identity is preserved across local, hybrid, and workbench services.
  * Hook configuration editing now supports platform-specific command mappings.

* **Bug Fixes**
  * Improved command health checks to evaluate the command selected for the current platform.
  * Requests without user information now use an anonymous identity consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->