### PR TITLE
fix(wework): enable goal feature for remote/cloud devices

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/lib/workspace-target'
 import {
   WEWORK_MIN_EXECUTOR_VERSION,
+  isClaudeCodeDevice,
   isDeviceBelowWeWorkVersion,
   isWeWorkCompatibleDevice,
   isCloudDevice,
@@ -1420,9 +1421,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const hasConversation = paneMessages.length > 0 || currentRuntimeTask
   const hasMainBackground = Boolean(background.imagePath && background.inMain)
   const activeDevice = findWorkbenchDevice(devices, activeDeviceId)
-  const activeDeviceSupportsGoal = Boolean(
-    activeDevice?.device_type === 'local' || activeDeviceId === 'local-device'
-  )
+  const activeDeviceSupportsGoal = Boolean(activeDevice && isClaudeCodeDevice(activeDevice))
   const currentRuntimeTaskSupportsGoal = Boolean(currentRuntimeTask && activeDeviceSupportsGoal)
   const canEditLastUserMessage = Boolean(
     currentRuntimeTask && activeDeviceSupportsGoal && !paneSession.status.isBusy


### PR DESCRIPTION
Allow goal slash command to be shown on all ClaudeCode-compatible devices, not just local devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal-related behavior detection for supported devices by using a shared device capability check.
  * Updated whether the last user message is editable to stay consistent with device goal support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->