### PR TITLE
fix(executor): retry empty Anthropic responses

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
@@ -42,6 +42,12 @@ When the upstream has not started a response stream and the model service return
 
 If the upstream returns a standard `Retry-After` header, the proxy uses that delay instead, capped at 60 seconds for one wait. Non-429 responses do not activate this policy. After the retry budget is exhausted, the proxy returns the final 429 status and error body to Codex. A stream that has already started is never replayed by this mechanism, preventing duplicate generation or tool execution.
 
+### Anthropic Empty-Output Recovery
+
+Some Anthropic Messages-compatible services may return a stop reason and positive `output_tokens` in `message_delta` without sending any text, thinking content, or tool call. The executor Codex compatibility proxy converts this incomplete response into a failure event instead of incorrectly emitting a successful completion. Codex can then retry the current model request through its stream-error recovery path, preventing Wework from ending the task without an assistant response.
+
+This check activates only when no model output has been observed. Responses that already produced text, thinking content, or a tool call are not replayed, and valid connection-prewarm responses with zero `output_tokens` remain unaffected.
+
 ### Namespace Tool Compatibility
 
 Codex can group child tools under a `type: "namespace"` tool when it sends an OpenAI Responses request. OpenAI Chat Completions and Anthropic Messages have no equivalent namespace field, so the executor Codex compatibility proxy applies a reversible mapping at the protocol boundary:

--- a/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
@@ -42,6 +42,12 @@ executor 的 Codex compat proxy 在上游尚未开始返回响应流、且模型
 
 如果上游返回标准 `Retry-After` 响应头，proxy 会优先采用该等待时间，并将单次等待限制在 60 秒以内。非 429 响应不会触发这项策略；重试耗尽后，proxy 会把最后一次 429 状态和错误正文返回给 Codex。已经开始输出的流不会通过这项机制重放，避免重复生成或重复执行工具。
 
+### Anthropic 空输出恢复
+
+部分 Anthropic Messages 兼容服务可能在 `message_delta` 中返回结束原因和大于零的 `output_tokens`，却没有发送任何文本、思考内容或工具调用。executor 的 Codex compat proxy 会把这种不完整响应转换为失败事件，而不是错误地发出成功完成事件。Codex 随后按流错误恢复机制重试当前模型请求，避免 Wework 在没有 assistant 回复时提前结束任务。
+
+只有完全没有观察到模型输出时才会触发这项检查。已经收到文本、思考内容或工具调用的响应不会被重放；用于连接预热且 `output_tokens` 为零的合法空响应也不受影响。
+
 ### Namespace 工具兼容
 
 Codex 向 OpenAI Responses API 发送工具时，可以使用 `type: "namespace"` 把多个子工具组织在同一个 namespace 下。OpenAI Chat Completions 和 Anthropic Messages 没有对应的 namespace 字段，因此 executor 的 Codex compat proxy 会在协议转换边界执行可逆映射：

--- a/executor/src/server/local_model_proxy/anthropic.rs
+++ b/executor/src/server/local_model_proxy/anthropic.rs
@@ -194,6 +194,7 @@ struct AnthropicStreamState<S> {
     model: String,
     input_tokens: u64,
     output_tokens: u64,
+    output_observed: bool,
 }
 
 pub(super) fn anthropic_sse_to_responses<S, E>(
@@ -213,6 +214,7 @@ where
         model: String::new(),
         input_tokens: 0,
         output_tokens: 0,
+        output_observed: false,
     };
     chat::chat_sse_to_responses(anthropic_to_chat_stream(state).fuse(), context)
 }
