### PR TITLE
fix(wework): persist local model keys locally

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-connection.md
+++ b/docs/en/wework/developer-guide/wework-cloud-connection.md
@@ -93,7 +93,7 @@ The local Codex model catalog follows only the active provider in the current Co
 
 ## Local Model Configs
 
-Non-secret local model metadata is stored in local browser storage. It is not written to Backend as a Model CRD and does not become account-level persistent configuration. API keys are never written to browser storage; the desktop app stores them in the operating system credential store: Keychain on macOS, Credential Manager on Windows, and Secret Service on Linux. Wework restores credentials into renderer memory during startup. On the first read after upgrading, it migrates any legacy browser-stored API key into the operating system credential store and immediately removes the plaintext browser copy. Each config includes:
+Local model configs, including API keys, are stored in Wework's local browser storage. They are not written to Backend as Model CRDs, do not become account-level persistent configuration, and are not cloud-synchronized. For versions that previously moved API keys into the desktop operating system credential store, Wework migrates those credentials back to local storage the first time the related model is used after upgrading and then stops accessing the system credential store before each request. Each config includes:
 
 - Display name.
 - Model ID.

--- a/docs/zh/wework/developer-guide/wework-cloud-connection.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-connection.md
@@ -93,7 +93,7 @@ wework /path/to/project
 
 ## 本地模型配置
 
