### PR TITLE
feat(chat_shell): add AI history-backtracking tools

### DIFF
--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -35,6 +35,10 @@ from app.models.user import User
 from app.services.auth.internal_service_token import verify_internal_service_token
 from app.services.chat.compaction_checkpoint import resolve_history_subtasks
 from app.services.chat.guidance_queue import guidance_queue
+from app.services.chat.subtask_history import (
+    list_subtask_summaries,
+    read_subtask_record,
+)
 from app.services.chat.webpage_ws_chat_emitter import get_webpage_ws_emitter
 from app.stores.tasks import subtask_store, task_store
 from shared.prompts.constants import parse_prompt_blocks
@@ -944,22 +948,6 @@ async def get_chat_history(
     return HistoryResponse(session_id=session_id, messages=messages)
 
 
-_SUBTASK_PREVIEW_CHARS = 200
-
-
-def _subtask_primary_text(subtask: Subtask) -> str:
-    """Un-compacted plain text of a subtask, for preview and size.
-
-    Deliberately reads the raw record (prompt / result.value), not the
-    compaction-scoped history flatten, so previews reflect the original turn.
-    """
-    if subtask.role == SubtaskRole.USER:
-        return subtask.prompt or ""
-    result = subtask.result if isinstance(subtask.result, dict) else {}
-    value = result.get("value")
-    return value if isinstance(value, str) else ""
-
-
 class SubtaskSummary(BaseModel):
     """One-line summary of a history subtask for AI backtracking."""
 
@@ -1011,24 +999,11 @@ async def list_history_subtasks(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    subtasks = subtask_store.list_new_messages_since(
-        db, task_id=task_id, owner_user_id=task.user_id
+    summaries = list_subtask_summaries(db, task_id=task_id, user_id=task.user_id)
+    return SubtaskListResponse(
+        session_id=session_id,
+        subtasks=[SubtaskSummary(**s) for s in summaries],
     )
-    summaries = []
-    for st in subtasks:
-        if st.status == SubtaskStatus.DELETE:
-            continue
-        text = _subtask_primary_text(st)
-        summaries.append(
-            SubtaskSummary(
-                id=st.id,
-                role=st.role.value.lower(),
-                status=st.status.value,
-                char_count=len(text),
-                preview=text[:_SUBTASK_PREVIEW_CHARS],
-            )
-        )
-    return SubtaskListResponse(session_id=session_id, subtasks=summaries)
 
 
 @router.get(
@@ -1050,29 +1025,12 @@ async def read_history_subtask(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    subtask = subtask_store.get_by_id(
-        db, subtask_id=subtask_id, owner_user_id=task.user_id
+    record = read_subtask_record(
+        db, task_id=task_id, subtask_id=subtask_id, user_id=task.user_id
     )
-    # Owner filter alone is not enough: a same-user subtask in a different task
-    # must not be readable through this session. Enforce task ownership too.
-    if subtask is None or subtask.task_id != task_id:
+    if record is None:
         raise HTTPException(status_code=404, detail="Subtask not found in this session")
-
-    role = subtask.role.value.lower()
-    status = subtask.status.value
-    if subtask.role == SubtaskRole.USER:
-        return SubtaskRecordResponse(
-            id=subtask.id, role=role, status=status, prompt=subtask.prompt or ""
-        )
-    result = subtask.result if isinstance(subtask.result, dict) else {}
-    return SubtaskRecordResponse(
-        id=subtask.id,
-        role=role,
-        status=status,
-        blocks=result.get("blocks"),
-        messages_chain=result.get("messages_chain"),
-        value=result.get("value"),
-    )
+    return SubtaskRecordResponse(**record)
 
 
 class AttachmentTextResponse(BaseModel):

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -944,6 +944,137 @@ async def get_chat_history(
     return HistoryResponse(session_id=session_id, messages=messages)
 
 
+_SUBTASK_PREVIEW_CHARS = 200
+
+
+def _subtask_primary_text(subtask: Subtask) -> str:
+    """Un-compacted plain text of a subtask, for preview and size.
+
+    Deliberately reads the raw record (prompt / result.value), not the
+    compaction-scoped history flatten, so previews reflect the original turn.
+    """
+    if subtask.role == SubtaskRole.USER:
+        return subtask.prompt or ""
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    value = result.get("value")
+    return value if isinstance(value, str) else ""
+
+
+class SubtaskSummary(BaseModel):
+    """One-line summary of a history subtask for AI backtracking."""
+
+    id: int
+    role: str
+    status: str
+    char_count: int
+    preview: str
+
+
+class SubtaskListResponse(BaseModel):
+    session_id: str
+    subtasks: list[SubtaskSummary]
+
+
+class SubtaskRecordResponse(BaseModel):
+    """Raw, un-compaction-scoped record of a single subtask.
+
+    ``blocks`` is the as-streamed ground truth (never compaction-lossy);
+    ``messages_chain`` / ``value`` are fallbacks for legacy/simple turns. The
+    caller (chat_shell) renders and paginates by block.
+    """
+
+    id: int
+    role: str
+    status: str
+    prompt: Optional[str] = None
+    blocks: Optional[list] = None
+    messages_chain: Optional[list] = None
+    value: Optional[str] = None
+
+
+@router.get("/history/{session_id}/subtasks", response_model=SubtaskListResponse)
+async def list_history_subtasks(
+    session_id: str,
+    db: Session = Depends(get_db),
+):
+    """List the whole session's subtasks as summaries (AI history backtracking).
+
+    Unlike ``/history``, this is NOT compaction-scoped: it lists every subtask so
+    the model can page back into detail that compaction summarized away.
+    """
+    session_type, task_id = parse_session_id(session_id)
+    if session_type != "task":
+        raise HTTPException(
+            status_code=400, detail="Only task-based sessions are supported"
+        )
+    task = task_store.get_by_id(db, task_id=task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    subtasks = subtask_store.list_new_messages_since(
+        db, task_id=task_id, owner_user_id=task.user_id
+    )
+    summaries = []
+    for st in subtasks:
+        if st.status == SubtaskStatus.DELETE:
+            continue
+        text = _subtask_primary_text(st)
+        summaries.append(
+            SubtaskSummary(
+                id=st.id,
+                role=st.role.value.lower(),
+                status=st.status.value,
+                char_count=len(text),
+                preview=text[:_SUBTASK_PREVIEW_CHARS],
+            )
+        )
+    return SubtaskListResponse(session_id=session_id, subtasks=summaries)
+
+
+@router.get(
+    "/history/{session_id}/subtasks/{subtask_id}",
+    response_model=SubtaskRecordResponse,
+)
+async def read_history_subtask(
+    session_id: str,
+    subtask_id: int,
+    db: Session = Depends(get_db),
+):
+    """Return one subtask's raw record (un-compaction-scoped) for backtracking."""
+    session_type, task_id = parse_session_id(session_id)
+    if session_type != "task":
+        raise HTTPException(
+            status_code=400, detail="Only task-based sessions are supported"
+        )
+    task = task_store.get_by_id(db, task_id=task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    subtask = subtask_store.get_by_id(
+        db, subtask_id=subtask_id, owner_user_id=task.user_id
+    )
+    # Owner filter alone is not enough: a same-user subtask in a different task
+    # must not be readable through this session. Enforce task ownership too.
+    if subtask is None or subtask.task_id != task_id:
+        raise HTTPException(status_code=404, detail="Subtask not found in this session")
+
+    role = subtask.role.value.lower()
+    status = subtask.status.value
+    if subtask.role == SubtaskRole.USER:
+        return SubtaskRecordResponse(
+            id=subtask.id, role=role, status=status, prompt=subtask.prompt or ""
+        )
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    return SubtaskRecordResponse(
+        id=subtask.id,
+        role=role,
+        status=status,
+        blocks=result.get("blocks"),
+        messages_chain=result.get("messages_chain"),
+        value=result.get("value"),
+    )
+
+
 class AttachmentTextResponse(BaseModel):
     """A character slice of an attachment's extracted text."""
 

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -961,28 +961,33 @@ class SubtaskSummary(BaseModel):
 class SubtaskListResponse(BaseModel):
     session_id: str
     subtasks: list[SubtaskSummary]
+    total: int
+    has_more: bool
 
 
 class SubtaskRecordResponse(BaseModel):
-    """Raw, un-compaction-scoped record of a single subtask.
+    """One page of a subtask's rendered, un-compaction-scoped transcript.
 
-    ``blocks`` is the as-streamed ground truth (never compaction-lossy);
-    ``messages_chain`` / ``value`` are fallbacks for legacy/simple turns. The
-    caller (chat_shell) renders and paginates by block.
+    Paged by a compound cursor (``"<unit_idx>:<char_off>"``): whole units in the
+    common case, a within-unit character split only when a single unit alone
+    overflows the page. ``next_cursor`` is ``None`` at the end.
     """
 
     id: int
     role: str
     status: str
-    prompt: Optional[str] = None
-    blocks: Optional[list] = None
-    messages_chain: Optional[list] = None
-    value: Optional[str] = None
+    content: str
+    cursor: str
+    next_cursor: Optional[str] = None
+    has_more: bool
+    total_units: int
 
 
 @router.get("/history/{session_id}/subtasks", response_model=SubtaskListResponse)
 async def list_history_subtasks(
     session_id: str,
+    limit: Optional[int] = Query(None, description="Max summaries to return"),
+    offset: int = Query(0, description="Number of summaries to skip"),
     db: Session = Depends(get_db),
 ):
     """List the whole session's subtasks as summaries (AI history backtracking).
@@ -999,10 +1004,14 @@ async def list_history_subtasks(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    summaries = list_subtask_summaries(db, task_id=task_id, user_id=task.user_id)
+    result = list_subtask_summaries(
+        db, task_id=task_id, user_id=task.user_id, limit=limit, offset=offset
+    )
     return SubtaskListResponse(
         session_id=session_id,
-        subtasks=[SubtaskSummary(**s) for s in summaries],
+        subtasks=[SubtaskSummary(**s) for s in result["subtasks"]],
+        total=result["total"],
+        has_more=result["has_more"],
     )
 
 
@@ -1013,9 +1022,11 @@ async def list_history_subtasks(
 async def read_history_subtask(
     session_id: str,
     subtask_id: int,
+    cursor: str = Query("0:0", description="Compound cursor '<unit>:<char_off>'"),
+    max_chars: int = Query(0, description="Per-page char budget (0 = default)"),
     db: Session = Depends(get_db),
 ):
-    """Return one subtask's raw record (un-compaction-scoped) for backtracking."""
+    """Return one page of a subtask's rendered transcript (for backtracking)."""
     session_type, task_id = parse_session_id(session_id)
     if session_type != "task":
         raise HTTPException(
@@ -1026,7 +1037,12 @@ async def read_history_subtask(
         raise HTTPException(status_code=404, detail="Task not found")
 
     record = read_subtask_record(
-        db, task_id=task_id, subtask_id=subtask_id, user_id=task.user_id
+        db,
+        task_id=task_id,
+        subtask_id=subtask_id,
+        user_id=task.user_id,
+        cursor=cursor,
+        max_chars=max_chars,
     )
     if record is None:
         raise HTTPException(status_code=404, detail="Subtask not found in this session")

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -32,6 +32,11 @@ from app.models.subtask_context import (
     SubtaskContext,
 )
 from app.models.user import User
+from app.schemas.subtask_history import (
+    SubtaskListResponse,
+    SubtaskRecordResponse,
+    SubtaskSummary,
+)
 from app.services.auth.internal_service_token import verify_internal_service_token
 from app.services.chat.compaction_checkpoint import resolve_history_subtasks
 from app.services.chat.guidance_queue import guidance_queue
@@ -948,42 +953,15 @@ async def get_chat_history(
     return HistoryResponse(session_id=session_id, messages=messages)
 
 
-class SubtaskSummary(BaseModel):
-    """One-line summary of a history subtask for AI backtracking."""
-
-    id: int
-    role: str
-    status: str
-    char_count: int
-    preview: str
-
-
-class SubtaskListResponse(BaseModel):
-    session_id: str
-    subtasks: list[SubtaskSummary]
-    total: int
-    has_more: bool
-
-
-class SubtaskRecordResponse(BaseModel):
-    """One page of a subtask's rendered, un-compaction-scoped transcript.
-
-    Paged by a compound cursor (``"<unit_idx>:<char_off>"``): whole units in the
-    common case, a within-unit character split only when a single unit alone
-    overflows the page. ``next_cursor`` is ``None`` at the end.
-    """
-
-    id: int
-    role: str
-    status: str
-    content: str
-    cursor: str
-    next_cursor: Optional[str] = None
-    has_more: bool
-    total_units: int
-
-
 @router.get("/history/{session_id}/subtasks", response_model=SubtaskListResponse)
+@trace_async(
+    "internal.chat_storage.list_subtasks",
+    "internal.chat_storage",
+    extract_attributes=lambda *args, **kwargs: {
+        "chat.session_id": kwargs.get("session_id", ""),
+        "chat.offset": kwargs.get("offset", 0),
+    },
+)
 async def list_history_subtasks(
     session_id: str,
     limit: Optional[int] = Query(None, description="Max summaries to return"),
@@ -1018,6 +996,14 @@ async def list_history_subtasks(
 @router.get(
     "/history/{session_id}/subtasks/{subtask_id}",
     response_model=SubtaskRecordResponse,
+)
+@trace_async(
+    "internal.chat_storage.read_subtask",
+    "internal.chat_storage",
+    extract_attributes=lambda *args, **kwargs: {
+        "chat.session_id": kwargs.get("session_id", ""),
+        "chat.subtask_id": kwargs.get("subtask_id", 0),
+    },
 )
 async def read_history_subtask(
     session_id: str,

--- a/backend/app/schemas/subtask_history.py
+++ b/backend/app/schemas/subtask_history.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Response schemas for the AI history-backtracking endpoints."""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SubtaskSummary(BaseModel):
+    """One-line summary of a history subtask for AI backtracking."""
+
+    id: int
+    role: str
+    status: str
+    char_count: int
+    preview: str
+
+
+class SubtaskListResponse(BaseModel):
+    """A page of subtask summaries."""
+
+    session_id: str
+    subtasks: list[SubtaskSummary]
+    total: int
+    has_more: bool
+
+
+class SubtaskRecordResponse(BaseModel):
+    """One page of a subtask's rendered, un-compaction-scoped transcript.
+
+    Paged by a compound cursor (``"<unit_idx>:<char_off>"``): whole units in the
+    common case, a within-unit character split only when a single unit alone
+    overflows the page. ``next_cursor`` is ``None`` at the end.
+    """
+
+    id: int
+    role: str
+    status: str
+    content: str
+    cursor: str
+    next_cursor: Optional[str] = None
+    has_more: bool
+    total_units: int

--- a/backend/app/services/chat/subtask_history.py
+++ b/backend/app/services/chat/subtask_history.py
@@ -6,12 +6,23 @@
 
 Single source of truth for "list the session's subtasks" and "read one subtask's
 raw record", used by BOTH the internal HTTP endpoints and chat_shell package mode
-(direct import) — so the query, scoping, DELETE filtering and preview logic are
-never implemented twice. Reads the raw record (``result.blocks`` / ``prompt``),
-deliberately un-compaction-scoped: backtracking recovers detail that compaction
-summarized away.
+(direct import) — so query, scoping, DELETE filtering, rendering and pagination
+are never implemented twice. Pagination lives here (the API layer), not in
+chat_shell.
+
+- ``list`` pages by ``limit`` / ``offset``.
+- ``read`` renders the subtask to a transcript and pages it with a **compound
+  cursor** ``"<unit_idx>:<char_off>"``: whole units in the common case (clean
+  boundaries), and — only when a single unit alone exceeds the page budget — a
+  character split *within that one unit*, so even a giant tool output is fully
+  reachable (there is no grep tool). Budget is measured in characters
+  (tokenizer-free); the request-level tool-output guard is the head+tail backstop.
+
+Reads the raw record (``result.blocks`` / ``prompt``), deliberately
+un-compaction-scoped: backtracking recovers detail compaction summarized away.
 """
 
+import json
 from typing import Any, Optional
 
 from sqlalchemy.orm import Session
@@ -20,6 +31,11 @@ from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
 from app.stores.tasks import subtask_store
 
 PREVIEW_CHARS = 200
+DEFAULT_LIST_LIMIT = 50
+# Fallback page size (characters) when the caller does not pass max_chars.
+# chat_shell derives its value from the tool-output guard limit; this default just
+# keeps a direct API call bounded.
+DEFAULT_READ_MAX_CHARS = 14_000
 
 
 def subtask_primary_text(subtask: Subtask) -> str:
@@ -32,36 +48,125 @@ def subtask_primary_text(subtask: Subtask) -> str:
 
 
 def list_subtask_summaries(
-    db: Session, *, task_id: int, user_id: int
-) -> list[dict[str, Any]]:
-    """Summaries for every non-deleted subtask of the task's session."""
+    db: Session,
+    *,
+    task_id: int,
+    user_id: int,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Paged summaries for the task's non-deleted subtasks.
+
+    Returns ``{"subtasks": [...], "total": int, "has_more": bool}``.
+    """
     subtasks = subtask_store.list_new_messages_since(
         db, task_id=task_id, owner_user_id=user_id
     )
-    summaries: list[dict[str, Any]] = []
-    for st in subtasks:
-        if st.status == SubtaskStatus.DELETE:
-            continue
-        text = subtask_primary_text(st)
-        summaries.append(
-            {
-                "id": st.id,
-                "role": st.role.value.lower(),
-                "status": st.status.value,
-                "char_count": len(text),
-                "preview": text[:PREVIEW_CHARS],
-            }
-        )
-    return summaries
+    visible = [st for st in subtasks if st.status != SubtaskStatus.DELETE]
+    total = len(visible)
+
+    offset = max(0, offset)
+    window = visible[offset : offset + limit] if limit else visible[offset:]
+    summaries = [
+        {
+            "id": st.id,
+            "role": st.role.value.lower(),
+            "status": st.status.value,
+            "char_count": len(text),
+            "preview": text[:PREVIEW_CHARS],
+        }
+        for st in window
+        for text in [subtask_primary_text(st)]
+    ]
+    return {
+        "subtasks": summaries,
+        "total": total,
+        "has_more": offset + len(window) < total,
+    }
+
+
+# ---- read: render + compound-cursor pagination -----------------------------
+
+
+def _render_block(block: dict[str, Any]) -> str:
+    """Render one stored block into a readable transcript fragment."""
+    btype = block.get("type")
+    if btype == "text":
+        return str(block.get("content") or "")
+    if btype == "tool":
+        name = block.get("display_name") or block.get("tool_name") or "tool"
+        tool_input = block.get("tool_input") or {}
+        lines = [f"[tool: {name}] input={json.dumps(tool_input, ensure_ascii=False)}"]
+        output = block.get("tool_output")
+        if output:
+            lines.append(f"output: {output}")
+        return "\n".join(lines)
+    if btype in ("guidance", "subagent"):
+        return str(block.get("content") or "")
+    return json.dumps(block, ensure_ascii=False)
+
+
+def _render_message(message: dict[str, Any]) -> str:
+    """Render one messages_chain entry (fallback for legacy turns)."""
+    role = message.get("role", "assistant")
+    content = message.get("content")
+    text = (
+        content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+    )
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        text = f"{text}\n[tool_calls: {json.dumps(tool_calls, ensure_ascii=False)}]"
+    return f"{role}: {text}"
+
+
+def _rendered_units(subtask: Subtask) -> list[str]:
+    """Ordered, non-empty rendered unit strings for the subtask.
+
+    ``blocks`` is the as-streamed ground truth (never compaction-lossy);
+    ``messages`` / ``text`` are fallbacks for legacy/simple turns.
+    """
+    if subtask.role == SubtaskRole.USER:
+        return [subtask.prompt] if subtask.prompt else []
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    blocks = result.get("blocks")
+    if isinstance(blocks, list) and blocks:
+        rendered = [_render_block(b) for b in blocks if isinstance(b, dict)]
+    else:
+        chain = result.get("messages_chain")
+        if isinstance(chain, list) and chain:
+            rendered = [_render_message(m) for m in chain if isinstance(m, dict)]
+        else:
+            value = result.get("value")
+            rendered = [value] if isinstance(value, str) and value else []
+    return [r for r in rendered if r]
+
+
+def _parse_cursor(cursor: str, total: int) -> tuple[int, int]:
+    """Parse ``"<unit_idx>:<char_off>"`` defensively into clamped ints."""
+    unit_idx, char_off = 0, 0
+    if isinstance(cursor, str) and ":" in cursor:
+        head, _, tail = cursor.partition(":")
+        if head.isdigit():
+            unit_idx = int(head)
+        if tail.isdigit():
+            char_off = int(tail)
+    return max(0, min(unit_idx, total)), max(0, char_off)
 
 
 def read_subtask_record(
-    db: Session, *, task_id: int, subtask_id: int, user_id: int
+    db: Session,
+    *,
+    task_id: int,
+    subtask_id: int,
+    user_id: int,
+    cursor: str = "0:0",
+    max_chars: int = DEFAULT_READ_MAX_CHARS,
 ) -> Optional[dict[str, Any]]:
-    """One subtask's raw record, scoped to the task's session.
+    """One subtask's rendered record, scoped to the session and paged.
 
     Returns ``None`` when the subtask is missing, belongs to another task, or has
-    been deleted — callers surface that as a 404 / not-available.
+    been deleted. Otherwise a dict with the ``content`` page and
+    ``cursor`` / ``next_cursor`` / ``has_more`` / ``total_units``.
     """
     subtask = subtask_store.get_by_id(db, subtask_id=subtask_id, owner_user_id=user_id)
     # Owner filter alone is not enough: a same-user subtask in a different task
@@ -74,21 +179,43 @@ def read_subtask_record(
     ):
         return None
 
-    role = subtask.role.value.lower()
-    status = subtask.status.value
-    if subtask.role == SubtaskRole.USER:
-        return {
-            "id": subtask.id,
-            "role": role,
-            "status": status,
-            "prompt": subtask.prompt or "",
-        }
-    result = subtask.result if isinstance(subtask.result, dict) else {}
+    units = _rendered_units(subtask)
+    total = len(units)
+    if max_chars <= 0:
+        max_chars = DEFAULT_READ_MAX_CHARS
+    unit_idx, char_off = _parse_cursor(cursor, total)
+
+    parts: list[str] = []
+    budget = max_chars
+    i, off = unit_idx, char_off
+    next_cursor: Optional[str] = None
+    while i < total:
+        piece = units[i][off:]
+        if len(piece) > budget:
+            if not parts:
+                # A single unit alone overflows the page — split within it so a
+                # giant tool output stays fully reachable (never lost).
+                parts.append(piece[:budget])
+                new_off = off + budget
+                next_cursor = (
+                    f"{i + 1}:0" if new_off >= len(units[i]) else f"{i}:{new_off}"
+                )
+            else:
+                # Page already has content: stop on this whole-unit boundary.
+                next_cursor = f"{i}:{off}"
+            break
+        parts.append(piece)
+        budget -= len(piece)
+        i += 1
+        off = 0
+
     return {
         "id": subtask.id,
-        "role": role,
-        "status": status,
-        "blocks": result.get("blocks"),
-        "messages_chain": result.get("messages_chain"),
-        "value": result.get("value"),
+        "role": subtask.role.value.lower(),
+        "status": subtask.status.value,
+        "content": "\n\n".join(parts),
+        "cursor": f"{unit_idx}:{char_off}",
+        "next_cursor": next_cursor,
+        "has_more": next_cursor is not None,
+        "total_units": total,
     }

--- a/backend/app/services/chat/subtask_history.py
+++ b/backend/app/services/chat/subtask_history.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared subtask-history retrieval for AI backtracking.
+
+Single source of truth for "list the session's subtasks" and "read one subtask's
+raw record", used by BOTH the internal HTTP endpoints and chat_shell package mode
+(direct import) — so the query, scoping, DELETE filtering and preview logic are
+never implemented twice. Reads the raw record (``result.blocks`` / ``prompt``),
+deliberately un-compaction-scoped: backtracking recovers detail that compaction
+summarized away.
+"""
+
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
+from app.stores.tasks import subtask_store
+
+PREVIEW_CHARS = 200
+
+
+def subtask_primary_text(subtask: Subtask) -> str:
+    """Un-compacted plain text of a subtask, for preview and size."""
+    if subtask.role == SubtaskRole.USER:
+        return subtask.prompt or ""
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    value = result.get("value")
+    return value if isinstance(value, str) else ""
+
+
+def list_subtask_summaries(
+    db: Session, *, task_id: int, user_id: int
+) -> list[dict[str, Any]]:
+    """Summaries for every non-deleted subtask of the task's session."""
+    subtasks = subtask_store.list_new_messages_since(
+        db, task_id=task_id, owner_user_id=user_id
+    )
+    summaries: list[dict[str, Any]] = []
+    for st in subtasks:
+        if st.status == SubtaskStatus.DELETE:
+            continue
+        text = subtask_primary_text(st)
+        summaries.append(
+            {
+                "id": st.id,
+                "role": st.role.value.lower(),
+                "status": st.status.value,
+                "char_count": len(text),
+                "preview": text[:PREVIEW_CHARS],
+            }
+        )
+    return summaries
+
+
+def read_subtask_record(
+    db: Session, *, task_id: int, subtask_id: int, user_id: int
+) -> Optional[dict[str, Any]]:
+    """One subtask's raw record, scoped to the task's session.
+
+    Returns ``None`` when the subtask is missing, belongs to another task, or has
+    been deleted — callers surface that as a 404 / not-available.
+    """
+    subtask = subtask_store.get_by_id(db, subtask_id=subtask_id, owner_user_id=user_id)
+    # Owner filter alone is not enough: a same-user subtask in a different task
+    # must not be readable through this session. Deleted subtasks are excluded to
+    # match the listing.
+    if (
+        subtask is None
+        or subtask.task_id != task_id
+        or subtask.status == SubtaskStatus.DELETE
+    ):
+        return None
+
+    role = subtask.role.value.lower()
+    status = subtask.status.value
+    if subtask.role == SubtaskRole.USER:
+        return {
+            "id": subtask.id,
+            "role": role,
+            "status": status,
+            "prompt": subtask.prompt or "",
+        }
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    return {
+        "id": subtask.id,
+        "role": role,
+        "status": status,
+        "blocks": result.get("blocks"),
+        "messages_chain": result.get("messages_chain"),
+        "value": result.get("value"),
+    }

--- a/backend/app/services/chat/subtask_history.py
+++ b/backend/app/services/chat/subtask_history.py
@@ -31,61 +31,13 @@ from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
 from app.stores.tasks import subtask_store
 
 PREVIEW_CHARS = 200
-DEFAULT_LIST_LIMIT = 50
 # Fallback page size (characters) when the caller does not pass max_chars.
 # chat_shell derives its value from the tool-output guard limit; this default just
 # keeps a direct API call bounded.
 DEFAULT_READ_MAX_CHARS = 14_000
 
 
-def subtask_primary_text(subtask: Subtask) -> str:
-    """Un-compacted plain text of a subtask, for preview and size."""
-    if subtask.role == SubtaskRole.USER:
-        return subtask.prompt or ""
-    result = subtask.result if isinstance(subtask.result, dict) else {}
-    value = result.get("value")
-    return value if isinstance(value, str) else ""
-
-
-def list_subtask_summaries(
-    db: Session,
-    *,
-    task_id: int,
-    user_id: int,
-    limit: Optional[int] = None,
-    offset: int = 0,
-) -> dict[str, Any]:
-    """Paged summaries for the task's non-deleted subtasks.
-
-    Returns ``{"subtasks": [...], "total": int, "has_more": bool}``.
-    """
-    subtasks = subtask_store.list_new_messages_since(
-        db, task_id=task_id, owner_user_id=user_id
-    )
-    visible = [st for st in subtasks if st.status != SubtaskStatus.DELETE]
-    total = len(visible)
-
-    offset = max(0, offset)
-    window = visible[offset : offset + limit] if limit else visible[offset:]
-    summaries = [
-        {
-            "id": st.id,
-            "role": st.role.value.lower(),
-            "status": st.status.value,
-            "char_count": len(text),
-            "preview": text[:PREVIEW_CHARS],
-        }
-        for st in window
-        for text in [subtask_primary_text(st)]
-    ]
-    return {
-        "subtasks": summaries,
-        "total": total,
-        "has_more": offset + len(window) < total,
-    }
-
-
-# ---- read: render + compound-cursor pagination -----------------------------
+# ---- rendering (shared by read paging and list previews) -------------------
 
 
 def _render_block(block: dict[str, Any]) -> str:
@@ -139,6 +91,72 @@ def _rendered_units(subtask: Subtask) -> list[str]:
             value = result.get("value")
             rendered = [value] if isinstance(value, str) and value else []
     return [r for r in rendered if r]
+
+
+def _preview_text(subtask: Subtask) -> str:
+    """A short preview source for the summary list.
+
+    Prefers ``result.value`` (the final text, a clean one-line preview) and falls
+    back to the first rendered unit so block-only turns still get a non-empty
+    preview — consistent with ``_rendered_units``' block-first source.
+    """
+    if subtask.role == SubtaskRole.USER:
+        return subtask.prompt or ""
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    value = result.get("value")
+    if isinstance(value, str) and value:
+        return value
+    units = _rendered_units(subtask)
+    return units[0] if units else ""
+
+
+# ---- list ------------------------------------------------------------------
+
+
+def list_subtask_summaries(
+    db: Session,
+    *,
+    task_id: int,
+    user_id: int,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Paged summaries for the task's non-deleted subtasks.
+
+    Returns ``{"subtasks": [...], "total": int, "has_more": bool}``. ``limit=None``
+    means no limit; ``limit=0`` returns an empty page (``total`` still reflects
+    all visible subtasks).
+    """
+    subtasks = subtask_store.list_new_messages_since(
+        db, task_id=task_id, owner_user_id=user_id
+    )
+    visible = [st for st in subtasks if st.status != SubtaskStatus.DELETE]
+    total = len(visible)
+
+    offset = max(0, offset)
+    if limit is None:
+        window = visible[offset:]
+    else:
+        window = visible[offset : offset + max(0, limit)]
+    summaries = [
+        {
+            "id": st.id,
+            "role": st.role.value.lower(),
+            "status": st.status.value,
+            "char_count": len(text),
+            "preview": text[:PREVIEW_CHARS],
+        }
+        for st in window
+        for text in [_preview_text(st)]
+    ]
+    return {
+        "subtasks": summaries,
+        "total": total,
+        "has_more": offset + len(window) < total,
+    }
+
+
+# ---- read: compound-cursor pagination --------------------------------------
 
 
 def _parse_cursor(cursor: str, total: int) -> tuple[int, int]:

--- a/backend/tests/api/test_internal_chat_storage_history_subtasks.py
+++ b/backend/tests/api/test_internal_chat_storage_history_subtasks.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AI history-backtracking internal endpoints:
+
+- ``GET /chat/history/{session_id}/subtasks`` — whole-session summary list.
+- ``GET /chat/history/{session_id}/subtasks/{subtask_id}`` — one raw record.
+
+Both are un-compaction-scoped and strictly session-owned.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_db
+from app.api.endpoints.internal import chat_storage
+from app.core.config import settings
+from app.models.subtask import SubtaskRole, SubtaskStatus
+
+
+def _subtask(sid, role, **kw):
+    base = dict(
+        id=sid,
+        task_id=2,
+        user_id=7,
+        role=role,
+        status=SubtaskStatus.COMPLETED,
+        message_id=sid,
+        prompt=None,
+        result=None,
+        contexts=[],
+        sender_user_id=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def internal_chat_client(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
+    app = FastAPI()
+    app.include_router(chat_storage.router, prefix="/internal")
+    app.dependency_overrides[get_db] = lambda: SimpleNamespace()
+    return TestClient(app, headers={"Authorization": "Bearer test-internal-token"})
+
+
+def _patch_task(monkeypatch, user_id=7):
+    monkeypatch.setattr(
+        chat_storage,
+        "task_store",
+        SimpleNamespace(
+            get_by_id=lambda db, *, task_id: (
+                SimpleNamespace(user_id=user_id) if task_id == 2 else None
+            )
+        ),
+        raising=False,
+    )
+
+
+def test_list_subtasks_returns_summaries(internal_chat_client, monkeypatch):
+    _patch_task(monkeypatch)
+    subtasks = [
+        _subtask(1, SubtaskRole.USER, prompt="hello world"),
+        _subtask(2, SubtaskRole.ASSISTANT, result={"value": "hi there"}),
+    ]
+    monkeypatch.setattr(
+        chat_storage.subtask_store,
+        "list_new_messages_since",
+        lambda db, **kw: subtasks,
+        raising=False,
+    )
+
+    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks")
+
+    assert resp.status_code == 200
+    data = resp.json()["subtasks"]
+    assert [s["id"] for s in data] == [1, 2]
+    assert data[0]["role"] == "user"
+    assert data[0]["preview"] == "hello world"
+    assert data[0]["char_count"] == len("hello world")
+    assert data[1]["preview"] == "hi there"
+
+
+def test_list_subtasks_skips_deleted(internal_chat_client, monkeypatch):
+    _patch_task(monkeypatch)
+    deleted = _subtask(3, SubtaskRole.ASSISTANT, result={"value": "gone"})
+    deleted.status = SubtaskStatus.DELETE
+    subtasks = [_subtask(1, SubtaskRole.USER, prompt="keep"), deleted]
+    monkeypatch.setattr(
+        chat_storage.subtask_store,
+        "list_new_messages_since",
+        lambda db, **kw: subtasks,
+        raising=False,
+    )
+
+    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks")
+
+    assert resp.status_code == 200
+    assert [s["id"] for s in resp.json()["subtasks"]] == [1]
+
+
+def test_read_subtask_returns_blocks(internal_chat_client, monkeypatch):
+    _patch_task(monkeypatch)
+    st = _subtask(
+        2,
+        SubtaskRole.ASSISTANT,
+        result={"blocks": [{"type": "text", "text": "a"}], "value": "a"},
+    )
+    monkeypatch.setattr(
+        chat_storage.subtask_store,
+        "get_by_id",
+        lambda db, *, subtask_id, owner_user_id=None: st if subtask_id == 2 else None,
+        raising=False,
+    )
+
+    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/2")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["role"] == "assistant"
+    assert body["blocks"] == [{"type": "text", "text": "a"}]
+    assert body["value"] == "a"
+
+
+def test_read_subtask_user_returns_prompt(internal_chat_client, monkeypatch):
+    _patch_task(monkeypatch)
+    st = _subtask(1, SubtaskRole.USER, prompt="the question")
+    monkeypatch.setattr(
+        chat_storage.subtask_store,
+        "get_by_id",
+        lambda db, *, subtask_id, owner_user_id=None: st,
+        raising=False,
+    )
+
+    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/1")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["role"] == "user"
+    assert body["prompt"] == "the question"
+    assert body["blocks"] is None
+
+
+def test_read_subtask_rejects_foreign_task(internal_chat_client, monkeypatch):
+    _patch_task(monkeypatch)
+    foreign = _subtask(9, SubtaskRole.ASSISTANT, task_id=999, result={"value": "x"})
+    monkeypatch.setattr(
+        chat_storage.subtask_store,
+        "get_by_id",
+        lambda db, *, subtask_id, owner_user_id=None: foreign,
+        raising=False,
+    )
+
+    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/9")
+
+    assert resp.status_code == 404

--- a/backend/tests/api/test_internal_chat_storage_history_subtasks.py
+++ b/backend/tests/api/test_internal_chat_storage_history_subtasks.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the AI history-backtracking internal endpoints:
+"""HTTP-wiring tests for the AI history-backtracking endpoints.
 
-- ``GET /chat/history/{session_id}/subtasks`` — whole-session summary list.
-- ``GET /chat/history/{session_id}/subtasks/{subtask_id}`` — one raw record.
+- ``GET /chat/history/{session_id}/subtasks`` — paged summary list.
+- ``GET /chat/history/{session_id}/subtasks/{subtask_id}`` — one transcript page.
 
-Both are un-compaction-scoped and strictly session-owned.
+Windowing/rendering logic is unit-tested in ``services/chat/test_subtask_history``;
+these cover the HTTP shape and session ownership.
 """
 
 from types import SimpleNamespace
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -32,15 +32,12 @@ def _subtask(sid, role, **kw):
         message_id=sid,
         prompt=None,
         result=None,
-        contexts=[],
-        sender_user_id=None,
     )
     base.update(kw)
     return SimpleNamespace(**base)
 
 
-@pytest.fixture
-def internal_chat_client(monkeypatch):
+def _internal_client(monkeypatch):
     monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
     app = FastAPI()
     app.include_router(chat_storage.router, prefix="/internal")
@@ -61,7 +58,8 @@ def _patch_task(monkeypatch, user_id=7):
     )
 
 
-def test_list_subtasks_returns_summaries(internal_chat_client, monkeypatch):
+def test_list_subtasks_returns_paged_summaries(monkeypatch):
+    client = _internal_client(monkeypatch)
     _patch_task(monkeypatch)
     subtasks = [
         _subtask(1, SubtaskRole.USER, prompt="hello world"),
@@ -74,41 +72,23 @@ def test_list_subtasks_returns_summaries(internal_chat_client, monkeypatch):
         raising=False,
     )
 
-    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks")
+    resp = client.get("/internal/chat/history/task-2/subtasks")
 
     assert resp.status_code == 200
-    data = resp.json()["subtasks"]
-    assert [s["id"] for s in data] == [1, 2]
-    assert data[0]["role"] == "user"
-    assert data[0]["preview"] == "hello world"
-    assert data[0]["char_count"] == len("hello world")
-    assert data[1]["preview"] == "hi there"
+    body = resp.json()
+    assert body["total"] == 2
+    assert body["has_more"] is False
+    assert [s["id"] for s in body["subtasks"]] == [1, 2]
+    assert body["subtasks"][0]["preview"] == "hello world"
 
 
-def test_list_subtasks_skips_deleted(internal_chat_client, monkeypatch):
-    _patch_task(monkeypatch)
-    deleted = _subtask(3, SubtaskRole.ASSISTANT, result={"value": "gone"})
-    deleted.status = SubtaskStatus.DELETE
-    subtasks = [_subtask(1, SubtaskRole.USER, prompt="keep"), deleted]
-    monkeypatch.setattr(
-        chat_storage.subtask_store,
-        "list_new_messages_since",
-        lambda db, **kw: subtasks,
-        raising=False,
-    )
-
-    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks")
-
-    assert resp.status_code == 200
-    assert [s["id"] for s in resp.json()["subtasks"]] == [1]
-
-
-def test_read_subtask_returns_blocks(internal_chat_client, monkeypatch):
+def test_read_subtask_returns_rendered_page(monkeypatch):
+    client = _internal_client(monkeypatch)
     _patch_task(monkeypatch)
     st = _subtask(
         2,
         SubtaskRole.ASSISTANT,
-        result={"blocks": [{"type": "text", "text": "a"}], "value": "a"},
+        result={"blocks": [{"type": "text", "content": "hello detail"}]},
     )
     monkeypatch.setattr(
         chat_storage.subtask_store,
@@ -117,35 +97,18 @@ def test_read_subtask_returns_blocks(internal_chat_client, monkeypatch):
         raising=False,
     )
 
-    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/2")
+    resp = client.get("/internal/chat/history/task-2/subtasks/2")
 
     assert resp.status_code == 200
     body = resp.json()
     assert body["role"] == "assistant"
-    assert body["blocks"] == [{"type": "text", "text": "a"}]
-    assert body["value"] == "a"
+    assert body["content"] == "hello detail"
+    assert body["has_more"] is False
+    assert body["cursor"] == "0:0"
 
 
-def test_read_subtask_user_returns_prompt(internal_chat_client, monkeypatch):
-    _patch_task(monkeypatch)
-    st = _subtask(1, SubtaskRole.USER, prompt="the question")
-    monkeypatch.setattr(
-        chat_storage.subtask_store,
-        "get_by_id",
-        lambda db, *, subtask_id, owner_user_id=None: st,
-        raising=False,
-    )
-
-    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/1")
-
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["role"] == "user"
-    assert body["prompt"] == "the question"
-    assert body["blocks"] is None
-
-
-def test_read_subtask_rejects_deleted(internal_chat_client, monkeypatch):
+def test_read_subtask_rejects_deleted(monkeypatch):
+    client = _internal_client(monkeypatch)
     _patch_task(monkeypatch)
     deleted = _subtask(4, SubtaskRole.ASSISTANT, result={"value": "gone"})
     deleted.status = SubtaskStatus.DELETE
@@ -156,12 +119,12 @@ def test_read_subtask_rejects_deleted(internal_chat_client, monkeypatch):
         raising=False,
     )
 
-    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/4")
-
+    resp = client.get("/internal/chat/history/task-2/subtasks/4")
     assert resp.status_code == 404
 
 
-def test_read_subtask_rejects_foreign_task(internal_chat_client, monkeypatch):
+def test_read_subtask_rejects_foreign_task(monkeypatch):
+    client = _internal_client(monkeypatch)
     _patch_task(monkeypatch)
     foreign = _subtask(9, SubtaskRole.ASSISTANT, task_id=999, result={"value": "x"})
     monkeypatch.setattr(
@@ -171,6 +134,5 @@ def test_read_subtask_rejects_foreign_task(internal_chat_client, monkeypatch):
         raising=False,
     )
 
-    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/9")
-
+    resp = client.get("/internal/chat/history/task-2/subtasks/9")
     assert resp.status_code == 404

--- a/backend/tests/api/test_internal_chat_storage_history_subtasks.py
+++ b/backend/tests/api/test_internal_chat_storage_history_subtasks.py
@@ -145,6 +145,22 @@ def test_read_subtask_user_returns_prompt(internal_chat_client, monkeypatch):
     assert body["blocks"] is None
 
 
+def test_read_subtask_rejects_deleted(internal_chat_client, monkeypatch):
+    _patch_task(monkeypatch)
+    deleted = _subtask(4, SubtaskRole.ASSISTANT, result={"value": "gone"})
+    deleted.status = SubtaskStatus.DELETE
+    monkeypatch.setattr(
+        chat_storage.subtask_store,
+        "get_by_id",
+        lambda db, *, subtask_id, owner_user_id=None: deleted,
+        raising=False,
+    )
+
+    resp = internal_chat_client.get("/internal/chat/history/task-2/subtasks/4")
+
+    assert resp.status_code == 404
+
+
 def test_read_subtask_rejects_foreign_task(internal_chat_client, monkeypatch):
     _patch_task(monkeypatch)
     foreign = _subtask(9, SubtaskRole.ASSISTANT, task_id=999, result={"value": "x"})

--- a/backend/tests/services/chat/test_subtask_history.py
+++ b/backend/tests/services/chat/test_subtask_history.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the shared subtask-history service (list + read paging)."""
+
+from types import SimpleNamespace
+
+from app.models.subtask import SubtaskRole, SubtaskStatus
+from app.services.chat import subtask_history
+
+
+def _subtask(sid, role, **kw):
+    base = dict(
+        id=sid,
+        task_id=2,
+        user_id=7,
+        role=role,
+        status=SubtaskStatus.COMPLETED,
+        message_id=sid,
+        prompt=None,
+        result=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _patch_get_by_id(monkeypatch, subtask):
+    monkeypatch.setattr(
+        subtask_history.subtask_store,
+        "get_by_id",
+        lambda db, *, subtask_id, owner_user_id=None: subtask,
+        raising=False,
+    )
+
+
+def test_list_summaries_pagination_and_delete_filter(monkeypatch):
+    deleted = _subtask(3, SubtaskRole.ASSISTANT, result={"value": "gone"})
+    deleted.status = SubtaskStatus.DELETE
+    rows = [
+        _subtask(1, SubtaskRole.USER, prompt="a"),
+        _subtask(2, SubtaskRole.ASSISTANT, result={"value": "b"}),
+        deleted,
+        _subtask(4, SubtaskRole.USER, prompt="c"),
+    ]
+    monkeypatch.setattr(
+        subtask_history.subtask_store,
+        "list_new_messages_since",
+        lambda db, **kw: rows,
+        raising=False,
+    )
+
+    out = subtask_history.list_subtask_summaries(
+        None, task_id=2, user_id=7, limit=2, offset=0
+    )
+
+    assert out["total"] == 3  # deleted excluded
+    assert [s["id"] for s in out["subtasks"]] == [1, 2]
+    assert out["has_more"] is True
+
+
+def test_read_stops_on_whole_unit_boundary(monkeypatch):
+    st = _subtask(
+        2,
+        SubtaskRole.ASSISTANT,
+        result={
+            "blocks": [
+                {"type": "text", "content": "AAAA"},
+                {"type": "text", "content": "BBBB"},
+            ]
+        },
+    )
+    _patch_get_by_id(monkeypatch, st)
+
+    # Budget fits one 4-char block but not two -> first page is block A whole.
+    page1 = subtask_history.read_subtask_record(
+        None, task_id=2, subtask_id=2, user_id=7, max_chars=5
+    )
+    assert page1["content"] == "AAAA"
+    assert page1["next_cursor"] == "1:0"
+    assert page1["has_more"] is True
+
+    page2 = subtask_history.read_subtask_record(
+        None, task_id=2, subtask_id=2, user_id=7, cursor="1:0", max_chars=5
+    )
+    assert page2["content"] == "BBBB"
+    assert page2["has_more"] is False
+
+
+def test_read_splits_oversized_single_unit(monkeypatch):
+    st = _subtask(
+        2,
+        SubtaskRole.ASSISTANT,
+        result={"blocks": [{"type": "text", "content": "ABCDEFGHIJ"}]},
+    )
+    _patch_get_by_id(monkeypatch, st)
+
+    page1 = subtask_history.read_subtask_record(
+        None, task_id=2, subtask_id=2, user_id=7, max_chars=4
+    )
+    assert page1["content"] == "ABCD"
+    assert page1["next_cursor"] == "0:4"
+    assert page1["has_more"] is True
+
+    page_end = subtask_history.read_subtask_record(
+        None, task_id=2, subtask_id=2, user_id=7, cursor="0:8", max_chars=4
+    )
+    assert page_end["content"] == "IJ"
+    assert page_end["has_more"] is False
+
+
+def test_read_renders_tool_block(monkeypatch):
+    st = _subtask(
+        2,
+        SubtaskRole.ASSISTANT,
+        result={
+            "blocks": [
+                {
+                    "type": "tool",
+                    "tool_name": "Bash",
+                    "tool_input": {"cmd": "ls"},
+                    "tool_output": "a.txt",
+                },
+            ]
+        },
+    )
+    _patch_get_by_id(monkeypatch, st)
+
+    out = subtask_history.read_subtask_record(None, task_id=2, subtask_id=2, user_id=7)
+    assert "Bash" in out["content"]
+    assert "a.txt" in out["content"]
+
+
+def test_read_user_prompt(monkeypatch):
+    st = _subtask(1, SubtaskRole.USER, prompt="the question")
+    _patch_get_by_id(monkeypatch, st)
+
+    out = subtask_history.read_subtask_record(None, task_id=2, subtask_id=1, user_id=7)
+    assert out["content"] == "the question"
+    assert out["role"] == "user"
+    assert out["has_more"] is False
+
+
+def test_read_rejects_deleted_and_foreign(monkeypatch):
+    deleted = _subtask(2, SubtaskRole.ASSISTANT, result={"value": "x"})
+    deleted.status = SubtaskStatus.DELETE
+    _patch_get_by_id(monkeypatch, deleted)
+    assert (
+        subtask_history.read_subtask_record(None, task_id=2, subtask_id=2, user_id=7)
+        is None
+    )
+
+    foreign = _subtask(9, SubtaskRole.ASSISTANT, task_id=999, result={"value": "x"})
+    _patch_get_by_id(monkeypatch, foreign)
+    assert (
+        subtask_history.read_subtask_record(None, task_id=2, subtask_id=9, user_id=7)
+        is None
+    )

--- a/backend/tests/services/chat/test_subtask_history.py
+++ b/backend/tests/services/chat/test_subtask_history.py
@@ -59,6 +59,47 @@ def test_list_summaries_pagination_and_delete_filter(monkeypatch):
     assert out["has_more"] is True
 
 
+def test_list_preview_falls_back_to_blocks(monkeypatch):
+    # Assistant turn whose content is only in blocks (no result.value).
+    st = _subtask(
+        2,
+        SubtaskRole.ASSISTANT,
+        result={"blocks": [{"type": "text", "content": "block-only detail"}]},
+    )
+    monkeypatch.setattr(
+        subtask_history.subtask_store,
+        "list_new_messages_since",
+        lambda db, **kw: [st],
+        raising=False,
+    )
+
+    out = subtask_history.list_subtask_summaries(None, task_id=2, user_id=7)
+
+    assert out["subtasks"][0]["preview"] == "block-only detail"
+    assert out["subtasks"][0]["char_count"] == len("block-only detail")
+
+
+def test_list_limit_zero_returns_empty_page(monkeypatch):
+    rows = [
+        _subtask(1, SubtaskRole.USER, prompt="a"),
+        _subtask(2, SubtaskRole.ASSISTANT, result={"value": "b"}),
+    ]
+    monkeypatch.setattr(
+        subtask_history.subtask_store,
+        "list_new_messages_since",
+        lambda db, **kw: rows,
+        raising=False,
+    )
+
+    out = subtask_history.list_subtask_summaries(
+        None, task_id=2, user_id=7, limit=0, offset=0
+    )
+
+    assert out["subtasks"] == []
+    assert out["total"] == 2
+    assert out["has_more"] is True
+
+
 def test_read_stops_on_whole_unit_boundary(monkeypatch):
     st = _subtask(
         2,

--- a/chat_shell/chat_shell/history/subtask_records.py
+++ b/chat_shell/chat_shell/history/subtask_records.py
@@ -21,8 +21,6 @@ from typing import Any
 
 from chat_shell.history.loader import _get_remote_history_store, _is_http_mode
 
-_PREVIEW_CHARS = 200
-
 
 class SubtaskRecordNotAvailable(Exception):
     """Raised when a subtask cannot be read (missing or out of scope)."""
@@ -47,81 +45,40 @@ async def fetch_subtask_record(*, task_id: int, subtask_id: int) -> dict[str, An
     return await asyncio.to_thread(_read_local, task_id, subtask_id)
 
 
-def _primary_text(subtask: Any) -> str:
-    """Un-compacted plain text of a subtask (matches the backend endpoint)."""
-    from app.models.subtask import SubtaskRole
-
-    if subtask.role == SubtaskRole.USER:
-        return subtask.prompt or ""
-    result = subtask.result if isinstance(subtask.result, dict) else {}
-    value = result.get("value")
-    return value if isinstance(value, str) else ""
-
-
 def _list_local(task_id: int) -> list[dict[str, Any]]:
-    """Package-mode summary list with the same scoping as the endpoint."""
+    """Package-mode summary list — delegates to the shared backend service."""
     from app.db.session import SessionLocal
-    from app.models.subtask import Subtask, SubtaskStatus
+    from app.services.chat.subtask_history import list_subtask_summaries
+    from app.stores.tasks import task_store
 
     db = SessionLocal()
     try:
-        rows = (
-            db.query(Subtask)
-            .filter(Subtask.task_id == task_id)
-            .order_by(Subtask.message_id.asc(), Subtask.created_at.asc())
-            .all()
-        )
-        summaries = []
-        for st in rows:
-            if st.status == SubtaskStatus.DELETE:
-                continue
-            text = _primary_text(st)
-            summaries.append(
-                {
-                    "id": st.id,
-                    "role": st.role.value.lower(),
-                    "status": st.status.value,
-                    "char_count": len(text),
-                    "preview": text[:_PREVIEW_CHARS],
-                }
-            )
-        return summaries
+        task = task_store.get_by_id(db, task_id=task_id)
+        if task is None:
+            return []
+        return list_subtask_summaries(db, task_id=task_id, user_id=task.user_id)
     finally:
         db.close()
 
 
 def _read_local(task_id: int, subtask_id: int) -> dict[str, Any]:
-    """Package-mode raw record read, scoped to the task."""
+    """Package-mode raw record read — delegates to the shared backend service."""
     from app.db.session import SessionLocal
-    from app.models.subtask import Subtask, SubtaskRole
+    from app.services.chat.subtask_history import read_subtask_record
+    from app.stores.tasks import task_store
 
     db = SessionLocal()
     try:
-        subtask = (
-            db.query(Subtask)
-            .filter(Subtask.id == subtask_id, Subtask.task_id == task_id)
-            .first()
+        task = task_store.get_by_id(db, task_id=task_id)
+        record = (
+            read_subtask_record(
+                db, task_id=task_id, subtask_id=subtask_id, user_id=task.user_id
+            )
+            if task is not None
+            else None
         )
-        if subtask is None:
+        if record is None:
             raise SubtaskRecordNotAvailable("Subtask not found in this session")
-
-        role = subtask.role.value.lower()
-        status = subtask.status.value
-        if subtask.role == SubtaskRole.USER:
-            return {
-                "id": subtask.id,
-                "role": role,
-                "status": status,
-                "prompt": subtask.prompt or "",
-            }
-        result = subtask.result if isinstance(subtask.result, dict) else {}
-        return {
-            "id": subtask.id,
-            "role": role,
-            "status": status,
-            "blocks": result.get("blocks"),
-            "messages_chain": result.get("messages_chain"),
-            "value": result.get("value"),
-        }
+        return record
     finally:
         db.close()

--- a/chat_shell/chat_shell/history/subtask_records.py
+++ b/chat_shell/chat_shell/history/subtask_records.py
@@ -2,16 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Fetch history subtask summaries and raw records for AI backtracking.
+"""Fetch history subtask summaries and record pages for AI backtracking.
 
 Mirrors the loader's mode switch: HTTP mode calls the backend internal endpoints
 (``/chat/history/{session_id}/subtasks[/{id}]``) via ``RemoteHistoryStore``;
-package mode reads the database directly. Both enforce the same session (task)
-scoping as the endpoint, so the model can never read another conversation.
-
-Reads the raw record (``result.blocks`` / ``prompt``), deliberately bypassing the
-compaction-scoped history loader — the point of backtracking is to recover detail
-that compaction summarized away.
+package mode calls the shared backend service directly. Both enforce the same
+session (task) scoping, and pagination + rendering live in that shared service —
+this module is only the transport switch.
 """
 
 from __future__ import annotations
@@ -26,26 +23,31 @@ class SubtaskRecordNotAvailable(Exception):
     """Raised when a subtask cannot be read (missing or out of scope)."""
 
 
-async def fetch_history_subtasks(*, task_id: int) -> list[dict[str, Any]]:
-    """Return summaries for every non-deleted subtask of the task's session."""
+async def fetch_history_subtasks(
+    *, task_id: int, limit: int | None = None, offset: int = 0
+) -> dict[str, Any]:
+    """A page of subtask summaries: ``{subtasks, total, has_more}``."""
     session_id = f"task-{task_id}"
     if _is_http_mode():
         store = _get_remote_history_store()
-        payload = await store.list_history_subtasks(session_id)
-        return payload.get("subtasks", [])
-    return await asyncio.to_thread(_list_local, task_id)
+        return await store.list_history_subtasks(session_id, limit=limit, offset=offset)
+    return await asyncio.to_thread(_list_local, task_id, limit, offset)
 
 
-async def fetch_subtask_record(*, task_id: int, subtask_id: int) -> dict[str, Any]:
-    """Return one subtask's raw record, scoped to the task's session."""
+async def fetch_subtask_record(
+    *, task_id: int, subtask_id: int, cursor: str = "0:0", max_chars: int = 0
+) -> dict[str, Any]:
+    """One page of a subtask's rendered transcript, scoped to the task."""
     session_id = f"task-{task_id}"
     if _is_http_mode():
         store = _get_remote_history_store()
-        return await store.get_history_subtask(session_id, subtask_id)
-    return await asyncio.to_thread(_read_local, task_id, subtask_id)
+        return await store.get_history_subtask(
+            session_id, subtask_id, cursor=cursor, max_chars=max_chars
+        )
+    return await asyncio.to_thread(_read_local, task_id, subtask_id, cursor, max_chars)
 
 
-def _list_local(task_id: int) -> list[dict[str, Any]]:
+def _list_local(task_id: int, limit: int | None, offset: int) -> dict[str, Any]:
     """Package-mode summary list — delegates to the shared backend service."""
     from app.db.session import SessionLocal
     from app.services.chat.subtask_history import list_subtask_summaries
@@ -55,14 +57,18 @@ def _list_local(task_id: int) -> list[dict[str, Any]]:
     try:
         task = task_store.get_by_id(db, task_id=task_id)
         if task is None:
-            return []
-        return list_subtask_summaries(db, task_id=task_id, user_id=task.user_id)
+            return {"subtasks": [], "total": 0, "has_more": False}
+        return list_subtask_summaries(
+            db, task_id=task_id, user_id=task.user_id, limit=limit, offset=offset
+        )
     finally:
         db.close()
 
 
-def _read_local(task_id: int, subtask_id: int) -> dict[str, Any]:
-    """Package-mode raw record read — delegates to the shared backend service."""
+def _read_local(
+    task_id: int, subtask_id: int, cursor: str, max_chars: int
+) -> dict[str, Any]:
+    """Package-mode record page — delegates to the shared backend service."""
     from app.db.session import SessionLocal
     from app.services.chat.subtask_history import read_subtask_record
     from app.stores.tasks import task_store
@@ -72,7 +78,12 @@ def _read_local(task_id: int, subtask_id: int) -> dict[str, Any]:
         task = task_store.get_by_id(db, task_id=task_id)
         record = (
             read_subtask_record(
-                db, task_id=task_id, subtask_id=subtask_id, user_id=task.user_id
+                db,
+                task_id=task_id,
+                subtask_id=subtask_id,
+                user_id=task.user_id,
+                cursor=cursor,
+                max_chars=max_chars,
             )
             if task is not None
             else None

--- a/chat_shell/chat_shell/history/subtask_records.py
+++ b/chat_shell/chat_shell/history/subtask_records.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch history subtask summaries and raw records for AI backtracking.
+
+Mirrors the loader's mode switch: HTTP mode calls the backend internal endpoints
+(``/chat/history/{session_id}/subtasks[/{id}]``) via ``RemoteHistoryStore``;
+package mode reads the database directly. Both enforce the same session (task)
+scoping as the endpoint, so the model can never read another conversation.
+
+Reads the raw record (``result.blocks`` / ``prompt``), deliberately bypassing the
+compaction-scoped history loader — the point of backtracking is to recover detail
+that compaction summarized away.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from chat_shell.history.loader import _get_remote_history_store, _is_http_mode
+
+_PREVIEW_CHARS = 200
+
+
+class SubtaskRecordNotAvailable(Exception):
+    """Raised when a subtask cannot be read (missing or out of scope)."""
+
+
+async def fetch_history_subtasks(*, task_id: int) -> list[dict[str, Any]]:
+    """Return summaries for every non-deleted subtask of the task's session."""
+    session_id = f"task-{task_id}"
+    if _is_http_mode():
+        store = _get_remote_history_store()
+        payload = await store.list_history_subtasks(session_id)
+        return payload.get("subtasks", [])
+    return await asyncio.to_thread(_list_local, task_id)
+
+
+async def fetch_subtask_record(*, task_id: int, subtask_id: int) -> dict[str, Any]:
+    """Return one subtask's raw record, scoped to the task's session."""
+    session_id = f"task-{task_id}"
+    if _is_http_mode():
+        store = _get_remote_history_store()
+        return await store.get_history_subtask(session_id, subtask_id)
+    return await asyncio.to_thread(_read_local, task_id, subtask_id)
+
+
+def _primary_text(subtask: Any) -> str:
+    """Un-compacted plain text of a subtask (matches the backend endpoint)."""
+    from app.models.subtask import SubtaskRole
+
+    if subtask.role == SubtaskRole.USER:
+        return subtask.prompt or ""
+    result = subtask.result if isinstance(subtask.result, dict) else {}
+    value = result.get("value")
+    return value if isinstance(value, str) else ""
+
+
+def _list_local(task_id: int) -> list[dict[str, Any]]:
+    """Package-mode summary list with the same scoping as the endpoint."""
+    from app.db.session import SessionLocal
+    from app.models.subtask import Subtask, SubtaskStatus
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(Subtask)
+            .filter(Subtask.task_id == task_id)
+            .order_by(Subtask.message_id.asc(), Subtask.created_at.asc())
+            .all()
+        )
+        summaries = []
+        for st in rows:
+            if st.status == SubtaskStatus.DELETE:
+                continue
+            text = _primary_text(st)
+            summaries.append(
+                {
+                    "id": st.id,
+                    "role": st.role.value.lower(),
+                    "status": st.status.value,
+                    "char_count": len(text),
+                    "preview": text[:_PREVIEW_CHARS],
+                }
+            )
+        return summaries
+    finally:
+        db.close()
+
+
+def _read_local(task_id: int, subtask_id: int) -> dict[str, Any]:
+    """Package-mode raw record read, scoped to the task."""
+    from app.db.session import SessionLocal
+    from app.models.subtask import Subtask, SubtaskRole
+
+    db = SessionLocal()
+    try:
+        subtask = (
+            db.query(Subtask)
+            .filter(Subtask.id == subtask_id, Subtask.task_id == task_id)
+            .first()
+        )
+        if subtask is None:
+            raise SubtaskRecordNotAvailable("Subtask not found in this session")
+
+        role = subtask.role.value.lower()
+        status = subtask.status.value
+        if subtask.role == SubtaskRole.USER:
+            return {
+                "id": subtask.id,
+                "role": role,
+                "status": status,
+                "prompt": subtask.prompt or "",
+            }
+        result = subtask.result if isinstance(subtask.result, dict) else {}
+        return {
+            "id": subtask.id,
+            "role": role,
+            "status": status,
+            "blocks": result.get("blocks"),
+            "messages_chain": result.get("messages_chain"),
+            "value": result.get("value"),
+        }
+    finally:
+        db.close()

--- a/chat_shell/chat_shell/services/chat_service.py
+++ b/chat_shell/chat_shell/services/chat_service.py
@@ -131,6 +131,11 @@ class ChatService(ChatInterface):
         if kb_meta_prompt and kb_meta_prompt not in parts:
             parts.append(kb_meta_prompt)
 
+        # History-backtracking nudge (only set once compaction has dropped detail).
+        backtrack_hint = getattr(ctx_result, "backtrack_hint", "")
+        if backtrack_hint:
+            parts.append(backtrack_hint)
+
         return "\n\n".join(parts) if parts else ""
 
     @trace_async(

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -982,22 +982,15 @@ class ChatContext:
         # compaction) is on, so the model can page back into detail that
         # compaction summarized away. Task-scoped and read-only.
         if self._backtrack_tools_enabled():
-            from chat_shell.compression.token_counter import TokenCounter
             from chat_shell.tools.builtin import ListHistoryTool, ReadSubtaskTool
 
-            model_id = (self._request.model_config or {}).get("model_id")
             extra_tools.append(
                 ListHistoryTool(
                     task_id=self._request.task_id,
                     in_context_ids=in_context_ids,
                 )
             )
-            extra_tools.append(
-                ReadSubtaskTool(
-                    task_id=self._request.task_id,
-                    token_counter=TokenCounter(model_name=model_id),
-                )
-            )
+            extra_tools.append(ReadSubtaskTool(task_id=self._request.task_id))
             logger.info(
                 "[CHAT_CONTEXT] Added history-backtracking tools for task_id=%d "
                 "(in_context_subtasks=%d)",

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -56,6 +56,37 @@ class ChatContextResult:
 _DOCUMENT_ATTACHMENT = re.compile(r"\[Attachment:")
 
 
+_HISTORY_BACKTRACK_HINT = (
+    "\n\nSome earlier turns have been summarized out of your current context to "
+    "save space. If you need details you no longer see verbatim, call "
+    "`list_history` to find the relevant turn, then `read_subtask` to read its "
+    "full original content."
+)
+
+
+def _history_backtrack_signals(history: list) -> tuple[frozenset[int], bool]:
+    """Derive (in-context subtask ids, compaction-seen) from loaded history.
+
+    History dicts carry ``id`` (``"<subtask_id>"`` or ``"<subtask_id>-<idx>"``);
+    a ``metadata.summary_compacted`` flag marks a compaction summary present in
+    the live window, i.e. this session has been compacted.
+    """
+    ids: set[int] = set()
+    had_compaction = False
+    for message in history:
+        if not isinstance(message, dict):
+            continue
+        raw_id = message.get("id")
+        if raw_id is not None:
+            head = str(raw_id).split("-", 1)[0]
+            if head.isdigit():
+                ids.add(int(head))
+        metadata = message.get("metadata")
+        if isinstance(metadata, dict) and metadata.get("summary_compacted") is True:
+            had_compaction = True
+    return frozenset(ids), had_compaction
+
+
 def _attachments_have_document(attachments: Any) -> bool:
     """Return True if the structured request payload includes a document attachment.
 
@@ -250,10 +281,18 @@ class ChatContext:
                 )
             )
 
+            # History-backtracking signals: which subtasks are still in the live
+            # window, and whether compaction has summarized any away.
+            in_context_ids, had_compaction = _history_backtrack_signals(history)
+
             # Build extra_tools from all sources (including builtin tools)
             add_span_event("building_extra_tools")
             extra_tools = self._build_extra_tools(
-                kb_result, skill_tools, mcp_result, has_attachments=has_attachments
+                kb_result,
+                skill_tools,
+                mcp_result,
+                has_attachments=has_attachments,
+                in_context_ids=in_context_ids,
             )
 
             # Process KB tools result for system prompt
@@ -261,6 +300,15 @@ class ChatContext:
             if kb_result.extra_tools:
                 system_prompt = kb_result.enhanced_system_prompt
             kb_meta_prompt = kb_result.kb_meta_prompt
+
+            # Point the model at the backtracking tools only when compaction has
+            # actually dropped detail and the tools were registered.
+            if (
+                had_compaction
+                and self._request.enable_tools
+                and not settings.DISABLE_SUMMARY_COMPACT
+            ):
+                system_prompt = f"{system_prompt}{_HISTORY_BACKTRACK_HINT}"
 
             # Track MCP clients for cleanup (both from MCP servers and skills)
             _, mcp_clients = mcp_result
@@ -799,6 +847,7 @@ class ChatContext:
         skill_tools: list,
         mcp_result: tuple[list, list],
         has_attachments: bool = False,
+        in_context_ids: frozenset[int] = frozenset(),
     ) -> list:
         """Build the complete list of extra tools from all sources.
 
@@ -910,6 +959,33 @@ class ChatContext:
             logger.info(
                 "[CHAT_CONTEXT] Added ReadAttachmentTool for task_id=%d",
                 self._request.task_id,
+            )
+
+        # Add history-backtracking tools when context governance (summary
+        # compaction) is on, so the model can page back into detail that
+        # compaction summarized away. Task-scoped and read-only.
+        if not settings.DISABLE_SUMMARY_COMPACT:
+            from chat_shell.compression.token_counter import TokenCounter
+            from chat_shell.tools.builtin import ListHistoryTool, ReadSubtaskTool
+
+            model_id = (self._request.model_config or {}).get("model_id")
+            extra_tools.append(
+                ListHistoryTool(
+                    task_id=self._request.task_id,
+                    in_context_ids=in_context_ids,
+                )
+            )
+            extra_tools.append(
+                ReadSubtaskTool(
+                    task_id=self._request.task_id,
+                    token_counter=TokenCounter(model_name=model_id),
+                )
+            )
+            logger.info(
+                "[CHAT_CONTEXT] Added history-backtracking tools for task_id=%d "
+                "(in_context_subtasks=%d)",
+                self._request.task_id,
+                len(in_context_ids),
             )
 
         # Note: Subscription tools (preview_subscription, create_subscription) have been moved

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -38,6 +38,7 @@ class ChatContextResult:
         extra_tools: All tools including builtin tools (LoadSkillTool, WebSearchTool, etc.)
         system_prompt: System prompt (may be updated by KB tools)
         kb_meta_prompt: Knowledge base meta prompt (dynamic, injected via dynamic_context)
+        backtrack_hint: History-backtracking nudge (dynamic, injected via dynamic_context)
         mcp_clients: MCP clients for cleanup
     """
 
@@ -45,6 +46,7 @@ class ChatContextResult:
     extra_tools: list = field(default_factory=list)
     system_prompt: str = ""
     kb_meta_prompt: str = ""
+    backtrack_hint: str = ""
     mcp_clients: list = field(default_factory=list)
 
 
@@ -57,10 +59,8 @@ _DOCUMENT_ATTACHMENT = re.compile(r"\[Attachment:")
 
 
 _HISTORY_BACKTRACK_HINT = (
-    "\n\nSome earlier turns have been summarized out of your current context to "
-    "save space. If you need details you no longer see verbatim, call "
-    "`list_history` to find the relevant turn, then `read_subtask` to read its "
-    "full original content."
+    "Earlier turns were summarized out of your context — use `list_history` and "
+    "`read_subtask` to recover their original detail when you need it."
 )
 
 
@@ -301,14 +301,19 @@ class ChatContext:
                 system_prompt = kb_result.enhanced_system_prompt
             kb_meta_prompt = kb_result.kb_meta_prompt
 
-            # Point the model at the backtracking tools only when compaction has
-            # actually dropped detail and the tools were registered.
-            if (
-                had_compaction
-                and self._request.enable_tools
-                and not settings.DISABLE_SUMMARY_COMPACT
-            ):
-                system_prompt = f"{system_prompt}{_HISTORY_BACKTRACK_HINT}"
+            # Nudge the model toward the backtracking tools only when compaction
+            # has actually dropped detail AND the tools were registered. Delivered
+            # via dynamic_context (message channel), never the system prompt, so
+            # the cacheable prefix stays stable across turns.
+            backtrack_hint = (
+                _HISTORY_BACKTRACK_HINT
+                if (
+                    had_compaction
+                    and self._request.enable_tools
+                    and self._backtrack_tools_enabled()
+                )
+                else ""
+            )
 
             # Track MCP clients for cleanup (both from MCP servers and skills)
             _, mcp_clients = mcp_result
@@ -329,6 +334,7 @@ class ChatContext:
                 extra_tools=extra_tools,
                 system_prompt=system_prompt,
                 kb_meta_prompt=kb_meta_prompt,
+                backtrack_hint=backtrack_hint,
                 mcp_clients=all_mcp_clients,
             )
 
@@ -841,6 +847,17 @@ class ChatContext:
         except Exception as e:
             logger.warning("[CHAT_CONTEXT] Failed to close MCP client: %s", e)
 
+    def _backtrack_tools_enabled(self) -> bool:
+        """Whether history-backtracking tools apply: summary compaction is active.
+
+        Mirrors the exact condition under which the summary compactor is created
+        (chat_service), so the tools/hint follow compaction rather than drifting.
+        """
+        return (
+            settings.MESSAGE_COMPRESSION_ENABLED
+            and not settings.DISABLE_SUMMARY_COMPACT
+        )
+
     def _build_extra_tools(
         self,
         kb_result,
@@ -964,7 +981,7 @@ class ChatContext:
         # Add history-backtracking tools when context governance (summary
         # compaction) is on, so the model can page back into detail that
         # compaction summarized away. Task-scoped and read-only.
-        if not settings.DISABLE_SUMMARY_COMPACT:
+        if self._backtrack_tools_enabled():
             from chat_shell.compression.token_counter import TokenCounter
             from chat_shell.tools.builtin import ListHistoryTool, ReadSubtaskTool
 

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -293,6 +293,7 @@ class ChatContext:
                 mcp_result,
                 has_attachments=has_attachments,
                 in_context_ids=in_context_ids,
+                had_compaction=had_compaction,
             )
 
             # Process KB tools result for system prompt
@@ -865,6 +866,7 @@ class ChatContext:
         mcp_result: tuple[list, list],
         has_attachments: bool = False,
         in_context_ids: frozenset[int] = frozenset(),
+        had_compaction: bool = False,
     ) -> list:
         """Build the complete list of extra tools from all sources.
 
@@ -978,10 +980,11 @@ class ChatContext:
                 self._request.task_id,
             )
 
-        # Add history-backtracking tools when context governance (summary
-        # compaction) is on, so the model can page back into detail that
-        # compaction summarized away. Task-scoped and read-only.
-        if self._backtrack_tools_enabled():
+        # Add history-backtracking tools only once compaction has actually
+        # summarized detail out of context (had_compaction). Most tasks never
+        # compact, so gating here keeps the tools — and their prompt hint — out of
+        # those turns entirely. Task-scoped and read-only.
+        if self._backtrack_tools_enabled() and had_compaction:
             from chat_shell.tools.builtin import ListHistoryTool, ReadSubtaskTool
 
             extra_tools.append(

--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -243,25 +243,41 @@ class RemoteHistoryStore(HistoryStoreInterface):
         response.raise_for_status()
         return response.json()
 
-    async def list_history_subtasks(self, session_id: str) -> dict:
-        """Fetch the whole session's subtask summaries (AI backtracking).
+    async def list_history_subtasks(
+        self, session_id: str, limit: int | None = None, offset: int = 0
+    ) -> dict:
+        """Fetch a page of the session's subtask summaries (AI backtracking).
 
         Returns the backend ``SubtaskListResponse`` payload
-        (``session_id`` / ``subtasks[]``).
+        (``subtasks[]`` / ``total`` / ``has_more``).
         """
+        params: dict[str, Any] = {"offset": offset}
+        if limit is not None:
+            params["limit"] = limit
         client = await self._get_client()
-        response = await client.get(f"/chat/history/{session_id}/subtasks")
+        response = await client.get(
+            f"/chat/history/{session_id}/subtasks", params=params
+        )
         response.raise_for_status()
         return response.json()
 
-    async def get_history_subtask(self, session_id: str, subtask_id: int) -> dict:
-        """Fetch one subtask's raw record (un-compaction-scoped).
+    async def get_history_subtask(
+        self,
+        session_id: str,
+        subtask_id: int,
+        cursor: str = "0:0",
+        max_chars: int = 0,
+    ) -> dict:
+        """Fetch one page of a subtask's rendered transcript (un-compaction-scoped).
 
         Returns the backend ``SubtaskRecordResponse`` payload
-        (``blocks`` / ``messages_chain`` / ``value`` / ``prompt``).
+        (``content`` / ``cursor`` / ``next_cursor`` / ``has_more``).
         """
         client = await self._get_client()
-        response = await client.get(f"/chat/history/{session_id}/subtasks/{subtask_id}")
+        response = await client.get(
+            f"/chat/history/{session_id}/subtasks/{subtask_id}",
+            params={"cursor": cursor, "max_chars": max_chars},
+        )
         response.raise_for_status()
         return response.json()
 

--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -243,6 +243,28 @@ class RemoteHistoryStore(HistoryStoreInterface):
         response.raise_for_status()
         return response.json()
 
+    async def list_history_subtasks(self, session_id: str) -> dict:
+        """Fetch the whole session's subtask summaries (AI backtracking).
+
+        Returns the backend ``SubtaskListResponse`` payload
+        (``session_id`` / ``subtasks[]``).
+        """
+        client = await self._get_client()
+        response = await client.get(f"/chat/history/{session_id}/subtasks")
+        response.raise_for_status()
+        return response.json()
+
+    async def get_history_subtask(self, session_id: str, subtask_id: int) -> dict:
+        """Fetch one subtask's raw record (un-compaction-scoped).
+
+        Returns the backend ``SubtaskRecordResponse`` payload
+        (``blocks`` / ``messages_chain`` / ``value`` / ``prompt``).
+        """
+        client = await self._get_client()
+        response = await client.get(f"/chat/history/{session_id}/subtasks/{subtask_id}")
+        response.raise_for_status()
+        return response.json()
+
     async def append_message(
         self,
         session_id: str,

--- a/chat_shell/chat_shell/tools/builtin/__init__.py
+++ b/chat_shell/chat_shell/tools/builtin/__init__.py
@@ -7,6 +7,10 @@
 from .data_table import DataTableTool
 from .evaluation import SubmitEvaluationResultTool
 from .file_reader import FileListSkill, FileReaderSkill
+from .history_backtrack import (
+    ListHistoryTool,
+    ReadSubtaskTool,
+)
 from .knowledge_base import KnowledgeBaseTool, ScopedKnowledgeBaseTool
 from .knowledge_listing import (
     KbHeadTool,
@@ -23,6 +27,8 @@ __all__ = [
     "WebSearchTool",
     "ReadAttachmentTool",
     "ReadAttachmentInput",
+    "ListHistoryTool",
+    "ReadSubtaskTool",
     "KnowledgeBaseTool",
     "ScopedKnowledgeBaseTool",
     "KbLsTool",

--- a/chat_shell/chat_shell/tools/builtin/history_backtrack.py
+++ b/chat_shell/chat_shell/tools/builtin/history_backtrack.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""AI history-backtracking tools: ``list_history`` and ``read_subtask``.
+
+Compaction is lossy: older turns get summarized out of the live window. These
+tools let the model page back into the *un-compacted* original detail — each
+earlier subtask's own record is never rewritten by compaction, so reading it by
+id recovers full fidelity.
+
+- ``list_history``: whole-session subtask summaries, each marked ``in_context``
+  or ``compacted`` so the model knows what it can no longer see verbatim.
+- ``read_subtask``: one subtask's raw record, **paginated by whole blocks** (never
+  splitting a block mid-structure) under the per-page token budget.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field, PrivateAttr
+
+from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.history.subtask_records import (
+    SubtaskRecordNotAvailable,
+    fetch_history_subtasks,
+    fetch_subtask_record,
+)
+
+logger = logging.getLogger(__name__)
+
+# Aligned with the tool-output budget so a page stays within what the
+# request-level guard allows (no re-truncation that would break paging).
+DEFAULT_PAGE_TOKEN_LIMIT = 15000
+DEFAULT_LIST_PAGE_SIZE = 50
+
+
+def _render_block(block: dict[str, Any]) -> str:
+    """Render one stored block into a readable transcript fragment."""
+    btype = block.get("type")
+    if btype == "text":
+        return str(block.get("content") or "")
+    if btype == "tool":
+        name = block.get("display_name") or block.get("tool_name") or "tool"
+        tool_input = block.get("tool_input") or {}
+        lines = [f"[tool: {name}] input={json.dumps(tool_input, ensure_ascii=False)}"]
+        output = block.get("tool_output")
+        if output:
+            lines.append(f"output: {output}")
+        return "\n".join(lines)
+    if btype in ("guidance", "subagent"):
+        return str(block.get("content") or "")
+    return json.dumps(block, ensure_ascii=False)
+
+
+def _render_message(message: dict[str, Any]) -> str:
+    """Render one messages_chain entry (fallback for legacy turns)."""
+    role = message.get("role", "assistant")
+    content = message.get("content")
+    text = (
+        content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+    )
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        text = f"{text}\n[tool_calls: {json.dumps(tool_calls, ensure_ascii=False)}]"
+    return f"{role}: {text}"
+
+
+def _record_to_blocks(record: dict[str, Any]) -> list[str]:
+    """Normalize a subtask record into an ordered list of renderable blocks."""
+    if record.get("role") == "user":
+        return [str(record.get("prompt") or "")]
+    blocks = record.get("blocks")
+    if isinstance(blocks, list) and blocks:
+        return [_render_block(b) for b in blocks if isinstance(b, dict)]
+    chain = record.get("messages_chain")
+    if isinstance(chain, list) and chain:
+        return [_render_message(m) for m in chain if isinstance(m, dict)]
+    value = record.get("value")
+    return [str(value)] if value else []
+
+
+class ListHistoryInput(BaseModel):
+    """Input schema for the list_history tool."""
+
+    page: int = Field(default=1, description="1-indexed page of the summary list")
+
+
+class ListHistoryTool(BaseTool):
+    """List the whole conversation's subtasks as summaries."""
+
+    name: str = "list_history"
+    description: str = (
+        "List every turn (subtask) of this conversation as a summary: id, role, "
+        "a short preview, and whether it is still 'in_context' or was 'compacted' "
+        "(summarized out of your current context). Use it to find turns whose full "
+        "detail you no longer see, then read them with read_subtask."
+    )
+    args_schema: type[BaseModel] = ListHistoryInput
+
+    task_id: int
+    in_context_ids: frozenset[int] = frozenset()
+    page_size: int = DEFAULT_LIST_PAGE_SIZE
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def _run(self, *args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("list_history is async-only; use _arun")
+
+    async def _arun(self, page: int = 1, **_: Any) -> str:
+        try:
+            summaries = await fetch_history_subtasks(task_id=self.task_id)
+        except Exception as exc:  # network / HTTP errors
+            logger.warning("[list_history] fetch failed: %s", exc)
+            return json.dumps(
+                {"status": "error", "message": "History could not be listed"}
+            )
+
+        for item in summaries:
+            item["location"] = (
+                "in_context" if item.get("id") in self.in_context_ids else "compacted"
+            )
+
+        page = max(1, page)
+        start = (page - 1) * self.page_size
+        window = summaries[start : start + self.page_size]
+        return json.dumps(
+            {
+                "status": "success",
+                "page": page,
+                "page_size": self.page_size,
+                "total": len(summaries),
+                "has_more": start + self.page_size < len(summaries),
+                "subtasks": window,
+            },
+            ensure_ascii=False,
+        )
+
+
+class ReadSubtaskInput(BaseModel):
+    """Input schema for the read_subtask tool."""
+
+    subtask_id: int = Field(description="Subtask id from list_history")
+    cursor: int = Field(
+        default=0, description="Block index to start from (0 = first block)"
+    )
+    max_tokens: int = Field(
+        default=0, description="Per-page token budget override (0 = default)"
+    )
+
+
+class ReadSubtaskTool(BaseTool):
+    """Read one subtask's raw detail, paginated by whole blocks."""
+
+    name: str = "read_subtask"
+    description: str = (
+        "Read the full original detail of one turn (subtask) by id, with "
+        "pagination. Recovers content that compaction summarized away. Returns a "
+        "page of whole blocks plus next_cursor / has_more for paging."
+    )
+    args_schema: type[BaseModel] = ReadSubtaskInput
+
+    task_id: int
+    token_counter: TokenCounter
+    page_token_limit: int = DEFAULT_PAGE_TOKEN_LIMIT
+    max_calls: int = 30
+    _call_count: int = PrivateAttr(default=0)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def _run(self, *args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("read_subtask is async-only; use _arun")
+
+    async def _arun(
+        self, subtask_id: int, cursor: int = 0, max_tokens: int = 0, **_: Any
+    ) -> str:
+        if self._call_count >= self.max_calls:
+            return json.dumps(
+                {
+                    "status": "rejected",
+                    "message": f"read_subtask call limit ({self.max_calls}) reached",
+                }
+            )
+        self._call_count += 1
+
+        try:
+            record = await fetch_subtask_record(
+                task_id=self.task_id, subtask_id=subtask_id
+            )
+        except SubtaskRecordNotAvailable as exc:
+            return json.dumps({"status": "error", "message": str(exc)})
+        except Exception as exc:  # network / HTTP errors
+            logger.warning("[read_subtask] fetch failed: %s", exc)
+            return json.dumps(
+                {"status": "error", "message": "Subtask could not be read"}
+            )
+
+        blocks = _record_to_blocks(record)
+        budget = max_tokens if max_tokens > 0 else self.page_token_limit
+        cursor = max(0, cursor)
+
+        page_parts: list[str] = []
+        used = 0
+        index = cursor
+        total = len(blocks)
+        while index < total:
+            rendered = blocks[index]
+            tokens = self.token_counter.count_text(rendered)
+            if not page_parts and tokens > budget:
+                # A single oversized block must be split *within* the block, never
+                # across neighbours — token-clamp it and mark the truncation.
+                clamped = self._clamp_to_tokens(rendered, budget)
+                page_parts.append(
+                    f"{clamped}\n[block {index} truncated: {tokens} tokens total]"
+                )
+                index += 1
+                break
+            if page_parts and used + tokens > budget:
+                break  # stop before this block; never split a whole block
+            page_parts.append(rendered)
+            used += tokens
+            index += 1
+
+        next_cursor = index if index < total else None
+        return json.dumps(
+            {
+                "status": "success",
+                "subtask_id": subtask_id,
+                "role": record.get("role"),
+                "cursor": cursor,
+                "next_cursor": next_cursor,
+                "has_more": next_cursor is not None,
+                "total_blocks": total,
+                "content": "\n\n".join(page_parts),
+            },
+            ensure_ascii=False,
+        )
+
+    def _clamp_to_tokens(self, text: str, token_limit: int) -> str:
+        """Return the longest prefix of *text* within *token_limit* tokens."""
+        encoding = self.token_counter.encoding
+        ids = encoding.encode(text, disallowed_special=())
+        if len(ids) <= token_limit:
+            return text
+        return encoding.decode(ids[:token_limit])

--- a/chat_shell/chat_shell/tools/builtin/history_backtrack.py
+++ b/chat_shell/chat_shell/tools/builtin/history_backtrack.py
@@ -25,6 +25,7 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field, PrivateAttr
 
 from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.core.config import settings
 from chat_shell.history.subtask_records import (
     SubtaskRecordNotAvailable,
     fetch_history_subtasks,
@@ -33,10 +34,17 @@ from chat_shell.history.subtask_records import (
 
 logger = logging.getLogger(__name__)
 
-# Aligned with the tool-output budget so a page stays within what the
-# request-level guard allows (no re-truncation that would break paging).
-DEFAULT_PAGE_TOKEN_LIMIT = 15000
 DEFAULT_LIST_PAGE_SIZE = 50
+# A page must land strictly under the request-level tool-output guard limit, or
+# the guard re-truncates the JSON tail and breaks block-boundary paging. Derive
+# the budget from that single source of truth minus a buffer for the JSON
+# envelope (and tokenizer variance), so the two can never drift apart.
+_PAGE_TOKEN_SELF_BUFFER = 1024
+
+
+def _page_token_budget() -> int:
+    """Per-page token budget: the guard limit minus the envelope self-buffer."""
+    return max(1, settings.TOOL_OUTPUT_TOKEN_LIMIT - _PAGE_TOKEN_SELF_BUFFER)
 
 
 def _render_block(block: dict[str, Any]) -> str:
@@ -167,7 +175,6 @@ class ReadSubtaskTool(BaseTool):
 
     task_id: int
     token_counter: TokenCounter
-    page_token_limit: int = DEFAULT_PAGE_TOKEN_LIMIT
     max_calls: int = 30
     _call_count: int = PrivateAttr(default=0)
 
@@ -202,7 +209,9 @@ class ReadSubtaskTool(BaseTool):
             )
 
         blocks = _record_to_blocks(record)
-        budget = max_tokens if max_tokens > 0 else self.page_token_limit
+        # Never exceed the guard limit (minus buffer); an override only shrinks it.
+        budget_cap = _page_token_budget()
+        budget = min(max_tokens, budget_cap) if max_tokens > 0 else budget_cap
         cursor = max(0, cursor)
 
         page_parts: list[str] = []

--- a/chat_shell/chat_shell/tools/builtin/history_backtrack.py
+++ b/chat_shell/chat_shell/tools/builtin/history_backtrack.py
@@ -9,10 +9,10 @@ tools let the model page back into the *un-compacted* original detail — each
 earlier subtask's own record is never rewritten by compaction, so reading it by
 id recovers full fidelity.
 
-- ``list_history``: whole-session subtask summaries, each marked ``in_context``
-  or ``compacted`` so the model knows what it can no longer see verbatim.
-- ``read_subtask``: one subtask's raw record, **paginated by whole blocks** (never
-  splitting a block mid-structure) under the per-page token budget.
+Thin transport over the shared backend service: listing, rendering and
+pagination live there. ``list_history`` marks each summary ``in_context`` /
+``compacted``; ``read_subtask`` returns one transcript page plus an opaque
+``next_cursor`` to continue.
 """
 
 from __future__ import annotations
@@ -24,7 +24,6 @@ from typing import Any
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field, PrivateAttr
 
-from chat_shell.compression.token_counter import TokenCounter
 from chat_shell.core.config import settings
 from chat_shell.history.subtask_records import (
     SubtaskRecordNotAvailable,
@@ -35,61 +34,14 @@ from chat_shell.history.subtask_records import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_LIST_PAGE_SIZE = 50
-# A page must land strictly under the request-level tool-output guard limit, or
-# the guard re-truncates the JSON tail and breaks block-boundary paging. Derive
-# the budget from that single source of truth minus a buffer for the JSON
-# envelope (and tokenizer variance), so the two can never drift apart.
-_PAGE_TOKEN_SELF_BUFFER = 1024
+# Per-page char budget derived from the tool-output guard limit (single source of
+# truth; conservative 1 char ≈ 1 token). A page renders under the guard, so its
+# head+tail truncation only ever fires on a single oversized unit.
+_PAGE_CHAR_SELF_BUFFER = 1024
 
 
-def _page_token_budget() -> int:
-    """Per-page token budget: the guard limit minus the envelope self-buffer."""
-    return max(1, settings.TOOL_OUTPUT_TOKEN_LIMIT - _PAGE_TOKEN_SELF_BUFFER)
-
-
-def _render_block(block: dict[str, Any]) -> str:
-    """Render one stored block into a readable transcript fragment."""
-    btype = block.get("type")
-    if btype == "text":
-        return str(block.get("content") or "")
-    if btype == "tool":
-        name = block.get("display_name") or block.get("tool_name") or "tool"
-        tool_input = block.get("tool_input") or {}
-        lines = [f"[tool: {name}] input={json.dumps(tool_input, ensure_ascii=False)}"]
-        output = block.get("tool_output")
-        if output:
-            lines.append(f"output: {output}")
-        return "\n".join(lines)
-    if btype in ("guidance", "subagent"):
-        return str(block.get("content") or "")
-    return json.dumps(block, ensure_ascii=False)
-
-
-def _render_message(message: dict[str, Any]) -> str:
-    """Render one messages_chain entry (fallback for legacy turns)."""
-    role = message.get("role", "assistant")
-    content = message.get("content")
-    text = (
-        content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
-    )
-    tool_calls = message.get("tool_calls")
-    if tool_calls:
-        text = f"{text}\n[tool_calls: {json.dumps(tool_calls, ensure_ascii=False)}]"
-    return f"{role}: {text}"
-
-
-def _record_to_blocks(record: dict[str, Any]) -> list[str]:
-    """Normalize a subtask record into an ordered list of renderable blocks."""
-    if record.get("role") == "user":
-        return [str(record.get("prompt") or "")]
-    blocks = record.get("blocks")
-    if isinstance(blocks, list) and blocks:
-        return [_render_block(b) for b in blocks if isinstance(b, dict)]
-    chain = record.get("messages_chain")
-    if isinstance(chain, list) and chain:
-        return [_render_message(m) for m in chain if isinstance(m, dict)]
-    value = record.get("value")
-    return [str(value)] if value else []
+def _read_max_chars() -> int:
+    return max(1, settings.TOOL_OUTPUT_TOKEN_LIMIT - _PAGE_CHAR_SELF_BUFFER)
 
 
 class ListHistoryInput(BaseModel):
@@ -121,30 +73,31 @@ class ListHistoryTool(BaseTool):
         raise NotImplementedError("list_history is async-only; use _arun")
 
     async def _arun(self, page: int = 1, **_: Any) -> str:
+        page = max(1, page)
+        offset = (page - 1) * self.page_size
         try:
-            summaries = await fetch_history_subtasks(task_id=self.task_id)
+            result = await fetch_history_subtasks(
+                task_id=self.task_id, limit=self.page_size, offset=offset
+            )
         except Exception as exc:  # network / HTTP errors
             logger.warning("[list_history] fetch failed: %s", exc)
             return json.dumps(
                 {"status": "error", "message": "History could not be listed"}
             )
 
-        for item in summaries:
+        subtasks = result.get("subtasks", [])
+        for item in subtasks:
             item["location"] = (
                 "in_context" if item.get("id") in self.in_context_ids else "compacted"
             )
-
-        page = max(1, page)
-        start = (page - 1) * self.page_size
-        window = summaries[start : start + self.page_size]
         return json.dumps(
             {
                 "status": "success",
                 "page": page,
                 "page_size": self.page_size,
-                "total": len(summaries),
-                "has_more": start + self.page_size < len(summaries),
-                "subtasks": window,
+                "total": result.get("total", len(subtasks)),
+                "has_more": result.get("has_more", False),
+                "subtasks": subtasks,
             },
             ensure_ascii=False,
         )
@@ -154,27 +107,25 @@ class ReadSubtaskInput(BaseModel):
     """Input schema for the read_subtask tool."""
 
     subtask_id: int = Field(description="Subtask id from list_history")
-    cursor: int = Field(
-        default=0, description="Block index to start from (0 = first block)"
-    )
-    max_tokens: int = Field(
-        default=0, description="Per-page token budget override (0 = default)"
+    cursor: str = Field(
+        default="0:0",
+        description="Page cursor; start at '0:0' and pass back the returned "
+        "next_cursor to continue.",
     )
 
 
 class ReadSubtaskTool(BaseTool):
-    """Read one subtask's raw detail, paginated by whole blocks."""
+    """Read one subtask's original detail, one transcript page at a time."""
 
     name: str = "read_subtask"
     description: str = (
-        "Read the full original detail of one turn (subtask) by id, with "
-        "pagination. Recovers content that compaction summarized away. Returns a "
-        "page of whole blocks plus next_cursor / has_more for paging."
+        "Read the full original detail of one turn (subtask) by id, one page at a "
+        "time. Recovers content that compaction summarized away. Start at cursor "
+        "'0:0'; if has_more is true, call again with the returned next_cursor."
     )
     args_schema: type[BaseModel] = ReadSubtaskInput
 
     task_id: int
-    token_counter: TokenCounter
     max_calls: int = 30
     _call_count: int = PrivateAttr(default=0)
 
@@ -184,9 +135,7 @@ class ReadSubtaskTool(BaseTool):
     def _run(self, *args: Any, **kwargs: Any) -> str:
         raise NotImplementedError("read_subtask is async-only; use _arun")
 
-    async def _arun(
-        self, subtask_id: int, cursor: int = 0, max_tokens: int = 0, **_: Any
-    ) -> str:
+    async def _arun(self, subtask_id: int, cursor: str = "0:0", **_: Any) -> str:
         if self._call_count >= self.max_calls:
             return json.dumps(
                 {
@@ -198,7 +147,10 @@ class ReadSubtaskTool(BaseTool):
 
         try:
             record = await fetch_subtask_record(
-                task_id=self.task_id, subtask_id=subtask_id
+                task_id=self.task_id,
+                subtask_id=subtask_id,
+                cursor=cursor,
+                max_chars=_read_max_chars(),
             )
         except SubtaskRecordNotAvailable as exc:
             return json.dumps({"status": "error", "message": str(exc)})
@@ -208,53 +160,16 @@ class ReadSubtaskTool(BaseTool):
                 {"status": "error", "message": "Subtask could not be read"}
             )
 
-        blocks = _record_to_blocks(record)
-        # Never exceed the guard limit (minus buffer); an override only shrinks it.
-        budget_cap = _page_token_budget()
-        budget = min(max_tokens, budget_cap) if max_tokens > 0 else budget_cap
-        cursor = max(0, cursor)
-
-        page_parts: list[str] = []
-        used = 0
-        index = cursor
-        total = len(blocks)
-        while index < total:
-            rendered = blocks[index]
-            tokens = self.token_counter.count_text(rendered)
-            if not page_parts and tokens > budget:
-                # A single oversized block must be split *within* the block, never
-                # across neighbours — token-clamp it and mark the truncation.
-                clamped = self._clamp_to_tokens(rendered, budget)
-                page_parts.append(
-                    f"{clamped}\n[block {index} truncated: {tokens} tokens total]"
-                )
-                index += 1
-                break
-            if page_parts and used + tokens > budget:
-                break  # stop before this block; never split a whole block
-            page_parts.append(rendered)
-            used += tokens
-            index += 1
-
-        next_cursor = index if index < total else None
         return json.dumps(
             {
                 "status": "success",
                 "subtask_id": subtask_id,
                 "role": record.get("role"),
-                "cursor": cursor,
-                "next_cursor": next_cursor,
-                "has_more": next_cursor is not None,
-                "total_blocks": total,
-                "content": "\n\n".join(page_parts),
+                "cursor": record.get("cursor"),
+                "next_cursor": record.get("next_cursor"),
+                "has_more": record.get("has_more", False),
+                "total_units": record.get("total_units"),
+                "content": record.get("content", ""),
             },
             ensure_ascii=False,
         )
-
-    def _clamp_to_tokens(self, text: str, token_limit: int) -> str:
-        """Return the longest prefix of *text* within *token_limit* tokens."""
-        encoding = self.token_counter.encoding
-        ids = encoding.encode(text, disallowed_special=())
-        if len(ids) <= token_limit:
-            return text
-        return encoding.decode(ids[:token_limit])

--- a/chat_shell/chat_shell/tools/builtin/history_backtrack.py
+++ b/chat_shell/chat_shell/tools/builtin/history_backtrack.py
@@ -35,9 +35,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_LIST_PAGE_SIZE = 50
 # Per-page char budget derived from the tool-output guard limit (single source of
-# truth; conservative 1 char ≈ 1 token). A page renders under the guard, so its
-# head+tail truncation only ever fires on a single oversized unit.
-_PAGE_CHAR_SELF_BUFFER = 1024
+# truth; conservative 1 char ≈ 1 token). The buffer leaves headroom for the JSON
+# envelope and escaping (quotes/backslashes) added around ``content`` below. Even
+# if an escaping-heavy page still exceeds the guard, the guard truncates the
+# middle (head+tail), and the paging metadata is emitted BEFORE ``content`` so
+# next_cursor/has_more always survive in the head.
+_PAGE_CHAR_SELF_BUFFER = 2048
 
 
 def _read_max_chars() -> int:

--- a/chat_shell/tests/tools/test_history_backtrack.py
+++ b/chat_shell/tests/tools/test_history_backtrack.py
@@ -2,216 +2,137 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the AI history-backtracking tools (list_history / read_subtask)."""
+"""Tests for the (thin) AI history-backtracking tools.
+
+Rendering + pagination live in the shared backend service; these tools only mark
+location, forward pagination params, and relay the page. See the backend
+``test_subtask_history`` for the windowing/rendering logic.
+"""
 
 import json
 from types import SimpleNamespace
 
 import pytest
 
-from chat_shell.compression.token_counter import TokenCounter
 from chat_shell.core.config import settings
+from chat_shell.history.subtask_records import SubtaskRecordNotAvailable
 from chat_shell.services.chat_service import ChatService
 from chat_shell.tools.builtin import history_backtrack
-from chat_shell.tools.builtin.history_backtrack import (
-    ListHistoryTool,
-    ReadSubtaskTool,
-)
+from chat_shell.tools.builtin.history_backtrack import ListHistoryTool, ReadSubtaskTool
 
 
 @pytest.mark.asyncio
-async def test_list_history_marks_location_and_paginates(monkeypatch):
-    summaries = [
-        {
-            "id": 1,
-            "role": "user",
-            "status": "COMPLETED",
-            "char_count": 5,
-            "preview": "hi",
-        },
-        {
-            "id": 2,
-            "role": "assistant",
-            "status": "COMPLETED",
-            "char_count": 9,
-            "preview": "hello",
-        },
-        {
-            "id": 3,
-            "role": "user",
-            "status": "COMPLETED",
-            "char_count": 3,
-            "preview": "yo",
-        },
-    ]
-
-    async def fake_fetch(*, task_id):
+async def test_list_history_marks_location_and_relays(monkeypatch):
+    async def fake_fetch(*, task_id, limit, offset):
         assert task_id == 2
-        return summaries
+        return {
+            "subtasks": [
+                {
+                    "id": 1,
+                    "role": "user",
+                    "status": "COMPLETED",
+                    "char_count": 2,
+                    "preview": "hi",
+                },
+                {
+                    "id": 2,
+                    "role": "assistant",
+                    "status": "COMPLETED",
+                    "char_count": 5,
+                    "preview": "hey",
+                },
+            ],
+            "total": 5,
+            "has_more": True,
+        }
 
     monkeypatch.setattr(history_backtrack, "fetch_history_subtasks", fake_fetch)
 
-    tool = ListHistoryTool(task_id=2, in_context_ids=frozenset({3}), page_size=2)
+    tool = ListHistoryTool(task_id=2, in_context_ids=frozenset({2}), page_size=2)
     result = json.loads(await tool._arun(page=1))
 
-    assert result["total"] == 3
+    assert result["total"] == 5
     assert result["has_more"] is True
-    assert [s["id"] for s in result["subtasks"]] == [1, 2]
     assert result["subtasks"][0]["location"] == "compacted"
-    # id 3 is in context but on page 2
-    page2 = json.loads(await tool._arun(page=2))
-    assert page2["subtasks"][0]["location"] == "in_context"
-    assert page2["has_more"] is False
+    assert result["subtasks"][1]["location"] == "in_context"
 
 
 @pytest.mark.asyncio
-async def test_read_subtask_renders_assistant_blocks(monkeypatch):
-    record = {
-        "id": 2,
-        "role": "assistant",
-        "status": "COMPLETED",
-        "blocks": [
-            {"type": "text", "content": "let me check"},
-            {
-                "type": "tool",
-                "tool_name": "Bash",
-                "tool_input": {"cmd": "ls"},
-                "tool_output": "a.txt",
-            },
-        ],
-    }
+async def test_list_history_forwards_pagination(monkeypatch):
+    seen = {}
 
-    async def fake_fetch(*, task_id, subtask_id):
-        return record
+    async def fake_fetch(*, task_id, limit, offset):
+        seen["limit"] = limit
+        seen["offset"] = offset
+        return {"subtasks": [], "total": 0, "has_more": False}
 
-    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+    monkeypatch.setattr(history_backtrack, "fetch_history_subtasks", fake_fetch)
 
-    tool = ReadSubtaskTool(task_id=2, token_counter=TokenCounter())
-    result = json.loads(await tool._arun(subtask_id=2))
+    tool = ListHistoryTool(task_id=2, page_size=50)
+    await tool._arun(page=3)
 
-    assert result["status"] == "success"
-    assert result["has_more"] is False
-    assert "let me check" in result["content"]
-    assert "Bash" in result["content"] and "a.txt" in result["content"]
+    assert seen == {"limit": 50, "offset": 100}
 
 
 @pytest.mark.asyncio
-async def test_read_subtask_never_splits_a_block(monkeypatch):
-    tc = TokenCounter()
-    block_a = "alpha " * 20
-    block_b = "beta " * 20
-    record = {
-        "id": 5,
-        "role": "assistant",
-        "blocks": [
-            {"type": "text", "content": block_a},
-            {"type": "text", "content": block_b},
-        ],
-    }
-
-    async def fake_fetch(*, task_id, subtask_id):
-        return record
-
-    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
-
-    # Budget fits one block but not two -> page must contain exactly block A whole.
-    budget = tc.count_text(block_a) + 1
-    tool = ReadSubtaskTool(task_id=2, token_counter=tc)
-    result = json.loads(await tool._arun(subtask_id=5, max_tokens=budget))
-
-    assert result["content"] == block_a
-    assert result["next_cursor"] == 1
-    assert result["has_more"] is True
-
-    # Next page returns block B.
-    page2 = json.loads(await tool._arun(subtask_id=5, cursor=1, max_tokens=budget))
-    assert page2["content"] == block_b
-    assert page2["has_more"] is False
-
-
-@pytest.mark.asyncio
-async def test_read_subtask_truncates_oversized_single_block(monkeypatch):
-    tc = TokenCounter()
-    big = "word " * 200
-    record = {
-        "id": 7,
-        "role": "assistant",
-        "blocks": [{"type": "text", "content": big}],
-    }
-
-    async def fake_fetch(*, task_id, subtask_id):
-        return record
-
-    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
-
-    tool = ReadSubtaskTool(task_id=2, token_counter=tc)
-    result = json.loads(await tool._arun(subtask_id=7, max_tokens=10))
-
-    assert "[block 0 truncated" in result["content"]
-    assert result["has_more"] is False  # only one block, fully consumed
-
-
-@pytest.mark.asyncio
-async def test_read_subtask_user_prompt_and_value_fallback(monkeypatch):
-    async def fake_user(*, task_id, subtask_id):
+async def test_read_subtask_relays_page(monkeypatch):
+    async def fake_fetch(*, task_id, subtask_id, cursor, max_chars):
+        assert max_chars > 0  # derived from the guard limit
         return {
-            "id": 1,
-            "role": "user",
-            "status": "COMPLETED",
-            "prompt": "the question",
-        }
-
-    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_user)
-    tool = ReadSubtaskTool(task_id=2, token_counter=TokenCounter())
-    result = json.loads(await tool._arun(subtask_id=1))
-    assert result["content"] == "the question"
-    assert result["role"] == "user"
-
-    async def fake_value(*, task_id, subtask_id):
-        return {
-            "id": 3,
             "role": "assistant",
-            "status": "FAILED",
-            "value": "partial reply",
+            "content": "rendered page",
+            "cursor": "0:0",
+            "next_cursor": "2:0",
+            "has_more": True,
+            "total_units": 5,
         }
 
-    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_value)
-    result = json.loads(await tool._arun(subtask_id=3))
-    assert result["content"] == "partial reply"
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+
+    tool = ReadSubtaskTool(task_id=2)
+    result = json.loads(await tool._arun(subtask_id=7))
+
+    assert result["content"] == "rendered page"
+    assert result["next_cursor"] == "2:0"
+    assert result["has_more"] is True
 
 
 @pytest.mark.asyncio
-async def test_read_subtask_default_budget_derives_from_guard_limit(monkeypatch):
-    tc = TokenCounter()
-    block_a = "alpha " * 20
-    block_b = "beta " * 20
-    record = {
-        "id": 5,
-        "role": "assistant",
-        "blocks": [
-            {"type": "text", "content": block_a},
-            {"type": "text", "content": block_b},
-        ],
-    }
+async def test_read_subtask_forwards_cursor_and_budget(monkeypatch):
+    seen = {}
 
-    async def fake_fetch(*, task_id, subtask_id):
-        return record
+    async def fake_fetch(*, task_id, subtask_id, cursor, max_chars):
+        seen.update(cursor=cursor, max_chars=max_chars)
+        return {
+            "role": "assistant",
+            "content": "",
+            "cursor": cursor,
+            "next_cursor": None,
+            "has_more": False,
+            "total_units": 0,
+        }
 
     monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
-    # Size the guard limit so the derived budget (limit - buffer) fits exactly one
-    # whole block. No max_tokens passed -> the default budget must come from here.
-    monkeypatch.setattr(
-        settings,
-        "TOOL_OUTPUT_TOKEN_LIMIT",
-        history_backtrack._PAGE_TOKEN_SELF_BUFFER + tc.count_text(block_a) + 1,
-    )
+    monkeypatch.setattr(settings, "TOOL_OUTPUT_TOKEN_LIMIT", 5000)
 
-    tool = ReadSubtaskTool(task_id=2, token_counter=tc)
-    result = json.loads(await tool._arun(subtask_id=5))
+    tool = ReadSubtaskTool(task_id=2)
+    await tool._arun(subtask_id=7, cursor="3:100")
 
-    assert result["content"] == block_a
-    assert result["next_cursor"] == 1
-    assert result["has_more"] is True
+    assert seen["cursor"] == "3:100"
+    assert seen["max_chars"] == 5000 - history_backtrack._PAGE_CHAR_SELF_BUFFER
+
+
+@pytest.mark.asyncio
+async def test_read_subtask_not_available(monkeypatch):
+    async def fake_fetch(*, task_id, subtask_id, cursor, max_chars):
+        raise SubtaskRecordNotAvailable("Subtask not found in this session")
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+
+    tool = ReadSubtaskTool(task_id=2)
+    result = json.loads(await tool._arun(subtask_id=9))
+
+    assert result["status"] == "error"
 
 
 def test_dynamic_context_includes_backtrack_hint():

--- a/chat_shell/tests/tools/test_history_backtrack.py
+++ b/chat_shell/tests/tools/test_history_backtrack.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AI history-backtracking tools (list_history / read_subtask)."""
+
+import json
+
+import pytest
+
+from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.tools.builtin import history_backtrack
+from chat_shell.tools.builtin.history_backtrack import (
+    ListHistoryTool,
+    ReadSubtaskTool,
+)
+
+
+@pytest.mark.asyncio
+async def test_list_history_marks_location_and_paginates(monkeypatch):
+    summaries = [
+        {
+            "id": 1,
+            "role": "user",
+            "status": "COMPLETED",
+            "char_count": 5,
+            "preview": "hi",
+        },
+        {
+            "id": 2,
+            "role": "assistant",
+            "status": "COMPLETED",
+            "char_count": 9,
+            "preview": "hello",
+        },
+        {
+            "id": 3,
+            "role": "user",
+            "status": "COMPLETED",
+            "char_count": 3,
+            "preview": "yo",
+        },
+    ]
+
+    async def fake_fetch(*, task_id):
+        assert task_id == 2
+        return summaries
+
+    monkeypatch.setattr(history_backtrack, "fetch_history_subtasks", fake_fetch)
+
+    tool = ListHistoryTool(task_id=2, in_context_ids=frozenset({3}), page_size=2)
+    result = json.loads(await tool._arun(page=1))
+
+    assert result["total"] == 3
+    assert result["has_more"] is True
+    assert [s["id"] for s in result["subtasks"]] == [1, 2]
+    assert result["subtasks"][0]["location"] == "compacted"
+    # id 3 is in context but on page 2
+    page2 = json.loads(await tool._arun(page=2))
+    assert page2["subtasks"][0]["location"] == "in_context"
+    assert page2["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_subtask_renders_assistant_blocks(monkeypatch):
+    record = {
+        "id": 2,
+        "role": "assistant",
+        "status": "COMPLETED",
+        "blocks": [
+            {"type": "text", "content": "let me check"},
+            {
+                "type": "tool",
+                "tool_name": "Bash",
+                "tool_input": {"cmd": "ls"},
+                "tool_output": "a.txt",
+            },
+        ],
+    }
+
+    async def fake_fetch(*, task_id, subtask_id):
+        return record
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+
+    tool = ReadSubtaskTool(task_id=2, token_counter=TokenCounter())
+    result = json.loads(await tool._arun(subtask_id=2))
+
+    assert result["status"] == "success"
+    assert result["has_more"] is False
+    assert "let me check" in result["content"]
+    assert "Bash" in result["content"] and "a.txt" in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_subtask_never_splits_a_block(monkeypatch):
+    tc = TokenCounter()
+    block_a = "alpha " * 20
+    block_b = "beta " * 20
+    record = {
+        "id": 5,
+        "role": "assistant",
+        "blocks": [
+            {"type": "text", "content": block_a},
+            {"type": "text", "content": block_b},
+        ],
+    }
+
+    async def fake_fetch(*, task_id, subtask_id):
+        return record
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+
+    # Budget fits one block but not two -> page must contain exactly block A whole.
+    budget = tc.count_text(block_a) + 1
+    tool = ReadSubtaskTool(task_id=2, token_counter=tc)
+    result = json.loads(await tool._arun(subtask_id=5, max_tokens=budget))
+
+    assert result["content"] == block_a
+    assert result["next_cursor"] == 1
+    assert result["has_more"] is True
+
+    # Next page returns block B.
+    page2 = json.loads(await tool._arun(subtask_id=5, cursor=1, max_tokens=budget))
+    assert page2["content"] == block_b
+    assert page2["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_subtask_truncates_oversized_single_block(monkeypatch):
+    tc = TokenCounter()
+    big = "word " * 200
+    record = {
+        "id": 7,
+        "role": "assistant",
+        "blocks": [{"type": "text", "content": big}],
+    }
+
+    async def fake_fetch(*, task_id, subtask_id):
+        return record
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+
+    tool = ReadSubtaskTool(task_id=2, token_counter=tc)
+    result = json.loads(await tool._arun(subtask_id=7, max_tokens=10))
+
+    assert "[block 0 truncated" in result["content"]
+    assert result["has_more"] is False  # only one block, fully consumed
+
+
+@pytest.mark.asyncio
+async def test_read_subtask_user_prompt_and_value_fallback(monkeypatch):
+    async def fake_user(*, task_id, subtask_id):
+        return {
+            "id": 1,
+            "role": "user",
+            "status": "COMPLETED",
+            "prompt": "the question",
+        }
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_user)
+    tool = ReadSubtaskTool(task_id=2, token_counter=TokenCounter())
+    result = json.loads(await tool._arun(subtask_id=1))
+    assert result["content"] == "the question"
+    assert result["role"] == "user"
+
+    async def fake_value(*, task_id, subtask_id):
+        return {
+            "id": 3,
+            "role": "assistant",
+            "status": "FAILED",
+            "value": "partial reply",
+        }
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_value)
+    result = json.loads(await tool._arun(subtask_id=3))
+    assert result["content"] == "partial reply"

--- a/chat_shell/tests/tools/test_history_backtrack.py
+++ b/chat_shell/tests/tools/test_history_backtrack.py
@@ -5,10 +5,13 @@
 """Tests for the AI history-backtracking tools (list_history / read_subtask)."""
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.core.config import settings
+from chat_shell.services.chat_service import ChatService
 from chat_shell.tools.builtin import history_backtrack
 from chat_shell.tools.builtin.history_backtrack import (
     ListHistoryTool,
@@ -175,3 +178,51 @@ async def test_read_subtask_user_prompt_and_value_fallback(monkeypatch):
     monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_value)
     result = json.loads(await tool._arun(subtask_id=3))
     assert result["content"] == "partial reply"
+
+
+@pytest.mark.asyncio
+async def test_read_subtask_default_budget_derives_from_guard_limit(monkeypatch):
+    tc = TokenCounter()
+    block_a = "alpha " * 20
+    block_b = "beta " * 20
+    record = {
+        "id": 5,
+        "role": "assistant",
+        "blocks": [
+            {"type": "text", "content": block_a},
+            {"type": "text", "content": block_b},
+        ],
+    }
+
+    async def fake_fetch(*, task_id, subtask_id):
+        return record
+
+    monkeypatch.setattr(history_backtrack, "fetch_subtask_record", fake_fetch)
+    # Size the guard limit so the derived budget (limit - buffer) fits exactly one
+    # whole block. No max_tokens passed -> the default budget must come from here.
+    monkeypatch.setattr(
+        settings,
+        "TOOL_OUTPUT_TOKEN_LIMIT",
+        history_backtrack._PAGE_TOKEN_SELF_BUFFER + tc.count_text(block_a) + 1,
+    )
+
+    tool = ReadSubtaskTool(task_id=2, token_counter=tc)
+    result = json.loads(await tool._arun(subtask_id=5))
+
+    assert result["content"] == block_a
+    assert result["next_cursor"] == 1
+    assert result["has_more"] is True
+
+
+def test_dynamic_context_includes_backtrack_hint():
+    request = SimpleNamespace(kb_meta_prompt="")
+    ctx = SimpleNamespace(kb_meta_prompt="", backtrack_hint="RECOVER-VIA-TOOLS")
+    out = ChatService._build_dynamic_context(None, request, ctx)
+    assert "RECOVER-VIA-TOOLS" in out
+
+
+def test_dynamic_context_omits_empty_backtrack_hint():
+    request = SimpleNamespace(kb_meta_prompt="")
+    ctx = SimpleNamespace(kb_meta_prompt="", backtrack_hint="")
+    out = ChatService._build_dynamic_context(None, request, ctx)
+    assert out == ""

--- a/chat_shell/tests/tools/test_history_backtrack_signals.py
+++ b/chat_shell/tests/tools/test_history_backtrack_signals.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the history-backtracking wiring helper in chat context."""
+
+from chat_shell.services.context import _history_backtrack_signals
+
+
+def test_signals_extract_subtask_ids_and_compaction():
+    history = [
+        {"id": "10", "role": "user", "content": "hi"},
+        {
+            "id": "11-0",
+            "role": "assistant",
+            "content": "sum",
+            "metadata": {"summary_compacted": True},
+        },
+        {"id": "11-1", "role": "assistant", "content": "reply"},
+        {"role": "assistant", "content": "no id"},
+        "not-a-dict",
+    ]
+
+    ids, had_compaction = _history_backtrack_signals(history)
+
+    assert ids == frozenset({10, 11})
+    assert had_compaction is True
+
+
+def test_signals_no_compaction_marker():
+    history = [{"id": "5", "role": "user", "content": "hi", "metadata": {}}]
+    ids, had_compaction = _history_backtrack_signals(history)
+    assert ids == frozenset({5})
+    assert had_compaction is False

--- a/docs/en/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/wegent/developer-guide/chat-shell-context-governance.md
@@ -324,6 +324,31 @@ Not in Phase 2a (deferred): letting non-`COMPLETED` terminals (FAILED / CANCELLE
 carry and persist `messages_chain`, and relaxing the checkpoint locator to
 recognize them.
 
+## Phase 2b (evaluated and deferred)
+
+Phase 2b would have let FAILED / CANCELLED terminals also carry and persist
+`messages_chain`. After evaluation it was **deliberately deferred**:
+
+- **It is a token-saving optimization, not a data-loss fix.** On failure the partial
+  reply the user already saw is rebuilt into `result.value` by
+  `collect_completed_result(status="FAILED")` from the streamed blocks, so reload
+  still shows it; only the failed turn's structured `messages_chain` is missing. And
+  compaction only rewrites the runtime window — **it never rewrites earlier subtasks'
+  records** — so continuation reloads the full original history and re-compacts once.
+  The cost is one redundant compaction's tokens, not user-visible lost content.
+- **Narrow trigger.** It requires (compaction within a turn) ∩ (that turn ending
+  FAILED) — a small intersection.
+- **Cost/risk out of proportion.** Wiring the failure chain through means changing the
+  SSE `error` terminal contract (the `error` event terminates the SSE read loop before
+  `response.completed`, and `_status_updated` blocks any later update), with a blast
+  radius across the SSE / WebSocket / HTTP-callback transports.
+
+**Cheaper direction if revisited:** rather than forcing the chain through the error
+terminal, persist the summary as its own durable record **at compaction time** (not at
+turn end), so it survives any terminal state for free. Restart when telemetry shows
+material re-compaction churn from failures, or when the compaction persistence structure
+is being changed anyway.
+
 ## Implementation map
 
 These modules are the best entry points for future maintenance:

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -241,7 +241,7 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
 Phase 2b 原计划让 FAILED / CANCELLED 终止也携带并落库 `messages_chain`。经评估后**主动搁置**，
 理由如下：
 
-- **性质是"省 token 优化"，不是"补数据丢失"。** 失败时用户已看到的 partial 回复经
+- **性质是"省 token 优化"，不是"弥补数据丢失"。** 失败时用户已看到的 partial 回复经
   `collect_completed_result(status="FAILED")` 从流式 blocks 重建进 `result.value`，reload
   仍能看到；真正缺失的只是失败轮的结构化 `messages_chain`。而 compaction 只改运行时上下文、
   **从不改写更早 subtask 的记录**，所以续聊会重新加载全量原始历史并重压一次——代价是一次重复

--- a/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/wegent/developer-guide/chat-shell-context-governance.md
@@ -236,6 +236,25 @@ Phase 2a 让**最后的权威 LangGraph state** 成为唯一收口的唯一来�
 不在 Phase 2a 范围（推迟）：让非 `COMPLETED` 终止（FAILED / CANCELLED）携带并持久化
 `messages_chain`，以及放宽检查点定位以识别它们。
 
+## Phase 2b（已评估搁置）
+
+Phase 2b 原计划让 FAILED / CANCELLED 终止也携带并落库 `messages_chain`。经评估后**主动搁置**，
+理由如下：
+
+- **性质是"省 token 优化"，不是"补数据丢失"。** 失败时用户已看到的 partial 回复经
+  `collect_completed_result(status="FAILED")` 从流式 blocks 重建进 `result.value`，reload
+  仍能看到；真正缺失的只是失败轮的结构化 `messages_chain`。而 compaction 只改运行时上下文、
+  **从不改写更早 subtask 的记录**，所以续聊会重新加载全量原始历史并重压一次——代价是一次重复
+  压缩的 token，而非用户可见内容丢失。
+- **触发面窄。** 需 (同一轮内发生 compaction) ∩ (该轮以 FAILED 收尾)，交集小。
+- **成本/风险不成比例。** 打通失败链需改 SSE `error` 终止事件契约（`error` 事件先于
+  `response.completed` 终止 SSE 读取循环，且 `_status_updated` 会拦截后续更新），blast radius
+  覆盖 SSE / WebSocket / HTTP callback 三种 transport。
+
+**若将来要做，更省的方向：** 不要把 chain 从 error 终止事件里艰难打通，而是在 **compaction
+发生的那一刻就把 summary 落成独立持久化记录**（而非等 turn 结束），使其对任何结束态天然免疫。
+重启条件：telemetry 显示失败重压 churn 可观，或届时正好要动 compaction 持久化结构。
+
 ## 实现落点
 
 下列模块是后续维护最值得先看的入口：


### PR DESCRIPTION
Compaction summarizes older turns out of the live window; give the model tools to page back into the un-compacted original detail. Each earlier subtask's own record is never rewritten by compaction, so reading it by id recovers full fidelity.

- backend: two read-only internal endpoints — whole-session subtask summaries and one subtask's raw record — strictly session-scoped (foreign subtask 404).
- chat_shell: list_history (summaries + in_context/compacted marker) and read_subtask (block-cursor pagination that never splits a block; assistant reads blocks, user reads prompt, falls back to messages_chain/value), plus a http/package fetch helper mirroring read_attachment.
- wiring: register the tools when summary compaction is on; add a system-prompt hint once a session has been compacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internal chat-history endpoints to list paged subtask summaries and read cursor/char-budgeted transcript pages.
  * Enabled chat-side history backtracking tools to browse un-compacted history, including in-context vs. compacted labeling and an automatic hint when compaction is detected.
* **Bug Fixes**
  * Strengthened task-scoped access so deleted or out-of-scope subtasks can’t be retrieved.
* **Tests**
  * Added API, service, and tool coverage for pagination, rendering, cursor behavior, error paths, and access control.
* **Documentation**
  * Updated context governance guidance with a deferred Phase 2b note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->