### PR TITLE
feat(ci): add merge queue validation

### DIFF
--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -112,6 +112,20 @@ for workflow in e2e-tests.yml wework-e2e.yml; do
     printf '%s must force E2E for the ci:all label\n' "$workflow" >&2
     exit 1
   fi
+  if ! grep -q "merge_group:" "$workflow_path"; then
+    printf '%s must run for merge queue groups\n' "$workflow" >&2
+    exit 1
+  fi
+  if ! grep -q "checks_requested" "$workflow_path"; then
+    printf '%s must limit merge group runs to checks_requested\n' \
+      "$workflow" >&2
+    exit 1
+  fi
+  if ! grep -q "github.event_name != 'pull_request'" "$workflow_path"; then
+    printf '%s must force all E2E outside pull request events\n' \
+      "$workflow" >&2
+    exit 1
+  fi
 done
 
 for workflow in test.yml lint.yml; do
@@ -120,16 +134,41 @@ for workflow in test.yml lint.yml; do
     printf '%s must classify every module for pushes to main\n' "$workflow" >&2
     exit 1
   fi
+  if ! grep -q "merge_group:" "$workflow_path"; then
+    printf '%s must run for merge queue groups\n' "$workflow" >&2
+    exit 1
+  fi
+  if ! grep -q "GITHUB_EVENT_NAME.*merge_group\\|github.event_name == 'merge_group'" \
+    "$workflow_path"; then
+    printf '%s must classify every module for merge groups\n' "$workflow" >&2
+    exit 1
+  fi
 done
 
 wework_workflow="$script_dir/../workflows/wework-e2e.yml"
-if [[ "$(grep -c "github.event.action != 'labeled'" "$wework_workflow")" -ne 2 ]]; then
+if [[ "$(grep -c "github.event.action != 'labeled'" "$wework_workflow")" -lt 2 ]]; then
   printf 'Wework non-memory E2E jobs must filter pull_request label events\n' >&2
   exit 1
 fi
 
 if ! grep -q "github.event.label.name || 'code'" "$wework_workflow"; then
   printf 'Wework label events must not cancel code-change E2E runs\n' >&2
+  exit 1
+fi
+
+if ! grep -q "name: Platform E2E Summary" \
+  "$script_dir/../workflows/e2e-tests.yml"; then
+  printf 'Platform E2E must expose a stable summary check\n' >&2
+  exit 1
+fi
+
+if ! grep -q "name: Wework E2E Summary" "$wework_workflow"; then
+  printf 'Wework E2E must expose a stable summary check\n' >&2
+  exit 1
+fi
+
+if ! grep -q "github.event_name != 'merge_group'" "$wework_workflow"; then
+  printf 'Wework memory E2E must remain outside regular merge groups\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Run daily at 2 AM UTC
     - cron: "0 2 * * *"
@@ -975,3 +977,51 @@ jobs:
           name: playwright-report-merged
           path: frontend/playwright-report/
           retention-days: 30
+
+  platform-e2e-summary:
+    name: Platform E2E Summary
+    needs:
+      - changes
+      - build-frontend-e2e
+      - build-executor-e2e-runtime
+      - e2e-tests
+      - executor-e2e-tests
+      - merge-reports
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Platform E2E results
+        env:
+          RUN_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.platform_e2e == 'true') }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          FRONTEND_BUILD_RESULT: ${{ needs.build-frontend-e2e.result }}
+          EXECUTOR_BUILD_RESULT: ${{ needs.build-executor-e2e-runtime.result }}
+          PLATFORM_E2E_RESULT: ${{ needs.e2e-tests.result }}
+          EXECUTOR_E2E_RESULT: ${{ needs.executor-e2e-tests.result }}
+          REPORT_RESULT: ${{ needs.merge-reports.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Platform E2E change detection completed with: $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [[ "$RUN_E2E" != "true" ]]; then
+            echo "Platform E2E is not required for this pull request"
+            exit 0
+          fi
+
+          assert_success() {
+            local result="$1"
+            local name="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "$name completed with: $result"
+              exit 1
+            fi
+          }
+
+          assert_success "$FRONTEND_BUILD_RESULT" "Frontend E2E build"
+          assert_success "$EXECUTOR_BUILD_RESULT" "Executor E2E build"
+          assert_success "$PLATFORM_E2E_RESULT" "Platform E2E"
+          assert_success "$EXECUTOR_E2E_RESULT" "Executor E2E"
+          assert_success "$REPORT_RESULT" "E2E report merge"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read
@@ -41,7 +44,8 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]] ||
+            [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
@@ -197,6 +201,9 @@ jobs:
 
       - name: Test CI change classifier
         run: .github/scripts/test-classify-ci-changes.sh
+
+      - name: Test repository policy workflow
+        run: scripts/test-repository-policy-workflow.sh
 
       - name: Run repository policy check
         # Fork PRs run this in repository-policy.yml using pull_request_target

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -13,12 +13,15 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,11 +34,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.event.repository.default_branch }}
           path: trusted-policy
           persist-credentials: false
 
       - name: Checkout pull request merge tree
+        if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
@@ -43,6 +47,15 @@ jobs:
           path: policy-target
           persist-credentials: false
           allow-unsafe-pr-checkout: true
