### PR TITLE
fix(wework): restore streaming task scroll position

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Code uses CRD terms. In Chinese UI, `Team` is “智能体” and `Bot` is “�
 
 ## Engineering rules
 
-- Analyze concrete problems using logs and the actual code, and complete tasks based on evidence rather than speculation.
+- Diagnose problems from logs, actual code, and other concrete evidence first. When evidence is insufficient, add focused diagnostic logging before changing behavior; do not guess.
 - Comments are English. Use clear names, type hints for Python, and keep functions focused (prefer under 50 lines).
 - Before adding code, search for and reuse existing components, services, utilities, and patterns. Extract shared logic instead of duplicating it.
 - Favor cohesive modules, explicit interfaces, and standard practices. Split files over 1000 lines.
@@ -61,6 +61,7 @@ Code uses CRD terms. In Chinese UI, `Team` is “智能体” and `Bot` is “�
 ## Testing and verification
 
 Run focused tests before committing; run broader tests when risk warrants it. E2E tests must use real backend requests, may not silently skip or fail gracefully, and failures must be fixed rather than skipped.
+Every E2E scenario must be invoked by GitHub CI. Focused local E2E commands may exist for debugging, but they must also be included by a CI-covered suite; do not add dead E2E coverage that CI never runs.
 
 ```bash
 cd backend && uv run pytest

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -15,7 +15,7 @@ const ATTACHMENT_FILENAME = 'streaming-turn-navigation.png'
 const ATTACHMENT_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEklEQVR4nGP4z8CAB+GTG8HSALfKY52fTcuYAAAAAElFTkSuQmCC'
 const TURN_NAVIGATION_MARKER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"]`
