### PR TITLE
feat(wework): support stable and beta update channels

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -836,15 +836,21 @@ jobs:
             local asset_name="${channel}-darwin-aarch64.json"
             local current_manifest="$work_dir/current-${channel}.json"
             local assets_file="$work_dir/wework-updater-assets.json"
+            local required_asset
 
             if ! gh release view wework-updater --json assets > "$assets_file"; then
               echo "Failed to inspect existing Wework updater assets." >&2
               return 2
             fi
-            if ! jq -e --arg name "$asset_name" \
-              'any(.assets[]; .name == $name)' "$assets_file" >/dev/null; then
-              return 0
-            fi
+            for required_asset in \
+              "${channel}-darwin-aarch64.json" \
+              "${channel}-darwin-x86_64.json" \
+              "${channel}-windows-x86_64.json"; do
+              if ! jq -e --arg name "$required_asset" \
+                'any(.assets[]; .name == $name)' "$assets_file" >/dev/null; then
+                return 0
+              fi
+            done
             if ! gh release download wework-updater \
               --pattern "$asset_name" \
               --output "$current_manifest" \

--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -3,8 +3,16 @@ name: Wework App
 on:
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Release channel. Beta users receive both Beta and stable updates."
+        type: choice
+        options:
+          - stable
+          - beta
+        required: true
+        default: stable
       version:
-        description: "Optional Wework version override, for example 0.1.0 or v0.1.0. If empty, auto-increment from latest wework-vX.Y.Z tag"
+        description: "Optional stable version override, for example 1.2.3. Beta versions are always generated automatically."
         type: string
         required: false
       publish_release:
@@ -27,6 +35,8 @@ jobs:
       release_tag: ${{ steps.version.outputs.release_tag }}
       release_sha: ${{ steps.version-files.outputs.release_sha }}
       version: ${{ steps.version.outputs.value }}
+      channel: ${{ steps.version.outputs.channel }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
       publish_release: ${{ steps.version.outputs.publish_release }}
 
     steps:
@@ -49,57 +59,9 @@ jobs:
         shell: bash
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel || 'stable' }}
           PUBLISH_RELEASE: ${{ github.event_name == 'push' || github.event.inputs.publish_release == 'true' }}
-        run: |
-          set -euo pipefail
-
-          validate_version() {
-            local version="$1"
-            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Error: Invalid Wework version '$version'. Expected MAJOR.MINOR.PATCH, for example 1.2.3." >&2
-              exit 1
-            fi
-          }
-
-          bump_patch() {
-            local version="$1"
-            IFS='.' read -r major minor patch <<< "$version"
-            echo "${major}.${minor}.$((patch + 1))"
-          }
-
-          if [ -n "${INPUT_VERSION:-}" ]; then
-            version="${INPUT_VERSION#v}"
-            validate_version "$version"
-          elif [[ "${GITHUB_REF:-}" == refs/tags/wework-v* ]]; then
-            version="${GITHUB_REF_NAME#wework-v}"
-            validate_version "$version"
-          else
-            latest_tag="$(git tag -l 'wework-v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
-            if [ -z "$latest_tag" ]; then
-              version="0.0.1"
-            else
-              latest_version="${latest_tag#wework-v}"
-              validate_version "$latest_version"
-              version="$(bump_patch "$latest_version")"
-            fi
-          fi
-
-          publish_release="${PUBLISH_RELEASE:-false}"
-          if [[ "${GITHUB_REF:-}" == refs/tags/wework-v* ]]; then
-            publish_release="true"
-          fi
-
-          if [[ "${GITHUB_REF:-}" == refs/tags/wework-v* ]]; then
-            release_tag="$GITHUB_REF_NAME"
-          else
-            release_tag="wework-v$version"
-          fi
-
-          {
-            echo "value=$version"
-            echo "release_tag=$release_tag"
-            echo "publish_release=$publish_release"
-          } >> "$GITHUB_OUTPUT"
+        run: node wework/scripts/resolve-release-version.mjs
 
       - name: Commit Wework version files
         id: version-files
