### PR TITLE
test(ci): fix main branch executor and wework E2E failures

### DIFF
--- a/executor/tests/codex_app_server_contract.rs
+++ b/executor/tests/codex_app_server_contract.rs
@@ -289,8 +289,14 @@ async fn codex_app_server_engine_uses_user_runtime_proxy_without_provider_overri
     );
     assert_eq!(messages[0]["env"]["HTTP_PROXY"], "socks5://127.0.0.1:7890");
     assert_eq!(messages[0]["env"]["HTTPS_PROXY"], "socks5://127.0.0.1:7890");
-    assert_eq!(messages[0]["env"]["NO_PROXY"], "localhost,.internal");
-    assert_eq!(messages[0]["env"]["no_proxy"], "localhost,.internal");
+    assert_eq!(
+        messages[0]["env"]["NO_PROXY"],
+        "localhost,.internal,127.0.0.1,::1,host.docker.internal"
+    );
+    assert_eq!(
+        messages[0]["env"]["no_proxy"],
+        "localhost,.internal,127.0.0.1,::1,host.docker.internal"
+    );
     assert_eq!(messages[3]["params"]["modelProvider"], "openai");
 }
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -186,6 +186,15 @@ const PROVIDER_SWITCH_LUNA_LABEL = 'GPT 5.6 Luna (海外)'
 const PROVIDER_SWITCH_LUNA_MODEL_ID = 'gpt-5.6-luna'
 const PROVIDER_SWITCH_SOL_OPTION_ID = 'gpt-5.6-sol'
 const PROVIDER_SWITCH_SOL_LABEL = 'GPT 5.6 Sol'
+// Official Codex option used to verify the provider boundary restriction. The
+// local E2E Codex catalog is classified as third-party (custom provider), so
+// the official option is served from the cloud model catalog with a model id
+// that does not collide with the local Codex catalog (otherwise the catalog
+// merge drops it as a duplicate runtime Codex model).
+const PROVIDER_SWITCH_OFFICIAL_OPTION_ID = 'codex-gpt-5.5'
+const PROVIDER_SWITCH_OFFICIAL_LABEL = 'GPT 5.5'
+const PROVIDER_SWITCH_OFFICIAL_MODEL_ID = 'gpt-5.5'
+const PROVIDER_SWITCH_OFFICIAL_MODEL_LABEL = 'GPT 5.5'
 const PROVIDER_SWITCH_PROMPT =
   'WEWORK_DESKTOP_E2E_PROVIDER_SWITCH: fail on Luna, then retry this turn with Sol.'
 const PROVIDER_SWITCH_FAILURE = 'WEWORK_DESKTOP_E2E_LUNA_INTENTIONAL_FAILURE'
@@ -1851,10 +1860,10 @@ async function verifyProviderBoundaryRestriction(control, composerSelector) {
   await control.command('waitFor', '[data-testid="model-selector-menu"]', {
     timeoutMs: UI_TIMEOUT_MS,
   })
-  await ensureModelOptionVisible(control, `model-option-${PROVIDER_SWITCH_SOL_OPTION_ID}`)
-  const officialModelSelector = `[data-testid="model-option-${PROVIDER_SWITCH_SOL_OPTION_ID}"]`
+  await ensureModelOptionVisible(control, `model-option-${PROVIDER_SWITCH_OFFICIAL_OPTION_ID}`)
+  const officialModelSelector = `[data-testid="model-option-${PROVIDER_SWITCH_OFFICIAL_OPTION_ID}"]`
   await control.command('waitFor', officialModelSelector, {
-    text: PROVIDER_SWITCH_SOL_LABEL,
+    text: PROVIDER_SWITCH_OFFICIAL_LABEL,
     timeoutMs: UI_TIMEOUT_MS,
   })
   const disabledModelText = await control.command('getText', officialModelSelector)
@@ -4123,6 +4132,22 @@ class DesktopE2EServer {
                 apiFormat: 'responses',
                 weworkModelKind: 'codex-official',
                 ui: { family: 'codex-official', modelLabel: DEFAULT_MODEL_LABEL },
+              },
+              runtime: { family: 'openai.openai-responses' },
+              isActive: true,
+            },
+            {
+              name: PROVIDER_SWITCH_OFFICIAL_OPTION_ID,
+              type: 'runtime',
+              displayName: PROVIDER_SWITCH_OFFICIAL_LABEL,
+              provider: 'openai',
+              modelId: PROVIDER_SWITCH_OFFICIAL_MODEL_ID,
+              namespace: 'default',
+              config: {
+                protocol: 'openai-responses',
+                apiFormat: 'responses',
+                weworkModelKind: 'codex-official',
+                ui: { family: 'codex-official', modelLabel: PROVIDER_SWITCH_OFFICIAL_MODEL_LABEL },
               },
               runtime: { family: 'openai.openai-responses' },
               isActive: true,


### PR DESCRIPTION
## 问题

main 分支 CI 两处失败（#2259 合并后）：

1. **Tests / Executor Rust**：契约测试断言的 NO_PROXY 仍是旧值 localhost,.internal，而 #2258 已将必须的 loopback 主机合并进代理绕过列表。

2. **Wework E2E / verifyProviderBoundaryRestriction**：桌面 E2E 的本地 Codex 目录使用自定义 provider，所有本地 Codex 模型被归类为第三方桶；云端官方 Codex 模型又因 modelId 与本地目录重复被 mergeModelCatalogs 去重丢弃，菜单里不存在任何官方桶模型，断言永远失败。

## 修改

- executor/tests/codex_app_server_contract.rs：期望更新为合并后的 NO_PROXY。
- wework/e2e/desktop/task-flow.e2e.mjs：云端模型 mock 增加 modelId 不冲突的官方 Codex 模型（codex-gpt-5.5），provider boundary 断言改为针对该官方选项。

## 验证

- cargo test --test codex_app_server_contract：15 passed
- node e2e/desktop/task-flow.e2e.mjs --model-switch-only（本地完整跑通）：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy bypass handling for local and internal hosts, including loopback and Docker host addresses.
  * Updated provider-boundary behavior so the official Codex model is correctly recognized and disabled when unavailable through the selected provider.

* **Tests**
  * Expanded automated coverage for proxy configuration and model availability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->