### PR TITLE
fix(executor): stop persisting runtime running state

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -177,6 +177,12 @@ A terminal task event must immediately mark the local task as `running: false` a
 
 Unread is created only when the current Wework renderer observes a `running: true -> false` edge. It must not infer execution history from free-form `status` text or persisted records; local persistence stores only unread results that were already created, never running state. A task whose persisted Goal remains `active` while the executor is no longer running is waiting for recovery and must not become completion-unread because the application or executor restarted. The current task and every running task must be excluded from visible unread state. Opening a task clears its unread state.
 
+The executor's `RuntimeTaskLink.running` field exists only in current-process
+memory and runtime API responses. `runtime-work/index.json` must not serialize
+the field, and readers must ignore any legacy `running` value left in an older
+index. Whether a task is executing is determined only by the current
+executor's active-task set.
+
 ## Composer Mode Indicators
 
 When the composer is in plan mode or goal-draft mode, its bottom mode pill must show a semantic icon to the left of its label: a checklist for plan mode and a target for goal draft. Desktop and compact layouts must reuse the same mode-pill implementation so the state is expressed consistently.

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -153,6 +153,10 @@ turn 被取消后 goal 在暂停请求到达前启动下一 turn。如果 goal �
 
 未读只在当前 Wework renderer 生命周期内观察到 `running: true -> false` 边沿时产生，不根据 `status` 文本或持久化记录猜测运行历史；本地持久化只保存已经产生的未读结果，不保存运行态。持久化 Goal 仍为 `active` 但 executor 已不再运行的任务属于待恢复状态，不得因应用或 executor 重启产生完成未读。当前任务和所有运行中任务都必须从可见未读集合排除；打开任务会清除其未读状态。
 
