### PR TITLE
Fix/chat shell compaction phase1

### DIFF
--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -33,12 +33,12 @@ from app.models.subtask_context import (
 )
 from app.models.user import User
 from app.services.auth.internal_service_token import verify_internal_service_token
+from app.services.chat.compaction_checkpoint import resolve_history_subtasks
 from app.services.chat.guidance_queue import guidance_queue
 from app.services.chat.webpage_ws_chat_emitter import get_webpage_ws_emitter
-from app.services.task_fork_history import task_fork_history_resolver
 from app.stores.tasks import subtask_store, task_store
 from shared.prompts.constants import parse_prompt_blocks
-from shared.telemetry.decorators import trace_sync
+from shared.telemetry.decorators import trace_async, trace_sync
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +115,9 @@ class MessageResponse(BaseModel):
     loaded_skills: Optional[list[str]] = None  # Skills loaded in this message turn
     model_info: Optional[dict] = (
         None  # Provider/model metadata for think-block filtering
+    )
+    metadata: Optional[dict] = (
+        None  # Controlled marker whitelist (e.g. summary_compacted) for HTTP mode
     )
 
 
@@ -298,6 +301,16 @@ def subtask_to_messages(
         for idx, msg in enumerate(messages_chain):
             msg_id = f"{subtask.id}-{idx}"
             role = msg.get("role", "assistant")
+            # Forward the summary-compaction marker through a controlled metadata
+            # whitelist (the flat MessageResponse otherwise drops additional_kwargs,
+            # so a reloaded summary would look like a plain user message).
+            msg_kwargs = msg.get("additional_kwargs")
+            resp_metadata = (
+                {"summary_compacted": True}
+                if isinstance(msg_kwargs, dict)
+                and msg_kwargs.get("summary_compacted") is True
+                else None
+            )
             resp = MessageResponse(
                 id=msg_id,
                 role=role,
@@ -308,6 +321,7 @@ def subtask_to_messages(
                 reasoning_content=msg.get("reasoning_content"),
                 created_at=created_at,
                 model_info=msg.get("model_info"),
+                metadata=resp_metadata,
             )
             responses.append(resp)
         # Attach loaded_skills to the last *assistant* message in the chain,
@@ -833,6 +847,16 @@ async def expire_guidance(task_id: int, subtask_id: int):
 
 
 @router.get("/history/{session_id}", response_model=HistoryResponse)
+@trace_async(
+    "internal.chat_storage.get_history",
+    "internal.chat_storage",
+    extract_attributes=lambda *args, **kwargs: {
+        "chat.session_id": kwargs.get("session_id", ""),
+        "chat.from_latest_compaction": kwargs.get("from_latest_compaction", False),
+        "chat.limit": kwargs.get("limit") if kwargs.get("limit") is not None else -1,
+        "chat.is_group_chat": kwargs.get("is_group_chat", False),
+    },
+)
 async def get_chat_history(
     session_id: str,
     limit: Optional[int] = Query(
@@ -842,6 +866,10 @@ async def get_chat_history(
         None, description="Only return messages before this ID"
     ),
     is_group_chat: bool = Query(False, description="Whether this is a group chat"),
+    from_latest_compaction: bool = Query(
+        False,
+        description="Return history from the latest summary-compaction checkpoint",
+    ),
     db: Session = Depends(get_db),
 ):
     """
@@ -868,12 +896,14 @@ async def get_chat_history(
         )
 
     logger.info(
-        "get_chat_history:start session_id=%s task_id=%s before_message_id=%s limit=%s is_group_chat=%s statuses=%s",
+        "get_chat_history:start session_id=%s task_id=%s before_message_id=%s "
+        "limit=%s is_group_chat=%s from_latest_compaction=%s statuses=%s",
         session_id,
         task_id,
         before_message_id,
         limit,
         is_group_chat,
+        from_latest_compaction,
         [status.value for status in history_statuses],
     )
 
@@ -881,17 +911,15 @@ async def get_chat_history(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    items = task_fork_history_resolver.resolve_for_task(
-        db,
+    subtasks = resolve_history_subtasks(
+        db=db,
         task_id=task_id,
         user_id=task.user_id,
         before_message_id=before_message_id,
+        limit=limit,
+        from_latest_compaction=from_latest_compaction,
+        statuses=history_statuses,
     )
-    subtasks = [
-        item.subtask for item in items if item.subtask.status in history_statuses
-    ]
-    if limit is not None and limit > 0:
-        subtasks = subtasks[-limit:]
 
     # Convert to message format with full context loading
     messages = [

--- a/backend/app/services/chat/compaction_checkpoint.py
+++ b/backend/app/services/chat/compaction_checkpoint.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Locate the latest summary-compaction checkpoint in a subtask stream.
+
+The checkpoint is identified by an in-chain ``summary_compacted`` marker (the
+event-level ``context_compactions`` is diagnostic only — its message id is a
+LangChain runtime id not persisted in ``messages_chain``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.subtask import SubtaskRole, SubtaskStatus
+from app.services.task_fork_history import task_fork_history_resolver
+
+_DEFAULT_STATUSES = (
+    SubtaskStatus.COMPLETED,
+    SubtaskStatus.CANCELLED,
+    SubtaskStatus.FAILED,
+)
+
+
+def subtask_has_summary_checkpoint(subtask: Any) -> bool:
+    """True for a COMPLETED assistant subtask whose chain carries a summary marker."""
+    if subtask.role != SubtaskRole.ASSISTANT:
+        return False
+    if subtask.status != SubtaskStatus.COMPLETED:
+        return False
+    result = subtask.result
+    if not isinstance(result, dict):
+        return False
+    chain = result.get("messages_chain")
+    if not isinstance(chain, list):
+        return False
+    return any(
+        isinstance(m, dict)
+        and isinstance(m.get("additional_kwargs"), dict)
+        and m["additional_kwargs"].get("summary_compacted") is True
+        for m in chain
+    )
+
+
+def scope_to_latest_checkpoint(subtasks: list[Any]) -> tuple[list[Any], int | None]:
+    """Slice ``subtasks`` to start at the latest checkpoint subtask.
+
+    Returns ``(sliced, checkpoint_index)``; ``(subtasks, None)`` when no
+    checkpoint is present (caller falls back to full history).
+    """
+    latest: int | None = None
+    for i, subtask in enumerate(subtasks):
+        if subtask_has_summary_checkpoint(subtask):
+            latest = i
+    if latest is None:
+        return subtasks, None
+    return subtasks[latest:], latest
+
+
+def apply_checkpoint_limit(
+    subtasks: list[Any],
+    *,
+    limit: int | None,
+    from_latest_compaction: bool,
+) -> list[Any]:
+    """Apply ``limit`` without ever dropping the checkpoint subtask (index 0).
+
+    When scoping from a checkpoint, the first subtask is the checkpoint chain and
+    must always be returned; ``limit`` only bounds the turns after it. Otherwise
+    this is the plain "most recent N subtasks" behaviour.
+    """
+    if not limit or limit <= 0:
+        return subtasks
+    if from_latest_compaction and subtasks:
+        head, tail = subtasks[:1], subtasks[1:]
+        return head if limit <= 1 else head + tail[-(limit - 1) :]
+    return subtasks[-limit:]
+
+
+def resolve_history_subtasks(
+    *,
+    db,
+    task_id,
+    user_id,
+    before_message_id=None,
+    limit=None,
+    from_latest_compaction=False,
+    statuses=None,
+) -> list[Any]:
+    """Single resolve -> status-filter -> checkpoint-scope -> limit pipeline.
+
+    Used by both the HTTP history endpoint and the package-mode loader so fork,
+    ``before_message_id``, ``limit``, and checkpoint semantics stay identical.
+    """
+    statuses = tuple(statuses) if statuses else _DEFAULT_STATUSES
+    items = task_fork_history_resolver.resolve_for_task(
+        db, task_id=task_id, user_id=user_id, before_message_id=before_message_id
+    )
+    subtasks = [item.subtask for item in items if item.subtask.status in statuses]
+    # Only preserve subtasks[0] as inviolable when a checkpoint was actually
+    # found; otherwise (uncompacted task) fall back to plain "most recent N",
+    # or `limit` would wrongly pin the oldest turn instead of the checkpoint.
+    scoped_to_checkpoint = False
+    if from_latest_compaction:
+        subtasks, checkpoint_index = scope_to_latest_checkpoint(subtasks)
+        scoped_to_checkpoint = checkpoint_index is not None
+    return apply_checkpoint_limit(
+        subtasks, limit=limit, from_latest_compaction=scoped_to_checkpoint
+    )

--- a/backend/app/services/correction_service.py
+++ b/backend/app/services/correction_service.py
@@ -150,7 +150,6 @@ class CorrectionService:
                 tool_registry=tool_registry,
                 # Increase iterations to allow: Search -> Read -> Search -> Evaluate
                 max_iterations=12,
-                enable_checkpointing=False,
             )
 
             # 4. Construct Payload (Structured Input)
@@ -241,7 +240,6 @@ class CorrectionService:
                 llm=llm,
                 tool_registry=tool_registry,
                 max_iterations=12,
-                enable_checkpointing=False,
             )
 
             # 4. Construct Payload

--- a/backend/tests/api/test_internal_chat_storage_fork_history.py
+++ b/backend/tests/api/test_internal_chat_storage_fork_history.py
@@ -12,6 +12,7 @@ from app.api.dependencies import get_db
 from app.api.endpoints.internal import chat_storage
 from app.core.config import settings
 from app.models.subtask import SubtaskRole, SubtaskStatus
+from app.services.chat import compaction_checkpoint
 from app.services.task_fork_history import ForkHistoryItem
 
 
@@ -42,8 +43,9 @@ def _patch_internal_history(monkeypatch, items, *, resolver_applies_limit=False)
         SimpleNamespace(get_by_id=lambda db, *, task_id: SimpleNamespace(user_id=7)),
         raising=False,
     )
+    # The resolver call now lives in the shared compaction_checkpoint pipeline.
     monkeypatch.setattr(
-        chat_storage,
+        compaction_checkpoint,
         "task_fork_history_resolver",
         SimpleNamespace(resolve_for_task=resolve_for_task),
         raising=False,

--- a/backend/tests/services/chat/test_compaction_checkpoint.py
+++ b/backend/tests/services/chat/test_compaction_checkpoint.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from app.models.subtask import SubtaskRole, SubtaskStatus
+
+
+def _assistant(msg_id, chain, status=SubtaskStatus.COMPLETED):
+    return SimpleNamespace(
+        role=SubtaskRole.ASSISTANT,
+        status=status,
+        message_id=msg_id,
+        result={"messages_chain": chain},
+    )
+
+
+def test_scope_to_latest_checkpoint():
+    from app.services.chat.compaction_checkpoint import (
+        scope_to_latest_checkpoint,
+        subtask_has_summary_checkpoint,
+    )
+
+    plain = _assistant(1, [{"role": "assistant", "content": "hi"}])
+    ckpt = _assistant(
+        2,
+        [
+            {
+                "role": "user",
+                "content": "q",
+                "additional_kwargs": {"checkpoint_retained": True},
+            },
+            {
+                "role": "user",
+                "content": "[COMPACT SUMMARY] ...",
+                "additional_kwargs": {"summary_compacted": True},
+            },
+            {"role": "assistant", "content": "final"},
+        ],
+    )
+    after = _assistant(3, [{"role": "assistant", "content": "later"}])
+
+    assert not subtask_has_summary_checkpoint(plain)
+    assert subtask_has_summary_checkpoint(ckpt)
+
+    sliced, idx = scope_to_latest_checkpoint([plain, ckpt, after])
+    assert idx == 1
+    assert sliced == [ckpt, after]
+
+    unchanged, none_idx = scope_to_latest_checkpoint([plain, after])
+    assert none_idx is None and unchanged == [plain, after]
+
+
+def test_event_without_marker_is_not_checkpoint():
+    from app.services.chat.compaction_checkpoint import subtask_has_summary_checkpoint
+
+    # Chain has NO summary_compacted marker even though a compaction event exists.
+    st = _assistant(9, [{"role": "assistant", "content": "no marker here"}])
+    st.result["context_compactions"] = [{"status": "completed"}]
+    assert not subtask_has_summary_checkpoint(st)
+
+
+def test_checkpoint_chain_preserves_summary_and_suffix():
+    from app.services.chat.compaction_checkpoint import (
+        scope_to_latest_checkpoint,
+        subtask_has_summary_checkpoint,
+    )
+
+    chain = [
+        {
+            "role": "user",
+            "content": "keep me",
+            "additional_kwargs": {"checkpoint_retained": True},
+        },
+        {
+            "role": "user",
+            "content": "[COMPACT SUMMARY] body",
+            "additional_kwargs": {"summary_compacted": True},
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "t1",
+                    "type": "function",
+                    "function": {"name": "exec", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "content": "tool result", "tool_call_id": "t1"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+    ckpt = _assistant(1, chain)
+    assert subtask_has_summary_checkpoint(ckpt)
+    sliced, idx = scope_to_latest_checkpoint([ckpt])
+    assert idx == 0 and sliced == [ckpt]
+    # The persisted chain itself carries retained-user + summary + full suffix
+    # (tool_call, matching tool_result, final answer) — nothing is sliced out.
+    roles = [m["role"] for m in ckpt.result["messages_chain"]]
+    assert roles == ["user", "user", "assistant", "tool", "assistant"]
+    assert ckpt.result["messages_chain"][2]["tool_calls"][0]["id"] == "t1"
+    assert ckpt.result["messages_chain"][3]["tool_call_id"] == "t1"
+
+
+def test_from_latest_compaction_limit_keeps_checkpoint():
+    from app.services.chat.compaction_checkpoint import (
+        apply_checkpoint_limit,
+        scope_to_latest_checkpoint,
+    )
+
+    def st(i, is_ckpt=False):
+        chain = [{"role": "assistant", "content": f"t{i}"}]
+        if is_ckpt:
+            chain = [
+                {
+                    "role": "user",
+                    "content": "[COMPACT SUMMARY]",
+                    "additional_kwargs": {"summary_compacted": True},
+                },
+            ]
+        node = _assistant(i, chain)
+        node.is_ckpt = is_ckpt
+        return node
+
+    subtasks = [st(0), st(1, True), st(2), st(3), st(4)]
+
+    scoped, idx = scope_to_latest_checkpoint(subtasks)
+    assert idx == 1
+
+    # limit=2 must keep the checkpoint (index 0 of scoped) + last (limit-1) tail.
+    kept = apply_checkpoint_limit(scoped, limit=2, from_latest_compaction=True)
+    assert kept[0].is_ckpt is True
+    assert kept[-1].message_id == 4
+    assert len(kept) == 2
+
+
+def test_resolve_history_subtasks_is_single_pipeline(monkeypatch):
+    from app.services.chat import compaction_checkpoint as cc
+
+    def st(i, is_ckpt=False):
+        chain = [{"role": "assistant", "content": f"t{i}"}]
+        if is_ckpt:
+            chain = [
+                {
+                    "role": "user",
+                    "content": "[COMPACT SUMMARY]",
+                    "additional_kwargs": {"summary_compacted": True},
+                }
+            ]
+        return _assistant(i, chain)
+
+    items = [
+        SimpleNamespace(subtask=st(0)),
+        SimpleNamespace(subtask=st(1, True)),
+        SimpleNamespace(subtask=st(2)),
+    ]
+    monkeypatch.setattr(
+        cc.task_fork_history_resolver, "resolve_for_task", lambda *a, **k: items
+    )
+
+    out = cc.resolve_history_subtasks(
+        db=None,
+        task_id=1,
+        user_id=1,
+        before_message_id=None,
+        limit=None,
+        from_latest_compaction=True,
+        statuses=None,
+    )
+    assert [s.message_id for s in out] == [1, 2]
+
+
+def test_resolve_history_no_checkpoint_uses_plain_limit(monkeypatch):
+    from app.services.chat import compaction_checkpoint as cc
+
+    # Five uncompacted turns (no summary_compacted marker anywhere).
+    items = [
+        SimpleNamespace(
+            subtask=_assistant(i, [{"role": "assistant", "content": f"t{i}"}])
+        )
+        for i in range(5)
+    ]
+    monkeypatch.setattr(
+        cc.task_fork_history_resolver, "resolve_for_task", lambda *a, **k: items
+    )
+
+    out = cc.resolve_history_subtasks(
+        db=None,
+        task_id=1,
+        user_id=1,
+        before_message_id=None,
+        limit=2,
+        from_latest_compaction=True,
+        statuses=None,
+    )
+    # No checkpoint yet -> plain "most recent N", NOT [oldest] + last N-1.
+    assert [s.message_id for s in out] == [3, 4]
+
+
+def test_subtask_to_messages_forwards_summary_marker_via_metadata():
+    from app.api.endpoints.internal.chat_storage import subtask_to_messages
+
+    chain = [
+        {
+            "role": "user",
+            "content": "[COMPACT SUMMARY] body",
+            "additional_kwargs": {"summary_compacted": True},
+        },
+        {"role": "assistant", "content": "ok"},
+    ]
+    st = SimpleNamespace(
+        id=1,
+        role=SubtaskRole.ASSISTANT,
+        status=SubtaskStatus.COMPLETED,
+        created_at=None,
+        result={"messages_chain": chain},
+    )
+    resps = subtask_to_messages(st, db=None, is_group_chat=False)
+    assert resps[0].metadata == {"summary_compacted": True}
+    assert resps[1].metadata is None

--- a/chat_shell/.env.example
+++ b/chat_shell/.env.example
@@ -110,8 +110,6 @@ CHAT_SHELL_WEB_SEARCH_DEFAULT_MAX_RESULTS=50
 CHAT_SHELL_WORKSPACE_ROOT=/workspace
 # Enable/disable skills (default: True)
 CHAT_SHELL_ENABLE_SKILLS=True
-# Enable/disable checkpointing (default: False)
-CHAT_SHELL_ENABLE_CHECKPOINTING=False
 
 # =============================================================================
 # Attachment/Context Configuration

--- a/chat_shell/chat_shell/agent.py
+++ b/chat_shell/chat_shell/agent.py
@@ -90,7 +90,6 @@ class ChatAgent:
         workspace_root: str = "/workspace",
         enable_skills: bool = False,
         enable_web_search: bool = False,
-        enable_checkpointing: bool = False,
     ):
         """Initialize Chat Agent.
 
@@ -98,11 +97,9 @@ class ChatAgent:
             workspace_root: Root directory for file operations
             enable_skills: Enable built-in file skills
             enable_web_search: Enable web search tool (global default)
-            enable_checkpointing: Enable state checkpointing
         """
         self.workspace_root = workspace_root
         self.tool_registry = ToolRegistry()
-        self.enable_checkpointing = enable_checkpointing
         self._enable_web_search_default = enable_web_search
 
         # Register built-in skills
@@ -172,7 +169,6 @@ class ChatAgent:
             llm=llm,
             tool_registry=tool_registry,
             max_iterations=config.max_iterations,
-            enable_checkpointing=self.enable_checkpointing,
             pre_model_hook=config.pre_model_hook,
             on_model_usage=config.on_model_usage,
         )
@@ -489,7 +485,6 @@ def create_chat_agent(
     workspace_root: str | None = None,
     enable_skills: bool = True,
     enable_web_search: bool = False,
-    enable_checkpointing: bool = False,
 ) -> ChatAgent:
     """Create a ChatAgent instance with configuration from settings.
 
@@ -500,7 +495,6 @@ def create_chat_agent(
         workspace_root: Override workspace root (defaults to settings)
         enable_skills: Enable built-in file skills
         enable_web_search: Enable web search tool
-        enable_checkpointing: Enable state checkpointing
 
     Returns:
         Configured ChatAgent instance
@@ -512,5 +506,4 @@ def create_chat_agent(
         workspace_root=workspace_root,
         enable_skills=enable_skills,
         enable_web_search=enable_web_search,
-        enable_checkpointing=enable_checkpointing,
     )

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -533,6 +533,10 @@ def _normalize_content_for_storage(msg: AIMessage) -> str | list:
 def _serialize_compacted_additional_kwargs(msg: BaseMessage) -> dict[str, Any] | None:
     """Persist only compact markers needed for history reconstruction."""
     kwargs = dict(getattr(msg, "additional_kwargs", {}) or {})
+    if kwargs.get("checkpoint_retained") is True:
+        # Raw user message retained into the compaction checkpoint; keep it in
+        # messages_chain (passthrough content) so the checkpoint is self-contained.
+        return {"checkpoint_retained": True}
     if kwargs.get("compacted") is True:
         serialized = {"compacted": True}
         if kwargs.get("summary_compacted") is True:

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -2049,11 +2049,17 @@ class LangGraphAgentBuilder:
 
             # Check if we've exceeded retry limit
             if _truncation_retry_count >= self.max_truncation_retries:
-                self._last_termination_reason = "tool_call_truncation_retry_exhausted"
                 logger.error(
                     "[stream_tokens] Max truncation retries exceeded (%d). "
                     "Yielding final truncation warning.",
                     self.max_truncation_retries,
+                )
+                # Persist the authoritative state (incl. any compaction checkpoint)
+                # instead of returning with an empty/stale chain.
+                snapshot = await agent.aget_state({**exec_config})
+                authoritative = snapshot.values.get("messages", [])
+                self._finalize_turn_history(
+                    authoritative, turn_ctx, "tool_call_truncation_retry_exhausted"
                 )
                 logger.warning(
                     "[stream_tokens] Termination: reason=tool_call_truncation_retry_exhausted "
@@ -2062,9 +2068,9 @@ class LangGraphAgentBuilder:
                     agent_iteration,
                     self.max_iterations,
                     recursion_limit,
-                    len(_collected_state_messages),
-                    _tail_signature(_collected_state_messages),
-                    _last_tool_call_name(_collected_state_messages) or "none",
+                    len(authoritative),
+                    _tail_signature(authoritative),
+                    _last_tool_call_name(authoritative) or "none",
                 )
                 # Yield truncation marker to show warning in UI
                 yield f"{TRUNCATED_MARKER_START}{e.reason}{TRUNCATED_MARKER_END}"
@@ -2213,9 +2219,55 @@ class LangGraphAgentBuilder:
                 )
                 raise
 
-        except Exception as e:
+        except Exception:
             logger.exception("Error in stream_tokens")
             raise
+        finally:
+            # Per-level teardown: each stream_tokens invocation owns exactly its
+            # own thread and deletes it here on every exit path. Cleanup never
+            # breaks the turn, but failures are logged, not silently suppressed.
+            thread_id = turn_ctx.current_thread_id
+            saver = self._checkpointer
+            checkpoints_in_saver: int | None = None
+            adelete_thread_ok: bool | None = None
+            if saver is not None:
+                thread_config = {"configurable": {"thread_id": thread_id}}
+                try:
+                    # Measure BEFORE delete, else it is always 0.
+                    checkpoints_in_saver = len(list(saver.list(thread_config)))
+                except Exception:
+                    checkpoints_in_saver = -1
+                try:
+                    await saver.adelete_thread(thread_id)
+                    adelete_thread_ok = True
+                except Exception:
+                    adelete_thread_ok = False
+                    logger.warning(
+                        "[stream_tokens] Failed to delete turn checkpoint thread=%s",
+                        thread_id,
+                        exc_info=True,
+                    )
+            chain = self._last_messages_chain
+            has_summary_marker = any(
+                isinstance(entry.get("additional_kwargs"), dict)
+                and entry["additional_kwargs"].get("summary_compacted") is True
+                for entry in chain
+            )
+            post_compaction_tool_pairs = sum(
+                1 for entry in chain if entry.get("role") == "tool"
+            )
+            logger.info(
+                "[stream_tokens] turn persistence: thread=%s reason=%s chain_msgs=%d "
+                "has_summary_marker=%s post_compaction_tool_pairs=%d "
+                "checkpoints_in_saver=%s adelete_thread_ok=%s",
+                thread_id,
+                self._last_termination_reason,
+                len(chain),
+                has_summary_marker,
+                post_compaction_tool_pairs,
+                checkpoints_in_saver,
+                adelete_thread_ok,
+            )
 
     def get_final_content(self, state: dict[str, Any]) -> str:
         """Extract final content from agent state.

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -39,6 +39,7 @@ from opentelemetry import trace as otel_trace
 
 from shared.telemetry.decorators import add_span_event, trace_sync
 
+from ..compression.tool_sanitizer import sanitize_tool_pairs
 from ..core.config import settings
 from ..llm_logging import env_bool as _env_bool
 from ..llm_logging import log_direct_llm_request as _log_direct_llm_request
@@ -1399,6 +1400,32 @@ class LangGraphAgentBuilder:
                 logger.info("Streaming cancelled by user")
                 return
             yield event
+
+    def _finalize_turn_history(
+        self,
+        authoritative_messages: list[BaseMessage],
+        turn_ctx: TurnExecutionContext,
+        termination_reason: str,
+    ) -> None:
+        """Single atomic choke point for turn-result state.
+
+        Every terminal path funnels through here so ``_last_messages_chain``,
+        ``_last_live_state_messages`` and ``_last_termination_reason`` can never
+        drift apart. Sanitizes tool pairs, filters to this turn's new messages
+        using the turn-invariant ``original_input_ids``, then serializes and
+        validates.
+        """
+        sanitized = sanitize_tool_pairs(authoritative_messages)
+        new_msgs = _new_messages_from_state(sanitized, turn_ctx.original_input_ids)
+        self._last_messages_chain = _serialize_validated_messages_chain(
+            new_msgs,
+            provider=self._provider,
+            model_id=self._model_id,
+        )
+        self._last_live_state_messages = [
+            _message_to_context_metrics_dict(msg) for msg in authoritative_messages
+        ]
+        self._last_termination_reason = termination_reason
 
     async def stream_tokens(
         self,

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -746,35 +746,6 @@ def _new_messages_from_state(
     return [msg for msg in collected if not msg.id or msg.id not in input_ids]
 
 
-def _build_limit_recovery_messages_chain(
-    *,
-    collected_state_messages: list[BaseMessage],
-    limit_messages: list[BaseMessage],
-    input_ids: frozenset[str],
-    final_response_text: str,
-) -> list[BaseMessage]:
-    """Build persisted chain for tool-limit recovery turns.
-
-    When LangGraph raises ``GraphRecursionError`` before emitting a final
-    ``on_chain_end`` state, ``collected_state_messages`` can be empty even
-    though the turn should still persist the recovery notice. Fall back to the
-    synthetic ``limit_messages`` prompt so ``messages_chain`` is not lost.
-    """
-
-    chain = (
-        _new_messages_from_state(collected_state_messages, input_ids)
-        if collected_state_messages
-        else []
-    )
-    limit_recovery_messages = _new_messages_from_state(limit_messages, input_ids)
-    if limit_recovery_messages:
-        chain = list(chain) + list(limit_recovery_messages)
-
-    if final_response_text:
-        chain = list(chain) + [AIMessage(content=final_response_text)]
-    return chain
-
-
 class LangGraphAgentBuilder:
     """Builder for LangGraph-based agent workflows using prebuilt ReAct agent."""
 
@@ -952,17 +923,21 @@ class LangGraphAgentBuilder:
                 self.max_iterations,
                 len(all_events),
             )
-            limit_messages = list(lc_messages) + [
+            # Recover from the CURRENT authoritative state (post-compaction, with
+            # completed tool pairs), not the pre-run lc_messages.
+            snapshot = await agent.aget_state({**exec_config})
+            safe_state = sanitize_tool_pairs(snapshot.values.get("messages", []))
+            recovery_input = safe_state + [
                 HumanMessage(content=TOOL_LIMIT_REACHED_MESSAGE)
             ]
 
             try:
                 _log_direct_llm_request(
-                    messages=limit_messages,
+                    messages=recovery_input,
                     tool_names=[t.name for t in getattr(self, "all_tools", []) or []],
                     request_name="tool_limit_recovery",
                 )
-                response = await self.llm.ainvoke(limit_messages)
+                response = await self.llm.ainvoke(recovery_input)
                 _log_direct_llm_response(
                     response=response,
                     request_name="tool_limit_recovery",
@@ -982,7 +957,7 @@ class LangGraphAgentBuilder:
                         final_content = "".join(text_parts)
 
                 final_state = {
-                    "messages": list(lc_messages) + [AIMessage(content=final_content)]
+                    "messages": safe_state + [AIMessage(content=final_content)]
                 }
                 return final_state, all_events
             except Exception:
@@ -994,6 +969,19 @@ class LangGraphAgentBuilder:
         except Exception:
             logger.exception("Error while collecting final state from events")
             raise
+        finally:
+            # Non-streaming path owns its own thread too; delete it on every exit.
+            saver = self._checkpointer
+            if saver is not None:
+                try:
+                    await saver.adelete_thread(nonstream_thread_id)
+                except Exception:
+                    logger.warning(
+                        "[collect_final_state_from_events] Failed to delete turn "
+                        "checkpoint thread=%s",
+                        nonstream_thread_id,
+                        exc_info=True,
+                    )
 
     def _find_prompt_modifier_tools(self) -> list[Any]:
         """Find all tools that implement the PromptModifierTool protocol.

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -2116,8 +2116,13 @@ class LangGraphAgentBuilder:
             raise
 
         except GraphRecursionError:
+            # Set upfront so even a recovery-LLM failure records the reason.
             self._last_termination_reason = "graph_recursion_limit_recovery"
-            # Tool call limit reached - ask model to provide final response
+            # Tool call limit reached - ask the model for a final response using
+            # the CURRENT authoritative state (post-compaction, with completed
+            # tool pairs), not the pre-run lc_messages.
+            snapshot = await agent.aget_state({**exec_config})
+            safe_state = sanitize_tool_pairs(snapshot.values.get("messages", []))
             logger.warning(
                 "[stream_tokens] GraphRecursionError: Tool call limit reached "
                 "(agent_iteration=%d, max_iterations=%d, recursion_limit=%d). "
@@ -2125,14 +2130,13 @@ class LangGraphAgentBuilder:
                 agent_iteration,
                 self.max_iterations,
                 recursion_limit,
-                len(_collected_state_messages),
-                _tail_signature(_collected_state_messages),
-                _last_tool_call_name(_collected_state_messages) or "none",
+                len(safe_state),
+                _tail_signature(safe_state),
+                _last_tool_call_name(safe_state) or "none",
             )
 
-            # Build messages with the limit reached notice
-            # Add a human message to prompt the model to provide final response
-            limit_messages = list(lc_messages) + [
+            # Internal control message: fed to the recovery LLM but NOT persisted.
+            recovery_input = safe_state + [
                 HumanMessage(content=TOOL_LIMIT_REACHED_MESSAGE)
             ]
             recovery_response_parts: list[str] = []
@@ -2140,11 +2144,11 @@ class LangGraphAgentBuilder:
             # Call the LLM directly (without tools) to get final response
             try:
                 _log_direct_llm_request(
-                    messages=limit_messages,
+                    messages=recovery_input,
                     tool_names=[t.name for t in getattr(self, "all_tools", []) or []],
                     request_name="tool_limit_recovery_stream",
                 )
-                async for chunk in self.llm.astream(limit_messages):
+                async for chunk in self.llm.astream(recovery_input):
                     if hasattr(chunk, "content"):
                         content = chunk.content
                         if isinstance(content, str) and content:
@@ -2162,32 +2166,15 @@ class LangGraphAgentBuilder:
                                         yield text
 
                 recovery_response_text = "".join(recovery_response_parts)
-                recovery_chain_messages = _build_limit_recovery_messages_chain(
-                    collected_state_messages=_collected_state_messages,
-                    limit_messages=limit_messages,
-                    input_ids=_input_message_ids,
-                    final_response_text=recovery_response_text,
+                # Final state = safe authoritative state + recovery reply. The
+                # tool-limit instruction is excluded so it never persists.
+                final_state = safe_state + (
+                    [AIMessage(content=recovery_response_text)]
+                    if recovery_response_text
+                    else []
                 )
-                self._last_messages_chain = _serialize_validated_messages_chain(
-                    recovery_chain_messages,
-                    provider=self._provider,
-                    model_id=self._model_id,
-                )
-                self._last_live_state_messages = (
-                    [
-                        _message_to_context_metrics_dict(msg)
-                        for msg in _collected_state_messages
-                    ]
-                    if _collected_state_messages
-                    else [
-                        _message_to_context_metrics_dict(msg)
-                        for msg in list(limit_messages)
-                        + (
-                            [AIMessage(content=recovery_response_text)]
-                            if recovery_response_text
-                            else []
-                        )
-                    ]
+                self._finalize_turn_history(
+                    final_state, turn_ctx, "graph_recursion_limit_recovery"
                 )
 
                 logger.info(
@@ -2200,11 +2187,11 @@ class LangGraphAgentBuilder:
                     agent_iteration,
                     self.max_iterations,
                     recursion_limit,
-                    len(_collected_state_messages),
-                    _tail_signature(_collected_state_messages),
-                    _last_tool_call_name(_collected_state_messages) or "none",
+                    len(final_state),
+                    _tail_signature(final_state),
+                    _last_tool_call_name(final_state) or "none",
                 )
-            except Exception as recovery_error:
+            except Exception:
                 logger.exception(
                     "Error generating final response after tool limit reached"
                 )

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -18,6 +18,7 @@ import logging
 import time
 from collections.abc import AsyncGenerator
 from typing import Any, Callable, Optional
+from uuid import uuid4
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
@@ -30,7 +31,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.utils import convert_to_messages
 from langchain_core.tools.base import BaseTool
-from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.errors import GraphRecursionError
 from langgraph.graph.message import add_messages
 from langgraph.prebuilt import create_react_agent
@@ -48,6 +49,7 @@ from ..tools.argument_stream import ToolCallStreamTracker
 from ..tools.base import ToolRegistry
 from ..tools.builtin.silent_exit import SilentExitException
 from ..tools.deferred_input import DeferredUserInputExit
+from .turn_context import TurnExecutionContext
 
 logger = logging.getLogger(__name__)
 
@@ -779,7 +781,6 @@ class LangGraphAgentBuilder:
         llm: BaseChatModel,
         tool_registry: ToolRegistry | None = None,
         max_iterations: int = 10,
-        enable_checkpointing: bool = False,
         max_truncation_retries: int | None = None,
         pre_model_hook: Callable | None = None,
         on_model_usage: Callable[..., Any] | None = None,
@@ -790,7 +791,6 @@ class LangGraphAgentBuilder:
             llm: LangChain chat model instance
             tool_registry: Registry of available tools (optional)
             max_iterations: Maximum tool loop iterations
-            enable_checkpointing: Enable state checkpointing for resumability
             max_truncation_retries: Maximum retry attempts when tool calls are truncated.
                 If None, uses settings.MAX_TRUNCATION_RETRIES
             pre_model_hook: Optional LangGraph hook called before each model call
@@ -800,7 +800,6 @@ class LangGraphAgentBuilder:
         self.llm = llm
         self.tool_registry = tool_registry
         self.max_iterations = max_iterations
-        self.enable_checkpointing = enable_checkpointing
         self.pre_model_hook = pre_model_hook
         self.on_model_usage = on_model_usage
         self.max_truncation_retries = (
@@ -809,6 +808,9 @@ class LangGraphAgentBuilder:
             else settings.MAX_TRUNCATION_RETRIES
         )
         self._agent = None
+        # Request-local checkpointer, created unconditionally in _build_agent so
+        # authoritative post-compaction state is readable on every exit path.
+        self._checkpointer: InMemorySaver | None = None
 
         # Provider metadata set by LangChainModelFactory for think-block handling
         self._provider: str = getattr(llm, "_wegent_provider", "unknown")
@@ -850,7 +852,12 @@ class LangGraphAgentBuilder:
             target_model_id=self._model_id,
             target_api_format=self._api_format,
         )
-        exec_config = {"configurable": config} if config else None
+        # Request-local checkpointer needs a thread id (T11 adds the authoritative
+        # finalizer + teardown for this path).
+        nonstream_thread_id = str(uuid4())
+        exec_config = {
+            "configurable": {**(config or {}), "thread_id": nonstream_thread_id}
+        }
 
         all_events: list[dict[str, Any]] = []
         final_state: dict[str, Any] = {}
@@ -859,10 +866,11 @@ class LangGraphAgentBuilder:
             async for event in agent.astream_events(
                 {"messages": lc_messages},
                 config={
-                    **(exec_config or {}),
+                    **exec_config,
                     "recursion_limit": self.max_iterations * 2 + 1,
                 },
                 version="v2",
+                durability="exit",
             ):
                 if cancel_event and cancel_event.is_set():
                     logger.info("Streaming cancelled by user")
@@ -1255,7 +1263,6 @@ class LangGraphAgentBuilder:
         extract_attributes=lambda self, *args, **kwargs: {
             "agent.tools_count": len(self.tools),
             "agent.max_iterations": self.max_iterations,
-            "agent.enable_checkpointing": self.enable_checkpointing,
         },
     )
     def _build_agent(self):
@@ -1266,11 +1273,12 @@ class LangGraphAgentBuilder:
 
         add_span_event("building_new_agent")
 
-        # Use LangGraph's prebuilt create_react_agent
-        checkpointer = MemorySaver() if self.enable_checkpointing else None
-        add_span_event(
-            "checkpointer_created", {"has_checkpointer": checkpointer is not None}
-        )
+        # Authoritative-state persistence requires a request-local checkpointer on
+        # every turn — not optional, or exception paths lose the compaction
+        # checkpoint. Memory stays ~1x via durability="exit" at invocation time.
+        checkpointer = InMemorySaver()
+        self._checkpointer = checkpointer
+        add_span_event("checkpointer_created", {"has_checkpointer": True})
 
         # Create prompt modifier for dynamic skill prompt injection
         prompt_modifier = self._create_prompt_modifier()
@@ -1444,7 +1452,14 @@ class LangGraphAgentBuilder:
             msg.id for msg in lc_messages if msg.id
         )
 
-        exec_config = {"configurable": config} if config else None
+        # Request-local checkpointer needs a thread id; each turn owns a fresh
+        # one and reads authoritative state from it on exit (see TurnExecutionContext).
+        turn_thread_id = str(uuid4())
+        turn_ctx = TurnExecutionContext(
+            original_input_ids=_input_message_ids,
+            current_thread_id=turn_thread_id,
+        )
+        exec_config = {"configurable": {**(config or {}), "thread_id": turn_thread_id}}
 
         event_count = 0
         streamed_content = False  # Track if we've streamed any content
@@ -1485,10 +1500,11 @@ class LangGraphAgentBuilder:
             async for event in agent.astream_events(
                 {"messages": lc_messages},
                 config={
-                    **(exec_config or {}),
+                    **exec_config,
                     "recursion_limit": recursion_limit,
                 },
                 version="v2",
+                durability="exit",
             ):
                 event_count += 1
                 # Check cancellation

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -39,6 +39,7 @@ from opentelemetry import trace as otel_trace
 
 from shared.telemetry.decorators import add_span_event, trace_sync
 
+from ..compression.summary_compactor import EPHEMERAL_CONTROL_FLAG
 from ..compression.tool_sanitizer import sanitize_tool_pairs
 from ..core.config import settings
 from ..llm_logging import env_bool as _env_bool
@@ -1434,6 +1435,7 @@ class LangGraphAgentBuilder:
         cancel_event: asyncio.Event | None = None,
         on_tool_event: Callable[[str, dict], None] | None = None,
         _truncation_retry_count: int = 0,
+        _parent_turn_ctx: "TurnExecutionContext | None" = None,
     ) -> AsyncGenerator[str, None]:
         """Stream tokens from agent execution.
 
@@ -1479,13 +1481,18 @@ class LangGraphAgentBuilder:
             msg.id for msg in lc_messages if msg.id
         )
 
-        # Request-local checkpointer needs a thread id; each turn owns a fresh
-        # one and reads authoritative state from it on exit (see TurnExecutionContext).
+        # Request-local checkpointer needs a thread id; each turn (and each
+        # truncation-retry level) owns a fresh one and reads authoritative state
+        # from it on exit. A retry INHERITS the root's original_input_ids so the
+        # checkpoint clones / summary / suffix are never mis-filtered.
         turn_thread_id = str(uuid4())
-        turn_ctx = TurnExecutionContext(
-            original_input_ids=_input_message_ids,
-            current_thread_id=turn_thread_id,
-        )
+        if _parent_turn_ctx is not None:
+            turn_ctx = _parent_turn_ctx.with_retry(turn_thread_id)
+        else:
+            turn_ctx = TurnExecutionContext(
+                original_input_ids=_input_message_ids,
+                current_thread_id=turn_thread_id,
+            )
         exec_config = {"configurable": {**(config or {}), "thread_id": turn_thread_id}}
 
         event_count = 0
@@ -2063,27 +2070,35 @@ class LangGraphAgentBuilder:
                 yield f"{TRUNCATED_MARKER_START}{e.reason}{TRUNCATED_MARKER_END}"
                 return
 
-            # Construct error message for LLM
+            # Construct error message for LLM. It is an ephemeral CONTROL message:
+            # the model sees it this turn, but it must never be treated as a real
+            # user turn nor persisted (the compactor and serializer skip it).
             error_message = TOOL_CALL_TRUNCATION_ERROR_TEMPLATE.format(
                 reason=e.reason,
                 attempt=_truncation_retry_count + 1,
                 max_attempts=self.max_truncation_retries,
             )
 
-            # Add error message to conversation history
-            recovery_messages = list(lc_messages) + [
-                HumanMessage(content=error_message)
+            # Seed the retry from the CURRENT authoritative state (post-compaction,
+            # completed tool pairs), not the pre-run lc_messages. Re-submitting a
+            # sanitized list to the SAME thread would not delete the truncated tool
+            # call (add_messages merges by id), so the retry runs on a fresh thread
+            # while inheriting the root's original_input_ids via turn_ctx.
+            snapshot = await agent.aget_state({**exec_config})
+            safe_state = sanitize_tool_pairs(snapshot.values.get("messages", []))
+            retry_seed = safe_state + [
+                HumanMessage(
+                    content=error_message,
+                    additional_kwargs={EPHEMERAL_CONTROL_FLAG: True},
+                )
             ]
 
-            # Retry with the error context
             logger.info(
                 "[stream_tokens] Retrying with truncation error context (attempt %d/%d)",
                 _truncation_retry_count + 1,
                 self.max_truncation_retries,
             )
 
-            # Recursively call stream_tokens with incremented retry count
-            # This allows LLM to adjust its strategy based on the error
             async for token in self.stream_tokens(
                 messages=[
                     (
@@ -2091,12 +2106,13 @@ class LangGraphAgentBuilder:
                         if hasattr(msg, "model_dump")
                         else msg.dict() if hasattr(msg, "dict") else msg
                     )
-                    for msg in recovery_messages
+                    for msg in retry_seed
                 ],
                 config=config,
                 cancel_event=cancel_event,
                 on_tool_event=on_tool_event,
                 _truncation_retry_count=_truncation_retry_count + 1,
+                _parent_turn_ctx=turn_ctx,
             ):
                 yield token
 

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -1986,34 +1986,14 @@ class LangGraphAgentBuilder:
                 )
                 yield final_content
 
-            # Serialize collected messages chain for history persistence
-            # Only keep new messages generated in this turn (skip input messages)
-            if _collected_state_messages:
-                self._last_live_state_messages = [
-                    _message_to_context_metrics_dict(msg)
-                    for msg in _collected_state_messages
-                ]
-                new_msgs = _new_messages_from_state(
-                    _collected_state_messages, _input_message_ids
-                )
-                self._last_messages_chain = _serialize_validated_messages_chain(
-                    new_msgs,
-                    provider=self._provider,
-                    model_id=self._model_id,
-                )
-            else:
-                self._last_messages_chain = []
-                self._last_live_state_messages = []
+            # Read the authoritative post-run state from the checkpointer and
+            # funnel it through the single finalizer. Replaces the event-captured
+            # _collected_state_messages, which could miss the post-compaction
+            # state or be rejected by the length heuristic.
+            snapshot = await agent.aget_state({**exec_config})
+            authoritative = snapshot.values.get("messages", [])
 
-            logger.debug(
-                "[stream_tokens] Streaming completed: total_events=%d, streamed=%s, messages_chain_len=%d",
-                event_count,
-                streamed_content,
-                len(self._last_messages_chain),
-            )
-            final_message = (
-                _collected_state_messages[-1] if _collected_state_messages else None
-            )
+            final_message = authoritative[-1] if authoritative else None
             final_tool_calls = (
                 _tool_call_count(final_message)
                 if isinstance(final_message, AIMessage)
@@ -2026,8 +2006,15 @@ class LangGraphAgentBuilder:
             ):
                 termination_reason = "completed_with_unexecuted_tool_calls"
                 termination_log = logger.warning
-            self._last_termination_reason = termination_reason
 
+            self._finalize_turn_history(authoritative, turn_ctx, termination_reason)
+
+            logger.debug(
+                "[stream_tokens] Streaming completed: total_events=%d, streamed=%s, messages_chain_len=%d",
+                event_count,
+                streamed_content,
+                len(self._last_messages_chain),
+            )
             termination_log(
                 "[stream_tokens] Termination: reason=%s "
                 "agent_iteration=%d max_iterations=%d recursion_limit=%d messages=%d "
@@ -2036,9 +2023,9 @@ class LangGraphAgentBuilder:
                 agent_iteration,
                 self.max_iterations,
                 recursion_limit,
-                len(_collected_state_messages),
-                _tail_signature(_collected_state_messages),
-                _last_tool_call_name(_collected_state_messages) or "none",
+                len(authoritative),
+                _tail_signature(authoritative),
+                _last_tool_call_name(authoritative) or "none",
                 last_model_end_tool_calls,
                 final_tool_calls,
             )
@@ -2119,19 +2106,12 @@ class LangGraphAgentBuilder:
             logger.info(
                 "[stream_tokens] silent/deferred exit caught, re-raising for caller to handle"
             )
-            # Persist partial messages chain before re-raising
-            if _collected_state_messages:
-                self._last_live_state_messages = [
-                    _message_to_context_metrics_dict(msg)
-                    for msg in _collected_state_messages
-                ]
-                new_msgs = _new_messages_from_state(
-                    _collected_state_messages, _input_message_ids
-                )
-                self._last_messages_chain = _serialize_validated_messages_chain(
-                    new_msgs,
-                    provider=self._provider,
-                    model_id=self._model_id,
+            # Persist authoritative state before re-raising.
+            snapshot = await agent.aget_state({**exec_config})
+            authoritative = snapshot.values.get("messages", [])
+            if authoritative:
+                self._finalize_turn_history(
+                    authoritative, turn_ctx, "silent_or_deferred_exit"
                 )
             raise
 

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -39,9 +39,9 @@ from opentelemetry import trace as otel_trace
 
 from shared.telemetry.decorators import add_span_event, trace_sync
 
-from ..compression.summary_compactor import EPHEMERAL_CONTROL_FLAG
 from ..compression.tool_sanitizer import sanitize_tool_pairs
 from ..core.config import settings
+from ..guard.composition import chain_pre_model_hooks
 from ..llm_logging import env_bool as _env_bool
 from ..llm_logging import log_direct_llm_request as _log_direct_llm_request
 from ..llm_logging import log_direct_llm_response as _log_direct_llm_response
@@ -784,6 +784,10 @@ class LangGraphAgentBuilder:
         # Request-local checkpointer, created unconditionally in _build_agent so
         # authoritative post-compaction state is readable on every exit path.
         self._checkpointer: InMemorySaver | None = None
+        # Attempt-scoped control plane: guidance injected into the model input
+        # (via llm_input_messages, after compaction) but never persisted. Set at
+        # the top of each stream_tokens level; empty on the root turn.
+        self._attempt_guidance: list[BaseMessage] = []
 
         # Provider metadata set by LangChainModelFactory for think-block handling
         self._provider: str = getattr(llm, "_wegent_provider", "unknown")
@@ -1255,6 +1259,23 @@ class LangGraphAgentBuilder:
             "agent.max_iterations": self.max_iterations,
         },
     )
+    def _attempt_guidance_hook(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Inject attempt-scoped control guidance into the model input only.
+
+        Runs last in the pre-model chain, so it appends to the post-compaction,
+        post-guidance model-visible list via ``llm_input_messages``. The guidance
+        is never written to the ``messages`` channel, so it never reaches the
+        checkpoint, the summary source, or the persisted ``messages_chain``.
+        Injected on every model call while set, so a retry that compacts still
+        shows the model the guidance after compaction. Returns ``{}`` (a no-op)
+        on the root turn when no guidance is active.
+        """
+        guidance = self._attempt_guidance
+        if not guidance:
+            return {}
+        base = state.get("llm_input_messages") or state.get("messages") or []
+        return {"llm_input_messages": [*base, *guidance]}
+
     def _build_agent(self):
         """Build the LangGraph ReAct agent lazily."""
         if self._agent is not None:
@@ -1287,6 +1308,15 @@ class LangGraphAgentBuilder:
             },
         )
 
