### PR TITLE
fix(wework): tighten settings back spacing

### DIFF
--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -326,12 +326,15 @@ describe('ConnectionsSettingsPage', () => {
     expect(screen.getByTestId('settings-nav-general')).toHaveClass(
       'bg-[rgb(var(--color-sidebar-active))]'
     )
+    const personalCategory = screen.getByTestId('settings-category-personal')
     const integrationsCategory = screen.getByTestId('settings-category-integrations')
     const codingCategory = screen.getByTestId('settings-category-coding')
     const archivedCategory = screen.getByTestId('settings-category-archived')
     const pluginsNav = screen.getByTestId('settings-nav-plugins')
     const worktreesNav = screen.getByTestId('settings-nav-worktrees')
 
+    expect(personalCategory).toHaveClass('mt-2')
+    expect(integrationsCategory).toHaveClass('mt-5')
     expect(integrationsCategory).toHaveTextContent('集成')
     expect(codingCategory).toHaveTextContent('编码')
     expect(archivedCategory).toHaveTextContent('已归档')
@@ -354,7 +357,7 @@ describe('ConnectionsSettingsPage', () => {
     expect(screen.getByTestId('worktrees-settings-page')).toBeInTheDocument()
   })
 
-  test('adds titlebar clearance for the settings back button in Tauri', () => {
+  test('does not duplicate titlebar clearance beneath the Tauri app chrome', () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
       value: {},
@@ -363,13 +366,11 @@ describe('ConnectionsSettingsPage', () => {
 
     render(<ConnectionsSettingsPage onBack={vi.fn()} />)
 
-    expect(screen.getByTestId('settings-sidebar-topbar')).toHaveClass('h-[76px]', 'pt-6', 'mb-1')
+    expect(screen.getByTestId('settings-sidebar-topbar')).toHaveClass('h-[52px]', 'mb-1')
+    expect(screen.getByTestId('settings-sidebar-topbar')).not.toHaveClass('h-[76px]', 'pt-6')
     expect(screen.getByTestId('settings-back-button')).toBeInTheDocument()
-    expect(
-      within(screen.getByTestId('settings-main-titlebar-drag-region')).getByTestId(
-        'macos-titlebar-drag-region'
-      )
-    ).toHaveAttribute('data-tauri-drag-region')
+    expect(screen.queryByTestId('settings-main-titlebar-drag-region')).not.toBeInTheDocument()
+    expect(screen.getByTestId('wework-settings-page').querySelector('main')).toHaveClass('pt-8')
   })
 
   test('opens the add device dialog from the cloud work route query', async () => {

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -43,7 +43,6 @@ import { navigateTo } from '@/lib/navigation'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { cn } from '@/lib/utils'
 import { DesktopTopBar } from '@/components/layout/DesktopTopBar'
-import { MacOSTitleBarDragRegion } from '@/components/layout/MacOSTitleBarDragRegion'
 import { RemoteTerminal } from '@/components/layout/workspace-panels/RemoteTerminal'
 import { useResizableSidebar } from '@/components/layout/useResizableSidebar'
 import {
@@ -1363,9 +1362,9 @@ export function ConnectionsSettingsPage({
   const appearance = appearanceContext?.appearance ?? defaultAppearance
   const background = getWorkbenchBackground(appearance, appearanceContext?.resolvedMode ?? 'light')
   const { sidebarWidth, handleResizeStart } = useResizableSidebar()
-  const usesOverlayTitlebar = isTauriRuntime()
+  const isDesktopRuntime = isTauriRuntime()
   const visibleSettingsNavItems = settingsNavItems.filter(
-    item => !['keyboard-shortcuts', 'appshots'].includes(item.key) || usesOverlayTitlebar
+    item => !['keyboard-shortcuts', 'appshots'].includes(item.key) || isDesktopRuntime
   )
   const shouldAutoOpenAddCloudDeviceDialog =
     autoOpenAddCloudDeviceDialog ||
@@ -1406,10 +1405,7 @@ export function ConnectionsSettingsPage({
       >
         <DesktopTopBar
           testId="settings-sidebar-topbar"
-          className={cn(
-            '-mx-1.5 mb-1 w-[calc(100%+0.75rem)] shrink-0 bg-transparent pr-2 pl-2',
-            usesOverlayTitlebar && 'h-[76px] pt-6'
-          )}
+          className="-mx-1.5 mb-1 w-[calc(100%+0.75rem)] shrink-0 bg-transparent pr-2 pl-2"
           left={
             <button
               type="button"
@@ -1436,7 +1432,10 @@ export function ConnectionsSettingsPage({
                 {showCategory && categoryLabel && (
                   <div
                     data-testid={`settings-category-${item.category}`}
-                    className="mb-1 mt-5 px-2.5 text-xs font-medium text-text-muted"
+                    className={cn(
+                      'mb-1 px-2.5 text-xs font-medium text-text-muted',
+                      index === 0 ? 'mt-2' : 'mt-5'
+                    )}
                   >
                     {t(`workbench.${categoryLabel.label}`, categoryLabel.fallback)}
                   </div>
@@ -1472,21 +1471,10 @@ export function ConnectionsSettingsPage({
         />
       </aside>
 
-      {usesOverlayTitlebar && (
-        <div
-          data-testid="settings-main-titlebar-drag-region"
-          className="absolute right-0 top-0 z-titlebar h-[52px]"
-          style={{ left: sidebarWidth }}
-        >
-          <MacOSTitleBarDragRegion className="h-full w-full" />
-        </div>
-      )}
-
       <main
         className={cn(
-          'min-w-0 flex-1 overflow-auto px-8 pb-8',
-          background.imagePath && background.inMain ? 'bg-background/20' : 'bg-background',
-          usesOverlayTitlebar ? 'pt-16' : 'pt-8'
+          'min-w-0 flex-1 overflow-auto px-8 pt-8 pb-8',
+          background.imagePath && background.inMain ? 'bg-background/20' : 'bg-background'
         )}
       >
         {activeNav === 'general' ? (


### PR DESCRIPTION
## What changed

- Removed the settings page's duplicate macOS titlebar clearance beneath the Wework app chrome.
- Kept the first settings category closer to the back button while preserving spacing between later categories.
- Updated layout regression coverage for the compact Tauri settings header.

## Why

The settings page is rendered below Wework's existing `ChromeTitlebar`, but it also added its own `76px` titlebar-safe header, `24px` top padding, and a second main-content drag region. The first category then used the same large top margin as later category groups. Together these made the back button appear surrounded by excessive vertical whitespace.

## Impact

The settings sidebar now starts with a compact back row and first category. Navigation behavior, later category separation, and Tauri-only settings entries are unchanged.

## Validation

- `pnpm --filter wework exec prettier --check src/components/settings/ConnectionsSettingsPage.tsx src/components/settings/ConnectionsSettingsPage.test.tsx`
- `pnpm --filter wework exec eslint src/components/settings/ConnectionsSettingsPage.tsx src/components/settings/ConnectionsSettingsPage.test.tsx`
- `pnpm --filter wework exec vitest run src/components/settings/ConnectionsSettingsPage.test.tsx` (42 tests)
- Full pre-push Wework ESLint, TypeScript, and unit-test checks
- Isolated real-Tauri verification: opened settings, visually confirmed compact spacing, and returned to the workbench successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings page layout consistency across desktop and Tauri environments.
  * Removed duplicate title-bar spacing and adjusted content padding for a more compact presentation.
  * Refined settings navigation spacing, including the Personal category heading.
  * Updated navigation and layout behavior to match the latest desktop design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->