### PR TITLE
fix(wework): route desktop scenario captures through the platform-aware helper

### DIFF
--- a/wework/e2e/desktop/scenarios/cloud-space-mention.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/cloud-space-mention.scenario.mjs
@@ -1,6 +1,4 @@
 import assert from 'node:assert/strict'
-import { writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
@@ -73,20 +71,12 @@ function json(response, status, body) {
   response.end(JSON.stringify(body))
 }
 
-async function capture(control, resultDir, name) {
-  const dataUrl = await control.command('capture', ACTIVE_WORKBENCH_SELECTOR, {
-    timeoutMs: 30_000,
-  })
-  const prefix = 'data:image/png;base64,'
-  assert.ok(dataUrl.startsWith(prefix), 'Desktop screenshot did not return PNG data')
-  await writeFile(join(resultDir, name), Buffer.from(dataUrl.slice(prefix.length), 'base64'))
-}
-
 async function snapshot(control) {
   return JSON.parse(await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR))
 }
 
-export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
+export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
+  const capture = (control, name) => captureScreenshot(control, name, ACTIVE_WORKBENCH_SELECTOR)
   const projects = [WEBSITE_PROJECT, MOBILE_PROJECT]
   let createdProjectPayload = null
 
@@ -148,7 +138,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         !menuSnapshot.testIds.includes('mention-cloud-create-action'),
         'The retired create action is still rendered'
       )
-      await capture(control, resultDir, 'cloud-space-mention-01-menu-entries.png')
+      await capture(control, 'cloud-space-mention-01-menu-entries.png')
 
       // Scene 2: the direct row inserts the generic cloud://projects chip
       // without binding anything.
@@ -166,7 +156,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         !directSnapshot.testIds.includes('transient-notice'),
         'The generic reference unexpectedly bound a cloud context'
       )
-      await capture(control, resultDir, 'cloud-space-mention-02-direct-chip.png')
+      await capture(control, 'cloud-space-mention-02-direct-chip.png')
 
       // Scene 3: the project space list drills into every accessible project.
       await control.command('fill', COMPOSER_SELECTOR, { value: '@' })
@@ -190,7 +180,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         drillSnapshot.testIds.includes('mention-cloud-back-action'),
         'The project space drill lost its back row'
       )
-      await capture(control, resultDir, 'cloud-space-mention-03-project-list.png')
+      await capture(control, 'cloud-space-mention-03-project-list.png')
 
       // Scene 4: selecting a project inserts the mention chip and binds the space.
       await control.command(
@@ -218,7 +208,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         spaceSnapshot.testIds.includes('cloud-reference-status-cloud-todo-GW-1'),
         'The todo row did not render its status badge'
       )
-      await capture(control, resultDir, 'cloud-space-mention-04-bound-filter.png')
+      await capture(control, 'cloud-space-mention-04-bound-filter.png')
       await control.command('click', '[data-testid="cloud-reference-option-cloud-todo-GW-1"]')
       const todoSnapshot = await snapshot(control)
       assert.ok(
@@ -244,7 +234,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         ),
         'The @项目空间: keyword did not filter the project list'
       )
-      await capture(control, resultDir, 'cloud-space-mention-05-typed-scope.png')
+      await capture(control, 'cloud-space-mention-05-typed-scope.png')
 
       // Scene 7: a non-matching typed phrase keeps only the direct row, which
       // still inserts the generic chip.

--- a/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
@@ -1,6 +1,4 @@
 import assert from 'node:assert/strict'
