### PR TITLE
fix(wework): resize images for non-official models

### DIFF
--- a/docs/en/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/en/wework/developer-guide/wework-codex-plugins.md
@@ -55,6 +55,10 @@ The interaction style uses the same `config.toml` as its single source of truth.
 
 Wework requests the model catalog from the Codex app-server's `model/list` method through the local executor, then uses the returned provider and model array order unchanged in the model picker. The frontend does not reorder official or default models or custom providers, and does not add models that Codex did not return. The request uses `includeHidden: false`, so models Codex marks as hidden are not displayed.
 
+### Image Attachment Preprocessing
+
+Wework includes the current model category in local runtime requests. Official Codex models receive the original image. Codex providers, local model interfaces, and cloud models are treated as non-official models; before sending an image, the executor creates a temporary model-input file and proportionally reduces the image's short edge to at most `720px`. The long edge is not capped, so panoramic and long screenshots preserve their full aspect ratio instead of being forced into a fixed `1280×720` box. Images whose short edge is already at most `720px` remain unchanged. The original attachment, transcript, and preview URL are never rewritten. Temporary model-input files exist only for the current turn and are removed after it finishes.
+
 ## Chat Runtime
 
 When a user selects a skill, app, or plugin in the composer, the editor inserts an indivisible inline mention. The cursor can only stop before or after the mention; copy and submit serialize it as Codex app-server-compatible Markdown:

--- a/docs/zh/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-codex-plugins.md
@@ -55,6 +55,10 @@ executor 在启动 Codex app-server 前会解析并规范化 Wework Codex home �
 
 Wework 通过本机 executor 请求 Codex app-server 的 `model/list` 获取模型目录，并将返回的 provider 和模型数组顺序原样用于模型选择器。前端不会重排官方模型、默认模型或自定义 provider，也不会补充未由 Codex 返回的模型。请求使用 `includeHidden: false`，因此 Codex 标记为隐藏的模型不会显示。
 
