### PR TITLE
fix(executor): restore local Claude tracking headers

### DIFF
--- a/executor/src/agents/claude_code.rs
+++ b/executor/src/agents/claude_code.rs
@@ -542,16 +542,15 @@ fn apply_claude_header_environment(
         runtime_custom_headers.as_str(),
     ]);
 
-    let mut default_headers = extract_default_headers(request);
+    let mut default_headers = merge_missing_header_map(
+        extract_default_headers(request),
+        vec![
+            ("wecode-action".to_owned(), "wegent".to_owned()),
+            ("wecode-source".to_owned(), "wegent-local".to_owned()),
+            ("wecode-executor".to_owned(), "claudecode".to_owned()),
+        ],
+    );
     if let Some(project_id) = project_id(request) {
-        default_headers = merge_missing_header_map(
-            default_headers,
-            vec![
-                ("wecode-action".to_owned(), "wegent".to_owned()),
-                ("wecode-source".to_owned(), "wegent-local".to_owned()),
-                ("wecode-executor".to_owned(), "claudecode".to_owned()),
-            ],
-        );
         default_headers = merge_header_map(
             default_headers,
             vec![("wecode-project".to_owned(), project_id)],

--- a/executor/tests/agent_command_contract.rs
+++ b/executor/tests/agent_command_contract.rs
@@ -733,6 +733,31 @@ fn claude_project_headers_merge_custom_headers_and_default_headers() {
 }
 
 #[test]
+fn claude_non_project_request_includes_local_tracking_headers() {
+    let _lock = env_lock();
+    let home = unique_dir("claude-non-project-headers-home");
+    let _home = EnvGuard::set("HOME", &home.display().to_string());
+    let _process_headers = EnvGuard::remove("ANTHROPIC_CUSTOM_HEADERS");
+    let request = ExecutionRequest {
+        prompt: json!("answer without a project"),
+        ..ExecutionRequest::default()
+    };
+
+    let spec = build_claude_command(&request, "claude");
+    let default_headers: serde_json::Value =
+        serde_json::from_str(spec.envs().get("DEFAULT_HEADERS").unwrap()).unwrap();
+
+    assert_eq!(
+        spec.envs().get("ANTHROPIC_CUSTOM_HEADERS").unwrap(),
+        "wecode-action: wegent\nwecode-source: wegent-local\nwecode-executor: claudecode"
+    );
+    assert_eq!(default_headers["wecode-action"], "wegent");
+    assert_eq!(default_headers["wecode-source"], "wegent-local");
+    assert_eq!(default_headers["wecode-executor"], "claudecode");
+    assert!(default_headers.get("wecode-project").is_none());
+}
+
+#[test]
 fn claude_standalone_project_zero_keeps_global_capabilities_and_project_header() {
     let _lock = env_lock();
     let home = unique_dir("claude-standalone-zero-home");

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -1011,6 +1011,8 @@ describe('createLocalAppServices', () => {
               'X-Wegent-Model-Type': 'user',
               'X-Wegent-Model-Namespace': 'default',
               'X-Wegent-Model-User-Id': '42',
+              'X-Wegent-Upstream-Header-wecode-executor': 'codex',
+              'X-Wegent-Upstream-Header-wecode-source': 'wegent-local',
             },
           }),
         }),
@@ -1355,6 +1357,8 @@ describe('createLocalAppServices', () => {
           'X-Wegent-Model-Type': 'user',
           'X-Wegent-Model-Namespace': 'default',
           'X-Wegent-Model-User-Id': '42',
+          'X-Wegent-Upstream-Header-wecode-executor': 'codex',
+          'X-Wegent-Upstream-Header-wecode-source': 'wegent-local',
         },
         runtime_config: {
           codex: {
@@ -1418,6 +1422,8 @@ describe('createLocalAppServices', () => {
           'X-Wegent-Model-Type': 'user',
           'X-Wegent-Model-Namespace': 'default',
           'X-Wegent-Model-User-Id': '42',
+          'X-Wegent-Upstream-Header-wecode-executor': 'codex',
+          'X-Wegent-Upstream-Header-wecode-source': 'wegent-local',
         },
         runtime_config: {
           codex: {

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -769,7 +769,16 @@ function providerIdFromLocalConfig(config: LocalModelConfig): string {
   return `local-${config.id}`.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'local'
 }
 
+function wecodeExecutorForRuntime(runtime: string): string {
+  const normalized = runtime
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+  return normalized === 'claude' || normalized === 'claudecode' ? 'claudecode' : normalized
+}
+
 function localRuntimeModelConfig(
+  runtime: string,
   modelName?: string,
   modelType?: string | null,
   modelOptions?: Record<string, string>,
@@ -853,6 +862,8 @@ function localRuntimeModelConfig(
         'X-Wegent-Model-Type': modelType,
         'X-Wegent-Model-Namespace': namespace,
         'X-Wegent-Model-User-Id': resourceUserId,
+        'X-Wegent-Upstream-Header-wecode-executor': wecodeExecutorForRuntime(runtime),
+        'X-Wegent-Upstream-Header-wecode-source': 'wegent-local',
       },
       ...(Number.isFinite(contextWindow) && contextWindow > 0
         ? { model_context_window: contextWindow }
@@ -1255,6 +1266,7 @@ function buildLocalRuntimeExecutionRequest(
   const taskId = input.taskId || derivedTaskId
   const modelConfig = applyRuntimeModelOptions(
     localRuntimeModelConfig(
+      input.runtime,
       input.modelId,
       input.modelType,
       input.modelOptions,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standard tracking headers are now consistently included for Claude requests, including requests without a project.
  * Project-specific headers remain limited to requests associated with a project.
  * Cloud model requests now include consistent runtime and source tracking information across supported request types.

* **Tests**
  * Added coverage to verify header behavior for non-project Claude requests.
  * Added validation for tracking headers on cloud runtime execution requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->