### PR TITLE
fix(wework): preserve release bundle resources

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -410,34 +410,13 @@ jobs:
           }
           trap cleanup EXIT
           CONFIG_OVERRIDE="$config_override" \
+          BASE_CONFIG="$PWD/src-tauri/tauri.conf.json" \
           VERSION="${{ needs.prepare-release.outputs.version }}" \
           UPDATER_ENDPOINT="https://github.com/${GH_REPO}/releases/latest/download/latest.json" \
-          TAURI_UPDATER_PUBKEY="$TAURI_UPDATER_PUBKEY" \
-          python3 - <<'PY'
-          import json
-          import os
-
-          config = {
-              "version": os.environ["VERSION"],
-              "bundle": {
-                  "createUpdaterArtifacts": True,
-                  "macOS": {
-                      "signingIdentity": "-",
-                      "hardenedRuntime": True,
-                  },
-              },
-              "plugins": {
-                  "updater": {
-                      "endpoints": [os.environ["UPDATER_ENDPOINT"]],
-                      "pubkey": os.environ["TAURI_UPDATER_PUBKEY"],
-                  },
-              },
-          }
-
-          with open(os.environ["CONFIG_OVERRIDE"], "w", encoding="utf-8") as handle:
-              json.dump(config, handle, indent=2)
-              handle.write("\n")
-          PY
+          UPDATER_PUBKEY="$TAURI_UPDATER_PUBKEY" \
+          SIGNING_IDENTITY="-" \
+          ENABLE_INSECURE_TRANSPORT="false" \
+          node scripts/generate-release-config.mjs
           pnpm exec tauri build \
             --target "${{ matrix.rust_target }}" \
             --bundles app,dmg \

--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -6,13 +6,13 @@ sidebar_position: 27
 
 English | [简体中文](../../zh/developer-guide/wework-macos-release.md)
 
-The Wework macOS app uses the Tauri updater for automatic upgrades. The release flow is handled by `wework/scripts/release-mac-app.sh`, which calculates the release version, builds the Tauri app, signs updater artifacts, handles the DMG, and uploads the release.
+The Wework macOS app uses the Tauri updater for automatic upgrades. Local or standalone releases are handled by `wework/scripts/release-mac-app.sh`, while GitHub Releases are built and published by `.github/workflows/wework-app.yml`.
 
 ## Release Model
 
 - The default build target is `universal-apple-darwin`, producing one installer that supports both Apple Silicon and Intel Macs.
 - The updater manifest includes both `darwin-aarch64` and `darwin-x86_64`; both platform entries can point to the same universal archive.
-- `src-tauri/tauri.conf.json` does not store the update service URL or updater public key. The release script injects them through a temporary Tauri config at build time.
+- `src-tauri/tauri.conf.json` does not store the update service URL or updater public key. Both the local release script and GitHub Actions use `wework/scripts/generate-release-config.mjs` to create a temporary Tauri config that injects release parameters while preserving the complete `bundle.resources` list from the base config. Tauri config overrides replace resource arrays as a whole, so release paths must not maintain a separate incomplete resources list.
 - Updater private keys and publish tokens are read only from environment variables or local files and must not be committed.
 - Codex CLI is not compiled locally. Before building, `wework/scripts/prepare-codex-binary.mjs` downloads the npm tarball pinned by `wework/codex-binaries.lock.json`, verifies its SHA256, and bundles it as a Tauri resource.
 
@@ -94,6 +94,8 @@ The repository includes `.github/workflows/wework-app.yml` for producing macOS D
 ```text
 https://github.com/<owner>/<repo>/releases/latest/download/latest.json
 ```
+
+The macOS CI job does not invoke `release-mac-app.sh`, but both release paths share `wework/scripts/generate-release-config.mjs`. The generator copies the complete `bundle.resources` list from `src-tauri/tauri.conf.json`, ensuring that Codex, hooks, bundled plugins, and hidden marketplace manifests are included in formal release packages. Update the base Tauri config when desktop resources change instead of duplicating the list in the workflow.
 
 The workflow can only be started manually from GitHub Actions and does not respond to tag pushes. A formal run creates or updates a `wework-v<version>` draft release. After both architecture builds finish, it generates `latest.json`, uploads it to the same release, and then publishes that release as GitHub latest. The client reads this manifest during automatic startup checks and when the titlebar update action is used. Preventing tag-push triggers ensures that the tag created while publishing the release cannot start a second build of the same version and overwrite signed artifacts.
 

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -6,13 +6,13 @@ sidebar_position: 27
 
 [English](../../en/developer-guide/wework-macos-release.md) | 简体中文
 
