### PR TITLE
test(wework): target shared titlebar controls in desktop e2e

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -5171,22 +5171,21 @@ async function main() {
     phase = 'workspace-resources-across-conversation-switch'
     const activeBrowserInputSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-url-input"]`
     const activeTerminalSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-terminal-window"]`
-    const activeRightPanelToggleSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="toggle-right-workspace-panel-button"]`
+    const rightPanelToggleSelector = '[data-testid="toggle-right-workspace-panel-button"]'
+    const bottomPanelToggleSelector = '[data-testid="toggle-bottom-workspace-panel-button"]'
+    const rightBrowserTabCloseSelector = '[data-testid="right-workspace-browser-tab-close-button"]'
     const retainedBrowserUrl = 'https://example.com/session-state'
-    await control.command('waitFor', activeRightPanelToggleSelector, {
+    await control.command('waitFor', rightPanelToggleSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
-    await control.command('click', activeRightPanelToggleSelector)
+    await control.command('click', rightPanelToggleSelector)
     await control.command(
       'click',
       `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-browser-option"]`
     )
     await control.command('waitFor', activeBrowserInputSelector, { timeoutMs: UI_TIMEOUT_MS })
     await control.command('fill', activeBrowserInputSelector, { value: retainedBrowserUrl })
-    await control.command(
-      'click',
-      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="toggle-bottom-workspace-panel-button"]`
-    )
+    await control.command('click', bottomPanelToggleSelector)
     await control.command('waitFor', activeTerminalSelector, { timeoutMs: UI_TIMEOUT_MS })
     await control.command('click', `[data-testid="${secondTaskRowTestId}"]`)
     const secondTaskWorkspaceSnapshot = JSON.parse(
@@ -5222,10 +5221,7 @@ async function main() {
       'click',
       `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="close-bottom-workspace-tab-button"]`
     )
-    await control.command(
-      'click',
-      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-browser-tab-close-button"]`
-    )
+    await control.command('click', rightBrowserTabCloseSelector)
 
     await control.command('fill', composerSelector, { value: '' })
     await control.command('click', `[data-testid="${secondTaskRowTestId}"]`)


### PR DESCRIPTION
## What changed

- Target shared titlebar controls globally in the desktop task-flow E2E.
- Keep workspace panel content selectors scoped to the active workbench pane.

## Why

PR #2194 made the active visible cached pane the sole owner of the shared titlebar portal. The desktop E2E still searched for titlebar controls as descendants of `desktop-workbench-main`, but portal content intentionally lives outside that DOM subtree. The control existed in the failure snapshot, so the descendant selector timed out before the workspace-resource switching scenario could run.

This follow-up fixes the E2E boundary exposed by the merged titlebar change.

## Validation

- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `node --check wework/e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx` (147 passed)
- Pre-push Wework ESLint, TypeScript, and unit tests

## CI evidence

The #2194 Desktop E2E diagnostic snapshot contained `toggle-right-workspace-panel-button` globally while the failing selector incorrectly required it below `desktop-workbench-main`:

`Timed out running UI action waitFor for [data-testid="desktop-workbench-main"] [data-testid="toggle-right-workspace-panel-button"]`
