### PR TITLE
fix(wework): support Kimi K3 dynamic tools

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -136,6 +136,9 @@ jobs:
           - id: cloud
             name: Cloud
             command: e2e:desktop:cloud
+          - id: kimi
+            name: Kimi K3
+            command: e2e:desktop:kimi
 
     steps:
       - name: Checkout code

--- a/docs/en/wework/settings.md
+++ b/docs/en/wework/settings.md
@@ -22,6 +22,8 @@ Common macOS shortcuts include:
 
 In **Settings → Models**, click **Add model** and choose a provider first. Wework includes profiles for Kimi Coding, the Kimi API Platform, DeepSeek, and GLM. After entering the corresponding platform API key, Wework discovers available models through the provider's `/models` endpoint. Each profile supplies its connection URL, Chat Completions protocol, tool mode, and known model context windows; the Kimi API Platform profile uses the China-region `api.moonshot.cn` endpoint. Kimi Coding K3 automatically uses the built-in Codex Catalog profile with a 256K context window and `low` default reasoning effort.
 
+Kimi K3, K3-256K, and `kimi-k3` support Codex dynamic tool loading for both local custom models and Wegent cloud models. Wework detects this capability from the provider's real `model_id`, so a cloud Model CRD may use a custom display name. Dynamic loading and namespaces are different concepts: `tool_search` discovers tools on demand, while a namespace organizes tools and preserves their routing identity. At Kimi's Chat Completions protocol boundary, Wework expands namespace tools and restores the original namespace when a tool call returns.
+
 Each custom model has an optional **Group** field that controls how it appears in the model picker. Kimi Coding defaults this field to **Kimi**, but users can edit or clear it. Models without a group appear under **Custom models**.
 
 Choose **Custom** to configure an OpenAI Responses, Chat Completions, or Anthropic Messages-compatible endpoint. Model capabilities use structured controls instead of raw Catalog JSON:

--- a/docs/zh/wework/settings.md
+++ b/docs/zh/wework/settings.md
@@ -34,6 +34,8 @@ Windows 和 Linux 使用界面中显示的对应组合键。
 
 在“设置 → 模型”中点击“添加模型”后，先选择提供商。Wework 内置 Kimi Coding、Kimi 开放平台、DeepSeek 和 GLM profile；填写对应平台的 API Key 后，可以从提供商的 `/models` 接口读取可用模型。连接地址、Chat Completions 协议、工具模式和已知模型的上下文长度由 profile 自动填写，其中 Kimi 开放平台使用中国区 `api.moonshot.cn` 端点。Kimi Coding 的 K3 会自动使用内置的 Codex Catalog profile，包括 256K 上下文和默认 `low` 推理等级。
 
