### PR TITLE
fix(wework): hide Codex models without auth

### DIFF
--- a/docs/en/wework/settings.md
+++ b/docs/en/wework/settings.md
@@ -18,6 +18,13 @@ Common macOS shortcuts include:
 | Select model           | `Control+Shift+M`         |
 | Appshot                | `Command+Shift+2`         |
 
+## Model availability
+
+**My Codex** shows official Codex models only when the current device has a configured
+`auth.json`. Without that file, the group is omitted from the model picker; provider models,
+local custom models, and cloud models remain available according to their own configuration. If
+no source provides a model, the picker displays **No models available**.
+
 ## Custom Codex models
 
 In **Settings → Models**, click **Add model** and choose a provider first. Wework includes profiles for Kimi Coding, the Kimi API Platform, DeepSeek, and GLM. After entering the corresponding platform API key, Wework discovers available models through the provider's `/models` endpoint. Each profile supplies its connection URL, API protocol, tool mode, and known model context windows; the Kimi API Platform profile uses the China-region `api.moonshot.cn` endpoint. Kimi Coding K3 automatically uses the built-in Codex Catalog profile with a 256K context window and `low` default reasoning effort.

--- a/docs/zh/wework/settings.md
+++ b/docs/zh/wework/settings.md
@@ -30,6 +30,12 @@ sidebar_position: 9
 
 Windows 和 Linux 使用界面中显示的对应组合键。
 
