### PR TITLE
fix(executor): raise macOS open file limit

### DIFF
--- a/executor/src/bin/wegent-executor.rs
+++ b/executor/src/bin/wegent-executor.rs
@@ -6,7 +6,71 @@ use std::env;
 
 use wegent_executor::app::cli::CliArgs;
 
+#[cfg(any(target_os = "macos", test))]
+const OPEN_FILES_SOFT_LIMIT: libc::rlim_t = 65_536;
+
+#[cfg(any(target_os = "macos", test))]
+fn open_files_soft_limit_target(
+    hard_limit: libc::rlim_t,
+    kernel_limit: Option<libc::rlim_t>,
+) -> libc::rlim_t {
+    let target = OPEN_FILES_SOFT_LIMIT.min(hard_limit);
+    kernel_limit.map_or(target, |limit| target.min(limit))
+}
+
+#[cfg(target_os = "macos")]
+fn raise_open_files_soft_limit() {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) };
+    if result != 0 {
+        eprintln!(
+            "failed to read wegent-executor open files limit: {}",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+
+    let target = open_files_soft_limit_target(limit.rlim_max, macos_max_files_per_process());
+    if limit.rlim_cur >= target {
+        return;
+    }
+
+    let previous = limit.rlim_cur;
+    limit.rlim_cur = target;
+    let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) };
+    if result != 0 {
+        eprintln!(
+            "failed to raise wegent-executor open files soft limit from {previous} to {target}: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_max_files_per_process() -> Option<libc::rlim_t> {
+    let name = b"kern.maxfilesperproc\0";
+    let mut value: libc::c_int = 0;
+    let mut value_size = std::mem::size_of_val(&value);
+    let result = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr().cast(),
+            (&mut value as *mut libc::c_int).cast(),
+            &mut value_size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (result == 0 && value > 0).then_some(value as libc::rlim_t)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn raise_open_files_soft_limit() {}
+
 fn main() {
+    raise_open_files_soft_limit();
     install_termination_signal_diagnostics();
     if wegent_executor::connector_mcp::is_connector_mcp_command() {
         if let Err(error) = runtime().block_on(wegent_executor::connector_mcp::run()) {
@@ -135,5 +199,31 @@ fn append_signal_number(buffer: &mut [u8], length: &mut usize, value: libc::pid_
     }
     for digit in digits[..digit_count].iter().rev() {
         append_signal_text(buffer, length, &[*digit]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_files_target_uses_configured_limit_when_supported() {
+        assert_eq!(
+            open_files_soft_limit_target(libc::RLIM_INFINITY, Some(245_760)),
+            OPEN_FILES_SOFT_LIMIT
+        );
+    }
+
+    #[test]
+    fn open_files_target_respects_process_hard_limit() {
+        assert_eq!(open_files_soft_limit_target(4_096, Some(245_760)), 4_096);
+    }
+
+    #[test]
+    fn open_files_target_respects_macos_kernel_limit() {
+        assert_eq!(
+            open_files_soft_limit_target(libc::RLIM_INFINITY, Some(24_576)),
+            24_576
+        );
     }
 }

--- a/executor/src/bin/wegent-executor.rs
+++ b/executor/src/bin/wegent-executor.rs
@@ -63,7 +63,15 @@ fn macos_max_files_per_process() -> Option<libc::rlim_t> {
             0,
         )
     };
-    (result == 0 && value > 0).then_some(value as libc::rlim_t)
+    if result != 0 {
+        eprintln!(
+            "failed to read macOS max open files per process: {}",
+            std::io::Error::last_os_error()
+        );
+        return None;
+    }
+
+    (value > 0).then_some(value as libc::rlim_t)
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## What changed

- Raise the macOS `wegent-executor` soft `RLIMIT_NOFILE` value to 65,536 during process startup.
- Clamp the requested value to both the process hard limit and macOS `kern.maxfilesperproc`.
- Keep other operating systems unchanged and report system-call failures without preventing startup.
- Add unit coverage for configured, process-hard-limit, and macOS-kernel-limit cases.

## Why

Wework launches `wegent-executor` with the macOS launchd default soft open-file limit of 256. The executor owns long-lived sockets, file watchers, PTYs, MCP processes, and agent subprocesses, so it can approach or reach that per-process limit even when the macOS global file table still has capacity.

Raising the limit in the executor entry point fixes the process that owns these resources and ensures its child processes inherit the higher soft limit.

## Impact

macOS executor sessions have substantially more file-descriptor headroom. The configured target remains bounded by the limits supported by the host.

## Validation

- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executor reliability on macOS and test environments by automatically increasing the process limit for open files when supported.
  * Safely respects system-imposed limits and reports errors if the adjustment cannot be applied.

* **Tests**
  * Added coverage for open-file limit calculations across configured, process, and macOS kernel limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->