### PR TITLE
fix(wework): keep live reasoning preview visible

### DIFF
--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -11,9 +11,11 @@ export type {
 export { nestMessageBlocks } from './message-blocks'
 export type { MessageBlock, MessageBlockStatus } from './message-blocks'
 export {
+  getLatestThinkingContent,
   isGenericTaskStatusError,
   normalizeWorkbenchBlockStatus,
   reduceWorkbenchMessages,
+  resolveStreamingThinkingContent
 } from './workbench-message-reducer'
 export type {
   BaseWorkbenchProcessingBlock,

--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -423,6 +423,112 @@ describe('reduceWorkbenchMessages', () => {
       { type: 'thinking', status: 'done' },
       { type: 'tool', toolName: 'bash', status: 'pending' }
     ])
+    expect(withTool[0].streamingThinkingContent).toBe('Running a command')
+  })
+
+  test('clears the active thinking summary when assistant text starts streaming', () => {
+    const withReasoning = reduceWorkbenchMessages([], {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '',
+      reasoningChunk: 'Inspecting the current state'
+    })
+
+    expect(withReasoning[0].streamingThinkingContent).toBe(
+      'Inspecting the current state'
+    )
+
+    const withText = reduceWorkbenchMessages(withReasoning, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: 'I found the issue.'
+    })
+
+    expect(withText[0].streamingThinkingContent).toBeUndefined()
+  })
+
+  test('restores the latest thinking summary when a tool starts after process text', () => {
+    const withReasoning = reduceWorkbenchMessages([], {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '',
+      reasoningChunk: 'Preparing to inspect the files'
+    })
+    const withProcessText = reduceWorkbenchMessages(withReasoning, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: 'I will inspect the current implementation.'
+    })
+    const withTool = reduceWorkbenchMessages(withProcessText, {
+      type: 'block_created',
+      subtaskId: '9',
+      block: {
+        id: 'call_1',
+        subtaskId: '9',
+        type: 'tool',
+        toolName: 'bash',
+        toolInput: { command: 'pwd' },
+        status: 'pending',
+        createdAt: 1770000000000
+      }
+    })
+
+    expect(withProcessText[0].streamingThinkingContent).toBeUndefined()
+    expect(withTool[0].streamingThinkingContent).toBe(
+      'Preparing to inspect the files'
+    )
+  })
+
+  test('restores the latest thinking summary when a tool arrives in a stream chunk', () => {
+    const withReasoning = reduceWorkbenchMessages([], {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '',
+      reasoningChunk: 'Preparing to inspect the files'
+    })
+    const withProcessText = reduceWorkbenchMessages(withReasoning, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: 'I will inspect the current implementation.'
+    })
+    const withTool = reduceWorkbenchMessages(withProcessText, {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '',
+      blocks: [
+        {
+          id: 'call_1',
+          subtaskId: '9',
+          type: 'tool',
+          toolName: 'bash',
+          toolInput: { command: 'pwd' },
+          status: 'pending',
+          createdAt: 1770000000000
+        }
+      ]
+    })
+
+    expect(withTool[0].streamingThinkingContent).toBe(
+      'Preparing to inspect the files'
+    )
+  })
+
+  test('keeps the active thinking summary when a tool continuation starts', () => {
+    const withReasoning = reduceWorkbenchMessages([], {
+      type: 'assistant_chunk',
+      subtaskId: '9',
+      content: '',
+      reasoningChunk: 'Preparing the next step'
+    })
+    const continued = reduceWorkbenchMessages(withReasoning, {
+      type: 'assistant_started',
+      taskId: '1',
+      subtaskId: '9'
+    })
+
+    expect(continued[0].streamingThinkingContent).toBe(
+      'Preparing the next step'
+    )
   })
 
   test('orders tool blocks by creation time when create events arrive out of order', () => {

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -91,6 +91,7 @@ export interface WorkbenchMessage<
   completedAt?: string | number | null
   stoppedNotice?: boolean | null
   streamTextOffset?: number
+  streamingThinkingContent?: string
   contentTruncated?: boolean
   contentOriginalChars?: number
   contentLoadRef?: WorkbenchContentLoadRef
@@ -252,6 +253,7 @@ export function reduceWorkbenchMessages<
                 ...clearMessageError(message),
                 taskId: action.taskId ?? message.taskId,
                 content: action.content,
+                streamingThinkingContent: undefined,
                 status: 'streaming' as const,
                 blocks: action.blocks ?? message.blocks
               })
@@ -291,7 +293,11 @@ export function reduceWorkbenchMessages<
           limitWorkbenchMessage({
             ...message,
             streamTextOffset: contentMerge.streamTextOffset,
-            blocks: getChunkBlocks(message, action)
+            blocks: getChunkBlocks(message, action),
+            streamingThinkingContent: getStreamingThinkingContent(
+              message,
+              action
+            )
           })
         ]
       }
@@ -299,18 +305,26 @@ export function reduceWorkbenchMessages<
         isAssistantMessageForAction(message, action)
           ? message.status === 'done'
             ? message
-            : limitWorkbenchMessage({
-                ...clearMessageError(message),
-                ...mergeWorkbenchChunkContent(
-                  message.content,
-                  message.streamTextOffset,
-                  message.contentOriginalChars,
-                  action.content,
-                  action.offset
-                ),
-                status: 'streaming' as const,
-                blocks: getChunkBlocks(message, action)
-              })
+            : (() => {
+                const blocks = getChunkBlocks(message, action)
+                return limitWorkbenchMessage({
+                  ...clearMessageError(message),
+                  ...mergeWorkbenchChunkContent(
+                    message.content,
+                    message.streamTextOffset,
+                    message.contentOriginalChars,
+                    action.content,
+                    action.offset
+                  ),
+                  status: 'streaming' as const,
+                  blocks,
+                  streamingThinkingContent: getStreamingThinkingContent(
+                    message,
+                    action,
+                    blocks
+                  )
+                })
+              })()
           : message
       )
     case 'assistant_done': {
@@ -348,6 +362,7 @@ export function reduceWorkbenchMessages<
                 contentLoadRef: undefined
               }),
               status: 'done' as const,
+              streamingThinkingContent: undefined,
               blocks: finalizeProcessingBlocks(
                 action.blocks ?? message.blocks,
                 'done'
@@ -394,6 +409,7 @@ export function reduceWorkbenchMessages<
               }),
               status: 'done' as const,
               runtimeStatus: 'cancelled' as const,
+              streamingThinkingContent: undefined,
               completedAt,
               stoppedNotice: true,
               blocks: finalizeProcessingBlocks(message.blocks, 'done')
@@ -430,6 +446,7 @@ export function reduceWorkbenchMessages<
           ? limitWorkbenchMessage({
               ...message,
               status: 'failed' as const,
+              streamingThinkingContent: undefined,
               error:
                 message.error && isGenericTaskStatusError(action.error)
                   ? message.error
@@ -461,21 +478,31 @@ export function reduceWorkbenchMessages<
           : message
       )
     case 'block_updated':
-      return state.map((message) =>
-        isAssistantMessageForAction(message, action)
-          ? limitWorkbenchMessage({
-              ...withActiveStreamState(
-                message,
-                isActiveBlockStatus(action.updates.status)
-              ),
-              blocks: (message.blocks ?? []).map((block) =>
-                block.id === action.blockId
-                  ? mergeProcessingBlockUpdate(block, action.updates)
-                  : block
-              )
-            })
-          : message
-      )
+      return state.map((message) => {
+        if (!isAssistantMessageForAction(message, action)) return message
+
+        const previousBlock = message.blocks?.find(
+          (block) => block.id === action.blockId
+        )
+        const blocks = (message.blocks ?? []).map((block) =>
+          block.id === action.blockId
+            ? mergeProcessingBlockUpdate(block, action.updates)
+            : block
+        )
+        return limitWorkbenchMessage({
+          ...withActiveStreamState(
+            message,
+            isActiveBlockStatus(action.updates.status)
+          ),
+          blocks,
+          streamingThinkingContent:
+            previousBlock?.type === 'thinking'
+              ? latestThinkingContent(blocks)
+              : previousBlock?.type === 'text' || previousBlock?.type === 'plan'
+                ? undefined
+                : message.streamingThinkingContent
+        })
+      })
     default:
       return state
   }