-const SCROLLER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-chat-scroll"]`
+const SCROLLER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`
 const VIEWPORT_ANCHOR_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="assistant-message-content"] p[data-scroll-anchor]:nth-of-type(13)`
 const INITIAL_PARAGRAPHS = Array.from({ length: 28 }, (_, index) => {
   if (index === 11) {
@@ -169,6 +169,21 @@ async function getSingleElementMetrics(control, selector, description) {
   return metrics[0]
 }
 
+function distanceFromBottom(metrics) {
+  return Math.max(0, metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop)
+}
+
+async function waitForBottom(control, description, timeoutMs) {
+  const startedAt = Date.now()
+  let metrics
+  while (Date.now() - startedAt < timeoutMs) {
+    metrics = await getSingleElementMetrics(control, SCROLLER_SELECTOR, description)
+    if (distanceFromBottom(metrics) <= 8) return metrics
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`${description} remained ${distanceFromBottom(metrics)}px from the bottom`)
+}
+
 async function waitForFolderPath(control, expectedPath, timeoutMs) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < timeoutMs) {
@@ -237,7 +252,8 @@ async function waitForNewTaskRow(control, knownTaskRows, expectedText, timeoutMs
   throw new Error(`The streaming task row did not appear for ${expectedText}`)
 }
 
-export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath }) {
+export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, workspacePath }) {
+  let active = false
   let releaseAppend
   let releaseResponse
   let resolveRequest
@@ -253,9 +269,8 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
   })
 
   return {
-    codexConfigToml: '\n[features]\nplugins = false\n',
-
     async handleHttp(request, response, url) {
+      if (!active) return false
       if (request.method !== 'POST' || !['/v1/responses', '/responses'].includes(url.pathname)) {
         return false
       }
@@ -302,7 +317,13 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
     },
 
     async verify(control) {
-      await createLocalProject(control, workspacePath, uiTimeoutMs)
+      active = true
+      if (standalone) {
+        await createLocalProject(control, workspacePath, uiTimeoutMs)
+      } else {
+        await control.command('click', '[data-testid="new-chat-button"]')
+        await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      }
       const knownTaskRows = new Set(
         JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
           testId.startsWith('runtime-local-task-row-')
@@ -365,6 +386,16 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
         streamingSnapshot.text.indexOf(MARKER) < streamingSnapshot.text.lastIndexOf('正在思考'),
         'The thinking indicator was not rendered below the partial assistant response'
       )
+      await control.command('scrollToBottomAsUser', SCROLLER_SELECTOR)
+      const pinnedBeforeSwitch = await waitForBottom(
+        control,
+        'The streaming conversation before switching tasks',
+        5_000
+      )
+      assert.ok(
+        distanceFromBottom(pinnedBeforeSwitch) <= 8,
+        `The streaming conversation was ${distanceFromBottom(pinnedBeforeSwitch)}px from the bottom before switching tasks`
+      )
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
       await control.command('clickWhenEnabled', `[data-testid="${taskRowTestId}"]`, {
@@ -376,6 +407,16 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
         { text: MARKER, stableMs: 750, timeoutMs: uiTimeoutMs }
       )
       await new Promise(resolve => setTimeout(resolve, 1_500))
+      const pinnedAfterSwitch = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The bottom-pinned streaming conversation after switching back'
+      )
+      assert.ok(
+        distanceFromBottom(pinnedAfterSwitch) <= 8,
+        `The bottom-pinned streaming conversation reopened ${distanceFromBottom(pinnedAfterSwitch)}px from the bottom`
+      )
+      await capture(control, resultDir, 'streaming-text-01-bottom-restored-after-task-switch.png')
       assert.equal(
         Number(await control.command('getElementCount', TURN_NAVIGATION_MARKER_SELECTOR)),
         2,
@@ -398,30 +439,56 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
         !streamingTurnPreview.includes('application_context'),
         'The streaming turn preview exposed injected application context'
       )
-      await capture(control, resultDir, 'streaming-text-01-thinking-below-partial-response.png')
+      await capture(control, resultDir, 'streaming-text-02-thinking-below-partial-response.png')
 
       assert.equal(
         await control.command('getText', VIEWPORT_ANCHOR_SELECTOR),
         `${VIEWPORT_MARKER}: this paragraph must remain fixed after the user scrolls upward.`,
         'The viewport anchor paragraph was not rendered at the expected position'
       )
-      await control.command('scrollIntoViewAsUser', VIEWPORT_ANCHOR_SELECTOR)
-      await control.command(
-        'waitFor',
-        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="scroll-to-bottom-button"]`,
-        { timeoutMs: uiTimeoutMs }
+      await control.command('scrollToRatioAsUser', SCROLLER_SELECTOR, { value: '0.35' })
+      const userScrollPosition = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The streaming conversation immediately after the user scrolled upward'
       )
+      assert.ok(
+        distanceFromBottom(userScrollPosition) > 8,
+        'The simulated user scroll did not move the streaming conversation away from the bottom'
+      )
+      await new Promise(resolve => setTimeout(resolve, 750))
+      const stableUserScrollPosition = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The streaming conversation after pending bottom restores had time to run'
+      )
+      assert.ok(
+        Math.abs(stableUserScrollPosition.scrollTop - userScrollPosition.scrollTop) <= 8,
+        `The streaming conversation jumped from ${userScrollPosition.scrollTop}px to ${stableUserScrollPosition.scrollTop}px after the user scrolled upward`
+      )
+
+      await control.command('scrollIntoView', VIEWPORT_ANCHOR_SELECTOR)
+      await new Promise(resolve => setTimeout(resolve, 250))
       const scrollerBeforeAppend = await getSingleElementMetrics(
         control,
         SCROLLER_SELECTOR,
         'The streaming conversation scroller before later content'
+      )
+      assert.ok(
+        distanceFromBottom(scrollerBeforeAppend) > 8,
+        'The simulated user scroll did not move the streaming conversation away from the bottom'
       )
       const anchorBeforeAppend = await getSingleElementMetrics(
         control,
         VIEWPORT_ANCHOR_SELECTOR,
         'The viewport anchor before later content'
       )
-      await capture(control, resultDir, 'streaming-text-02-user-scrolled-up.png')
+      assert.ok(
+        anchorBeforeAppend.top >= scrollerBeforeAppend.top &&
+          anchorBeforeAppend.bottom <= scrollerBeforeAppend.bottom,
+        `The viewport anchor was not visible after the user scroll (top=${anchorBeforeAppend.top}px, bottom=${anchorBeforeAppend.bottom}px)`
+      )
+      await capture(control, resultDir, 'streaming-text-03-user-scrolled-up.png')
 
       releaseAppend()
       await control.command(
@@ -447,7 +514,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
         Math.abs(scrollerAfterAppend.scrollTop - scrollerBeforeAppend.scrollTop) <= 8,
         `The paused streaming scroller moved from ${scrollerBeforeAppend.scrollTop}px to ${scrollerAfterAppend.scrollTop}px`
       )
-      await capture(control, resultDir, 'streaming-text-03-anchor-stable-after-append.png')
+      await capture(control, resultDir, 'streaming-text-04-anchor-stable-after-append.png')
 
       releaseResponse()
       await control.command(
@@ -470,7 +537,8 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs, workspacePath })
         !completedSnapshot.testIds.includes('pause-response-button'),
         'The pause button remained after completion'
       )
-      await capture(control, resultDir, 'streaming-text-04-response-completed.png')
+      await capture(control, resultDir, 'streaming-text-05-response-completed.png')
+      active = false
     },
 
     diagnostics() {

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -6746,7 +6746,12 @@ async function main() {
 
   const desktopScenario = await loadDesktopScenario(
     process.env.WEWORK_E2E_DESKTOP_SCENARIO_MODULE,
-    { resultDir, uiTimeoutMs: UI_TIMEOUT_MS, workspacePath }
+    {
+      resultDir,
+      standalone: DESKTOP_SCENARIO_ONLY,
+      uiTimeoutMs: UI_TIMEOUT_MS,
+      workspacePath,
+    }
   )
   if (DESKTOP_SCENARIO_ONLY && !desktopScenario) {
     throw new Error('Desktop scenario-only mode requires WEWORK_E2E_DESKTOP_SCENARIO_MODULE')
@@ -7074,18 +7079,16 @@ async function main() {
       return
     }
 
-    if (desktopScenario) {
+    if (desktopScenario && DESKTOP_SCENARIO_ONLY) {
       phase = 'desktop-extension-scenario'
       await desktopScenario.verify(control)
-      if (DESKTOP_SCENARIO_ONLY) {
-        await writeFile(
-          join(resultDir, 'model-requests.json'),
-          `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-          'utf8'
-        )
-        console.log(`Wework desktop extension scenario E2E passed. Evidence: ${resultDir}`)
-        return
-      }
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(`Wework desktop extension scenario E2E passed. Evidence: ${resultDir}`)
+      return
     }
 
     phase = 'system-drag-panel-layout'
