### PR TITLE
fix(ci): stabilize merge queue validation

### DIFF
--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -36,6 +36,7 @@ workflow_has_top_level_trigger() {
       if (!in_on) {
         if (line !~ /^on:[[:space:]]*/) next
         sub(/^on:[[:space:]]*/, "", line)
+        sub(/^[[:space:]]*#.*/, "", line)
         if (line != "") {
           found = inline_has_target(line)
           exit
@@ -298,6 +299,7 @@ for workflow in test.yml lint.yml; do
 done
 
 assert_workflow_trigger_case "block mapping push trigger" "true" $'on:\n  push:\n  pull_request:'
+assert_workflow_trigger_case "block mapping with on comment" "true" $'on: # workflow triggers\n  push:\n  pull_request:'
 assert_workflow_trigger_case "block sequence push trigger" "true" $'on:\n  - push\n  - pull_request'
 assert_workflow_trigger_case "inline scalar push trigger" "true" "on: push"
 assert_workflow_trigger_case "inline array push trigger" "true" "on: [push, pull_request]"

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -147,16 +147,9 @@ fi
 
 for workflow in e2e-tests.yml wework-e2e.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
-  push_config="$(
-    sed -n '/^  push:/,/^  pull_request:/p' "$workflow_path"
-  )"
   pull_request_config="$(
     sed -n '/^  pull_request:/,/^  [a-z_]*:/p' "$workflow_path"
   )"
-  if grep -q "paths:" <<<"$push_config"; then
-    printf '%s must run for every push to main\n' "$workflow" >&2
-    exit 1
-  fi
   if ! grep -q "ready_for_review" <<<"$pull_request_config"; then
     printf '%s must run E2E when a draft PR becomes ready for review\n' \
       "$workflow" >&2
@@ -195,7 +188,7 @@ done
 for workflow in test.yml lint.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
   if ! grep -q "classify-ci-changes.sh --all" "$workflow_path"; then
-    printf '%s must classify every module for pushes to main\n' "$workflow" >&2
+    printf '%s must classify every module for merge groups\n' "$workflow" >&2
     exit 1
   fi
   if ! grep -q "merge_group:" "$workflow_path"; then
@@ -211,6 +204,13 @@ done
 
 for workflow in lint.yml test.yml e2e-tests.yml wework-e2e.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
+  if grep -q "^  push:" "$workflow_path"; then
+    printf '%s must not repeat merge queue validation after entering main\n' \
+      "$workflow" >&2
+    exit 1
+  fi
+  # GitHub expressions are matched literally in workflow source.
+  # shellcheck disable=SC2016
   if ! grep -Fq 'git diff --name-only "$BASE_SHA...$HEAD_SHA"' "$workflow_path"; then
     printf '%s must classify pull request changes from the merge base\n' \
       "$workflow" >&2
@@ -242,6 +242,13 @@ fi
 
 if ! grep -q "wework_desktop_e2e_matrix" "$wework_workflow"; then
   printf 'Wework desktop E2E must use the changed-feature segment matrix\n' >&2
+  exit 1
+fi
+
+# GitHub expressions are matched literally in workflow source.
+# shellcheck disable=SC2016
+if ! grep -Fq '${{ matrix.command }}-e2e-' "$wework_workflow"; then
+  printf 'Wework desktop E2E caches must be isolated by E2E command\n' >&2
   exit 1
 fi
 

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -6,6 +6,101 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 classifier="$script_dir/classify-ci-changes.sh"
 desktop_classifier="$script_dir/classify-wework-desktop-e2e.sh"
 
+workflow_has_top_level_trigger() {
+  local workflow_path="$1"
+  local trigger="$2"
+
+  awk -v target="$trigger" '
+    function normalize_token(token) {
+      gsub(/^[[:space:]"]+|[[:space:]"]+$/, "", token)
+      gsub(/^\047+|\047+$/, "", token)
+      return token
+    }
+
+    function inline_has_target(value, tokens, token_count, token_index) {
+      sub(/[[:space:]]+#.*/, "", value)
+      gsub(/[\[\],]/, " ", value)
+      token_count = split(value, tokens, /[[:space:]]+/)
+      for (token_index = 1; token_index <= token_count; token_index++) {
+        if (normalize_token(tokens[token_index]) == target) return 1
+      }
+      return 0
+    }
+
+    /^[[:space:]]*(#|$)/ {
+      next
+    }
+
+    {
+      line = $0
+      if (!in_on) {
+        if (line !~ /^on:[[:space:]]*/) next
+        sub(/^on:[[:space:]]*/, "", line)
+        if (line != "") {
+          found = inline_has_target(line)
+          exit
+        }
+        in_on = 1
+        child_indent = -1
+        next
+      }
+
+      if (line ~ /^[^[:space:]]/) exit
+
+      indentation = line
+      sub(/[^[:space:]].*$/, "", indentation)
+      indent = length(indentation)
+      if (child_indent == -1) child_indent = indent
+      if (indent != child_indent) next
+
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+#.*/, "", line)
+      sub(/^-[[:space:]]*/, "", line)
+      sub(/:.*/, "", line)
+      if (normalize_token(line) == target) {
+        found = 1
+        exit
+      }
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$workflow_path"
+}
+
+assert_workflow_trigger_case() {
+  local name="$1"
+  local expected="$2"
+  local workflow="$3"
+  local actual="false"
+
+  if workflow_has_top_level_trigger <(printf '%s\n' "$workflow") "push"; then
+    actual="true"
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'Workflow trigger case "%s" failed.\n' "$name" >&2
+    exit 1
+  fi
+}
+
+extract_named_workflow_step() {
+  local workflow_path="$1"
+  local step_name="$2"
+
+  awk -v target="$step_name" '
+    found && /^      - name:/ {
+      exit
+    }
+    $0 == "      - name: " target {
+      found = 1
+    }
+    found {
+      print
+    }
+  ' "$workflow_path"
+}
+
 assert_case() {
   local name="$1"
   local expected="$2"
@@ -202,9 +297,15 @@ for workflow in test.yml lint.yml; do
   fi
 done
 
+assert_workflow_trigger_case "block mapping push trigger" "true" $'on:\n  push:\n  pull_request:'
+assert_workflow_trigger_case "block sequence push trigger" "true" $'on:\n  - push\n  - pull_request'
+assert_workflow_trigger_case "inline scalar push trigger" "true" "on: push"
+assert_workflow_trigger_case "inline array push trigger" "true" "on: [push, pull_request]"
+assert_workflow_trigger_case "push job is not a trigger" "false" $'on: pull_request\njobs:\n  push:\n    runs-on: ubuntu-latest'
+
 for workflow in lint.yml test.yml e2e-tests.yml wework-e2e.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
-  if grep -q "^  push:" "$workflow_path"; then
+  if workflow_has_top_level_trigger "$workflow_path" "push"; then
     printf '%s must not repeat merge queue validation after entering main\n' \
       "$workflow" >&2
     exit 1
@@ -245,9 +346,30 @@ if ! grep -q "wework_desktop_e2e_matrix" "$wework_workflow"; then
   exit 1
 fi
 
+desktop_cache_step="$(
+  extract_named_workflow_step "$wework_workflow" "Cache Cargo dependencies"
+)"
+desktop_cache_key="$(
+  sed -n 's/^          key:[[:space:]]*//p' <<<"$desktop_cache_step"
+)"
+desktop_cache_restore_keys="$(
+  awk '
+    /^          restore-keys:/ {
+      in_restore_keys = 1
+      next
+    }
+    in_restore_keys && /^          [[:alnum:]_-]+:/ {
+      exit
+    }
+    in_restore_keys {
+      print
+    }
+  ' <<<"$desktop_cache_step"
+)"
 # GitHub expressions are matched literally in workflow source.
 # shellcheck disable=SC2016
-if ! grep -Fq '${{ matrix.command }}-e2e-' "$wework_workflow"; then
+if ! grep -Fq '${{ matrix.command }}' <<<"$desktop_cache_key" ||
+  ! grep -Fq '${{ matrix.command }}' <<<"$desktop_cache_restore_keys"; then
   printf 'Wework desktop E2E caches must be isolated by E2E command\n' >&2
   exit 1
 fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,8 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -44,8 +41,7 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]] ||