+executor 的 `RuntimeTaskLink.running` 只存在于当前进程内存和 runtime API
+响应中。`runtime-work/index.json` 不得序列化该字段，读取旧索引时也必须忽略其中
+残留的 `running` 值；任务是否正在执行只能由当前 executor 的活动任务集合决定。
+
 ## Composer 模式提示
 
 当 composer 处于计划模式或目标草稿模式时，底部模式胶囊必须在标签左侧显示对应的语义图标：计划模式使用清单图标，目标草稿使用靶心图标。桌面和紧凑布局必须复用同一个模式胶囊实现，确保表达一致。

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -26,6 +26,7 @@ pub(crate) struct RuntimeTaskLink {
     pub title: String,
     pub runtime: String,
     pub status: String,
+    #[serde(skip)]
     pub running: bool,
     pub continuable: bool,
     pub thread_status: String,
@@ -845,6 +846,25 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn runtime_task_link_does_not_persist_running_state() {
+        let link = RuntimeTaskLink::new_pending(
+            "task-1".to_owned(),
+            "/tmp/project".to_owned(),
+            "Task".to_owned(),
+        );
+
+        let serialized = serde_json::to_value(&link).expect("task link should serialize");
+        assert!(serialized.get("running").is_none());
+
+        let restored: RuntimeTaskLink = serde_json::from_value(json!({
+            "local_task_id": "task-1",
+            "running": true,
+        }))
+        .expect("task link should deserialize");
+        assert!(!restored.running);
+    }
 
     #[test]
     fn workspace_response_omits_runtime_handle_messages_from_task_list() {

--- a/executor/tests/app_runtime_work_native_update_contract.rs
+++ b/executor/tests/app_runtime_work_native_update_contract.rs
@@ -137,7 +137,7 @@ async fn runtime_task_list_does_not_infer_execution_from_native_thread_status() 
 }
 
 #[tokio::test]
-async fn runtime_task_list_uses_native_idle_state_when_local_running_is_stale() {
+async fn runtime_task_list_ignores_persisted_running_state_when_thread_is_idle() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-local-running-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -208,14 +208,10 @@ async fn runtime_task_list_uses_native_idle_state_when_local_running_is_stale() 
     assert_eq!(locally_running["title"], "Locally running idle");
     assert_eq!(locally_running["status"], "active");
     assert_eq!(locally_running["running"], false);
-    let persisted: serde_json::Value =
-        serde_json::from_slice(&fs::read(&index_path).unwrap()).unwrap();
-    assert_eq!(persisted["tasks"]["local-running-idle"]["status"], "active");
-    assert_eq!(persisted["tasks"]["local-running-idle"]["running"], false);
 }
 
 #[tokio::test]
-async fn runtime_task_list_clears_local_running_state_when_thread_is_missing() {
+async fn runtime_task_list_ignores_persisted_running_state_when_thread_is_missing() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-local-missing-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -268,18 +264,7 @@ async fn runtime_task_list_clears_local_running_state_when_thread_is_missing() {
         .find(|task| task["taskId"] == "local-running-missing")
         .unwrap();
 
-    assert_eq!(missing["status"], "active");
     assert_eq!(missing["running"], false);
-    let persisted: serde_json::Value =
-        serde_json::from_slice(&fs::read(&index_path).unwrap()).unwrap();
-    assert_eq!(
-        persisted["tasks"]["local-running-missing"]["status"],
-        "active"
-    );
-    assert_eq!(
-        persisted["tasks"]["local-running-missing"]["running"],
-        false
-    );
 }
 
 #[tokio::test]

--- a/executor/tests/app_runtime_work_workspace_contract.rs
+++ b/executor/tests/app_runtime_work_workspace_contract.rs
@@ -1513,7 +1513,7 @@ async fn runtime_task_list_keeps_distinct_tasks_with_matching_titles() {
 }
 
 #[tokio::test]
-async fn runtime_task_list_normalizes_unmapped_pending_codex_tasks() {
+async fn runtime_task_list_ignores_persisted_running_state_for_unmapped_tasks() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-stale-pending-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -1563,7 +1563,6 @@ async fn runtime_task_list_normalizes_unmapped_pending_codex_tasks() {
     let tasks = listed["workspaces"][0]["tasks"].as_array().unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0]["taskId"], "unmapped-pending");
-    assert_eq!(tasks[0]["status"], "active");
     assert_eq!(tasks[0]["running"], false);
 }
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1988,11 +1988,6 @@ async function verifyRunningFollowUpFork({
       runtimeIndex.tasks[forkTaskId]?.parent?.lastTurnId,
       'Forking during a follow-up did not persist the selected first turn'
     )
-    assert.equal(
-      runtimeIndex.tasks[sourceTaskId]?.running,
-      true,
-      'Forking the first turn stopped the source follow-up'
-    )
     await control.command('waitFor', '[data-testid="message-assistant"]', {
       text: COMPLETION_TEXT,
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,


### PR DESCRIPTION
## What changed

- exclude `RuntimeTaskLink.running` from serialization and deserialization
- ignore legacy persisted `running` values instead of treating them as executor state
- update runtime task contract tests for the in-memory-only running-state boundary
- document the rule in both Chinese and English Wework state-source guides

## Why

The runtime-work index persisted the same `running` field that is returned by the runtime API. When a release Wework process and a dev process shared one executor home, each process had an independent active-task set but read and wrote the same `runtime-work/index.json`. A process that did not own another process's task could therefore rewrite its running state.

`running` is process-owned execution state. It must come only from the current executor's active-task set and must never be restored from disk.

## Compatibility

There is intentionally no migration or fallback path. Older `running` fields are ignored on read, and all new writes omit the field.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wegent-executor --lib runtime_task_link_does_not_persist_running_state`
- `cargo test -p wegent-executor --test app_runtime_work_native_update_contract`
- pre-push `cargo test --all-features --lib`
- pre-push `cargo clippy`
- isolated real-Tauri startup with `pnpm --filter wework ai:verify start`; verified the local executor connected and the workbench loaded, then stopped and cleaned the session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task `running` state is no longer persisted, so task listings now reflect the currently active executor state.
  * Legacy indexes that include a saved `running` flag are ignored to prevent stale “running” indicators.
  * Runtime task lists correctly show idle, missing, and unmapped tasks as not running.
* **Documentation**
  * Clarified the rules for how `running` is determined and what runtime data is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->