### PR TITLE
fix(wework): preserve composer platform shortcuts

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -9,6 +9,7 @@ This directory implements the Wework desktop workbench: Tauri, Vite, React, Type
 - Follow the Codex-derived, neutral-first visual system in `DESIGN.md`: grayscale surfaces, `14px` default desktop UI text, sparse hairlines and shadows, inverse-neutral primary actions, and blue only for focus, links, or narrow selection accents. Green and teal are restricted to semantic success/addition states and must never define product chrome or default actions.
 - Use the Codex component density documented in `DESIGN.md`: `30px` sidebar rows, `28px` app-shell tabs and composer actions, `16px` standard desktop icons, and `4px–8px` action-group gaps. Reuse the shared component's established size instead of inventing a local height.
 - Use the shared typography scale and semantic `heading-*`, `text-chat`, and `text-code` roles. Never add arbitrary `text-[Npx]`, literal CSS `font-size`, or literal inline `fontSize` values; `pnpm lint` enforces this rule.
+- Preserve platform text-navigation semantics in the ProseMirror chat composer. Register only composer-specific key bindings instead of the document-level `baseKeymap`, and scope mention caret workarounds to unmodified arrow keys.
 
 ## i18n
 

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
@@ -244,7 +244,52 @@ describe('ComposerProseMirrorEditor', () => {
     expect(editorRef.current?.getSnapshot().value).toBe(value)
   })
 
-  test('keeps Command-Left at the real start of text before a skill', () => {
+  test.each(['ArrowLeft', 'ArrowRight'])(
+    'does not override modified %s visual line navigation',
+    key => {
+      const value = `first line\nsecond line with ${GMAIL_REFERENCE} content\nthird line`
+      const mentionOffset = value.indexOf(GMAIL_REFERENCE)
+      const { editorRef } = renderEditor(value)
+      const editor = screen.getByTestId('composer-editor')
+
+      act(() => {
+        editorRef.current?.setValue(value, mentionOffset)
+        editorRef.current?.focus()
+      })
+
+      expect(
+        fireEvent.keyDown(editor, {
+          key,
+          code: key,
+          keyCode: key === 'ArrowLeft' ? 37 : 39,
+          metaKey: true,
+        })
+      ).toBe(true)
+      expect(editorRef.current?.getSnapshot().selectionOffset).toBe(mentionOffset)
+    }
+  )
+
+  test.each([
+    ['a', 65],
+    ['e', 69],
+  ])('does not override macOS Control-%s visual line navigation', (key, keyCode) => {
+    const value = `first line\nsecond line with ${GMAIL_REFERENCE} content\nthird line`
+    const mentionOffset = value.indexOf(GMAIL_REFERENCE)
+    const { editorRef } = renderEditor(value)
+    const editor = screen.getByTestId('composer-editor')
+
+    act(() => {
+      editorRef.current?.setValue(value, mentionOffset)
+      editorRef.current?.focus()
+    })
+
+    expect(
+      fireEvent.keyDown(editor, { key, code: `Key${key.toUpperCase()}`, keyCode, ctrlKey: true })
+    ).toBe(true)
+    expect(editorRef.current?.getSnapshot().selectionOffset).toBe(mentionOffset)
+  })
+
+  test('keeps unmodified arrow navigation protected at a skill boundary', () => {
     const value = `DF${GMAIL_REFERENCE} `
     const { editorRef } = renderEditor(value)
     const editor = screen.getByTestId('composer-editor')
@@ -254,16 +299,10 @@ describe('ComposerProseMirrorEditor', () => {
       editorRef.current?.focus()
     })
 
-    expect(
-      fireEvent.keyDown(editor, {
-        key: 'ArrowLeft',
-        code: 'ArrowLeft',
-        keyCode: 37,
-        metaKey: true,
-      })
-    ).toBe(false)
-    fireEvent.keyUp(editor, { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37, metaKey: true })
-    expect(editorRef.current?.getSnapshot().selectionOffset).toBe(0)
+    expect(fireEvent.keyDown(editor, { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 })).toBe(
+      false
+    )
+    expect(editorRef.current?.getSnapshot().selectionOffset).toBe(2 + GMAIL_REFERENCE.length)
   })
 
   test('copies the complete markdown value after Command-A', () => {

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react'
 import type { RefObject } from 'react'
-import { baseKeymap } from 'prosemirror-commands'
 import { history, redo, undo } from 'prosemirror-history'
 import { keymap } from 'prosemirror-keymap'
 import { Slice, type Node as ProseMirrorNode } from 'prosemirror-model'
@@ -117,7 +116,6 @@ export const ComposerProseMirrorEditor = forwardRef<
               return true
             },
           }),
-          keymap(baseKeymap),
         ],
       }),
       attributes: editorAttributes(initialProps),
@@ -325,19 +323,13 @@ function moveCaretAcrossComposerMention(view: EditorView, event: KeyboardEvent):
     event.shiftKey ||
     event.altKey ||
     event.ctrlKey ||
+    event.metaKey ||
     !view.state.selection.empty
   ) {
     return false
   }
 
   const { $head } = view.state.selection
-  if (event.metaKey) {
-    return setComposerSelection(
-      view,
-      event,
-      event.key === 'ArrowLeft' ? $head.start() : $head.end()
-    )
-  }
   if (event.key === 'ArrowLeft' && $head.pos === $head.start()) {
     return setComposerSelection(view, event, $head.pos)
   }


### PR DESCRIPTION
## What changed

- remove the document-oriented ProseMirror `baseKeymap` from the chat composer
- keep only composer-owned history, redo, and hard-break bindings
- limit mention caret correction to unmodified horizontal arrow keys
- add regression coverage for Command-Arrow and macOS Control-A/Control-E navigation
- document the composer keyboard-boundary rule in `wework/AGENTS.md`

## Why

The composer represents multiline input as one ProseMirror text block containing hard breaks. The document-level keymap mapped platform line-navigation shortcuts to text-block boundaries, so Command-Arrow and Control-A/Control-E jumped to the beginning or end of the entire draft instead of the current visual line.

The composer now leaves modified navigation shortcuts to the ProseMirror/WebKit platform editing pipeline while retaining its explicit chat-specific commands and mention-node protection.

## User impact

macOS text-navigation shortcuts in the Wework chat composer once again follow platform visual-line behavior, including wrapped lines, without regressing movement across skill and plugin mention chips.

## Validation

- `pnpm --filter wework test` — 235 test files, 2354 tests passed
- focused composer tests — 26 tests passed
- Prettier passed
- ESLint passed
- TypeScript passed in pre-push checks
- `git diff --check` passed
- isolated Tauri composer smoke verification completed
