### PR TITLE
fix(executor): support namespaced tools for chat APIs

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
@@ -36,6 +36,17 @@ The provider `base_url` may be a service root, a versioned API base, or a comple
 
 When a task runs on a cloud or remote device, the model selector hides custom models configured only on the current desktop. Local custom models can only use the local executor; built-in Codex models and cloud Model CRDs can use either local or cloud execution.
 
+### Namespace Tool Compatibility
+
+Codex can group child tools under a `type: "namespace"` tool when it sends an OpenAI Responses request. OpenAI Chat Completions and Anthropic Messages have no equivalent namespace field, so the executor Codex compatibility proxy applies a reversible mapping at the protocol boundary:
+
+1. During request conversion, child tools are expanded into ordinary Chat or Anthropic function tools. A unique child keeps its original name; collisions receive a stable alias containing the namespace.
+2. Aliases use only characters accepted by Chat function names and are limited to 64 bytes. Longer names are truncated with a stable hash.
+3. Historical tool calls and an explicit `tool_choice` use the same mapping so tool identity remains stable across turns.
+4. When the upstream returns a flat tool call, the proxy restores the original `name` and `namespace` before emitting Responses events back to Codex.
+
+The mapping is request-scoped protocol context. It is not persisted in model configuration and does not guess a namespace from the returned tool name. Tools with the same child name in different namespaces therefore continue to route to the correct executor.
+
 ## Security Benefits
 
 - The Wework desktop client and local executor never receive the real provider `api_key`.

--- a/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
@@ -36,6 +36,17 @@ provider `base_url` 可以是服务根地址、带版本前缀的 API base，或
 
 云端或远端设备执行任务时，模型选择器不会展示只配置在当前桌面端的本机自定义模型。本机模型只能由本机 executor 使用；Codex 内置模型和云端 Model CRD 可以用于本机或云端执行。
 
+### Namespace 工具兼容
+
+Codex 向 OpenAI Responses API 发送工具时，可以使用 `type: "namespace"` 把多个子工具组织在同一个 namespace 下。OpenAI Chat Completions 和 Anthropic Messages 没有对应的 namespace 字段，因此 executor 的 Codex compat proxy 会在协议转换边界执行可逆映射：
+
+1. 请求转换时，将 namespace 内的子工具展开为 Chat/Anthropic 的普通 function tools。没有重名时保留子工具原名；存在重名时使用包含 namespace 的稳定别名。
+2. 别名只使用 Chat function name 允许的字符，并限制在 64 字节内；过长名称使用稳定哈希截断。
+3. 历史 tool call 和指定 `tool_choice` 使用同一份映射，避免多轮对话切换工具身份。
+4. 上游返回平铺 tool call 后，proxy 恢复原始 `name` 和 `namespace`，再以 Responses 事件交给 Codex 路由。
+
+这个映射属于单次模型请求的协议上下文，不写入模型配置，也不依赖根据工具名猜测 namespace。不同 namespace 中的同名工具仍能准确路由到各自的执行器。
+
 ## 安全收益
 
 - Wework 桌面端和本地 executor 永远不会拿到真实 provider `api_key`。

--- a/executor/src/server/local_model_proxy/anthropic.rs
+++ b/executor/src/server/local_model_proxy/anthropic.rs
@@ -430,6 +430,34 @@ mod tests {
     }
 
     #[test]
