### PR TITLE
feat(wework): add Kimi DeepSeek and GLM providers

### DIFF
--- a/docs/en/wework/settings.md
+++ b/docs/en/wework/settings.md
@@ -20,7 +20,7 @@ Common macOS shortcuts include:
 
 ## Custom Codex models
 
-In **Settings → Models**, click **Add model** and choose a provider first. For Kimi Coding, Wework discovers the provider's models. K3 automatically uses the built-in Codex Catalog profile with a 256K context window and `low` default reasoning effort.
+In **Settings → Models**, click **Add model** and choose a provider first. Wework includes profiles for Kimi Coding, the Kimi API Platform, DeepSeek, and GLM. After entering the corresponding platform API key, Wework discovers available models through the provider's `/models` endpoint. Each profile supplies its connection URL, Chat Completions protocol, tool mode, and known model context windows; the Kimi API Platform profile uses the China-region `api.moonshot.cn` endpoint. Kimi Coding K3 automatically uses the built-in Codex Catalog profile with a 256K context window and `low` default reasoning effort.
 
 Each custom model has an optional **Group** field that controls how it appears in the model picker. Kimi Coding defaults this field to **Kimi**, but users can edit or clear it. Models without a group appear under **Custom models**.
 

--- a/docs/zh/wework/settings.md
+++ b/docs/zh/wework/settings.md
@@ -32,7 +32,7 @@ Windows 和 Linux 使用界面中显示的对应组合键。
 
 ## 自定义 Codex 模型
 
-在“设置 → 模型”中点击“添加模型”后，先选择提供商。选择 Kimi Coding 时，Wework 从服务端读取模型列表；K3 会自动使用内置的 Codex Catalog profile，包括 256K 上下文和默认 `low` 推理等级。
+在“设置 → 模型”中点击“添加模型”后，先选择提供商。Wework 内置 Kimi Coding、Kimi 开放平台、DeepSeek 和 GLM profile；填写对应平台的 API Key 后，可以从提供商的 `/models` 接口读取可用模型。连接地址、Chat Completions 协议、工具模式和已知模型的上下文长度由 profile 自动填写，其中 Kimi 开放平台使用中国区 `api.moonshot.cn` 端点。Kimi Coding 的 K3 会自动使用内置的 Codex Catalog profile，包括 256K 上下文和默认 `low` 推理等级。
 
 每个自定义模型都可以设置可选的“分组”，模型选择器会使用该名称组织模型。Kimi Coding 默认填写“Kimi”，用户可以修改或清空；未设置分组的模型统一显示在“自定义模型”下。
 

--- a/wework/src/features/model-settings/localModelProviders.test.ts
+++ b/wework/src/features/model-settings/localModelProviders.test.ts
@@ -25,6 +25,55 @@ describe('localModelProviders', () => {
     })
   })
 
