### PR TITLE
fix(wework): refine Codex usage and fast mode UI

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1616,6 +1616,8 @@ describe('ChatInput', () => {
 
     expect(screen.getByTestId('model-control-speed-standard')).toBeInTheDocument()
     expect(screen.getByTestId('model-control-speed-fast')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-speed-fast')).toHaveTextContent('快速')
+    expect(screen.getByTestId('model-control-speed-fast')).not.toHaveTextContent('⚡')
     expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ left: '256px' })
 
     const speedMenuItem = screen.getByTestId('model-control-menu-speed')
@@ -1638,6 +1640,50 @@ describe('ChatInput', () => {
 
     expect(setSelectedModelOption).toHaveBeenCalledWith('speed', 'fast')
     expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
+  })
+
+  test('uses a Codex-style monochrome fast indicator instead of an emoji', async () => {
+    const model: UnifiedModel = {
+      name: 'gpt-5.6-sol',
+      type: 'runtime',
+      displayName: 'GPT 5.6 Sol',
+      config: {
+        ui: {
+          family: 'codex-official',
+          modelLabel: 'GPT 5.6 Sol',
+          reasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
+          defaultReasoningEffort: 'medium',
+          controls: ['speed'],
+        },
+      },
+    }
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [model],
+          selectedModel: model,
+          selectedModelOptions: { reasoning: 'high', speed: 'fast' },
+        })}
+      />
+    )
+
+    const trigger = screen.getByTestId('model-selector-button')
+    expect(trigger).toHaveTextContent('GPT 5.6 Sol High')
+    expect(trigger).not.toHaveTextContent('⚡')
+    expect(trigger).not.toHaveTextContent('快速')
+    expect(screen.getByTestId('model-selector-fast-mode-icon')).toHaveClass('text-text-primary')
+    expect(trigger).toHaveAccessibleName(/快速/)
+
+    await userEvent.click(trigger)
+
+    expect(screen.getByTestId('model-control-menu-speed')).toHaveTextContent('快速')
+    expect(screen.getByTestId('model-control-menu-speed')).not.toHaveTextContent('⚡')
   })
 
   test('shows an empty state when no desktop models are available', async () => {

--- a/wework/src/components/chat/composer/FastModeIcon.tsx
+++ b/wework/src/components/chat/composer/FastModeIcon.tsx
@@ -1,0 +1,12 @@
+import type { SVGProps } from 'react'
+
+export function FastModeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false" {...props}>
+      <path
+        fill="currentColor"
+        d="M9.47 1.25 2.96 8.56a.5.5 0 0 0 .38.83h4.02l-.68 5.08a.5.5 0 0 0 .88.39l6.49-7.76a.5.5 0 0 0-.38-.82H9.72l.62-4.58a.5.5 0 0 0-.87-.45Z"
+      />
+    </svg>
+  )
+}

