### PR TITLE
fix(wework): align menu text hierarchy with Codex

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -166,6 +166,12 @@ The primary weight is regular. Codex uses subtle intermediate platform weights,
 but Wework maps them to `400` for body and `500` for emphasis. Use `600`
 sparingly and avoid `700` in product chrome.
 
+Entered composer text uses the primary text color so it reads as content. Normal
+menu labels and composer actions such as the quick-phrase trigger also use the
+primary text color, but remain at regular weight so they stay crisp without
+appearing bold. Descriptions, metadata, and shortcuts use secondary or tertiary
+text colors.
+
 Keep sentence case. Do not use uppercase labels for visual hierarchy. Use no
 more than three type roles in a compact surface. Truncate repeated secondary
 context only when the full value remains available through a tooltip, detail

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -848,6 +848,7 @@ describe('ChatInput', () => {
       'py-[14px]',
       'scrollbar-none',
       'text-chat',
+      'text-text-primary',
       'leading-5'
     )
     expect(screen.getByTestId('send-message-button')).toHaveClass(
@@ -2529,6 +2530,14 @@ describe('ChatInput', () => {
     expect(menu.getByText('设置 WeWork 将持续努力实现的目标')).toBeInTheDocument()
     expect(menu.queryByText('Attach Google Chrome')).not.toBeInTheDocument()
     expect(menu.queryByText('插件')).not.toBeInTheDocument()
+    expect(screen.getByTestId('attach-files-button')).toHaveClass(
+      'font-normal',
+      'text-text-primary'
+    )
+    expect(screen.getByTestId('set-plan-mode-button')).toHaveClass(
+      'font-normal',
+      'text-text-primary'
+    )
 
     await userEvent.click(screen.getByTestId('set-plan-mode-button'))
 

--- a/wework/src/components/chat/composer/AddContextMenu.tsx
+++ b/wework/src/components/chat/composer/AddContextMenu.tsx
@@ -66,7 +66,7 @@ export function AddContextMenu({
             type="button"
             data-testid="attach-files-button"
             onClick={() => fileInputRef.current?.click()}
-            className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base font-medium leading-[18px] text-text-primary hover:bg-muted"
+            className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base font-normal leading-[18px] text-text-primary hover:bg-muted"
           >
             <Paperclip className="h-[18px] w-[18px] shrink-0 text-text-secondary" />
             <span>{t('workbench.add_photos_files', '添加照片和文件')}</span>
@@ -76,11 +76,11 @@ export function AddContextMenu({
               type="button"
               data-testid="set-plan-mode-button"
               onClick={handleSetPlanMode}
-              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base leading-[18px] text-text-primary hover:bg-muted"
+              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base font-normal leading-[18px] text-text-primary hover:bg-muted"
             >
               <ClipboardList className="h-[18px] w-[18px] shrink-0 text-text-secondary" />
               <span className="min-w-0 truncate">
-                <span className="font-semibold">{t('workbench.plan_mode', '计划模式')}</span>
+                <span>{t('workbench.plan_mode', '计划模式')}</span>
                 <span className="ml-2 text-text-muted">
                   {t('workbench.enable_plan_mode', '开启计划模式')}
                 </span>
@@ -92,11 +92,11 @@ export function AddContextMenu({
               type="button"
               data-testid="set-goal-button"
               onClick={handleSetGoal}
-              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base leading-[18px] text-text-primary hover:bg-muted"
+              className="flex h-9 w-full items-center gap-2.5 rounded-lg px-3 text-left text-base font-normal leading-[18px] text-text-primary hover:bg-muted"
             >
               <Target className="h-[18px] w-[18px] shrink-0 text-text-secondary" />
               <span className="min-w-0 truncate">
-                <span className="font-semibold">{t('workbench.goal_chip', '目标')}</span>
+                <span>{t('workbench.goal_chip', '目标')}</span>
                 <span className="ml-2 text-text-muted">
                   {t('workbench.pursue_goal_description', '设置 WeWork 将持续努力实现的目标')}
                 </span>

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -275,7 +275,7 @@ export function CompactChatComposer({
             onOpenSkillFile={onOpenSkillFile}
             workspaceTarget={workspaceTarget}
             workspaceFileApi={workspaceFileApi}
-            className="scrollbar-none max-h-32 min-h-6 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-[14px] text-chat leading-5 text-text-secondary outline-none placeholder:text-text-muted"
+            className="scrollbar-none max-h-32 min-h-6 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-[14px] text-chat leading-5 text-text-primary outline-none placeholder:text-text-muted"
             skillMenuClassName={[
               'left-[-1rem]',
               isStreaming && canSend ? 'right-[-5.75rem]' : 'right-[-3.5rem]',
@@ -460,7 +460,7 @@ export function CompactChatComposer({
               onOpenSkillFile={onOpenSkillFile}
               workspaceTarget={workspaceTarget}
               workspaceFileApi={workspaceFileApi}
-              className="h-full w-full overflow-y-auto rounded-2xl border border-border bg-background px-4 pb-4 pt-14 text-chat text-text-secondary outline-none"
+              className="h-full w-full overflow-y-auto rounded-2xl border border-border bg-background px-4 pb-4 pt-14 text-chat text-text-primary outline-none"
               skillMenuClassName="left-4 right-4 bottom-[calc(100%+0.5rem)]"
               onListLocalSkills={onListLocalSkills}
               onListLocalApps={onListLocalApps}

--- a/wework/src/components/chat/composer/ComposerMentionMenu.tsx
+++ b/wework/src/components/chat/composer/ComposerMentionMenu.tsx
@@ -133,7 +133,7 @@ export function ComposerMentionMenu({
             >
               <Icon className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
               <span className="flex min-w-0 flex-1 items-baseline gap-2">
-                <span className="shrink-0 truncate text-sm font-medium leading-5 text-text-primary">
+                <span className="shrink-0 truncate text-sm font-normal leading-5 text-text-primary">
                   {title}
                 </span>
                 {description && (

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -552,7 +552,7 @@ export function ComposerTextarea({
       if (!trigger || !editor) return false
       if (row.kind === 'candidate') {
         if (!row.candidate.enabled) return false
-        return selectMentionCandidate(row.candidate)
+        return selectMentionCandidate(row.candidate, trigger)
       }
 
       const snapshot = editor.getSnapshot()

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -476,7 +476,7 @@ export function ModelSelector({
                   className="flex min-h-8 w-full items-center gap-3 rounded-lg px-3 py-1.5 text-left text-sm text-text-primary hover:bg-muted"
                 >
                   <span className="min-w-0 flex-1">
-                    <span className="block font-medium">
+                    <span className="block font-normal">
                       {option.labelKey ? t(option.labelKey, option.label) : option.label}
                     </span>
                     {option.description && (
@@ -517,13 +517,13 @@ export function ModelSelector({
         onFocus={() => activateControl(control.id)}
         onClick={() => activateControl(control.id)}
         className={[
-          'flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-medium leading-[18px]',
+          'flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-normal leading-[18px]',
           active
             ? 'bg-muted text-text-primary'
             : 'text-text-secondary hover:bg-muted hover:text-text-primary',
         ].join(' ')}
       >
-        <span className="min-w-0 flex-1 truncate text-text-primary">
+        <span className="min-w-0 flex-1 truncate">
           {control.labelKey ? t(control.labelKey, control.label) : control.label}
         </span>
         <span className="max-w-24 truncate text-text-muted">{selectedLabel}</span>
@@ -568,7 +568,7 @@ export function ModelSelector({
               : 'text-text-primary hover:bg-muted',
           ].join(' ')}
         >
-          <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate font-medium">
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate font-normal">
             {disabledMessage ? (
               <span className="min-w-0 flex-1 truncate">
                 <span className="block truncate">
@@ -864,13 +864,13 @@ export function ModelSelector({
                       onFocus={activateModels}
                       onClick={activateModels}
                       className={cn(
-                        'flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-medium leading-[18px]',
+                        'flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-normal leading-[18px]',
                         modelRowActive
                           ? 'bg-muted text-text-primary'
                           : 'text-text-secondary hover:bg-muted hover:text-text-primary'
                       )}
                     >
-                      <span className="min-w-0 flex-1 truncate text-text-primary">
+                      <span className="min-w-0 flex-1 truncate">
                         {t('workbench.model_version', '模型')}
                       </span>
                       <span className="max-w-24 truncate text-text-muted">{desktopModelLabel}</span>

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -250,7 +250,7 @@ export function ProjectChatComposer({
           onOpenSkillFile={onOpenSkillFile}
           workspaceTarget={workspaceTarget}
           workspaceFileApi={workspaceFileApi}
-          className="max-h-[112px] min-h-[48px] w-full resize-none overflow-y-auto bg-transparent px-0 pb-0 pt-1 text-chat text-text-secondary outline-none placeholder:text-text-muted/55"
+          className="max-h-[112px] min-h-[48px] w-full resize-none overflow-y-auto bg-transparent px-0 pb-0 pt-1 text-chat text-text-primary outline-none placeholder:text-text-muted/55"
           skillMenuClassName="left-[-1rem] right-[-0.5rem]"
           onListLocalSkills={onListLocalSkills}
           onListLocalApps={onListLocalApps}

--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -632,7 +632,6 @@ export function ProjectWorkBar({
                       : true
                     const DeviceIcon = device && isCloudDevice(device) ? Cloud : HardDrive
                     const selected = project.id === currentProjectId
-                    const projectTextClass = selected ? 'text-text-primary' : 'text-text-secondary'
                     const expanded =
                       option?.kind === 'multi' && pendingProjectWorkspaceProjectId === project.id
                     const bindRequired =
@@ -643,7 +642,7 @@ export function ProjectWorkBar({
                           type="button"
                           data-testid={`project-option-${project.id}`}
                           onClick={() => handleSelectProject(project.id)}
-                          className={`flex h-9 w-full rounded-lg px-4 text-left hover:bg-muted ${projectTextClass}`}
+                          className="flex h-9 w-full rounded-lg px-4 text-left text-text-primary hover:bg-muted"
                         >
                           <div className="flex min-h-0 w-full items-center gap-3">
                             <ProjectFolderIcon
@@ -654,7 +653,7 @@ export function ProjectWorkBar({
                             <div className="flex min-w-0 flex-1 items-center gap-2">
                               <span
                                 className={cn(
-                                  'min-w-0 truncate text-sm font-semibold leading-[18px]',
+                                  'min-w-0 truncate text-sm font-normal leading-[18px]',
                                   deviceLabel ? 'max-w-[9rem] shrink' : 'flex-1',
                                   'text-text-primary'
                                 )}

--- a/wework/src/components/chat/composer/QuickPhraseMenu.test.tsx
+++ b/wework/src/components/chat/composer/QuickPhraseMenu.test.tsx
@@ -44,6 +44,20 @@ describe('QuickPhraseMenu', () => {
     expect(screen.queryByTestId('quick-phrase-menu')).not.toBeInTheDocument()
   })
 
+  test('uses subdued regular text for the trigger and menu options', () => {
+    render(<QuickPhraseMenu onSelect={vi.fn()} />)
+
+    expect(screen.getByTestId('quick-phrase-button')).toHaveClass(
+      'font-normal',
+      'text-text-primary'
+    )
+
+    fireEvent.click(screen.getByTestId('quick-phrase-button'))
+
+    expect(screen.getByTestId('quick-phrase-menu')).toHaveClass('text-text-primary')
+    expect(screen.getByText('总结进展')).toHaveClass('font-normal')
+  })
+
   test('filters and selects a phrase with the keyboard', () => {
     const onSelect = vi.fn()
     render(<QuickPhraseMenu onSelect={onSelect} />)

--- a/wework/src/components/chat/composer/QuickPhraseMenu.tsx
+++ b/wework/src/components/chat/composer/QuickPhraseMenu.tsx
@@ -225,13 +225,15 @@ export function QuickPhraseMenu({ disabled, compact, iconOnly, onSelect }: Quick
             ? 'flex h-11 w-11 items-center justify-center rounded-full text-text-secondary hover:bg-muted disabled:opacity-40'
             : iconOnly
               ? 'flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary hover:bg-muted disabled:opacity-40'
-              : 'flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm text-text-secondary hover:bg-muted disabled:opacity-40'
+              : 'flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm font-normal text-text-primary hover:bg-muted disabled:opacity-40'
         }
         aria-label={t('workbench.quick_phrases', '快捷短语')}
         aria-expanded={open}
       >
-        <MessageSquareText className="h-4 w-4" />
-        {!compact && !iconOnly && <span>{t('workbench.quick_phrases', '快捷短语')}</span>}
+        <MessageSquareText className="h-4 w-4 text-text-secondary" />
+        {!compact && !iconOnly && (
+          <span className="text-text-primary">{t('workbench.quick_phrases', '快捷短语')}</span>
+        )}
       </button>
       {open && (
         <div
@@ -320,7 +322,7 @@ export function QuickPhraseMenu({ disabled, compact, iconOnly, onSelect }: Quick
                 className={`flex w-full items-start gap-2 rounded-lg px-2 py-2 text-left ${selectedIndex === stashed.length + index ? 'bg-muted' : 'hover:bg-muted'}`}
               >
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium">{phrase.title}</span>
+                  <span className="block truncate text-sm font-normal">{phrase.title}</span>
                   <span className="block truncate text-xs text-text-muted">
                     {phrase.content ||
                       t('workbench.quick_phrase_attachment_count', '{{count}} 个附件', {

--- a/wework/src/components/chat/composer/SlashCommandMenu.tsx
+++ b/wework/src/components/chat/composer/SlashCommandMenu.tsx
@@ -88,7 +88,7 @@ export function SlashCommandMenu({
                 >
                   <Icon className="h-4 w-4 shrink-0 text-text-secondary" />
                   <span className="flex min-w-0 flex-1 items-baseline gap-2">
-                    <span className="shrink-0 truncate text-sm font-medium leading-5 text-text-primary">
+                    <span className="shrink-0 truncate text-sm font-normal leading-5 text-text-primary">
                       {command.title}
                     </span>
                     {command.description && (

--- a/wework/src/components/chat/composer/SlashModelMenu.tsx
+++ b/wework/src/components/chat/composer/SlashModelMenu.tsx
@@ -192,7 +192,7 @@ export function SlashModelMenu({
                   highlighted ? 'bg-muted' : 'hover:bg-muted',
                 ].join(' ')}
               >
-                <span className="min-w-0 flex-1 truncate text-sm font-medium leading-5 text-text-primary">
+                <span className="min-w-0 flex-1 truncate text-sm font-normal leading-5 text-text-primary">
                   {getModelDisplayLabel(model, selectedModelOptions, resolveLabel)}
                 </span>
                 {description && (

--- a/wework/src/components/layout/DesktopSettingsMenu.test.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.test.tsx
@@ -82,6 +82,15 @@ describe('DesktopSettingsMenu', () => {
     expect(mockCheckNow).toHaveBeenCalledTimes(1)
   })
 
+  test('uses subdued regular text for normal menu actions', () => {
+    renderMenu()
+
+    expect(screen.getByTestId('settings-menu-button')).toHaveClass(
+      'font-normal',
+      'text-text-primary'
+    )
+  })
+
   test('does not render the old account or quota summary row', () => {
     renderMenu()
 

--- a/wework/src/components/layout/DesktopSettingsMenu.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.tsx
@@ -317,7 +317,7 @@ function SettingsMenuItem({
       disabled={disabled}
       aria-expanded={ariaExpanded}
       aria-controls={ariaControls}
-      className={`flex w-full items-center gap-3 px-4 text-left text-sm font-semibold leading-[18px] text-text-primary transition-colors hover:bg-hover disabled:cursor-not-allowed disabled:opacity-60 ${
+      className={`flex w-full items-center gap-3 px-4 text-left text-sm font-normal leading-[18px] text-text-primary transition-colors hover:bg-hover disabled:cursor-not-allowed disabled:opacity-60 ${
         description ? 'min-h-12 py-2' : 'h-9'
       } ${active ? 'bg-hover' : ''}`}
     >
@@ -325,7 +325,7 @@ function SettingsMenuItem({
       <span className="min-w-0 flex-1">
         <span className="block truncate">{label}</span>
         {description ? (
-          <span className="block truncate text-xs font-medium leading-4 text-text-secondary">
+          <span className="block truncate text-xs font-normal leading-4 text-text-muted">
             {description}
           </span>
         ) : null}

--- a/wework/src/components/layout/workspace-panels/LocalWorkspaceOpenerMenu.tsx
+++ b/wework/src/components/layout/workspace-panels/LocalWorkspaceOpenerMenu.tsx
@@ -165,7 +165,7 @@ export function LocalWorkspaceOpenerPicker({
                 role="menuitem"
                 data-testid={optionTestIdPrefix ? `${optionTestIdPrefix}-${opener.id}` : undefined}
                 onClick={() => void selectOpener(opener.id)}
-                className="flex h-10 w-full items-center gap-3 rounded-xl px-2.5 text-left text-base font-medium leading-5 text-text-primary transition-colors hover:bg-muted"
+                className="flex h-10 w-full items-center gap-3 rounded-xl px-2.5 text-left text-base font-normal leading-5 text-text-primary transition-colors hover:bg-muted"
               >
                 <LocalWorkspaceOpenerIcon opener={opener.id} className="h-5 w-5 shrink-0" />
                 <span className="min-w-0 flex-1 truncate">{opener.label}</span>

--- a/wework/src/components/layout/workspace-panels/WorkspaceAddMenu.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceAddMenu.tsx
@@ -175,7 +175,7 @@ export function WorkspaceAddMenu({
                 data-testid={item.testId}
                 disabled={item.disabled}
                 onClick={() => void selectItem(item)}
-                className="flex h-8 w-full items-center gap-2.5 rounded-lg px-2.5 text-left text-sm font-medium leading-5 text-text-primary transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent"
+                className="flex h-8 w-full items-center gap-2.5 rounded-lg px-2.5 text-left text-sm font-normal leading-5 text-text-primary transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent"
               >
                 <item.icon className="h-4 w-4 shrink-0 text-text-secondary" />
                 <span className="min-w-0 flex-1 truncate">{item.label}</span>

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -617,7 +617,7 @@ describe('ConnectionsSettingsPage', () => {
       additional_speed_tiers: ['fast'],
       default_service_tier: 'priority',
     })
-  }, 10_000)
+  }, 15_000)
 
   test('keeps a custom model pending when active tasks prevent a silent restart', async () => {
     api.getAllDevices.mockResolvedValue([localDevice()])


### PR DESCRIPTION
## What changed

- keep entered composer text at the primary text color
- use primary text with regular weight for normal menu labels, matching Codex without the heavy semibold appearance
- keep quick-phrase titles dark while leaving icons, descriptions, metadata, and shortcuts visually secondary
- apply the hierarchy consistently to composer, project, model, workspace, and settings menus
- document the durable text hierarchy in `wework/DESIGN.md`
- remove a composer mention-selection ref race found during repeated pre-push verification
- give the long custom-model interaction test an explicit 15-second budget instead of the insufficient global 5-second default

## Why

Wework mixed primary text colors with medium or semibold weights for ordinary menu actions, which looked heavier than the Codex desktop baseline. An intermediate revision made the labels too gray. The final hierarchy matches Codex: primary-color regular labels, with secondary colors reserved for supporting information.

## Validation

- `pnpm --filter wework test` — 206 files, 2034 tests passed
- focused menu/composer tests — 5 files, 146 tests passed
- composer skill-selection race regression — 10 consecutive runs passed
- custom-model long-interaction regression — 3 consecutive runs passed under load
- pre-commit Prettier, ESLint, and typography checks passed
- pre-push ESLint, TypeScript, and all unit tests passed
- isolated real-Tauri verification covered entered text, quick-phrase menu/title, and settings menu
- GitHub Wework lint, unit tests, Wework E2E, desktop E2E, memory E2E, all four frontend E2E shards, and executor E2E passed