@@ -202,9 +164,13 @@ jobs:
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
           RELEASE_SHA: ${{ steps.version-files.outputs.release_sha }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          RELEASE_CHANNEL: ${{ steps.version.outputs.channel }}
         run: |
           set -euo pipefail
           release_title="Wework $RELEASE_VERSION"
+          if [ "$RELEASE_CHANNEL" = "beta" ]; then
+            release_title="$release_title Beta"
+          fi
           release_notes="$(mktemp)"
           generated_notes="$(mktemp)"
           previous_tag="$(git tag -l 'wework-v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | awk -v current="$RELEASE_TAG" '$0 != current { print; exit }')"
@@ -412,7 +378,7 @@ jobs:
           CONFIG_OVERRIDE="$config_override" \
           BASE_CONFIG="$PWD/src-tauri/tauri.conf.json" \
           VERSION="${{ needs.prepare-release.outputs.version }}" \
-          UPDATER_ENDPOINT="https://github.com/${GH_REPO}/releases/latest/download/latest.json" \
+          UPDATER_ENDPOINT="https://github.com/${GH_REPO}/releases/download/wework-updater/{{target}}-{{arch}}.json" \
           UPDATER_PUBKEY="$TAURI_UPDATER_PUBKEY" \
           SIGNING_IDENTITY="-" \
           ENABLE_INSECURE_TRANSPORT="false" \
@@ -624,7 +590,7 @@ jobs:
             bundle = @{ createUpdaterArtifacts = $true }
             plugins = @{
               updater = @{
-                endpoints = @("https://github.com/$env:GH_REPO/releases/latest/download/latest.json")
+                endpoints = @("https://github.com/$env:GH_REPO/releases/download/wework-updater/{{target}}-{{arch}}.json")
                 pubkey = $env:TAURI_UPDATER_PUBKEY
               }
             }
@@ -771,7 +737,7 @@ jobs:
           {
             echo "### Wework updater manifest"
             echo ""
-            echo "- Endpoint: https://github.com/${GH_REPO}/releases/latest/download/latest.json"
+            echo "- Version release manifest: https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/latest.json"
             echo "- Version: ${RELEASE_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -800,14 +766,112 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.channel }}
+          PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
         run: |
           set -euo pipefail
           release_id="$(gh release view "$RELEASE_TAG" --json databaseId --jq .databaseId)"
+          make_latest="true"
+          if [ "$RELEASE_CHANNEL" = "beta" ]; then
+            make_latest="false"
+          fi
           gh api \
             --method PATCH \
             "repos/${GH_REPO}/releases/${release_id}" \
             --field draft=false \
-            --field prerelease=false \
-            --raw-field make_latest=true >/dev/null
+            --field prerelease="$PRERELEASE" \
+            --raw-field make_latest="$make_latest" >/dev/null
           release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
-          echo "Published Wework release and updater manifest: $release_url" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published Wework ${RELEASE_CHANNEL} release and updater manifest: $release_url" >> "$GITHUB_STEP_SUMMARY"
+
+  publish-channel-manifests:
+    name: Publish channel manifests
+    runs-on: ubuntu-latest
+    if: needs.prepare-release.outputs.publish_release == 'true'
+    needs:
+      - prepare-release
+      - publish-release
+
+    steps:
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID || secrets.RELEASE_APP_ID || vars.RELEASE_APP_CLIENT_ID || secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout release scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
+
+      - name: Publish rolling update manifests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.channel }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          work_dir="$(mktemp -d)"
+          gh release download "$RELEASE_TAG" \
+            --pattern latest.json \
+            --dir "$work_dir"
+
+          if ! gh release view wework-updater >/dev/null 2>&1; then
+            gh release create wework-updater \
+              --target "$RELEASE_SHA" \
+              --title "Wework updater manifests" \
+              --notes "Rolling manifests for the stable and Beta update channels." \
+              --prerelease
+          fi
+
+          is_newer_than_channel() {
+            local channel="$1"
+            local current_manifest="$work_dir/current-${channel}.json"
+            if ! gh release download wework-updater \
+              --pattern "${channel}-darwin-aarch64.json" \
+              --output "$current_manifest" 2>/dev/null; then
+              return 0
+            fi
+
+            current_version="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' "$current_manifest")"
+            node wework/scripts/update-channel-manifests.mjs \
+              is-newer "$RELEASE_VERSION" "$current_version"
+          }
+
+          publish_channel() {
+            local channel="$1"
+            if ! is_newer_than_channel "$channel"; then
+              echo "Keeping newer ${channel} channel manifest."
+              return
+            fi
+
+            node wework/scripts/update-channel-manifests.mjs \
+              generate "$work_dir/latest.json" "$work_dir" "$channel"
+
+            gh release upload wework-updater \
+              "$work_dir/${channel}-darwin-aarch64.json" \
+              "$work_dir/${channel}-darwin-x86_64.json" \
+              "$work_dir/${channel}-windows-x86_64.json" \
+              --clobber
+          }
+
+          publish_channel "$RELEASE_CHANNEL"
+          if [ "$RELEASE_CHANNEL" = "stable" ]; then
+            publish_channel beta
+          fi
+
+          {
+            echo "### Wework update channels"
+            echo ""
+            echo "- Published release channel: ${RELEASE_CHANNEL}"
+            echo "- Rolling endpoint: https://github.com/${GH_REPO}/releases/download/wework-updater/{{target}}-{{arch}}.json"
+            if [ "$RELEASE_CHANNEL" = "stable" ]; then
+              echo "- Stable releases also advance the Beta channel when they are newer."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -805,6 +805,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare-release.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Publish rolling update manifests
         shell: bash
@@ -832,11 +833,24 @@ jobs:
 
           is_newer_than_channel() {
             local channel="$1"
+            local asset_name="${channel}-darwin-aarch64.json"
             local current_manifest="$work_dir/current-${channel}.json"
-            if ! gh release download wework-updater \
-              --pattern "${channel}-darwin-aarch64.json" \
-              --output "$current_manifest" 2>/dev/null; then
+            local assets_file="$work_dir/wework-updater-assets.json"
+
+            if ! gh release view wework-updater --json assets > "$assets_file"; then
+              echo "Failed to inspect existing Wework updater assets." >&2
+              return 2
+            fi
+            if ! jq -e --arg name "$asset_name" \
+              'any(.assets[]; .name == $name)' "$assets_file" >/dev/null; then
               return 0
+            fi
+            if ! gh release download wework-updater \
+              --pattern "$asset_name" \
+              --output "$current_manifest" \
+              --clobber; then
+              echo "Failed to download existing ${channel} channel manifest." >&2
+              return 2
             fi
 
             current_version="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' "$current_manifest")"
@@ -846,10 +860,18 @@ jobs:
 
           publish_channel() {
             local channel="$1"
-            if ! is_newer_than_channel "$channel"; then
-              echo "Keeping newer ${channel} channel manifest."
-              return
-            fi
+            local comparison_status=0
+            is_newer_than_channel "$channel" || comparison_status=$?
+            case "$comparison_status" in
+              0) ;;
+              1)
+                echo "Keeping newer ${channel} channel manifest."
+                return
+                ;;
+              *)
+                return "$comparison_status"
+                ;;
+            esac
 
             node wework/scripts/update-channel-manifests.mjs \
               generate "$work_dir/latest.json" "$work_dir" "$channel"

--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -91,15 +91,32 @@ python3 -m http.server 8787 --directory src-tauri/target/release/local-update-se
 
 ## GitHub Release Auto Update
 
-The repository includes `.github/workflows/wework-app.yml` for producing macOS DMGs, Tauri updater archives, signature files, and `latest.json` on GitHub Actions. The updater endpoint embedded in the client points to the GitHub Release latest asset:
+The repository includes `.github/workflows/wework-app.yml` for producing macOS DMGs, Windows installers, Tauri updater archives, signatures, and updater manifests on GitHub Actions. The updater endpoint embedded in the client points to the fixed `wework-updater` Release and uses Tauri `target` and `arch` placeholders to select the update channel and platform:
 
 ```text
-https://github.com/<owner>/<repo>/releases/latest/download/latest.json
+https://github.com/<owner>/<repo>/releases/download/wework-updater/{{target}}-{{arch}}.json
 ```
 
 The macOS CI job does not invoke `release-mac-app.sh`, but both release paths share `wework/scripts/generate-release-config.mjs`. The generator copies the complete `bundle.resources` list from `src-tauri/tauri.conf.json`, ensuring that Codex, hooks, bundled plugins, and hidden marketplace manifests are included in formal release packages. Update the base Tauri config when desktop resources change instead of duplicating the list in the workflow.
 
-The workflow can only be started manually from GitHub Actions and does not respond to tag pushes. A formal run creates or updates a `wework-v<version>` draft release. After both architecture builds finish, it generates `latest.json`, uploads it to the same release, and then publishes that release as GitHub latest. The client reads this manifest during automatic startup checks and when the titlebar update action is used. Preventing tag-push triggers ensures that the tag created while publishing the release cannot start a second build of the same version and overwrite signed artifacts.
+The workflow can only be started manually from GitHub Actions and does not respond to tag pushes. Select a release channel when starting it:
+
+- `stable`: publishes a stable release. Leave `version` empty to increment the latest stable patch, or enter an `X.Y.Z` override.
+- `beta`: publishes a Beta release. Do not enter a version; the workflow always derives the next `X.Y.Z-beta.N` from existing stable and Beta tags.
+- `publish_release=false`: produces test artifacts only and does not commit version files or publish a Release.
+- `publish_release=true`: synchronizes version files, builds signed artifacts, and publishes a GitHub Release.
+
+For example, when the latest stable version is `1.2.3`, the first Beta is `1.2.4-beta.1`, followed by `1.2.4-beta.2` and `1.2.4-beta.3`. After publishing stable `1.2.4`, the next automatic Beta is `1.2.5-beta.1`.
+
+A formal run creates or updates a `wework-v<version>` draft release. After the builds finish, the workflow generates that version's `latest.json`, uploads it to the same Release, and publishes the Release. Stable releases become GitHub latest. Beta releases are marked as prereleases and do not replace GitHub latest. Preventing tag-push triggers ensures that a tag created by the workflow cannot start another build of the same version and overwrite signed artifacts.
+
+After publishing the versioned Release, the workflow updates rolling manifests in the fixed `wework-updater` Release:
+
+- `stable-*` points only to the latest stable release.
+- `beta-*` points to whichever Beta or stable release has the higher SemVer, so Beta users also receive newer stable releases.
+- A release only replaces a rolling manifest when its SemVer is higher; historical or lower releases cannot downgrade users.
+
+Users opt into Beta updates under Wework **Settings → About** by enabling **Receive Beta updates**. The client uses the `stable` target by default and the `beta` target after opt-in. Changing the setting immediately checks for updates and persists locally.
 
 Configure these repository secrets in GitHub Actions:
 
@@ -119,11 +136,11 @@ The workflow uploads these release assets:
 - `WeWork_<version>_macos_x64.app.tar.gz.sig`
 - `latest.json`
 
-When downloaded from GitHub Release assets, the link points directly to the `.dmg` file and is not wrapped by an Actions artifact `.zip`. When the workflow is triggered manually without a version input, the release tag auto-increments the patch version from the latest `wework-vX.Y.Z` tag.
+When downloaded from GitHub Release assets, the link points directly to the `.dmg` file and is not wrapped by an Actions artifact `.zip`. With the stable channel, leaving `version` empty increments the latest stable `wework-vX.Y.Z` tag. The Beta channel always derives its version automatically and ignores the `version` input.
 
 For a formal release, the workflow syncs `wework/package.json`, `wework/src-tauri/tauri.conf.json`, `wework/src-tauri/Cargo.toml`, and `wework/src-tauri/Cargo.lock` to the release version before building, then commits those files directly back to the triggering `main` branch. The macOS build jobs and GitHub Release target use that version commit, keeping the About page version, Tauri bundle version, and source version aligned.
 
-Manual workflow runs that do not publish a formal release only produce test artifacts and do not commit version files. An existing `wework-vX.Y.Z` tag can also be selected explicitly when manually starting the workflow; the tag then points to an immutable commit, so the workflow does not rewrite source files. If the tagged version files do not match the tag version, the release fails and the version files must be updated before creating the tag again. Pushing a tag alone does not start a release.
+Manual workflow runs that do not publish a formal release only produce test artifacts and do not commit version files. An existing stable or Beta `wework-v<version>` tag can also be selected explicitly when manually starting the workflow. The workflow derives the version and channel from the tag, which points to an immutable commit, so it does not rewrite source files. If the tagged version files do not match the tag version, the release fails and the version files must be updated before creating the tag again. Pushing a tag alone does not start a release.
 
 ## CI DMG Without Apple Developer
 

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -91,15 +91,32 @@ python3 -m http.server 8787 --directory src-tauri/target/release/local-update-se
 
 ## GitHub Release 自动更新
 
-仓库提供 `.github/workflows/wework-app.yml`，用于在 GitHub Actions 上生成 macOS DMG、Tauri updater archive、签名文件和 `latest.json`。客户端内置的 updater endpoint 指向 GitHub Release latest asset：
+仓库提供 `.github/workflows/wework-app.yml`，用于在 GitHub Actions 上生成 macOS DMG、Windows installer、Tauri updater archive、签名文件和 updater manifest。客户端内置的 updater endpoint 指向固定的 `wework-updater` Release，并通过 Tauri 的 `target` 和 `arch` 占位符选择更新渠道与平台：
 
 ```text
-https://github.com/<owner>/<repo>/releases/latest/download/latest.json
+https://github.com/<owner>/<repo>/releases/download/wework-updater/{{target}}-{{arch}}.json
 ```
 
 macOS CI job 不调用 `release-mac-app.sh`，但两条发布路径共享 `wework/scripts/generate-release-config.mjs`。该生成器从 `src-tauri/tauri.conf.json` 复制完整的 `bundle.resources`，确保 Codex、hooks、bundled plugins 及隐藏的 marketplace manifests 都进入正式发布包。修改桌面资源清单时应更新基础 Tauri 配置，不要在 workflow 中重新复制资源列表。
 
-workflow 只能通过 GitHub Actions 手动触发，不会响应 tag push。正式发布会创建或更新 `wework-v<version>` draft release；两个架构构建完成后，workflow 生成 `latest.json`，上传到同一个 Release，最后把 Release 发布为 GitHub latest。客户端启动后的自动检查或标题栏手动更新都会读取这个 manifest。禁止 tag push 自动触发可以避免 workflow 发布 Release 时创建的 tag 再次启动同版本构建并覆盖已签名产物。
+workflow 只能通过 GitHub Actions 手动触发，不会响应 tag push。启动 workflow 时选择发布渠道：
+
+- `stable`：发布正式版。`version` 可以留空并自动增加最新正式版的 patch，也可以填写 `X.Y.Z` 覆盖。
+- `beta`：发布 Beta 版。不要填写版本；workflow 总是根据现有正式版和 Beta tag 自动生成下一个 `X.Y.Z-beta.N`。
+- `publish_release=false`：只生成测试 artifacts，不提交版本文件或发布 Release。
+- `publish_release=true`：同步版本文件、构建签名产物并发布 GitHub Release。
+
+例如最新正式版是 `1.2.3` 时，第一次 Beta 发布得到 `1.2.4-beta.1`，后续依次得到 `1.2.4-beta.2`、`1.2.4-beta.3`。正式发布 `1.2.4` 后，下一个自动 Beta 是 `1.2.5-beta.1`。
+
+正式发布会创建或更新 `wework-v<version>` draft release。构建完成后，workflow 生成该版本自己的 `latest.json` 并上传到同一个 Release，再发布 Release。正式版设置为 GitHub latest；Beta 设置为 prerelease，不改变 GitHub latest。禁止 tag push 自动触发可以避免 workflow 创建 tag 时再次启动同版本构建并覆盖已签名产物。
+
+发布完成后，workflow 更新固定 `wework-updater` Release 中的滚动 manifest：
+
+- `stable-*` 只指向最新正式版。
+- `beta-*` 指向 Beta 和正式版中 SemVer 更高的版本，因此选择 Beta 的用户也会收到更新的正式版。
+- 新版本只有在 SemVer 高于当前渠道版本时才覆盖滚动 manifest，历史发布或较低版本不会让用户降级。
+
+用户可以在 Wework 的“设置 → 关于”中打开“接收 Beta 版本更新”。默认关闭时客户端使用 `stable` target；打开后使用 `beta` target。切换后立即检查更新，并把选择保存在本机。
 
 GitHub Actions 需要配置这些 repository secrets：
 
@@ -119,11 +136,11 @@ workflow 分别上传这些 Release assets：
 - `WeWork_<version>_macos_x64.app.tar.gz.sig`
 - `latest.json`
 
-从 GitHub Release assets 下载时，下载链接本身就是 `.dmg` 文件，不会被 Actions artifact 额外套一层 `.zip`。手动触发 workflow 且未填写版本号时，release tag 会自动基于最新的 `wework-vX.Y.Z` tag 增加 patch 版本。
+从 GitHub Release assets 下载时，下载链接本身就是 `.dmg` 文件，不会被 Actions artifact 额外套一层 `.zip`。正式渠道未填写版本时，会基于最新正式版 `wework-vX.Y.Z` tag 增加 patch；Beta 渠道始终自动生成版本，不读取 `version` 输入。
 
 正式发布时，workflow 会在构建前把 `wework/package.json`、`wework/src-tauri/tauri.conf.json`、`wework/src-tauri/Cargo.toml` 和 `wework/src-tauri/Cargo.lock` 同步到本次 release version，并直接提交回触发 workflow 的 `main` 分支。后续 macOS 构建和 GitHub Release 都会使用这个版本提交，确保关于页版本、Tauri 包版本和源码版本一致。
 
-手动触发但未勾选正式发布时只生成测试 artifacts，不会提交版本文件。也可以在 GitHub Actions 中选择已有的 `wework-vX.Y.Z` tag 后手动运行 workflow；此时 tag 已经指向固定提交，workflow 不会改写源码。如果 tag 指向的版本文件和 tag 版本不一致，发布会失败，需要先更新版本文件并重新打 tag。仅推送 tag 不会启动发布。
+手动触发但未勾选正式发布时只生成测试 artifacts，不会提交版本文件。也可以在 GitHub Actions 中选择已有的正式版或 Beta `wework-v<version>` tag 后手动运行 workflow；workflow 会从 tag 自动识别版本和渠道，此时不会改写源码。如果 tag 指向的版本文件和 tag 版本不一致，发布会失败，需要先更新版本文件并重新打 tag。仅推送 tag 不会启动发布。
 
 ## 无 Apple Developer 账号的 CI DMG
 

--- a/wework/scripts/resolve-release-version.mjs
+++ b/wework/scripts/resolve-release-version.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { appendFile } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { compareWeworkVersions, parseWeworkVersion } from './update-channel-manifests.mjs'
+
+const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/
+const BETA_VERSION_PATTERN = /^\d+\.\d+\.\d+-beta\.[1-9]\d*$/
+
+function validateStableVersion(version) {
+  if (!STABLE_VERSION_PATTERN.test(version)) {
+    throw new Error(
+      `Invalid stable Wework version '${version}'. Expected MAJOR.MINOR.PATCH, for example 1.2.3.`
+    )
+  }
+}
+
+function validateBetaVersion(version) {
+  if (!BETA_VERSION_PATTERN.test(version)) {
+    throw new Error(
+      `Invalid Beta Wework version '${version}'. Expected MAJOR.MINOR.PATCH-beta.NUMBER, for example 1.2.4-beta.1.`
+    )
+  }
+}
+
+function latestVersion(versions) {
+  return versions.toSorted((left, right) => compareWeworkVersions(right, left))[0]
+}
+
+function bumpPatch(version) {
+  const [major, minor, patch] = parseWeworkVersion(version)
+  return `${major}.${minor}.${patch + 1}`
+}
+
+function nextBetaVersion(tags) {
+  const stableVersions = tags
+    .filter(tag => /^wework-v\d+\.\d+\.\d+$/.test(tag))
+    .map(tag => tag.slice('wework-v'.length))
+  const betaVersions = tags
+    .filter(tag => /^wework-v\d+\.\d+\.\d+-beta\.[1-9]\d*$/.test(tag))
+    .map(tag => tag.slice('wework-v'.length))
+
+  const nextStable = stableVersions.length ? bumpPatch(latestVersion(stableVersions)) : '0.0.1'
+  if (!betaVersions.length) return `${nextStable}-beta.1`
+
+  const latestBeta = latestVersion(betaVersions)
+  const [betaBase, betaNumber] = latestBeta.split('-beta.')
+  if (compareWeworkVersions(betaBase, nextStable) >= 0) {
+    return `${betaBase}-beta.${Number(betaNumber) + 1}`
+  }
+  return `${nextStable}-beta.1`
+}
+
+export function resolveReleaseVersion({
+  tags,
+  inputChannel = 'stable',
+  inputVersion = '',
+  githubRef = '',
+  githubRefName = '',
+  publishRelease = false,
+}) {
+  if (githubRef.startsWith('refs/tags/wework-v')) {
+    const version = githubRefName.slice('wework-v'.length)
+    const channel = version.includes('-beta.') ? 'beta' : 'stable'
+    if (channel === 'beta') validateBetaVersion(version)
+    else validateStableVersion(version)
+    return {
+      version,
+      channel,
+      releaseTag: githubRefName,
+      prerelease: channel === 'beta',
+      publishRelease: true,
+    }
+  }
+
+  if (inputChannel !== 'stable' && inputChannel !== 'beta') {
+    throw new Error(`Invalid Wework release channel '${inputChannel}'.`)
+  }
+
+  let version
+  if (inputChannel === 'beta') {
+    version = nextBetaVersion(tags)
+  } else if (inputVersion) {
+    version = inputVersion.replace(/^v/, '')
+    validateStableVersion(version)
+  } else {
+    const stableVersions = tags
+      .filter(tag => /^wework-v\d+\.\d+\.\d+$/.test(tag))
+      .map(tag => tag.slice('wework-v'.length))
+    version = stableVersions.length ? bumpPatch(latestVersion(stableVersions)) : '0.0.1'
+  }
+
+  return {
+    version,
+    channel: inputChannel,
+    releaseTag: `wework-v${version}`,
+    prerelease: inputChannel === 'beta',
+    publishRelease,
+  }
+}
+
+function readTags() {
+  const output = execFileSync('git', ['tag', '--list', 'wework-v*'], {
+    encoding: 'utf8',
+  })
+  return output
+    .split('\n')
+    .map(tag => tag.trim())
+    .filter(Boolean)
+}
+
+async function main() {
+  const result = resolveReleaseVersion({
+    tags: readTags(),
+    inputChannel: process.env.INPUT_CHANNEL || 'stable',
+    inputVersion: process.env.INPUT_VERSION || '',
+    githubRef: process.env.GITHUB_REF || '',
+    githubRefName: process.env.GITHUB_REF_NAME || '',
+    publishRelease: process.env.PUBLISH_RELEASE === 'true',
+  })
+  const output = [
+    `value=${result.version}`,
+    `release_tag=${result.releaseTag}`,
+    `channel=${result.channel}`,
+    `prerelease=${result.prerelease}`,
+    `publish_release=${result.publishRelease}`,
+    '',
+  ].join('\n')
+
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, output, 'utf8')
+  } else {
+    process.stdout.write(output)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main()
+}

