### PR TITLE
fix(wework): restore main window close flow

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -55,6 +55,7 @@ pnpm --filter wework ai:verify hover --session <session-path> --selector '[data-
 pnpm --filter wework ai:verify pointer-move --session <session-path> --selector 'body'
 pnpm --filter wework ai:verify wait-for --session <session-path> --selector '[data-testid="..."]' --text '...'
 pnpm --filter wework ai:verify capture --session <session-path> --output <png-path>
+pnpm --filter wework ai:verify request-close --session <session-path>
 pnpm --filter wework ai:verify close-to-tray --session <session-path>
 pnpm --filter wework ai:verify stop --session <session-path>
 ```
@@ -65,6 +66,7 @@ pnpm --filter wework ai:verify stop --session <session-path>
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.
 - Execute the complete QA test plan in the isolated Tauri session, including the primary path, relevant boundary and error cases, and recovery. Document the environment, cases run, actual results, and evidence in the change handoff or pull request.
 - Use `capture` after the final assertion when a visual verification artifact is required. It renders the current WebView without macOS screen-recording permission.
+- Use `request-close` to exercise the native main-window close request and its close-to-tray preference or confirmation flow.
 - Use `close-to-tray` only for window-lifecycle verification. It destroys the controlled WebView while leaving the isolated Tauri process running so native reopen behavior can be tested.
 - On failure, inspect `app.log`, `executor.log`, and Tauri logs under `test-results/ai-verify/`; do not silently downgrade to mocked verification.
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -3639,6 +3639,18 @@ async function verifyBackgroundTaskWindowLifecycle({
   const lifecycleScreenshotName = name => `window-lifecycle-${name}`
   setPhase('popout-window-lifecycle')
   await verifyPopoutWindowLifecycle(control, composerSelector)
+  setPhase('close-request-without-running-task')
+  await control.command('requestMainWindowClose', 'body')
+  await control.command('waitFor', '[data-testid="runtime-task-close-confirm-overlay"]', {
+    visible: true,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('click', '[data-testid="runtime-task-close-cancel-button"]')
+  const closeCancelledSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+  assert.ok(
+    !closeCancelledSnapshot.testIds.includes('runtime-task-close-confirm-overlay'),
+    'The close-to-tray prompt remained open after cancelling'
+  )
   setPhase('background-streaming-task')
   control.setScenario('window_lifecycle')
   await control.command('click', '[data-testid="new-chat-button"]')
@@ -3703,7 +3715,12 @@ async function verifyBackgroundTaskWindowLifecycle({
       'The executor process was not alive before close'
     )
 
-    await control.command('closeMainWindowToTray', 'body')
+    await control.command('requestMainWindowClose', 'body')
+    await control.command('waitFor', '[data-testid="runtime-task-close-confirm-overlay"]', {
+      visible: true,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    await control.command('click', '[data-testid="runtime-task-close-confirm-button"]')
     await waitForLogPattern(join(resultDir, `wework-tauri-${app.pid}.log`), /windowWillClose:/)
     assert.equal(processIsAlive(app.pid), true, 'Closing to tray terminated the Wework process')
     assert.equal(

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -27,7 +27,7 @@ const corsHeaders = {
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
-  pnpm --filter wework ai:verify <capture|capture-popout|snapshot|click|close-to-tray|dismiss-popout|drag|drop-file|drop-paths|fill|hover|metrics|navigate|paste-paths|pointer-move|press|scroll-into-view|select-text|show-popout|system-drag-drop|wait-for|window-focus-snapshot|text|status|stop> --session PATH [options]
+  pnpm --filter wework ai:verify <capture|capture-popout|snapshot|click|close-to-tray|request-close|dismiss-popout|drag|drop-file|drop-paths|fill|hover|metrics|navigate|paste-paths|pointer-move|press|scroll-into-view|select-text|show-popout|system-drag-drop|wait-for|window-focus-snapshot|text|status|stop> --session PATH [options]
 
 Options:
   --codex-home-initialization true
@@ -386,6 +386,7 @@ async function main() {
     snapshot: 'snapshot',
     click: 'click',
     'close-to-tray': 'closeMainWindowToTray',
+    'request-close': 'requestMainWindowClose',
     'dismiss-popout': 'dismissPopoutWindow',
     drag: 'drag',
     'drop-file': 'dropFile',
@@ -422,7 +423,8 @@ async function main() {
     command === 'show-popout' ||
     command === 'system-drag-drop' ||
     command === 'window-focus-snapshot' ||
-    command === 'close-to-tray'
+    command === 'close-to-tray' ||
+    command === 'request-close'
       ? 'body'
       : null)
   if (!selector) throw new Error('--selector is required')

--- a/wework/src/components/layout/WindowFrameControls.test.tsx
+++ b/wework/src/components/layout/WindowFrameControls.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, test, vi, beforeEach } from 'vitest'
-import { invoke } from '@tauri-apps/api/core'
 import { WindowFrameControls } from './WindowFrameControls'
 
 const mocks = vi.hoisted(() => {
@@ -18,10 +17,6 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: vi.fn(() => mocks.windowMock),
-}))
-
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
 }))
 
 describe('WindowFrameControls', () => {
@@ -78,19 +73,9 @@ describe('WindowFrameControls', () => {
     expect(mocks.windowMock.maximize).not.toHaveBeenCalled()
   })
 
-  test('close button invokes close_main_window_to_tray command', async () => {
+  test('close button requests the standard window close flow', async () => {
     render(<WindowFrameControls />)
     fireEvent.click(screen.getByTestId('window-close-button'))
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith('close_main_window_to_tray'))
-  })
-
-  test('falls back to window.close when close_main_window_to_tray command fails', async () => {
-    const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>
-    invokeMock.mockRejectedValueOnce(new Error('command unavailable'))
-
-    render(<WindowFrameControls />)
-    fireEvent.click(screen.getByTestId('window-close-button'))
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith('close_main_window_to_tray'))
     await waitFor(() => expect(mocks.windowMock.close).toHaveBeenCalledTimes(1))
   })
 

--- a/wework/src/components/layout/WindowFrameControls.tsx
+++ b/wework/src/components/layout/WindowFrameControls.tsx
@@ -1,7 +1,6 @@
 import { Minus, Square, Copy, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { invoke } from '@tauri-apps/api/core'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 
@@ -60,14 +59,9 @@ export function WindowFrameControls({ className }: { className?: string }) {
 
   const handleClose = useCallback(async () => {
     try {
-      await invoke('close_main_window_to_tray')
+      await getCurrentWindow().close()
     } catch {
-      // Fallback to direct window close if the command is unavailable
-      try {
-        await getCurrentWindow().close()
-      } catch {
-        // Ignore
-      }
+      // Ignore
     }
   }, [])
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -725,6 +725,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return invoke<string>('capture_popout_webview')
     case 'closeMainWindowToTray':
       return ''
+    case 'requestMainWindowClose':
+      return ''
     case 'dispatchLocalModelSettingsChanged':
       window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
       return ''
@@ -1077,6 +1079,8 @@ async function runDesktopControlClient(url: string): Promise<void> {
         await postDesktopControlResult(url, { id: command.id, clientId, ok: true, value })
         if (command.action === 'closeMainWindowToTray') {
           await closeMainWindowToTray()
+        } else if (command.action === 'requestMainWindowClose') {
+          await getCurrentWindow().close()
         }
       } catch (error) {
         await postDesktopControlResult(url, {

--- a/wework/src/features/workbench/RuntimeTaskCloseGuard.test.tsx
+++ b/wework/src/features/workbench/RuntimeTaskCloseGuard.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { RuntimeTaskCloseGuard } from './RuntimeTaskCloseGuard'
+
+const mocks = vi.hoisted(() => ({
+  closeRequestHandler: undefined as (() => void) | undefined,
+  installRuntimeTaskCloseGuard: vi.fn(),
+  closeMainWindowToTray: vi.fn(),
+  updateAppPreferences: vi.fn(),
+  unlisten: vi.fn(),
+}))
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/lib/runtime-environment', () => ({
+  isTauriRuntime: () => true,
+}))
+
+vi.mock('@/tauri/appPreferences', () => ({
+  updateAppPreferences: mocks.updateAppPreferences,
+}))
+
+vi.mock('@/tauri/runtimeTaskCloseGuard', () => ({
+  closeMainWindowToTray: mocks.closeMainWindowToTray,
+  installRuntimeTaskCloseGuard: mocks.installRuntimeTaskCloseGuard,
+}))
+
+describe('RuntimeTaskCloseGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.closeRequestHandler = undefined
+    mocks.installRuntimeTaskCloseGuard.mockImplementation(async handler => {
+      mocks.closeRequestHandler = handler
+      return mocks.unlisten
+    })
+  })
+
+  test('shows the close-to-tray prompt for every intercepted first close request', async () => {
+    render(<RuntimeTaskCloseGuard />)
+
+    await waitFor(() => expect(mocks.closeRequestHandler).toBeDefined())
+    act(() => {
+      mocks.closeRequestHandler?.()
+    })
+
+    expect(screen.getByTestId('runtime-task-close-confirm-overlay')).toBeInTheDocument()
+  })
+})

--- a/wework/src/features/workbench/RuntimeTaskCloseGuard.tsx
+++ b/wework/src/features/workbench/RuntimeTaskCloseGuard.tsx
@@ -6,11 +6,9 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { updateAppPreferences } from '@/tauri/appPreferences'
 import { closeMainWindowToTray, installRuntimeTaskCloseGuard } from '@/tauri/runtimeTaskCloseGuard'
-import { useRuntimeTaskLifecycleStoreSnapshot } from './runtimeTaskLifecycle'
 
 export function RuntimeTaskCloseGuard() {
   const { t } = useTranslation('common')
-  const lifecycle = useRuntimeTaskLifecycleStoreSnapshot()
   const [closeDialogOpen, setCloseDialogOpen] = useState(false)
   const [closing, setClosing] = useState(false)
 
@@ -21,7 +19,6 @@ export function RuntimeTaskCloseGuard() {
     let cancelled = false
 
     void installRuntimeTaskCloseGuard(() => {
-      if (lifecycle.runningTaskKeys.size === 0) return
       setClosing(false)
       setCloseDialogOpen(true)
     })
@@ -40,7 +37,7 @@ export function RuntimeTaskCloseGuard() {
       cancelled = true
       unlisten?.()
     }
-  }, [lifecycle.runningTaskKeys.size])
+  }, [])
 
   return (
     <RuntimeTaskCloseConfirmDialog


### PR DESCRIPTION
## What changed

- restore handling for every intercepted first main-window close request, including when no runtime task is running
- route the Windows custom close button through Tauri's standard window close request
- add unit coverage for the close guard and Windows frame control
- extend the desktop E2E controller and lifecycle scenario to exercise the native close request, cancellation, and confirmation paths
- document the new isolated `ai:verify request-close` command

## Why

The Rust window lifecycle handler prevents the first close and emits a close-to-tray hint request. A runtime lifecycle refactor ignored that event when no task was running, leaving the close request prevented with no visible response. Separately, the Windows custom frame button directly destroyed the main WebView instead of following the same close-request path as native window controls.

This change makes native and custom close controls share one lifecycle flow and restores the close-to-tray confirmation behavior.

## User impact

- clicking the main-window close button now shows the first-run background-mode prompt instead of doing nothing
- cancelling keeps the window open
- confirming closes the main window while Wework continues running in the tray
- Windows custom controls now respect the same preferences and confirmation behavior as native controls

## Validation

- pre-push ESLint, TypeScript, and unit test suite
- focused Vitest coverage: 3 files, 15 tests
- Prettier and `git diff --check`
- isolated real-Tauri verification:
  - close request without a running task displayed the prompt
  - cancellation kept the window open
  - confirmation produced the native `windowWillClose` event and destroyed the main WebView while keeping the app process running


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a close-request flow that displays a confirmation dialog before closing the desktop window.
  * Added support for closing the window after confirming the dialog, including during background task activity.

* **Bug Fixes**
  * Improved close-button behavior by using the standard desktop window close flow.
  * Ensured the close confirmation appears consistently when requesting to close the window.

* **Documentation**
  * Documented the new desktop verification command for testing close requests and close-to-tray behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->