+        # Chain the caller's hook (guard + user guidance) with the builder-owned
+        # attempt-guidance hook, so truncation-retry control reaches the model
+        # via llm_input_messages after compaction without ever being persisted.
+        effective_pre_model_hook = (
+            chain_pre_model_hooks(self.pre_model_hook, self._attempt_guidance_hook)
+            if self.pre_model_hook is not None
+            else chain_pre_model_hooks(self._attempt_guidance_hook)
+        )
+
         # Store all_tools for external access (e.g., for display_name lookup)
         self.all_tools = all_tools
         load_skill_tool = self._find_load_skill_tool()
@@ -1306,7 +1336,7 @@ class LangGraphAgentBuilder:
                 tools=tool_node_or_tools,
                 checkpointer=checkpointer,
                 prompt=prompt_modifier,
-                pre_model_hook=self.pre_model_hook,
+                pre_model_hook=effective_pre_model_hook,
             )
         else:
             self._agent = create_react_agent(
@@ -1314,7 +1344,7 @@ class LangGraphAgentBuilder:
                 tools=tool_node_or_tools,
                 checkpointer=checkpointer,
                 prompt=prompt_modifier,
-                pre_model_hook=self.pre_model_hook,
+                pre_model_hook=effective_pre_model_hook,
             )
         add_span_event("react_agent_created")
 
@@ -1343,52 +1373,6 @@ class LangGraphAgentBuilder:
             collect_all_events=False,
         )
         return result
-
-    async def stream_execute(
-        self,
-        messages: list[dict[str, Any]],
-        config: dict[str, Any] | None = None,
-        cancel_event: asyncio.Event | None = None,
-    ) -> AsyncGenerator[dict[str, Any], None]:
-        """Stream agent workflow execution.
-
-        Args:
-            messages: Initial conversation messages
-            config: Optional configuration (thread_id for checkpointing)
-            cancel_event: Optional cancellation event
-
-        Yields:
-            State updates as they occur
-        """
-        agent = self._build_agent()
-        lc_messages = _convert_validated_messages(
-            messages,
-            context="stream_execute input messages",
-            target_provider=self._provider,
-            target_model_id=self._model_id,
-            target_api_format=self._api_format,
-        )
-
-        exec_config = {"configurable": config} if config else None
-
-        _log_direct_llm_request(
-            messages=lc_messages,
-            tool_names=[t.name for t in getattr(self, "all_tools", []) or []],
-            request_name="stream_execute",
-        )
-
-        async for event in agent.astream(
-            {"messages": lc_messages},
-            config={
-                **(exec_config or {}),
-                "recursion_limit": self.max_iterations * 2 + 1,
-            },
-        ):
-            # Check cancellation
-            if cancel_event and cancel_event.is_set():
-                logger.info("Streaming cancelled by user")
-                return
-            yield event
 
     def _finalize_turn_history(
         self,
@@ -1424,6 +1408,7 @@ class LangGraphAgentBuilder:
         on_tool_event: Callable[[str, dict], None] | None = None,
         _truncation_retry_count: int = 0,
         _parent_turn_ctx: "TurnExecutionContext | None" = None,
+        _attempt_guidance: list[BaseMessage] | None = None,
     ) -> AsyncGenerator[str, None]:
         """Stream tokens from agent execution.
 
@@ -1441,6 +1426,11 @@ class LangGraphAgentBuilder:
             Content tokens as they are generated
         """
         add_span_event("stream_tokens_started", {"message_count": len(messages)})
