### PR TITLE
fix(wework): skip model switch warning for new conversations

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1436,6 +1436,7 @@ function RuntimeModelSelectionProbe() {
   return (
     <div>
       <span data-testid="selected-model">{workbench.projectChat.selectedModel?.name ?? ''}</span>
+      <span data-testid="active-model">{workbench.projectChat.activeModel?.name ?? ''}</span>
       <span data-testid="selected-mode">
         {workbench.projectChat.selectedModelOptions.collaborationMode ?? 'default'}
       </span>
@@ -3005,6 +3006,95 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('selected-mode')).toHaveTextContent('default')
     await userEvent.click(screen.getByText('select mimo'))
     expect(updateCurrentUser).not.toHaveBeenCalled()
+  })
+
+  test('only exposes an active model while a runtime task owns the conversation', async () => {
+    const models: UnifiedModel[] = [
+      {
+        name: 'gpt-5.5',
+        type: 'runtime',
+        provider: 'local',
+        config: {
+          weworkModelKind: 'codex-provider',
+          ui: { family: 'codex-provider', controls: ['collaborationMode'] },
+        },
+        runtime: { family: 'openai.openai-responses' },
+      },
+      {
+        name: 'local-model:mimo',
+        type: 'runtime',
+        provider: 'local',
+        config: {
+          weworkModelKind: 'model-interface',
+          ui: { family: 'model-interface', controls: ['collaborationMode'] },
+        },
+        runtime: { family: 'openai.openai-responses' },
+      },
+    ]
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  id: 22,
+                  projectId: 7,
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [
+                    {
+                      taskId: 'runtime-a',
+                      workspacePath: '/workspace/project-alpha',
+                      title: 'Runtime A',
+                      runtime: 'codex',
+                      modelSelection: {
+                        modelName: 'local-model:mimo',
+                        modelType: 'runtime',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        })
+      ),
+    })
+    const services = createWorkbenchServices({
+      deviceApi: {
+        listDevices: vi.fn().mockResolvedValue([createDevice({ device_type: 'local' })]),
+      } as Partial<WorkbenchServices['deviceApi']> as WorkbenchServices['deviceApi'],
+      modelApi: {
+        listModels: vi.fn().mockResolvedValue({ data: models }),
+      },
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    } as Partial<WorkbenchServices>)
+
+    renderWorkbench(<RuntimeModelSelectionProbe />, services)
+
+    // A new chat has no conversation context, so no model owns it yet. The
+    // model selector must not treat the persisted new-chat preference as an
+    // active model, otherwise switching models would warn unnecessarily.
+    await waitFor(() => expect(screen.getByTestId('selected-model')).toHaveTextContent('gpt-5.5'))
+    expect(screen.getByTestId('active-model')).toHaveTextContent(/^$/)
+    await userEvent.click(screen.getByText('select mimo'))
+    await waitFor(() =>
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('local-model:mimo')
+    )
+    expect(screen.getByTestId('active-model')).toHaveTextContent(/^$/)
+
+    await userEvent.click(screen.getByText('open runtime a'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('active-model')).toHaveTextContent('local-model:mimo')
+    )
   })
 
   test('creates a runtime task for a new project message', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -465,8 +465,11 @@ export function WorkbenchProvider({
     onSelectionBlocked: handleBlockedModelSelection,
   })
   const activeModel = useMemo(
-    () => findModelForSelection(modelSelection.models, modelSelectionConfig),
-    [modelSelection.models, modelSelectionConfig]
+    () =>
+      state.currentRuntimeTask
+        ? findModelForSelection(modelSelection.models, modelSelectionConfig)
+        : null,
+    [modelSelection.models, modelSelectionConfig, state.currentRuntimeTask]
   )
   const skillSelection = useWorkbenchSkills({
     api: resolvedServices.skillApi,


### PR DESCRIPTION
## What changed

New conversations in Wework no longer show the "Switch model?" confirmation dialog when picking a different model in the composer. The warning still appears when switching models in an existing conversation that already owns context.

## Why

The dialog introduced in #2245 warns that a different model may interpret existing conversation context differently. In a brand-new conversation there is no context to protect, so the confirmation was pure friction. The user guide already documents the intended behavior ("No warning is shown when selecting a model for a new conversation"), but the implementation did not match it.

## Root cause

`WorkbenchProvider` derived `activeModel` from `modelSelectionConfig` unconditionally. For a new chat (no `currentRuntimeTask`) that config falls back to the persisted new-chat preference (`wework_new_chat_model_selection`), so `activeModel` was non-null even though no conversation existed, and `ChatInput.requestModelSelection` treated the persisted preference as the model owning the conversation context and showed the warning.

The fix only computes `activeModel` while a runtime task owns the conversation; it is `null` for a new chat.

## Validation

- Unit: new regression test in `WorkbenchProvider.test.tsx` asserts `projectChat.activeModel` is `null` in a new chat (before and after selecting a model) and equals the task-bound model after opening a runtime task; full `WorkbenchProvider` + `ChatInput` suites pass (225 tests).
- Pre-push: ESLint, TypeScript, and Wework unit tests all passed.
- Real Tauri verification (`scripts/ai-verify.mjs`, isolated session): on the new-task home, switched the composer model from GPT 5.6 Sol to GPT 5.6 Terra — no warning dialog appeared (no `model-switch-warning-dialog` testid, no dialog copy) and the selector label updated to GPT 5.6 Terra immediately.
