### PR TITLE
fix(wework): Windows plugin flicker, dev:windows dws, and PowerShell unzip

### DIFF
--- a/wework/scripts/dev-windows-app.mjs
+++ b/wework/scripts/dev-windows-app.mjs
@@ -607,6 +607,10 @@ async function main() {
 
   log(`Sidecar source: ${sidecarSource}`)
 
+  log('Preparing DWS sidecar...')
+  process.env.WEWORK_DWS_TARGET = target
+  await run('pnpm', ['run', 'prepare:dws'], { cwd: WEWORK_DIR })
+
   if (useDevReload) {
     process.env.WEGENT_EXECUTOR_TARGET_DIR = executorTargetDir
   }

--- a/wework/scripts/prepare-dws-binary.mjs
+++ b/wework/scripts/prepare-dws-binary.mjs
@@ -13,13 +13,13 @@ const packageJson = require.resolve('dingtalk-workspace-cli/package.json')
 const packageRoot = dirname(packageJson)
 const target =
   process.env.WEWORK_DWS_TARGET?.trim() ||
-  ({
+  {
     'darwin-arm64': 'aarch64-apple-darwin',
     'darwin-x64': 'x86_64-apple-darwin',
     'linux-x64': 'x86_64-unknown-linux-gnu',
     'linux-arm64': 'aarch64-unknown-linux-gnu',
     'win32-x64': 'x86_64-pc-windows-msvc',
-  }[`${platform}-${arch}`])
+  }[`${platform}-${arch}`]
 
 if (!target) throw new Error(`Unsupported DWS build platform: ${platform}-${arch}`)
 
@@ -49,14 +49,33 @@ async function findBinary(directory) {
   return null
 }
 
-try {
-  const archive = join(packageRoot, 'assets', archiveName)
-  const command = archiveName.endsWith('.zip') ? 'unzip' : 'tar'
-  const args = archiveName.endsWith('.zip')
-    ? ['-q', archive, '-d', temporaryDirectory]
-    : ['-xzf', archive, '-C', temporaryDirectory]
+function extractArchive(archive, destination) {
+  const isZip = archive.endsWith('.zip')
+  if (process.platform === 'win32') {
+    if (isZip) {
+      const escapedPath = archive.replace(/'/g, "''")
+      const escapedDest = destination.replace(/'/g, "''")
+      const command = `Expand-Archive -LiteralPath '${escapedPath}' -DestinationPath '${escapedDest}' -Force`
+      const result = spawnSync('powershell', ['-NoProfile', '-Command', command], {
+        stdio: 'inherit',
+      })
+      if (result.status !== 0) throw new Error(`Failed to extract ${archiveName}`)
+      return
+    }
+    const result = spawnSync('tar', ['-xzf', archive, '-C', destination], { stdio: 'inherit' })
+    if (result.status !== 0) throw new Error(`Failed to extract ${archiveName}`)
+    return
+  }
+
+  const command = isZip ? 'unzip' : 'tar'
+  const args = isZip ? ['-q', archive, '-d', destination] : ['-xzf', archive, '-C', destination]
   const result = spawnSync(command, args, { stdio: 'inherit' })
   if (result.status !== 0) throw new Error(`Failed to extract ${archiveName}`)
+}
+
+try {
+  const archive = join(packageRoot, 'assets', archiveName)
+  extractArchive(archive, temporaryDirectory)
   const source = await findBinary(temporaryDirectory)
   if (!source) throw new Error(`DWS binary is missing from ${archiveName}`)
   const destination = resolve(

--- a/wework/scripts/prepare-dws-binary.mjs
+++ b/wework/scripts/prepare-dws-binary.mjs
@@ -53,12 +53,7 @@ function extractArchive(archive, destination) {
   const isZip = archive.endsWith('.zip')
   if (process.platform === 'win32') {
     if (isZip) {
-      const escapedPath = archive.replace(/'/g, "''")
-      const escapedDest = destination.replace(/'/g, "''")
-      const command = `Expand-Archive -LiteralPath '${escapedPath}' -DestinationPath '${escapedDest}' -Force`
-      const result = spawnSync('powershell', ['-NoProfile', '-Command', command], {
-        stdio: 'inherit',
-      })
+      const result = spawnSync('tar', ['-xf', archive, '-C', destination], { stdio: 'inherit' })
       if (result.status !== 0) throw new Error(`Failed to extract ${archiveName}`)
       return
     }

--- a/wework/src/components/layout/DesktopTopBar.test.tsx
+++ b/wework/src/components/layout/DesktopTopBar.test.tsx
@@ -24,4 +24,19 @@ describe('DesktopTopBar', () => {
       )
     ).toHaveAttribute('data-tauri-drag-region')
   })
+
+  test('hides the drag region on Windows to avoid conflicting with the custom titlebar', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)',
+    })
+    render(
+      <DesktopTopBar
+        left={<button type="button">Left</button>}
+        right={<button type="button">Right</button>}
+      />
+    )
+
+    expect(screen.getByTestId('desktop-topbar-drag-region')).toHaveClass('hidden')
+  })
 })

--- a/wework/src/components/layout/DesktopTopBar.tsx
+++ b/wework/src/components/layout/DesktopTopBar.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from 'react'
 import { cn } from '@/lib/utils'
+import { getPlatform } from '@/lib/platform'
 import { MacOSTitleBarDragRegion } from './MacOSTitleBarDragRegion'
 
 export const DESKTOP_TOP_BAR_BUTTON_CLASS =
@@ -26,6 +27,9 @@ export function DesktopTopBar({
   testId = 'desktop-topbar',
   style,
 }: DesktopTopBarProps) {
+  const platform = getPlatform()
+  const dragRegionHidden = platform === 'win'
+
   return (
     <header
       data-testid={testId}
@@ -42,7 +46,11 @@ export function DesktopTopBar({
       )}
       <div
         data-testid={`${testId}-drag-region`}
-        className={cn('min-w-4 flex-1 self-stretch', dragRegionClassName)}
+        className={cn(
+          'min-w-4 flex-1 self-stretch',
+          dragRegionHidden && 'hidden',
+          dragRegionClassName
+        )}
       >
         <MacOSTitleBarDragRegion className="h-full w-full" />
       </div>

--- a/wework/src/components/layout/DesktopWindowsTitlebar.tsx
+++ b/wework/src/components/layout/DesktopWindowsTitlebar.tsx
@@ -31,14 +31,15 @@ export function DesktopWindowsTitlebar({
     <div
       data-testid="desktop-windows-titlebar"
       data-window-focused={windowFocused}
+      data-tauri-drag-region
       className={cn(
-        'relative z-chrome flex h-[38px] w-full shrink-0 items-center bg-[rgb(var(--color-sidebar))] backdrop-blur-xl backdrop-saturate-150',
+        'relative z-chrome h-[38px] w-full shrink-0 bg-[rgb(var(--color-sidebar))] backdrop-blur-xl backdrop-saturate-150',
         !windowFocused && 'bg-[rgb(var(--color-sidebar-unfocused))]',
         className
       )}
     >
       <div
-        className="pointer-events-auto flex h-full items-center gap-1 px-1"
+        className="pointer-events-auto absolute left-0 top-0 z-chrome flex h-full items-center gap-1 px-1"
         data-tauri-drag-region={false}
       >
         <DesktopWindowControls
@@ -48,8 +49,10 @@ export function DesktopWindowsTitlebar({
         />
         <DesktopAppSwitcher activeApp={activeApp} onNavigate={onNavigate} />
       </div>
-      <div data-tauri-drag-region className="min-w-4 flex-1 self-stretch" />
-      <div className="pointer-events-auto h-full w-[138px]" data-tauri-drag-region={false}>
+      <div
+        className="pointer-events-auto absolute right-0 top-0 z-chrome h-full w-[138px]"
+        data-tauri-drag-region={false}
+      >
         <WindowFrameControls className="h-full justify-end" />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Fix continuous flicker when opening the plugin interface on Windows by aligning the custom Windows titlebar drag region with the workbench titlebar pattern (full-bar drag region with absolute-positioned controls) and disabling nested drag regions in `DesktopTopBar` on Windows.
- Prepare the DWS sidecar in `dev:windows` before launching Tauri dev, matching the macOS dev script behavior.
- Use Windows built-in `tar` for DWS zip extraction instead of PowerShell `Expand-Archive`, which can fail when the `Microsoft.PowerShell.Archive` module is not loadable.

## Test plan

- [ ] Windows: open `/plugins` and verify the page no longer flickers continuously
- [ ] Windows: run `pnpm --filter wework dev:windows` and confirm the DWS sidecar is extracted successfully
- [ ] macOS/Linux: confirm plugin page and workbench titlebar remain visually and functionally unchanged
- [ ] CI: wework unit tests and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows desktop titlebar behavior and positioning.
  * Windows now uses a custom titlebar without conflicting drag regions.
  * Development startup now prepares the required DWS sidecar automatically.

* **Bug Fixes**
  * Improved cross-platform extraction of DWS binaries, including Windows archive handling.

* **Tests**
  * Added coverage to verify Windows drag-region behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->