### PR TITLE
fix(wework): preserve pasted file attachments

### DIFF
--- a/wework/src/lib/workspace-path-transfer.test.ts
+++ b/wework/src/lib/workspace-path-transfer.test.ts
@@ -112,6 +112,20 @@ describe('workspace path transfer', () => {
     })
   })
 
+  test('keeps pasted files as attachments when no native path can be resolved', async () => {
+    const file = new File(['archive'], 'feedback.zip', { type: 'application/zip' })
+    const data = clipboardData({}, [file])
+    mocks.invoke.mockResolvedValue([])
+
+    await expect(resolveDataTransferWorkspacePaths(data, 'clipboard', 'local')).resolves.toEqual({
+      attachmentFiles: [file],
+      referenceEntries: [],
+    })
+    expect(mocks.invoke).toHaveBeenCalledWith('read_clipboard_workspace_paths', {
+      fallbackPaths: [],
+    })
+  })
+
   test('reads bytes only for image paths when resolving stored local paths', async () => {
     const image = new File(['image'], 'preview.png', { type: 'image/png' })
     mocks.invoke.mockResolvedValue([

--- a/wework/src/lib/workspace-path-transfer.ts
+++ b/wework/src/lib/workspace-path-transfer.ts
@@ -135,6 +135,9 @@ export async function resolveDataTransferWorkspacePaths(
       source === 'clipboard'
         ? await readNativeClipboardWorkspacePaths(dataTransfer)
         : await readNativeDroppedWorkspacePaths(dataTransfer)
+    if (entries.length === 0) {
+      return { attachmentFiles: files, referenceEntries: [] }
+    }
     return partitionLocalWorkspaceTransfer(entries, files)
   } catch (error) {
     console.warn(`[Wework workspace transfer] native ${source} path inspection failed`, error)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved files copied from the clipboard as attachments when no native workspace paths are detected.
  - Prevented clipboard file handling from being incorrectly processed as workspace references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->