### PR TITLE
fix(wework): keep startup independent of remote network

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
 import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
+import { createServer as createTcpServer } from 'node:net'
 import {
   access,
   appendFile,
@@ -645,6 +646,67 @@ async function reservePort() {
   assert.ok(address && typeof address !== 'string', 'Unable to reserve an E2E port')
   await new Promise(resolvePromise => server.close(resolvePromise))
   return address.port
+}
+
+class BlockingNetworkProxy {
+  constructor() {
+    this.requests = []
+    this.sockets = new Set()
+    this.released = false
+    this.server = createTcpServer(socket => {
+      this.sockets.add(socket)
+      socket.on('close', () => this.sockets.delete(socket))
+      socket.on('error', () => this.sockets.delete(socket))
+      if (this.released) {
+        socket.end('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+        return
+      }
+      let request = ''
+      socket.on('data', chunk => {
+        if (request) return
+        request = chunk.toString('utf8').split(/\r?\n/, 1)[0]?.trim() ?? ''
+        if (request) this.requests.push(request)
+      })
+    })
+  }
+
+  async start() {
+    await new Promise((resolvePromise, reject) => {
+      this.server.once('error', reject)
+      this.server.listen(0, '127.0.0.1', resolvePromise)
+    })
+    const address = this.server.address()
+    assert.ok(address && typeof address !== 'string', 'Unable to start blocking network proxy')
+    this.url = `http://127.0.0.1:${address.port}`
+  }
+
+  async waitForRequest(timeoutMs = WORKBENCH_READY_TIMEOUT_MS) {
+    return this.waitForRequestAfter(0, timeoutMs)
+  }
+
+  async waitForRequestAfter(requestCount, timeoutMs = WORKBENCH_READY_TIMEOUT_MS) {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < timeoutMs) {
+      if (this.requests.length > requestCount) return this.requests[requestCount]
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 25))
+    }
+    throw new Error('Codex did not reach the blocking network proxy')
+  }
+
+  release() {
+    if (this.released) return
+    this.released = true
+    for (const socket of this.sockets) {
+      socket.end('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+    }
+  }
+
+  async stop() {
+    this.release()
+    for (const socket of this.sockets) socket.destroy()
+    this.sockets.clear()
+    await new Promise(resolvePromise => this.server.close(resolvePromise))
+  }
 }
 
 async function waitForUrl(url, message, timeoutMs = WORKBENCH_READY_TIMEOUT_MS) {
@@ -2704,6 +2766,61 @@ async function initializeBlankCodexHome({ codexHome, control }) {
     false,
     'Creating a blank Codex home unexpectedly migrated native Codex content'
   )
+}
+
+async function waitForBundledMarketplaceRegistration(codexHome) {
+  const configPath = join(codexHome, 'config.toml')
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < WORKBENCH_READY_TIMEOUT_MS) {
+    if (await pathExists(configPath)) {
+      const config = await readFile(configPath, 'utf8')
+      if (
+        config.includes('[marketplaces.wework-personal]') &&
+        config.includes('source_type = "local"')
+      ) {
+        return
+      }
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
+  }
+  throw new Error('The bundled local plugin marketplace was not registered in the background')
+}
+
+async function verifyStartupIgnoresBlockedCodexNetwork({
+  blockingNetworkProxy,
+  codexNetworkProbeEnabledPath,
+  control,
+  restartDesktopApp,
+}) {
+  await control.command('storeLocalProxyUrl', 'body', { value: blockingNetworkProxy.url })
+  await writeFile(codexNetworkProbeEnabledPath, 'enabled\n', 'utf8')
+  await restartDesktopApp()
+  await control.command('waitFor', '[data-testid="projects-create-button"]', {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  const blockedRequest = await blockingNetworkProxy.waitForRequest()
+  await rm(codexNetworkProbeEnabledPath, { force: true })
+  assert.match(
+    blockedRequest,
+    /^(CONNECT|GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) /,
+    'The blocking proxy did not capture an HTTP request'
+  )
+  blockingNetworkProxy.release()
+  await control.command('click', '[data-testid="plugins-button"]')
+  await control.command('waitFor', '[data-testid="plugins-workspace"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('setLocalProxyUrl', 'body', { value: '' })
+  const snapshot = JSON.parse(await control.command('snapshot', 'body'))
+  assert.ok(
+    snapshot.testIds.includes('desktop-workbench-main'),
+    'Blocked Codex network traffic hid the ready workbench'
+  )
+
+  await control.command('navigate', 'body', { value: '/' })
+  await control.command('waitFor', '[data-testid="projects-create-button"]', {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
 }
 
 async function verifyOfficialPluginSource(repositoryRoot) {
@@ -8720,6 +8837,68 @@ async function writeCodexConfig(
   )
 }
 
+async function createBlockingCodexLauncher(realCodexBinary, expectedProxyUrl, resultDir) {
+  const launcherPath = join(resultDir, 'codex-network-probe.mjs')
+  const enabledPath = join(resultDir, 'codex-network-probe.enabled')
+  await writeFile(
+    launcherPath,
+    `#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { connect } from 'node:net'
+
+const realCodexBinary = ${JSON.stringify(realCodexBinary)}
+const expectedProxyUrl = ${JSON.stringify(expectedProxyUrl)}
+const enabledPath = ${JSON.stringify(enabledPath)}
+const args = process.argv.slice(2)
+let delegated = false
+
+function delegateToRealCodex() {
+  if (delegated) return
+  delegated = true
+  const child = spawn(realCodexBinary, args, {
+    env: process.env,
+    stdio: 'inherit',
+  })
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => child.kill(signal))
+  }
+  child.once('error', error => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  child.once('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(code ?? 1)
+  })
+}
+
+if (!args.includes('app-server') || !existsSync(enabledPath)) {
+  delegateToRealCodex()
+} else {
+  const proxy = new URL(expectedProxyUrl)
+  const socket = connect({
+    host: proxy.hostname,
+    port: Number(proxy.port),
+  })
+  socket.once('connect', () => {
+    socket.write(
+      'CONNECT chatgpt.com:443 HTTP/1.1\\r\\nHost: chatgpt.com:443\\r\\nConnection: keep-alive\\r\\n\\r\\n'
+    )
+  })
+  socket.once('close', delegateToRealCodex)
+  socket.once('error', delegateToRealCodex)
+}
+`,
+    'utf8'
+  )
+  await chmod(launcherPath, 0o755)
+  return { enabledPath, launcherPath }
+}
+
 function codexUpstreamApiFormat(protocol) {
   return protocol === 'responses'
     ? 'openai-responses'
@@ -9533,10 +9712,15 @@ async function main() {
   const modelSwitchVerification = []
   let app
   let appBundlePath
+  let blockingNetworkProxy
   let cloudEnvironment
   let phase = 'startup'
   try {
     await control.start()
+    if (RUNS_PLUGIN_E2E) {
+      blockingNetworkProxy = new BlockingNetworkProxy()
+      await blockingNetworkProxy.start()
+    }
     const codexBinary = await resolveExecutable(
       process.env.CODEX_BIN ?? process.env.CODEX_BINARY_PATH,
       'codex',
@@ -9545,6 +9729,10 @@ async function main() {
     const codexVersion = commandOutput(codexBinary, ['--version'])
     assert.ok(codexVersion.length > 0, 'Real Codex did not return a version')
     console.log(`Using real Codex: ${codexVersion}`)
+    const blockingCodexLauncher = RUNS_PLUGIN_E2E
+      ? await createBlockingCodexLauncher(codexBinary, blockingNetworkProxy.url, resultDir)
+      : null
+    const appCodexBinary = blockingCodexLauncher?.launcherPath ?? codexBinary
 
     const appIdentifier = `io.wecode.wework.e2e.run${process.pid}`
     const executorBinary = await buildExecutor()
@@ -9572,7 +9760,7 @@ async function main() {
 
     const appEnvironment = {
       ...process.env,
-      CODEX_BIN: codexBinary,
+      CODEX_BIN: appCodexBinary,
       HOME: homePath,
       WEGENT_CODEX_HOME: codexHome,
       WEGENT_EXECUTOR_HOME: executorHome,
@@ -9683,12 +9871,14 @@ async function main() {
         codexHome,
         control,
       })
-      await restartDesktopApp(() =>
-        writeCodexConfig(codexHome, control.url, '[features]\nplugins = true')
-      )
-      await control.command('waitFor', '[data-testid="projects-create-button"]', {
-        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      await writeCodexConfig(codexHome, control.url, '[features]\nplugins = true')
+      await verifyStartupIgnoresBlockedCodexNetwork({
+        blockingNetworkProxy,
+        codexNetworkProbeEnabledPath: blockingCodexLauncher.enabledPath,
+        control,
+        restartDesktopApp,
       })
+      await waitForBundledMarketplaceRegistration(codexHome)
     }
     if (SYSTEM_DRAG_PANEL_ONLY) {
       phase = 'system-drag-panel-layout'
@@ -11569,6 +11759,7 @@ async function main() {
     throw error
   } finally {
     await cloudEnvironment?.stop()
+    await blockingNetworkProxy?.stop()
     await stopDesktopAppProcess(app)
     await control.close()
     if (appBundlePath) {

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import {
+  ensureBundledPluginMarketplaceRegistered,
   ensureLocalExecutorStarted,
   getInitializedBundledPluginMarketplace,
   requestLocalExecutor,
@@ -552,6 +553,8 @@ async function readState(
   } = {}
 ): Promise<LocalCodexPluginsState> {
   if (!isTauriRuntime()) return emptyState
+  await ensureLocalExecutorStarted()
+  await ensureBundledPluginMarketplaceRegistered()
   const requestedMarketplaceId = params.marketplaceId?.trim() || selectedMarketplaceId()
   const [availableResponse, installedResponse] = await Promise.all([
     codexAppServerRequest<{

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -17,12 +17,14 @@ import {
   LOCAL_MODEL_SETTINGS_CHANGED_EVENT,
   saveLocalModelConfig,
 } from '@/features/model-settings/localModelSettings'
+import { saveLocalProxyUrl } from '@/features/model-settings/localProxySettings'
 import { saveLocalUserPreferences } from '@/api/local/localSession'
 import { desktopControlExtension } from '@extensions/desktop-control'
 import type { DesktopControlCommand } from '@/extensions/desktop-control-contract'
 import { parseDesktopControlKey } from './desktop-control-keyboard'
 import { getWorkbenchDebugSnapshot } from '@/lib/debugPanel'
 import { getRuntimeConversationCacheStats } from '@/features/workbench/runtimeConversationCache'
+import { LOCAL_EXECUTOR_COMMANDS } from '@/tauri/localExecutor'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -730,6 +732,17 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
     case 'dispatchLocalModelSettingsChanged':
       window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
       return ''
+    case 'storeLocalProxyUrl':
+      return JSON.stringify(saveLocalProxyUrl(command.value?.trim() ?? ''))
+    case 'setLocalProxyUrl': {
+      const proxyUrl = command.value?.trim() ?? ''
+      const config = saveLocalProxyUrl(proxyUrl)
+      await invoke(LOCAL_EXECUTOR_COMMANDS.request, {
+        method: 'runtime.codex.runtime_config.update',
+        params: { proxyUrl: proxyUrl || null },
+      })
+      return JSON.stringify(config)
+    }
     case 'toggleSidebar': {
       const event = new Event('wework:desktop-sidebar-toggle-request', { cancelable: true })
       window.dispatchEvent(event)

--- a/wework/src/features/cloud-connection/CloudConnectionProvider.test.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createHttpClient } from '@/api/http'
@@ -313,6 +313,43 @@ describe('CloudConnectionProvider', () => {
 
     await waitFor(() => expect(httpMocks.get).toHaveBeenCalledWith('/plugins/installed'))
     expect(httpMocks.post).not.toHaveBeenCalled()
+  })
+
+  it('keeps the cached cloud connection when the initial refresh times out', async () => {
+    vi.useFakeTimers()
+    try {
+      saveStoredCloudConnection({
+        backendUrl: 'https://cloud.example.com',
+        apiBaseUrl: 'https://cloud.example.com/api',
+        socketBaseUrl: 'wss://backend-socket.example.com',
+        socketPath: '/socket.io',
+        webUrl: 'https://cloud.example.com',
+        token: 'cloud-token',
+        tokenExpiresAt: null,
+        user: { id: 7, user_name: 'alice', email: 'alice@example.com' },
+        connectedAt: '2026-07-20T00:00:00.000Z',
+      })
+      httpMocks.get.mockReturnValue(new Promise(() => undefined))
+
+      render(
+        <CloudConnectionProvider initializeSitesPlugin={false}>
+          <CloudSocketProbe />
+        </CloudConnectionProvider>
+      )
+
+      expect(screen.getByTestId('cloud-connection-status')).toHaveTextContent('connected')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(8000)
+      })
+
+      expect(screen.getByTestId('cloud-connection-status')).toHaveTextContent('connected')
+      expect(JSON.parse(localStorage.getItem('wework.cloudConnection') || '{}').token).toBe(
+        'cloud-token'
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses the configured Socket URL for the packaged Backend', async () => {

--- a/wework/src/features/cloud-connection/CloudConnectionProvider.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionProvider.tsx
@@ -3,6 +3,7 @@ import { ApiError, createHttpClient } from '@/api/http'
 import { createPluginApi } from '@/api/plugins'
 import { getConfiguredSocketBaseUrl, getRuntimeConfig } from '@/config/runtime'
 import { WEGENT_SITES_PLUGIN_NAME } from '@/features/plugins/builtinPlugins'
+import { raceWithTimeout } from '@/lib/promise-timeout'
 import type { User } from '@/types/api'
 import {
   CloudConnectionContext,
@@ -46,6 +47,7 @@ interface WeworkCloudConfigResponse {
 
 const DEFAULT_AUTH_POLL_INTERVAL_MS = 2000
 const CLOUD_AUTHORIZATION_CLOSED_MESSAGE = '云端授权窗口已关闭，请重新连接'
+const CLOUD_STARTUP_REQUEST_TIMEOUT_MS = 8000
 
 function resolveCloudRuntimeConfig(
   backendUrl: string,
@@ -178,20 +180,27 @@ async function runCloudRequest<T>(
   config: CloudConnectionRuntimeConfig,
   endpoint: string,
   request: () => Promise<T>,
-  options: { preserveErrorCodes?: string[] } = {}
+  options: {
+    preserveErrorCodes?: string[]
+    preserveStatuses?: number[]
+    timeoutMs?: number
+  } = {}
 ): Promise<T> {
   const url = cloudRequestUrl(config, endpoint)
   console.info('[CloudConnection] request start', { stage, url })
   try {
-    const response = await request()
+    const response = await raceWithTimeout(request(), options.timeoutMs, timeoutMs => {
+      return new Error(`Request timed out after ${timeoutMs}ms`)
+    })
     console.info('[CloudConnection] request success', { stage, url })
     return response
   } catch (error) {
     console.error('[CloudConnection] request failed', { stage, url, error })
     if (
       error instanceof ApiError &&
-      typeof error.errorCode === 'string' &&
-      options.preserveErrorCodes?.includes(error.errorCode)
+      ((typeof error.errorCode === 'string' &&
+        options.preserveErrorCodes?.includes(error.errorCode)) ||
+        options.preserveStatuses?.includes(error.status))
     ) {
       throw error
     }
@@ -207,12 +216,20 @@ async function checkCloudHealth(config: CloudConnectionRuntimeConfig): Promise<v
 }
 
 async function fetchCloudConfig(
-  config: CloudConnectionRuntimeConfig
+  config: CloudConnectionRuntimeConfig,
+  timeoutMs?: number
 ): Promise<{ webUrl: string; socketUrl?: string }> {
   const client = createCloudClient(config, null)
-  const metadata = await client.get<WeworkCloudConfigResponse>('/auth/wework/config', {
-    redirectOnUnauthorized: false,
-  })
+  const metadata = await runCloudRequest(
+    '读取云端配置',
+    config,
+    '/auth/wework/config',
+    () =>
+      client.get<WeworkCloudConfigResponse>('/auth/wework/config', {
+        redirectOnUnauthorized: false,
+      }),
+    { timeoutMs }
+  )
   if (typeof metadata.web_url !== 'string' || !metadata.web_url.trim()) {
     throw new Error('Cloud Backend did not provide a Web URL')
   }
@@ -226,10 +243,18 @@ async function fetchCloudConfig(
   }
 }
 
-async function fetchCloudUser(config: CloudConnectionRuntimeConfig, token: string): Promise<User> {
+async function fetchCloudUser(
+  config: CloudConnectionRuntimeConfig,
+  token: string,
+  timeoutMs?: number
+): Promise<User> {
   const client = createCloudClient(config, token)
-  return runCloudRequest('读取云端用户', config, '/users/me', () =>
-    client.get<User>('/users/me', { redirectOnUnauthorized: false })
+  return runCloudRequest(
+    '读取云端用户',
+    config,
+    '/users/me',
+    () => client.get<User>('/users/me', { redirectOnUnauthorized: false }),
+    { preserveStatuses: [401], timeoutMs }
   )
 }
 
@@ -242,7 +267,8 @@ async function ensureCloudSitesPlugin(
     '检查云端 Sites 插件',
     config,
     '/plugins/installed',
-    () => pluginApi.listInstalledPlugins()
+    () => pluginApi.listInstalledPlugins(),
+    { timeoutMs: CLOUD_STARTUP_REQUEST_TIMEOUT_MS }
   )
   const sitesInstalled = installedPlugins.items.some(plugin => {
     const source = plugin.spec.source
@@ -261,7 +287,8 @@ async function ensureCloudSitesPlugin(
     '安装云端 Sites 插件',
     config,
     `/plugins/builtin/${WEGENT_SITES_PLUGIN_NAME}/ensure-installed`,
-    () => pluginApi.ensureBuiltinPluginInstalled(WEGENT_SITES_PLUGIN_NAME)
+    () => pluginApi.ensureBuiltinPluginInstalled(WEGENT_SITES_PLUGIN_NAME),
+    { timeoutMs: CLOUD_STARTUP_REQUEST_TIMEOUT_MS }
   )
 }
 
@@ -362,7 +389,7 @@ export function CloudConnectionProvider({
     if (snapshot.status !== 'connected' || !snapshot.backendUrl) return
     const backendUrl = snapshot.backendUrl
     const config = resolveCloudRuntimeConfig(backendUrl, snapshot.socketBaseUrlOverride)
-    void fetchCloudConfig(config)
+    void fetchCloudConfig(config, CLOUD_STARTUP_REQUEST_TIMEOUT_MS)
       .then(metadata => {
         const resolvedConfig = resolveCloudRuntimeConfig(
           backendUrl,
@@ -516,7 +543,7 @@ export function CloudConnectionProvider({
     }
 
     try {
-      const user = await fetchCloudUser(config, snapshot.token)
+      const user = await fetchCloudUser(config, snapshot.token, CLOUD_STARTUP_REQUEST_TIMEOUT_MS)
       setSnapshot(current => {
         const nextSnapshot = { ...current, status: 'connected' as const, user, error: null }
         persistSnapshot(nextSnapshot)
@@ -524,12 +551,19 @@ export function CloudConnectionProvider({
       })
       return user
     } catch (error) {
-      setSnapshot(current => ({
-        ...current,
-        status: error instanceof ApiError && error.status === 401 ? 'expired' : 'error',
-        token: null,
-        error: getCloudErrorMessage(error),
-      }))
+      setSnapshot(current =>
+        error instanceof ApiError && error.status === 401
+          ? {
+              ...current,
+              status: 'expired',
+              token: null,
+              error: getCloudErrorMessage(error),
+            }
+          : {
+              ...current,
+              error: getCloudErrorMessage(error),
+            }
+      )
       return null
     }
   }, [snapshot])

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -51,6 +51,8 @@ interface UseWorkbenchDataRefreshOptions {
   services: WorkbenchServices
 }
 
+const CLOUD_BACKGROUND_REQUEST_TIMEOUT_MS = 8000
+
 function createCloudRuntimeStateWithCache(runtimeWork: RuntimeWorkListResponse): CloudRuntimeState {
   if (runtimeWork.projects.length === 0 && runtimeWork.chats.length === 0) {
     return EMPTY_CLOUD_RUNTIME_STATE
@@ -320,7 +322,8 @@ export function useWorkbenchDataRefresh({
         const inFlightBackgroundApi = backgroundApi
         const devicesResult = await timedWorkbenchBootstrapRequest(
           'cloudDevices',
-          backgroundApi.listDevices()
+          backgroundApi.listDevices(),
+          CLOUD_BACKGROUND_REQUEST_TIMEOUT_MS
         )
         if (
           options?.isCancelled?.() ||
@@ -353,13 +356,25 @@ export function useWorkbenchDataRefresh({
       const revision = startedState.inFlightRevision
 
       const teamsRequest = backgroundApi?.listTeams
-        ? timedWorkbenchBootstrapRequest('cloudTeams', backgroundApi.listTeams())
+        ? timedWorkbenchBootstrapRequest(
+            'cloudTeams',
+            backgroundApi.listTeams(),
+            CLOUD_BACKGROUND_REQUEST_TIMEOUT_MS
+          )
         : Promise.resolve(undefined)
       const devicesRequest = backgroundApi?.listDevices
-        ? timedWorkbenchBootstrapRequest('cloudDevices', backgroundApi.listDevices())
+        ? timedWorkbenchBootstrapRequest(
+            'cloudDevices',
+            backgroundApi.listDevices(),
+            CLOUD_BACKGROUND_REQUEST_TIMEOUT_MS
+          )
         : Promise.resolve(undefined)
       const runtimeWorkRequest = backgroundApi?.listRuntimeWork
-        ? timedWorkbenchBootstrapRequest('cloudRuntimeWork', backgroundApi.listRuntimeWork())
+        ? timedWorkbenchBootstrapRequest(
+            'cloudRuntimeWork',
+            backgroundApi.listRuntimeWork(),
+            CLOUD_BACKGROUND_REQUEST_TIMEOUT_MS
+          )
         : Promise.resolve(undefined)
       const devicesResult = await devicesRequest
 

--- a/wework/src/features/workbench/workbenchCloudStatus.test.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import type { DeviceInfo, RuntimeDeviceWorkspace, RuntimeWorkListResponse } from '@/types/api'
 import {
   EMPTY_CLOUD_RUNTIME_STATE,
@@ -10,6 +10,7 @@ import {
   selectRuntimeWorkView,
   selectVisibleDevices,
   startCloudRuntimeSync,
+  timedWorkbenchBootstrapRequest,
 } from './workbenchCloudStatus'
 
 function workspace(
@@ -153,6 +154,28 @@ describe('mergeRuntimeWorkLists', () => {
     }
 
     expect(mergeRuntimeWorkLists(localWork, cloudWork).chats).toEqual([])
+  })
+})
+
+describe('timedWorkbenchBootstrapRequest', () => {
+  test('settles an unreachable background request after the configured timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const resultPromise = timedWorkbenchBootstrapRequest(
+        'cloudRuntimeWork',
+        new Promise(() => undefined),
+        8000
+      )
+
+      await vi.advanceTimersByTimeAsync(8000)
+
+      await expect(resultPromise).resolves.toMatchObject({
+        status: 'rejected',
+        reason: new Error('cloudRuntimeWork timed out after 8000ms'),
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/wework/src/features/workbench/workbenchCloudStatus.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.ts
@@ -5,6 +5,7 @@ import {
   isCloudDevice,
   isRemoteDevice,
 } from '@/lib/device-capabilities'
+import { raceWithTimeout } from '@/lib/promise-timeout'
 import type {
   DeviceInfo,
   DeviceRuntimeRoute,
@@ -897,11 +898,14 @@ export function nowMs(): number {
 
 export async function timedWorkbenchBootstrapRequest<T>(
   label: string,
-  request: Promise<T>
+  request: Promise<T>,
+  timeoutMs?: number
 ): Promise<PromiseSettledResult<T>> {
   const startedAt = nowMs()
   try {
-    const value = await request
+    const value = await raceWithTimeout(request, timeoutMs, timeout => {
+      return new Error(`${label} timed out after ${timeout}ms`)
+    })
     const elapsedMs = Math.round(nowMs() - startedAt)
     if (elapsedMs > 5000) {
       console.warn(`[Wework] Workbench bootstrap ${label} completed slowly in ${elapsedMs}ms.`)

--- a/wework/src/lib/promise-timeout.ts
+++ b/wework/src/lib/promise-timeout.ts
@@ -1,0 +1,15 @@
+export function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number | undefined,
+  createTimeoutError: (timeoutMs: number) => unknown
+): Promise<T> {
+  if (timeoutMs == null) return promise
+
+  let timeoutId: number | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(createTimeoutError(timeoutMs)), timeoutMs)
+  })
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId != null) window.clearTimeout(timeoutId)
+  })
+}

--- a/wework/src/tauri/localExecutor.test.ts
+++ b/wework/src/tauri/localExecutor.test.ts
@@ -6,10 +6,12 @@ import {
   LOCAL_EXECUTOR_EVENT,
   connectLocalExecutorToBackend,
   disconnectLocalExecutorFromBackend,
+  ensureBundledPluginMarketplaceRegistered,
   ensureLocalExecutorStarted,
   getLocalExecutorStatus,
   getInitializedBundledPluginMarketplace,
   requestLocalExecutor,
+  resetLocalExecutorStateForTests,
   subscribeLocalExecutorEvents,
 } from './localExecutor'
 
@@ -26,6 +28,7 @@ const listenMock = vi.mocked(listen)
 
 describe('localExecutor', () => {
   beforeEach(() => {
+    resetLocalExecutorStateForTests()
     invokeMock.mockReset()
     listenMock.mockReset()
   })
@@ -51,12 +54,6 @@ describe('localExecutor', () => {
         })
       }
       if (command === LOCAL_EXECUTOR_COMMANDS.request) {
-        const request = invokeMock.mock.calls.at(-1)?.[1] as
-          | { params?: { method?: string } }
-          | undefined
-        if (request?.params?.method === 'plugin/list') {
-          return Promise.resolve({ marketplaces: [] })
-        }
         return Promise.resolve({ marketplaceName: 'wework-personal' })
       }
       return Promise.reject(new Error(`Unexpected command: ${String(command)}`))
@@ -75,38 +72,12 @@ describe('localExecutor', () => {
     })
     expect(invokeMock.mock.calls).toEqual([
       [LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace],
-      [LOCAL_EXECUTOR_COMMANDS.codexHomeMigrationStatus],
       [LOCAL_EXECUTOR_COMMANDS.ensure],
       [
         LOCAL_EXECUTOR_COMMANDS.request,
         {
           method: 'runtime.codex.runtime_config.update',
           params: { proxyUrl: null },
-        },
-      ],
-      [
-        LOCAL_EXECUTOR_COMMANDS.request,
-        {
-          method: 'codex.app_server_request',
-          params: {
-            method: 'plugin/list',
-            params: { cwds: null },
-          },
-        },
-      ],
-      [
-        LOCAL_EXECUTOR_COMMANDS.request,
-        {
-          method: 'codex.app_server_request',
-          params: {
-            method: 'marketplace/add',
-            params: {
-              source:
-                '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal',
-              refName: null,
-              sparsePaths: null,
-            },
-          },
         },
       ],
     ])
@@ -130,19 +101,139 @@ describe('localExecutor', () => {
         })
       }
       if (command === LOCAL_EXECUTOR_COMMANDS.request) {
-        return Promise.resolve({
-          marketplaces: [{ name: 'wework-personal', path: `${path}/` }],
-        })
+        return Promise.resolve({ marketplaceName: 'wework-personal' })
       }
       return Promise.reject(new Error(`Unexpected command: ${String(command)}`))
     })
 
     await ensureLocalExecutorStarted()
 
-    expect(invokeMock).toHaveBeenCalledTimes(5)
+    expect(invokeMock).toHaveBeenCalledTimes(3)
   })
 
-  test('defers bundled marketplace registration until Codex home initialization finishes', async () => {
+  test('does not start bundled marketplace registration before reporting ready', async () => {
+    const path =
+      '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal-background'
+    let finishMarketplaceRegistration: (value: { marketplaceName: string }) => void = () =>
+      undefined
+    const marketplaceRegistration = new Promise<{ marketplaceName: string }>(resolve => {
+      finishMarketplaceRegistration = resolve
+    })
+    invokeMock.mockImplementation(command => {
+      if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {
+        return Promise.resolve({ id: 'wework-personal', path, pluginCount: 0 })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.codexHomeMigrationStatus) {
+        return Promise.resolve({ shouldPromptMigration: false })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.ensure) {
+        return Promise.resolve({
+          running: true,
+          ready: true,
+          deviceId: 'local-device',
+          runtimeInstanceId: 'runtime-background',
+        })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.status) {
+        return Promise.resolve({
+          running: true,
+          ready: true,
+          runtimeInstanceId: 'runtime-background',
+        })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.request) {
+        const request = invokeMock.mock.calls.at(-1)?.[1] as
+          | { params?: { method?: string } }
+          | undefined
+        if (request?.params?.method === 'marketplace/add') {
+          return marketplaceRegistration
+        }
+        return Promise.resolve(undefined)
+      }
+      return Promise.reject(new Error(`Unexpected command: ${String(command)}`))
+    })
+
+    await expect(ensureLocalExecutorStarted()).resolves.toMatchObject({
+      running: true,
+      ready: true,
+      runtimeInstanceId: 'runtime-background',
+    })
+
+    expect(invokeMock).not.toHaveBeenCalledWith(LOCAL_EXECUTOR_COMMANDS.request, {
+      method: 'codex.app_server_request',
+      params: expect.anything(),
+    })
+    const registration = ensureBundledPluginMarketplaceRegistered()
+    finishMarketplaceRegistration({ marketplaceName: 'wework-personal' })
+    await registration
+  })
+
+  test('repairs a stale bundled marketplace using local-only discovery', async () => {
+    const path =
+      '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal-repaired'
+    let addAttempts = 0
+    invokeMock.mockImplementation(command => {
+      if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {
+        return Promise.resolve({ id: 'wework-personal', path, pluginCount: 0 })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.codexHomeMigrationStatus) {
+        return Promise.resolve({ shouldPromptMigration: false })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.ensure) {
+        return Promise.resolve({
+          running: true,
+          ready: true,
+          deviceId: 'local-device',
+          runtimeInstanceId: 'runtime-repaired',
+        })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.status) {
+        return Promise.resolve({
+          running: true,
+          ready: true,
+          runtimeInstanceId: 'runtime-repaired',
+        })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.request) {
+        const request = invokeMock.mock.calls.at(-1)?.[1] as
+          | { params?: { method?: string } }
+          | undefined
+        if (request?.params?.method === 'marketplace/add') {
+          addAttempts += 1
+          return addAttempts === 1
+            ? Promise.reject(new Error('marketplace name already exists'))
+            : Promise.resolve({ marketplaceName: 'wework-personal' })
+        }
+        if (request?.params?.method === 'plugin/list') {
+          return Promise.resolve({
+            marketplaces: [{ name: 'wework-personal', path: '/Users/test/old-marketplace' }],
+          })
+        }
+        if (request?.params?.method === 'marketplace/remove') {
+          return Promise.resolve(undefined)
+        }
+        return Promise.resolve(undefined)
+      }
+      return Promise.reject(new Error(`Unexpected command: ${String(command)}`))
+    })
+
+    await ensureLocalExecutorStarted()
+    await ensureBundledPluginMarketplaceRegistered()
+    expect(addAttempts).toBe(2)
+
+    expect(invokeMock).toHaveBeenCalledWith(LOCAL_EXECUTOR_COMMANDS.request, {
+      method: 'codex.app_server_request',
+      params: {
+        method: 'plugin/list',
+        params: {
+          cwds: null,
+          marketplaceKinds: ['local'],
+        },
+      },
+    })
+  })
+
+  test('defers bundled marketplace registration until it is explicitly requested', async () => {
     const path =
       '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal-deferred'
     let shouldPromptMigration = true
@@ -158,6 +249,13 @@ describe('localExecutor', () => {
           running: true,
           ready: true,
           deviceId: 'local-device',
+          runtimeInstanceId: 'runtime-deferred',
+        })
+      }
+      if (command === LOCAL_EXECUTOR_COMMANDS.status) {
+        return Promise.resolve({
+          running: true,
+          ready: true,
           runtimeInstanceId: 'runtime-deferred',
         })
       }
@@ -185,7 +283,7 @@ describe('localExecutor', () => {
     })
 
     shouldPromptMigration = false
-    await ensureLocalExecutorStarted()
+    await ensureBundledPluginMarketplaceRegistered()
 
     expect(invokeMock).toHaveBeenCalledWith(LOCAL_EXECUTOR_COMMANDS.request, {
       method: 'codex.app_server_request',

--- a/wework/src/tauri/localExecutor.ts
+++ b/wework/src/tauri/localExecutor.ts
@@ -60,14 +60,17 @@ export interface BundledPluginMarketplace {
   pluginCount: number
 }
 
-interface CodexHomeMigrationStatus {
-  shouldPromptMigration: boolean
-}
-
 let ensureLocalExecutorStartedPromise: Promise<LocalExecutorStatus> | null = null
+let initializedLocalExecutorStatus: LocalExecutorStatus | null = null
 let initializedBundledPluginMarketplace: BundledPluginMarketplace | null = null
 let reconciledBundledPluginMarketplaceKey = ''
+let reconcilingBundledPluginMarketplaceKey = ''
+let reconcileBundledPluginMarketplacePromise: Promise<void> | null = null
 let synchronizedCodexRuntimeConfigKey = ''
+
+function isExecutorHealthy(status: LocalExecutorStatus): boolean {
+  return status.running && status.ready !== false && !status.error
+}
 
 async function synchronizeCodexRuntimeConfig(runtimeInstanceId?: string): Promise<void> {
   const proxyUrl = getLocalProxyUrl().trim()
@@ -94,24 +97,48 @@ async function reconcileBundledPluginMarketplace(
   ].join(':')
   if (reconciledBundledPluginMarketplaceKey === reconciliationKey) return
 
-  const available = await invoke<{
-    marketplaces: Array<{ name: string; path?: string | null }>
-  }>(LOCAL_EXECUTOR_COMMANDS.request, {
-    method: 'codex.app_server_request',
-    params: {
-      method: 'plugin/list',
-      params: { cwds: null },
-    },
-  })
-  const existing = available.marketplaces.find(candidate => candidate.name === marketplace.id)
-  if (
-    existing &&
-    normalizedMarketplacePath(existing.path) === normalizedMarketplacePath(marketplace.path)
-  ) {
-    reconciledBundledPluginMarketplaceKey = reconciliationKey
-    return
-  }
-  if (existing) {
+  const addMarketplace = () =>
+    invoke<{ marketplaceName: string }>(LOCAL_EXECUTOR_COMMANDS.request, {
+      method: 'codex.app_server_request',
+      params: {
+        method: 'marketplace/add',
+        params: {
+          source: marketplace.path,
+          refName: null,
+          sparsePaths: null,
+        },
+      },
+    })
+
+  let added: { marketplaceName: string }
+  try {
+    added = await addMarketplace()
+  } catch (addError) {
+    const available = await invoke<{
+      marketplaces: Array<{ name: string; path?: string | null }>
+    }>(LOCAL_EXECUTOR_COMMANDS.request, {
+      method: 'codex.app_server_request',
+      params: {
+        method: 'plugin/list',
+        params: {
+          cwds: null,
+          marketplaceKinds: ['local'],
+        },
+      },
+    })
+    const existing = available.marketplaces.find(candidate => candidate.name === marketplace.id)
+    if (
+      existing &&
+      normalizedMarketplacePath(existing.path) === normalizedMarketplacePath(marketplace.path)
+    ) {
+      reconciledBundledPluginMarketplaceKey = reconciliationKey
+      return
+    }
+    if (!existing) {
+      throw new Error(`Bundled plugin marketplace ${marketplace.id} could not be registered`, {
+        cause: addError,
+      })
+    }
     await invoke(LOCAL_EXECUTOR_COMMANDS.request, {
       method: 'codex.app_server_request',
       params: {
@@ -119,24 +146,45 @@ async function reconcileBundledPluginMarketplace(
         params: { marketplaceName: marketplace.id },
       },
     })
+    added = await addMarketplace()
   }
-  const added = await invoke<{ marketplaceName: string }>(LOCAL_EXECUTOR_COMMANDS.request, {
-    method: 'codex.app_server_request',
-    params: {
-      method: 'marketplace/add',
-      params: {
-        source: marketplace.path,
-        refName: null,
-        sparsePaths: null,
-      },
-    },
-  })
   if (added.marketplaceName !== marketplace.id) {
     throw new Error(
       `Bundled plugin marketplace resolved to ${added.marketplaceName || 'an unknown name'}`
     )
   }
   reconciledBundledPluginMarketplaceKey = reconciliationKey
+}
+
+export async function ensureBundledPluginMarketplaceRegistered(): Promise<void> {
+  const marketplace = initializedBundledPluginMarketplace
+  const status = initializedLocalExecutorStatus
+  if (!marketplace || !status) return
+  if (!isExecutorHealthy(status)) return
+  const reconciliationKey = [
+    status.runtimeInstanceId || 'current-runtime',
+    normalizedMarketplacePath(marketplace.path),
+  ].join(':')
+  if (
+    reconciledBundledPluginMarketplaceKey === reconciliationKey ||
+    (reconcilingBundledPluginMarketplaceKey === reconciliationKey &&
+      reconcileBundledPluginMarketplacePromise)
+  ) {
+    return reconcileBundledPluginMarketplacePromise ?? Promise.resolve()
+  }
+
+  reconcilingBundledPluginMarketplaceKey = reconciliationKey
+  const reconciliation = reconcileBundledPluginMarketplace(
+    marketplace,
+    status.runtimeInstanceId
+  ).finally(() => {
+    if (reconcileBundledPluginMarketplacePromise === reconciliation) {
+      reconcileBundledPluginMarketplacePromise = null
+      reconcilingBundledPluginMarketplaceKey = ''
+    }
+  })
+  reconcileBundledPluginMarketplacePromise = reconciliation
+  return reconciliation
 }
 
 export function getInitializedBundledPluginMarketplace(): BundledPluginMarketplace | null {
@@ -150,20 +198,10 @@ export function ensureLocalExecutorStarted(): Promise<LocalExecutorStatus> {
         LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace
       )
       initializedBundledPluginMarketplace = marketplace
-      const migrationStatus = await invoke<CodexHomeMigrationStatus>(
-        LOCAL_EXECUTOR_COMMANDS.codexHomeMigrationStatus
-      )
       const status = await invoke<LocalExecutorStatus>(LOCAL_EXECUTOR_COMMANDS.ensure)
-      if (status.running && status.ready !== false && !status.error) {
+      initializedLocalExecutorStatus = status
+      if (isExecutorHealthy(status)) {
         await synchronizeCodexRuntimeConfig(status.runtimeInstanceId)
-      }
-      if (
-        !migrationStatus.shouldPromptMigration &&
-        status.running &&
-        status.ready !== false &&
-        !status.error
-      ) {
-        await reconcileBundledPluginMarketplace(marketplace, status.runtimeInstanceId)
       }
       return status
     })().finally(() => {
@@ -172,6 +210,16 @@ export function ensureLocalExecutorStarted(): Promise<LocalExecutorStatus> {
   }
 
   return ensureLocalExecutorStartedPromise
+}
+
+export function resetLocalExecutorStateForTests(): void {
+  ensureLocalExecutorStartedPromise = null
+  initializedLocalExecutorStatus = null
+  initializedBundledPluginMarketplace = null
+  reconciledBundledPluginMarketplaceKey = ''
+  reconcilingBundledPluginMarketplaceKey = ''
+  reconcileBundledPluginMarketplacePromise = null
+  synchronizedCodexRuntimeConfigKey = ''
 }
 
 export function getLocalExecutorStatus(): Promise<LocalExecutorStatus> {


### PR DESCRIPTION
## Summary
- keep cloud bootstrap requests from blocking the local workbench shell
- defer the bundled Codex plugin marketplace registration until the plugin workspace is opened
- add a real Tauri blackhole-proxy regression test that verifies network connections cannot hide the ready workbench

## Root cause
Codex app-server starts an online model refresh worker immediately. Startup-time marketplace reconciliation launched app-server before the workbench shell was ready, so an unreachable overseas endpoint could hold startup open.

## Verification
- `pnpm --filter wework e2e:desktop:plugins -- --segment plugin-lifecycle`
- Wework pre-push: ESLint, TypeScript, and all 2,425 unit tests
- focused unit tests and TypeScript checks after rebasing onto latest main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud connection and background data refresh reliability with configurable request timeouts.
  * Preserved cached cloud connection/token when initial refresh times out.
  * Refined authentication handling so only HTTP 401 expires the sign-in token.

* **Improvements**
  * Strengthened bundled plugin marketplace setup with better recovery from stale registrations and improved readiness sequencing.
  * Enhanced desktop plugin E2E coverage using a local network proxy to validate blocked networking behavior and startup timing.
  * Added support for persisting and applying the local proxy URL during automation.

* **Tests**
  * Updated/added cloud, workbench, local-executor, and desktop E2E tests for new timeout, initialization, and proxy flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->