+
+      - name: Checkout merge group
+        if: github.event_name == 'merge_group'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          path: policy-target
+          persist-credentials: false
 
       - name: Run repository policy check
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ on:
       - reopened
       - ready_for_review
       - labeled
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
@@ -47,10 +50,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          FORCE_ALL: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+          FORCE_ALL: ${{ github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
         run: |
           if [[ "$FORCE_ALL" == "true" ]]; then
-            # Main pushes and the ci:all label force every module test.
+            # Merge groups, main pushes, and ci:all force every module test.
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" |

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -13,6 +13,9 @@ on:
       - reopened
       - ready_for_review
       - labeled
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
@@ -216,10 +219,47 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  wework-e2e-summary:
+    name: Wework E2E Summary
+    needs:
+      - changes
+      - wework-e2e
+      - wework-desktop-e2e
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Wework E2E results
+        env:
+          RUN_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          WEB_E2E_RESULT: ${{ needs.wework-e2e.result }}
+          DESKTOP_E2E_RESULT: ${{ needs.wework-desktop-e2e.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Wework E2E change detection completed with: $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [[ "$RUN_E2E" != "true" ]]; then
+            echo "Wework E2E is not required for this pull request"
+            exit 0
+          fi
+
+          if [[ "$WEB_E2E_RESULT" != "success" ]]; then
+            echo "Wework browser E2E completed with: $WEB_E2E_RESULT"
+            exit 1
+          fi
+
+          if [[ "$DESKTOP_E2E_RESULT" != "success" ]]; then
+            echo "Wework desktop E2E completed with: $DESKTOP_E2E_RESULT"
+            exit 1
+          fi
+
   wework-desktop-memory-e2e:
     name: Wework Desktop Memory E2E
     needs: changes
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && (contains(github.event.pull_request.labels.*.name, 'ci:memory') || contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    if: github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (github.event.pull_request.draft == false && (contains(github.event.pull_request.labels.*.name, 'ci:memory') || contains(github.event.pull_request.labels.*.name, 'ci:all'))))
     runs-on: macos-14
     timeout-minutes: 30
 

--- a/scripts/test-repository-policy-workflow.sh
+++ b/scripts/test-repository-policy-workflow.sh
@@ -30,10 +30,17 @@ require_line() {
 
 require_file "$POLICY_WORKFLOW"
 require_line "$POLICY_WORKFLOW" "pull_request_target:" "trusted fork PR trigger"
+require_line "$POLICY_WORKFLOW" "merge_group:" "merge queue trigger"
+require_line "$POLICY_WORKFLOW" "checks_requested" "merge queue checks activity"
 require_line "$POLICY_WORKFLOW" "contents: read" "read-only repository permission"
 require_line "$POLICY_WORKFLOW" "path: trusted-policy" "trusted script checkout path"
 require_line "$POLICY_WORKFLOW" "path: policy-target" "PR content checkout path"
+# GitHub expressions are matched literally in workflow source.
+# shellcheck disable=SC2016
 require_line "$POLICY_WORKFLOW" 'ref: refs/pull/${{ github.event.pull_request.number }}/merge' "PR merge ref checkout"
+require_line "$POLICY_WORKFLOW" "Checkout merge group" "merge group checkout step"
+# shellcheck disable=SC2016
+require_line "$POLICY_WORKFLOW" 'ref: ${{ github.sha }}' "merge group SHA checkout"
 require_line "$POLICY_WORKFLOW" "allow-unsafe-pr-checkout: true" "reviewed fork PR checkout opt-in"
 require_line "$POLICY_WORKFLOW" "REPOSITORY_POLICY_ROOT: \${{ github.workspace }}/policy-target" "target repository scan root"
 require_line "$POLICY_WORKFLOW" "trusted-policy/scripts/hooks/check-repository-policy.sh" "trusted policy script execution"


### PR DESCRIPTION
## What changed

- add `merge_group` support to Tests, Lint, Platform E2E, Wework E2E, and Repository Policy workflows
- keep pull request E2E path-aware while forcing full core E2E coverage for merge queue groups
- add stable `Platform E2E Summary` and `Wework E2E Summary` gate checks
- keep the macOS memory E2E outside regular merge groups
- extend CI workflow regression coverage for merge queue behavior

## Why

Wegent currently runs path-aware checks on pull requests, but GitHub Merge Queue requires required checks to report results for the separate `merge_group` event. Without this change, required checks would either be missing or would not provide stable E2E gate names.

## Impact

Pull requests continue to run only relevant E2E suites. Pull requests admitted to the merge queue run all core Platform and Wework E2E suites before entering `main`.

## Validation

- `shellcheck .github/scripts/test-classify-ci-changes.sh scripts/test-repository-policy-workflow.sh`
- `actionlint` on all changed workflows
- `.github/scripts/test-classify-ci-changes.sh`
- `scripts/test-repository-policy-workflow.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI workflows now support GitHub merge queue validation.
  * Added consolidated E2E status checks for Platform and Wework test suites.
  * Repository policy checks now validate merge-group changes and required permissions.

* **Bug Fixes**
  * Improved CI classification and E2E coverage for merge-group events.
  * Prevented memory E2E tests from running in unsupported merge-group contexts.

* **Tests**
  * Expanded workflow regression checks for merge queue triggers, checkout behavior, and stable summary results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->