--- a/wework/scripts/resolve-release-version.mjs
+++ b/wework/scripts/resolve-release-version.mjs
@@ -34,15 +34,19 @@ function bumpPatch(version) {
   return `${major}.${minor}.${patch + 1}`
 }
 
-function nextBetaVersion(tags) {
+function nextStableVersion(tags) {
   const stableVersions = tags
     .filter(tag => /^wework-v\d+\.\d+\.\d+$/.test(tag))
     .map(tag => tag.slice('wework-v'.length))
+  return stableVersions.length ? bumpPatch(latestVersion(stableVersions)) : '0.0.1'
+}
+
+function nextBetaVersion(tags) {
   const betaVersions = tags
     .filter(tag => /^wework-v\d+\.\d+\.\d+-beta\.[1-9]\d*$/.test(tag))
     .map(tag => tag.slice('wework-v'.length))
 
-  const nextStable = stableVersions.length ? bumpPatch(latestVersion(stableVersions)) : '0.0.1'
+  const nextStable = nextStableVersion(tags)
   if (!betaVersions.length) return `${nextStable}-beta.1`
 
   const latestBeta = latestVersion(betaVersions)
@@ -86,10 +90,7 @@ export function resolveReleaseVersion({
     version = inputVersion.replace(/^v/, '')
     validateStableVersion(version)
   } else {
-    const stableVersions = tags
-      .filter(tag => /^wework-v\d+\.\d+\.\d+$/.test(tag))
-      .map(tag => tag.slice('wework-v'.length))
-    version = stableVersions.length ? bumpPatch(latestVersion(stableVersions)) : '0.0.1'
+    version = nextStableVersion(tags)
   }
 
   return {

--- a/wework/scripts/resolve-release-version.test.mjs
+++ b/wework/scripts/resolve-release-version.test.mjs
@@ -59,4 +59,23 @@ describe('resolveReleaseVersion', () => {
       publishRelease: true,
     })
   })
+
+  test('rejects an unknown release channel', () => {
+    expect(() =>
+      resolveReleaseVersion({
+        tags: [],
+        inputChannel: 'nightly',
+      })
+    ).toThrow('Invalid Wework release channel')
+  })
+
+  test('rejects an invalid stable version override', () => {
+    expect(() =>
+      resolveReleaseVersion({
+        tags: [],
+        inputChannel: 'stable',
+        inputVersion: '1.2',
+      })
+    ).toThrow('Invalid stable Wework version')
+  })
 })

