### PR TITLE
fix(backend): route loop item task validation through store

### DIFF
--- a/backend/app/services/loop_items/service.py
+++ b/backend/app/services/loop_items/service.py
@@ -24,12 +24,12 @@ from app.models.cloud_project import (
 from app.models.delivery import LoopItem, LoopItemAttachment, LoopItemCollaborator
 from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.share_link import ResourceType
-from app.models.task import TaskResource
 from app.models.user import User
 from app.schemas.base_role import BaseRole
 from app.schemas.delivery import LoopItemCreate, LoopItemTaskBind, LoopItemUpdate
 from app.services.cloud_projects.access import require_cloud_project_role
 from app.services.delivery.storage import delivery_storage
+from app.stores.tasks import task_store
 
 
 class LoopItemService:
@@ -459,14 +459,10 @@ class LoopItemService:
     ) -> None:
         if backend_task_id is None:
             return
-        backend_task = (
-            db.query(TaskResource.id)
-            .filter(
-                TaskResource.id == backend_task_id,
-                TaskResource.user_id == user_id,
-                TaskResource.is_active.in_(TaskResource.is_active_query()),
-            )
-            .first()
+        backend_task = task_store.get_active_task(
+            db,
+            task_id=backend_task_id,
+            owner_user_id=user_id,
         )
         if backend_task is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Task not found")

--- a/backend/tests/services/test_loop_items_service.py
+++ b/backend/tests/services/test_loop_items_service.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.services.loop_items.service import LoopItemService
+from app.stores.tasks import task_store
+
+
+def test_validate_backend_task_uses_owned_active_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = Mock(spec=Session)
+    get_active_task = Mock(return_value=object())
+    monkeypatch.setattr(task_store, "get_active_task", get_active_task)
+
+    LoopItemService._validate_backend_task(db, backend_task_id=42, user_id=7)
+
+    get_active_task.assert_called_once_with(
+        db,
+        task_id=42,
+        owner_user_id=7,
+    )
+
+
+def test_validate_backend_task_rejects_missing_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = Mock(spec=Session)
+    monkeypatch.setattr(task_store, "get_active_task", Mock(return_value=None))
+
+    with pytest.raises(HTTPException) as error:
+        LoopItemService._validate_backend_task(db, backend_task_id=42, user_id=7)
+
+    assert error.value.status_code == 404
+    assert error.value.detail == "Task not found"


### PR DESCRIPTION
## What changed

- validate Loop Item backend task references through the existing `task_store` boundary
- preserve owner and active-task checks through `get_active_task`
- add focused regression coverage for owned active tasks and missing tasks

## Root cause

The Loop Item service introduced a direct `TaskResource` ORM query outside `app/stores/tasks`. This violated the repository's task/subtask data-access boundary and caused the Backend CI suite to fail on the latest `main` baseline.

## Impact

Task validation now follows the shared store abstraction and unblocks the static boundary check used by Backend CI.

## Validation

- `cd backend && uv run --frozen pytest tests/services/test_task_store_boundary_static.py tests/services/test_loop_items_service.py tests/api/test_deliveries_api.py -q` — 20 passed
- `uv run --frozen black --check app/services/loop_items/service.py tests/services/test_loop_items_service.py`
- `uv run --frozen isort --check-only app/services/loop_items/service.py tests/services/test_loop_items_service.py`

Discovered while validating production-error fix PRs #2189 and #2190.