### PR TITLE
fix(backend): validate loop item tasks through store

### DIFF
--- a/backend/app/services/loop_items/service.py
+++ b/backend/app/services/loop_items/service.py
@@ -24,6 +24,7 @@ from app.models.cloud_project import (
 from app.models.delivery import LoopItem, LoopItemAttachment, LoopItemCollaborator
 from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.share_link import ResourceType
+from app.models.task import TaskResource
 from app.models.user import User
 from app.schemas.base_role import BaseRole
 from app.schemas.delivery import LoopItemCreate, LoopItemTaskBind, LoopItemUpdate

--- a/backend/tests/api/test_deliveries_api.py
+++ b/backend/tests/api/test_deliveries_api.py
@@ -17,6 +17,7 @@ from app.core.security import create_access_token, get_password_hash
 from app.models.cloud_project import CloudProject
 from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.share_link import ResourceType
+from app.models.task import TaskResource
 from app.models.user import User
 from app.services.delivery import delivery_service
 from app.services.delivery.storage import DeliveryStorageUnavailableError
@@ -347,6 +348,44 @@ def test_binding_task_advances_unstarted_todo_to_in_progress(
     ).json()
     assert item["status"] == "in_progress"
     assert item["version"] == created["version"] + 1
+
+
+def test_binding_subscription_backend_task_uses_task_store(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_token: str,
+    delivery_project: CloudProject,
+) -> None:
+    backend_task = TaskResource(
+        user_id=test_user.id,
+        kind="Task",
+        name=f"delivery-subscription-{uuid.uuid4()}",
+        namespace="default",
+        json={},
+        is_active=TaskResource.STATE_SUBSCRIPTION,
+    )
+    test_db.add(backend_task)
+    test_db.commit()
+    test_db.refresh(backend_task)
+    created = test_client.post(
+        f"/api/v1/cloud-projects/{delivery_project.id}/loop-items",
+        headers=_auth(test_token),
+        json={"title": "Bind subscription task"},
+    ).json()
+
+    response = test_client.post(
+        f"/api/v1/loop-items/{created['id']}/tasks",
+        headers=_auth(test_token),
+        json={
+            "deviceId": "local-device",
+            "taskId": "subscription-task",
+            "backendTaskId": backend_task.id,
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["backend_task_id"] == backend_task.id
 
 
 @pytest.mark.parametrize("initial_status", ["in_progress", "in_review", "completed"])


### PR DESCRIPTION
## What changed

- restore the `TaskResource` import used to resolve active task states
- keep loop item backend task validation behind `task_store`
- add an API regression test for binding subscription tasks

## Why

The backend CI boundary test rejected a direct `TaskResource` query from the loop item service. A subsequent store-based fix removed the model import while still calling `TaskResource.is_active_query()`, which would raise `NameError` when a backend task ID is supplied.

This change completes the store migration while preserving the original active and subscription task semantics.

## Impact

Runtime tasks can bind to cloud TODOs using a backend task ID without bypassing the task store or failing at runtime.

## Validation

- `uv run pytest tests/services/test_task_store_boundary_static.py tests/api/test_deliveries_api.py::test_binding_subscription_backend_task_uses_task_store -q`
- `uv run pytest tests/api/test_deliveries_api.py -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task validation when creating runtime tasks for loop items.
  * Ensured tasks can be correctly linked to existing subscription tasks through their backend task ID.
  * Added coverage to verify the API returns the expected backend task reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->