### PR TITLE
fix(wework): render created file diff as additions

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -738,7 +738,7 @@ function fileDiffPreviewLines(
 ): DiffPreviewLine[] {
   if (file.binary || !summary.diff?.trim()) return []
   const sectionLines = fileDiffLines(file, summary)
-  return parseDiffPreviewLines(sectionLines)
+  return parseDiffPreviewLines(sectionLines, file.change_type)
 }
 
 function fileDiffLines(file: TurnFileChangeItem, summary: TurnFileChangesSummary): string[] {
@@ -763,7 +763,10 @@ function pathsMatch(left: string | undefined, right: string | undefined): boolea
   return left === right || left.endsWith(`/${right}`) || right.endsWith(`/${left}`)
 }
 
-function parseDiffPreviewLines(lines: string[]): DiffPreviewLine[] {
+function parseDiffPreviewLines(
+  lines: string[],
+  changeType: TurnFileChangeItem['change_type']
+): DiffPreviewLine[] {
   const previewLines: DiffPreviewLine[] = []
   let oldLine: number | undefined
   let newLine: number | undefined
@@ -800,8 +803,8 @@ function parseDiffPreviewLines(lines: string[]): DiffPreviewLine[] {
     if (prefix === '+') {
       previewLines.push({
         key: `addition-${index}`,
-        type: 'addition',
-        lineNumber: newLine,
+        type: diffPreviewLineType(prefix, changeType),
+        lineNumber: changeType === 'deleted' ? (oldLine ?? newLine) : (newLine ?? oldLine),
         content: rawLine.slice(1),
       })
       if (newLine !== undefined) newLine += 1
@@ -810,8 +813,8 @@ function parseDiffPreviewLines(lines: string[]): DiffPreviewLine[] {
     if (prefix === '-') {
       previewLines.push({
         key: `deletion-${index}`,
-        type: 'deletion',
-        lineNumber: oldLine,
+        type: diffPreviewLineType(prefix, changeType),
+        lineNumber: changeType === 'created' ? (newLine ?? oldLine) : (oldLine ?? newLine),
         content: rawLine.slice(1),
       })
       if (oldLine !== undefined) oldLine += 1
@@ -829,6 +832,17 @@ function parseDiffPreviewLines(lines: string[]): DiffPreviewLine[] {
   })
 
   return previewLines
+}
+
+function diffPreviewLineType(
+  prefix: '+' | '-',
+  changeType: TurnFileChangeItem['change_type']
+): DiffPreviewLine['type'] {
+  // Runtime patches can be reversed, but the file summary remains the
+  // authoritative semantic direction for whole-file creation and deletion.
+  if (changeType === 'created') return 'addition'
+  if (changeType === 'deleted') return 'deletion'
+  return prefix === '+' ? 'addition' : 'deletion'
 }
 
 function basename(path: string): string {

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -804,7 +804,7 @@ function parseDiffPreviewLines(
       previewLines.push({
         key: `addition-${index}`,
         type: diffPreviewLineType(prefix, changeType),
-        lineNumber: changeType === 'deleted' ? (oldLine ?? newLine) : (newLine ?? oldLine),
+        lineNumber: newLine ?? oldLine,
         content: rawLine.slice(1),
       })
       if (newLine !== undefined) newLine += 1
@@ -814,7 +814,7 @@ function parseDiffPreviewLines(
       previewLines.push({
         key: `deletion-${index}`,
         type: diffPreviewLineType(prefix, changeType),
-        lineNumber: changeType === 'created' ? (newLine ?? oldLine) : (oldLine ?? newLine),
+        lineNumber: oldLine ?? newLine,
         content: rawLine.slice(1),
       })
       if (oldLine !== undefined) oldLine += 1

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -492,6 +492,7 @@ describe('ToolBlocksDisplay', () => {
     const content = screen.getByText('课程标题：云端工作模式实战')
     const line = content.parentElement
 
+    expect(line?.firstElementChild).toHaveTextContent('1')
     expect(line).toHaveClass('border-green-500', 'bg-green-500/10')
     expect(line).not.toHaveClass('border-red-500', 'bg-red-500/10')
   })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -453,6 +453,49 @@ describe('ToolBlocksDisplay', () => {
     ).toBeInTheDocument()
   })
 
+  test('renders reversed diff lines for a created file as additions', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            ...completedFileChangesBlock,
+            fileChanges: {
+              ...completedFileChangesBlock.fileChanges,
+              additions: 1,
+              deletions: 0,
+              files: [
+                {
+                  path: 'shot-list.md',
+                  change_type: 'created',
+                  additions: 1,
+                  deletions: 0,
+                  binary: false,
+                },
+              ],
+              diff: [
+                'diff --git a/shot-list.md b/shot-list.md',
+                '--- a/shot-list.md',
+                '+++ /dev/null',
+                '@@ -1 +0,0 @@',
+                '-课程标题：云端工作模式实战',
+              ].join('\n'),
+            },
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /编辑 1 个文件 已处理/ }))
+    fireEvent.click(screen.getByRole('button', { name: /创建 shot-list.md/ }))
+
+    const content = screen.getByText('课程标题：云端工作模式实战')
+    const line = content.parentElement
+
+    expect(line).toHaveClass('border-green-500', 'bg-green-500/10')
+    expect(line).not.toHaveClass('border-red-500', 'bg-red-500/10')
+  })
+
   test('shows each file change duration from its matching edit tool', () => {
     const firstEdit: ProcessingBlock = {
       id: 'edit-first',


### PR DESCRIPTION
## What changed

- Treat the file summary change type as authoritative for whole-file creation and deletion in inline diff previews.
- Render reversed patch lines for created files with addition semantics and green styling.
- Add a regression test covering a created file whose runtime patch is reversed.

## Root cause

The inline preview derived each line color only from the raw patch prefix. Some runtime-created file patches arrive in reverse orientation, so their content lines start with `-` even though the file summary reports `created`, `+N`, and `-0`.

## Impact

Newly created file content now matches its semantic status and statistics: additions are displayed in green instead of red. Modified-file line coloring remains prefix-based.

## Validation

- `pnpm --filter wework test` (247 files, 2442 tests passed)
- `pnpm --filter wework typecheck`
- Prettier and ESLint on changed files
- Isolated real-Tauri flow created a file and confirmed the runtime emitted `created`, `+1`, `-0`; the line-color DOM regression is covered by the focused component test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline file-diff previews to consistently map diff hunk lines to addition/deletion semantics based on the overall file operation.
  * Fixed displayed diff line numbers so they align correctly for both added and removed hunk lines.

* **Tests**
  * Expanded coverage to assert diff line number rendering and addition styling for created-file diffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->