@@ -917,6 +944,12 @@ function createBlockCreatedMessage<TAttachment, TFileChanges>(
     message,
     isActiveBlockStatus(action.block.status)
   )
+  const blocks = mergeProcessingBlock(
+    subtaskId
+      ? getBlocksBeforeIncomingBlock(message, subtaskId, action.block)
+      : (message.blocks ?? []),
+    action.block
+  )
   return {
     ...activeMessage,
     content: movesPendingContent ? '' : message.content,
@@ -926,12 +959,13 @@ function createBlockCreatedMessage<TAttachment, TFileChanges>(
       contentOriginalChars: undefined,
       contentLoadRef: undefined
     }),
-    blocks: mergeProcessingBlock(
-      subtaskId
-        ? getBlocksBeforeIncomingBlock(message, subtaskId, action.block)
-        : (message.blocks ?? []),
-      action.block
-    )
+    blocks,
+    streamingThinkingContent:
+      action.block.type === 'thinking' || action.block.type === 'tool'
+        ? latestThinkingContent(blocks)
+        : action.block.type === 'text' || action.block.type === 'plan'
+          ? undefined
+          : message.streamingThinkingContent
   }
 }
 
@@ -981,6 +1015,35 @@ function getChunkBlocks<TAttachment, TFileChanges>(
 
   if (!action.blocks) return withReasoning
   return action.blocks.reduce(mergeProcessingBlock, withReasoning ?? [])
+}
+
+function getStreamingThinkingContent<TAttachment, TFileChanges>(
+  message: WorkbenchMessage<TAttachment, TFileChanges>,
+  action: Extract<
+    WorkbenchMessageAction<TAttachment, TFileChanges>,
+    { type: 'assistant_chunk' }
+  >,
+  blocks = getChunkBlocks(message, action)
+): string | undefined {
+  if (action.reasoningChunk) return latestThinkingContent(blocks)
+  if (action.content) return undefined
+  if (action.blocks?.some(block => block.type === 'tool')) {
+    return latestThinkingContent(blocks)
+  }
+  return message.streamingThinkingContent
+}
+
+function latestThinkingContent<TFileChanges>(
+  blocks: WorkbenchProcessingBlock<TFileChanges>[] | undefined
+): string | undefined {
+  if (!blocks?.length) return undefined
+
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index]
+    if (block?.type === 'thinking' && block.content.trim()) return block.content
+  }
+
+  return undefined
 }
 
 function mergeWorkbenchChunkContent(

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -294,10 +294,13 @@ export function reduceWorkbenchMessages<
             ...message,
             streamTextOffset: contentMerge.streamTextOffset,
             blocks: getChunkBlocks(message, action),
-            streamingThinkingContent: getStreamingThinkingContent(
-              message,
-              action
-            )
+            streamingThinkingContent: resolveStreamingThinkingContent({
+              previousContent: message.streamingThinkingContent,
+              reasoningChunk: action.reasoningChunk,
+              content: action.content,
+              incomingBlocks: action.blocks,
+              blocks: getChunkBlocks(message, action)
+            })
           })
         ]
       }
@@ -318,11 +321,13 @@ export function reduceWorkbenchMessages<
                   ),
                   status: 'streaming' as const,
                   blocks,
-                  streamingThinkingContent: getStreamingThinkingContent(
-                    message,
-                    action,
+                  streamingThinkingContent: resolveStreamingThinkingContent({
+                    previousContent: message.streamingThinkingContent,
+                    reasoningChunk: action.reasoningChunk,
+                    content: action.content,
+                    incomingBlocks: action.blocks,
                     blocks
-                  )
+                  })
                 })
               })()
           : message
@@ -497,7 +502,7 @@ export function reduceWorkbenchMessages<
           blocks,
           streamingThinkingContent:
             previousBlock?.type === 'thinking'
-              ? latestThinkingContent(blocks)
+              ? getLatestThinkingContent(blocks)
               : previousBlock?.type === 'text' || previousBlock?.type === 'plan'
                 ? undefined
                 : message.streamingThinkingContent