--- a/wework/scripts/resolve-release-version.test.mjs
+++ b/wework/scripts/resolve-release-version.test.mjs
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+import { resolveReleaseVersion } from './resolve-release-version.mjs'
+
+describe('resolveReleaseVersion', () => {
+  test('starts the next patch Beta without a version input', () => {
+    expect(
+      resolveReleaseVersion({
+        tags: ['wework-v1.2.3'],
+        inputChannel: 'beta',
+        inputVersion: '9.9.9',
+      })
+    ).toMatchObject({
+      version: '1.2.4-beta.1',
+      channel: 'beta',
+      prerelease: true,
+    })
+  })
+
+  test('increments the latest Beta number', () => {
+    expect(
+      resolveReleaseVersion({
+        tags: ['wework-v1.2.3', 'wework-v1.2.4-beta.2', 'wework-v1.2.4-beta.10'],
+        inputChannel: 'beta',
+      }).version
+    ).toBe('1.2.4-beta.11')
+  })
+
+  test('starts a new Beta patch after the matching stable release', () => {
+    expect(
+      resolveReleaseVersion({
+        tags: ['wework-v1.2.4-beta.3', 'wework-v1.2.4'],
+        inputChannel: 'beta',
+      }).version
+    ).toBe('1.2.5-beta.1')
+  })
+
+  test('supports an optional stable override', () => {
+    expect(
+      resolveReleaseVersion({
+        tags: ['wework-v1.2.4'],
+        inputChannel: 'stable',
+        inputVersion: 'v2.0.0',
+      }).version
+    ).toBe('2.0.0')
+  })
+
+  test('derives a Beta channel when rerunning an existing tag', () => {
+    expect(
+      resolveReleaseVersion({
+        tags: [],
+        githubRef: 'refs/tags/wework-v1.3.0-beta.4',
+        githubRefName: 'wework-v1.3.0-beta.4',
+      })
+    ).toEqual({
+      version: '1.3.0-beta.4',
+      channel: 'beta',
+      releaseTag: 'wework-v1.3.0-beta.4',
+      prerelease: true,
+      publishRelease: true,
+    })
+  })
+})

--- a/wework/scripts/update-channel-manifests.mjs
+++ b/wework/scripts/update-channel-manifests.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+
+const VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-beta\.([1-9]\d*))?$/
+
+export function parseWeworkVersion(version) {
+  const match = VERSION_PATTERN.exec(version)
+  if (!match) {
+    throw new Error(`Unsupported Wework version: ${version}`)
+  }
+
+  const [, major, minor, patch, beta] = match
+  return [
+    Number(major),
+    Number(minor),
+    Number(patch),
+    beta === undefined ? 1 : 0,
+    beta === undefined ? 0 : Number(beta),
+  ]
+}
+
+export function compareWeworkVersions(left, right) {
+  const leftParts = parseWeworkVersion(left)
+  const rightParts = parseWeworkVersion(right)
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] > rightParts[index] ? 1 : -1
+    }
+  }
+
+  return 0
+}
+
+export function isNewerWeworkVersion(candidate, current) {
+  return compareWeworkVersions(candidate, current) > 0
+}
+
+export async function generateChannelManifests({ sourcePath, outputDirectory, channel }) {
+  if (channel !== 'stable' && channel !== 'beta') {
+    throw new Error(`Unsupported Wework update channel: ${channel}`)
+  }
+
+  const source = JSON.parse(await readFile(sourcePath, 'utf8'))
+  const platforms = ['darwin-aarch64', 'darwin-x86_64', 'windows-x86_64']
+  await mkdir(outputDirectory, { recursive: true })
+
+  for (const platform of platforms) {
+    const [operatingSystem, ...architectureParts] = platform.split('-')
+    const architecture = architectureParts.join('-')
+    const target = `${channel}-${operatingSystem}`
+    const data = {
+      version: source.version,
+      notes: source.notes,
+      pub_date: source.pub_date,
+      platforms: {
+        [target]: source.platforms[platform],
+      },
+    }
+    await writeFile(
+      resolve(outputDirectory, `${target}-${architecture}.json`),
+      `${JSON.stringify(data, null, 2)}\n`,
+      'utf8'
+    )
+  }
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2)
+  if (command === 'is-newer') {
+    const [candidate, current] = args
+    if (!candidate || !current) {
+      throw new Error('Usage: update-channel-manifests.mjs is-newer <candidate> <current>')
+    }
+    process.exitCode = isNewerWeworkVersion(candidate, current) ? 0 : 1
+    return
+  }
+
+  if (command === 'generate') {
+    const [sourcePath, outputDirectory, channel] = args
+    if (!sourcePath || !outputDirectory || !channel) {
+      throw new Error(
+        'Usage: update-channel-manifests.mjs generate <source> <output-directory> <channel>'
+      )
+    }
+    await generateChannelManifests({ sourcePath, outputDirectory, channel })
+    return
+  }
+
+  throw new Error('Expected command: is-newer or generate')
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main()
+}

