### PR TITLE
fix(ci): run all checks on main

### DIFF
--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -56,6 +56,8 @@ EOF
 assert_case "shared dependencies" "$shared_expected" "shared/utils/example.py"
 
 all_true="${all_false//false/true}"
+assert_case "explicit all modules" "$all_true" --all
+
 assert_case "workflow changes validate all modules" "$all_true" \
   ".github/workflows/test.yml"
 
@@ -83,9 +85,16 @@ fi
 
 for workflow in e2e-tests.yml wework-e2e.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
+  push_config="$(
+    sed -n '/^  push:/,/^  pull_request:/p' "$workflow_path"
+  )"
   pull_request_config="$(
     sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$workflow_path"
   )"
+  if grep -q "paths:" <<<"$push_config"; then
+    printf '%s must run for every push to main\n' "$workflow" >&2
+    exit 1
+  fi
   if ! grep -q "ready_for_review" <<<"$pull_request_config"; then
     printf '%s must run E2E when a draft PR becomes ready for review\n' \
       "$workflow" >&2
@@ -101,6 +110,14 @@ for workflow in e2e-tests.yml wework-e2e.yml; do
   fi
   if ! grep -q "ci:all" "$workflow_path"; then
     printf '%s must force E2E for the ci:all label\n' "$workflow" >&2
+    exit 1
+  fi
+done
+
+for workflow in test.yml lint.yml; do
+  workflow_path="$script_dir/../workflows/$workflow"
+  if ! grep -q "classify-ci-changes.sh --all" "$workflow_path"; then
+    printf '%s must classify every module for pushes to main\n' "$workflow" >&2
     exit 1
   fi
 done

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,24 +3,6 @@ name: E2E Tests
 on:
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/e2e-tests.yml"
-      - ".github/scripts/archive-executor-e2e-runtime.sh"
-      - ".github/scripts/archive-frontend-e2e-build.sh"
-      - ".github/scripts/restore-executor-e2e-runtime.sh"
-      - ".github/scripts/restore-frontend-e2e-build.sh"
-      - ".github/scripts/start-frontend-e2e-server.sh"
-      - "backend/**"
-      - "chat_shell/**"
-      - "docker/**"
-      - "executor/**"
-      - "executor_manager/**"
-      - "frontend/**"
-      - "package.json"
-      - "packages/chat-core/**"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "shared/**"
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,8 +41,12 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
-            .github/scripts/classify-ci-changes.sh
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            .github/scripts/classify-ci-changes.sh --all
+          else
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+              .github/scripts/classify-ci-changes.sh
+          fi
 
   lint-backend:
     name: Lint Backend (Black & isort)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+          FORCE_ALL: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
         run: |
           if [[ "$FORCE_ALL" == "true" ]]; then
-            # The ci:all label forces every module test regardless of changed paths.
+            # Main pushes and the ci:all label force every module test.
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" |

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/wework-e2e.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "executor/**"
-      - "packages/chat-core/**"
-      - "wework/**"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## What changed

- Run every module test job for pushes to `main`
- Run every lint and TypeScript check for pushes to `main`
- Remove push path filters from the platform and Wework E2E workflows
- Keep pull requests scoped by changed paths, while preserving `ci:all` support
- Add CI classifier regression assertions for the main-branch behavior

## Why

The main branch previously reused commit-path classification, so a merged commit only exercised the modules detected in that commit. This could leave the integrated main branch without a complete test, lint, and E2E pass.

After this change, every push to `main` validates the complete repository CI surface. Pull requests retain selective execution to avoid unnecessary CI cost.

## Validation

- `.github/scripts/test-classify-ci-changes.sh`
- `bash -n .github/scripts/classify-ci-changes.sh .github/scripts/test-classify-ci-changes.sh`
- `git diff --check origin/main...HEAD`
- Rebasing onto the latest `origin/main` completed successfully

`actionlint` also parsed the changed workflows and reported only existing ShellCheck findings in unchanged workflow steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI tests and linting now run for all modules when changes are pushed to the main branch.
  * End-to-end workflows now run on every push to the main branch, regardless of which files changed.
  * Improved validation of CI change classification and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->