### PR TITLE
fix(wework): track active turn across virtualized messages

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -117,7 +117,8 @@ const CHECKPOINT_TASK_PROMPT =
 const CHECKPOINT_TASK_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CHECKPOINT_TASK_COMPLETE'
 const TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX = 'WEWORK_DESKTOP_E2E_TURN_NAVIGATION'
 const TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX = 'WEWORK_DESKTOP_E2E_TURN_NAVIGATION_COMPLETE'
-const TURN_NAVIGATION_REGRESSION_TURN_COUNT = 10
+const TURN_NAVIGATION_REGRESSION_TURN_COUNT = 30
+const TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN = 6
 const CANCELLATION_PROMPT = 'WEWORK_DESKTOP_E2E_CANCEL: wait until the response is cancelled.'
 const CANCELLATION_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CANCEL_COMPLETE'
 const RETRY_PROMPT = 'WEWORK_DESKTOP_E2E_RETRY: fail once and then succeed after retry.'
@@ -1290,6 +1291,82 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     })
   }
+}
+
+async function verifyVirtualizedTurnNavigationActiveMarker(control) {
+  const turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN
+  const turnIndex = turnNumber - 1
+  const targetResponseText = `Virtualized navigation response ${turnNumber}.1`
+  await control.command(
+    'scrollToRatioAsUser',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`,
+    { value: '0' }
+  )
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    {
+      text: targetResponseText,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    }
+  )
+
+  const assistantText = await control.command(
+    'scrollIntoViewAsUser',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    { text: targetResponseText }
+  )
+  const turnMatch = assistantText.match(/Virtualized navigation response (\d+)\.\d+/)
+  assert.ok(turnMatch, `Unable to identify the virtualized navigation turn from "${assistantText}"`)
+
+  assert.equal(Number(turnMatch[1]), turnNumber, 'Scrolled to the wrong navigation turn')
+  const promptText = `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 750))
+
+  const mountedUserMessages = await control.command(
+    'getText',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`
+  )
+  assert.ok(
+    !mountedUserMessages.includes(promptText),
+    `Turn ${turnNumber} user row remained mounted, so the active-marker regression was not reproduced`
+  )
+
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="${turnIndex}"][data-active="true"]`,
+    {
+      stableMs: COMPOSER_READY_STABILITY_MS,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    }
+  )
+}
+
+async function reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp) {
+  const debugSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+  const taskId = debugSnapshot.workbench?.currentRuntimeTask?.taskId
+  assert.ok(taskId, 'The turn-navigation fixture did not expose its runtime task ID')
+
+  await control.command('click', '[data-testid="new-chat-button"]')
+  await control.command('waitFor', composerSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await restartDesktopApp()
+  await control.command('waitFor', composerSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await ensureTaskRowVisible(control, `runtime-local-task-row-${taskId}`)
+  await control.command('clickWhenEnabled', `[data-testid="runtime-local-task-row-${taskId}"]`, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+    {
+      text: `${TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX}_${TURN_NAVIGATION_REGRESSION_TURN_COUNT}`,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    }
+  )
 }
 
 async function verifyStandaloneViewImageTask({ composerSelector, control, projectRowSelector }) {
@@ -3912,6 +3989,7 @@ async function verifyBackgroundTaskWindowLifecycle({
   composerSelector,
   control,
   executorLogPath,
+  restartDesktopApp,
   setPhase,
 }) {
   const lifecycleScreenshotName = name => `window-lifecycle-${name}`
@@ -4281,6 +4359,8 @@ async function verifyBackgroundTaskWindowLifecycle({
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp)
+  await verifyVirtualizedTurnNavigationActiveMarker(control)
   await control.command('click', '[data-testid="message-turn-navigation-marker"]')
   await new Promise(resolvePromise => setTimeout(resolvePromise, 2_000))
   const navigationTopMetrics = await waitForTopMetrics(
@@ -7527,8 +7607,8 @@ class DesktopE2EServer {
         completionText,
         ...Array.from(
           { length: 6 },
-          (_, index) =>
-            `Virtualized navigation response ${turnNumber}.${index + 1}. ${'Measured content '.repeat(12)}`
+          (_, paragraphIndex) =>
+            `Virtualized navigation response ${turnNumber}.${paragraphIndex + 1}. ${'Measured content '.repeat(12)}`
         ),
       ].join('\n\n')
       this.writeSse(response, [
@@ -9231,6 +9311,7 @@ async function buildDesktopApp(
         VITE_WEWORK_E2E_MODEL_SERVER_URL: modelServerUrl,
         VITE_WEWORK_E2E_LOCAL_MODELS_CATALOG_READY: CLOUD_ONLY ? 'true' : 'false',
         VITE_WEWORK_E2E: 'true',
+        VITE_WEWORK_E2E_TRANSCRIPT_PAGE_SIZE: '49',
         VITE_WEWORK_E2E_CODEX_HOME_INITIALIZATION: RUNS_PLUGIN_E2E ? 'true' : 'false',
         VITE_WEWORK_E2E_SEED_LOCAL_MODELS: RUNS_PLUGIN_E2E || MEMORY_ONLY ? 'false' : 'true',
         VITE_WEWORK_RUNTIME_MODE: 'local-first',
@@ -10324,6 +10405,8 @@ last_updated = "2026-07-30T00:00:00Z"`
       await control.command('waitFor', '[data-testid="message-turn-navigation-marker"]', {
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
+      await reopenCurrentTurnNavigationTask(control, ACTIVE_COMPOSER_SELECTOR, restartDesktopApp)
+      await verifyVirtualizedTurnNavigationActiveMarker(control)
       console.log(`Wework desktop turn-navigation E2E passed. Evidence: ${resultDir}`)
       return
     }
@@ -11416,6 +11499,7 @@ last_updated = "2026-07-30T00:00:00Z"`
         composerSelector,
         control,
         executorLogPath,
+        restartDesktopApp,
         setPhase: value => {
           phase = value
         },

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1295,7 +1295,17 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
 
 async function verifyVirtualizedTurnNavigationActiveMarker(control) {
   const turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN
-  const turnIndex = turnNumber - 1
+  const promptText = `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
+  const previewSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-preview"]`
+  await control.command('waitFor', previewSelector, {
+    text: promptText,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  const turnIndex = await control.command('getAttribute', previewSelector, {
+    text: promptText,
+    value: 'data-turn-index',
+  })
+  assert.match(turnIndex, /^\d+$/, `Unable to identify the navigation marker for "${promptText}"`)
   const targetResponseText = `Virtualized navigation response ${turnNumber}.1`
   await control.command(
     'scrollToRatioAsUser',
@@ -1320,7 +1330,6 @@ async function verifyVirtualizedTurnNavigationActiveMarker(control) {
   assert.ok(turnMatch, `Unable to identify the virtualized navigation turn from "${assistantText}"`)
 
   assert.equal(Number(turnMatch[1]), turnNumber, 'Scrolled to the wrong navigation turn')
-  const promptText = `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
   await new Promise(resolvePromise => setTimeout(resolvePromise, 750))
 
   const mountedUserMessages = await control.command(
@@ -4359,8 +4368,6 @@ async function verifyBackgroundTaskWindowLifecycle({
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
-  await reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp)
-  await verifyVirtualizedTurnNavigationActiveMarker(control)
   await control.command('click', '[data-testid="message-turn-navigation-marker"]')
   await new Promise(resolvePromise => setTimeout(resolvePromise, 2_000))
   const navigationTopMetrics = await waitForTopMetrics(
@@ -4380,7 +4387,6 @@ async function verifyBackgroundTaskWindowLifecycle({
     control,
     lifecycleScreenshotName('09-first-virtualized-turn-navigation-target.png')
   )
-
   setPhase('archived-task-cache-eviction')
   const cacheBeforeArchive = JSON.parse(
     await control.command('performanceSnapshot', 'body')
@@ -4426,6 +4432,8 @@ async function verifyBackgroundTaskWindowLifecycle({
     `${JSON.stringify({ before: cacheBeforeArchive, after: cacheAfterArchive }, null, 2)}\n`,
     'utf8'
   )
+  await reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp)
+  await verifyVirtualizedTurnNavigationActiveMarker(control)
   return taskRowTestId
 }
 

--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -771,13 +771,7 @@ function findActiveMarkerFromMountedMessages(
 ): MessageTurnMarker | null {
   if (!anchorByMessageId || anchorByMessageId.size === 0) return null
 
-  const messageIndexById = new Map(
-    messages.flatMap(message =>
-      Number.isFinite(message.runtimeMessageIndex)
-        ? [[message.id, message.runtimeMessageIndex as number] as const]
-        : []
-    )
-  )
+  const messagePositionById = buildMessageTimelinePositions(messages)
   const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
   let currentMessageIndex: number | null = null
   let currentMessageTop = Number.NEGATIVE_INFINITY
@@ -785,17 +779,17 @@ function findActiveMarkerFromMountedMessages(
   let firstMountedMessageTop = Number.POSITIVE_INFINITY
 
   anchorByMessageId.forEach((anchor, messageId) => {
-    const messageIndex = messageIndexById.get(messageId)
-    if (messageIndex === undefined) return
+    const messagePosition = messagePositionById.get(messageId)
+    if (messagePosition === undefined) return
 
     const targetTop = getMessageAnchorTargetTop(scroller, anchor)
     if (targetTop < firstMountedMessageTop) {
       firstMountedMessageTop = targetTop
-      firstMountedMessageIndex = messageIndex
+      firstMountedMessageIndex = messagePosition
     }
     if (targetTop <= currentPosition && targetTop > currentMessageTop) {
       currentMessageTop = targetTop
-      currentMessageIndex = messageIndex
+      currentMessageIndex = messagePosition
     }
   })
 
@@ -808,6 +802,29 @@ function findActiveMarkerFromMountedMessages(
     activeMarker = marker
   }
   return activeMarker
+}
+
+function buildMessageTimelinePositions(messages: WorkbenchMessage[]): Map<string, number> {
+  const positions = new Map<string, number>()
+  let nextMessageIndex: number | null = null
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (Number.isFinite(message.runtimeMessageIndex)) {
+      nextMessageIndex = message.runtimeMessageIndex as number
+      positions.set(message.id, nextMessageIndex)
+      continue
+    }
+
+    // A persisted page can start with an assistant message whose preceding user
+    // message belongs to the previous page. Keep it in the absolute transcript
+    // coordinate system by placing it immediately before the next indexed row.
+    if (nextMessageIndex !== null) {
+      positions.set(message.id, nextMessageIndex - 0.5)
+    }
+  }
+
+  return positions
 }
 
 function getScrollMetrics(scroller: HTMLElement, anchor?: HTMLElement | null) {

--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -277,6 +277,8 @@ export function MessageTurnNavigation({
     const content = contentRef.current
     if (!scroller || !content) return
 
+    // Mounted anchors are recalculated by observers; raw scroll events reuse
+    // measured user targets and preserve the last valid virtualized marker.
     const handleScroll = () => updateActiveMarker(markersRef.current, 'scroll')
     const handleResize = () => scheduleCalculateMarkers('window-resize')
     scroller.addEventListener('scroll', handleScroll, { passive: true })
@@ -770,10 +772,11 @@ function findActiveMarkerFromMountedMessages(
   if (!anchorByMessageId || anchorByMessageId.size === 0) return null
 
   const messageIndexById = new Map(
-    messages.map((message, index) => [
-      message.id,
-      typeof message.runtimeMessageIndex === 'number' ? message.runtimeMessageIndex : index,
-    ])
+    messages.flatMap(message =>
+      Number.isFinite(message.runtimeMessageIndex)
+        ? [[message.id, message.runtimeMessageIndex as number] as const]
+        : []
+    )
   )
   const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
   let currentMessageIndex: number | null = null

--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -149,11 +149,26 @@ export function MessageTurnNavigation({
   }, [messages, turnNavigation, userTurnsSignature])
 
   const updateActiveMarker = useCallback(
-    (nextMarkers: MessageTurnMarker[], reason = 'unknown') => {
+    (
+      nextMarkers: MessageTurnMarker[],
+      reason = 'unknown',
+      anchorByMessageId?: ReadonlyMap<string, HTMLElement>
+    ) => {
       void reason
       const scroller = scrollRef.current
       if (!scroller || nextMarkers.length === 0) {
         setActiveMarkerId(null)
+        return
+      }
+
+      const mountedMessageMarker = findActiveMarkerFromMountedMessages(
+        nextMarkers,
+        messagesRef.current,
+        anchorByMessageId,
+        scroller
+      )
+      if (mountedMessageMarker) {
+        setActiveMarkerId(mountedMessageMarker.id)
         return
       }
 
@@ -162,7 +177,6 @@ export function MessageTurnNavigation({
         (marker): marker is MessageTurnMarker & { targetTop: number } => marker.targetTop !== null
       )
       if (loadedMarkers.length === 0) {
-        setActiveMarkerId(null)
         return
       }
 
@@ -215,7 +229,7 @@ export function MessageTurnNavigation({
 
       markersRef.current = nextMarkers
       setMarkers(nextMarkers)
-      updateActiveMarker(nextMarkers, reason)
+      updateActiveMarker(nextMarkers, reason, anchorByMessageId)
     },
     [contentRef, scrollRef, updateActiveMarker]
   )
@@ -745,6 +759,52 @@ function getMessageAnchorTargetTop(scroller: HTMLDivElement, anchor: HTMLElement
   const scrollerRect = scroller.getBoundingClientRect()
   const anchorRect = anchor.getBoundingClientRect()
   return Math.max(0, scroller.scrollTop + anchorRect.top - scrollerRect.top)
+}
+
+function findActiveMarkerFromMountedMessages(
+  markers: MessageTurnMarker[],
+  messages: WorkbenchMessage[],
+  anchorByMessageId: ReadonlyMap<string, HTMLElement> | undefined,
+  scroller: HTMLDivElement
+): MessageTurnMarker | null {
+  if (!anchorByMessageId || anchorByMessageId.size === 0) return null
+
+  const messageIndexById = new Map(
+    messages.map((message, index) => [
+      message.id,
+      typeof message.runtimeMessageIndex === 'number' ? message.runtimeMessageIndex : index,
+    ])
+  )
+  const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
+  let currentMessageIndex: number | null = null
+  let currentMessageTop = Number.NEGATIVE_INFINITY
+  let firstMountedMessageIndex: number | null = null
+  let firstMountedMessageTop = Number.POSITIVE_INFINITY
+
+  anchorByMessageId.forEach((anchor, messageId) => {
+    const messageIndex = messageIndexById.get(messageId)
+    if (messageIndex === undefined) return
+
+    const targetTop = getMessageAnchorTargetTop(scroller, anchor)
+    if (targetTop < firstMountedMessageTop) {
+      firstMountedMessageTop = targetTop
+      firstMountedMessageIndex = messageIndex
+    }
+    if (targetTop <= currentPosition && targetTop > currentMessageTop) {
+      currentMessageTop = targetTop
+      currentMessageIndex = messageIndex
+    }
+  })
+
+  const viewportMessageIndex = currentMessageIndex ?? firstMountedMessageIndex
+  if (viewportMessageIndex === null) return null
+
+  let activeMarker: MessageTurnMarker | null = null
+  for (const marker of markers) {
+    if (marker.messageIndex > viewportMessageIndex) break
+    activeMarker = marker
+  }
+  return activeMarker
 }
 
 function getScrollMetrics(scroller: HTMLElement, anchor?: HTMLElement | null) {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1297,7 +1297,7 @@ describe('ScrollableMessageArea', () => {
         content: 'First request',
         status: 'done' as const,
         createdAt: '2026-07-31T00:00:00.000Z',
-        runtimeMessageIndex: 0,
+        runtimeMessageIndex: 100,
       },
       {
         id: 'virtual-active-assistant-1',
@@ -1305,7 +1305,7 @@ describe('ScrollableMessageArea', () => {
         content: 'First response',
         status: 'done' as const,
         createdAt: '2026-07-31T00:00:01.000Z',
-        runtimeMessageIndex: 1,
+        runtimeMessageIndex: 101,
       },
       {
         id: 'virtual-active-user-2',
@@ -1313,7 +1313,7 @@ describe('ScrollableMessageArea', () => {
         content: 'Second request',
         status: 'done' as const,
         createdAt: '2026-07-31T00:00:02.000Z',
-        runtimeMessageIndex: 2,
+        runtimeMessageIndex: 102,
       },
       {
         id: 'virtual-active-assistant-2',
@@ -1321,7 +1321,7 @@ describe('ScrollableMessageArea', () => {
         content: 'Long second response',
         status: 'done' as const,
         createdAt: '2026-07-31T00:00:03.000Z',
-        runtimeMessageIndex: 3,
+        runtimeMessageIndex: 103,
       },
       {
         id: 'virtual-active-user-3',
@@ -1329,14 +1329,25 @@ describe('ScrollableMessageArea', () => {
         content: 'Third request',
         status: 'done' as const,
         createdAt: '2026-07-31T00:00:04.000Z',
-        runtimeMessageIndex: 4,
+        runtimeMessageIndex: 104,
+      },
+      {
+        id: 'virtual-active-unindexed-assistant',
+        role: 'assistant' as const,
+        content: 'Transient response without a transcript index',
+        status: 'done' as const,
+        createdAt: '2026-07-31T00:00:05.000Z',
       },
     ]
 
     render(
       <div ref={scrollRef}>
         <div ref={contentRef}>
+          <div data-message-id="virtual-active-assistant-1">First response</div>
           <div data-message-id="virtual-active-assistant-2">Long second response</div>
+          <div data-message-id="virtual-active-unindexed-assistant">
+            Transient response without a transcript index
+          </div>
         </div>
         <MessageTurnNavigation messages={messages} scrollRef={scrollRef} contentRef={contentRef} />
       </div>
@@ -1351,7 +1362,9 @@ describe('ScrollableMessageArea', () => {
       configurable: true,
     })
     mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('First response'), -200, 120)
     mockRect(screen.getByText('Long second response'), 40, 1_200)
+    mockRect(screen.getByText('Transient response without a transcript index'), 80, 120)
 
     fireEvent.resize(window)
     flushScheduledTimers()

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1381,6 +1381,91 @@ describe('ScrollableMessageArea', () => {
     expect(markers[1]).toHaveAttribute('data-active', 'true')
   })
 
+  test('tracks a page-leading assistant without a runtime message index', () => {
+    const scrollRef = createRef<HTMLDivElement>()
+    const contentRef = createRef<HTMLDivElement>()
+
+    render(
+      <div ref={scrollRef}>
+        <div ref={contentRef}>
+          <div data-message-id="boundary-assistant">Boundary response</div>
+        </div>
+        <MessageTurnNavigation
+          messages={[
+            {
+              id: 'boundary-assistant',
+              role: 'assistant',
+              content: 'Boundary response',
+              status: 'done',
+              createdAt: '2026-07-31T00:00:11.000Z',
+            },
+            {
+              id: 'next-user',
+              role: 'user',
+              content: 'Next request',
+              status: 'done',
+              createdAt: '2026-07-31T00:00:12.000Z',
+              runtimeMessageIndex: 12,
+            },
+            {
+              id: 'next-assistant',
+              role: 'assistant',
+              content: 'Next response',
+              status: 'done',
+              createdAt: '2026-07-31T00:00:13.000Z',
+              runtimeMessageIndex: 13,
+            },
+          ]}
+          turnNavigation={[
+            {
+              id: 'previous-user',
+              turnIndex: 4,
+              messageIndex: 8,
+              promptPreview: 'Previous request',
+              responsePreview: 'Previous response',
+            },
+            {
+              id: 'boundary-user',
+              turnIndex: 5,
+              messageIndex: 10,
+              promptPreview: 'Boundary request',
+              responsePreview: 'Boundary response',
+            },
+            {
+              id: 'next-user',
+              turnIndex: 6,
+              messageIndex: 12,
+              promptPreview: 'Next request',
+              responsePreview: 'Next response',
+            },
+          ]}
+          scrollRef={scrollRef}
+          contentRef={contentRef}
+        />
+      </div>
+    )
+
+    const scroller = scrollRef.current!
+    Object.defineProperty(scroller, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 4_000, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 2_800,
+      writable: true,
+      configurable: true,
+    })
+    mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('Boundary response'), 40, 1_200)
+
+    fireEvent.resize(window)
+    flushScheduledTimers()
+
+    const markers = screen.getAllByTestId('message-turn-navigation-marker')
+    expect(markers).toHaveLength(3)
+    expect(markers[0]).toHaveAttribute('data-active', 'false')
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
+    expect(markers[2]).toHaveAttribute('data-active', 'false')
+  })
+
   test('clicks a message navigation marker to jump to that user message', () => {
     render(
       <ScrollableMessageArea

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1287,6 +1287,87 @@ describe('ScrollableMessageArea', () => {
     expect(screen.getAllByTestId('message-turn-navigation-marker')).toHaveLength(2)
   })
 
+  test('tracks the active turn from a mounted assistant row when the user row is virtualized', () => {
+    const scrollRef = createRef<HTMLDivElement>()
+    const contentRef = createRef<HTMLDivElement>()
+    const messages = [
+      {
+        id: 'virtual-active-user-1',
+        role: 'user' as const,
+        content: 'First request',
+        status: 'done' as const,
+        createdAt: '2026-07-31T00:00:00.000Z',
+        runtimeMessageIndex: 0,
+      },
+      {
+        id: 'virtual-active-assistant-1',
+        role: 'assistant' as const,
+        content: 'First response',
+        status: 'done' as const,
+        createdAt: '2026-07-31T00:00:01.000Z',
+        runtimeMessageIndex: 1,
+      },
+      {
+        id: 'virtual-active-user-2',
+        role: 'user' as const,
+        content: 'Second request',
+        status: 'done' as const,
+        createdAt: '2026-07-31T00:00:02.000Z',
+        runtimeMessageIndex: 2,
+      },
+      {
+        id: 'virtual-active-assistant-2',
+        role: 'assistant' as const,
+        content: 'Long second response',
+        status: 'done' as const,
+        createdAt: '2026-07-31T00:00:03.000Z',
+        runtimeMessageIndex: 3,
+      },
+      {
+        id: 'virtual-active-user-3',
+        role: 'user' as const,
+        content: 'Third request',
+        status: 'done' as const,
+        createdAt: '2026-07-31T00:00:04.000Z',
+        runtimeMessageIndex: 4,
+      },
+    ]
+
+    render(
+      <div ref={scrollRef}>
+        <div ref={contentRef}>
+          <div data-message-id="virtual-active-assistant-2">Long second response</div>
+        </div>
+        <MessageTurnNavigation messages={messages} scrollRef={scrollRef} contentRef={contentRef} />
+      </div>
+    )
+
+    const scroller = scrollRef.current!
+    Object.defineProperty(scroller, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 4_000, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 2_800,
+      writable: true,
+      configurable: true,
+    })
+    mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('Long second response'), 40, 1_200)
+
+    fireEvent.resize(window)
+    flushScheduledTimers()
+
+    const markers = screen.getAllByTestId('message-turn-navigation-marker')
+    expect(markers).toHaveLength(3)
+    expect(markers[0]).toHaveAttribute('data-active', 'false')
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
+    expect(markers[2]).toHaveAttribute('data-active', 'false')
+
+    scroller.scrollTop = 2_900
+    fireEvent.scroll(scroller)
+
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
+  })
+
   test('clicks a message navigation marker to jump to that user message', () => {
     render(
       <ScrollableMessageArea

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -121,7 +121,16 @@ interface PendingRuntimeGoalState {
 }
 
 const runtimePaneGoalSeeds = new Map<string, PendingRuntimeGoalState>()
-const RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
+const DEFAULT_RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
+const configuredRuntimeTranscriptPageSize = Number(
+  import.meta.env.VITE_WEWORK_E2E_TRANSCRIPT_PAGE_SIZE
+)
+const RUNTIME_TRANSCRIPT_PAGE_SIZE =
+  import.meta.env.VITE_WEWORK_E2E === 'true' &&
+  Number.isInteger(configuredRuntimeTranscriptPageSize) &&
+  configuredRuntimeTranscriptPageSize > 0
+    ? configuredRuntimeTranscriptPageSize
+    : DEFAULT_RUNTIME_TRANSCRIPT_PAGE_SIZE
 const MAX_CACHED_RUNTIME_PANE_GOALS = 3
 const noopSetInput = () => undefined
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -805,6 +805,16 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return String(findDesktopControlElements(command.selector).length)
     case 'getElementMetrics':
       return desktopControlElementMetrics(command.selector)
+    case 'getAttribute': {
+      const elements = findDesktopControlElements(command.selector)
+      const element = command.text
+        ? elements.find(candidate => candidate.textContent?.includes(command.text ?? ''))
+        : elements[0]
+      if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      const attribute = command.value?.trim()
+      if (!attribute) throw new Error('getAttribute requires an attribute name')
+      return element.getAttribute(attribute) ?? ''
+    }
     case 'getStyle': {
       const element = findDesktopControlElements(command.selector)[0]
       if (!element) throw new Error(`Unable to find selector "${command.selector}"`)

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -853,8 +853,12 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
     case 'expandProcessingSummaries':
       return expandDesktopProcessingSummaries()
     case 'scrollIntoViewAsUser': {
-      const element = findDesktopControlElements(command.selector)[0]
+      const elements = findDesktopControlElements(command.selector)
+      const element = command.text
+        ? elements.find(candidate => candidate.textContent?.includes(command.text ?? ''))
+        : elements[0]
       if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+      const text = element.textContent?.trim() ?? ''
       element.dispatchEvent(
         new WheelEvent('wheel', {
           bubbles: true,
@@ -864,7 +868,7 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
         })
       )
       element.scrollIntoView({ block: 'center', inline: 'nearest' })
-      return element.textContent?.trim() ?? ''
+      return text
     }
     case 'scrollToBottomAsUser': {
       const element = findDesktopControlElements(command.selector)[0]


### PR DESCRIPTION
## Summary

- track the active turn from any mounted transcript message, including an assistant row whose user row is outside the loaded/virtualized range
- keep the last valid active marker when no user-turn anchors are mounted
- add unit coverage and a real desktop E2E that reloads a paginated 30-turn transcript at an assistant-first page boundary

## Root cause

The turn navigation derived its active marker only from mounted user-message anchors. At a transcript pagination boundary, the first loaded row can be an assistant message while the corresponding user message remains on the previous page. In that state there were no mounted user anchors, so the active marker was cleared.

The prior E2E only clicked a marker and asserted the jump target. Clicking sets the active marker directly, so it did not exercise passive scroll-based active-marker tracking.

## Verification

- `pnpm test` (247 files, 2442 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm e2e:desktop -- --turn-navigation-only`
- verified the new E2E fails on the previous production logic at the active-marker assertion and passes with this fix
- pre-push quality checks: ESLint, TypeScript, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turn navigation while scrolling through long, virtualized conversations.
  * Active navigation markers now remain accurate when related message rows are not currently rendered.
  * Improved desktop automation when locating and scrolling to text-matching elements.

* **Tests**
  * Added regression coverage for virtualized message navigation, including scrolling persistence and page-leading messages.
  * Expanded desktop restart, task reopening, and turn-navigation flow coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->