--- a/wework/scripts/update-channel-manifests.mjs
+++ b/wework/scripts/update-channel-manifests.mjs
@@ -52,12 +52,16 @@ export async function generateChannelManifests({ sourcePath, outputDirectory, ch
     const [operatingSystem, ...architectureParts] = platform.split('-')
     const architecture = architectureParts.join('-')
     const target = `${channel}-${operatingSystem}`
+    const entry = source.platforms?.[platform]
+    if (!entry) {
+      throw new Error(`Missing platform '${platform}' in ${sourcePath}`)
+    }
     const data = {
       version: source.version,
       notes: source.notes,
       pub_date: source.pub_date,
       platforms: {
-        [target]: source.platforms[platform],
+        [target]: entry,
       },
     }
     await writeFile(

--- a/wework/scripts/update-channel-manifests.test.mjs
+++ b/wework/scripts/update-channel-manifests.test.mjs
@@ -58,4 +58,31 @@ describe('Wework update channel manifests', () => {
       'beta-darwin': source.platforms['darwin-aarch64'],
     })
   })
+
+  test('rejects a source manifest that omits a required platform', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'wework-update-channel-'))
+    temporaryDirectories.push(directory)
+    const sourcePath = resolve(directory, 'latest.json')
+    await writeFile(
+      sourcePath,
+      JSON.stringify({
+        version: '1.2.4',
+        notes: 'Stable release',
+        pub_date: '2026-08-03T00:00:00Z',
+        platforms: {
+          'darwin-aarch64': { signature: 'mac-arm', url: 'https://example.com/mac-arm' },
+          'darwin-x86_64': { signature: 'mac-x64', url: 'https://example.com/mac-x64' },
+        },
+      }),
+      'utf8'
+    )
+
+    await expect(
+      generateChannelManifests({
+        sourcePath,
+        outputDirectory: directory,
+        channel: 'stable',
+      })
+    ).rejects.toThrow("Missing platform 'windows-x86_64'")
+  })
 })

--- a/wework/scripts/update-channel-manifests.test.mjs
+++ b/wework/scripts/update-channel-manifests.test.mjs
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  generateChannelManifests,
+  isNewerWeworkVersion,
+  parseWeworkVersion,
+} from './update-channel-manifests.mjs'
+
+const temporaryDirectories = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true }))
+  )
+})
+
+describe('Wework update channel manifests', () => {
+  test('orders stable and Beta versions using SemVer precedence', () => {
+    expect(isNewerWeworkVersion('1.2.4-beta.2', '1.2.4-beta.1')).toBe(true)
+    expect(isNewerWeworkVersion('1.2.4', '1.2.4-beta.2')).toBe(true)
+    expect(isNewerWeworkVersion('1.2.4-beta.1', '1.2.4')).toBe(false)
+    expect(isNewerWeworkVersion('1.3.0-beta.1', '1.2.9')).toBe(true)
+  })
+
+  test('rejects unsupported prerelease formats', () => {
+    expect(() => parseWeworkVersion('1.2.3-alpha.1')).toThrow('Unsupported Wework version')
+  })
+
+  test('creates architecture-specific manifests for a custom channel target', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'wework-update-channel-'))
+    temporaryDirectories.push(directory)
+    const sourcePath = resolve(directory, 'latest.json')
+    const source = {
+      version: '1.2.4-beta.1',
+      notes: 'Beta release',
+      pub_date: '2026-08-02T00:00:00Z',
+      platforms: {
+        'darwin-aarch64': { signature: 'mac-arm', url: 'https://example.com/mac-arm' },
+        'darwin-x86_64': { signature: 'mac-x64', url: 'https://example.com/mac-x64' },
+        'windows-x86_64': { signature: 'win-x64', url: 'https://example.com/win-x64' },
+      },
+    }
+    await writeFile(sourcePath, JSON.stringify(source), 'utf8')
+
+    await generateChannelManifests({
+      sourcePath,
+      outputDirectory: directory,
+      channel: 'beta',
+    })
+
+    const manifest = JSON.parse(
+      await readFile(resolve(directory, 'beta-darwin-aarch64.json'), 'utf8')
+    )
+    expect(manifest.version).toBe(source.version)
+    expect(manifest.platforms).toEqual({
+      'beta-darwin': source.platforms['darwin-aarch64'],
+    })
+  })
+})

