### PR TITLE
fix(wework): prefer injected browser bridge identity over stale runtime file

### DIFF
--- a/executor/src/browser_mcp/bridge_identity.rs
+++ b/executor/src/browser_mcp/bridge_identity.rs
@@ -25,12 +25,26 @@ struct BridgeRuntimeRecord {
 }
 
 pub(crate) fn current_bridge_identity() -> BridgeIdentity {
-    read_runtime_identity().unwrap_or_else(environment_identity)
+    bridge_identity_from_sources(environment_identity(), runtime_file_path())
 }
 
-fn read_runtime_identity() -> Option<BridgeIdentity> {
-    let content = fs::read_to_string(runtime_file_path()?).ok()?;
-    parse_runtime_identity(&content).ok()
+fn bridge_identity_from_sources(
+    environment: Option<BridgeIdentity>,
+    runtime_path: Option<PathBuf>,
+) -> BridgeIdentity {
+    environment
+        .or_else(|| read_runtime_identity(runtime_path))
+        .unwrap_or_else(default_identity)
+}
+
+fn read_runtime_identity(path: Option<PathBuf>) -> Option<BridgeIdentity> {
+    let content = fs::read_to_string(path?).ok()?;
+    let identity = parse_runtime_identity(&content).ok()?;
+    if identity.runtime_process_is_alive() {
+        Some(identity)
+    } else {
+        None
+    }
 }
 
 fn parse_runtime_identity(content: &str) -> Result<BridgeIdentity, String> {
@@ -57,9 +71,17 @@ fn parse_runtime_identity(content: &str) -> Result<BridgeIdentity, String> {
     })
 }
 
