### PR TITLE
fix(executor): preserve UTF-8 across stream chunks

### DIFF
--- a/executor/src/server/local_model_proxy/anthropic.rs
+++ b/executor/src/server/local_model_proxy/anthropic.rs
@@ -185,6 +185,7 @@ fn text_value(value: Option<&Value>) -> String {
 struct AnthropicStreamState<S> {
     stream: Pin<Box<S>>,
     pending: String,
+    pending_utf8: Vec<u8>,
     output: VecDeque<Result<Bytes, std::io::Error>>,
     response_id: String,
     model: String,
@@ -203,6 +204,7 @@ where
     let state = AnthropicStreamState {
         stream: Box::pin(stream),
         pending: String::new(),
+        pending_utf8: Vec::new(),
         output: VecDeque::new(),
         response_id: "msg_wework_anthropic".to_owned(),
         model: String::new(),
@@ -282,7 +284,13 @@ where
             }
             match state.stream.next().await {
                 Some(Ok(bytes)) => {
-                    state.pending.push_str(&String::from_utf8_lossy(&bytes));
+                    if let Err(error) = super::append_stream_utf8(
+                        &mut state.pending,
+                        &mut state.pending_utf8,
+                        &bytes,
+                    ) {
+                        return Some((Err(error), state));
+                    }
                     while let Some(block) = take_sse_block(&mut state.pending) {
                         state.handle_block(&block);
                     }
@@ -290,7 +298,12 @@ where
                 Some(Err(error)) => {
                     return Some((Err(std::io::Error::other(error.to_string())), state));
                 }
-                None => return None,
+                None => {
+                    if let Err(error) = super::finish_stream_utf8(&state.pending_utf8) {
+                        return Some((Err(error), state));
+                    }
+                    return None;
+                }
             }
         }
     })
