### PR TITLE
fix(wework): gate experimental workspace features

### DIFF
--- a/wework/src/components/layout/DesktopAppSwitcher.test.tsx
+++ b/wework/src/components/layout/DesktopAppSwitcher.test.tsx
@@ -50,7 +50,20 @@ describe('DesktopAppSwitcher', () => {
     expect(screen.getByTestId('chrome-tab-wework')).toHaveAttribute('aria-haspopup', 'menu')
   })
 
+  test('hides Kanban while experimental features are disabled', () => {
+    render(<DesktopAppSwitcher activeApp="wework" onNavigate={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('chrome-tab-wework'))
+    expect(screen.queryByTestId('app-switcher-option-todo')).not.toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('desktop-app-switcher-menu'))
+        .getAllByRole('menuitemradio')
+        .map(option => option.textContent)
+    ).toEqual(['任务使用 AI 解决具体问题', '智能体构建并交付可嵌入业务的云端智能体'])
+  })
+
   test('keeps Kanban visible but unavailable while disconnected', () => {
+    experimentalFeatures.enabled = true
     const onNavigate = vi.fn()
     render(<DesktopAppSwitcher activeApp="wework" onNavigate={onNavigate} />)
 
@@ -140,6 +153,7 @@ describe('DesktopAppSwitcher', () => {
   })
 
   test('labels the TODO board as Kanban', () => {
+    experimentalFeatures.enabled = true
     render(<DesktopAppSwitcher activeApp="todo" onNavigate={vi.fn()} />)
 
     expect(screen.getByTestId('desktop-app-switcher')).toHaveTextContent('看板')

--- a/wework/src/components/layout/DesktopAppSwitcher.tsx
+++ b/wework/src/components/layout/DesktopAppSwitcher.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import { CloudConnectionContext } from '@/features/cloud-connection/CloudConnectionContext'
+import { useExperimentalFeaturesEnabled } from '@/features/experimental-features/useExperimentalFeaturesEnabled'
 import { useTranslation } from '@/hooks/useTranslation'
 import { dispatchOpenSettingsShortcut } from '@/lib/keybindings'
 import { cn } from '@/lib/utils'
@@ -109,6 +110,7 @@ export function DesktopAppSwitcher({
 }: DesktopAppSwitcherProps) {
   const { t } = useTranslation('common')
   const cloudConnection = useContext(CloudConnectionContext)
+  const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled()
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const timerRef = useRef<number | null>(null)
@@ -120,14 +122,17 @@ export function DesktopAppSwitcher({
   const [rollingLabel, setRollingLabel] = useState<RollingLabel | null>(null)
   const [menuBlurred, setMenuBlurred] = useState(false)
 
-  const options = useMemo<AppOption[]>(
-    () => [
+  const options = useMemo<AppOption[]>(() => {
+    const appOptions: AppOption[] = [
       {
         key: 'wework',
         label: t('workbench.app_wework_label', '任务'),
         description: t('workbench.app_wework_description', '使用 AI 解决具体问题'),
       },
-      {
+    ]
+
+    if (experimentalFeaturesEnabled || activeApp === 'todo') {
+      appOptions.push({
         key: 'todo',
         label: t('workbench.app_weloop_label', '看板'),
         description: t('workbench.app_weloop_description', '用 AI 管理项目的规划、执行与反馈'),
@@ -135,19 +140,21 @@ export function DesktopAppSwitcher({
           ? undefined
           : t('workbench.app_weloop_requires_cloud', '连接云端后可用'),
         disabled: !cloudConnection?.isConnected,
-      },
-      {
-        key: 'wegent',
-        label: t('workbench.app_wegent_label', '智能体'),
-        description: t('workbench.app_wegent_description', '构建并交付可嵌入业务的云端智能体'),
-        availabilityLabel: cloudConnection?.isConnected
-          ? undefined
-          : t('workbench.app_wegent_requires_cloud', '连接云端后可用'),
-        disabled: !cloudConnection?.isConnected && activeApp !== 'wegent',
-      },
-    ],
-    [activeApp, cloudConnection?.isConnected, t]
-  )
+      })
+    }
+
+    appOptions.push({
+      key: 'wegent',
+      label: t('workbench.app_wegent_label', '智能体'),
+      description: t('workbench.app_wegent_description', '构建并交付可嵌入业务的云端智能体'),
+      availabilityLabel: cloudConnection?.isConnected
+        ? undefined
+        : t('workbench.app_wegent_requires_cloud', '连接云端后可用'),
+      disabled: !cloudConnection?.isConnected && activeApp !== 'wegent',
+    })
+
+    return appOptions
+  }, [activeApp, cloudConnection?.isConnected, experimentalFeaturesEnabled, t])
   const displayedAppKey = rollingLabel ? displayedKey : activeApp
   const selected =
     options.find(option => option.key === displayedAppKey) ??

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1758,7 +1758,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       onCreateEnvironmentBranch={createEnvironmentBranch}
       onOpenEnvironmentChangesReview={openDefaultEnvironmentChangesReview}
       onDeliver={
-        currentRuntimeTask && services?.deliveryApi
+        experimentalFeaturesEnabled && currentRuntimeTask && services?.deliveryApi
           ? () => {
               if (activeDeliveryItem) {
                 setDeliveryDialogOpen(true)
@@ -1773,7 +1773,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         boundCloudItem ? `${boundCloudItem.id} · ${boundCloudItem.title}` : boundCloudProject?.name
       }
       onManageTodo={
-        currentRuntimeTask && services?.deliveryApi
+        experimentalFeaturesEnabled && currentRuntimeTask && services?.deliveryApi
           ? () => {
               setDeliverAfterBinding(false)
               setTodoBindingPickerOpen(true)


### PR DESCRIPTION
## Summary

- hide the Kanban app-switcher entry unless experimental features are enabled
- hide project-space binding and task-delivery actions unless experimental features are enabled
- preserve the Kanban label when the user is already on the Kanban route
- add regression coverage for the disabled experimental-feature state

## Why

Kanban, project-space binding, and task delivery are still experimental, but their entry points were visible when the global experimental-features preference was disabled. This made the preference inconsistent with the features it is intended to control.

## User impact

These entry points are hidden by default and appear after enabling **Settings → General → Experimental features**. Users already viewing Kanban continue to see the correct current-app label if the preference changes.

## Validation

- `pnpm --filter wework exec prettier --check src/components/layout/DesktopAppSwitcher.tsx src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopAppSwitcher.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopAppSwitcher.tsx src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopAppSwitcher.test.tsx`
- focused Vitest run: 34 tests passed
- full Wework Vitest run: 2,083 tests passed across 213 test files
- pre-push ESLint, TypeScript, and unit-test checks passed
- isolated real-Tauri verification confirmed that Kanban is hidden by default and appears immediately after enabling experimental features