-fn environment_identity() -> BridgeIdentity {
+fn environment_identity() -> Option<BridgeIdentity> {
+    non_empty_env(BRIDGE_URL_ENV).map(|base_url| BridgeIdentity {
+        base_url,
+        token: non_empty_env(BRIDGE_TOKEN_ENV),
+        generation: None,
+    })
+}
+
+fn default_identity() -> BridgeIdentity {
     BridgeIdentity {
-        base_url: non_empty_env(BRIDGE_URL_ENV).unwrap_or_else(|| DEFAULT_BRIDGE_URL.to_owned()),
+        base_url: DEFAULT_BRIDGE_URL.to_owned(),
         token: non_empty_env(BRIDGE_TOKEN_ENV),
         generation: None,
     }
@@ -86,9 +108,35 @@ fn non_empty_env(name: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+impl BridgeIdentity {
+    fn runtime_process_is_alive(&self) -> bool {
+        self.generation
+            .map(|(pid, _)| process_is_alive(pid))
+            .unwrap_or(true)
+    }
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_is_alive(pid: u32) -> bool {
+    pid != 0
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_runtime_identity;
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{bridge_identity_from_sources, parse_runtime_identity, BridgeIdentity};
 
     #[test]
     fn runtime_identity_accepts_only_authenticated_loopback_bridges() {
@@ -107,5 +155,62 @@ mod tests {
             r#"{"schemaVersion":1,"pid":42,"address":"127.0.0.1:43127","token":"","startedAtUnixMs":123}"#
         )
         .is_err());
+    }
+
+    #[test]
+    fn environment_bridge_identity_takes_precedence_over_runtime_file() {
+        let directory = tempdir().unwrap();
+        let runtime_path = directory.path().join("embedded-browser-bridge.json");
+        fs::write(
+            &runtime_path,
+            r#"{"schemaVersion":1,"pid":999999,"address":"127.0.0.1:43127","token":"stale","startedAtUnixMs":123}"#,
+        )
+        .unwrap();
+
+        let identity = bridge_identity_from_sources(
+            Some(BridgeIdentity {
+                base_url: "http://127.0.0.1:60398".to_owned(),
+                token: Some("current-token".to_owned()),
+                generation: None,
+            }),
+            Some(runtime_path),
+        );
+
+        assert_eq!(identity.base_url, "http://127.0.0.1:60398");
+        assert_eq!(identity.token.as_deref(), Some("current-token"));
+    }
+
+    #[test]
+    fn stale_runtime_file_falls_back_to_default_identity() {
+        let directory = tempdir().unwrap();
+        let runtime_path = directory.path().join("embedded-browser-bridge.json");
+        fs::write(
+            &runtime_path,
+            r#"{"schemaVersion":1,"pid":999999,"address":"127.0.0.1:43127","token":"stale","startedAtUnixMs":123}"#,
+        )
+        .unwrap();
+
+        let identity = bridge_identity_from_sources(None, Some(runtime_path));
+
+        assert_eq!(identity.base_url, "http://127.0.0.1:9231");
+    }
+
+    #[test]
+    fn live_runtime_file_is_used_when_environment_url_is_missing() {
+        let directory = tempdir().unwrap();
+        let runtime_path = directory.path().join("embedded-browser-bridge.json");
+        fs::write(
+            &runtime_path,
+            format!(
+                r#"{{"schemaVersion":1,"pid":{},"address":"127.0.0.1:43127","token":"runtime-token","startedAtUnixMs":123}}"#,
+                std::process::id()
+            ),
+        )
+        .unwrap();
+
+        let identity = bridge_identity_from_sources(None, Some(runtime_path));
+
+        assert_eq!(identity.base_url, "http://127.0.0.1:43127");
+        assert_eq!(identity.token.as_deref(), Some("runtime-token"));
     }
 }

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -106,6 +106,20 @@ async function waitForBridgeIdentity(executorHome, timeoutMs) {
   throw new Error('Timed out waiting for authenticated embedded browser bridge runtime')
 }
 
+async function writeStaleBridgeRuntime(identity) {
+  await writeFile(
+    identity.runtimePath,
+    `${JSON.stringify({
+      schemaVersion: 1,
+      pid: process.pid,
+      address: '127.0.0.1:9',
+      token: 'stale-upgrade-token',
+      startedAtUnixMs: Date.now() - 60_000,
+    })}\n`,
+    'utf8'
+  )
+}
+
 async function callBridge(identity, payload) {
   const response = await fetch(`${identity.baseUrl}/browser`, {
     method: 'POST',
@@ -226,6 +240,10 @@ async function withBrowserMcp(identity, callback) {
       })
     })
     assert.equal(stderr.includes('lifecycle=fatal'), false, stderr)
+    assert.ok(
+      stderr.includes(`bridge_url=${identity.baseUrl}`),
+      `MCP server did not use the injected bridge URL. stderr:\n${stderr}`
+    )
   }
 }
 
@@ -317,6 +335,7 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
       await control.command('click', BROWSER_AGENT_RESUME_SELECTOR)
       await pendingAgentWait
 
+      await writeStaleBridgeRuntime(bridgeIdentity)
       const mcpResult = await withBrowserMcp(bridgeIdentity, async callTool => {
         const openText = await callTool('browser_open_and_inspect', {
           url: redirectUrl,


### PR DESCRIPTION
## Problem
The embedded browser bridge binds an ephemeral port (`127.0.0.1:0`) and generates a fresh token on every app start. The browser MCP server resolved the bridge from the on-disk runtime record first, so after an app upgrade/restart it could pick up a stale record written by a previous, now-dead bridge instance — pointing at a dead address or carrying an outdated token — and every bridge call failed even though the correct identity was injected through its environment.
## Changes
- `executor/src/browser_mcp/bridge_identity.rs`
  - Identity resolution order is now: injected environment (`WEWORK_EMBEDDED_BROWSER_BRIDGE_URL`) → live runtime file → built-in default.
  - Runtime records are only honored when the recorded bridge process is still alive (`kill(pid, 0)` on Unix; non-zero pid elsewhere); stale records fall back to the default identity.
  - Added unit tests for the three resolution paths.
- `wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs`
  - Writes a stale runtime record (live pid, dead address, wrong token) before spawning the MCP server and asserts the server logs the injected bridge URL, guarding the precedence against regression.
## Verification
- `cargo test bridge_identity` — 4 passed (3 new)
- `cargo fmt --check` / `cargo clippy --all-targets` — clean
- E2E: `pnpm --filter wework e2e:desktop:embedded-browser`
## Notes
When an injected identity is present, the runtime file is never consulted, so a long-lived MCP process whose injected bridge died cannot self-heal from a newer runtime record. This is an accepted trade-off: the bridge shares the wework app lifecycle, so a dead injected bridge implies the parent process tree is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge connection discovery by prioritizing configured settings and safely falling back to valid runtime information or the default connection.
  * Prevented stale or invalid runtime records from being used.
  * Improved handling of bridge process availability across platforms.
* **Tests**
  * Added coverage for configuration precedence, stale runtime fallback, and active runtime connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->