@@ -350,6 +352,22 @@ impl<S> AnthropicStreamState<S> {
                     .and_then(Value::as_u64)
                     .unwrap_or(self.output_tokens);
                 let upstream_stop = event.pointer("/delta/stop_reason").and_then(Value::as_str);
+                if upstream_stop.is_some() && self.output_tokens > 0 && !self.output_observed {
+                    log_executor_event(
+                        "local model proxy anthropic empty response",
+                        &[
+                            ("output_tokens", self.output_tokens.to_string()),
+                            ("stop_reason", upstream_stop.unwrap_or_default().to_owned()),
+                        ],
+                    );
+                    self.emit(json!({
+                        "error": {
+                            "type": "upstream_empty_response",
+                            "message": "Anthropic upstream reported output tokens without returning content"
+                        }
+                    }));
+                    return;
+                }
                 let stop = upstream_stop.map(anthropic_finish_reason);
                 if let Some(upstream_stop) = upstream_stop {
                     log_executor_event(
@@ -378,6 +396,7 @@ impl<S> AnthropicStreamState<S> {
         let index = event.get("index").and_then(Value::as_u64).unwrap_or(0);
         let block = event.get("content_block").unwrap_or(&Value::Null);
         if block.get("type").and_then(Value::as_str) == Some("tool_use") {
+            self.output_observed = true;
             log_executor_event(
                 "local model proxy anthropic tool use",
                 &[
@@ -405,12 +424,27 @@ impl<S> AnthropicStreamState<S> {
         let index = event.get("index").and_then(Value::as_u64).unwrap_or(0);
         let delta = event.get("delta").unwrap_or(&Value::Null);
         let chat_delta = match delta.get("type").and_then(Value::as_str) {
-            Some("text_delta") => json!({"content": delta.get("text")}),
-            Some("thinking_delta") => json!({"reasoning_content": delta.get("thinking")}),
-            Some("input_json_delta") => json!({"tool_calls": [{
-                "index": index,
-                "function": {"arguments": delta.get("partial_json")}
-            }]}),
+            Some("text_delta") => {
+                self.output_observed |= delta
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.is_empty());
+                json!({"content": delta.get("text")})
+            }
+            Some("thinking_delta") => {
+                self.output_observed |= delta
+                    .get("thinking")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.is_empty());
+                json!({"reasoning_content": delta.get("thinking")})
+            }
+            Some("input_json_delta") => {
+                self.output_observed = true;
+                json!({"tool_calls": [{
+                    "index": index,
+                    "function": {"arguments": delta.get("partial_json")}
+                }]})
+            }
             _ => return,
         };
         self.emit(json!({"choices": [{"delta": chat_delta}]}));
@@ -628,6 +662,32 @@ mod tests {
 
         assert!(output.contains("实现成本主要在 UI。"));
         assert!(!output.contains('\u{fffd}'));
+    }
+
+    #[tokio::test]
+    async fn fails_when_anthropic_reports_tokens_without_output() {
+        let events = [
+            json!({"type":"message_start","message":{"id":"msg_1","model":"kimi-k2.5","usage":{"input_tokens":1}}}),
+            json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":157}}),
+            json!({"type":"message_stop"}),
+        ];
+        let source = futures_util::stream::iter(
+            events
+                .into_iter()
+                .map(|event| Ok::<_, std::io::Error>(Bytes::from(format!("data: {event}\n\n")))),
+        );
+
+        let output = anthropic_sse_to_responses(source, ToolContext::default())
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .collect::<String>();
+
+        assert!(output.contains("response.failed"));
+        assert!(output.contains("reported output tokens without returning content"));
+        assert!(!output.contains("response.completed"));
     }
 
     #[tokio::test]

--- a/executor/src/server/local_model_proxy/anthropic.rs
+++ b/executor/src/server/local_model_proxy/anthropic.rs
@@ -691,6 +691,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completes_zero_token_anthropic_response_without_output() {
+        let events = [
+            json!({"type":"message_start","message":{"id":"msg_1","model":"kimi-k2.5","usage":{"input_tokens":1}}}),
+            json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}),
+            json!({"type":"message_stop"}),
+        ];
+        let source = futures_util::stream::iter(
+            events
+                .into_iter()
+                .map(|event| Ok::<_, std::io::Error>(Bytes::from(format!("data: {event}\n\n")))),
+        );
+
+        let output = anthropic_sse_to_responses(source, ToolContext::default())
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .collect::<String>();
+
+        assert!(output.contains("response.completed"));
+        assert!(!output.contains("response.failed"));
+    }
+
+    #[tokio::test]
     async fn restores_namespace_on_anthropic_tool_calls() {
         let events = [
             json!({"type":"message_start","message":{"id":"msg_1","model":"kimi-for-coding","usage":{"input_tokens":1}}}),

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -8721,7 +8721,7 @@ class DesktopE2EServer {
         {
           type: 'message_delta',
           delta: { stop_reason: 'end_turn', stop_sequence: null },
-          usage: { output_tokens: 1 },
+          usage: { output_tokens: text ? 1 : 0 },
         },
       ],
       ['message_stop', { type: 'message_stop' }],

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -125,6 +125,9 @@ const RETRY_CODEX_ERROR_TEXT = "Codex ran out of room in the model's context win
 const RETRY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RETRY_COMPLETE'
 const RATE_LIMIT_PROMPT = 'WEWORK_DESKTOP_E2E_RATE_LIMIT: recover from one model 429.'
 const RATE_LIMIT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RATE_LIMIT_COMPLETE'
+const ANTHROPIC_EMPTY_PROMPT =
+  'WEWORK_DESKTOP_E2E_ANTHROPIC_EMPTY: recover when Kimi reports tokens without output.'
+const ANTHROPIC_EMPTY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_ANTHROPIC_EMPTY_COMPLETE'
 const RECONNECT_PROMPT = 'WEWORK_DESKTOP_E2E_RECONNECT: recover after the stream disconnects.'
 const RECONNECT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RECONNECT_COMPLETE'
 const MEMORY_PROMPT = 'WEWORK_DESKTOP_E2E_MEMORY: run a tool and stream the report.'
@@ -4723,6 +4726,49 @@ async function verifyRateLimitRecovery({ composerSelector, control }) {
   )
 }
 
+async function verifyAnthropicEmptyResponseRecovery({ composerSelector, control }) {
+  const anthropicModel = CLOUD_MODEL_CASES.find(model => model.protocol === 'anthropic')
+  assert.ok(anthropicModel, 'The Anthropic cloud model fixture is missing')
+  control.setScenario('anthropic_empty_response')
+  await control.command('click', '[data-testid="new-chat-button"]')
+  await control.command('waitFor', composerSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await selectE2EModel(control, anthropicModel.optionId, anthropicModel.label)
+  await sendPromptUntilScenarioRequest(
+    control,
+    composerSelector,
+    ANTHROPIC_EMPTY_PROMPT,
+    'anthropic_empty_response'
+  )
+  await withTimeout(
+    control.awaitScenarioRequestCount('anthropic_empty_response', 2),
+    DEFAULT_STEP_TIMEOUT_MS,
+    'Codex did not retry the empty Anthropic response'
+  )
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    { text: ANTHROPIC_EMPTY_COMPLETION_TEXT, timeoutMs: DEFAULT_STEP_TIMEOUT_MS }
+  )
+  assert.equal(
+    control.scenarioRequests.get('anthropic_empty_response')?.length,
+    2,
+    'The empty Anthropic response did not recover with exactly one retry'
+  )
+  const recoveredSnapshot = JSON.parse(await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR))
+  assert.equal(
+    recoveredSnapshot.testIds.includes('assistant-error-card'),
+    false,
+    'The recovered Anthropic response rendered an assistant error'
+  )
+  await captureVerificationScreenshot(
+    control,
+    'anthropic-empty-01-recovered.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+}
+
 function createSse(events) {
   return events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
 }
@@ -6023,6 +6069,7 @@ class DesktopE2EServer {
         'queue_management',
         'retry',
         'rate_limit',
+        'anthropic_empty_response',
         'reconnect',
         'checkpoint_task',
         'fresh_chat',
@@ -6557,6 +6604,52 @@ class DesktopE2EServer {
 
     if (requestKind === 'prewarm') {
       this.writeSse(response, [responseCreated(responseId), responseCompleted(responseId)])
+      return
+    }
+
+    if (this.scenario === 'anthropic_empty_response') {
+      assert.equal(protocol, 'anthropic', 'The empty-response regression used the wrong protocol')
+      assert.equal(
+        body.model,
+        CLOUD_MODEL_CASES.find(model => model.protocol === 'anthropic')?.modelId,
+        'The empty-response regression used the wrong cloud model'
+      )
+      this.recordScenarioRequest('anthropic_empty_response', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(ANTHROPIC_EMPTY_PROMPT),
+        'The Anthropic empty-response request lost the user prompt'
+      )
+      const requests = this.scenarioRequests.get('anthropic_empty_response') ?? []
+      if (requests.length === 1) {
+        this.writeAnthropicSse(response, [
+          [
+            'message_start',
+            {
+              type: 'message_start',
+              message: {
+                id: 'anthropic-empty-response',
+                type: 'message',
+                role: 'assistant',
+                content: [],
+                model: 'kimi-k2.5',
+                stop_reason: null,
+                usage: { input_tokens: 1, output_tokens: 0 },
+              },
+            },
+          ],
+          [
+            'message_delta',
+            {
+              type: 'message_delta',
+              delta: { stop_reason: 'end_turn', stop_sequence: null },
+              usage: { output_tokens: 157 },
+            },
+          ],
+          ['message_stop', { type: 'message_stop' }],
+        ])
+        return
+      }
+      this.writeAnthropicMessage(response, ANTHROPIC_EMPTY_COMPLETION_TEXT)
       return
     }
 
@@ -9195,6 +9288,8 @@ async function verifyCloudProjectFlow(control, cloudEnvironment, workspacePath) 
     'The cloud follow-up task did not settle before project removal'
   )
   await captureVerificationScreenshot(control, 'cloud-06-follow-up-completed.png')
+
+  await verifyAnthropicEmptyResponseRecovery({ composerSelector, control })
 
   await verifyModelProtocolMatrix({
     cases: REMOTE_MODEL_PROTOCOL_MATRIX_CASES,


### PR DESCRIPTION
## Summary

- detect malformed Anthropic streams that report positive output tokens without returning text, thinking, or tool content
- surface the malformed stream as a retryable Responses failure instead of completing an empty assistant turn
- add a real cloud Wework desktop E2E regression that reproduces the Kimi K2.5 response shape and verifies recovery on the next request
- preserve valid zero-token empty acknowledgements used by compaction and connection-prewarm flows
- document the Anthropic empty-output recovery behavior in Chinese and English

## Root cause

Kimi K2.5 returned `stop_reason=end_turn` and `output_tokens=157`, but emitted no content blocks or deltas. The Anthropic compatibility adapter treated that stream as a successful completion, so Codex completed the turn and Wework showed a finished task without an assistant response.

## Verification

- `cargo test --lib server::local_model_proxy::anthropic::tests` (11 passed)
- `cargo fmt --check`
- `pnpm exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `node --check e2e/desktop/task-flow.e2e.mjs`
- real cloud Tauri E2E regression: first empty Anthropic response produced `Reconnecting... 1/5`, the second request completed with `WEWORK_DESKTOP_E2E_ANTHROPIC_EMPTY_COMPLETE` and no assistant error card
- `pnpm --filter wework e2e:desktop` passed after correcting the zero-token Anthropic compaction fixture exposed by the first CI run
- pre-push: Wework ESLint, TypeScript, and unit tests; Executor `cargo fmt`, `cargo test --all-features --lib`, and Clippy

## CI follow-up

The first Wework Core Desktop E2E run exposed an inconsistent test fixture: an empty Anthropic compaction acknowledgement reported `output_tokens: 1`. The fixture now reports zero output tokens when its text is empty, and a Rust regression test locks in the distinction between valid zero-token empty responses and malformed positive-token empty responses.

## Impact

Valid Anthropic responses, tool calls, and zero-token connection-prewarm or compaction responses retain their existing behavior. Only streams claiming positive output tokens while producing no observable model output are converted to a retryable failure.