@@ -570,6 +583,48 @@ mod tests {
         assert!(output.contains("response.output_text.delta"));
         assert!(output.contains("response.custom_tool_call_input.done"));
         assert!(output.contains("\"input_tokens\":10"));
+    }
+
+    #[tokio::test]
+    async fn preserves_utf8_text_split_across_upstream_chunks() {
+        let events = [
+            json!({"type":"message_start","message":{"id":"msg_1","model":"kimi-for-coding","usage":{"input_tokens":1}}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"实现成本主要在 UI。"}}),
+            json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}),
+        ];
+        let payload = events
+            .into_iter()
+            .map(|event| format!("data: {event}\n\n"))
+            .collect::<String>()
+            .into_bytes();
+        let target = "在".as_bytes();
+        let target_offset = payload
+            .windows(target.len())
+            .position(|window| window == target)
+            .expect("payload should contain the target character");
+        let chunks = vec![
+            payload[..target_offset + 1].to_vec(),
+            payload[target_offset + 1..target_offset + 2].to_vec(),
+            payload[target_offset + 2..].to_vec(),
+        ];
+        let source = futures_util::stream::iter(
+            chunks
+                .into_iter()
+                .map(|chunk| Ok::<_, std::io::Error>(Bytes::from(chunk))),
+        );
+
+        let output = anthropic_sse_to_responses(source, ToolContext::default())
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|bytes| {
+                String::from_utf8(bytes.to_vec()).expect("converted stream should be UTF-8")
+            })
+            .collect::<String>();
+
+        assert!(output.contains("实现成本主要在 UI。"));
+        assert!(!output.contains('\u{fffd}'));
     }
 
     #[tokio::test]

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -812,6 +812,7 @@ struct CallState {
 struct ChatStreamState<S> {
     stream: Pin<Box<S>>,
     pending: String,
+    pending_utf8: Vec<u8>,
     output: std::collections::VecDeque<Result<Bytes, std::io::Error>>,
     context: ToolContext,
     response_started: bool,
@@ -927,6 +928,7 @@ where
     let state = ResponsesStreamState {
         stream: Box::pin(stream),
         pending: String::new(),
+        pending_utf8: Vec::new(),
         output: VecDeque::new(),
         context_state: ResponsesCustomToolState {
             context,
@@ -955,7 +957,18 @@ where
             }
             match state.stream.next().await {
                 Some(Ok(bytes)) => {
-                    state.pending.push_str(&String::from_utf8_lossy(&bytes));
+                    if let Err(error) = super::append_stream_utf8(
+                        &mut state.pending,
+                        &mut state.pending_utf8,
+                        &bytes,
+                    ) {
+                        state.source_done = true;
+                        state.terminal_seen = true;
+                        return Some((
+                            Ok(super::responses_failed_event(&error.to_string())),
+                            state,
+                        ));
+                    }
                     while let Some(block) = super::take_sse_block(&mut state.pending) {
                         if super::is_responses_terminal_event(&block) {
                             state.terminal_seen = true;
@@ -982,6 +995,13 @@ where
                 }
                 None => {
                     state.source_done = true;
+                    if let Err(error) = super::finish_stream_utf8(&state.pending_utf8) {
+                        state.terminal_seen = true;
+                        return Some((
+                            Ok(super::responses_failed_event(&error.to_string())),
+                            state,
+                        ));
+                    }
                     if !state.pending.trim().is_empty() {
                         let trailing = std::mem::take(&mut state.pending);
                         let trailing = trailing.trim_end();
@@ -1011,6 +1031,7 @@ where
 struct ResponsesStreamState<S> {
     stream: Pin<Box<S>>,
     pending: String,
+    pending_utf8: Vec<u8>,
     output: std::collections::VecDeque<Result<Bytes, std::io::Error>>,
     context_state: ResponsesCustomToolState,
     source_done: bool,
@@ -1214,6 +1235,7 @@ where
     let state = ChatStreamState {
         stream: Box::pin(stream),
         pending: String::new(),
+        pending_utf8: Vec::new(),
         output: std::collections::VecDeque::new(),
         context,
         response_started: false,
@@ -1238,7 +1260,15 @@ where
             }
             match state.stream.next().await {
                 Some(Ok(bytes)) => {
-                    state.pending.push_str(&String::from_utf8_lossy(&bytes));
+                    if let Err(error) = super::append_stream_utf8(
+                        &mut state.pending,
+                        &mut state.pending_utf8,
+                        &bytes,
+                    ) {
+                        let event = state.failed_event(error.to_string());
+                        state.completed = true;
+                        return Some((Ok(event), state));
+                    }
                     while let Some(block) = super::take_sse_block(&mut state.pending) {
                         state.handle_block(&block, true);
                     }
@@ -1251,6 +1281,11 @@ where
                 None => {
                     if state.completed {
                         return None;
+                    }
+                    if let Err(error) = super::finish_stream_utf8(&state.pending_utf8) {
+                        let event = state.failed_event(error.to_string());
+                        state.completed = true;
+                        return Some((Ok(event), state));
                     }
                     if !state.pending.trim().is_empty() {
                         let trailing = std::mem::take(&mut state.pending);

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -999,6 +999,7 @@ fn safe_url(value: &str) -> String {
 struct ResponsesStreamState<S> {
     stream: Pin<Box<S>>,
     pending: String,
+    pending_utf8: Vec<u8>,
     output: VecDeque<Result<Bytes, std::io::Error>>,
     source_done: bool,
     terminal_seen: bool,
@@ -1016,6 +1017,7 @@ where
     let state = ResponsesStreamState {
         stream: Box::pin(stream),
         pending: String::new(),
+        pending_utf8: Vec::new(),
         output: VecDeque::new(),
         source_done: false,
         terminal_seen: false,
@@ -1040,7 +1042,13 @@ where
             }
             match state.stream.next().await {
                 Some(Ok(bytes)) => {
-                    state.pending.push_str(&String::from_utf8_lossy(&bytes));
+                    if let Err(error) =
+                        append_stream_utf8(&mut state.pending, &mut state.pending_utf8, &bytes)
+                    {
+                        state.source_done = true;
+                        state.terminal_seen = true;
+                        return Some((Ok(responses_failed_event(&error.to_string())), state));
+                    }
                     while let Some(event) = take_sse_block(&mut state.pending) {
                         state.terminal_seen |= is_responses_terminal_event(&event);
                         let normalized = if state.expanded_browser_tools.is_empty() {
@@ -1063,6 +1071,10 @@ where
                 }
                 None => {
                     state.source_done = true;
+                    if let Err(error) = finish_stream_utf8(&state.pending_utf8) {
+                        state.terminal_seen = true;
+                        return Some((Ok(responses_failed_event(&error.to_string())), state));
+                    }
                     if !state.pending.trim().is_empty() {
                         let trailing = std::mem::take(&mut state.pending);
                         let trailing = trailing.trim_end();
@@ -1273,6 +1285,48 @@ pub(super) fn take_sse_block(buffer: &mut String) -> Option<String> {
     let block = buffer[..index].to_owned();
     buffer.drain(..index + delimiter_len);
     Some(block)
+}
+
+pub(super) fn append_stream_utf8(
+    buffer: &mut String,
+    pending_utf8: &mut Vec<u8>,
+    chunk: &[u8],
+) -> Result<(), std::io::Error> {
+    pending_utf8.extend_from_slice(chunk);
+    match std::str::from_utf8(pending_utf8) {
+        Ok(text) => {
+            buffer.push_str(text);
+            pending_utf8.clear();
+            Ok(())
+        }
+        Err(error) => {
+            let valid_up_to = error.valid_up_to();
+            let error_len = error.error_len();
+            if valid_up_to > 0 {
+                let valid = std::str::from_utf8(&pending_utf8[..valid_up_to])
+                    .expect("UTF-8 validator should identify a valid prefix");
+                buffer.push_str(valid);
+                pending_utf8.drain(..valid_up_to);
+            }
+            if error_len.is_some() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Upstream stream contains invalid UTF-8",
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+pub(super) fn finish_stream_utf8(pending_utf8: &[u8]) -> Result<(), std::io::Error> {
+    if pending_utf8.is_empty() {
+        return Ok(());
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "Upstream stream ended with an incomplete UTF-8 sequence",
+    ))
 }
 
 fn normalize_responses_event(event: &str) -> String {
@@ -1705,6 +1759,33 @@ mod tests {
     fn leaves_non_completed_events_unchanged() {
         let event = "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}";
         assert_eq!(normalize_responses_event(event), event);
+    }
+
+    #[test]
+    fn buffers_incomplete_utf8_until_the_next_stream_chunk() {
+        let mut buffer = String::new();
+        let mut pending_utf8 = Vec::new();
+
+        for byte in "在".as_bytes() {
+            append_stream_utf8(&mut buffer, &mut pending_utf8, &[*byte])
+                .expect("split UTF-8 should remain valid");
+        }
+
+        finish_stream_utf8(&pending_utf8).expect("all UTF-8 bytes should be consumed");
+        assert_eq!(buffer, "在");
+    }
+
+    #[test]
+    fn rejects_an_incomplete_utf8_sequence_at_stream_end() {
+        let mut buffer = String::new();
+        let mut pending_utf8 = Vec::new();
+        append_stream_utf8(&mut buffer, &mut pending_utf8, &["在".as_bytes()[0]])
+            .expect("an incomplete trailing sequence should be buffered");
+
+        let error = finish_stream_utf8(&pending_utf8).expect_err("stream should be incomplete");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert!(buffer.is_empty());
     }
 
     async fn collect_responses_stream<S, E>(stream: S) -> String


### PR DESCRIPTION
## What changed

- Added a shared incremental UTF-8 decoder for upstream model streams.
- Buffered incomplete multi-byte sequences across HTTP chunk boundaries.
- Applied the decoder to Anthropic Messages, Chat Completions, native Responses normalization, and Responses custom-tool rewriting.
- Added regression coverage that splits a Chinese character across three upstream byte chunks.

## Why

The local model proxy decoded every HTTP body chunk independently with `String::from_utf8_lossy`. HTTP chunk boundaries can split a multi-byte UTF-8 character, causing each partial byte sequence to be permanently replaced with `U+FFFD`. As a result, valid model output such as `实现成本主要在 UI。` could reach Codex and Wework as `实现成本主要��� UI。`.

## Impact

Streaming responses now preserve non-ASCII text when network chunks split inside Chinese characters, emoji, or other multi-byte UTF-8 code points. Truly invalid UTF-8 is reported as a stream failure instead of being silently corrupted.

## Validation

- `cargo fmt --manifest-path executor/Cargo.toml -- --check`
- `cargo test --manifest-path executor/Cargo.toml --lib server::local_model_proxy --no-fail-fast`
  - 90 passed
  - 0 failed
  - 1 ignored because it requires an external model and Codex binary
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability for responses containing multi-byte characters split across data chunks.
  * Prevented corrupted text and replacement characters from appearing in streamed output.
  * Streams now report a clear failure when invalid or incomplete UTF-8 data is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->