+    fn flattens_namespace_tools_for_anthropic_messages() {
+        let input = json!({
+            "model": "kimi-for-coding",
+            "input": [{"role": "user", "content": "Inspect the page"}],
+            "tools": [{
+                "type": "namespace",
+                "name": "wework_browser",
+                "tools": [{
+                    "type": "function",
+                    "name": "browser_snapshot",
+                    "description": "Capture the page",
+                    "parameters": {"type": "object", "properties": {}}
+                }]
+            }]
+        });
+
+        let (converted, _) = responses_to_anthropic(&input).expect("request should convert");
+
+        assert_eq!(converted["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(converted["tools"][0]["name"], "browser_snapshot");
+        assert_eq!(converted["tools"][0]["description"], "Capture the page");
+        assert_eq!(
+            converted["tools"][0]["input_schema"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
     fn preserves_friendly_apply_patch_failure_guidance() {
         let input = json!({
             "model": "kimi-for-coding",
@@ -481,6 +509,45 @@ mod tests {
         assert!(output.contains("response.output_text.delta"));
         assert!(output.contains("response.custom_tool_call_input.done"));
         assert!(output.contains("\"input_tokens\":10"));
+    }
+
+    #[tokio::test]
+    async fn restores_namespace_on_anthropic_tool_calls() {
+        let events = [
+            json!({"type":"message_start","message":{"id":"msg_1","model":"kimi-for-coding","usage":{"input_tokens":1}}}),
+            json!({"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool_1","name":"browser_snapshot","input":{}}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}),
+            json!({"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}),
+        ];
+        let source = futures_util::stream::iter(
+            events
+                .into_iter()
+                .map(|event| Ok::<_, std::io::Error>(Bytes::from(format!("data: {event}\n\n")))),
+        );
+        let input = json!({
+            "tools": [{
+                "type": "namespace",
+                "name": "wework_browser",
+                "tools": [{
+                    "type": "function",
+                    "name": "browser_snapshot",
+                    "parameters": {"type": "object"}
+                }]
+            }]
+        });
+        let context = chat::responses_to_chat(&input)
+            .expect("context should build")
+            .1;
+        let output = anthropic_sse_to_responses(source, context)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .collect::<String>();
+
+        assert!(output.contains("\"name\":\"browser_snapshot\""));
+        assert!(output.contains("\"namespace\":\"wework_browser\""));
     }
 
     #[tokio::test]

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -51,18 +51,58 @@ enum ToolKind {
     Custom,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolIdentity {
+    name: String,
+    namespace: Option<String>,
+    kind: ToolKind,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(super) struct ToolContext {
-    kinds: BTreeMap<String, ToolKind>,
+    tools: BTreeMap<String, ToolIdentity>,
+    wire_names: BTreeMap<(Option<String>, String), String>,
 }
 
 impl ToolContext {
+    fn insert_tool(&mut self, wire_name: String, identity: ToolIdentity) {
+        self.wire_names
+            .entry((identity.namespace.clone(), identity.name.clone()))
+            .or_insert_with(|| wire_name.clone());
+        self.tools.entry(wire_name).or_insert(identity);
+    }
+
+    #[cfg(test)]
     fn insert(&mut self, name: String, kind: ToolKind) {
-        self.kinds.entry(name).or_insert(kind);
+        self.insert_tool(
+            name.clone(),
+            ToolIdentity {
+                name,
+                namespace: None,
+                kind,
+            },
+        );
     }
 
     fn is_custom(&self, name: &str) -> bool {
-        self.kinds.get(name) == Some(&ToolKind::Custom)
+        self.tools
+            .get(name)
+            .or_else(|| {
+                self.wire_name(None, name)
+                    .and_then(|wire_name| self.tools.get(wire_name))
+            })
+            .map(|tool| &tool.kind)
+            == Some(&ToolKind::Custom)
+    }
+
+    fn wire_name(&self, namespace: Option<&str>, name: &str) -> Option<&str> {
+        self.wire_names
+            .get(&(namespace.map(str::to_owned), name.to_owned()))
+            .map(String::as_str)
+    }
+
+    fn identity(&self, wire_name: &str) -> Option<&ToolIdentity> {
+        self.tools.get(wire_name)
     }
 }
 
@@ -116,7 +156,7 @@ pub(super) fn responses_to_chat(body: &Value) -> Result<(Value, ToolContext), St
         result.insert("tools".to_owned(), Value::Array(tools));
         if let Some(choice) = body.get("tool_choice") {
             if choice != "auto" {
-                result.insert("tool_choice".to_owned(), chat_tool_choice(choice));
+                result.insert("tool_choice".to_owned(), chat_tool_choice(choice, &context));
             }
         }
     }
@@ -130,13 +170,61 @@ fn copy_field(body: &Value, result: &mut Map<String, Value>, source: &str, targe
 }
 
 fn build_tool_context(body: &Value) -> ToolContext {
-    let mut context = ToolContext::default();
-    for tool in body
+    let tools = body
         .get("tools")
         .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-    {
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let mut name_counts = BTreeMap::<String, usize>::new();
+    for tool in tools {
+        if tool.get("type").and_then(Value::as_str) == Some("namespace") {
+            for inner_tool in tool
+                .get("tools")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if let Some(name) = inner_tool.get("name").and_then(Value::as_str) {
+                    *name_counts.entry(name.to_owned()).or_default() += 1;
+                }
+            }
+        } else if let Some(name) = tool.get("name").and_then(Value::as_str) {
+            *name_counts.entry(name.to_owned()).or_default() += 1;
+        }
+    }
+
+    let mut context = ToolContext::default();
+    for tool in tools {
+        if tool.get("type").and_then(Value::as_str) == Some("namespace") {
+            let Some(namespace) = tool.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            for inner_tool in tool
+                .get("tools")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let Some(name) = inner_tool.get("name").and_then(Value::as_str) else {
+                    continue;
+                };
+                let preferred_wire_name = if name_counts.get(name) == Some(&1) {
+                    bounded_wire_name(name)
+                } else {
+                    flattened_namespace_tool_name(namespace, name)
+                };
+                let wire_name = unique_wire_name(&context, preferred_wire_name);
+                context.insert_tool(
+                    wire_name,
+                    ToolIdentity {
+                        name: name.to_owned(),
+                        namespace: Some(namespace.to_owned()),
+                        kind: ToolKind::Function,
+                    },
+                );
+            }
+            continue;
+        }
         let Some(name) = tool.get("name").and_then(Value::as_str) else {
             continue;
         };
@@ -145,60 +233,145 @@ fn build_tool_context(body: &Value) -> ToolContext {
         } else {
             ToolKind::Function
         };
-        context.insert(name.to_owned(), kind);
+        let preferred_wire_name = if name_counts.get(name) == Some(&1) {
+            bounded_wire_name(name)
+        } else {
+            bounded_wire_name(&format!("functions__{name}"))
+        };
+        let wire_name = unique_wire_name(&context, preferred_wire_name);
+        context.insert_tool(
+            wire_name,
+            ToolIdentity {
+                name: name.to_owned(),
+                namespace: None,
+                kind,
+            },
+        );
     }
     context
 }
 
+fn flattened_namespace_tool_name(namespace: &str, name: &str) -> String {
+    let flattened = if namespace.ends_with('_') || name.starts_with('_') {
+        format!("{namespace}{name}")
+    } else {
+        format!("{namespace}__{name}")
+    };
+    bounded_wire_name(&flattened)
+}
+
+fn bounded_wire_name(value: &str) -> String {
+    const MAX_TOOL_NAME_BYTES: usize = 64;
+    let sanitized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '_' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.len() <= MAX_TOOL_NAME_BYTES {
+        return sanitized;
+    }
+
+    let hash = sanitized
+        .as_bytes()
+        .iter()
+        .fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x100_0000_01b3)
+        });
+    let suffix = format!("__{hash:016x}");
+    let prefix_bytes = MAX_TOOL_NAME_BYTES - suffix.len();
+    format!("{}{}", &sanitized[..prefix_bytes], suffix)
+}
+
+fn unique_wire_name(context: &ToolContext, preferred: String) -> String {
+    if !context.tools.contains_key(&preferred) {
+        return preferred;
+    }
+    for suffix in 2.. {
+        let candidate = bounded_wire_name(&format!("{preferred}__{suffix}"));
+        if !context.tools.contains_key(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("an unused tool name suffix must exist")
+}
+
 fn chat_tools(body: &Value, context: &ToolContext) -> Vec<Value> {
-    body.get("tools")
+    let mut converted = Vec::new();
+    for tool in body
+        .get("tools")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
-        .filter_map(|tool| {
-            let name = tool.get("name")?.as_str()?;
-            if context.is_custom(name) {
-                let definition = serde_json::to_string(tool).ok()?;
-                let contract = if name == "apply_patch" {
-                    format!("{APPLY_PATCH_OUTPUT_CONTRACT}\n\n")
-                } else {
-                    "Put only the custom tool's raw input in the function's `input` field. Do not add Markdown fences or explanatory text.\n\n".to_owned()
-                };
-                let description =
-                    format!("{contract}Original tool definition:\n```json\n{definition}\n```");
-                return Some(json!({
-                    "type": "function",
-                    "function": {
-                        "name": name,
-                        "description": description,
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                CUSTOM_TOOL_INPUT_FIELD: {
-                                    "type": "string",
-                                    "description": CUSTOM_TOOL_INPUT_DESCRIPTION
-                                }
-                            },
-                            "required": [CUSTOM_TOOL_INPUT_FIELD],
-                            "additionalProperties": false
-                        }
-                    }
-                }));
-            }
-            Some(json!({
-                "type": "function",
-                "function": {
-                    "name": name,
-                    "description": tool.get("description").cloned().unwrap_or(Value::Null),
-                    "parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({
-                        "type": "object",
-                        "properties": {}
-                    })),
-                    "strict": tool.get("strict").cloned().unwrap_or(Value::Bool(false))
+    {
+        if tool.get("type").and_then(Value::as_str) == Some("namespace") {
+            let Some(namespace) = tool.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            for inner_tool in tool
+                .get("tools")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if let Some(converted_tool) = chat_tool(inner_tool, Some(namespace), context) {
+                    converted.push(converted_tool);
                 }
-            }))
-        })
-        .collect()
+            }
+        } else if let Some(converted_tool) = chat_tool(tool, None, context) {
+            converted.push(converted_tool);
+        }
+    }
+    converted
+}
+
+fn chat_tool(tool: &Value, namespace: Option<&str>, context: &ToolContext) -> Option<Value> {
+    let name = tool.get("name")?.as_str()?;
+    let wire_name = context.wire_name(namespace, name)?;
+    if context.is_custom(wire_name) {
+        let definition = serde_json::to_string(tool).ok()?;
+        let contract = if name == "apply_patch" {
+            format!("{APPLY_PATCH_OUTPUT_CONTRACT}\n\n")
+        } else {
+            "Put only the custom tool's raw input in the function's `input` field. Do not add Markdown fences or explanatory text.\n\n".to_owned()
+        };
+        let description =
+            format!("{contract}Original tool definition:\n```json\n{definition}\n```");
+        return Some(json!({
+            "type": "function",
+            "function": {
+                "name": wire_name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        CUSTOM_TOOL_INPUT_FIELD: {
+                            "type": "string",
+                            "description": CUSTOM_TOOL_INPUT_DESCRIPTION
+                        }
+                    },
+                    "required": [CUSTOM_TOOL_INPUT_FIELD],
+                    "additionalProperties": false
+                }
+            }
+        }));
+    }
+    Some(json!({
+        "type": "function",
+        "function": {
+            "name": wire_name,
+            "description": tool.get("description").cloned().unwrap_or(Value::Null),
+            "parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({
+                "type": "object",
+                "properties": {}
+            })),
+            "strict": tool.get("strict").cloned().unwrap_or(Value::Bool(false))
+        }
+    }))
 }
 
 fn responses_tools(tools: &[Value], context: &ToolContext) -> Vec<Value> {
@@ -347,9 +520,11 @@ fn convert_responses_input_item(
     }
 }
 