+Kimi K3、K3-256K 和 `kimi-k3` 在本机自定义模型与 Wegent 云端模型中都支持 Codex 动态工具加载。Wework 会根据 provider 的真实 `model_id` 识别这项能力，因此云端 Model CRD 可以使用自定义显示名称。动态加载与 namespace 不是同一个概念：动态加载由 `tool_search` 按需发现工具，namespace 用于组织工具并保留调用路由身份；Wework 会在 Kimi 的 Chat Completions 协议边界展开 namespace，并在工具调用返回时恢复原始 namespace。
+
 每个自定义模型都可以设置可选的“分组”，模型选择器会使用该名称组织模型。Kimi Coding 默认填写“Kimi”，用户可以修改或清空；未设置分组的模型统一显示在“自定义模型”下。
 
 选择“完全自定义”可以配置兼容 OpenAI Responses、Chat Completions 或 Anthropic Messages 的接口。模型能力使用结构化表单维护，不需要编辑 Catalog JSON：

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2055,6 +2055,9 @@ fn explicit_codex_upstream(
         convert_custom_tools: non_empty_config(model_config, "tool_profile")
             .or_else(|| non_empty_config(model_config, "toolProfile"))
             .is_some_and(|profile| profile.eq_ignore_ascii_case("function")),
+        kimi_dynamic_tools: bool_value(model_config.get("kimi_dynamic_tools"))
+            .or_else(|| bool_value(model_config.get("kimiDynamicTools")))
+            .unwrap_or(false),
         api_key: api_key.to_owned(),
         default_headers: parse_header_map(model_config.get("default_headers")),
         proxy_url: runtime_proxy_url(model_config).map(str::to_owned),
@@ -2214,6 +2217,7 @@ fn configured_codex_provider(
         base_url,
         api_format,
         convert_custom_tools,
+        kimi_dynamic_tools: false,
         api_key,
         default_headers,
         proxy_url: proxy_url.map(str::to_owned),

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -376,6 +376,21 @@ fn function_tool_profile_enables_responses_tool_conversion() {
 }
 
 #[test]
+fn explicit_upstream_preserves_kimi_dynamic_tool_capability_for_cloud_aliases() {
+    let upstream = explicit_codex_upstream(
+        &json!({
+            "model_id": "shared-kimi-model",
+            "upstream_api_format": "openai-chat-completions",
+            "kimi_dynamic_tools": true
+        }),
+        "https://example.com",
+        "secret",
+    );
+
+    assert!(upstream.kimi_dynamic_tools);
+}
+
+#[test]
 fn explicit_upstream_uses_configured_max_output_tokens() {
     let upstream = explicit_codex_upstream(
         &json!({

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -180,6 +180,8 @@ pub(super) fn responses_to_chat_with_options(
 }
 
 fn supports_kimi_dynamic_tools(body: &Value) -> bool {
+    // Keep this compatibility fallback aligned with
+    // wework/src/features/workbench/runtimeModelSelection.ts.
     matches!(
         body.get("model")
             .and_then(Value::as_str)
@@ -2129,7 +2131,16 @@ fn normalize_arguments(arguments: &str) -> String {
 }
 
 fn parse_arguments_value(arguments: &str) -> Value {
-    serde_json::from_str(arguments).unwrap_or_else(|_| json!({}))
+    serde_json::from_str(arguments).unwrap_or_else(|error| {
+        log_executor_event(
+            "local model proxy tool search arguments unparsable",
+            &[
+                ("error", error.to_string()),
+                ("arguments_bytes", arguments.len().to_string()),
+            ],
+        );
+        json!({})
+    })
 }
 
 fn responses_usage(usage: Option<&Value>) -> Value {

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -9,7 +9,7 @@
 //! shapes and custom-tool mapping preserve Codex semantics across protocols.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     pin::Pin,
 };
 
@@ -49,6 +49,7 @@ Valid update example:
 enum ToolKind {
     Function,
     Custom,
+    ToolSearch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,6 +96,10 @@ impl ToolContext {
             == Some(&ToolKind::Custom)
     }
 
+    fn is_tool_search(&self, name: &str) -> bool {
+        self.tools.get(name).map(|tool| &tool.kind) == Some(&ToolKind::ToolSearch)
+    }
+
     fn wire_name(&self, namespace: Option<&str>, name: &str) -> Option<&str> {
         self.wire_names
             .get(&(namespace.map(str::to_owned), name.to_owned()))
@@ -107,9 +112,17 @@ impl ToolContext {
 }
 
 pub(super) fn responses_to_chat(body: &Value) -> Result<(Value, ToolContext), String> {
+    responses_to_chat_with_options(body, false)
+}
+
+pub(super) fn responses_to_chat_with_options(
+    body: &Value,
+    kimi_dynamic_tools: bool,
+) -> Result<(Value, ToolContext), String> {
     let mut result = Map::new();
     copy_field(body, &mut result, "model", "model");
     let context = build_tool_context(body);
+    let kimi_dynamic_tools = kimi_dynamic_tools || supports_kimi_dynamic_tools(body);
     let mut messages = Vec::new();
 
     if let Some(instructions) = body.get("instructions") {
@@ -119,7 +132,7 @@ pub(super) fn responses_to_chat(body: &Value) -> Result<(Value, ToolContext), St
         }
     }
     if let Some(input) = body.get("input") {
-        append_input(input, &context, &mut messages)?;
+        append_input(input, &context, &mut messages, kimi_dynamic_tools)?;
     }
     result.insert(
         "messages".to_owned(),
@@ -151,7 +164,10 @@ pub(super) fn responses_to_chat(body: &Value) -> Result<(Value, ToolContext), St
         result.insert("reasoning_effort".to_owned(), effort.clone());
     }
 
-    let tools = chat_tools(body, &context);
+    let mut tools = chat_tools(body, &context);
+    if kimi_dynamic_tools {
+        normalize_kimi_chat_tools(&mut tools);
+    }
     if !tools.is_empty() {
         result.insert("tools".to_owned(), Value::Array(tools));
         if let Some(choice) = body.get("tool_choice") {
@@ -163,6 +179,16 @@ pub(super) fn responses_to_chat(body: &Value) -> Result<(Value, ToolContext), St
     Ok((Value::Object(result), context))
 }
 
+fn supports_kimi_dynamic_tools(body: &Value) -> bool {
+    matches!(
+        body.get("model")
+            .and_then(Value::as_str)
+            .map(|model| model.to_ascii_lowercase())
+            .as_deref(),
+        Some("k3" | "k3-256k" | "kimi-k3")
+    )
+}
+
 fn copy_field(body: &Value, result: &mut Map<String, Value>, source: &str, target: &str) {
     if let Some(value) = body.get(source) {
         result.insert(target.to_owned(), value.clone());
@@ -170,31 +196,73 @@ fn copy_field(body: &Value, result: &mut Map<String, Value>, source: &str, targe
 }
 
 fn build_tool_context(body: &Value) -> ToolContext {
-    let tools = body
-        .get("tools")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default();
+    let tools = tool_definitions(body);
     let mut name_counts = BTreeMap::<String, usize>::new();
-    for tool in tools {
-        if tool.get("type").and_then(Value::as_str) == Some("namespace") {
-            for inner_tool in tool
-                .get("tools")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-            {
-                if let Some(name) = inner_tool.get("name").and_then(Value::as_str) {
-                    *name_counts.entry(name.to_owned()).or_default() += 1;
-                }
+    let mut identities = BTreeSet::new();
+    for (namespace, tool) in &tools {
+        if let Some(name) = tool_definition_name(tool) {
+            if !identities.insert((namespace.clone(), name.to_owned())) {
+                continue;
             }
-        } else if let Some(name) = tool.get("name").and_then(Value::as_str) {
             *name_counts.entry(name.to_owned()).or_default() += 1;
         }
     }
 
     let mut context = ToolContext::default();
-    for tool in tools {
+    for (namespace, tool) in tools {
+        let Some(name) = tool_definition_name(tool) else {
+            continue;
+        };
+        if context.wire_name(namespace.as_deref(), name).is_some() {
+            continue;
+        };
+        let kind = match tool.get("type").and_then(Value::as_str) {
+            Some("custom") => ToolKind::Custom,
+            Some("tool_search") => ToolKind::ToolSearch,
+            _ => ToolKind::Function,
+        };
+        let preferred_wire_name = if name_counts.get(name) == Some(&1) {
+            bounded_wire_name(name)
+        } else if let Some(namespace) = namespace.as_deref() {
+            flattened_namespace_tool_name(namespace, name)
+        } else {
+            bounded_wire_name(&format!("functions__{name}"))
+        };
+        let wire_name = unique_wire_name(&context, preferred_wire_name);
+        context.insert_tool(
+            wire_name,
+            ToolIdentity {
+                name: name.to_owned(),
+                namespace,
+                kind,
+            },
+        );
+    }
+    context
+}
+
+fn tool_definitions(body: &Value) -> Vec<(Option<String>, &Value)> {
+    let mut definitions = Vec::new();
+    collect_tool_definitions(body.get("tools"), &mut definitions);
+    let input_items = body.get("input").into_iter().flat_map(|input| {
+        input
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_else(|| std::slice::from_ref(input))
+    });
+    for item in input_items {
+        if item.get("type").and_then(Value::as_str) == Some("tool_search_output") {
+            collect_tool_definitions(item.get("tools"), &mut definitions);
+        }
+    }
+    definitions
+}
+
+fn collect_tool_definitions<'a>(
+    tools: Option<&'a Value>,
+    definitions: &mut Vec<(Option<String>, &'a Value)>,
+) {
+    for tool in tools.and_then(Value::as_array).into_iter().flatten() {
         if tool.get("type").and_then(Value::as_str) == Some("namespace") {
             let Some(namespace) = tool.get("name").and_then(Value::as_str) else {
                 continue;
@@ -205,50 +273,18 @@ fn build_tool_context(body: &Value) -> ToolContext {
                 .into_iter()
                 .flatten()
             {
-                let Some(name) = inner_tool.get("name").and_then(Value::as_str) else {
-                    continue;
-                };
-                let preferred_wire_name = if name_counts.get(name) == Some(&1) {
-                    bounded_wire_name(name)
-                } else {
-                    flattened_namespace_tool_name(namespace, name)
-                };
-                let wire_name = unique_wire_name(&context, preferred_wire_name);
-                context.insert_tool(
-                    wire_name,
-                    ToolIdentity {
-                        name: name.to_owned(),
-                        namespace: Some(namespace.to_owned()),
-                        kind: ToolKind::Function,
-                    },
-                );
+                definitions.push((Some(namespace.to_owned()), inner_tool));
             }
-            continue;
+        } else {
+            definitions.push((None, tool));
         }
-        let Some(name) = tool.get("name").and_then(Value::as_str) else {
-            continue;
-        };
-        let kind = if tool.get("type").and_then(Value::as_str) == Some("custom") {
-            ToolKind::Custom
-        } else {
-            ToolKind::Function
-        };
-        let preferred_wire_name = if name_counts.get(name) == Some(&1) {
-            bounded_wire_name(name)
-        } else {
-            bounded_wire_name(&format!("functions__{name}"))
-        };
-        let wire_name = unique_wire_name(&context, preferred_wire_name);
-        context.insert_tool(
-            wire_name,
-            ToolIdentity {
-                name: name.to_owned(),
-                namespace: None,
-                kind,
-            },
-        );
     }
-    context
+}
+
+fn tool_definition_name(tool: &Value) -> Option<&str> {
+    tool.get("name").and_then(Value::as_str).or_else(|| {
+        (tool.get("type").and_then(Value::as_str) == Some("tool_search")).then_some("tool_search")
+    })
 }
 
 fn flattened_namespace_tool_name(namespace: &str, name: &str) -> String {
@@ -330,8 +366,27 @@ fn chat_tools(body: &Value, context: &ToolContext) -> Vec<Value> {
 }
 
 fn chat_tool(tool: &Value, namespace: Option<&str>, context: &ToolContext) -> Option<Value> {
-    let name = tool.get("name")?.as_str()?;
+    let name = tool_definition_name(tool)?;
     let wire_name = context.wire_name(namespace, name)?;
+    if context.is_tool_search(wire_name) {
+        return Some(json!({
+            "type": "function",
+            "function": {
+                "name": wire_name,
+                "description": tool.get("description").cloned().unwrap_or(Value::Null),
+                "parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "number"}
+                    },
+                    "required": ["query"],
+                    "additionalProperties": false
+                })),
+                "strict": false
+            }
+        }));
+    }
     if context.is_custom(wire_name) {
         let definition = serde_json::to_string(tool).ok()?;
         let contract = if name == "apply_patch" {
@@ -372,6 +427,103 @@ fn chat_tool(tool: &Value, namespace: Option<&str>, context: &ToolContext) -> Op
             "strict": tool.get("strict").cloned().unwrap_or(Value::Bool(false))
         }
     }))
+}
+
+fn chat_dynamic_tools(tools: &Value, context: &ToolContext) -> Vec<Value> {
+    let mut converted = Vec::new();
+    for tool in tools.as_array().into_iter().flatten() {
+        if tool.get("type").and_then(Value::as_str) == Some("namespace") {
+            let Some(namespace) = tool.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            for inner_tool in tool
+                .get("tools")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if let Some(converted_tool) = chat_tool(inner_tool, Some(namespace), context) {
+                    converted.push(converted_tool);
+                }
+            }
+        } else if let Some(converted_tool) = chat_tool(tool, None, context) {
+            converted.push(converted_tool);
+        }
+    }
+    converted
+}
+
+fn normalize_kimi_chat_tools(tools: &mut [Value]) {
+    for tool in tools {
+        if let Some(parameters) = tool.pointer_mut("/function/parameters") {
+            normalize_kimi_root_tool_schema(parameters);
+            normalize_kimi_tool_schema(parameters);
+        }
+    }
+}
+
+fn normalize_kimi_root_tool_schema(schema: &mut Value) {
+    let Some(object) = schema.as_object_mut() else {
+        *schema = json!({"type": "object", "properties": {}});
+        return;
+    };
+    let variants = object.remove("anyOf").and_then(|value| match value {
+        Value::Array(variants) => Some(variants),
+        _ => None,
+    });
+    if let Some(variants) = variants {
+        let properties = object
+            .entry("properties".to_owned())
+            .or_insert_with(|| json!({}));
+        if let Some(properties) = properties.as_object_mut() {
+            for variant in variants {
+                let Some(variant_properties) = variant.get("properties").and_then(Value::as_object)
+                else {
+                    continue;
+                };
+                for (name, definition) in variant_properties {
+                    properties
+                        .entry(name.to_owned())
+                        .or_insert_with(|| definition.clone());
+                }
+            }
+        }
+        object.remove("required");
+    }
+    object.insert("type".to_owned(), Value::String("object".to_owned()));
+}
+
+fn normalize_kimi_tool_schema(schema: &mut Value) {
+    match schema {
+        Value::Object(object) => {
+            let inherited_type = if object.get("anyOf").and_then(Value::as_array).is_some() {
+                object.remove("type")
+            } else {
+                None
+            };
+            if let (Some(inherited_type), Some(variants)) = (
+                inherited_type,
+                object.get_mut("anyOf").and_then(Value::as_array_mut),
+            ) {
+                for variant in variants {
+                    if let Some(variant) = variant.as_object_mut() {
+                        variant
+                            .entry("type".to_owned())
+                            .or_insert_with(|| inherited_type.clone());
+                    }
+                }
+            }
+            for value in object.values_mut() {
+                normalize_kimi_tool_schema(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                normalize_kimi_tool_schema(value);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn responses_tools(tools: &[Value], context: &ToolContext) -> Vec<Value> {
@@ -534,6 +686,7 @@ fn append_input(
     input: &Value,
     context: &ToolContext,
     messages: &mut Vec<Value>,
+    kimi_dynamic_tools: bool,
 ) -> Result<(), String> {
     let items: Vec<&Value> = match input {
         Value::Array(values) => values.iter().collect(),
@@ -548,8 +701,14 @@ fn append_input(
             Some("reasoning") => {
                 append_text(&mut pending_reasoning, &reasoning_text(item));
             }
-            Some("function_call") | Some("custom_tool_call") => {
-                let name = item.get("name").and_then(Value::as_str).unwrap_or_default();
+            Some("function_call") | Some("custom_tool_call") | Some("tool_search_call") => {
+                let is_tool_search =
+                    item.get("type").and_then(Value::as_str) == Some("tool_search_call");
+                let name = if is_tool_search {
+                    "tool_search"
+                } else {
+                    item.get("name").and_then(Value::as_str).unwrap_or_default()
+                };
                 let namespace = item.get("namespace").and_then(Value::as_str);
                 let wire_name = context.wire_name(namespace, name).unwrap_or(name);
                 let call_id = item
@@ -589,6 +748,29 @@ fn append_input(
                     output
                 };
                 messages.push(json!({"role": "tool", "tool_call_id": call_id, "content": output}));
+            }
+            Some("tool_search_output") => {
+                flush_calls(messages, &mut pending_calls, &mut pending_reasoning);
+                let call_id = item
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let tools = item.get("tools").cloned().unwrap_or_else(|| json!([]));
+                messages.push(json!({
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": json!({"tools": tools}).to_string()
+                }));
+                if kimi_dynamic_tools {
+                    let mut tools = chat_dynamic_tools(&tools, context);
+                    normalize_kimi_chat_tools(&mut tools);
+                    if !tools.is_empty() {
+                        messages.push(json!({
+                            "role": "system",
+                            "tools": tools
+                        }));
+                    }
+                }
             }
             _ => {
                 flush_calls(messages, &mut pending_calls, &mut pending_reasoning);
@@ -718,7 +900,9 @@ fn collapse_system_messages(messages: Vec<Value>) -> Vec<Value> {
     let mut system = Vec::new();
     let mut rest = Vec::new();
     for message in messages {
-        if message.get("role").and_then(Value::as_str) == Some("system") {
+        if message.get("role").and_then(Value::as_str) == Some("system")
+            && message.get("tools").is_none()
+        {
             let text = text_value(message.get("content").unwrap_or(&Value::Null));
             if !text.is_empty() {
                 system.push(text);
@@ -805,6 +989,7 @@ struct CallState {
     name: String,
     namespace: Option<String>,
     custom: bool,
+    tool_search: bool,
     arguments: String,
 }
 
@@ -1519,7 +1704,15 @@ impl<S> ChatStreamState<S> {
             }
             _ => String::new(),
         };
-        let (needs_start, call_id, complete_name, complete_namespace, custom, matched_tool) = {
+        let (
+            needs_start,
+            call_id,
+            complete_name,
+            complete_namespace,
+            custom,
+            tool_search,
+            matched_tool,
+        ) = {
             let state = self.calls.entry(index).or_default();
             if !id.is_empty() {
                 state.call_id = super::normalized_responses_api_id(id);
@@ -1530,11 +1723,13 @@ impl<S> ChatStreamState<S> {
                     state.name = identity.name.clone();
                     state.namespace = identity.namespace.clone();
                     state.custom = identity.kind == ToolKind::Custom;
+                    state.tool_search = identity.kind == ToolKind::ToolSearch;
                     matched_tool = true;
                 } else {
                     state.name = name.to_owned();
                     state.namespace = None;
                     state.custom = false;
+                    state.tool_search = false;
                 }
             }
             if !arguments.is_empty() {
@@ -1550,6 +1745,7 @@ impl<S> ChatStreamState<S> {
                 state.name.clone(),
                 state.namespace.clone(),
                 state.custom,
+                state.tool_search,
                 matched_tool,
             )
         };
@@ -1566,12 +1762,16 @@ impl<S> ChatStreamState<S> {
             state.output_index = output_index;
             state.item_id = item_id.clone();
             state.call_id = call_id.clone();
-            let item_type = if custom {
+            let item_type = if tool_search {
+                "tool_search_call"
+            } else if custom {
                 "custom_tool_call"
             } else {
                 "function_call"
             };
-            let mut item = if item_type == "custom_tool_call" {
+            let mut item = if tool_search {
+                json!({"id": item_id, "type": item_type, "status": "in_progress", "call_id": call_id, "execution": "client", "arguments": {}})
+            } else if custom {
                 json!({"id": item_id, "type": item_type, "status": "in_progress", "call_id": call_id, "name": complete_name.clone(), "input": ""})
             } else {
                 json!({"id": item_id, "type": item_type, "status": "in_progress", "call_id": call_id, "name": complete_name.clone(), "arguments": ""})
@@ -1594,16 +1794,22 @@ impl<S> ChatStreamState<S> {
                             .to_owned(),
                     ),
                     ("custom_tool", custom.to_string()),
+                    ("tool_search", tool_search.to_string()),
                 ],
             );
             self.emit(sse("response.output_item.added", json!({"type": "response.output_item.added", "output_index": output_index, "item": item})));
         }
         if !arguments.is_empty() {
-            let (output_index, item_id, custom) = {
+            let (output_index, item_id, custom, tool_search) = {
                 let state = self.calls.entry(index).or_default();
-                (state.output_index, state.item_id.clone(), state.custom)
+                (
+                    state.output_index,
+                    state.item_id.clone(),
+                    state.custom,
+                    state.tool_search,
+                )
             };
-            if !custom && !item_id.is_empty() {
+            if !custom && !tool_search && !item_id.is_empty() {
                 let event = "response.function_call_arguments.delta";
                 self.emit(sse(event, json!({"type": event, "item_id": item_id, "output_index": output_index, "delta": arguments})));
             }
@@ -1669,16 +1875,27 @@ impl<S> ChatStreamState<S> {
                     ("tool_name", state.name.clone()),
                     ("namespace", state.namespace.clone().unwrap_or_default()),
                     ("custom_tool", state.custom.to_string()),
+                    ("tool_search", state.tool_search.to_string()),
                     ("arguments_bytes", state.arguments.len().to_string()),
                 ],
             );
             let custom = state.custom;
+            let tool_search = state.tool_search;
             let arguments = if custom {
                 custom_input(&state.name, &state.arguments)
             } else {
                 normalize_arguments(&state.arguments)
             };
-            let mut item = if custom {
+            let mut item = if tool_search {
+                json!({
+                    "id": state.item_id,
+                    "type": "tool_search_call",
+                    "status": "completed",
+                    "call_id": state.call_id,
+                    "execution": "client",
+                    "arguments": parse_arguments_value(&arguments)
+                })
+            } else if custom {
                 json!({"id": state.item_id, "type": "custom_tool_call", "status": "completed", "call_id": state.call_id, "name": state.name, "input": arguments})
             } else {
                 json!({"id": state.item_id, "type": "function_call", "status": "completed", "call_id": state.call_id, "name": state.name, "arguments": arguments})
@@ -1703,12 +1920,14 @@ impl<S> ChatStreamState<S> {
                     }),
                 ));
             }
-            let done_payload = if custom {
-                json!({"type": done_event, "item_id": state.item_id, "output_index": state.output_index, "input": arguments})
-            } else {
-                json!({"type": done_event, "item_id": state.item_id, "output_index": state.output_index, "arguments": arguments})
-            };
-            self.emit(sse(done_event, done_payload));
+            if !tool_search {
+                let done_payload = if custom {
+                    json!({"type": done_event, "item_id": state.item_id, "output_index": state.output_index, "input": arguments})
+                } else {
+                    json!({"type": done_event, "item_id": state.item_id, "output_index": state.output_index, "arguments": arguments})
+                };
+                self.emit(sse(done_event, done_payload));
+            }
             self.emit(sse("response.output_item.done", json!({"type": "response.output_item.done", "output_index": state.output_index, "item": item})));
             output.push((state.output_index, item));
         }
@@ -1907,6 +2126,10 @@ fn normalize_arguments(arguments: &str) -> String {
     } else {
         arguments.to_owned()
     }
+}
+
+fn parse_arguments_value(arguments: &str) -> Value {
+    serde_json::from_str(arguments).unwrap_or_else(|_| json!({}))
 }
 
 fn responses_usage(usage: Option<&Value>) -> Value {
@@ -2136,6 +2359,189 @@ mod tests {
     }
 
     #[test]
+    fn converts_tool_search_and_injects_kimi_dynamic_namespace_tools() {
+        let input = json!({
+            "model": "k3",
+            "instructions": "Use deferred tools when necessary.",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Calculate 19 * 23"}]},
+                {
+                    "type": "tool_search_call",
+                    "call_id": "search_1",
+                    "execution": "client",
+                    "arguments": {"query": "calculator", "limit": 1}
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "search_1",
+                    "status": "completed",
+                    "execution": "client",
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "math",
+                        "description": "Arithmetic tools.",
+                        "tools": [{
+                            "type": "function",
+                            "name": "calculate",
+                            "description": "Calculate an expression.",
+                            "defer_loading": true,
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"expression": {"type": "string"}},
+                                "required": ["expression"],
+                                "additionalProperties": false
+                            }
+                        }]
+                    }]
+                }
+            ],
+            "tools": [{
+                "type": "tool_search",
+                "execution": "client",
+                "description": "Search deferred tools.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "number"}
+                    },
+                    "required": ["query"],
+                    "additionalProperties": false
+                }
+            }]
+        });
+
+        let (converted, context) = responses_to_chat(&input).expect("request should convert");
+        let messages = converted["messages"].as_array().expect("messages");
+
+        assert_eq!(
+            converted["tools"][0]["function"]["name"],
+            Value::String("tool_search".to_owned())
+        );
+        assert_eq!(
+            messages[2]["tool_calls"][0]["function"]["name"],
+            Value::String("tool_search".to_owned())
+        );
+        assert_eq!(messages[3]["role"], "tool");
+        assert_eq!(messages[4]["role"], "system");
+        assert!(messages[4].get("content").is_none());
+        assert_eq!(
+            messages[4]["tools"][0]["function"]["name"],
+            Value::String("calculate".to_owned())
+        );
+        assert_eq!(
+            context.identity("calculate"),
+            Some(&ToolIdentity {
+                name: "calculate".to_owned(),
+                namespace: Some("math".to_owned()),
+                kind: ToolKind::Function,
+            })
+        );
+    }
+
+    #[test]
+    fn does_not_emit_kimi_dynamic_system_messages_for_other_chat_models() {
+        let input = json!({
+            "model": "other-model",
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "status": "completed",
+                "execution": "client",
+                "tools": [{
+                    "type": "function",
+                    "name": "calculate",
+                    "parameters": {"type": "object"}
+                }]
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let messages = converted["messages"].as_array().expect("messages");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "tool");
+        assert!(messages
+            .iter()
+            .all(|message| message.get("tools").is_none()));
+    }
+
+    #[test]
+    fn emits_kimi_dynamic_tools_for_cloud_model_alias_when_capability_is_explicit() {
+        let input = json!({
+            "model": "shared-kimi-model",
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "status": "completed",
+                "execution": "client",
+                "tools": [{
+                    "type": "function",
+                    "name": "calculate",
+                    "parameters": {"type": "object"}
+                }]
+            }]
+        });
+
+        let (converted, _) =
+            responses_to_chat_with_options(&input, true).expect("request should convert");
+        let messages = converted["messages"].as_array().expect("messages");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1]["role"], "system");
+        assert_eq!(messages[1]["tools"][0]["function"]["name"], "calculate");
+    }
+
+    #[test]
+    fn normalizes_root_and_nested_any_of_schemas_for_kimi() {
+        let input = json!({
+            "model": "k3",
+            "input": "Choose a value.",
+            "tools": [{
+                "type": "function",
+                "name": "choose",
+                "parameters": {
+                    "type": "object",
+                    "anyOf": [
+                        {
+                            "properties": {"text": {"type": "string"}},
+                            "required": ["text"]
+                        },
+                        {
+                            "properties": {
+                                "count": {
+                                    "type": "number",
+                                    "anyOf": [
+                                        {"minimum": 1},
+                                        {"maximum": 10}
+                                    ]
+                                }
+                            },
+                            "required": ["count"]
+                        }
+                    ]
+                }
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let parameters = &converted["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("anyOf").is_none());
+        assert!(parameters.get("required").is_none());
+        assert_eq!(parameters["properties"]["text"]["type"], "string");
+        assert_eq!(
+            parameters["properties"]["count"]["anyOf"][0]["type"],
+            "number"
+        );
+        assert_eq!(
+            parameters["properties"]["count"]["anyOf"][1]["type"],
+            "number"
+        );
+    }
+
+    #[test]
     fn explains_apply_patch_hunk_failures_and_requests_a_retry() {
         let input = json!({
             "model": "kimi-for-coding",
@@ -2208,6 +2614,31 @@ mod tests {
         assert!(output.contains("\"input\":\"patch\""));
         assert!(output.contains("response.completed"));
         assert!(output.contains("\"input_tokens\":10"));
+    }
+
+    #[tokio::test]
+    async fn converts_chat_tool_search_call_to_responses_tool_search_item() {
+        let chunks = vec![Ok::<_, std::io::Error>(Bytes::from(
+            "data: {\"id\":\"chatcmpl-1\",\"model\":\"k3\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"search_1\",\"function\":{\"name\":\"tool_search\",\"arguments\":\"{\\\"query\\\":\\\"calculator\\\",\\\"limit\\\":1}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\ndata: [DONE]\n\n",
+        ))];
+        let mut context = ToolContext::default();
+        context.insert("tool_search".to_owned(), ToolKind::ToolSearch);
+
+        let output = chat_sse_to_responses(futures_util::stream::iter(chunks), context)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .collect::<String>();
+
+        assert!(
+            output.contains("\"type\":\"tool_search_call\""),
+            "unexpected converted stream: {output}"
+        );
+        assert!(output.contains("\"execution\":\"client\""));
+        assert!(output.contains("\"query\":\"calculator\""));
+        assert!(!output.contains("response.function_call_arguments.done"));
     }
 
     #[tokio::test]

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -62,6 +62,7 @@ pub(crate) struct LocalModelProxyUpstream {
     pub request_url: Option<String>,
     pub api_format: String,
     pub convert_custom_tools: bool,
+    pub kimi_dynamic_tools: bool,
     pub api_key: String,
     pub default_headers: Vec<(String, String)>,
     pub proxy_url: Option<String>,
@@ -290,6 +291,7 @@ async fn handle_for_token(
     let (request_body, conversion, expanded_browser_tools) = prepare_request_with_history(
         &upstream.api_format,
         upstream.convert_custom_tools,
+        upstream.kimi_dynamic_tools,
         upstream.max_output_tokens,
         &request_body,
         history.as_ref(),
@@ -780,6 +782,7 @@ where
 async fn prepare_request_with_history(
     api_format: &str,
     convert_custom_tools: bool,
+    kimi_dynamic_tools: bool,
     max_output_tokens: Option<u64>,
     body: &[u8],
     history: &history::CodexToolHistory,
@@ -806,7 +809,13 @@ async fn prepare_request_with_history(
             status: StatusCode::INTERNAL_SERVER_ERROR,
             detail: format!("Failed to serialize enriched Codex request: {error}"),
         })?;
-        return prepare_request(api_format, convert_custom_tools, max_output_tokens, &body);
+        return prepare_request(
+            api_format,
+            convert_custom_tools,
+            kimi_dynamic_tools,
+            max_output_tokens,
+            &body,
+        );
     }
     let mut responses_body = serde_json::from_slice::<Value>(body).map_err(|error| HttpError {
         status: StatusCode::BAD_REQUEST,
@@ -829,6 +838,7 @@ async fn prepare_request_with_history(
     prepare_request(
         api_format,
         convert_custom_tools,
+        kimi_dynamic_tools,
         max_output_tokens,
         &enriched,
     )
@@ -838,6 +848,7 @@ async fn prepare_request_with_history(
 fn prepare_request(
     api_format: &str,
     convert_custom_tools: bool,
+    kimi_dynamic_tools: bool,
     max_output_tokens: Option<u64>,
     body: &[u8],
 ) -> Result<(Vec<u8>, Option<Conversion>, HashSet<String>), HttpError> {
@@ -871,8 +882,10 @@ fn prepare_request(
         return Ok((body, conversion, expanded_browser_tools));
     }
     let (converted, context) = match api_format {
-        "openai-chat-completions" => chat::responses_to_chat(&responses_body)
-            .map(|(body, context)| (body, Conversion::Chat(context))),
+        "openai-chat-completions" => {
+            chat::responses_to_chat_with_options(&responses_body, kimi_dynamic_tools)
+                .map(|(body, context)| (body, Conversion::Chat(context)))
+        }
         "anthropic-messages" => anthropic::responses_to_anthropic(&responses_body)
             .map(|(body, context)| (body, Conversion::Anthropic(context))),
         _ => return Ok((body.to_vec(), None, HashSet::new())),
@@ -1632,6 +1645,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -1686,6 +1700,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -1717,6 +1732,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -1753,7 +1769,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_chat_request() {
-        let error = prepare_request("openai-chat-completions", false, None, b"not-json")
+        let error = prepare_request("openai-chat-completions", false, false, None, b"not-json")
             .expect_err("invalid JSON should fail");
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
     }
@@ -1772,7 +1788,7 @@ mod tests {
         .expect("request body");
 
         let (prepared, conversion, _) =
-            prepare_request("openai-responses", false, None, &body).expect("native request");
+            prepare_request("openai-responses", false, false, None, &body).expect("native request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
 
         assert_eq!(prepared["tools"][0]["type"], "custom");
@@ -1784,7 +1800,7 @@ mod tests {
         let body = cross_protocol_history_with_invalid_ids();
 
         let (prepared, conversion, _) =
-            prepare_request("openai-responses", false, None, &body).expect("native request");
+            prepare_request("openai-responses", false, false, None, &body).expect("native request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
         let call = &prepared["input"][0];
         let output = &prepared["input"][1];
@@ -1804,7 +1820,8 @@ mod tests {
         let body = cross_protocol_history_with_invalid_ids();
 
         let (prepared, conversion, _) =
-            prepare_request("openai-chat-completions", false, None, &body).expect("chat request");
+            prepare_request("openai-chat-completions", false, false, None, &body)
+                .expect("chat request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
         let call = &prepared["messages"][0]["tool_calls"][0];
         let output = &prepared["messages"][1];
@@ -1821,7 +1838,8 @@ mod tests {
         let body = cross_protocol_history_with_invalid_ids();
 
         let (prepared, conversion, _) =
-            prepare_request("anthropic-messages", false, None, &body).expect("Anthropic request");
+            prepare_request("anthropic-messages", false, false, None, &body)
+                .expect("Anthropic request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
         let call = &prepared["messages"][0]["content"][0];
         let output = &prepared["messages"][1]["content"][0];
@@ -1841,8 +1859,8 @@ mod tests {
         }))
         .expect("request body");
 
-        let (prepared, _, _) =
-            prepare_request("anthropic-messages", false, None, &body).expect("Anthropic request");
+        let (prepared, _, _) = prepare_request("anthropic-messages", false, false, None, &body)
+            .expect("Anthropic request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
 
         assert_eq!(prepared["max_tokens"], 96_000);
@@ -1856,8 +1874,9 @@ mod tests {
         }))
         .expect("request body");
 
-        let (prepared, _, _) = prepare_request("anthropic-messages", false, Some(12_345), &body)
-            .expect("Anthropic request");
+        let (prepared, _, _) =
+            prepare_request("anthropic-messages", false, false, Some(12_345), &body)
+                .expect("Anthropic request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
 
         assert_eq!(prepared["max_tokens"], 12_345);
@@ -1872,8 +1891,9 @@ mod tests {
         }))
         .expect("request body");
 
-        let (prepared, _, _) = prepare_request("anthropic-messages", false, Some(96_000), &body)
-            .expect("Anthropic request");
+        let (prepared, _, _) =
+            prepare_request("anthropic-messages", false, false, Some(96_000), &body)
+                .expect("Anthropic request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
 
         assert_eq!(prepared["max_tokens"], 2_048);
@@ -1920,7 +1940,8 @@ mod tests {
         .expect("request body");
 
         let (prepared, conversion, _) =
-            prepare_request("openai-responses", true, None, &body).expect("converted request");
+            prepare_request("openai-responses", true, false, None, &body)
+                .expect("converted request");
         let prepared: Value = serde_json::from_slice(&prepared).expect("prepared JSON");
 
         assert_eq!(prepared["tools"][0]["type"], "function");
@@ -2068,6 +2089,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "luna-secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -2089,6 +2111,7 @@ mod tests {
             request_url: Some("https://sol.example.com/v1/responses".to_owned()),
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "sol-secret".to_owned(),
             default_headers: vec![("x-route".to_owned(), "sol".to_owned())],
             proxy_url: None,
@@ -2141,6 +2164,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -2181,6 +2205,7 @@ mod tests {
                 request_url: None,
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "luna-secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2213,6 +2238,7 @@ mod tests {
                 request_url: None,
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "sol-secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2254,6 +2280,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -2275,6 +2302,7 @@ mod tests {
             request_url: None,
             api_format: "openai-responses".to_owned(),
             convert_custom_tools: false,
+            kimi_dynamic_tools: false,
             api_key: "secret".to_owned(),
             default_headers: Vec::new(),
             proxy_url: None,
@@ -2298,6 +2326,7 @@ mod tests {
                 request_url: None,
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2339,6 +2368,7 @@ mod tests {
                 request_url: None,
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2403,6 +2433,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/chat/completions")),
                 api_format: "openai-chat-completions".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2477,6 +2508,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/chat/completions")),
                 api_format: "openai-chat-completions".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2537,6 +2569,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/responses")),
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2596,6 +2629,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/responses")),
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2619,6 +2653,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/responses")),
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2694,6 +2729,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/chat/completions")),
                 api_format: "openai-chat-completions".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2781,6 +2817,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/chat/completions")),
                 api_format: "openai-chat-completions".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -2819,6 +2856,246 @@ mod tests {
         assert!(response_body.contains("response.output_text.delta"));
         assert!(response_body.contains("\"type\":\"function_call\""));
         assert!(response_body.contains("\"name\":\"exec_command\""));
+
+        unregister(&token);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn kimi_k3_dynamic_tool_loading_round_trips_end_to_end() {
+        let requests = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("upstream listener");
+        let address = listener.local_addr().expect("upstream address");
+        let server = tokio::spawn({
+            let requests = requests.clone();
+            async move {
+                axum::serve(
+                    listener,
+                    Router::new().route(
+                        "/chat/completions",
+                        post(move |Json(body): Json<Value>| {
+                            let requests = requests.clone();
+                            async move {
+                                let stage = {
+                                    let mut requests =
+                                        requests.lock().expect("captured request lock");
+                                    let stage = requests.len();
+                                    requests.push(body);
+                                    stage
+                                };
+                                let response = match stage {
+                                    0 => concat!(
+                                        "data: {\"id\":\"chatcmpl-search\",\"model\":\"k3\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"search_1\",\"type\":\"function\",\"function\":{\"name\":\"tool_search\",\"arguments\":\"{\\\"query\\\":\\\"calculator\\\",\\\"limit\\\":1}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                                        "data: [DONE]\n\n"
+                                    ),
+                                    1 => concat!(
+                                        "data: {\"id\":\"chatcmpl-dynamic\",\"model\":\"k3\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"calculate\",\"arguments\":\"{\\\"expression\\\":\\\"19 * 23\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                                        "data: [DONE]\n\n"
+                                    ),
+                                    2 => concat!(
+                                        "data: {\"id\":\"chatcmpl-final\",\"model\":\"k3\",\"choices\":[{\"delta\":{\"content\":\"The result is 437.\"},\"finish_reason\":\"stop\"}]}\n\n",
+                                        "data: [DONE]\n\n"
+                                    ),
+                                    _ => panic!("unexpected Kimi request stage {stage}"),
+                                };
+                                (
+                                    [(
+                                        header::CONTENT_TYPE,
+                                        HeaderValue::from_static("text/event-stream"),
+                                    )],
+                                    response,
+                                )
+                            }
+                        }),
+                    ),
+                )
+                .await
+                .expect("upstream server");
+            }
+        });
+        let token = register(
+            "kimi-dynamic-tools-e2e",
+            LocalModelProxyUpstream {
+                base_url: format!("http://{address}"),
+                request_url: Some(format!("http://{address}/chat/completions")),
+                api_format: "openai-chat-completions".to_owned(),
+                convert_custom_tools: false,
+                kimi_dynamic_tools: true,
+                api_key: "secret".to_owned(),
+                default_headers: Vec::new(),
+                proxy_url: None,
+                model_id: Some("shared-kimi-model".to_owned()),
+                routing_model_id: None,
+                max_output_tokens: None,
+            },
+        );
+
+        let first = json!({
+            "model": "cloud-alias",
+            "stream": true,
+            "input": "Calculate 19 * 23.",
+            "tools": [
+                {
+                    "type": "tool_search",
+                    "execution": "client",
+                    "description": "Search deferred tools.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "limit": {"type": "number"}
+                        },
+                        "required": ["query"],
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "schema_probe",
+                    "parameters": {
+                        "type": "object",
+                        "anyOf": [
+                            {"properties": {"text": {"type": "string"}}},
+                            {"properties": {"count": {"type": "number"}}}
+                        ]
+                    }
+                }
+            ]
+        });
+        let first_response = handle(
+            proxy_headers(&token),
+            Bytes::from(serde_json::to_vec(&first).expect("first request")),
+        )
+        .await
+        .expect("first proxy response");
+        let first_body = String::from_utf8_lossy(
+            &to_bytes(first_response.into_body(), usize::MAX)
+                .await
+                .expect("first response body"),
+        )
+        .into_owned();
+        assert!(first_body.contains("\"type\":\"tool_search_call\""));
+        assert!(first_body.contains("\"execution\":\"client\""));
+
+        let search_output = json!({
+            "type": "tool_search_output",
+            "call_id": "search_1",
+            "status": "completed",
+            "execution": "client",
+            "tools": [{
+                "type": "namespace",
+                "name": "math",
+                "description": "Arithmetic tools.",
+                "tools": [{
+                    "type": "function",
+                    "name": "calculate",
+                    "description": "Calculate an expression.",
+                    "defer_loading": true,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"expression": {"type": "string"}},
+                        "required": ["expression"],
+                        "additionalProperties": false
+                    }
+                }]
+            }]
+        });
+        let second = json!({
+            "model": "cloud-alias",
+            "stream": true,
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Calculate 19 * 23."}]},
+                {
+                    "type": "tool_search_call",
+                    "call_id": "search_1",
+                    "execution": "client",
+                    "arguments": {"query": "calculator", "limit": 1}
+                },
+                search_output
+            ],
+            "tools": [first["tools"][0].clone()]
+        });
+        let second_response = handle(
+            proxy_headers(&token),
+            Bytes::from(serde_json::to_vec(&second).expect("second request")),
+        )
+        .await
+        .expect("second proxy response");
+        let second_body = String::from_utf8_lossy(
+            &to_bytes(second_response.into_body(), usize::MAX)
+                .await
+                .expect("second response body"),
+        )
+        .into_owned();
+        assert!(second_body.contains("\"type\":\"function_call\""));
+        assert!(second_body.contains("\"namespace\":\"math\""));
+        assert!(second_body.contains("\"name\":\"calculate\""));
+
+        let third = json!({
+            "model": "cloud-alias",
+            "stream": true,
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Calculate 19 * 23."}]},
+                {
+                    "type": "tool_search_call",
+                    "call_id": "search_1",
+                    "execution": "client",
+                    "arguments": {"query": "calculator", "limit": 1}
+                },
+                search_output,
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "namespace": "math",
+                    "name": "calculate",
+                    "arguments": "{\"expression\":\"19 * 23\"}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "437"
+                }
+            ],
+            "tools": [first["tools"][0].clone()]
+        });
+        let third_response = handle(
+            proxy_headers(&token),
+            Bytes::from(serde_json::to_vec(&third).expect("third request")),
+        )
+        .await
+        .expect("third proxy response");
+        let third_body = String::from_utf8_lossy(
+            &to_bytes(third_response.into_body(), usize::MAX)
+                .await
+                .expect("third response body"),
+        )
+        .into_owned();
+        assert!(third_body.contains("The result is 437."));
+
+        let requests = requests.lock().expect("captured requests");
+        assert_eq!(requests.len(), 3);
+        assert_eq!(
+            requests[0]["tools"][1]["function"]["parameters"]["type"],
+            "object"
+        );
+        assert!(requests[0]["tools"][1]["function"]["parameters"]
+            .get("anyOf")
+            .is_none());
+        let dynamic_message = requests[1]["messages"]
+            .as_array()
+            .expect("second messages")
+            .iter()
+            .find(|message| message["role"] == "system" && message.get("tools").is_some())
+            .expect("dynamic system message");
+        assert!(dynamic_message.get("content").is_none());
+        assert_eq!(dynamic_message["tools"][0]["function"]["name"], "calculate");
+        assert!(requests[2]["messages"]
+            .as_array()
+            .expect("third messages")
+            .iter()
+            .any(|message| message["role"] == "tool" && message["content"] == "437"));
 
         unregister(&token);
         server.abort();
@@ -2890,6 +3167,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/messages")),
                 api_format: "anthropic-messages".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -3015,6 +3293,7 @@ mod tests {
                 request_url: Some(format!("http://{address}/responses")),
                 api_format: "openai-responses".to_owned(),
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key: "secret".to_owned(),
                 default_headers: Vec::new(),
                 proxy_url: None,
@@ -3075,6 +3354,7 @@ mod tests {
                 request_url: Some(request_url),
                 api_format,
                 convert_custom_tools: false,
+                kimi_dynamic_tools: false,
                 api_key,
                 default_headers: Vec::new(),
                 proxy_url: None,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -26,7 +26,11 @@ const DEFAULT_STEP_TIMEOUT_MS = readPositiveTimeout(
   10_000,
   'WEWORK_E2E_STEP_TIMEOUT_MS'
 )
-const MODEL_PROTOCOL_MATRIX_TIMEOUT_MS = 10_000
+const MODEL_PROTOCOL_MATRIX_TIMEOUT_MS = readPositiveTimeout(
+  process.env.WEWORK_E2E_MODEL_MATRIX_TIMEOUT_MS,
+  10_000,
+  'WEWORK_E2E_MODEL_MATRIX_TIMEOUT_MS'
+)
 const COMPOSER_READY_STABILITY_MS = 750
 
 function readPositiveTimeout(value, fallback, name) {
@@ -180,15 +184,34 @@ const LOCAL_MODEL_CASES = [
     label: 'Desktop E2E Anthropic',
     modelId: 'desktop-e2e-anthropic-model',
   },
+  {
+    protocol: 'chat',
+    optionId: 'local-model:desktop-e2e-kimi-k3',
+    label: 'Desktop E2E Kimi K3',
+    modelId: 'k3',
+    variant: 'kimi-k3',
+    kimiDynamicTools: true,
+  },
 ]
 const MODEL_PROTOCOLS = ['responses', 'chat', 'anthropic']
-const CLOUD_MODEL_CASES = MODEL_PROTOCOLS.map(protocol => ({
-  source: 'cloud',
-  protocol,
-  optionId: `desktop-e2e-cloud-${protocol}`,
-  label: `desktop-e2e-cloud-${protocol}`,
-  modelId: `desktop-e2e-cloud-${protocol}-upstream`,
-}))
+const CLOUD_MODEL_CASES = [
+  ...MODEL_PROTOCOLS.map(protocol => ({
+    source: 'cloud',
+    protocol,
+    optionId: `desktop-e2e-cloud-${protocol}`,
+    label: `desktop-e2e-cloud-${protocol}`,
+    modelId: `desktop-e2e-cloud-${protocol}-upstream`,
+  })),
+  {
+    source: 'cloud',
+    protocol: 'chat',
+    optionId: 'desktop-e2e-cloud-kimi-k3',
+    label: 'k3',
+    modelId: 'k3',
+    variant: 'kimi-k3',
+    kimiDynamicTools: true,
+  },
+]
 const MODEL_PROTOCOL_MATRIX_CASES = [
   ...LOCAL_MODEL_CASES.map(model => ({ ...model, source: 'local' })),
   ...MODEL_PROTOCOLS.map(protocol => ({
@@ -225,6 +248,15 @@ const MIXED_TOOL_TURN_MODEL_PROTOCOL_MATRIX_CASES = LOCAL_CUSTOM_MODEL_PROTOCOL_
 )
 const LOCAL_CONNECTED_MODEL_PROTOCOL_MATRIX_CASES =
   LOCAL_EXECUTION_MODEL_PROTOCOL_MATRIX_CASES.filter(model => model.source !== 'local')
+const KIMI_MODEL_PROTOCOL_MATRIX_CASES = LOCAL_EXECUTION_MODEL_PROTOCOL_MATRIX_CASES.filter(
+  model => model.kimiDynamicTools === true
+)
+const KIMI_LOCAL_MODEL_PROTOCOL_MATRIX_CASES = KIMI_MODEL_PROTOCOL_MATRIX_CASES.filter(
+  model => model.source === 'local'
+)
+const KIMI_CLOUD_MODEL_PROTOCOL_MATRIX_CASES = KIMI_MODEL_PROTOCOL_MATRIX_CASES.filter(
+  model => model.source === 'cloud'
+)
 const HIDDEN_CLOUD_MODEL_PROTOCOL_MATRIX_CASES = CLOUD_EXECUTION_MODEL_PROTOCOL_MATRIX_CASES.filter(
   model => model.source === 'local'
 )
@@ -326,6 +358,7 @@ const GUIDANCE_BACKGROUND_ONLY = process.argv.includes('--guidance-background-on
 const GUIDANCE_SCROLL_ONLY = process.argv.includes('--guidance-scroll-only')
 const QUEUE_MANAGEMENT_ONLY = process.argv.includes('--queue-management-only')
 const TASK_PLAN_ONLY = process.argv.includes('--task-plan-only')
+const KIMI_ONLY = process.env.WEWORK_E2E_KIMI_ONLY === '1'
 const DESKTOP_SCENARIO_ONLY = process.env.WEWORK_E2E_DESKTOP_SCENARIO_ONLY === 'true'
 const MIXED_TOOL_TURNS_ONLY = process.env.WEWORK_E2E_MIXED_TOOL_TURNS_ONLY === '1'
 const DESKTOP_CHECKPOINTS = [
@@ -3940,7 +3973,7 @@ function localModelSwitchCommand() {
 }
 
 function matrixCaseId(model) {
-  return `${model.execution}-${model.source}-${model.protocol}`
+  return `${model.execution}-${model.source}-${model.variant ?? model.protocol}`
 }
 
 function matrixTextPrompt(model) {
@@ -7548,6 +7581,7 @@ async function buildDesktopApp(
 }
 
 async function verifyConnectedModelsOnLocalExecution({
+  cases = LOCAL_CONNECTED_MODEL_PROTOCOL_MATRIX_CASES,
   control,
   cloudEnvironment,
   setCodexUpstreamProtocol,
@@ -7591,7 +7625,7 @@ async function verifyConnectedModelsOnLocalExecution({
   const newConversationSelector = `[data-testid="project-row-${projectId}"] [data-testid="project-new-conversation-button"]`
 
   await verifyModelProtocolMatrix({
-    cases: LOCAL_CONNECTED_MODEL_PROTOCOL_MATRIX_CASES,
+    cases,
     composerSelector,
     control,
     newConversationSelector,
@@ -8282,6 +8316,7 @@ async function main() {
     if (CLOUD_ONLY) {
       phase = 'local-connected-model-protocol-matrix'
       await verifyConnectedModelsOnLocalExecution({
+        ...(KIMI_ONLY ? { cases: KIMI_CLOUD_MODEL_PROTOCOL_MATRIX_CASES } : {}),
         control,
         cloudEnvironment,
         setCodexUpstreamProtocol: protocol =>
@@ -8293,6 +8328,15 @@ async function main() {
           ),
         workspacePath,
       })
+      if (KIMI_ONLY) {
+        await writeFile(
+          join(resultDir, 'model-requests.json'),
+          `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+          'utf8'
+        )
+        console.log(`Wework cloud Kimi K3 desktop E2E passed. Evidence: ${resultDir}`)
+        return
+      }
       phase = 'cloud-project-flow'
       await verifyCloudProjectFlow(control, cloudEnvironment, workspacePath)
       await writeFile(
@@ -8777,14 +8821,16 @@ async function main() {
       return
     }
 
-    if (MIXED_TOOL_TURNS_ONLY) {
-      phase = 'mixed-assistant-tool-turns'
+    if (KIMI_ONLY || MIXED_TOOL_TURNS_ONLY) {
+      phase = KIMI_ONLY ? 'kimi-model-protocol-matrix' : 'mixed-assistant-tool-turns'
       await verifyModelProtocolMatrix({
-        cases: MIXED_TOOL_TURN_MODEL_PROTOCOL_MATRIX_CASES,
+        cases: KIMI_ONLY
+          ? KIMI_LOCAL_MODEL_PROTOCOL_MATRIX_CASES
+          : MIXED_TOOL_TURN_MODEL_PROTOCOL_MATRIX_CASES,
         composerSelector,
         control,
         newConversationSelector: `${projectRowSelector} [data-testid="project-new-conversation-button"]`,
-        screenshotPrefix: 'mixed-assistant-tool-turn',
+        screenshotPrefix: KIMI_ONLY ? 'kimi-matrix' : 'mixed-assistant-tool-turn',
         workspacePath,
       })
       await writeFile(
@@ -8792,7 +8838,9 @@ async function main() {
         `${JSON.stringify(control.modelRequests, null, 2)}\n`,
         'utf8'
       )
-      console.log(`Wework mixed assistant tool-turn desktop E2E passed. Evidence: ${resultDir}`)
+      console.log(
+        `Wework ${KIMI_ONLY ? 'Kimi K3' : 'mixed assistant tool-turn'} desktop E2E passed. Evidence: ${resultDir}`
+      )
       return
     }
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -257,6 +257,14 @@ const KIMI_LOCAL_MODEL_PROTOCOL_MATRIX_CASES = KIMI_MODEL_PROTOCOL_MATRIX_CASES.
 const KIMI_CLOUD_MODEL_PROTOCOL_MATRIX_CASES = KIMI_MODEL_PROTOCOL_MATRIX_CASES.filter(
   model => model.source === 'cloud'
 )
+assert.ok(
+  KIMI_LOCAL_MODEL_PROTOCOL_MATRIX_CASES.length > 0,
+  'The local Kimi K3 E2E matrix must contain at least one case'
+)
+assert.ok(
+  KIMI_CLOUD_MODEL_PROTOCOL_MATRIX_CASES.length > 0,
+  'The cloud Kimi K3 E2E matrix must contain at least one case'
+)
 const HIDDEN_CLOUD_MODEL_PROTOCOL_MATRIX_CASES = CLOUD_EXECUTION_MODEL_PROTOCOL_MATRIX_CASES.filter(
   model => model.source === 'local'
 )

--- a/wework/package.json
+++ b/wework/package.json
@@ -29,6 +29,7 @@
     "e2e": "playwright test",
     "e2e:desktop": "WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/streaming-text.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "e2e:desktop:cloud": "node e2e/desktop/task-flow.e2e.mjs --cloud-only",
+    "e2e:desktop:kimi": "WEWORK_E2E_KIMI_ONLY=1 WEWORK_E2E_MODEL_MATRIX_TIMEOUT_MS=30000 node e2e/desktop/task-flow.e2e.mjs && WEWORK_E2E_KIMI_ONLY=1 WEWORK_E2E_MODEL_MATRIX_TIMEOUT_MS=30000 node e2e/desktop/task-flow.e2e.mjs --cloud-only",
     "e2e:desktop:plugins": "node e2e/desktop/task-flow.e2e.mjs --plugins-only",
     "e2e:desktop:memory": "node e2e/desktop/task-flow.e2e.mjs --memory-only",
     "e2e:desktop:streaming-text": "WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/streaming-text.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -1185,6 +1185,7 @@ describe('createLocalAppServices', () => {
         codex_catalog_model_id: 'wework-kimi-k3',
         model_context_window: 262_144,
         reasoning: { effort: 'low' },
+        kimi_dynamic_tools: true,
       })
     )
   })
@@ -1344,6 +1345,7 @@ describe('createLocalAppServices', () => {
         weworkCloudModelNamespace: 'default',
         weworkCloudModelResourceUserId: '42',
         weworkCloudModelUpstreamApiFormat: 'openai-chat-completions',
+        weworkCloudModelKimiDynamicTools: 'true',
       },
     })
 
@@ -1358,6 +1360,7 @@ describe('createLocalAppServices', () => {
         protocol: 'openai-responses',
         base_url: 'https://cloud.example.com/api/runtime-work/llm-responses-proxy',
         api_key: 'cloud-login-token',
+        kimi_dynamic_tools: true,
         default_headers: {
           'X-Wegent-Model-Type': 'user',
           'X-Wegent-Model-Namespace': 'default',

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -120,6 +120,7 @@ import {
   CLOUD_MODEL_NAMESPACE_OPTION,
   CLOUD_MODEL_RESOURCE_USER_ID_OPTION,
   CLOUD_MODEL_UPSTREAM_API_FORMAT_OPTION,
+  supportsKimiDynamicTools,
 } from '@/features/workbench/runtimeModelSelection'
 
 const LOCAL_DEVICE_ID = 'local-device'
@@ -140,7 +141,6 @@ const KIMI_K3_CATALOG_MODEL_ID = 'wework-kimi-k3'
 const DEFAULT_GPT_56_CATALOG_MODEL_ID = 'wework-gpt-5.6-sol'
 const KIMI_K3_REASONING_EFFORTS = ['low', 'high', 'max']
 const KIMI_K3_DEFAULT_REASONING_EFFORT = 'low'
-const KIMI_DYNAMIC_TOOL_MODEL_IDS = new Set(['k3', 'k3-256k', 'kimi-k3'])
 
 export const LOCAL_WORKBENCH_TEAM = {
   id: 0,
@@ -698,7 +698,7 @@ function providerIdFromLocalConfig(config: LocalModelConfig): string {
 function localModelSupportsKimiDynamicTools(config: LocalModelConfig): boolean {
   return (
     (config.providerProfileId === 'kimi-coding' || config.providerProfileId === 'kimi') &&
-    KIMI_DYNAMIC_TOOL_MODEL_IDS.has(config.modelId.trim().toLowerCase())
+    supportsKimiDynamicTools(config.modelId)
   )
 }
 

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -115,6 +115,7 @@ import { LOCAL_USER, saveLocalUserPreferences } from './localSession'
 import type { KeybindingOverride } from '@/lib/keybindings'
 import {
   CLOUD_MODEL_CONTEXT_WINDOW_OPTION,
+  CLOUD_MODEL_KIMI_DYNAMIC_TOOLS_OPTION,
   CLOUD_MODEL_MAX_OUTPUT_TOKENS_OPTION,
   CLOUD_MODEL_NAMESPACE_OPTION,
   CLOUD_MODEL_RESOURCE_USER_ID_OPTION,
@@ -139,6 +140,7 @@ const KIMI_K3_CATALOG_MODEL_ID = 'wework-kimi-k3'
 const DEFAULT_GPT_56_CATALOG_MODEL_ID = 'wework-gpt-5.6-sol'
 const KIMI_K3_REASONING_EFFORTS = ['low', 'high', 'max']
 const KIMI_K3_DEFAULT_REASONING_EFFORT = 'low'
+const KIMI_DYNAMIC_TOOL_MODEL_IDS = new Set(['k3', 'k3-256k', 'kimi-k3'])
 
 export const LOCAL_WORKBENCH_TEAM = {
   id: 0,
@@ -693,6 +695,13 @@ function providerIdFromLocalConfig(config: LocalModelConfig): string {
   return `local-${config.id}`.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'local'
 }
 
+function localModelSupportsKimiDynamicTools(config: LocalModelConfig): boolean {
+  return (
+    (config.providerProfileId === 'kimi-coding' || config.providerProfileId === 'kimi') &&
+    KIMI_DYNAMIC_TOOL_MODEL_IDS.has(config.modelId.trim().toLowerCase())
+  )
+}
+
 function localRuntimeModelConfig(
   modelName?: string,
   modelType?: string | null,
@@ -729,6 +738,7 @@ function localRuntimeModelConfig(
       ...(localModel.contextWindow ? { model_context_window: localModel.contextWindow } : {}),
       web_search: localModel.webSearchMode ?? 'disabled',
       image_generation: localModel.imageGenerationEnabled === true,
+      kimi_dynamic_tools: localModelSupportsKimiDynamicTools(localModel),
       ...(localModelDefaultReasoningEffort(localModel)
         ? { reasoning: { effort: localModelDefaultReasoningEffort(localModel) } }
         : {}),
@@ -763,6 +773,7 @@ function localRuntimeModelConfig(
     const maxOutputTokens = Number(modelOptions?.[CLOUD_MODEL_MAX_OUTPUT_TOKENS_OPTION])
     const upstreamApiFormat =
       modelOptions?.[CLOUD_MODEL_UPSTREAM_API_FORMAT_OPTION] ?? 'openai-responses'
+    const kimiDynamicTools = modelOptions?.[CLOUD_MODEL_KIMI_DYNAMIC_TOOLS_OPTION] === 'true'
     return {
       model: 'openai',
       model_id: modelName,
@@ -773,6 +784,7 @@ function localRuntimeModelConfig(
       protocol: OPENAI_RESPONSES_PROTOCOL,
       base_url: cloudModelGateway.baseUrl,
       api_key: cloudModelGateway.apiKey,
+      kimi_dynamic_tools: kimiDynamicTools,
       default_headers: {
         'X-Wegent-Model-Type': modelType,
         'X-Wegent-Model-Namespace': namespace,

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -225,6 +225,16 @@ function seedDesktopE2ECloudConnection() {
             requestPath: '/v1/messages',
           },
           {
+            id: 'desktop-e2e-kimi-k3',
+            providerProfileId: 'kimi-coding',
+            displayName: 'Desktop E2E Kimi K3',
+            modelId: 'k3',
+            codexCatalogModelId: 'wework-kimi-k3',
+            apiFormat: 'openai-chat-completions' as const,
+            toolProfile: 'function' as const,
+            requestPath: '/v1/chat/completions',
+          },
+          {
             id: 'desktop-e2e-luna-overseas',
             displayName: 'GPT 5.6 Luna (海外)',
             modelId: 'gpt-5.6-luna',
@@ -239,7 +249,7 @@ function seedDesktopE2ECloudConnection() {
       ...model,
       baseUrl: modelServerUrl,
       apiKey: 'wework-e2e-test-key',
-      catalogReady: localModelsCatalogReady,
+      catalogReady: model.id === 'desktop-e2e-kimi-k3' || localModelsCatalogReady,
       enabled: true,
     })
   }

--- a/wework/src/features/workbench/runtimeModelSelection.test.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.test.ts
@@ -348,6 +348,33 @@ describe('runtimeModelSelection', () => {
     })
   })
 
+  test('passes Kimi dynamic-tool capability using the cloud provider model id', () => {
+    const cloudModel: UnifiedModel = {
+      name: 'shared-kimi-model',
+      type: 'user',
+      modelId: 'k3',
+      namespace: 'default',
+      resourceUserId: 42,
+      provider: 'cloud',
+      config: {
+        protocol: 'openai',
+        apiFormat: 'chat/completions',
+      },
+    }
+
+    expect(selectedModelExecutionFields(cloudModel, {})).toEqual({
+      modelId: 'shared-kimi-model',
+      modelType: 'user',
+      modelOptions: {
+        collaborationMode: 'default',
+        weworkCloudModelNamespace: 'default',
+        weworkCloudModelResourceUserId: '42',
+        weworkCloudModelUpstreamApiFormat: 'openai-chat-completions',
+        weworkCloudModelKimiDynamicTools: 'true',
+      },
+    })
+  })
+
   test('passes upstream api format for Anthropic Messages cloud model', () => {
     const cloudModel: UnifiedModel = {
       name: 'shared-model',

--- a/wework/src/features/workbench/runtimeModelSelection.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.ts
@@ -18,7 +18,7 @@ export const CLOUD_MODEL_MAX_OUTPUT_TOKENS_OPTION = 'weworkCloudModelMaxOutputTo
 export const CLOUD_MODEL_UPSTREAM_API_FORMAT_OPTION = 'weworkCloudModelUpstreamApiFormat'
 export const CLOUD_MODEL_KIMI_DYNAMIC_TOOLS_OPTION = 'weworkCloudModelKimiDynamicTools'
 
-const KIMI_DYNAMIC_TOOL_MODEL_IDS = new Set(['k3', 'k3-256k', 'kimi-k3'])
+export const KIMI_DYNAMIC_TOOL_MODEL_IDS = new Set(['k3', 'k3-256k', 'kimi-k3'])
 
 function getStringConfigValue(
   config: Record<string, unknown> | null | undefined,
@@ -93,8 +93,8 @@ function isCodexCompatibleModel(model: UnifiedModel): boolean {
   return supportsCloudExecution(model)
 }
 
-function supportsKimiDynamicTools(model: UnifiedModel): boolean {
-  return KIMI_DYNAMIC_TOOL_MODEL_IDS.has(model.modelId?.trim().toLowerCase() ?? '')
+export function supportsKimiDynamicTools(modelId: string | null | undefined): boolean {
+  return KIMI_DYNAMIC_TOOL_MODEL_IDS.has(modelId?.trim().toLowerCase() ?? '')
 }
 
 export function resolveAutomaticModel(models: UnifiedModel[]): UnifiedModel | null {
@@ -154,7 +154,7 @@ export function selectedModelExecutionFields(
     if (upstreamApiFormat) {
       modelOptions[CLOUD_MODEL_UPSTREAM_API_FORMAT_OPTION] = upstreamApiFormat
     }
-    if (supportsKimiDynamicTools(selectedModel)) {
+    if (supportsKimiDynamicTools(selectedModel.modelId)) {
       modelOptions[CLOUD_MODEL_KIMI_DYNAMIC_TOOLS_OPTION] = 'true'
     }
 

--- a/wework/src/features/workbench/runtimeModelSelection.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.ts
@@ -16,6 +16,9 @@ export const CLOUD_MODEL_RESOURCE_USER_ID_OPTION = 'weworkCloudModelResourceUser
 export const CLOUD_MODEL_CONTEXT_WINDOW_OPTION = 'weworkCloudModelContextWindow'
 export const CLOUD_MODEL_MAX_OUTPUT_TOKENS_OPTION = 'weworkCloudModelMaxOutputTokens'
 export const CLOUD_MODEL_UPSTREAM_API_FORMAT_OPTION = 'weworkCloudModelUpstreamApiFormat'
+export const CLOUD_MODEL_KIMI_DYNAMIC_TOOLS_OPTION = 'weworkCloudModelKimiDynamicTools'
+
+const KIMI_DYNAMIC_TOOL_MODEL_IDS = new Set(['k3', 'k3-256k', 'kimi-k3'])
 
 function getStringConfigValue(
   config: Record<string, unknown> | null | undefined,
@@ -90,6 +93,10 @@ function isCodexCompatibleModel(model: UnifiedModel): boolean {
   return supportsCloudExecution(model)
 }
 
+function supportsKimiDynamicTools(model: UnifiedModel): boolean {
+  return KIMI_DYNAMIC_TOOL_MODEL_IDS.has(model.modelId?.trim().toLowerCase() ?? '')
+}
+
 export function resolveAutomaticModel(models: UnifiedModel[]): UnifiedModel | null {
   return models.find(model => !model.compatibilityDisabled) ?? null
 }
@@ -146,6 +153,9 @@ export function selectedModelExecutionFields(
     const upstreamApiFormat = getCloudModelUpstreamApiFormat(selectedModel)
     if (upstreamApiFormat) {
       modelOptions[CLOUD_MODEL_UPSTREAM_API_FORMAT_OPTION] = upstreamApiFormat
+    }
+    if (supportsKimiDynamicTools(selectedModel)) {
+      modelOptions[CLOUD_MODEL_KIMI_DYNAMIC_TOOLS_OPTION] = 'true'
     }
 
     const contextWindow =


### PR DESCRIPTION
## Summary

- bridge Codex `tool_search` and deferred namespace tools through Kimi K3 Chat Completions
- normalize Kimi-incompatible tool schemas while preserving namespace identity across tool calls
- enable the capability for both local custom Kimi models and cloud Model CRDs by real provider `model_id`
- add CI-covered Kimi K3 desktop E2E cases for local custom and cloud models
- document the difference between dynamic tool loading and namespaces

## Verification

- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `pnpm --filter wework test` — 232 files, 2306 tests passed
- `cargo test --manifest-path executor/Cargo.toml server::local_model_proxy --lib --no-fail-fast` — 104 passed, 1 ignored
- `cargo test --manifest-path executor/Cargo.toml agents::codex::tests --lib --no-fail-fast` — 72 passed
- `cargo clippy --manifest-path executor/Cargo.toml --all-targets -- -D warnings`
- `WEWORK_E2E_STEP_TIMEOUT_MS=30000 pnpm --filter wework e2e:desktop:kimi`
  - local custom Kimi K3 passed
  - cloud Kimi K3 passed
- real Kimi API verification returned HTTP 200 after schema normalization

## E2E evidence

- local screenshot: `kimi-matrix-01-local-local-kimi-k3.png`
- cloud screenshot: `local-connected-matrix-05-local-cloud-kimi-k3.png`
- each E2E run records three model requests covering text generation, tool execution, and the follow-up result


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kimi K3 “dynamic tools” support for both local and cloud models.
  * Introduced desktop Kimi K3 end-to-end coverage and a new `e2e:desktop:kimi` script.
* **Documentation**
  * Updated settings docs (EN/ZH) with Kimi dynamic tool loading behavior and namespace handling.
* **Bug Fixes**
  * Fixed tool-search and dynamic tool call/result translation for Chat Completions and Responses flows.
* **Tests**
  * Extended unit and E2E tests to validate Kimi K3 dynamic tool injection and protocol event rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->