### PR TITLE
fix(wework): keep long conversation composer docked

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -535,6 +535,12 @@ recipe closely:
   than roughly `440px–475px`;
 - drag state uses a subtle neutral overlay; blocked/submitting state dims and
   becomes inert without destroying entered content.
+- In an active desktop thread, the workbench viewport owns vertical scrolling.
+  Its conversation column must be a `min-height: 100%`, non-shrinking flex
+  column, with the composer rendered as the sticky footer inside that flow.
+  Short threads therefore fill the viewport while long and virtualized threads
+  grow naturally. Keep bottom following stable across delayed virtual
+  measurements, but stop following immediately after an explicit user scroll.
 
 The Composer is not a green brand block, a thick outlined form, or a card with
 an exaggerated shadow.

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -25,6 +25,7 @@ const ATTACHMENT_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEklEQVR4nGP4z8CAB+GTG8HSALfKY52fTcuYAAAAAElFTkSuQmCC'
 const TURN_NAVIGATION_MARKER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"]`
 const SCROLLER_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`
+const COMPOSER_CARD_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-floating-composer-card"]`
 const ASSISTANT_CONTENT_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="assistant-message-content"]`
 const THINKING_INDICATOR_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="thinking-indicator"]`
 const USER_MESSAGE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`
@@ -326,6 +327,20 @@ function toolDurationSeconds(text) {
   return Number(text.match(/(\d+(?:\.\d+)?)s/)?.[1] ?? 0)
 }
 
+async function assertComposerDocked(control, scrollerMetrics, description) {
+  const composerMetrics = await getSingleElementMetrics(
+    control,
+    COMPOSER_CARD_SELECTOR,
+    description
+  )
+  assertElementFullyVisible(composerMetrics, scrollerMetrics, description)
+  const bottomGap = scrollerMetrics.bottom - composerMetrics.bottom
+  assert.ok(
+    bottomGap >= 0 && bottomGap <= 32,
+    `${description} drifted ${bottomGap}px above the conversation viewport bottom`
+  )
+}
+
 async function waitForToolDuration(control, minimumSeconds, timeoutMs) {
   const startedAt = Date.now()
   let text = ''
@@ -349,19 +364,6 @@ async function waitForBottom(control, description, timeoutMs) {
     await new Promise(resolve => setTimeout(resolve, 100))
   }
   throw new Error(`${description} remained ${distanceFromBottom(metrics)}px from the bottom`)
-}
-
-async function waitForScrollHeightIncrease(control, previousHeight, description, timeoutMs) {
-  const startedAt = Date.now()
-  let metrics
-  while (Date.now() - startedAt < timeoutMs) {
-    metrics = await getSingleElementMetrics(control, SCROLLER_SELECTOR, description)
-    if (metrics.scrollHeight > previousHeight + 8) return metrics
-    await new Promise(resolve => setTimeout(resolve, 100))
-  }
-  throw new Error(
-    `${description} remained at ${metrics?.scrollHeight ?? previousHeight}px after content was appended`
-  )
 }
 
 async function waitForFolderPath(control, expectedPath, timeoutMs) {
@@ -457,6 +459,7 @@ export function createDesktopScenario({
   let releaseAppend
   let releaseResponse
   let releaseStart
+  let resolveAppendWritten
   let resolveRequest
   let targetRequest
   const appendRelease = new Promise(resolve => {
@@ -467,6 +470,9 @@ export function createDesktopScenario({
   })
   const startRelease = new Promise(resolve => {
     releaseStart = resolve
+  })
+  const appendWritten = new Promise(resolve => {
+    resolveAppendWritten = resolve
   })
   const requestReceived = new Promise(resolve => {
     resolveRequest = resolve
@@ -618,6 +624,7 @@ export function createDesktopScenario({
           response,
           textDeltaEvents(stream.itemId, APPENDED_TEXT, PARTIAL_TEXT.length)
         )
+        resolveAppendWritten()
         await responseRelease
         response.end(sse(stream.finish))
         return true
@@ -719,6 +726,17 @@ export function createDesktopScenario({
         'The completed response retained its reasoning summary'
       )
       await capture(control, 'streaming-text-01-reasoning-removed.png')
+      const shortConversationScroller = await waitForBottom(
+        control,
+        'The short control conversation',
+        uiTimeoutMs
+      )
+      await assertComposerDocked(
+        control,
+        shortConversationScroller,
+        'The composer in the short control conversation'
+      )
+      await capture(control, 'streaming-text-06-short-control-composer-docked.png')
 
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
@@ -920,6 +938,11 @@ export function createDesktopScenario({
         Math.abs(stableUserScrollPosition.scrollTop - userScrollPosition.scrollTop) <= 8,
         `The streaming conversation jumped from ${userScrollPosition.scrollTop}px to ${stableUserScrollPosition.scrollTop}px after the user scrolled upward`
       )
+      await assertComposerDocked(
+        control,
+        stableUserScrollPosition,
+        'The composer after the user scrolled the streaming conversation'
+      )
 
       await control.command('scrollIntoViewAsUser', VIEWPORT_ANCHOR_SELECTOR)
       await new Promise(resolve => setTimeout(resolve, 250))
@@ -945,13 +968,13 @@ export function createDesktopScenario({
       await capture(control, 'streaming-text-11-user-scrolled-up.png')
 
       releaseAppend()
-      const scrollerAfterAppend = await waitForScrollHeightIncrease(
-        control,
-        scrollerBeforeAppend.scrollHeight,
-        'The virtualized streaming conversation after later content',
-        uiTimeoutMs
-      )
+      await appendWritten
       await new Promise(resolve => setTimeout(resolve, 750))
+      const scrollerAfterAppend = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The virtualized streaming conversation after later content'
+      )
       const anchorAfterAppend = await getSingleElementMetrics(
         control,
         VIEWPORT_ANCHOR_SELECTOR,
@@ -964,6 +987,11 @@ export function createDesktopScenario({
       assert.ok(
         Math.abs(scrollerAfterAppend.scrollTop - scrollerBeforeAppend.scrollTop) <= 8,
         `The paused streaming scroller moved from ${scrollerBeforeAppend.scrollTop}px to ${scrollerAfterAppend.scrollTop}px`
+      )
+      await assertComposerDocked(
+        control,
+        scrollerAfterAppend,
+        'The composer after streamed content changed the virtualized conversation height'
       )
       await capture(control, 'streaming-text-12-anchor-stable-after-append.png')
 
@@ -1002,6 +1030,11 @@ export function createDesktopScenario({
         distanceFromBottom(pinnedAfterSwitch) <= 8,
         `The bottom-pinned streaming conversation reopened ${distanceFromBottom(pinnedAfterSwitch)}px from the bottom`
       )
+      await assertComposerDocked(
+        control,
+        pinnedAfterSwitch,
+        'The composer after reopening the long virtualized conversation'
+      )
       await capture(control, 'streaming-text-13-bottom-restored-after-task-switch.png')
 
       for (let index = 0; index < PANE_EVICTION_BLANK_COUNT; index += 1) {
@@ -1016,6 +1049,17 @@ export function createDesktopScenario({
         stableMs: 750,
         timeoutMs: uiTimeoutMs,
       })
+      const remountedScroller = await waitForBottom(
+        control,
+        'The remounted long virtualized conversation',
+        uiTimeoutMs
+      )
+      await assertComposerDocked(
+        control,
+        remountedScroller,
+        'The composer after remounting the long virtualized conversation'
+      )
+      await capture(control, 'streaming-text-14-composer-docked-after-pane-remount.png')
       assert.equal(
         Number(await control.command('getElementCount', TURN_NAVIGATION_MARKER_SELECTOR)),
         HISTORY_TURNS.length + 2,
@@ -1054,7 +1098,7 @@ export function createDesktopScenario({
         !streamingTurnPreview.includes('application_context'),
         'The streaming turn preview exposed injected application context'
       )
-      await capture(control, 'streaming-text-14-thinking-below-partial-response.png')
+      await capture(control, 'streaming-text-15-thinking-below-partial-response.png')
 
       releaseResponse()
       await control.command(
@@ -1086,7 +1130,7 @@ export function createDesktopScenario({
         !completedSnapshot.testIds.includes('pause-response-button'),
         'The pause button remained after completion'
       )
-      await capture(control, 'streaming-text-15-response-completed.png')
+      await capture(control, 'streaming-text-16-response-completed.png')
       await verifyStoppedTurnOrder(control)
       active = false
     },

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -366,6 +366,32 @@ async function waitForBottom(control, description, timeoutMs) {
   throw new Error(`${description} remained ${distanceFromBottom(metrics)}px from the bottom`)
 }
 
+function activeAssistantContentLength(snapshot) {
+  const contentLength = snapshot?.pane?.messageSummary?.activeAssistantMessage?.contentLength
+  return typeof contentLength === 'number' ? contentLength : null
+}
+
+async function waitForRenderedAppend(control, previousContentLength, timeoutMs) {
+  const startedAt = Date.now()
+  let snapshot
+  while (Date.now() - startedAt < timeoutMs) {
+    snapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    if ((activeAssistantContentLength(snapshot) ?? 0) > previousContentLength) {
+      return getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The virtualized streaming conversation after the append rendered'
+      )
+    }
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+  throw new Error(
+    `The rendered streaming append did not increase active assistant content from ${previousContentLength} characters; latest snapshot: ${JSON.stringify(
+      snapshot
+    )}`
+  )
+}
+
 async function waitForFolderPath(control, expectedPath, timeoutMs) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < timeoutMs) {
@@ -967,13 +993,20 @@ export function createDesktopScenario({
       )
       await capture(control, 'streaming-text-11-user-scrolled-up.png')
 
+      const streamingBeforeAppend = JSON.parse(
+        await control.command('getWorkbenchDebugSnapshot', 'body')
+      )
+      const previousContentLength = activeAssistantContentLength(streamingBeforeAppend)
+      assert.ok(
+        previousContentLength !== null,
+        'The streaming response disappeared before the later content arrived'
+      )
       releaseAppend()
       await appendWritten
-      await new Promise(resolve => setTimeout(resolve, 750))
-      const scrollerAfterAppend = await getSingleElementMetrics(
+      const scrollerAfterAppend = await waitForRenderedAppend(
         control,
-        SCROLLER_SELECTOR,
-        'The virtualized streaming conversation after later content'
+        previousContentLength,
+        uiTimeoutMs
       )
       const anchorAfterAppend = await getSingleElementMetrics(
         control,
@@ -996,16 +1029,16 @@ export function createDesktopScenario({
       await capture(control, 'streaming-text-12-anchor-stable-after-append.png')
 
       await control.command('scrollToBottomAsUser', SCROLLER_SELECTOR)
-      await control.command('waitFor', ASSISTANT_CONTENT_SELECTOR, {
-        text: APPEND_MARKER,
-        stableMs: 750,
-        timeoutMs: uiTimeoutMs,
-      })
       const pinnedBeforeSwitch = await waitForBottom(
         control,
         'The streaming conversation before switching tasks',
         5_000
       )
+      await control.command('waitFor', ASSISTANT_CONTENT_SELECTOR, {
+        text: APPEND_MARKER,
+        stableMs: 750,
+        timeoutMs: uiTimeoutMs,
+      })
       assert.ok(
         distanceFromBottom(pinnedBeforeSwitch) <= 8,
         `The streaming conversation was ${distanceFromBottom(pinnedBeforeSwitch)}px from the bottom before switching tasks`

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -119,6 +119,7 @@ interface MessageListProps {
   hiddenRequestUserInputIds?: ReadonlySet<string>
   onAddSelectionToConversation?: (text: string) => void
   onAskSelectionInSidebar?: (text: string) => void
+  onVirtualLayoutChange?: () => void
   renderGapAfterMessage?: (
     message: WorkbenchMessage,
     nextMessage: WorkbenchMessage | undefined
@@ -210,6 +211,7 @@ export const MessageList = memo(function MessageList({
   hiddenRequestUserInputIds,
   onAddSelectionToConversation,
   onAskSelectionInSidebar,
+  onVirtualLayoutChange,
   renderGapAfterMessage,
 }: MessageListProps) {
   const { t } = useTranslation('common')
@@ -318,6 +320,12 @@ export const MessageList = memo(function MessageList({
     },
     initialMeasurementsCache,
   })
+  const virtualTotalSize = virtualMessages ? messageVirtualizer.getTotalSize() : 0
+
+  useLayoutEffect(() => {
+    if (!virtualMessages) return
+    onVirtualLayoutChange?.()
+  }, [onVirtualLayoutChange, virtualMessages, virtualTotalSize])
 
   useLayoutEffect(() => {
     if (
@@ -497,8 +505,7 @@ export const MessageList = memo(function MessageList({
         virtualMessages
           ? {
               height:
-                messageVirtualizer.getTotalSize() +
-                (shouldShowWaitingIndicator ? MESSAGE_LIST_GAP_PX + 32 : 0),
+                virtualTotalSize + (shouldShowWaitingIndicator ? MESSAGE_LIST_GAP_PX + 32 : 0),
             }
           : undefined
       }
@@ -750,6 +757,7 @@ function areMessageListPropsEqual(previous: MessageListProps, next: MessageListP
     previous.onAskSelectionInSidebar !== next.onAskSelectionInSidebar
       ? 'onAskSelectionInSidebar'
       : null,
+    previous.onVirtualLayoutChange !== next.onVirtualLayoutChange ? 'onVirtualLayoutChange' : null,
     previous.renderGapAfterMessage !== next.renderGapAfterMessage ? 'renderGapAfterMessage' : null,
   ].filter((key): key is string => key !== null)
 

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -417,6 +417,74 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('keeps following the external scroller when a virtualized response grows after render', () => {
+    const externalScrollRef = createRef<HTMLDivElement>()
+    const completedMessage = {
+      id: 'completed-message',
+      role: 'assistant' as const,
+      content: '已完成的长会话',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <div ref={externalScrollRef}>
+        <ScrollableMessageArea
+          conversationKey="external-growing-stream"
+          externalScrollRef={externalScrollRef}
+          messages={[completedMessage]}
+        />
+      </div>
+    )
+
+    const scroller = externalScrollRef.current!
+    let scrollHeight = 1000
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      get: () => scrollHeight,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 800,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+
+    fireEvent.scroll(scroller)
+    flushScheduledTimers()
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+
+    rerender(
+      <div ref={externalScrollRef}>
+        <ScrollableMessageArea
+          conversationKey="external-growing-stream"
+          externalScrollRef={externalScrollRef}
+          messages={[
+            completedMessage,
+            {
+              id: 'late-measured-streaming-message',
+              role: 'assistant',
+              content: '刚开始流式输出',
+              status: 'streaming',
+              createdAt: '2026-05-29T00:00:01.000Z',
+            },
+          ]}
+        />
+      </div>
+    )
+
+    scrollHeight = 3000
+    flushScheduledTimers()
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 3000,
+      behavior: 'auto',
+    })
+    expect(scroller.scrollTop).toBe(3000)
+  })
+
   test('stops external bottom following when the scroll position leaves the bottom', () => {
     const externalScrollRef = createRef<HTMLDivElement>()
     const streamingMessage = {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -338,6 +338,7 @@ describe('ScrollableMessageArea', () => {
       scroller.scrollTop = 1000
       fireEvent.scroll(scroller)
       scroller.scrollTop = 300
+      fireEvent.wheel(scroller)
       fireEvent.scroll(scroller)
       ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
 
@@ -388,6 +389,7 @@ describe('ScrollableMessageArea', () => {
       scroller.scrollTop = Number(top)
     })
 
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     rerender(
       <div ref={externalScrollRef}>
@@ -540,6 +542,7 @@ describe('ScrollableMessageArea', () => {
     ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
 
     scroller.scrollTop = 350
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     flushScheduledTimers()
 
@@ -2461,6 +2464,7 @@ describe('ScrollableMessageArea', () => {
       scroller.scrollTop = Number(top)
     })
 
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     rerender(<ScrollableMessageArea conversationKey="transient-layout-b" messages={[messageB]} />)
     ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
@@ -2663,6 +2667,7 @@ describe('ScrollableMessageArea', () => {
       scroller.scrollTop = Number(top)
     })
 
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     rerender(
       <ScrollableMessageArea conversationKey="conversation-loading-b" messages={[messageB]} />
@@ -2743,6 +2748,7 @@ describe('ScrollableMessageArea', () => {
     mockRect(screen.getByText('会话 A 当前阅读内容').closest('[data-message-id]')!, 80, 220)
     mockRect(screen.getByText('会话 A 后续内容').closest('[data-message-id]')!, 240, 360)
 
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     rerender(
       <ScrollableMessageArea conversationKey="conversation-anchor-b" messages={[messageB]} />
@@ -2827,6 +2833,7 @@ describe('ScrollableMessageArea', () => {
     mockRect(screen.getByText('Node').closest('[data-scroll-anchor]')!, 92, 124)
     mockRect(screen.getByText('Pod').closest('[data-scroll-anchor]')!, 140, 172)
 
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     rerender(
       <ScrollableMessageArea
@@ -2901,6 +2908,7 @@ describe('ScrollableMessageArea', () => {
       scroller.scrollTop = Number(top)
     })
 
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     rerender(
       <ScrollableMessageArea conversationKey="conversation-growth-b" messages={[messageB]} />
@@ -3224,6 +3232,7 @@ describe('ScrollableMessageArea', () => {
     fireEvent.scroll(scroller)
     ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
     scroller.scrollTop = 360
+    fireEvent.wheel(scroller)
     fireEvent.scroll(scroller)
     Object.defineProperty(scroller, 'scrollHeight', {
       value: 800,

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -2027,6 +2027,92 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('keeps an unopened conversation pinned when the external scroller height changes', () => {
+    const resizeObservers: Array<{
+      callback: ResizeObserverCallback
+      targets: Set<Element>
+    }> = []
+    vi.stubGlobal(
+      'ResizeObserver',
+      class ResizeObserverMock {
+        targets = new Set<Element>()
+
+        constructor(public callback: ResizeObserverCallback) {
+          resizeObservers.push(this)
+        }
+
+        observe(target: Element) {
+          this.targets.add(target)
+        }
+
+        disconnect() {}
+      }
+    )
+
+    const externalScrollRef = createRef<HTMLDivElement>()
+    render(
+      <div ref={externalScrollRef}>
+        <ScrollableMessageArea
+          conversationKey="unopened-external-resize"
+          externalScrollRef={externalScrollRef}
+          messages={[
+            {
+              id: 'completed-response',
+              role: 'assistant',
+              content: '后台完成的长回复',
+              status: 'done',
+              createdAt: '2026-05-29T00:00:00.000Z',
+            },
+          ]}
+        />
+      </div>
+    )
+
+    const scroller = externalScrollRef.current!
+    let clientHeight = 600
+    const scrollHeight = 1_600
+    Object.defineProperty(scroller, 'clientHeight', {
+      get: () => clientHeight,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: scrollHeight,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Math.min(Number(top), scrollHeight - clientHeight)
+    })
+
+    flushScheduledTimers()
+    expect(scroller.scrollTop).toBe(1_000)
+    fireEvent.scroll(scroller)
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+
+    expect(resizeObservers.some(observer => observer.targets.has(scroller))).toBe(true)
+    expect(getConversationScrollSnapshot('unopened-external-resize')).toEqual({
+      distanceFromBottomPx: 0,
+      pinnedToBottom: true,
+    })
+
+    clientHeight = 460
+    act(() => {
+      resizeObservers
+        .filter(observer => observer.targets.has(scroller))
+        .forEach(observer => observer.callback([], {} as ResizeObserver))
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: scrollHeight,
+      behavior: 'auto',
+    })
+    expect(scroller.scrollTop).toBe(1_140)
+  })
+
   test('follows the assistant response after latest-user placement stabilizes', () => {
     const resizeCallbacks: ResizeObserverCallback[] = []
     vi.stubGlobal(

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -571,6 +571,14 @@ function ScrollableMessagePaneContent({
     [setScrollToBottom]
   )
 
+  const markCurrentConversationPinnedToBottom = useCallback(() => {
+    if (currentScrollKey === null) return
+    setConversationScrollSnapshot(currentScrollKey, {
+      distanceFromBottomPx: 0,
+      pinnedToBottom: true,
+    })
+  }, [currentScrollKey])
+
   const scheduleStableScrollToBottom = useCallback(
     (
       behavior: ScrollBehavior = 'auto',
@@ -578,6 +586,7 @@ function ScrollableMessagePaneContent({
     ) => {
       clearScheduledScrolls()
       followingBottomKeyRef.current = currentScrollKey
+      markCurrentConversationPinnedToBottom()
       STABLE_SCROLL_DELAYS.forEach(delay => {
         scheduleScrollTimer(() => {
           scrollToBottom(behavior, options)
@@ -604,7 +613,13 @@ function ScrollableMessagePaneContent({
         )
       }
     },
-    [clearScheduledScrolls, currentScrollKey, scheduleScrollTimer, scrollToBottom]
+    [
+      clearScheduledScrolls,
+      currentScrollKey,
+      markCurrentConversationPinnedToBottom,
+      scheduleScrollTimer,
+      scrollToBottom,
+    ]
   )
 
   useLayoutEffect(() => {
@@ -781,7 +796,8 @@ function ScrollableMessagePaneContent({
   useEffect(() => {
     const content = contentRef.current
     const footer = stickyFooterRef.current
-    if (!content || typeof ResizeObserver === 'undefined') return
+    const scroller = activeScrollRefRef.current.current
+    if (!content || !scroller || typeof ResizeObserver === 'undefined') return
 
     const resizeObserver = new ResizeObserver(() => {
       if (autoScrollSuspended || isTurnNavigationAutoScrollSuspended()) {
@@ -806,7 +822,11 @@ function ScrollableMessagePaneContent({
         return
       }
 
-      if (followingBottomKeyRef.current === currentScrollKey) {
+      const shouldFollowBottom =
+        followingBottomKeyRef.current === currentScrollKey ||
+        (currentScrollKey !== null &&
+          getConversationScrollSnapshot(currentScrollKey)?.pinnedToBottom === true)
+      if (shouldFollowBottom) {
         setScrollToBottom('auto', { saveSnapshot: false })
         return
       }
@@ -821,6 +841,7 @@ function ScrollableMessagePaneContent({
       }
     })
 
+    resizeObserver.observe(scroller)
     resizeObserver.observe(content)
     if (footer) {
       resizeObserver.observe(footer)

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -793,6 +793,48 @@ function ScrollableMessagePaneContent({
     lastScrollTopRef.current = scroller.scrollTop
   }, [])
 
+  const handleContentLayoutChange = useCallback(() => {
+    if (autoScrollSuspended || isTurnNavigationAutoScrollSuspended()) {
+      return
+    }
+
+    const restoringKey = restoringScrollKeyRef.current
+    if (restoringKey && restoringKey === currentScrollKey) {
+      restoreSavedScrollPosition(restoringKey)
+      return
+    }
+
+    if (preserveLatestUserTurnRef.current) {
+      return
+    }
+
+    const shouldFollowBottom =
+      followingBottomKeyRef.current === currentScrollKey ||
+      (currentScrollKey !== null &&
+        getConversationScrollSnapshot(currentScrollKey)?.pinnedToBottom === true)
+    if (shouldFollowBottom) {
+      setScrollToBottom('auto', { saveSnapshot: false })
+      return
+    }
+
+    if (userScrollPausedAutoFollowRef.current) {
+      restoreUserViewportAnchor()
+      return
+    }
+
+    if (isAtBottomRef.current) {
+      scrollToBottom('auto', { saveSnapshot: false })
+    }
+  }, [
+    autoScrollSuspended,
+    currentScrollKey,
+    isTurnNavigationAutoScrollSuspended,
+    restoreSavedScrollPosition,
+    restoreUserViewportAnchor,
+    scrollToBottom,
+    setScrollToBottom,
+  ])
+
   useEffect(() => {
     const content = contentRef.current
     const footer = stickyFooterRef.current
@@ -800,45 +842,7 @@ function ScrollableMessagePaneContent({
     if (!content || !scroller || typeof ResizeObserver === 'undefined') return
 
     const resizeObserver = new ResizeObserver(() => {
-      if (autoScrollSuspended || isTurnNavigationAutoScrollSuspended()) {
-        if (turnNavigationScrollingRef.current) {
-          console.warn('[Wework] Message turn navigation ignored content resize', {
-            conversationKey: currentScrollKey,
-            scrollTop: activeScrollRefRef.current.current?.scrollTop ?? null,
-            scrollHeight: activeScrollRefRef.current.current?.scrollHeight ?? null,
-            clientHeight: activeScrollRefRef.current.current?.clientHeight ?? null,
-          })
-        }
-        return
-      }
-
-      const restoringKey = restoringScrollKeyRef.current
-      if (restoringKey && restoringKey === currentScrollKey) {
-        restoreSavedScrollPosition(restoringKey)
-        return
-      }
-
-      if (preserveLatestUserTurnRef.current) {
-        return
-      }
-
-      const shouldFollowBottom =
-        followingBottomKeyRef.current === currentScrollKey ||
-        (currentScrollKey !== null &&
-          getConversationScrollSnapshot(currentScrollKey)?.pinnedToBottom === true)
-      if (shouldFollowBottom) {
-        setScrollToBottom('auto', { saveSnapshot: false })
-        return
-      }
-
-      if (userScrollPausedAutoFollowRef.current) {
-        restoreUserViewportAnchor()
-        return
-      }
-
-      if (isAtBottomRef.current && !userScrollPausedAutoFollowRef.current) {
-        scrollToBottom('auto', { saveSnapshot: false })
-      }
+      handleContentLayoutChange()
     })
 
     resizeObserver.observe(scroller)
@@ -847,16 +851,7 @@ function ScrollableMessagePaneContent({
       resizeObserver.observe(footer)
     }
     return () => resizeObserver.disconnect()
-  }, [
-    currentScrollKey,
-    autoScrollSuspended,
-    isTurnNavigationAutoScrollSuspended,
-    restoreSavedScrollPosition,
-    restoreUserViewportAnchor,
-    scrollToBottom,
-    setScrollToBottom,
-    stickyFooter,
-  ])
+  }, [handleContentLayoutChange, stickyFooter])
 
   useEffect(() => clearScheduledScrolls, [clearScheduledScrolls])
 
@@ -884,11 +879,34 @@ function ScrollableMessagePaneContent({
       }
       clearScheduledScrolls()
     }
+    if (!userInitiated) {
+      const shouldFollowBottom =
+        followingBottomKeyRef.current === currentScrollKey ||
+        (currentScrollKey !== null &&
+          getConversationScrollSnapshot(currentScrollKey)?.pinnedToBottom === true)
+      const scroller = activeScrollRefRef.current.current
+      const distanceFromBottom =
+        scroller === null
+          ? Number.POSITIVE_INFINITY
+          : scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+      if (shouldFollowBottom && distanceFromBottom > SCROLLED_TO_BOTTOM_THRESHOLD) {
+        setScrollToBottom('auto', { saveSnapshot: false })
+        return
+      }
+      updateScrollState({ skipSave: true })
+      return
+    }
     updateScrollState({ forceSave: true })
     if (userScrollPausedAutoFollowRef.current) {
       captureUserViewportAnchor()
     }
-  }, [captureUserViewportAnchor, clearScheduledScrolls, currentScrollKey, updateScrollState])
+  }, [
+    captureUserViewportAnchor,
+    clearScheduledScrolls,
+    currentScrollKey,
+    setScrollToBottom,
+    updateScrollState,
+  ])
 
   useEffect(() => {
     const externalScroller = externalScrollRef?.current
@@ -1042,6 +1060,7 @@ function ScrollableMessagePaneContent({
                 hiddenRequestUserInputIds={hiddenRequestUserInputIds}
                 onAddSelectionToConversation={onAddSelectionToConversation}
                 onAskSelectionInSidebar={onAskSelectionInSidebar}
+                onVirtualLayoutChange={handleContentLayoutChange}
                 renderGapAfterMessage={renderTranscriptGapAfterMessage}
               />
             </>

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -25,7 +25,7 @@ import {
 
 const BOTTOM_THRESHOLD = 48
 const SCROLLED_TO_BOTTOM_THRESHOLD = 8
-const STABLE_SCROLL_DELAYS = [0, 50, 150, 300]
+const STABLE_SCROLL_DELAYS = [0, 50, 150, 300, 600, 1000]
 const SCROLL_ANCHOR_SELECTOR = '[data-scroll-anchor]'
 interface RuntimeTranscriptGap {
   start: number
@@ -702,7 +702,7 @@ function ScrollableMessagePaneContent({
     }
 
     if (isAtBottomRef.current && !userScrollPausedAutoFollowRef.current) {
-      scheduleStableScrollToBottom('auto', { saveSnapshot: false })
+      scrollToBottom('auto', { saveSnapshot: false })
     }
   }, [
     conversationKey,
@@ -719,6 +719,7 @@ function ScrollableMessagePaneContent({
     messages.length,
     scheduleStableRestoreSavedScrollPosition,
     scheduleStableScrollToBottom,
+    scrollToBottom,
     setScrollToBottom,
   ])
 

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -702,7 +702,7 @@ function ScrollableMessagePaneContent({
     }
 
     if (isAtBottomRef.current && !userScrollPausedAutoFollowRef.current) {
-      scrollToBottom('auto', { saveSnapshot: false })
+      scheduleStableScrollToBottom('auto', { saveSnapshot: false })
     }
   }, [
     conversationKey,
@@ -719,7 +719,6 @@ function ScrollableMessagePaneContent({
     messages.length,
     scheduleStableRestoreSavedScrollPosition,
     scheduleStableScrollToBottom,
-    scrollToBottom,
     setScrollToBottom,
   ])
 

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -702,13 +702,22 @@ function ScrollableMessagePaneContent({
     }
 
     if (isAtBottomRef.current && !userScrollPausedAutoFollowRef.current) {
-      scrollToBottom('auto', { saveSnapshot: false })
+      const shouldStabilizeExternalBottom =
+        externalScrollRef?.current &&
+        currentScrollKey !== null &&
+        getConversationScrollSnapshot(currentScrollKey)?.pinnedToBottom === true
+      if (shouldStabilizeExternalBottom) {
+        scheduleStableScrollToBottom('auto', { saveSnapshot: false })
+      } else {
+        scrollToBottom('auto', { saveSnapshot: false })
+      }
     }
   }, [
     conversationKey,
     autoScrollSuspended,
     currentScrollKey,
     clearScheduledScrolls,
+    externalScrollRef,
     isTurnNavigationAutoScrollSuspended,
     isWaitingForAssistant,
     lastMessage,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1708,12 +1708,22 @@ describe('DesktopWorkbenchLayout', () => {
     const desktopContent = screen.getByTestId('desktop-workbench-content')
     expect(desktopContent).toHaveClass('h-full', 'overflow-x-hidden', 'overflow-y-auto', 'pt-11')
     expect(desktopContent.style.getPropertyValue('--desktop-floating-composer-clearance')).toBe('')
+    expect(screen.getByTestId('desktop-chat-scroll').parentElement?.parentElement).toHaveClass(
+      'flex',
+      'min-h-full',
+      'shrink-0',
+      'flex-col'
+    )
     expect(screen.getByTestId('desktop-chat-scroll')).toHaveClass(
       'h-full',
+      'min-h-full',
       'overflow-visible',
-      'scrollbar-none',
       'flex',
       'flex-col'
+    )
+    expect(screen.getByTestId('desktop-chat-scroll')).not.toHaveClass(
+      'overflow-y-auto',
+      'scrollbar-none'
     )
     expect(screen.getByTestId('desktop-chat-scroll')).not.toHaveClass(
       'pb-[var(--desktop-floating-composer-clearance)]'

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2313,7 +2313,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           {isBootstrapping ? (
             <div className="flex min-w-0 flex-1" data-testid="desktop-workbench-loading" />
           ) : hasConversation ? (
-            <div className="relative min-h-0 min-w-0 flex-1">
+            <div className="relative flex min-h-full min-w-0 shrink-0 flex-col">
               <ScrollableMessageArea
                 messages={paneMessages}
                 loading={paneSession.transcriptLoading}
@@ -2332,11 +2332,11 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                     ? `${currentRuntimeTask.deviceId}:${currentRuntimeTask.taskId}`
                     : null
                 }
-                className="h-full"
+                className="min-h-full"
                 scrollTestId="desktop-chat-scroll"
                 externalScrollRef={workbenchScrollRef}
                 turnNavigationPortalTarget={turnNavigationPortalTarget}
-                scrollerClassName="overflow-visible scrollbar-none"
+                scrollerClassName="min-h-full overflow-visible"
                 contentClassName={rightPanelExpanded ? 'invisible' : undefined}
                 messageListClassName={cn(
                   DESKTOP_MESSAGE_LIST_CLASS,


### PR DESCRIPTION
## What changed

- make the desktop conversation column fill the viewport for short tasks and grow naturally for long virtualized tasks
- keep the sticky composer docked while virtualized response measurements settle
- preserve explicit user scroll position while streamed content is appended
- add CI-covered desktop E2E geometry assertions for short-task control, long history, user scrolling, task switching, and pane remounting
- document the desktop thread scrolling and composer layout invariant

## Root cause

The desktop workbench owns the actual vertical scroll container, while the nested message area previously had a fixed-height containing block with visible overflow. Short conversations fit inside that block, so they appeared normal. Long virtualized conversations grew outside it, causing the sticky composer to use the wrong containing geometry. A second race occurred when a new virtualized response was measured after the initial bottom scroll, leaving the viewport pinned to the old height.

## Impact

Only tasks with sufficiently long or late-measured virtualized history exhibited the broken layout. Short tasks remain unchanged, while long tasks now keep the composer at the viewport bottom across streaming, task switches, and pane eviction/remount.

## Validation

- `pnpm exec vitest run src/components/chat/ScrollableMessageArea.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx` — 214 tests passed
- focused ESLint — passed
- `pnpm typecheck` — passed
- `pnpm e2e:desktop:streaming-text` — passed in a real isolated Tauri app
- `pnpm ai:verify start` / `snapshot` / `stop` — passed
- pre-push ESLint, TypeScript, and full unit test suite — passed
- reviewed the 14-frame E2E screenshot chain with no composer drift, clipping, anchor jump, or remount regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop conversation scrolling and composer positioning.
  * Kept the composer fully visible and docked near the conversation viewport bottom.
  * Preserved bottom-following during streaming, delayed content measurement, task switching, and pane remounting.
  * Prevented unexpected scrolling after users manually scroll through a conversation.
  * Improved behavior for short conversations and dynamically resizing conversation panes.

* **Tests**
  * Added coverage for streaming content, virtualized message growth, external scrolling, composer placement, and desktop layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->