### PR TITLE
fix(backend): pass encryption config to backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,11 @@ CONNECTOR_OAUTH_CALLBACK_BASE_URL=
 # When enabled, chunk content is also saved to knowledge_documents.chunks column
 # BACKEND_CHUNK_STORAGE_ENABLED=False
 
+# Sensitive-data encryption. Keep these values stable after deployment.
+# Generate exactly 32 and 16 characters as documented.
+GIT_TOKEN_AES_KEY=
+GIT_TOKEN_AES_IV=
+
 # Initialize built-in data on startup
 # BACKEND_INIT_DATA_ENABLED=True
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,8 @@ services:
       # OTEL_SERVICE_NAME: "wegent-backend"
       # OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4317"
       # OTEL_TRACES_SAMPLER_ARG: "1.0"
+      GIT_TOKEN_AES_KEY: ${GIT_TOKEN_AES_KEY:?Set GIT_TOKEN_AES_KEY in .env}
+      GIT_TOKEN_AES_IV: ${GIT_TOKEN_AES_IV:?Set GIT_TOKEN_AES_IV in .env}
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Document `GIT_TOKEN_AES_KEY` and `GIT_TOKEN_AES_IV` in the root `.env.example`.
- Pass both variables to the Backend service in `docker-compose.yml`.
- Fail during Compose configuration with an actionable message when either variable is missing.

## Problem

Since commit `816482bf8`, the shared sensitive-data encryption code requires `GIT_TOKEN_AES_IV` to be explicitly configured.

Although the variables are documented in `backend/.env.example`, Docker Compose deployments do not read that file. The root `.env.example` does not expose the variables, and the Backend service does not receive them.

As a result, requests such as `GET /api/models/unified` return HTTP 500 when the Backend attempts to decrypt an encrypted model API key:

```text
CryptoConfigurationError: GIT_TOKEN_AES_IV must be configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Added new required settings for encrypting sensitive data (`GIT_TOKEN_AES_KEY` and `GIT_TOKEN_AES_IV`) to the example environment configuration.
  * Updated container startup to require these encryption settings, preventing the backend from starting if they’re not set.
  * Included guidance to generate values with the expected lengths and to keep them stable after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->