### PR TITLE
fix(wework): preserve queued follow-ups across conversations

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -6980,6 +6980,15 @@ async function main() {
         control,
         projectRowSelector,
       })
+      if (QUEUE_NAVIGATION_ONLY) {
+        await writeFile(
+          join(resultDir, 'model-requests.json'),
+          `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+          'utf8'
+        )
+        console.log(`Wework queue navigation desktop E2E passed. Evidence: ${resultDir}`)
+        return
+      }
     }
 
     phase = 'initial-task-completion'
@@ -7141,16 +7150,6 @@ async function main() {
       control.toolOutput,
       'Codex did not report its real tool execution to the model service'
     )
-
-    if (QUEUE_NAVIGATION_ONLY) {
-      await writeFile(
-        join(resultDir, 'model-requests.json'),
-        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-        'utf8'
-      )
-      console.log(`Wework queue navigation desktop E2E passed. Evidence: ${resultDir}`)
-      return
-    }
 
     phase = 'conversation-model-restore'
     const taskSnapshot = await waitForSnapshot(

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -29,6 +29,7 @@ const REQUEST_USER_INPUT_PROMPT =
 const REQUEST_USER_INPUT_QUESTION = 'Which implementation direction should be used?'
 const REQUEST_USER_INPUT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_REQUEST_INPUT_COMPLETE'
 const SEND_MODE_DRAFT = 'WEWORK_DESKTOP_E2E_SEND_MODE_DRAFT'
+const QUEUED_FOLLOW_UP = 'WEWORK_DESKTOP_E2E_QUEUED_FOLLOW_UP'
 const UNSENT_BLANK_TASK_DRAFT = 'WEWORK_DESKTOP_E2E_UNSENT_BLANK_TASK_DRAFT'
 const UNSENT_FIRST_TASK_DRAFT = 'WEWORK_DESKTOP_E2E_UNSENT_FIRST_TASK_DRAFT'
 const UNSENT_SECOND_TASK_DRAFT = 'WEWORK_DESKTOP_E2E_UNSENT_SECOND_TASK_DRAFT'
@@ -230,6 +231,7 @@ const CLOUD_ONLY = process.argv.includes('--cloud-only')
 const PLUGINS_ONLY = process.argv.includes('--plugins-only')
 const MEMORY_ONLY = process.argv.includes('--memory-only')
 const TOOL_BLOCK_ORDER_ONLY = process.argv.includes('--tool-block-order-only')
+const QUEUE_NAVIGATION_ONLY = process.argv.includes('--queue-navigation-only')
 const DESKTOP_SCENARIO_ONLY = process.env.WEWORK_E2E_DESKTOP_SCENARIO_ONLY === 'true'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -429,6 +431,56 @@ async function sendPromptWithButton(
   })
   await control.command('press', selector, { key: 'Enter', timeoutMs })
   await waitForSuccessfulMatrixSubmission(control, selector, prompt, timeoutMs)
+}
+
+async function verifyQueuedFollowUpNavigation({ composerSelector, control, projectRowSelector }) {
+  await control.command('fill', composerSelector, { value: QUEUED_FOLLOW_UP })
+  await control.command('press', composerSelector, { key: 'Enter' })
+  await control.command('waitFor', '[data-testid="conversation-queue-panel"]', {
+    text: QUEUED_FOLLOW_UP,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await captureVerificationScreenshot(control, 'queue-navigation-01-source-queued.png')
+
+  const runningTaskSnapshot = await waitForSnapshot(
+    control,
+    snapshot => snapshot.testIds.some(testId => testId.startsWith('runtime-local-task-row-')),
+    'The streaming task row was not available before switching conversations'
+  )
+  const runningTaskRowTestId = runningTaskSnapshot.testIds.find(testId =>
+    testId.startsWith('runtime-local-task-row-')
+  )
+  assert.ok(runningTaskRowTestId, 'The streaming task row identity was not found')
+
+  await control.command(
+    'clickWhenEnabled',
+    `${projectRowSelector} [data-testid="project-new-conversation-button"]`,
+    { timeoutMs: UI_TIMEOUT_MS }
+  )
+  await control.command('waitFor', composerSelector, { timeoutMs: UI_TIMEOUT_MS })
+  await waitForSnapshot(
+    control,
+    snapshot => !snapshot.testIds.includes('conversation-queue-panel'),
+    'The queued follow-up leaked into the other conversation'
+  )
+  await captureVerificationScreenshot(control, 'queue-navigation-02-other-conversation.png')
+
+  await ensureTaskRowVisible(control, runningTaskRowTestId)
+  await control.command('clickWhenEnabled', `[data-testid="${runningTaskRowTestId}"]`, {
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await control.command('waitFor', '[data-testid="conversation-queue-panel"]', {
+    text: QUEUED_FOLLOW_UP,
+    timeoutMs: UI_TIMEOUT_MS,
+  })
+  await captureVerificationScreenshot(control, 'queue-navigation-03-source-restored.png')
+
+  await control.command('click', '[data-testid^="queue-cancel-button-"]')
+  await waitForSnapshot(
+    control,
+    snapshot => !snapshot.testIds.includes('conversation-queue-panel'),
+    'The queued follow-up could not be cleared after restoration'
+  )
 }
 
 async function waitForSuccessfulMatrixSubmission(control, selector, prompt, timeoutMs) {
@@ -6923,7 +6975,11 @@ async function main() {
       )
       await captureVerificationScreenshot(control, '02-send-mode-menu-open.png')
       await control.command('press', 'body', { key: 'Escape' })
-      await control.command('fill', composerSelector, { value: '' })
+      await verifyQueuedFollowUpNavigation({
+        composerSelector,
+        control,
+        projectRowSelector,
+      })
     }
 
     phase = 'initial-task-completion'
@@ -7085,6 +7141,16 @@ async function main() {
       control.toolOutput,
       'Codex did not report its real tool execution to the model service'
     )
+
+    if (QUEUE_NAVIGATION_ONLY) {
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(`Wework queue navigation desktop E2E passed. Evidence: ${resultDir}`)
+      return
+    }
 
     phase = 'conversation-model-restore'
     const taskSnapshot = await waitForSnapshot(

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from 'react'
 import i18n from '@/i18n'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
 import {
@@ -47,14 +47,13 @@ import type {
   RuntimeAdditionalContext,
   RuntimeRollbackRequest,
   RuntimeSubagentActivityPayload,
-  RuntimeSendRequest,
   RuntimeTaskAddress,
   RuntimeTurnNavigationItem,
   TurnFileChangesSummary,
 } from '@/types/api'
 import type {
   GuidanceWorkbenchMessage,
-  QueuedWorkbenchMessage,
+  RuntimePaneQueuedMessage,
   RuntimePaneTranscript,
   RuntimeSubagentStatus,
   WorkbenchMessage,
@@ -63,7 +62,11 @@ import type { CodeCommentContext } from '@/types/workspace-files'
 import { reduceWorkbenchMessages } from '@wegent/chat-core'
 import {
   cacheRuntimeConversationMessages,
+  cacheRuntimeConversationQueuedMessagesByKey,
+  cacheRuntimeConversationQueuePausedByKey,
   getRuntimeConversationMessages,
+  getRuntimeConversationQueuedMessagesByKey,
+  getRuntimeConversationQueuePausedByKey,
   runtimeConversationKey,
 } from '@/features/workbench/runtimeConversationCache'
 import { getCachedRuntimeTaskPlan } from '@/stream/responseApiStream'
@@ -71,17 +74,6 @@ import { getRuntimeMessageIndex, mergeRuntimeTranscriptMessages } from './runtim
 
 interface WorkbenchPaneSessionOptions {
   currentRuntimeTask: RuntimeTaskAddress | null
-}
-
-interface RuntimePaneQueuedMessage extends QueuedWorkbenchMessage {
-  attachments?: Attachment[]
-  displayContent?: string
-  codeComments?: CodeCommentContext[]
-  modelId?: string
-  modelType?: RuntimeSendRequest['modelType']
-  modelOptions?: ModelOptions
-  runtimeGoalRequest?: boolean
-  additionalContext?: RuntimeAdditionalContext
 }
 
 interface SendRequestUserInputResponseOptions {
@@ -145,8 +137,37 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     refreshWorkLists,
   } = useWorkbenchPaneContext()
   const lifecycleStore = useRuntimeTaskLifecycleStore()
-  const [queuedMessages, setQueuedMessages] = useState<RuntimePaneQueuedMessage[]>([])
-  const [queuedMessagesPaused, setQueuedMessagesPaused] = useState(false)
+  const queuedMessageScopeKey = currentRuntimeTask
+    ? runtimeConversationKey(currentRuntimeTask)
+    : null
+  const [queuedMessages, setQueuedMessagesState] = useState<RuntimePaneQueuedMessage[]>(() =>
+    queuedMessageScopeKey ? getRuntimeConversationQueuedMessagesByKey(queuedMessageScopeKey) : []
+  )
+  const [queuedMessagesPaused, setQueuedMessagesPausedState] = useState(() =>
+    queuedMessageScopeKey ? getRuntimeConversationQueuePausedByKey(queuedMessageScopeKey) : false
+  )
+  const setQueuedMessages = useCallback(
+    (update: SetStateAction<RuntimePaneQueuedMessage[]>) => {
+      if (!queuedMessageScopeKey) return
+      const previous = getRuntimeConversationQueuedMessagesByKey(queuedMessageScopeKey)
+      const next = typeof update === 'function' ? update(previous) : update
+      if (next === previous) return
+      cacheRuntimeConversationQueuedMessagesByKey(queuedMessageScopeKey, next)
+      setQueuedMessagesState(next)
+    },
+    [queuedMessageScopeKey]
+  )
+  const setQueuedMessagesPaused = useCallback(
+    (update: SetStateAction<boolean>) => {
+      if (!queuedMessageScopeKey) return
+      const previous = getRuntimeConversationQueuePausedByKey(queuedMessageScopeKey)
+      const next = typeof update === 'function' ? update(previous) : update
+      if (next === previous) return
+      cacheRuntimeConversationQueuePausedByKey(queuedMessageScopeKey, next)
+      setQueuedMessagesPausedState(next)
+    },
+    [queuedMessageScopeKey]
+  )
   const [guidanceMessages] = useState<GuidanceWorkbenchMessage[]>([])
   const [codeCommentContexts, setCodeCommentContexts] = useState<CodeCommentContext[]>([])
   const input = projectChat.input ?? ''
@@ -819,6 +840,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     dispatchMessages,
     lifecycleStore,
     runtimeTaskStreamTargetKey,
+    setQueuedMessages,
   ])
 
   const loadMoreTranscriptBefore = useCallback(async () => {
@@ -1138,7 +1160,12 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       )
       return true
     },
-    [appendLocalUserMessage, currentRuntimeTask, interruptAndSendRuntimePaneMessage]
+    [
+      appendLocalUserMessage,
+      currentRuntimeTask,
+      interruptAndSendRuntimePaneMessage,
+      setQueuedMessages,
+    ]
   )
 
   const retryFailedMessageInPane = useCallback(
@@ -1399,7 +1426,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         queuedMessageSendInFlightIdsRef.current.delete(queuedMessage.id)
       }
     },
-    [sendRuntimeMessage]
+    [sendRuntimeMessage, setQueuedMessages]
   )
 
   useEffect(() => {
@@ -1561,7 +1588,13 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         )
       }
     },
-    [currentRuntimeTask, paneStatus.isBusy, sendRuntimeMessage, sendRuntimePaneGuidance]
+    [
+      currentRuntimeTask,
+      paneStatus.isBusy,
+      sendRuntimeMessage,
+      sendRuntimePaneGuidance,
+      setQueuedMessages,
+    ]
   )
 
   const send: (inputOverride?: string, options?: RuntimePaneSendOptions) => Promise<void> =
@@ -1923,6 +1956,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         sendRuntimeMessage,
         scopedSetInput,
         setInput,
+        setQueuedMessages,
         setRuntimeGoal,
       ]
     )
@@ -1935,9 +1969,12 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     setCodeCommentContexts([])
   }, [])
 
-  const cancelQueuedMessage = useCallback((id: string) => {
-    setQueuedMessages(messages => messages.filter(message => message.id !== id))
-  }, [])
+  const cancelQueuedMessage = useCallback(
+    (id: string) => {
+      setQueuedMessages(messages => messages.filter(message => message.id !== id))
+    },
+    [setQueuedMessages]
+  )
 
   const resumeQueuedMessages = useCallback(() => {
     setQueuedMessagesPaused(false)
@@ -1945,7 +1982,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     const queuedMessage =
       interruptedGuidance ?? queuedMessages.find(message => message.status === 'queued')
     if (queuedMessage) void sendQueuedMessage(queuedMessage)
-  }, [queuedMessages, sendQueuedMessage])
+  }, [queuedMessages, sendQueuedMessage, setQueuedMessagesPaused])
 
   const resumeQueuedMessagesWithInput = useCallback(
     async (inputOverride?: string, options?: RuntimePaneSendOptions) => {
@@ -1965,31 +2002,34 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       setQueuedMessagesPaused(false)
       await sendQueuedMessage(combinedMessage)
     },
-    [input, queuedMessages, send, sendQueuedMessage]
+    [input, queuedMessages, send, sendQueuedMessage, setQueuedMessagesPaused]
   )
 
   const clearQueuedMessages = useCallback(() => {
     setQueuedMessages([])
     setQueuedMessagesPaused(false)
-  }, [])
+  }, [setQueuedMessages, setQueuedMessagesPaused])
 
-  const reorderQueuedMessages = useCallback((sourceId: string, targetId: string) => {
-    setQueuedMessages(messages => {
-      const sourceIndex = messages.findIndex(message => message.id === sourceId)
-      const targetIndex = messages.findIndex(message => message.id === targetId)
-      if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) return messages
+  const reorderQueuedMessages = useCallback(
+    (sourceId: string, targetId: string) => {
+      setQueuedMessages(messages => {
+        const sourceIndex = messages.findIndex(message => message.id === sourceId)
+        const targetIndex = messages.findIndex(message => message.id === targetId)
+        if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) return messages
 
-      const source = messages[sourceIndex]
-      const target = messages[targetIndex]
-      if (source.status !== 'queued' || target.status !== 'queued') return messages
+        const source = messages[sourceIndex]
+        const target = messages[targetIndex]
+        if (source.status !== 'queued' || target.status !== 'queued') return messages
 
-      const reordered = [...messages]
-      reordered.splice(sourceIndex, 1)
-      const insertIndex = sourceIndex < targetIndex ? targetIndex - 1 : targetIndex
-      reordered.splice(insertIndex, 0, source)
-      return reordered
-    })
-  }, [])
+        const reordered = [...messages]
+        reordered.splice(sourceIndex, 1)
+        const insertIndex = sourceIndex < targetIndex ? targetIndex - 1 : targetIndex
+        reordered.splice(insertIndex, 0, source)
+        return reordered
+      })
+    },
+    [setQueuedMessages]
+  )
 
   const editQueuedMessage = useCallback(
     (id: string) => {
@@ -2002,7 +2042,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       })
       setQueuedMessages(messages => messages.filter(message => message.id !== id))
     },
-    [projectChat, queuedMessages, setInput]
+    [projectChat, queuedMessages, setInput, setQueuedMessages]
   )
 
   const sendQueuedAsGuidance = useCallback(
@@ -2151,6 +2191,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     goal?.status,
     queuedMessages,
     refreshWorkLists,
+    setQueuedMessagesPaused,
     taskGoalStatus,
     updateCurrentGoalStatus,
   ])

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -7690,6 +7690,82 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('composer-input')).toHaveTextContent('')
   })
 
+  test('restores queued follow-ups after switching away from a streaming task', async () => {
+    const streamHandlersByTask = new Map<string, ChatStreamHandlers>()
+    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
+      if (hasRuntimeStreamHandler(handlers) && handlers.scope?.taskId) {
+        streamHandlersByTask.set(handlers.scope.taskId, handlers)
+      }
+      return vi.fn()
+    })
+    const sendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: true,
+      taskId: 'runtime-a',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockImplementation((address: RuntimeTaskAddress) =>
+        Promise.resolve({
+          taskId: address.taskId,
+          workspacePath: '/workspace/project-alpha',
+          runtime: 'claude_code',
+          messages: [
+            {
+              id: `${address.taskId}:user:1`,
+              role: 'user',
+              content: `message ${address.taskId}`,
+            },
+          ],
+        })
+      ),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      chatStream: {
+        subscribe,
+      } as unknown as WorkbenchServices['chatStream'],
+    })
+
+    renderWorkbench(<FollowUpProbe />, services)
+
+    await userEvent.click(await screen.findByText('open follow-up runtime a'))
+    await waitFor(() => expect(streamHandlersByTask.get('runtime-a')).toBeDefined())
+    act(() => {
+      streamHandlersByTask.get('runtime-a')?.onChatStart?.({
+        taskId: 'runtime-a',
+        subtaskId: '101',
+        shellType: 'Chat',
+        deviceId: 'device-1',
+      })
+    })
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+
+    expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:继续修')
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByText('open follow-up runtime b'))
+    await waitFor(() =>
+      expect(screen.getByTestId('follow-up-current-runtime-task')).toHaveTextContent(
+        'device-1:runtime-b'
+      )
+    )
+    expect(screen.getByTestId('queued-messages')).toBeEmptyDOMElement()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByText('open follow-up runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('follow-up-current-runtime-task')).toHaveTextContent(
+        'device-1:runtime-a'
+      )
+    )
+    expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:继续修')
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
   test('refreshes runtime work when the current runtime task starts streaming', async () => {
     let streamHandlers: Parameters<WorkbenchServices['chatStream']['subscribe']>[0] | null = null
     const subscribe = vi.fn(handlers => {

--- a/wework/src/features/workbench/runtimeConversationCache.test.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.test.ts
@@ -1,14 +1,18 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   applyRuntimeConversationAction,
-  cacheRuntimeConversationMessages,
   cacheConversationScrollSnapshot,
   cacheConversationVirtualMeasurements,
+  cacheRuntimeConversationMessages,
+  cacheRuntimeConversationQueuedMessages,
+  cacheRuntimeConversationQueuePaused,
   clearRuntimeConversationCacheForTests,
   evictRuntimeConversation,
   getConversationScrollSnapshot,
   getConversationVirtualMeasurements,
   getRuntimeConversationMessages,
+  getRuntimeConversationQueuedMessages,
+  getRuntimeConversationQueuePaused,
 } from './runtimeConversationCache'
 
 const address = {
@@ -109,10 +113,21 @@ describe('runtimeConversationCache', () => {
     cacheConversationVirtualMeasurements('device-1:task-1', [
       { index: 0, key: 'user-1', start: 0, end: 120, size: 120, lane: 0 },
     ])
+    cacheRuntimeConversationQueuedMessages(address, [
+      {
+        id: 'queued-1',
+        content: 'follow up',
+        status: 'queued',
+        createdAt: '2026-07-27T00:00:00.000Z',
+      },
+    ])
+    cacheRuntimeConversationQueuePaused(address, true)
 
     evictRuntimeConversation(address)
 
     expect(getRuntimeConversationMessages(address)).toEqual([])
+    expect(getRuntimeConversationQueuedMessages(address)).toEqual([])
+    expect(getRuntimeConversationQueuePaused(address)).toBe(false)
     expect(getConversationScrollSnapshot('device-1:task-1')).toBeUndefined()
     expect(getConversationVirtualMeasurements('device-1:task-1')).toBeUndefined()
   })

--- a/wework/src/features/workbench/runtimeConversationCache.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.ts
@@ -1,11 +1,13 @@
 import type { RuntimePaneMessageAction } from './runtimePaneMessages'
 import type { Attachment, RuntimeTaskAddress, TurnFileChangesSummary } from '@/types/api'
-import type { WorkbenchMessage } from '@/types/workbench'
+import type { RuntimePaneQueuedMessage, WorkbenchMessage } from '@/types/workbench'
 import type { VirtualItem } from '@tanstack/react-virtual'
 import { reduceWorkbenchMessages } from '@wegent/chat-core'
 
 const MAX_CONVERSATION_CACHE_ENTRIES = 50
 const messagesByConversation = new Map<string, WorkbenchMessage[]>()
+const queuedMessagesByConversation = new Map<string, RuntimePaneQueuedMessage[]>()
+const queuedMessagesPausedByConversation = new Map<string, boolean>()
 const scrollSnapshotsByConversation = new Map<string, ConversationScrollSnapshot>()
 const virtualMeasurementsByConversation = new Map<string, VirtualItem[]>()
 
@@ -36,6 +38,54 @@ export function applyRuntimeConversationAction(
     key,
     reduceWorkbenchMessages<Attachment, TurnFileChangesSummary>(currentMessages, action)
   )
+}
+
+export function getRuntimeConversationQueuedMessages(
+  address: RuntimeTaskAddress
+): RuntimePaneQueuedMessage[] {
+  return getRuntimeConversationQueuedMessagesByKey(runtimeConversationKey(address))
+}
+
+export function getRuntimeConversationQueuedMessagesByKey(key: string): RuntimePaneQueuedMessage[] {
+  return touchEntry(queuedMessagesByConversation, key) ?? []
+}
+
+export function cacheRuntimeConversationQueuedMessages(
+  address: RuntimeTaskAddress,
+  messages: RuntimePaneQueuedMessage[]
+) {
+  cacheRuntimeConversationQueuedMessagesByKey(runtimeConversationKey(address), messages)
+}
+
+export function cacheRuntimeConversationQueuedMessagesByKey(
+  key: string,
+  messages: RuntimePaneQueuedMessage[]
+) {
+  if (messages.length === 0) {
+    queuedMessagesByConversation.delete(key)
+    return
+  }
+  cacheBoundedEntry(queuedMessagesByConversation, key, messages)
+}
+
+export function getRuntimeConversationQueuePaused(address: RuntimeTaskAddress): boolean {
+  return getRuntimeConversationQueuePausedByKey(runtimeConversationKey(address))
+}
+
+export function getRuntimeConversationQueuePausedByKey(key: string): boolean {
+  return touchEntry(queuedMessagesPausedByConversation, key) ?? false
+}
+
+export function cacheRuntimeConversationQueuePaused(address: RuntimeTaskAddress, paused: boolean) {
+  cacheRuntimeConversationQueuePausedByKey(runtimeConversationKey(address), paused)
+}
+
+export function cacheRuntimeConversationQueuePausedByKey(key: string, paused: boolean) {
+  if (!paused) {
+    queuedMessagesPausedByConversation.delete(key)
+    return
+  }
+  cacheBoundedEntry(queuedMessagesPausedByConversation, key, true)
 }
 
 export function runtimeConversationKey(address: RuntimeTaskAddress): string {
@@ -70,7 +120,10 @@ export function cacheConversationVirtualMeasurements(key: string, measurements: 
 }
 
 export function evictRuntimeConversation(address: RuntimeTaskAddress) {
-  messagesByConversation.delete(runtimeConversationKey(address))
+  const key = runtimeConversationKey(address)
+  messagesByConversation.delete(key)
+  queuedMessagesByConversation.delete(key)
+  queuedMessagesPausedByConversation.delete(key)
   const viewKey = runtimeConversationViewKey(address)
   scrollSnapshotsByConversation.delete(viewKey)
   virtualMeasurementsByConversation.delete(viewKey)
@@ -86,6 +139,8 @@ export function getRuntimeConversationCacheStats() {
 
 export function clearRuntimeConversationCacheForTests() {
   messagesByConversation.clear()
+  queuedMessagesByConversation.clear()
+  queuedMessagesPausedByConversation.clear()
   scrollSnapshotsByConversation.clear()
   virtualMeasurementsByConversation.clear()
 }

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -3,8 +3,11 @@ import type {
   CodexMemoryCitation,
   CodexReference,
   DeviceInfo,
+  ModelOptions,
   ProjectWithTasks,
+  RuntimeAdditionalContext,
   RuntimeContextUsage,
+  RuntimeSendRequest,
   RuntimeTaskAddress,
   RuntimeTurnNavigationItem,
   RuntimeWorkListResponse,
@@ -91,6 +94,17 @@ export interface QueuedWorkbenchMessage {
   createdAt: string
   error?: string
   notice?: string
+}
+
+export interface RuntimePaneQueuedMessage extends QueuedWorkbenchMessage {
+  attachments?: Attachment[]
+  displayContent?: string
+  codeComments?: CodeCommentContext[]
+  modelId?: string
+  modelType?: RuntimeSendRequest['modelType']
+  modelOptions?: ModelOptions
+  runtimeGoalRequest?: boolean
+  additionalContext?: RuntimeAdditionalContext
 }
 
 export interface GuidanceWorkbenchMessage {


### PR DESCRIPTION
## Summary

- persist queued follow-ups and paused state by runtime conversation key
- restore the correct queue when switching back to a streaming task without leaking it into other conversations
- evict queued state together with archived runtime conversations
- add unit coverage and a real desktop E2E screenshot chain for queue navigation

## Root cause

The queued follow-up state lived only in the mounted pane hook. Switching conversations remounted the pane, so the pending queue was discarded instead of being restored for the original runtime task.

## Verification

- `pnpm --filter wework test` — 221 files, 2202 tests passed
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --queue-navigation-only`
- screenshot chain reviewed: source queued → other conversation clean → source queue restored
- pre-push Wework checks passed

## Verification note

A real `ai:verify` session reached the queued-follow-up state, but the only available internal Kimi model returned HTTP 502 and ended streaming before the full navigation chain could be captured. The deterministic real desktop E2E completed and captured the entire chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queued follow-up messages are now preserved separately for each conversation when switching between runtime tasks.
  * Queued messages and their paused state are restored when returning to a streaming task.
  * Queued follow-ups can be cleared after navigating between conversations.

* **Bug Fixes**
  * Prevented queued follow-ups from appearing in unrelated conversations.
  * Conversation cleanup now removes associated queued messages and paused queue state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->