-Wework macOS 应用使用 Tauri updater 支持自动升级。发布流程由 `wework/scripts/release-mac-app.sh` 负责完成版本号计算、Tauri 构建、updater 签名、DMG 处理和上传。
+Wework macOS 应用使用 Tauri updater 支持自动升级。本地或独立发布由 `wework/scripts/release-mac-app.sh` 负责；GitHub Release 由 `.github/workflows/wework-app.yml` 构建和发布。
 
 ## 发布模型
 
 - 默认构建 `universal-apple-darwin`，生成一个同时支持 Apple Silicon 和 Intel Mac 的安装包。
 - updater manifest 同时写入 `darwin-aarch64` 和 `darwin-x86_64`，两个平台可以指向同一个 universal archive。
-- `src-tauri/tauri.conf.json` 不保存发布服务地址或 updater 公钥。发布脚本会在构建时通过临时 Tauri config 注入。
+- `src-tauri/tauri.conf.json` 不保存发布服务地址或 updater 公钥。本地发布脚本和 GitHub Actions 都通过 `wework/scripts/generate-release-config.mjs` 生成临时 Tauri config，在注入发布参数的同时完整保留基础配置中的 `bundle.resources`。Tauri config 覆盖会整体替换资源数组，因此发布路径不能单独维护一份不完整的 resources 列表。
 - updater 私钥和发布 token 只通过环境变量或本机文件读取，不提交到仓库。
 - Codex CLI 不在本地编译。构建前通过 `wework/scripts/prepare-codex-binary.mjs` 按 `wework/codex-binaries.lock.json` 下载 npm tarball，校验 SHA256 后打进 Tauri resources。
 
@@ -94,6 +94,8 @@ python3 -m http.server 8787 --directory src-tauri/target/release/local-update-se
 ```text
 https://github.com/<owner>/<repo>/releases/latest/download/latest.json
 ```
+
+macOS CI job 不调用 `release-mac-app.sh`，但两条发布路径共享 `wework/scripts/generate-release-config.mjs`。该生成器从 `src-tauri/tauri.conf.json` 复制完整的 `bundle.resources`，确保 Codex、hooks、bundled plugins 及隐藏的 marketplace manifests 都进入正式发布包。修改桌面资源清单时应更新基础 Tauri 配置，不要在 workflow 中重新复制资源列表。
 
 workflow 只能通过 GitHub Actions 手动触发，不会响应 tag push。正式发布会创建或更新 `wework-v<version>` draft release；两个架构构建完成后，workflow 生成 `latest.json`，上传到同一个 Release，最后把 Release 发布为 GitHub latest。客户端启动后的自动检查或标题栏手动更新都会读取这个 manifest。禁止 tag push 自动触发可以避免 workflow 发布 Release 时创建的 tag 再次启动同版本构建并覆盖已签名产物。
 

