### PR TITLE
fix(wework): share cached Codex binaries across worktrees

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -33,6 +33,8 @@ cd wework
 WEWORK_CODEX_TARGET=universal-apple-darwin pnpm run prepare:codex
 ```
 
+The Codex tarball and extracted binaries are cached in a user-level directory so multiple worktrees reuse the same copy. On macOS, the default directory is `~/Library/Caches/wegent/codex`; set `WEGENT_CODEX_CACHE_DIR` to customize it. Development preparation creates links under `src-tauri/binaries/codex`, while release builds automatically use `--materialize` to place real files in the worktree for Tauri packaging and code signing.
+
 Release builds verify the target Codex binary in `wework/src-tauri/build.rs`; the build fails if it is missing. At runtime, Wework injects the bundled Codex path into the local executor sidecar:
 
 - `CODEX_BINARY_PATH`

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -33,6 +33,8 @@ cd wework
 WEWORK_CODEX_TARGET=universal-apple-darwin pnpm run prepare:codex
 ```
 
+Codex 的下载包和解压后的二进制默认缓存到用户级目录，多个 worktree 会复用同一份缓存。macOS 默认目录为 `~/Library/Caches/wegent/codex`；如需自定义，可设置 `WEGENT_CODEX_CACHE_DIR`。开发准备阶段只在 `src-tauri/binaries/codex` 下创建指向缓存的链接，发布构建会自动使用 `--materialize` 将文件物化到当前 worktree，以便 Tauri 打包和代码签名。
+
 release 构建会在 `wework/src-tauri/build.rs` 中校验目标平台的 Codex 二进制存在；缺失时构建会失败。运行时 Wework 会把 bundled Codex 路径注入本地 executor sidecar：
 
 - `CODEX_BINARY_PATH`

--- a/wework/package.json
+++ b/wework/package.json
@@ -18,7 +18,7 @@
     "ios:init": "tauri ios init",
     "dev:ios": "bash scripts/dev-ios-app.sh",
     "build:ios": "bash scripts/build-ios-app.sh",
-    "tauri:build": "pnpm run prepare:codex && pnpm run prepare:dws && tauri build",
+    "tauri:build": "pnpm run prepare:codex -- --materialize && pnpm run prepare:dws && tauri build",
     "lint": "eslint . && pnpm run lint:typography && pnpm run lint:task-lifecycle",
     "lint:typography": "node scripts/check-typography.mjs",
     "lint:task-lifecycle": "node scripts/check-runtime-task-lifecycle.mjs",

--- a/wework/scripts/build-mac-app.sh
+++ b/wework/scripts/build-mac-app.sh
@@ -239,7 +239,7 @@ if [ "$NO_SIGN" = "1" ]; then
   TAURI_ARGS+=(--no-sign)
 fi
 
-WEWORK_CODEX_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:codex
+WEWORK_CODEX_MATERIALIZE=1 WEWORK_CODEX_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:codex
 WEWORK_DWS_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:dws
 wework_sign_prepared_codex_macos_binaries \
   "$WEWORK_DIR" \

--- a/wework/scripts/build-windows-app.sh
+++ b/wework/scripts/build-windows-app.sh
@@ -206,7 +206,7 @@ if [ -n "$TAURI_BUNDLES" ]; then
   TAURI_ARGS+=(--bundles "$TAURI_BUNDLES")
 fi
 
-WEWORK_CODEX_TARGET="$WINDOWS_BUILD_TARGET" pnpm run prepare:codex
+WEWORK_CODEX_MATERIALIZE=1 WEWORK_CODEX_TARGET="$WINDOWS_BUILD_TARGET" pnpm run prepare:codex
 WEWORK_DWS_TARGET="$WINDOWS_BUILD_TARGET" pnpm run prepare:dws
 pnpm exec tauri "${TAURI_ARGS[@]}"
 

--- a/wework/scripts/prepare-codex-binary.mjs
+++ b/wework/scripts/prepare-codex-binary.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
 import { createWriteStream } from 'node:fs'
-import { chmod, cp, mkdir, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { chmod, cp, mkdir, rename, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { pipeline } from 'node:stream/promises'
 import { extract } from 'tar'
@@ -11,7 +11,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url))
 const weworkDir = resolve(scriptDir, '..')
 const lockPath = join(weworkDir, 'codex-binaries.lock.json')
 const outputRoot = join(weworkDir, 'src-tauri', 'binaries', 'codex')
-const cacheRoot = join(weworkDir, 'node_modules', '.cache', 'wework-codex')
+const legacyCacheRoot = join(weworkDir, 'node_modules', '.cache', 'wework-codex')
 const DOWNLOAD_ATTEMPTS = 3
 const DOWNLOAD_RETRY_DELAY_MS = 1_000
 
