### PR TITLE
chore(ci): run executor tests on larger runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
     name: Test Executor
     needs: changes
     if: needs.changes.outputs.executor == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 45
     permissions:
       contents: read
@@ -122,11 +122,6 @@ jobs:
 
       - name: Configure executor target directory
         run: echo "CARGO_TARGET_DIR=$RUNNER_TEMP/executor-target" >> "$GITHUB_ENV"
-
-      - name: Free executor runner disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          df -h
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8


### PR DESCRIPTION
## What changed

- run the Executor test job on the `ubuntu-latest-m` 4-core larger runner
- remove the standard-runner disk cleanup step, since the larger runner provides 150 GB of storage

## Why

Recent CI timing showed `Test Executor` as the clearest execution bottleneck. The other test, lint, and E2E jobs remain on the free standard runners to minimize paid Actions usage.

## Runner configuration

- repository access: `wecode-ai/Wegent` only
- public repository access: enabled
- workflow access: all workflows
- maximum runner concurrency: 10
- Actions budget: $10/month with a hard stop

## Validation

- `actionlint -ignore 'label "ubuntu-latest-m" is unknown' .github/workflows/test.yml`
- `scripts/test-repository-policy-workflow.sh`
- `.github/scripts/test-classify-ci-changes.sh`
- `git diff --check`
