### PR TITLE
fix(runtime): inherit shell environment and enable apps

### DIFF
--- a/docs/en/wegent/developer-guide/local-device-architecture.md
+++ b/docs/en/wegent/developer-guide/local-device-architecture.md
@@ -61,6 +61,12 @@ The parent-child relationship defines the stdio lifecycle directly: a write fail
 
 Backend connectivity is optional, not a required dependency for the local app. When login, model/capability sync, cloud projects, or web control of the local computer are needed, the executor can register as a local device over the Backend Socket.IO channel. The same executor sidecar reuses one command handler and one runtime work handler while serving Wework App over stdio and Backend over Socket.IO. This design does not introduce a local HTTP gateway and does not require Wework App to start Backend itself.
 
+### Executor Startup Environment and Codex Home Initialization
+
+Before creating its asynchronous runtime or starting Agent child processes, a Unix executor runs the current user's interactive login shell to read the complete environment. It prefers the login shell from the system user database and falls back through `$SHELL`, `zsh`, `bash`, and `sh`. Environment capture has a fixed timeout. On failure, the executor keeps its parent environment and still appends standard developer locations such as Homebrew and `/usr/local`. The executor then passes the resulting environment consistently to Codex, Claude Code, plugins, skills, hooks, PTYs, and device commands, so Wework local sidecars, standalone local devices, and Linux cloud or remote devices share the same PATH resolution behavior.
+
+Wework uses an isolated Codex Home for local runtime configuration. During first-run initialization, users can copy configuration, plugins, skills, and plugin marketplace data from the native Codex Home. After initialization, Wework writes `apps = true` under `[features]` by default so migrated plugin Apps are immediately available. If a user explicitly disables Apps later in Settings, ordinary subsequent startups preserve that choice.
+
 ### Runtime Task and Goal State
 
 The runtime task `running` field represents only whether a model turn is currently executing. After a turn completes, fails, or is cancelled, the executor must settle that field to `false`. Wework uses it to decide whether to render the stop control and running indicator, and whether a new message can be sent directly.

--- a/docs/zh/wegent/developer-guide/local-device-architecture.md
+++ b/docs/zh/wegent/developer-guide/local-device-architecture.md
@@ -61,6 +61,12 @@ stdio 生命周期由父子进程关系直接确定：写入失败、stdout EOF 
 
 Backend 是可选能力，而不是本地 app 的必需依赖。需要登录、模型/能力同步、云端项目或网页版控制本机时，executor 可以使用 Backend Socket.IO 通道注册为本地设备；同一个 executor sidecar 会复用同一个 command handler 和 runtime work handler，一边通过 stdio 服务 Wework App，一边通过 Socket.IO 服务 Backend。这个设计不引入本机 HTTP gateway，也不要求 Wework App 自己启动 Backend。
 
+### Executor 启动环境与 Codex Home 初始化
+
+Unix executor 在创建异步运行时和启动 Agent 子进程之前，通过运行当前用户的交互式登录 shell 读取完整环境。shell 优先使用系统用户数据库中的登录 shell，并依次回退到 `$SHELL`、`zsh`、`bash` 和 `sh`。采集过程有固定超时；失败时 executor 保留父进程环境，并继续补充 Homebrew、`/usr/local` 等标准开发目录。最终环境由 executor 统一传递给 Codex、Claude Code、插件、技能、Hooks、PTY 和设备命令，因此 Wework 本地 sidecar、独立本地设备以及 Linux 云端或远程设备使用同一套 PATH 解析逻辑。
+
+Wework 使用独立 Codex Home 隔离本地运行时配置。首次初始化时，用户可以把原生 Codex Home 中的配置、插件、技能和插件市场复制到该目录。初始化完成后，Wework 默认在 `[features]` 中写入 `apps = true`，使迁移后的插件 Apps 能力立即可用；用户之后在设置中明确关闭 Apps 时，后续普通启动不会覆盖该选择。
+
 ### 运行时任务与目标状态
 
 运行时任务的 `running` 字段只表示当前是否存在正在执行的模型回合。回合完成、失败或取消后，executor 必须把该字段收敛为 `false`，供 Wework 决定是否显示停止按钮、运行中图标，以及新消息能否直接发送。

--- a/executor/src/app/mod.rs
+++ b/executor/src/app/mod.rs
@@ -9,7 +9,10 @@ use crate::local::{
     app_ipc::normalize_device_id,
     backend::{serve_local_app_sidecar, serve_remote_local_backend},
 };
