### PR TITLE
feat(wework): show keyboard shortcuts in streaming send-mode menu

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -429,6 +429,10 @@ describe('ChatInput', () => {
     expect(
       screen.getByTestId('send-after-turn-option').querySelector('.lucide-clock-3')
     ).toBeInTheDocument()
+    const sendAfterTurnOption = screen.getByTestId('send-after-turn-option')
+    expect(sendAfterTurnOption.querySelector('.lucide-corner-down-left')).toBeInTheDocument()
+    expect(screen.getByTestId('guide-current-turn-option')).toHaveTextContent('⌘')
+    expect(screen.getByTestId('interrupt-and-send-option')).toHaveTextContent('⇧')
     await userEvent.click(screen.getByTestId('interrupt-and-send-option'))
 
     expect(onSubmit).toHaveBeenCalledWith('立即改方向', { interruptWhenBusy: true })

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -359,6 +359,7 @@ export function CompactChatComposer({
                     icon: Clock3,
                     testId: 'send-after-turn-option',
                     onSelect: () => onSubmit(value),
+                    shortcut: 'Enter',
                   },
                   {
                     label:
@@ -372,6 +373,7 @@ export function CompactChatComposer({
                     icon: CornerDownRight,
                     testId: 'guide-current-turn-option',
                     onSelect: () => onSubmit(value, { guideWhenBusy: true }),
+                    shortcut: 'Command+Enter',
                   },
                   {
                     label:
@@ -385,6 +387,7 @@ export function CompactChatComposer({
                     icon: Zap,
                     testId: 'interrupt-and-send-option',
                     onSelect: () => onSubmit(value, { interruptWhenBusy: true }),
+                    shortcut: 'Command+Shift+Enter',
                   },
                 ]}
               />

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -186,6 +186,7 @@ export function ComposerToolbar({
                   icon: Clock3,
                   testId: 'send-after-turn-option',
                   onSelect: () => onSubmit(),
+                  shortcut: 'Enter',
                 },
                 {
                   label:
@@ -201,6 +202,7 @@ export function ComposerToolbar({
                   icon: CornerDownRight,
                   testId: 'guide-current-turn-option',
                   onSelect: () => onSubmit({ guideWhenBusy: true }),
+                  shortcut: 'Command+Enter',
                 },
                 {
                   label:
@@ -216,6 +218,7 @@ export function ComposerToolbar({
                   icon: Zap,
                   testId: 'interrupt-and-send-option',
                   onSelect: () => onSubmit({ interruptWhenBusy: true }),
+                  shortcut: 'Command+Shift+Enter',
                 },
               ]}
             />

--- a/wework/src/components/common/ActionMenu.tsx
+++ b/wework/src/components/common/ActionMenu.tsx
@@ -2,10 +2,30 @@ import type { ComponentType, MouseEvent } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { MoreHorizontal } from 'lucide-react'
+import { KeyboardShortcut } from './KeyboardShortcut'
 
 const MENU_GAP = 8
 const VIEWPORT_PADDING = 8
 const MIN_MENU_WIDTH = 176
+const SHORTCUT_MODIFIER_ALIASES: Record<string, string> = {
+  Cmd: 'Command',
+  Meta: 'Command',
+  Ctrl: 'Control',
+  Option: 'Alt',
+}
+
+function formatActionMenuShortcut(shortcut: string): string {
+  const parts = shortcut
+    .split('+')
+    .map(part => part.trim())
+    .filter(Boolean)
+  if (parts.length === 0) return ''
+  const key = parts[parts.length - 1]
+  const modifiers = ['Control', 'Alt', 'Shift', 'Command'].filter(modifier =>
+    parts.slice(0, -1).some(part => (SHORTCUT_MODIFIER_ALIASES[part] ?? part) === modifier)
+  )
+  return [...modifiers, key].join('+')
+}
 
 export interface ActionMenuItem {
   label: string
@@ -14,6 +34,7 @@ export interface ActionMenuItem {
   testId: string
   danger?: boolean
   disabled?: boolean
+  shortcut?: string
 }
 
 interface ActionMenuProps {
@@ -215,6 +236,12 @@ export function ActionMenu({
               >
                 <item.icon className="h-4 w-4 shrink-0" />
                 <span className="truncate">{item.label}</span>
+                {item.shortcut ? (
+                  <KeyboardShortcut
+                    value={formatActionMenuShortcut(item.shortcut)}
+                    className="ml-auto h-5 bg-muted px-1.5 text-xs text-text-secondary"
+                  />
+                ) : null}
               </button>
             ))}
           </div>,


### PR DESCRIPTION
## 变更说明

流式输出过程中，输入框发送按钮下拉菜单的三个选项现在会展示对应的键盘快捷键：

| 选项 | 快捷键 |
| --- | --- |
| 当前回复结束后发送 | ⏎ (Enter) |
| 引导当前回复 | ⌘⏎ (Command+Enter) |
| 打断并立即发送 | ⇧⌘⏎ (Command+Shift+Enter) |

## 实现方式

- `ActionMenu` 组件的 `ActionMenuItem` 新增可选 `shortcut` 字段，渲染时复用共享的 `KeyboardShortcut` 组件（Enter 显示为 ⏎ 图标，Command 显示为 ⌘ 等），并附带修饰键别名规范化（Cmd/Meta/Ctrl/Option）。
- 桌面 `ComposerToolbar` 与紧凑/移动端 `CompactChatComposer` 的三个菜单项分别传入 `Enter`、`Command+Enter`、`Command+Shift+Enter`。
- 快捷键与 `ComposerTextarea` 的实际 Enter 键行为一致：无修饰键 Enter 默认发送；⌘/Ctrl+Enter 为 `guideWhenBusy`；⌘/Ctrl+Shift+Enter 为 `interruptWhenBusy`。

## 验证

- 单元测试：`ChatInput.test.tsx` 98 个测试通过（新增断言：send-after-turn 含 Enter 图标、guide 含 ⌘、interrupt 含 ⇧）；composer 目录 8 个文件 105 个测试全过。
- prettier / eslint / tsc --noEmit 均通过。
- 真实 Tauri 验证（`pnpm --filter wework ai:verify`）：隔离会话中触发流式，填入后续消息使 send-mode 菜单按钮出现，打开菜单后文本断言通过（当前回复结束后发送⏎ / 引导当前回复⌘⏎ / 打断并立即发送⇧⌘⏎），截图确认视觉效果。
- 既有 E2E（task-flow.e2e.mjs 的 send-mode-menu 场景）已覆盖该菜单且属 CI 范围，新增快捷键符号不影响既有文本断言。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut hints to chat send-mode menus.
  * Displays shortcuts for sending after a response, guiding the current response, and interrupting to send.
  * Shortcut labels are consistently formatted across menu items.

* **Tests**
  * Updated chat input coverage to verify shortcut glyphs and the send-after-response icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->