+### 图片附件预处理
+
+Wework 会把当前模型类别写入本地运行时请求。Codex 官方模型直接接收原始图片；Codex provider、本地模型接口和云端模型属于非官方模型，executor 在发送图片前会生成临时的模型输入文件，并把图片短边等比缩小到最多 `720px`。长边不设上限，因此超长截图会保留完整长边比例，而不会被强制塞入固定的 `1280×720` 边界。短边本来不超过 `720px` 的图片保持原样；原始附件、聊天记录和预览地址都不会被改写。临时输入文件只在当前 turn 使用，并在 turn 结束后清理。
+
 ## 对话运行时
 
 用户在输入框中选择 skill、app 或插件时，编辑器插入不可拆分的行内 mention。光标只能停在 mention 前后；复制或提交时，编辑器会把 mention 序列化为 Codex app-server 支持的 markdown 输入：

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -26,7 +26,7 @@ use tokio::{
 use crate::{
     agents::{runtime_capabilities, task_identity::task_identity_env},
     attachments::{process_prompt, AttachmentPromptProcessor, AttachmentRecord},
-    image_preprocessor::prepare_image_bytes_for_model,
+    image_preprocessor::prepare_image_bytes_for_model_with_short_edge_limit,
     logging::{log_executor_event, task_fields},
     process_environment,
     protocol::ExecutionRequest,
@@ -45,6 +45,7 @@ const DEFAULT_CODEX_TURN_STARTUP_TIMEOUT_SECONDS: u64 = 180;
 const DEFAULT_PROVIDER_ID: &str = "wecode-openai";
 pub const CODEX_APP_SERVER_TURN_CANCELLED: &str = "codex app-server turn cancelled";
 const DEFAULT_REASONING_EFFORT: &str = "medium";
+const NON_OFFICIAL_MODEL_IMAGE_SHORT_EDGE: u32 = 720;
 const DEFAULT_NO_PROXY: &str = "localhost,127.0.0.1,::1,host.docker.internal";
 const EXECUTOR_INTERNAL_ENV_KEYS: &[&str] = &[
     "WEGENT_EXECUTOR_BINARY",
@@ -3287,6 +3288,7 @@ fn prepare_codex_execution_request(mut request: ExecutionRequest) -> PreparedCod
     let mut success = Vec::new();
     let mut failed = Vec::new();
     let mut local_images = Vec::new();
+    let resize_images = !is_official_codex_model(&request.model_config);
     for attachment in attachments {
         if let Some(local_path) = attachment
             .local_path
@@ -3302,6 +3304,7 @@ fn prepare_codex_execution_request(mut request: ExecutionRequest) -> PreparedCod
                         .mime_type
                         .as_deref()
                         .unwrap_or("image/png"),
+                    resize_images,
                     &mut generated_files,
                 )
                 .unwrap_or_else(|| local_path.to_owned());
@@ -3419,10 +3422,18 @@ fn is_image_attachment(attachment: &AttachmentRecord) -> bool {
 fn prepare_local_image_path(
     path: &str,
     mime_type: &str,
+    resize: bool,
     generated_files: &mut Vec<PathBuf>,
 ) -> Option<String> {
+    if !resize {
+        return Some(path.to_owned());
+    }
     let image_data = fs::read(path).ok()?;
-    let prepared = prepare_image_bytes_for_model(&image_data, mime_type, None);
+    let prepared = prepare_image_bytes_for_model_with_short_edge_limit(
+        &image_data,
+        mime_type,
+        NON_OFFICIAL_MODEL_IMAGE_SHORT_EDGE,
+    );
     if !prepared.resized {
         return Some(path.to_owned());
     }
@@ -3433,6 +3444,12 @@ fn prepare_local_image_path(
     }
     generated_files.push(output_path.clone());
     Some(output_path.display().to_string())
+}
+
+fn is_official_codex_model(model_config: &Value) -> bool {
+    non_empty_config(model_config, "wework_model_kind")
+        .or_else(|| non_empty_config(model_config, "weworkModelKind"))
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("codex-official"))
 }
 
 fn model_input_image_path(path: &Path, mime_type: &str) -> PathBuf {

--- a/executor/src/image_preprocessor.rs
+++ b/executor/src/image_preprocessor.rs
@@ -22,6 +22,29 @@ pub fn prepare_image_bytes_for_model(
     mime_type: &str,
     max_long_edge: Option<u32>,
 ) -> PreparedModelImage {
+    let max_long_edge = max_long_edge.unwrap_or(MAX_MODEL_IMAGE_LONG_EDGE);
+    prepare_image_bytes_for_model_with_limits(
+        image_data,
+        mime_type,
+        Some(max_long_edge),
+        max_long_edge,
+    )
+}
+
+pub fn prepare_image_bytes_for_model_with_short_edge_limit(
+    image_data: &[u8],
+    mime_type: &str,
+    max_short_edge: u32,
+) -> PreparedModelImage {
+    prepare_image_bytes_for_model_with_limits(image_data, mime_type, None, max_short_edge)
+}
+
+fn prepare_image_bytes_for_model_with_limits(
+    image_data: &[u8],
+    mime_type: &str,
+    max_long_edge: Option<u32>,
+    max_short_edge: u32,
+) -> PreparedModelImage {
     if image_data.is_empty() {
         return unchanged(image_data, mime_type);
     }
@@ -35,8 +58,8 @@ pub fn prepare_image_bytes_for_model(
         return unchanged(image_data, &input_mime);
     };
     let original_size = image.dimensions();
-    let max_long_edge = max_long_edge.unwrap_or(MAX_MODEL_IMAGE_LONG_EDGE);
-    let needs_resize = original_size.0.max(original_size.1) > max_long_edge;
+    let needs_resize = original_size.0.min(original_size.1) > max_short_edge
+        || max_long_edge.is_some_and(|limit| original_size.0.max(original_size.1) > limit);
     let output_mime = output_mime(&input_mime, output_format);
     let needs_convert = output_mime != input_mime;
 
@@ -51,7 +74,12 @@ pub fn prepare_image_bytes_for_model(
     }
 
     if needs_resize {
-        image = image.thumbnail(max_long_edge, max_long_edge);
+        let bounds = if original_size.0 >= original_size.1 {
+            (max_long_edge.unwrap_or(original_size.0), max_short_edge)
+        } else {
+            (max_short_edge, max_long_edge.unwrap_or(original_size.1))
+        };
+        image = image.thumbnail(bounds.0, bounds.1);
     }
 
     let final_format = if input_mime == "image/gif" && needs_resize {

--- a/executor/tests/codex_attachment_input_contract.rs
+++ b/executor/tests/codex_attachment_input_contract.rs
@@ -99,6 +99,7 @@ async fn codex_app_server_replaces_downloaded_image_blocks_with_local_images() {
         model_config: json!({
             "model": "openai",
             "model_id": "gpt-5",
+            "wework_model_kind": "codex-official",
             "protocol": "openai-responses"
         }),
         ..ExecutionRequest::default()
@@ -166,6 +167,7 @@ async fn codex_app_server_keeps_failed_download_placeholder_order() {
         model_config: json!({
             "model": "openai",
             "model_id": "gpt-5",
+            "wework_model_kind": "codex-official",
             "protocol": "openai-responses"
         }),
         ..ExecutionRequest::default()
@@ -240,6 +242,7 @@ async fn codex_app_server_cleans_generated_model_input_images() {
         model_config: json!({
             "model": "openai",
             "model_id": "gpt-5",
+            "wework_model_kind": "codex-provider",
             "protocol": "openai-responses"
         }),
         ..ExecutionRequest::default()
@@ -286,6 +289,63 @@ async fn codex_app_server_cleans_generated_model_input_images() {
     );
     assert!(large_image.exists());
     assert!(!Path::new(&generated_path).exists());
+}
+
+#[tokio::test]
+async fn codex_app_server_keeps_official_model_images_at_original_size() {
+    let _lock = env_lock().await;
+    let workspace = unique_dir("codex-official-image");
+    let large_image = workspace.join("large.png");
+    fs::write(&large_image, png_bytes(3000, 1500)).unwrap();
+    let log_path = workspace.join("codex-rpc.jsonl");
+    let fake_codex = write_fake_codex(&log_path);
+    let engine = CodexAppServerEngine::new(fake_codex.display().to_string());
+    let mut request = ExecutionRequest {
+        task_id: "29".to_owned(),
+        subtask_id: "44".to_owned(),
+        auth_token: Some("token".to_owned()),
+        prompt: json!([
+            {"type": "input_text", "text": "Analyze this image"},
+            {"type": "input_image", "image_url": "data:image/png;base64,abc"}
+        ]),
+        bot: json!([{"shell_type": "ClaudeCode"}]),
+        model_config: json!({
+            "model": "openai",
+            "model_id": "gpt-5",
+            "wework_model_kind": "codex-official",
+            "protocol": "openai-responses"
+        }),
+        ..ExecutionRequest::default()
+    };
+    request.extra.insert(
+        "attachments".to_owned(),
+        json!([{
+            "id": 15,
+            "original_filename": "large.png",
+            "mime_type": "image/png",
+            "file_size": fs::metadata(&large_image).unwrap().len(),
+            "subtask_id": 43,
+            "local_path": large_image
+        }]),
+    );
+
+    let outcome = engine.run(request).await;
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "done".to_owned()
+        }
+    );
+    let messages = read_json_lines(&log_path);
+    assert_eq!(
+        messages[3]["params"]["input"][1]["path"],
+        large_image.display().to_string()
+    );
+    assert_eq!(
+        png_dimensions(&fs::read(&large_image).unwrap()),
+        Some((3000, 1500))
+    );
 }
 
 fn png_bytes(width: u32, height: u32) -> Vec<u8> {

--- a/executor/tests/image_preprocessor_contract.rs
+++ b/executor/tests/image_preprocessor_contract.rs
@@ -8,7 +8,9 @@ use image::{
     codecs::gif::{GifEncoder, Repeat},
     DynamicImage, Frame, ImageBuffer, ImageFormat, Rgb, Rgba,
 };
-use wegent_executor::image_preprocessor::prepare_image_bytes_for_model;
+use wegent_executor::image_preprocessor::{
+    prepare_image_bytes_for_model, prepare_image_bytes_for_model_with_short_edge_limit,
+};
 
 fn image_bytes(format: ImageFormat, size: (u32, u32)) -> Vec<u8> {
     let image = ImageBuffer::from_pixel(size.0, size.1, Rgb([32, 144, 208]));
@@ -69,4 +71,52 @@ fn animated_gif_resize_outputs_first_frame_as_png() {
     assert_eq!(prepared.mime_type, "image/png");
     assert_eq!(png_dimensions(&prepared.data), (128, 64));
     assert!(prepared.resized);
+}
+
+#[test]
+fn short_edge_limit_resizes_landscape_and_portrait_images() {
+    let landscape = prepare_image_bytes_for_model_with_short_edge_limit(
+        &image_bytes(ImageFormat::Png, (3000, 2000)),
+        "image/png",
+        720,
+    );
+    let portrait = prepare_image_bytes_for_model_with_short_edge_limit(
+        &image_bytes(ImageFormat::Png, (2000, 3000)),
+        "image/png",
+        720,
+    );
+
+    assert_eq!(landscape.size, Some((1080, 720)));
+    assert_eq!(portrait.size, Some((720, 1080)));
+    assert!(landscape.resized);
+    assert!(portrait.resized);
+}
+
+#[test]
+fn short_edge_limit_preserves_the_long_dimension_of_panorama_images() {
+    let panorama = prepare_image_bytes_for_model_with_short_edge_limit(
+        &image_bytes(ImageFormat::Png, (10_000, 1000)),
+        "image/png",
+        720,
+    );
+    let tall = prepare_image_bytes_for_model_with_short_edge_limit(
+        &image_bytes(ImageFormat::Png, (1000, 10_000)),
+        "image/png",
+        720,
+    );
+
+    assert_eq!(panorama.size, Some((7200, 720)));
+    assert_eq!(tall.size, Some((720, 7200)));
+}
+
+#[test]
+fn short_edge_limit_leaves_images_below_720p_unchanged() {
+    let original = image_bytes(ImageFormat::Png, (640, 360));
+    let prepared = prepare_image_bytes_for_model_with_short_edge_limit(&original, "image/png", 720);
+
+    assert_eq!(prepared.original_size, Some((640, 360)));
+    assert_eq!(prepared.size, Some((640, 360)));
+    assert_eq!(prepared.mime_type, "image/png");
+    assert!(!prepared.resized);
+    assert_eq!(prepared.data, original);
 }

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -605,6 +605,7 @@ describe('createLocalAppServices', () => {
         model_config: expect.objectContaining({
           model: 'openai',
           model_id: 'gpt-5',
+          wework_model_kind: 'codex-official',
           api_format: 'responses',
           protocol: 'openai-responses',
           runtime_config: {
@@ -1743,6 +1744,7 @@ describe('createLocalAppServices', () => {
       expect.objectContaining({
         model: 'openai',
         model_id: 'Doubao-Seed-2.0-pro-260215',
+        wework_model_kind: 'codex-provider',
         api_format: 'responses',
         protocol: 'openai-responses',
         model_provider: 'wecode-openai',

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -1719,6 +1719,7 @@ describe('createLocalAppServices', () => {
       modelOptions: {
         codexProviderId: 'wecode-openai',
         codexProviderName: 'wecode openai',
+        codexProviderType: 'provider',
       },
     })
     await services.runtimeWorkApi?.sendRuntimeMessage({
@@ -1732,6 +1733,7 @@ describe('createLocalAppServices', () => {
       modelOptions: {
         codexProviderId: 'wecode-openai',
         codexProviderName: 'wecode openai',
+        codexProviderType: 'provider',
       },
     })
 
@@ -1760,6 +1762,41 @@ describe('createLocalAppServices', () => {
     expect(createPayload.executionRequest.model_config).not.toHaveProperty('api_key')
     expect(sendPayload.executionRequest.model_config).toEqual(
       createPayload.executionRequest.model_config
+    )
+  })
+
+  test('keeps official Codex classification when OpenAI provider metadata is present', async () => {
+    const request = vi.fn().mockResolvedValue({ accepted: true })
+    const services = createLocalAppServices({
+      ensure: vi.fn().mockResolvedValue({ running: true, ready: true, deviceId: 'device-uuid' }),
+      request,
+      subscribe: vi.fn(),
+    })
+    await services.runtimeWorkApi?.sendRuntimeMessage({
+      address: {
+        deviceId: 'local-device',
+        workspacePath: '/Users/me/project',
+        taskId: 'task-1',
+      },
+      message: 'continue',
+      modelId: 'gpt-5.5',
+      modelOptions: {
+        codexProviderId: 'openai',
+        codexProviderName: 'OpenAI',
+        codexProviderType: 'official',
+      },
+    })
+
+    const sendPayload = request.mock.calls.find(([method]) => method === 'runtime.tasks.send')?.[1]
+
+    expect(sendPayload.executionRequest.model_config).toEqual(
+      expect.objectContaining({
+        model: 'openai',
+        model_id: 'gpt-5.5',
+        wework_model_kind: 'codex-official',
+        model_provider: 'openai',
+        provider_name: 'OpenAI',
+      })
     )
   })
 

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -832,6 +832,7 @@ function localRuntimeModelConfig(
     return {
       model: 'openai',
       model_id: localModel.modelId,
+      wework_model_kind: 'model-interface',
       codex_catalog_model_id: localModel.codexCatalogModelId || DEFAULT_GPT_56_CATALOG_MODEL_ID,
       api_format: RESPONSES_API_FORMAT,
       upstream_api_format: localModel.apiFormat,
@@ -883,6 +884,7 @@ function localRuntimeModelConfig(
     return {
       model: 'openai',
       model_id: modelName,
+      wework_model_kind: 'cloud',
       codex_catalog_model_id: DEFAULT_GPT_56_CATALOG_MODEL_ID,
       api_format: RESPONSES_API_FORMAT,
       upstream_api_format: upstreamApiFormat,
@@ -918,6 +920,7 @@ function localRuntimeModelConfig(
   return {
     model: 'openai',
     model_id: builtInCodexModelId(modelName),
+    wework_model_kind: codexProviderId ? 'codex-provider' : 'codex-official',
     api_format: RESPONSES_API_FORMAT,
     protocol: OPENAI_RESPONSES_PROTOCOL,
     ...(codexProviderId ? { model_provider: codexProviderId } : {}),

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -917,10 +917,11 @@ function localRuntimeModelConfig(
 
   const codexProviderId = modelOptions?.codexProviderId || modelOptions?.codex_model_provider
   const codexProviderName = modelOptions?.codexProviderName || modelOptions?.codex_provider_name
+  const codexProviderType = modelOptions?.codexProviderType || modelOptions?.codex_provider_type
   return {
     model: 'openai',
     model_id: builtInCodexModelId(modelName),
-    wework_model_kind: codexProviderId ? 'codex-provider' : 'codex-official',
+    wework_model_kind: codexProviderType === 'provider' ? 'codex-provider' : 'codex-official',
     api_format: RESPONSES_API_FORMAT,
     protocol: OPENAI_RESPONSES_PROTOCOL,
     ...(codexProviderId ? { model_provider: codexProviderId } : {}),

--- a/wework/src/features/workbench/runtimeModelSelection.test.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.test.ts
@@ -191,6 +191,7 @@ describe('runtimeModelSelection', () => {
         weworkModelKind: 'codex-provider',
         codexProviderId: 'wecode-openai',
         codexProviderName: 'wecode openai',
+        codexProviderType: 'provider',
         ui: { family: 'codex-provider', controls: ['speed'] },
       },
     }
@@ -245,6 +246,7 @@ describe('runtimeModelSelection', () => {
         weworkModelKind: 'codex-provider',
         codexProviderId: 'wecode-openai',
         codexProviderName: 'wecode openai',
+        codexProviderType: 'provider',
         ui: { family: 'codex-provider', controls: ['speed'] },
       },
     }
@@ -260,6 +262,7 @@ describe('runtimeModelSelection', () => {
         collaborationMode: 'default',
         codexProviderId: 'wecode-openai',
         codexProviderName: 'wecode openai',
+        codexProviderType: 'provider',
       },
     })
   })

--- a/wework/src/features/workbench/runtimeModelSelection.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.ts
@@ -129,8 +129,10 @@ export function selectedModelExecutionFields(
   }
   const codexProviderId = getRawStringConfigValue(selectedModel.config, 'codexProviderId')
   const codexProviderName = getRawStringConfigValue(selectedModel.config, 'codexProviderName')
+  const codexProviderType = getRawStringConfigValue(selectedModel.config, 'codexProviderType')
   if (codexProviderId) modelOptions.codexProviderId = codexProviderId
   if (codexProviderName) modelOptions.codexProviderName = codexProviderName
+  if (codexProviderType) modelOptions.codexProviderType = codexProviderType
   const executionModel = resolveModelExecutionSelection(selectedModel)
   if (
     executionModel.modelType === 'public' ||


### PR DESCRIPTION
## What changed

- classify Wework runtime models as official Codex or non-official before execution
- resize image attachments for non-official models so the short edge is at most 720 pixels
- keep the long edge unconstrained to preserve panoramic and long screenshots
- keep official Codex images and images already within the short-edge limit unchanged
- document the runtime image preprocessing behavior in Chinese and English

## Why

Third-party and custom model providers can receive unnecessarily large image inputs from Wework. A fixed 1280×720 bounding box would make long screenshots unreadable, so the executor now limits only the short edge while preserving the full aspect ratio.

The original attachment and preview remain untouched. The executor creates a temporary model-input image for the current turn and removes it after the turn completes.

## Validation

- `cargo test --test image_preprocessor_contract --test codex_attachment_input_contract`
- `pnpm --filter wework exec vitest run src/api/local/localServices.test.ts`
- `pnpm --filter wework exec prettier --check src/api/local/localServices.ts src/api/local/localServices.test.ts`
- `pnpm --filter wework exec eslint src/api/local/localServices.ts src/api/local/localServices.test.ts`
- `cargo fmt --manifest-path executor/Cargo.toml --check`
- isolated real-Tauri verification with `pnpm --filter wework ai:verify`
- pre-push Wework ESLint, TypeScript, unit tests
- pre-push Executor `cargo test --all-features --lib` and `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved image attachment handling for Codex models.
  * Official Codex models use original images.
  * Other models receive temporary images resized to a maximum 720-pixel short edge while preserving proportions.
  * Original attachments, previews, and chat records remain unchanged; temporary files are cleaned up after each turn.

* **Documentation**
  * Added English and Chinese guidance describing image preprocessing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->