+
+        # Attempt-scoped control guidance for this recursion level. The pre-model
+        # hook reads it and injects it into the model input after compaction; it
+        # is never persisted. Reset per level (empty on the root turn).
+        self._attempt_guidance = list(_attempt_guidance or [])
 
         add_span_event("building_agent_started")
         agent = self._build_agent()
@@ -2064,9 +2054,12 @@ class LangGraphAgentBuilder:
                 yield f"{TRUNCATED_MARKER_START}{e.reason}{TRUNCATED_MARKER_END}"
                 return
 
-            # Construct error message for LLM. It is an ephemeral CONTROL message:
-            # the model sees it this turn, but it must never be treated as a real
-            # user turn nor persisted (the compactor and serializer skip it).
+            # The truncation instruction is attempt-scoped CONTROL: the retry
+            # model must see it, but it must never be persisted nor compete with
+            # real user turns. It rides the attempt control plane (injected via
+            # llm_input_messages by _attempt_guidance_hook AFTER compaction), not
+            # the messages channel — so it survives the retry thread's own
+            # compaction while staying out of the summary/checkpoint/chain.
             error_message = TOOL_CALL_TRUNCATION_ERROR_TEMPLATE.format(
                 reason=e.reason,
                 attempt=_truncation_retry_count + 1,
@@ -2074,18 +2067,12 @@ class LangGraphAgentBuilder:
             )
 
             # Seed the retry from the CURRENT authoritative state (post-compaction,
-            # completed tool pairs), not the pre-run lc_messages. Re-submitting a
-            # sanitized list to the SAME thread would not delete the truncated tool
-            # call (add_messages merges by id), so the retry runs on a fresh thread
-            # while inheriting the root's original_input_ids via turn_ctx.
+            # completed tool pairs) only, not the pre-run lc_messages. Re-submitting
+            # a sanitized list to the SAME thread would not delete the truncated
+            # tool call (add_messages merges by id), so the retry runs on a fresh
+            # thread while inheriting the root's original_input_ids via turn_ctx.
             snapshot = await agent.aget_state({**exec_config})
             safe_state = sanitize_tool_pairs(snapshot.values.get("messages", []))
-            retry_seed = safe_state + [
-                HumanMessage(
-                    content=error_message,
-                    additional_kwargs={EPHEMERAL_CONTROL_FLAG: True},
-                )
-            ]
 
             logger.info(
                 "[stream_tokens] Retrying with truncation error context (attempt %d/%d)",
@@ -2100,13 +2087,14 @@ class LangGraphAgentBuilder:
                         if hasattr(msg, "model_dump")
                         else msg.dict() if hasattr(msg, "dict") else msg
                     )
-                    for msg in retry_seed
+                    for msg in safe_state
                 ],
                 config=config,
                 cancel_event=cancel_event,
                 on_tool_event=on_tool_event,
                 _truncation_retry_count=_truncation_retry_count + 1,
                 _parent_turn_ctx=turn_ctx,
+                _attempt_guidance=[HumanMessage(content=error_message)],
             ):
                 yield token
 

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -1251,14 +1251,6 @@ class LangGraphAgentBuilder:
 
         return ToolNode(all_tools, awrap_tool_call=awrap_tool_call)
 
-    @trace_sync(
-        span_name="agent_builder.build_agent",
-        tracer_name="chat_shell.agents",
-        extract_attributes=lambda self, *args, **kwargs: {
-            "agent.tools_count": len(self.tools),
-            "agent.max_iterations": self.max_iterations,
-        },
-    )
     def _attempt_guidance_hook(self, state: dict[str, Any]) -> dict[str, Any]:
         """Inject attempt-scoped control guidance into the model input only.
 
@@ -1276,6 +1268,14 @@ class LangGraphAgentBuilder:
         base = state.get("llm_input_messages") or state.get("messages") or []
         return {"llm_input_messages": [*base, *guidance]}
 
+    @trace_sync(
+        span_name="agent_builder.build_agent",
+        tracer_name="chat_shell.agents",
+        extract_attributes=lambda self, *args, **kwargs: {
+            "agent.tools_count": len(self.tools),
+            "agent.max_iterations": self.max_iterations,
+        },
+    )
     def _build_agent(self):
         """Build the LangGraph ReAct agent lazily."""
         if self._agent is not None:

--- a/chat_shell/chat_shell/agents/turn_context.py
+++ b/chat_shell/chat_shell/agents/turn_context.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn-scoped execution context for authoritative-state persistence.
+
+Holds state that must stay invariant across (recursive) truncation retries —
+above all the root turn's ``original_input_ids``, so ``_new_messages_from_state``
+keeps compaction clones / summary / suffix (fresh ids) and excludes only the
+unchanged input history, identically on every exit path.
+
+Thread ownership is *per recursion level*: each ``stream_tokens`` invocation owns
+exactly its ``current_thread_id`` and deletes it in its own ``finally``. A
+truncation retry derives a child context (``with_retry``) carrying a new thread;
+the child tears down its own thread, the parent tears down its own — no shared
+registry, no child deleting a parent's state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class TurnExecutionContext:
+    """Immutable per-level execution context for a single turn."""
+
+    original_input_ids: frozenset[str]
+    current_thread_id: str
+    truncation_retry_count: int = 0
+
+    def with_retry(self, new_thread_id: str) -> "TurnExecutionContext":
+        """Derive a child context for a truncation retry.
+
+        Inherits ``original_input_ids`` unchanged, takes over the new thread as
+        its own ``current_thread_id``, and increments the retry count.
+        """
+        return replace(
+            self,
+            current_thread_id=new_thread_id,
+            truncation_retry_count=self.truncation_retry_count + 1,
+        )

--- a/chat_shell/chat_shell/compression/summary_compactor.py
+++ b/chat_shell/chat_shell/compression/summary_compactor.py
@@ -50,11 +50,6 @@ SUMMARY_METADATA_FLAG = "summary_compacted"
 # serializer persists messages carrying this flag (see graph_builder), so the
 # checkpoint chain is self-contained ([retained user] + [summary] + [suffix]).
 CHECKPOINT_RETAINED_FLAG = "checkpoint_retained"
-# Marks an internal control message (e.g. the truncation-retry instruction) that
-# is fed to the model in-turn but must never be treated as a real user turn:
-# never the current user, never retained into the checkpoint, never summarized,
-# never persisted.
-EPHEMERAL_CONTROL_FLAG = "ephemeral_control"
 SUMMARY_COMPACT_VERSION = 1
 DEFAULT_RECENT_USER_TOKEN_LIMIT = 20_000
 
@@ -130,12 +125,6 @@ def _is_summary_message(message: BaseMessage) -> bool:
     """
     kwargs = getattr(message, "additional_kwargs", {}) or {}
     return kwargs.get(SUMMARY_METADATA_FLAG) is True
-
-
-def _is_ephemeral_control(message: BaseMessage) -> bool:
-    """True for an internal control message that must never enter the checkpoint."""
-    kwargs = getattr(message, "additional_kwargs", {}) or {}
-    return kwargs.get(EPHEMERAL_CONTROL_FLAG) is True
 
 
 def _extract_text(message: BaseMessage) -> str:
@@ -244,13 +233,7 @@ class SummaryCompactor:
         while True:
             try:
                 summary_body = await self._generate_summary(
-                    [
-                        message
-                        for message in self._sanitize_tool_message_sequence(
-                            working_messages
-                        )
-                        if not _is_ephemeral_control(message)
-                    ]
+                    self._sanitize_tool_message_sequence(working_messages)
                 )
                 break
             except Exception as exc:
@@ -454,7 +437,7 @@ class SummaryCompactor:
         for message in reversed(messages):
             if not isinstance(message, HumanMessage):
                 continue
-            if _is_summary_message(message) or _is_ephemeral_control(message):
+            if _is_summary_message(message):
                 continue
             message_tokens = self._token_counter.count_messages(
                 [_message_to_counter_dict(message)]
@@ -512,7 +495,7 @@ class SummaryCompactor:
         for message in reversed(messages):
             if not isinstance(message, HumanMessage):
                 continue
-            if _is_summary_message(message) or _is_ephemeral_control(message):
+            if _is_summary_message(message):
                 continue
             return message
         return None

--- a/chat_shell/chat_shell/compression/summary_compactor.py
+++ b/chat_shell/chat_shell/compression/summary_compactor.py
@@ -36,6 +36,7 @@ from langchain_core.messages import (
 )
 
 from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.compression.tool_sanitizer import sanitize_tool_pairs
 
 logger = logging.getLogger(__name__)
 
@@ -384,50 +385,7 @@ class SummaryCompactor:
         self, messages: list[BaseMessage]
     ) -> list[BaseMessage]:
         """Drop orphan tool messages and strip unresolved assistant tool calls."""
