### PR TITLE
fix(wework): reduce accidental sidebar sorting

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -389,6 +389,11 @@ may reveal on hover/focus but must remain keyboard accessible.
 - Sidebar rows are `30px` high with a `10px` radius, `8px–10px` horizontal
   padding, `14px` text, and an ordinary `16px` icon.
 - Hover and active states use subtle neutral surface changes, not colored fills.
+- Sortable sidebar rows must keep the sortable container separate from the
+  pointer activator. Only the primary icon-and-label or label region may start
+  pointer sorting, after at least `6px` of movement; trailing actions, metadata,
+  and unused row space must remain click-only. Preserve keyboard sorting on the
+  sortable container.
 - Section spacing may be larger than row spacing; avoid divider-heavy grouping.
 - On macOS light theme, use the captured warm translucent/off-white sidebar
   material and keep the main canvas pure white. Preserve the traffic-light safe

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -20,6 +20,7 @@ import {
   RuntimeTaskLifecycleProvider,
   RuntimeTaskLifecycleStore,
 } from '@/features/workbench/runtimeTaskLifecycle'
+import { isSidebarDragActivatorTarget } from './sidebarDragActivator'
 
 const experimentalFeatures = vi.hoisted(() => ({ enabled: true }))
 
@@ -323,7 +324,9 @@ describe('DesktopSidebar', () => {
     ) as HTMLElement
     expect(remoteSortable).toHaveAttribute('tabindex', '0')
     expect(remoteSortable).toHaveAttribute('role', 'button')
-    expect(remoteSortable).toHaveClass('touch-none')
+    expect(remoteSortable.querySelector('[data-testid="project-item-button"]')).toHaveAttribute(
+      'data-sidebar-drag-activator'
+    )
   })
 
   test('shows an interactive Codex-style project hover card', async () => {
@@ -1556,6 +1559,7 @@ describe('DesktopSidebar', () => {
 
   test('exposes pointer and keyboard sorting affordances in the task section', () => {
     const onReorderRuntimeProjectTasks = vi.fn().mockResolvedValue(undefined)
+    const onOpenRuntimeTask = vi.fn()
     const chatPath = '/Users/alice/Documents/Codex/2026-07-12/manual'
     renderSidebar({
       runtimeWork: {
@@ -1589,6 +1593,7 @@ describe('DesktopSidebar', () => {
         totalTasks: 2,
       },
       onReorderRuntimeProjectTasks,
+      onOpenRuntimeTask,
     })
 
     const firstSortable = document.querySelector(
@@ -1600,8 +1605,23 @@ describe('DesktopSidebar', () => {
     expect(screen.getByTestId('runtime-chat-task-sortable-list')).toContainElement(firstSortable)
     expect(firstSortable).toHaveAttribute('tabindex', '0')
     expect(firstSortable).toHaveAttribute('role', 'button')
-    expect(firstSortable).toHaveClass('touch-none')
     expect(secondSortable).toHaveAttribute('tabindex', '0')
+
+    const firstActivator = screen.getByTestId('runtime-local-task-drag-activator-chat-1')
+    const firstActions = screen.getByTestId('runtime-local-task-hover-actions-chat-1')
+    expect(firstSortable).toContainElement(firstActivator)
+    expect(firstActivator).not.toContainElement(firstActions)
+    expect(firstActivator).toHaveAttribute('data-sidebar-drag-activator')
+    expect(isSidebarDragActivatorTarget(firstActivator)).toBe(true)
+    expect(isSidebarDragActivatorTarget(firstActions)).toBe(false)
+    expect(isSidebarDragActivatorTarget(screen.getByTestId('runtime-local-task-row-chat-1'))).toBe(
+      false
+    )
+
+    fireEvent.click(screen.getByTestId('runtime-local-task-row-chat-1'))
+    fireEvent.click(screen.getByTestId('runtime-local-task-row-chat-1'))
+    expect(onOpenRuntimeTask).toHaveBeenCalledTimes(2)
+    expect(onReorderRuntimeProjectTasks).not.toHaveBeenCalled()
   })
 
   test('refreshes relative runtime task time while the sidebar stays mounted', () => {

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -20,7 +20,6 @@ import {
   RuntimeTaskLifecycleProvider,
   RuntimeTaskLifecycleStore,
 } from '@/features/workbench/runtimeTaskLifecycle'
-import { isSidebarDragActivatorTarget } from './sidebarDragActivator'
 
 const experimentalFeatures = vi.hoisted(() => ({ enabled: true }))
 
@@ -155,6 +154,26 @@ function enableTauri() {
   })
 }
 
+function mockSidebarSortableRect(element: HTMLElement, top: number) {
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 240,
+    bottom: top + 30,
+    width: 240,
+    height: 30,
+    toJSON: () => ({}),
+  } as DOMRect)
+}
+
+async function waitForSidebarPointerSensorCleanup() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 60))
+  })
+}
+
 describe('DesktopSidebar', () => {
   beforeEach(() => {
     experimentalFeatures.enabled = true
@@ -251,7 +270,7 @@ describe('DesktopSidebar', () => {
     })
   })
 
-  test('exposes a remote project as sortable through its local Codex state identity', () => {
+  test('starts project pointer sorting only from its content-sized activator', async () => {
     const onReorderRuntimeProjects = vi.fn().mockResolvedValue(undefined)
     renderSidebar({
       devices: [
@@ -322,11 +341,73 @@ describe('DesktopSidebar', () => {
     const remoteSortable = document.querySelector(
       '[data-sidebar-sortable-id="local-device:remote-project-id"]'
     ) as HTMLElement
+    const localSortable = document.querySelector(
+      '[data-sidebar-sortable-id="local-device:/repo/local"]'
+    ) as HTMLElement
+    const remoteActivator = screen.getByTestId('project-drag-activator-8')
+    const remoteButton = remoteActivator.closest('button') as HTMLButtonElement
+
+    mockSidebarSortableRect(localSortable, 0)
+    mockSidebarSortableRect(remoteSortable, 30)
+
     expect(remoteSortable).toHaveAttribute('tabindex', '0')
     expect(remoteSortable).toHaveAttribute('role', 'button')
-    expect(remoteSortable.querySelector('[data-testid="project-item-button"]')).toHaveAttribute(
-      'data-sidebar-drag-activator'
-    )
+    expect(remoteActivator).toHaveAttribute('data-sidebar-drag-activator')
+    expect(remoteButton).not.toHaveAttribute('data-sidebar-drag-activator')
+
+    fireEvent.pointerDown(remoteButton, {
+      button: 0,
+      buttons: 1,
+      clientX: 220,
+      clientY: 45,
+      isPrimary: true,
+      pointerId: 1,
+    })
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 220,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+    })
+    expect(remoteSortable).not.toHaveAttribute('data-dragging')
+    fireEvent.pointerUp(document, { button: 0, clientX: 220, clientY: 10, pointerId: 1 })
+
+    fireEvent.pointerDown(remoteActivator, {
+      button: 0,
+      buttons: 1,
+      clientX: 20,
+      clientY: 45,
+      isPrimary: true,
+      pointerId: 2,
+    })
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 20,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 2,
+    })
+    expect(remoteSortable).toHaveAttribute('data-dragging', 'true')
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 20,
+      clientY: 5,
+      isPrimary: true,
+      pointerId: 2,
+    })
+    fireEvent.pointerUp(document, {
+      button: 0,
+      buttons: 0,
+      clientX: 20,
+      clientY: 5,
+      isPrimary: true,
+      pointerId: 2,
+    })
+
+    await waitFor(() => expect(onReorderRuntimeProjects).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(remoteSortable).not.toHaveAttribute('data-dragging'))
+    await waitForSidebarPointerSensorCleanup()
   })
 
   test('shows an interactive Codex-style project hover card', async () => {
@@ -1557,7 +1638,7 @@ describe('DesktopSidebar', () => {
     })
   })
 
-  test('exposes pointer and keyboard sorting affordances in the task section', () => {
+  test('starts task pointer sorting only from its content-sized activator', async () => {
     const onReorderRuntimeProjectTasks = vi.fn().mockResolvedValue(undefined)
     const onOpenRuntimeTask = vi.fn()
     const chatPath = '/Users/alice/Documents/Codex/2026-07-12/manual'
@@ -1608,20 +1689,95 @@ describe('DesktopSidebar', () => {
     expect(secondSortable).toHaveAttribute('tabindex', '0')
 
     const firstActivator = screen.getByTestId('runtime-local-task-drag-activator-chat-1')
+    const firstTitleSpace = firstActivator.parentElement as HTMLElement
+    const firstTrailing = screen.getByTestId('runtime-local-task-trailing-chat-1')
     const firstActions = screen.getByTestId('runtime-local-task-hover-actions-chat-1')
+    mockSidebarSortableRect(firstSortable, 0)
+    mockSidebarSortableRect(secondSortable, 30)
+
     expect(firstSortable).toContainElement(firstActivator)
     expect(firstActivator).not.toContainElement(firstActions)
     expect(firstActivator).toHaveAttribute('data-sidebar-drag-activator')
-    expect(isSidebarDragActivatorTarget(firstActivator)).toBe(true)
-    expect(isSidebarDragActivatorTarget(firstActions)).toBe(false)
-    expect(isSidebarDragActivatorTarget(screen.getByTestId('runtime-local-task-row-chat-1'))).toBe(
-      false
+    expect(firstTitleSpace).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(firstTrailing).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(firstActions).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(screen.getByTestId('runtime-local-task-row-chat-1')).not.toHaveAttribute(
+      'data-sidebar-drag-activator'
     )
 
     fireEvent.click(screen.getByTestId('runtime-local-task-row-chat-1'))
     fireEvent.click(screen.getByTestId('runtime-local-task-row-chat-1'))
     expect(onOpenRuntimeTask).toHaveBeenCalledTimes(2)
     expect(onReorderRuntimeProjectTasks).not.toHaveBeenCalled()
+
+    for (const [pointerId, target] of [firstTitleSpace, firstTrailing, firstActions].entries()) {
+      fireEvent.pointerDown(target, {
+        button: 0,
+        buttons: 1,
+        clientX: 220,
+        clientY: 10,
+        isPrimary: true,
+        pointerId: pointerId + 1,
+      })
+      fireEvent.pointerMove(document, {
+        buttons: 1,
+        clientX: 220,
+        clientY: 45,
+        isPrimary: true,
+        pointerId: pointerId + 1,
+      })
+      expect(firstSortable).not.toHaveAttribute('data-dragging')
+      fireEvent.pointerUp(document, {
+        button: 0,
+        clientX: 220,
+        clientY: 45,
+        pointerId: pointerId + 1,
+      })
+    }
+
+    fireEvent.pointerDown(firstActivator, {
+      button: 0,
+      buttons: 1,
+      clientX: 20,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 4,
+    })
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 20,
+      clientY: 15,
+      isPrimary: true,
+      pointerId: 4,
+    })
+    expect(firstSortable).not.toHaveAttribute('data-dragging')
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 20,
+      clientY: 45,
+      isPrimary: true,
+      pointerId: 4,
+    })
+    expect(firstSortable).toHaveAttribute('data-dragging', 'true')
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 20,
+      clientY: 50,
+      isPrimary: true,
+      pointerId: 4,
+    })
+    fireEvent.pointerUp(document, {
+      button: 0,
+      buttons: 0,
+      clientX: 20,
+      clientY: 50,
+      isPrimary: true,
+      pointerId: 4,
+    })
+
+    await waitFor(() => expect(onReorderRuntimeProjectTasks).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(firstSortable).not.toHaveAttribute('data-dragging'))
+    await waitForSidebarPointerSensorCleanup()
   })
 
   test('refreshes relative runtime task time while the sidebar stays mounted', () => {
@@ -2552,7 +2708,8 @@ describe('DesktopSidebar', () => {
 
     await user.click(screen.getByTestId('project-item-button'))
 
-    const title = screen.getByText(taskTitle)
+    const titleActivator = screen.getByText(taskTitle)
+    const title = titleActivator.parentElement as HTMLElement
     const trailing = screen.getByTestId('runtime-local-task-trailing-codex-1')
     const hoverActions = screen.getByTestId('runtime-local-task-hover-actions-codex-1')
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1600,7 +1600,13 @@ function RuntimeTaskRow({
             (archivePending || archiving) && 'hidden'
           )}
         >
-          <span className="min-w-0 flex-1 truncate">{task.title}</span>
+          <span
+            data-sidebar-drag-activator
+            data-testid={`runtime-local-task-drag-activator-${task.taskId}`}
+            className="min-w-0 flex-1 truncate"
+          >
+            {task.title}
+          </span>
           <span
             data-testid={`runtime-local-task-trailing-${task.taskId}`}
             className="relative ml-1 flex h-[30px] min-w-[30px] shrink-0 items-center justify-end transition-[width] group-hover/task:w-[68px]"
@@ -2136,6 +2142,7 @@ function ProjectItem({
           <button
             type="button"
             data-testid="project-item-button"
+            data-sidebar-drag-activator
             onClick={() => {
               onToggleProject(project.id)
             }}

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1600,12 +1600,13 @@ function RuntimeTaskRow({
             (archivePending || archiving) && 'hidden'
           )}
         >
-          <span
-            data-sidebar-drag-activator
-            data-testid={`runtime-local-task-drag-activator-${task.taskId}`}
-            className="min-w-0 flex-1 truncate"
-          >
-            {task.title}
+          <span className="min-w-0 flex-1 truncate">
+            <span
+              data-sidebar-drag-activator
+              data-testid={`runtime-local-task-drag-activator-${task.taskId}`}
+            >
+              {task.title}
+            </span>
           </span>
           <span
             data-testid={`runtime-local-task-trailing-${task.taskId}`}
@@ -2142,7 +2143,6 @@ function ProjectItem({
           <button
             type="button"
             data-testid="project-item-button"
-            data-sidebar-drag-activator
             onClick={() => {
               onToggleProject(project.id)
             }}
@@ -2153,41 +2153,47 @@ function ProjectItem({
             )}
           >
             <span
-              className="flex h-4 w-4 shrink-0 items-center justify-center"
-              style={projectAppearanceColor ? { color: projectAppearanceColor } : undefined}
+              data-sidebar-drag-activator
+              data-testid={`project-drag-activator-${project.id}`}
+              className="flex min-w-0 max-w-full items-center gap-2.5"
             >
-              {projectMarker?.kind === 'emoji' && 'emoji' in projectMarker ? (
-                <span data-testid={`project-appearance-emoji-${project.id}`} className="text-sm">
-                  {String(projectMarker.emoji)}
-                </span>
-              ) : (
-                <ProjectFolderIcon
-                  project={project}
-                  remote={isRuntimeRemoteProject(runtimeProjectWork)}
-                  className="h-3.5 w-3.5 shrink-0"
-                />
-              )}
-            </span>
-            <span className="flex min-w-0 flex-1 items-center gap-1.5">
-              <span data-testid={`project-title-${project.id}`} className="min-w-0 truncate">
-                {project.name}
+              <span
+                className="flex h-4 w-4 shrink-0 items-center justify-center"
+                style={projectAppearanceColor ? { color: projectAppearanceColor } : undefined}
+              >
+                {projectMarker?.kind === 'emoji' && 'emoji' in projectMarker ? (
+                  <span data-testid={`project-appearance-emoji-${project.id}`} className="text-sm">
+                    {String(projectMarker.emoji)}
+                  </span>
+                ) : (
+                  <ProjectFolderIcon
+                    project={project}
+                    remote={isRuntimeRemoteProject(runtimeProjectWork)}
+                    className="h-3.5 w-3.5 shrink-0"
+                  />
+                )}
               </span>
-              <ChevronRight
-                data-testid={`project-collapsed-hover-indicator-${project.id}`}
-                className={cn(
-                  'hidden h-3.5 w-3.5 shrink-0 text-[rgb(var(--color-sidebar-text-primary))] opacity-0 transition-opacity',
-                  !expanded &&
-                    'group-hover/project:block group-hover/project:opacity-100 group-focus-within/project:block group-focus-within/project:opacity-100'
-                )}
-              />
-              <ChevronDown
-                data-testid={`project-expanded-hover-indicator-${project.id}`}
-                className={cn(
-                  'hidden h-3.5 w-3.5 shrink-0 text-[rgb(var(--color-sidebar-text-primary))] opacity-0 transition-opacity',
-                  expanded &&
-                    'group-hover/project:block group-hover/project:opacity-100 group-focus-within/project:block group-focus-within/project:opacity-100'
-                )}
-              />
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span data-testid={`project-title-${project.id}`} className="min-w-0 truncate">
+                  {project.name}
+                </span>
+                <ChevronRight
+                  data-testid={`project-collapsed-hover-indicator-${project.id}`}
+                  className={cn(
+                    'hidden h-3.5 w-3.5 shrink-0 text-[rgb(var(--color-sidebar-text-primary))] opacity-0 transition-opacity',
+                    !expanded &&
+                      'group-hover/project:block group-hover/project:opacity-100 group-focus-within/project:block group-focus-within/project:opacity-100'
+                  )}
+                />
+                <ChevronDown
+                  data-testid={`project-expanded-hover-indicator-${project.id}`}
+                  className={cn(
+                    'hidden h-3.5 w-3.5 shrink-0 text-[rgb(var(--color-sidebar-text-primary))] opacity-0 transition-opacity',
+                    expanded &&
+                      'group-hover/project:block group-hover/project:opacity-100 group-focus-within/project:block group-focus-within/project:opacity-100'
+                  )}
+                />
+              </span>
             </span>
           </button>
           {showProjectDeviceStatus && (

--- a/wework/src/components/layout/SidebarSortableList.tsx
+++ b/wework/src/components/layout/SidebarSortableList.tsx
@@ -3,7 +3,6 @@ import {
   DndContext,
   DragOverlay,
   KeyboardSensor,
-  PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -19,6 +18,9 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useMemo, useState, type ReactNode } from 'react'
 import { cn } from '@/lib/utils'
+import { SidebarPointerSensor } from './sidebarDragActivator'
+
+const SIDEBAR_SORTABLE_POINTER_DISTANCE = 6
 
 interface SidebarSortableListProps<T> {
   items: T[]
@@ -86,7 +88,9 @@ export function SidebarSortableList<T>({
     [getId, items]
   )
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(SidebarPointerSensor, {
+      activationConstraint: { distance: SIDEBAR_SORTABLE_POINTER_DISTANCE },
+    }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 

--- a/wework/src/components/layout/sidebarDragActivator.ts
+++ b/wework/src/components/layout/sidebarDragActivator.ts
@@ -1,0 +1,26 @@
+import { PointerSensor, type PointerSensorOptions } from '@dnd-kit/core'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+
+const SIDEBAR_DRAG_ACTIVATOR_SELECTOR = '[data-sidebar-drag-activator]'
+
+export function isSidebarDragActivatorTarget(target: EventTarget | null) {
+  return target instanceof Element && Boolean(target.closest(SIDEBAR_DRAG_ACTIVATOR_SELECTOR))
+}
+
+export class SidebarPointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown' as const,
+      handler: (
+        { nativeEvent: event }: ReactPointerEvent,
+        { onActivation }: PointerSensorOptions
+      ) => {
+        if (!event.isPrimary || event.button !== 0 || !isSidebarDragActivatorTarget(event.target)) {
+          return false
+        }
+        onActivation?.({ event })
+        return true
+      },
+    },
+  ]
+}


### PR DESCRIPTION
## What changed

- Restrict sidebar pointer sorting to the primary project or task content region.
- Keep trailing metadata, hover actions, and unused row space click-only.
- Preserve the existing 6px movement threshold and keyboard sorting behavior.
- Add regression coverage for activator targeting and repeated task-row clicks.
- Document the sidebar sorting interaction contract in `wework/DESIGN.md`.

## Why

The sortable pointer listeners were attached to the entire sidebar row wrapper. Small pointer movement while clicking a task or its trailing controls could therefore activate sorting unintentionally.

This follows the ChatGPT desktop pattern: the sortable container still owns measurement and keyboard behavior, while pointer activation is limited to the row's primary content.

## User impact

Normal and repeated task-row clicks continue to open the task. Project and task sorting remains available from the primary content area, but trailing actions and metadata no longer start a drag.

## Validation

- `pnpm --filter wework test` — 259 files, 2559 tests passed before syncing main.
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- Post-main focused regression: `pnpm --filter wework exec vitest run src/components/layout/DesktopSidebar.test.tsx` — 87 tests passed.
- Pre-push Wework ESLint, TypeScript, and unit-test gates passed.
- Isolated real-Tauri verification with two local runtime tasks:
  - dragging from trailing metadata left task order unchanged;
  - dragging from the title activator entered the sortable flow;
  - two consecutive clicks on the same task row opened the task without entering drag state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sidebar drag-and-drop behavior with a 6px movement threshold.
  * Dragging starts only from project and task names/icons, while trailing actions, metadata, and unused row space remain click-only.
  * Keyboard-based sorting remains supported.

* **Bug Fixes**
  * Clicking task rows continues to open tasks without unintentionally triggering reordering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->