### PR TITLE
fix(standalone): include shared assets in Wework build

### DIFF
--- a/backend/tests/docker/test_standalone_wework_contract.py
+++ b/backend/tests/docker/test_standalone_wework_contract.py
@@ -21,6 +21,7 @@ def test_standalone_image_includes_wework_executor_and_workspace_volume() -> Non
 
     assert "AS wework-builder" in dockerfile
     assert "pnpm install --frozen-lockfile --filter wework..." in dockerfile
+    assert "COPY shared/assets ./shared/assets" in dockerfile
     assert "pnpm run build" in dockerfile
     assert "COPY --from=wework-builder /app/wework/dist /app/wework/dist" in dockerfile
     assert "nginx" in dockerfile

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -66,6 +66,7 @@ RUN corepack enable \
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages ./packages
+COPY shared/assets ./shared/assets
 COPY wework ./wework
 
 ARG WEWORK_APP_BASE_PATH="/wework"


### PR DESCRIPTION
## Summary

- copy shared model instruction assets into the standalone Wework builder stage
- add a Dockerfile contract assertion to prevent the build dependency from being omitted again

## Root cause

`wework/src/features/model-settings/localModelCatalog.ts` imports
`shared/assets/gptDefaultInstructions.md` at build time. The standalone
Dockerfile copied `wework` and `packages` into the Wework builder stage, but
did not copy `shared/assets`, so both amd64 and arm64 release builds failed
with an unresolved import.

## Impact

Standalone release images can build Wework successfully on both supported
architectures. There is no runtime configuration or user-facing behavior
change.

## Validation

- `cd backend && uv run pytest tests/docker/test_standalone_wework_contract.py`
  - 17 passed
- `pnpm --filter wework build`
  - production build passed
- `bash scripts/test-publish-image-standalone-gate.sh`
  - passed
- `git diff --check`
  - passed

The targeted Docker build could not be run locally because the Docker daemon
was not running. The Docker build context is covered by the new contract
assertion, and the referenced asset was successfully resolved by the Wework
production build.

Fixes the standalone failures in:
https://github.com/wecode-ai/Wegent/actions/runs/30337638874


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Included shared static assets in the standalone Wework Docker build.
  * Added validation to ensure these assets are included in future standalone builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->