--- a/wework/scripts/generate-release-config.mjs
+++ b/wework/scripts/generate-release-config.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises'
+
+function requiredEnvironment(name) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}
+
+const baseConfigPath = requiredEnvironment('BASE_CONFIG')
+const outputConfigPath = requiredEnvironment('CONFIG_OVERRIDE')
+const baseConfig = JSON.parse(await readFile(baseConfigPath, 'utf8'))
+const resources = baseConfig.bundle?.resources
+
+if (!Array.isArray(resources)) {
+  throw new Error(`Base Tauri config has no bundle.resources array: ${baseConfigPath}`)
+}
+
+const config = {
+  version: requiredEnvironment('VERSION'),
+  bundle: {
+    createUpdaterArtifacts: true,
+    resources,
+  },
+  plugins: {
+    updater: {
+      endpoints: [requiredEnvironment('UPDATER_ENDPOINT')],
+      pubkey: requiredEnvironment('UPDATER_PUBKEY'),
+    },
+  },
+}
+
+const identity = process.env.SIGNING_IDENTITY?.trim()
+if (identity) {
+  config.bundle.macOS = {
+    signingIdentity: identity,
+    hardenedRuntime: true,
+  }
+}
+
+if (process.env.ENABLE_INSECURE_TRANSPORT === 'true') {
+  config.plugins.updater.dangerousInsecureTransportProtocol = true
+}
+
+await writeFile(outputConfigPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8')

--- a/wework/scripts/release-mac-app.sh
+++ b/wework/scripts/release-mac-app.sh
@@ -526,38 +526,9 @@ UPDATER_ENDPOINT="${download_base_url%/}/latest.json" \
 UPDATER_PUBKEY="$UPDATER_PUBKEY" \
 SIGNING_IDENTITY="$app_sign_identity" \
 ENABLE_INSECURE_TRANSPORT="$([ "$TARGET" = "local" ] && printf 'true' || printf 'false')" \
+BASE_CONFIG="$WEWORK_DIR/src-tauri/tauri.conf.json" \
 CONFIG_OVERRIDE="$config_override" \
-python3 - <<'PY'
-import json
-import os
-
-config = {
-    "version": os.environ["VERSION"],
-    "bundle": {
-        "createUpdaterArtifacts": True,
-    },
-    "plugins": {
-        "updater": {
-            "endpoints": [os.environ["UPDATER_ENDPOINT"]],
-            "pubkey": os.environ["UPDATER_PUBKEY"],
-        },
-    },
-}
-
-identity = os.environ["SIGNING_IDENTITY"].strip()
-if identity:
-    config["bundle"]["macOS"] = {
-        "signingIdentity": identity,
-        "hardenedRuntime": True,
-    }
-
-if os.environ["ENABLE_INSECURE_TRANSPORT"] == "true":
-    config["plugins"]["updater"]["dangerousInsecureTransportProtocol"] = True
-
-with open(os.environ["CONFIG_OVERRIDE"], "w", encoding="utf-8") as handle:
-    json.dump(config, handle, indent=2)
-    handle.write("\n")
-PY
+node "$SCRIPT_DIR/generate-release-config.mjs"
 
 echo "Release target: $TARGET"
 echo "Releasing version: $next_version"

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -1,11 +1,21 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
-import { describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 
 const bundledMarketplaceManifests = [
   'bundled-plugins/wework-personal/.agents/plugins/marketplace.json',
   'bundled-plugins/wework-personal/.claude-plugin/marketplace.json',
 ]
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
 
 describe('bundled plugin resources', () => {
   test('explicitly packages hidden marketplace manifests', () => {
@@ -20,5 +30,55 @@ describe('bundled plugin resources', () => {
       expect(config.bundle.resources).toContain(manifest)
       expect(existsSync(resolve(tauriDirectory, manifest))).toBe(true)
     }
+  })
+
+  test('preserves bundled plugins in the macOS release config override', () => {
+    const weworkDirectory = process.cwd()
+    const baseConfigPath = resolve(weworkDirectory, 'src-tauri/tauri.conf.json')
+    const outputDirectory = mkdtempSync(resolve(tmpdir(), 'wework-release-config-'))
+    temporaryDirectories.push(outputDirectory)
+    const outputConfigPath = resolve(outputDirectory, 'tauri.release.json')
+
+    execFileSync(
+      process.execPath,
+      [resolve(weworkDirectory, 'scripts/generate-release-config.mjs')],
+      {
+        env: {
+          ...process.env,
+          BASE_CONFIG: baseConfigPath,
+          CONFIG_OVERRIDE: outputConfigPath,
+          VERSION: '1.2.3',
+          UPDATER_ENDPOINT: 'https://updates.example.com/latest.json',
+          UPDATER_PUBKEY: 'test-pubkey',
+          SIGNING_IDENTITY: '',
+          ENABLE_INSECURE_TRANSPORT: 'false',
+        },
+      }
+    )
+
+    const baseConfig = JSON.parse(readFileSync(baseConfigPath, 'utf8')) as {
+      bundle: {
+        resources: string[]
+      }
+    }
+    const releaseConfig = JSON.parse(readFileSync(outputConfigPath, 'utf8')) as {
+      bundle: {
+        resources: string[]
+      }
+    }
+
+    expect(releaseConfig.bundle.resources).toEqual(baseConfig.bundle.resources)
+    for (const manifest of bundledMarketplaceManifests) {
+      expect(releaseConfig.bundle.resources).toContain(manifest)
+    }
+  })
+
+  test('uses the shared release config generator in GitHub macOS releases', () => {
+    const workflow = readFileSync(
+      resolve(process.cwd(), '../.github/workflows/wework-app.yml'),
+      'utf8'
+    )
+
+    expect(workflow).toContain('node scripts/generate-release-config.mjs')
   })
 })


### PR DESCRIPTION
## What changed

- generate macOS release Tauri overrides through a shared Node.js generator
- preserve the complete `bundle.resources` list from `tauri.conf.json`
- use the same generator in the standalone release script and GitHub Actions
- add regression coverage for bundled plugin resources and the GitHub release path
- document the relationship between local and GitHub macOS release flows

## Root cause

Tauri config overrides replace `bundle.resources` as a whole. The GitHub macOS release workflow generated its own override independently of the base config, so bundled plugin resources and hidden marketplace manifests could be omitted even though they were present in `tauri.conf.json`.

## Impact

Formal macOS release packages now include Codex resources, hooks, bundled plugins, and both hidden marketplace manifests. Wework can initialize the bundled personal marketplace instead of failing during startup because `marketplace.json` is missing.

## Validation

- Wework unit tests: 246 files, 2419 tests passed
- focused bundled plugin release tests: 3 passed
- pre-push ESLint, TypeScript, and unit tests passed
- Prettier, Actionlint, Node syntax, shell syntax, and diff checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release packaging to preserve all required bundled resources, including plugins and marketplace assets.
  * Standardized updater configuration across local and GitHub-based macOS releases.
  * Ensured macOS release builds consistently apply updater settings and signing configuration.

* **Documentation**
  * Clarified the macOS release process, update configuration, and resource-management guidance in English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->