### PR TITLE
fix(executor): restore local Codex tracking headers

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2291,6 +2291,7 @@ fn build_codex_launch_config(request: &ExecutionRequest) -> CodexLaunchConfig {
                 &mut launch_config,
                 &request.task_id,
                 upstream,
+                project_id.as_deref(),
                 model.clone(),
             );
         } else {
@@ -2309,6 +2310,7 @@ fn build_codex_launch_config(request: &ExecutionRequest) -> CodexLaunchConfig {
             &mut launch_config,
             &request.task_id,
             explicit_codex_upstream(&request.model_config, &base_url, &api_key),
+            project_id.as_deref(),
             model.clone(),
         );
     } else {
@@ -2332,8 +2334,10 @@ fn configure_codex_router(
     launch_config: &mut CodexLaunchConfig,
     task_id: &str,
     mut upstream: LocalModelProxyUpstream,
+    project_id: Option<&str>,
     routing_model_id: Option<String>,
 ) {
+    upstream.default_headers = merge_codex_tracking_headers(upstream.default_headers, project_id);
     upstream.routing_model_id = routing_model_id;
     let local_token = local_model_proxy::register(task_id, upstream);
     let local_base_url = executor_loopback_base_url()
@@ -2764,31 +2768,7 @@ fn header_overrides(
     default_headers: Option<&Value>,
     project_id: Option<&str>,
 ) -> Vec<String> {
-    let Some(project_id) = project_id.map(str::trim).filter(|value| !value.is_empty()) else {
-        let headers = parse_header_map(default_headers);
-        return if headers.is_empty() {
-            Vec::new()
-        } else {
-            headers
-                .into_iter()
-                .map(|(key, value)| {
-                    format!(
-                        "{}={}",
-                        toml_key_path(&["model_providers", model_provider, "http_headers", &key]),
-                        toml_value(&value)
-                    )
-                })
-                .collect()
-        };
-    };
-
-    let mut headers = parse_header_map(default_headers);
-    insert_missing_header(&mut headers, "wecode-action", "wegent");
-    insert_missing_header(&mut headers, "wecode-source", "wegent-local");
-    insert_missing_header(&mut headers, "wecode-executor", "codex");
-    insert_header(&mut headers, "wecode-project", project_id);
-
-    headers
+    merge_codex_tracking_headers(parse_header_map(default_headers), project_id)
         .into_iter()
         .map(|(key, value)| {
             format!(
@@ -2798,6 +2778,21 @@ fn header_overrides(
             )
         })
         .collect()
+}
+
+fn merge_codex_tracking_headers(
+    mut headers: Vec<(String, String)>,
+    project_id: Option<&str>,
+) -> Vec<(String, String)> {
+    let Some(project_id) = project_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return headers;
+    };
+
+    insert_missing_header(&mut headers, "wecode-action", "wegent");
+    insert_missing_header(&mut headers, "wecode-source", "wegent-local");
+    insert_missing_header(&mut headers, "wecode-executor", "codex");
+    insert_header(&mut headers, "wecode-project", project_id);
+    headers
 }
 
 fn parse_header_map(value: Option<&Value>) -> Vec<(String, String)> {

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -485,6 +485,54 @@ fn explicit_upstream_uses_configured_max_output_tokens() {
 }
 
 #[test]
+fn codex_router_forwards_project_tracking_headers_to_anthropic_upstream() {
+    let request = ExecutionRequest {
+        task_id: format!("codex-tracking-headers-{}", std::process::id()),
+        model_config: json!({
+            "model_id": "claude-sonnet",
+            "base_url": "https://example.com/v1",
+            "api_key": "secret",
+            "upstream_api_format": "anthropic-messages",
+            "default_headers": {
+                "WeCode-Action": "configured-action",
+                "x-custom": "custom-value"
+            }
+        }),
+        extra: serde_json::Map::from_iter([("project_id".to_owned(), json!(42))]),
+        ..ExecutionRequest::default()
+    };
+
+    let launch_config = build_codex_launch_config(&request);
+    let token = &launch_config
+        .local_proxy_registration
+        .as_ref()
+        .expect("local proxy registration")
+        .0;
+    let upstream = local_model_proxy::registered_upstream(token).expect("registered upstream");
+    let header = |name: &str| {
+        upstream
+            .default_headers
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    };
+
+    assert_eq!(upstream.api_format, "anthropic-messages");
+    assert_eq!(header("wecode-source"), Some("wegent-local"));
+    assert_eq!(header("wecode-action"), Some("configured-action"));
+    assert_eq!(header("wecode-executor"), Some("codex"));
+    assert_eq!(header("wecode-project"), Some("42"));
+    assert_eq!(header("x-custom"), Some("custom-value"));
+}
+
+#[test]
+fn codex_router_preserves_configured_headers_without_a_project() {
+    let headers = vec![("x-custom".to_owned(), "custom-value".to_owned())];
+
+    assert_eq!(merge_codex_tracking_headers(headers.clone(), None), headers);
+}
+
+#[test]
 fn kimi_k3_profile_uses_the_built_in_catalog_entry() {
     let request = ExecutionRequest {
         model_config: json!({

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -197,6 +197,16 @@ pub(crate) fn unregister(token: &str) {
     );
 }
 
+#[cfg(test)]
+pub(crate) fn registered_upstream(token: &str) -> Option<LocalModelProxyUpstream> {
+    registry()
+        .lock()
+        .expect("local model proxy registry should not be poisoned")
+        .routes
+        .get(token)
+        .map(|registered| registered.upstream.clone())
+}
+
 fn generate_registration_token(registry: &LocalModelProxyRegistry) -> String {
     loop {
         let mut bytes = [0_u8; 24];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex requests now forward project and tracking information to upstream services.
  * Existing custom headers are preserved when project tracking is unavailable.
* **Tests**
  * Added coverage for tracking header forwarding, custom header preservation, and upstream registration lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->