### PR TITLE
fix(wework): stop transcript gap scroll jumping

### DIFF
--- a/docs/en/wegent/developer-guide/runtime-local-work.md
+++ b/docs/en/wegent/developer-guide/runtime-local-work.md
@@ -86,6 +86,8 @@ Wework uses one primary read path for local Codex conversations so list, open, a
 
 The list, read, and thread-management paths share one persistent Codex app-server connection, avoiding per-RPC child process startup. Wework still does not use Codex app-server `thread/turns/list` for long transcript paging because the current Codex implementation still replays the whole rollout file on each request. That has the same cost as a full read and cannot reuse the executor's normalized tool/message cache. Opening with `includeTurns: true` is also avoided because large transcripts would be serialized through app-server before the executor normalizes them, increasing IPC and frontend pressure.
 
+Paging or turn navigation can leave the frontend holding non-contiguous transcript ranges. Wework shows a missing-range marker between adjacent message indexes and automatically requests that range once when the marker first enters the viewport. If the runtime still cannot fill the same range, the frontend must stop automatic retries and keep only explicit user-triggered retry. Loading a missing range only updates that marker's state; it must not take ownership of turn-navigation scrolling, disable browser scroll anchoring, or switch message virtualization modes, because an unfillable range would otherwise create a request and layout-jitter loop.
+
 Use this manual benchmark to recheck a local rollout:
 
 ```bash

--- a/docs/zh/wegent/developer-guide/runtime-local-work.md
+++ b/docs/zh/wegent/developer-guide/runtime-local-work.md
@@ -86,6 +86,8 @@ Wework 的 Codex 本机会话只使用一条主读取路径，避免列表、打
 
 列表、读取和线程管理共享同一个常驻 Codex app-server 连接，避免每次 RPC 都重新启动子进程。没有使用 Codex app-server `thread/turns/list` 做长会话分页，因为当前 Codex 实现仍会在每次请求时 replay 整个 rollout 文件；对 Wework 来说它和全量读取成本相同，却不能复用 executor 已经标准化好的 tool/message cache。打开时也不请求 `includeTurns: true`，因为大 transcript 会把完整 turns 通过 app-server 再序列化一次，反而增加 IPC 和前端压力。
 
+分页或按发言跳转可能让前端同时持有不连续的 transcript 区间。Wework 会在相邻消息索引之间显示缺失区间，并在该标记首次进入视口时自动请求一次；如果运行时仍无法补齐同一个区间，前端必须停止自动重试，只保留用户点击重试。缺失区间加载只更新当前标记的状态，不能接管发言导航的滚动状态、关闭浏览器滚动锚定或切换消息虚拟化模式，否则无法补齐的历史会形成请求与布局抖动循环。
+
 可用下面的手工 benchmark 复测本机 rollout：
 
 ```bash

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1013,6 +1013,93 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('loads an unresolved transcript gap once without taking over message layout', async () => {
+    const observerCallbacks: IntersectionObserverCallback[] = []
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          observerCallbacks.push(callback)
+        }
+        observe() {}
+        disconnect() {}
+      }
+    )
+    let resolveGapLoad: (() => void) | undefined
+    const onLoadTranscriptGap = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveGapLoad = resolve
+        })
+    )
+
+    render(
+      <ScrollableMessageArea
+        conversationKey="unresolved-transcript-gap"
+        messages={[
+          {
+            id: 'before-gap',
+            role: 'user',
+            content: '触发模型报错',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:00.000Z',
+            runtimeMessageIndex: 0,
+          },
+          {
+            id: 'after-gap',
+            role: 'user',
+            content: '报错后的下一条消息',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:02.000Z',
+            runtimeMessageIndex: 2,
+          },
+        ]}
+        onLoadTranscriptGap={onLoadTranscriptGap}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    const firstMessage = screen.getByText('触发模型报错').closest('[data-message-id]')!
+    expect(observerCallbacks).toHaveLength(1)
+
+    await act(async () => {
+      observerCallbacks[0](
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+      await Promise.resolve()
+    })
+
+    expect(onLoadTranscriptGap).toHaveBeenCalledTimes(1)
+    expect(onLoadTranscriptGap).toHaveBeenCalledWith({ start: 1, end: 2 })
+    expect(
+      screen.getByTestId('runtime-transcript-gap-marker').querySelector('button')
+    ).toBeDisabled()
+    expect(screen.queryByTestId('message-turn-navigation-loading')).not.toBeInTheDocument()
+    expect(scroller).not.toHaveClass('[overflow-anchor:none]')
+    expect(firstMessage).toHaveClass('[content-visibility:auto]')
+
+    await act(async () => {
+      resolveGapLoad?.()
+      await Promise.resolve()
+    })
+    expect(observerCallbacks).toHaveLength(2)
+
+    await act(async () => {
+      observerCallbacks[1](
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+      await Promise.resolve()
+    })
+
+    expect(onLoadTranscriptGap).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('runtime-transcript-gap-marker').querySelector('button')!)
+    expect(onLoadTranscriptGap).toHaveBeenCalledTimes(2)
+    vi.unstubAllGlobals()
+  })
+
   test('pins the conversation to the bottom after opening a chat', () => {
     render(
       <ScrollableMessageArea

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -232,6 +232,7 @@ function ScrollableMessagePaneContent({
   const scheduledScrollStateSignatureRef = useRef<string | null>(null)
   const completedScrollStateSignatureRef = useRef<string | null>(null)
   const loadingTranscriptGapKeyRef = useRef<string | null>(null)
+  const autoLoadedTranscriptGapKeysRef = useRef(new Set<string>())
   const [showScrollButton, setShowScrollButton] = useState(false)
   const [turnNavigationLoading, setTurnNavigationLoading] = useState(false)
   const [turnNavigationTargetMessageId, setTurnNavigationTargetMessageId] = useState<string | null>(
@@ -336,10 +337,13 @@ function ScrollableMessagePaneContent({
       if (!onLoadTranscriptGap) return
       const gapKey = runtimeTranscriptGapKey(gap)
       if (loadingTranscriptGapKeyRef.current !== null) return
+      if (reason === 'visible') {
+        if (autoLoadedTranscriptGapKeysRef.current.has(gapKey)) return
+        autoLoadedTranscriptGapKeysRef.current.add(gapKey)
+      }
 
       loadingTranscriptGapKeyRef.current = gapKey
       setLoadingTranscriptGapKey(gapKey)
-      handleTurnNavigationLoadStateChange(true)
       try {
         await onLoadTranscriptGap(gap)
       } catch (error) {
@@ -352,11 +356,14 @@ function ScrollableMessagePaneContent({
       } finally {
         loadingTranscriptGapKeyRef.current = null
         setLoadingTranscriptGapKey(current => (current === gapKey ? null : current))
-        handleTurnNavigationLoadStateChange(false)
       }
     },
-    [handleTurnNavigationLoadStateChange, onLoadTranscriptGap]
+    [onLoadTranscriptGap]
   )
+
+  useEffect(() => {
+    autoLoadedTranscriptGapKeysRef.current.clear()
+  }, [currentScrollKey])
 
   const renderTranscriptGapAfterMessage = useCallback(
     (message: WorkbenchMessage, nextMessage: WorkbenchMessage | undefined) => {


### PR DESCRIPTION
## What changed

- prevent the same unresolved runtime transcript gap from auto-loading more than once per conversation
- keep explicit click-to-retry behavior for gaps that cannot be filled automatically
- decouple transcript gap loading from turn-navigation scroll ownership so loading a gap no longer disables scroll anchoring or changes message virtualization/content visibility
- document the missing-range loading contract in the Chinese and English runtime local work guides

## Why

When adjacent runtime messages had non-contiguous indexes, the visible gap marker automatically requested the missing range. If the runtime could not fill that range, finishing the request recreated the intersection observer and immediately triggered the same request again.

Gap loading also reused the global turn-navigation loading state. Every retry disabled browser scroll anchoring and changed the message rendering strategy, producing a repeated request and layout-jitter loop in long task conversations.

## Impact

Task conversations with unresolved transcript gaps no longer continuously jump or retry in the background. Normal turn navigation remains unchanged, and users can still manually retry an unresolved gap.

## Validation

- `pnpm --filter wework test` — 213 files, 2083 tests passed
- focused transcript and virtualization tests — 39 tests passed
- Prettier and ESLint passed
- pre-push ESLint, TypeScript, and unit-test checks passed
- isolated real-Tauri smoke verification reached the workbench and exercised the project menu successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcript gap markers when message history contains missing ranges.
  * Automatically requests each missing range once when its marker enters view.
  * Provides an explicit retry option if the range cannot be loaded automatically.

* **Bug Fixes**
  * Prevented gap loading from disrupting scroll position, anchoring, or message virtualization.
  * Stopped repeated automatic requests and layout jitter during transcript loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->