@@ -962,7 +967,7 @@ function createBlockCreatedMessage<TAttachment, TFileChanges>(
     blocks,
     streamingThinkingContent:
       action.block.type === 'thinking' || action.block.type === 'tool'
-        ? latestThinkingContent(blocks)
+        ? getLatestThinkingContent(blocks)
         : action.block.type === 'text' || action.block.type === 'plan'
           ? undefined
           : message.streamingThinkingContent
@@ -1017,23 +1022,28 @@ function getChunkBlocks<TAttachment, TFileChanges>(
   return action.blocks.reduce(mergeProcessingBlock, withReasoning ?? [])
 }
 
-function getStreamingThinkingContent<TAttachment, TFileChanges>(
-  message: WorkbenchMessage<TAttachment, TFileChanges>,
-  action: Extract<
-    WorkbenchMessageAction<TAttachment, TFileChanges>,
-    { type: 'assistant_chunk' }
-  >,
-  blocks = getChunkBlocks(message, action)
-): string | undefined {
-  if (action.reasoningChunk) return latestThinkingContent(blocks)
-  if (action.content) return undefined
-  if (action.blocks?.some(block => block.type === 'tool')) {
-    return latestThinkingContent(blocks)
+export function resolveStreamingThinkingContent<TFileChanges>({
+  previousContent,
+  reasoningChunk,
+  content,
+  incomingBlocks,
+  blocks
+}: {
+  previousContent?: string
+  reasoningChunk?: string
+  content?: string
+  incomingBlocks?: WorkbenchProcessingBlock<TFileChanges>[]
+  blocks?: WorkbenchProcessingBlock<TFileChanges>[]
+}): string | undefined {
+  if (reasoningChunk) return getLatestThinkingContent(blocks)
+  if (content) return undefined
+  if (incomingBlocks?.some(block => block.type === 'tool')) {
+    return getLatestThinkingContent(blocks)
   }
-  return message.streamingThinkingContent
+  return previousContent
 }
 
-function latestThinkingContent<TFileChanges>(
+export function getLatestThinkingContent<TFileChanges>(
   blocks: WorkbenchProcessingBlock<TFileChanges>[] | undefined
 ): string | undefined {
   if (!blocks?.length) return undefined

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -14,6 +14,7 @@ const ORDER_COMPLETION_PREFIX = 'WEWORK_DESKTOP_E2E_ORDER_COMPLETION'
 const ORDER_FOLLOW_UP_COUNT = 26
 const HIDDEN_REASONING = 'WEWORK_DESKTOP_E2E_HIDDEN_REASONING_CONTENT'
 const REASONING_SUMMARY = 'WEWORK_DESKTOP_E2E_REASONING_SUMMARY'
+const REASONING_PREVIEW = REASONING_SUMMARY.replaceAll('_', ' ')
 const INITIAL_PROMPT = 'WEWORK_DESKTOP_E2E_STREAMING_TEXT_INITIAL'
 const HISTORY_PROMPT_PREFIX = 'WEWORK_DESKTOP_E2E_STREAMING_TEXT_HISTORY'
 const PROMPT = 'WEWORK_DESKTOP_E2E_STREAMING_TEXT: keep the partial response active until released.'
@@ -457,7 +458,9 @@ export function createDesktopScenario({
   let releaseAppend
   let releaseResponse
   let releaseStart
+  let releaseToolCompletion
   let resolveRequest
+  let resolveToolFollowUp
   let targetRequest
   const appendRelease = new Promise(resolve => {
     releaseAppend = resolve
@@ -470,6 +473,12 @@ export function createDesktopScenario({
   })
   const requestReceived = new Promise(resolve => {
     resolveRequest = resolve
+  })
+  const toolCompletionRelease = new Promise(resolve => {
+    releaseToolCompletion = resolve
+  })
+  const toolFollowUpReceived = new Promise(resolve => {
+    resolveToolFollowUp = resolve
   })
 
   const verifyStoppedTurnOrder = async control => {
@@ -571,6 +580,9 @@ export function createDesktopScenario({
         return true
       }
       if (toolRegressionStage === 'awaiting-tool-output' && requestContainsToolOutput(body)) {
+        toolRegressionStage = 'awaiting-completion-release'
+        resolveToolFollowUp()
+        await toolCompletionRelease
         toolRegressionStage = 'complete'
         response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
         response.end(
@@ -687,6 +699,13 @@ export function createDesktopScenario({
       }
       await control.command('fill', COMPOSER_SELECTOR, { value: TOOL_REGRESSION_PROMPT })
       await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
+      await toolFollowUpReceived
+      await control.command('waitFor', THINKING_INDICATOR_SELECTOR, {
+        text: `正在思考 · ${REASONING_PREVIEW}`,
+        timeoutMs: uiTimeoutMs,
+      })
+      await capture(control, 'streaming-text-00-live-reasoning-summary.png')
+      releaseToolCompletion()
       await control.command('waitFor', '[data-testid="message-assistant"]', {
         text: TOOL_COMPLETION,
         timeoutMs: uiTimeoutMs,
@@ -703,7 +722,7 @@ export function createDesktopScenario({
         false,
         'The collapsed reasoning disclosure exposed its full summary'
       )
-      await capture(control, 'streaming-text-00-processing-collapsed.png')
+      await capture(control, 'streaming-text-01-processing-collapsed.png')
       await control.command('click', '[data-testid="final-processing-toggle"]')
       const expandedProcessingSnapshot = JSON.parse(
         await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
@@ -718,7 +737,7 @@ export function createDesktopScenario({
         false,
         'The completed response retained its reasoning summary'
       )
-      await capture(control, 'streaming-text-01-reasoning-removed.png')
+      await capture(control, 'streaming-text-02-reasoning-removed.png')
 
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -341,6 +341,26 @@ async function waitForToolDuration(control, minimumSeconds, timeoutMs) {
   throw new Error(`The running tool duration did not reach ${minimumSeconds}s; latest row: ${text}`)
 }
 
+async function completedToolDuration(control, timeoutMs) {
+  const selector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="tool-block-duration"]`
+  const finalToggle = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="final-processing-toggle"]`
+  if ((await control.command('getAttribute', finalToggle, { value: 'aria-expanded' })) !== 'true') {
+    await control.command('click', finalToggle)
+  }
+  const summaryToggle = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="processing-summary-toggle"]`
+  await control.command('waitFor', summaryToggle, { timeoutMs })
+  if (
+    (await control.command('getAttribute', summaryToggle, { value: 'aria-expanded' })) !== 'true'
+  ) {
+    await control.command('click', summaryToggle)
+  }
+  await control.command('waitFor', selector, { timeoutMs })
+  const text = await control.command('getText', selector)
+  const duration = toolDurationSeconds(text)
+  assert.ok(duration > 0, `The completed tool duration was missing: ${text}`)
+  return duration
+}
+
 async function waitForBottom(control, description, timeoutMs) {
   const startedAt = Date.now()
   let metrics
@@ -825,7 +845,25 @@ export function createDesktopScenario({
         text: TIMER_COMPLETION,
         timeoutMs: 25_000,
       })
+      const completedDurationBeforeSwitch = await completedToolDuration(control, uiTimeoutMs)
       await capture(control, 'streaming-text-05-tool-completed.png')
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await control.command('clickWhenEnabled', `[data-testid="${timerTaskRowTestId}"]`, {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: TIMER_COMPLETION,
+        stableMs: 750,
+        timeoutMs: uiTimeoutMs,
+      })
+      const completedDurationAfterSwitch = await completedToolDuration(control, uiTimeoutMs)
+      assert.equal(
+        completedDurationAfterSwitch,
+        completedDurationBeforeSwitch,
+        `The completed tool duration changed from ${completedDurationBeforeSwitch}s to ${completedDurationAfterSwitch}s after switching conversations`
+      )
+      await capture(control, 'streaming-text-06-tool-duration-restored.png')
 
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -711,7 +711,21 @@ export function createDesktopScenario({
       }
       await control.command('fill', COMPOSER_SELECTOR, { value: TOOL_REGRESSION_PROMPT })
       await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
-      await toolFollowUpReceived
+      try {
+        await Promise.race([
+          toolFollowUpReceived,
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error('The tool-output follow-up request was not received')),
+              uiTimeoutMs
+            )
+          ),
+        ])
+      } catch (error) {
+        releaseToolCompletion()
+        releaseToolFinalCompletion()
+        throw error
+      }
       await control.command('waitFor', THINKING_INDICATOR_SELECTOR, {
         text: `正在思考 · ${REASONING_PREVIEW}`,
         timeoutMs: uiTimeoutMs,

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -747,6 +747,11 @@ export function createDesktopScenario({
       )
       await capture(control, 'streaming-text-01-reasoning-hidden-during-text.png')
       releaseToolFinalCompletion()
+      await control.command(
+        'waitFor',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="send-message-button"]`,
+        { stableMs: 750, timeoutMs: uiTimeoutMs }
+      )
       const toolRegressionSnapshot = JSON.parse(
         await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
       )

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -169,7 +169,7 @@ function reasoningEvents(itemId, text) {
   ]
 }
 
-function streamingEvents(id) {
+function streamingEvents(id, completionText = COMPLETION_TEXT) {
   const itemId = `${id}-message`
   return {
     itemId,
@@ -200,7 +200,7 @@ function streamingEvents(id) {
         item_id: itemId,
         output_index: 0,
         content_index: 0,
-        text: COMPLETION_TEXT,
+        text: completionText,
       },
       {
         type: 'response.output_item.done',
@@ -210,7 +210,7 @@ function streamingEvents(id) {
           type: 'message',
           status: 'completed',
           role: 'assistant',
-          content: [{ type: 'output_text', text: COMPLETION_TEXT, annotations: [] }],
+          content: [{ type: 'output_text', text: completionText, annotations: [] }],
         },
       },
       responseCompleted(id),
@@ -459,7 +459,9 @@ export function createDesktopScenario({
   let releaseResponse
   let releaseStart
   let releaseToolCompletion
+  let releaseToolFinalCompletion
   let resolveRequest
+  let resolveToolFinalTextStarted
   let resolveToolFollowUp
   let targetRequest
   const appendRelease = new Promise(resolve => {
@@ -479,6 +481,12 @@ export function createDesktopScenario({
   })
   const toolFollowUpReceived = new Promise(resolve => {
     resolveToolFollowUp = resolve
+  })
+  const toolFinalTextStarted = new Promise(resolve => {
+    resolveToolFinalTextStarted = resolve
+  })
+  const toolFinalCompletionRelease = new Promise(resolve => {
+    releaseToolFinalCompletion = resolve
   })
 
   const verifyStoppedTurnOrder = async control => {
@@ -583,15 +591,19 @@ export function createDesktopScenario({
         toolRegressionStage = 'awaiting-completion-release'
         resolveToolFollowUp()
         await toolCompletionRelease
+        const stream = streamingEvents(responseId, TOOL_COMPLETION)
+        response.writeHead(200, {
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'Content-Type': 'text/event-stream; charset=utf-8',
+        })
+        response.flushHeaders()
+        response.write(sse(stream.start))
+        await writeSseEvents(response, textDeltaEvents(stream.itemId, TOOL_COMPLETION))
+        resolveToolFinalTextStarted()
+        await toolFinalCompletionRelease
         toolRegressionStage = 'complete'
-        response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
-        response.end(
-          sse([
-            responseCreated(responseId),
-            assistantMessage(TOOL_COMPLETION),
-            responseCompleted(responseId),
-          ])
-        )
+        response.end(sse(stream.finish))
         return true
       }
 
@@ -706,10 +718,21 @@ export function createDesktopScenario({
       })
       await capture(control, 'streaming-text-00-live-reasoning-summary.png')
       releaseToolCompletion()
+      await toolFinalTextStarted
       await control.command('waitFor', '[data-testid="message-assistant"]', {
         text: TOOL_COMPLETION,
         timeoutMs: uiTimeoutMs,
       })
+      const liveFinalTextSnapshot = JSON.parse(
+        await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
+      )
+      assert.equal(
+        liveFinalTextSnapshot.text.includes(REASONING_PREVIEW),
+        false,
+        'The stale reasoning summary remained visible after assistant text started streaming'
+      )
+      await capture(control, 'streaming-text-01-reasoning-hidden-during-text.png')
+      releaseToolFinalCompletion()
       const toolRegressionSnapshot = JSON.parse(
         await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
       )
@@ -722,7 +745,7 @@ export function createDesktopScenario({
         false,
         'The collapsed reasoning disclosure exposed its full summary'
       )
-      await capture(control, 'streaming-text-01-processing-collapsed.png')
+      await capture(control, 'streaming-text-02-processing-collapsed.png')
       await control.command('click', '[data-testid="final-processing-toggle"]')
       const expandedProcessingSnapshot = JSON.parse(
         await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
@@ -737,7 +760,7 @@ export function createDesktopScenario({
         false,
         'The completed response retained its reasoning summary'
       )
-      await capture(control, 'streaming-text-02-reasoning-removed.png')
+      await capture(control, 'streaming-text-03-reasoning-removed.png')
 
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })

--- a/wework/src/components/chat/AssistantThinkingIndicator.tsx
+++ b/wework/src/components/chat/AssistantThinkingIndicator.tsx
@@ -1,11 +1,42 @@
 import { useTranslation } from '@/hooks/useTranslation'
 
-export function AssistantThinkingIndicator() {
+const THINKING_PREVIEW_MAX_LENGTH = 96
+
+export function AssistantThinkingIndicator({
+  content = '',
+  testId = 'thinking-indicator',
+}: {
+  content?: string
+  testId?: string
+}) {
   const { t } = useTranslation('chat')
+  const preview = buildThinkingPreview(content)
+  const text = preview ? `${t('thinking.running')} · ${preview}` : t('thinking.running')
 
   return (
-    <div className="inline-flex items-center text-sm" data-testid="thinking-indicator">
-      <span className="waiting-thinking-text">{t('thinking.running')}</span>
+    <div className="inline-flex min-w-0 max-w-full items-center text-sm" data-testid={testId}>
+      <span className="waiting-thinking-text min-w-0 truncate">{text}</span>
     </div>
   )
+}
+
+function buildThinkingPreview(content: string): string {
+  const normalized = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/[#>*_[\]()-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!normalized) return ''
+
+  const segments = normalized
+    .split(/[。！？!?]+|\.(?=\s|$)/)
+    .map(segment => segment.trim())
+    .filter(Boolean)
+  const preview = segments[segments.length - 1] ?? normalized
+
+  return preview.length <= THINKING_PREVIEW_MAX_LENGTH
+    ? preview
+    : `${preview.substring(0, THINKING_PREVIEW_MAX_LENGTH)}...`
 }

--- a/wework/src/components/chat/AssistantThinkingIndicator.tsx
+++ b/wework/src/components/chat/AssistantThinkingIndicator.tsx
@@ -38,5 +38,5 @@ function buildThinkingPreview(content: string): string {
 
   return preview.length <= THINKING_PREVIEW_MAX_LENGTH
     ? preview
-    : `${preview.substring(0, THINKING_PREVIEW_MAX_LENGTH)}...`
+    : `${preview.substring(0, THINKING_PREVIEW_MAX_LENGTH - 3)}...`
 }

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1704,14 +1704,14 @@ describe('MessageList', () => {
     expect(screen.queryByText('正在执行 pwd')).not.toBeInTheDocument()
   })
 
-  test('shows the live reasoning summary while reasoning is streaming', () => {
+  test('shows the latest reasoning summary while the assistant turn is streaming', () => {
     const blocks: ProcessingBlock[] = [
       {
         id: 'thinking-1',
         subtaskId: 11,
         type: 'thinking',
         content: '检查运行日志并定位事件边界',
-        status: 'streaming',
+        status: 'done',
         createdAt: 1770000000000,
       },
     ]
@@ -1731,9 +1731,52 @@ describe('MessageList', () => {
       />
     )
 
-    const preview = screen.getByTestId('thinking-live-preview')
+    const preview = screen.getByTestId('thinking-indicator')
     expect(preview).toHaveTextContent('正在思考')
+    expect(preview).toHaveTextContent('·')
     expect(preview).toHaveTextContent('检查运行日志并定位事件边界')
+    expect(screen.queryByTestId('thinking-live-preview')).not.toBeInTheDocument()
+  })
+
+  test('keeps the latest reasoning summary on the thinking row after a tool completes', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'thinking-1',
+        subtaskId: 11,
+        type: 'thinking',
+        content: '先检查监督线程与后续请求的事件衔接。',
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+      {
+        id: 'tool-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'search_query',
+        toolInput: { q: 'runtime supervisor events' },
+        status: 'done',
+        createdAt: 1770000001000,
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-blocks',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            blocks,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('tool-block-thinking')).toHaveTextContent(
+      '正在思考 · 先检查监督线程与后续请求的事件衔接'
+    )
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1739,6 +1739,29 @@ describe('MessageList', () => {
     expect(screen.queryByTestId('thinking-live-preview')).not.toBeInTheDocument()
   })
 
+  test('keeps the truncated reasoning preview within the configured maximum length', () => {
+    const content = 'a'.repeat(120)
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-blocks',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            streamingThinkingContent: content,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    const preview = screen.getByTestId('thinking-indicator').textContent?.split(' · ')[1]
+    expect(preview).toHaveLength(96)
+    expect(preview).toMatch(/\.\.\.$/)
+  })
+
   test('hides the stale reasoning summary once assistant text starts streaming', () => {
     const blocks: ProcessingBlock[] = [
       {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1725,6 +1725,7 @@ describe('MessageList', () => {
             content: '',
             status: 'streaming',
             blocks,
+            streamingThinkingContent: '检查运行日志并定位事件边界',
             createdAt: '2026-06-24T08:00:01.000Z',
           },
         ]}
@@ -1736,6 +1737,38 @@ describe('MessageList', () => {
     expect(preview).toHaveTextContent('·')
     expect(preview).toHaveTextContent('检查运行日志并定位事件边界')
     expect(screen.queryByTestId('thinking-live-preview')).not.toBeInTheDocument()
+  })
+
+  test('hides the stale reasoning summary once assistant text starts streaming', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'thinking-1',
+        subtaskId: 11,
+        type: 'thinking',
+        content: '检查运行日志并定位事件边界',
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-blocks',
+            role: 'assistant',
+            content: '已经定位到问题，接下来修复状态边界。',
+            status: 'streaming',
+            blocks,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    const indicator = screen.getByTestId('thinking-indicator')
+    expect(indicator).toHaveTextContent('正在思考')
+    expect(indicator).not.toHaveTextContent('检查运行日志并定位事件边界')
   })
 
   test('keeps the latest reasoning summary on the thinking row after a tool completes', () => {
@@ -1768,6 +1801,7 @@ describe('MessageList', () => {
             content: '',
             status: 'streaming',
             blocks,
+            streamingThinkingContent: '先检查监督线程与后续请求的事件衔接。',
             createdAt: '2026-06-24T08:00:01.000Z',
           },
         ]}

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1854,12 +1854,19 @@ function getDisplayProcessingBlocks(
     })
 }
 
-function getLatestThinkingContent(blocks: ProcessingBlock[] | undefined): string {
+function getLatestActiveThinkingContent(blocks: ProcessingBlock[] | undefined): string {
   if (!blocks?.length) return ''
 
   for (let index = blocks.length - 1; index >= 0; index -= 1) {
     const block = blocks[index]
-    if (block?.type === 'thinking' && block.content.trim()) return block.content
+    if (
+      block?.type === 'thinking' &&
+      block.status !== 'done' &&
+      block.status !== 'error' &&
+      block.content.trim()
+    ) {
+      return block.content
+    }
   }
 
   return ''
@@ -1942,7 +1949,9 @@ function AssistantMessage({
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = !isCancelled && message.status === 'streaming'
-  const activeThinkingContent = isStreaming ? getLatestThinkingContent(message.blocks) : ''
+  const activeThinkingContent = isStreaming
+    ? (message.streamingThinkingContent ?? getLatestActiveThinkingContent(message.blocks))
+    : ''
   const hasRunningBlocks = hasRunningProcessingBlocks(displayBlocks)
   const isAssistantRunning = isStreaming || hasRunningBlocks
   const canShowFinalArtifacts = !isAssistantRunning

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1847,13 +1847,22 @@ function getDisplayProcessingBlocks(
         : block
     )
     .filter(block => {
-      if (block.type === 'thinking') {
-        return block.status !== 'done' && block.status !== 'error' && Boolean(block.content.trim())
-      }
+      if (block.type === 'thinking') return false
       if (block.type !== 'text') return true
 
       return Boolean(block.content.trim())
     })
+}
+
+function getLatestThinkingContent(blocks: ProcessingBlock[] | undefined): string {
+  if (!blocks?.length) return ''
+
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index]
+    if (block?.type === 'thinking' && block.content.trim()) return block.content
+  }
+
+  return ''
 }
 
 function getWebSearchToolBlocks(blocks: ProcessingBlock[]) {
@@ -1933,6 +1942,7 @@ function AssistantMessage({
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = !isCancelled && message.status === 'streaming'
+  const activeThinkingContent = isStreaming ? getLatestThinkingContent(message.blocks) : ''
   const hasRunningBlocks = hasRunningProcessingBlocks(displayBlocks)
   const isAssistantRunning = isStreaming || hasRunningBlocks
   const canShowFinalArtifacts = !isAssistantRunning
@@ -1995,6 +2005,7 @@ function AssistantMessage({
             segment.kind === 'tool' &&
             !processingSegments.slice(index + 1).some(candidate => candidate.kind === 'tool')
           }
+          thinkingContent={activeThinkingContent}
           showSummary={segment.kind === 'tool'}
           stateKey={`${processingStateKey}:${index}`}
           onOpenWorkspaceFile={onOpenWorkspaceFile}
@@ -2061,7 +2072,9 @@ function AssistantMessage({
           ) : (
             processingTimeline
           )}
-          {shouldShowThinking && !hasVisibleContent && <AssistantThinkingIndicator />}
+          {shouldShowThinking && !hasVisibleContent && (
+            <AssistantThinkingIndicator content={activeThinkingContent} />
+          )}
           {generatedImages.length > 0 ? <GeneratedImageGallery images={generatedImages} /> : null}
           {message.contentTruncated ? (
             <ContentTruncatedNotice
@@ -2080,7 +2093,9 @@ function AssistantMessage({
               />
             </div>
           ) : null}
-          {shouldShowThinking && hasVisibleContent && <AssistantThinkingIndicator />}
+          {shouldShowThinking && hasVisibleContent && (
+            <AssistantThinkingIndicator content={activeThinkingContent} />
+          )}
           {canShowFinalArtifacts && hasVisibleContent && webSearchSources.length > 0 && (
             <WebSearchSourcesChip sources={webSearchSources} />
           )}

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -6,15 +6,6 @@ import { describe, expect, test, vi } from 'vitest'
 import { ToolBlockItem } from './ToolBlockItem'
 import type { ProcessingBlock } from '@/types/workbench'
 
-const streamingThinkingBlock: ProcessingBlock = {
-  id: 'thinking-1',
-  subtaskId: 1,
-  type: 'thinking',
-  content: 'First step. Latest visible thought',
-  status: 'streaming',
-  createdAt: 1770000000000,
-}
-
 const streamingTextBlock: ProcessingBlock = {
   id: 'text-1',
   subtaskId: 1,
@@ -77,37 +68,6 @@ describe('ToolBlockItem', () => {
     )
 
     expect(screen.getByRole('button')).toHaveClass('min-h-8')
-  })
-
-  test('renders streaming thinking as a single live preview row', () => {
-    render(<ToolBlockItem block={streamingThinkingBlock} />)
-
-    const preview = screen.getByTestId('thinking-live-preview')
-
-    expect(preview).toHaveTextContent('正在思考')
-    expect(preview.firstElementChild).toHaveTextContent('正在思考')
-    expect(preview.firstElementChild?.tagName).toBe('SPAN')
-    expect(preview).toHaveTextContent('Latest visible thought')
-    expect(screen.queryByText('First step. Latest visible thought')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('thinking-toggle-button')).not.toBeInTheDocument()
-  })
-
-  test('does not render completed thinking placeholders', () => {
-    render(
-      <ToolBlockItem
-        block={{
-          ...streamingThinkingBlock,
-          status: 'done',
-          content: 'I will inspect the repository before answering.',
-        }}
-      />
-    )
-
-    expect(screen.queryByTestId('thinking-toggle-button')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('thinking-detail')).not.toBeInTheDocument()
-    expect(
-      screen.queryByText('I will inspect the repository before answering.')
-    ).not.toBeInTheDocument()
   })
 
   test('renders streaming process text directly in the timeline', () => {

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -31,7 +31,6 @@ import { WebSearchActivityRows } from './WebSearchSources'
 import { getWebSearchActivityItems } from './webSearchActivity'
 import { usePersistentProcessingExpansion } from './processingExpansionState'
 
-const THINKING_PREVIEW_MAX_LENGTH = 96
 const INLINE_DIFF_MAX_LINES = 96
 
 interface ToolBlockItemProps {
@@ -81,7 +80,7 @@ export function ToolBlockItem({
   }, [block.type, expanded, onExpandedChange])
 
   if (block.type === 'thinking') {
-    return <ThinkingBlockItem block={block} isRunning={isRunning} />
+    return null
   }
   if (block.type === 'text') {
     return (
@@ -852,37 +851,6 @@ function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() || path
 }
 
-function ThinkingBlockItem({
-  block,
-  isRunning,
-}: {
-  block: Extract<ProcessingBlock, { type: 'thinking' }>
-  isRunning: boolean
-}) {
-  const { t } = useTranslation('chat')
-
-  if (!block.content || !isRunning) return null
-
-  const preview = buildBlockPreview(block.content)
-
-  return (
-    <div className="min-w-0 overflow-x-hidden text-sm" data-processing-block-id={block.id}>
-      <div
-        className="flex max-w-full items-center gap-1.5 text-text-secondary"
-        role="status"
-        aria-live="polite"
-        data-testid="thinking-live-preview"
-      >
-        <span className="shrink-0">{t('thinking.running')}</span>
-        <span className="shrink-0 text-text-muted">·</span>
-        <span className="min-w-0 truncate text-text-muted">
-          {preview || t('thinking.updating')}
-        </span>
-      </div>
-    </div>
-  )
-}
-
 function ProcessTextBlockItem({
   block,
   isRunning,
@@ -1585,23 +1553,4 @@ function getStringField(record: Record<string, unknown>, ...keys: string[]): str
 function truncate(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str
   return str.substring(0, maxLen) + '...'
-}
-
-function buildBlockPreview(content: string): string {
-  const normalized = content
-    .replace(/```[\s\S]*?```/g, ' ')
-    .replace(/`([^`]*)`/g, '$1')
-    .replace(/[#>*_[\]()-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-
-  if (!normalized) return ''
-
-  const segments = normalized
-    .split(/[。！？!?]+|\.(?=\s|$)/)
-    .map(segment => segment.trim())
-    .filter(Boolean)
-  const preview = segments[segments.length - 1] ?? normalized
-
-  return truncate(preview, THINKING_PREVIEW_MAX_LENGTH)
 }

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1554,20 +1554,18 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.queryByTestId('runtime-reconnecting-status')).not.toBeInTheDocument()
   })
 
-  test('does not duplicate the generic thinking indicator when live thinking is visible', () => {
-    const thinkingBlock: ProcessingBlock = {
-      id: 'thinking-1',
-      subtaskId: 1,
-      type: 'thinking',
-      content: 'Reading files',
-      status: 'streaming',
-      createdAt: 1770000000000,
-    }
+  test('shows the current reasoning summary in the trailing tool thinking row', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[completedCommandBlock]}
+        isStreaming={true}
+        thinkingContent="First step. Reading the latest files"
+      />
+    )
 
-    render(<ToolBlocksDisplay blocks={[thinkingBlock]} isStreaming={true} />)
-
-    expect(screen.getByTestId('thinking-live-preview')).toBeInTheDocument()
-    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+    const preview = screen.getByTestId('tool-block-thinking')
+    expect(preview).toHaveTextContent('正在思考 · Reading the latest files')
+    expect(preview).not.toHaveTextContent('First step.')
   })
 
   test('does not duplicate the generic thinking indicator when live process text is visible', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -20,6 +20,7 @@ import {
   isRequestUserInputBlock,
   type RequestUserInputBlock,
 } from '../requestUserInputMessages'
+import { AssistantThinkingIndicator } from '../AssistantThinkingIndicator'
 import {
   ToolBlockItem,
   type FileEditDuration,
@@ -72,6 +73,7 @@ interface ToolBlocksDisplayProps {
   forceExpanded?: boolean
   processingPhase?: 'live' | 'intermediate' | 'final'
   showInterToolThinking?: boolean
+  thinkingContent?: string
   showSummary?: boolean
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
@@ -92,6 +94,7 @@ export function ToolBlocksDisplay({
   forceExpanded = false,
   processingPhase = 'live',
   showInterToolThinking = false,
+  thinkingContent = '',
   showSummary = true,
   stateKey,
   onOpenWorkspaceFile,
@@ -358,6 +361,7 @@ export function ToolBlocksDisplay({
             !hasRunningToolActivity &&
             (processingPhase === 'live' || showInterToolThinking)
           }
+          thinkingContent={thinkingContent}
           onOpenWorkspaceFile={onOpenWorkspaceFile}
           fileEditDurations={fileEditDurations}
           stateKey={stateKey}
@@ -486,17 +490,18 @@ function ToolActivityStats({
 function LiveProcessingPreview({
   rows,
   showThinking,
+  thinkingContent,
   onOpenWorkspaceFile,
   fileEditDurations,
   stateKey,
 }: {
   rows: ProcessingDisplayRow[]
   showThinking: boolean
+  thinkingContent: string
   onOpenWorkspaceFile?: (path: string) => void
   fileEditDurations: FileEditDurationsByBlock
   stateKey?: string
 }) {
-  const { t } = useTranslation('chat')
   const scrollRef = useRef<HTMLDivElement>(null)
   const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
   const hasExpandedDetail = rows.some(row => expandedRowIds.has(row.id))
@@ -547,7 +552,10 @@ function LiveProcessingPreview({
         ))}
         {showThinking ? (
           <div className="flex min-h-8 items-center py-1 text-sm" data-testid="tool-block-thinking">
-            <span className="waiting-thinking-text">{t('thinking.running')}</span>
+            <AssistantThinkingIndicator
+              content={thinkingContent}
+              testId="tool-thinking-indicator"
+            />
           </div>
         ) : null}
       </div>

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -755,6 +755,92 @@ describe('runtimeConversationTurns', () => {
     expect(merged[0].status).toBe('done')
   })
 
+  test('preserves completed tool timing when a conversation snapshot is restored', () => {
+    const localBlock: ProcessingBlock = {
+      id: 'tool-1',
+      subtaskId: 'turn-1',
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      status: 'done',
+      createdAt: 1_770_000_000_000,
+      completedAt: 1_770_000_004_250,
+    }
+    const snapshotBlock: ProcessingBlock = {
+      ...localBlock,
+      createdAt: 1_770_000_005_000,
+      completedAt: undefined,
+    }
+    const local: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [{ id: localBlock.id, type: 'block', block: localBlock }],
+        status: 'done',
+      },
+    ]
+    const snapshot: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [{ id: snapshotBlock.id, type: 'block', block: snapshotBlock }],
+        status: 'done',
+      },
+    ]
+
+    const mergedBlock = mergeRuntimeConversationTurns(local, snapshot)[0].items[0]
+
+    expect(mergedBlock).toEqual({
+      id: localBlock.id,
+      type: 'block',
+      block: {
+        ...snapshotBlock,
+        createdAt: localBlock.createdAt,
+        completedAt: localBlock.completedAt,
+      },
+    })
+  })
+
+  test('records tool completion time in runtime conversation state', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-08-03T13:00:04.250Z'))
+      const createdAt = new Date('2026-08-03T13:00:00.000Z').getTime()
+      let turns = reduceRuntimeConversationTurns(
+        [{ id: 'turn-1', items: [], status: 'streaming' }],
+        {
+          type: 'block_created',
+          subtaskId: 'turn-1',
+          block: {
+            id: 'tool-1',
+            subtaskId: 'turn-1',
+            type: 'tool',
+            toolName: 'bash',
+            toolInput: { command: 'pwd' },
+            status: 'streaming',
+            createdAt,
+          },
+        }
+      )
+
+      turns = reduceRuntimeConversationTurns(turns, {
+        type: 'block_updated',
+        subtaskId: 'turn-1',
+        blockId: 'tool-1',
+        updates: { status: 'done' },
+      })
+
+      expect(turns[0].items[0]).toMatchObject({
+        type: 'block',
+        block: {
+          createdAt,
+          completedAt: new Date('2026-08-03T13:00:04.250Z').getTime(),
+          status: 'done',
+        },
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('keeps a live Codex turn failure when the provider snapshot omits the failure', () => {
     const local = reduceRuntimeConversationTurns(
       [
@@ -903,6 +989,27 @@ describe('runtimeConversationTurns', () => {
     expect(projectRuntimeConversationTurns(turns)[0].streamingThinkingContent).toBeUndefined()
   })
 
+  test('clears stale reasoning when cached assistant content is applied', () => {
+    const turns = reduceRuntimeConversationTurns(
+      [
+        {
+          id: 'turn-1',
+          items: [],
+          status: 'streaming',
+          streamingThinkingContent: 'Old reasoning',
+        },
+      ],
+      {
+        type: 'assistant_cached',
+        subtaskId: 'turn-1',
+        content: 'Cached answer',
+        blocks: [],
+      }
+    )
+
+    expect(turns[0].streamingThinkingContent).toBeUndefined()
+  })
+
   test('keeps the active reasoning summary across a tool continuation', () => {
     let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
       type: 'assistant_chunk',
@@ -939,6 +1046,67 @@ describe('runtimeConversationTurns', () => {
     })
 
     expect(turns[0].streamingThinkingContent).toBe('Checking the implementation')
+  })
+
+  test('recomputes the reasoning summary from merged streaming items', () => {
+    const local: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [
+          {
+            id: 'thinking-1',
+            type: 'block',
+            block: {
+              id: 'thinking-1',
+              subtaskId: 'turn-1',
+              type: 'thinking',
+              content: 'Old reasoning',
+              status: 'streaming',
+              createdAt: 1,
+            },
+          },
+          {
+            id: 'tool-1',
+            type: 'block',
+            block: {
+              id: 'tool-1',
+              subtaskId: 'turn-1',
+              type: 'tool',
+              toolName: 'bash',
+              toolInput: { command: 'pwd' },
+              status: 'streaming',
+              createdAt: 2,
+            },
+          },
+        ],
+        status: 'streaming',
+        streamingThinkingContent: 'Old reasoning',
+      },
+    ]
+    const snapshot: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [
+          {
+            id: 'thinking-1',
+            type: 'block',
+            block: {
+              id: 'thinking-1',
+              subtaskId: 'turn-1',
+              type: 'thinking',
+              content: 'Updated reasoning',
+              status: 'streaming',
+              createdAt: 1,
+            },
+          },
+        ],
+        status: 'streaming',
+      },
+    ]
+
+    expect(mergeRuntimeConversationTurns(local, snapshot)[0].streamingThinkingContent).toBe(
+      'Updated reasoning'
+    )
   })
 
   test('uses UTF-16 code-unit offsets when replacing streamed text', () => {

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -878,6 +878,67 @@ describe('runtimeConversationTurns', () => {
         }),
       }),
     ])
+    expect(turns[0].streamingThinkingContent).toBe('Reading files and checking tests')
+    expect(projectRuntimeConversationTurns(turns)[0].streamingThinkingContent).toBe(
+      'Reading files and checking tests'
+    )
+  })
+
+  test('clears the active reasoning summary when final text starts streaming', () => {
+    let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      content: '',
+      reasoningChunk: 'Checking the implementation',
+    })
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      itemId: 'message-1',
+      content: 'The fix is ready.',
+    })
+
+    expect(turns[0].streamingThinkingContent).toBeUndefined()
+    expect(projectRuntimeConversationTurns(turns)[0].streamingThinkingContent).toBeUndefined()
+  })
+
+  test('keeps the active reasoning summary across a tool continuation', () => {
+    let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      content: '',
+      reasoningChunk: 'Checking the implementation',
+    })
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      itemId: 'message-1',
+      content: 'I will inspect the files.',
+    })
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      content: '',
+      blocks: [
+        {
+          id: 'tool-1',
+          subtaskId: 'turn-1',
+          type: 'tool',
+          toolName: 'bash',
+          toolInput: { command: 'pwd' },
+          status: 'pending',
+          createdAt: 1770000000000,
+        },
+      ],
+    })
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'assistant_started',
+      subtaskId: 'turn-1',
+    })
+
+    expect(turns[0].streamingThinkingContent).toBe('Checking the implementation')
   })
 
   test('uses UTF-16 code-unit offsets when replacing streamed text', () => {

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -84,7 +84,12 @@ export function reduceRuntimeConversationTurns(
             })
           }
         }
-        return { ...turn, items, status: 'streaming' }
+        return {
+          ...turn,
+          items,
+          status: 'streaming',
+          streamingThinkingContent: resolveStreamingThinkingContent(turn, action, items),
+        }
       })
     case 'assistant_cached':
       return updateTurn(turns, action.subtaskId, turn => ({
@@ -97,6 +102,7 @@ export function reduceRuntimeConversationTurns(
         ...turn,
         items: upsertBlocks(turn.items, action.blocks),
         status: 'done',
+        streamingThinkingContent: undefined,
         completedAt: new Date().toISOString(),
         fileChanges: action.fileChanges ?? turn.fileChanges,
         error: undefined,
@@ -106,6 +112,7 @@ export function reduceRuntimeConversationTurns(
       return updateTurn(turns, action.subtaskId, turn => ({
         ...turn,
         status: 'cancelled',
+        streamingThinkingContent: undefined,
         completedAt: new Date().toISOString(),
         stoppedNotice: true,
       }))
@@ -113,6 +120,7 @@ export function reduceRuntimeConversationTurns(
       return updateTurn(turns, action.subtaskId, turn => ({
         ...turn,
         status: 'failed',
+        streamingThinkingContent: undefined,
         completedAt: new Date().toISOString(),
         error: action.error,
         errorType: action.errorType,
@@ -123,22 +131,44 @@ export function reduceRuntimeConversationTurns(
         fileChanges: action.fileChanges,
       }))
     case 'block_created':
-      return updateTurn(turns, action.subtaskId, turn => ({
-        ...turn,
-        items: upsertBlocks(turn.items, [action.block]),
-      }))
+      return updateTurn(turns, action.subtaskId, turn => {
+        const items = upsertBlocks(turn.items, [action.block])
+        return {
+          ...turn,
+          items,
+          streamingThinkingContent:
+            action.block.type === 'thinking' || action.block.type === 'tool'
+              ? latestThinkingContent(items)
+              : action.block.type === 'text' || action.block.type === 'plan'
+                ? undefined
+                : turn.streamingThinkingContent,
+        }
+      })
     case 'block_updated':
-      return updateTurn(turns, action.subtaskId, turn => ({
-        ...turn,
-        items: turn.items.map(item =>
+      return updateTurn(turns, action.subtaskId, turn => {
+        const previousBlock = turn.items.find(
+          item => item.type === 'block' && item.id === action.blockId
+        )
+        const items = turn.items.map(item =>
           item.type === 'block' && item.id === action.blockId
             ? {
                 ...item,
                 block: mergeProcessingBlockUpdate(item.block, action.updates),
               }
             : item
-        ),
-      }))
+        )
+        return {
+          ...turn,
+          items,
+          streamingThinkingContent:
+            previousBlock?.type === 'block' && previousBlock.block.type === 'thinking'
+              ? latestThinkingContent(items)
+              : previousBlock?.type === 'block' &&
+                  (previousBlock.block.type === 'text' || previousBlock.block.type === 'plan')
+                ? undefined
+                : turn.streamingThinkingContent,
+        }
+      })
   }
 }
 
@@ -205,6 +235,9 @@ function mergeRuntimeConversationTurn(
 ): RuntimeConversationTurn {
   const items = mergeRuntimeConversationItems(local.items, snapshot.items)
   const preserveLocalFailure = local.status === 'failed' && Boolean(local.error) && !snapshot.error
+  const preserveStreamingThinking =
+    snapshot.status === 'streaming' &&
+    assistantTextContent(local.items) === assistantTextContent(snapshot.items)
   return {
     ...local,
     ...snapshot,
@@ -215,6 +248,9 @@ function mergeRuntimeConversationTurn(
     completedAt: preserveLocalFailure ? local.completedAt : snapshot.completedAt,
     error: preserveLocalFailure ? local.error : snapshot.error,
     errorType: preserveLocalFailure ? local.errorType : snapshot.errorType,
+    streamingThinkingContent: preserveStreamingThinking
+      ? local.streamingThinkingContent
+      : snapshot.streamingThinkingContent,
   }
 }
 
@@ -532,6 +568,7 @@ function projectRuntimeConversationTurn(turn: RuntimeConversationTurn): Workbenc
       errorType: isLast ? turn.errorType : undefined,
       completedAt: isLast ? turn.completedAt : undefined,
       stoppedNotice: isLast ? turn.stoppedNotice : undefined,
+      streamingThinkingContent: isLast ? turn.streamingThinkingContent : undefined,
       references: isLast ? turn.references : undefined,
       memoryCitations: isLast ? turn.memoryCitations : undefined,
       runtimeGuidanceSplitBefore: splitBefore || undefined,
@@ -579,6 +616,31 @@ function projectedGuidanceBlock(
 function turnStatus(turn: RuntimeConversationTurn): WorkbenchMessage['status'] {
   if (turn.status === 'cancelled') return 'done'
   return turn.status
+}
+
+function resolveStreamingThinkingContent(
+  turn: RuntimeConversationTurn,
+  action: Extract<RuntimePaneMessageAction, { type: 'assistant_chunk' }>,
+  items: RuntimeConversationItem[]
+): string | undefined {
+  if (action.reasoningChunk) return latestThinkingContent(items)
+  if (action.blocks?.some(block => block.type === 'tool')) return latestThinkingContent(items)
+  if (action.content) return undefined
+  return turn.streamingThinkingContent
+}
+
+function latestThinkingContent(items: RuntimeConversationItem[]): string | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]
+    if (item?.type === 'block' && item.block.type === 'thinking' && item.block.content.trim()) {
+      return item.block.content
+    }
+  }
+  return undefined
+}
+
+function assistantTextContent(items: RuntimeConversationItem[]): string {
+  return items.flatMap(item => (item.type === 'assistant_text' ? [item.content] : [])).join('\n\n')
 }
 
 function mergeProcessingBlockUpdate(

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -1,4 +1,5 @@
 import type { RuntimePaneMessageAction } from './runtimePaneMessages'
+import { getLatestThinkingContent, resolveStreamingThinkingContent } from '@wegent/chat-core'
 import type {
   ProcessingBlock,
   RuntimeConversationItem,
@@ -88,7 +89,7 @@ export function reduceRuntimeConversationTurns(
           ...turn,
           items,
           status: 'streaming',
-          streamingThinkingContent: resolveStreamingThinkingContent(turn, action, items),
+          streamingThinkingContent: resolveRuntimeStreamingThinkingContent(turn, action, items),
         }
       })
     case 'assistant_cached':
@@ -96,6 +97,7 @@ export function reduceRuntimeConversationTurns(
         ...turn,
         items: upsertBlocks(turn.items, action.blocks),
         status: 'streaming',
+        streamingThinkingContent: undefined,
       }))
     case 'assistant_done':
       return updateTurn(turns, action.subtaskId, turn => ({
@@ -138,7 +140,7 @@ export function reduceRuntimeConversationTurns(
           items,
           streamingThinkingContent:
             action.block.type === 'thinking' || action.block.type === 'tool'
-              ? latestThinkingContent(items)
+              ? getLatestThinkingContent(processingBlocks(items))
               : action.block.type === 'text' || action.block.type === 'plan'
                 ? undefined
                 : turn.streamingThinkingContent,
@@ -162,7 +164,7 @@ export function reduceRuntimeConversationTurns(
           items,
           streamingThinkingContent:
             previousBlock?.type === 'block' && previousBlock.block.type === 'thinking'
-              ? latestThinkingContent(items)
+              ? getLatestThinkingContent(processingBlocks(items))
               : previousBlock?.type === 'block' &&
                   (previousBlock.block.type === 'text' || previousBlock.block.type === 'plan')
                 ? undefined
@@ -249,7 +251,7 @@ function mergeRuntimeConversationTurn(
     error: preserveLocalFailure ? local.error : snapshot.error,
     errorType: preserveLocalFailure ? local.errorType : snapshot.errorType,
     streamingThinkingContent: preserveStreamingThinking
-      ? local.streamingThinkingContent
+      ? getLatestThinkingContent(processingBlocks(items))
       : snapshot.streamingThinkingContent,
   }
 }
@@ -307,12 +309,16 @@ function mergeRuntimeConversationItems(
   localItems: RuntimeConversationItem[],
   snapshotItems: RuntimeConversationItem[]
 ): RuntimeConversationItem[] {
-  if (localItems.length <= snapshotItems.length) return snapshotItems
+  const localById = new Map(localItems.map(item => [item.id, item]))
+  const mergedSnapshotItems = snapshotItems.map(item =>
+    mergeRuntimeConversationItem(localById.get(item.id), item)
+  )
+  if (localItems.length <= snapshotItems.length) return mergedSnapshotItems
 
-  const snapshotById = new Map(snapshotItems.map(item => [item.id, item]))
+  const snapshotById = new Map(mergedSnapshotItems.map(item => [item.id, item]))
   const mergedLocalItems = localItems.map(item => snapshotById.get(item.id) ?? item)
-  for (let index = snapshotItems.length - 1; index >= 0; index -= 1) {
-    const snapshotItem = snapshotItems[index]
+  for (let index = mergedSnapshotItems.length - 1; index >= 0; index -= 1) {
+    const snapshotItem = mergedSnapshotItems[index]
     if (snapshotItem?.type !== 'assistant_text') continue
     const localMatch = mergedLocalItems.find(
       item =>
@@ -325,6 +331,23 @@ function mergeRuntimeConversationItems(
     )
   }
   return mergedLocalItems
+}
+
+function mergeRuntimeConversationItem(
+  local: RuntimeConversationItem | undefined,
+  snapshot: RuntimeConversationItem
+): RuntimeConversationItem {
+  if (local?.type !== 'block' || snapshot.type !== 'block') return snapshot
+  const localComplete = local.block.status === 'done' || local.block.status === 'error'
+  const snapshotComplete = snapshot.block.status === 'done' || snapshot.block.status === 'error'
+  if (!localComplete || !snapshotComplete || local.block.completedAt === undefined) {
+    return snapshot
+  }
+
+  return {
+    ...snapshot,
+    block: preserveCompletedProcessingBlockTiming(local.block, snapshot.block),
+  }
 }
 
 function seedRuntimeConversationTurns(
@@ -530,7 +553,10 @@ function upsertBlocks(
     const canonicalItem: RuntimeConversationItem = {
       id: block.id,
       type: 'block',
-      block,
+      block:
+        index >= 0 && next[index]?.type === 'block'
+          ? preserveCompletedProcessingBlockTiming(next[index].block, block)
+          : block,
     }
     next = index < 0 ? [...next, canonicalItem] : replaceAt(next, index, canonicalItem)
   }
@@ -547,7 +573,7 @@ function projectRuntimeConversationTurn(turn: RuntimeConversationTurn): Workbenc
       return
     }
     const textItems = assistantItems.filter(item => item.type === 'assistant_text')
-    const blocks = assistantItems.flatMap(item => (item.type === 'block' ? [item.block] : []))
+    const blocks = processingBlocks(assistantItems)
     const firstItem = assistantItems[0]
     const createdAt =
       textItems[0]?.createdAt ??
@@ -618,25 +644,22 @@ function turnStatus(turn: RuntimeConversationTurn): WorkbenchMessage['status'] {
   return turn.status
 }
 
-function resolveStreamingThinkingContent(
+function resolveRuntimeStreamingThinkingContent(
   turn: RuntimeConversationTurn,
   action: Extract<RuntimePaneMessageAction, { type: 'assistant_chunk' }>,
   items: RuntimeConversationItem[]
 ): string | undefined {
-  if (action.reasoningChunk) return latestThinkingContent(items)
-  if (action.blocks?.some(block => block.type === 'tool')) return latestThinkingContent(items)
-  if (action.content) return undefined
-  return turn.streamingThinkingContent
+  return resolveStreamingThinkingContent({
+    previousContent: turn.streamingThinkingContent,
+    reasoningChunk: action.reasoningChunk,
+    content: action.content,
+    incomingBlocks: action.blocks,
+    blocks: processingBlocks(items),
+  })
 }
 
-function latestThinkingContent(items: RuntimeConversationItem[]): string | undefined {
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    const item = items[index]
-    if (item?.type === 'block' && item.block.type === 'thinking' && item.block.content.trim()) {
-      return item.block.content
-    }
-  }
-  return undefined
+function processingBlocks(items: RuntimeConversationItem[]): ProcessingBlock[] {
+  return items.flatMap(item => (item.type === 'block' ? [item.block] : []))
 }
 
 function assistantTextContent(items: RuntimeConversationItem[]): string {
@@ -647,11 +670,37 @@ function mergeProcessingBlockUpdate(
   block: ProcessingBlock,
   updates: Extract<RuntimePaneMessageAction, { type: 'block_updated' }>['updates']
 ): ProcessingBlock {
-  const merged = { ...block, ...updates } as ProcessingBlock
+  let merged = { ...block, ...updates } as ProcessingBlock
   if (merged.type === 'tool' && block.type === 'tool') {
     merged.toolInput = updates.toolInput ?? block.toolInput
   }
+  const wasActive = block.status !== 'done' && block.status !== 'error'
+  const isComplete = merged.status === 'done' || merged.status === 'error'
+  if (wasActive && isComplete && merged.completedAt === undefined) {
+    merged = { ...merged, completedAt: Date.now() } as ProcessingBlock
+  }
   return merged
+}
+
+function preserveCompletedProcessingBlockTiming(
+  previous: ProcessingBlock,
+  next: ProcessingBlock
+): ProcessingBlock {
+  const previousComplete = previous.status === 'done' || previous.status === 'error'
+  const nextComplete = next.status === 'done' || next.status === 'error'
+  if (
+    !previousComplete ||
+    !nextComplete ||
+    previous.completedAt === undefined ||
+    next.completedAt !== undefined
+  ) {
+    return next
+  }
+  return {
+    ...next,
+    createdAt: previous.createdAt,
+    completedAt: previous.completedAt,
+  } as ProcessingBlock
 }
 
 function replaceAt<T>(items: T[], index: number, item: T): T[] {

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -141,6 +141,7 @@ export interface RuntimeConversationTurn {
   error?: string
   errorType?: string
   stoppedNotice?: boolean | null
+  streamingThinkingContent?: string
   fileChanges?: TurnFileChangesSummary
   references?: CodexReference[]
   memoryCitations?: CodexMemoryCitation[]


### PR DESCRIPTION
## What changed

- Keep the latest reasoning summary attached to the active “正在思考” status for the whole running turn
- Show the same live summary whether the thinking status is below a tool group or below assistant text
- Remove reasoning processing blocks from the historical timeline and keep them absent after completion
- Add deterministic desktop E2E coverage for the post-tool waiting state

## Root cause

A reasoning item can finish before a tool call while the assistant turn remains active. The UI filtered the completed reasoning block immediately, so the later waiting row fell back to plain “正在思考” even though the latest reasoning summary was still the effective progress description.

The fix derives the latest reasoning summary from the running assistant message and passes it to the existing thinking status row. The turn lifecycle remains the visibility boundary: completion, failure, or cancellation removes the summary.

## Impact

- Running: “正在思考 · 当前 reasoning 摘要”
- Completed: no reasoning placeholder or reasoning history
- Tool aggregation behavior is unchanged

## Validation

- 203 focused Wework unit tests passed
- TypeScript, ESLint, typography, and runtime lifecycle checks passed
- Real Tauri desktop streaming-text E2E passed
- Isolated `ai:verify` displayed “正在思考 · Planning safe file and git inspection” during execution and removed it after completion
- Full pre-push Wework quality checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live, readable previews of the assistant’s current reasoning while responses are generated.
  * Improved thinking indicators with concise, cleaned-up previews of the latest reasoning segment.
  * Retained the latest reasoning summary in tool activity displays after tool completion.

* **Bug Fixes**
  * Reasoning previews now disappear when final assistant text begins streaming.
  * Improved synchronization across streaming responses and tool follow-ups for more consistent status updates.
  * Updated visual verification coverage for the revised thinking flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->