--- a/wework/src/components/chat/composer/ModelAdvancedHeader.tsx
+++ b/wework/src/components/chat/composer/ModelAdvancedHeader.tsx
@@ -1,5 +1,6 @@
-import { ChevronRight, ChevronUp, Zap } from 'lucide-react'
+import { ChevronRight, ChevronUp } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { FastModeIcon } from './FastModeIcon'
 
 interface ModelAdvancedHeaderProps {
   disabled: boolean
@@ -29,7 +30,7 @@ export function ModelAdvancedHeader({
       data-testid="model-advanced-row"
       onMouseEnter={onClearSubmenu}
       onPointerEnter={onClearSubmenu}
-      className="flex h-8 items-center px-3 text-sm font-medium leading-[18px] text-text-muted"
+      className="flex h-8 items-center px-2 text-sm font-medium leading-[18px] text-text-muted"
     >
       {interacting ? (
         <>
@@ -70,9 +71,9 @@ export function ModelAdvancedHeader({
               onClick={onToggleFastMode}
               className="ml-auto flex h-8 w-8 items-center justify-center rounded-lg text-text-muted hover:bg-muted hover:text-text-primary focus-visible:bg-muted focus-visible:text-text-primary focus-visible:outline-none"
             >
-              <Zap
+              <FastModeIcon
                 data-testid="model-advanced-intelligence-icon"
-                className={fastModeEnabled ? 'h-4 w-4 fill-current text-primary' : 'h-4 w-4'}
+                className={fastModeEnabled ? 'h-3.5 w-3.5 text-text-primary' : 'h-3.5 w-3.5'}
               />
             </button>
           ) : null}

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from '@/lib/utils'
 import { TOGGLE_MODEL_SELECTOR_COMMAND } from '@/lib/keybindings'
 import type { UnifiedModel } from '@/types/api'
+import { FastModeIcon } from './FastModeIcon'
 import { ModelAdvancedHeader } from './ModelAdvancedHeader'
 import { ModelAutomaticReasoningOption } from './ModelAutomaticReasoningOption'
 import { ModelPowerSlider } from './ModelPowerSlider'
@@ -480,7 +481,7 @@ export function ModelSelector({
                   data-testid={`model-control-${control.id}-${option.value}`}
                   onFocus={clearSubmenuOnHover ? clearDesktopSubmenu : undefined}
                   onClick={() => handleSelectModelOption(control.id, option.value)}
-                  className="flex min-h-8 w-full items-center gap-3 rounded-lg px-3 py-1.5 text-left text-sm text-text-primary hover:bg-muted"
+                  className="flex min-h-8 w-full items-center gap-2 rounded-lg px-2 py-1 text-left text-sm text-text-primary hover:bg-muted"
                 >
                   <span className="min-w-0 flex-1">
                     <span className="block font-normal">
@@ -524,7 +525,7 @@ export function ModelSelector({
         onFocus={() => activateControl(control.id)}
         onClick={() => activateControl(control.id)}
         className={[
-          'flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-normal leading-[18px]',
+          'flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-normal leading-[18px]',
           active
             ? 'bg-muted text-text-primary'
             : 'text-text-secondary hover:bg-muted hover:text-text-primary',
@@ -569,7 +570,7 @@ export function ModelSelector({
             handleSelectModel(model)
           }}
           className={[
-            'flex min-h-8 w-full items-center gap-3 rounded-lg px-3 py-1.5 text-left text-sm leading-[18px]',
+            'flex min-h-8 w-full items-center gap-2 rounded-lg px-2 py-1 text-left text-sm leading-[18px]',
             modelDisabled
               ? 'cursor-not-allowed text-text-muted hover:bg-transparent'
               : 'text-text-primary hover:bg-muted',
@@ -850,7 +851,7 @@ export function ModelSelector({
               data-enter-animation="main"
               style={{ maxHeight: desktopMenuMaxHeight }}
               className={cn(
-                'w-64 shrink-0 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+                'w-64 shrink-0 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
                 styles.mainMenu
               )}
             >
@@ -866,7 +867,7 @@ export function ModelSelector({
                       onFocus={activateModels}
                       onClick={activateModels}
                       className={cn(
-                        'flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-normal leading-[18px]',
+                        'flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-normal leading-[18px]',
                         modelRowActive
                           ? 'bg-muted text-text-primary'
                           : 'text-text-secondary hover:bg-muted hover:text-text-primary'
@@ -885,7 +886,7 @@ export function ModelSelector({
                         type="button"
                         data-testid="model-control-menu-reasoning"
                         disabled
-                        className="flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-medium leading-[18px] text-text-muted opacity-60"
+                        className="flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-medium leading-[18px] text-text-muted opacity-60"
                       >
                         <span className="min-w-0 flex-1 truncate">
                           {t('workbench.reasoning_level', '推理强度')}
@@ -900,7 +901,7 @@ export function ModelSelector({
                         type="button"
                         data-testid="model-control-menu-speed"
                         disabled
-                        className="flex h-8 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-medium leading-[18px] text-text-muted opacity-60"
+                        className="flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-medium leading-[18px] text-text-muted opacity-60"
                       >
                         <span className="min-w-0 flex-1 truncate">
                           {t('workbench.speed', '速度')}
@@ -909,7 +910,7 @@ export function ModelSelector({
                       </button>
                     )}
                   </div>
-                  <div className="mx-3 my-1.5 border-t border-border" />
+                  <div className="mx-2 my-1 border-t border-border" />
                 </>
               ) : null}
               {selectedPowerSettingAvailable ? (
@@ -979,7 +980,7 @@ export function ModelSelector({
                 data-enter-animation="submenu"
                 style={{ top: submenuOffset, left: submenuLeft, width: submenuWidth }}
                 className={cn(
-                  'absolute max-h-[min(28rem,calc(100vh-8rem))] w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+                  'absolute max-h-[min(28rem,calc(100vh-8rem))] w-72 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
                   styles.submenu
                 )}
               >
@@ -996,7 +997,7 @@ export function ModelSelector({
                 data-enter-animation="submenu"
                 style={{ top: submenuOffset, left: submenuLeft, width: submenuWidth }}
                 className={cn(
-                  'absolute max-h-[min(28rem,calc(100vh-8rem))] min-h-48 w-72 overflow-y-auto rounded-2xl border border-border bg-background p-2 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+                  'absolute max-h-[min(28rem,calc(100vh-8rem))] min-h-48 w-72 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
                   styles.submenu
                 )}
               >
@@ -1026,9 +1027,21 @@ export function ModelSelector({
         disabled={disabled}
         isMobile={isMobile}
         label={buttonLabel}
+        leadingIcon={
+          fastModeState.enabled ? (
+            <FastModeIcon
+              data-testid="model-selector-fast-mode-icon"
+              className="h-3.5 w-3.5 shrink-0 text-text-primary"
+            />
+          ) : undefined
+        }
         highlightedLabel={isMobile ? undefined : ultraLabel}
         shortcut={modelSelectorShortcut}
-        ariaLabel={t('workbench.model_selector')}
+        ariaLabel={
+          fastModeState.enabled
+            ? `${t('workbench.model_selector')}, ${t('workbench.speed_fast', '快速')}`
+            : t('workbench.model_selector')
+        }
         tooltipLabel={t('workbench.model_picker_title', '选择模型')}
         buttonClassName={buttonClassName}
         maxClosedWidth={maxClosedWidth}

--- a/wework/src/components/chat/composer/ModelSelectorTrigger.tsx
+++ b/wework/src/components/chat/composer/ModelSelectorTrigger.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from 'lucide-react'
 import {
   type CSSProperties,
+  type ReactNode,
   type RefObject,
   useEffect,
   useLayoutEffect,
@@ -12,6 +13,7 @@ import { cn } from '@/lib/utils'
 
 const CLOSED_MAX_WIDTH = 208
 const HORIZONTAL_CHROME = 36
+const LEADING_ICON_CHROME = 18
 
 interface ModelSelectorTriggerProps {
   buttonRef: RefObject<HTMLButtonElement | null>
@@ -19,6 +21,7 @@ interface ModelSelectorTriggerProps {
   disabled: boolean
   isMobile: boolean
   label: string
+  leadingIcon?: ReactNode
   highlightedLabel?: string
   shortcut?: string | null
   ariaLabel: string
@@ -47,6 +50,7 @@ export function ModelSelectorTrigger({
   disabled,
   isMobile,
   label,
+  leadingIcon,
   highlightedLabel,
   shortcut,
   ariaLabel,
@@ -58,6 +62,7 @@ export function ModelSelectorTrigger({
   const measureRef = useRef<HTMLSpanElement>(null)
   const previousOpenRef = useRef(open)
   const [tooltipSuppressed, setTooltipSuppressed] = useState(false)
+  const hasLeadingIcon = Boolean(leadingIcon)
 
   useEffect(() => {
     if (previousOpenRef.current && !open) {
@@ -75,7 +80,8 @@ export function ModelSelectorTrigger({
         measureRef.current?.scrollWidth ?? 0
       )
       if (measuredWidth <= 0) return
-      const naturalWidth = Math.ceil(measuredWidth) + HORIZONTAL_CHROME
+      const naturalWidth =
+        Math.ceil(measuredWidth) + HORIZONTAL_CHROME + (hasLeadingIcon ? LEADING_ICON_CHROME : 0)
       button.style.setProperty(
         '--model-selector-width',
         `${Math.max(64, Math.min(maxClosedWidth, naturalWidth))}px`
@@ -91,7 +97,7 @@ export function ModelSelectorTrigger({
       observer?.disconnect()
       window.removeEventListener('resize', updateWidth)
     }
-  }, [buttonRef, isMobile, label, maxClosedWidth])
+  }, [buttonRef, hasLeadingIcon, isMobile, label, maxClosedWidth])
 
   const desktopStyle: CSSProperties | undefined = isMobile
     ? undefined
@@ -122,8 +128,11 @@ export function ModelSelectorTrigger({
         aria-label={ariaLabel}
         aria-describedby={showTooltip ? 'model-selector-tooltip' : undefined}
       >
-        <span className="min-w-0 flex-1 truncate text-center">
-          <TriggerLabel label={label} highlightedLabel={highlightedLabel} />
+        <span className="flex min-w-0 flex-1 items-center justify-center gap-1">
+          {leadingIcon}
+          <span className="min-w-0 truncate">
+            <TriggerLabel label={label} highlightedLabel={highlightedLabel} />
+          </span>
         </span>
         <ChevronDown className="h-4 w-4 shrink-0 text-text-secondary" />
       </button>

--- a/wework/src/components/layout/DesktopSettingsMenu.test.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { getLocalCodexUsageDisplay } from '@/api/local/codexUsage'
 import { DesktopSettingsMenu } from './DesktopSettingsMenu'
 
 const mockCheckNow = vi.fn()
@@ -42,6 +43,8 @@ vi.mock('@/api/local/codexUsage', () => ({
   }),
 }))
 
+const getLocalCodexUsageDisplayMock = vi.mocked(getLocalCodexUsageDisplay)
+
 function renderMenu({
   showLogout,
   onLogout = vi.fn(),
@@ -70,6 +73,13 @@ describe('DesktopSettingsMenu', () => {
       installUpdate: mockInstallUpdate,
     }
     runtimeModeMock.isLocalFirstAppRuntime.mockReturnValue(false)
+    getLocalCodexUsageDisplayMock.mockResolvedValue({
+      status: 'available',
+      fiveHour: { label: '5h', title: '5小时额度', value: '90%', percent: 90, resetsAt: 1 },
+      sevenDay: { label: '7d', title: '7天额度', value: '80%', percent: 80, resetsAt: 2 },
+      trayTitle: '5h 90%\n7d 80%',
+      tooltip: '5小时额度 90%\n7天额度 80%',
+    })
   })
 
   test('checks for app updates from the settings menu', async () => {
@@ -184,5 +194,62 @@ describe('DesktopSettingsMenu', () => {
 
     expect(await screen.findByText('11:30 重置')).toBeInTheDocument()
     expect(screen.getByText('1月5日 09:15 重置')).toBeInTheDocument()
+  })
+
+  test('hides an unavailable five-hour quota without leaving an empty value row', async () => {
+    getLocalCodexUsageDisplayMock.mockResolvedValue({
+      status: 'available',
+      fiveHour: {
+        label: '5h',
+        title: '5小时额度',
+        value: '无',
+        percent: null,
+        resetsAt: null,
+      },
+      sevenDay: {
+        label: '7d',
+        title: '7天额度',
+        value: '44%',
+        percent: 44,
+        resetsAt: 2,
+      },
+      trayTitle: '5h --\n7d 44%',
+      tooltip: '5小时额度 无\n7天额度 44%',
+    })
+
+    renderMenu()
+    await userEvent.click(screen.getByTestId('usage-menu-button'))
+
+    expect(await screen.findByText('44%')).toBeInTheDocument()
+    expect(screen.queryByText('5小时额度')).not.toBeInTheDocument()
+    expect(screen.queryByText('无')).not.toBeInTheDocument()
+  })
+
+  test('keeps an exhausted five-hour quota visible', async () => {
+    getLocalCodexUsageDisplayMock.mockResolvedValue({
+      status: 'available',
+      fiveHour: {
+        label: '5h',
+        title: '5小时额度',
+        value: '0%',
+        percent: 0,
+        resetsAt: 1,
+      },
+      sevenDay: {
+        label: '7d',
+        title: '7天额度',
+        value: '44%',
+        percent: 44,
+        resetsAt: 2,
+      },
+      trayTitle: '5h 0%\n7d 44%',
+      tooltip: '5小时额度 0%\n7天额度 44%',
+    })
+
+    renderMenu()
+    await userEvent.click(screen.getByTestId('usage-menu-button'))
+
+    expect(await screen.findByText('5小时额度')).toBeInTheDocument()
+    expect(screen.getByText('0%')).toBeInTheDocument()
   })
 })

--- a/wework/src/components/layout/DesktopSettingsMenu.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Clock, Download, Loader2, LogIn, LogOut, Settings } from 'lucide-react'
+import { ChevronDown, Download, Gauge, Loader2, LogIn, LogOut, Settings } from 'lucide-react'
 import { useState } from 'react'
 import type { ReactNode } from 'react'
 import {
@@ -148,18 +148,18 @@ export function DesktopSettingsMenu({
   return (
     <div
       data-testid="settings-menu"
-      className="absolute bottom-[72px] left-1.5 right-1.5 z-30 overflow-hidden rounded-[20px] border border-border/70 bg-popover/95 py-2.5 text-text-primary shadow-[0_24px_60px_rgba(0,0,0,0.36)] ring-1 ring-border/40 backdrop-blur-xl"
+      className="absolute bottom-[72px] left-1.5 right-1.5 z-30 overflow-hidden rounded-xl border border-border/70 bg-popover/95 p-1 text-text-primary shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl"
     >
       {onLogin ? (
         <>
           <SettingsMenuItem
             testId="login-menu-button"
-            icon={<LogIn className="h-4 w-4 shrink-0 text-primary" />}
+            icon={<LogIn className="h-4 w-4 shrink-0 text-text-secondary" />}
             label={t('workbench.account_cloud_login', '登录 Wegent')}
             description={t('workbench.account_cloud_login_description', '连接云端模型、设备和同步')}
             onClick={onLogin}
           />
-          <div className="mx-4 my-1.5 border-t border-border/70" />
+          <div className="mx-2 my-1 border-t border-border/70" />
         </>
       ) : null}
       <SettingsMenuItem
@@ -188,7 +188,7 @@ export function DesktopSettingsMenu({
       {downloadMessage ? (
         <div
           data-testid="app-update-download-progress"
-          className="space-y-1.5 px-4 pb-2 pl-[44px] pr-5 text-xs font-medium leading-[18px] text-text-secondary"
+          className="space-y-1.5 pb-2 pl-8 pr-3 text-xs font-medium leading-[18px] text-text-secondary"
         >
           <div className="h-1 overflow-hidden rounded-full bg-muted">
             <div
@@ -206,17 +206,17 @@ export function DesktopSettingsMenu({
       {updateMessage || updateError ? (
         <div
           data-testid="app-update-status"
-          className="px-4 pb-2 pl-[44px] pr-5 text-xs font-medium leading-[18px] text-text-secondary"
+          className="pb-2 pl-8 pr-3 text-xs font-medium leading-[18px] text-text-secondary"
         >
           <span className={updateError ? 'text-red-400' : undefined}>
             {updateError ?? updateMessage}
           </span>
         </div>
       ) : null}
-      <div className="mx-4 my-1.5 border-t border-border/70" />
+      <div className="mx-2 my-1 border-t border-border/70" />
       <SettingsMenuItem
         testId="usage-menu-button"
-        icon={<Clock className="h-4 w-4 shrink-0 text-text-secondary" />}
+        icon={<Gauge className="h-4 w-4 shrink-0 text-text-secondary" />}
         label={t('workbench.remaining_usage', 'Codex 剩余额度')}
         onClick={handleUsageClick}
         ariaExpanded={isUsageExpanded}
@@ -233,7 +233,7 @@ export function DesktopSettingsMenu({
         <div
           id="remaining-usage-panel"
           data-testid="usage-detail-panel"
-          className="px-4 pb-3 pl-[44px] pt-1"
+          className="pb-2 pl-8 pr-3 pt-1"
         >
           {isQuotaLoading ? (
             <div className="py-1 text-sm leading-[18px] text-text-secondary">
@@ -243,9 +243,11 @@ export function DesktopSettingsMenu({
           {quotaError ? (
             <div className="py-1 text-sm leading-[18px] text-text-secondary">{quotaError}</div>
           ) : null}
-          {!quotaError ? (
-            <div className="space-y-2 text-xs leading-5 text-text-secondary">
-              <UsageWindowRow window={codexUsage.fiveHour} />
+          {!isQuotaLoading && !quotaError ? (
+            <div className="space-y-1.5 text-xs leading-5 text-text-secondary">
+              {codexUsage.fiveHour.percent !== null ? (
+                <UsageWindowRow window={codexUsage.fiveHour} />
+              ) : null}
               <UsageWindowRow window={codexUsage.sevenDay} />
             </div>
           ) : null}
@@ -317,8 +319,8 @@ function SettingsMenuItem({
       disabled={disabled}
       aria-expanded={ariaExpanded}
       aria-controls={ariaControls}
-      className={`flex w-full items-center gap-3 px-4 text-left text-sm font-normal leading-[18px] text-text-primary transition-colors hover:bg-hover disabled:cursor-not-allowed disabled:opacity-60 ${
-        description ? 'min-h-12 py-2' : 'h-9'
+      className={`flex w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-normal leading-[18px] text-text-primary transition-colors hover:bg-hover disabled:cursor-not-allowed disabled:opacity-60 ${
+        description ? 'min-h-12 py-2' : 'h-8'
       } ${active ? 'bg-hover' : ''}`}
     >
       {icon}

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -769,7 +769,7 @@
     "reset_default_model_settings": "Reset to default settings",
     "speed_standard": "Standard",
     "speed_standard_description": "Default speed",
-    "speed_fast": "⚡ Fast",
+    "speed_fast": "Fast",
     "speed_fast_description": "1.5x speed, increased usage",
     "default_permission": "Default permission",
     "auto_review": "Auto review",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -769,7 +769,7 @@
     "reset_default_model_settings": "重置为默认设置",
     "speed_standard": "标准",
     "speed_standard_description": "默认速度",
-    "speed_fast": "⚡ 快速",
+    "speed_fast": "快速",
     "speed_fast_description": "1.5 倍速度，消耗增加",
     "default_permission": "默认权限",
     "auto_review": "自动审查",

--- a/wework/src/lib/model-ui.ts
+++ b/wework/src/lib/model-ui.ts
@@ -163,7 +163,7 @@ const OPENAI_RESPONSES_CONTROLS: ModelControlConfig[] = [
     defaultValue: 'standard',
     placement: 'belowModels',
     scope: 'model',
-    includeInLabel: 'whenNonDefault',
+    includeInLabel: 'never',
     options: [
       {
         value: 'standard',
@@ -175,9 +175,8 @@ const OPENAI_RESPONSES_CONTROLS: ModelControlConfig[] = [
       },
       {
         value: 'fast',
-        label: '⚡ 快速',
+        label: '快速',
         labelKey: 'workbench.speed_fast',
-        summaryLabel: '⚡',
         description: '1.5 倍速度，消耗增加',
         descriptionKey: 'workbench.speed_fast_description',
         order: 20,


### PR DESCRIPTION
# 优化 Wework Codex 额度和模型选择体验

## Summary

- 当 Codex 的 5 小时额度不可用时隐藏该行，不再展示“无”；有效的 `0%` 仍会正常显示。
- 始终保留 7 天额度信息，避免一个缺失的额度窗口影响其他有效数据。
- 用 Codex 风格的单色实心闪电替换 Fast 模式 Emoji，并在模型选择按钮和高级设置中复用同一图标。
- 收紧设置菜单和模型选择浮层的间距、圆角与阴影，使桌面端界面更简洁、统一。

## Screenshots

### Codex 剩余额度

5 小时额度不可用时，仅展示有效的 7 天额度。

<img width="432" height="448" alt="codex-usage-menu" src="https://github.com/user-attachments/assets/cd731cda-4b56-47f5-b746-9c68bf6fc7f8" />


### Fast 模式关闭态

模型选择按钮使用单色 Codex 风格图标，不再使用 Emoji。


<img width="284" height="64" alt="model-fast-trigger" src="https://github.com/user-attachments/assets/5b496f5d-1eab-4437-aaa5-bafcadfb9de8" />


### 模型选择菜单

速度文案保持为纯文本“快速”，并统一浮层间距、圆角和阴影。

<img width="512" height="298" alt="model-selector-menu" src="https://github.com/user-attachments/assets/14c3212d-796a-415a-99ec-5c78bd22bd98" />


### 高级 Fast 模式

高级设置中的 Fast 模式复用相同图标语言。


<img width="512" height="192" alt="model-advanced-fast" src="https://github.com/user-attachments/assets/764f2e39-1081-4c90-8acf-056646676654" />


## Test plan

- [x] 拉取并 rebase 最新 `origin/main`。
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter wework build`
- [x] 使用仓库标准脚本构建未签名 macOS Tauri dev app：
      `bash wework/scripts/build-mac-app.sh --profile dev --target aarch64-apple-darwin --bundles app --no-sign`
- [x] 在隔离的真实 Tauri 应用中验证设置菜单和模型选择器。
- [x] 验证 5 小时额度缺失时不展示该行，7 天额度仍正常展示。
- [x] 验证 Standard 模式不展示 Fast 图标，Fast 模式展示新的单色图标。
- [x] 聚焦单元测试：3 个文件、121 项测试通过。
- [x] 变更文件 ESLint 检查通过。
- [x] 变更文件 Prettier 检查通过。
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fast-mode icon and improved fast-mode controls for supported models.
  * Updated model menus with clearer accessibility labels and streamlined spacing.

* **Bug Fixes**
  * Fast mode now displays localized text without the lightning emoji.
  * Model labels no longer duplicate selected speed details.
  * Usage panels now hide unavailable data and handle loading or error states correctly.

* **Style**
  * Refined settings and model menus with updated spacing, borders, sizing, and visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->