### PR TITLE
fix(executor): preserve task update time on selection

### DIFF
--- a/docs/en/wegent/developer-guide/runtime-local-work.md
+++ b/docs/en/wegent/developer-guide/runtime-local-work.md
@@ -44,6 +44,14 @@ Wework requests the task list on startup, explicit refresh, or device-state chan
 5. Backend performs light aggregation and returns the result to Wework without reading or matching the Backend `projects` table.
 6. Wework renders Projects and Conversations from the runtime work response, while each LocalTask is still opened and notified by `deviceId + localTaskId`.
 
+Selecting or opening a LocalTask is read-only. When Wework calls read APIs such
+as `runtime.tasks.transcript` or `runtime.tasks.goal.get` to restore pane state,
+the executor may hydrate local cache fields but must not change the LocalTask
+`updatedAt`. Only operations that change task content or lifecycle, such as
+sending a message, renaming, or an actual goal status transition, may advance
+task activity time. Otherwise, merely viewing a task would change list ordering
+and the displayed update time.
+
 The `runtime.tasks.list` response has two workspace levels. The outer workspace is the sidebar Project grouping, so Codex git worktree tasks should be grouped under their shared repository root. The inner LocalTask is the actual execution directory and must keep its own `workspacePath`. When that directory is a git worktree, the LocalTask must carry `workspaceKind: worktree` and `worktreeId`; the sidebar worktree icon, bottom terminal cwd, and right-side workspace tools all derive from LocalTask fields. A worktree LocalTask must not turn the parent workspace into a worktree, and the LocalTask path must not be overwritten with the parent workspace path.
 
 The executor does not poll or push task lists to Backend by itself. Offline devices do not contribute LocalTasks. Wework may show an offline mapped workspace, but it does not keep a central cache of local tasks.

--- a/docs/zh/wegent/developer-guide/runtime-local-work.md
+++ b/docs/zh/wegent/developer-guide/runtime-local-work.md
@@ -44,6 +44,12 @@ Codex 任务通过 `codex app-server --stdio` 的 JSON-RPC 协议发现和控制
 5. Backend 做轻量聚合后返回给 Wework，不再读取或匹配 Backend `projects` 表。
 6. Wework 根据 runtime work 响应展示 Project 和 Conversation；每个 LocalTask 的打开和通知身份仍是 `deviceId + localTaskId`。
 
+选择或打开 LocalTask 是只读操作。为恢复 pane 状态而调用
+`runtime.tasks.transcript`、`runtime.tasks.goal.get` 等读取接口时，executor
+可以水合本地缓存字段，但不能修改 LocalTask 的 `updatedAt`。只有发送消息、
+重命名、goal 状态真实变化等任务内容或生命周期发生变化的操作，才可以推进任务
+活动时间；否则单纯查看任务会改变列表排序和“更新时间”展示。
+
 `runtime.tasks.list` 的响应有两层工作区语义。外层 workspace 表示侧栏 Project 分组，Codex git worktree 任务应归并到共同的仓库根目录；内层 LocalTask 表示任务实际运行目录，必须保留自己的 `workspacePath`。如果该目录是 git worktree，LocalTask 需要携带 `workspaceKind: worktree` 和 `worktreeId`，侧栏 worktree 图标、底部终端 cwd 和右侧工具目录都只从 LocalTask 字段判断。不能因为某个 LocalTask 是 worktree 就把父 workspace 标记为 worktree，也不能把 LocalTask 路径覆盖成父 workspace 路径。
 
 executor 不主动向 Backend 轮询或推送任务列表。离线设备不会贡献 LocalTask；Wework 可以显示映射目录离线，但不会从中心库缓存本地任务。

