### PR TITLE
fix(wework): enable devtools in release workflow

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -438,6 +438,7 @@ jobs:
           pnpm exec tauri build \
             --target "${{ matrix.rust_target }}" \
             --bundles app,dmg \
+            --features release-devtools \
             --config "$config_override"
 
       - name: Verify and collect release assets
@@ -644,7 +645,7 @@ jobs:
             }
           } | ConvertTo-Json -Depth 10 | Set-Content $configPath -Encoding utf8
 
-          pnpm exec tauri build --target x86_64-pc-windows-msvc --bundles nsis --config $configPath
+          pnpm exec tauri build --target x86_64-pc-windows-msvc --bundles nsis --features release-devtools --config $configPath
 
       - name: Verify and collect release assets
         id: package


### PR DESCRIPTION
## What changed

- Enable the `release-devtools` Cargo feature in the macOS GitHub Release build.
- Enable the same feature in the Windows GitHub Release build.

## Why

The developer command menu exposes **Open Web Inspector**, but GitHub Actions invoked `tauri build` directly without the feature required by the release-only native implementation. As a result, published packages compiled the branch that rejects Web Inspector requests.

## Impact

GitHub Release packages can open Web Inspector through the existing developer command on supported desktop platforms. On macOS, the existing runtime check still requires macOS 13.3 or newer.

## Validation

- Parsed `.github/workflows/wework-app.yml` as YAML.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled developer tools in macOS and Windows release builds of the Wework app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->