### PR TITLE
fix(ci): run minimal Wework E2E segments

### DIFF
--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+core_segments=(
+  core-task-flow
+  window-lifecycle
+  goal-lifecycle
+  resilience
+  conversation-state
+  workspace-attachments
+  rendering-extensions
+)
+plugin_segments=(
+  plugin-lifecycle
+  skill-mention-rendering
+  sites-plugin-auto-install
+)
+
+declare -A selected=()
+desktop_runner_changed=false
+
+select_target() {
+  selected["$1"]=true
+}
+
+select_all_desktop_suites() {
+  select_target "core:all"
+  select_target "plugins:all"
+  select_target "cloud:all"
+}
+
+classify_wework_path() {
+  local path="$1"
+
+  case "$path" in
+    # Browser-runner changes do not require a real desktop application.
+    wework/e2e/tests/* | \
+      wework/e2e/fixtures/* | \
+      wework/playwright.config.ts)
+      return
+      ;;
+    wework/e2e/desktop/task-flow.e2e.mjs)
+      desktop_runner_changed=true
+      return
+      ;;
+
+    # Plugin features have independently bootstrapped desktop segments.
+    wework/src/components/plugins/* | \
+      wework/src/features/plugins/* | \
+      wework/src/pages/Plugin*)
+      select_target "plugins:plugin-lifecycle"
+      return
+      ;;
+    wework/src/components/sites/* | \
+      wework/src/pages/SitesPage.tsx)
+      select_target "plugins:sites-plugin-auto-install"
+      return
+      ;;
+    wework/src/features/workbench/useWorkbenchSkills.ts | \
+      wework/src/components/chat/composer/ComposerMentionMenu.tsx | \
+      wework/src/components/chat/composer/composerMentionCandidates*)
+      select_target "plugins:skill-mention-rendering"
+      select_target "core:core-task-flow"
+      return
+      ;;
+
+    # Cloud execution has a separate backend/executor-backed desktop suite.
+    wework/src/api/cloud/* | \
+      wework/src/features/cloud-connection/* | \
+      wework/src/lib/cloud-authorization-window* | \
+      wework/src/extensions/cloud-desktop*)
+      select_target "cloud:all"
+      return
+      ;;
+
+    # Window and native lifecycle behavior.
+    wework/src/tauri/tray* | \
+      wework/src/tauri/runtimeTaskCloseGuard* | \
+      wework/src/components/layout/WindowFrameControls* | \
+      wework/src/components/layout/DesktopWindowsTitlebar.tsx)
+      select_target "core:window-lifecycle"
+      return
+      ;;
+
+    # Goal creation, idle continuation, and restart recovery.
+    wework/src/lib/runtime-goal* | \
+      wework/src/components/chat/composer/Goal* | \
+      wework/src/features/workbench/runtimeTaskReminders*)
+      select_target "core:goal-lifecycle"
+      return
+      ;;
+
+    # Queueing, cancellation, retry, rate-limit, and reconnect behavior.
+    wework/src/components/chat/ConversationQueuePanel* | \
+      wework/src/lib/chat-error* | \
+      wework/src/features/workbench/runtimeTaskLifecycle/*)
+      select_target "core:resilience"
+      return
+      ;;
+
+    # Conversation switching, restoration, navigation, and pane isolation.
+    wework/src/features/workbench/runtimeConversationCache* | \
+      wework/src/features/workbench/runtimePaneMessages* | \
+      wework/src/components/layout/useWorkbenchPaneSession* | \
+      wework/src/components/chat/MessageTurnNavigation* | \
+      wework/src/components/chat/ScrollableMessageArea*)
+      select_target "core:conversation-state"
+      return
+      ;;
+    wework/src/components/chat/MessageList*)
+      select_target "core:conversation-state"
+      select_target "core:rendering-extensions"
+      return
+      ;;
+
+    # Project/worktree creation and composer path or attachment transfer.
+    wework/src/api/attachments* | \
+      wework/src/api/projects* | \
+      wework/src/api/runtimeWork* | \
+      wework/src/components/projects/* | \
+      wework/src/features/workbench/useWorkbenchAttachments* | \
+      wework/src/components/chat/composer/AttachmentBadges* | \
+      wework/src/components/chat/composer/WorktreeBranchSelector* | \
+      wework/src/components/chat/composer/composerPathTransfer*)
+      select_target "core:workspace-attachments"
+      return
+      ;;
+
+    # Assistant/tool rendering and desktop extension surfaces.
+    wework/src/components/chat/blocks/* | \
+      wework/src/components/chat/AttachmentImagePreview* | \
+      wework/src/extensions/desktop* | \
+      wework/e2e/desktop/scenarios/*)
+      select_target "core:rendering-extensions"
+      return
+      ;;
+
+    # The main composer, model transport, and task launch path.
+    wework/src/components/chat/composer/* | \
+      wework/src/features/model-settings/* | \
+      wework/src/features/local-runtime/* | \
+      wework/src/stream/*)
+      select_target "core:core-task-flow"
+      return
+      ;;
+
+    # Shared desktop infrastructure can affect every independently registered
+    # checkpoint. Keep the fallback explicit instead of guessing one segment.
+    wework/*)
+      select_all_desktop_suites
+      return
+      ;;
+  esac
+}
+
+classify_path() {
+  local path="$1"
+
+  case "$path" in
+    executor/* | packages/chat-core/* | package.json | pnpm-lock.yaml | pnpm-workspace.yaml)
+      select_all_desktop_suites
+      ;;
+    .github/workflows/wework-e2e.yml | \
+      .github/scripts/classify-ci-changes.sh | \
+      .github/scripts/classify-wework-desktop-e2e.sh | \
+      .github/scripts/test-classify-ci-changes.sh)
+      select_all_desktop_suites
+      ;;
+    wework/*)
+      classify_wework_path "$path"
+      ;;
+  esac
+}
+
+append_matrix_entry() {
+  local id="$1"
+  local name="$2"
+  local command="$3"
+  local segment="${4:-}"
+  local entry
+
+  printf -v entry \
+    '{"id":"%s","name":"%s","command":"%s","segment":"%s"}' \
+    "$id" "$name" "$command" "$segment"
+  matrix_entries+=("$entry")
+}
+
+build_matrix() {
+  matrix_entries=()
+
+  if [[ "${selected[core:all]:-false}" == "true" ]]; then
+    append_matrix_entry core Core e2e:desktop
+  else
+    local segment
+    for segment in "${core_segments[@]}"; do
+      if [[ "${selected[core:$segment]:-false}" == "true" ]]; then
+        append_matrix_entry \
+          "core-$segment" \
+          "Core / $segment" \
+          e2e:desktop \
+          "$segment"
+      fi
+    done
+  fi
+
+  if [[ "${selected[plugins:all]:-false}" == "true" ]]; then
+    append_matrix_entry plugins Plugins e2e:desktop:plugins
+  else
+    local segment
+    for segment in "${plugin_segments[@]}"; do
+      if [[ "${selected[plugins:$segment]:-false}" == "true" ]]; then
+        append_matrix_entry \
+          "plugins-$segment" \
+          "Plugins / $segment" \
+          e2e:desktop:plugins \
+          "$segment"
+      fi
+    done
+  fi
+
+  if [[ "${selected[cloud:all]:-false}" == "true" ]]; then
+    append_matrix_entry cloud Cloud e2e:desktop:cloud
+  fi
+}
+
+if [[ "${1:-}" == "--all" ]]; then
+  select_all_desktop_suites
+elif (($# > 0)); then
+  for path in "$@"; do
+    classify_path "$path"
+  done
+else
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && classify_path "$path"
+  done
+fi
+
+if [[ "$desktop_runner_changed" == "true" && ${#selected[@]} -eq 0 ]]; then
+  select_all_desktop_suites
+fi
+
+build_matrix
+
+matrix_json='{"include":[]}'
+run_desktop=false
+if ((${#matrix_entries[@]} > 0)); then
+  joined_entries="$(IFS=,; printf '%s' "${matrix_entries[*]}")"
+  matrix_json="{\"include\":[$joined_entries]}"
+  run_desktop=true
+fi
+
+output_file="${GITHUB_OUTPUT:-/dev/stdout}"
+printf 'wework_desktop_e2e=%s\n' "$run_desktop" >> "$output_file"
+printf 'wework_desktop_e2e_matrix=%s\n' "$matrix_json" >> "$output_file"

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 classifier="$script_dir/classify-ci-changes.sh"
+desktop_classifier="$script_dir/classify-wework-desktop-e2e.sh"
 
 assert_case() {
   local name="$1"
@@ -70,6 +71,67 @@ assert_case "docker changes run platform E2E" "$platform_e2e_expected" \
 wework_e2e_expected="${all_false/wework_e2e=false/wework_e2e=true}"
 assert_case "Wework workflow changes run Wework E2E" "$wework_e2e_expected" \
   ".github/workflows/wework-e2e.yml"
+
+assert_desktop_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+
+  local output
+  output="$(GITHUB_OUTPUT=/dev/stdout "$desktop_classifier" "$@")"
+  if [[ "$output" != "$expected" ]]; then
+    printf 'Desktop case "%s" failed.\nExpected:\n%s\nActual:\n%s\n' \
+      "$name" "$expected" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_desktop_case "conversation files select one core segment" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"}]}' \
+  "wework/src/features/workbench/runtimeConversationCache.ts"
+
+assert_desktop_case "independent features select the union of minimum segments" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"core-goal-lifecycle","name":"Core / goal-lifecycle","command":"e2e:desktop","segment":"goal-lifecycle"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}' \
+  "wework/src/lib/runtime-goal.ts" \
+  "wework/src/components/chat/blocks/ToolBlockItem.tsx"
+
+assert_desktop_case "runner coverage does not broaden a classified feature" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}' \
+  "wework/e2e/desktop/task-flow.e2e.mjs" \
+  "wework/src/components/chat/MessageList.tsx"
+
+assert_desktop_case "runner-only changes retain full coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"core","name":"Core","command":"e2e:desktop","segment":""},{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""},{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
+  "wework/e2e/desktop/task-flow.e2e.mjs"
+
+assert_desktop_case "skill mention files select plugin and core coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"plugins-skill-mention-rendering","name":"Plugins / skill-mention-rendering","command":"e2e:desktop:plugins","segment":"skill-mention-rendering"}]}' \
+  "wework/src/components/chat/composer/ComposerMentionMenu.tsx"
+
+assert_desktop_case "browser E2E changes avoid desktop jobs" \
+  'wework_desktop_e2e=false
+wework_desktop_e2e_matrix={"include":[]}' \
+  "wework/e2e/tests/workbench.spec.ts"
+
+assert_desktop_case "cloud files select only the cloud suite" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
+  "wework/src/features/cloud-connection/CloudConnectionProvider.tsx"
+
+assert_desktop_case "plugin files select only their plugin segment" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"plugins-plugin-lifecycle","name":"Plugins / plugin-lifecycle","command":"e2e:desktop:plugins","segment":"plugin-lifecycle"}]}' \
+  "wework/src/components/plugins/PluginsWorkspace.tsx"
+
+assert_desktop_case "shared desktop infrastructure remains full coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_e2e_matrix={"include":[{"id":"core","name":"Core","command":"e2e:desktop","segment":""},{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""},{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
+  "wework/src/App.tsx"
 
 test_workflow="$script_dir/../workflows/test.yml"
 if ! sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$test_workflow" |
@@ -166,6 +228,29 @@ fi
 
 if ! grep -q "name: Wework E2E Summary" "$wework_workflow"; then
   printf 'Wework E2E must expose a stable summary check\n' >&2
+  exit 1
+fi
+
+if ! grep -q "wework_desktop_e2e_matrix" "$wework_workflow"; then
+  printf 'Wework desktop E2E must use the changed-feature segment matrix\n' >&2
+  exit 1
+fi
+
+wework_browser_job="$(
+  sed -n '/^  wework-e2e:/,/^  wework-desktop-e2e:/p' "$wework_workflow"
+)"
+if ! grep -q "needs.changes.outputs.wework_e2e == 'true'" <<<"$wework_browser_job"; then
+  printf 'Wework browser E2E must use the broad Wework change classification\n' >&2
+  exit 1
+fi
+
+wework_desktop_job="$(
+  sed -n '/^  wework-desktop-e2e:/,/^  wework-e2e-summary:/p' "$wework_workflow"
+)"
+if ! grep -q \
+  "needs.changes.outputs.wework_desktop_e2e == 'true'" \
+  <<<"$wework_desktop_job"; then
+  printf 'Wework desktop E2E must use the desktop segment classification\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       wework_e2e: ${{ steps.classify.outputs.wework_e2e }}
+      wework_desktop_e2e: ${{ steps.classify.outputs.wework_desktop_e2e }}
+      wework_desktop_e2e_matrix: ${{ steps.classify.outputs.wework_desktop_e2e_matrix }}
 
     steps:
       - name: Checkout code
@@ -49,9 +51,12 @@ jobs:
         run: |
           if [[ "$FORCE_ALL" == "true" ]]; then
             .github/scripts/classify-ci-changes.sh --all
+            .github/scripts/classify-wework-desktop-e2e.sh --all
           else
-            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
-              .github/scripts/classify-ci-changes.sh
+            changed_files="$(mktemp)"
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_files"
+            .github/scripts/classify-ci-changes.sh < "$changed_files"
+            .github/scripts/classify-wework-desktop-e2e.sh < "$changed_files"
           fi
 
   wework-e2e:
@@ -123,22 +128,12 @@ jobs:
   wework-desktop-e2e:
     name: Wework Desktop E2E (${{ matrix.name }})
     needs: changes
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - id: plugins
-            name: Plugins
-            command: e2e:desktop:plugins
-          - id: core
-            name: Core
-            command: e2e:desktop
-          - id: cloud
-            name: Cloud
-            command: e2e:desktop:cloud
+      matrix: ${{ fromJSON(needs.changes.outputs.wework_desktop_e2e_matrix) }}
 
     steps:
       - name: Checkout code
@@ -203,10 +198,16 @@ jobs:
         env:
           CI: true
           CODEX_BIN: ${{ github.workspace }}/wework/src-tauri/binaries/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex
+          E2E_COMMAND: ${{ matrix.command }}
+          E2E_SEGMENT: ${{ matrix.segment }}
         run: |
           test -x "$CODEX_BIN"
+          args=()
+          if [[ -n "$E2E_SEGMENT" ]]; then
+            args=(-- --segment "$E2E_SEGMENT")
+          fi
           xvfb-run -a --server-args="-screen 0 1280x720x24" \
-            pnpm --filter wework ${{ matrix.command }}
+            pnpm --filter wework "$E2E_COMMAND" "${args[@]}"
 
       - name: Upload Wework desktop E2E diagnostics
         if: always()
@@ -232,6 +233,7 @@ jobs:
       - name: Check Wework E2E results
         env:
           RUN_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
+          RUN_DESKTOP_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           WEB_E2E_RESULT: ${{ needs.wework-e2e.result }}
           DESKTOP_E2E_RESULT: ${{ needs.wework-desktop-e2e.result }}
@@ -251,7 +253,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "$DESKTOP_E2E_RESULT" != "success" ]]; then
+          if [[ "$RUN_DESKTOP_E2E" == "true" && "$DESKTOP_E2E_RESULT" != "success" ]]; then
             echo "Wework desktop E2E completed with: $DESKTOP_E2E_RESULT"
             exit 1
           fi

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -113,8 +113,12 @@ project initialization, then runs only the selected checkpoint.
 `--from-segment <checkpoint>` starts there and continues through every later
 checkpoint. When upstream checkpoints are skipped, each checkpoint establishes
 its own minimal fixtures instead of depending on tasks or UI state created only
-by the complete flow. Segment commands are for fast local iteration; run the
-complete `pnpm --filter wework e2e:desktop` flow before pushing:
+by the complete flow. PR CI builds the smallest segment matrix for the changed
+feature paths. Shared desktop infrastructure, main, merge queue, scheduled
+runs, and `ci:all` still run the complete desktop suites. The mapping lives in
+`.github/scripts/classify-wework-desktop-e2e.sh` and must be updated when new
+feature coverage is registered. Segment commands are also useful for focused
+local iteration:
 
 ```bash
 pnpm --filter wework e2e:desktop -- --segment window-lifecycle

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -111,8 +111,10 @@ node e2e/utils/mock-connector-upstream-server.mjs
 `--segment <checkpoint>` 在公共启动和项目初始化后只运行指定 checkpoint；
 `--from-segment <checkpoint>` 从指定 checkpoint 开始并继续执行所有后续
 checkpoint。跳过上游时，每个 checkpoint 会自行建立最小前置 fixture，不依赖只有
-完整流程才创建的任务或 UI 状态。分段命令用于本地快速迭代，推送前仍需运行完整
-`pnpm --filter wework e2e:desktop`：
+完整流程才创建的任务或 UI 状态。PR CI 会根据改动的功能路径组合最小 segment
+矩阵；共享桌面基础设施、主分支、merge queue、定时任务和 `ci:all` 仍运行完整桌面
+套件。映射规则位于 `.github/scripts/classify-wework-desktop-e2e.sh`，新增功能覆盖时
+必须同步登记对应 segment。分段命令也可用于本地快速迭代：
 
 ```bash
 pnpm --filter wework e2e:desktop -- --segment window-lifecycle


### PR DESCRIPTION
## Summary

- classify Wework desktop E2E coverage by changed feature paths
- run only the required Core checkpoint, plugin segment, or Cloud suite for pull requests
- keep full desktop coverage for shared infrastructure, `main`, merge queue, scheduled runs, and `ci:all`
- document the segment selection behavior in Chinese and English

## Why

The desktop runner already supported `--segment`, but the pull request workflow always invoked the complete Core suite together with Plugins and Cloud. As a result, a focused feature change paid the cost of every Core checkpoint even when only one independently bootstrapped segment was relevant.

## Impact

Pull requests now build a deterministic dynamic matrix from their changed paths. Multiple affected features produce the deduplicated union of their minimum segments. Browser-only E2E changes can skip the real desktop job, while unclassified shared infrastructure remains conservative and runs all desktop suites.

## Validation

- `.github/scripts/test-classify-ci-changes.sh`
- `shellcheck .github/scripts/classify-wework-desktop-e2e.sh .github/scripts/test-classify-ci-changes.sh`
- `pnpm --filter wework exec prettier --check ../.github/workflows/wework-e2e.yml ../docs/zh/wework/developer-guide/wework-e2e-automation.md ../docs/en/wework/developer-guide/wework-e2e-automation.md`
- `actionlint .github/workflows/wework-e2e.yml`
- `git diff --check`
- pre-push quality checks
