### PR TITLE
fix(wework): collapse dev instance badge by default

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -702,6 +702,9 @@ Change composition rather than proportionally shrinking desktop UI.
 - Mobile interactive targets are at least `44px × 44px`.
 - Desktop exceptional dense targets never fall below WCAG's `24px` floor.
 - Collapse lower-priority labels before controls overlap.
+- Development-only status and diagnostic overlays default to a compact control;
+  reveal full text and details only after deliberate activation, and never cover
+  primary controls.
 - Switch panes to overlays or sequential views before the main content becomes
   unusable.
 - Test long Chinese and English text, constrained height, system scaling, and

--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -256,6 +256,12 @@ describe('App center route', () => {
     render(<App />)
 
     await waitForStartupScreenToClose()
+    expect(screen.getByTestId('wework-dev-instance-trigger')).toHaveClass(
+      'h-8',
+      'w-8',
+      'rounded-full'
+    )
+    fireEvent.click(screen.getByTestId('wework-dev-instance-trigger'))
     expect(screen.getByTestId('wework-dev-instance-badge')).toHaveTextContent('Runtime task')
     fireEvent.click(screen.getByTestId('copy-wework-dev-port-button'))
     expect(writeText).toHaveBeenCalledWith('1420')

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -489,7 +489,7 @@ function AppShell() {
 function WeworkDevInstanceBadge() {
   const info = getWeworkDevInstanceInfo()
   const [copiedKey, setCopiedKey] = useState<string | null>(null)
-  const [collapsed, setCollapsed] = useState(false)
+  const [collapsed, setCollapsed] = useState(true)
   const [position, setPosition] = useState<CSSProperties>()
   const draggedRef = useRef(false)
   if (!info) return null


### PR DESCRIPTION
## Summary

- collapse the development instance badge to a compact info icon by default
- preserve click-to-expand, hover details, dragging, copying, and manual collapse
- document that development-only diagnostic overlays should not cover primary controls

## Root cause

The development instance badge initialized in its expanded text state and was
fixed to the bottom-right corner, so it could cover nearby workbench content and
controls whenever a development instance started.

## User impact

Development builds now start with a 32px info icon instead of a horizontal text
bar. Full instance information remains available on deliberate interaction.

## Validation

- Wework unit tests: 213 files and 2082 tests passed
- Prettier and ESLint passed
- TypeScript passed
- pre-push quality checks passed
- isolated real-Tauri verification covered default collapsed state, expansion,
  hover details, and collapse recovery