-import { writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
@@ -51,15 +49,6 @@ async function readJson(request) {
   return JSON.parse(Buffer.concat(chunks).toString('utf8'))
 }
 
-async function capture(control, resultDir, name) {
-  const dataUrl = await control.command('capture', ACTIVE_WORKBENCH_SELECTOR, {
-    timeoutMs: 30_000,
-  })
-  const prefix = 'data:image/png;base64,'
-  assert.ok(dataUrl.startsWith(prefix), 'Desktop screenshot did not return PNG data')
-  await writeFile(join(resultDir, name), Buffer.from(dataUrl.slice(prefix.length), 'base64'))
-}
-
 async function waitForConversationOption(control, timeoutMs) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < timeoutMs) {
@@ -91,7 +80,8 @@ async function selectConversationOption(control, timeoutMs) {
   throw new Error('The referenced conversation could not be selected from the @ menu')
 }
 
-export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
+export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
+  const capture = (control, name) => captureScreenshot(control, name, ACTIVE_WORKBENCH_SELECTOR)
   let sourceRequest = null
   let targetRequest = null
 
@@ -148,12 +138,12 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         menuSnapshot.text.includes('WEWORK_CONVERSATION_REFERENCE_SOURCE'),
         'The @ menu selected an unrelated conversation'
       )
-      await capture(control, resultDir, 'conversation-mention-01-menu.png')
+      await capture(control, 'conversation-mention-01-menu.png')
       await selectConversationOption(control, uiTimeoutMs)
       await control.command('waitFor', '[data-testid^="conversation-chip-"]', {
         timeoutMs: uiTimeoutMs,
       })
