### PR TITLE
fix(executor): preserve loopback proxy bypasses

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2258,11 +2258,11 @@ fn runtime_proxy_env(model_config: &Value) -> BTreeMap<String, String> {
         return BTreeMap::new();
     };
 
-    let no_proxy = env::var("NO_PROXY")
+    let configured_no_proxy = env::var("NO_PROXY")
         .ok()
         .or_else(|| env::var("no_proxy").ok())
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| DEFAULT_NO_PROXY.to_owned());
+        .filter(|value| !value.trim().is_empty());
+    let no_proxy = merge_required_no_proxy(configured_no_proxy.as_deref());
     [
         ("ALL_PROXY", proxy_url),
         ("HTTP_PROXY", proxy_url),
@@ -2276,6 +2276,27 @@ fn runtime_proxy_env(model_config: &Value) -> BTreeMap<String, String> {
     .into_iter()
     .map(|(key, value)| (key.to_owned(), value.to_owned()))
     .collect()
+}
+
+fn merge_required_no_proxy(configured: Option<&str>) -> String {
+    let mut entries = configured
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+
+    for required in DEFAULT_NO_PROXY.split(',') {
+        if !entries
+            .iter()
+            .any(|entry| entry.eq_ignore_ascii_case(required))
+        {
+            entries.push(required.to_owned());
+        }
+    }
+
+    entries.join(",")
 }
 
 fn runtime_proxy_url(model_config: &Value) -> Option<&str> {

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -687,6 +687,19 @@ fn codex_launch_config_forwards_runtime_proxy_env() {
 }
 
 #[test]
+fn required_loopback_hosts_are_merged_into_no_proxy() {
+    assert_eq!(
+        merge_required_no_proxy(Some("example.com, localhost")),
+        "example.com,localhost,127.0.0.1,::1,host.docker.internal"
+    );
+    assert_eq!(
+        merge_required_no_proxy(Some("LOCALHOST,127.0.0.1,::1,HOST.DOCKER.INTERNAL")),
+        "LOCALHOST,127.0.0.1,::1,HOST.DOCKER.INTERNAL"
+    );
+    assert_eq!(merge_required_no_proxy(None), DEFAULT_NO_PROXY);
+}
+
+#[test]
 fn codex_launch_config_does_not_forward_task_identity() {
     let request = ExecutionRequest {
         task_id: "task-525".to_owned(),


### PR DESCRIPTION
## What changed

- Preserve user-defined `NO_PROXY` and `no_proxy` entries for local Codex runtimes.
- Always append the loopback bypasses required by Wework:
  `localhost`, `127.0.0.1`, `::1`, and `host.docker.internal`.
- Add unit coverage for missing entries, case-insensitive deduplication, and the default configuration.

## Why

Codex connects to the executor's local model router through a dynamic
`127.0.0.1` HTTP endpoint. When a user supplied a non-empty `NO_PROXY` value
that omitted loopback addresses, the runtime previously forwarded that value
unchanged. An HTTP proxy could then intercept the local router request and make
the executor-backed Codex session fail.

## Impact

Custom proxy configurations continue to work, while executor-local HTTP traffic
is consistently kept off the proxy.

## Validation

- `cargo fmt --check --manifest-path executor/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml --lib agents::codex::tests::required_loopback_hosts_are_merged_into_no_proxy`
- `cargo test --manifest-path executor/Cargo.toml --lib agents::codex::tests::codex_launch_config_forwards_runtime_proxy_env`
- Pre-push checks