-            [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA...$HEAD_SHA" |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -50,10 +47,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          FORCE_ALL: ${{ github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+          FORCE_ALL: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
         run: |
           if [[ "$FORCE_ALL" == "true" ]]; then
-            # Merge groups, main pushes, and ci:all force every module test.
+            # Merge groups and ci:all force every module test.
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA...$HEAD_SHA" |

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -1,9 +1,6 @@
 name: Wework E2E
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -216,9 +213,9 @@ jobs:
             ~/.cargo/git
             executor/target
             wework/src-tauri/target
-          key: ${{ runner.os }}-wework-desktop-e2e-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-wework-desktop-${{ matrix.command }}-e2e-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-wework-desktop-e2e-
+            ${{ runner.os }}-wework-desktop-${{ matrix.command }}-e2e-
 
       - name: Prepare bundled sidecars
         working-directory: ./wework

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -122,9 +122,11 @@ project initialization, then runs only the selected checkpoint.
 checkpoint. When upstream checkpoints are skipped, each checkpoint establishes
 its own minimal fixtures instead of depending on tasks or UI state created only
 by the complete flow. PR CI builds the smallest segment matrix for the changed
-feature paths. Shared desktop infrastructure, main, merge queue, scheduled
-runs, and `ci:all` still run the complete desktop suites. The mapping lives in
-`.github/scripts/classify-wework-desktop-e2e.sh` and must be updated when new
+feature paths. Shared desktop infrastructure, merge queue, scheduled runs, and
+`ci:all` still run the complete desktop suites. Merge queue validates the final
+commit that enters `main`, so Tests, Lint, Platform E2E, and Wework E2E do not
+repeat the same validation after the merge through a `push main` trigger. The
+mapping lives in `.github/scripts/classify-wework-desktop-e2e.sh` and must be updated when new
 feature coverage is registered. Segment commands are also useful for focused
 local iteration:
 
@@ -373,6 +375,11 @@ Home, ports, and diagnostic artifact. This preserves the existing real Tauri,
 Executor, and Codex verification semantics while removing the serial wait
 between the three scenarios. Matrix fail-fast is disabled so the remaining
 scenarios can finish and upload diagnostics when one scenario fails.
+The three scenarios inject different build-time Vite environment variables, so
+their Tauri/Cargo build caches must be isolated by E2E command. The plugins
+scenario must not restore an application binary built by the core or cloud
+scenario, because that binary may contain a different Codex Home initialization
+setting.
 
 The Linux desktop scenarios cache the downloaded `.deb` files for Tauri system
 dependencies in the runner user's home directory. Cache keys rotate weekly and
@@ -390,9 +397,11 @@ pnpm --filter wework e2e:desktop:memory
 ```
 
 The repository includes a basic workflow at `.github/workflows/wework-e2e.yml`. It runs when Wework, `packages/chat-core`, the pnpm lockfile, or the workflow itself changes.
-Regular draft PRs do not run browser or Linux desktop E2E. The macOS memory gate
-runs by default only on `main`, scheduled runs, and manual runs. Add the
-`ci:memory` label when a PR must validate the memory boundary. Applying that
+Regular draft PRs do not run browser or Linux desktop E2E. Merge queue runs the
+complete browser and Linux desktop suites before a commit enters `main`; `main`
+does not repeat checks that already passed for the merge group. The macOS memory
+gate runs by default only on scheduled and manual runs. Add the `ci:memory`
+label when a PR must validate the memory boundary. Applying that
 label starts only the memory gate and does not repeat browser or Linux desktop
 E2E. Applying `ci:all` runs browser, Linux desktop, and macOS memory E2E even
 when the PR's changed paths would not normally select Wework E2E. The workflow

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -120,8 +120,10 @@ node e2e/utils/mock-connector-upstream-server.mjs
 `--from-segment <checkpoint>` 从指定 checkpoint 开始并继续执行所有后续
 checkpoint。跳过上游时，每个 checkpoint 会自行建立最小前置 fixture，不依赖只有
 完整流程才创建的任务或 UI 状态。PR CI 会根据改动的功能路径组合最小 segment
-矩阵；共享桌面基础设施、主分支、merge queue、定时任务和 `ci:all` 仍运行完整桌面
-套件。映射规则位于 `.github/scripts/classify-wework-desktop-e2e.sh`，新增功能覆盖时
+矩阵；共享桌面基础设施、merge queue、定时任务和 `ci:all` 仍运行完整桌面套件。
+merge queue 会验证最终进入 `main` 的合并提交，因此合入后不再通过 `push main`
+重复运行同一套 Tests、Lint、Platform E2E 和 Wework E2E。映射规则位于
+`.github/scripts/classify-wework-desktop-e2e.sh`，新增功能覆盖时
 必须同步登记对应 segment。分段命令也可用于本地快速迭代：
 
 ```bash
@@ -363,6 +365,9 @@ GitHub Actions 将 plugins、core 和 cloud 三个 Linux 桌面场景作为矩�
 每个场景使用独立 runner、HOME、Executor Home、端口和诊断 artifact，保留原有
 真实 Tauri、Executor 与 Codex 验证语义，同时避免三个场景在同一个 job 中串行等待。
 矩阵关闭 fail-fast，使一个场景失败时其他场景仍能完成并上传各自诊断。
+三类场景会注入不同的构建期 Vite 环境变量，因此 Tauri/Cargo 编译缓存必须按
+E2E 命令隔离。plugins 场景不得恢复 core 或 cloud 场景生成的应用二进制，否则
+编译进应用的 Codex Home 初始化开关可能不匹配当前测试。
 
 Linux 桌面场景会把 Tauri 系统依赖下载得到的 `.deb` 文件缓存在 runner 用户目录，
 并按操作系统、CPU 架构和自然周轮换缓存。每次运行仍执行 `apt-get update`，旧缓存
@@ -378,8 +383,10 @@ pnpm --filter wework e2e:desktop:memory
 ```
 
 仓库内的基础 workflow 是 `.github/workflows/wework-e2e.yml`，会在 Wework、`packages/chat-core`、pnpm lockfile 或 workflow 自身变化时运行。
-普通 Draft PR 不运行浏览器或 Linux 桌面 E2E。macOS 内存门禁默认只在 `main`、
-定时任务和手动任务中运行；需要在 PR 中验证内存边界时，添加 `ci:memory` 标签。
+普通 Draft PR 不运行浏览器或 Linux 桌面 E2E。merge queue 会在提交进入 `main`
+之前运行完整浏览器和 Linux 桌面套件；`main` 不再重复运行已经通过的合并队列
+检查。macOS 内存门禁默认只在定时任务和手动任务中运行；需要在 PR 中验证内存
+边界时，添加 `ci:memory` 标签。
 添加该标签只触发内存门禁，不会重复运行浏览器或 Linux 桌面 E2E。workflow 每天
 UTC 04:00 运行一次完整回归。添加 `ci:all` 标签则会运行浏览器、Linux 桌面和
 macOS 内存 E2E，即使 PR 的改动路径通常不会触发 Wework E2E。

--- a/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
@@ -104,4 +104,22 @@ describe('CodexHomeInitializer', () => {
     expect(await screen.findByTestId('workbench-child')).toBeInTheDocument()
     expect(screen.queryByTestId('codex-home-initializer-dialog')).not.toBeInTheDocument()
   })
+
+  test('surfaces status lookup failures instead of bypassing initialization', async () => {
+    localCodexPluginApiMock.codexHomeMigrationStatus.mockRejectedValue(
+      new Error('Codex home status unavailable')
+    )
+
+    render(
+      <CodexHomeInitializer>
+        <div data-testid="workbench-child" />
+      </CodexHomeInitializer>
+    )
+
+    expect(await screen.findByTestId('codex-home-initializer-dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('codex-home-initializer-error')).toHaveTextContent(
+      'Codex home status unavailable'
+    )
+    expect(screen.queryByTestId('workbench-child')).not.toBeInTheDocument()
+  })
 })

--- a/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
@@ -122,4 +122,18 @@ describe('CodexHomeInitializer', () => {
     )
     expect(screen.queryByTestId('workbench-child')).not.toBeInTheDocument()
   })
+
+  test('uses a localized fallback for non-Error status lookup failures', async () => {
+    localCodexPluginApiMock.codexHomeMigrationStatus.mockRejectedValue(null)
+
+    render(
+      <CodexHomeInitializer>
+        <div data-testid="workbench-child" />
+      </CodexHomeInitializer>
+    )
+
+    expect(await screen.findByTestId('codex-home-initializer-dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('codex-home-initializer-error')).toHaveTextContent('工作台暂时不可用')
+    expect(screen.queryByTestId('workbench-child')).not.toBeInTheDocument()
+  })
 })

--- a/wework/src/features/local-runtime/CodexHomeInitializer.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.tsx
@@ -9,6 +9,12 @@ const SHOULD_SKIP_CODEX_HOME_INITIALIZATION =
   import.meta.env.VITE_WEWORK_E2E === 'true' &&
   import.meta.env.VITE_WEWORK_E2E_CODEX_HOME_INITIALIZATION !== 'true'
 
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+  return fallback
+}
+
 function CodexHomeInitializationDialog({
   isInitializing,
   error,
@@ -74,6 +80,7 @@ function CodexHomeInitializationDialog({
 }
 
 export function CodexHomeInitializer({ children }: { children?: ReactNode }) {
+  const { t } = useTranslation('localRuntime')
   const localPluginApi = useMemo(() => createLocalCodexPluginApi(), [])
   const [status, setStatus] = useState<LocalCodexHomeMigrationStatus | null>(null)
   const [checked, setChecked] = useState(SHOULD_SKIP_CODEX_HOME_INITIALIZATION)
@@ -100,18 +107,18 @@ export function CodexHomeInitializer({ children }: { children?: ReactNode }) {
         setStatus(nextStatus.shouldPromptMigration ? nextStatus : null)
         setChecked(true)
       })
-      .catch((statusError: Error) => {
+      .catch((statusError: unknown) => {
         if (!isCurrent) return
         console.warn('[Wework Codex init] status check failed', statusError)
         setStatus(null)
-        setError(statusError.message)
+        setError(errorMessage(statusError, t('fallback_error')))
         setChecked(true)
       })
 
     return () => {
       isCurrent = false
     }
-  }, [localPluginApi])
+  }, [localPluginApi, t])
 
   const initialize = (migrateNativeHome: boolean) => {
     console.warn('[Wework Codex init] initialization requested', {
@@ -141,7 +148,7 @@ export function CodexHomeInitializer({ children }: { children?: ReactNode }) {
 
   if (!checked) return null
 
-  if (!status && !error) return <>{children}</>
+  if (!status && error === null) return <>{children}</>
 
   return (
     <CodexHomeInitializationDialog

--- a/wework/src/features/local-runtime/CodexHomeInitializer.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.tsx
@@ -100,9 +100,11 @@ export function CodexHomeInitializer({ children }: { children?: ReactNode }) {
         setStatus(nextStatus.shouldPromptMigration ? nextStatus : null)
         setChecked(true)
       })
-      .catch(() => {
+      .catch((statusError: Error) => {
         if (!isCurrent) return
+        console.warn('[Wework Codex init] status check failed', statusError)
         setStatus(null)
+        setError(statusError.message)
         setChecked(true)
       })
 
@@ -139,7 +141,7 @@ export function CodexHomeInitializer({ children }: { children?: ReactNode }) {
 
   if (!checked) return null
 
-  if (!status) return <>{children}</>
+  if (!status && !error) return <>{children}</>
 
   return (
     <CodexHomeInitializationDialog


### PR DESCRIPTION
## What changed

- stop repeating the full required CI suite on `push main` after the merge queue already validated the exact merge commit
- isolate Wework desktop Tauri/Cargo caches by E2E command so plugin runs cannot restore binaries compiled with core/cloud Vite flags
- surface Codex Home status lookup failures instead of silently bypassing initialization
- add workflow regression coverage and update the Chinese and English E2E documentation

## Why

The same commit could pass `merge_group`, enter `main`, and then fail a duplicate post-merge run. The plugin E2E was also nondeterministic because core, cloud, and plugin matrix jobs shared compiled application caches despite using different build-time environment variables.

## Validation

- `bash .github/scripts/test-classify-ci-changes.sh`
- `bash scripts/test-repository-policy-workflow.sh`
- `shellcheck .github/scripts/test-classify-ci-changes.sh scripts/test-repository-policy-workflow.sh`
- `actionlint -shellcheck= -ignore 'label "ubuntu-latest-m" is unknown' .github/workflows/test.yml .github/workflows/lint.yml .github/workflows/e2e-tests.yml .github/workflows/wework-e2e.yml`\n- `pnpm --filter wework test` — 252 files, 2509 tests passed\n- `pnpm --filter wework typecheck`\n- focused Prettier and ESLint checks\n- pre-push ESLint, TypeScript, and Wework unit tests passed\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration status check failures now display an error dialog and prevent dependent content from loading, instead of failing silently.

* **CI Improvements**
  * Duplicate checks after changes reach the main branch have been reduced.
  * Merge-queue validation now performs the appropriate full test coverage.
  * Desktop end-to-end test caches are isolated to prevent incorrect build reuse.

* **Documentation**
  * Updated English and Chinese guidance for end-to-end testing, merge-queue validation, and memory test requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->