### PR TITLE
fix(wework): restore open files after task switches

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -48,11 +48,17 @@ Any Wework UI, Tauri command, local-runtime, IPC, or desktop integration behavio
 ```bash
 pnpm --filter wework ai:verify start
 pnpm --filter wework ai:verify snapshot --session <session-path>
+pnpm --filter wework ai:verify debug --session <session-path>
 pnpm --filter wework ai:verify click --session <session-path> --selector '[data-testid="..."]'
+pnpm --filter wework ai:verify click-at --session <session-path> --value '{"x":640,"y":360}'
+pnpm --filter wework ai:verify click-then-macrotask --session <session-path> --selector '[data-testid="..."]' --target '[data-testid="..."]'
 pnpm --filter wework ai:verify drag --session <session-path> --selector '[data-testid="..."]' --target '[data-testid="..."]'
 pnpm --filter wework ai:verify fill --session <session-path> --selector '[data-testid="..."]' --value '...'
 pnpm --filter wework ai:verify hover --session <session-path> --selector '[data-testid="..."]'
 pnpm --filter wework ai:verify pointer-move --session <session-path> --selector 'body'
+pnpm --filter wework ai:verify seed-local-project --session <session-path> --value '{"name":"AI Verify","path":"/absolute/workspace/path"}'
+pnpm --filter wework ai:verify reload --session <session-path>
+pnpm --filter wework ai:verify wait-for --session <session-path> --selector 'body' --text '<expected post-reload text>'
 pnpm --filter wework ai:verify wait-for --session <session-path> --selector '[data-testid="..."]' --text '...'
 pnpm --filter wework ai:verify capture --session <session-path> --output <png-path>
 pnpm --filter wework ai:verify request-close --session <session-path>
@@ -64,6 +70,8 @@ pnpm --filter wework ai:verify stop --session <session-path>
 - Use `start --codex-home-initialization true` to verify the first-run Codex migration flow with a session-local native Codex home and synthetic authentication; it does not read or modify personal Codex credentials.
 - Session files and credentials are secrets: never print their contents. Always stop the session; it removes the auth link and terminates the isolated process group.
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.
+- Use `seed-local-project` only to establish an isolated local-project fixture when a native folder picker would block automation. `reload` waits for the new control client to reconnect; always follow it with `wait-for` so the expected post-reload UI state is asserted.
+- Prefer selector-based actions. Use `click-at` only for visible controls that cannot expose a stable selector, including controls inside open shadow roots, and retain a screenshot showing the target coordinates.
 - Execute the complete QA test plan in the isolated Tauri session, including the primary path, relevant boundary and error cases, and recovery. Document the environment, cases run, actual results, and evidence in the change handoff or pull request.
 - Use `capture` after the final assertion when a visual verification artifact is required. It renders the current WebView without macOS screen-recording permission.
 - Use `request-close` to exercise the native main-window close request and its close-to-tray preference or confirmation flow.

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -27,17 +27,17 @@ const corsHeaders = {
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
-  pnpm --filter wework ai:verify <capture|capture-popout|snapshot|click|close-to-tray|request-close|dismiss-popout|drag|drop-file|drop-paths|fill|hover|metrics|navigate|paste-paths|pointer-move|press|scroll-into-view|select-text|show-popout|system-drag-drop|wait-for|window-focus-snapshot|text|status|stop> --session PATH [options]
+  pnpm --filter wework ai:verify <capture|capture-popout|snapshot|debug|click|click-at|click-then-macrotask|seed-local-project|reload|close-to-tray|request-close|dismiss-popout|drag|drop-file|drop-paths|fill|hover|metrics|navigate|paste-paths|pointer-move|press|scroll-into-view|select-text|show-popout|system-drag-drop|wait-for|window-focus-snapshot|text|status|stop> --session PATH [options]
 
 Options:
   --codex-home-initialization true
                             Seed and verify isolated first-run Codex migration
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
-  --value TEXT              Replacement value for fill
+  --value TEXT_OR_JSON      Replacement value for fill; JSON for click-at,
+                            seed-local-project, paste-paths, or drop-paths
   --target SELECTOR         Event target selector for pointer-move (default: body)
-                            Required destination selector for drag
+                            Required destination for drag and click-then-macrotask
   --file PATH               File to dispatch for drop-file
-  --value JSON              Path descriptors for paste-paths or drop-paths
   --key KEY                 Keyboard key for press
   --output PATH             PNG output path for capture
   --text TEXT               Expected text for wait-for
@@ -307,6 +307,17 @@ async function request(session, token, path, method = 'GET', body) {
   return value
 }
 
+async function waitForFreshControlClient(session, token, previousClientId, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const status = await request(session, token, '/status')
+    const clientId = status.readyInfo?.clientId
+    if (clientId && clientId !== previousClientId) return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error('Timed out waiting for the reloaded Wework WebView to reconnect')
+}
+
 async function main() {
   const { command, options } = parseArgs(process.argv.slice(2))
   if (command === 'serve') return runServer(options.session, options.token)
@@ -384,7 +395,12 @@ async function main() {
     capture: 'capture',
     'capture-popout': 'capturePopoutWindow',
     snapshot: 'snapshot',
+    debug: 'getWorkbenchDebugSnapshot',
     click: 'click',
+    'click-at': 'clickAt',
+    'click-then-macrotask': 'clickThenMacrotask',
+    'seed-local-project': 'seedLocalProject',
+    reload: 'reloadApp',
     'close-to-tray': 'closeMainWindowToTray',
     'request-close': 'requestMainWindowClose',
     'dismiss-popout': 'dismissPopoutWindow',
@@ -416,6 +432,10 @@ async function main() {
     (command === 'capture' ||
     command === 'capture-popout' ||
     command === 'snapshot' ||
+    command === 'debug' ||
+    command === 'click-at' ||
+    command === 'seed-local-project' ||
+    command === 'reload' ||
     command === 'navigate' ||
     command === 'text' ||
     command === 'pointer-move' ||
@@ -439,6 +459,8 @@ async function main() {
         : dropFileExtension === '.txt'
           ? 'text/plain'
           : 'application/octet-stream'
+  const previousReady =
+    command === 'reload' ? await request(session, session.token, '/status') : null
   const value = await request(session, session.token, '/command', 'POST', {
     action,
     selector,
@@ -452,6 +474,14 @@ async function main() {
     stableMs: options.stable ? Number(options.stable) : undefined,
     timeoutMs: options.timeout ? Number(options.timeout) : undefined,
   })
+  if (command === 'reload') {
+    await waitForFreshControlClient(
+      session,
+      session.token,
+      previousReady?.readyInfo?.clientId,
+      options.timeout ? Number(options.timeout) : defaultTimeoutMs
+    )
+  }
   if (command === 'capture' || command === 'capture-popout') {
     if (!options.output) throw new Error('--output is required')
     const prefix = 'data:image/png;base64,'

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -69,6 +69,13 @@ export function resolveStartupTimeout(timeout) {
   return configuredTimeout
 }
 
+export function resolveCommandTimeout(timeout) {
+  const configuredTimeout = Number(timeout)
+  return Number.isFinite(configuredTimeout) && configuredTimeout > 0
+    ? configuredTimeout
+    : defaultTimeoutMs
+}
+
 function json(response, status, value) {
   response.writeHead(status, {
     ...corsHeaders,
@@ -461,6 +468,7 @@ async function main() {
           : 'application/octet-stream'
   const previousReady =
     command === 'reload' ? await request(session, session.token, '/status') : null
+  const effectiveTimeoutMs = resolveCommandTimeout(options.timeout)
   const value = await request(session, session.token, '/command', 'POST', {
     action,
     selector,
@@ -472,14 +480,14 @@ async function main() {
     text: options.text,
     visible: options.visible === 'true',
     stableMs: options.stable ? Number(options.stable) : undefined,
-    timeoutMs: options.timeout ? Number(options.timeout) : undefined,
+    timeoutMs: effectiveTimeoutMs,
   })
   if (command === 'reload') {
     await waitForFreshControlClient(
       session,
       session.token,
       previousReady?.readyInfo?.clientId,
-      options.timeout ? Number(options.timeout) : defaultTimeoutMs
+      effectiveTimeoutMs
     )
   }
   if (command === 'capture' || command === 'capture-popout') {

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, test, vi } from 'vitest'
-import { resolveStartupTimeout, takeWritableCommandPoll } from './ai-verify.mjs'
+import {
+  resolveCommandTimeout,
+  resolveStartupTimeout,
+  takeWritableCommandPoll,
+} from './ai-verify.mjs'
 
 function commandPoll(response) {
   return {
@@ -46,4 +50,17 @@ describe('resolveStartupTimeout', () => {
       '--timeout must be a finite positive number'
     )
   })
+})
+
+describe('resolveCommandTimeout', () => {
+  test('uses finite positive timeout values', () => {
+    expect(resolveCommandTimeout('120000')).toBe(120000)
+  })
+
+  test.each([undefined, '0', '-1', 'Infinity', 'not-a-number'])(
+    'uses the command default for %s',
+    timeout => {
+      expect(resolveCommandTimeout(timeout)).toBe(30000)
+    }
+  )
 })

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -7848,6 +7848,96 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
+  test('preserves the open file when switching runtime tasks', async () => {
+    const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
+    const workspaceFileApi = {
+      listWorkspaceEntries: vi.fn().mockImplementation((_deviceId: string, path: string) =>
+        Promise.resolve({
+          path,
+          entries: [
+            {
+              name: 'README.md',
+              path: `${path}/README.md`,
+              isDirectory: false,
+              size: 12,
+              modifiedAt: null,
+            },
+          ],
+        })
+      ),
+      readWorkspaceTextFile: vi.fn().mockImplementation((_deviceId: string, path: string) =>
+        Promise.resolve({
+          path,
+          name: 'README.md',
+          content: `preview for ${path}`,
+          editable: true,
+          revision: 'sha256:readme',
+          truncated: false,
+          size: 28,
+          modifiedAt: null,
+        })
+      ),
+    }
+    const propsWithFiles = (task: typeof taskA) => ({
+      ...propsForTask(task),
+      workspaceFileApi,
+    })
+    const layoutForTask = (task: typeof taskA) => (
+      <StrictMode>
+        <DesktopWorkbenchLayout {...propsWithFiles(task)} />
+      </StrictMode>
+    )
+    const activePane = () => within(screen.getByTestId('desktop-workbench-main'))
+    const { rerender } = render(layoutForTask(taskA))
+
+    await userEvent.click(activePane().getByTestId('toggle-right-workspace-panel-button'))
+    await userEvent.click(activePane().getByTestId('right-workspace-file-option'))
+    await userEvent.click(await activePane().findByText('README.md'))
+
+    expect(await activePane().findByTestId('workspace-file-path')).toHaveTextContent(
+      '/Users/me/Wegent/.worktrees/a/README.md'
+    )
+
+    rerender(layoutForTask(taskB))
+    await userEvent.click(activePane().getByTestId('toggle-right-workspace-panel-button'))
+    await userEvent.click(activePane().getByTestId('right-workspace-file-option'))
+    await userEvent.click(await activePane().findByText('README.md'))
+
+    expect(await activePane().findByTestId('workspace-file-path')).toHaveTextContent(
+      '/Users/me/Wegent/.worktrees/b/README.md'
+    )
+    expect(activePane().getByTestId('workspace-markdown-preview')).toHaveTextContent(
+      'preview for /Users/me/Wegent/.worktrees/b/README.md'
+    )
+
+    rerender(layoutForTask(taskA))
+
+    await waitFor(() => {
+      expect(activePane().getByTestId('right-workspace-file-tab')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+      expect(activePane().getByTestId('workspace-file-path')).toHaveTextContent(
+        '/Users/me/Wegent/.worktrees/a/README.md'
+      )
+      expect(activePane().getByTestId('workspace-markdown-preview')).toHaveTextContent(
+        'preview for /Users/me/Wegent/.worktrees/a/README.md'
+      )
+    })
+
+    rerender(layoutForTask(taskB))
+
+    await waitFor(() => {
+      expect(activePane().getByTestId('workspace-file-path')).toHaveTextContent(
+        '/Users/me/Wegent/.worktrees/b/README.md'
+      )
+      expect(activePane().getByTestId('workspace-markdown-preview')).toHaveTextContent(
+        'preview for /Users/me/Wegent/.worktrees/b/README.md'
+      )
+    })
+    expect(workspaceFileApi.readWorkspaceTextFile).toHaveBeenCalledTimes(4)
+  })
+
   test('restores serializable right workspace state without retaining the conversation pane', async () => {
     const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
     const activePane = () => within(screen.getByTestId('desktop-workbench-main'))

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -7938,6 +7938,61 @@ describe('DesktopWorkbenchLayout', () => {
     expect(workspaceFileApi.readWorkspaceTextFile).toHaveBeenCalledTimes(4)
   })
 
+  test('preserves the open directory when switching runtime tasks', async () => {
+    const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
+    const workspaceFileApi = {
+      listWorkspaceEntries: vi.fn().mockImplementation((_deviceId: string, path: string) =>
+        Promise.resolve({
+          path,
+          entries: path.endsWith('/docs')
+            ? []
+            : [
+                {
+                  name: 'docs',
+                  path: `${path}/docs`,
+                  isDirectory: true,
+                  size: 0,
+                  modifiedAt: null,
+                },
+              ],
+        })
+      ),
+      readWorkspaceTextFile: vi.fn(),
+    }
+    const propsWithFiles = (task: typeof taskA) => ({
+      ...propsForTask(task),
+      workspaceFileApi,
+    })
+    const activePane = () => within(screen.getByTestId('desktop-workbench-main'))
+    const { rerender } = render(<DesktopWorkbenchLayout {...propsWithFiles(taskA)} />)
+
+    await userEvent.click(activePane().getByTestId('toggle-right-workspace-panel-button'))
+    await userEvent.click(activePane().getByTestId('right-workspace-file-option'))
+    await userEvent.click(await activePane().findByText('docs'))
+
+    await waitFor(() => {
+      expect(workspaceFileApi.listWorkspaceEntries).toHaveBeenCalledWith(
+        expect.any(String),
+        '/Users/me/Wegent/.worktrees/a/docs'
+      )
+    })
+
+    rerender(<DesktopWorkbenchLayout {...propsWithFiles(taskB)} />)
+    rerender(<DesktopWorkbenchLayout {...propsWithFiles(taskA)} />)
+
+    await waitFor(() => {
+      expect(
+        workspaceFileApi.listWorkspaceEntries.mock.calls.filter(
+          ([, path]) => path === '/Users/me/Wegent/.worktrees/a/docs'
+        )
+      ).toHaveLength(2)
+      expect(activePane().getByTestId('right-workspace-file-tab')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+  })
+
   test('restores serializable right workspace state without retaining the conversation pane', async () => {
     const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
     const activePane = () => within(screen.getByTestId('desktop-workbench-main'))

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -234,6 +234,12 @@ interface WorkbenchPaneWorkspaceState {
   rightPanelExpanded: boolean
   rightPanelView: RightWorkspacePanelView
   rightPanelTabs: RightWorkspacePanelTab[]
+  selectedFileWorkspaceTargetKey: string | null
+  selectedWorkspaceFile: {
+    targetKey: string
+    path: string
+    isDirectory: boolean
+  } | null
 }
 
 interface PendingBlankBrowserMigration {
@@ -986,12 +992,21 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     () =>
       initialBlankBrowserMigration?.rightPanelTabs ?? initialWorkspaceState?.rightPanelTabs ?? []
   )
+  const [selectedFileWorkspaceTargetKey, setSelectedFileWorkspaceTargetKey] = useState<
+    string | null
+  >(() => initialWorkspaceState?.selectedFileWorkspaceTargetKey ?? null)
+  const [selectedWorkspaceFile, setSelectedWorkspaceFile] = useState(
+    () => initialWorkspaceState?.selectedWorkspaceFile ?? null
+  )
+  const [fileWorkspaceDirty, setFileWorkspaceDirty] = useState(false)
   useEffect(() => {
     onWorkspaceStateChange(paneKey, {
       rightPanelOpen,
       rightPanelExpanded,
       rightPanelTabs,
       rightPanelView,
+      selectedFileWorkspaceTargetKey,
+      selectedWorkspaceFile,
     })
   }, [
     onWorkspaceStateChange,
@@ -1000,6 +1015,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     rightPanelOpen,
     rightPanelTabs,
     rightPanelView,
+    selectedFileWorkspaceTargetKey,
+    selectedWorkspaceFile,
   ])
   const [migratedEmbeddedBrowserLabel, setMigratedEmbeddedBrowserLabel] = useState<string | null>(
     () => initialBlankBrowserMigration?.browserLabel ?? null
@@ -1019,9 +1036,6 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [bottomPanelOpenByKey, setBottomPanelOpenByKey] = useState<Record<string, boolean>>({})
   const [bottomPanelContexts, setBottomPanelContexts] = useState<BottomPanelRenderContext[]>([])
   const [openFileRequest, setOpenFileRequest] = useState<WorkspaceFileOpenRequest | null>(null)
-  const [selectedFileWorkspaceTargetKey, setSelectedFileWorkspaceTargetKey] = useState<
-    string | null
-  >(null)
   const [forkDialogOpen, setForkDialogOpen] = useState(false)
   const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false)
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
@@ -1149,9 +1163,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   }, [openFileRequest?.target, rightPanelTabs, rightPanelView, workspaceProject])
   const temporaryChatExpanded = rightPanelExpanded && rightPanelView.startsWith('chat:')
   const shouldRenderRightPanel = rightPanelOpen || effectiveRightPanelTabs.length > 0
-  const hasPersistentRightPanelResource = rightPanelTabs.some(
-    tab => tab === 'terminal' || tab === 'browser'
-  )
+  const hasPersistentRightPanelResource =
+    fileWorkspaceDirty || rightPanelTabs.some(tab => tab === 'terminal' || tab === 'browser')
   useEffect(() => {
     onTerminalPanePinChange(paneKey, 'right-panel', hasPersistentRightPanelResource)
     return () => onTerminalPanePinChange(paneKey, 'right-panel', false)
@@ -1241,6 +1254,16 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     ) ?? null
   const fileWorkspaceTarget =
     openFileRequest?.target ?? selectedFileWorkspaceTarget ?? effectiveWorkspaceTarget
+  const fileWorkspaceTargetKey = fileWorkspaceTarget
+    ? `${fileWorkspaceTarget.deviceId}:${fileWorkspaceTarget.path}`
+    : null
+  const initialFileWorkspaceSelection =
+    selectedWorkspaceFile && selectedWorkspaceFile.targetKey === fileWorkspaceTargetKey
+      ? {
+          path: selectedWorkspaceFile.path,
+          isDirectory: selectedWorkspaceFile.isDirectory,
+        }
+      : null
   const canBrowseFiles = Boolean(workspaceProject || openFileRequest?.target)
   const workspaceTargetDevice = effectiveWorkspaceTarget?.deviceId
     ? devices.find(device => device.device_id === effectiveWorkspaceTarget.deviceId)
@@ -1721,6 +1744,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     setSelectedFileWorkspaceTargetKey(`${target.deviceId}:${target.path}`)
     setOpenFileRequest(null)
   }, [])
+  const handleFileWorkspaceSelectionChange = useCallback(
+    (selection: { path: string; isDirectory: boolean }) => {
+      if (!fileWorkspaceTargetKey) return
+      setSelectedWorkspaceFile({
+        targetKey: fileWorkspaceTargetKey,
+        path: selection.path,
+        isDirectory: selection.isDirectory,
+      })
+    },
+    [fileWorkspaceTargetKey]
+  )
   const selectBrowserView = useCallback(() => {
     openRightPanelTab('browser')
   }, [openRightPanelTab])
@@ -2798,6 +2832,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               workspaceSessionApi={workspaceSessionApi}
               workspaceFileApi={workspaceFileApi}
               openFileRequest={openFileRequest}
+              initialFileSelection={initialFileWorkspaceSelection}
               workspaceTargetError={openFileRequest?.target ? null : workspaceTargetError}
               review={reviewState}
               planContent={rightPanelPlanContent}
@@ -2807,6 +2842,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               reviewViewOptions={reviewViewOptions}
               canOpenReview={Boolean(loadEnvironmentDiff && workspaceTarget)}
               onAddCodeComment={paneSession.addCodeComment}
+              onFileDirtyChange={setFileWorkspaceDirty}
+              onFileSelectionChange={handleFileWorkspaceSelectionChange}
               onSelectFileWorkspaceTarget={selectFileWorkspaceTarget}
               onSelectReview={selectReviewView}
               onSelectTerminal={selectTerminalView}

--- a/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
@@ -318,6 +318,7 @@ export function FileWorkspacePanel({
     (entry: WorkspaceFileEntry) => {
       if (!entry.isDirectory) return
       setActiveDirectoryPath(entry.path)
+      onSelectionChange?.({ path: entry.path, isDirectory: true })
       setTreeError(null)
       setTreeRetryPath(null)
 
@@ -325,7 +326,7 @@ export function FileWorkspacePanel({
         void loadTree(entry.path)
       }
     },
-    [loadTree, loadingPaths]
+    [loadTree, loadingPaths, onSelectionChange]
   )
 
   const openFile = useCallback(

--- a/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
@@ -41,12 +41,20 @@ import { WorkspaceFilePreview } from './WorkspaceFilePreview'
 import { WorkspaceFileTree } from './WorkspaceFileTree'
 import { isMarkdownFile } from './workspaceFileTypes'
 
+export interface FileWorkspacePanelSelection {
+  path: string
+  isDirectory: boolean
+}
+
 interface FileWorkspacePanelProps {
   target: WorkspaceTarget | null
   workspaceTargets?: WorkspaceTarget[]
   workspaceFileApi: WorkspaceFileApi
   openFileRequest?: WorkspaceFileOpenRequest | null
+  initialSelection?: FileWorkspacePanelSelection | null
   onAddCodeComment: (context: CodeCommentContext) => void
+  onDirtyChange?: (dirty: boolean) => void
+  onSelectionChange?: (selection: FileWorkspacePanelSelection) => void
   onSelectWorkspaceTarget?: (target: WorkspaceTarget) => void
 }
 
@@ -154,7 +162,10 @@ export function FileWorkspacePanel({
   workspaceTargets = [],
   workspaceFileApi,
   openFileRequest,
+  initialSelection,
   onAddCodeComment,
+  onDirtyChange,
+  onSelectionChange,
   onSelectWorkspaceTarget,
 }: FileWorkspacePanelProps) {
   const { t } = useTranslation('common')
@@ -208,6 +219,7 @@ export function FileWorkspacePanel({
   const [workspaceTargetMenuOpen, setWorkspaceTargetMenuOpen] = useState(false)
   const [selectedApplicationPath, setSelectedApplicationPath] = useState<string | null>(null)
   const [, setFileOpenerIconCacheVersion] = useState(0)
+  const initialSelectionRef = useRef(initialSelection)
   const treeRequestSequence = useRef(0)
   const latestTreeRequestByPath = useRef(new Map<string, number>())
   const directoryLoadedAtByPath = useRef(new Map<string, number>())
@@ -323,6 +335,7 @@ export function FileWorkspacePanel({
       const nextLineTarget = createPreviewLineTarget(entry.path, options)
       fileRequestSequence.current = requestId
       setSelectedFilePath(entry.path)
+      onSelectionChange?.({ path: entry.path, isDirectory: false })
       setMarkdownMode('preview')
       setSelectedPathIsDirectory(false)
       setSelectedApplicationPath(null)
@@ -397,7 +410,14 @@ export function FileWorkspacePanel({
         }
       }
     },
-    [loadFileOpeners, readWorkspaceFileChunk, readWorkspaceTextFile, stableTarget, t]
+    [
+      loadFileOpeners,
+      onSelectionChange,
+      readWorkspaceFileChunk,
+      readWorkspaceTextFile,
+      stableTarget,
+      t,
+    ]
   )
 
   const openFilePath = useCallback(
@@ -410,6 +430,7 @@ export function FileWorkspacePanel({
         fileRequestSequence.current += 1
         fileOpenerRequestSequence.current += 1
         setSelectedFilePath(resolvedPath)
+        onSelectionChange?.({ path: resolvedPath, isDirectory: true })
         setMarkdownMode('preview')
         setSelectedPathIsDirectory(true)
         setActiveDirectoryPath(resolvedPath)
@@ -470,10 +491,21 @@ export function FileWorkspacePanel({
         openAsFile
       )
     },
-    [listWorkspaceEntries, loadTree, openFile, stableTarget]
+    [listWorkspaceEntries, loadTree, onSelectionChange, openFile, stableTarget]
   )
 
   const dirty = editing && preview !== null && editedContent !== preview.content
+
+  useEffect(() => {
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
+
+  useEffect(
+    () => () => {
+      onDirtyChange?.(false)
+    },
+    [onDirtyChange]
+  )
 
   const saveFile = useCallback(async () => {
     if (!stableTarget || !preview || !writeWorkspaceTextFile || !dirty || saving) return !dirty
@@ -539,6 +571,23 @@ export function FileWorkspacePanel({
       cancelled = true
     }
   }, [loadTree, stableTarget])
+
+  useEffect(() => {
+    if (!stableTarget || openFileRequest?.path) return
+    const selection = initialSelectionRef.current
+    if (!selection?.path) return
+
+    let cancelled = false
+    void Promise.resolve().then(() => {
+      if (!cancelled) {
+        initialSelectionRef.current = null
+        openFilePath(selection.path, { isDirectory: selection.isDirectory })
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [openFilePath, openFileRequest?.path, stableTarget])
 
   useEffect(() => {
     if (!openFileRequest?.path) return

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -32,7 +32,7 @@ import type { EmbeddedBrowserOpenRequest } from '@/lib/embedded-browser'
 import { cn } from '@/lib/utils'
 import type { DeviceInfo, ProjectWithTasks, RuntimeTaskAddress } from '@/types/api'
 import { isEditableShortcutTarget } from '@/lib/keybindings'
-import { FileWorkspacePanel } from './FileWorkspacePanel'
+import { FileWorkspacePanel, type FileWorkspacePanelSelection } from './FileWorkspacePanel'
 import { WorkspaceAddMenu, type WorkspaceAddMenuItem } from './WorkspaceAddMenu'
 import { WorkspaceBrowserPanel } from './WorkspaceBrowserPanel'
 import { WorkspacePanelCards } from './WorkspacePanelCards'
@@ -102,6 +102,7 @@ interface RightWorkspacePanelProps {
   workspaceSessionApi?: WorkspaceSessionApi
   workspaceFileApi: WorkspaceFileApi
   openFileRequest?: WorkspaceFileOpenRequest | null
+  initialFileSelection?: FileWorkspacePanelSelection | null
   workspaceTargetError?: string | null
   review: RightWorkspaceReviewState
   planContent?: string | null
@@ -111,6 +112,8 @@ interface RightWorkspacePanelProps {
   canOpenReview: boolean
   reviewViewOptions?: FileChangesReviewViewOption[]
   onAddCodeComment: (context: CodeCommentContext) => void
+  onFileDirtyChange?: (dirty: boolean) => void
+  onFileSelectionChange?: (selection: FileWorkspacePanelSelection) => void
   onSelectFileWorkspaceTarget?: (target: WorkspaceTarget) => void
   onSelectReview: () => void
   onSelectTerminal: () => void
@@ -143,6 +146,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
   workspaceSessionApi,
   workspaceFileApi,
   openFileRequest,
+  initialFileSelection,
   workspaceTargetError,
   review,
   planContent,
@@ -152,6 +156,8 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
   canOpenReview,
   reviewViewOptions,
   onAddCodeComment,
+  onFileDirtyChange,
+  onFileSelectionChange,
   onSelectFileWorkspaceTarget,
   onSelectReview,
   onSelectTerminal,
@@ -421,7 +427,10 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
               workspaceTargets={fileWorkspaceTargets}
               workspaceFileApi={workspaceFileApi}
               openFileRequest={openFileRequest}
+              initialSelection={initialFileSelection}
               onAddCodeComment={onAddCodeComment}
+              onDirtyChange={onFileDirtyChange}
+              onSelectionChange={onFileSelectionChange}
               onSelectWorkspaceTarget={onSelectFileWorkspaceTarget}
             />
           )

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -24,7 +24,8 @@ import type { DesktopControlCommand } from '@/extensions/desktop-control-contrac
 import { parseDesktopControlKey } from './desktop-control-keyboard'
 import { getWorkbenchDebugSnapshot } from '@/lib/debugPanel'
 import { getRuntimeConversationCacheStats } from '@/features/workbench/runtimeConversationCache'
-import { LOCAL_EXECUTOR_COMMANDS, requestLocalExecutor } from '@/tauri/localExecutor'
+import { LOCAL_EXECUTOR_COMMANDS } from '@/tauri/localExecutor'
+import { executeVerificationControlCommand } from './verification-control'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -720,6 +721,11 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
     })
   }
 
+  const verificationResult = await executeVerificationControlCommand(command, {
+    elementEnabled: desktopControlElementEnabled,
+  })
+  if (verificationResult.handled) return verificationResult.value
+
   switch (command.action) {
     case 'capture':
       return captureDesktopControlScreenshot(command.selector)
@@ -905,56 +911,6 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       }
       element.click()
       return element.textContent?.trim() ?? ''
-    }
-    case 'clickAt': {
-      const coordinates = JSON.parse(command.value ?? '{}') as { x?: number; y?: number }
-      if (!Number.isFinite(coordinates.x) || !Number.isFinite(coordinates.y)) {
-        throw new Error('clickAt requires finite x and y coordinates')
-      }
-      let element = document.elementFromPoint(coordinates.x!, coordinates.y!)
-      while (element?.shadowRoot) {
-        const nested = element.shadowRoot.elementFromPoint(coordinates.x!, coordinates.y!)
-        if (!nested || nested === element) break
-        element = nested
-      }
-      const clickable = element?.closest('button') ?? element
-      if (!clickable) {
-        throw new Error(`Unable to find element at ${coordinates.x},${coordinates.y}`)
-      }
-      if (!desktopControlElementEnabled(clickable as HTMLElement)) {
-        throw new Error(`Element at ${coordinates.x},${coordinates.y} is disabled`)
-      }
-      clickable.dispatchEvent(
-        new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-          composed: true,
-          clientX: coordinates.x,
-          clientY: coordinates.y,
-        })
-      )
-      return clickable.textContent?.trim() ?? ''
-    }
-    case 'seedLocalProject': {
-      const fixture = JSON.parse(command.value ?? '{}') as {
-        name?: string
-        path?: string
-        projectKey?: string
-      }
-      if (!fixture.path?.trim()) {
-        throw new Error('seedLocalProject requires a workspace path')
-      }
-      const response = await requestLocalExecutor('runtime.projects.upsert_local', {
-        projectKey: fixture.projectKey ?? crypto.randomUUID(),
-        name: fixture.name?.trim() || 'AI Verify',
-        roots: [fixture.path.trim()],
-        runtime: 'codex',
-      })
-      return JSON.stringify(response)
-    }
-    case 'reloadApp': {
-      window.setTimeout(() => window.location.reload(), 50)
-      return ''
     }
     case 'clickThenMacrotask': {
       const element = findDesktopControlElements(command.selector)[0]

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -24,7 +24,7 @@ import type { DesktopControlCommand } from '@/extensions/desktop-control-contrac
 import { parseDesktopControlKey } from './desktop-control-keyboard'
 import { getWorkbenchDebugSnapshot } from '@/lib/debugPanel'
 import { getRuntimeConversationCacheStats } from '@/features/workbench/runtimeConversationCache'
-import { LOCAL_EXECUTOR_COMMANDS } from '@/tauri/localExecutor'
+import { LOCAL_EXECUTOR_COMMANDS, requestLocalExecutor } from '@/tauri/localExecutor'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -905,6 +905,56 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       }
       element.click()
       return element.textContent?.trim() ?? ''
+    }
+    case 'clickAt': {
+      const coordinates = JSON.parse(command.value ?? '{}') as { x?: number; y?: number }
+      if (!Number.isFinite(coordinates.x) || !Number.isFinite(coordinates.y)) {
+        throw new Error('clickAt requires finite x and y coordinates')
+      }
+      let element = document.elementFromPoint(coordinates.x!, coordinates.y!)
+      while (element?.shadowRoot) {
+        const nested = element.shadowRoot.elementFromPoint(coordinates.x!, coordinates.y!)
+        if (!nested || nested === element) break
+        element = nested
+      }
+      const clickable = element?.closest('button') ?? element
+      if (!clickable) {
+        throw new Error(`Unable to find element at ${coordinates.x},${coordinates.y}`)
+      }
+      if (!desktopControlElementEnabled(clickable as HTMLElement)) {
+        throw new Error(`Element at ${coordinates.x},${coordinates.y} is disabled`)
+      }
+      clickable.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          clientX: coordinates.x,
+          clientY: coordinates.y,
+        })
+      )
+      return clickable.textContent?.trim() ?? ''
+    }
+    case 'seedLocalProject': {
+      const fixture = JSON.parse(command.value ?? '{}') as {
+        name?: string
+        path?: string
+        projectKey?: string
+      }
+      if (!fixture.path?.trim()) {
+        throw new Error('seedLocalProject requires a workspace path')
+      }
+      const response = await requestLocalExecutor('runtime.projects.upsert_local', {
+        projectKey: fixture.projectKey ?? crypto.randomUUID(),
+        name: fixture.name?.trim() || 'AI Verify',
+        roots: [fixture.path.trim()],
+        runtime: 'codex',
+      })
+      return JSON.stringify(response)
+    }
+    case 'reloadApp': {
+      window.setTimeout(() => window.location.reload(), 50)
+      return ''
     }
     case 'clickThenMacrotask': {
       const element = findDesktopControlElements(command.selector)[0]

--- a/wework/src/e2e/verification-control.ts
+++ b/wework/src/e2e/verification-control.ts
@@ -1,0 +1,83 @@
+import type {
+  DesktopControlCommand,
+  DesktopControlExtensionResult,
+} from '@/extensions/desktop-control-contract'
+import { requestLocalExecutor } from '@/tauri/localExecutor'
+
+interface VerificationControlDependencies {
+  elementEnabled: (element: HTMLElement) => boolean
+}
+
+function clickAt(
+  command: DesktopControlCommand,
+  { elementEnabled }: VerificationControlDependencies
+): string {
+  const coordinates = JSON.parse(command.value ?? '{}') as { x?: number; y?: number }
+  if (!Number.isFinite(coordinates.x) || !Number.isFinite(coordinates.y)) {
+    throw new Error('clickAt requires finite x and y coordinates')
+  }
+
+  let element = document.elementFromPoint(coordinates.x!, coordinates.y!)
+  while (element?.shadowRoot) {
+    const nested = element.shadowRoot.elementFromPoint(coordinates.x!, coordinates.y!)
+    if (!nested || nested === element) break
+    element = nested
+  }
+  const clickable = (element?.closest('button') ?? element) as HTMLElement | null
+  if (!clickable) {
+    throw new Error(`Unable to find element at ${coordinates.x},${coordinates.y}`)
+  }
+  if (!elementEnabled(clickable)) {
+    throw new Error(`Element at ${coordinates.x},${coordinates.y} is disabled`)
+  }
+
+  clickable.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: coordinates.x,
+      clientY: coordinates.y,
+    })
+  )
+  return clickable.textContent?.trim() ?? ''
+}
+
+async function seedLocalProject(command: DesktopControlCommand): Promise<string> {
+  const fixture = JSON.parse(command.value ?? '{}') as {
+    name?: string
+    path?: string
+    projectKey?: string
+  }
+  if (!fixture.path?.trim()) {
+    throw new Error('seedLocalProject requires a workspace path')
+  }
+  const response = await requestLocalExecutor('runtime.projects.upsert_local', {
+    projectKey: fixture.projectKey ?? crypto.randomUUID(),
+    name: fixture.name?.trim() || 'AI Verify',
+    roots: [fixture.path.trim()],
+    runtime: 'codex',
+  })
+  return JSON.stringify(response)
+}
+
+function reloadApp(): string {
+  window.setTimeout(() => window.location.reload(), 50)
+  return ''
+}
+
+export async function executeVerificationControlCommand(
+  command: DesktopControlCommand,
+  dependencies: VerificationControlDependencies
+): Promise<DesktopControlExtensionResult> {
+  switch (command.action) {
+    case 'clickAt':
+      return { handled: true, value: clickAt(command, dependencies) }
+    case 'seedLocalProject':
+      return { handled: true, value: await seedLocalProject(command) }
+    case 'reloadApp':
+      return { handled: true, value: reloadApp() }
+    default:
+      return { handled: false }
+  }
+}


### PR DESCRIPTION
## Summary

- persist the selected file/directory and workspace target separately for each runtime task
- restore the file preview after the previous task pane is evicted and later revisited
- keep unsaved edits alive by pinning only dirty file panes
- make deferred restoration safe under React development Strict Mode
- retain reusable isolated-Tauri verification commands and harden their help, disabled-control checks, reload handshake, timeout handling, and shadow-root guidance

## Root cause

Switching tasks evicts the previous conversation pane because the desktop pane cache is bounded. The file preview selection previously lived only inside that pane. The first restoration implementation also consumed the saved selection before its deferred open executed; React Strict Mode cancelled that first effect setup, leaving the repeated setup with no selection.

## Verification

- `pnpm --filter wework exec vitest run scripts/ai-verify.test.mjs scripts/ai-verify-environment.test.mjs src/components/layout/DesktopWorkbenchLayout.test.tsx`
  - 172 tests passed
  - task tests verify independent A/B file selections across A → B → A → B and directory restoration across A → B → A
- changed-file ESLint passed
- TypeScript passed
- pre-push Wework ESLint, TypeScript, and full unit-test checks passed
- isolated real-Tauri task-switch flow passed:
  1. created task A and task B in an isolated local project
  2. opened `AGENTS.md` in task A
  3. directly switched to task B
  4. switched back to task A
  5. asserted that the same `AGENTS.md` path and rendered content were restored
- manually reviewed the complete A → B → A screenshot chain; task selection and restored file content are both visible
- isolated reload verification passed: `reload` waited for a new control-client ID, then a post-reload `wait-for` assertion succeeded
- GitHub CI passed with 18 successful checks and 0 failures, including all Wework desktop E2E shards

## Review follow-ups

- fixed the Strict Mode restoration race
- persisted directory selections opened from the file tree and added task-switch coverage
- documented required `--target` and JSON `--value` arguments in CLI help
- added the enabled-state guard to coordinate clicks
- moved reload reconnection waiting to the controller and reused one effective timeout for dispatch and reconnection
- extracted the new verification controls into a focused module
- corrected the guide to claim open-shadow-root support only
