### PR TITLE
feat(ci): add ci:all PR label to force all module tests

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -11,6 +11,8 @@ declare -A changed=(
   [frontend]=false
   [wework]=false
   [wegent_cli]=false
+  [platform_e2e]=false
+  [wework_e2e]=false
 )
 
 mark_all() {
@@ -31,19 +33,36 @@ classify_path() {
       mark_all
       return
       ;;
+    .github/workflows/e2e-tests.yml | \
+      .github/scripts/archive-executor-e2e-runtime.sh | \
+      .github/scripts/archive-frontend-e2e-build.sh | \
+      .github/scripts/restore-executor-e2e-runtime.sh | \
+      .github/scripts/restore-frontend-e2e-build.sh | \
+      .github/scripts/start-frontend-e2e-server.sh)
+      changed[platform_e2e]=true
+      ;;
+    .github/workflows/wework-e2e.yml)
+      changed[wework_e2e]=true
+      ;;
     package.json | pnpm-lock.yaml | pnpm-workspace.yaml)
       changed[frontend]=true
       changed[wework]=true
+      changed[platform_e2e]=true
+      changed[wework_e2e]=true
       ;;
     backend/* | chat_shell/*)
       changed[backend]=true
       changed[wegent_cli]=true
+      changed[platform_e2e]=true
       ;;
     executor/*)
       changed[executor]=true
+      changed[platform_e2e]=true
+      changed[wework_e2e]=true
       ;;
     executor_manager/*)
       changed[executor_manager]=true
+      changed[platform_e2e]=true
       ;;
     shared/*)
       changed[backend]=true
@@ -51,22 +70,30 @@ classify_path() {
       changed[shared]=true
       changed[knowledge_engine]=true
       changed[wegent_cli]=true
+      changed[platform_e2e]=true
       ;;
     knowledge_engine/*)
       changed[knowledge_engine]=true
       ;;
     frontend/*)
       changed[frontend]=true
+      changed[platform_e2e]=true
       ;;
     packages/chat-core/*)
       changed[frontend]=true
       changed[wework]=true
+      changed[platform_e2e]=true
+      changed[wework_e2e]=true
       ;;
     wework/*)
       changed[wework]=true
+      changed[wework_e2e]=true
       ;;
     wegent-cli/*)
       changed[wegent_cli]=true
+      ;;
+    docker/*)
+      changed[platform_e2e]=true
       ;;
   esac
 }
@@ -84,6 +111,6 @@ else
 fi
 
 output_file="${GITHUB_OUTPUT:-/dev/stdout}"
-for key in backend executor executor_manager shared knowledge_engine frontend wework wegent_cli; do
+for key in backend executor executor_manager shared knowledge_engine frontend wework wegent_cli platform_e2e wework_e2e; do
   printf '%s=%s\n' "$key" "${changed[$key]}" >> "$output_file"
 done

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -71,7 +71,9 @@ classify_path() {
   esac
 }
 
-if (($# > 0)); then
+if [[ "${1:-}" == "--all" ]]; then
+  mark_all
+elif (($# > 0)); then
   for path in "$@"; do
     classify_path "$path"
   done

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -54,6 +54,20 @@ all_true="${all_false//false/true}"
 assert_case "workflow changes validate all modules" "$all_true" \
   ".github/workflows/test.yml"
 
+assert_case "ci:all label forces all modules" "$all_true" --all
+
+test_workflow="$script_dir/../workflows/test.yml"
+if ! sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$test_workflow" |
+  grep -q -- "- labeled"; then
+  printf 'test.yml must run when the ci:all label is applied\n' >&2
+  exit 1
+fi
+
+if ! grep -q "ci:all" "$test_workflow"; then
+  printf 'test.yml must force all module tests for the ci:all label\n' >&2
+  exit 1
+fi
+
 for workflow in e2e-tests.yml wework-e2e.yml; do
   if ! sed -n '/^  pull_request:/,/^  [a-z_]*:/p' \
     "$script_dir/../workflows/$workflow" |

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -28,13 +28,16 @@ knowledge_engine=false
 frontend=false
 wework=false
 wegent_cli=false
+platform_e2e=false
+wework_e2e=false
 EOF
 )
 
 assert_case "docs only" "$all_false" "docs/zh/index.md"
 
-assert_case "wework only" "${all_false/wework=false/wework=true}" \
-  "wework/src/App.tsx"
+wework_expected="${all_false/wework=false/wework=true}"
+wework_expected="${wework_expected/wework_e2e=false/wework_e2e=true}"
+assert_case "wework only" "$wework_expected" "wework/src/App.tsx"
 
 shared_expected=$(
   cat <<'EOF'
@@ -46,6 +49,8 @@ knowledge_engine=true
 frontend=false
 wework=false
 wegent_cli=true
+platform_e2e=true
+wework_e2e=false
 EOF
 )
 assert_case "shared dependencies" "$shared_expected" "shared/utils/example.py"
@@ -55,6 +60,14 @@ assert_case "workflow changes validate all modules" "$all_true" \
   ".github/workflows/test.yml"
 
 assert_case "ci:all label forces all modules" "$all_true" --all
+
+platform_e2e_expected="${all_false/platform_e2e=false/platform_e2e=true}"
+assert_case "docker changes run platform E2E" "$platform_e2e_expected" \
+  "docker/docker-compose.yml"
+
+wework_e2e_expected="${all_false/wework_e2e=false/wework_e2e=true}"
+assert_case "Wework workflow changes run Wework E2E" "$wework_e2e_expected" \
+  ".github/workflows/wework-e2e.yml"
 
 test_workflow="$script_dir/../workflows/test.yml"
 if ! sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$test_workflow" |
@@ -69,24 +82,32 @@ if ! grep -q "ci:all" "$test_workflow"; then
 fi
 
 for workflow in e2e-tests.yml wework-e2e.yml; do
-  if ! sed -n '/^  pull_request:/,/^  [a-z_]*:/p' \
-    "$script_dir/../workflows/$workflow" |
-    grep -q "ready_for_review"; then
+  workflow_path="$script_dir/../workflows/$workflow"
+  pull_request_config="$(
+    sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$workflow_path"
+  )"
+  if ! grep -q "ready_for_review" <<<"$pull_request_config"; then
     printf '%s must run E2E when a draft PR becomes ready for review\n' \
       "$workflow" >&2
+    exit 1
+  fi
+  if ! grep -q "labeled" <<<"$pull_request_config"; then
+    printf '%s must run when the ci:all label is applied\n' "$workflow" >&2
+    exit 1
+  fi
+  if grep -q "paths:" <<<"$pull_request_config"; then
+    printf '%s must not path-filter ci:all label events\n' "$workflow" >&2
+    exit 1
+  fi
+  if ! grep -q "ci:all" "$workflow_path"; then
+    printf '%s must force E2E for the ci:all label\n' "$workflow" >&2
     exit 1
   fi
 done
 
 wework_workflow="$script_dir/../workflows/wework-e2e.yml"
-if ! sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$wework_workflow" |
-  grep -q -- "- labeled"; then
-  printf 'wework-e2e.yml must run when the ci:memory label is applied\n' >&2
-  exit 1
-fi
-
 if [[ "$(grep -c "github.event.action != 'labeled'" "$wework_workflow")" -ne 2 ]]; then
-  printf 'Wework non-memory E2E jobs must skip pull_request label events\n' >&2
+  printf 'Wework non-memory E2E jobs must filter pull_request label events\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,25 +23,7 @@ on:
       - "shared/**"
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - ".github/workflows/e2e-tests.yml"
-      - ".github/scripts/archive-executor-e2e-runtime.sh"
-      - ".github/scripts/archive-frontend-e2e-build.sh"
-      - ".github/scripts/restore-executor-e2e-runtime.sh"
-      - ".github/scripts/restore-frontend-e2e-build.sh"
-      - ".github/scripts/start-frontend-e2e-server.sh"
-      - "backend/**"
-      - "chat_shell/**"
-      - "docker/**"
-      - "executor/**"
-      - "executor_manager/**"
-      - "frontend/**"
-      - "package.json"
-      - "packages/chat-core/**"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "shared/**"
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
     # Run daily at 2 AM UTC
     - cron: "0 2 * * *"
@@ -53,9 +35,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Platform E2E Changes
+    runs-on: ubuntu-latest
+    outputs:
+      platform_e2e: ${{ steps.classify.outputs.platform_e2e }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          FORCE_ALL: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+        run: |
+          if [[ "$FORCE_ALL" == "true" ]]; then
+            .github/scripts/classify-ci-changes.sh --all
+          else
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+              .github/scripts/classify-ci-changes.sh
+          fi
+
   build-frontend-e2e:
     name: Build Frontend E2E Artifact
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.platform_e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -122,7 +131,8 @@ jobs:
 
   build-executor-e2e-runtime:
     name: Build Executor E2E Runtime Artifact
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.platform_e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -933,8 +943,8 @@ jobs:
   # Merge test reports from all E2E jobs
   merge-reports:
     name: Merge Test Reports
-    needs: [e2e-tests, executor-e2e-tests]
-    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    needs: [changes, e2e-tests, executor-e2e-tests]
+    if: always() && (github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.platform_e2e == 'true'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
@@ -41,9 +47,15 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:all') }}
         run: |
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
-            .github/scripts/classify-ci-changes.sh
+          if [[ "$FORCE_ALL" == "true" ]]; then
+            # The ci:all label forces every module test regardless of changed paths.
+            .github/scripts/classify-ci-changes.sh --all
+          else
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+              .github/scripts/classify-ci-changes.sh
+          fi
 
   test-backend:
     name: Test Backend

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -21,14 +21,6 @@ on:
       - reopened
       - ready_for_review
       - labeled
-    paths:
-      - ".github/workflows/wework-e2e.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "executor/**"
-      - "packages/chat-core/**"
-      - "wework/**"
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
@@ -41,9 +33,36 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Wework E2E Changes
+    runs-on: ubuntu-latest
+    outputs:
+      wework_e2e: ${{ steps.classify.outputs.wework_e2e }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          FORCE_ALL: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+        run: |
+          if [[ "$FORCE_ALL" == "true" ]]; then
+            .github/scripts/classify-ci-changes.sh --all
+          else
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+              .github/scripts/classify-ci-changes.sh
+          fi
+
   wework-e2e:
     name: Wework E2E
-    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.pull_request.draft == false)
+    needs: changes
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -108,7 +127,8 @@ jobs:
 
   wework-desktop-e2e:
     name: Wework Desktop E2E (${{ matrix.name }})
-    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.pull_request.draft == false)
+    needs: changes
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -204,7 +224,8 @@ jobs:
 
   wework-desktop-memory-e2e:
     name: Wework Desktop Memory E2E
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:memory'))
+    needs: changes
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && (contains(github.event.pull_request.labels.*.name, 'ci:memory') || contains(github.event.pull_request.labels.*.name, 'ci:all')))
     runs-on: macos-14
     timeout-minutes: 30
 

--- a/docs/en/wegent/developer-guide/testing.md
+++ b/docs/en/wegent/developer-guide/testing.md
@@ -237,6 +237,11 @@ and CLI suites, while a `packages/chat-core/` change runs both Frontend and
 Wework checks. Changes to the test workflows or the classifier itself select
 every module so CI orchestration changes receive full validation.
 
+Apply the `ci:all` label to a PR to bypass path classification and force every
+module test, which is useful when the changed paths might not capture the full
+blast radius of a change. Applying a label re-triggers `test.yml`; without
+`ci:all`, module selection still follows the changed paths.
+
 Feature-branch pushes do not run a duplicate CI suite; the `pull_request` event
 validates the branch after a PR is opened. A newer commit to the same PR or to
 `main` cancels the older in-progress run. `test-summary` and `lint-summary`

--- a/docs/en/wegent/developer-guide/testing.md
+++ b/docs/en/wegent/developer-guide/testing.md
@@ -238,9 +238,11 @@ Wework checks. Changes to the test workflows or the classifier itself select
 every module so CI orchestration changes receive full validation.
 
 Apply the `ci:all` label to a PR to bypass path classification and force every
-module test, which is useful when the changed paths might not capture the full
-blast radius of a change. Applying a label re-triggers `test.yml`; without
-`ci:all`, module selection still follows the changed paths.
+module test, the platform E2E suite, Wework browser and desktop E2E, and the
+Wework macOS memory gate. This is useful when changed paths might not capture
+the full blast radius of a change. All three test workflows respond to label
+events; without `ci:all`, test selection still follows the changed paths.
+`ci:memory` continues to trigger only the Wework macOS memory gate.
 
 Feature-branch pushes do not run a duplicate CI suite; the `pull_request` event
 validates the branch after a PR is opened. A newer commit to the same PR or to

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -323,6 +323,8 @@ Regular draft PRs do not run browser or Linux desktop E2E. The macOS memory gate
 runs by default only on `main`, scheduled runs, and manual runs. Add the
 `ci:memory` label when a PR must validate the memory boundary. Applying that
 label starts only the memory gate and does not repeat browser or Linux desktop
-E2E. The workflow also runs a complete regression every day at 04:00 UTC.
+E2E. Applying `ci:all` runs browser, Linux desktop, and macOS memory E2E even
+when the PR's changed paths would not normally select Wework E2E. The workflow
+also runs a complete regression every day at 04:00 UTC.
 
 Authenticated flows should create users and data through backend APIs before the test, then use real login or a real token injection. Do not mock backend HTTP responses in Playwright.

--- a/docs/zh/wegent/developer-guide/testing.md
+++ b/docs/zh/wegent/developer-guide/testing.md
@@ -236,6 +236,10 @@ Executor Manager、Knowledge Engine、Shared 和 CLI 测试；修改
 `packages/chat-core/` 时会同时运行 Frontend 与 Wework 检查。修改测试 workflow
 或分类脚本本身时会运行全部模块，确保 CI 编排变更经过完整验证。
 
+在 PR 上添加 `ci:all` 标签可以跳过路径分类，强制运行全部模块测试，适合
+路径分类可能遗漏影响面的改动。给 PR 打标签会重新触发 `test.yml`；没有
+`ci:all` 标签时仍按改动路径决定测试范围。
+
 功能分支不在普通 `push` 事件中运行重复 CI；创建 PR 后由 `pull_request` 事件验证。
 同一 PR 或 `main` 上有更新提交时，旧的未完成运行会被取消。`test-summary` 和
 `lint-summary` 始终存在，并验证所有被分类为必需的任务确实成功，未执行的无关模块

--- a/docs/zh/wegent/developer-guide/testing.md
+++ b/docs/zh/wegent/developer-guide/testing.md
@@ -236,9 +236,10 @@ Executor Manager、Knowledge Engine、Shared 和 CLI 测试；修改
 `packages/chat-core/` 时会同时运行 Frontend 与 Wework 检查。修改测试 workflow
 或分类脚本本身时会运行全部模块，确保 CI 编排变更经过完整验证。
 
-在 PR 上添加 `ci:all` 标签可以跳过路径分类，强制运行全部模块测试，适合
-路径分类可能遗漏影响面的改动。给 PR 打标签会重新触发 `test.yml`；没有
-`ci:all` 标签时仍按改动路径决定测试范围。
+在 PR 上添加 `ci:all` 标签可以跳过路径分类，强制运行全部模块测试、平台 E2E、
+Wework 浏览器和桌面 E2E，以及 Wework macOS 内存门禁，适合路径分类可能遗漏
+影响面的改动。三个测试 workflow 都会响应标签事件；没有 `ci:all` 标签时仍按
+改动路径决定测试范围。`ci:memory` 仍然只触发 Wework macOS 内存门禁。
 
 功能分支不在普通 `push` 事件中运行重复 CI；创建 PR 后由 `pull_request` 事件验证。
 同一 PR 或 `main` 上有更新提交时，旧的未完成运行会被取消。`test-summary` 和

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -320,6 +320,7 @@ pnpm --filter wework e2e:desktop:memory
 普通 Draft PR 不运行浏览器或 Linux 桌面 E2E。macOS 内存门禁默认只在 `main`、
 定时任务和手动任务中运行；需要在 PR 中验证内存边界时，添加 `ci:memory` 标签。
 添加该标签只触发内存门禁，不会重复运行浏览器或 Linux 桌面 E2E。workflow 每天
-UTC 04:00 运行一次完整回归。
+UTC 04:00 运行一次完整回归。添加 `ci:all` 标签则会运行浏览器、Linux 桌面和
+macOS 内存 E2E，即使 PR 的改动路径通常不会触发 Wework E2E。
 
 登录后流程应在测试前通过后端 API 创建测试用户和测试数据，再使用真实登录或真实 token 注入。不要在 Playwright 中 mock 后端 HTTP 响应。


### PR DESCRIPTION
## Summary

Add a `ci:all` PR label that bypasses path classification and runs the repository's complete test suite.

- Force every module test in `test.yml`.
- Run the platform E2E workflow even when changed paths would normally skip it.
- Run Wework browser E2E, all Linux desktop E2E groups, and the macOS memory gate.
- Keep normal PR behavior path-selective when `ci:all` is absent.
- Keep `ci:memory` scoped to the Wework macOS memory gate.
- Document the label in the Chinese and English testing guides.

The shared CI classifier now emits platform and Wework E2E decisions, so all PR events can enter the lightweight detection job without starting expensive E2E jobs for unrelated changes.

## Verification

- `shellcheck .github/scripts/classify-ci-changes.sh .github/scripts/test-classify-ci-changes.sh`
- `bash .github/scripts/test-classify-ci-changes.sh`
- `actionlint` passes for the changed workflow logic (existing unrelated ShellCheck findings in `e2e-tests.yml` ignored)
- Live PR run confirms `ci:all` starts platform E2E and all Wework E2E jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `ci:all` pull request label to run the full test matrix, including platform E2E and Wework E2E jobs.
  * Workflows now react to `labeled` events so applying the label retriggers the appropriate runs.
* **Documentation**
  * Updated English and Chinese CI testing guides to explain `ci:all` (and existing `ci:memory`) behavior versus path-based selection.
* **Tests**
  * Extended end-to-end coverage to verify `ci:all` forces all-module execution and correctly wires related E2E workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->