@@ -24,11 +24,15 @@ const hostTargetByPlatform = {
 }
 
 function parseArgs(argv) {
-  const result = { target: null, all: false }
+  const result = { target: null, all: false, materialize: false }
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (arg === '--all') {
       result.all = true
+      continue
+    }
+    if (arg === '--materialize') {
+      result.materialize = true
       continue
     }
     if (arg === '--target') {
@@ -77,6 +81,29 @@ async function pathExists(path) {
   } catch {
     return false
   }
+}
+
+function cacheRoot() {
+  if (process.env.WEGENT_CODEX_CACHE_DIR) {
+    return resolve(process.env.WEGENT_CODEX_CACHE_DIR)
+  }
+
+  if (process.platform === 'darwin') {
+    return join(process.env.HOME || tmpdir(), 'Library', 'Caches', 'wegent', 'codex')
+  }
+  if (process.platform === 'win32') {
+    return join(process.env.LOCALAPPDATA || process.env.USERPROFILE || tmpdir(), 'wegent', 'codex')
+  }
+  return join(
+    process.env.XDG_CACHE_HOME || join(process.env.HOME || tmpdir(), '.cache'),
+    'wegent',
+    'codex'
+  )
+}
+
+export function codexTarballName(entry, target) {
+  const integrityKey = createHash('sha256').update(entry.integrity).digest('hex').slice(0, 16)
+  return `codex-${entry.version}-${target}-${integrityKey}.tgz`
 }
 
 async function integrityFile(path) {
@@ -141,29 +168,14 @@ async function extractTarball(tarball, destination) {
   await extract({ file: tarball, cwd: destination, strip: 1 })
 }
 
-async function prepareTarget(target, entry) {
-  const tarballName = `${entry.package.replace('/', '-').replace('@', '')}-${entry.version}.tgz`
-  const tarballPath = join(cacheRoot, tarballName)
-  const targetRoot = join(outputRoot, target)
-  const binaryPath = join(targetRoot, entry.binaryPath)
-  const codeModeHostPath = join(
-    dirname(binaryPath),
-    target === 'x86_64-pc-windows-msvc' ? 'codex-code-mode-host.exe' : 'codex-code-mode-host'
-  )
+function shouldMaterializeTarget() {
+  return process.env.WEWORK_CODEX_MATERIALIZE === '1'
+}
 
-  if (!(await pathExists(tarballPath))) {
-    console.log(`Downloading Codex ${entry.version} for ${target}`)
-    await downloadWithRetry(entry.tarball, tarballPath)
+async function ensureExtractedTarget(tarballPath, targetRoot, binaryPath, codeModeHostPath) {
+  if ((await pathExists(binaryPath)) && (await pathExists(codeModeHostPath))) {
+    return
   }
-
-  const actualIntegrity = await integrityFile(tarballPath)
-  if (actualIntegrity !== entry.integrity) {
-    await rm(tarballPath, { force: true })
-    throw new Error(
-      `Codex tarball integrity mismatch for ${target}: expected ${entry.integrity}, got ${actualIntegrity}`
-    )
-  }
-
   await extractTarball(tarballPath, targetRoot)
   if (!(await pathExists(binaryPath))) {
     throw new Error(`Codex binary not found after extraction: ${binaryPath}`)
@@ -175,8 +187,95 @@ async function prepareTarget(target, entry) {
     await chmod(binaryPath, 0o755)
     await chmod(codeModeHostPath, 0o755)
   }
+}
+
+async function exposeTarget(targetRoot, outputTargetRoot) {
+  await rm(outputTargetRoot, { recursive: true, force: true })
+  await mkdir(dirname(outputTargetRoot), { recursive: true })
+  if (shouldMaterializeTarget()) {
+    await cp(targetRoot, outputTargetRoot, { recursive: true })
+    return
+  }
+  await symlink(targetRoot, outputTargetRoot, process.platform === 'win32' ? 'junction' : 'dir')
+}
+
+async function downloadToCache(url, destination) {
+  const temporaryPath = join(
+    dirname(destination),
+    `${basename(destination)}.${process.pid}.${Date.now()}.part`
+  )
+  try {
+    await downloadWithRetry(url, temporaryPath)
+    await mkdir(dirname(destination), { recursive: true })
+    await rename(temporaryPath, destination)
+  } finally {
+    await rm(temporaryPath, { force: true })
+  }
+}
+
+async function findLegacyTarball(paths) {
+  const existingPaths = await Promise.all(
+    paths.map(async path => ((await pathExists(path)) ? path : null))
+  )
+  return existingPaths.find(Boolean)
+}
+
+async function ensureTarballIntegrity(tarballPath, entry, target) {
+  const actualIntegrity = await integrityFile(tarballPath)
+  if (actualIntegrity === entry.integrity) return
+
+  await rm(tarballPath, { force: true })
+  console.log(`Cached Codex archive is invalid for ${target}; downloading a fresh copy`)
+  await downloadToCache(entry.tarball, tarballPath)
+  const refreshedIntegrity = await integrityFile(tarballPath)
+  if (refreshedIntegrity !== entry.integrity) {
+    await rm(tarballPath, { force: true })
+    throw new Error(
+      `Codex tarball integrity mismatch for ${target}: expected ${entry.integrity}, got ${refreshedIntegrity}`
+    )
+  }
+}
+
+async function prepareTarget(target, entry) {
+  const sharedCacheRoot = cacheRoot()
+  const tarballName = codexTarballName(entry, target)
+  const tarballPath = join(sharedCacheRoot, tarballName)
+  const extractedRoot = join(sharedCacheRoot, 'extracted', tarballName.replace(/\.tgz$/, ''))
+  const legacyTarballPaths = [
+    join(legacyCacheRoot, tarballName),
+    join(
+      legacyCacheRoot,
+      `${entry.package.replace('/', '-').replace('@', '')}-${entry.version}.tgz`
+    ),
+  ]
+  const outputTargetRoot = join(outputRoot, target)
+  const targetRoot = extractedRoot
+  const binaryPath = join(targetRoot, entry.binaryPath)
+  const codeModeHostPath = join(
+    dirname(binaryPath),
+    target === 'x86_64-pc-windows-msvc' ? 'codex-code-mode-host.exe' : 'codex-code-mode-host'
+  )
+
+  if (!(await pathExists(tarballPath))) {
+    const legacyTarballPath = await findLegacyTarball(legacyTarballPaths)
+    if (legacyTarballPath) {
+      await mkdir(sharedCacheRoot, { recursive: true })
+      await cp(legacyTarballPath, tarballPath)
+      console.log(`Reused legacy Codex cache for ${target}`)
+    }
+  }
+
+  if (!(await pathExists(tarballPath))) {
+    console.log(`Downloading Codex ${entry.version} for ${target}`)
+    await downloadToCache(entry.tarball, tarballPath)
+  }
+
+  await ensureTarballIntegrity(tarballPath, entry, target)
+
+  await ensureExtractedTarget(tarballPath, targetRoot, binaryPath, codeModeHostPath)
+  await exposeTarget(targetRoot, outputTargetRoot)
   await writeFile(
-    join(targetRoot, 'WEGENT_CODEX_BINARY.json'),
+    join(outputTargetRoot, 'WEGENT_CODEX_BINARY.json'),
     `${JSON.stringify(
       {
         target,
@@ -213,6 +312,9 @@ async function copyLegalFiles() {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2))
+  if (args.materialize) {
+    process.env.WEWORK_CODEX_MATERIALIZE = '1'
+  }
   const lock = JSON.parse(
     await import('node:fs/promises').then(fs => fs.readFile(lockPath, 'utf8'))
   )

--- a/wework/scripts/prepare-codex-binary.test.mjs
+++ b/wework/scripts/prepare-codex-binary.test.mjs
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { downloadWithRetry } from './prepare-codex-binary.mjs'
+import { codexTarballName, downloadWithRetry } from './prepare-codex-binary.mjs'
 
 const temporaryDirectories = []
 
@@ -53,5 +53,27 @@ describe('downloadWithRetry', () => {
       })
     ).rejects.toThrow('network unavailable')
     expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('codexTarballName', () => {
+  const entry = {
+    version: '0.144.5',
+    integrity: 'sha512-test-integrity',
+  }
+
+  test('keeps platform archives separate in the shared cache', () => {
+    expect(codexTarballName(entry, 'aarch64-apple-darwin')).not.toBe(
+      codexTarballName(entry, 'x86_64-apple-darwin')
+    )
+  })
+
+  test('invalidates a cached archive when its integrity changes', () => {
+    expect(codexTarballName(entry, 'aarch64-apple-darwin')).not.toBe(
+      codexTarballName(
+        { ...entry, integrity: 'sha512-different-integrity' },
+        'aarch64-apple-darwin'
+      )
+    )
   })
 })

--- a/wework/scripts/release-mac-app.sh
+++ b/wework/scripts/release-mac-app.sh
@@ -558,7 +558,7 @@ if [ "$RELEASE_DEVTOOLS" = "1" ]; then
   TAURI_BUILD_ARGS+=(--features release-devtools)
 fi
 TAURI_BUILD_ARGS+=(--config "$config_override")
-WEWORK_CODEX_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:codex
+WEWORK_CODEX_MATERIALIZE=1 WEWORK_CODEX_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:codex
 WEWORK_DWS_TARGET="${MACOS_BUILD_TARGET:-}" pnpm run prepare:dws
 if [ -n "$app_sign_identity" ]; then
   wework_sign_prepared_codex_macos_binaries \


### PR DESCRIPTION
## What changed

- Cache downloaded Codex archives and extracted target directories in the user-level cache.
- Expose development binaries through lightweight links instead of copying them into every worktree.
- Materialize real files for release builds and signing.
- Add cache migration, integrity recovery, platform separation, and bilingual documentation.

## Why

Each worktree previously downloaded and extracted its own Codex binary under `wework/node_modules` and `src-tauri/binaries`, wasting disk space and slowing development startup.

## Validation

- Wework pre-commit checks passed.
- Pre-push ESLint, TypeScript, and unit tests passed.
- Development run confirmed the Codex preparation step reuses the cached artifact without downloading it again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared caching for Codex binaries across macOS and Windows builds.
  * Added configurable cache location and automatic integrity validation.
  * Development builds reuse cached files, while release builds create packaged files for signing.

* **Bug Fixes**
  * Invalid or incomplete cached downloads are now safely replaced.

* **Documentation**
  * Updated English and Chinese macOS release guides with caching and build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->