### PR TITLE
fix(wework): prevent cached titlebar overlap

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4766,6 +4766,9 @@ describe('DesktopWorkbenchLayout', () => {
       expect(screen.getAllByTestId('workbench-main-header')).toHaveLength(1)
       expect(screen.getByTestId('workbench-main-header')).toBe(sharedMainHeader)
       expect(sharedMainHeader).toHaveClass('h-[38px]', 'shrink-0')
+      expect(screen.getAllByTestId('workbench-pane-task-title')).toHaveLength(1)
+      expect(screen.getByTestId('workbench-pane-task-title')).toHaveTextContent('Task B')
+      expect(screen.getByTestId('workbench-pane-task-title')).not.toHaveTextContent('Task A')
       expect(within(titlebarRightPanel).queryByTestId('right-workspace-file-tab')).toBeNull()
     } finally {
       if (previousTauriInternals === undefined) {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2001,7 +2001,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         !isTauri && 'mt-1.5 rounded-xl border border-border/60 shadow-[0_3px_16px_rgba(0,0,0,0.04)]'
       )}
     >
-      {tauriMainHeaderContent ? (
+      {/* Portals escape the hidden cached pane, so only the visible active pane may own the header. */}
+      {tauriMainHeaderContent && paneActive && workbenchVisible ? (
         <WorkbenchMainHeaderPortal>{tauriMainHeaderContent}</WorkbenchMainHeaderPortal>
       ) : null}
       <>


### PR DESCRIPTION
## What changed

- Render the shared Wework titlebar portal only from the active, visible cached pane.
- Add regression coverage for switching between runtime tasks without retaining the previous task title.

## Why

Cached workbench panes remain mounted so their live resources survive task switches. React portals escape the hidden pane DOM, so during a switch an inactive cached pane could still render its title and actions into the shared titlebar, causing overlapping chrome.

## Impact

Switching between Wework runtime tasks now leaves exactly one current task title and one set of titlebar controls.

## Validation

- `pnpm --filter wework exec prettier --check src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx` (147 passed)
- `pnpm --filter wework typecheck`
- Pre-push Wework ESLint, TypeScript, and unit test suite
- Isolated real-Tauri flow: create task A, create/switch to task B, switch back to task A; reviewed screenshots at every step and confirmed a single current title with stable controls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the desktop title bar so it displays the active task title when switching between local runtime tasks.
  * Prevented hidden or inactive workbench panes from displaying duplicate main headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->