-        pending_call_ids: dict[str, None] = {}
-        matched_call_ids: set[str] = set()
-        tool_message_indices_to_keep: set[int] = set()
-
-        for index, message in enumerate(messages):
-            if isinstance(message, AIMessage):
-                for tool_call in message.tool_calls or []:
-                    tool_id = tool_call.get("id")
-                    if isinstance(tool_id, str) and tool_id:
-                        pending_call_ids[tool_id] = None
-                continue
-
-            if isinstance(message, ToolMessage):
-                tool_call_id = getattr(message, "tool_call_id", "")
-                if tool_call_id in pending_call_ids:
-                    matched_call_ids.add(tool_call_id)
-                    tool_message_indices_to_keep.add(index)
-
-        sanitized: list[BaseMessage] = []
-        for index, message in enumerate(messages):
-            if isinstance(message, AIMessage) and message.tool_calls:
-                kept_tool_calls = [
-                    deepcopy(tool_call)
-                    for tool_call in message.tool_calls
-                    if tool_call.get("id") in matched_call_ids
-                ]
-                if len(kept_tool_calls) == len(message.tool_calls):
-                    sanitized.append(message)
-                    continue
-
-                cloned = message.model_copy(deep=True)
-                cloned.tool_calls = kept_tool_calls
-                if cloned.content or cloned.tool_calls:
-                    sanitized.append(cloned)
-                continue
-
-            if isinstance(message, ToolMessage):
-                if index in tool_message_indices_to_keep:
-                    sanitized.append(message)
-                continue
-
-            sanitized.append(message)
-
-        return sanitized
+        return sanitize_tool_pairs(messages)
 
     def _build_replacement_history(
         self,

--- a/chat_shell/chat_shell/compression/summary_compactor.py
+++ b/chat_shell/chat_shell/compression/summary_compactor.py
@@ -74,8 +74,11 @@ Include:
 - Critical facts, paths, parameters, and tool findings needed to continue
 - The most important next step
 
-Output only the summary. Be concise, structured, and focused on helping the next \
-model seamlessly continue the work."""
+Output ONLY the summary content itself. Do NOT restate this instruction, and do \
+NOT add any preamble or meta-commentary (no "The user wants…", no "Let me \
+summarize…", no "Here is the summary"). Start directly with the current \
+objective. Be concise, structured, and focused on helping the next model \
+seamlessly continue the work."""
 
 
 @dataclass

--- a/chat_shell/chat_shell/compression/summary_compactor.py
+++ b/chat_shell/chat_shell/compression/summary_compactor.py
@@ -50,6 +50,11 @@ SUMMARY_METADATA_FLAG = "summary_compacted"
 # serializer persists messages carrying this flag (see graph_builder), so the
 # checkpoint chain is self-contained ([retained user] + [summary] + [suffix]).
 CHECKPOINT_RETAINED_FLAG = "checkpoint_retained"
+# Marks an internal control message (e.g. the truncation-retry instruction) that
+# is fed to the model in-turn but must never be treated as a real user turn:
+# never the current user, never retained into the checkpoint, never summarized,
+# never persisted.
+EPHEMERAL_CONTROL_FLAG = "ephemeral_control"
 SUMMARY_COMPACT_VERSION = 1
 DEFAULT_RECENT_USER_TOKEN_LIMIT = 20_000
 
@@ -125,6 +130,12 @@ def _is_summary_message(message: BaseMessage) -> bool:
     """
     kwargs = getattr(message, "additional_kwargs", {}) or {}
     return kwargs.get(SUMMARY_METADATA_FLAG) is True
+
+
+def _is_ephemeral_control(message: BaseMessage) -> bool:
+    """True for an internal control message that must never enter the checkpoint."""
+    kwargs = getattr(message, "additional_kwargs", {}) or {}
+    return kwargs.get(EPHEMERAL_CONTROL_FLAG) is True
 
 
 def _extract_text(message: BaseMessage) -> str:
@@ -233,7 +244,13 @@ class SummaryCompactor:
         while True:
             try:
                 summary_body = await self._generate_summary(
-                    self._sanitize_tool_message_sequence(working_messages)
+                    [
+                        message
+                        for message in self._sanitize_tool_message_sequence(
+                            working_messages
+                        )
+                        if not _is_ephemeral_control(message)
+                    ]
                 )
                 break
             except Exception as exc:
@@ -437,7 +454,7 @@ class SummaryCompactor:
         for message in reversed(messages):
             if not isinstance(message, HumanMessage):
                 continue
-            if _is_summary_message(message):
+            if _is_summary_message(message) or _is_ephemeral_control(message):
                 continue
             message_tokens = self._token_counter.count_messages(
                 [_message_to_counter_dict(message)]
@@ -495,7 +512,7 @@ class SummaryCompactor:
         for message in reversed(messages):
             if not isinstance(message, HumanMessage):
                 continue
-            if _is_summary_message(message):
+            if _is_summary_message(message) or _is_ephemeral_control(message):
                 continue
             return message
         return None

--- a/chat_shell/chat_shell/compression/summary_compactor.py
+++ b/chat_shell/chat_shell/compression/summary_compactor.py
@@ -17,11 +17,14 @@ governance phase:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import math
 import time
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
+from uuid import uuid4
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
@@ -36,31 +39,42 @@ from chat_shell.compression.token_counter import TokenCounter
 
 logger = logging.getLogger(__name__)
 
-SUMMARY_PREFIX = "[COMPACT SUMMARY]"
+SUMMARY_PREFIX = (
+    "[COMPACT SUMMARY] Another model worked on this task and produced the summary "
+    "below. Use it to continue the work and avoid repeating completed steps."
+)
 SUMMARY_COMPACTED_FLAG = "compacted"
 SUMMARY_METADATA_FLAG = "summary_compacted"
+# Marks a raw user message retained into the compaction checkpoint. The turn
+# serializer persists messages carrying this flag (see graph_builder), so the
+# checkpoint chain is self-contained ([retained user] + [summary] + [suffix]).
+CHECKPOINT_RETAINED_FLAG = "checkpoint_retained"
 SUMMARY_COMPACT_VERSION = 1
 DEFAULT_RECENT_USER_TOKEN_LIMIT = 20_000
 
-COMPACT_TASK_INSTRUCTION = """You are generating a compact handoff summary for a follow-up model.
+# Overflow-retry policy for the summary request. Codex retries this call
+# unboundedly, shedding a single oldest item each time, because in codex that
+# loop is the *only* overflow defense for summarization. Here it is not: the
+# guard runs a deterministic non-LLM fallback (``_apply_compression_pass`` /
+# emergency pass) whenever ``compact()`` raises, and ``_trim_to_budget`` already
+# trims proactively before the first call. So we cap the retries and shed a
+# *batch* each pass (converging in a few calls on a mis-estimate), then defer to
+# the guard fallback instead of grinding one item at a time.
+MAX_SUMMARY_OVERFLOW_RETRIES = 3
+SUMMARY_OVERFLOW_TRIM_FRACTION = 0.25
 
-Output only the compact summary body in the exact structure below.
-Do not add commentary or markdown outside the structure.
+COMPACT_TASK_INSTRUCTION = """You are performing a CONTEXT CHECKPOINT COMPACTION. \
+Create a handoff summary for another model that will resume this task.
 
-Current objective:
-<current user goal and active task>
+Include:
+- Current objective and active task
+- Progress and key decisions made so far
+- Important context, constraints, user preferences
+- Critical facts, paths, parameters, and tool findings needed to continue
+- The most important next step
 
-Key completed work:
-<important actions already completed>
-
-Important findings:
-<facts, paths, parameters, constraints, tool findings that matter>
-
-Next step:
-<the most important next action to continue the task>
-"""
-
-COMPACT_TASK_FINAL_PROMPT = "Produce the compact summary now."
+Output only the summary. Be concise, structured, and focused on helping the next \
+model seamlessly continue the work."""
 
 
 @dataclass
@@ -98,6 +112,20 @@ def _message_to_counter_dict(message: BaseMessage) -> dict[str, Any]:
     return payload
 
 
+def _is_summary_message(message: BaseMessage) -> bool:
+    """True for a compaction summary message.
+
+    Recognized only by the trusted ``summary_compacted`` marker. In package mode
+    it rides in ``additional_kwargs`` directly; in HTTP mode the backend forwards
+    it via a controlled ``metadata`` whitelist that the loader restores into
+    ``additional_kwargs``. Content is never used to infer type — a user could
+    legitimately send text starting with the summary prefix, and misclassifying
+    it would drop their real request.
+    """
+    kwargs = getattr(message, "additional_kwargs", {}) or {}
+    return kwargs.get(SUMMARY_METADATA_FLAG) is True
+
+
 def _extract_text(message: BaseMessage) -> str:
     content = getattr(message, "content", "")
     if isinstance(content, str):
@@ -116,7 +144,18 @@ def _extract_text(message: BaseMessage) -> str:
 
 
 def _is_context_too_long_error(exc: Exception) -> bool:
-    """Best-effort classifier for compact-task overflow failures."""
+    """Best-effort classifier for compact-task overflow failures.
+
+    Matches by HTTP status (400/413), English markers, and common Chinese /
+    heteroglyph phrasings from non-OpenAI providers.
+    """
+    # 413 (payload too large) is unconditionally an overflow. A bare 400 is
+    # ambiguous (invalid params, bad model config, malformed request), so it
+    # only counts as overflow when a length marker is also present — otherwise a
+    # non-overflow 400 would trigger a remove-one-message-and-retry storm.
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int) and status == 413:
+        return True
     text = " ".join(
         part for part in (str(exc), getattr(exc, "message", None)) if part
     ).lower()
@@ -129,6 +168,11 @@ def _is_context_too_long_error(exc: Exception) -> bool:
         "request too large",
         "maximum number of tokens",
         "token limit exceeded",
+        "输入长度超过",
+        "输入过长",
+        "请求体过大",
+        "token 数量超过",
+        "上下文长度",
     )
     return any(marker in text for marker in markers)
 
@@ -143,11 +187,13 @@ class SummaryCompactor:
         token_counter: TokenCounter,
         recent_user_token_limit: int = DEFAULT_RECENT_USER_TOKEN_LIMIT,
         max_compact_input_tokens: int | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         self._llm = llm
         self._token_counter = token_counter
         self._recent_user_token_limit = recent_user_token_limit
         self._max_compact_input_tokens = max_compact_input_tokens
+        self._request_timeout = request_timeout
 
     async def compact(
         self,
@@ -155,9 +201,11 @@ class SummaryCompactor:
         *,
         preserve_initial_context: bool,
     ) -> SummaryCompactResult:
-        """Run compact task with codex-style ``remove_oldest`` self-retry."""
-        working_messages = list(messages)
-        removed = 0
+        """Run compact task with a bounded, batched overflow self-retry."""
+        # Sanitize up front so the budget reflects what will actually be sent
+        # (orphan tool messages and unresolved tool_calls are dropped), rather
+        # than over-counting raw messages that sanitize would remove anyway.
+        working_messages = self._sanitize_tool_message_sequence(list(messages))
         current_user = self._find_current_user_message(working_messages)
         logger.info(
             "[SummaryCompact] compact() start: messages=%d "
@@ -166,51 +214,54 @@ class SummaryCompactor:
             self._max_compact_input_tokens,
         )
 
-        attempt = 0
+        # Proactive budget trim runs once: it is a complete single pass, so a
+        # later re-trim would be a no-op. The loop below only handles the case
+        # where the provider still rejects our (estimated) request as too long.
+        trim_started = time.perf_counter()
+        removed = self._trim_to_budget(working_messages, current_user=current_user)
+        if removed:
+            logger.info(
+                "[SummaryCompact] budget trim removed=%d remaining_messages=%d "
+                "elapsed_ms=%.1f",
+                removed,
+                len(working_messages),
+                (time.perf_counter() - trim_started) * 1000,
+            )
+
+        overflow_retries = 0
         while True:
-            attempt += 1
-            trim_started = time.perf_counter()
-            trim_removed = 0
-            while self._is_compact_prompt_over_limit(working_messages):
-                if not self._remove_oldest_history_item(
-                    working_messages,
-                    current_user=current_user,
-                ):
-                    raise SummaryCompactNotApplicable(
-                        "Summary compact cannot reduce the request because the "
-                        "remaining floor still exceeds the compact-task input budget."
-                    )
-                removed += 1
-                trim_removed += 1
-            if trim_removed:
-                logger.info(
-                    "[SummaryCompact] trim pass done: attempt=%d "
-                    "removed_this_pass=%d removed_total=%d remaining_messages=%d "
-                    "elapsed_ms=%.1f",
-                    attempt,
-                    trim_removed,
-                    removed,
-                    len(working_messages),
-                    (time.perf_counter() - trim_started) * 1000,
-                )
             try:
                 summary_body = await self._generate_summary(
                     self._sanitize_tool_message_sequence(working_messages)
                 )
                 break
             except Exception as exc:
-                if not _is_context_too_long_error(
-                    exc
-                ) or not self._remove_oldest_history_item(
-                    working_messages,
-                    current_user=current_user,
-                ):
+                if not _is_context_too_long_error(exc):
                     raise
-                removed += 1
+                if overflow_retries >= MAX_SUMMARY_OVERFLOW_RETRIES:
+                    # Hand the still-too-large request to the guard's
+                    # deterministic fallback instead of grinding further.
+                    raise
+                removable = len(
+                    self._removable_history_indices(
+                        working_messages, current_user=current_user
+                    )
+                )
+                step = max(1, math.ceil(removable * SUMMARY_OVERFLOW_TRIM_FRACTION))
+                dropped = self._remove_oldest_history_items(
+                    working_messages, current_user=current_user, count=step
+                )
+                if not dropped:
+                    raise
+                overflow_retries += 1
+                removed += dropped
                 logger.info(
                     "[SummaryCompact] retry-trim after context-length failure: "
-                    "attempt=%d removed_total=%d remaining_messages=%d",
-                    attempt,
+                    "retry=%d step=%d dropped=%d removed_total=%d "
+                    "remaining_messages=%d",
+                    overflow_retries,
+                    step,
+                    dropped,
                     removed,
                     len(working_messages),
                 )
@@ -227,10 +278,11 @@ class SummaryCompactor:
         )
 
     async def _generate_summary(self, messages: list[BaseMessage]) -> str:
+        # Instruction is the final user turn (recency), so the model summarizes
+        # rather than continuing/answering the last question in the history.
         prompt_messages: list[BaseMessage] = [
-            SystemMessage(content=COMPACT_TASK_INSTRUCTION),
             *messages,
-            HumanMessage(content=COMPACT_TASK_FINAL_PROMPT),
+            HumanMessage(content=COMPACT_TASK_INSTRUCTION),
         ]
         prompt_tokens = self._token_counter.count_messages(
             [_message_to_counter_dict(message) for message in prompt_messages]
@@ -242,7 +294,14 @@ class SummaryCompactor:
         )
         request_started = time.perf_counter()
         try:
-            result = await self._llm.ainvoke(prompt_messages)
+            if self._request_timeout is not None:
+                # asyncio.wait_for (not asyncio.timeout, which is 3.11+) keeps the
+                # chat_shell >=3.10 support floor.
+                result = await asyncio.wait_for(
+                    self._llm.ainvoke(prompt_messages), self._request_timeout
+                )
+            else:
+                result = await self._llm.ainvoke(prompt_messages)
         except BaseException as exc:
             # BaseException so a CancelledError (task/timeout cancellation) is
             # surfaced here rather than vanishing silently at the hang point.
@@ -264,22 +323,62 @@ class SummaryCompactor:
             )
         return summary_text
 
-    def _is_compact_prompt_over_limit(self, messages: list[BaseMessage]) -> bool:
-        """Return True when the compact task prompt itself exceeds input budget."""
+    def _trim_to_budget(
+        self,
+        messages: list[BaseMessage],
+        *,
+        current_user: HumanMessage | None,
+    ) -> int:
+        """Drop oldest removable messages in one O(n) pass to fit the budget.
+
+        Token counts are computed once per message (not re-summed per removal).
+        System messages and the current user message are never dropped. Callers
+        pass an already-sanitized list so the estimate matches the sent prompt.
+
+        Per-message cost excludes the counter's one-time reply-priming so the sum
+        does not inflate by ~priming*N; the priming is added back exactly once via
+        ``framing``. The result equals a single ``count_messages`` over the full
+        compact prompt.
+        """
         if self._max_compact_input_tokens is None:
-            return False
-        compact_prompt = [
-            SystemMessage(content=COMPACT_TASK_INSTRUCTION),
-            *self._sanitize_tool_message_sequence(messages),
-            HumanMessage(content=COMPACT_TASK_FINAL_PROMPT),
+            return 0
+
+        priming = self._token_counter.count_messages([])
+        counts = [
+            self._token_counter.count_messages([_message_to_counter_dict(m)]) - priming
+            for m in messages
         ]
-        compact_prompt_dicts = [
-            _message_to_counter_dict(message) for message in compact_prompt
-        ]
-        return (
-            self._token_counter.count_messages(compact_prompt_dicts)
-            > self._max_compact_input_tokens
+        framing = self._token_counter.count_messages(
+            [
+                _message_to_counter_dict(
+                    HumanMessage(content=COMPACT_TASK_INSTRUCTION)
+                ),
+            ]
         )
+        total = sum(counts) + framing
+        budget = self._max_compact_input_tokens
+        if total <= budget:
+            return 0
+
+        drop: set[int] = set()
+        for i, message in enumerate(messages):
+            if total <= budget:
+                break
+            if isinstance(message, SystemMessage):
+                continue
+            if current_user is not None and message is current_user:
+                continue
+            drop.add(i)
+            total -= counts[i]
+
+        if total > budget:
+            raise SummaryCompactNotApplicable(
+                "Summary compact cannot reduce the request because the remaining "
+                "floor still exceeds the compact-task input budget."
+            )
+
+        messages[:] = [m for i, m in enumerate(messages) if i not in drop]
+        return len(drop)
 
     def _sanitize_tool_message_sequence(
         self, messages: list[BaseMessage]
@@ -357,6 +456,20 @@ class SummaryCompactor:
         )
         return replacement
 
+    @staticmethod
+    def _clone_retained_user(message: HumanMessage) -> HumanMessage:
+        """Clone a retained user message with a fresh id + checkpoint marker.
+
+        A fresh id keeps the clone out of the turn's input-id set so
+        ``_new_messages_from_state`` treats it as generated-this-turn; the marker
+        makes the turn serializer persist it into ``messages_chain``.
+        """
+        kwargs = dict(getattr(message, "additional_kwargs", {}) or {})
+        kwargs[CHECKPOINT_RETAINED_FLAG] = True
+        return HumanMessage(
+            content=message.content, id=str(uuid4()), additional_kwargs=kwargs
+        )
+
     def _select_recent_user_messages(
         self, messages: list[BaseMessage]
     ) -> list[HumanMessage]:
@@ -366,8 +479,7 @@ class SummaryCompactor:
         for message in reversed(messages):
             if not isinstance(message, HumanMessage):
                 continue
-            kwargs = getattr(message, "additional_kwargs", {}) or {}
-            if kwargs.get(SUMMARY_METADATA_FLAG) is True:
+            if _is_summary_message(message):
                 continue
             message_tokens = self._token_counter.count_messages(
                 [_message_to_counter_dict(message)]
@@ -377,13 +489,13 @@ class SummaryCompactor:
                 break
 
             if message_tokens <= remaining_budget:
-                selected.append(message)
+                selected.append(self._clone_retained_user(message))
                 used_tokens += message_tokens
                 continue
 
             truncated = self._truncate_user_message(message, remaining_budget)
             if truncated is not None:
-                selected.append(truncated)
+                selected.append(self._clone_retained_user(truncated))
                 break
 
         selected.reverse()
@@ -425,23 +537,50 @@ class SummaryCompactor:
         for message in reversed(messages):
             if not isinstance(message, HumanMessage):
                 continue
-            kwargs = getattr(message, "additional_kwargs", {}) or {}
-            if kwargs.get(SUMMARY_METADATA_FLAG) is True:
+            if _is_summary_message(message):
                 continue
             return message
         return None
 
     @staticmethod
-    def _remove_oldest_history_item(
+    def _removable_history_indices(
         messages: list[BaseMessage],
         *,
         current_user: HumanMessage | None,
-    ) -> bool:
-        for index, message in enumerate(messages):
-            if isinstance(message, SystemMessage):
-                continue
-            if current_user is not None and message is current_user:
-                continue
-            del messages[index]
-            return True
-        return False
+    ) -> list[int]:
+        """Indices eligible for overflow trimming, oldest first.
+
+        System messages and the current user turn are always protected. When no
+        current user turn exists, the newest removable message is also protected
+        so at least one non-system message always survives.
+        """
+        removable = [
+            index
+            for index, message in enumerate(messages)
+            if not isinstance(message, SystemMessage)
+            and not (current_user is not None and message is current_user)
+        ]
+        if current_user is None and removable:
+            removable = removable[:-1]
+        return removable
+
+    @classmethod
+    def _remove_oldest_history_items(
+        cls,
+        messages: list[BaseMessage],
+        *,
+        current_user: HumanMessage | None,
+        count: int,
+    ) -> int:
+        """Drop up to ``count`` oldest removable items; return how many went."""
+        if count <= 0:
+            return 0
+        to_drop = set(
+            cls._removable_history_indices(messages, current_user=current_user)[:count]
+        )
+        if not to_drop:
+            return 0
+        messages[:] = [
+            message for index, message in enumerate(messages) if index not in to_drop
+        ]
+        return len(to_drop)

--- a/chat_shell/chat_shell/compression/tool_sanitizer.py
+++ b/chat_shell/chat_shell/compression/tool_sanitizer.py
@@ -12,8 +12,32 @@ and the history finalizer so every path applies identical pairing rules.
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import Any
 
 from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+
+
+def _strip_unmatched_tool_use_blocks(content: Any, matched_call_ids: set[str]) -> Any:
+    """Drop id-based ``tool_use`` content blocks whose id is not matched.
+
+    For block-list assistant content (Anthropic format), stripping an entry from
+    ``tool_calls`` is not enough: the parallel ``{"type": "tool_use", "id": ...}``
+    block stays in ``content`` and would be sent without a matching
+    ``tool_result``, which the provider rejects. Only list content is filtered;
+    string content is returned unchanged.
+    """
+    if not isinstance(content, list):
+        return content
+    kept_blocks: list[Any] = []
+    for block in content:
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "tool_use"
+            and block.get("id") not in matched_call_ids
+        ):
+            continue
+        kept_blocks.append(block)
+    return kept_blocks
 
 
 def sanitize_tool_pairs(messages: list[BaseMessage]) -> list[BaseMessage]:
@@ -55,6 +79,11 @@ def sanitize_tool_pairs(messages: list[BaseMessage]) -> list[BaseMessage]:
 
             cloned = message.model_copy(deep=True)
             cloned.tool_calls = kept_tool_calls
+            # Also drop the parallel unmatched tool_use blocks from block-list
+            # content, else they ship without a matching tool_result.
+            cloned.content = _strip_unmatched_tool_use_blocks(
+                cloned.content, matched_call_ids
+            )
             if cloned.content or cloned.tool_calls:
                 sanitized.append(cloned)
             continue

--- a/chat_shell/chat_shell/compression/tool_sanitizer.py
+++ b/chat_shell/chat_shell/compression/tool_sanitizer.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared tool-call/tool-result pairing sanitizer.
+
+A single source of truth for dropping orphan ``ToolMessage``s and stripping
+unresolved assistant ``tool_calls``. Used by summary compaction, graph recovery,
+and the history finalizer so every path applies identical pairing rules.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+
+
+def sanitize_tool_pairs(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Drop orphan tool messages and strip unresolved assistant tool calls.
+
+    Preserves message order. An assistant ``tool_call`` is kept only if a
+    matching ``ToolMessage`` (same ``tool_call_id``) exists; a ``ToolMessage`` is
+    kept only if it resolves a known assistant ``tool_call``.
+    """
+    pending_call_ids: dict[str, None] = {}
+    matched_call_ids: set[str] = set()
+    tool_message_indices_to_keep: set[int] = set()
+
+    for index, message in enumerate(messages):
+        if isinstance(message, AIMessage):
+            for tool_call in message.tool_calls or []:
+                tool_id = tool_call.get("id")
+                if isinstance(tool_id, str) and tool_id:
+                    pending_call_ids[tool_id] = None
+            continue
+
+        if isinstance(message, ToolMessage):
+            tool_call_id = getattr(message, "tool_call_id", "")
+            if tool_call_id in pending_call_ids:
+                matched_call_ids.add(tool_call_id)
+                tool_message_indices_to_keep.add(index)
+
+    sanitized: list[BaseMessage] = []
+    for index, message in enumerate(messages):
+        if isinstance(message, AIMessage) and message.tool_calls:
+            kept_tool_calls = [
+                deepcopy(tool_call)
+                for tool_call in message.tool_calls
+                if tool_call.get("id") in matched_call_ids
+            ]
+            if len(kept_tool_calls) == len(message.tool_calls):
+                sanitized.append(message)
+                continue
+
+            cloned = message.model_copy(deep=True)
+            cloned.tool_calls = kept_tool_calls
+            if cloned.content or cloned.tool_calls:
+                sanitized.append(cloned)
+            continue
+
+        if isinstance(message, ToolMessage):
+            if index in tool_message_indices_to_keep:
+                sanitized.append(message)
+            continue
+
+        sanitized.append(message)
+
+    return sanitized

--- a/chat_shell/chat_shell/core/config.py
+++ b/chat_shell/chat_shell/core/config.py
@@ -112,7 +112,6 @@ class Settings(BaseSettings):
     # Workspace configuration
     WORKSPACE_ROOT: str = "/workspace"
     ENABLE_SKILLS: bool = True
-    ENABLE_CHECKPOINTING: bool = False
 
     # Attachment/Context configuration
     MAX_EXTRACTED_TEXT_LENGTH: int = 100000

--- a/chat_shell/chat_shell/guard/composition.py
+++ b/chat_shell/chat_shell/guard/composition.py
@@ -14,11 +14,15 @@ The chained hook:
   prior hooks' state mutations;
 * tolerates a mix of sync and async hooks transparently;
 * concatenates ``messages`` updates from every hook (in order);
-* keeps the LAST hook's ``llm_input_messages`` if any hook supplied one.
+* rolls each hook's ``llm_input_messages`` forward into the state passed to the
+  next hook, so multiple model-input producers compose instead of clobbering
+  one another. The merged result carries the LAST such value.
 
 Order matters. Place hooks that mutate state (e.g., the budget guard) BEFORE
 hooks that only override the LLM's input list (e.g., guidance injection) so the
-latter sees post-mutation state.
+latter sees post-mutation state. A later model-input producer should base its
+output on ``state.get("llm_input_messages") or state["messages"]`` to build on
+the earlier producer's list.
 """
 
 from __future__ import annotations
@@ -47,8 +51,8 @@ def chain_pre_model_hooks(
 
     Hooks fire in the order given. Each hook sees a state where prior hooks'
     ``messages`` updates have already been applied via the ``add_messages``
-    reducer. ``llm_input_messages`` is forwarded from the last hook that
-    produced one (so place the guidance-style hook last).
+    reducer, and where any prior ``llm_input_messages`` has been rolled forward
+    so guidance-style hooks stack (place the guidance-style hooks last).
     """
     if not hooks:
         raise ValueError("chain_pre_model_hooks requires at least one hook")
@@ -77,6 +81,12 @@ def chain_pre_model_hooks(
 
             if "llm_input_messages" in update:
                 last_llm_input = update["llm_input_messages"]
+                # Roll forward so a later model-input producer builds on this
+                # list instead of overwriting it.
+                current_state = {
+                    **current_state,
+                    "llm_input_messages": last_llm_input,
+                }
 
         merged: dict[str, Any] = {}
         if accumulated_messages:

--- a/chat_shell/chat_shell/guard/context_guard.py
+++ b/chat_shell/chat_shell/guard/context_guard.py
@@ -36,6 +36,7 @@ material changed.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from copy import deepcopy
@@ -71,6 +72,7 @@ from chat_shell.compression.context_metrics import (
 from chat_shell.compression.summary_compactor import (
     SummaryCompactNotApplicable,
     SummaryCompactor,
+    SummaryCompactResult,
 )
 from chat_shell.compression.token_counter import TokenCounter
 from chat_shell.guard.tool_output import COMPACTED_FLAG
@@ -79,6 +81,11 @@ from chat_shell.guard.types import GuardSource
 from chat_shell.guard_flags import BYPASS_COMPACTION_FLAG
 
 logger = logging.getLogger(__name__)
+
+# Interval between in-progress heartbeat status emits during summary compaction.
+# The emits keep the SSE stream alive so the backend read-timeout does not fire
+# while a long compaction runs; the model call, not this value, bounds duration.
+COMPACTION_HEARTBEAT_INTERVAL_S = 15.0
 
 
 class ContextGuardFailFastError(RuntimeError):
@@ -719,6 +726,73 @@ class UnifiedContextGuard:
     # Stage 2: request-level compression
     # ------------------------------------------------------------------
 
+    async def _emit_compaction_heartbeats(
+        self,
+        snapshot: ContextMetricsSnapshot,
+        before_tokens: int,
+        created_at: str,
+    ) -> None:
+        """Emit a non-terminal in_progress status every interval to keep SSE alive.
+
+        Runs concurrently with the (potentially slow, non-streaming) compaction so
+        the backend read-timeout is reset by real bytes on the wire. Emit failures
+        are swallowed — telemetry must never break compaction.
+        """
+        if self._tracker is None:
+            return
+        try:
+            while True:
+                await asyncio.sleep(COMPACTION_HEARTBEAT_INTERVAL_S)
+                try:
+                    await self._tracker.emit_status(
+                        phase="summary_compact",
+                        snapshot=snapshot,
+                        context_compaction=ContextCompactionEvent(
+                            type="summary_compact",
+                            status="in_progress",
+                            before_tokens=before_tokens,
+                            trigger_limit=self.trigger_limit,
+                            target_limit=self.target_limit,
+                            used_legacy_fallback=False,
+                            created_at=created_at,
+                        ),
+                    )
+                except Exception:
+                    logger.debug(
+                        "[UnifiedContextGuard] compaction heartbeat emit failed",
+                        exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            # Cleanup is already handled above; re-raise so the cancellation is
+            # observed rather than swallowed (structured-concurrency correctness).
+            raise
+
+    async def _compact_with_heartbeat(
+        self,
+        view: list[dict[str, Any]],
+        *,
+        snapshot: ContextMetricsSnapshot,
+        before_tokens: int,
+        created_at: str,
+    ) -> SummaryCompactResult:
+        """Run compaction while a heartbeat ticker keeps the SSE stream alive.
+
+        The ticker is always cancelled (success, error, or cancellation) via the
+        ``finally`` so no background task is left running past the compaction.
+        """
+        heartbeat = asyncio.create_task(
+            self._emit_compaction_heartbeats(snapshot, before_tokens, created_at)
+        )
+        try:
+            return await self._summary_compactor.compact(
+                [_dict_to_state_message(message_dict) for message_dict in view],
+                preserve_initial_context=True,
+            )
+        finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+
     async def _apply_summary_compaction_pass(
         self,
         view: list[dict[str, Any]],
@@ -749,9 +823,11 @@ class UnifiedContextGuard:
         )
         compact_started = time.perf_counter()
         try:
-            result = await self._summary_compactor.compact(
-                [_dict_to_state_message(message_dict) for message_dict in view],
-                preserve_initial_context=True,
+            result = await self._compact_with_heartbeat(
+                view,
+                snapshot=before_snapshot,
+                before_tokens=before_tokens,
+                created_at=created_at,
             )
         except asyncio.CancelledError:
             # CancelledError is a BaseException; the ``except Exception`` below

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -240,6 +240,7 @@ async def get_chat_history(
     is_group_chat: bool,
     exclude_after_message_id: int | None = None,
     limit: int | None = None,
+    from_latest_compaction: bool = True,
 ) -> list[dict[str, Any]]:
     """Get chat history for a task.
 
@@ -253,6 +254,8 @@ async def get_chat_history(
         exclude_after_message_id: If provided, exclude messages with message_id >= this value.
         limit: If provided, limit the number of messages returned (most recent N messages).
             Used by subscription tasks to control history context size.
+        from_latest_compaction: If True (default), load from the latest summary-
+            compaction checkpoint instead of the full transcript.
 
     Returns:
         List of message dictionaries with 'role' and 'content' keys
@@ -278,11 +281,19 @@ async def get_chat_history(
 
     if is_http:
         history = await _load_history_from_remote(
-            task_id, is_group_chat, exclude_after_message_id, limit
+            task_id,
+            is_group_chat,
+            exclude_after_message_id,
+            limit,
+            from_latest_compaction,
         )
     else:
         history = await _load_history_from_db(
-            task_id, is_group_chat, exclude_after_message_id, limit
+            task_id,
+            is_group_chat,
+            exclude_after_message_id,
+            limit,
+            from_latest_compaction,
         )
 
     logger.debug(
@@ -302,6 +313,7 @@ async def _load_history_from_remote(
     is_group_chat: bool,
     exclude_after_message_id: int | None = None,
     limit: int | None = None,
+    from_latest_compaction: bool = False,
 ) -> list[dict[str, Any]]:
     """Load chat history from Backend via RemoteHistoryStore.
 
@@ -312,6 +324,8 @@ async def _load_history_from_remote(
         is_group_chat: Whether to include username prefix in user messages
         exclude_after_message_id: If provided, exclude messages with message_id >= this value.
         limit: If provided, limit the number of messages returned (most recent N messages).
+        from_latest_compaction: If True, request history from the latest summary-
+            compaction checkpoint instead of the full transcript.
     """
     logger.debug(
         "[history] _load_history_from_remote: START task_id=%d, is_group_chat=%s, "
@@ -343,6 +357,7 @@ async def _load_history_from_remote(
             before_message_id=before_id,
             is_group_chat=is_group_chat,
             limit=limit,
+            from_latest_compaction=from_latest_compaction,
         )
 
         logger.debug(
@@ -359,6 +374,14 @@ async def _load_history_from_remote(
             # RemoteHistoryStore returns Message objects
             # Use to_dict() to get all fields and pass through directly
             msg_dict = msg.to_dict()
+            # Restore the trusted summary marker from the controlled metadata
+            # whitelist into additional_kwargs (LangChain preserves it), so the
+            # compactor recognizes reloaded summaries without content sniffing.
+            metadata = msg_dict.get("metadata")
+            if isinstance(metadata, dict) and metadata.get("summary_compacted"):
+                kwargs = dict(msg_dict.get("additional_kwargs") or {})
+                kwargs["summary_compacted"] = True
+                msg_dict["additional_kwargs"] = kwargs
             history.append(msg_dict)
 
         logger.debug(
@@ -386,6 +409,7 @@ async def _load_history_from_db(
     is_group_chat: bool,
     exclude_after_message_id: int | None = None,
     limit: int | None = None,
+    from_latest_compaction: bool = False,
 ) -> list[dict[str, Any]]:
     """Load chat history from database (Package mode).
 
@@ -396,6 +420,7 @@ async def _load_history_from_db(
         is_group_chat: Whether to include username prefix in user messages
         exclude_after_message_id: If provided, exclude messages with message_id >= this value.
         limit: If provided, limit the number of messages returned (most recent N messages).
+        from_latest_compaction: If True, load from the latest compaction checkpoint.
     """
     return await asyncio.to_thread(
         _load_history_from_db_sync,
@@ -403,6 +428,7 @@ async def _load_history_from_db(
         is_group_chat,
         exclude_after_message_id,
         limit,
+        from_latest_compaction,
     )
 
 
@@ -411,6 +437,7 @@ def _load_history_from_db_sync(
     is_group_chat: bool,
     exclude_after_message_id: int | None = None,
     limit: int | None = None,
+    from_latest_compaction: bool = False,
 ) -> list[dict[str, Any]]:
     """Synchronous implementation of chat history retrieval.
 
@@ -421,43 +448,50 @@ def _load_history_from_db_sync(
         is_group_chat: Whether to include username prefix in user messages
         exclude_after_message_id: If provided, exclude messages with message_id >= this value.
         limit: If provided, limit the number of messages returned (most recent N messages).
+        from_latest_compaction: If True, load from the latest compaction checkpoint
+            (wired to the shared backend pipeline in Task 10).
     """
     # Import backend's models and database session
     # This works in package mode since we're running within the backend process
     from app.db.session import SessionLocal
-    from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
-    from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
+    from app.models.subtask import SubtaskStatus
     from app.models.user import User
+    from app.services.chat.compaction_checkpoint import resolve_history_subtasks
+    from app.stores.tasks import task_store
 
     history: list[dict[str, Any]] = []
 
     db = SessionLocal()
     try:
-        query = (
-            db.query(Subtask, User.user_name)
-            .outerjoin(User, Subtask.sender_user_id == User.id)
-            .filter(
-                Subtask.task_id == task_id,
-                Subtask.status.in_([SubtaskStatus.COMPLETED, SubtaskStatus.FAILED]),
-            )
+        # Delegate to the shared backend pipeline so fork lineage, before/limit,
+        # and checkpoint scoping stay identical to the HTTP endpoint. (Package's
+        # original direct query bypassed the fork resolver — a latent divergence.)
+        task = task_store.get_by_id(db, task_id=task_id)
+        task_user_id = task.user_id if task else None
+        subtasks = resolve_history_subtasks(
+            db=db,
+            task_id=task_id,
+            user_id=task_user_id,
+            before_message_id=exclude_after_message_id,
+            limit=limit,
+            from_latest_compaction=from_latest_compaction,
+            statuses=[SubtaskStatus.COMPLETED, SubtaskStatus.FAILED],
         )
 
-        if exclude_after_message_id is not None:
-            query = query.filter(Subtask.message_id < exclude_after_message_id)
+        # Look up sender usernames (for group-chat prefixing) in one batch.
+        sender_ids = {s.sender_user_id for s in subtasks if s.sender_user_id}
+        username_by_id: dict[Any, str] = {}
+        if sender_ids:
+            rows = (
+                db.query(User.id, User.user_name).filter(User.id.in_(sender_ids)).all()
+            )
+            username_by_id = {uid: name for uid, name in rows}
 
-        # If limit is specified, we need to get the most recent N messages
-        # First order by message_id desc to get the latest, then reverse
-        if limit is not None and limit > 0:
-            # Get the most recent N messages by ordering desc and limiting
-            subtasks = query.order_by(Subtask.message_id.desc()).limit(limit).all()
-            # Reverse to get chronological order
-            subtasks = list(reversed(subtasks))
-        else:
-            subtasks = query.order_by(Subtask.message_id.asc()).all()
-
-        for subtask, sender_username in subtasks:
-            msgs = _build_history_messages(db, subtask, sender_username, is_group_chat)
-            history.extend(msgs)
+        for subtask in subtasks:
+            sender_username = username_by_id.get(subtask.sender_user_id)
+            history.extend(
+                _build_history_messages(db, subtask, sender_username, is_group_chat)
+            )
     finally:
         db.close()
 

--- a/chat_shell/chat_shell/models/factory.py
+++ b/chat_shell/chat_shell/models/factory.py
@@ -111,6 +111,7 @@ class LangChainModelFactory:
                 "temperature": kw.get("temperature"),
                 "max_tokens": cfg.get("max_tokens"),
                 "streaming": kw.get("streaming", False),
+                "timeout": kw.get("request_timeout"),
                 "model_kwargs": (
                     {"extra_headers": cfg.get("default_headers")}
                     if cfg.get("default_headers")
@@ -143,6 +144,7 @@ class LangChainModelFactory:
                 "temperature": kw.get("temperature"),
                 "max_tokens": cfg.get("max_tokens"),
                 "streaming": kw.get("streaming", False),
+                "default_request_timeout": kw.get("request_timeout"),
                 # Caching strategy:
                 # - Automatic caching (top-level cache_control): available when
                 #   the provider supports it (is_support_claude_automatic_caching).
@@ -175,6 +177,7 @@ class LangChainModelFactory:
                 "temperature": kw.get("temperature"),
                 "max_output_tokens": cfg.get("max_tokens"),
                 "streaming": kw.get("streaming", False),
+                "timeout": kw.get("request_timeout"),
                 "additional_headers": cfg.get("default_headers") or None,
             },
         },

--- a/chat_shell/chat_shell/services/chat_service.py
+++ b/chat_shell/chat_shell/services/chat_service.py
@@ -351,6 +351,7 @@ class ChatService(ChatInterface):
                         "model": guard_model_type or "openai",
                     },
                     streaming=False,
+                    request_timeout=240,
                 )
                 context_config = get_model_context_config(
                     guard_model_id,
@@ -363,7 +364,8 @@ class ChatService(ChatInterface):
                         DEFAULT_RECENT_USER_TOKEN_LIMIT,
                         max(1, int(context_config.target_limit * 0.5)),
                     ),
-                    max_compact_input_tokens=context_config.available_tokens,
+                    max_compact_input_tokens=context_config.target_limit,
+                    request_timeout=240,
                 )
             context_guard = UnifiedContextGuard(
                 model_id=guard_model_id,

--- a/chat_shell/chat_shell/services/chat_service.py
+++ b/chat_shell/chat_shell/services/chat_service.py
@@ -270,7 +270,6 @@ class ChatService(ChatInterface):
                 workspace_root=settings.WORKSPACE_ROOT,
                 enable_skills=settings.ENABLE_SKILLS,
                 enable_web_search=False,
-                enable_checkpointing=settings.ENABLE_CHECKPOINTING,
             )
 
             add_span_event(

--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -93,6 +93,7 @@ class RemoteHistoryStore(HistoryStoreInterface):
         limit: Optional[int] = None,
         before_message_id: Optional[str] = None,
         is_group_chat: bool = False,
+        from_latest_compaction: bool = False,
     ) -> list[Message]:
         """Get chat history for a session."""
         total_start = time.perf_counter()
@@ -108,6 +109,8 @@ class RemoteHistoryStore(HistoryStoreInterface):
             params["before_message_id"] = before_message_id
         # Pass is_group_chat to API for proper username prefix handling
         params["is_group_chat"] = str(is_group_chat).lower()
+        if from_latest_compaction:
+            params["from_latest_compaction"] = "true"
 
         url = f"/chat/history/{session_id}"
         full_url = f"{self.base_url}{url}"

--- a/chat_shell/tests/services/test_guidance.py
+++ b/chat_shell/tests/services/test_guidance.py
@@ -143,11 +143,25 @@ async def test_remote_guidance_queue_client_uses_internal_chat_guidance_endpoint
     ]
 
 
-def test_langgraph_agent_builder_passes_pre_model_hook_to_create_react_agent():
-    pre_model_hook = MagicMock()
+@pytest.mark.asyncio
+async def test_langgraph_agent_builder_composes_caller_pre_model_hook():
+    """The caller's hook is chained (not passed by identity) so the builder can
+    append attempt-scoped guidance after it; the caller's hook still runs."""
+    calls: list = []
+
+    def pre_model_hook(state):
+        calls.append(state)
+        return {"llm_input_messages": [HumanMessage(content="hooked")]}
+
     builder = LangGraphAgentBuilder(llm=MagicMock(), pre_model_hook=pre_model_hook)
 
     with patch("chat_shell.agents.graph_builder.create_react_agent") as create_agent:
         builder._build_agent()
 
-    assert create_agent.call_args.kwargs["pre_model_hook"] is pre_model_hook
+    chained = create_agent.call_args.kwargs["pre_model_hook"]
+    assert chained is not pre_model_hook  # composed, not identity
+
+    result = await chained({"messages": [HumanMessage(content="hi")]})
+    assert calls  # the caller's hook was invoked inside the chain
+    # No attempt guidance active -> the caller's model input is preserved.
+    assert [m.content for m in result["llm_input_messages"]] == ["hooked"]

--- a/chat_shell/tests/test_context_guard.py
+++ b/chat_shell/tests/test_context_guard.py
@@ -1044,6 +1044,52 @@ class TestTrackerEmits:
             "completed",
         ]
 
+    async def test_summary_compaction_emits_heartbeats(self, guard, monkeypatch):
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock
+
+        from chat_shell.compression.context_metrics import ContextMetricsTracker
+
+        monkeypatch.setattr(
+            "chat_shell.guard.context_guard.COMPACTION_HEARTBEAT_INTERVAL_S", 0.01
+        )
+
+        class _SlowCompactor:
+            async def compact(self, messages, *, preserve_initial_context):
+                await _asyncio.sleep(0.05)
+                return SummaryCompactResult(
+                    summary_text="Current objective:\ncontinue",
+                    replacement_history=[
+                        HumanMessage(content="[COMPACT SUMMARY]\n\ncontinue")
+                    ],
+                    removed_history_items=1,
+                )
+
+        emitter = AsyncMock()
+        tracker = ContextMetricsTracker(
+            task_id=1, subtask_id=2, metrics_fn=guard.metrics, emitter=emitter
+        )
+        guard.set_tracker(tracker)
+        guard._summary_compactor = _SlowCompactor()
+
+        state = {
+            "messages": [
+                HumanMessage(content="x" * 40000, id="h-1"),
+                AIMessage(content="y" * 40000, id="a-1"),
+            ]
+        }
+        await guard(state)
+
+        statuses = [
+            call.kwargs["context_compaction"]["status"]
+            for call in emitter.status_updated.await_args_list
+            if call.kwargs.get("context_compaction", {}).get("type")
+            == "summary_compact"
+        ]
+        assert "in_progress" in statuses
+        assert statuses[0] == "started"
+        assert statuses[-1] == "completed"
+
     async def test_summary_compaction_failure_emits_fallback_runtime_event(self, guard):
         from unittest.mock import AsyncMock
 

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -343,3 +343,68 @@ async def test_tool_limit_recovery_persists_full_chain_without_instruction(monke
         "Tool call limit" in str(getattr(m, "content", "")) for m in recovery_seen
     )
     assert builder._last_termination_reason == "graph_recursion_limit_recovery"
+
+
+@pytest.mark.asyncio
+async def test_truncation_retry_seeds_new_thread_with_ephemeral_instruction(
+    monkeypatch,
+):
+    from chat_shell.agents.graph_builder import (
+        LangGraphAgentBuilder,
+        ToolCallTruncatedError,
+    )
+    from chat_shell.compression.summary_compactor import EPHEMERAL_CONTROL_FLAG
+
+    # Authoritative state at the truncation point: a real user + partial reply.
+    authoritative = [
+        HumanMessage(content="analyze data", id="u-real"),
+        AIMessage(content="partial", id="a-partial"),
+    ]
+
+    class _Snap:
+        values = {"messages": authoritative}
+
+    calls = {"n": 0}
+    captured: dict = {}
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                captured["root_thread"] = config["configurable"]["thread_id"]
+                raise ToolCallTruncatedError(reason="length", has_tool_calls=True)
+            # Second call = the retry: capture its seed + thread, then complete.
+            captured["retry_input"] = _input["messages"]
+            captured["retry_thread"] = config["configurable"]["thread_id"]
+            for _ in []:
+                yield
+
+        async def aget_state(self, _config):
+            return _Snap()
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+    monkeypatch.setattr(builder, "max_truncation_retries", 2)
+
+    async for _token in builder.stream_tokens(
+        messages=[{"role": "user", "content": "hi"}]
+    ):
+        pass
+
+    retry_msgs = captured["retry_input"]
+    # The retry ran on a DIFFERENT thread than the root turn.
+    assert captured["retry_thread"] != captured["root_thread"]
+    # The sanitized authoritative state was seeded into the retry.
+    assert any(getattr(m, "content", "") == "analyze data" for m in retry_msgs)
+    # The truncation instruction rides as an ephemeral control message.
+    ephemeral = [
+        m
+        for m in retry_msgs
+        if getattr(m, "additional_kwargs", {}).get(EPHEMERAL_CONTROL_FLAG) is True
+    ]
+    assert len(ephemeral) == 1
+    assert "[SYSTEM ERROR]" in ephemeral[0].content

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -161,3 +161,52 @@ async def test_stream_tokens_injects_unique_thread_and_exit_durability(monkeypat
     t0 = captured[0]["config"]["configurable"]["thread_id"]
     t1 = captured[1]["config"]["configurable"]["thread_id"]
     assert t0 and t1 and t0 != t1  # present and unique per turn
+
+
+def test_finalize_turn_history_sets_all_three_fields_atomically():
+    from langchain_core.messages import ToolMessage
+
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+    from chat_shell.agents.turn_context import TurnExecutionContext
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    # Authoritative post-compaction state: input "u1" already removed; the
+    # retained clone / summary / suffix carry fresh ids (not in original_input_ids).
+    state = [
+        HumanMessage(
+            content="retained",
+            additional_kwargs={"checkpoint_retained": True},
+            id="r1",
+        ),
+        HumanMessage(
+            content="[COMPACT SUMMARY] s",
+            additional_kwargs={"compacted": True, "summary_compacted": True},
+            id="s1",
+        ),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "t2", "name": "_probe", "args": {}}],
+            id="a2",
+        ),
+        ToolMessage(content="ok", tool_call_id="t2", name="_probe", id="tm2"),
+        AIMessage(content="final answer", id="a3"),
+    ]
+    ctx = TurnExecutionContext(
+        original_input_ids=frozenset({"u1"}), current_thread_id="root"
+    )
+
+    builder._finalize_turn_history(state, ctx, "normal_completion")
+
+    chain = builder._last_messages_chain
+    assert [c["role"] for c in chain] == [
+        "user",
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert chain[0]["additional_kwargs"]["checkpoint_retained"] is True
+    assert chain[1]["additional_kwargs"]["summary_compacted"] is True
+    assert chain[3]["tool_call_id"] == "t2"
+    assert builder._last_termination_reason == "normal_completion"
+    assert len(builder._last_live_state_messages) == len(state)

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -112,5 +112,10 @@ async def test_exit_durability_yields_post_compaction_state_after_recursion():
     assert any(m.additional_kwargs.get(SUMMARY_FLAG) for m in msgs)
     # Post-compaction completed tool pair (t2) survives.
     assert any(getattr(m, "tool_call_id", None) == "t2" for m in msgs)
+    # Pre-compaction content was actually REPLACED, not merely appended to:
+    # the input user and the pre-compaction tool pair are gone. This proves we
+    # read the post-replacement authoritative state, not just "summary present".
+    assert all(m.id != "u1" for m in msgs)
+    assert not any(getattr(m, "tool_call_id", None) == "t1" for m in msgs)
     # exit durability => a single committed checkpoint, not one per super-step.
     assert len(list(saver.list(config))) == 1

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -712,3 +712,77 @@ async def test_truncation_retry_then_compaction_end_to_end(monkeypatch):
 
     # 6. Both the parent turn and the retry thread were torn down.
     assert len(set(deleted)) == 2
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_returns_post_compaction_state_and_frees_thread():
+    """The non-streaming path (``_collect_final_state_from_events``) does not build
+    a ``messages_chain``, but it must still return the *post-compaction*
+    LangGraph final state and free its own thread. This pins the contract that
+    the docs describe (non-streaming returns final state, no finalizer)."""
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    class _FinishModel(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "finish"
+
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="final ok"))]
+            )
+
+    class _CompactOnFirst:
+        """Compacts before the only model call: drop all history for a summary."""
+
+        def __init__(self) -> None:
+            self.done = False
+
+        def __call__(self, state):
+            if self.done:
+                return {}
+            self.done = True
+            msgs = state["messages"]
+            summary = HumanMessage(
+                content="[COMPACT SUMMARY] earlier",
+                additional_kwargs={SUMMARY_FLAG: True, "compacted": True},
+                id="s-1",
+            )
+            removals = [RemoveMessage(id=m.id) for m in msgs if m.id]
+            return {"messages": [*removals, summary]}
+
+    builder = LangGraphAgentBuilder(llm=_FinishModel())
+    builder.pre_model_hook = _CompactOnFirst()
+
+    # Build once so we can spy on the request-local checkpointer teardown.
+    builder._build_agent()
+    saver = builder._checkpointer
+    deleted: list[str] = []
+    orig_delete = saver.adelete_thread
+
+    async def _spy_delete(thread_id):
+        deleted.append(thread_id)
+        return await orig_delete(thread_id)
+
+    saver.adelete_thread = _spy_delete
+
+    final_state, _events = await builder._collect_final_state_from_events(
+        messages=[{"role": "user", "content": "analyze data"}],
+        config=None,
+        cancel_event=None,
+        collect_all_events=False,
+    )
+
+    msgs = final_state["messages"]
+    # The returned state is the post-compaction authoritative state...
+    assert any(m.additional_kwargs.get(SUMMARY_FLAG) for m in msgs)
+    assert msgs[-1].content == "final ok"
+    # ...with the pre-compaction user input actually replaced, not appended.
+    assert all(getattr(m, "content", "") != "analyze data" for m in msgs)
+    # The non-streaming path builds no messages_chain (no finalizer runs).
+    assert not builder._last_messages_chain
+    # Its own thread was torn down.
+    assert len(deleted) == 1

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -493,3 +493,75 @@ async def test_stream_tokens_deletes_turn_thread_on_exit(monkeypatch):
         pass
 
     assert len(deleted) == 1  # exactly the turn's own thread torn down
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_recovery_uses_current_state_and_deletes_thread(monkeypatch):
+    from langchain_core.messages import ToolMessage
+
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    authoritative = [
+        HumanMessage(
+            content="[COMPACT SUMMARY] s",
+            additional_kwargs={"compacted": True, "summary_compacted": True},
+            id="s1",
+        ),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "t2", "name": "_probe", "args": {}}],
+            id="a2",
+        ),
+        ToolMessage(content="ok", tool_call_id="t2", name="_probe", id="tm2"),
+    ]
+
+    class _Snap:
+        values = {"messages": authoritative}
+
+    recovery_seen: list = []
+    deleted: list[str] = []
+
+    class _Resp:
+        content = "final answer"
+
+    class _RecoveryLLM:
+        async def ainvoke(self, messages):
+            recovery_seen.extend(messages)
+            return _Resp()
+
+    class _MockSaver:
+        async def adelete_thread(self, thread_id):
+            deleted.append(thread_id)
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            raise GraphRecursionError("limit")
+            yield  # pragma: no cover
+
+        async def aget_state(self, _config):
+            return _Snap()
+
+    builder = LangGraphAgentBuilder(llm=_RecoveryLLM())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+    builder._checkpointer = _MockSaver()
+
+    final_state, _events = await builder._collect_final_state_from_events(
+        messages=[{"role": "user", "content": "hi"}]
+    )
+
+    msgs = final_state["messages"]
+    # final_state built from the current authoritative state + recovery reply
+    assert any(
+        getattr(m, "additional_kwargs", {}).get("summary_compacted") for m in msgs
+    )
+    assert msgs[-1].content == "final answer"
+    # recovery LLM saw the current state (with the checkpoint), not just lc_messages
+    assert any(
+        getattr(m, "additional_kwargs", {}).get("summary_compacted")
+        for m in recovery_seen
+    )
+    assert len(deleted) == 1  # non-streaming thread torn down

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -119,3 +119,45 @@ async def test_exit_durability_yields_post_compaction_state_after_recursion():
     assert not any(getattr(m, "tool_call_id", None) == "t1" for m in msgs)
     # exit durability => a single committed checkpoint, not one per super-step.
     assert len(list(saver.list(config))) == 1
