### PR TITLE
test(ci): strengthen merge queue E2E contract

### DIFF
--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -121,7 +121,9 @@ for workflow in e2e-tests.yml wework-e2e.yml; do
       "$workflow" >&2
     exit 1
   fi
-  if ! grep -q "github.event_name != 'pull_request'" "$workflow_path"; then
+  if ! grep -Fq \
+    "FORCE_ALL: \${{ github.event_name != 'pull_request'" \
+    "$workflow_path"; then
     printf '%s must force all E2E outside pull request events\n' \
       "$workflow" >&2
     exit 1


### PR DESCRIPTION
## What changed

- strengthen the workflow regression assertion so merge queue E2E coverage must be enabled specifically through the `FORCE_ALL` expression

## Why

The previous assertion only searched for a generic non-pull-request expression anywhere in the workflow. This tighter contract prevents an unrelated condition from accidentally satisfying the merge queue full-E2E regression test.

## Validation

- `shellcheck .github/scripts/test-classify-ci-changes.sh`
- `.github/scripts/test-classify-ci-changes.sh`
- `git diff --check`

This PR also serves as the first end-to-end validation of the newly enabled merge queue and its required `merge_group` checks.