+## 模型可用状态
+
+“我的 CodeX”只展示当前设备已经通过 `auth.json` 配置的官方 Codex 模型。缺少
+`auth.json` 时，该分组不会出现在模型选择器中；Provider 模型、本地自定义模型和云端模型
+仍按各自配置展示。如果所有来源都没有可用模型，选择器直接显示“暂无可用模型”。
+
 ## 自定义 Codex 模型
 
 在“设置 → 模型”中点击“添加模型”后，先选择提供商。Wework 内置 Kimi Coding、Kimi 开放平台、DeepSeek 和 GLM profile；填写对应平台的 API Key 后，可以从提供商的 `/models` 接口读取可用模型。连接地址、接口协议、工具模式和已知模型的上下文长度由 profile 自动填写，其中 Kimi 开放平台使用中国区 `api.moonshot.cn` 端点。Kimi Coding 的 K3 会自动使用内置的 Codex Catalog profile，包括 256K 上下文和默认 `low` 推理等级。

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -45,6 +45,14 @@ describe('createLocalAppServices', () => {
       catalogReady: true,
     })
     const request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === 'device.execute_command') {
+        return {
+          success: true,
+          stdout: { exists: true },
+          stderr: '',
+          error: null,
+        }
+      }
       if (method === 'runtime.codex.models.list') {
         return {
           providers: [
@@ -268,8 +276,16 @@ describe('createLocalAppServices', () => {
     await Promise.all([firstDevices, secondDevices])
   })
 
-  test('returns Codex provider models in local model list', async () => {
+  test('hides official Codex models without auth while keeping provider models', async () => {
     const request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === 'device.execute_command') {
+        return {
+          success: true,
+          stdout: { exists: false },
+          stderr: '',
+          error: null,
+        }
+      }
       if (method === 'runtime.codex.models.list') {
         return {
           providers: [
@@ -280,7 +296,7 @@ describe('createLocalAppServices', () => {
               current: false,
               available: true,
               error: null,
-              data: [],
+              data: OFFICIAL_CODEX_MODELS,
             },
             {
               id: 'wecode-openai',
@@ -323,7 +339,9 @@ describe('createLocalAppServices', () => {
       subscribe: vi.fn(),
     })
 
-    await expect(services.modelApi.listModels()).resolves.toEqual({
+    const models = await services.modelApi.listModels()
+
+    expect(models).toEqual({
       data: expect.arrayContaining([
         expect.objectContaining({
           name: 'Doubao-Seed-2.0-pro-260215',
@@ -342,6 +360,9 @@ describe('createLocalAppServices', () => {
         }),
       ]),
     })
+    expect(models.data.some(model => model.config?.weworkModelKind === 'codex-official')).toBe(
+      false
+    )
   })
 
   test('normalizes runtime handles returned by local executor task lists', async () => {

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -305,17 +305,25 @@ function localRuntimeModels(
   codexOfficialError: string | null = null,
   codexAuthConfigured = false
 ): UnifiedModel[] {
-  const officialModels =
-    codexOfficialError || codexOfficialModels.length === 0
+  const officialCatalogModels = codexOfficialModels.filter(
+    model => model.providerType === 'official'
+  )
+  const officialModels = !codexAuthConfigured
+    ? []
+    : codexOfficialError || officialCatalogModels.length === 0
       ? [
           unavailableCodexModel(
             codexOfficialError || 'Codex model list returned no available models'
           ),
         ]
-      : codexOfficialModels.map(model => localCodexModel(model, codexAuthConfigured))
+      : officialCatalogModels.map(model => localCodexModel(model, true))
+  const providerModels = codexOfficialModels
+    .filter(model => model.providerType === 'provider')
+    .map(model => localCodexModel(model, codexAuthConfigured))
 
   return [
     ...officialModels,
+    ...providerModels,
     ...listLocalModelConfigs()
       .filter(config => config.enabled && config.catalogReady)
       .map(localModelConfigToUnifiedModel),

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1698,9 +1698,10 @@ describe('ChatInput', () => {
       />
     )
 
-    expect(screen.getByTestId('model-selector-button')).toHaveTextContent('Default')
+    expect(screen.getByTestId('model-selector-button')).toHaveTextContent('No models available')
     await userEvent.click(screen.getByTestId('model-selector-button'))
     expect(screen.queryByTestId('model-selector-submenu')).not.toBeInTheDocument()
+    expect(screen.getByTestId('model-control-menu-model')).toHaveTextContent('No models available')
     await userEvent.hover(screen.getByTestId('model-control-menu-model'))
 
     expect(screen.getByTestId('model-selector-submenu')).toHaveTextContent('No models available')

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -351,10 +351,14 @@ export function ModelSelector({
 
   useMobileModelSelectorFocus(open, isMobile, mobileCloseButtonRef)
 
-  const selectedButtonLabel =
-    getSelectedModelDisplayLabel(selectedModel, selectedModelOptions, (key, fallback) =>
-      t(key, fallback)
-    ) || t('workbench.default_model', 'Default')
+  const emptyModelLabel = t('workbench.no_models', 'No models available')
+  const selectedButtonLabel = selectedModel
+    ? getSelectedModelDisplayLabel(selectedModel, selectedModelOptions, (key, fallback) =>
+        t(key, fallback)
+      )
+    : familyGroups.length === 0
+      ? emptyModelLabel
+      : t('workbench.default_model', 'Default')
   const buttonLabel = nextTurn
     ? t('workbench.next_turn_model', 'Next · {{model}}', { model: selectedButtonLabel })
     : selectedButtonLabel
@@ -831,7 +835,9 @@ export function ModelSelector({
 
   const desktopModelLabel = selectedModel
     ? getModelDisplayLabel(selectedModel, {}, resolveControlLabel)
-    : t('workbench.default_model', 'Default')
+    : familyGroups.length === 0
+      ? emptyModelLabel
+      : t('workbench.default_model', 'Default')
   const modelRowActive = activeDesktopSubmenu?.type === 'models'
 
   return (


### PR DESCRIPTION
## What changed

- hide the local official Codex model group when the device has no `auth.json`
- keep provider, local custom, and cloud models available independently
- show “No models available” instead of the ambiguous “Default” label when the catalog is empty
- document model availability behavior in Chinese and English

## Why

The local model catalog already read the Codex authentication status, but it only attached that
status to model metadata. Official Codex models were still returned to the picker when
`auth.json` was missing, so Wework displayed “My Codex” even though those models could not be
used.

## Impact

Users without Codex authentication no longer see unusable official models. If another provider,
custom model, or cloud model exists, Wework selects from those sources. If no source provides a
model, the picker clearly reports that no models are available.

## Validation

- Wework full unit suite: 259 files, 2559 tests passed
- focused unit tests: 141 tests passed
- TypeScript project check passed
- ESLint and Prettier passed
- isolated real-Tauri verification:
  - removing session `auth.json` hid official Codex models while retaining provider models
  - removing all isolated model sources displayed “暂无可用模型” in the trigger and model menu
- repository pre-push quality checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model selection now clearly indicates when no models are available.
  - Official Codex models appear only when authentication is configured.
  - Other configured provider and local models remain available independently.
  - Authentication status and unavailable model sources are handled more clearly.

- **Documentation**
  - Added English and Chinese guidance explaining model availability rules and the empty-model message.

- **Bug Fixes**
  - Improved model listing behavior when official authentication is missing or no official models are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->