### PR TITLE
fix(backend): keep Sites plugin optional

### DIFF
--- a/backend/tests/docker/test_backend_dockerfile_contract.py
+++ b/backend/tests/docker/test_backend_dockerfile_contract.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static contract tests for the Backend Docker image."""
+
+from pathlib import Path
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[3]
+BACKEND_DOCKERFILE: Path = REPO_ROOT / "docker" / "backend" / "Dockerfile"
+
+
+def test_backend_image_does_not_require_optional_sites_plugin() -> None:
+    """Backend images remain buildable when the optional Sites plugin is absent."""
+    dockerfile = BACKEND_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "COPY backend/init_data /app/init_data" in dockerfile
+    assert "wegent-sites" not in dockerfile

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -30,11 +30,6 @@ COPY backend /app
 # - skills/: Skill packages (mermaid-diagram, wiki_submit, sandbox)
 COPY backend/init_data /app/init_data
 
-# The Sites plugin is required for Backend marketplace initialization. Keep this
-# check in the image build as well as Backend startup so an incomplete release
-# image cannot be published.
-RUN test -f /app/init_data/plugins/wegent-sites/.codex-plugin/plugin.json
-
 # Create .env file (if it doesn't exist)
 RUN if [ ! -f .env ]; then cp .env.example .env; fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backend container builds no longer require the optional Sites plugin to be present.
  - Improved deployment reliability by removing an unnecessary build-time validation that could block image creation.

- **Tests**
  - Added automated validation to ensure required initialization data is included in backend images and optional plugin dependencies are not introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->