### PR TITLE
fix(wework): clarify cloud authorization popup

### DIFF
--- a/wework/src/features/cloud-connection/CloudConnectionDialog.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionDialog.tsx
@@ -270,7 +270,10 @@ export function CloudConnectionDialog({
                 {submitting ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
-                    {t('workbench.cloud_connection_waiting_authorization', '等待云端授权')}
+                    {t(
+                      'workbench.cloud_connection_waiting_authorization',
+                      '请在弹出窗口中完成 Wework 授权'
+                    )}
                   </>
                 ) : (
                   <>

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -301,7 +301,7 @@
     "cloud_connection_login": "Authorize and connect",
     "cloud_connection_logging_in": "Waiting for authorization",
     "cloud_connection_authorize": "Connect",
-    "cloud_connection_waiting_authorization": "Waiting for cloud authorization",
+    "cloud_connection_waiting_authorization": "Complete Wework authorization in the popup window",
     "cloud_connection_login_failed": "Connection failed",
     "remote_host": "Remote host",
     "no_local_project_device": "No available local device",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -301,7 +301,7 @@
     "cloud_connection_login": "授权并连接",
     "cloud_connection_logging_in": "等待授权",
     "cloud_connection_authorize": "连接",
-    "cloud_connection_waiting_authorization": "等待云端授权",
+    "cloud_connection_waiting_authorization": "请在弹出窗口中完成 Wework 授权",
     "cloud_connection_login_failed": "连接失败",
     "remote_host": "远程主机",
     "no_local_project_device": "暂无可用本地设备",


### PR DESCRIPTION
## What changed

- Updated the Wework cloud authorization waiting state to explicitly direct users to the popup window.
- Added matching Chinese and English translations.

## Why

The previous “Waiting for cloud authorization” message did not make it clear that authorization must be completed in a newly opened window, so users could miss the popup and remain stuck.

## Impact

Users now see “请在弹出窗口中完成 Wework 授权” while authorization is pending, making the required next action clear.

## Validation

- `pnpm --filter wework exec prettier --check src/features/cloud-connection/CloudConnectionDialog.tsx src/i18n/locales/zh-CN/common.json src/i18n/locales/en/common.json`
- `pnpm --filter wework exec eslint src/features/cloud-connection/CloudConnectionDialog.tsx`
- `pnpm --filter wework exec vitest run src/features/cloud-connection` (31 tests passed)
- Real isolated Tauri verification with `pnpm --filter wework ai:verify`: confirmed the pending button displays the new Chinese copy
- Pre-push Wework checks: ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the cloud connection authorization message to clearly instruct users to complete WeWork authorization in the pop-up window.
  * Added equivalent wording for English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->