### PR TITLE
fix(wework): allow forking while task runs

### DIFF
--- a/docs/en/wegent/developer-guide/runtime-local-work.md
+++ b/docs/en/wegent/developer-guide/runtime-local-work.md
@@ -249,6 +249,7 @@ Empty projects are runtime-owned as well. After Wework creates or selects a dire
 
 When Wework forks a runtime task, it only offers target workspaces that belong to the source task's Project:
 
+- When a message action forks into a new task, Wework passes the selected completed turn as `lastTurnId` to the executor. The executor may call Codex `thread/fork` while the source task is running a later turn; `lastTurnId` defines the history boundary, and the fork must not stop, cancel, or mutate the source task's active turn.
 - Other Device Workspaces already bound to that Project can be used directly.
 - An online device that is not yet bound to that Project must first use the same device-directory preparation flow as project creation and editing: choose a directory on the device, then choose whether that Project path is a `worktree` or a regular `workspace`.
 - Backend writes the Device Workspace mapping through `POST /api/runtime-work/device-workspaces/prepare` before continuing the fork.

--- a/docs/zh/wegent/developer-guide/runtime-local-work.md
+++ b/docs/zh/wegent/developer-guide/runtime-local-work.md
@@ -249,6 +249,7 @@ Project 场景使用运行时 workspace 引用：
 
 复制运行时任务时，Wework 只在当前任务所属 Project 内选择目标工作区：
 
+- 从消息操作复制到新任务时，Wework 会把所选已完成回合的 `lastTurnId` 传给 executor。executor 可以在源任务正在执行后续回合时调用 Codex `thread/fork`；fork 的历史边界由 `lastTurnId` 决定，不得停止、取消或修改源任务当前正在运行的回合。
 - 已经绑定到该 Project 的其他 Device Workspace 可以直接作为目标。
 - 没有绑定到该 Project 的在线设备，需要先走和项目创建/编辑一致的设备目录准备流程：选择设备目录，并选择该目录在 Project 下的类型是 `worktree` 还是普通 `workspace`。
 - Backend 调用 `POST /api/runtime-work/device-workspaces/prepare` 写入 Device Workspace 映射后，再继续执行任务复制。

