### PR TITLE
fix(export): 隐藏消息关联的知识库信息并统一 DOCX 中英文字体

### DIFF
--- a/backend/app/services/export/docx_generator.py
+++ b/backend/app/services/export/docx_generator.py
@@ -20,7 +20,9 @@ from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_LINE_SPACING
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
+from docx.oxml.text.font import CT_RPr
 from docx.shared import Inches, Pt, RGBColor
+from docx.text.run import Run
 from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
@@ -37,6 +39,11 @@ PRIMARY_COLOR = RGBColor(20, 184, 166)  # #14B8A6
 TEXT_COLOR = RGBColor(36, 41, 46)
 CODE_BG_COLOR = RGBColor(246, 248, 250)
 LINK_COLOR = RGBColor(85, 185, 247)
+LATIN_FONT = "Arial"
+EAST_ASIA_FONT = "Microsoft YaHei"
+MONOSPACE_FONT = "Courier New"
+DOCUMENT_LANGUAGE = "en-US"
+EAST_ASIA_LANGUAGE = "zh-CN"
 
 
 def generate_task_docx(
@@ -89,25 +96,56 @@ def generate_task_docx(
 
 def _setup_document_styles(doc: Document):
     """Configure document-wide styles with emoji support for Word, WPS, and macOS"""
-    # Set default font
     style = doc.styles["Normal"]
     font = style.font
-    # Use Arial which has better emoji support than Calibri
-    font.name = "Arial"
+    font.name = LATIN_FONT
     font.size = Pt(11)
     font.color.rgb = TEXT_COLOR
 
-    # Note: We don't set document-wide emoji font here because different platforms
-    # have different emoji fonts (Apple Color Emoji on macOS, Segoe UI Emoji on Windows).
-    # Instead, we rely on the Office application's automatic font fallback mechanism,
-    # which works well in modern versions (Word 2016+, macOS Word, WPS Office).
-    #
-    # The key is to ensure text is properly UTF-8 encoded, which python-docx handles automatically.
+    style_rpr = style._element.get_or_add_rPr()
+    _set_rpr_fonts(style_rpr, LATIN_FONT, EAST_ASIA_FONT)
+    _set_rpr_language(style_rpr)
 
     # Set paragraph spacing
     paragraph_format = style.paragraph_format
     paragraph_format.space_after = Pt(12)
     paragraph_format.line_spacing_rule = WD_LINE_SPACING.SINGLE
+
+
+def _set_rpr_fonts(rpr: CT_RPr, latin_font: str, east_asia_font: str) -> None:
+    """Set explicit Latin and East Asian fonts on a run-properties element."""
+    r_fonts = rpr.find(qn("w:rFonts"))
+    if r_fonts is None:
+        r_fonts = OxmlElement("w:rFonts")
+        rpr.insert(0, r_fonts)
+
+    r_fonts.set(qn("w:ascii"), latin_font)
+    r_fonts.set(qn("w:hAnsi"), latin_font)
+    r_fonts.set(qn("w:eastAsia"), east_asia_font)
+    r_fonts.set(qn("w:cs"), latin_font)
+
+
+def _set_rpr_language(rpr: CT_RPr) -> None:
+    """Mark run properties as English text with Simplified Chinese East Asia text."""
+    language = rpr.find(qn("w:lang"))
+    if language is None:
+        language = OxmlElement("w:lang")
+        rpr.append(language)
+
+    language.set(qn("w:val"), DOCUMENT_LANGUAGE)
+    language.set(qn("w:eastAsia"), EAST_ASIA_LANGUAGE)
+
+
+def _set_run_fonts(
+    run: Run,
+    latin_font: str = LATIN_FONT,
+    east_asia_font: str = EAST_ASIA_FONT,
+) -> None:
+    """Apply the document font contract to a run."""
+    run.font.name = latin_font
+    rpr = run._element.get_or_add_rPr()
+    _set_rpr_fonts(rpr, latin_font, east_asia_font)
+    _set_rpr_language(rpr)
 
 
 def _add_document_header(doc: Document, task_title: str):
@@ -116,6 +154,7 @@ def _add_document_header(doc: Document, task_title: str):
     logo = doc.add_paragraph()
     logo.alignment = WD_ALIGN_PARAGRAPH.CENTER
     run = logo.add_run("Wegent AI")
+    _set_run_fonts(run)
     run.font.size = Pt(24)
     run.font.bold = True
     run.font.color.rgb = PRIMARY_COLOR
@@ -640,7 +679,7 @@ def _add_inline_formatting(paragraph, text: str):
             _add_text_with_emoji_support(paragraph, seg_data, bold=True, italic=True)
         elif seg_type == "code":
             run = paragraph.add_run(seg_data)
-            run.font.name = "Courier New"
+            _set_run_fonts(run, MONOSPACE_FONT)
             run.font.size = Pt(10)
             run.font.color.rgb = RGBColor(207, 34, 46)
         elif seg_type == "link":
@@ -707,6 +746,8 @@ def _add_text_with_emoji_support(
         # Apply emoji-specific font configuration
         if is_emoji:
             _set_emoji_font(run)
+        else:
+            _set_run_fonts(run)
 
 
 def _set_emoji_font(run):
@@ -760,6 +801,8 @@ def _add_hyperlink(paragraph, url: str, text: str):
 
     new_run = OxmlElement("w:r")
     rPr = OxmlElement("w:rPr")
+    _set_rpr_fonts(rPr, LATIN_FONT, EAST_ASIA_FONT)
+    _set_rpr_language(rPr)
 
     # Style (blue + underline)
     color = OxmlElement("w:color")
@@ -789,7 +832,7 @@ def _add_code_block(doc: Document, code: str, language: str):
 
     # Add code content
     run = p.add_run(code)
-    run.font.name = "Courier New"
+    _set_run_fonts(run, MONOSPACE_FONT)
     run.font.size = Pt(9)
     run.font.color.rgb = TEXT_COLOR
 

--- a/backend/app/services/export/docx_generator.py
+++ b/backend/app/services/export/docx_generator.py
@@ -203,11 +203,11 @@ def _add_message(doc: Document, subtask: Subtask, task: Kind, user: User, db: Se
     time_run.font.size = Pt(9)
     time_run.font.color.rgb = RGBColor(160, 160, 160)
 
-    # Contexts (attachments and knowledge bases) for user messages
+    # Export attachment contexts for user messages.
+    # Knowledge base contexts are runtime metadata and must not be exported.
     if is_user and subtask.contexts:
         from app.models.subtask_context import ContextType
 
-        # Filter attachment type contexts
         attachment_contexts = [
             ctx
             for ctx in subtask.contexts
@@ -215,15 +215,6 @@ def _add_message(doc: Document, subtask: Subtask, task: Kind, user: User, db: Se
         ]
         if attachment_contexts:
             _add_attachments(doc, attachment_contexts, db)
-
-        # Filter knowledge base type contexts
-        knowledge_base_contexts = [
-            ctx
-            for ctx in subtask.contexts
-            if ctx.context_type == ContextType.KNOWLEDGE_BASE.value
-        ]
-        if knowledge_base_contexts:
-            _add_knowledge_bases(doc, knowledge_base_contexts)
 
     # Message content — strip system-injected metadata (<system-reminder> etc.) for user messages
     content = (
@@ -380,36 +371,6 @@ def _add_file_attachment(doc: Document, attachment: SubtaskContext):
     p_fmt = p.paragraph_format
     p_fmt.left_indent = Inches(0.2)
     p_fmt.space_after = Pt(6)
-
-
-def _add_knowledge_bases(doc: Document, knowledge_bases: List[SubtaskContext]):
-    """Add knowledge base info cards"""
-    for kb in knowledge_bases:
-        p = doc.add_paragraph()
-
-        # Get knowledge base info from type_data
-        type_data = kb.type_data or {}
-        document_count = type_data.get("document_count", 0)
-
-        # Knowledge base type label (gray color, consistent with attachment labels)
-        type_run = p.add_run("[KB] ")
-        type_run.font.bold = True
-        type_run.font.size = Pt(9)
-        type_run.font.color.rgb = RGBColor(100, 100, 100)
-
-        # Knowledge base name
-        name_run = p.add_run(kb.name)
-        name_run.font.size = Pt(10)
-
-        # Document count
-        count_run = p.add_run(f" ({document_count} docs)")
-        count_run.font.size = Pt(9)
-        count_run.font.color.rgb = RGBColor(150, 150, 150)
-
-        # Add background shading
-        p_fmt = p.paragraph_format
-        p_fmt.left_indent = Inches(0.2)
-        p_fmt.space_after = Pt(6)
 
 
 def _get_file_type_label(extension: str) -> str:

--- a/backend/app/services/shared_task.py
+++ b/backend/app/services/shared_task.py
@@ -827,10 +827,13 @@ class SharedTaskService:
         # Convert to public subtask data (exclude sensitive fields)
         public_subtasks = []
         for sub in subtasks:
-            # Get ALL contexts for this subtask (attachments and knowledge bases)
+            # Knowledge base contexts are runtime metadata and are not public.
             contexts = (
                 db.query(SubtaskContext)
-                .filter(SubtaskContext.subtask_id == sub.id)
+                .filter(
+                    SubtaskContext.subtask_id == sub.id,
+                    SubtaskContext.context_type != ContextType.KNOWLEDGE_BASE.value,
+                )
                 .all()
             )
 

--- a/backend/tests/services/test_docx_generator_fonts.py
+++ b/backend/tests/services/test_docx_generator_fonts.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for explicit Latin and East Asian fonts in DOCX exports."""
+
+from docx import Document
+from docx.oxml.ns import qn
+from docx.oxml.text.font import CT_RPr
+
+from app.services.export.docx_generator import (
+    DOCUMENT_LANGUAGE,
+    EAST_ASIA_FONT,
+    EAST_ASIA_LANGUAGE,
+    LATIN_FONT,
+    MONOSPACE_FONT,
+    _add_inline_formatting,
+    _setup_document_styles,
+)
+
+
+def _font_attributes(rpr: CT_RPr) -> dict[str, str]:
+    r_fonts = rpr.find(qn("w:rFonts"))
+    return {
+        "ascii": r_fonts.get(qn("w:ascii")),
+        "hAnsi": r_fonts.get(qn("w:hAnsi")),
+        "eastAsia": r_fonts.get(qn("w:eastAsia")),
+        "cs": r_fonts.get(qn("w:cs")),
+    }
+
+
+def test_normal_style_defines_latin_and_east_asian_fonts():
+    doc = Document()
+
+    _setup_document_styles(doc)
+
+    rpr = doc.styles["Normal"]._element.rPr
+    assert _font_attributes(rpr) == {
+        "ascii": LATIN_FONT,
+        "hAnsi": LATIN_FONT,
+        "eastAsia": EAST_ASIA_FONT,
+        "cs": LATIN_FONT,
+    }
+
+    language = rpr.find(qn("w:lang"))
+    assert language.get(qn("w:val")) == DOCUMENT_LANGUAGE
+    assert language.get(qn("w:eastAsia")) == EAST_ASIA_LANGUAGE
+
+
+def test_inline_code_uses_monospace_latin_and_document_cjk_font():
+    doc = Document()
+    _setup_document_styles(doc)
+    paragraph = doc.add_paragraph()
+
+    _add_inline_formatting(paragraph, "`配置 config`")
+
+    assert len(paragraph.runs) == 1
+    assert _font_attributes(paragraph.runs[0]._element.rPr) == {
+        "ascii": MONOSPACE_FONT,
+        "hAnsi": MONOSPACE_FONT,
+        "eastAsia": EAST_ASIA_FONT,
+        "cs": MONOSPACE_FONT,
+    }

--- a/backend/tests/services/test_docx_generator_prompt_sanitization.py
+++ b/backend/tests/services/test_docx_generator_prompt_sanitization.py
@@ -74,6 +74,29 @@ class TestDocxGeneratorPromptSanitization:
         full_text = "\n".join(p.text for p in doc.paragraphs)
         assert "What is the capital of France?" in full_text
 
+    def test_knowledge_base_context_not_written_to_document(self):
+        """Knowledge base runtime metadata must not appear in DOCX exports."""
+        knowledge_base = MagicMock()
+        knowledge_base.context_type = "knowledge_base"
+        knowledge_base.name = "Private Knowledge Base"
+        knowledge_base.type_data = {"document_count": 12}
+
+        doc = Document()
+        task, user = _make_task_and_user()
+        subtask = _make_user_subtask(
+            "Answer from available knowledge", [knowledge_base]
+        )
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        _add_message(doc, subtask, task, user, db)
+
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Answer from available knowledge" in full_text
+        assert "Private Knowledge Base" not in full_text
+        assert "[KB]" not in full_text
+
     def test_system_reminder_stripped_from_docx_output(self):
         """<system-reminder> block in JSON array prompt must NOT appear in DOCX."""
         raw_prompt = json.dumps(

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -39,7 +39,6 @@ import TaskShareModal from '../share/TaskShareModal'
 import ExportSelectModal, {
   type SelectableMessage,
   type SelectableAttachment,
-  type SelectableKnowledgeBase,
   type ExportFormat,
 } from '../share/ExportSelectModal'
 import { taskApis } from '@/apis/tasks'
@@ -633,10 +632,8 @@ function MessagesArea({
             content = content.substring(6)
           }
 
-          // Extract attachments and knowledge bases from contexts (new unified context system)
-          // or fall back to legacy attachments field
+          // Only attachments are exportable. Knowledge base contexts are runtime metadata.
           let attachments: SelectableAttachment[] | undefined
-          let knowledgeBases: SelectableKnowledgeBase[] | undefined
 
           if (msg.contexts && msg.contexts.length > 0) {
             // Filter attachment type contexts and convert to SelectableAttachment format
@@ -647,16 +644,6 @@ function MessagesArea({
                 filename: ctx.name,
                 file_size: ctx.file_size || 0,
                 file_extension: ctx.file_extension || '',
-              }))
-            }
-
-            // Filter knowledge base type contexts and convert to SelectableKnowledgeBase format
-            const kbContexts = msg.contexts.filter(ctx => ctx.context_type === 'knowledge_base')
-            if (kbContexts.length > 0) {
-              knowledgeBases = kbContexts.map(ctx => ({
-                id: ctx.id,
-                name: ctx.name,
-                document_count: ctx.document_count ?? undefined,
               }))
             }
           } else if (msg.attachments && msg.attachments.length > 0) {
@@ -679,8 +666,6 @@ function MessagesArea({
             userName: msg.senderUserName || selectedTaskDetail?.user?.user_name,
             teamName: selectedTaskDetail?.team?.name,
             attachments: attachments && attachments.length > 0 ? attachments : undefined,
-            knowledgeBases:
-              knowledgeBases && knowledgeBases.length > 0 ? knowledgeBases : undefined,
           }
         })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * DOCX exports now include attachment context only; knowledge base content is excluded.
  * DOCX font rendering was improved with clearer handling of Latin, East Asian, and monospace styles.
  * Public shared task responses no longer include knowledge base runtime context.
  * Export selection now focuses on attachments only, simplifying the workflow.
* **Bug Fixes**
  * Prevented knowledge base metadata (including “[KB]” markers) from appearing in exported documents and shared task responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->