### PR TITLE
fix(wework): retry rate-limited model requests

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
@@ -36,6 +36,12 @@ The provider `base_url` may be a service root, a versioned API base, or a comple
 
 When a task runs on a cloud or remote device, the model selector hides custom models configured only on the current desktop. Local custom models can only use the local executor; built-in Codex models and cloud Model CRDs can use either local or cloud execution.
 
+### Model Rate-Limit Retries
+
+When the upstream has not started a response stream and the model service returns HTTP `429 Too Many Requests`, the executor Codex compatibility proxy automatically resends the same model request. It retries at most five times, waiting 1, 5, 10, 30, and 60 seconds between attempts.
+
+If the upstream returns a standard `Retry-After` header, the proxy uses that delay instead, capped at 60 seconds for one wait. Non-429 responses do not activate this policy. After the retry budget is exhausted, the proxy returns the final 429 status and error body to Codex. A stream that has already started is never replayed by this mechanism, preventing duplicate generation or tool execution.
+
 ### Namespace Tool Compatibility
 
 Codex can group child tools under a `type: "namespace"` tool when it sends an OpenAI Responses request. OpenAI Chat Completions and Anthropic Messages have no equivalent namespace field, so the executor Codex compatibility proxy applies a reversible mapping at the protocol boundary:

--- a/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
@@ -36,6 +36,12 @@ provider `base_url` 可以是服务根地址、带版本前缀的 API base，或
 
 云端或远端设备执行任务时，模型选择器不会展示只配置在当前桌面端的本机自定义模型。本机模型只能由本机 executor 使用；Codex 内置模型和云端 Model CRD 可以用于本机或云端执行。
 
+### 模型限流重试
+
+executor 的 Codex compat proxy 在上游尚未开始返回响应流、且模型服务返回 HTTP `429 Too Many Requests` 时，会自动重发同一模型请求。默认最多重试 5 次，退避等待依次为 1 秒、5 秒、10 秒、30 秒和 60 秒。
+
+如果上游返回标准 `Retry-After` 响应头，proxy 会优先采用该等待时间，并将单次等待限制在 60 秒以内。非 429 响应不会触发这项策略；重试耗尽后，proxy 会把最后一次 429 状态和错误正文返回给 Codex。已经开始输出的流不会通过这项机制重放，避免重复生成或重复执行工具。
+
 ### Namespace 工具兼容
 
 Codex 向 OpenAI Responses API 发送工具时，可以使用 `type: "namespace"` 把多个子工具组织在同一个 namespace 下。OpenAI Chat Completions 和 Anthropic Messages 没有对应的 namespace 字段，因此 executor 的 Codex compat proxy 会在协议转换边界执行可逆映射：

--- a/executor/Cargo.lock
+++ b/executor/Cargo.lock
@@ -2731,6 +2731,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.4",
  "http-body-util",
+ "httpdate",
  "image",
  "libc",
  "notify",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -36,6 +36,7 @@ regex = "1.11"
 futures-util = "0.3"
 flate2 = "1.0"
 getrandom = "0.3"
+httpdate = "1"
 image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "webp"] }
 libc = "0.2"
 notify = { version = "6.1", optional = true }

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -17,7 +17,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     pin::Pin,
     sync::{Mutex, OnceLock},
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use axum::{
@@ -39,6 +39,15 @@ pub(crate) const ROUTE: &str = "/v1/codex-router/{token}/responses";
 const MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
 const NORMALIZED_API_ID_PREFIX_LENGTH: usize = 48;
 const DEFAULT_MAX_OUTPUT_TOKENS: u64 = 96_000;
+const RATE_LIMIT_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_secs(1),
+    Duration::from_secs(5),
+    Duration::from_secs(10),
+    Duration::from_secs(30),
+    Duration::from_secs(60),
+];
+const MAX_RATE_LIMIT_RETRIES: u32 = RATE_LIMIT_RETRY_DELAYS.len() as u32;
+const MAX_RATE_LIMIT_RETRY_DELAY: Duration = Duration::from_secs(60);
 
 pub(crate) fn route<S>() -> MethodRouter<S>
 where
