### PR TITLE
fix(wework): refresh project selector after reopen

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -4694,8 +4694,8 @@ async function main() {
       testId.startsWith('project-menu-')
     )
     assert.ok(projectMenuTestId, 'The newly opened folder project was not shown in the sidebar')
-    const projectId = projectMenuTestId.slice('project-menu-'.length)
-    const projectRowSelector = `[data-testid="project-row-${projectId}"]`
+    let projectId = projectMenuTestId.slice('project-menu-'.length)
+    let projectRowSelector = `[data-testid="project-row-${projectId}"]`
     await control.command('waitFor', projectRowSelector, {
       text: 'workspace',
       timeoutMs: UI_TIMEOUT_MS,
@@ -4772,7 +4772,19 @@ async function main() {
     await control.command('waitFor', composerSelector, {
       timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
     })
-    await control.command('waitFor', '[data-testid^="project-menu-"]', {
+    const reopenedProjectSnapshot = await waitForSnapshot(
+      control,
+      snapshot => snapshot.testIds.some(testId => testId.startsWith('project-menu-')),
+      'The reopened folder project was not shown in the sidebar'
+    )
+    const reopenedProjectMenuTestId = reopenedProjectSnapshot.testIds.find(testId =>
+      testId.startsWith('project-menu-')
+    )
+    assert.ok(reopenedProjectMenuTestId, 'The reopened folder project was not shown in the sidebar')
+    projectId = reopenedProjectMenuTestId.slice('project-menu-'.length)
+    projectRowSelector = `[data-testid="project-row-${projectId}"]`
+    await control.command('waitFor', projectRowSelector, {
+      text: 'workspace',
       timeoutMs: UI_TIMEOUT_MS,
     })
 


### PR DESCRIPTION
## What changed

- Refresh the desktop E2E project ID and row selector after removing and reopening a local project.
- Wait for the reopened project row to become visible before continuing the task-flow scenario.

## Root cause

Reopening the same workspace creates a new project resource with a new database ID. The desktop E2E cached the original project ID before removing the project, then reused that stale selector during blank-task draft restoration. The test consequently waited for a project row that no longer existed.

## Impact

The desktop task-flow E2E now follows the current project resource after reopen and can continue validating blank-task draft restoration without depending on an obsolete database ID.

## Validation

- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework e2e:desktop`
- Pre-push ESLint, TypeScript, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for reopening folder-based projects.
  * Added validation that the reopened project appears in the sidebar and displays the correct workspace information.
  * No user-facing product changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->