### PR TITLE
fix(ci): parallelize Wework core desktop E2E

### DIFF
--- a/.github/scripts/archive-wework-core-e2e-build.sh
+++ b/.github/scripts/archive-wework-core-e2e-build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_dir="${1:-.ci-artifacts}"
+manifest="${2:-$artifact_dir/wework-core-e2e-build.json}"
+archive="$artifact_dir/wework-core-e2e-build.tar.zst"
+staging_dir="$artifact_dir/wework-core-e2e-build"
+codex_target="x86_64-unknown-linux-gnu"
+
+test -s "$manifest"
+
+app_binary="$(
+  node -e \
+    'const fs = require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).appBinary)' \
+    "$manifest"
+)"
+executor_binary="$(
+  node -e \
+    'const fs = require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).executorBinary)' \
+    "$manifest"
+)"
+codex_root="wework/src-tauri/binaries/codex/$codex_target"
+
+test -x "$app_binary"
+test -x "$executor_binary"
+test -d "$codex_root"
+test ! -L "$codex_root"
+
+rm -rf "$staging_dir"
+mkdir -p "$staging_dir/codex"
+cp "$app_binary" "$staging_dir/WeWork"
+cp "$executor_binary" "$staging_dir/wegent-executor"
+cp -R "$codex_root" "$staging_dir/codex/$codex_target"
+chmod 0755 "$staging_dir/WeWork" "$staging_dir/wegent-executor"
+
+tar -I 'zstd -T0 -3' -cf "$archive" -C "$artifact_dir" wework-core-e2e-build
+test -s "$archive"

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -41,7 +41,10 @@ classify_path() {
       .github/scripts/start-frontend-e2e-server.sh)
       changed[platform_e2e]=true
       ;;
-    .github/workflows/wework-e2e.yml)
+    .github/workflows/wework-e2e.yml | \
+      .github/scripts/archive-wework-core-e2e-build.sh | \
+      .github/scripts/classify-wework-desktop-e2e.sh | \
+      .github/scripts/restore-wework-core-e2e-build.sh)
       changed[wework_e2e]=true
       ;;
     package.json | pnpm-lock.yaml | pnpm-workspace.yaml)

--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -168,8 +168,10 @@ classify_path() {
       select_all_desktop_suites
       ;;
     .github/workflows/wework-e2e.yml | \
+      .github/scripts/archive-wework-core-e2e-build.sh | \
       .github/scripts/classify-ci-changes.sh | \
       .github/scripts/classify-wework-desktop-e2e.sh | \
+      .github/scripts/restore-wework-core-e2e-build.sh | \
       .github/scripts/test-classify-ci-changes.sh)
       select_all_desktop_suites
       ;;
