### PR TITLE
docs(wework): clarify desktop e2e coverage

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -29,6 +29,8 @@ E2E tests use real backend requests. Do not skip, silently fail, or replace a fa
 
 - Design verification cases as a QA test plan before running them. For every changed behavior, cover the preconditions, environment and test data, exact steps, expected results, negative and recovery paths, and cleanup. Record the actual result and retain reproducible evidence for failures and critical-path success.
 - Changes to a core user flow must add or update automated E2E regression coverage in the same change. Treat task creation and launch, agent interaction, local-runtime lifecycle, permissions, and failure recovery as core flows when they are affected.
+- Add Wework E2E regression cases under `e2e/desktop/` and integrate them with the existing desktop runner so the GitHub desktop E2E jobs execute them. Do not place desktop regressions behind standalone local-only entry points.
+- Reuse the existing `e2e:desktop` command and its established CI variants. Do not add a package script or GitHub Actions command for each scenario; extend the desktop runner or its scenario discovery instead. Add a new command only when the test requires a genuinely different CI environment or job boundary.
 - E2E coverage complements, but never replaces, verification in the real Tauri application.
 
 ## Real desktop verification


### PR DESCRIPTION
## What changed

- Require Wework E2E regression cases to live under `e2e/desktop/` and use the existing desktop runner.
- Prevent per-scenario package scripts and GitHub Actions commands unless a genuinely different CI environment or job boundary is required.

## Why

Desktop regressions must run through the entry points covered by GitHub CI. Reusing the runner and scenario discovery also keeps the test interface maintainable instead of growing one command per case.

## Impact

Contributors now have explicit guidance for adding Wework desktop E2E coverage that CI will execute.

## Validation

- `git diff --check`
- Documentation-only change; no runtime tests required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance for desktop end-to-end regression cases.
  * Documented how to run new scenarios through the existing desktop test commands and CI jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->