-      await capture(control, resultDir, 'conversation-mention-02-chip.png')
+      await capture(control, 'conversation-mention-02-chip.png')
       await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
       await control.command('waitFor', '[data-testid="message-assistant"]', {
         text: TARGET_COMPLETION,
@@ -178,7 +168,7 @@ export function createDesktopScenario({ resultDir, uiTimeoutMs }) {
         serializedTarget.includes('ORBIT-42'),
         'The referenced conversation content was not delivered to the model'
       )
-      await capture(control, resultDir, 'conversation-mention-03-sent.png')
+      await capture(control, 'conversation-mention-03-sent.png')
     },
 
     diagnostics() {

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -1,6 +1,4 @@
 import assert from 'node:assert/strict'
-import { writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
@@ -146,15 +144,6 @@ async function readJson(request) {
   return JSON.parse(Buffer.concat(chunks).toString('utf8'))
 }
 
-async function capture(control, resultDir, name) {
-  const dataUrl = await control.command('capture', ACTIVE_WORKBENCH_SELECTOR, {
-    timeoutMs: 30_000,
-  })
-  const prefix = 'data:image/png;base64,'
-  assert.ok(dataUrl.startsWith(prefix), 'Desktop screenshot did not return PNG data')
-  await writeFile(join(resultDir, name), Buffer.from(dataUrl.slice(prefix.length), 'base64'))
-}
-
 function requestContainsPrompt(body) {
   return JSON.stringify(body.input ?? []).includes(PROMPT)
 }
@@ -252,7 +241,13 @@ async function waitForNewTaskRow(control, knownTaskRows, expectedText, timeoutMs
   throw new Error(`The streaming task row did not appear for ${expectedText}`)
 }
 
-export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, workspacePath }) {
+export function createDesktopScenario({
+  captureScreenshot,
+  standalone,
+  uiTimeoutMs,
+  workspacePath,
+}) {
+  const capture = (control, name) => captureScreenshot(control, name, ACTIVE_WORKBENCH_SELECTOR)
   let active = false
   let releaseAppend
   let releaseResponse
@@ -341,7 +336,7 @@ export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, work
         INITIAL_PROMPT,
         uiTimeoutMs
       )
-      await capture(control, resultDir, 'streaming-text-00-ready-to-send.png')
+      await capture(control, 'streaming-text-00-ready-to-send.png')
       await control.command('pasteFile', COMPOSER_SELECTOR, {
         filename: ATTACHMENT_FILENAME,
         mimeType: 'image/png',
@@ -416,7 +411,7 @@ export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, work
         distanceFromBottom(pinnedAfterSwitch) <= 8,
         `The bottom-pinned streaming conversation reopened ${distanceFromBottom(pinnedAfterSwitch)}px from the bottom`
       )
-      await capture(control, resultDir, 'streaming-text-01-bottom-restored-after-task-switch.png')
+      await capture(control, 'streaming-text-01-bottom-restored-after-task-switch.png')
       assert.equal(
         Number(await control.command('getElementCount', TURN_NAVIGATION_MARKER_SELECTOR)),
         2,
@@ -439,7 +434,7 @@ export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, work
         !streamingTurnPreview.includes('application_context'),
         'The streaming turn preview exposed injected application context'
       )
-      await capture(control, resultDir, 'streaming-text-02-thinking-below-partial-response.png')
+      await capture(control, 'streaming-text-02-thinking-below-partial-response.png')
 
       assert.equal(
         await control.command('getText', VIEWPORT_ANCHOR_SELECTOR),
@@ -488,7 +483,7 @@ export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, work
           anchorBeforeAppend.bottom <= scrollerBeforeAppend.bottom,
         `The viewport anchor was not visible after the user scroll (top=${anchorBeforeAppend.top}px, bottom=${anchorBeforeAppend.bottom}px)`
       )
-      await capture(control, resultDir, 'streaming-text-03-user-scrolled-up.png')
+      await capture(control, 'streaming-text-03-user-scrolled-up.png')
 
       releaseAppend()
       await control.command(
@@ -514,7 +509,7 @@ export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, work
         Math.abs(scrollerAfterAppend.scrollTop - scrollerBeforeAppend.scrollTop) <= 8,
         `The paused streaming scroller moved from ${scrollerBeforeAppend.scrollTop}px to ${scrollerAfterAppend.scrollTop}px`
       )
-      await capture(control, resultDir, 'streaming-text-04-anchor-stable-after-append.png')
+      await capture(control, 'streaming-text-04-anchor-stable-after-append.png')
 
       releaseResponse()
       await control.command(
@@ -537,7 +532,7 @@ export function createDesktopScenario({ resultDir, standalone, uiTimeoutMs, work
         !completedSnapshot.testIds.includes('pause-response-button'),
         'The pause button remained after completion'
       )
-      await capture(control, resultDir, 'streaming-text-05-response-completed.png')
+      await capture(control, 'streaming-text-05-response-completed.png')
       active = false
     },
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -6747,6 +6747,8 @@ async function main() {
   const desktopScenario = await loadDesktopScenario(
     process.env.WEWORK_E2E_DESKTOP_SCENARIO_MODULE,
     {
+      captureScreenshot: (control, name, selector) =>
+        captureVerificationScreenshot(control, name, selector),
       resultDir,
       standalone: DESKTOP_SCENARIO_ONLY,
       uiTimeoutMs: UI_TIMEOUT_MS,


### PR DESCRIPTION
## 问题

[Wework Desktop E2E (Core)](https://github.com/wecode-ai/Wegent/actions/runs/30268433616/job/89984836415) 在 Linux 上报错：

```
Error: Main webview snapshots are currently supported on macOS only
```

## 根因

#2250 把 `e2e:desktop` 改为始终加载 streaming-text 场景。场景内的 `capture()` 直接调用 webview 的 `capture` 控制命令，底层走 Tauri 的 `capture_main_webview`，而该命令只在 macOS 上实现（`desktop_capture.rs`）。Linux Core 任务在场景末尾截图时因此失败。

## 修复

把 runner 中已有的平台感知截图助手 `captureVerificationScreenshot`（Linux 用 ImageMagick `import -window root`，macOS 用 webview 快照）通过 `createDesktopScenario` 选项注入，三个桌面场景（streaming-text / cloud-space-mention / conversation-mention）统一改走该助手，删除各自重复的 `capture()` 实现。

## 验证

- `pnpm --filter wework test`：222 个测试文件、2223 个用例全部通过
- ESLint / Prettier / TypeScript 检查通过
- 本地 macOS 实机跑了 `e2e:desktop:streaming-text`：新截图链路正常工作（`streaming-text-00-ready-to-send.png` 成功产出）；后续在 waitFor 阶段超时，已用未修改的 origin/main 对照复现同样失败（本地 codex-cli 0.144.5 未转发模型请求，0 条 model requests），确认与本次改动无关
- pre-push 全量检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved desktop end-to-end test screenshot capture through a shared mechanism.
  * Added more consistent screenshots for conversation mentions, including menu, selected conversation, and sent states.
  * Preserved existing request validation and streaming-text verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->