### PR TITLE
fix(executor): keep runtime task status in memory

### DIFF
--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -100,10 +100,9 @@ impl RuntimeWorkRpcHandler {
             {
                 continue;
             }
-            if !self.is_active_local_task(&link.local_task_id)
-                && normalize_inactive_running_codex_task(&mut link)
-            {
-                self.store.upsert_task(link.clone());
+            let running = self.is_active_local_task(&link.local_task_id);
+            if apply_local_execution_state(&mut link, running) {
+                self.store.update_task_execution_state(&link);
             }
             link.list_order = Some(links.len());
             links.push(link);
@@ -550,7 +549,7 @@ impl RuntimeWorkRpcHandler {
             .is_some_and(|link| self.is_active_local_task(&link.local_task_id));
         if let Some(link) = &mut local_link {
             if !local_active && normalize_inactive_running_codex_task(link) {
-                self.store.upsert_task(link.clone());
+                self.store.update_task_execution_state(link);
             }
         }
         let workspace_path = string_field(thread, "cwd")

--- a/executor/src/runtime_work/handler/helpers/routing.rs
+++ b/executor/src/runtime_work/handler/helpers/routing.rs
@@ -16,6 +16,22 @@ fn normalize_inactive_running_codex_task(link: &mut RuntimeTaskLink) -> bool {
     true
 }
 
+fn apply_local_execution_state(link: &mut RuntimeTaskLink, running: bool) -> bool {
+    if !running {
+        return normalize_inactive_running_codex_task(link);
+    }
+
+    let changed = !link.running
+        || link.status != "running"
+        || link.thread_status != "active"
+        || link.turn_status.as_deref() != Some("inProgress");
+    link.running = true;
+    link.status = "running".to_owned();
+    link.thread_status = "active".to_owned();
+    link.turn_status = Some("inProgress".to_owned());
+    changed
+}
+
 fn is_inactive_running_codex_task(link: &RuntimeTaskLink) -> bool {
     if !link.running || !is_codex_runtime(&link.runtime) {
         return false;

--- a/executor/src/runtime_work/handler/tasks.rs
+++ b/executor/src/runtime_work/handler/tasks.rs
@@ -244,7 +244,7 @@ impl RuntimeWorkRpcHandler {
         }
         if existing_link
             .as_ref()
-            .is_some_and(|link| link.running && self.is_active_local_task(&link.local_task_id))
+            .is_some_and(|link| self.is_active_local_task(&link.local_task_id))
         {
             return Ok(json!({
                 "success": false,
@@ -388,7 +388,7 @@ impl RuntimeWorkRpcHandler {
             .ok_or_else(|| AppIpcError::new("bad_request", "taskId is required"))?;
         let existing_link = self.task_link_from_payload(&payload, false).await?;
         let local_task_id = existing_link.local_task_id.clone();
-        if existing_link.running && self.is_active_local_task(&existing_link.local_task_id) {
+        if self.is_active_local_task(&existing_link.local_task_id) {
             return Ok(json!({
                 "success": false,
                 "accepted": false,

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -88,6 +88,28 @@ pub(crate) struct RuntimeTaskLink {
 }
 
 impl RuntimeTaskLink {
+    pub(crate) fn copy_execution_state_from(&mut self, current: &Self) {
+        self.status = current.status.clone();
+        self.running = current.running;
+        self.thread_status = current.thread_status.clone();
+        self.turn_status = current.turn_status.clone();
+        self.updated_at = current.updated_at;
+    }
+
+    pub(crate) fn preserve_runtime_state_from(&mut self, current: &Self) {
+        self.git_info = current.git_info.clone();
+        self.list_order = current.list_order;
+        self.group_workspace_path = current.group_workspace_path.clone();
+        self.group_project_key = current.group_project_key.clone();
+        self.pinned = current.pinned;
+        self.pinned_order = current.pinned_order;
+        let archived = self.status == "archived";
+        let current_archived = current.status == "archived";
+        if archived == current_archived {
+            self.copy_execution_state_from(current);
+        }
+    }
+
     pub fn new_pending(local_task_id: String, workspace_path: String, title: String) -> Self {
         Self {
             local_task_id,

--- a/executor/src/runtime_work/store.rs
+++ b/executor/src/runtime_work/store.rs
@@ -266,7 +266,13 @@ fn strip_transient_task_state(index: &mut Value) {
         task.remove("status");
         task.remove("running");
         task.remove("thread_status");
-        task.remove("turn_status");
+        if !task
+            .get("turn_status")
+            .and_then(Value::as_str)
+            .is_some_and(is_terminal_turn_status)
+        {
+            task.remove("turn_status");
+        }
         task.insert("archived".to_owned(), Value::Bool(archived));
     }
 }
@@ -281,22 +287,50 @@ fn restore_persisted_task_metadata(index: &mut Value) {
         let Some(task) = task.as_object_mut() else {
             continue;
         };
+        let legacy_status = task
+            .remove("status")
+            .and_then(|value| value.as_str().map(str::to_owned));
         let archived = task
             .remove("archived")
             .and_then(|value| value.as_bool())
             .unwrap_or_else(|| {
-                task.get("status")
-                    .and_then(Value::as_str)
+                legacy_status
+                    .as_deref()
                     .is_some_and(|status| status.eq_ignore_ascii_case("archived"))
             });
+        let restored_status = legacy_status
+            .filter(|status| {
+                matches!(
+                    status.trim().to_ascii_lowercase().as_str(),
+                    "done" | "cancelled" | "canceled" | "failed"
+                )
+            })
+            .unwrap_or_else(|| "active".to_owned());
         task.insert(
             "status".to_owned(),
-            Value::String(if archived { "archived" } else { "active" }.to_owned()),
+            Value::String(if archived {
+                "archived".to_owned()
+            } else {
+                restored_status
+            }),
         );
         task.remove("running");
         task.remove("thread_status");
-        task.remove("turn_status");
+        if !task
+            .get("turn_status")
+            .and_then(Value::as_str)
+            .is_some_and(is_terminal_turn_status)
+        {
+            task.remove("turn_status");
+        }
     }
+}
+
+fn is_terminal_turn_status(status: &str) -> bool {
+    matches!(
+        status.replace(['_', '-'], "").to_ascii_lowercase().as_str(),
+        "completed" | "done" | "failed" | "error" | "interrupted" | "cancelled" | "canceled"
+    )
 }
 
 fn index_file_signature(index_path: &Path) -> Option<IndexFileSignature> {
@@ -521,6 +555,47 @@ mod tests {
         assert!(!restored.running);
         assert_eq!(restored.thread_status, "notLoaded");
         assert_eq!(restored.turn_status, None);
+    }
+
+    #[test]
+    fn terminal_turn_status_persists_without_live_execution_state() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let index_path = directory.path().join("index.json");
+        let store = RuntimeWorkStore::new(index_path.clone());
+        let mut completed = RuntimeTaskLink::new_imported(
+            "completed-task".to_owned(),
+            "/tmp/completed".to_owned(),
+            "Completed task".to_owned(),
+            "codex".to_owned(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        );
+        completed.status = "done".to_owned();
+        completed.turn_status = Some("completed".to_owned());
+
+        store.upsert_task(completed);
+
+        let persisted: Value =
+            serde_json::from_slice(&fs::read(&index_path).expect("index should be readable"))
+                .expect("index should contain JSON");
+        let task = persisted["tasks"]["completed-task"]
+            .as_object()
+            .expect("completed task should be persisted");
+        assert!(!task.contains_key("status"));
+        assert!(!task.contains_key("running"));
+        assert!(!task.contains_key("thread_status"));
+        assert_eq!(
+            task.get("turn_status"),
+            Some(&Value::String("completed".to_owned()))
+        );
+
+        let restored = RuntimeWorkStore::new(index_path)
+            .get_task("completed-task")
+            .expect("completed task should be restored");
+        assert!(!restored.running);
+        assert_eq!(restored.status, "active");
+        assert_eq!(restored.thread_status, "notLoaded");
+        assert_eq!(restored.turn_status.as_deref(), Some("completed"));
     }
 
     #[test]

--- a/executor/src/runtime_work/store.rs
+++ b/executor/src/runtime_work/store.rs
@@ -104,6 +104,7 @@ impl RuntimeWorkStore {
     }
 
     pub fn mark_deleted_archived_task_ids(&self, task_ids: impl IntoIterator<Item = String>) {
+        self.refresh_index_from_disk_if_changed();
         let Some(mut index) = self.index.lock().ok() else {
             return;
         };
@@ -118,6 +119,7 @@ impl RuntimeWorkStore {
     }
 
     pub fn upsert_task(&self, link: RuntimeTaskLink) {
+        self.refresh_index_from_disk_if_changed();
         let Some(mut index) = self.index.lock().ok() else {
             return;
         };
@@ -133,12 +135,21 @@ impl RuntimeWorkStore {
         self.update_task_with_persistence(local_task_id, updater, true)
     }
 
+    pub fn update_task_execution_state(&self, runtime_state: &RuntimeTaskLink) {
+        self.update_task_with_persistence(
+            &runtime_state.local_task_id,
+            |task| task.copy_execution_state_from(runtime_state),
+            false,
+        );
+    }
+
     fn update_task_with_persistence(
         &self,
         local_task_id: &str,
         updater: impl FnOnce(&mut RuntimeTaskLink),
         persist: bool,
     ) -> Option<RuntimeTaskLink> {
+        self.refresh_index_from_disk_if_changed();
         let mut index = self.index.lock().ok()?;
         let task = index.tasks.get_mut(local_task_id)?;
         updater(task);
@@ -150,6 +161,7 @@ impl RuntimeWorkStore {
     }
 
     pub fn delete_task(&self, local_task_id: &str) -> Option<RuntimeTaskLink> {
+        self.refresh_index_from_disk_if_changed();
         let mut index = self.index.lock().ok()?;
         let removed = index.tasks.remove(local_task_id)?;
         self.write_index(&index);
@@ -163,7 +175,7 @@ impl RuntimeWorkStore {
         let now_ms = current_time_ms();
         let mut deleted_archived_task_ids = index.deleted_archived_task_ids.clone();
         prune_deleted_archived_task_ids(&mut deleted_archived_task_ids, now_ms);
-        let payload = serde_json::to_vec(&RuntimeWorkIndex {
+        let payload = serialize_index(&RuntimeWorkIndex {
             version: INDEX_VERSION,
             tasks: index.tasks.clone(),
             workspaces: index.workspaces.clone(),
@@ -192,8 +204,13 @@ impl RuntimeWorkStore {
             return;
         }
 
-        let disk_index = read_index_from_path(&self.index_path);
+        let mut disk_index = read_index_from_path(&self.index_path);
         if let Ok(mut index) = self.index.lock() {
+            for (task_id, disk_task) in &mut disk_index.tasks {
+                if let Some(current_task) = index.tasks.get(task_id) {
+                    disk_task.preserve_runtime_state_from(current_task);
+                }
+            }
             *index = disk_index;
         }
         if let Ok(mut signature) = self.index_signature.lock() {
@@ -219,7 +236,67 @@ fn read_index_from_path(index_path: &Path) -> RuntimeWorkIndex {
     let Ok(content) = fs::read_to_string(index_path) else {
         return empty_index();
     };
-    serde_json::from_str::<RuntimeWorkIndex>(&content).unwrap_or_else(|_| empty_index())
+    let Ok(mut value) = serde_json::from_str::<Value>(&content) else {
+        return empty_index();
+    };
+    restore_persisted_task_metadata(&mut value);
+    serde_json::from_value::<RuntimeWorkIndex>(value).unwrap_or_else(|_| empty_index())
+}
+
+fn serialize_index(index: &RuntimeWorkIndex) -> Result<Vec<u8>, serde_json::Error> {
+    let mut value = serde_json::to_value(index)?;
+    strip_transient_task_state(&mut value);
+    serde_json::to_vec(&value)
+}
+
+fn strip_transient_task_state(index: &mut Value) {
+    for task in index
+        .get_mut("tasks")
+        .and_then(Value::as_object_mut)
+        .into_iter()
+        .flat_map(|tasks| tasks.values_mut())
+    {
+        let Some(task) = task.as_object_mut() else {
+            continue;
+        };
+        let archived = task
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| status.eq_ignore_ascii_case("archived"));
+        task.remove("status");
+        task.remove("running");
+        task.remove("thread_status");
+        task.remove("turn_status");
+        task.insert("archived".to_owned(), Value::Bool(archived));
+    }
+}
+
+fn restore_persisted_task_metadata(index: &mut Value) {
+    for task in index
+        .get_mut("tasks")
+        .and_then(Value::as_object_mut)
+        .into_iter()
+        .flat_map(|tasks| tasks.values_mut())
+    {
+        let Some(task) = task.as_object_mut() else {
+            continue;
+        };
+        let archived = task
+            .remove("archived")
+            .and_then(|value| value.as_bool())
+            .unwrap_or_else(|| {
+                task.get("status")
+                    .and_then(Value::as_str)
+                    .is_some_and(|status| status.eq_ignore_ascii_case("archived"))
+            });
+        task.insert(
+            "status".to_owned(),
+            Value::String(if archived { "archived" } else { "active" }.to_owned()),
+        );
+        task.remove("running");
+        task.remove("thread_status");
+        task.remove("turn_status");
+    }
 }
 
 fn index_file_signature(index_path: &Path) -> Option<IndexFileSignature> {
@@ -335,4 +412,140 @@ fn expand_home(value: impl AsRef<str>) -> PathBuf {
 
 fn home_dir() -> PathBuf {
     dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_index_reload_preserves_process_local_running_state() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let index_path = directory.path().join("index.json");
+        let owner_store = RuntimeWorkStore::new(index_path.clone());
+        let peer_store = RuntimeWorkStore::new(index_path.clone());
+
+        owner_store.upsert_task(RuntimeTaskLink::new_pending(
+            "owner-task".to_owned(),
+            "/tmp/owner".to_owned(),
+            "Owner task".to_owned(),
+        ));
+        peer_store.upsert_task(RuntimeTaskLink::new_imported(
+            "peer-task".to_owned(),
+            "/tmp/peer".to_owned(),
+            "Peer task".to_owned(),
+            "codex".to_owned(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        ));
+
+        let owner_task = owner_store
+            .get_task("owner-task")
+            .expect("owner task should survive peer writes");
+        assert!(owner_task.running);
+        assert_eq!(owner_task.status, "running");
+        assert_eq!(owner_task.thread_status, "active");
+        assert_eq!(owner_task.turn_status.as_deref(), Some("inProgress"));
+
+        let persisted: Value = serde_json::from_slice(
+            &fs::read(&index_path).expect("shared index should be readable"),
+        )
+        .expect("shared index should contain JSON");
+        let persisted_owner = persisted["tasks"]["owner-task"]
+            .as_object()
+            .expect("owner task should be persisted");
+        assert!(!persisted_owner.contains_key("running"));
+        assert!(!persisted_owner.contains_key("status"));
+        assert!(!persisted_owner.contains_key("thread_status"));
+        assert!(!persisted_owner.contains_key("turn_status"));
+        assert_eq!(persisted_owner.get("archived"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn shared_index_reload_preserves_process_local_inactive_execution_state() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let index_path = directory.path().join("index.json");
+        let owner_store = RuntimeWorkStore::new(index_path.clone());
+        let peer_store = RuntimeWorkStore::new(index_path);
+        let mut owner_task = RuntimeTaskLink::new_pending(
+            "owner-task".to_owned(),
+            "/tmp/owner".to_owned(),
+            "Owner task".to_owned(),
+        );
+
+        owner_store.upsert_task(owner_task.clone());
+        owner_task.status = "done".to_owned();
+        owner_task.running = false;
+        owner_task.thread_status = "idle".to_owned();
+        owner_task.turn_status = Some("completed".to_owned());
+        owner_store.update_task_execution_state(&owner_task);
+        peer_store.upsert_task(RuntimeTaskLink::new_imported(
+            "peer-task".to_owned(),
+            "/tmp/peer".to_owned(),
+            "Peer task".to_owned(),
+            "codex".to_owned(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        ));
+
+        let reloaded = owner_store
+            .get_task("owner-task")
+            .expect("owner task should survive peer writes");
+        assert_eq!(reloaded.status, "done");
+        assert!(!reloaded.running);
+        assert_eq!(reloaded.thread_status, "idle");
+        assert_eq!(reloaded.turn_status.as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn persisted_archive_metadata_restores_without_task_status_fields() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let index_path = directory.path().join("index.json");
+        let store = RuntimeWorkStore::new(index_path.clone());
+        let mut archived = RuntimeTaskLink::new_imported(
+            "archived-task".to_owned(),
+            "/tmp/archived".to_owned(),
+            "Archived task".to_owned(),
+            "codex".to_owned(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        );
+        archived.status = "archived".to_owned();
+
+        store.upsert_task(archived);
+
+        let restored = RuntimeWorkStore::new(index_path)
+            .get_task("archived-task")
+            .expect("archived task should be restored");
+        assert_eq!(restored.status, "archived");
+        assert!(!restored.running);
+        assert_eq!(restored.thread_status, "notLoaded");
+        assert_eq!(restored.turn_status, None);
+    }
+
+    #[test]
+    fn legacy_archived_status_migrates_to_archive_metadata() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let index_path = directory.path().join("index.json");
+        fs::write(
+            &index_path,
+            serde_json::to_vec(&serde_json::json!({
+                "version": 1,
+                "tasks": {
+                    "legacy-task": {
+                        "local_task_id": "legacy-task",
+                        "status": "archived"
+                    }
+                },
+                "workspaces": {}
+            }))
+            .expect("legacy index should serialize"),
+        )
+        .expect("legacy index should be written");
+
+        let restored = RuntimeWorkStore::new(index_path)
+            .get_task("legacy-task")
+            .expect("legacy archived task should be restored");
+        assert_eq!(restored.status, "archived");
+    }
 }

--- a/executor/tests/app_runtime_work_native_update_contract.rs
+++ b/executor/tests/app_runtime_work_native_update_contract.rs
@@ -268,7 +268,7 @@ async fn runtime_task_list_ignores_persisted_running_state_when_thread_is_missin
 }
 
 #[tokio::test]
-async fn runtime_task_list_preserves_local_failed_state_when_codex_thread_is_idle() {
+async fn runtime_task_list_ignores_persisted_failed_state_when_codex_thread_is_idle() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-local-failed-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -321,11 +321,11 @@ async fn runtime_task_list_preserves_local_failed_state_when_codex_thread_is_idl
         .find(|task| task["taskId"] == "local-failed-running-rollout")
         .unwrap();
 
-    assert_eq!(locally_failed["status"], "failed");
+    assert_eq!(locally_failed["status"], "active");
     assert_eq!(locally_failed["running"], false);
     assert_eq!(locally_failed["continuable"], true);
     assert_eq!(locally_failed["threadStatus"], "idle");
-    assert_eq!(locally_failed["turnStatus"], "failed");
+    assert_eq!(locally_failed["turnStatus"], json!(null));
 }
 
 fn write_fake_codex(log_path: &Path) -> PathBuf {

--- a/executor/tests/app_runtime_work_native_update_contract.rs
+++ b/executor/tests/app_runtime_work_native_update_contract.rs
@@ -268,7 +268,7 @@ async fn runtime_task_list_ignores_persisted_running_state_when_thread_is_missin
 }
 
 #[tokio::test]
-async fn runtime_task_list_ignores_persisted_failed_state_when_codex_thread_is_idle() {
+async fn runtime_task_list_preserves_local_failed_state_when_codex_thread_is_idle() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-local-failed-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -321,11 +321,11 @@ async fn runtime_task_list_ignores_persisted_failed_state_when_codex_thread_is_i
         .find(|task| task["taskId"] == "local-failed-running-rollout")
         .unwrap();
 
-    assert_eq!(locally_failed["status"], "active");
+    assert_eq!(locally_failed["status"], "failed");
     assert_eq!(locally_failed["running"], false);
     assert_eq!(locally_failed["continuable"], true);
     assert_eq!(locally_failed["threadStatus"], "idle");
-    assert_eq!(locally_failed["turnStatus"], json!(null));
+    assert_eq!(locally_failed["turnStatus"], "failed");
 }
 
 fn write_fake_codex(log_path: &Path) -> PathBuf {


### PR DESCRIPTION
## What changed

- keep `status`, `running`, `thread_status`, and non-terminal `turn_status` out of the shared runtime task index
- retain terminal `turn_status` values as durable turn history without treating them as live execution state
- derive local execution state from each executor process's active-task memory
- preserve process-local execution state when another Wework process updates the shared index
- persist archive intent separately as `archived` metadata and migrate legacy `status: archived` entries on read
- refresh the shared index before mutations to avoid overwriting changes from another process

## Why

Production and development Wework processes can share the same runtime task index. Persisted execution status allowed one process to overwrite another process's live `running` state, so a running task could briefly appear completed until opening the task caused the live state to be derived again.

Live execution status is process-local runtime state and must not be persisted or accepted from another process. Terminal turn outcomes remain durable history for completed, failed, interrupted, or cancelled turns.

## Impact

Running and terminal task presentation remains stable within the owning Wework process when another process writes the shared task index. Archive state remains durable and compatible with existing index files.

## Validation

- `cargo fmt --manifest-path executor/Cargo.toml -- --check`
- `cargo test --manifest-path executor/Cargo.toml --lib runtime_work::` (201 passed)
- `cargo test --manifest-path executor/Cargo.toml --lib` (590 passed, 1 ignored)
- `cargo test --manifest-path executor/Cargo.toml` (all unit and integration tests passed)
- `node wework/e2e/desktop/run-checkpoints.mjs --segment core-task-flow`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task status synchronization during local execution.
  - Fixed running and stopped task states so displayed statuses remain accurate across updates and reloads.
  - Preserved execution progress while refreshing task metadata, reducing unintended state resets.
  - Corrected task action checks to recognize active tasks consistently.
  - Improved restoration of archived task status, including compatibility with previously saved task data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->