@@ -301,32 +310,19 @@ async fn handle_for_token(
         ],
     );
 
-    let client = proxy_client(upstream.proxy_url.as_deref())?;
-    let mut request = client
-        .post(request_url)
-        .bearer_auth(&upstream.api_key)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header(reqwest::header::ACCEPT, "text/event-stream")
-        .body(request_body);
-    if upstream.api_format == "anthropic-messages" {
-        request = request
-            .header("x-api-key", upstream.api_key)
-            .header("anthropic-version", "2023-06-01");
-    }
-    if let Some(user_agent) = headers
+    let user_agent = headers
         .get(header::USER_AGENT)
         .and_then(|value| value.to_str().ok())
-    {
-        request = request.header(reqwest::header::USER_AGENT, user_agent);
-    }
-    for (key, value) in upstream.default_headers {
-        request = request.header(key, value);
-    }
-
-    let upstream_response = request.send().await.map_err(|error| HttpError {
-        status: StatusCode::BAD_GATEWAY,
-        detail: format!("Local model proxy request failed: {error}"),
-    })?;
+        .map(str::to_owned);
+    let client = proxy_client(upstream.proxy_url.as_deref())?;
+    let upstream_response = send_upstream_request_with_rate_limit_retry(
+        &client,
+        &upstream,
+        &request_url,
+        &request_body,
+        user_agent.as_deref(),
+    )
+    .await?;
     let status = upstream_response.status();
     if status.is_success() {
         commit_model_request(&token, &model_routing);
@@ -1013,6 +1009,101 @@ fn proxy_client(proxy_url: Option<&str>) -> Result<reqwest::Client, HttpError> {
         })
 }
 
+async fn send_upstream_request_with_rate_limit_retry(
+    client: &reqwest::Client,
+    upstream: &LocalModelProxyUpstream,
+    request_url: &str,
+    request_body: &[u8],
+    user_agent: Option<&str>,
+) -> Result<reqwest::Response, HttpError> {
+    for retry_count in 0..=MAX_RATE_LIMIT_RETRIES {
+        let response =
+            build_upstream_request(client, upstream, request_url, request_body, user_agent)
+                .send()
+                .await
+                .map_err(|error| HttpError {
+                    status: StatusCode::BAD_GATEWAY,
+                    detail: format!("Local model proxy request failed: {error}"),
+                })?;
+        if response.status() != reqwest::StatusCode::TOO_MANY_REQUESTS
+            || retry_count == MAX_RATE_LIMIT_RETRIES
+        {
+            return Ok(response);
+        }
+
+        let delay = rate_limit_retry_delay(response.headers(), retry_count);
+        log_executor_event(
+            "local model proxy rate limited; retrying",
+            &[
+                ("api_format", upstream.api_format.clone()),
+                ("retry", (retry_count + 1).to_string()),
+                ("max_retries", MAX_RATE_LIMIT_RETRIES.to_string()),
+                ("delay_ms", delay.as_millis().to_string()),
+            ],
+        );
+        tokio::time::sleep(delay).await;
+    }
+
+    unreachable!("rate limit retry loop always returns a response")
+}
+
+fn build_upstream_request(
+    client: &reqwest::Client,
+    upstream: &LocalModelProxyUpstream,
+    request_url: &str,
+    request_body: &[u8],
+    user_agent: Option<&str>,
+) -> reqwest::RequestBuilder {
+    let mut request = client
+        .post(request_url)
+        .bearer_auth(&upstream.api_key)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(reqwest::header::ACCEPT, "text/event-stream")
+        .body(request_body.to_vec());
+    if upstream.api_format == "anthropic-messages" {
+        request = request
+            .header("x-api-key", &upstream.api_key)
+            .header("anthropic-version", "2023-06-01");
+    }
+    if let Some(user_agent) = user_agent {
+        request = request.header(reqwest::header::USER_AGENT, user_agent);
+    }
+    for (key, value) in &upstream.default_headers {
+        request = request.header(key, value);
+    }
+    request
+}
+
+fn rate_limit_retry_delay(headers: &reqwest::header::HeaderMap, retry_count: u32) -> Duration {
+    let retry_after = headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_retry_after);
+    retry_after
+        .unwrap_or_else(|| configured_rate_limit_delay(retry_count))
+        .min(MAX_RATE_LIMIT_RETRY_DELAY)
+}
+
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+    let retry_at = httpdate::parse_http_date(value).ok()?;
+    Some(
+        retry_at
+            .duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO),
+    )
+}
+
+fn configured_rate_limit_delay(retry_count: u32) -> Duration {
+    RATE_LIMIT_RETRY_DELAYS
+        .get(retry_count as usize)
+        .copied()
+        .unwrap_or(MAX_RATE_LIMIT_RETRY_DELAY)
+}
+
 fn safe_url(value: &str) -> String {
     reqwest::Url::parse(value)
         .ok()
@@ -1452,7 +1543,13 @@ fn ensure_usage_detail(usage: &mut Map<String, Value>, details_key: &str, field:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, fs, sync::Arc};
+    use std::{
+        env, fs,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
 
     use axum::{body::to_bytes, routing::post, Json, Router};
     use serde_json::json;
@@ -1833,6 +1930,40 @@ mod tests {
     #[test]
     fn proxy_client_rejects_invalid_url() {
         assert!(proxy_client(Some("not a proxy url")).is_err());
+    }
+
+    #[test]
+    fn rate_limit_retry_delay_uses_retry_after_and_caps_large_values() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_static("2"),
+        );
+        assert_eq!(rate_limit_retry_delay(&headers, 0), Duration::from_secs(2));
+
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_static("120"),
+        );
+        assert_eq!(
+            rate_limit_retry_delay(&headers, 0),
+            MAX_RATE_LIMIT_RETRY_DELAY
+        );
+    }
+
+    #[test]
+    fn rate_limit_retry_delay_falls_back_to_configured_backoff_sequence() {
+        let headers = reqwest::header::HeaderMap::new();
+
+        let delays = (0..MAX_RATE_LIMIT_RETRIES)
+            .map(|retry_count| rate_limit_retry_delay(&headers, retry_count))
+            .collect::<Vec<_>>();
+
+        assert_eq!(delays, RATE_LIMIT_RETRY_DELAYS);
+        assert_eq!(
+            rate_limit_retry_delay(&headers, 20),
+            Duration::from_secs(60)
+        );
     }
 
     #[test]