--- a/executor/src/runtime_work/handler/tasks.rs
+++ b/executor/src/runtime_work/handler/tasks.rs
@@ -7,11 +7,6 @@ use super::*;
 impl RuntimeWorkRpcHandler {
     pub(super) async fn fork_task_at_turn(&self, payload: Value) -> Result<Value, AppIpcError> {
         let source = self.task_link_from_payload(&payload, false).await?;
-        if source.running || self.is_active_local_task(&source.local_task_id) {
-            return Ok(
-                json!({"success": false, "accepted": false, "error": "runtime task is already running", "code": "bad_request"}),
-            );
-        }
         let requested_turn_id = string_field(&payload, "lastTurnId")
             .or_else(|| string_field(&payload, "last_turn_id"))
             .ok_or_else(|| AppIpcError::new("bad_request", "lastTurnId is required"))?;

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -5,7 +5,7 @@
 use super::*;
 
 #[tokio::test]
-async fn fork_rejects_each_running_signal_independently() {
+async fn fork_resolves_the_requested_turn_even_when_the_source_is_running() {
     for (case, persisted_running, active_in_memory) in
         [("persisted", true, false), ("active", false, true)]
     {
@@ -17,6 +17,7 @@ async fn fork_rejects_each_running_signal_independently() {
             "/tmp/project".to_owned(),
             "Task".to_owned(),
         );
+        link.thread_id = Some("thread-1".to_owned());
         link.running = persisted_running;
         handler.upsert_local_task(link);
         if active_in_memory {
@@ -26,17 +27,14 @@ async fn fork_rejects_each_running_signal_independently() {
         let response = handler
             .fork_task_at_turn(json!({
                 "taskId": "task-1",
-                "lastTurnId": "turn-1",
+                "lastTurnId": "missing-turn",
             }))
             .await
-            .expect("running task fork should return a structured failure");
+            .expect("running task fork should continue to turn resolution");
 
         assert_eq!(response["accepted"], false, "{case}");
         assert_eq!(response["code"], "bad_request", "{case}");
-        assert_eq!(
-            response["error"], "runtime task is already running",
-            "{case}"
-        );
+        assert_eq!(response["error"], "fork turn was not found", "{case}");
 
         let _ = fs::remove_file(index_path);
     }

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -19,6 +19,10 @@ const TASK_PROMPT = 'WEWORK_DESKTOP_E2E_TASK: create the requested verification 
 const COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_COMPLETE'
 const FOLLOW_UP_PROMPT = 'WEWORK_DESKTOP_E2E_FOLLOW_UP: confirm the completed task.'
 const FOLLOW_UP_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_FOLLOW_UP_COMPLETE'
+const RUNNING_FORK_FOLLOW_UP_PROMPT =
+  'WEWORK_DESKTOP_E2E_RUNNING_FORK: keep streaming while the first turn is forked.'
+const RUNNING_FORK_STREAMING_TEXT = 'WEWORK_DESKTOP_E2E_RUNNING_FORK_STREAMING'
+const RUNNING_FORK_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RUNNING_FORK_COMPLETE'
 const FORK_FOLLOW_UP_PROMPT = 'WEWORK_DESKTOP_E2E_FORK_FOLLOW_UP: continue only in the forked task.'
 const FORK_FOLLOW_UP_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_FORK_FOLLOW_UP_COMPLETE'
 const REQUEST_USER_INPUT_PROMPT =
@@ -732,9 +736,9 @@ async function captureTotalMemorySample(control, phase) {
   }
 }
 
-async function waitForNewTaskRow(control, knownTaskRows, expectedText) {
+async function waitForNewTaskRow(control, knownTaskRows, expectedText, timeoutMs = UI_TIMEOUT_MS) {
   const startedAt = Date.now()
-  while (Date.now() - startedAt < UI_TIMEOUT_MS) {
+  while (Date.now() - startedAt < timeoutMs) {
     const snapshot = JSON.parse(await control.command('snapshot', 'body'))
     const candidates = snapshot.testIds.filter(
       testId => testId.startsWith('runtime-local-task-row-') && !knownTaskRows.has(testId)
@@ -762,6 +766,94 @@ async function waitForTaskRowByText(control, expectedText) {
     await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
   }
   throw new Error(`The sidebar did not expose a task row containing ${expectedText}`)
+}
+
+async function verifyRunningFollowUpFork({
+  composerSelector,
+  control,
+  executorHome,
+  sourceTaskRowTestId,
+}) {
+  const taskRowsBeforeFork = new Set(
+    JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
+      testId.startsWith('runtime-local-task-row-')
+    )
+  )
+  control.setScenario('running_fork_follow_up')
+  await sendPromptUntilScenarioRequest(
+    control,
+    composerSelector,
+    RUNNING_FORK_FOLLOW_UP_PROMPT,
+    'running_fork_follow_up'
+  )
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: RUNNING_FORK_STREAMING_TEXT,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('waitFor', '[data-testid="pause-response-button"]', {
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('scrollIntoView', '[data-testid="fork-message-button"]')
+  await captureVerificationScreenshot(control, 'running-follow-up-fork-01-streaming.png')
+
+  try {
+    await control.command('clickWhenEnabled', '[data-testid="fork-message-button"]')
+    const forkTaskRowTestId = await waitForNewTaskRow(control, taskRowsBeforeFork, '', 15_000)
+    assert.notEqual(
+      forkTaskRowTestId,
+      sourceTaskRowTestId,
+      'Forking the first turn reused the running source task'
+    )
+
+    const sourceTaskId = sourceTaskRowTestId.replace('runtime-local-task-row-', '')
+    const forkTaskId = forkTaskRowTestId.replace('runtime-local-task-row-', '')
+    const runtimeIndex = JSON.parse(
+      await readFile(join(executorHome, 'runtime-work', 'index.json'), 'utf8')
+    )
+    assert.equal(
+      runtimeIndex.tasks[forkTaskId]?.parent?.taskId,
+      sourceTaskId,
+      'Forking during a follow-up did not persist the source task relationship'
+    )
+    assert.ok(
+      runtimeIndex.tasks[forkTaskId]?.parent?.lastTurnId,
+      'Forking during a follow-up did not persist the selected first turn'
+    )
+    assert.equal(
+      runtimeIndex.tasks[sourceTaskId]?.running,
+      true,
+      'Forking the first turn stopped the source follow-up'
+    )
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: COMPLETION_TEXT,
+      timeoutMs: UI_TIMEOUT_MS,
+    })
+    const forkSnapshot = JSON.parse(await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR))
+    assert.equal(
+      forkSnapshot.text.includes(RUNNING_FORK_FOLLOW_UP_PROMPT),
+      false,
+      'The forked task included the in-flight follow-up after the selected turn'
+    )
+    await captureVerificationScreenshot(control, 'running-follow-up-fork-02-target-open.png')
+  } finally {
+    control.releaseRunningForkFollowUpResponse()
+  }
+
+  await ensureTaskRowVisible(control, sourceTaskRowTestId)
+  await control.command('click', `[data-testid="${sourceTaskRowTestId}"]`)
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: RUNNING_FORK_COMPLETION_TEXT,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  const completedRuntimeIndex = JSON.parse(
+    await readFile(join(executorHome, 'runtime-work', 'index.json'), 'utf8')
+  )
+  const sourceTaskId = sourceTaskRowTestId.replace('runtime-local-task-row-', '')
+  assert.equal(
+    completedRuntimeIndex.tasks[sourceTaskId]?.turn_status,
+    'completed',
+    'The source follow-up was interrupted instead of completing after the fork'
+  )
 }
 
 async function verifyCompletedTurnFork({
@@ -3390,6 +3482,9 @@ class DesktopE2EServer {
     this.windowLifecycleResponseStarted = new Promise(resolvePromise => {
       this.resolveWindowLifecycleResponseStarted = resolvePromise
     })
+    this.runningForkFollowUpRelease = new Promise(resolvePromise => {
+      this.releaseRunningForkFollowUp = resolvePromise
+    })
     this.goalIdleInitialRelease = new Promise(resolvePromise => {
       this.releaseGoalIdleInitial = resolvePromise
     })
@@ -3547,6 +3642,7 @@ class DesktopE2EServer {
       [
         'initial',
         'follow_up',
+        'running_fork_follow_up',
         'fork_follow_up',
         'request_user_input',
         'window_lifecycle',
@@ -3646,6 +3742,10 @@ class DesktopE2EServer {
 
   releaseWindowLifecycleResponse() {
     this.releaseWindowLifecycle()
+  }
+
+  releaseRunningForkFollowUpResponse() {
+    this.releaseRunningForkFollowUp()
   }
 
   releaseGoalIdleInitialResponse() {
@@ -4298,6 +4398,50 @@ class DesktopE2EServer {
         assistantMessage(GOAL_IDLE_COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
+      return
+    }
+
+    if (this.scenario === 'running_fork_follow_up') {
+      this.recordScenarioRequest('running_fork_follow_up', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(RUNNING_FORK_FOLLOW_UP_PROMPT),
+        'The real Codex request did not contain the running-fork follow-up prompt'
+      )
+      const completedText = `${RUNNING_FORK_STREAMING_TEXT}\n${RUNNING_FORK_COMPLETION_TEXT}`
+      const stream = streamingTextEvents(responseId, completedText)
+      response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      })
+      response.write(createSse(stream.start))
+      response.write(
+        createSse([
+          {
+            type: 'response.output_text.delta',
+            item_id: stream.itemId,
+            output_index: 0,
+            content_index: 0,
+            delta: RUNNING_FORK_STREAMING_TEXT,
+            offset: 0,
+          },
+        ])
+      )
+      await this.runningForkFollowUpRelease
+      response.write(
+        createSse([
+          {
+            type: 'response.output_text.delta',
+            item_id: stream.itemId,
+            output_index: 0,
+            content_index: 0,
+            delta: `\n${RUNNING_FORK_COMPLETION_TEXT}`,
+            offset: RUNNING_FORK_STREAMING_TEXT.length,
+          },
+        ])
+      )
+      response.end(createSse(stream.finish))
       return
     }
 
@@ -6883,6 +7027,14 @@ async function main() {
       testId.startsWith('runtime-local-task-row-')
     )
     assert.ok(taskRowTestId, 'The completed task row was not found')
+
+    phase = 'running-follow-up-fork'
+    await verifyRunningFollowUpFork({
+      composerSelector,
+      control,
+      executorHome,
+      sourceTaskRowTestId: taskRowTestId,
+    })
 
     phase = 'completed-turn-fork'
     await verifyCompletedTurnFork({

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -19,7 +19,6 @@ import {
   File as FileIcon,
   FileText,
   Folder,
-  GitFork,
   LibraryBig,
   ListTodo,
   MessageSquare,
@@ -133,6 +132,28 @@ const VIRTUAL_MESSAGE_FULL_MEASUREMENT_COUNT = VIRTUAL_MESSAGE_OVERSCAN * 2 + 1
 const MESSAGE_LIST_GAP_PX = 16
 const MESSAGE_LIST_PADDING_TOP_PX = 32
 const MESSAGE_LIST_PADDING_BOTTOM_PX = 8
+
+function ForkTurnIcon() {
+  return (
+    <svg
+      data-testid="fork-message-icon"
+      aria-hidden="true"
+      className="h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 12h4c4 0 4-6 8-6h6" />
+      <path d="M7 12c4 0 4 6 8 6h6" />
+      <path d="m18 3 3 3-3 3" />
+      <path d="m18 15 3 3-3 3" />
+    </svg>
+  )
+}
+
 interface MessageTextSelection {
   text: string
   left: number
@@ -1590,7 +1611,7 @@ function MessageHoverActions({
         aria-label={t('continue_in_new_task')}
         className="flex h-6 w-6 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-muted hover:text-text-secondary disabled:pointer-events-none disabled:opacity-50"
       >
-        <GitFork data-testid="fork-message-icon" className="h-3.5 w-3.5" />
+        <ForkTurnIcon />
       </button>
       <span className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-base px-1.5 py-0.5 text-xs text-text-secondary opacity-0 shadow-sm transition-opacity group-hover/fork:opacity-100">
         {t('continue_in_new_task')}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -795,6 +795,8 @@ describe('DesktopWorkbenchLayout', () => {
     onOpenStandaloneWorkspace?: (...args: unknown[]) => Promise<void> | void
     onOpenRuntimeTask?: (...args: unknown[]) => Promise<void> | void
     onSearchRuntimeWork?: (...args: unknown[]) => Promise<unknown>
+    onCancelRuntimePaneTask?: WorkbenchContextValue['cancelRuntimePaneTask']
+    onForkCurrentRuntimeTask?: WorkbenchContextValue['forkCurrentRuntimeTask']
     onListImPrivateSessions?: () => Promise<unknown>
     onBindRuntimeTaskToImSessions?: (...args: unknown[]) => Promise<unknown>
     onGetImNotificationSettings?: () => Promise<unknown>
@@ -1023,7 +1025,8 @@ describe('DesktopWorkbenchLayout', () => {
       archiveProjectConversations: vi.fn().mockResolvedValue(undefined),
       archiveProjectsConversations: vi.fn().mockResolvedValue(undefined),
       archiveChatConversations: vi.fn().mockResolvedValue(undefined),
-      forkCurrentRuntimeTask: vi.fn().mockResolvedValue(undefined),
+      forkCurrentRuntimeTask:
+        props.onForkCurrentRuntimeTask ?? vi.fn().mockResolvedValue(undefined),
       listImPrivateSessions:
         props.onListImPrivateSessions ?? vi.fn().mockResolvedValue({ total: 0, items: [] }),
       bindRuntimeTaskToImSessions:
@@ -1080,7 +1083,7 @@ describe('DesktopWorkbenchLayout', () => {
       createEnvironmentBranch:
         props.onCreateEnvironmentBranch ?? baseProps.onCreateEnvironmentBranch,
       sendRuntimePaneMessage: vi.fn().mockResolvedValue(true),
-      cancelRuntimePaneTask: vi.fn().mockResolvedValue(true),
+      cancelRuntimePaneTask: props.onCancelRuntimePaneTask ?? vi.fn().mockResolvedValue(true),
       sendCurrentInput: props.onSend ?? baseProps.onSend,
       retryFailedMessage: vi.fn().mockResolvedValue(true),
       pauseCurrentResponse: vi.fn().mockResolvedValue(undefined),
@@ -1846,6 +1849,58 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(screen.queryByTestId('fork-runtime-task-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('continue-in-im-button')).not.toBeInTheDocument()
+  })
+
+  test('forks an earlier completed turn without stopping the running follow-up', async () => {
+    const currentRuntimeTask = {
+      deviceId: 'device-1',
+      workspacePath: '/workspace/project-alpha',
+      taskId: 'runtime-1',
+    }
+    const onCancelRuntimePaneTask = vi.fn().mockResolvedValue(true)
+    const onForkCurrentRuntimeTask = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          currentRuntimeTask,
+        }}
+        lifecycleTaskRunning
+        messages={[
+          {
+            id: 'assistant-turn-1',
+            role: 'assistant',
+            content: 'First turn complete',
+            status: 'done',
+            turnId: 'turn-1',
+            createdAt: '2026-07-25T12:00:00.000Z',
+          },
+          {
+            id: 'assistant-turn-2',
+            role: 'assistant',
+            content: 'Follow-up is streaming',
+            status: 'streaming',
+            turnId: 'turn-2',
+            createdAt: '2026-07-25T12:01:00.000Z',
+          },
+        ]}
+        onCancelRuntimePaneTask={onCancelRuntimePaneTask}
+        onForkCurrentRuntimeTask={onForkCurrentRuntimeTask}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('fork-message-button'))
+
+    expect(onCancelRuntimePaneTask).not.toHaveBeenCalled()
+    expect(onForkCurrentRuntimeTask).toHaveBeenCalledWith(
+      {
+        deviceId: 'device-1',
+        workspacePath: '/workspace/project-alpha',
+      },
+      { lastTurnId: 'turn-1' }
+    )
   })
 
   test('keeps continue-in-im action with workspace panel actions on web', () => {


### PR DESCRIPTION
## Summary

- replace the message Fork action icon with the Codex-style branching arrow
- allow a completed historical turn to be forked while a later source turn is still streaming
- keep the source turn running and preserve the selected `lastTurnId` as the fork boundary
- document the runtime turn-fork behavior in Chinese and English

## Root cause

The executor rejected `runtime.tasks.fork_at_turn` whenever either persisted task state or in-memory execution state reported the source task as running. This prevented Codex `thread/fork` from using an already completed historical turn even though the active follow-up was outside the requested `lastTurnId` boundary. The frontend callback swallowed that structured rejection, so clicking Fork appeared to do nothing.

## Verification

- `cargo test --locked --lib runtime_work::handler::tests::`
- `cargo test --locked --test app_runtime_work_send_contract runtime_tasks_fork_completed_turn_preserves_workspace_and_rejects_missing_turn`
- `pnpm --filter wework exec vitest run src/components/chat/MessageList.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework e2e:desktop`
- pre-push ESLint, TypeScript, Wework unit tests, Cargo fmt, Cargo lib tests, and Clippy

The desktop E2E holds a follow-up in streaming state, forks the first completed turn, verifies that a new task is created, confirms the source remains running, then releases the source stream and verifies it completes instead of being interrupted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fork a task from the last completed turn while a follow-up response is still streaming.
  - The source task continues independently, without canceling or altering its active turn.
  - Forked tasks include only conversation history up to the selected completed turn.

- **Bug Fixes**
  - Improved handling of fork requests when tasks are actively running.
  - Clearer feedback is provided when the selected fork point cannot be found.

- **Documentation**
  - Updated English and Chinese runtime guides with the new task-forking behavior and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->