-use crate::logging::{init_executor_logging, reserve_executor_stdout_for_protocol};
+use crate::logging::{
+    init_executor_logging, log_executor_event, reserve_executor_stdout_for_protocol,
+};
+use crate::process_environment::ShellEnvironmentLoad;
 use crate::server::{self, ServerConfig};
 use crate::services::updater::UpdaterService;
 use crate::version::get_version;
@@ -113,6 +116,13 @@ pub async fn run_from_env() -> Result<(), AppError> {
 }
 
 pub async fn run(args: CliArgs) -> Result<(), AppError> {
+    run_with_shell_environment(args, None).await
+}
+
+pub async fn run_with_shell_environment(
+    args: CliArgs,
+    shell_environment: Option<Result<Option<ShellEnvironmentLoad>, String>>,
+) -> Result<(), AppError> {
     if args.help {
         println!("{}", CliArgs::usage());
         return Ok(());
@@ -132,6 +142,7 @@ pub async fn run(args: CliArgs) -> Result<(), AppError> {
         reserve_executor_stdout_for_protocol();
     }
     init_executor_logging(&DeviceConfig::default());
+    log_shell_environment_load(shell_environment);
     let config = load_device_config(args.config_path.as_deref())?;
     init_executor_logging(&config);
     let plan = startup_plan_for_config(&config)?;
@@ -161,6 +172,27 @@ pub async fn run(args: CliArgs) -> Result<(), AppError> {
         (None, None) => Err(AppError::Server(
             "startup plan has no runtime target".to_owned(),
         )),
+    }
+}
+
+fn log_shell_environment_load(result: Option<Result<Option<ShellEnvironmentLoad>, String>>) {
+    match result {
+        Some(Ok(Some(loaded))) => {
+            log_executor_event(
+                "user login shell environment loaded",
+                &[
+                    ("shell", loaded.shell),
+                    ("path_entries", loaded.path_entry_count.to_string()),
+                ],
+            );
+        }
+        Some(Ok(None)) | None => {}
+        Some(Err(error)) => {
+            log_executor_event(
+                "user login shell environment load failed",
+                &[("error", error), ("fallback", "process_path".to_string())],
+            );
+        }
     }
 }
 

--- a/executor/src/bin/wegent-executor.rs
+++ b/executor/src/bin/wegent-executor.rs
@@ -2,27 +2,57 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#[tokio::main]
-async fn main() {
+use std::env;
+
+use wegent_executor::app::cli::CliArgs;
+
+fn main() {
     install_termination_signal_diagnostics();
     if wegent_executor::connector_mcp::is_connector_mcp_command() {
-        if let Err(error) = wegent_executor::connector_mcp::run().await {
+        if let Err(error) = runtime().block_on(wegent_executor::connector_mcp::run()) {
             eprintln!("connector MCP server failed: {error}");
             std::process::exit(1);
         }
         return;
     }
     if wegent_executor::browser_mcp::is_browser_mcp_command() {
-        if let Err(error) = wegent_executor::browser_mcp::run().await {
+        if let Err(error) = runtime().block_on(wegent_executor::browser_mcp::run()) {
             eprintln!("browser MCP server failed: {error}");
             std::process::exit(1);
         }
         return;
     }
-    if let Err(error) = wegent_executor::app::run_from_env().await {
+
+    let args = match CliArgs::parse_from(env::args()) {
+        Ok(args) => args,
+        Err(error) => {
+            wegent_executor::logging::write_executor_error_line(&error.to_string());
+            std::process::exit(2);
+        }
+    };
+    let shell_environment = if should_hydrate_shell_environment(&args) {
+        Some(wegent_executor::process_environment::hydrate_process_environment())
+    } else {
+        None
+    };
+    if let Err(error) = runtime().block_on(wegent_executor::app::run_with_shell_environment(
+        args,
+        shell_environment,
+    )) {
         wegent_executor::logging::write_executor_error_line(&error.to_string());
         std::process::exit(error.exit_code());
     }
+}
+
+fn should_hydrate_shell_environment(args: &CliArgs) -> bool {
+    !args.help && !args.version && !args.upgrade
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Tokio runtime should initialize")
 }
 
 #[cfg(target_os = "macos")]

--- a/executor/src/process_environment.rs
+++ b/executor/src/process_environment.rs
@@ -4,6 +4,18 @@
 
 use std::{collections::HashMap, env, path::PathBuf};
 
+#[cfg(unix)]
+use std::{
+    io::{Read, Seek, SeekFrom},
+    process::{Command, ExitStatus, Stdio},
+    sync::OnceLock,
+    thread,
+    time::{Duration, Instant},
+};
+
+#[cfg(unix)]
+use regex::Regex;
+
 const STANDARD_DEVELOPER_PATHS: &[&str] = &[
     "/opt/homebrew/bin",
     "/opt/homebrew/sbin",
@@ -11,6 +23,32 @@ const STANDARD_DEVELOPER_PATHS: &[&str] = &[
     "/usr/local/sbin",
     "/Library/Apple/usr/bin",
 ];
+
+#[cfg(unix)]
+const SHELL_ENV_DELIMITER: &str = "_WEGENT_SHELL_ENV_DELIMITER_";
+#[cfg(unix)]
+const SHELL_ENV_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(unix)]
+const SHELL_ENV_POLL_INTERVAL: Duration = Duration::from_millis(10);
+#[cfg(unix)]
+const MAX_CAPTURED_STREAM_BYTES: usize = 1024 * 1024;
+#[cfg(unix)]
+const SHELL_ENV_MARKER: &str = "WEGENT_SHELL_ENV_CAPTURE";
+#[cfg(unix)]
+const TRANSIENT_SHELL_ENV_KEYS: &[&str] = &[
+    "OLDPWD",
+    "PWD",
+    "SHLVL",
+    "_",
+    "CODEX_SHELL",
+    SHELL_ENV_MARKER,
+];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShellEnvironmentLoad {
+    pub shell: String,
+    pub path_entry_count: usize,
+}
 
 pub fn process_env(extra_env: &[(String, String)]) -> HashMap<String, String> {
     let mut values = env::vars().collect::<HashMap<_, _>>();
@@ -22,10 +60,39 @@ pub fn process_env(extra_env: &[(String, String)]) -> HashMap<String, String> {
 }
 
 pub fn normalized_process_path(current_path: &str) -> String {
+    normalized_process_path_with_extra(current_path, env::var("WEGENT_EXTRA_PATHS").ok().as_deref())
+}
+
+pub fn hydrate_process_environment() -> Result<Option<ShellEnvironmentLoad>, String> {
+    #[cfg(unix)]
+    {
+        let shells = shell_candidates();
+        let loaded = load_shell_environment_from_candidates(&shells, SHELL_ENV_TIMEOUT)?;
+        let values = merged_shell_environment(env::vars().collect(), &loaded);
+        let path_entry_count = values
+            .get("PATH")
+            .map(|path| env::split_paths(path).count())
+            .unwrap_or_default();
+        for (key, value) in values {
+            env::set_var(key, value);
+        }
+        Ok(Some(ShellEnvironmentLoad {
+            shell: loaded.shell,
+            path_entry_count,
+        }))
+    }
+
+    #[cfg(not(unix))]
+    {
+        Ok(None)
+    }
+}
+
+fn normalized_process_path_with_extra(current_path: &str, extra_paths: Option<&str>) -> String {
     let mut paths = Vec::new();
     append_path_entries(&mut paths, current_path);
-    if let Ok(extra_paths) = env::var("WEGENT_EXTRA_PATHS") {
-        append_path_entries(&mut paths, &extra_paths);
+    if let Some(extra_paths) = extra_paths {
+        append_path_entries(&mut paths, extra_paths);
     }
     for path in STANDARD_DEVELOPER_PATHS {
         append_unique_path(&mut paths, PathBuf::from(path));
@@ -34,6 +101,254 @@ pub fn normalized_process_path(current_path: &str) -> String {
     env::join_paths(paths)
         .map(|value| value.to_string_lossy().to_string())
         .unwrap_or_else(|_| current_path.to_owned())
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LoadedShellEnvironment {
+    shell: String,
+    values: HashMap<String, String>,
+}
+
+#[cfg(unix)]
+fn load_shell_environment_from_candidates(
+    shells: &[String],
+    timeout: Duration,
+) -> Result<LoadedShellEnvironment, String> {
+    let mut last_error = None;
+    for shell in shells {
+        match capture_shell_environment(shell, timeout) {
+            Ok(mut values) => {
+                values.insert("SHELL".to_string(), shell.clone());
+                return Ok(LoadedShellEnvironment {
+                    shell: shell.clone(),
+                    values,
+                });
+            }
+            Err(error) => last_error = Some(format!("{shell}: {error}")),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "No supported login shell was found".to_string()))
+}
+
+#[cfg(unix)]
+fn shell_candidates() -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(shell) = login_shell_from_user_database() {
+        append_unique_shell(&mut candidates, shell);
+    }
+    if let Ok(shell) = env::var("SHELL") {
+        append_unique_shell(&mut candidates, shell);
+    }
+    append_unique_shell(&mut candidates, "/bin/zsh".to_string());
+    append_unique_shell(&mut candidates, "/bin/bash".to_string());
+    append_unique_shell(&mut candidates, "/bin/sh".to_string());
+    candidates
+}
+
+#[cfg(unix)]
+fn append_unique_shell(shells: &mut Vec<String>, shell: String) {
+    let shell = shell.trim();
+    if shell.is_empty() || shells.iter().any(|candidate| candidate == shell) {
+        return;
+    }
+    shells.push(shell.to_string());
+}
+
+#[cfg(unix)]
+fn login_shell_from_user_database() -> Option<String> {
+    use std::{ffi::CStr, mem, ptr};
+
+    let buffer_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let buffer_size = if buffer_size <= 0 {
+        16 * 1024
+    } else {
+        usize::try_from(buffer_size).ok()?.clamp(1024, 1024 * 1024)
+    };
+    let mut password_entry = unsafe { mem::zeroed::<libc::passwd>() };
+    let mut result = ptr::null_mut();
+    let mut buffer = vec![0_u8; buffer_size];
+    let status = unsafe {
+        libc::getpwuid_r(
+            libc::getuid(),
+            &mut password_entry,
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+    if status != 0 || result.is_null() || password_entry.pw_shell.is_null() {
+        return None;
+    }
+    unsafe { CStr::from_ptr(password_entry.pw_shell) }
+        .to_str()
+        .ok()
+        .map(str::trim)
+        .filter(|shell| !shell.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(unix)]
+fn capture_shell_environment(
+    shell: &str,
+    timeout: Duration,
+) -> Result<HashMap<String, String>, String> {
+    let mut stdout = tempfile::tempfile()
+        .map_err(|error| format!("failed to create login shell stdout capture: {error}"))?;
+    let stderr = tempfile::tempfile()
+        .map_err(|error| format!("failed to create login shell stderr capture: {error}"))?;
+    let script = format!(
+        "printf '%s' '{0}'; command env; printf '%s' '{0}'; exit",
+        SHELL_ENV_DELIMITER
+    );
+    let mut child = Command::new(shell)
+        .args(["-ilc", &script])
+        .env("CODEX_SHELL", "1")
+        .env(SHELL_ENV_MARKER, "1")
+        .env("DISABLE_AUTO_UPDATE", "true")
+        .env("ZSH_TMUX_AUTOSTARTED", "true")
+        .env("ZSH_TMUX_AUTOSTART", "false")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout.try_clone().map_err(|error| {
+            format!("failed to clone login shell stdout: {error}")
+        })?))
+        .stderr(Stdio::from(stderr.try_clone().map_err(|error| {
+            format!("failed to clone login shell stderr: {error}")
+        })?))
+        .spawn()
+        .map_err(|error| format!("failed to start login shell: {error}"))?;
+
+    let status = wait_for_child(&mut child, timeout)?;
+    if !status.success() {
+        let stderr_bytes = stderr
+            .metadata()
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        return Err(format!(
+            "login shell exited with {status}; stderr_bytes={}",
+            stderr_bytes
+        ));
+    }
+    stdout
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| format!("failed to rewind login shell stdout: {error}"))?;
+    parse_shell_environment(&String::from_utf8_lossy(&read_stream_with_limit(stdout)))
+}
+
+#[cfg(unix)]
+fn read_stream_with_limit(mut stream: impl Read) -> Vec<u8> {
+    let mut captured = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    while let Ok(read) = stream.read(&mut buffer) {
+        if read == 0 {
+            break;
+        }
+        let remaining = MAX_CAPTURED_STREAM_BYTES.saturating_sub(captured.len());
+        captured.extend_from_slice(&buffer[..read.min(remaining)]);
+    }
+    captured
+}
+
+#[cfg(unix)]
+fn wait_for_child(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Result<ExitStatus, String> {
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if started_at.elapsed() < timeout => {
+                thread::sleep(SHELL_ENV_POLL_INTERVAL);
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "login shell environment load timed out after {}ms",
+                    timeout.as_millis()
+                ));
+            }
+            Err(error) => return Err(format!("failed to wait for login shell: {error}")),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn parse_shell_environment(output: &str) -> Result<HashMap<String, String>, String> {
+    let Some((_, delimited)) = output.split_once(SHELL_ENV_DELIMITER) else {
+        return Err("login shell output did not contain the first delimiter".to_string());
+    };
+    let Some((environment, _)) = delimited.split_once(SHELL_ENV_DELIMITER) else {
+        return Err("login shell output did not contain the closing delimiter".to_string());
+    };
+    let environment = strip_ansi_codes(environment);
+    let mut values = HashMap::new();
+    for line in environment.lines() {
+        let Some((key, value)) = line.trim_end().split_once('=') else {
+            continue;
+        };
+        if !key.is_empty() && !TRANSIENT_SHELL_ENV_KEYS.contains(&key) {
+            values.insert(key.to_string(), value.to_string());
+        }
+    }
+    if values.is_empty() {
+        return Err("login shell returned an empty environment".to_string());
+    }
+    Ok(values)
+}
+
+#[cfg(unix)]
+fn strip_ansi_codes(value: &str) -> String {
+    static ANSI_PATTERN: OnceLock<Regex> = OnceLock::new();
+    ANSI_PATTERN
+        .get_or_init(|| {
+            Regex::new(r"(?:\x1B\][\s\S]*?(?:\x07|\x1B\\)|\x1B\[[0-?]*[ -/]*[@-~])")
+                .expect("ANSI escape pattern should compile")
+        })
+        .replace_all(value, "")
+        .into_owned()
+}
+
+#[cfg(unix)]
+fn merged_shell_environment(
+    process_environment: HashMap<String, String>,
+    shell_environment: &LoadedShellEnvironment,
+) -> HashMap<String, String> {
+    let mut merged = process_environment.clone();
+    merged.extend(shell_environment.values.clone());
+    for (key, value) in process_environment {
+        if protected_executor_env_key(&key) {
+            merged.insert(key, value);
+        }
+    }
+    let current_path = merged.get("PATH").map(String::as_str).unwrap_or_default();
+    let extra_paths = merged.get("WEGENT_EXTRA_PATHS").map(String::as_str);
+    merged.insert(
+        "PATH".to_string(),
+        normalized_process_path_with_extra(current_path, extra_paths),
+    );
+    merged
+}
+
+#[cfg(unix)]
+fn protected_executor_env_key(key: &str) -> bool {
+    key.starts_with("WEGENT_")
+        || key.starts_with("WEWORK_")
+        || key.starts_with("DEVICE_")
+        || key.starts_with("EXECUTOR_")
+        || matches!(
+            key,
+            "AUTH_TOKEN"
+                | "BIND_SHELL"
+                | "CLAUDE_BINARY_PATH"
+                | "CLAUDE_BIN"
+                | "CODEX_BINARY_PATH"
+                | "CODEX_BIN"
+                | "CODEX_HOME"
+                | "LOCAL_WORKSPACE_ROOT"
+                | "TASK_API_DOMAIN"
+        )
 }
 
 fn append_path_entries(paths: &mut Vec<PathBuf>, value: &str) {
@@ -51,4 +366,115 @@ fn append_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
 
 fn ignored_process_env_key(key: &str) -> bool {
     key.starts_with("_PYI_") || key.starts_with("_MEI_") || key == "_MEIPASS"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_environment_parser_ignores_noise_and_transient_values() {
+        let output = format!(
+            "welcome\u{1b}[31m!\u{1b}[0m{0}PATH=/Users/test/.npm-global/bin:/usr/bin\n\
+             TOKEN=value=with=equals\nPWD=/tmp\nSHLVL=2\n{0}goodbye",
+            SHELL_ENV_DELIMITER
+        );
+
+        let environment = parse_shell_environment(&output).expect("environment should parse");
+
+        assert_eq!(
+            environment.get("PATH").map(String::as_str),
+            Some("/Users/test/.npm-global/bin:/usr/bin")
+        );
+        assert_eq!(
+            environment.get("TOKEN").map(String::as_str),
+            Some("value=with=equals")
+        );
+        assert!(!environment.contains_key("PWD"));
+        assert!(!environment.contains_key("SHLVL"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_environment_loader_falls_back_to_the_next_shell() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let script_path = directory.path().join("shell");
+        let script = format!(
+            "#!/bin/sh\nprintf 'startup noise{0}PATH=/Users/test/.npm-global/bin:/usr/bin\\n\
+             CUSTOM_ENV=loaded\\n{0}'\n",
+            SHELL_ENV_DELIMITER
+        );
+        std::fs::write(&script_path, script).expect("script should be written");
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700))
+            .expect("script should be executable");
+
+        let environment = load_shell_environment_from_candidates(
+            &[
+                "/missing/wework-shell".to_string(),
+                script_path.display().to_string(),
+            ],
+            Duration::from_secs(1),
+        )
+        .expect("fallback shell should load");
+
+        assert_eq!(environment.shell, script_path.display().to_string());
+        assert_eq!(
+            environment.values.get("PATH").map(String::as_str),
+            Some("/Users/test/.npm-global/bin:/usr/bin")
+        );
+        assert_eq!(
+            environment.values.get("CUSTOM_ENV").map(String::as_str),
+            Some("loaded")
+        );
+        assert_eq!(
+            environment.values.get("SHELL").map(String::as_str),
+            Some(script_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn merged_shell_environment_preserves_shell_path_order_and_executor_values() {
+        let process_environment = HashMap::from([
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("DEVICE_ID".to_string(), "parent-device".to_string()),
+            (
+                "CODEX_HOME".to_string(),
+                "/isolated/wework/codex".to_string(),
+            ),
+        ]);
+        let shell_environment = LoadedShellEnvironment {
+            shell: "/bin/zsh".to_string(),
+            values: HashMap::from([
+                (
+                    "PATH".to_string(),
+                    "/Users/test/.npm-global/bin:/usr/bin:/bin".to_string(),
+                ),
+                ("SHELL".to_string(), "/bin/zsh".to_string()),
+                ("DEVICE_ID".to_string(), "profile-device".to_string()),
+                ("CODEX_HOME".to_string(), "/Users/test/.codex".to_string()),
+            ]),
+        };
+
+        let merged = merged_shell_environment(process_environment, &shell_environment);
+
+        assert!(merged["PATH"].starts_with("/Users/test/.npm-global/bin:/usr/bin:/bin"));
+        assert!(merged["PATH"].contains("/opt/homebrew/bin"));
+        assert_eq!(merged["SHELL"], "/bin/zsh");
+        assert_eq!(merged["DEVICE_ID"], "parent-device");
+        assert_eq!(merged["CODEX_HOME"], "/isolated/wework/codex");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_environment_loader_times_out() {
+        let result = capture_shell_environment("/usr/bin/yes", Duration::from_millis(50));
+
+        assert!(result
+            .expect_err("environment load should time out")
+            .contains("timed out"));
+    }
 }

--- a/executor/src/process_environment.rs
+++ b/executor/src/process_environment.rs
@@ -471,7 +471,19 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn shell_environment_loader_times_out() {
-        let result = capture_shell_environment("/usr/bin/yes", Duration::from_millis(50));
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let script_path = directory.path().join("slow-shell");
+        std::fs::write(&script_path, "#!/bin/sh\nexec /bin/sleep 10\n")
+            .expect("script should be written");
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700))
+            .expect("script should be executable");
+
+        let result = capture_shell_environment(
+            &script_path.display().to_string(),
+            Duration::from_millis(50),
+        );
 
         assert!(result
             .expect_err("environment load should time out")

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -27,7 +27,7 @@ async fn env_lock() -> EnvLockGuard {
         _guard: LOCK
             .get_or_init(|| StdMutex::new(()))
             .lock()
-            .expect("environment lock should be available"),
+            .unwrap_or_else(|poisoned| poisoned.into_inner()),
     }
 }
 
@@ -196,7 +196,7 @@ async fn runtime_tasks_send_accepts_address_content_source_and_attachments() {
     let _sqlite_home = EnvGuard::set("CODEX_SQLITE_HOME", &sqlite_home.display().to_string());
     write_codex_state_db_thread(&sqlite_home);
     let log_path = temp_path("runtime-send-log", "jsonl");
-    let fake_codex = write_fake_codex(&log_path);
+    let fake_codex = write_fake_codex_for_turns(&log_path, 2);
     let (event_tx, mut events) = broadcast::channel(32);
     let handler = RuntimeWorkRpcHandler::with_event_sender(
         "device-1",
@@ -1488,7 +1488,7 @@ async fn runtime_tasks_send_includes_local_text_attachment_content() {
     let _sqlite_home = EnvGuard::set("CODEX_SQLITE_HOME", &sqlite_home.display().to_string());
     write_codex_state_db_thread(&sqlite_home);
     let log_path = temp_path("runtime-send-text-log", "jsonl");
-    let fake_codex = write_fake_codex(&log_path);
+    let fake_codex = write_fake_codex_for_turns(&log_path, 2);
     let (event_tx, mut events) = broadcast::channel(32);
     let handler = RuntimeWorkRpcHandler::with_event_sender(
         "device-1",
@@ -2195,11 +2195,16 @@ async fn runtime_tasks_rollback_uses_nested_address_runtime_handle_without_local
 }
 
 fn write_fake_codex(log_path: &Path) -> PathBuf {
+    write_fake_codex_for_turns(log_path, 1)
+}
+
+fn write_fake_codex_for_turns(log_path: &Path, exit_after_turns: usize) -> PathBuf {
     let path = temp_path("fake-codex-send", "sh");
     let _ = fs::remove_file(log_path);
     let content = format!(
         r#"#!/bin/sh
 LOG_PATH='{}'
+turn_count=0
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$LOG_PATH"
   request_id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
@@ -2260,6 +2265,7 @@ while IFS= read -r line; do
       printf '%s\n' '{{"id":'"$request_id"',"result":{{}}}}'
       ;;
     *'"method":"turn/start"'*)
+      turn_count=$((turn_count + 1))
       progress_id='progress-1'
       case "$line" in
         *'"model":"gpt-4.1"'*) progress_id='progress-2' ;;
@@ -2271,12 +2277,15 @@ while IFS= read -r line; do
       printf '%s\n' '{{"method":"item/completed","params":{{"item":{{"id":"'"$progress_id"'","type":"agentMessage","text":"Inspecting workspace.","phase":"commentary"}}}}}}'
       printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"delta":"done","phase":"finalAnswer"}}}}'
       printf '%s\n' '{{"method":"turn/completed","params":{{"turn":{{"id":"turn-1","status":"completed"}}}}}}'
-      exit 0
+      if [ "$turn_count" -ge {} ]; then
+        exit 0
+      fi
       ;;
   esac
 done
 "#,
-        log_path.display()
+        log_path.display(),
+        exit_after_turns
     );
     write_executable(&path, &content);
     path
@@ -3056,7 +3065,7 @@ async fn recv_events_until<F>(events: &mut broadcast::Receiver<Value>, mut done:
 where
     F: FnMut(&[Value]) -> bool,
 {
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
     let mut received = Vec::new();
     loop {
         if done(&received) {

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -402,7 +402,12 @@ pub struct CodexHomeMigrationStatus {
 #[serde(rename_all = "camelCase")]
 pub struct CodexHomeInitializeOptions {
     migrate_native_home: bool,
+    #[serde(default = "default_remote_apps_enabled")]
     remote_apps_enabled: bool,
+}
+
+fn default_remote_apps_enabled() -> bool {
+    true
 }
 
 #[derive(Deserialize)]
@@ -2127,7 +2132,7 @@ pub async fn local_executor_migrate_native_codex_home() -> Result<CodexHomeMigra
 {
     local_executor_initialize_codex_home(CodexHomeInitializeOptions {
         migrate_native_home: true,
-        remote_apps_enabled: false,
+        remote_apps_enabled: true,
     })
     .await
 }
@@ -2323,7 +2328,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_local_config_remote_apps_defaults_to_disabled() {
+    fn codex_local_config_remote_apps_reports_missing_or_false_as_disabled() {
         assert!(!read_remote_apps_enabled_from_config(""));
         assert!(!read_remote_apps_enabled_from_config("[features]\n"));
         assert!(!read_remote_apps_enabled_from_config(
@@ -2332,6 +2337,14 @@ mod tests {
         assert!(!read_remote_apps_enabled_from_config(
             "[other]\napps = true\n"
         ));
+    }
+
+    #[test]
+    fn codex_home_initialization_defaults_remote_apps_to_enabled() {
+        let options: CodexHomeInitializeOptions =
+            serde_json::from_value(serde_json::json!({ "migrateNativeHome": true })).unwrap();
+
+        assert!(options.remote_apps_enabled);
     }
 
     #[test]
@@ -2410,9 +2423,9 @@ shell_environment_policy = "inherit"
 
     #[test]
     fn codex_local_config_remote_apps_inserts_features_section() {
-        let next = set_remote_apps_enabled_in_config("model = \"gpt-5.5\"\n", false);
+        let next = set_remote_apps_enabled_in_config("model = \"gpt-5.5\"\n", true);
 
-        assert_eq!(next, "model = \"gpt-5.5\"\n\n[features]\napps = false\n");
+        assert_eq!(next, "model = \"gpt-5.5\"\n\n[features]\napps = true\n");
     }
 
     #[test]

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -65,7 +65,7 @@ export interface LocalCodexPluginApi {
   codexHomeMigrationStatus(): Promise<LocalCodexHomeMigrationStatus>
   initializeCodexHome(options: {
     migrateNativeHome: boolean
-    remoteAppsEnabled: boolean
+    remoteAppsEnabled?: boolean
   }): Promise<LocalCodexHomeMigrationStatus>
   migrateNativeCodexHome(remoteAppsEnabled?: boolean): Promise<LocalCodexHomeMigrationStatus>
   readCodexLocalConfig(): Promise<LocalCodexLocalConfig>
@@ -530,7 +530,7 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
   const defaultCodexLocalConfig: LocalCodexLocalConfig = {
     codexHome: '',
     configPath: '',
-    remoteAppsEnabled: false,
+    remoteAppsEnabled: true,
   }
   return {
     importExternalContent(source) {
@@ -564,10 +564,13 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
         })
       }
       return invoke<LocalCodexHomeMigrationStatus>('local_executor_initialize_codex_home', {
-        options,
+        options: {
+          ...options,
+          remoteAppsEnabled: options.remoteAppsEnabled ?? true,
+        },
       })
     },
-    migrateNativeCodexHome(remoteAppsEnabled = false) {
+    migrateNativeCodexHome(remoteAppsEnabled = true) {
       return this.initializeCodexHome({
         migrateNativeHome: true,
         remoteAppsEnabled,

--- a/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
@@ -49,7 +49,7 @@ describe('CodexHomeInitializer', () => {
     expect(screen.queryByText(migrationStatus.weworkCodexHome)).not.toBeInTheDocument()
   })
 
-  test('creates Wework Codex config with online connectors disabled', async () => {
+  test('creates Wework Codex config with apps enabled by default', async () => {
     render(<CodexHomeInitializer />)
 
     await screen.findByTestId('codex-home-initializer-dialog')
@@ -61,10 +61,24 @@ describe('CodexHomeInitializer', () => {
     await waitFor(() =>
       expect(localCodexPluginApiMock.initializeCodexHome).toHaveBeenCalledWith({
         migrateNativeHome: false,
-        remoteAppsEnabled: false,
+        remoteAppsEnabled: true,
       })
     )
     expect(window.localStorage.getItem('wework.plugins.codexMigrationDismissed')).toBe('1')
+  })
+
+  test('migrates native Codex config with apps enabled by default', async () => {
+    render(<CodexHomeInitializer />)
+
+    await screen.findByTestId('codex-home-initializer-dialog')
+    await userEvent.click(screen.getByTestId('codex-home-initializer-migrate-button'))
+
+    await waitFor(() =>
+      expect(localCodexPluginApiMock.initializeCodexHome).toHaveBeenCalledWith({
+        migrateNativeHome: true,
+        remoteAppsEnabled: true,
+      })
+    )
   })
 
   test('keeps prompting after dismissal when the Wework Codex config is still missing', async () => {

--- a/wework/src/features/local-runtime/CodexHomeInitializer.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.tsx
@@ -120,7 +120,7 @@ export function CodexHomeInitializer({ children }: { children?: ReactNode }) {
     localPluginApi
       .initializeCodexHome({
         migrateNativeHome,
-        remoteAppsEnabled: false,
+        remoteAppsEnabled: true,
       })
       .then(() => {
         console.warn('[Wework Codex init] initialization finished')


### PR DESCRIPTION
## Summary

- hydrate the executor process environment from the user's interactive login shell before starting the async runtime, matching desktop-app launch behavior on macOS and preserving executor control variables
- normalize `PATH` with common developer tool locations so imported Codex plugins and skills can locate CLIs when Wework is launched outside a terminal
- default Codex Apps migration to enabled across the Wework UI, TypeScript API, and Tauri command
- document the local executor environment and Apps migration behavior
- stabilize runtime send contract fixtures exposed by the full pre-push suite

## Root cause

Wework launches its bundled executor from a desktop process, whose environment does not normally include the user's login-shell initialization. Codex could therefore locate user-installed CLIs in a terminal while the Wework executor could not. Separately, the Apps migration path treated the Apps flag as opt-in, so imported plugins did not expose Apps by default.

## Verification

- Wework ESLint, TypeScript checks, unit tests, and production build
- Tauri unit tests
- executor `cargo test --all-features`
- executor `cargo clippy --all-targets --all-features -- -D warnings`
- runtime send contract suite repeated five times
- real Tauri Codex-home migration flow verified with `apps = true`
- full `AI_VERIFIED=1 AI_PUSH_FULL_TESTS=1` pre-push gate