+
+
+def test_build_agent_attaches_request_local_checkpointer():
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    agent = builder._build_agent()
+
+    assert builder._checkpointer is not None  # always present now
+    assert agent.checkpointer is builder._checkpointer
+
+
+@pytest.mark.asyncio
+async def test_stream_tokens_injects_unique_thread_and_exit_durability(monkeypatch):
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    captured: list[dict] = []
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            captured.append({"config": config, "durability": durability})
+            for _ in []:  # empty async generator
+                yield
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+
+    for _ in range(2):
+        async for _token in builder.stream_tokens(
+            messages=[{"role": "user", "content": "hi"}]
+        ):
+            pass
+
+    assert len(captured) == 2
+    assert all(c["durability"] == "exit" for c in captured)
+    t0 = captured[0]["config"]["configurable"]["thread_id"]
+    t1 = captured[1]["config"]["configurable"]["thread_id"]
+    assert t0 and t1 and t0 != t1  # present and unique per turn

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -137,6 +137,9 @@ async def test_stream_tokens_injects_unique_thread_and_exit_durability(monkeypat
 
     captured: list[dict] = []
 
+    class _EmptySnap:
+        values: dict = {"messages": []}
+
     class _FakeAgent:
         checkpointer = object()
 
@@ -146,6 +149,9 @@ async def test_stream_tokens_injects_unique_thread_and_exit_durability(monkeypat
             captured.append({"config": config, "durability": durability})
             for _ in []:  # empty async generator
                 yield
+
+        async def aget_state(self, _config):
+            return _EmptySnap()
 
     builder = LangGraphAgentBuilder(llm=_LoopingModel())
     monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
@@ -210,3 +216,58 @@ def test_finalize_turn_history_sets_all_three_fields_atomically():
     assert chain[3]["tool_call_id"] == "t2"
     assert builder._last_termination_reason == "normal_completion"
     assert len(builder._last_live_state_messages) == len(state)
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_persists_from_aget_state(monkeypatch):
+    from langchain_core.messages import ToolMessage
+
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    # Authoritative post-compaction state the checkpointer would return: input
+    # user already replaced by summary; post-compaction tool pair + final answer.
+    authoritative = [
+        HumanMessage(
+            content="[COMPACT SUMMARY] s",
+            additional_kwargs={"compacted": True, "summary_compacted": True},
+            id="s1",
+        ),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "t2", "name": "_probe", "args": {}}],
+            id="a2",
+        ),
+        ToolMessage(content="ok", tool_call_id="t2", name="_probe", id="tm2"),
+        AIMessage(content="done", id="a3"),
+    ]
+
+    class _Snap:
+        values = {"messages": authoritative}
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            for _ in []:  # complete immediately, no events
+                yield
+
+        async def aget_state(self, _config):
+            return _Snap()
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+
+    async for _token in builder.stream_tokens(
+        messages=[{"role": "user", "content": "hi"}]
+    ):
+        pass
+
+    chain = builder._last_messages_chain
+    # Persisted from the authoritative state: summary marker + post-compaction
+    # tool pair + final assistant, not just the last message.
+    assert any(c.get("additional_kwargs", {}).get("summary_compacted") for c in chain)
+    assert any(c["role"] == "tool" for c in chain)
+    assert chain[-1]["role"] == "assistant"
+    assert builder._last_termination_reason == "normal_completion"

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -271,3 +271,75 @@ async def test_normal_completion_persists_from_aget_state(monkeypatch):
     assert any(c["role"] == "tool" for c in chain)
     assert chain[-1]["role"] == "assistant"
     assert builder._last_termination_reason == "normal_completion"
+
+
+@pytest.mark.asyncio
+async def test_tool_limit_recovery_persists_full_chain_without_instruction(monkeypatch):
+    from langchain_core.messages import ToolMessage
+
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    authoritative = [
+        HumanMessage(
+            content="[COMPACT SUMMARY] s",
+            additional_kwargs={"compacted": True, "summary_compacted": True},
+            id="s1",
+        ),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "t2", "name": "_probe", "args": {}}],
+            id="a2",
+        ),
+        ToolMessage(content="ok", tool_call_id="t2", name="_probe", id="tm2"),
+    ]
+
+    class _Snap:
+        values = {"messages": authoritative}
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            raise GraphRecursionError("limit")
+            yield  # pragma: no cover - marks this an async generator
+
+        async def aget_state(self, _config):
+            return _Snap()
+
+    recovery_seen: list = []
+
+    class _Chunk:
+        def __init__(self, content):
+            self.content = content
+
+    class _RecoveryLLM:
+        async def astream(self, messages):
+            recovery_seen.extend(messages)
+            yield _Chunk("final ")
+            yield _Chunk("answer")
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+    monkeypatch.setattr(builder, "llm", _RecoveryLLM())
+
+    tokens: list[str] = []
+    async for token in builder.stream_tokens(
+        messages=[{"role": "user", "content": "hi"}]
+    ):
+        tokens.append(token)
+
+    assert "".join(tokens) == "final answer"  # recovery streamed to the client
+    chain = builder._last_messages_chain
+    assert any(c.get("additional_kwargs", {}).get("summary_compacted") for c in chain)
+    assert any(c["role"] == "tool" for c in chain)  # post-compaction pair kept
+    assert chain[-1]["role"] == "assistant"
+    assert chain[-1]["content"] == "final answer"  # recovery reply last
+    # The tool-limit instruction never persists...
+    assert all("Tool call limit reached" not in str(c.get("content")) for c in chain)
+    # ...but the recovery LLM did see it (control message).
+    assert any(
+        "Tool call limit" in str(getattr(m, "content", "")) for m in recovery_seen
+    )
+    assert builder._last_termination_reason == "graph_recursion_limit_recovery"

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -408,3 +408,88 @@ async def test_truncation_retry_seeds_new_thread_with_ephemeral_instruction(
     ]
     assert len(ephemeral) == 1
     assert "[SYSTEM ERROR]" in ephemeral[0].content