@@ -189,31 +191,32 @@ append_matrix_entry() {
   printf -v entry \
     '{"id":"%s","name":"%s","command":"%s","segment":"%s"}' \
     "$id" "$name" "$command" "$segment"
-  matrix_entries+=("$entry")
+  if [[ "$command" == "e2e:desktop" ]]; then
+    core_matrix_entries+=("$entry")
+  else
+    other_matrix_entries+=("$entry")
+  fi
 }
 
 build_matrix() {
-  matrix_entries=()
+  core_matrix_entries=()
+  other_matrix_entries=()
 
-  if [[ "${selected[core:all]:-false}" == "true" ]]; then
-    append_matrix_entry core Core e2e:desktop
-  else
-    local segment
-    for segment in "${core_segments[@]}"; do
-      if [[ "${selected[core:$segment]:-false}" == "true" ]]; then
-        append_matrix_entry \
-          "core-$segment" \
-          "Core / $segment" \
-          e2e:desktop \
-          "$segment"
-      fi
-    done
-  fi
+  local segment
+  for segment in "${core_segments[@]}"; do
+    if [[ "${selected[core:all]:-false}" == "true" || \
+      "${selected[core:$segment]:-false}" == "true" ]]; then
+      append_matrix_entry \
+        "core-$segment" \
+        "Core / $segment" \
+        e2e:desktop \
+        "$segment"
+    fi
+  done
 
   if [[ "${selected[plugins:all]:-false}" == "true" ]]; then
     append_matrix_entry plugins Plugins e2e:desktop:plugins
   else
-    local segment
     for segment in "${plugin_segments[@]}"; do
       if [[ "${selected[plugins:$segment]:-false}" == "true" ]]; then
         append_matrix_entry \
@@ -248,14 +251,30 @@ fi
 
 build_matrix
 
-matrix_json='{"include":[]}'
+core_matrix_json='{"include":[]}'
+other_matrix_json='{"include":[]}'
+run_core=false
+run_other=false
 run_desktop=false
-if ((${#matrix_entries[@]} > 0)); then
-  joined_entries="$(IFS=,; printf '%s' "${matrix_entries[*]}")"
-  matrix_json="{\"include\":[$joined_entries]}"
+
+if ((${#core_matrix_entries[@]} > 0)); then
+  joined_core_entries="$(IFS=,; printf '%s' "${core_matrix_entries[*]}")"
+  core_matrix_json="{\"include\":[$joined_core_entries]}"
+  run_core=true
+  run_desktop=true
+fi
+if ((${#other_matrix_entries[@]} > 0)); then
+  joined_other_entries="$(IFS=,; printf '%s' "${other_matrix_entries[*]}")"
+  other_matrix_json="{\"include\":[$joined_other_entries]}"
+  run_other=true
   run_desktop=true
 fi
 
 output_file="${GITHUB_OUTPUT:-/dev/stdout}"
-printf 'wework_desktop_e2e=%s\n' "$run_desktop" >> "$output_file"
-printf 'wework_desktop_e2e_matrix=%s\n' "$matrix_json" >> "$output_file"
+{
+  printf 'wework_desktop_e2e=%s\n' "$run_desktop"
+  printf 'wework_desktop_core_e2e=%s\n' "$run_core"
+  printf 'wework_desktop_core_e2e_matrix=%s\n' "$core_matrix_json"
+  printf 'wework_desktop_other_e2e=%s\n' "$run_other"
+  printf 'wework_desktop_other_e2e_matrix=%s\n' "$other_matrix_json"
+} >> "$output_file"

--- a/.github/scripts/restore-wework-core-e2e-build.sh
+++ b/.github/scripts/restore-wework-core-e2e-build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_dir="${1:-.ci-artifacts}"
+archive="$artifact_dir/wework-core-e2e-build.tar.zst"
+build_dir="$artifact_dir/wework-core-e2e-build"
+codex_binary="$build_dir/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex"
+
+test -s "$archive"
+
+rm -rf "$build_dir"
+tar -I zstd -xf "$archive" -C "$artifact_dir"
+chmod 0755 "$build_dir/WeWork" "$build_dir/wegent-executor" "$codex_binary"
+
+test -x "$build_dir/WeWork"
+test -x "$build_dir/wegent-executor"
+test -x "$codex_binary"

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -168,6 +168,9 @@ wework_e2e_expected="${all_false/wework_e2e=false/wework_e2e=true}"
 assert_case "Wework workflow changes run Wework E2E" "$wework_e2e_expected" \
   ".github/workflows/wework-e2e.yml"
 
+assert_case "Wework artifact scripts run Wework E2E" "$wework_e2e_expected" \
+  ".github/scripts/archive-wework-core-e2e-build.sh"
+
 assert_desktop_case() {
   local name="$1"
   local expected="$2"
@@ -184,49 +187,78 @@ assert_desktop_case() {
 
 assert_desktop_case "conversation cache selects guidance and conversation segments" \
   'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"}]}' \
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/workbench/runtimeConversationCache.ts"
 
 assert_desktop_case "independent features select the union of minimum segments" \
   'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"core-goal-lifecycle","name":"Core / goal-lifecycle","command":"e2e:desktop","segment":"goal-lifecycle"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}' \
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-goal-lifecycle","name":"Core / goal-lifecycle","command":"e2e:desktop","segment":"goal-lifecycle"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/lib/runtime-goal.ts" \
   "wework/src/components/chat/blocks/ToolBlockItem.tsx"
 
 assert_desktop_case "runner coverage does not broaden a classified feature" \
   'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}' \
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/e2e/desktop/task-flow.e2e.mjs" \
   "wework/src/components/chat/MessageList.tsx"
 
+full_desktop_expected='wework_desktop_e2e=true
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-workspace-tabs","name":"Core / workspace-tabs","command":"e2e:desktop","segment":"workspace-tabs"},{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"core-window-lifecycle","name":"Core / window-lifecycle","command":"e2e:desktop","segment":"window-lifecycle"},{"id":"core-goal-lifecycle","name":"Core / goal-lifecycle","command":"e2e:desktop","segment":"goal-lifecycle"},{"id":"core-resilience","name":"Core / resilience","command":"e2e:desktop","segment":"resilience"},{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"},{"id":"core-workspace-attachments","name":"Core / workspace-attachments","command":"e2e:desktop","segment":"workspace-attachments"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"}]}
+wework_desktop_other_e2e=true
+wework_desktop_other_e2e_matrix={"include":[{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""},{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}'
+
 assert_desktop_case "runner-only changes retain full coverage" \
-  'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"core","name":"Core","command":"e2e:desktop","segment":""},{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""},{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
+  "$full_desktop_expected" \
   "wework/e2e/desktop/task-flow.e2e.mjs"
+
+assert_desktop_case "Core artifact changes retain full coverage" \
+  "$full_desktop_expected" \
+  ".github/scripts/archive-wework-core-e2e-build.sh"
 
 assert_desktop_case "skill mention files select plugin and core coverage" \
   'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"plugins-skill-mention-rendering","name":"Plugins / skill-mention-rendering","command":"e2e:desktop:plugins","segment":"skill-mention-rendering"}]}' \
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"}]}
+wework_desktop_other_e2e=true
+wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-skill-mention-rendering","name":"Plugins / skill-mention-rendering","command":"e2e:desktop:plugins","segment":"skill-mention-rendering"}]}' \
   "wework/src/components/chat/composer/ComposerMentionMenu.tsx"
 
 assert_desktop_case "browser E2E changes avoid desktop jobs" \
   'wework_desktop_e2e=false
-wework_desktop_e2e_matrix={"include":[]}' \
+wework_desktop_core_e2e=false
+wework_desktop_core_e2e_matrix={"include":[]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/e2e/tests/workbench.spec.ts"
 
 assert_desktop_case "cloud files select only the cloud suite" \
   'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
+wework_desktop_core_e2e=false
+wework_desktop_core_e2e_matrix={"include":[]}
+wework_desktop_other_e2e=true
+wework_desktop_other_e2e_matrix={"include":[{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
   "wework/src/features/cloud-connection/CloudConnectionProvider.tsx"
 
 assert_desktop_case "plugin files select only their plugin segment" \
   'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"plugins-plugin-lifecycle","name":"Plugins / plugin-lifecycle","command":"e2e:desktop:plugins","segment":"plugin-lifecycle"}]}' \
+wework_desktop_core_e2e=false
+wework_desktop_core_e2e_matrix={"include":[]}
+wework_desktop_other_e2e=true
+wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-plugin-lifecycle","name":"Plugins / plugin-lifecycle","command":"e2e:desktop:plugins","segment":"plugin-lifecycle"}]}' \
   "wework/src/components/plugins/PluginsWorkspace.tsx"
 
 assert_desktop_case "shared desktop infrastructure remains full coverage" \
-  'wework_desktop_e2e=true
-wework_desktop_e2e_matrix={"include":[{"id":"core","name":"Core","command":"e2e:desktop","segment":""},{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""},{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}' \
+  "$full_desktop_expected" \
   "wework/src/App.tsx"
 
 test_workflow="$script_dir/../workflows/test.yml"
@@ -343,8 +375,9 @@ if ! grep -q "name: Wework E2E Summary" "$wework_workflow"; then
   exit 1
 fi
 
-if ! grep -q "wework_desktop_e2e_matrix" "$wework_workflow"; then
-  printf 'Wework desktop E2E must use the changed-feature segment matrix\n' >&2
+if ! grep -q "wework_desktop_core_e2e_matrix" "$wework_workflow" ||
+  ! grep -q "wework_desktop_other_e2e_matrix" "$wework_workflow"; then
+  printf 'Wework desktop E2E must use the split changed-feature matrices\n' >&2
   exit 1
 fi
 
@@ -388,9 +421,19 @@ wework_desktop_job="$(
   sed -n '/^  wework-desktop-e2e:/,/^  wework-e2e-summary:/p' "$wework_workflow"
 )"
 if ! grep -q \
-  "needs.changes.outputs.wework_desktop_e2e == 'true'" \
+  "needs.changes.outputs.wework_desktop_other_e2e == 'true'" \
   <<<"$wework_desktop_job"; then
-  printf 'Wework desktop E2E must use the desktop segment classification\n' >&2
+  printf 'Wework non-Core desktop E2E must use its segment classification\n' >&2
+  exit 1
+fi
+
+wework_desktop_core_job="$(
+  sed -n '/^  wework-desktop-core-e2e:/,/^  wework-desktop-e2e:/p' "$wework_workflow"
+)"
+if ! grep -q \
+  "needs.changes.outputs.wework_desktop_core_e2e == 'true'" \
+  <<<"$wework_desktop_core_job"; then
+  printf 'Wework Core desktop E2E must use its segment classification\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -31,7 +31,10 @@ jobs:
     outputs:
       wework_e2e: ${{ steps.classify.outputs.wework_e2e }}
       wework_desktop_e2e: ${{ steps.classify.outputs.wework_desktop_e2e }}
-      wework_desktop_e2e_matrix: ${{ steps.classify.outputs.wework_desktop_e2e_matrix }}
+      wework_desktop_core_e2e: ${{ steps.classify.outputs.wework_desktop_core_e2e }}
+      wework_desktop_core_e2e_matrix: ${{ steps.classify.outputs.wework_desktop_core_e2e_matrix }}
+      wework_desktop_other_e2e: ${{ steps.classify.outputs.wework_desktop_other_e2e }}
+      wework_desktop_other_e2e_matrix: ${{ steps.classify.outputs.wework_desktop_other_e2e_matrix }}
 
     steps:
       - name: Checkout code
@@ -122,15 +125,234 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  build-wework-desktop-core-e2e:
+    name: Build Wework Desktop Core E2E Artifact
+    needs: changes
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_core_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set APT cache key
+        id: apt-cache-key
+        run: |
+          week="$(date -u +'%G-%V')"
+          echo "key=apt-$RUNNER_OS-$RUNNER_ARCH-wework-v1-$week" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Cache Tauri system packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/wework-apt/archives
+          key: ${{ steps.apt-cache-key.outputs.key }}
+          restore-keys: |
+            apt-${{ runner.os }}-${{ runner.arch }}-wework-v1-
+
+      - name: Install Tauri build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt_archives="$HOME/.cache/wework-apt/archives"
+          mkdir -p "$apt_archives/partial"
+          sudo chown _apt:root "$apt_archives/partial"
+          sudo chmod 700 "$apt_archives/partial"
+
+          apt_options=(
+            -o "Dir::Cache::archives=$apt_archives/"
+            -o "Acquire::Retries=5"
+            -o "Acquire::http::Timeout=30"
+            -o "Acquire::https::Timeout=30"
+            -o "Binary::apt-get::APT::Keep-Downloaded-Packages=true"
+          )
+
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y --no-install-recommends \
+            build-essential \
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev
+
+          sudo chown -R "$USER:$(id -gn)" "$apt_archives"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Core E2E build Cargo dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            executor/target
+            wework/src-tauri/target
+          key: ${{ runner.os }}-wework-desktop-core-build-e2e-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wework-desktop-core-build-e2e-
+            ${{ runner.os }}-wework-desktop-
+
+      - name: Prepare bundled sidecars
+        working-directory: ./wework
+        run: |
+          pnpm run prepare:codex --materialize
+          pnpm run prepare:dws
+
+      - name: Build Wework desktop Core E2E binaries
+        env:
+          CI: true
+          WEWORK_E2E_BUILD_MANIFEST: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build.json
+          WEWORK_E2E_CODEX_BIN: ${{ github.workspace }}/wework/src-tauri/binaries/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex
+          WEWORK_E2E_CONTROL_SERVER_PORT: "43111"
+          WEWORK_E2E_MODEL_SERVER_PORT: "43112"
+        run: node wework/e2e/desktop/task-flow.e2e.mjs --build-only
+
+      - name: Archive Wework desktop Core E2E build
+        run: .github/scripts/archive-wework-core-e2e-build.sh
+
+      - name: Upload Wework desktop Core E2E build
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-desktop-core-e2e-build
+          path: .ci-artifacts/wework-core-e2e-build.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: Upload Wework desktop Core E2E build diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-desktop-core-e2e-build-diagnostics
+          path: wework/test-results/desktop-e2e/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  wework-desktop-core-e2e:
+    name: Wework Desktop E2E (${{ matrix.name }})
+    needs:
+      - changes
+      - build-wework-desktop-core-e2e
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_core_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.wework_desktop_core_e2e_matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set APT cache key
+        id: apt-cache-key
+        run: |
+          week="$(date -u +'%G-%V')"
+          echo "key=apt-$RUNNER_OS-$RUNNER_ARCH-wework-v1-$week" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Cache Tauri system packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/wework-apt/archives
+          key: ${{ steps.apt-cache-key.outputs.key }}
+          restore-keys: |
+            apt-${{ runner.os }}-${{ runner.arch }}-wework-v1-
+
+      - name: Install Tauri runtime dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt_archives="$HOME/.cache/wework-apt/archives"
+          mkdir -p "$apt_archives/partial"
+          sudo chown _apt:root "$apt_archives/partial"
+          sudo chmod 700 "$apt_archives/partial"
+
+          apt_options=(
+            -o "Dir::Cache::archives=$apt_archives/"
+            -o "Acquire::Retries=5"
+            -o "Acquire::http::Timeout=30"
+            -o "Acquire::https::Timeout=30"
+            -o "Binary::apt-get::APT::Keep-Downloaded-Packages=true"
+          )
+
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y --no-install-recommends \
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            imagemagick \
+            librsvg2-dev \
+            xvfb
+
+          sudo chown -R "$USER:$(id -gn)" "$apt_archives"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Download Wework desktop Core E2E build
+        uses: actions/download-artifact@v4
+        with:
+          name: wework-desktop-core-e2e-build
+          path: .ci-artifacts
+
+      - name: Restore Wework desktop Core E2E build
+        run: .github/scripts/restore-wework-core-e2e-build.sh
+
+      - name: Run Wework desktop Core ${{ matrix.segment }} E2E
+        env:
+          CI: true
+          WEWORK_E2E_APP_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/WeWork
+          WEWORK_E2E_CONTROL_SERVER_PORT: "43111"
+          WEWORK_E2E_DESKTOP_SCENARIO_MODULE: ./scenarios/streaming-text.scenario.mjs
+          WEWORK_E2E_EXECUTOR_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/wegent-executor
+          WEWORK_E2E_CODEX_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex
+          WEWORK_E2E_MODEL_SERVER_PORT: "43112"
+          E2E_SEGMENT: ${{ matrix.segment }}
+        run: |
+          test -x "$WEWORK_E2E_APP_BIN"
+          test -x "$WEWORK_E2E_EXECUTOR_BIN"
+          test -x "$WEWORK_E2E_CODEX_BIN"
+          xvfb-run -a --server-args="-screen 0 1280x720x24" \
+            node wework/e2e/desktop/run-checkpoints.mjs --segment "$E2E_SEGMENT"
+
+      - name: Upload Wework desktop E2E diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-desktop-${{ matrix.id }}-e2e-diagnostics
+          path: |
+            wework/test-results/desktop-e2e/
+            !wework/test-results/desktop-e2e/**/executor-home/**
+          if-no-files-found: ignore
+          retention-days: 7
+
   wework-desktop-e2e:
     name: Wework Desktop E2E (${{ matrix.name }})
     needs: changes
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_other_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.changes.outputs.wework_desktop_e2e_matrix) }}
+      matrix: ${{ fromJSON(needs.changes.outputs.wework_desktop_other_e2e_matrix) }}
 
     steps:
       - name: Checkout code
@@ -154,6 +376,7 @@ jobs:
       - name: Install Tauri system dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
+          E2E_COMMAND: ${{ matrix.command }}
         run: |
           apt_archives="$HOME/.cache/wework-apt/archives"
           mkdir -p "$apt_archives/partial"
@@ -167,17 +390,22 @@ jobs:
             -o "Acquire::https::Timeout=30"
             -o "Binary::apt-get::APT::Keep-Downloaded-Packages=true"
           )
+          packages=(
+            build-essential
+            libayatana-appindicator3-dev
+            libssl-dev
+            libwebkit2gtk-4.1-dev
+            imagemagick
+            librsvg2-dev
+            xvfb
+          )
+          if [[ "$E2E_COMMAND" == "e2e:desktop:cloud" ]]; then
+            packages+=(redis-server)
+          fi
 
           sudo apt-get "${apt_options[@]}" update
           sudo apt-get "${apt_options[@]}" install -y --no-install-recommends \
-            build-essential \
-            libayatana-appindicator3-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            imagemagick \
-            librsvg2-dev \
-            redis-server \
-            xvfb
+            "${packages[@]}"
 
           sudo chown -R "$USER:$(id -gn)" "$apt_archives"
 
@@ -195,11 +423,13 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Set up Python
+        if: matrix.command == 'e2e:desktop:cloud'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
       - name: Install uv
+        if: matrix.command == 'e2e:desktop:cloud'
         run: pip install uv
 
       - name: Install dependencies
@@ -254,6 +484,8 @@ jobs:
     needs:
       - changes
       - wework-e2e
+      - build-wework-desktop-core-e2e
+      - wework-desktop-core-e2e
       - wework-desktop-e2e
     if: always()
     runs-on: ubuntu-latest
@@ -262,10 +494,13 @@ jobs:
       - name: Check Wework E2E results
         env:
           RUN_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
-          RUN_DESKTOP_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
+          RUN_DESKTOP_CORE_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_core_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
+          RUN_DESKTOP_OTHER_E2E: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.wework_desktop_other_e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ci:all')) }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           WEB_E2E_RESULT: ${{ needs.wework-e2e.result }}
-          DESKTOP_E2E_RESULT: ${{ needs.wework-desktop-e2e.result }}
+          DESKTOP_CORE_BUILD_RESULT: ${{ needs.build-wework-desktop-core-e2e.result }}
+          DESKTOP_CORE_E2E_RESULT: ${{ needs.wework-desktop-core-e2e.result }}
+          DESKTOP_OTHER_E2E_RESULT: ${{ needs.wework-desktop-e2e.result }}
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "Wework E2E change detection completed with: $CHANGES_RESULT"
@@ -282,8 +517,21 @@ jobs:
             exit 1
           fi
 
-          if [[ "$RUN_DESKTOP_E2E" == "true" && "$DESKTOP_E2E_RESULT" != "success" ]]; then
-            echo "Wework desktop E2E completed with: $DESKTOP_E2E_RESULT"
+          if [[ "$RUN_DESKTOP_CORE_E2E" == "true" && \
+            "$DESKTOP_CORE_BUILD_RESULT" != "success" ]]; then
+            echo "Wework desktop Core E2E build completed with: $DESKTOP_CORE_BUILD_RESULT"
+            exit 1
+          fi
+
+          if [[ "$RUN_DESKTOP_CORE_E2E" == "true" && \
+            "$DESKTOP_CORE_E2E_RESULT" != "success" ]]; then
+            echo "Wework desktop Core E2E completed with: $DESKTOP_CORE_E2E_RESULT"
+            exit 1
+          fi
+
+          if [[ "$RUN_DESKTOP_OTHER_E2E" == "true" && \
+            "$DESKTOP_OTHER_E2E_RESULT" != "success" ]]; then
+            echo "Wework desktop non-Core E2E completed with: $DESKTOP_OTHER_E2E_RESULT"
             exit 1
           fi
 

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -114,18 +114,26 @@ Matrix submissions use a 10-second timeout. If the composer already displays a s
 The main desktop flow's short-conversation layout regression stores `short-conversation-00-ready.png`, `short-conversation-01-prompt-filled.png`, `short-conversation-02-completed-top-aligned.png`, and `short-conversation-layout-metrics.json`. The final screenshot and metrics are captured after switching away and reopening the conversation. The gate requires the first message to remain within `160px` of the message viewport's top edge. For focused local diagnosis, run `node wework/e2e/desktop/task-flow.e2e.mjs --short-conversation-only`; the same check remains part of the regular `e2e:desktop` flow rather than a separate CI entrypoint.
 
 The main desktop runner also supports execution through ordered checkpoints.
-The checkpoints are `core-task-flow`, `window-lifecycle`, `goal-lifecycle`,
-`resilience`, `conversation-state`, `workspace-attachments`, and
-`rendering-extensions`. `--segment <checkpoint>` performs common startup and
-project initialization, then runs only the selected checkpoint.
+The checkpoints are `workspace-tabs`, `core-task-flow`, `window-lifecycle`,
+`goal-lifecycle`, `resilience`, `conversation-state`, `workspace-attachments`,
+and `rendering-extensions`. `--segment <checkpoint>` performs common startup
+and project initialization, then runs only the selected checkpoint.
 `--from-segment <checkpoint>` starts there and continues through every later
 checkpoint. When upstream checkpoints are skipped, each checkpoint establishes
 its own minimal fixtures instead of depending on tasks or UI state created only
 by the complete flow. PR CI builds the smallest segment matrix for the changed
 feature paths. Shared desktop infrastructure, merge queue, scheduled runs, and
-`ci:all` still run the complete desktop suites. Merge queue validates the final
-commit that enters `main`, so Tests, Lint, Platform E2E, and Wework E2E do not
-repeat the same validation after the merge through a `push main` trigger. The
+`ci:all` still run the complete desktop suites. The complete Core suite expands
+every checkpoint into an independent GitHub Actions matrix job so the
+checkpoints run in parallel instead of serially inside one
+`Wework Desktop E2E (Core)` job. CI first builds one Core Tauri application,
+Executor, and Codex artifact with fixed test ports. Each checkpoint installs
+only desktop runtime dependencies and reuses that artifact instead of
+reinstalling pnpm, Rust, Python, or uv and rebuilding Vite, Tauri, and Executor.
+The plugin and cloud suites require different build-time configuration, so they
+remain independent jobs that run alongside the Core build. Merge queue validates
+the final commit that enters `main`, so Tests, Lint, Platform E2E, and Wework E2E
+do not repeat the same validation after the merge through a `push main` trigger. The
 mapping lives in `.github/scripts/classify-wework-desktop-e2e.sh` and must be updated when new
 feature coverage is registered. Segment commands are also useful for focused
 local iteration:

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -114,13 +114,20 @@ node e2e/utils/mock-connector-upstream-server.mjs
 主桌面流程的短对话布局回归会保存 `short-conversation-00-ready.png`、`short-conversation-01-prompt-filled.png`、`short-conversation-02-completed-top-aligned.png` 和 `short-conversation-layout-metrics.json`。最后一个截图和 metrics 均在切走并重新打开对话后生成；门禁要求首条消息距离消息视口顶部不超过 `160px`。本地排查该回归时可直接运行 `node wework/e2e/desktop/task-flow.e2e.mjs --short-conversation-only`，但该检查同时属于常规 `e2e:desktop` 主流程，不是独立 CI 入口。
 
 主桌面 runner 也支持按有序 checkpoint 分段执行。当前 checkpoint 依次为
-`core-task-flow`、`window-lifecycle`、`goal-lifecycle`、`resilience`、
-`conversation-state`、`workspace-attachments` 和 `rendering-extensions`。
+`workspace-tabs`、`core-task-flow`、`window-lifecycle`、`goal-lifecycle`、
+`resilience`、`conversation-state`、`workspace-attachments` 和
+`rendering-extensions`。
 `--segment <checkpoint>` 在公共启动和项目初始化后只运行指定 checkpoint；
 `--from-segment <checkpoint>` 从指定 checkpoint 开始并继续执行所有后续
 checkpoint。跳过上游时，每个 checkpoint 会自行建立最小前置 fixture，不依赖只有
 完整流程才创建的任务或 UI 状态。PR CI 会根据改动的功能路径组合最小 segment
 矩阵；共享桌面基础设施、merge queue、定时任务和 `ci:all` 仍运行完整桌面套件。
+完整 Core 套件会把每个 checkpoint 展开为独立的 GitHub Actions matrix job 并行
+执行，而不是在单个 `Wework Desktop E2E (Core)` job 中串行运行。CI 会先构建一次
+带固定测试端口的 Core Tauri 应用、Executor 和 Codex artifact；各 checkpoint
+只安装桌面运行时依赖并下载复用该 artifact，不再重复安装 pnpm、Rust、Python 或
+uv，也不重复执行 Vite、Tauri 和 Executor 构建。插件与云端套件需要不同的构建时
+配置，仍作为独立 job 与 Core 构建并行。
 merge queue 会验证最终进入 `main` 的合并提交，因此合入后不再通过 `push main`
 重复运行同一套 Tests、Lint、Platform E2E 和 Wework E2E。映射规则位于
 `.github/scripts/classify-wework-desktop-e2e.sh`，新增功能覆盖时

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -358,6 +358,7 @@ const GUIDANCE_SCROLL_ONLY = process.argv.includes('--guidance-scroll-only')
 const MESSAGE_RESTORATION_ONLY = process.argv.includes('--message-restoration-only')
 const QUEUE_MANAGEMENT_ONLY = process.argv.includes('--queue-management-only')
 const TASK_PLAN_ONLY = process.argv.includes('--task-plan-only')
+const BUILD_ONLY = process.argv.includes('--build-only')
 const DESKTOP_SCENARIO_ONLY = process.env.WEWORK_E2E_DESKTOP_SCENARIO_ONLY === 'true'
 const MIXED_TOOL_TURNS_ONLY = process.env.WEWORK_E2E_MIXED_TOOL_TURNS_ONLY === '1'
 const DESKTOP_SEGMENT = readCommandLineOption('--segment')
@@ -438,6 +439,7 @@ function validateDesktopSegmentOptions() {
     ['--message-restoration-only', MESSAGE_RESTORATION_ONLY],
     ['--queue-management-only', QUEUE_MANAGEMENT_ONLY],
     ['--task-plan-only', TASK_PLAN_ONLY],
+    ['--build-only', BUILD_ONLY],
     ['WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true', DESKTOP_SCENARIO_ONLY],
     ['WEWORK_E2E_MIXED_TOOL_TURNS_ONLY=1', MIXED_TOOL_TURNS_ONLY],
   ].filter(([, enabled]) => enabled)
@@ -456,6 +458,9 @@ function validateDesktopSegmentOptions() {
   }
   if (PLUGINS_ONLY && DESKTOP_CHECKPOINTS.includes(SELECTED_DESKTOP_SEGMENT)) {
     throw new Error('--plugins-only accepts only plugin E2E segments')
+  }
+  if (BUILD_ONLY && !process.env.WEWORK_E2E_BUILD_MANIFEST) {
+    throw new Error('--build-only requires WEWORK_E2E_BUILD_MANIFEST')
   }
 }
 
@@ -9999,7 +10004,7 @@ function hostCodexTarget() {
 }
 
 async function resolveDesktopCodexBinary() {
-  const configured = process.env.WEWORK_E2E_CODEX_BIN
+  const configured = process.env.WEWORK_E2E_CODEX_BIN || process.env.CODEX_BIN
   if (configured) {
     return resolveExecutable(configured, 'codex', 'Configured Wework E2E Codex')
   }
@@ -10967,6 +10972,10 @@ async function main() {
         )}\n`,
         'utf8'
       )
+    }
+    if (BUILD_ONLY) {
+      console.log(`Wework desktop E2E build passed. Manifest: ${buildManifestPath}`)
+      return
     }
     if (!RUNS_PLUGIN_E2E) {
       await writeCodexConfig(codexHome, control.url, desktopScenario?.codexConfigToml)

--- a/wework/package.json
+++ b/wework/package.json
@@ -18,7 +18,7 @@
     "ios:init": "tauri ios init",
     "dev:ios": "bash scripts/dev-ios-app.sh",
     "build:ios": "bash scripts/build-ios-app.sh",
-    "tauri:build": "pnpm run prepare:codex -- --materialize && pnpm run prepare:dws && tauri build",
+    "tauri:build": "pnpm run prepare:codex --materialize && pnpm run prepare:dws && tauri build",
     "lint": "eslint . && pnpm run lint:typography && pnpm run lint:task-lifecycle",
     "lint:typography": "node scripts/check-typography.mjs",
     "lint:task-lifecycle": "node scripts/check-runtime-task-lifecycle.mjs",


### PR DESCRIPTION
## Summary

- split full Core desktop E2E coverage into one GitHub Actions matrix job per registered checkpoint
- build the Core Tauri app, Executor, and Codex package once, then restore that artifact in every checkpoint job
- keep plugin and cloud suites independent so they run alongside the Core build
- preserve minimal segment selection for feature-scoped changes
- skip Python/uv setup outside the cloud suite and make the runner reuse an explicitly prepared `CODEX_BIN`
- update classifier coverage and bilingual developer documentation

## Why

The complete Core suite previously ran all independently bootstrapped checkpoints serially. A direct matrix split reduced wall-clock time but repeated pnpm, Rust, Python/uv, Vite, Tauri, Executor, and sidecar setup in every Core job. The final structure separates compilation from execution: one build job publishes an executable artifact configured with fixed E2E ports, and lightweight checkpoint jobs download it and run in parallel.

## Impact

Full Core runs triggered by shared desktop infrastructure, merge queue, schedules, or `ci:all` now compile once and execute the eight Core checkpoints in parallel. Scoped PR changes continue to run only the minimum selected checkpoints. Plugin and cloud jobs retain their suite-specific build configuration; only cloud installs Python and uv.

## Validation

- `bash .github/scripts/test-classify-ci-changes.sh`
- `shellcheck .github/scripts/classify-ci-changes.sh .github/scripts/classify-wework-desktop-e2e.sh .github/scripts/test-classify-ci-changes.sh .github/scripts/archive-wework-core-e2e-build.sh .github/scripts/restore-wework-core-e2e-build.sh`
- `pnpm --filter wework test` (259 files, 2559 tests passed)
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs ../.github/workflows/wework-e2e.yml ../docs/zh/wework/developer-guide/wework-e2e-automation.md ../docs/en/wework/developer-guide/wework-e2e-automation.md`
- Node syntax check, YAML parse, and `git diff --check`
- pre-push ESLint, TypeScript, and unit-test checks