+  it.each([
+    [
+      'kimi',
+      {
+        baseUrl: 'https://api.moonshot.cn/v1',
+        group: 'Kimi',
+        contextWindow: 1_000_000,
+        modelDefaults: {
+          'kimi-k3': { contextWindow: 1_000_000 },
+          'kimi-k2.6': { contextWindow: 262_144 },
+          'moonshot-v1-8k': { contextWindow: 8_192 },
+          'moonshot-v1-32k': { contextWindow: 32_768 },
+          'moonshot-v1-128k': { contextWindow: 131_072 },
+        },
+      },
+    ],
+    [
+      'deepseek',
+      {
+        baseUrl: 'https://api.deepseek.com',
+        group: 'DeepSeek',
+        contextWindow: 1_000_000,
+        modelDefaults: {
+          'deepseek-v4-flash': { contextWindow: 1_000_000 },
+          'deepseek-v4-pro': { contextWindow: 1_000_000 },
+        },
+      },
+    ],
+    [
+      'glm',
+      {
+        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+        group: 'GLM',
+        contextWindow: 200_000,
+        modelDefaults: { 'glm-5.2': { contextWindow: 1_000_000 } },
+      },
+    ],
+  ] as const)('defines the %s official provider profile', (profileId, expected) => {
+    expect(findLocalModelProviderProfile(profileId)).toMatchObject({
+      ...expected,
+      apiFormat: 'openai-chat-completions',
+      requestPath: '/chat/completions',
+      modelsPath: '/models',
+      toolProfile: 'function',
+      webSearchMode: 'disabled',
+      imageGenerationEnabled: false,
+    })
+  })
+
   it('loads, validates, sorts, and deduplicates provider model entries', async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(

--- a/wework/src/features/model-settings/localModelProviders.ts
+++ b/wework/src/features/model-settings/localModelProviders.ts
@@ -9,7 +9,7 @@ import {
   type LocalModelWebSearchMode,
 } from './localModelSettings'
 
-export type LocalModelProviderProfileId = 'custom' | 'kimi-coding'
+export type LocalModelProviderProfileId = 'custom' | 'deepseek' | 'glm' | 'kimi' | 'kimi-coding'
 
 export interface LocalModelProviderProfile {
   id: LocalModelProviderProfileId
@@ -65,6 +65,68 @@ export const LOCAL_MODEL_PROVIDER_PROFILES: LocalModelProviderProfile[] = [
         contextWindow: KIMI_CODING_CONTEXT_WINDOW,
         codexCatalogModelId: KIMI_K27_CATALOG_MODEL_ID,
       },
+    },
+  },
+  {
+    id: 'kimi',
+    displayName: 'Kimi',
+    description: 'Kimi API Open Platform',
+    baseUrl: 'https://api.moonshot.cn/v1',
+    apiFormat: 'openai-chat-completions',
+    requestPath: '/chat/completions',
+    modelsPath: '/models',
+    toolProfile: 'function',
+    group: 'Kimi',
+    contextWindow: 1_000_000,
+    webSearchMode: 'disabled',
+    imageGenerationEnabled: false,
+    modelDefaults: {
+      'kimi-k3': { contextWindow: 1_000_000 },
+      'kimi-k2.7-code': { contextWindow: 262_144 },
+      'kimi-k2.7-code-highspeed': { contextWindow: 262_144 },
+      'kimi-k2.6': { contextWindow: 262_144 },
+      'kimi-k2.5': { contextWindow: 262_144 },
+      'moonshot-v1-8k': { contextWindow: 8_192 },
+      'moonshot-v1-32k': { contextWindow: 32_768 },
+      'moonshot-v1-128k': { contextWindow: 131_072 },
+      'moonshot-v1-8k-vision-preview': { contextWindow: 8_192 },
+      'moonshot-v1-32k-vision-preview': { contextWindow: 32_768 },
+      'moonshot-v1-128k-vision-preview': { contextWindow: 131_072 },
+    },
+  },
+  {
+    id: 'deepseek',
+    displayName: 'DeepSeek',
+    description: 'DeepSeek API',
+    baseUrl: 'https://api.deepseek.com',
+    apiFormat: 'openai-chat-completions',
+    requestPath: '/chat/completions',
+    modelsPath: '/models',
+    toolProfile: 'function',
+    group: 'DeepSeek',
+    contextWindow: 1_000_000,
+    webSearchMode: 'disabled',
+    imageGenerationEnabled: false,
+    modelDefaults: {
+      'deepseek-v4-flash': { contextWindow: 1_000_000 },
+      'deepseek-v4-pro': { contextWindow: 1_000_000 },
+    },
+  },
+  {
+    id: 'glm',
+    displayName: 'GLM',
+    description: 'Zhipu AI Open Platform API',
+    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    apiFormat: 'openai-chat-completions',
+    requestPath: '/chat/completions',
+    modelsPath: '/models',
+    toolProfile: 'function',
+    group: 'GLM',
+    contextWindow: 200_000,
+    webSearchMode: 'disabled',
+    imageGenerationEnabled: false,
+    modelDefaults: {
+      'glm-5.2': { contextWindow: 1_000_000 },
     },
   },
   {


### PR DESCRIPTION
## What changed

- add managed Wework model-provider profiles for the Kimi API Platform, DeepSeek, and GLM
- configure each provider's official base URL, Chat Completions endpoint, model discovery endpoint, tool mode, and known context-window defaults
- keep Kimi API Platform separate from the existing Kimi Coding profile
- document the built-in provider profiles in Chinese and English

## Why

Users previously had to reproduce these providers through the fully custom model form. Built-in profiles reduce configuration errors and keep provider endpoints and model defaults aligned with their official documentation.

## User impact

In **Settings → Models → Add model**, users can select Kimi, DeepSeek, or GLM, enter an API key, load the provider's available models, and save the model without manually configuring protocol details.

## Validation

- `pnpm --filter wework exec vitest run src/features/model-settings/localModelProviders.test.ts src/components/settings/ConnectionsSettingsPage.test.tsx`
- focused Prettier and ESLint checks
- full pre-push Wework ESLint, TypeScript, and unit-test suite
- isolated real-Tauri verification for all three provider selections and generated request URLs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kimi API Platform, DeepSeek, and GLM provider profiles.
  * Added provider-specific connection settings, supported model discovery, context windows, tool modes, and default model parameters.
  * Kimi Coding K3 now uses the built-in Codex Catalog profile with a 256K context window and low default reasoning effort.

* **Documentation**
  * Expanded English and Chinese guidance for configuring custom Codex models in **Settings → Models**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->