@@ -8248,6 +8251,11 @@ async function main() {
       restartDesktopApp,
       workspacePath,
     })
+
+    if (desktopScenario) {
+      phase = 'desktop-extension-scenario'
+      await desktopScenario.verify(control)
+    }
 
     await writeFile(
       join(resultDir, 'model-requests.json'),

--- a/wework/package.json
+++ b/wework/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest",
     "test:kimi-k3-profile": "node scripts/verify-kimi-k3-profile.mjs",
     "e2e": "playwright test",
-    "e2e:desktop": "node e2e/desktop/task-flow.e2e.mjs",
+    "e2e:desktop": "WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/streaming-text.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "e2e:desktop:cloud": "node e2e/desktop/task-flow.e2e.mjs --cloud-only",
     "e2e:desktop:plugins": "node e2e/desktop/task-flow.e2e.mjs --plugins-only",
     "e2e:desktop:memory": "node e2e/desktop/task-flow.e2e.mjs --memory-only",

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -3,6 +3,7 @@ import { createRef } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ScrollableMessageArea } from './ScrollableMessageArea'
 import { MessageTurnNavigation } from './MessageTurnNavigation'
+import { getConversationScrollSnapshot } from '@/features/workbench/runtimeConversationCache'
 
 function mockRect(element: Element, top: number, bottom: number) {
   element.getBoundingClientRect = vi.fn(
@@ -333,7 +334,9 @@ describe('ScrollableMessageArea', () => {
       mockRect(scroller, 100, 300)
       mockScrollRelativeRect(anchor, scroller, 450, 40)
 
-      fireEvent.wheel(scroller, { deltaY: -80 })
+      scroller.scrollTop = 1000
+      fireEvent.scroll(scroller)
+      scroller.scrollTop = 300
       fireEvent.scroll(scroller)
       ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
 
@@ -410,6 +413,71 @@ describe('ScrollableMessageArea', () => {
     expect(scroller.scrollTo).toHaveBeenLastCalledWith({
       top: 320,
       behavior: 'auto',
+    })
+  })
+
+  test('stops external bottom following when the scroll position leaves the bottom', () => {
+    const externalScrollRef = createRef<HTMLDivElement>()
+    const streamingMessage = {
+      id: 'external-streaming-message',
+      role: 'assistant' as const,
+      content: '正在流式输出',
+      status: 'streaming' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <div ref={externalScrollRef}>
+        <ScrollableMessageArea
+          conversationKey="external-stream-a"
+          externalScrollRef={externalScrollRef}
+          messages={[streamingMessage]}
+        />
+      </div>
+    )
+
+    const scroller = externalScrollRef.current!
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 800,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+
+    fireEvent.scroll(scroller)
+    rerender(
+      <div ref={externalScrollRef}>
+        <ScrollableMessageArea
+          conversationKey="external-stream-b"
+          externalScrollRef={externalScrollRef}
+          messages={[{ ...streamingMessage, id: 'external-streaming-message-b' }]}
+        />
+      </div>
+    )
+    rerender(
+      <div ref={externalScrollRef}>
+        <ScrollableMessageArea
+          conversationKey="external-stream-a"
+          externalScrollRef={externalScrollRef}
+          messages={[streamingMessage]}
+        />
+      </div>
+    )
+
+    flushScheduledTimers()
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+
+    scroller.scrollTop = 350
+    fireEvent.scroll(scroller)
+    flushScheduledTimers()
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled()
+    expect(getConversationScrollSnapshot('external-stream-a')).toEqual({
+      distanceFromBottomPx: 450,
+      pinnedToBottom: false,
     })
   })
 
@@ -1695,6 +1763,38 @@ describe('ScrollableMessageArea', () => {
     expect(screen.queryByTestId('scroll-to-bottom-button')).not.toBeInTheDocument()
   })
 
+  test('captures a bottom-pinned streaming conversation before its pane unmounts', () => {
+    const streamingMessage = {
+      id: 'streaming-unmount',
+      role: 'assistant' as const,
+      content: '正在处理',
+      status: 'streaming' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { unmount } = render(
+      <ScrollableMessageArea
+        conversationKey="streaming-unmount-bottom"
+        messages={[streamingMessage]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 600, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 400,
+      writable: true,
+      configurable: true,
+    })
+
+    unmount()
+
+    expect(getConversationScrollSnapshot('streaming-unmount-bottom')).toEqual({
+      distanceFromBottomPx: 0,
+      pinnedToBottom: true,
+    })
+  })
+
   test('unmounts previously selected conversation DOM while preserving switch-back rendering', () => {
     const messageA = {
       id: 'cached-message-a',
@@ -2100,13 +2200,15 @@ describe('ScrollableMessageArea', () => {
       configurable: true,
     })
     Object.defineProperty(scroller, 'scrollTop', {
-      value: 0,
+      value: 400,
       writable: true,
       configurable: true,
     })
     scroller.scrollTo = vi.fn()
 
-    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.scroll(scroller)
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    scroller.scrollTop = 0
     fireEvent.scroll(scroller)
     rerender(
       <ScrollableMessageArea
@@ -2280,7 +2382,6 @@ describe('ScrollableMessageArea', () => {
     fireEvent.scroll(scroller)
     ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
     scroller.scrollTop = 360
-    fireEvent.wheel(scroller, { deltaY: -80 })
     fireEvent.scroll(scroller)
     Object.defineProperty(scroller, 'scrollHeight', {
       value: 800,

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -240,6 +240,7 @@ function ScrollableMessagePaneContent({
   const followingBottomKeyRef = useRef<string | null>(null)
   const userScrollPausedAutoFollowRef = useRef(false)
   const userViewportAnchorRef = useRef<UserViewportAnchor | null>(null)
+  const lastScrollTopRef = useRef<number | null>(null)
   const scheduledScrollStateSignatureRef = useRef<string | null>(null)
   const completedScrollStateSignatureRef = useRef<string | null>(null)
   const loadingTranscriptGapKeyRef = useRef<string | null>(null)
@@ -403,6 +404,13 @@ function ScrollableMessagePaneContent({
     [currentScrollKey, messages.length]
   )
 
+  useLayoutEffect(
+    () => () => {
+      saveCurrentScrollPosition()
+    },
+    [saveCurrentScrollPosition]
+  )
+
   const updateScrollState = useCallback(
     (options: { forceSave?: boolean; skipSave?: boolean } = {}) => {
       const element = activeScrollRefRef.current.current
@@ -418,6 +426,9 @@ function ScrollableMessagePaneContent({
       const distanceToBottom = element.scrollHeight - element.clientHeight - element.scrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
       const isScrolledToBottom = distanceToBottom <= SCROLLED_TO_BOTTOM_THRESHOLD
+      const scrolledUp =
+        lastScrollTopRef.current !== null && element.scrollTop < lastScrollTopRef.current - 0.5
+      lastScrollTopRef.current = element.scrollTop
       isAtBottomRef.current = isAtBottom
       if (isScrolledToBottom) {
         userScrollPausedAutoFollowRef.current = false
@@ -425,11 +436,7 @@ function ScrollableMessagePaneContent({
       } else if (options.forceSave) {
         userScrollPausedAutoFollowRef.current = true
       }
-      if (
-        !isAtBottom &&
-        restoringScrollKeyRef.current !== currentScrollKey &&
-        followingBottomKeyRef.current !== currentScrollKey
-      ) {
+      if (!isScrolledToBottom && options.forceSave && scrolledUp) {
         clearScheduledScrolls()
       }
       if (
@@ -456,6 +463,7 @@ function ScrollableMessagePaneContent({
       } else {
         element.scrollTop = element.scrollHeight
       }
+      lastScrollTopRef.current = element.scrollTop
       if (options.saveSnapshot) {
         saveCurrentScrollPosition(element.scrollHeight)
       }
@@ -482,6 +490,7 @@ function ScrollableMessagePaneContent({
     } else {
       element.scrollTop = nextScrollTop
     }
+    lastScrollTopRef.current = element.scrollTop
 
     const overflow = element.scrollHeight > element.clientHeight + 8
     const distanceToBottom = element.scrollHeight - element.clientHeight - nextScrollTop
@@ -654,6 +663,7 @@ function ScrollableMessagePaneContent({
     const offsetDelta = offsetFromScrollerTop - anchor.offsetFromScrollerTop
     if (Math.abs(offsetDelta) < 0.5) return
     scroller.scrollTop += offsetDelta
+    lastScrollTopRef.current = scroller.scrollTop
   }, [])
 
   useEffect(() => {
@@ -719,23 +729,12 @@ function ScrollableMessagePaneContent({
     scrollToBottom('smooth', { saveSnapshot: true })
   }
 
-  const pauseAutoFollowForUserScroll = useCallback(() => {
-    userScrollPausedAutoFollowRef.current = true
-    clearScheduledScrolls()
-    captureUserViewportAnchor()
-  }, [captureUserViewportAnchor, clearScheduledScrolls])
-
   const handleScroll = useCallback(() => {
-    if (restoringScrollKeyRef.current === currentScrollKey) {
-      updateScrollState({ skipSave: true })
-      return
-    }
-    restoringScrollKeyRef.current = null
     updateScrollState({ forceSave: true })
     if (userScrollPausedAutoFollowRef.current) {
       captureUserViewportAnchor()
     }
-  }, [captureUserViewportAnchor, currentScrollKey, updateScrollState])
+  }, [captureUserViewportAnchor, updateScrollState])
 
   useEffect(() => {
     const externalScroller = externalScrollRef?.current
@@ -791,12 +790,6 @@ function ScrollableMessagePaneContent({
             '[overflow-anchor:none]',
           scrollerClassName
         )}
-        onWheel={event => {
-          if (event.deltaY < 0) {
-            pauseAutoFollowForUserScroll()
-          }
-        }}
-        onTouchMove={pauseAutoFollowForUserScroll}
         onScroll={handleScroll}
       >
         <div

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -775,6 +775,27 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       element.scrollIntoView({ block: 'center', inline: 'nearest' })
       return element.textContent?.trim() ?? ''
     }
+    case 'scrollToBottomAsUser': {
+      const element = findDesktopControlElements(command.selector)[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      element.scrollTop = element.scrollHeight
+      element.dispatchEvent(new Event('scroll', { bubbles: true }))
+      return String(element.scrollTop)
+    }
+    case 'scrollToRatioAsUser': {
+      const scroller = findDesktopControlElements(command.selector)[0]
+      if (!scroller) throw new Error(`Unable to find selector "${command.selector}"`)
+      const ratio = Number(command.value)
+      if (!Number.isFinite(ratio) || ratio < 0 || ratio > 1) {
+        throw new Error('scrollToRatioAsUser requires a value between 0 and 1')
+      }
+
+      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+      const nextScrollTop = maxScrollTop * ratio
+      scroller.scrollTop = nextScrollTop
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+      return String(scroller.scrollTop)
+    }
     case 'click': {
       const element = findDesktopControlElements(command.selector)[0]
       if (!element) throw new Error(`Unable to find selector "${command.selector}"`)


### PR DESCRIPTION
## Summary

- save the active conversation scroll snapshot before a cached task pane unmounts
- stop bottom following from actual scroll position changes instead of synthetic wheel input
- restore bottom-pinned streaming tasks after switching away and back
- extend the real desktop streaming E2E with task switching, rebound detection, and viewport-stability assertions
- run the streaming scenario inside the existing Core desktop E2E process so CI does not rebuild or launch a second app
- document evidence-first debugging and require every E2E scenario to be covered by GitHub CI

## Root cause

The active task pane could unmount before its latest external scroll position was persisted. After reopening, the cached snapshot no longer reliably represented a bottom-pinned streaming conversation.

The desktop scroll listener also needs to attach after the parent-owned external scroll ref is available. During diagnosis, attaching it in a layout effect caused the listener to be missed after pane remounts, leaving stale bottom-follow ownership active.

## Verification

- `pnpm --filter wework exec vitest run src/components/chat/ScrollableMessageArea.test.tsx` — 44 passed
- pre-push Wework ESLint — passed
- pre-push Wework TypeScript — passed
- pre-push Wework unit tests — passed
- focused real-Tauri streaming-text E2E — passed during development
- integrated single-process Core desktop E2E — added for CI coverage; the final local full run was interrupted before completion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling during streaming responses, including more reliable bottom-following behavior.
  * Scrolling upward now consistently pauses automatic following so the viewport remains where the user left it.
  * Preserved scroll position and viewport anchors when switching conversations or when streaming content is removed.
  * Improved restoration of the conversation view after navigating away and returning.
* **Tests**
  * Expanded automated coverage for streaming, scrolling, viewport anchoring, and bottom-position behavior across desktop scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->