### PR TITLE
fix(docker): stabilize release image builds

### DIFF
--- a/backend/tests/docker/test_frontend_dockerfile_contract.py
+++ b/backend/tests/docker/test_frontend_dockerfile_contract.py
@@ -4,10 +4,12 @@
 
 """Static contract tests for the frontend Docker image."""
 
+import json
 from pathlib import Path
 
 REPO_ROOT: Path = Path(__file__).resolve().parents[3]
 FRONTEND_DOCKERFILE: Path = REPO_ROOT / "docker" / "frontend" / "Dockerfile"
+PACKAGE_JSON: Path = REPO_ROOT / "package.json"
 
 
 def test_frontend_builder_includes_chat_core_workspace_dependencies() -> None:
@@ -21,3 +23,12 @@ def test_frontend_builder_includes_chat_core_workspace_dependencies() -> None:
         "COPY --from=deps /app/packages/chat-core/node_modules "
         "./packages/chat-core/node_modules"
     ) in dockerfile
+
+
+def test_frontend_builders_use_workspace_pnpm_version() -> None:
+    """Frontend image builds should not download a second pnpm version."""
+    dockerfile = FRONTEND_DOCKERFILE.read_text(encoding="utf-8")
+    package_json = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    prepare_command = f"corepack prepare {package_json['packageManager']} --activate"
+
+    assert dockerfile.count(prepare_command) == 2

--- a/backend/tests/docker/test_standalone_wework_contract.py
+++ b/backend/tests/docker/test_standalone_wework_contract.py
@@ -4,10 +4,12 @@
 
 """Static contract tests for the standalone Wework launch path."""
 
+import json
 from pathlib import Path
 
 REPO_ROOT: Path = Path(__file__).resolve().parents[3]
 STANDALONE_DOCKERFILE: Path = REPO_ROOT / "docker" / "standalone" / "Dockerfile"
+PACKAGE_JSON: Path = REPO_ROOT / "package.json"
 STANDALONE_START: Path = REPO_ROOT / "docker" / "standalone" / "start.sh"
 STANDALONE_NGINX_CONFIG: Path = REPO_ROOT / "docker" / "standalone" / "nginx.conf"
 INSTALL_SCRIPT: Path = REPO_ROOT / "install.sh"
@@ -41,6 +43,25 @@ def test_standalone_image_includes_wework_executor_and_workspace_volume() -> Non
     assert (
         "PYTHONPATH=/app:/app/backend:/app/chat_shell:/app/executor" not in dockerfile
     )
+
+
+def test_standalone_wework_builder_installs_postinstall_dependencies() -> None:
+    """DingTalk CLI postinstall requires unzip in the Wework build stage."""
+    dockerfile = STANDALONE_DOCKERFILE.read_text(encoding="utf-8")
+    wework_builder = dockerfile.split("AS wework-builder", maxsplit=1)[1].split(
+        "AS python-base", maxsplit=1
+    )[0]
+
+    assert "apt-get install -y --no-install-recommends unzip" in wework_builder
+
+
+def test_standalone_builders_use_workspace_pnpm_version() -> None:
+    """Standalone image builds should not download a second pnpm version."""
+    dockerfile = STANDALONE_DOCKERFILE.read_text(encoding="utf-8")
+    package_json = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    prepare_command = f"corepack prepare {package_json['packageManager']} --activate"
+
+    assert dockerfile.count(prepare_command) == 4
 
 
 def test_standalone_image_installs_codex_runtime_dependencies() -> None:

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -24,7 +24,7 @@ ENV HUSKY=0
 
 # Install workspace dependencies needed by the frontend.
 RUN corepack enable \
-    && corepack prepare pnpm@10.34.3 --activate \
+    && corepack prepare pnpm@11.7.0 --activate \
     && pnpm install --frozen-lockfile --filter wecode-ai-assistant...
 
 # ---- Build Stage ----
@@ -53,7 +53,7 @@ ENV HUSKY=0
 # Build Next.js application
 WORKDIR /app/frontend
 RUN corepack enable \
-    && corepack prepare pnpm@10.34.3 --activate \
+    && corepack prepare pnpm@11.7.0 --activate \
     && pnpm run build
 
 # ---- Production Stage ----

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -27,7 +27,7 @@ ENV HUSKY=0
 
 # Install workspace dependencies needed by the frontend.
 RUN corepack enable \
-    && corepack prepare pnpm@10.34.3 --activate \
+    && corepack prepare pnpm@11.7.0 --activate \
     && pnpm install --frozen-lockfile --filter wecode-ai-assistant...
 
 # Copy source code
@@ -46,13 +46,17 @@ ENV HUSKY=0
 # Build Next.js application
 WORKDIR /app/frontend
 RUN corepack enable \
-    && corepack prepare pnpm@10.34.3 --activate \
+    && corepack prepare pnpm@11.7.0 --activate \
     && pnpm run build
 
 # ========== Stage 2: Build Wework ==========
 FROM node:22-slim AS wework-builder
 
 WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/chat-core/package.json ./packages/chat-core/package.json
@@ -61,7 +65,7 @@ COPY wework/package.json ./wework/package.json
 ENV HUSKY=0
 
 RUN corepack enable \
-    && corepack prepare pnpm@10.34.3 --activate \
+    && corepack prepare pnpm@11.7.0 --activate \
     && pnpm install --frozen-lockfile --filter wework...
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -75,7 +79,7 @@ ENV HUSKY=0
 
 WORKDIR /app/wework
 RUN corepack enable \
-    && corepack prepare pnpm@10.34.3 --activate \
+    && corepack prepare pnpm@11.7.0 --activate \
     && pnpm run build
 
 # ========== Stage 3: Build Python Base with Tools ==========


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Updated frontend and standalone container builds to use pnpm 11.7.0.
  - Ensured all build stages consistently use the workspace-configured package manager version.
  - Added required `unzip` support for standalone Wework builds.

- **Tests**
  - Expanded Docker build checks to verify package manager setup and required build dependencies.
  - Added coverage confirming package manager activation commands are consistently applied across build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->