### PR TITLE
fix(wework): restore desktop project creation e2e flow

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1352,6 +1352,11 @@ async function confirmLocalProjectName(control, name) {
   await control.command('clickWhenEnabled', '[data-testid="confirm-local-project-create-button"]', {
     timeoutMs: UI_TIMEOUT_MS,
   })
+  await waitForSnapshot(
+    control,
+    snapshot => !snapshot.testIds.includes('local-project-create-dialog'),
+    'The local project create dialog did not close after confirmation'
+  )
 }
 
 async function selectE2EModel(control, modelId = MODEL_ID, modelLabel = MODEL_LABEL) {
@@ -4646,15 +4651,6 @@ async function verifyConnectedModelsOnLocalExecution({
     timeoutMs: UI_TIMEOUT_MS,
   })
   await confirmLocalProjectName(control, 'workspace')
-  await control.command('waitFor', '[data-testid="local-project-create-dialog"]', {
-    timeoutMs: UI_TIMEOUT_MS,
-  })
-  await control.command('fill', '[data-testid="local-project-create-name-input"]', {
-    value: 'workspace',
-  })
-  await control.command('clickWhenEnabled', '[data-testid="confirm-local-project-create-button"]', {
-    timeoutMs: UI_TIMEOUT_MS,
-  })
   await control.command('waitFor', composerSelector, {
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
@@ -5378,7 +5374,6 @@ async function main() {
         timeoutMs: UI_TIMEOUT_MS,
       }
     )
-    await confirmLocalProjectName(control, 'workspace')
     await control.command('waitFor', '[data-testid="local-project-create-dialog"]', {
       timeoutMs: UI_TIMEOUT_MS,
     })
@@ -5491,7 +5486,6 @@ async function main() {
         timeoutMs: UI_TIMEOUT_MS,
       }
     )
-    await confirmLocalProjectName(control, 'workspace')
     await control.command('waitFor', '[data-testid="local-project-create-dialog"]', {
       timeoutMs: UI_TIMEOUT_MS,
     })


### PR DESCRIPTION
## What changed

- remove duplicate project confirmation in the connected-model desktop flow
- keep the multi-root project dialog open until secondary roots are added
- assert that single-root project confirmation actually closes the dialog before continuing

## Root cause

The latest main change introduced a shared project-name confirmation helper but also left the previous confirmation steps in place. In the multi-root flow, the helper was called too early. Both desktop jobs therefore waited for `local-project-create-dialog` after it had already been closed.

## Impact

Restores the Wework Desktop E2E and Desktop Memory E2E setup flow without changing product behavior.

## Validation

- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework test` (215 files, 2115 tests)
- pre-push ESLint, TypeScript, and unit tests
- two real macOS `e2e:desktop:memory` runs progressed beyond the original dialog timeout; the second completed long-response memory sampling and created all ten concurrent tasks before a local high-load WebView screenshot timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end task flows by ensuring the local project creation dialog closes before proceeding.
  * Reduced unnecessary confirmation steps during project and workspace setup, improving flow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->