### PR TITLE
fix(wework): prepare debug DWS sidecar for Rust builds

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -26,6 +26,11 @@ pnpm --filter wework exec prettier --check <changed-files>
 pnpm --filter wework exec eslint <changed-files>
 ```
 
+Direct debug Cargo builds create marked, unavailable stubs for ignored bundled
+sidecars when their real binaries have not been prepared. Do not prepare DWS
+only to run Rust unit tests or checks. Real Tauri verification and release
+builds must still use the standard scripts that prepare the actual sidecars.
+
 E2E tests use real backend requests. Do not skip, silently fail, or replace a failing integration with frontend mocks.
 
 - Design verification cases as a QA test plan before running them. For every changed behavior, cover the preconditions, environment and test data, exact steps, expected results, negative and recovery paths, and cleanup. Record the actual result and retain reproducible evidence for failures and critical-path success.

--- a/wework/scripts/prepare-dws-binary.mjs
+++ b/wework/scripts/prepare-dws-binary.mjs
@@ -80,6 +80,7 @@ try {
   )
   await mkdir(dirname(destination), { recursive: true })
   await copyFile(source, destination)
+  await rm(destination.replace(/(?:\.exe)?$/, '.debug-stub'), { force: true })
   if (!isWindowsTarget) await chmod(destination, 0o755)
   console.log(`Prepared DWS sidecar: ${destination}`)
 } finally {

--- a/wework/src-tauri/build.rs
+++ b/wework/src-tauri/build.rs
@@ -4,12 +4,14 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const SIDECAR_NAME: &str = "wegent-executor";
+const DWS_SIDECAR_NAME: &str = "dws";
 const SIDECAR_ENV: &str = "WEWORK_EXECUTOR_SIDECAR";
 const EXECUTOR_NAMESPACE_ENV: &str = "WEWORK_EXECUTOR_NAMESPACE";
 
 fn main() {
     println!("cargo:rerun-if-env-changed={EXECUTOR_NAMESPACE_ENV}");
     prepare_local_executor_sidecar();
+    prepare_dws_sidecar();
     verify_bundled_codex_binary();
     ensure_codex_resource_glob_exists();
     tauri_build::build()
@@ -24,7 +26,7 @@ fn prepare_local_executor_sidecar() {
     let target = env::var("TARGET").expect("TARGET must be set by Cargo");
     let sidecar_path = manifest_dir
         .join("binaries")
-        .join(sidecar_file_name(&target));
+        .join(sidecar_file_name(SIDECAR_NAME, &target));
     let marker_path = sidecar_path.with_extension("debug-stub");
 
     fs::create_dir_all(
@@ -63,8 +65,46 @@ fn prepare_local_executor_sidecar() {
     }
 
     if !sidecar_path.exists() || marker_path.exists() {
-        build_debug_stub(&sidecar_path, &marker_path, &target);
+        build_debug_stub(
+            &sidecar_path,
+            &marker_path,
+            &target,
+            "wegent_executor_debug_stub.rs",
+            "local executor",
+            EXECUTOR_DEBUG_STUB_SOURCE,
+        );
     }
+}
+
+fn prepare_dws_sidecar() {
+    let manifest_dir = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo"),
+    );
+    let target = env::var("TARGET").expect("TARGET must be set by Cargo");
+    let sidecar_path = manifest_dir
+        .join("binaries")
+        .join(sidecar_file_name(DWS_SIDECAR_NAME, &target));
+    let marker_path = sidecar_path.with_extension("debug-stub");
+
+    if sidecar_path.exists() && !marker_path.exists() {
+        return;
+    }
+
+    if env::var("PROFILE").as_deref() == Ok("release") {
+        panic!(
+            "Missing bundled DWS sidecar for {target}: {}. Run `pnpm --filter wework run prepare:dws` with WEWORK_DWS_TARGET={target} before creating a release app bundle.",
+            sidecar_path.display()
+        );
+    }
+
+    build_debug_stub(
+        &sidecar_path,
+        &marker_path,
+        &target,
+        "dws_debug_stub.rs",
+        "DWS",
+        DWS_DEBUG_STUB_SOURCE,
+    );
 }
 
 fn verify_bundled_codex_binary() {
@@ -166,11 +206,11 @@ fn default_executor_dist_path(manifest_dir: &Path, target: &str) -> PathBuf {
         .join(default_executor_file_name(target))
 }
 
-fn sidecar_file_name(target: &str) -> String {
+fn sidecar_file_name(name: &str, target: &str) -> String {
     if target.contains("windows") {
-        format!("{SIDECAR_NAME}-{target}.exe")
+        format!("{name}-{target}.exe")
     } else {
-        format!("{SIDECAR_NAME}-{target}")
+        format!("{name}-{target}")
     }
 }
 
@@ -196,11 +236,9 @@ fn copy_sidecar(source: &Path, destination: &Path) {
     // On Windows the destination may be briefly locked by a previous dev
     // process or by Cargo's fingerprinting. Remove or rename it first, then
     // copy the new sidecar into place.
-    if destination.exists() {
-        if fs::remove_file(destination).is_err() {
-            let backup = destination.with_extension("old.exe");
-            let _ = fs::rename(destination, &backup);
-        }
+    if destination.exists() && fs::remove_file(destination).is_err() {
+        let backup = destination.with_extension("old.exe");
+        let _ = fs::rename(destination, &backup);
     }
     fs::copy(source, destination).unwrap_or_else(|error| {
         panic!(
@@ -223,12 +261,19 @@ fn remove_debug_marker(marker_path: &Path) {
     }
 }
 
-fn build_debug_stub(destination: &Path, marker_path: &Path, target: &str) {
+fn build_debug_stub(
+    destination: &Path,
+    marker_path: &Path,
+    target: &str,
+    source_file_name: &str,
+    sidecar_label: &str,
+    source: &str,
+) {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo"));
-    let source_path = out_dir.join("wegent_executor_debug_stub.rs");
-    fs::write(&source_path, DEBUG_STUB_SOURCE).unwrap_or_else(|error| {
+    let source_path = out_dir.join(source_file_name);
+    fs::write(&source_path, source).unwrap_or_else(|error| {
         panic!(
-            "Failed to write local executor debug stub source {}: {error}",
+            "Failed to write {sidecar_label} debug stub source {}: {error}",
             source_path.display()
         )
     });
@@ -246,16 +291,16 @@ fn build_debug_stub(destination: &Path, marker_path: &Path, target: &str) {
     }
 
     let status = command.status().unwrap_or_else(|error| {
-        panic!("Failed to invoke rustc for local executor debug stub: {error}")
+        panic!("Failed to invoke rustc for {sidecar_label} debug stub: {error}")
     });
     if !status.success() {
-        panic!("Failed to compile local executor debug stub");
+        panic!("Failed to compile {sidecar_label} debug stub");
     }
 
     make_executable(destination);
     fs::write(marker_path, b"debug stub\n").unwrap_or_else(|error| {
         panic!(
-            "Failed to write local executor debug marker {}: {error}",
+            "Failed to write {sidecar_label} debug marker {}: {error}",
             marker_path.display()
         )
     });
@@ -285,7 +330,7 @@ fn make_executable(path: &Path) {
 #[cfg(not(unix))]
 fn make_executable(_path: &Path) {}
 
-const DEBUG_STUB_SOURCE: &str = r##"
+const EXECUTOR_DEBUG_STUB_SOURCE: &str = r##"
 use std::io::{self, BufRead, Write};
 
 fn json_escape(value: &str) -> String {
@@ -332,5 +377,14 @@ fn main() {
         );
         let _ = io::stdout().flush();
     }
+}
+"##;
+
+const DWS_DEBUG_STUB_SOURCE: &str = r##"
+fn main() {
+    eprintln!(
+        "DWS sidecar is not prepared. Run `pnpm --filter wework run prepare:dws` before launching Wework."
+    );
+    std::process::exit(1);
 }
 "##;


### PR DESCRIPTION
## What changed

- generate a marked DWS debug stub during non-release Cargo builds when the ignored real sidecar is absent
- keep release builds strict and require the actual DWS binary
- remove the debug marker when `prepare:dws` installs the real binary
- document the Rust test and real-Tauri sidecar expectations for contributors

## Why

Fresh isolated worktrees do not contain `wework/src-tauri/binaries`, but Tauri
validates every configured `externalBin` while running the Rust build script.
Direct `cargo test` and `cargo check` therefore failed before reaching any test
assertion unless contributors manually prepared DWS first.

The local executor already used a marked debug stub for the same build-time
constraint. This change applies that existing mechanism consistently to DWS
while preserving real sidecars for application and release verification.

## Validation

- direct `cargo test --no-run` with the DWS binary absent
- verified the generated stub exits with an actionable error
- verified `prepare:dws` replaces the stub, removes its marker, and produces DWS v1.0.32
- `cargo test --manifest-path wework/src-tauri/Cargo.toml` — 105 passed
- `pnpm --filter wework test` — 239 files and 2375 tests passed
- Prettier and ESLint for changed JavaScript and Markdown
- isolated real-Tauri `ai:verify` startup, snapshot, status, and cleanup
- pre-push ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Reliability**
  * Improved desktop build handling for the DWS sidecar.
  * Release builds now require the bundled DWS binary and provide clearer setup guidance when it is missing.
  * Development builds use an explicit debug stub when the real sidecar is unavailable.
  * Prepared binaries now remove stale debug markers, helping ensure the correct sidecar is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->