@@ -2297,6 +2428,140 @@ mod tests {
             .await
             .expect("response body");
         assert!(String::from_utf8_lossy(&body).contains("tools are unsupported"));
+
+        unregister(&token);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn retries_rate_limited_model_requests_until_success() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("upstream listener");
+        let address = listener.local_addr().expect("upstream address");
+        let server = tokio::spawn({
+            let request_count = request_count.clone();
+            async move {
+                axum::serve(
+                    listener,
+                    Router::new().route(
+                        "/chat/completions",
+                        post(move || {
+                            let request_count = request_count.clone();
+                            async move {
+                                if request_count.fetch_add(1, Ordering::SeqCst) < 2 {
+                                    return (
+                                        StatusCode::TOO_MANY_REQUESTS,
+                                        [(header::RETRY_AFTER, "0")],
+                                        Json(json!({"error": {"message": "rate limited"}})),
+                                    );
+                                }
+                                (
+                                    StatusCode::OK,
+                                    [(header::RETRY_AFTER, "0")],
+                                    Json(json!({"choices": [{"message": {"content": "hi"}}]})),
+                                )
+                            }
+                        }),
+                    ),
+                )
+                .await
+                .expect("upstream server");
+            }
+        });
+        let token = register(
+            "rate-limit-retry-success",
+            LocalModelProxyUpstream {
+                base_url: format!("http://{address}"),
+                request_url: Some(format!("http://{address}/chat/completions")),
+                api_format: "openai-chat-completions".to_owned(),
+                convert_custom_tools: false,
+                api_key: "secret".to_owned(),
+                default_headers: Vec::new(),
+                proxy_url: None,
+                model_id: None,
+                routing_model_id: None,
+                max_output_tokens: None,
+            },
+        );
+
+        let response = handle(
+            proxy_headers(&token),
+            Bytes::from_static(br#"{"model":"m","input":"hi","stream":true}"#),
+        )
+        .await
+        .expect("proxy response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(request_count.load(Ordering::SeqCst), 3);
+
+        unregister(&token);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn returns_last_rate_limit_response_after_retry_budget_is_exhausted() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("upstream listener");
+        let address = listener.local_addr().expect("upstream address");
+        let server = tokio::spawn({
+            let request_count = request_count.clone();
+            async move {
+                axum::serve(
+                    listener,
+                    Router::new().route(
+                        "/responses",
+                        post(move || {
+                            request_count.fetch_add(1, Ordering::SeqCst);
+                            async {
+                                (
+                                    StatusCode::TOO_MANY_REQUESTS,
+                                    [(header::RETRY_AFTER, "0")],
+                                    Json(json!({"error": {"message": "still rate limited"}})),
+                                )
+                            }
+                        }),
+                    ),
+                )
+                .await
+                .expect("upstream server");
+            }
+        });
+        let token = register(
+            "rate-limit-retry-exhausted",
+            LocalModelProxyUpstream {
+                base_url: format!("http://{address}"),
+                request_url: Some(format!("http://{address}/responses")),
+                api_format: "openai-responses".to_owned(),
+                convert_custom_tools: false,
+                api_key: "secret".to_owned(),
+                default_headers: Vec::new(),
+                proxy_url: None,
+                model_id: None,
+                routing_model_id: None,
+                max_output_tokens: None,
+            },
+        );
+
+        let response = handle(
+            proxy_headers(&token),
+            Bytes::from_static(br#"{"model":"m","input":"hi","stream":true}"#),
+        )
+        .await
+        .expect("proxy response");
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            (MAX_RATE_LIMIT_RETRIES + 1) as usize
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        assert!(String::from_utf8_lossy(&body).contains("still rate limited"));
 
         unregister(&token);
         server.abort();

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -75,6 +75,8 @@ const RETRY_PROMPT = 'WEWORK_DESKTOP_E2E_RETRY: fail once and then succeed after
 const RETRY_FAILURE_TEXT = 'WEWORK_DESKTOP_E2E_RETRY_FAILURE'
 const RETRY_CODEX_ERROR_TEXT = "Codex ran out of room in the model's context window."
 const RETRY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RETRY_COMPLETE'
+const RATE_LIMIT_PROMPT = 'WEWORK_DESKTOP_E2E_RATE_LIMIT: recover from one model 429.'
+const RATE_LIMIT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RATE_LIMIT_COMPLETE'
 const RECONNECT_PROMPT = 'WEWORK_DESKTOP_E2E_RECONNECT: recover after the stream disconnects.'
 const RECONNECT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RECONNECT_COMPLETE'
 const MEMORY_PROMPT = 'WEWORK_DESKTOP_E2E_MEMORY: run a tool and stream the report.'
@@ -259,6 +261,7 @@ const REQUEST_INPUT_ONLY = process.env.WEWORK_DESKTOP_E2E_REQUEST_INPUT_ONLY ===
 const VIEW_IMAGE_ONLY = process.argv.includes('--view-image-only')
 const SHORT_CONVERSATION_ONLY = process.argv.includes('--short-conversation-only')
 const RETRY_ONLY = process.argv.includes('--retry-only')
+const RATE_LIMIT_ONLY = process.argv.includes('--rate-limit-only')
 const RUNNING_FORK_ONLY = process.argv.includes('--running-fork-only')
 const SIDE_CHAT_ONLY = process.argv.includes('--side-chat-only')
 const GOAL_IDLE_ONLY = process.argv.includes('--goal-idle-only')
@@ -3052,6 +3055,37 @@ async function verifyReconnectRecovery({ composerSelector, control }) {
   )
 }
 
+async function verifyRateLimitRecovery({ composerSelector, control }) {
+  control.setScenario('rate_limit')
+  await sendPromptUntilScenarioRequest(control, composerSelector, RATE_LIMIT_PROMPT, 'rate_limit')
+  await withTimeout(
+    control.awaitScenarioRequestCount('rate_limit', 2),
+    UI_TIMEOUT_MS,
+    'The local model proxy did not retry the rate-limited request'
+  )
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    { text: RATE_LIMIT_COMPLETION_TEXT, timeoutMs: UI_TIMEOUT_MS }
+  )
+  const recoveredSnapshot = JSON.parse(await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR))
+  assert.equal(
+    recoveredSnapshot.testIds.includes('assistant-error-card'),
+    false,
+    'The recovered rate-limit request rendered an assistant error'
+  )
+  assert.equal(
+    control.scenarioRequests.get('rate_limit')?.length,
+    2,
+    'The rate-limit recovery did not issue exactly one retry'
+  )
+  await captureVerificationScreenshot(
+    control,
+    'rate-limit-01-recovered.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+}
+
 function createSse(events) {
   return events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
 }
@@ -4226,6 +4260,7 @@ class DesktopE2EServer {
         'cancellation',
         'queue_management',
         'retry',
+        'rate_limit',
         'reconnect',
         'fresh_chat',
         'attachment_only',
@@ -5321,6 +5356,26 @@ class DesktopE2EServer {
       this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(RETRY_COMPLETION_TEXT),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'rate_limit') {
+      this.recordScenarioRequest('rate_limit', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(RATE_LIMIT_PROMPT),
+        'The real Codex request did not contain the rate-limit prompt'
+      )
+      const rateLimitRequests = this.scenarioRequests.get('rate_limit') ?? []
+      if (rateLimitRequests.length === 1) {
+        response.setHeader('Retry-After', '0')
+        json(response, 429, { error: { message: 'Desktop E2E intentional rate limit' } })
+        return
+      }
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(RATE_LIMIT_COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
       return
@@ -7406,6 +7461,21 @@ async function main() {
       return
     }
 
+    if (RATE_LIMIT_ONLY) {
+      phase = 'rate-limit-recovery'
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
+        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      })
+      await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
+      await verifyRateLimitRecovery({
+        composerSelector: ACTIVE_COMPOSER_SELECTOR,
+        control,
+      })
+      console.log(`Wework desktop rate-limit E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
     if (GOAL_IDLE_ONLY) {
       phase = 'goal-idle-state-lifecycle'
       await verifyActiveGoalIdleUnreadLifecycle({
@@ -8431,6 +8501,9 @@ async function main() {
 
     phase = 'retry'
     await verifyRetryFailureRestoration(control, composerSelector)
+
+    phase = 'rate-limit-recovery'
+    await verifyRateLimitRecovery({ composerSelector, control })
 
     phase = 'reconnect'
     await verifyReconnectRecovery({ composerSelector, control })


### PR DESCRIPTION
## What changed

- retry model requests when the Wework Executor model proxy receives HTTP 429 before a response stream starts
- use up to five retries with 1, 5, 10, 30, and 60 second backoff delays
- honor the upstream `Retry-After` header with a 60 second per-wait cap
- preserve the final upstream 429 response after the retry budget is exhausted
- add unit, proxy integration, and real Tauri desktop E2E coverage
- document the retry behavior in the Chinese and English Wework model proxy guides

## Why

Transient provider rate limits previously propagated directly to Codex and failed the active Wework turn. The Wework model router owns the upstream request before streaming begins, so it is the safe boundary for retrying a rejected request without resubmitting an entire UI turn or replaying a response that has already started.

## Impact

Users can recover automatically from short-lived model provider rate limits. Non-429 failures are unchanged, and started response streams are never replayed.

## Validation

- Wework ESLint, TypeScript, and unit tests passed in pre-push
- Executor `cargo fmt --check`, `cargo test --all-features --lib`, and `cargo clippy` passed in pre-push
- local model proxy test module: 43 passed, 1 external-model test ignored
- isolated real Tauri desktop E2E verified one 429 followed by one successful retry without an assistant error card


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model requests that receive a temporary rate-limit response can now be retried automatically.
  * Retries honor the server’s `Retry-After` guidance or use a controlled backoff schedule.
  * Requests are not replayed after response streaming begins, preventing duplicate output or tool actions.
  * Added end-to-end validation for successful recovery from rate limiting.

* **Documentation**
  * Updated English and Chinese guides with rate-limit retry behavior and limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->