### PR TITLE
fix(ci): cache Wework Tauri system packages

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -139,10 +139,40 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Tauri system dependencies
+      - name: Set APT cache key
+        id: apt-cache-key
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          week="$(date -u +'%G-%V')"
+          echo "key=apt-$RUNNER_OS-$RUNNER_ARCH-wework-v1-$week" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Cache Tauri system packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/wework-apt/archives
+          key: ${{ steps.apt-cache-key.outputs.key }}
+          restore-keys: |
+            apt-${{ runner.os }}-${{ runner.arch }}-wework-v1-
+
+      - name: Install Tauri system dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt_archives="$HOME/.cache/wework-apt/archives"
+          mkdir -p "$apt_archives/partial"
+          sudo chown _apt:root "$apt_archives/partial"
+          sudo chmod 700 "$apt_archives/partial"
+
+          apt_options=(
+            -o "Dir::Cache::archives=$apt_archives/"
+            -o "Acquire::Retries=5"
+            -o "Acquire::http::Timeout=30"
+            -o "Acquire::https::Timeout=30"
+            -o "Binary::apt-get::APT::Keep-Downloaded-Packages=true"
+          )
+
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y --no-install-recommends \
             build-essential \
             libayatana-appindicator3-dev \
             libssl-dev \
@@ -151,6 +181,8 @@ jobs:
             librsvg2-dev \
             redis-server \
             xvfb
+
+          sudo chown -R "$USER:$(id -gn)" "$apt_archives"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -366,6 +366,14 @@ Executor, and Codex verification semantics while removing the serial wait
 between the three scenarios. Matrix fail-fast is disabled so the remaining
 scenarios can finish and upload diagnostics when one scenario fails.
 
+The Linux desktop scenarios cache the downloaded `.deb` files for Tauri system
+dependencies in the runner user's home directory. Cache keys rotate weekly and
+are scoped by operating system and CPU architecture. Every run still executes
+`apt-get update`; an older cache is only a restore source, and missing or
+updated packages are downloaded from the Ubuntu repositories. Installation
+uses `--no-install-recommends` plus repository retries and timeouts to reduce
+whole-job timeouts caused by transient hosted-runner mirror degradation.
+
 The memory gate depends on macOS WebKit process association and physical-footprint sampling, so run it separately on a macOS runner:
 
 ```bash

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -356,6 +356,12 @@ GitHub Actions 将 plugins、core 和 cloud 三个 Linux 桌面场景作为矩�
 真实 Tauri、Executor 与 Codex 验证语义，同时避免三个场景在同一个 job 中串行等待。
 矩阵关闭 fail-fast，使一个场景失败时其他场景仍能完成并上传各自诊断。
 
+Linux 桌面场景会把 Tauri 系统依赖下载得到的 `.deb` 文件缓存在 runner 用户目录，
+并按操作系统、CPU 架构和自然周轮换缓存。每次运行仍执行 `apt-get update`，旧缓存
+只作为恢复来源，缺失或更新后的软件包会从 Ubuntu 软件源下载。安装使用
+`--no-install-recommends`，并为软件源请求设置重试和超时，降低托管 runner 镜像源
+抖动导致整个桌面 E2E job 超时的概率。
+
 内存门禁依赖 macOS 的 WebKit 进程关联和 physical footprint 采样，必须在 macOS runner 上单独运行：
 
 ```bash


### PR DESCRIPTION
## What changed

- cache downloaded Tauri system dependency `.deb` files for Linux desktop E2E
- rotate cache keys weekly by runner OS and architecture
- retain older caches as restore sources while continuing to refresh APT indexes
- reduce package downloads with `--no-install-recommends`
- add APT retries, network timeouts, and non-interactive installation
- document the cache behavior in Chinese and English Wework E2E guides

## Why

The `Install Tauri system dependencies` step occasionally exhausted the
25-minute desktop E2E job timeout. Actions logs showed that the Ubuntu Azure
mirror sometimes downloaded the 88 MB dependency set at extremely low speed,
including multi-minute waits for individual packages. Other matrix runners in
the same workflow completed the identical step in under a minute.

Caching the downloaded packages removes most repeated mirror traffic after the
cache is warmed, while retries and a smaller dependency set reduce cold-cache
risk.

## Impact

The desktop E2E test behavior is unchanged. Linux runners still refresh APT
indexes and install the same explicitly requested system packages before
running the real Tauri scenarios.

## Validation

- `actionlint .github/workflows/wework-e2e.yml`
- `pnpm --filter wework exec prettier --check ../.github/workflows/wework-e2e.yml ../docs/zh/wework/developer-guide/wework-e2e-automation.md ../docs/en/wework/developer-guide/wework-e2e-automation.md`
- `git diff --check origin/main...HEAD`
- repository pre-push quality checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Linux desktop end-to-end test setup by caching Tauri system dependency APT archives between runs.
  * Cache is keyed on a weekly rotation plus OS/CPU architecture, reused as a restore source; installs still run `apt-get update`.
  * Enhanced package installation resilience with retries/timeouts and keeping downloaded packages.
* **Documentation**
  * Updated English and Chinese CI guidance to describe the APT archive cache behavior, rotation scope, and fallback when packages are missing or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->