### PR TITLE
fix(wework): exclude conversation and cloud candidates from $ skill menu

### DIFF
--- a/wework/src/components/chat/composer/ComposerTextarea.test.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.test.tsx
@@ -1085,4 +1085,74 @@ describe('ComposerTextarea', () => {
       '修复登录流程'
     )
   })
+
+  test('keeps conversation and cloud candidates out of the $ skill menu', async () => {
+    const textareaRef = createRef<HTMLElement>()
+    const reference =
+      '[$Fix login flow](wework-conversation://%7B%22deviceId%22%3A%22local-device%22%2C%22taskId%22%3A%22source-task%22%7D)'
+    const conversationCandidates: ComposerConversationMentionCandidate[] = [
+      {
+        kind: 'conversation',
+        key: 'conversation:local-device:source-task',
+        title: 'Fix login flow',
+        description: 'Wegent',
+        metaLabel: 'Conversation',
+        testId: 'local-device-source-task',
+        enabled: true,
+        reference,
+        searchAliases: ['Fix login flow', 'Wegent'],
+        conversation: {
+          key: 'conversation:local-device:source-task',
+          title: 'Fix login flow',
+          address: { deviceId: 'local-device', taskId: 'source-task' },
+          reference,
+          testId: 'local-device-source-task',
+          projectName: 'Wegent',
+        },
+      },
+    ]
+    const cloudCandidate: ComposerCloudMentionCandidate = {
+      kind: 'cloud',
+      key: 'cloud-file:42',
+      title: 'design.md',
+      description: 'docs/design.md',
+      metaLabel: 'Cloud',
+      testId: 'cloud-file-42',
+      enabled: true,
+      reference: '[$design.md](cloud://projects/11/files/42)',
+      searchAliases: ['docs/design.md'],
+    }
+
+    function Harness() {
+      const [value, setValue] = useState('')
+      return (
+        <ComposerTextarea
+          value={value}
+          onChange={setValue}
+          onSubmit={vi.fn()}
+          canSend={false}
+          placeholder="Message"
+          rows={2}
+          textareaRef={textareaRef}
+          className="min-h-12"
+          onListLocalSkills={async () => [GMAIL_SKILL]}
+          cloudMentionCandidates={[cloudCandidate]}
+          conversationMentionCandidates={conversationCandidates}
+        />
+      )
+    }
+
+    render(<Harness />)
+    const editor = screen.getByTestId('chat-message-input') as HTMLElement & { value: string }
+    act(() => {
+      editor.value = '$'
+      editor.focus()
+    })
+
+    expect(await screen.findByTestId('local-skill-option-gmail')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('conversation-reference-option-local-device-source-task')
+    ).toBeNull()
+    expect(screen.queryByTestId('cloud-reference-option-cloud-file-42')).toBeNull()
+  })
 })

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -138,6 +138,17 @@ export function ComposerTextarea({
       conversationMentionCandidates
     )
 
+  // The `$` trigger searches skills and apps only. Conversation and cloud
+  // references belong to the `@` mention menu, so they must be excluded here
+  // even though both menus share the same candidate pipeline.
+  const filteredSkillCandidates = useMemo(
+    () =>
+      filteredMentionCandidates.filter(
+        candidate => candidate.kind === 'skill' || candidate.kind === 'app'
+      ),
+    [filteredMentionCandidates]
+  )
+
   const workspaceSearch = useWorkspaceMentionSearch(
     activeMenu?.kind === 'mention' ? activeMenu.trigger.query : '',
     workspaceTarget,
@@ -293,7 +304,7 @@ export function ComposerTextarea({
   const mentionMenuRows = useMemo<MentionMenuRow[]>(() => {
     if (!showSkillMenu) return []
     if (activeMenu?.kind === 'skill') {
-      return filteredMentionCandidates.map(candidate => ({ kind: 'candidate', candidate }))
+      return filteredSkillCandidates.map(candidate => ({ kind: 'candidate', candidate }))
     }
     if (!activeMenu?.trigger.query.trim()) {
       const nonCloudCandidates = filteredMentionCandidates.filter(
@@ -344,6 +355,7 @@ export function ComposerTextarea({
     cloudSpaceEnabled,
     filteredCloudProjectCandidates,
     filteredMentionCandidates,
+    filteredSkillCandidates,
     onSetGoal,
     onSetPlanMode,
     planModeActive,


### PR DESCRIPTION
## Problem

Typing `$` in the chat composer opens the skill autocomplete, but it was populated with the full mention candidate list. Referenced conversations (会话) and cloud references showed up in the skill results even though they are not skills.

## Root cause

`ComposerTextarea` builds one shared candidate pipeline via `useComposerMentionCandidates`, which merges conversation, cloud, skill, and app candidates into `filteredMentionCandidates`. The `$` skill-menu branch in `mentionMenuRows` returned that whole merged list instead of only skills and apps.

## Fix

Filter the `$` menu rows to `skill`/`app` candidates only (`filteredSkillCandidates`). Conversation and cloud references remain available through the `@` mention menu, which is their intended surface.

## Testing

- Added a regression test: `keeps conversation and cloud candidates out of the $ skill menu` — asserts the skill option is shown while conversation and cloud options stay hidden for the `$` trigger.
- `vitest run ComposerTextarea.test.tsx` — 21/21 pass.
- Prettier and ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `$` autocomplete menu to show only relevant local skills and apps.
  * Prevented conversation and cloud references from appearing in the `$` skill menu.
  * Added coverage to verify correct filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->