-fn chat_tool_choice(choice: &Value) -> Value {
+fn chat_tool_choice(choice: &Value, context: &ToolContext) -> Value {
     if let Some(name) = choice.get("name").and_then(Value::as_str) {
-        json!({"type": "function", "function": {"name": name}})
+        let namespace = choice.get("namespace").and_then(Value::as_str);
+        let wire_name = context.wire_name(namespace, name).unwrap_or(name);
+        json!({"type": "function", "function": {"name": wire_name}})
     } else {
         choice.clone()
     }
@@ -375,12 +550,14 @@ fn append_input(
             }
             Some("function_call") | Some("custom_tool_call") => {
                 let name = item.get("name").and_then(Value::as_str).unwrap_or_default();
+                let namespace = item.get("namespace").and_then(Value::as_str);
+                let wire_name = context.wire_name(namespace, name).unwrap_or(name);
                 let call_id = item
                     .get("call_id")
                     .or_else(|| item.get("id"))
                     .and_then(Value::as_str)
                     .unwrap_or_default();
-                let arguments = if context.is_custom(name)
+                let arguments = if context.is_custom(wire_name)
                     || item.get("type").and_then(Value::as_str) == Some("custom_tool_call")
                 {
                     let raw = item
@@ -396,7 +573,7 @@ fn append_input(
                 pending_calls.push(json!({
                     "id": call_id,
                     "type": "function",
-                    "function": {"name": name, "arguments": arguments}
+                    "function": {"name": wire_name, "arguments": arguments}
                 }));
             }
             Some("function_call_output") | Some("custom_tool_call_output") => {
@@ -602,6 +779,8 @@ struct CallState {
     item_id: String,
     call_id: String,
     name: String,
+    namespace: Option<String>,
+    custom: bool,
     arguments: String,
 }
 
@@ -1281,13 +1460,21 @@ impl<S> ChatStreamState<S> {
             }
             _ => String::new(),
         };
-        let (needs_start, call_id, complete_name) = {
+        let (needs_start, call_id, complete_name, complete_namespace, custom) = {
             let state = self.calls.entry(index).or_default();
             if !id.is_empty() {
                 state.call_id = super::normalized_responses_api_id(id);
             }
             if !name.is_empty() {
-                state.name = name.to_owned();
+                if let Some(identity) = self.context.identity(name) {
+                    state.name = identity.name.clone();
+                    state.namespace = identity.namespace.clone();
+                    state.custom = identity.kind == ToolKind::Custom;
+                } else {
+                    state.name = name.to_owned();
+                    state.namespace = None;
+                    state.custom = false;
+                }
             }
             if !arguments.is_empty() {
                 if is_snapshot {
@@ -1300,6 +1487,8 @@ impl<S> ChatStreamState<S> {
                 !state.started && !state.name.is_empty(),
                 state.call_id.clone(),
                 state.name.clone(),
+                state.namespace.clone(),
+                state.custom,
             )
         };
         if needs_start {
@@ -1315,26 +1504,25 @@ impl<S> ChatStreamState<S> {
             state.output_index = output_index;
             state.item_id = item_id.clone();
             state.call_id = call_id.clone();
-            let item_type = if self.context.is_custom(&complete_name) {
+            let item_type = if custom {
                 "custom_tool_call"
             } else {
                 "function_call"
             };
-            let item = if item_type == "custom_tool_call" {
+            let mut item = if item_type == "custom_tool_call" {
                 json!({"id": item_id, "type": item_type, "status": "in_progress", "call_id": call_id, "name": complete_name, "input": ""})
             } else {
                 json!({"id": item_id, "type": item_type, "status": "in_progress", "call_id": call_id, "name": complete_name, "arguments": ""})
             };
+            if let Some(namespace) = complete_namespace {
+                item["namespace"] = Value::String(namespace);
+            }
             self.emit(sse("response.output_item.added", json!({"type": "response.output_item.added", "output_index": output_index, "item": item})));
         }
         if !arguments.is_empty() {
             let (output_index, item_id, custom) = {
                 let state = self.calls.entry(index).or_default();
-                (
-                    state.output_index,
-                    state.item_id.clone(),
-                    self.context.is_custom(&state.name),
-                )
+                (state.output_index, state.item_id.clone(), state.custom)
             };
             if !custom && !item_id.is_empty() {
                 let event = "response.function_call_arguments.delta";
@@ -1377,17 +1565,20 @@ impl<S> ChatStreamState<S> {
             if !state.started {
                 continue;
             }
-            let custom = self.context.is_custom(&state.name);
+            let custom = state.custom;
             let arguments = if custom {
                 custom_input(&state.name, &state.arguments)
             } else {
                 normalize_arguments(&state.arguments)
             };
-            let item = if custom {
+            let mut item = if custom {
                 json!({"id": state.item_id, "type": "custom_tool_call", "status": "completed", "call_id": state.call_id, "name": state.name, "input": arguments})
             } else {
                 json!({"id": state.item_id, "type": "function_call", "status": "completed", "call_id": state.call_id, "name": state.name, "arguments": arguments})
             };
+            if let Some(namespace) = state.namespace {
+                item["namespace"] = Value::String(namespace);
+            }
             let done_event = if custom {
                 "response.custom_tool_call_input.done"
             } else {
@@ -1689,6 +1880,115 @@ mod tests {
     }
 
     #[test]
+    fn flattens_namespace_tools_and_namespaced_history_for_chat() {
+        let input = json!({
+            "model": "kimi-for-coding",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "browser_snapshot",
+                    "namespace": "wework_browser",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "snapshot"
+                }
+            ],
+            "tools": [{
+                "type": "namespace",
+                "name": "wework_browser",
+                "description": "Wework built-in browser tools",
+                "tools": [{
+                    "type": "function",
+                    "name": "browser_snapshot",
+                    "description": "Capture the page",
+                    "parameters": {"type": "object", "properties": {}}
+                }]
+            }],
+            "tool_choice": {
+                "type": "function",
+                "name": "browser_snapshot",
+                "namespace": "wework_browser"
+            }
+        });
+
+        let (converted, context) = responses_to_chat(&input).expect("request should convert");
+
+        assert_eq!(converted["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            converted["tools"][0]["function"]["name"],
+            "browser_snapshot"
+        );
+        assert_eq!(
+            converted["messages"][0]["tool_calls"][0]["function"]["name"],
+            "browser_snapshot"
+        );
+        assert_eq!(
+            converted["tool_choice"]["function"]["name"],
+            "browser_snapshot"
+        );
+        assert_eq!(
+            context.identity("browser_snapshot"),
+            Some(&ToolIdentity {
+                name: "browser_snapshot".to_owned(),
+                namespace: Some("wework_browser".to_owned()),
+                kind: ToolKind::Function,
+            })
+        );
+    }
+
+    #[test]
+    fn disambiguates_colliding_namespace_tool_names() {
+        let input = json!({
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "calendar",
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "parameters": {"type": "object"}
+                    }]
+                },
+                {
+                    "type": "namespace",
+                    "name": "mail",
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "parameters": {"type": "object"}
+                    }]
+                }
+            ]
+        });
+
+        let (converted, context) = responses_to_chat(&input).expect("request should convert");
+        let names = converted["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool.pointer("/function/name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["calendar__search", "mail__search"]);
+        assert_eq!(
+            context
+                .identity("calendar__search")
+                .and_then(|tool| tool.namespace.as_deref()),
+            Some("calendar")
+        );
+        assert_eq!(
+            context
+                .identity("mail__search")
+                .and_then(|tool| tool.namespace.as_deref()),
+            Some("mail")
+        );
+    }
+
+    #[test]
     fn explains_apply_patch_hunk_failures_and_requests_a_retry() {
         let input = json!({
             "model": "kimi-for-coding",
@@ -1862,6 +2162,33 @@ mod tests {
         .await;
         assert!(output.contains("\"call_id\":\"call_1\""));
         assert!(output.contains("\"name\":\"read_file\""));
+    }
+
+    #[tokio::test]
+    async fn restores_namespace_on_chat_tool_calls() {
+        let input = json!({
+            "tools": [{
+                "type": "namespace",
+                "name": "wework_browser",
+                "tools": [{
+                    "type": "function",
+                    "name": "browser_snapshot",
+                    "parameters": {"type": "object"}
+                }]
+            }]
+        });
+        let context = responses_to_chat(&input).expect("context should build").1;
+        let output = convert_stream(
+            concat!(
+                "data: {\"choices\":[{\"message\":{\"tool_calls\":[{\"id\":\"call_1\",\"function\":{\"name\":\"browser_snapshot\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                "data: [DONE]\n\n"
+            ),
+            context,
+        )
+        .await;
+
+        assert!(output.contains("\"name\":\"browser_snapshot\""));
+        assert!(output.contains("\"namespace\":\"wework_browser\""));
     }
 
     #[tokio::test]

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -4906,6 +4906,24 @@ class DesktopE2EServer {
         excludes: [followUpPrompt],
       })
       this.assertLocalApplyPatchTool(model, body)
+      this.assertLocalNamespaceTools(model, body)
+      if (model.protocol !== 'responses') {
+        state.stage = 'awaiting_namespace_tool_output'
+        this.writeLocalNamespaceToolCall(response, model)
+        return
+      }
+      state.stage = 'awaiting_tool_output'
+      this.writeLocalToolCall(response, model, localProtocolPatch(model))
+      return
+    }
+    if (state.stage === 'awaiting_namespace_tool_output') {
+      this.assertLocalConversation(model, body, {
+        includes: [],
+        excludes: [followUpPrompt],
+      })
+      this.assertLocalApplyPatchTool(model, body)
+      this.assertLocalNamespaceTools(model, body)
+      this.assertLocalNamespaceToolOutput(model, body)
       state.stage = 'awaiting_tool_output'
       this.writeLocalToolCall(response, model, localProtocolPatch(model))
       return
@@ -5104,6 +5122,57 @@ class DesktopE2EServer {
     )
   }
 
+  assertLocalNamespaceTools(model, body) {
+    if (model.protocol === 'responses') return
+    const tools = Array.isArray(body.tools) ? body.tools : []
+    const names = tools
+      .map(candidate => candidate?.name ?? candidate?.function?.name)
+      .filter(Boolean)
+
+    assert.ok(
+      names.includes('browser_snapshot'),
+      `${model.protocol} did not flatten the wework_browser namespace: ${names.join(', ')}`
+    )
+    assert.equal(
+      names.includes('wework_browser'),
+      false,
+      `${model.protocol} exposed the namespace container as a callable function`
+    )
+  }
+
+  assertLocalNamespaceToolOutput(model, body) {
+    const serialized = JSON.stringify(body)
+    assert.equal(
+      serialized.includes('unsupported function call: browser_snapshot'),
+      false,
+      `${model.protocol} did not restore the wework_browser namespace on the tool call`
+    )
+
+    if (model.protocol === 'chat') {
+      const call = body.messages
+        ?.flatMap(message => message?.tool_calls ?? [])
+        .find(candidate => candidate?.function?.name === 'browser_snapshot')
+      assert.ok(call, 'Chat lost the flattened browser_snapshot call history')
+      assert.ok(
+        body.messages?.some(
+          message => message?.role === 'tool' && message?.tool_call_id === call?.id
+        ),
+        'Chat lost the namespaced browser_snapshot result'
+      )
+      return
+    }
+
+    const blocks = body.messages?.flatMap(message => message?.content ?? []) ?? []
+    const call = blocks.find(
+      block => block?.type === 'tool_use' && block?.name === 'browser_snapshot'
+    )
+    assert.ok(call, 'Anthropic lost the flattened browser_snapshot call history')
+    assert.ok(
+      blocks.some(block => block?.type === 'tool_result' && block?.tool_use_id === call?.id),
+      'Anthropic lost the namespaced browser_snapshot result'
+    )
+  }
+
   assertApplyPatchOutputContract(model, description) {
     for (const instruction of [
       'Critical apply_patch input contract:',
@@ -5294,6 +5363,15 @@ class DesktopE2EServer {
       return
     }
     this.writeAnthropicToolCall(response, patch)
+  }
+
+  writeLocalNamespaceToolCall(response, model) {
+    const callId = `${model.protocol}-local-browser-snapshot`
+    if (model.protocol === 'chat') {
+      this.writeChatToolCall(response, {}, callId, 'browser_snapshot')
+      return
+    }
+    this.writeAnthropicToolCall(response, {}, callId, 'browser_snapshot')
   }
 
   writeLocalAssistantMessage(response, model, text) {


### PR DESCRIPTION
## Summary

- flatten Codex Responses namespace child tools into ordinary functions for OpenAI Chat Completions and Anthropic Messages
- preserve a reversible request-scoped mapping so upstream flat tool calls are restored with their original `name` and `namespace`
- disambiguate duplicate child names across namespaces and constrain generated aliases to Chat function-name requirements
- cover Chat and Anthropic request conversion, history, tool choice, response restoration, collisions, and the real Wework desktop tool loop
- document the protocol compatibility behavior in Chinese and English

## Root cause

The compatibility proxy treated a Responses `type: "namespace"` container as if it were a callable function. Chat Completions and Anthropic Messages do not have a namespace field, so child tools were not advertised correctly and returned flat tool calls could not be routed back to the namespaced Codex tool.

## Impact

Local and cloud models using Chat Completions or Anthropic Messages can now call Codex namespace tools such as `wework_browser.browser_snapshot`. Tool identity remains stable across history and explicit tool selection, including when multiple namespaces contain the same child tool name.

## Validation

- `cargo test local_model_proxy --no-fail-fast` — 74 passed, 1 ignored
- `cargo clippy --lib --tests -- -D warnings`
- `pnpm --filter wework e2e:desktop`
  - `local-local-chat` passed with a real namespaced `browser_snapshot` tool loop
  - `local-local-anthropic` passed with a real namespaced `browser_snapshot` tool loop
  - complete Wework desktop task-flow passed
- pre-push checks:
  - Wework ESLint, TypeScript, and unit tests
  - Executor `cargo fmt`, `cargo test --all-features --lib`, and `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace tool compatibility for OpenAI Chat Completions and Anthropic Messages.
  * Namespace tools are flattened into compatible function tools while preserving their original namespace and tool identity.
  * Added support for consistent tool selection and multi-turn tool calls, including tools with duplicate names across namespaces.
* **Documentation**
  * Documented namespace mapping, naming rules, and restoration behavior in English and Chinese guides.
* **Tests**
  * Added coverage for namespace tool conversion, streaming responses, and end-to-end protocol switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->