--- a/wework/src/components/settings/AboutSettingsPage.test.tsx
+++ b/wework/src/components/settings/AboutSettingsPage.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import {
+  AppUpdateContext,
+  type AppUpdateContextValue,
+} from '@/features/app-update/app-update-context'
+import { AboutSettingsPage } from './AboutSettingsPage'
+
+function renderPage(overrides: Partial<AppUpdateContextValue> = {}) {
+  const value: AppUpdateContextValue = {
+    updateChannel: 'stable',
+    availableUpdate: null,
+    status: 'idle',
+    downloadProgress: null,
+    message: null,
+    error: null,
+    checkNow: vi.fn().mockResolvedValue(null),
+    installUpdate: vi.fn().mockResolvedValue(undefined),
+    setUpdateChannel: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+
+  render(
+    <AppUpdateContext.Provider value={value}>
+      <AboutSettingsPage />
+    </AppUpdateContext.Provider>
+  )
+  return value
+}
+
+describe('AboutSettingsPage', () => {
+  test('lets the user opt into Beta and stable updates', () => {
+    const value = renderPage()
+
+    fireEvent.click(screen.getByTestId('about-beta-update-switch'))
+
+    expect(value.setUpdateChannel).toHaveBeenCalledWith('beta')
+  })
+
+  test('lets a Beta user return to stable-only updates', () => {
+    const value = renderPage({ updateChannel: 'beta' })
+    const channelSwitch = screen.getByTestId('about-beta-update-switch')
+
+    expect(channelSwitch).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(channelSwitch)
+
+    expect(value.setUpdateChannel).toHaveBeenCalledWith('stable')
+  })
+})

--- a/wework/src/components/settings/AboutSettingsPage.tsx
+++ b/wework/src/components/settings/AboutSettingsPage.tsx
@@ -3,7 +3,7 @@ import type { ComponentType } from 'react'
 import { useOptionalAppUpdate } from '@/features/app-update/app-update-context'
 import { useTranslation } from '@/hooks/useTranslation'
 import { openExternalUrl } from '@/lib/external-links'
-import { SettingsPage } from './settings-ui'
+import { SettingsGroup, SettingsPage, SettingsRow, SettingsSwitch } from './settings-ui'
 
 const PROJECT_URL = 'https://github.com/wecode-ai/Wegent'
 const LICENSE_URL = `${PROJECT_URL}/blob/main/LICENSE`
@@ -78,6 +78,7 @@ export function AboutSettingsPage() {
   const { t } = useTranslation('common')
   const appUpdate = useOptionalAppUpdate()
   const availableUpdate = appUpdate?.availableUpdate ?? null
+  const updateChannel = appUpdate?.updateChannel ?? 'stable'
   const updateStatus = appUpdate?.status ?? 'idle'
   const downloadProgress = appUpdate?.downloadProgress ?? null
   const updateError = appUpdate?.error ?? null
@@ -132,7 +133,33 @@ export function AboutSettingsPage() {
         {t('workbench.about_settings_description', '面向办公和编码场景的 AI 工作台。')}
       </p>
 
-      <div className="mt-7 flex flex-col items-center gap-2">
+      <SettingsGroup className="mt-7 w-full text-left">
+        <SettingsRow
+          label={t('workbench.app_update_beta_channel', {
+            defaultValue: '接收 Beta 版本更新',
+          })}
+          description={t('workbench.app_update_beta_channel_description', {
+            defaultValue: '同时接收 Beta 和正式版本，并优先更新到版本号更高的版本。',
+          })}
+          control={
+            <SettingsSwitch
+              data-testid="about-beta-update-switch"
+              aria-label={t('workbench.app_update_beta_channel', {
+                defaultValue: '接收 Beta 版本更新',
+              })}
+              checked={updateChannel === 'beta'}
+              disabled={!appUpdate || isUpdateBusy}
+              onCheckedChange={checked => {
+                if (appUpdate) {
+                  void appUpdate.setUpdateChannel(checked ? 'beta' : 'stable')
+                }
+              }}
+            />
+          }
+        />
+      </SettingsGroup>
+
+      <div className="mt-4 flex flex-col items-center gap-2">
         <AboutActionButton
           testId="about-check-update-button"
           icon={isUpdateBusy ? Loader2 : Download}

--- a/wework/src/features/app-update/AppUpdateProvider.test.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.test.tsx
@@ -3,6 +3,7 @@ import { useAppUpdate, type AppUpdateContextValue } from './app-update-context'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   APP_UPDATE_AUTO_CHECK_MIN_AGE_MS,
+  APP_UPDATE_CHANNEL_KEY,
   APP_UPDATE_INITIAL_CHECK_DELAY_MS,
   APP_UPDATE_LAST_AUTO_CHECK_KEY,
   APP_UPDATE_SIMULATE_EVENT,
@@ -52,7 +53,84 @@ describe('AppUpdateProvider', () => {
     await vi.advanceTimersByTimeAsync(APP_UPDATE_INITIAL_CHECK_DELAY_MS)
 
     expect(checkForWeworkUpdate).toHaveBeenCalledTimes(1)
+    expect(checkForWeworkUpdate).toHaveBeenCalledWith('stable')
     expect(localStorage.getItem(APP_UPDATE_LAST_AUTO_CHECK_KEY)).toBe(String(Date.now()))
+  })
+
+  test('persists the Beta channel and checks it immediately', async () => {
+    let appUpdate: AppUpdateContextValue | null = null
+
+    function Probe() {
+      appUpdate = useAppUpdate()
+      return null
+    }
+
+    render(
+      <AppUpdateProvider>
+        <Probe />
+      </AppUpdateProvider>
+    )
+
+    await act(async () => {
+      await appUpdate?.setUpdateChannel('beta')
+    })
+
+    expect(localStorage.getItem(APP_UPDATE_CHANNEL_KEY)).toBe('beta')
+    expect(appUpdate?.updateChannel).toBe('beta')
+    expect(checkForWeworkUpdate).toHaveBeenCalledWith('beta')
+  })
+
+  test('restores the persisted Beta channel for automatic checks', async () => {
+    localStorage.setItem(APP_UPDATE_CHANNEL_KEY, 'beta')
+
+    render(
+      <AppUpdateProvider>
+        <div />
+      </AppUpdateProvider>
+    )
+
+    await vi.advanceTimersByTimeAsync(APP_UPDATE_INITIAL_CHECK_DELAY_MS)
+
+    expect(checkForWeworkUpdate).toHaveBeenCalledWith('beta')
+    expect(localStorage.getItem(`${APP_UPDATE_LAST_AUTO_CHECK_KEY}:beta`)).toBe(String(Date.now()))
+  })
+
+  test('finishes a Beta check after an overlapping stable automatic check', async () => {
+    let appUpdate: AppUpdateContextValue | null = null
+    let finishStableCheck: (() => void) | undefined
+    vi.mocked(checkForWeworkUpdate).mockImplementation(channel =>
+      channel === 'stable'
+        ? new Promise(resolve => {
+            finishStableCheck = () => resolve(null)
+          })
+        : Promise.resolve({
+            currentVersion: '0.1.0',
+            version: '0.2.0-beta.1',
+          })
+    )
+
+    function Probe() {
+      appUpdate = useAppUpdate()
+      return null
+    }
+
+    render(
+      <AppUpdateProvider>
+        <Probe />
+      </AppUpdateProvider>
+    )
+
+    await vi.advanceTimersByTimeAsync(APP_UPDATE_INITIAL_CHECK_DELAY_MS)
+    const channelChange = appUpdate?.setUpdateChannel('beta')
+    finishStableCheck?.()
+    await act(async () => {
+      await channelChange
+    })
+
+    expect(checkForWeworkUpdate).toHaveBeenNthCalledWith(1, 'stable')
+    expect(checkForWeworkUpdate).toHaveBeenNthCalledWith(2, 'beta')
+    expect(appUpdate?.updateChannel).toBe('beta')
+    expect(appUpdate?.availableUpdate?.version).toBe('0.2.0-beta.1')
   })
 
   test('wakes hourly but only checks the update source after 24 hours', async () => {

--- a/wework/src/features/app-update/AppUpdateProvider.test.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.test.tsx
@@ -60,7 +60,7 @@ describe('AppUpdateProvider', () => {
   test('persists the Beta channel and checks it immediately', async () => {
     let appUpdate: AppUpdateContextValue | null = null
 
-    function Probe() {
+    const Probe = () => {
       appUpdate = useAppUpdate()
       return null
     }
@@ -109,7 +109,7 @@ describe('AppUpdateProvider', () => {
           })
     )
 
-    function Probe() {
+    const Probe = () => {
       appUpdate = useAppUpdate()
       return null
     }
@@ -143,7 +143,7 @@ describe('AppUpdateProvider', () => {
         })
     )
 
-    function Probe() {
+    const Probe = () => {
       appUpdate = useAppUpdate()
       return null
     }
@@ -164,7 +164,10 @@ describe('AppUpdateProvider', () => {
     expect(appUpdate?.status).toBe('checking')
     expect(checkForWeworkUpdate).toHaveBeenCalledTimes(1)
 
-    finishCheck?.()
+    if (!finishCheck) {
+      throw new Error('Automatic update check resolver was not initialized')
+    }
+    finishCheck()
     await act(async () => {
       await manualCheck
     })

--- a/wework/src/features/app-update/AppUpdateProvider.test.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.test.tsx
@@ -133,6 +133,46 @@ describe('AppUpdateProvider', () => {
     expect(appUpdate?.availableUpdate?.version).toBe('0.2.0-beta.1')
   })
 
+  test('shows manual feedback when reusing an in-flight automatic check', async () => {
+    let appUpdate: AppUpdateContextValue | null = null
+    let finishCheck: (() => void) | undefined
+    vi.mocked(checkForWeworkUpdate).mockImplementation(
+      () =>
+        new Promise(resolve => {
+          finishCheck = () => resolve(null)
+        })
+    )
+
+    function Probe() {
+      appUpdate = useAppUpdate()
+      return null
+    }
+
+    render(
+      <AppUpdateProvider>
+        <Probe />
+      </AppUpdateProvider>
+    )
+
+    await vi.advanceTimersByTimeAsync(APP_UPDATE_INITIAL_CHECK_DELAY_MS)
+    let manualCheck: Promise<unknown> | undefined
+    await act(async () => {
+      manualCheck = appUpdate?.checkNow()
+      await Promise.resolve()
+    })
+
+    expect(appUpdate?.status).toBe('checking')
+    expect(checkForWeworkUpdate).toHaveBeenCalledTimes(1)
+
+    finishCheck?.()
+    await act(async () => {
+      await manualCheck
+    })
+
+    expect(appUpdate?.status).toBe('upToDate')
+    expect(appUpdate?.message).toBe('upToDate')
+  })
+
   test('wakes hourly but only checks the update source after 24 hours', async () => {
     localStorage.setItem(APP_UPDATE_LAST_AUTO_CHECK_KEY, String(Date.now()))
 

--- a/wework/src/features/app-update/AppUpdateProvider.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.tsx
@@ -24,6 +24,11 @@ const SIMULATED_DOWNLOAD_TOTAL_BYTES = 10_000_000
 const SIMULATED_DOWNLOAD_STEP_BYTES = 1_000_000
 const SIMULATED_DOWNLOAD_INTERVAL_MS = 250
 
+interface UpdateCheckResult {
+  update: WeworkUpdateInfo | null
+  error: string | null
+}
+
 function readUpdateChannel(): WeworkUpdateChannel {
   return window.localStorage.getItem(APP_UPDATE_CHANNEL_KEY) === 'beta' ? 'beta' : 'stable'
 }
@@ -66,7 +71,7 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
   const updateChannelRef = useRef(updateChannel)
   const activeCheckRef = useRef<{
     channel: WeworkUpdateChannel
-    promise: Promise<WeworkUpdateInfo | null>
+    promise: Promise<UpdateCheckResult>
   } | null>(null)
   const simulationTimerRef = useRef<number | null>(null)
 
@@ -89,12 +94,37 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
       }
 
       const activeCheck = activeCheckRef.current
+      if (activeCheck?.channel === channel) {
+        if (!silent && channel === updateChannelRef.current) {
+          setStatus('checking')
+          setMessage(null)
+          setError(null)
+        }
+
+        const result = await activeCheck.promise
+        if (!silent && channel === updateChannelRef.current) {
+          setAvailableUpdate(result.update)
+          if (result.error) {
+            setStatus('error')
+            setMessage(null)
+            setError(result.error)
+          } else if (result.update) {
+            setStatus('available')
+            setMessage(null)
+            setError(null)
+          } else {
+            setStatus('upToDate')
+            setMessage('upToDate')
+            setError(null)
+          }
+        }
+        return result.update
+      }
       if (activeCheck) {
-        const activeResult = await activeCheck.promise
-        if (activeCheck.channel === channel) return activeResult
+        await activeCheck.promise
       }
 
-      const promise = (async () => {
+      const promise = (async (): Promise<UpdateCheckResult> => {
         if (!silent && channel === updateChannelRef.current) {
           setStatus('checking')
           setMessage(null)
@@ -103,7 +133,9 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
 
         try {
           const update = await checkForWeworkUpdate(channel)
-          if (channel !== updateChannelRef.current) return update
+          if (channel !== updateChannelRef.current) {
+            return { update, error: null }
+          }
 
           setAvailableUpdate(update)
 
@@ -117,20 +149,21 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
             setError(null)
           }
 
-          return update
+          return { update, error: null }
         } catch (caughtError) {
+          const checkError = messageFor(caughtError)
           if (!silent && channel === updateChannelRef.current) {
             setStatus('error')
             setMessage(null)
-            setError(messageFor(caughtError))
+            setError(checkError)
           }
-          return null
+          return { update: null, error: checkError }
         }
       })()
 
       activeCheckRef.current = { channel, promise }
       try {
-        return await promise
+        return (await promise).update
       } finally {
         if (activeCheckRef.current?.promise === promise) {
           activeCheckRef.current = null

--- a/wework/src/features/app-update/AppUpdateProvider.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.tsx
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import {
   checkForWeworkUpdate,
   installPendingWeworkUpdate,
+  type WeworkUpdateChannel,
   type WeworkUpdateDownloadProgress,
   type WeworkUpdateInfo,
 } from '@/lib/app-updater'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import {
   APP_UPDATE_AUTO_CHECK_MIN_AGE_MS,
+  APP_UPDATE_CHANNEL_KEY,
   APP_UPDATE_INITIAL_CHECK_DELAY_MS,
   APP_UPDATE_LAST_AUTO_CHECK_KEY,
   APP_UPDATE_SIMULATE_EVENT,
@@ -22,18 +24,28 @@ const SIMULATED_DOWNLOAD_TOTAL_BYTES = 10_000_000
 const SIMULATED_DOWNLOAD_STEP_BYTES = 1_000_000
 const SIMULATED_DOWNLOAD_INTERVAL_MS = 250
 
-function readLastAutoCheckAt(): number {
-  const raw = window.localStorage.getItem(APP_UPDATE_LAST_AUTO_CHECK_KEY)
+function readUpdateChannel(): WeworkUpdateChannel {
+  return window.localStorage.getItem(APP_UPDATE_CHANNEL_KEY) === 'beta' ? 'beta' : 'stable'
+}
+
+function lastAutoCheckKey(channel: WeworkUpdateChannel): string {
+  return channel === 'stable'
+    ? APP_UPDATE_LAST_AUTO_CHECK_KEY
+    : `${APP_UPDATE_LAST_AUTO_CHECK_KEY}:${channel}`
+}
+
+function readLastAutoCheckAt(channel: WeworkUpdateChannel): number {
+  const raw = window.localStorage.getItem(lastAutoCheckKey(channel))
   const value = Number(raw)
   return Number.isFinite(value) ? value : 0
 }
 
-function writeLastAutoCheckAt(value: number) {
-  window.localStorage.setItem(APP_UPDATE_LAST_AUTO_CHECK_KEY, String(value))
+function writeLastAutoCheckAt(channel: WeworkUpdateChannel, value: number) {
+  window.localStorage.setItem(lastAutoCheckKey(channel), String(value))
 }
 
-function shouldAutoCheck(now: number): boolean {
-  return now - readLastAutoCheckAt() >= APP_UPDATE_AUTO_CHECK_MIN_AGE_MS
+function shouldAutoCheck(channel: WeworkUpdateChannel, now: number): boolean {
+  return now - readLastAutoCheckAt(channel) >= APP_UPDATE_AUTO_CHECK_MIN_AGE_MS
 }
 
 function messageFor(error: unknown): string {
@@ -43,6 +55,7 @@ function messageFor(error: unknown): string {
 }
 
 export function AppUpdateProvider({ children }: { children: ReactNode }) {
+  const [updateChannel, setUpdateChannelState] = useState<WeworkUpdateChannel>(readUpdateChannel)
   const [availableUpdate, setAvailableUpdate] = useState<WeworkUpdateInfo | null>(null)
   const [status, setStatus] = useState<AppUpdateStatus>('idle')
   const [downloadProgress, setDownloadProgress] = useState<WeworkUpdateDownloadProgress | null>(
@@ -50,7 +63,11 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
   )
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const checkInFlightRef = useRef(false)
+  const updateChannelRef = useRef(updateChannel)
+  const activeCheckRef = useRef<{
+    channel: WeworkUpdateChannel
+    promise: Promise<WeworkUpdateInfo | null>
+  } | null>(null)
   const simulationTimerRef = useRef<number | null>(null)
 
   const clearSimulationTimer = useCallback(() => {
@@ -60,45 +77,67 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const runCheck = useCallback(
-    async ({ silent }: { silent: boolean }): Promise<WeworkUpdateInfo | null> => {
-      if (checkInFlightRef.current || status === 'installing') {
+    async ({
+      silent,
+      channel = updateChannel,
+    }: {
+      silent: boolean
+      channel?: WeworkUpdateChannel
+    }): Promise<WeworkUpdateInfo | null> => {
+      if (status === 'installing') {
         return availableUpdate
       }
 
-      checkInFlightRef.current = true
-      if (!silent) {
-        setStatus('checking')
-        setMessage(null)
-        setError(null)
+      const activeCheck = activeCheckRef.current
+      if (activeCheck) {
+        const activeResult = await activeCheck.promise
+        if (activeCheck.channel === channel) return activeResult
       }
 
+      const promise = (async () => {
+        if (!silent && channel === updateChannelRef.current) {
+          setStatus('checking')
+          setMessage(null)
+          setError(null)
+        }
+
+        try {
+          const update = await checkForWeworkUpdate(channel)
+          if (channel !== updateChannelRef.current) return update
+
+          setAvailableUpdate(update)
+
+          if (update) {
+            setStatus('available')
+            setMessage(null)
+            setError(null)
+          } else if (!silent) {
+            setStatus('upToDate')
+            setMessage('upToDate')
+            setError(null)
+          }
+
+          return update
+        } catch (caughtError) {
+          if (!silent && channel === updateChannelRef.current) {
+            setStatus('error')
+            setMessage(null)
+            setError(messageFor(caughtError))
+          }
+          return null
+        }
+      })()
+
+      activeCheckRef.current = { channel, promise }
       try {
-        const update = await checkForWeworkUpdate()
-        setAvailableUpdate(update)
-
-        if (update) {
-          setStatus('available')
-          setMessage(null)
-          setError(null)
-        } else if (!silent) {
-          setStatus('upToDate')
-          setMessage('upToDate')
-          setError(null)
-        }
-
-        return update
-      } catch (caughtError) {
-        if (!silent) {
-          setStatus('error')
-          setMessage(null)
-          setError(messageFor(caughtError))
-        }
-        return null
+        return await promise
       } finally {
-        checkInFlightRef.current = false
+        if (activeCheckRef.current?.promise === promise) {
+          activeCheckRef.current = null
+        }
       }
     },
-    [availableUpdate, status]
+    [availableUpdate, status, updateChannel]
   )
 
   const checkNow = useCallback(() => runCheck({ silent: false }), [runCheck])
@@ -119,14 +158,30 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
       setError(installError)
 
       try {
-        const refreshedUpdate = await checkForWeworkUpdate()
+        const refreshedUpdate = await checkForWeworkUpdate(updateChannel)
         setAvailableUpdate(refreshedUpdate)
         setStatus(refreshedUpdate ? 'available' : 'error')
       } catch {
         setStatus('error')
       }
     }
-  }, [availableUpdate, status])
+  }, [availableUpdate, status, updateChannel])
+
+  const setUpdateChannel = useCallback(
+    async (channel: WeworkUpdateChannel) => {
+      if (channel === updateChannel || status === 'installing') return
+
+      window.localStorage.setItem(APP_UPDATE_CHANNEL_KEY, channel)
+      updateChannelRef.current = channel
+      setUpdateChannelState(channel)
+      setAvailableUpdate(null)
+      setDownloadProgress(null)
+      setMessage(null)
+      setError(null)
+      await runCheck({ silent: false, channel })
+    },
+    [runCheck, status, updateChannel]
+  )
 
   const simulateUpdate = useCallback(() => {
     clearSimulationTimer()
@@ -168,9 +223,9 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
 
     const maybeAutoCheck = () => {
       const now = Date.now()
-      if (!shouldAutoCheck(now)) return
+      if (!shouldAutoCheck(updateChannel, now)) return
 
-      writeLastAutoCheckAt(now)
+      writeLastAutoCheckAt(updateChannel, now)
       void runCheck({ silent: true })
     }
 
@@ -181,10 +236,11 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
       window.clearTimeout(initialTimer)
       window.clearInterval(intervalTimer)
     }
-  }, [runCheck])
+  }, [runCheck, updateChannel])
 
   const value = useMemo<AppUpdateContextValue>(
     () => ({
+      updateChannel,
       availableUpdate,
       status,
       downloadProgress,
@@ -192,8 +248,19 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
       error,
       checkNow,
       installUpdate,
+      setUpdateChannel,
     }),
-    [availableUpdate, checkNow, downloadProgress, error, installUpdate, message, status]
+    [
+      availableUpdate,
+      checkNow,
+      downloadProgress,
+      error,
+      installUpdate,
+      message,
+      setUpdateChannel,
+      status,
+      updateChannel,
+    ]
   )
 
   return <AppUpdateContext.Provider value={value}>{children}</AppUpdateContext.Provider>

--- a/wework/src/features/app-update/app-update-context.ts
+++ b/wework/src/features/app-update/app-update-context.ts
@@ -1,7 +1,12 @@
 import { createContext, useContext } from 'react'
-import type { WeworkUpdateDownloadProgress, WeworkUpdateInfo } from '@/lib/app-updater'
+import type {
+  WeworkUpdateChannel,
+  WeworkUpdateDownloadProgress,
+  WeworkUpdateInfo,
+} from '@/lib/app-updater'
 
 export const APP_UPDATE_LAST_AUTO_CHECK_KEY = 'wework:lastAutoUpdateCheckAt'
+export const APP_UPDATE_CHANNEL_KEY = 'wework:updateChannel'
 export const APP_UPDATE_INITIAL_CHECK_DELAY_MS = 5_000
 export const APP_UPDATE_TIMER_INTERVAL_MS = 60 * 60 * 1000
 export const APP_UPDATE_AUTO_CHECK_MIN_AGE_MS = 24 * 60 * 60 * 1000
@@ -16,6 +21,7 @@ export type AppUpdateStatus =
   | 'error'
 
 export interface AppUpdateContextValue {
+  updateChannel: WeworkUpdateChannel
   availableUpdate: WeworkUpdateInfo | null
   status: AppUpdateStatus
   downloadProgress: WeworkUpdateDownloadProgress | null
@@ -23,6 +29,7 @@ export interface AppUpdateContextValue {
   error: string | null
   checkNow: () => Promise<WeworkUpdateInfo | null>
   installUpdate: () => Promise<void>
+  setUpdateChannel: (channel: WeworkUpdateChannel) => Promise<void>
 }
 
 export const AppUpdateContext = createContext<AppUpdateContextValue | null>(null)

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -445,6 +445,8 @@
     "app_update_endpoint_missing": "Automatic update checks are not available in this build",
     "app_update_check_failed": "Failed to check for updates",
     "app_update_install_failed": "Failed to install update",
+    "app_update_beta_channel": "Receive Beta updates",
+    "app_update_beta_channel_description": "Receive both Beta and stable releases, and update to whichever has the higher version.",
     "settings_category_integrations": "Integrations",
     "settings_category_coding": "Coding",
     "empty_title": "What should we do?",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -445,6 +445,8 @@
     "app_update_endpoint_missing": "当前版本暂不支持自动更新检查",
     "app_update_check_failed": "检查更新失败",
     "app_update_install_failed": "更新安装失败",
+    "app_update_beta_channel": "接收 Beta 版本更新",
+    "app_update_beta_channel_description": "同时接收 Beta 和正式版本，并优先更新到版本号更高的版本。",
     "settings_category_integrations": "集成",
     "settings_category_coding": "编码",
     "empty_title": "我们该做什么？",

--- a/wework/src/lib/app-updater.test.ts
+++ b/wework/src/lib/app-updater.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { getWeworkUpdateTarget } from './app-updater'
+
+function setUserAgent(userAgent: string) {
+  vi.stubGlobal('navigator', { userAgent })
+}
+
+describe('getWeworkUpdateTarget', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('routes stable macOS updates to the stable Darwin manifest', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+
+    expect(getWeworkUpdateTarget('stable')).toBe('stable-darwin')
+  })
+
+  test('routes Beta Windows updates to the Beta Windows manifest', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+
+    expect(getWeworkUpdateTarget('beta')).toBe('beta-windows')
+  })
+})

--- a/wework/src/lib/app-updater.test.ts
+++ b/wework/src/lib/app-updater.test.ts
@@ -21,4 +21,10 @@ describe('getWeworkUpdateTarget', () => {
 
     expect(getWeworkUpdateTarget('beta')).toBe('beta-windows')
   })
+
+  test('rejects Linux because desktop updates are unavailable', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+
+    expect(() => getWeworkUpdateTarget('stable')).toThrow()
+  })
 })

--- a/wework/src/lib/app-updater.ts
+++ b/wework/src/lib/app-updater.ts
@@ -1,4 +1,7 @@
 import { isTauriRuntime } from './runtime-environment'
+import { getPlatform } from './platform'
+
+export type WeworkUpdateChannel = 'stable' | 'beta'
 
 export interface WeworkUpdateInfo {
   currentVersion: string
@@ -28,14 +31,24 @@ function errorMessage(error: unknown): string {
   return 'Unknown updater error'
 }
 
-export async function checkForWeworkUpdate(): Promise<WeworkUpdateInfo | null> {
+export function getWeworkUpdateTarget(channel: WeworkUpdateChannel): string {
+  const platform = getPlatform()
+  if (platform === 'linux') {
+    throw new Error('Wework updater is not available on Linux.')
+  }
+  return `${channel}-${platform === 'mac' ? 'darwin' : 'windows'}`
+}
+
+export async function checkForWeworkUpdate(
+  channel: WeworkUpdateChannel
+): Promise<WeworkUpdateInfo | null> {
   if (!isTauriRuntime()) {
-    throw new Error('Wework updater is only available in the macOS app.')
+    throw new Error('Wework updater is only available in the desktop app.')
   }
 
   try {
     const { check } = await import('@tauri-apps/plugin-updater')
-    const update = await check()
+    const update = await check({ target: getWeworkUpdateTarget(channel) })
     if (!update) {
       pendingUpdate = null
       return null

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -81,4 +81,18 @@ describe('bundled plugin resources', () => {
 
     expect(workflow).toContain('node scripts/generate-release-config.mjs')
   })
+
+  test('publishes separate stable and Beta update channels', () => {
+    const workflow = readFileSync(
+      resolve(process.cwd(), '../.github/workflows/wework-app.yml'),
+      'utf8'
+    )
+
+    expect(workflow).toContain('Beta versions are always generated automatically')
+    expect(workflow).toContain('node wework/scripts/resolve-release-version.mjs')
+    expect(workflow).toContain('releases/download/wework-updater/{{target}}-{{arch}}.json')
+    expect(workflow).toContain('publish_channel "$RELEASE_CHANNEL"')
+    expect(workflow).toContain('publish_channel beta')
+    expect(workflow).toContain('--field prerelease="$PRERELEASE"')
+  })
 })


### PR DESCRIPTION
## Summary

- add a persisted stable/Beta update preference under Wework Settings → About
- route Tauri update checks through channel- and platform-specific rolling manifests
- generate Beta versions automatically while preserving stable overrides and tag reruns
- publish stable releases as GitHub latest and Beta releases as prereleases
- document the release and user opt-in flows in Chinese and English

## Why

Wework previously had one updater endpoint backed by GitHub's latest stable Release, so users could not opt into prerelease builds without affecting stable users. The release workflow also had no independent Beta version sequence or rolling Beta manifest.

## Behavior

- stable users receive stable releases only
- Beta users receive whichever Beta or stable release has the higher SemVer
- Beta versions are generated automatically, for example `0.1.8-beta.1`
- stable releases advance the Beta channel only when they are newer
- historical releases cannot move a rolling channel backward

## Validation

- `pnpm --filter wework test` — 264 files, 2596 tests passed
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- `actionlint .github/workflows/wework-app.yml`
- isolated real-Tauri verification of Settings → About, Beta opt-in, immediate update check, and missing-endpoint recovery
- pre-push Wework ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Beta updates alongside stable releases.
  * Users can switch update channels from About settings.
  * Update checks, downloads, and notifications follow the selected channel.
  * Stable and Beta releases use separate versioning and update manifests.
* **Documentation**
  * Updated English and Chinese release guides with channel behavior, versioning, downloads, and publishing details.
* **Tests**
  * Added coverage for channel switching, update checks, version handling, manifests, and platform-specific downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->