-本地模型的非敏感元数据存储在浏览器本机存储中，不作为 Model CRD 写入 Backend，也不会成为账号级持久化配置。API Key 不写入浏览器存储，而是通过桌面系统凭据库保存：macOS 使用 Keychain，Windows 使用 Credential Manager，Linux 使用 Secret Service。Wework 启动时会把凭据恢复到当前渲染进程内存；升级后首次读取旧配置时，会先把已有的本地存储 API Key 迁入系统凭据库，再立即清除浏览器存储中的明文副本。配置字段包括：
+本地模型配置（包括 API Key）存储在 Wework 的浏览器本机存储中，不作为 Model CRD 写入 Backend，也不会成为账号级持久化配置或参与云端同步。对于曾把 API Key 存入桌面系统凭据库的版本，Wework 会在升级后首次使用相关模型时把凭据一次性迁回本机存储，并停止在每次请求前访问系统凭据库。配置字段包括：
 
 - 显示名。
 - 模型 ID。

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -4590,7 +4590,7 @@ pub fn run() {
             #[cfg(desktop)]
             local_model_secrets::read_local_model_api_keys,
             #[cfg(desktop)]
-            local_model_secrets::update_local_model_api_key,
+            local_model_secrets::delete_local_model_api_keys,
             get_app_log_directory,
             get_app_preferences,
             close_main_window_to_tray,

--- a/wework/src-tauri/src/local_model_secrets.rs
+++ b/wework/src-tauri/src/local_model_secrets.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 const LOCAL_MODEL_SECRET_SERVICE: &str = "com.wecode.wework.local-model";
-const LOCAL_MODEL_SECRET_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn local_model_secret_entry(config_id: &str) -> Result<keyring::Entry, String> {
     let config_id = config_id.trim();
@@ -21,7 +19,7 @@ fn local_model_secret_entry(config_id: &str) -> Result<keyring::Entry, String> {
 pub async fn read_local_model_api_keys(
     config_ids: Vec<String>,
 ) -> Result<HashMap<String, String>, String> {
-    let read = tauri::async_runtime::spawn_blocking(move || {
+    tauri::async_runtime::spawn_blocking(move || {
         let mut api_keys = HashMap::new();
         for config_id in config_ids {
             let entry = local_model_secret_entry(&config_id)?;
@@ -36,34 +34,27 @@ pub async fn read_local_model_api_keys(
             }
         }
         Ok(api_keys)
-    });
-    tokio::time::timeout(LOCAL_MODEL_SECRET_TIMEOUT, read)
-        .await
-        .map_err(|_| "Timed out reading local model credentials".to_string())?
-        .map_err(|error| format!("Failed to join local model credential read: {error}"))?
+    })
+    .await
+    .map_err(|error| format!("Failed to join local model credential read: {error}"))?
 }
 
 #[tauri::command]
-pub async fn update_local_model_api_key(
-    config_id: String,
-    api_key: Option<String>,
-) -> Result<(), String> {
-    let update = tauri::async_runtime::spawn_blocking(move || {
-        let entry = local_model_secret_entry(&config_id)?;
-        match api_key.map(|value| value.trim().to_owned()) {
-            Some(api_key) if !api_key.is_empty() => entry
-                .set_password(&api_key)
-                .map_err(|error| format!("Failed to save local model credentials: {error}")),
-            _ => match entry.delete_credential() {
-                Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-                Err(error) => Err(format!("Failed to delete local model credentials: {error}")),
-            },
+pub async fn delete_local_model_api_keys(config_ids: Vec<String>) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        for config_id in config_ids {
+            let entry = local_model_secret_entry(&config_id)?;
+            match entry.delete_credential() {
+                Ok(()) | Err(keyring::Error::NoEntry) => {}
+                Err(error) => {
+                    return Err(format!("Failed to delete local model credentials: {error}"));
+                }
+            }
         }
-    });
-    tokio::time::timeout(LOCAL_MODEL_SECRET_TIMEOUT, update)
-        .await
-        .map_err(|_| "Timed out updating local model credentials".to_string())?
-        .map_err(|error| format!("Failed to join local model credential update: {error}"))?
+        Ok(())
+    })
+    .await
+    .map_err(|error| format!("Failed to join local model credential deletion: {error}"))?
 }
 
 #[cfg(test)]

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -1921,13 +1921,8 @@ export function createRuntimeWorkApiFromIpc(
   }
 
   const prepareRuntimeModel = async (data: RuntimeModelPrepareRequest): Promise<boolean> => {
-    let selectedModel = findLocalModelConfigByModelName(data.modelId)
-    try {
-      await ensureLocalModelApiKeysHydrated()
-      selectedModel = findLocalModelConfigByModelName(data.modelId)
-    } catch (error) {
-      if (selectedModel?.apiKeyConfigured && !selectedModel.apiKey) throw error
-    }
+    await ensureLocalModelApiKeysHydrated()
+    const selectedModel = findLocalModelConfigByModelName(data.modelId)
     if (!options.syncConfiguredModelCatalog) return true
     if (!selectedModel?.catalogEntry) return true
 

--- a/wework/src/components/settings/ModelSettingsPage.tsx
+++ b/wework/src/components/settings/ModelSettingsPage.tsx
@@ -45,7 +45,6 @@ import {
   ensureLocalModelApiKeysHydrated,
   listLocalModelConfigs,
   LOCAL_MODEL_SETTINGS_CHANGED_EVENT,
-  flushLocalModelSecretWrites,
   markLocalModelCatalogReady,
   normalizeLocalModelBaseUrl,
   normalizeLocalModelRequestPath,
@@ -968,7 +967,6 @@ function LocalModelSettingsSection({
           : undefined,
         enabled: form.enabled,
       })
-      await flushLocalModelSecretWrites()
       if (catalogEntry) {
         const catalogModels = listLocalModelConfigs().filter(model => model.catalogEntry)
         const writtenCatalogSnapshot = catalogModels.map(({ id: modelId, updatedAt }) => ({
@@ -1013,7 +1011,7 @@ function LocalModelSettingsSection({
     }
   }
 
-  const clearEditingApiKey = async () => {
+  const clearEditingApiKey = () => {
     if (!editingModel) return
     try {
       saveLocalModelConfig({
@@ -1035,7 +1033,6 @@ function LocalModelSettingsSection({
         catalogReady: editingModel.catalogReady,
         enabled: editingModel.enabled,
       })
-      await flushLocalModelSecretWrites()
       performStartEditing({ ...editingModel, apiKey: undefined })
     } catch (clearError) {
       setError(
@@ -1081,11 +1078,10 @@ function LocalModelSettingsSection({
     }
   }
 
-  const deleteModel = async (model: LocalModelConfig) => {
+  const deleteModel = (model: LocalModelConfig) => {
     setError(null)
     try {
       deleteLocalModelConfig(model.id)
-      await flushLocalModelSecretWrites()
       if (editingId === model.id) resetForm()
     } catch (deleteError) {
       setError(

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -242,7 +242,6 @@ async function seedDesktopE2ECloudConnection(): Promise<void> {
       ...model,
       baseUrl: modelServerUrl,
       apiKey: 'wework-e2e-test-key',
-      persistApiKey: false,
       catalogReady: localModelsCatalogReady,
       enabled: true,
     })

--- a/wework/src/features/model-settings/localModelSettings.secure.test.ts
+++ b/wework/src/features/model-settings/localModelSettings.secure.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/runtime-environment', () => ({
   isTauriRuntime: runtimeMocks.isTauriRuntime,
 }))
 
-describe('localModelSettings secure credentials', () => {
+describe('localModelSettings credential persistence', () => {
   beforeEach(() => {
     localStorage.clear()
     runtimeMocks.invoke.mockReset()
@@ -21,42 +21,25 @@ describe('localModelSettings secure credentials', () => {
     vi.resetModules()
   })
 
-  test('restores an API key from the native credential store after a renderer restart', async () => {
-    runtimeMocks.invoke.mockResolvedValue(undefined)
-    const firstSession = await import('./localModelSettings')
-    firstSession.saveLocalModelConfig({
+  test('persists API keys in local storage without accessing the native credential store', async () => {
+    const settings = await import('./localModelSettings')
+
+    settings.saveLocalModelConfig({
       id: 'restart-model',
       displayName: 'Restart model',
       modelId: 'restart-model',
       baseUrl: 'https://models.example/v1',
       apiKey: 'restart-secret',
     })
-    await firstSession.flushLocalModelSecretWrites()
 
-    expect(runtimeMocks.invoke).toHaveBeenCalledWith('update_local_model_api_key', {
-      configId: 'restart-model',
-      apiKey: 'restart-secret',
-    })
-    expect(localStorage.getItem(firstSession.LOCAL_MODEL_SETTINGS_STORAGE_KEY)).not.toContain(
+    expect(localStorage.getItem(settings.LOCAL_MODEL_SETTINGS_STORAGE_KEY)).toContain(
       'restart-secret'
     )
-
-    vi.resetModules()
-    runtimeMocks.invoke.mockResolvedValue({ 'restart-model': 'restart-secret' })
-    const restartedSession = await import('./localModelSettings')
-    const changed = vi.fn()
-    window.addEventListener(restartedSession.LOCAL_MODEL_SETTINGS_CHANGED_EVENT, changed)
-    await restartedSession.hydrateLocalModelApiKeys()
-
-    expect(runtimeMocks.invoke).toHaveBeenCalledWith('read_local_model_api_keys', {
-      configIds: ['restart-model'],
-    })
-    expect(changed).toHaveBeenCalledOnce()
-    expect(restartedSession.listLocalModelConfigs()[0].apiKey).toBe('restart-secret')
-    window.removeEventListener(restartedSession.LOCAL_MODEL_SETTINGS_CHANGED_EVENT, changed)
+    expect(settings.listLocalModelConfigs()[0].apiKey).toBe('restart-secret')
+    expect(runtimeMocks.invoke).not.toHaveBeenCalled()
   })
 
-  test('hydrates a persisted API key before the first workbench request', async () => {
+  test('moves a keychain API key back to local storage before the first workbench request', async () => {
     localStorage.setItem(
       'wework.localModelSettings.v1',
       JSON.stringify([
@@ -72,7 +55,12 @@ describe('localModelSettings secure credentials', () => {
         },
       ])
     )
-    runtimeMocks.invoke.mockResolvedValue({ 'cold-start-model': 'cold-start-secret' })
+    runtimeMocks.invoke.mockImplementation(async (command: string) => {
+      if (command === 'read_local_model_api_keys') {
+        return { 'cold-start-model': 'cold-start-secret' }
+      }
+      return undefined
+    })
     const request = vi.fn().mockResolvedValue({ accepted: true })
     const { createLocalAppServices } = await import('@/api/local/localServices')
     const services = createLocalAppServices({
@@ -96,9 +84,15 @@ describe('localModelSettings secure credentials', () => {
       modelId: 'local-model:cold-start-model',
     })
 
-    expect(runtimeMocks.invoke).toHaveBeenCalledWith('read_local_model_api_keys', {
+    expect(runtimeMocks.invoke).toHaveBeenNthCalledWith(1, 'read_local_model_api_keys', {
       configIds: ['cold-start-model'],
     })
+    await vi.waitFor(() => {
+      expect(runtimeMocks.invoke).toHaveBeenCalledWith('delete_local_model_api_keys', {
+        configIds: ['cold-start-model'],
+      })
+    })
+    expect(localStorage.getItem('wework.localModelSettings.v1')).toContain('cold-start-secret')
     const createCall = request.mock.calls.find(([method]) => method === 'runtime.tasks.create')
     expect(createCall?.[1]).toEqual(
       expect.objectContaining({
@@ -114,62 +108,31 @@ describe('localModelSettings secure credentials', () => {
     )
   })
 
-  test('migrates a legacy persisted API key into the native credential store', async () => {
+  test('does not access the native credential store after the API key is in local storage', async () => {
     localStorage.setItem(
       'wework.localModelSettings.v1',
       JSON.stringify([
         {
-          id: 'legacy-secret',
-          displayName: 'Legacy secret',
-          modelId: 'legacy-model',
-          baseUrl: 'https://models.local/v1',
-          apiKey: 'legacy-api-key',
+          id: 'stored-model',
+          displayName: 'Stored model',
+          modelId: 'stored-model',
+          baseUrl: 'https://models.example/v1',
+          apiKey: 'stored-secret',
+          apiKeyConfigured: true,
           enabled: true,
-          updatedAt: '2026-01-01T00:00:00.000Z',
-        },
-      ])
-    )
-    runtimeMocks.invoke.mockImplementation(async (command: string) => {
-      if (command === 'read_local_model_api_keys') return {}
-      return undefined
-    })
-    const settings = await import('./localModelSettings')
-
-    await settings.hydrateLocalModelApiKeys()
-
-    expect(runtimeMocks.invoke).toHaveBeenCalledWith('update_local_model_api_key', {
-      configId: 'legacy-secret',
-      apiKey: 'legacy-api-key',
-    })
-    expect(localStorage.getItem(settings.LOCAL_MODEL_SETTINGS_STORAGE_KEY)).not.toContain(
-      'legacy-api-key'
-    )
-    expect(settings.listLocalModelConfigs()[0].apiKey).toBe('legacy-api-key')
-  })
-
-  test('does not access the native credential store when no model has a saved API key', async () => {
-    localStorage.setItem(
-      'wework.localModelSettings.v1',
-      JSON.stringify([
-        {
-          id: 'keyless-model',
-          displayName: 'Keyless model',
-          modelId: 'keyless-model',
-          baseUrl: 'http://localhost:11434/v1',
-          apiKeyConfigured: false,
-          enabled: true,
-          updatedAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-08-01T00:00:00.000Z',
         },
       ])
     )
     const settings = await import('./localModelSettings')
 
-    await settings.hydrateLocalModelApiKeys()
+    await settings.ensureLocalModelApiKeysHydrated()
 
     expect(runtimeMocks.invoke).not.toHaveBeenCalled()
+    expect(settings.listLocalModelConfigs()[0].apiKey).toBe('stored-secret')
   })
 
-  test('reads only credentials marked as configured', async () => {
+  test('reads only configured credentials missing from local storage', async () => {
     localStorage.setItem(
       'wework.localModelSettings.v1',
       JSON.stringify([
@@ -178,6 +141,16 @@ describe('localModelSettings secure credentials', () => {
           displayName: 'Saved key',
           modelId: 'saved-key',
           baseUrl: 'https://models.example/v1',
+          apiKeyConfigured: true,
+          enabled: true,
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'stored-key',
+          displayName: 'Stored key',
+          modelId: 'stored-key',
+          baseUrl: 'https://models.example/v1',
+          apiKey: 'already-local',
           apiKeyConfigured: true,
           enabled: true,
           updatedAt: '2026-01-01T00:00:00.000Z',
@@ -193,13 +166,38 @@ describe('localModelSettings secure credentials', () => {
         },
       ])
     )
-    runtimeMocks.invoke.mockResolvedValue({ 'saved-key': 'restart-secret' })
+    runtimeMocks.invoke.mockResolvedValue({})
     const settings = await import('./localModelSettings')
 
-    await settings.hydrateLocalModelApiKeys()
+    await settings.ensureLocalModelApiKeysHydrated()
 
+    expect(runtimeMocks.invoke).toHaveBeenCalledOnce()
     expect(runtimeMocks.invoke).toHaveBeenCalledWith('read_local_model_api_keys', {
       configIds: ['saved-key'],
     })
+  })
+
+  test('does not repeatedly reopen the native credential store after migration fails', async () => {
+    localStorage.setItem(
+      'wework.localModelSettings.v1',
+      JSON.stringify([
+        {
+          id: 'denied-key',
+          displayName: 'Denied key',
+          modelId: 'denied-key',
+          baseUrl: 'https://models.example/v1',
+          apiKeyConfigured: true,
+          enabled: true,
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ])
+    )
+    runtimeMocks.invoke.mockRejectedValue(new Error('denied'))
+    const settings = await import('./localModelSettings')
+
+    await expect(settings.ensureLocalModelApiKeysHydrated()).rejects.toThrow('denied')
+    await expect(settings.ensureLocalModelApiKeysHydrated()).rejects.toThrow('denied')
+
+    expect(runtimeMocks.invoke).toHaveBeenCalledOnce()
   })
 })

--- a/wework/src/features/model-settings/localModelSettings.test.ts
+++ b/wework/src/features/model-settings/localModelSettings.test.ts
@@ -100,7 +100,7 @@ describe('localModelSettings', () => {
     expect(localStorage.getItem('wework.localModelSettings.v1')).toContain('local-secret')
   })
 
-  test('preserves legacy persisted API keys when the native credential store is unavailable', () => {
+  test('preserves persisted API keys in local storage', () => {
     localStorage.setItem(
       'wework.localModelSettings.v1',
       JSON.stringify([

--- a/wework/src/features/model-settings/localModelSettings.ts
+++ b/wework/src/features/model-settings/localModelSettings.ts
@@ -63,7 +63,6 @@ export interface SaveLocalModelConfigInput {
   catalogReady?: boolean
   catalogPendingRuntimeInstanceId?: string | null
   enabled?: boolean
-  persistApiKey?: boolean
 }
 
 export type LocalModelSettingsEventConfig = Omit<LocalModelConfig, 'apiKey'> & {
@@ -79,28 +78,7 @@ export const DEFAULT_LOCAL_MODEL_REQUEST_PATH = '/responses'
 export const DEFAULT_LOCAL_MODEL_CHAT_COMPLETIONS_REQUEST_PATH = '/chat/completions'
 export const DEFAULT_LOCAL_MODEL_ANTHROPIC_MESSAGES_REQUEST_PATH = '/v1/messages'
 
-const localModelApiKeys = new Map<string, string>()
-let localModelSecretWriteQueue: Promise<void> = Promise.resolve()
 let localModelApiKeyHydration: Promise<void> | null = null
-
-function scheduleLocalModelApiKeyWrite(configId: string, apiKey?: string): void {
-  if (!isTauriRuntime()) return
-  localModelSecretWriteQueue = localModelSecretWriteQueue
-    .catch(() => undefined)
-    .then(() =>
-      invoke('update_local_model_api_key', {
-        configId,
-        apiKey: apiKey || null,
-      })
-    )
-  void localModelSecretWriteQueue.catch(error => {
-    console.error('Failed to persist local model credentials', error)
-  })
-}
-
-export function flushLocalModelSecretWrites(): Promise<void> {
-  return localModelSecretWriteQueue
-}
 
 export async function hydrateLocalModelApiKeys(): Promise<void> {
   if (!isTauriRuntime()) return
@@ -116,35 +94,24 @@ export async function hydrateLocalModelApiKeys(): Promise<void> {
     configIds.length > 0
       ? await invoke<Record<string, string>>('read_local_model_api_keys', { configIds })
       : {}
-  localModelApiKeys.clear()
-  for (const [configId, apiKey] of Object.entries(storedApiKeys)) {
-    if (apiKey) localModelApiKeys.set(configId, apiKey)
-  }
-
-  const legacyApiKeys = configs.flatMap(config =>
-    config.apiKey ? [{ configId: config.id, apiKey: config.apiKey }] : []
+  if (Object.keys(storedApiKeys).length === 0) return
+  writeStoredConfigs(
+    configs.map(config => {
+      const apiKey = storedApiKeys[config.id]
+      return apiKey ? { ...config, apiKey, apiKeyConfigured: true } : config
+    })
   )
-  if (legacyApiKeys.length > 0) {
-    for (const { configId, apiKey } of legacyApiKeys) {
-      localModelApiKeys.set(configId, apiKey)
-      scheduleLocalModelApiKeyWrite(configId, apiKey)
-    }
-    globalThis.localStorage?.setItem(
-      LOCAL_MODEL_SETTINGS_STORAGE_KEY,
-      JSON.stringify(configs.map(persistableLocalModelConfig))
-    )
-    await flushLocalModelSecretWrites()
-  }
-  dispatchChanged(readStoredConfigs())
+  void invoke('delete_local_model_api_keys', {
+    configIds: Object.keys(storedApiKeys),
+  }).catch(error => {
+    console.error('Failed to remove migrated local model credentials', error)
+  })
 }
 
 export function ensureLocalModelApiKeysHydrated(): Promise<void> {
   if (!isTauriRuntime()) return Promise.resolve()
   if (!localModelApiKeyHydration) {
-    localModelApiKeyHydration = hydrateLocalModelApiKeys().catch(error => {
-      localModelApiKeyHydration = null
-      throw error
-    })
+    localModelApiKeyHydration = hydrateLocalModelApiKeys()
   }
   return localModelApiKeyHydration
 }
@@ -195,28 +162,7 @@ function readStoredConfigs(): LocalModelConfig[] {
     if (!raw) return []
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
-    const storedConfigs = parsed.filter(isLocalModelConfig)
-    const canMigrateLegacyApiKeys = isTauriRuntime()
-    let migratedLegacyApiKey = false
-    for (const config of storedConfigs) {
-      if (!config.apiKey) continue
-      localModelApiKeys.set(config.id, config.apiKey)
-      if (canMigrateLegacyApiKeys) {
-        scheduleLocalModelApiKeyWrite(config.id, config.apiKey)
-        migratedLegacyApiKey = true
-      }
-    }
-    if (migratedLegacyApiKey) {
-      globalThis.localStorage?.setItem(
-        LOCAL_MODEL_SETTINGS_STORAGE_KEY,
-        JSON.stringify(storedConfigs.map(persistableLocalModelConfig))
-      )
-    }
-    return storedConfigs.map(config => {
-      const normalized = normalizeStoredLocalModelConfig(config)
-      const apiKey = localModelApiKeys.get(normalized.id)
-      return apiKey ? { ...normalized, apiKey } : normalized
-    })
+    return parsed.filter(isLocalModelConfig).map(normalizeStoredLocalModelConfig)
   } catch {
     return []
   }
@@ -373,19 +319,8 @@ function normalizeStoredLocalModelConfig(config: LocalModelConfig): LocalModelCo
 }
 
 function writeStoredConfigs(configs: LocalModelConfig[]): void {
-  globalThis.localStorage?.setItem(
-    LOCAL_MODEL_SETTINGS_STORAGE_KEY,
-    JSON.stringify(
-      configs.map(config => (isTauriRuntime() ? persistableLocalModelConfig(config) : config))
-    )
-  )
+  globalThis.localStorage?.setItem(LOCAL_MODEL_SETTINGS_STORAGE_KEY, JSON.stringify(configs))
   dispatchChanged(configs)
-}
-
-function persistableLocalModelConfig(config: LocalModelConfig): Omit<LocalModelConfig, 'apiKey'> {
-  const persistableConfig = { ...config }
-  delete persistableConfig.apiKey
-  return persistableConfig
 }
 
 function dispatchChanged(configs: LocalModelConfig[]): void {
@@ -616,14 +551,6 @@ export function saveLocalModelConfig(input: SaveLocalModelConfigInput): LocalMod
     enabled: input.enabled ?? previous?.enabled ?? true,
     updatedAt: nextLocalModelUpdatedAt(previous),
   }
-  if (apiKey) {
-    localModelApiKeys.set(id, apiKey)
-  } else {
-    localModelApiKeys.delete(id)
-  }
-  if (input.persistApiKey !== false) {
-    scheduleLocalModelApiKeyWrite(id, apiKey)
-  }
   const index = existing.findIndex(config => config.id === id)
   const configs =
     index >= 0 ? existing.map(config => (config.id === id ? next : config)) : [...existing, next]
@@ -666,16 +593,11 @@ export function deleteLocalModelConfig(id: string): boolean {
   const configs = readStoredConfigs()
   const next = configs.filter(config => config.id !== id)
   if (next.length === configs.length) return false
-  localModelApiKeys.delete(id)
-  scheduleLocalModelApiKeyWrite(id)
   writeStoredConfigs(next)
   return true
 }
 
 export function clearLocalModelConfigs(): void {
-  const configIds = readStoredConfigs().map(config => config.id)
-  localModelApiKeys.clear()
-  for (const configId of configIds) scheduleLocalModelApiKeyWrite(configId)
   globalThis.localStorage?.removeItem(LOCAL_MODEL_SETTINGS_STORAGE_KEY)
   dispatchChanged([])
 }


### PR DESCRIPTION
## What changed

- persist local-model API keys in Wework local browser storage again
- migrate keys created by the system credential-store implementation back to local storage before the first model request
- remove the migrated credential-store entries after local persistence succeeds
- cache a failed migration attempt for the current renderer session so requests do not repeatedly reopen the macOS Keychain prompt
- remove the native credential write queue and update the settings, E2E seed, tests, and bilingual architecture documentation

## Root cause

The system credential-store implementation read local-model keys before sending a request and imposed a five-second timeout around a blocking macOS Keychain operation. The authorization dialog requires interactive user input, so the operation could time out and reset hydration state before authorization completed. The next request retried the same read and reopened the dialog.

## Impact

New local-model API keys no longer access Keychain, Credential Manager, or Secret Service during normal requests. Existing keys stored by recent builds are migrated once on first use. If migration authorization is denied, the same renderer session returns the cached failure instead of reopening the system prompt on every send.

## Validation

- `pnpm --filter wework test` — 266 files, 2617 tests passed
- focused Prettier, ESLint, and TypeScript checks passed
- `cargo check --manifest-path wework/src-tauri/Cargo.toml --lib`
- targeted Rust unit test passed
- real isolated Tauri verification:
  - saved a local model with an API key
  - reloaded the WebView and confirmed the saved-key state persisted
  - cleared the key, reloaded again, and confirmed the saved-key state was removed
  - inspected isolated app logs for credential migration errors
- pre-push Wework ESLint, TypeScript, and unit-test checks passed
