### PR TITLE
perf(wework): remove large backdrop blur surfaces

### DIFF
--- a/docs/en/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/wework/developer-guide/wework-performance-diagnostics.md
@@ -143,6 +143,8 @@ Each process group reports both `rss_kib` and `physical_footprint_kib`. RSS incl
 - Dense `longtask` or `event-loop-lag` events.
 - Repeated `slow-react-commit` events.
 
+The workbench's full-height sidebar and content-wide top bar should use ordinary semantic backgrounds instead of applying `backdrop-filter` to large persistent surfaces. These filters can cause WebKit to retain additional graphics backing stores for the entire region. When investigating Web Content memory, compare `physical_footprint_kib` before and after the change at the same window size and page state, and exclude the temporary reclaimable high-water mark created by Web Inspector heap snapshots from the steady-state baseline.
+
 Manual marks can also be added:
 
 ```js

--- a/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
@@ -143,6 +143,8 @@ window.__WEWORK_PERF__.snapshot();
 - 是否存在密集 `longtask` 或 `event-loop-lag`。
 - 是否存在重复的 `slow-react-commit`。
 
+主工作台的全高侧栏和横跨内容区的顶部栏应使用普通语义背景，避免在大面积常驻表面应用 `backdrop-filter`。这类滤镜可能让 WebKit 为整个区域保留额外图形 backing store；排查 Web Content 内存时，应在相同窗口尺寸和页面状态下比较启用前后的 `physical_footprint_kib`，并把 Web Inspector 堆快照产生的短期可回收内存高水位排除在稳定基线之外。
+
 也可以手动打点：
 
 ```js

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -3060,7 +3060,7 @@ export function DesktopSidebar({
         'relative z-popover h-full shrink-0 overflow-visible border-r border-black/[0.08] transition-[width,background-color] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[width] dark:border-white/[0.08]',
         background.imagePath && background.inSidebar
           ? 'bg-background/25'
-          : 'bg-[rgb(var(--color-sidebar))] backdrop-blur-xl backdrop-saturate-150',
+          : 'bg-[rgb(var(--color-sidebar))]',
         !windowFocused &&
           !(background.imagePath && background.inSidebar) &&
           'bg-[rgb(var(--color-sidebar-unfocused))]',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2018,9 +2018,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             testId="workbench-topbar"
             className={cn(
               'absolute left-0 top-0 z-chrome h-11 overflow-visible border-b border-border/50 pr-7',
-              background.imagePath && background.inTopBar
-                ? 'bg-background/20'
-                : 'bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80',
+              background.imagePath && background.inTopBar ? 'bg-background/20' : 'bg-background/95',
               isTauri && sidebarCollapsed ? 'pl-[14rem]' : 'pl-4',
               rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
             )}


### PR DESCRIPTION
## What changed

- remove the persistent backdrop blur and saturation filter from the full-height desktop sidebar
- remove the persistent backdrop blur from the workbench content-wide top bar
- document why large persistent backdrop filters should be avoided during WebKit memory investigations

## Why

WebKit process sampling showed that the elevated Wework memory footprint was dominated by graphics backing stores and reclaimable WebKit allocations rather than the JavaScript heap. Large persistent backdrop filters can force WebKit to retain additional compositing surfaces across the sidebar and top bar.

This change keeps the existing semantic background colors and layout while removing the two largest always-on blur regions, making it possible to compare visual quality and steady-state physical footprint without changing behavior.

## Impact

The desktop sidebar and workbench top bar render without backdrop blur. Small transient surfaces such as menus, tooltips, and dialogs retain their existing local blur treatment.

## Validation

- Wework pre-push ESLint passed
- Wework pre-push TypeScript checks passed
- Wework pre-push unit tests passed
- Prettier checks passed for changed code and documentation
- `git diff --check` passed
- isolated Tauri verification session started and produced the initializer snapshot; the verification process exited before the final workbench snapshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop workbench rendering performance by replacing large-area translucent blur effects with solid backgrounds in the sidebar and top bar.
  * Reduced the potential for excessive graphics memory usage during extended sessions.

* **Documentation**
  * Added performance diagnostic guidance in English and Chinese for comparing Web Content memory usage and interpreting graphics memory measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->