### PR TITLE
test(wework): handle limited local terminal state in desktop e2e

### DIFF
--- a/backend/app/services/loop_items/service.py
+++ b/backend/app/services/loop_items/service.py
@@ -24,12 +24,12 @@ from app.models.cloud_project import (
 from app.models.delivery import LoopItem, LoopItemAttachment, LoopItemCollaborator
 from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.share_link import ResourceType
-from app.models.task import TaskResource
 from app.models.user import User
 from app.schemas.base_role import BaseRole
 from app.schemas.delivery import LoopItemCreate, LoopItemTaskBind, LoopItemUpdate
 from app.services.cloud_projects.access import require_cloud_project_role
 from app.services.delivery.storage import delivery_storage
+from app.stores.tasks import task_store
 
 
 class LoopItemService:
@@ -459,14 +459,8 @@ class LoopItemService:
     ) -> None:
         if backend_task_id is None:
             return
-        backend_task = (
-            db.query(TaskResource.id)
-            .filter(
-                TaskResource.id == backend_task_id,
-                TaskResource.user_id == user_id,
-                TaskResource.is_active.in_(TaskResource.is_active_query()),
-            )
-            .first()
+        backend_task = task_store.get_active_task(
+            db, task_id=backend_task_id, owner_user_id=user_id
         )
         if backend_task is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Task not found")

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -5186,7 +5186,24 @@ async function main() {
     await control.command('waitFor', activeBrowserInputSelector, { timeoutMs: UI_TIMEOUT_MS })
     await control.command('fill', activeBrowserInputSelector, { value: retainedBrowserUrl })
     await control.command('click', bottomPanelToggleSelector)
-    await control.command('waitFor', activeTerminalSelector, { timeoutMs: UI_TIMEOUT_MS })
+    const firstTaskBottomWorkspaceSnapshot = await waitForSnapshot(
+      control,
+      value => {
+        const terminalOpened =
+          value.testIds.includes('workspace-terminal-window') &&
+          !value.testIds.includes('workspace-tool-launcher')
+        const localTerminalUnavailable =
+          value.testIds.includes('workspace-tool-launcher') &&
+          value.testIds.includes('workspace-local-device-limited-tools')
+        return terminalOpened || localTerminalUnavailable
+      },
+      'The first task bottom workspace panel did not open a terminal or limited-tools launcher',
+      UI_TIMEOUT_MS,
+      ACTIVE_WORKBENCH_SELECTOR
+    )
+    const firstTaskOpenedTerminal = firstTaskBottomWorkspaceSnapshot.testIds.includes(
+      'workspace-terminal-window'
+    )
     await control.command('click', `[data-testid="${secondTaskRowTestId}"]`)
     const secondTaskWorkspaceSnapshot = JSON.parse(
       await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
@@ -5201,19 +5218,35 @@ async function main() {
       false,
       'The first task browser leaked into the second task'
     )
+    assert.equal(
+      secondTaskWorkspaceSnapshot.testIds.includes('workspace-tool-launcher'),
+      false,
+      'The first task bottom workspace launcher leaked into the second task'
+    )
     await control.command('click', `[data-testid="${taskRowTestId}"]`)
-    await control.command('waitFor', activeTerminalSelector, { timeoutMs: UI_TIMEOUT_MS })
+    if (firstTaskOpenedTerminal) {
+      await control.command('waitFor', activeTerminalSelector, { timeoutMs: UI_TIMEOUT_MS })
+    } else {
+      await waitForSnapshot(
+        control,
+        value =>
+          value.testIds.includes('bottom-workspace-panel') &&
+          value.testIds.includes('workspace-tool-launcher') &&
+          value.testIds.includes('workspace-local-device-limited-tools'),
+        'The first task bottom workspace limited-tools state was not restored',
+        UI_TIMEOUT_MS,
+        ACTIVE_WORKBENCH_SELECTOR
+      )
+    }
     await control.command('waitFor', activeBrowserInputSelector, { timeoutMs: UI_TIMEOUT_MS })
     assert.equal(
       await control.command('getValue', activeBrowserInputSelector),
       retainedBrowserUrl,
       'The Wework built-in browser URL was reset after switching conversations'
     )
-    const restoredWorkspaceSnapshot = JSON.parse(
-      await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
-    )
-    assert.ok(
-      restoredWorkspaceSnapshot.testIds.includes('right-workspace-browser-tab'),
+    await waitForSnapshot(
+      control,
+      value => value.testIds.includes('right-workspace-browser-tab'),
       'The browser tab was not restored after switching conversations'
     )
     await captureVerificationScreenshot(control, 'workspace-resources-restored-after-switch.png')


### PR DESCRIPTION
## Summary
- handle Linux CI limited local-terminal state in the desktop workspace resources E2E
- wait for the shared right workspace tabbar to restore instead of asserting an immediate active-workbench-scoped snapshot
- route loop-item backend task validation through the task store boundary instead of direct TaskResource CRUD

## Validation
- `pnpm --dir wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `node --check wework/e2e/desktop/task-flow.e2e.mjs`
- `pnpm --dir wework lint`
- `pnpm --dir wework typecheck`
- `(cd backend && uv run pytest tests/services/test_task_store_boundary_static.py)`
- `git diff --check`
- pre-push Wework checks: ESLint, TypeScript, unit tests
- pre-push Backend checks: Black, isort, syntax, settings config, Alembic multi-head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task validation to ensure only active tasks can be linked, with clearer handling when a task cannot be found.
  - Improved workspace restoration when switching between tasks, correctly preserving either an available terminal or the limited-tools view.
  - Updated task-flow coverage to support environments where terminal access is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->