+
+
+@pytest.mark.asyncio
+async def test_truncation_exhausted_persists_checkpoint(monkeypatch):
+    from chat_shell.agents.graph_builder import (
+        LangGraphAgentBuilder,
+        ToolCallTruncatedError,
+    )
+
+    authoritative = [
+        HumanMessage(
+            content="[COMPACT SUMMARY] s",
+            additional_kwargs={"compacted": True, "summary_compacted": True},
+            id="s1",
+        ),
+        AIMessage(content="partial", id="a1"),
+    ]
+
+    class _Snap:
+        values = {"messages": authoritative}
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            raise ToolCallTruncatedError(reason="length", has_tool_calls=True)
+            yield  # pragma: no cover
+
+        async def aget_state(self, _config):
+            return _Snap()
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+    monkeypatch.setattr(builder, "max_truncation_retries", 1)
+
+    async for _token in builder.stream_tokens(
+        messages=[{"role": "user", "content": "hi"}]
+    ):
+        pass
+
+    chain = builder._last_messages_chain
+    assert any(c.get("additional_kwargs", {}).get("summary_compacted") for c in chain)
+    assert builder._last_termination_reason == "tool_call_truncation_retry_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_stream_tokens_deletes_turn_thread_on_exit(monkeypatch):
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    deleted: list[str] = []
+
+    class _MockSaver:
+        def list(self, _config):
+            return iter([object()])  # one committed checkpoint (exit durability)
+
+        async def adelete_thread(self, thread_id):
+            deleted.append(thread_id)
+
+    class _EmptySnap:
+        values: dict = {"messages": []}
+
+    class _FakeAgent:
+        checkpointer = object()
+
+        async def astream_events(
+            self, _input, config=None, version=None, durability=None
+        ):
+            for _ in []:
+                yield
+
+        async def aget_state(self, _config):
+            return _EmptySnap()
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+    monkeypatch.setattr(builder, "_build_agent", lambda: _FakeAgent())
+    builder._checkpointer = _MockSaver()
+
+    async for _token in builder.stream_tokens(
+        messages=[{"role": "user", "content": "hi"}]
+    ):
+        pass
+
+    assert len(deleted) == 1  # exactly the turn's own thread torn down

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -346,14 +346,14 @@ async def test_tool_limit_recovery_persists_full_chain_without_instruction(monke
 
 
 @pytest.mark.asyncio
-async def test_truncation_retry_seeds_new_thread_with_ephemeral_instruction(
-    monkeypatch,
-):
+async def test_truncation_retry_uses_attempt_control_plane(monkeypatch):
+    """The retry seed carries only authoritative state; the truncation
+    instruction rides the attempt control plane (``_attempt_guidance``), so it
+    never enters the persisted ``messages`` channel."""
     from chat_shell.agents.graph_builder import (
         LangGraphAgentBuilder,
         ToolCallTruncatedError,
     )
-    from chat_shell.compression.summary_compactor import EPHEMERAL_CONTROL_FLAG
 
     # Authoritative state at the truncation point: a real user + partial reply.
     authoritative = [
@@ -376,10 +376,14 @@ async def test_truncation_retry_seeds_new_thread_with_ephemeral_instruction(
             calls["n"] += 1
             if calls["n"] == 1:
                 captured["root_thread"] = config["configurable"]["thread_id"]
+                # Root turn must carry no attempt guidance.
+                captured["root_guidance"] = list(builder._attempt_guidance)
                 raise ToolCallTruncatedError(reason="length", has_tool_calls=True)
-            # Second call = the retry: capture its seed + thread, then complete.
+            # Second call = the retry: capture its seed, thread, and the
+            # attempt-scoped guidance that the pre-model hook would inject.
             captured["retry_input"] = _input["messages"]
             captured["retry_thread"] = config["configurable"]["thread_id"]
+            captured["retry_guidance"] = list(builder._attempt_guidance)
             for _ in []:
                 yield
 
@@ -400,14 +404,43 @@ async def test_truncation_retry_seeds_new_thread_with_ephemeral_instruction(
     assert captured["retry_thread"] != captured["root_thread"]
     # The sanitized authoritative state was seeded into the retry.
     assert any(getattr(m, "content", "") == "analyze data" for m in retry_msgs)
-    # The truncation instruction rides as an ephemeral control message.
-    ephemeral = [
-        m
-        for m in retry_msgs
-        if getattr(m, "additional_kwargs", {}).get(EPHEMERAL_CONTROL_FLAG) is True
+    # The instruction is NOT in the persisted seed (messages channel).
+    assert all(
+        "[SYSTEM ERROR]" not in str(getattr(m, "content", "")) for m in retry_msgs
+    )
+    # The root turn had no attempt guidance; the retry carries exactly one.
+    assert captured["root_guidance"] == []
+    assert len(captured["retry_guidance"]) == 1
+    assert "[SYSTEM ERROR]" in captured["retry_guidance"][0].content
+
+
+def test_attempt_guidance_hook_appends_to_model_input_only():
+    """``_attempt_guidance_hook`` appends guidance to the model-visible list via
+    ``llm_input_messages`` and never touches the ``messages`` channel; it is a
+    no-op when no guidance is active."""
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    builder = LangGraphAgentBuilder(llm=_LoopingModel())
+
+    # No guidance -> no-op (keeps whatever prior producer set).
+    assert builder._attempt_guidance_hook({"messages": [HumanMessage("hi")]}) == {}
+
+    # With guidance, it builds on a prior producer's llm_input_messages.
+    builder._attempt_guidance = [HumanMessage(content="[SYSTEM ERROR] retry")]
+    prior = [HumanMessage(content="compacted+guidance")]
+    update = builder._attempt_guidance_hook(
+        {"messages": [HumanMessage("raw")], "llm_input_messages": prior}
+    )
+    assert "messages" not in update  # never writes the persisted channel
+    out = update["llm_input_messages"]
+    assert [m.content for m in out] == ["compacted+guidance", "[SYSTEM ERROR] retry"]
+
+    # Falls back to messages when no prior llm_input_messages exists.
+    update = builder._attempt_guidance_hook({"messages": [HumanMessage("raw")]})
+    assert [m.content for m in update["llm_input_messages"]] == [
+        "raw",
+        "[SYSTEM ERROR] retry",
     ]
-    assert len(ephemeral) == 1
-    assert "[SYSTEM ERROR]" in ephemeral[0].content
 
 
 @pytest.mark.asyncio
@@ -565,3 +598,117 @@ async def test_nonstreaming_recovery_uses_current_state_and_deletes_thread(monke
         for m in recovery_seen
     )
     assert len(deleted) == 1  # non-streaming thread torn down
+
+
+@pytest.mark.asyncio
+async def test_truncation_retry_then_compaction_end_to_end(monkeypatch):
+    """Full combination path through a REAL agent:
+
+    root turn truncates -> fresh retry thread -> retry thread compacts ->
+    retry LLM succeeds. The truncation guidance must reach the retry LLM *after*
+    compaction while never entering the summary source, the checkpoint, or the
+    persisted ``messages_chain``, and both threads must be freed.
+    """
+    from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+
+    model_inputs: list[list] = []  # what each model call actually received
+    guard_inputs: list[list] = []  # what the compactor (guard) saw as messages
+
+    class _TruncateThenSucceedModel(BaseChatModel):
+        call_count: int = 0
+
+        @property
+        def _llm_type(self) -> str:
+            return "truncate-then-succeed"
+
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            self.call_count += 1
+            model_inputs.append(list(messages))
+            if self.call_count == 1:
+                # Root turn: a tool call cut off by the token limit.
+                msg = AIMessage(
+                    content="partial",
+                    tool_calls=[{"name": "_probe", "args": {"query": "q"}, "id": "t1"}],
+                    response_metadata={"finish_reason": "length"},
+                )
+            else:
+                # Retry turn (after compaction): a clean final answer, no tools.
+                msg = AIMessage(content="final ok")
+            return ChatResult(generations=[ChatGeneration(message=msg)])
+
+    class _CompactOnRetry:
+        """Guard-like hook: no-op on the root call, drops ALL history for a bare
+        summary on the retry call. Dropping everything also proves the guidance
+        survives maximal over-budget trimming (it is appended afterwards)."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, state):
+            self.calls += 1
+            msgs = state["messages"]
+            guard_inputs.append(list(msgs))
+            if self.calls == 2:
+                summary = HumanMessage(
+                    content="[COMPACT SUMMARY] earlier work",
+                    additional_kwargs={SUMMARY_FLAG: True, "compacted": True},
+                    id="s-1",
+                )
+                removals = [RemoveMessage(id=m.id) for m in msgs if m.id]
+                return {"messages": [*removals, summary]}
+            return {}
+
+    builder = LangGraphAgentBuilder(llm=_TruncateThenSucceedModel())
+    builder.pre_model_hook = _CompactOnRetry()
+    monkeypatch.setattr(builder, "max_truncation_retries", 2)
+
+    # Build once so the request-local checkpointer exists; spy on thread deletes.
+    builder._build_agent()
+    saver = builder._checkpointer
+    deleted: list[str] = []
+    orig_delete = saver.adelete_thread
+
+    async def _spy_delete(thread_id):
+        deleted.append(thread_id)
+        return await orig_delete(thread_id)
+
+    saver.adelete_thread = _spy_delete
+
+    tokens: list[str] = []
+    async for token in builder.stream_tokens(
+        messages=[{"role": "user", "content": "analyze data"}]
+    ):
+        tokens.append(token)
+
+    # The retry produced the successful final answer.
+    assert "".join(tokens) == "final ok"
+
+    # Two model calls happened: root (truncated) and retry (post-compaction).
+    assert len(model_inputs) == 2
+    retry_input_text = " ".join(str(getattr(m, "content", "")) for m in model_inputs[1])
+    # 1. The retry LLM saw the truncation guidance AFTER compaction...
+    assert "[SYSTEM ERROR]" in retry_input_text
+    # ...alongside the compaction summary (proves it survived maximal trimming).
+    assert "[COMPACT SUMMARY]" in retry_input_text
+
+    # 2. The summary source (what the guard/compactor saw) never had guidance.
+    assert guard_inputs, "compactor should have been invoked"
+    assert all(
+        "[SYSTEM ERROR]" not in str(getattr(m, "content", ""))
+        for seen in guard_inputs
+        for m in seen
+    )
+
+    chain = builder._last_messages_chain
+    # 5. Summary marker + post-compaction suffix are intact in the chain.
+    assert any(c.get("additional_kwargs", {}).get(SUMMARY_FLAG) for c in chain)
+    assert chain[-1]["role"] == "assistant"
+    assert chain[-1]["content"] == "final ok"
+    # 3 & 4. Guidance is absent from the persisted chain (checkpoint-derived).
+    assert all("[SYSTEM ERROR]" not in str(c.get("content", "")) for c in chain)
+
+    # 6. Both the parent turn and the retry thread were torn down.
+    assert len(set(deleted)) == 2

--- a/chat_shell/tests/test_graph_builder_persistence.py
+++ b/chat_shell/tests/test_graph_builder_persistence.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phase 2a: authoritative-state persistence across terminal paths.
+
+Task 1 is a feasibility gate: prove that a real ``create_react_agent`` with a
+compacting ``pre_model_hook`` and a forced ``GraphRecursionError`` yields the
+post-compaction authoritative state via ``aget_state`` under
+``durability="exit"`` while keeping a single checkpoint.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import GraphRecursionError
+from langgraph.prebuilt import create_react_agent
+
+SUMMARY_FLAG = "summary_compacted"
+
+
+@tool
+def _probe(query: str) -> str:
+    """Probe tool that echoes its query."""
+    return f"result::{query}"
+
+
+class _LoopingModel(BaseChatModel):
+    """Emits a fresh tool call on every call, so the ReAct loop never ends."""
+
+    call_count: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "looping"
+
+    def bind_tools(self, tools, **kwargs):  # create_react_agent calls this
+        return self
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        self.call_count += 1
+        n = self.call_count
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content=f"turn {n}",
+                        tool_calls=[
+                            {
+                                "name": "_probe",
+                                "args": {"query": f"q{n}"},
+                                "id": f"t{n}",
+                            }
+                        ],
+                    )
+                )
+            ]
+        )
+
+
+class _CompactOnSecond:
+    """pre_model_hook that compacts on its 2nd invocation, like the guard."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, state):
+        self.calls += 1
+        msgs = state["messages"]
+        if self.calls == 2:
+            summary = HumanMessage(
+                content="[COMPACT SUMMARY] x",
+                additional_kwargs={SUMMARY_FLAG: True},
+                id="s-1",
+            )
+            removals = [RemoveMessage(id=m.id) for m in msgs if m.id]
+            return {"messages": [*removals, summary]}
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_exit_durability_yields_post_compaction_state_after_recursion():
+    saver = InMemorySaver()
+    agent = create_react_agent(
+        model=_LoopingModel(),
+        tools=[_probe],
+        checkpointer=saver,
+        pre_model_hook=_CompactOnSecond(),
+    )
+    config = {"configurable": {"thread_id": str(uuid4())}, "recursion_limit": 8}
+
+    with pytest.raises(GraphRecursionError):
+        async for _ in agent.astream_events(
+            {"messages": [HumanMessage(content="q0", id="u1")]},
+            config,
+            version="v2",
+            durability="exit",
+        ):
+            pass
+
+    snap = await agent.aget_state(config)
+    msgs = snap.values["messages"]
+
+    # Summary checkpoint survives the error.
+    assert any(m.additional_kwargs.get(SUMMARY_FLAG) for m in msgs)
+    # Post-compaction completed tool pair (t2) survives.
+    assert any(getattr(m, "tool_call_id", None) == "t2" for m in msgs)
+    # exit durability => a single committed checkpoint, not one per super-step.
+    assert len(list(saver.list(config))) == 1

--- a/chat_shell/tests/test_guard_composition.py
+++ b/chat_shell/tests/test_guard_composition.py
@@ -83,6 +83,53 @@ class TestChainPreModelHooks:
         assert result["llm_input_messages"][0].content == "late"
 
     @pytest.mark.asyncio
+    async def test_llm_input_producers_compose_via_roll_forward(self):
+        """A later model-input producer that builds on the prior hook's
+        ``llm_input_messages`` stacks instead of clobbering it — this is what
+        lets user guidance and attempt guidance both reach the model."""
+
+        def guard(state):
+            # Mutating hook: compacts the channel (drop raw, add summary).
+            return {
+                "messages": [
+                    RemoveMessage(id="r-1"),
+                    HumanMessage(content="summary", id="sum-1"),
+                ]
+            }
+
+        def guidance_a(state):
+            base = state.get("llm_input_messages") or state["messages"]
+            return {"llm_input_messages": [*base, HumanMessage(content="guidance-A")]}
+
+        def guidance_b(state):
+            base = state.get("llm_input_messages") or state["messages"]
+            return {"llm_input_messages": [*base, HumanMessage(content="guidance-B")]}
+
+        chained = chain_pre_model_hooks(guard, guidance_a, guidance_b)
+        result = await chained({"messages": [HumanMessage(content="raw", id="r-1")]})
+
+        contents = [m.content for m in result["llm_input_messages"]]
+        assert contents == ["summary", "guidance-A", "guidance-B"]
+        # The channel update carries only the guard's compaction (the removal and
+        # the summary), never the guidance (guidance rides llm_input_messages).
+        channel_contents = [
+            m.content for m in result["messages"] if not isinstance(m, RemoveMessage)
+        ]
+        assert channel_contents == ["summary"]
+
+    @pytest.mark.asyncio
+    async def test_empty_update_keeps_prior_llm_input(self):
+        """A no-op guidance hook (no active guidance) must not discard the prior
+        producer's model input."""
+
+        def producer(state):
+            return {"llm_input_messages": [HumanMessage(content="kept")]}
+
+        chained = chain_pre_model_hooks(producer, lambda state: {})
+        result = await chained({"messages": []})
+        assert [m.content for m in result["llm_input_messages"]] == ["kept"]
+
+    @pytest.mark.asyncio
     async def test_empty_updates_are_dropped(self):
         chained = chain_pre_model_hooks(
             lambda state: {},

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -288,3 +288,57 @@ async def test_remote_restores_summary_marker_from_metadata(monkeypatch):
 
     assert history[0]["additional_kwargs"]["summary_compacted"] is True
     assert not history[1].get("additional_kwargs")
+
+
+@pytest.mark.asyncio
+async def test_recovery_checkpoint_chain_reloads_with_marker_and_tool_pairing(
+    monkeypatch,
+):
+    """A recovery-path checkpoint (summary + post-compaction tool pair + reply)
+    reloads through the loader identically to a normal-completion checkpoint:
+    marker restored, order preserved, tool-call/result still paired."""
+    from chat_shell.history import loader
+    from chat_shell.storage.interfaces import Message
+
+    class _FakeStore:
+        async def get_history(self, **kwargs):
+            return [
+                Message(
+                    role="user",
+                    content="[COMPACT SUMMARY] body",
+                    id="s1",
+                    metadata={"summary_compacted": True},
+                ),
+                Message(
+                    role="assistant",
+                    content="",
+                    id="a2",
+                    tool_calls=[
+                        {
+                            "id": "t2",
+                            "type": "function",
+                            "function": {"name": "probe", "arguments": "{}"},
+                        }
+                    ],
+                ),
+                Message(role="tool", content="ok", id="tm2", tool_call_id="t2"),
+                Message(role="assistant", content="final answer", id="a3"),
+            ]
+
+    monkeypatch.setattr(loader, "_get_remote_history_store", lambda: _FakeStore())
+
+    history = await loader._load_history_from_remote(task_id=1, is_group_chat=False)
+
+    # Summary marker restored so backend checkpoint scoping can anchor here.
+    assert history[0]["additional_kwargs"]["summary_compacted"] is True
+    # Order preserved.
+    assert [entry["role"] for entry in history] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    # Tool-call / tool-result pairing intact after reload.
+    tool_call_ids = [tc["id"] for tc in history[1]["tool_calls"]]
+    assert tool_call_ids == ["t2"]
+    assert history[2]["tool_call_id"] == "t2"

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -220,3 +220,71 @@ class TestGetChatHistory:
         )
 
         assert history == []
+
+
+@pytest.mark.asyncio
+async def test_get_history_sends_from_latest_compaction(monkeypatch):
+    from chat_shell.storage.remote import RemoteHistoryStore
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+        http_version = "HTTP/1.1"
+        elapsed = None
+        headers: dict = {}
+
+        def raise_for_status(self):
+            pass
+
+        async def aread(self):
+            return b"{}"
+
+        async def aclose(self):
+            pass
+
+        def json(self):
+            return {"messages": []}
+
+    class _FakeClient:
+        def build_request(self, method, url, params=None, headers=None):
+            captured["params"] = params
+            return object()
+
+        async def send(self, *_a, **_k):
+            return _Resp()
+
+    store = RemoteHistoryStore(base_url="http://x", auth_token="t")
+
+    async def _get_client():
+        return _FakeClient()
+
+    monkeypatch.setattr(store, "_get_client", _get_client)
+
+    await store.get_history(session_id="task-1", from_latest_compaction=True)
+    assert captured["params"].get("from_latest_compaction") == "true"
+
+
+@pytest.mark.asyncio
+async def test_remote_restores_summary_marker_from_metadata(monkeypatch):
+    from chat_shell.history import loader
+    from chat_shell.storage.interfaces import Message
+
+    class _FakeStore:
+        async def get_history(self, **kwargs):
+            return [
+                Message(
+                    role="user",
+                    content="[COMPACT SUMMARY] body",
+                    id="s1",
+                    metadata={"summary_compacted": True},
+                ),
+                Message(role="user", content="real", id="u1"),
+            ]
+
+    monkeypatch.setattr(loader, "_get_remote_history_store", lambda: _FakeStore())
+
+    history = await loader._load_history_from_remote(task_id=1, is_group_chat=False)
+
+    assert history[0]["additional_kwargs"]["summary_compacted"] is True
+    assert not history[1].get("additional_kwargs")

--- a/chat_shell/tests/test_new_messages_from_state.py
+++ b/chat_shell/tests/test_new_messages_from_state.py
@@ -278,3 +278,28 @@ class TestLimitRecoveryMessagesChain:
             limit_notice,
             AIMessage(content="Final summary after limit."),
         ]
+
+
+def test_cloned_retained_user_survives_new_messages_and_serialize():
+    from langchain_core.messages import HumanMessage
+
+    from chat_shell.agents.graph_builder import (
+        _new_messages_from_state,
+        _serialize_messages_chain,
+    )
+
+    input_user = HumanMessage(content="orig", id="in-1")
+    input_ids = frozenset({"in-1"})
+    cloned = HumanMessage(
+        content="orig", id="clone-1", additional_kwargs={"checkpoint_retained": True}
+    )
+    state = [input_user, cloned]
+
+    new_msgs = _new_messages_from_state(state, input_ids)
+    assert cloned in new_msgs and input_user not in new_msgs
+    chain = _serialize_messages_chain(new_msgs)
+    assert any(
+        m["role"] == "user"
+        and m.get("additional_kwargs", {}).get("checkpoint_retained") is True
+        for m in chain
+    )

--- a/chat_shell/tests/test_new_messages_from_state.py
+++ b/chat_shell/tests/test_new_messages_from_state.py
@@ -16,11 +16,7 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.graph.message import add_messages
 
-from chat_shell.agents.graph_builder import (
-    TOOL_LIMIT_REACHED_MESSAGE,
-    _build_limit_recovery_messages_chain,
-    _new_messages_from_state,
-)
+from chat_shell.agents.graph_builder import _new_messages_from_state
 
 
 def _assign_ids(*msgs):
@@ -234,50 +230,6 @@ class TestNewMessagesFromStateContextGuard:
         result = _new_messages_from_state(final_state, ids)
 
         assert ai_no_id in result
-
-
-class TestLimitRecoveryMessagesChain:
-    """Tests for tool-limit recovery message-chain persistence."""
-
-    def test_falls_back_to_limit_notice_when_collected_state_missing(self):
-        user = HumanMessage(content="please continue")
-        ids = _input_ids(user)
-        limit_notice = HumanMessage(content=TOOL_LIMIT_REACHED_MESSAGE)
-        _assign_ids(limit_notice)
-
-        result = _build_limit_recovery_messages_chain(
-            collected_state_messages=[],
-            limit_messages=[user, limit_notice],
-            input_ids=ids,
-            final_response_text="",
-        )
-
-        assert result == [limit_notice]
-
-    def test_appends_limit_notice_and_final_response_to_existing_chain(self):
-        user = HumanMessage(content="search")
-        ids = _input_ids(user)
-
-        ai_tool = _make_ai_with_tool("call_limit")
-        tool_result = _make_tool_result("call_limit")
-        _assign_ids(ai_tool, tool_result)
-
-        limit_notice = HumanMessage(content=TOOL_LIMIT_REACHED_MESSAGE)
-        _assign_ids(limit_notice)
-
-        result = _build_limit_recovery_messages_chain(
-            collected_state_messages=[user, ai_tool, tool_result],
-            limit_messages=[user, limit_notice],
-            input_ids=ids,
-            final_response_text="Final summary after limit.",
-        )
-
-        assert result == [
-            ai_tool,
-            tool_result,
-            limit_notice,
-            AIMessage(content="Final summary after limit."),
-        ]
 
 
 def test_cloned_retained_user_survives_new_messages_and_serialize():

--- a/chat_shell/tests/test_serialize_messages_chain.py
+++ b/chat_shell/tests/test_serialize_messages_chain.py
@@ -378,3 +378,20 @@ class TestSerializeMessagesChain:
         assert result[0]["content"] == [
             {"type": "reasoning", "reasoning": "thinking..."},
         ]
+
+
+def test_serializer_keeps_checkpoint_retained_user():
+    from langchain_core.messages import HumanMessage
+
+    from chat_shell.agents.graph_builder import _serialize_messages_chain
+
+    msg = HumanMessage(
+        content="retained question",
+        id="ret-1",
+        additional_kwargs={"checkpoint_retained": True},
+    )
+    chain = _serialize_messages_chain([msg])
+    assert len(chain) == 1
+    assert chain[0]["role"] == "user"
+    assert chain[0]["content"] == "retained question"
+    assert chain[0]["additional_kwargs"]["checkpoint_retained"] is True

--- a/chat_shell/tests/test_summary_compactor.py
+++ b/chat_shell/tests/test_summary_compactor.py
@@ -178,45 +178,6 @@ def test_remove_oldest_history_items_keeps_at_least_one_without_current_user():
 
 
 @pytest.mark.asyncio
-async def test_ephemeral_control_message_not_treated_as_user_or_retained():
-    from chat_shell.compression.summary_compactor import EPHEMERAL_CONTROL_FLAG
-
-    llm = _FakeLLM([AIMessage(content="Current objective:\ngo")])
-    counter = TokenCounter(model_name="gpt-4")
-    compactor = SummaryCompactor(llm=llm, token_counter=counter)
-
-    real_user = HumanMessage(content="analyze my data")
-    ephemeral = HumanMessage(
-        content="[SYSTEM ERROR] truncated, retry",
-        additional_kwargs={EPHEMERAL_CONTROL_FLAG: True},
-    )
-    messages = [real_user, AIMessage(content="partial"), ephemeral]
-
-    result = await compactor.compact(messages, preserve_initial_context=False)
-
-    retained = [
-        message.content
-        for message in result.replacement_history
-        if isinstance(message, HumanMessage)
-        and message.additional_kwargs.get(SUMMARY_METADATA_FLAG) is not True
-    ]
-    assert "analyze my data" in retained  # real user retained as checkpoint
-    assert all(
-        "[SYSTEM ERROR]" not in content for content in retained
-    )  # not the control msg
-    # The control message was never handed to the summary LLM either.
-    summary_source = llm.calls[0]
-    assert all(
-        "[SYSTEM ERROR]" not in _content_text(message) for message in summary_source
-    )
-
-
-def _content_text(message) -> str:
-    content = getattr(message, "content", "")
-    return content if isinstance(content, str) else str(content)
-
-
-@pytest.mark.asyncio
 async def test_compact_builds_summary_message_with_compacted_metadata():
     llm = _FakeLLM([AIMessage(content="Current objective:\nship it")])
     counter = TokenCounter(model_name="gpt-4")

--- a/chat_shell/tests/test_summary_compactor.py
+++ b/chat_shell/tests/test_summary_compactor.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
@@ -51,8 +53,8 @@ async def test_compact_retries_after_context_too_long_by_removing_oldest_history
 
     assert result.removed_history_items == 1
     assert len(llm.calls) == 2
-    first_history = llm.calls[0][1:-1]
-    second_history = llm.calls[1][1:-1]
+    first_history = llm.calls[0][:-1]
+    second_history = llm.calls[1][:-1]
     assert [msg.content for msg in first_history] == [
         "system",
         "old user",
@@ -92,7 +94,7 @@ async def test_compact_continues_trimming_until_only_current_user_floor_remains(
 
     assert result.removed_history_items == 2
     assert len(llm.calls) == 3
-    assert [msg.content for msg in llm.calls[-1][1:-1]] == [
+    assert [msg.content for msg in llm.calls[-1][:-1]] == [
         "system",
         "latest user",
     ]
@@ -103,6 +105,76 @@ async def test_compact_continues_trimming_until_only_current_user_floor_remains(
         and message.additional_kwargs.get(SUMMARY_METADATA_FLAG) is not True
     ]
     assert retained_user_messages == ["latest user"]
+
+
+@pytest.mark.asyncio
+async def test_compact_caps_overflow_retries_and_sheds_in_batches():
+    from chat_shell.compression.summary_compactor import (
+        MAX_SUMMARY_OVERFLOW_RETRIES,
+    )
+
+    # Always overflow so the retry cap (not success) terminates the loop.
+    llm = _FakeLLM(
+        [RuntimeError("context length exceeded")] * (MAX_SUMMARY_OVERFLOW_RETRIES + 1)
+    )
+    counter = TokenCounter(model_name="gpt-4")
+    compactor = SummaryCompactor(llm=llm, token_counter=counter)
+
+    current_user = HumanMessage(content="latest user")
+    messages = (
+        [SystemMessage(content="system")]
+        + [AIMessage(content=f"a{i}") for i in range(20)]
+        + [current_user]
+    )
+
+    with pytest.raises(RuntimeError, match="context length exceeded"):
+        await compactor.compact(messages, preserve_initial_context=True)
+
+    # Initial attempt + MAX retries, then it raises into the guard fallback
+    # instead of grinding a further retry.
+    assert len(llm.calls) == MAX_SUMMARY_OVERFLOW_RETRIES + 1
+    # Each retry sheds a batch (>1 for a large history), not a single item.
+    first_history_len = len(llm.calls[0][:-1])
+    second_history_len = len(llm.calls[1][:-1])
+    assert first_history_len - second_history_len > 1
+
+
+def test_remove_oldest_history_items_batches_and_protects_current_user():
+    counter = TokenCounter(model_name="gpt-4")
+    compactor = SummaryCompactor(llm=_FakeLLM([]), token_counter=counter)
+    current_user = HumanMessage(content="cu")
+    messages = [
+        SystemMessage(content="system"),
+        AIMessage(content="a1"),
+        AIMessage(content="a2"),
+        AIMessage(content="a3"),
+        current_user,
+    ]
+
+    dropped = compactor._remove_oldest_history_items(
+        messages, current_user=current_user, count=2
+    )
+
+    assert dropped == 2
+    assert [msg.content for msg in messages] == ["system", "a3", "cu"]
+
+
+def test_remove_oldest_history_items_keeps_at_least_one_without_current_user():
+    counter = TokenCounter(model_name="gpt-4")
+    compactor = SummaryCompactor(llm=_FakeLLM([]), token_counter=counter)
+    messages = [
+        SystemMessage(content="system"),
+        AIMessage(content="a1"),
+        AIMessage(content="a2"),
+    ]
+
+    dropped = compactor._remove_oldest_history_items(
+        messages, current_user=None, count=99
+    )
+
+    # The newest non-system message is protected even with no current user turn.
+    assert dropped == 1
+    assert [msg.content for msg in messages] == ["system", "a2"]
 
 
 @pytest.mark.asyncio
@@ -221,3 +293,222 @@ async def test_compact_raises_when_llm_returns_empty_summary():
             [HumanMessage(content="please continue")],
             preserve_initial_context=False,
         )
+
+
+def test_trim_to_budget_single_pass_counts_each_message_once():
+    counter = TokenCounter(model_name="gpt-4")
+    call_count = {"n": 0}
+    real = counter.count_messages
+
+    def counting(msgs):
+        call_count["n"] += 1
+        return real(msgs)
+
+    counter.count_messages = counting  # type: ignore[assignment]
+
+    # Budget above the instruction-framing floor but below the full total,
+    # so trimming is required and can succeed.
+    compactor = SummaryCompactor(
+        llm=object(),
+        token_counter=counter,
+        max_compact_input_tokens=300,
+    )
+    system = SystemMessage(content="sys")
+    current = HumanMessage(content="current question")
+    old = [HumanMessage(content="old " * 60) for _ in range(20)]
+    messages = [system, *old, current]
+    original_len = len(messages)
+
+    removed = compactor._trim_to_budget(messages, current_user=current)
+
+    # Budget met, system + current preserved.
+    assert system in messages
+    assert current in messages
+    assert removed > 0
+    # O(n): one priming baseline + one count per original message + one framing
+    # count (+1 slack), NOT O(n^2).
+    assert call_count["n"] <= original_len + 3
+
+
+def test_trim_to_budget_uses_exact_prompt_count_no_priming_inflation():
+    from chat_shell.compression.summary_compactor import (
+        COMPACT_TASK_INSTRUCTION,
+        _message_to_counter_dict,
+    )
+
+    counter = TokenCounter(model_name="gpt-4")
+    msgs = [
+        SystemMessage(content="sys"),
+        HumanMessage(content="a " * 30),
+        HumanMessage(content="b " * 30),
+        HumanMessage(content="current"),
+    ]
+    # Exact tokens of the prompt actually sent (messages + instruction), one call.
+    exact = counter.count_messages(
+        [_message_to_counter_dict(m) for m in msgs]
+        + [_message_to_counter_dict(HumanMessage(content=COMPACT_TASK_INSTRUCTION))]
+    )
+    compactor = SummaryCompactor(
+        llm=object(), token_counter=counter, max_compact_input_tokens=exact
+    )
+    before = list(msgs)
+    removed = compactor._trim_to_budget(msgs, current_user=msgs[-1])
+    # Budget == exact prompt size → nothing to trim. The old per-message priming
+    # inflation would have over-estimated and deleted messages.
+    assert removed == 0
+    assert msgs == before
+
+
+@pytest.mark.asyncio
+async def test_compact_sanitizes_orphan_before_budget():
+    from chat_shell.compression.summary_compactor import (
+        COMPACT_TASK_INSTRUCTION,
+        _message_to_counter_dict,
+    )
+
+    llm = _FakeLLM([AIMessage(content="Current objective:\nok")])
+    counter = TokenCounter(model_name="gpt-4")
+    valid = HumanMessage(content="valid old message")
+    orphan = ToolMessage(content="x " * 1000, tool_call_id="missing", name="t")
+    current = HumanMessage(content="current question")
+    # Budget fits only the sanitized prompt (valid + current + instruction); the
+    # orphan's tokens would push a raw-based estimate over and wrongly delete the
+    # valid message before it.
+    exact = counter.count_messages(
+        [
+            _message_to_counter_dict(valid),
+            _message_to_counter_dict(current),
+            _message_to_counter_dict(HumanMessage(content=COMPACT_TASK_INSTRUCTION)),
+        ]
+    )
+    compactor = SummaryCompactor(
+        llm=llm, token_counter=counter, max_compact_input_tokens=exact
+    )
+
+    result = await compactor.compact(
+        [valid, orphan, current], preserve_initial_context=False
+    )
+
+    assert result.removed_history_items == 0
+    sent_contents = [getattr(m, "content", "") for m in llm.calls[0]]
+    assert "valid old message" in sent_contents
+
+
+def test_is_context_too_long_error_matches_status_and_chinese():
+    from chat_shell.compression.summary_compactor import _is_context_too_long_error
+
+    class Boom(Exception):
+        def __init__(self, msg, status=None):
+            super().__init__(msg)
+            self.status_code = status
+
+    assert _is_context_too_long_error(Boom("输入长度超过最大限制"))
+    assert _is_context_too_long_error(Boom("请求体过大", status=413))
+    assert _is_context_too_long_error(Boom("token 数量超过上限"))
+    assert not _is_context_too_long_error(Boom("temporary network blip"))
+    # 413 is unconditional overflow; a bare 400 is not (avoids retry storm).
+    assert _is_context_too_long_error(Boom("anything", status=413))
+    assert not _is_context_too_long_error(Boom("invalid parameter", status=400))
+    # A 400 that also carries a length marker still counts as overflow.
+    assert _is_context_too_long_error(Boom("输入长度超过限制", status=400))
+    # Generic Chinese "exceeds" phrases about params must NOT be overflow, or a
+    # param-validation 400 would trigger a remove-and-retry storm.
+    assert not _is_context_too_long_error(Boom("temperature 超过上限", status=400))
+    assert not _is_context_too_long_error(Boom("top_p 超过最大允许值", status=400))
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_times_out():
+    class HangingLLM:
+        async def ainvoke(self, _messages):
+            await asyncio.sleep(5)
+
+    compactor = SummaryCompactor(
+        llm=HangingLLM(),
+        token_counter=TokenCounter(model_name="gpt-4"),
+        request_timeout=0.05,
+    )
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        await compactor._generate_summary([])
+
+
+@pytest.mark.asyncio
+async def test_summary_instruction_is_final_turn():
+    from chat_shell.compression.summary_compactor import COMPACT_TASK_INSTRUCTION
+
+    captured = {}
+
+    class CaptureLLM:
+        async def ainvoke(self, messages):
+            captured["messages"] = messages
+            return AIMessage(content="SUMMARY BODY")
+
+    compactor = SummaryCompactor(
+        llm=CaptureLLM(), token_counter=TokenCounter(model_name="gpt-4")
+    )
+    history = [HumanMessage(content="q1"), AIMessage(content="a1")]
+    body = await compactor._generate_summary(history)
+
+    assert body == "SUMMARY BODY"
+    msgs = captured["messages"]
+    # Instruction is the LAST message and a HumanMessage (recency wins).
+    assert isinstance(msgs[-1], HumanMessage)
+    assert COMPACT_TASK_INSTRUCTION in msgs[-1].content
+    # No leading SystemMessage instruction.
+    assert getattr(msgs[0], "content", "") != COMPACT_TASK_INSTRUCTION
+
+
+def test_summary_recognized_by_marker_not_content():
+    # A reloaded summary carries the trusted marker (restored from HTTP metadata):
+    # it must be excluded from retained recent-user messages, or summaries
+    # accumulate each compaction.
+    compactor = SummaryCompactor(
+        llm=object(), token_counter=TokenCounter(model_name="gpt-4")
+    )
+    summary = HumanMessage(
+        content=f"{SUMMARY_PREFIX}\n\nold objective",
+        additional_kwargs={"summary_compacted": True},
+    )
+    real_user = HumanMessage(content="real question")
+
+    selected = compactor._select_recent_user_messages([summary, real_user])
+
+    assert [m.content for m in selected] == ["real question"]
+    assert compactor._find_current_user_message([summary, real_user]) is real_user
+
+
+def test_user_message_starting_with_marker_is_not_summary():
+    # A user may legitimately send text starting with the summary prefix; without
+    # the trusted marker it must be treated as a real user message, not dropped.
+    compactor = SummaryCompactor(
+        llm=object(), token_counter=TokenCounter(model_name="gpt-4")
+    )
+    prev = HumanMessage(content="previous request")
+    spoof = HumanMessage(content="[COMPACT SUMMARY] please review this literal text")
+
+    selected = compactor._select_recent_user_messages([prev, spoof])
+
+    assert any("literal text" in m.content for m in selected)
+    assert compactor._find_current_user_message([prev, spoof]) is spoof
+
+
+def test_replacement_history_marks_retained_user():
+    compactor = SummaryCompactor(
+        llm=object(), token_counter=TokenCounter(model_name="gpt-4")
+    )
+    history = [HumanMessage(content="keep me")]
+    replacement = compactor._build_replacement_history(
+        history, summary_body="S", preserve_initial_context=False
+    )
+    retained = [
+        m
+        for m in replacement
+        if isinstance(m, HumanMessage)
+        and m.additional_kwargs.get("checkpoint_retained") is True
+    ]
+    assert retained, "retained user message must carry checkpoint_retained"
+    assert retained[0].id, "retained user message must have a fresh id"
+    # The summary message is separate and keeps its summary marker.
+    assert any(
+        m.additional_kwargs.get(SUMMARY_METADATA_FLAG) is True for m in replacement
+    )

--- a/chat_shell/tests/test_summary_compactor.py
+++ b/chat_shell/tests/test_summary_compactor.py
@@ -178,6 +178,45 @@ def test_remove_oldest_history_items_keeps_at_least_one_without_current_user():
 
 
 @pytest.mark.asyncio
+async def test_ephemeral_control_message_not_treated_as_user_or_retained():
+    from chat_shell.compression.summary_compactor import EPHEMERAL_CONTROL_FLAG
+
+    llm = _FakeLLM([AIMessage(content="Current objective:\ngo")])
+    counter = TokenCounter(model_name="gpt-4")
+    compactor = SummaryCompactor(llm=llm, token_counter=counter)
+
+    real_user = HumanMessage(content="analyze my data")
+    ephemeral = HumanMessage(
+        content="[SYSTEM ERROR] truncated, retry",
+        additional_kwargs={EPHEMERAL_CONTROL_FLAG: True},
+    )
+    messages = [real_user, AIMessage(content="partial"), ephemeral]
+
+    result = await compactor.compact(messages, preserve_initial_context=False)
+
+    retained = [
+        message.content
+        for message in result.replacement_history
+        if isinstance(message, HumanMessage)
+        and message.additional_kwargs.get(SUMMARY_METADATA_FLAG) is not True
+    ]
+    assert "analyze my data" in retained  # real user retained as checkpoint
+    assert all(
+        "[SYSTEM ERROR]" not in content for content in retained
+    )  # not the control msg
+    # The control message was never handed to the summary LLM either.
+    summary_source = llm.calls[0]
+    assert all(
+        "[SYSTEM ERROR]" not in _content_text(message) for message in summary_source
+    )
+
+
+def _content_text(message) -> str:
+    content = getattr(message, "content", "")
+    return content if isinstance(content, str) else str(content)
+
+
+@pytest.mark.asyncio
 async def test_compact_builds_summary_message_with_compacted_metadata():
     llm = _FakeLLM([AIMessage(content="Current objective:\nship it")])
     counter = TokenCounter(model_name="gpt-4")

--- a/chat_shell/tests/test_tool_sanitizer.py
+++ b/chat_shell/tests/test_tool_sanitizer.py
@@ -29,6 +29,51 @@ def test_drops_orphan_tool_message_and_unresolved_tool_call():
     assert tool_ids == ["a"]  # orphan dropped
 
 
+def test_strips_unmatched_tool_use_content_blocks():
+    # Anthropic block-list content: two tool_use blocks, only "a" is resolved.
+    msgs = [
+        HumanMessage(content="u"),
+        AIMessage(
+            content=[
+                {"type": "text", "text": "working"},
+                {"type": "tool_use", "id": "a", "name": "t", "input": {}},
+                {"type": "tool_use", "id": "b", "name": "t", "input": {}},
+            ],
+            tool_calls=[
+                {"id": "a", "name": "t", "args": {}},
+                {"id": "b", "name": "t", "args": {}},
+            ],
+        ),
+        ToolMessage(content="ok", tool_call_id="a", name="t"),
+    ]
+
+    out = sanitize_tool_pairs(msgs)
+
+    ai = next(m for m in out if isinstance(m, AIMessage))
+    assert [tc["id"] for tc in ai.tool_calls] == ["a"]  # unresolved "b" stripped
+    # The parallel unmatched tool_use block is gone; text and matched block stay.
+    block_ids = [
+        b.get("id")
+        for b in ai.content
+        if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+    assert block_ids == ["a"]
+    assert any(isinstance(b, dict) and b.get("type") == "text" for b in ai.content)
+
+
+def test_drops_ai_message_when_empty_and_all_tool_calls_unresolved():
+    # Empty content + every tool_call unresolved -> the assistant message is
+    # removed entirely (guards tool_sanitizer's drop branch).
+    msgs = [
+        HumanMessage(content="u"),
+        AIMessage(content="", tool_calls=[{"id": "x", "name": "t", "args": {}}]),
+    ]
+
+    out = sanitize_tool_pairs(msgs)
+
+    assert [type(m).__name__ for m in out] == ["HumanMessage"]
+
+
 def test_preserves_fully_paired_sequence_and_order():
     msgs = [
         HumanMessage(content="u"),

--- a/chat_shell/tests/test_tool_sanitizer.py
+++ b/chat_shell/tests/test_tool_sanitizer.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from chat_shell.compression.tool_sanitizer import sanitize_tool_pairs
+
+
+def test_drops_orphan_tool_message_and_unresolved_tool_call():
+    msgs = [
+        HumanMessage(content="u"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "a", "name": "t", "args": {}},
+                {"id": "b", "name": "t", "args": {}},
+            ],
+        ),
+        ToolMessage(content="ok", tool_call_id="a", name="t"),
+        ToolMessage(content="orphan", tool_call_id="zzz", name="t"),
+    ]
+
+    out = sanitize_tool_pairs(msgs)
+
+    ai = next(m for m in out if isinstance(m, AIMessage))
+    assert [tc["id"] for tc in ai.tool_calls] == ["a"]  # unresolved "b" stripped
+    tool_ids = [m.tool_call_id for m in out if isinstance(m, ToolMessage)]
+    assert tool_ids == ["a"]  # orphan dropped
+
+
+def test_preserves_fully_paired_sequence_and_order():
+    msgs = [
+        HumanMessage(content="u"),
+        AIMessage(content="", tool_calls=[{"id": "a", "name": "t", "args": {}}]),
+        ToolMessage(content="ok", tool_call_id="a", name="t"),
+        AIMessage(content="done"),
+    ]
+
+    out = sanitize_tool_pairs(msgs)
+
+    assert [type(m).__name__ for m in out] == [
+        "HumanMessage",
+        "AIMessage",
+        "ToolMessage",
+        "AIMessage",
+    ]

--- a/chat_shell/tests/test_turn_context.py
+++ b/chat_shell/tests/test_turn_context.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+
+import pytest
+
+from chat_shell.agents.turn_context import TurnExecutionContext
+
+
+def test_retry_inherits_input_ids_and_takes_new_thread():
+    ctx = TurnExecutionContext(
+        original_input_ids=frozenset({"u1"}), current_thread_id="root"
+    )
+
+    child = ctx.with_retry("retry-1")
+
+    assert child.original_input_ids == frozenset({"u1"})  # inherited, unchanged
+    assert child.truncation_retry_count == 1
+    assert child.current_thread_id == "retry-1"  # child owns its own thread
+    assert ctx.current_thread_id == "root"  # parent unchanged
+
+
+def test_nested_retries_increment_and_own_their_thread():
+    ctx = TurnExecutionContext(
+        original_input_ids=frozenset({"u1"}), current_thread_id="root"
+    )
+
+    grandchild = ctx.with_retry("retry-1").with_retry("retry-2")
+
+    assert grandchild.truncation_retry_count == 2
+    assert grandchild.current_thread_id == "retry-2"
+    assert grandchild.original_input_ids == frozenset({"u1"})
+
+
+def test_context_is_immutable():
+    ctx = TurnExecutionContext(
+        original_input_ids=frozenset({"u1"}), current_thread_id="root"
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ctx.current_thread_id = "mutated"  # type: ignore[misc]

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -113,8 +113,11 @@ The implementation borrows a few ideas that work well in practice:
 
 But Wegent keeps its own trade-offs:
 
-- **No persisted Codex-style `replacement_history`**
-  Compaction rewrites only the current live state.
+- **Checkpoint persisted in `messages_chain`, not a separate blob** (Phase 1)
+  The compacted turn becomes a self-contained checkpoint (retained recent user
+  messages + summary) inside its own `messages_chain`, and reload starts from the
+  latest checkpoint. This is functionally close to Codex's `replacement_history`,
+  but reuses existing persistence instead of a new field. See the Phase 1 section.
 - **Summary compact is not a long-term memory layer**
   It is a request-time governance tool.
 - **Fallback is not the main feature path**
@@ -173,6 +176,44 @@ Main outcomes:
 This turns attachments from an implicit history burden into an explicit,
 governed context source.
 
+## Phase 1: checkpoint reload and hang hardening
+
+Phase 1 closes two gaps left by Stage 2.
+
+### Checkpoint reload (no more full-history re-inflation)
+
+Previously every new subtask reloaded the full raw transcript and re-ran a full
+compaction — for multi-day sessions this meant compacting ~1.7M tokens on each
+new turn. Phase 1 makes the compacted turn a **self-contained checkpoint**:
+
+- `_select_recent_user_messages` clones the retained recent user messages with a
+  fresh id and a `checkpoint_retained` marker so the turn serializer keeps them
+  in `messages_chain` (alongside the `summary_compacted` summary and the in-turn
+  suffix generated after it).
+- The backend history endpoint accepts `from_latest_compaction=true`: it locates
+  the latest checkpoint by the in-chain `summary_compacted` marker and returns
+  `[checkpoint chain] + [subsequent complete turns]`. `limit` never truncates the
+  checkpoint chain itself.
+- The HTTP endpoint and the package-mode loader share one pipeline
+  (`resolve_history_subtasks`) so fork, `before_message_id`, `limit`, and
+  checkpoint scoping stay identical.
+- Because the HTTP transport drops `additional_kwargs`, a reloaded summary is
+  re-recognized by its content marker so it is not re-retained as a user message.
+
+### Hang hardening
+
+The summary compaction path was hardened against a production hang where an
+O(n²) trim pegged CPU for minutes and the backend read-timeout then cancelled the
+turn:
+
+- the trim is a single O(n) budget pass over the sanitized prompt (no per-removal
+  re-count, no per-message reply-priming inflation)
+- a heartbeat ticker emits `summary_compact` in_progress status during compaction
+  so the SSE stream stays alive instead of racing the backend read-timeout
+- the summary LLM call has a provider timeout plus an `asyncio.wait_for` backstop
+- context-length classification recognizes HTTP 413 and non-English markers; a
+  bare 400 is not treated as overflow (avoids a retry storm)
+
 ## Implementation map
 
 These modules are the best entry points for future maintenance:
@@ -181,7 +222,9 @@ These modules are the best entry points for future maintenance:
 |---|---|
 | `chat_shell/guard/context_guard.py` | Unified governance entry point: source pass, summary compact, emergency pass |
 | `chat_shell/guard/tool_output.py` | Compact tool-output rendering and emergency re-truncation |
-| `chat_shell/compression/summary_compactor.py` | Summary compact core logic |
+| `chat_shell/compression/summary_compactor.py` | Summary compact core logic, O(n) trim, checkpoint-retain markers |
+| `chat_shell/history/loader.py` | History reload; forwards `from_latest_compaction` |
+| `backend/app/services/chat/compaction_checkpoint.py` | Locate latest checkpoint + shared resolve→scope→limit pipeline (Phase 1) |
 | `chat_shell/compression/config.py` | Context window, reserved output, trigger / target limit calculation |
 | `chat_shell/compression/context_metrics.py` | Context metrics snapshots |
 | `chat_shell/messages/attachment_preview.py` | Attachment preview budgeting and truncation |
@@ -225,11 +268,14 @@ without observability, governance is hard to tune safely.
 
 ## Notes
 
-### Summary compact only rewrites live state
+### Reload starts from the latest compaction checkpoint (Phase 1)
 
-The compacted replacement history is not persisted as the new canonical session
-history. Later turns rebuild from the full stored history and re-evaluate
-compaction when needed. This is an intentional simplification.
+Earlier, later turns rebuilt from the full stored history and re-evaluated
+compaction every time, which re-inflated long sessions. Phase 1 persists a
+self-contained checkpoint in the compacted turn's `messages_chain` (retained
+recent user messages tagged `checkpoint_retained` plus the summary tagged
+`summary_compacted`) and reloads from the latest checkpoint via the backend
+`from_latest_compaction` path. See the Phase 1 section below.
 
 ### `max_output_tokens` is budget input, not a history-rewrite result
 

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -270,6 +270,12 @@ single finalizer, on every terminal path.
   `completed_with_unexecuted_tool_calls`, tool-limit recovery, truncation retry
   and retry-exhausted, and silent/deferred exit. The old
   `_collected_state_messages` / length-gate authority is gone.
+- **Finalizer execution ≠ durable persistence.** The finalizer only sets the
+  in-memory `_last_messages_chain` on the builder; whether that becomes durable in
+  `subtask.result.messages_chain` depends on the terminal status. Supported
+  (COMPLETED-style) terminals persist it; carrying and persisting it for `FAILED`
+  / `CANCELLED` is deferred to Phase 2b (see "Not in Phase 2a" below). So the
+  finalizer may run on a path whose chain is not ultimately stored.
 - The **engine-level non-streaming** path (`agent.execute` →
   `_collect_final_state_from_events`) does **not** build a `messages_chain`: it
   returns the LangGraph final state (its callers consume only content/tool-results,

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -117,7 +117,10 @@ But Wegent keeps its own trade-offs:
   The compacted turn becomes a self-contained checkpoint (retained recent user
   messages + summary) inside its own `messages_chain`, and reload starts from the
   latest checkpoint. This is functionally close to Codex's `replacement_history`,
-  but reuses existing persistence instead of a new field. See the Phase 1 section.
+  but reuses existing persistence instead of a new field. Phase 2a then makes that
+  persistence independent of how the turn terminates by reading the authoritative
+  LangGraph state through a request-local checkpointer. See the Phase 1 and Phase
+  2a sections.
 - **Summary compact is not a long-term memory layer**
   It is a request-time governance tool.
 - **Fallback is not the main feature path**
@@ -214,6 +217,75 @@ turn:
 - context-length classification recognizes HTTP 413 and non-English markers; a
   bare 400 is not treated as overflow (avoids a retry storm)
 
+## Phase 2a: authoritative-state persistence across terminal paths
+
+Phase 1 made a compacted turn a self-contained checkpoint, but persistence still
+depended on the happy path. The turn's `messages_chain` was serialized from
+`_collected_state_messages`, captured from top-level `on_chain_end` events under a
+"keep the longest snapshot" gate. Two consequences:
+
+- On a `GraphRecursionError` (tool-call limit) the top-level end may never fire,
+  and the recovery rebuilt the chain from the pre-run `lc_messages` — so a turn
+  that both compacted **and** hit the tool limit persisted only the recovery
+  reply and silently dropped the checkpoint. The next continuation then fell back
+  to an older checkpoint.
+- Compaction *shrinks* the live state, so the "longest snapshot" gate could reject
+  the real post-compaction state.
+
+Phase 2a makes the **last authoritative LangGraph state** the single source for a
+single finalizer, on every terminal path.
+
+### Request-local checkpointer read via `aget_state`
+
+- Every agent build attaches a **request-local `InMemorySaver`**, and each turn
+  (and each truncation-retry level) runs on a unique `thread_id` with
+  **`durability="exit"`**. Exit durability commits exactly one checkpoint at graph
+  exit — including on exception exit — so `aget_state(config)` returns the
+  authoritative post-compaction state (summary + completed post-compaction tool
+  pairs) at ~1× memory instead of one snapshot per super-step. The dormant
+  `ENABLE_CHECKPOINTING` toggle was removed; the checkpointer is not optional.
+- `_finalize_turn_history` is the single atomic choke point: it sanitizes tool
+  pairs, filters to this turn's new messages by a turn-invariant
+  `original_input_ids` (see `TurnExecutionContext`), serializes/validates, and
+  sets `_last_messages_chain`, `_last_live_state_messages`, and
+  `_last_termination_reason` together so they cannot drift.
+- Every terminal path funnels through it: normal completion,
+  `completed_with_unexecuted_tool_calls`, tool-limit recovery, truncation retry
+  and retry-exhausted, silent/deferred exit, and the non-streaming path. The old
+  `_collected_state_messages` / length-gate authority is gone.
+
+### Recovery and retry read the current state, not `lc_messages`
+
+- **Tool-limit recovery** feeds the recovery LLM the current authoritative state
+  (sanitized), so it sees the tool results it already produced; the final state is
+  `safe_state + [recovery reply]`, and the internal tool-limit instruction is
+  excluded from what persists.
+- **Truncation retry** seeds a **fresh thread** with the sanitized authoritative
+  state (re-submitting to the same thread would not delete the truncated tool call
+  — `add_messages` merges by id) and **inherits the root `original_input_ids`**.
+  The truncation instruction is an **ephemeral control message**
+  (`ephemeral_control` marker): the compactor never treats it as the current user,
+  never retains it into the checkpoint, and never folds it into the summary, and
+  the serializer skips it — so it can never leak into persisted history or crowd
+  out the real user turn.
+
+### Lifecycle and observability
+
+- Each `stream_tokens` level deletes **its own** thread in a `finally`
+  (`adelete_thread`); failures are logged, not silently suppressed, and
+  `checkpoints_in_saver` is measured before the delete. A per-turn persistence log
+  records `path`, `chain_msgs`, `has_summary_marker`,
+  `post_compaction_tool_pairs`, `checkpoints_in_saver`, and `adelete_thread_ok`.
+- The checkpointer is a per-request scratchpad for reading authoritative state
+  within one turn; the durable store remains `subtask.result.messages_chain`. No
+  separate checkpoint blob is introduced, and reconstruction is unchanged — the
+  finalizer reuses the same serializer, so recovery-path checkpoints reload
+  identically to normal-completion ones.
+
+Not in Phase 2a (deferred): letting non-`COMPLETED` terminals (FAILED / CANCELLED)
+carry and persist `messages_chain`, and relaxing the checkpoint locator to
+recognize them.
+
 ## Implementation map
 
 These modules are the best entry points for future maintenance:
@@ -222,7 +294,10 @@ These modules are the best entry points for future maintenance:
 |---|---|
 | `chat_shell/guard/context_guard.py` | Unified governance entry point: source pass, summary compact, emergency pass |
 | `chat_shell/guard/tool_output.py` | Compact tool-output rendering and emergency re-truncation |
-| `chat_shell/compression/summary_compactor.py` | Summary compact core logic, O(n) trim, checkpoint-retain markers |
+| `chat_shell/compression/summary_compactor.py` | Summary compact core logic, O(n) trim, checkpoint-retain + ephemeral-control markers |
+| `chat_shell/compression/tool_sanitizer.py` | Shared `sanitize_tool_pairs` used by compaction, recovery, and the finalizer (Phase 2a) |
+| `chat_shell/agents/graph_builder.py` | Request-local exit-durability checkpointer, `_finalize_turn_history`, per-path terminal handling (Phase 2a) |
+| `chat_shell/agents/turn_context.py` | `TurnExecutionContext`: turn-invariant `original_input_ids` + per-level thread ownership (Phase 2a) |
 | `chat_shell/history/loader.py` | History reload; forwards `from_latest_compaction` |
 | `backend/app/services/chat/compaction_checkpoint.py` | Locate latest checkpoint + shared resolve→scope→limit pipeline (Phase 1) |
 | `chat_shell/compression/config.py` | Context window, reserved output, trigger / target limit calculation |

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -70,6 +70,23 @@ This is more reliable than spreading budget logic across `build_messages`, tool
 events, history serialization, and other side paths. In the final shape,
 budgeting converges on `UnifiedContextGuard`.
 
+**Coverage boundary (important — do not be misled by "non-streaming").**
+`UnifiedContextGuard` is attached via `pre_model_hook` only when the **chat
+execution engine** builds its agent, so distinguish two kinds of "non-streaming":
+
+- **Transport-level non-streaming** (HTTP `stream=false` follow-ups): only buffers
+  the SSE events and returns once — the **execution engine is still
+  `stream_tokens`**, so the guard, compaction recovery, and persistence all apply.
+  It **is** governed.
+- **Engine-level non-streaming** (`agent.execute` → `_collect_final_state_from_events`):
+  whether the guard attaches depends on whether the caller passes a
+  `pre_model_hook`. The only current user is the answer-audit `correction_service`,
+  which does **not** pass one — a **guard-bypassing short path**: no compaction
+  governance, the history under review is embedded into the prompt, the result is
+  written only to `subtask.result.correction` (**no `messages_chain`**), with its
+  own try/except fallback. It is a one-shot auditor, not a conversation/follow-up
+  path, and is decoupled from this context governance.
+
 ### Separate UI-visible raw data from model-visible compact data
 
 This is one of the most important boundaries in the design.
@@ -253,12 +270,15 @@ single finalizer, on every terminal path.
   `completed_with_unexecuted_tool_calls`, tool-limit recovery, truncation retry
   and retry-exhausted, and silent/deferred exit. The old
   `_collected_state_messages` / length-gate authority is gone.
-- The **non-streaming** path (`_collect_final_state_from_events`) does **not**
-  build a `messages_chain`: it returns the LangGraph final state (its callers
-  consume only content/tool-results, and `messages_chain` is persisted on the
-  streaming path alone). It still shares the request-local checkpointer, exit
-  durability, recovery-from-current-state, and per-turn thread teardown; it just
-  has no finalizer because it produces no persisted history.
+- The **engine-level non-streaming** path (`agent.execute` →
+  `_collect_final_state_from_events`) does **not** build a `messages_chain`: it
+  returns the LangGraph final state (its callers consume only content/tool-results,
+  and `messages_chain` is persisted on the streaming path alone). It still shares
+  the request-local checkpointer, exit durability, recovery-from-current-state, and
+  per-turn thread teardown; it just has no finalizer because it produces no
+  persisted history. **Note:** HTTP `stream=false` follow-ups are **not** this
+  case — they still run on `stream_tokens` and go through the finalizer and
+  persistence (see the coverage boundary under "single control point").
 
 ### Recovery and retry read the current state, not `lc_messages`
 

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -263,11 +263,17 @@ single finalizer, on every terminal path.
 - **Truncation retry** seeds a **fresh thread** with the sanitized authoritative
   state (re-submitting to the same thread would not delete the truncated tool call
   — `add_messages` merges by id) and **inherits the root `original_input_ids`**.
-  The truncation instruction is an **ephemeral control message**
-  (`ephemeral_control` marker): the compactor never treats it as the current user,
-  never retains it into the checkpoint, and never folds it into the summary, and
-  the serializer skips it — so it can never leak into persisted history or crowd
-  out the real user turn.
+  The truncation instruction rides a separate **attempt control plane**: it lives
+  only in `_attempt_guidance` and is injected into the model input via
+  `llm_input_messages` by the builder's own `_attempt_guidance_hook` (the last link
+  in the pre-model chain), **after** compaction. It never enters the `messages`
+  channel, so it stays out of the summary source, the checkpoint, and the persisted
+  `messages_chain`, and never competes with the real user turn for the recent-user
+  budget. Because it is appended after compaction, the retry thread's own
+  compaction cannot trim it away, and it is naturally discarded when the retry
+  attempt ends. `chain_pre_model_hooks` rolls `llm_input_messages` forward through
+  each hook so user guidance and attempt guidance stack instead of clobbering each
+  other.
 
 ### Lifecycle and observability
 
@@ -294,9 +300,10 @@ These modules are the best entry points for future maintenance:
 |---|---|
 | `chat_shell/guard/context_guard.py` | Unified governance entry point: source pass, summary compact, emergency pass |
 | `chat_shell/guard/tool_output.py` | Compact tool-output rendering and emergency re-truncation |
-| `chat_shell/compression/summary_compactor.py` | Summary compact core logic, O(n) trim, checkpoint-retain + ephemeral-control markers |
+| `chat_shell/compression/summary_compactor.py` | Summary compact core logic, O(n) trim, checkpoint-retain markers |
 | `chat_shell/compression/tool_sanitizer.py` | Shared `sanitize_tool_pairs` used by compaction, recovery, and the finalizer (Phase 2a) |
-| `chat_shell/agents/graph_builder.py` | Request-local exit-durability checkpointer, `_finalize_turn_history`, per-path terminal handling (Phase 2a) |
+| `chat_shell/guard/composition.py` | `chain_pre_model_hooks`: composes pre-model hooks, rolling `llm_input_messages` forward so producers stack |
+| `chat_shell/agents/graph_builder.py` | Request-local exit-durability checkpointer, `_finalize_turn_history`, attempt control plane (`_attempt_guidance_hook`), per-path terminal handling (Phase 2a) |
 | `chat_shell/agents/turn_context.py` | `TurnExecutionContext`: turn-invariant `original_input_ids` + per-level thread ownership (Phase 2a) |
 | `chat_shell/history/loader.py` | History reload; forwards `from_latest_compaction` |
 | `backend/app/services/chat/compaction_checkpoint.py` | Locate latest checkpoint + shared resolve→scope→limit pipeline (Phase 1) |

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -249,10 +249,16 @@ single finalizer, on every terminal path.
   `original_input_ids` (see `TurnExecutionContext`), serializes/validates, and
   sets `_last_messages_chain`, `_last_live_state_messages`, and
   `_last_termination_reason` together so they cannot drift.
-- Every terminal path funnels through it: normal completion,
+- Every **streaming** terminal path funnels through it: normal completion,
   `completed_with_unexecuted_tool_calls`, tool-limit recovery, truncation retry
-  and retry-exhausted, silent/deferred exit, and the non-streaming path. The old
+  and retry-exhausted, and silent/deferred exit. The old
   `_collected_state_messages` / length-gate authority is gone.
+- The **non-streaming** path (`_collect_final_state_from_events`) does **not**
+  build a `messages_chain`: it returns the LangGraph final state (its callers
+  consume only content/tool-results, and `messages_chain` is persisted on the
+  streaming path alone). It still shares the request-local checkpointer, exit
+  durability, recovery-from-current-state, and per-turn thread teardown; it just
+  has no finalizer because it produces no persisted history.
 
 ### Recovery and retry read the current state, not `lc_messages`
 

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -49,6 +49,11 @@ sidebar_position: 31
 
 这比把长度控制分散在 `build_messages`、tool event、history serialization 等多处更稳。治理逻辑最终收敛到 `UnifiedContextGuard`，避免不同路径口径漂移。
 
+**覆盖边界（重要，别被“非流式”误导）。** `UnifiedContextGuard` 只在 **chat 执行引擎**构建 agent 时通过 `pre_model_hook` 挂载，所以要区分两种“非流式”：
+
+- **传输层非流式**（HTTP `stream=false` 追问）：只是把 SSE 事件缓冲后一次性返回，**底层执行引擎仍是 `stream_tokens`**，照常挂 guard、走压缩恢复与落库。它**受**治理。
+- **引擎级非流式**（`agent.execute` → `_collect_final_state_from_events`）：是否挂 guard 取决于调用方是否传入 `pre_model_hook`。当前唯一使用者是答案质检 `correction_service`，它**不传** `pre_model_hook`——这是一条 **guard 未覆盖的短路路径**：不做压缩治理、把待评估历史内嵌进 prompt、结果只写 `subtask.result.correction`（**不落 `messages_chain`**）、并自带 try/except 兜底。它是一次性质检器，不是对话/追问路径，与本上下文治理解耦。
+
 ### 区分“用户可见原始数据”和“模型可见紧凑数据”
 
 这是整个设计里最重要的边界之一。
@@ -191,11 +196,12 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
 - 所有**流式**终止路径都经它：正常结束、`completed_with_unexecuted_tool_calls`、
   工具上限 recovery、截断重试与重试耗尽、silent/deferred。旧的
   `_collected_state_messages` / 长度门槛权威判定已移除。
-- **非流式**路径（`_collect_final_state_from_events`）**不**构建 `messages_chain`：
-  它返回 LangGraph 最终 state（其调用方只消费 content/tool-results，`messages_chain`
-  仅在流式路径落库）。它仍复用 request-local checkpointer、exit durability、
-  recovery-from-current-state 与每轮 thread 释放，只是因为不产出持久化历史而没有
-  finalizer。
+- **引擎级非流式**路径（`agent.execute` → `_collect_final_state_from_events`）**不**
+  构建 `messages_chain`：它返回 LangGraph 最终 state（调用方只消费 content/tool-results，
+  `messages_chain` 仅在流式路径落库）。它仍复用 request-local checkpointer、exit
+  durability、recovery-from-current-state 与每轮 thread 释放，只是不产出持久化历史，
+  故没有 finalizer。**注意**：HTTP `stream=false` 的追问**不属于**此类——它底层仍是
+  `stream_tokens`，照常走 finalizer 与落库（见“统一入口”一节的覆盖边界）。
 
 ### recovery 与 retry 用当前状态，不用 `lc_messages`
 

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -196,6 +196,11 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
 - 所有**流式**终止路径都经它：正常结束、`completed_with_unexecuted_tool_calls`、
   工具上限 recovery、截断重试与重试耗尽、silent/deferred。旧的
   `_collected_state_messages` / 长度门槛权威判定已移除。
+- **finalizer 执行 ≠ 落库**：finalizer 只在 builder 上设置内存里的
+  `_last_messages_chain`；它是否 durable 落进 `subtask.result.messages_chain` 取决于
+  终止状态。受支持的（COMPLETED 类）终止会落库；`FAILED` / `CANCELLED` 的携带与落库
+  推迟到 Phase 2b（见下文“不在 Phase 2a 范围”）。因此 finalizer 可能在一条最终并不
+  落库的路径上运行。
 - **引擎级非流式**路径（`agent.execute` → `_collect_final_state_from_events`）**不**
   构建 `messages_chain`：它返回 LangGraph 最终 state（调用方只消费 content/tool-results，
   `messages_chain` 仅在流式路径落库）。它仍复用 request-local checkpointer、exit
@@ -283,7 +288,7 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
 
 ### reload 从最新压缩检查点开始（Phase 1）
 
-早期实现每一轮都从完整存储历史重建并重新评估压缩，长会话会因此“复原膨胀”。Phase 1 把自包含检查点持久化进压缩那一轮的 `messages_chain`（保留的近期 user 消息带 `checkpoint_retained`，summary 带 `summary_compacted`），并通过 backend 的 `from_latest_compaction` 路径从最新检查点 reload。详见下面的 Phase 1 一节。
+早期实现每一轮都从完整存储历史重建并重新评估压缩，长会话会因此“复原膨胀”。Phase 1 把自包含检查点持久化进压缩那一轮的 `messages_chain`（保留的近期 user 消息带 `checkpoint_retained`，summary 带 `summary_compacted`），并通过 backend 的 `from_latest_compaction` 路径从最新检查点 reload。详见上面的 Phase 1 一节。
 
 ### `max_output_tokens` 主要是预算输入，不是历史改写结果
 

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -198,9 +198,14 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
   已产生的工具结果；final state = `safe_state + [recovery 回复]`，内部指令不入库。
 - **截断重试** 用当前权威状态（sanitize 后）**新开一个 thread** 重建（向同一 thread 重交
   并不会删掉被截断的 tool call —— `add_messages` 按 id 合并），并**继承根轮的
-  `original_input_ids`**。截断指令是**临时控制消息**（`ephemeral_control` 标记）：压缩器
-  不会把它当当前 user、不会保留进检查点、不会折进 summary，序列化器也会跳过它，因此它
-  绝不会泄漏进持久化历史，也不会挤掉真实用户消息。
+  `original_input_ids`**。截断指令走独立的 **attempt 控制平面**：它只放在
+  `_attempt_guidance` 里，由 builder 自己的 `_attempt_guidance_hook`（挂在 pre-model
+  链的最后一环）在**压缩之后**通过 `llm_input_messages` 注入模型输入，从不写入
+  `messages` channel。因此它既不进 summary source、不进 checkpoint、不进
+  `messages_chain`，也不与真实用户消息争抢 recent-user 预算；因为在压缩之后才追加，重试
+  thread 自身压缩也不会把它裁掉，重试 attempt 结束即自然销毁。`chain_pre_model_hooks`
+  会把 `llm_input_messages` 逐环向后滚动，让用户 guidance 与 attempt guidance 叠加而非互相
+  覆盖。
 
 ### 生命周期与可观测
 
@@ -223,9 +228,10 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
 |---|---|
 | `chat_shell/guard/context_guard.py` | 统一治理主入口，串 source pass、summary compact、emergency pass |
 | `chat_shell/guard/tool_output.py` | tool output 的 compact 表示和紧急重截断 |
-| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑、O(n) 裁剪、检查点保留 + 临时控制消息标记 |
+| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑、O(n) 裁剪、检查点保留 |
 | `chat_shell/compression/tool_sanitizer.py` | 共享 `sanitize_tool_pairs`，压缩 / recovery / finalizer 共用（Phase 2a） |
-| `chat_shell/agents/graph_builder.py` | request-local exit-durability checkpointer、`_finalize_turn_history`、各终止路径处理（Phase 2a） |
+| `chat_shell/guard/composition.py` | `chain_pre_model_hooks`：组合多个 pre-model hook，`llm_input_messages` 逐环滚动叠加 |
+| `chat_shell/agents/graph_builder.py` | request-local exit-durability checkpointer、`_finalize_turn_history`、attempt 控制平面（`_attempt_guidance_hook`）、各终止路径处理（Phase 2a） |
 | `chat_shell/agents/turn_context.py` | `TurnExecutionContext`：turn 不变的 `original_input_ids` + 每层 thread 所有权（Phase 2a） |
 | `chat_shell/history/loader.py` | 历史 reload；透传 `from_latest_compaction` |
 | `backend/app/services/chat/compaction_checkpoint.py` | 定位最新检查点 + 共享 resolve→scope→limit 管线（Phase 1） |

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -87,8 +87,10 @@ sidebar_position: 31
 
 同时明确保留了 Wegent 自己的取舍：
 
-- **不做 Codex 式持久 `replacement_history`**
-  当前压缩只改本轮 live state，不把摘要后的历史永久写回为新的规范历史。
+- **检查点持久化进 `messages_chain`，而不是单独的 blob**（Phase 1）
+  压缩那一轮成为自包含检查点（保留的近期 user 消息 + summary）落进它自己的
+  `messages_chain`，reload 从最新检查点开始。功能上接近 Codex 的
+  `replacement_history`，但复用现有持久化而非新增字段。详见 Phase 1 一节。
 - **不把 summary compact 变成长期记忆层**
   它是 request-time 治理手段，不是新的会话存储模型。
 - **不让单个 fallback 路径承载全部功能**
@@ -138,6 +140,28 @@ Stage 3 解决的是另一个长期问题：附件提取文本会作为 `<attach
 
 这一步的实质是把附件从“隐式历史负担”改成“显式可控上下文源”。
 
+## Phase 1：检查点 reload 与卡死加固
+
+Phase 1 补齐了 Stage 2 遗留的两个缺口。
+
+### 检查点 reload（不再全量复原膨胀）
+
+此前每个新 subtask 都会 reload 完整原始转录并重跑一次全量压缩——跨多天的长会话意味着每一新轮都要压缩约 1.7M tokens。Phase 1 把压缩那一轮做成**自包含检查点**：
+
+- `_select_recent_user_messages` 把保留的近期 user 消息克隆成新 id 并打上 `checkpoint_retained` 标记，让本轮序列化器把它们保留进 `messages_chain`（和带 `summary_compacted` 的 summary、以及其后同轮生成的 suffix 一起）。
+- backend 历史接口新增 `from_latest_compaction=true`：用 chain 内 `summary_compacted` 标记定位最新检查点，返回 `[检查点 chain] + [其后完整 turns]`；`limit` 绝不截断检查点 chain 本身。
+- HTTP 端点与 package 模式共用同一条 `resolve_history_subtasks` 管线，保证 fork、`before_message_id`、`limit`、检查点切片语义一致。
+- 由于 HTTP 传输会丢弃 `additional_kwargs`，reload 回来的 summary 通过内容标记重新识别，避免被再次当作 user 消息保留。
+
+### 卡死加固
+
+针对一次生产卡死（O(n²) 裁剪把 CPU 打满数分钟、随后 backend 读超时取消该轮）对 summary 压缩路径做了加固：
+
+- 裁剪改为对 sanitized prompt 的单趟 O(n) 预算裁剪（不再每删一条重算、不再每条消息叠加一次 reply-priming）
+- 压缩期间心跳 ticker 持续发 `summary_compact` in_progress 状态，保持 SSE 不断连，不再与 backend 读超时赛跑
+- summary LLM 调用带 provider 超时 + `asyncio.wait_for` 兜底
+- 超长判定识别 HTTP 413 与非英文 marker；裸 400 不再直接当超长（避免重试风暴）
+
 ## 实现落点
 
 下列模块是后续维护最值得先看的入口：
@@ -146,7 +170,9 @@ Stage 3 解决的是另一个长期问题：附件提取文本会作为 `<attach
 |---|---|
 | `chat_shell/guard/context_guard.py` | 统一治理主入口，串 source pass、summary compact、emergency pass |
 | `chat_shell/guard/tool_output.py` | tool output 的 compact 表示和紧急重截断 |
-| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑 |
+| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑、O(n) 裁剪、检查点保留标记 |
+| `chat_shell/history/loader.py` | 历史 reload；透传 `from_latest_compaction` |
+| `backend/app/services/chat/compaction_checkpoint.py` | 定位最新检查点 + 共享 resolve→scope→limit 管线（Phase 1） |
 | `chat_shell/compression/config.py` | 上下文窗口、reserved output、trigger/target limit 计算 |
 | `chat_shell/compression/context_metrics.py` | 上下文指标快照 |
 | `chat_shell/messages/attachment_preview.py` | 附件 preview 预算分配与截断 |
@@ -182,9 +208,9 @@ Stage 3 解决的是另一个长期问题：附件提取文本会作为 `<attach
 
 ## 注意事项
 
-### summary compact 只治理 live state
+### reload 从最新压缩检查点开始（Phase 1）
 
-当前实现不会把 compact 后的 replacement history 永久写回成新的会话标准历史。下一轮仍会从重建后的完整历史重新评估，必要时再压一次。这是有意接受的简化。
+早期实现每一轮都从完整存储历史重建并重新评估压缩，长会话会因此“复原膨胀”。Phase 1 把自包含检查点持久化进压缩那一轮的 `messages_chain`（保留的近期 user 消息带 `checkpoint_retained`，summary 带 `summary_compacted`），并通过 backend 的 `from_latest_compaction` 路径从最新检查点 reload。详见下面的 Phase 1 一节。
 
 ### `max_output_tokens` 主要是预算输入，不是历史改写结果
 

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -90,7 +90,9 @@ sidebar_position: 31
 - **检查点持久化进 `messages_chain`，而不是单独的 blob**（Phase 1）
   压缩那一轮成为自包含检查点（保留的近期 user 消息 + summary）落进它自己的
   `messages_chain`，reload 从最新检查点开始。功能上接近 Codex 的
-  `replacement_history`，但复用现有持久化而非新增字段。详见 Phase 1 一节。
+  `replacement_history`，但复用现有持久化而非新增字段。Phase 2a 进一步通过
+  request-local checkpointer 读取权威 LangGraph state，让这份持久化不再依赖该轮
+  以何种方式结束。详见 Phase 1 与 Phase 2a 两节。
 - **不把 summary compact 变成长期记忆层**
   它是 request-time 治理手段，不是新的会话存储模型。
 - **不让单个 fallback 路径承载全部功能**
@@ -162,6 +164,57 @@ Phase 1 补齐了 Stage 2 遗留的两个缺口。
 - summary LLM 调用带 provider 超时 + `asyncio.wait_for` 兜底
 - 超长判定识别 HTTP 413 与非英文 marker；裸 400 不再直接当超长（避免重试风暴）
 
+## Phase 2a：终止路径无关的权威状态持久化
+
+Phase 1 让压缩那一轮成为自包含检查点，但持久化仍依赖 happy path：该轮的
+`messages_chain` 由 `_collected_state_messages` 序列化而来，而后者是在顶层
+`on_chain_end` 事件里、用“保留最长快照”门槛捕获的。两个后果：
+
+- 触发 `GraphRecursionError`（工具调用上限）时顶层 end 可能根本不触发，recovery
+  又用请求前的 `lc_messages` 重建 chain —— 于是一轮“既压缩又撞工具上限”只持久化了
+  recovery 回复，静默丢掉检查点，下次续聊回退到更早的检查点。
+- 压缩会让 state **变短**，“最长快照”门槛可能拒绝真正的压缩后权威状态。
+
+Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来源，覆盖所有终止路径。
+
+### request-local checkpointer + `aget_state`
+
+- 每次构建 agent 都挂一个 **request-local `InMemorySaver`**，每轮（以及每层截断重试）
+  用唯一 `thread_id` 且 **`durability="exit"`**。exit 只在图退出时（含异常退出）提交
+  一份 checkpoint，因此 `aget_state(config)` 能取到压缩后的权威状态（summary + 压缩后
+  已完成的 tool pair），内存约 ~1×，而不是每个 super-step 一份。已删除失效的
+  `ENABLE_CHECKPOINTING` 开关，checkpointer 不再可选。
+- `_finalize_turn_history` 是唯一的原子收口：sanitize tool pair → 用 turn 不变的
+  `original_input_ids`（见 `TurnExecutionContext`）过滤本轮新消息 → 序列化校验 →
+  同时设置 `_last_messages_chain`、`_last_live_state_messages`、
+  `_last_termination_reason`，三者不会漂移。
+- 所有终止路径都经它：正常结束、`completed_with_unexecuted_tool_calls`、工具上限
+  recovery、截断重试与重试耗尽、silent/deferred、非流式路径。旧的
+  `_collected_state_messages` / 长度门槛权威判定已移除。
+
+### recovery 与 retry 用当前状态，不用 `lc_messages`
+
+- **工具上限 recovery** 把当前权威状态（sanitize 后）喂给 recovery LLM，使其能看到本轮
+  已产生的工具结果；final state = `safe_state + [recovery 回复]`，内部指令不入库。
+- **截断重试** 用当前权威状态（sanitize 后）**新开一个 thread** 重建（向同一 thread 重交
+  并不会删掉被截断的 tool call —— `add_messages` 按 id 合并），并**继承根轮的
+  `original_input_ids`**。截断指令是**临时控制消息**（`ephemeral_control` 标记）：压缩器
+  不会把它当当前 user、不会保留进检查点、不会折进 summary，序列化器也会跳过它，因此它
+  绝不会泄漏进持久化历史，也不会挤掉真实用户消息。
+
+### 生命周期与可观测
+
+- 每层 `stream_tokens` 在自己的 `finally` 里删**自己那个** thread（`adelete_thread`），
+  失败会记日志而非静默吞掉，且在删除前测量 `checkpoints_in_saver`。每轮输出一条持久化
+  日志：`path`、`chain_msgs`、`has_summary_marker`、`post_compaction_tool_pairs`、
+  `checkpoints_in_saver`、`adelete_thread_ok`。
+- checkpointer 只是请求内读取权威状态的临时暂存，持久真源仍是
+  `subtask.result.messages_chain`；不引入独立 checkpoint blob，重建逻辑不变 —— finalizer
+  复用同一序列化器，recovery 路径的检查点与正常结束的检查点重建结果一致。
+
+不在 Phase 2a 范围（推迟）：让非 `COMPLETED` 终止（FAILED / CANCELLED）携带并持久化
+`messages_chain`，以及放宽检查点定位以识别它们。
+
 ## 实现落点
 
 下列模块是后续维护最值得先看的入口：
@@ -170,7 +223,10 @@ Phase 1 补齐了 Stage 2 遗留的两个缺口。
 |---|---|
 | `chat_shell/guard/context_guard.py` | 统一治理主入口，串 source pass、summary compact、emergency pass |
 | `chat_shell/guard/tool_output.py` | tool output 的 compact 表示和紧急重截断 |
-| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑、O(n) 裁剪、检查点保留标记 |
+| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑、O(n) 裁剪、检查点保留 + 临时控制消息标记 |
+| `chat_shell/compression/tool_sanitizer.py` | 共享 `sanitize_tool_pairs`，压缩 / recovery / finalizer 共用（Phase 2a） |
+| `chat_shell/agents/graph_builder.py` | request-local exit-durability checkpointer、`_finalize_turn_history`、各终止路径处理（Phase 2a） |
+| `chat_shell/agents/turn_context.py` | `TurnExecutionContext`：turn 不变的 `original_input_ids` + 每层 thread 所有权（Phase 2a） |
 | `chat_shell/history/loader.py` | 历史 reload；透传 `from_latest_compaction` |
 | `backend/app/services/chat/compaction_checkpoint.py` | 定位最新检查点 + 共享 resolve→scope→limit 管线（Phase 1） |
 | `chat_shell/compression/config.py` | 上下文窗口、reserved output、trigger/target limit 计算 |

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -188,9 +188,14 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
   `original_input_ids`（见 `TurnExecutionContext`）过滤本轮新消息 → 序列化校验 →
   同时设置 `_last_messages_chain`、`_last_live_state_messages`、
   `_last_termination_reason`，三者不会漂移。
-- 所有终止路径都经它：正常结束、`completed_with_unexecuted_tool_calls`、工具上限
-  recovery、截断重试与重试耗尽、silent/deferred、非流式路径。旧的
+- 所有**流式**终止路径都经它：正常结束、`completed_with_unexecuted_tool_calls`、
+  工具上限 recovery、截断重试与重试耗尽、silent/deferred。旧的
   `_collected_state_messages` / 长度门槛权威判定已移除。
+- **非流式**路径（`_collect_final_state_from_events`）**不**构建 `messages_chain`：
+  它返回 LangGraph 最终 state（其调用方只消费 content/tool-results，`messages_chain`
+  仅在流式路径落库）。它仍复用 request-local checkpointer、exit durability、
+  recovery-from-current-state 与每轮 thread 释放，只是因为不产出持久化历史而没有
+  finalizer。
 
 ### recovery 与 retry 用当前状态，不用 `lc_messages`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional chat history loading from the latest compaction checkpoint via `from_latest_compaction`.
  * Summary compaction now emits periodic “in progress” heartbeat updates during long-running compaction.
* **Bug Fixes**
  * More reliable summary/checkpoint marker detection and preservation across history reloads.
  * Improved history scoping, status/limit handling, and safer retention/truncation (including tool-call/tool-result pairing).
  * Hardened long-compaction and recovery behavior to reduce context-loss and retry issues.
* **Documentation**
  * Updated context governance guides with checkpoint reload and hardening details.
* **Tests**
  * Expanded coverage for checkpoint scoping, heartbeat telemetry, marker forwarding, and overflow/timeout trimming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->