--- a/executor/src/runtime_work/handler/archives.rs
+++ b/executor/src/runtime_work/handler/archives.rs
@@ -242,7 +242,7 @@ impl RuntimeWorkRpcHandler {
             .await
         {
             Ok(result) => {
-                self.sync_runtime_task_goal_status(
+                self.hydrate_runtime_task_goal_status(
                     &link.local_task_id,
                     result
                         .get("goal")

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -797,9 +797,31 @@ impl RuntimeWorkRpcHandler {
         local_task_id: &str,
         goal_status: Option<String>,
     ) {
+        self.update_runtime_task_goal_status(local_task_id, goal_status, true);
+    }
+
+    pub(super) fn hydrate_runtime_task_goal_status(
+        &self,
+        local_task_id: &str,
+        goal_status: Option<String>,
+    ) {
+        self.update_runtime_task_goal_status(local_task_id, goal_status, false);
+    }
+
+    fn update_runtime_task_goal_status(
+        &self,
+        local_task_id: &str,
+        goal_status: Option<String>,
+        update_activity_time: bool,
+    ) {
         self.store.update_task(local_task_id, |link| {
-            link.goal_status = goal_status.clone();
-            link.updated_at = now_ms();
+            if link.goal_status == goal_status {
+                return;
+            }
+            link.goal_status = goal_status;
+            if update_activity_time {
+                link.updated_at = now_ms();
+            }
         });
     }
 }

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -236,6 +236,30 @@ fn syncing_an_active_goal_does_not_start_an_idle_task() {
 }
 
 #[test]
+fn hydrating_goal_status_does_not_update_task_activity_time() {
+    let index_path = temp_runtime_work_index_path("hydrate-goal");
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(index_path.clone());
+    let mut link = RuntimeTaskLink::new_pending(
+        "task-1".to_owned(),
+        "/tmp/project".to_owned(),
+        "Task".to_owned(),
+    );
+    link.updated_at = 1_780_000_000_000;
+    handler.upsert_local_task(link);
+
+    handler.hydrate_runtime_task_goal_status("task-1", Some("active".to_owned()));
+
+    let task = handler
+        .local_task_link("task-1")
+        .expect("task should remain stored");
+    assert_eq!(task.goal_status.as_deref(), Some("active"));
+    assert_eq!(task.updated_at, 1_780_000_000_000);
+
+    let _ = fs::remove_file(index_path);
+}
+
+#[test]
 fn current_codex_model_provider_reads_configured_provider_name() {
     let provider = current_codex_model_provider_from_config(&json!({
         "config": {

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -260,6 +260,56 @@ fn hydrating_goal_status_does_not_update_task_activity_time() {
 }
 
 #[test]
+fn hydrating_unchanged_goal_status_does_not_update_task_activity_time() {
+    let index_path = temp_runtime_work_index_path("hydrate-unchanged-goal");
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(index_path.clone());
+    let mut link = RuntimeTaskLink::new_pending(
+        "task-1".to_owned(),
+        "/tmp/project".to_owned(),
+        "Task".to_owned(),
+    );
+    link.goal_status = Some("active".to_owned());
+    link.updated_at = 1_780_000_000_000;
+    handler.upsert_local_task(link);
+
+    handler.hydrate_runtime_task_goal_status("task-1", Some("active".to_owned()));
+
+    let task = handler
+        .local_task_link("task-1")
+        .expect("task should remain stored");
+    assert_eq!(task.goal_status.as_deref(), Some("active"));
+    assert_eq!(task.updated_at, 1_780_000_000_000);
+
+    let _ = fs::remove_file(index_path);
+}
+
+#[test]
+fn syncing_changed_goal_status_updates_task_activity_time() {
+    let index_path = temp_runtime_work_index_path("sync-changed-goal");
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(index_path.clone());
+    let mut link = RuntimeTaskLink::new_pending(
+        "task-1".to_owned(),
+        "/tmp/project".to_owned(),
+        "Task".to_owned(),
+    );
+    link.goal_status = Some("pending".to_owned());
+    link.updated_at = 1_780_000_000_000;
+    handler.upsert_local_task(link);
+
+    handler.sync_runtime_task_goal_status("task-1", Some("active".to_owned()));
+
+    let task = handler
+        .local_task_link("task-1")
+        .expect("task should remain stored");
+    assert_eq!(task.goal_status.as_deref(), Some("active"));
+    assert!(task.updated_at > 1_780_000_000_000);
+
+    let _ = fs::remove_file(index_path);
+}
+
+#[test]
 fn current_codex_model_provider_reads_configured_provider_name() {
     let provider = current_codex_model_provider_from_config(&json!({
         "config": {


### PR DESCRIPTION
## What changed

- treat `runtime.tasks.goal.get` as read-only task-state hydration
- keep real goal transitions updating task activity time while skipping unchanged status writes
- add a regression test for preserving `updated_at` during goal hydration
- document that opening or selecting a LocalTask must not advance `updatedAt`

## Root cause

Selecting a Wework task hydrates its goal state. The executor reused the mutation-oriented goal synchronization path, which unconditionally assigned `now_ms()` to the LocalTask `updated_at`. As a result, merely opening a task changed its displayed update time and could affect list ordering.

## Impact

Selecting or reopening a task no longer changes its update time. Actual task content and lifecycle changes continue to advance task activity time.

## Validation

- `cargo fmt --check --manifest-path executor/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml --lib goal_status`
- `cargo test --manifest-path executor/Cargo.toml --lib syncing_`
- pre-push: `cargo test --all-features --lib`
- pre-push: `cargo clippy`
- documentation Prettier check for Chinese and English runtime-local-work guides
- isolated real Tauri verification: created and completed a task, recorded `updatedAt = 1785743247743`, switched away, reopened it, reloaded Wework, and confirmed `updatedAt` remained `1785743247743`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reading or opening a local task no longer incorrectly changes its activity timestamp.
  * Goal-status hydration updates task information without altering the existing activity time.
  * Activity timestamps now advance only when task content, lifecycle, or notification-driven changes occur.

* **Documentation**
  * Updated English and Chinese developer guides to clarify read-only runtime behavior and activity timestamp rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->