### PR TITLE
fix(wework): persist Wegent webview storage

### DIFF
--- a/docs/en/wework/developer-guide/wework-embedded-browser.md
+++ b/docs/en/wework/developer-guide/wework-embedded-browser.md
@@ -69,6 +69,7 @@ Page-state polling owns the browser's actual URL, while the address field owns t
 ## WebView Compatibility
 
 - Browser WebViews use a fixed isolated data-store identifier and app data directory. They must not share Wework's main-interface sign-in storage, and the browser settings clear action only targets this store.
+- Wegent Agent application tabs in Tauri also use native child WebViews instead of cross-origin iframes. All application tabs share the same fixed data-store identifier, so the complete website storage for an origin, including every `localStorage` key, cookies, and IndexedDB, remains available after closing and reopening a tab or restarting the application. A tab label identifies only the WebView lifecycle; it does not partition storage. On macOS 14 and later, `data_store_identifier` selects the persistent `WKWebsiteDataStore`, while `data_directory` primarily serves other platforms. Do not mirror or restore page storage key by key in the Wework main interface.
 - Browser WebViews use a Safari-compatible User-Agent so websites do not treat a WebKit User-Agent without a browser product identifier as an unsupported client.
 - Popups, OAuth, SSO, and payment flows may use `window.open` or new-window navigation. Implementations should route them to a controlled browser window or explicitly hand them to the system; the Agent must not operate invisible hidden pages.
 - The download handler reads the download directory and ask-before-download preference. Cancelling the system save dialog must cancel that download.

--- a/docs/zh/wework/developer-guide/wework-embedded-browser.md
+++ b/docs/zh/wework/developer-guide/wework-embedded-browser.md
@@ -69,6 +69,7 @@ Agent 面向模型暴露的是浏览器动作工具，而不是底层 WebKit API
 ## WebView 兼容性
 
 - 浏览器 WebView 使用固定的独立数据存储标识和应用数据目录，不能与 Wework 主界面的登录存储混用。浏览器设置中的清理操作只作用于这个数据存储。
+- Tauri 中的 Wegent 智能体应用标签页也使用原生子 WebView，而不是跨源 iframe。所有应用标签共享同一个固定数据存储标识，因此同一来源的完整网站存储（包括全部 `localStorage` key、Cookie 和 IndexedDB）会在标签关闭、重新打开和应用重启后继续可用；标签 label 只标识 WebView 生命周期，不划分存储。macOS 14 及以上由 `data_store_identifier` 选择持久化 `WKWebsiteDataStore`，`data_directory` 主要服务其它平台。不要在 Wework 主界面逐 key 镜像或恢复页面存储。
 - 浏览器 WebView 使用 Safari 兼容 User-Agent，避免网站把缺少浏览器产品标识的 WebKit User-Agent 识别为不受支持的客户端。
 - 弹窗、OAuth、SSO 和支付流程可能通过 `window.open` 或新窗口导航触发。实现应把它们路由到受控浏览器窗口或明确交给外部系统处理，不能让 Agent 不可见地操作隐藏页面。
 - 下载处理器从应用偏好读取下载目录和“下载前询问”开关；取消系统保存对话框必须取消本次下载。

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -3630,64 +3630,128 @@ async function verifyWorkspaceTabIsolation(control) {
 
   const firstAgentId = initialAgentIds[0].slice('workspace-tab-'.length)
   const firstAgentContent = `[data-testid="workspace-tab-content-${firstAgentId}"]`
-  const firstAgentIframe = `${firstAgentContent} [data-testid="app-iframe-wegent"]`
+  const firstAgentWebview = `${firstAgentContent} [data-testid="app-iframe-wegent"]`
   await control.command('click', `[data-testid="workspace-tab-select-${firstAgentId}"]`)
-  await control.command('waitFor', firstAgentIframe, {
+  await control.command('waitFor', firstAgentWebview, {
     visible: true,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   assert.equal(
-    await control.command('getAttribute', firstAgentIframe, {
+    await control.command('getAttribute', firstAgentWebview, {
       value: 'data-workspace-tab-id',
     }),
     firstAgentId,
-    'The first Agent iframe was not bound to its tab identity'
+    'The first Agent webview was not bound to its tab identity'
   )
+  const agentStorageKey = 'wework-e2e-agent-storage'
+  const agentStorageValue = `persisted-${Date.now()}`
+  await control.command('setEmbeddedBrowserLocalStorageItem', 'body', {
+    value: JSON.stringify({
+      key: agentStorageKey,
+      label: `app-wegent-${firstAgentId}`,
+      value: agentStorageValue,
+    }),
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  assert.equal(
+    await control.command('getEmbeddedBrowserLocalStorageItem', 'body', {
+      value: JSON.stringify({
+        key: agentStorageKey,
+        label: `app-wegent-${firstAgentId}`,
+      }),
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    }),
+    agentStorageValue,
+    'The first Agent webview did not retain its localStorage write'
+  )
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 3000))
+  await control.command('click', `[data-testid="workspace-tab-close-${firstAgentId}"]`)
+  await waitForSnapshot(
+    control,
+    snapshot => !snapshot.testIds.includes(`workspace-tab-${firstAgentId}`),
+    'Closing the first Agent tab did not remove its webview host'
+  )
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 1500))
 
   await control.command('click', '[data-testid="workspace-tab-add"]')
   await control.command('click', '[data-testid="workspace-tab-add-agent"]')
   const withSecondAgent = await waitForSnapshot(
     control,
-    snapshot => workspaceTabIds(snapshot, 'agent').length === 2,
-    'The explicit new-Agent action did not create a second tab'
+    snapshot => workspaceTabIds(snapshot, 'agent').length === 1,
+    'The explicit new-Agent action did not reopen an Agent tab'
   )
-  const secondAgentTestId = workspaceTabIds(withSecondAgent, 'agent').find(
-    testId => !initialAgentIds.includes(testId)
-  )
+  const secondAgentTestId = workspaceTabIds(withSecondAgent, 'agent')[0]
   assert.ok(secondAgentTestId, 'The second Agent tab identity was not observable')
   const secondAgentId = secondAgentTestId.slice('workspace-tab-'.length)
   const secondAgentContent = `[data-testid="workspace-tab-content-${secondAgentId}"]`
-  const secondAgentIframe = `${secondAgentContent} [data-testid="app-iframe-wegent"]`
-  await control.command('waitFor', secondAgentIframe, {
+  const secondAgentWebview = `${secondAgentContent} [data-testid="app-iframe-wegent"]`
+  await control.command('waitFor', secondAgentWebview, {
     visible: true,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   assert.equal(
-    await control.command('getAttribute', secondAgentIframe, {
+    await control.command('getAttribute', secondAgentWebview, {
       value: 'data-workspace-tab-id',
     }),
     secondAgentId,
-    'The second Agent tab reused the first iframe identity'
+    'The second Agent tab reused the first webview identity'
+  )
+  assert.equal(
+    await control.command('getEmbeddedBrowserLocalStorageItem', 'body', {
+      value: JSON.stringify({
+        key: agentStorageKey,
+        label: `app-wegent-${secondAgentId}`,
+      }),
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    }),
+    agentStorageValue,
+    'Reopening Wegent did not restore its persisted localStorage'
+  )
+
+  await control.command('click', '[data-testid="workspace-tab-add"]')
+  await control.command('click', '[data-testid="workspace-tab-add-agent"]')
+  const withThirdAgent = await waitForSnapshot(
+    control,
+    snapshot => workspaceTabIds(snapshot, 'agent').length === 2,
+    'The explicit new-Agent action did not create an independent Agent tab'
+  )
+  const thirdAgentTestId = workspaceTabIds(withThirdAgent, 'agent').find(
+    testId => testId !== secondAgentTestId
+  )
+  assert.ok(thirdAgentTestId, 'The third Agent tab identity was not observable')
+  const thirdAgentId = thirdAgentTestId.slice('workspace-tab-'.length)
+  const thirdAgentContent = `[data-testid="workspace-tab-content-${thirdAgentId}"]`
+  const thirdAgentWebview = `${thirdAgentContent} [data-testid="app-iframe-wegent"]`
+  await control.command('waitFor', thirdAgentWebview, {
+    visible: true,
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  assert.equal(
+    await control.command('getAttribute', thirdAgentWebview, {
+      value: 'data-workspace-tab-id',
+    }),
+    thirdAgentId,
+    'The third Agent tab reused the reopened webview identity'
   )
   const agentSnapshot = JSON.parse(await control.command('snapshot', 'body'))
   assert.ok(
-    agentSnapshot.testIds.includes(`workspace-tab-content-${firstAgentId}`) &&
-      agentSnapshot.testIds.includes(`workspace-tab-content-${secondAgentId}`),
-    'Switching Agent tabs unmounted one of the iframe instances'
+    agentSnapshot.testIds.includes(`workspace-tab-content-${secondAgentId}`) &&
+      agentSnapshot.testIds.includes(`workspace-tab-content-${thirdAgentId}`),
+    'Switching Agent tabs unmounted one of the webview hosts'
   )
-  await control.command('click', `[data-testid="workspace-tab-select-${firstAgentId}"]`)
-  await control.command('waitFor', firstAgentIframe, {
+  await control.command('click', `[data-testid="workspace-tab-select-${secondAgentId}"]`)
+  await control.command('waitFor', secondAgentWebview, {
     visible: true,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   assert.equal(
-    await control.command('getAttribute', secondAgentIframe, {
+    await control.command('getAttribute', thirdAgentWebview, {
       value: 'data-workspace-tab-id',
     }),
-    secondAgentId,
-    'The hidden Agent iframe was recreated or detached after switching tabs'
+    thirdAgentId,
+    'The hidden Agent webview host was recreated or detached after switching tabs'
   )
-  await captureVerificationScreenshot(control, 'workspace-tabs-isolation-03-agent-iframes.png')
+  await captureVerificationScreenshot(control, 'workspace-tabs-isolation-03-agent-webviews.png')
 
   await control.command('click', `[data-testid="workspace-tab-select-${firstTaskId}"]`)
   await control.command('waitFor', `${firstTaskContent} [data-testid="plugins-button"]`, {
@@ -7931,7 +7995,7 @@ class DesktopE2EServer {
       return
     }
 
-    if (request.method === 'GET' && url.pathname === '/') {
+    if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/login/oidc')) {
       response.writeHead(200, {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'no-store',

--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -5,6 +5,22 @@ import './i18n'
 import App from './App'
 import { saveStoredCloudConnection } from '@/features/cloud-connection/cloudConnectionStorage'
 
+const embeddedBrowserMocks = vi.hoisted(() => ({
+  closeEmbeddedBrowser: vi.fn().mockResolvedValue(undefined),
+  navigateEmbeddedBrowser: vi.fn().mockResolvedValue(undefined),
+  openEmbeddedBrowser: vi.fn().mockResolvedValue({
+    nativeLabel: 'embedded-browser-native-1',
+    title: null,
+    url: 'https://app.example.com',
+  }),
+  setEmbeddedBrowserBounds: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/embedded-browser', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/embedded-browser')>()),
+  ...embeddedBrowserMocks,
+}))
+
 vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: () => ({
     startDragging: vi.fn(),
@@ -266,7 +282,7 @@ describe('App center route', () => {
     render(<App />)
 
     expect(await screen.findByTestId('app-iframe-wegent')).toHaveAttribute(
-      'src',
+      'data-src',
       'https://app.example.com/login/oidc?access_token=cloud-token&token_type=bearer&login_success=true'
     )
   })

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -270,6 +270,7 @@ function WorkspaceTabSurface({
           {renderedIframe ? (
             <div className={cn('h-full', !iframe && 'hidden')} aria-hidden={!iframe}>
               <AppIframe
+                active={active && Boolean(iframe)}
                 src={renderedIframe.src}
                 title={renderedIframe.title}
                 workspaceTabId={tab.id}

--- a/wework/src/components/topnav/AppIframe.test.tsx
+++ b/wework/src/components/topnav/AppIframe.test.tsx
@@ -1,11 +1,37 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
+import { StrictMode } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { AppIframe } from './AppIframe'
 
+const embeddedBrowserMocks = vi.hoisted(() => ({
+  closeEmbeddedBrowser: vi.fn().mockResolvedValue(undefined),
+  navigateEmbeddedBrowser: vi.fn().mockResolvedValue(undefined),
+  openEmbeddedBrowser: vi.fn().mockResolvedValue({
+    nativeLabel: 'embedded-browser-native-1',
+    title: null,
+    url: 'http://localhost:3000',
+  }),
+  setEmbeddedBrowserBounds: vi.fn().mockResolvedValue(undefined),
+}))
+const runtimeMocks = vi.hoisted(() => ({
+  isTauriRuntime: vi.fn(() => false),
+}))
+
+vi.mock('@/lib/embedded-browser', () => embeddedBrowserMocks)
+vi.mock('@/lib/runtime-environment', () => runtimeMocks)
+
 describe('AppIframe', () => {
+  beforeEach(() => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(false)
+    embeddedBrowserMocks.closeEmbeddedBrowser.mockClear()
+    embeddedBrowserMocks.navigateEmbeddedBrowser.mockClear()
+    embeddedBrowserMocks.openEmbeddedBrowser.mockClear()
+    embeddedBrowserMocks.setEmbeddedBrowserBounds.mockClear()
+  })
+
   test('renders iframe with src and title', () => {
     render(<AppIframe src="http://localhost:3000" title="Wegent" />)
-    const iframe = screen.getByTestId('app-iframe-wegent')
+    const iframe = screen.getByTitle('Wegent')
     expect(iframe).toBeInTheDocument()
     expect(iframe).toHaveAttribute('src', 'http://localhost:3000')
     expect(iframe).toHaveAttribute('title', 'Wegent')
@@ -18,23 +44,170 @@ describe('AppIframe', () => {
 
   test('hides loading on iframe load', () => {
     render(<AppIframe src="http://localhost:3000" title="Wegent" />)
-    const iframe = screen.getByTestId('app-iframe-wegent')
+    const iframe = screen.getByTitle('Wegent')
     fireEvent.load(iframe)
     expect(screen.queryByText('Loading Wegent...')).not.toBeInTheDocument()
   })
 
   test('has sandbox attribute for security', () => {
     render(<AppIframe src="http://localhost:3000" title="Wegent" />)
-    const iframe = screen.getByTestId('app-iframe-wegent')
+    const iframe = screen.getByTitle('Wegent')
     expect(iframe).toHaveAttribute('sandbox')
   })
 
   test('allows popup links to escape the iframe sandbox', () => {
     render(<AppIframe src="http://localhost:3000" title="Wegent" />)
-    const iframe = screen.getByTestId('app-iframe-wegent')
+    const iframe = screen.getByTitle('Wegent')
     expect(iframe).toHaveAttribute(
       'sandbox',
       expect.stringContaining('allow-popups-to-escape-sandbox')
     )
+  })
+
+  test('uses a persistent native webview in Tauri', async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true)
+    const boundsSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 620,
+      height: 600,
+      left: 10,
+      right: 810,
+      top: 20,
+      width: 800,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    const { container } = render(
+      <AppIframe src="http://localhost:3000" title="Wegent" workspaceTabId="agent-1" />
+    )
+
+    await waitFor(() =>
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledWith(
+        'http://localhost:3000',
+        { x: 10, y: 20, width: 800, height: 600 },
+        'app-wegent-agent-1'
+      )
+    )
+    expect(container.querySelector('iframe')).toBeNull()
+    boundsSpy.mockRestore()
+  })
+
+  test('keeps one native webview during the StrictMode effect replay', async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true)
+    const boundsSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 620,
+      height: 600,
+      left: 10,
+      right: 810,
+      top: 20,
+      width: 800,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    render(
+      <StrictMode>
+        <AppIframe src="http://localhost:3000" title="Wegent" workspaceTabId="agent-strict" />
+      </StrictMode>
+    )
+
+    await waitFor(() => expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1))
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(embeddedBrowserMocks.closeEmbeddedBrowser).not.toHaveBeenCalledWith(
+      'app-wegent-agent-strict'
+    )
+    boundsSpy.mockRestore()
+  })
+
+  test('shows an existing native webview without navigating again', async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true)
+    const boundsSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 620,
+      height: 600,
+      left: 10,
+      right: 810,
+      top: 20,
+      width: 800,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    const { rerender } = render(
+      <AppIframe active src="http://localhost:3000" title="Wegent" workspaceTabId="agent-1" />
+    )
+    await waitFor(() => expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1))
+
+    rerender(
+      <AppIframe
+        active={false}
+        src="http://localhost:3000"
+        title="Wegent"
+        workspaceTabId="agent-1"
+      />
+    )
+    rerender(
+      <AppIframe active src="http://localhost:3000" title="Wegent" workspaceTabId="agent-1" />
+    )
+
+    await waitFor(() =>
+      expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenLastCalledWith(
+        { x: 10, y: 20, width: 800, height: 600 },
+        true,
+        'app-wegent-agent-1'
+      )
+    )
+    expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1)
+    expect(embeddedBrowserMocks.navigateEmbeddedBrowser).not.toHaveBeenCalled()
+    boundsSpy.mockRestore()
+  })
+
+  test('hides a native webview that finishes opening after its tab becomes inactive', async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true)
+    let resolveOpen!: () => void
+    embeddedBrowserMocks.openEmbeddedBrowser.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveOpen = () =>
+          resolve({
+            nativeLabel: 'embedded-browser-native-1',
+            title: null,
+            url: 'http://localhost:3000',
+          })
+      })
+    )
+    const boundsSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 620,
+      height: 600,
+      left: 10,
+      right: 810,
+      top: 20,
+      width: 800,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    const { rerender } = render(
+      <AppIframe active src="http://localhost:3000" title="Wegent" workspaceTabId="agent-1" />
+    )
+    await waitFor(() => expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1))
+
+    rerender(
+      <AppIframe
+        active={false}
+        src="http://localhost:3000"
+        title="Wegent"
+        workspaceTabId="agent-1"
+      />
+    )
+    resolveOpen()
+
+    await waitFor(() =>
+      expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenLastCalledWith(
+        { x: 10, y: 20, width: 800, height: 600 },
+        false,
+        'app-wegent-agent-1'
+      )
+    )
+    boundsSpy.mockRestore()
   })
 })

--- a/wework/src/components/topnav/AppIframe.tsx
+++ b/wework/src/components/topnav/AppIframe.tsx
@@ -1,7 +1,16 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
+import {
+  closeEmbeddedBrowser,
+  navigateEmbeddedBrowser,
+  openEmbeddedBrowser,
+  setEmbeddedBrowserBounds,
+  type EmbeddedBrowserBounds,
+} from '@/lib/embedded-browser'
+import { isTauriRuntime } from '@/lib/runtime-environment'
 
 interface AppIframeProps {
+  active?: boolean
   src: string
   title: string
   workspaceTabId?: string
@@ -15,12 +24,189 @@ const APP_IFRAME_SANDBOX = [
   'allow-popups-to-escape-sandbox',
 ].join(' ')
 
-export function AppIframe({ src, title, workspaceTabId }: AppIframeProps) {
+function elementBounds(element: HTMLElement): EmbeddedBrowserBounds | null {
+  const rect = element.getBoundingClientRect()
+  if (rect.width < 1 || rect.height < 1) return null
+  return {
+    x: rect.left,
+    y: rect.top,
+    width: rect.width,
+    height: rect.height,
+  }
+}
+
+function nativeLabel(title: string, workspaceTabId?: string) {
+  return `app-${title.toLowerCase()}-${workspaceTabId ?? 'default'}`
+}
+
+export function AppIframe({ active = true, src, title, workspaceTabId }: AppIframeProps) {
+  const native = isTauriRuntime()
+  const hostRef = useRef<HTMLDivElement>(null)
+  const openedRef = useRef(false)
+  const openPromiseRef = useRef<Promise<void> | null>(null)
+  const loadedSrcRef = useRef<string | null>(null)
+  const lifecycleGenerationRef = useRef(0)
+  const activeRef = useRef(active)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [retryGeneration, setRetryGeneration] = useState(0)
+  const label = nativeLabel(title, workspaceTabId)
+
+  useLayoutEffect(() => {
+    activeRef.current = active
+  }, [active])
+
+  const syncNativeBounds = useCallback(
+    async (visible = activeRef.current) => {
+      if (!native || !openedRef.current) return
+      const bounds = hostRef.current ? elementBounds(hostRef.current) : null
+      await setEmbeddedBrowserBounds(
+        bounds ?? { x: 0, y: 0, width: 1, height: 1 },
+        visible && Boolean(bounds),
+        label
+      )
+    },
+    [label, native]
+  )
+
+  useEffect(() => {
+    if (!native || !active) {
+      if (native && openedRef.current) {
+        void syncNativeBounds(false).catch(error => {
+          console.error('Failed to hide app webview:', error)
+        })
+      }
+      return
+    }
+
+    if (openedRef.current) {
+      if (loadedSrcRef.current === src) {
+        void syncNativeBounds(true).catch(error => {
+          console.error('Failed to show app webview:', error)
+        })
+        return
+      }
+
+      let disposed = false
+      setLoading(true)
+      setError(false)
+      void navigateEmbeddedBrowser(src, label)
+        .then(() => {
+          loadedSrcRef.current = src
+          if (!disposed) setLoading(false)
+          void syncNativeBounds(activeRef.current).catch(error => {
+            console.error('Failed to update app webview after navigation:', error)
+          })
+        })
+        .catch(error => {
+          console.error('Failed to navigate app webview:', error)
+          if (disposed) return
+          setLoading(false)
+          setError(true)
+        })
+      return () => {
+        disposed = true
+      }
+    }
+
+    const host = hostRef.current
+    const bounds = host ? elementBounds(host) : null
+    if (!bounds) return
+
+    let disposed = false
+    setLoading(true)
+    setError(false)
+
+    let openPromise = openPromiseRef.current
+    if (!openPromise) {
+      const request = openEmbeddedBrowser(src, bounds, label).then(() => {
+        openedRef.current = true
+        loadedSrcRef.current = src
+      })
+      openPromiseRef.current = request
+      void request.then(
+        () => {
+          if (openPromiseRef.current === request) openPromiseRef.current = null
+        },
+        () => {
+          if (openPromiseRef.current === request) openPromiseRef.current = null
+        }
+      )
+      openPromise = request
+    }
+
+    void openPromise
+      .then(() => {
+        if (!disposed) setLoading(false)
+        void syncNativeBounds(activeRef.current).catch(error => {
+          console.error('Failed to update app webview after opening:', error)
+        })
+      })
+      .catch(error => {
+        console.error('Failed to open app webview:', error)
+        if (disposed) return
+        openedRef.current = false
+        setLoading(false)
+        setError(true)
+      })
+
+    return () => {
+      disposed = true
+    }
+  }, [active, label, native, retryGeneration, src, syncNativeBounds])
+
+  useEffect(() => {
+    if (!native) return
+
+    const handleBoundsChange = () => {
+      void syncNativeBounds().catch(error => {
+        console.error('Failed to update app webview bounds:', error)
+      })
+    }
+    const observer =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(handleBoundsChange)
+    if (hostRef.current) observer?.observe(hostRef.current)
+    window.addEventListener('resize', handleBoundsChange)
+
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener('resize', handleBoundsChange)
+    }
+  }, [native, syncNativeBounds])
+
+  useEffect(() => {
+    if (!native) return
+    const generation = lifecycleGenerationRef.current + 1
+    lifecycleGenerationRef.current = generation
+
+    return () => {
+      window.setTimeout(() => {
+        if (lifecycleGenerationRef.current !== generation) return
+
+        const close = () => {
+          if (lifecycleGenerationRef.current !== generation) return
+          openedRef.current = false
+          loadedSrcRef.current = null
+          void closeEmbeddedBrowser(label).catch(() => undefined)
+        }
+        const pendingOpen = openPromiseRef.current
+        if (pendingOpen) {
+          void pendingOpen.then(close, close)
+          return
+        }
+        close()
+      }, 0)
+    }
+  }, [label, native])
 
   return (
-    <div className="app-view-surface relative overflow-hidden rounded-xl border border-border/60 bg-background shadow-[0_3px_16px_rgba(0,0,0,0.04)]">
+    <div
+      ref={hostRef}
+      className="app-view-surface relative h-full overflow-hidden rounded-xl border border-border/60 bg-background shadow-[0_3px_16px_rgba(0,0,0,0.04)]"
+      data-testid={`app-iframe-${title.toLowerCase()}`}
+      data-workspace-tab-id={workspaceTabId}
+      data-src={src}
+    >
       {loading && !error && (
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-surface">
           <Loader2 className="h-6 w-6 animate-spin text-primary" />
@@ -35,23 +221,25 @@ export function AppIframe({ src, title, workspaceTabId }: AppIframeProps) {
             onClick={() => {
               setError(false)
               setLoading(true)
+              setRetryGeneration(current => current + 1)
             }}
             className="text-sm text-primary hover:underline"
+            data-testid={`app-webview-retry-${title.toLowerCase()}`}
           >
             Retry
           </button>
         </div>
       )}
-      <iframe
-        src={src}
-        title={title}
-        className="w-full h-full border-none"
-        onLoad={() => setLoading(false)}
-        onError={() => setError(true)}
-        sandbox={APP_IFRAME_SANDBOX}
-        data-testid={`app-iframe-${title.toLowerCase()}`}
-        data-workspace-tab-id={workspaceTabId}
-      />
+      {!native && (
+        <iframe
+          src={src}
+          title={title}
+          className="w-full h-full border-none"
+          onLoad={() => setLoading(false)}
+          onError={() => setError(true)}
+          sandbox={APP_IFRAME_SANDBOX}
+        />
+      )}
     </div>
   )
 }

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -26,6 +26,7 @@ import { getWorkbenchDebugSnapshot } from '@/lib/debugPanel'
 import { getRuntimeConversationCacheStats } from '@/features/workbench/runtimeConversationCache'
 import { LOCAL_EXECUTOR_COMMANDS } from '@/tauri/localExecutor'
 import { executeVerificationControlCommand } from './verification-control'
+import { evalEmbeddedBrowserJson } from '@/lib/embedded-browser'
 
 const DEFAULT_WAIT_TIMEOUT_MS = 5000
 const LOCAL_MODEL_SEND_CIRCUIT_BREAKER_ERROR = 'WEWORK_E2E_LOCAL_MODEL_SEND_CIRCUIT_OPEN'
@@ -93,6 +94,39 @@ function normalizeAppPath(path: string): string {
 function dispatchNavigationEvents() {
   window.dispatchEvent(new PopStateEvent('popstate'))
   window.dispatchEvent(new CustomEvent('wework:e2e:navigation'))
+}
+
+function embeddedBrowserStorageInput(command: DesktopControlCommand) {
+  const input = JSON.parse(command.value ?? '{}') as {
+    key?: string
+    label?: string
+    value?: string
+  }
+  if (!input.label?.trim() || !input.key) {
+    throw new Error(`${command.action} requires label and key`)
+  }
+  return {
+    key: input.key,
+    label: input.label.trim(),
+    value: input.value ?? '',
+  }
+}
+
+async function setEmbeddedBrowserLocalStorageItem(command: DesktopControlCommand) {
+  const input = embeddedBrowserStorageInput(command)
+  return evalEmbeddedBrowserJson<string>(
+    `(localStorage.setItem(${JSON.stringify(input.key)}, ${JSON.stringify(input.value)}), ` +
+      `localStorage.getItem(${JSON.stringify(input.key)}))`,
+    input.label
+  )
+}
+
+async function getEmbeddedBrowserLocalStorageItem(command: DesktopControlCommand) {
+  const input = embeddedBrowserStorageInput(command)
+  return evalEmbeddedBrowserJson<string | null>(
+    `localStorage.getItem(${JSON.stringify(input.key)})`,
+    input.label
+  )
 }
 
 function hasTestId(testId: string): boolean {
@@ -770,6 +804,10 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return JSON.stringify(saveLocalProxyUrl(command.value?.trim() ?? ''))
     case 'getLocalStorageItem':
       return localStorage.getItem(command.value ?? '') ?? ''
+    case 'setEmbeddedBrowserLocalStorageItem':
+      return (await setEmbeddedBrowserLocalStorageItem(command)) ?? ''
+    case 'getEmbeddedBrowserLocalStorageItem':
+      return (await getEmbeddedBrowserLocalStorageItem(command)) ?? ''
     case 'setLocalProxyUrl': {
       const proxyUrl = command.value?.trim() ?? ''
       const config = saveLocalProxyUrl(proxyUrl)


### PR DESCRIPTION
## What changed

- Render Wegent Agent tabs with persistent native child WebViews in the Tauri desktop runtime while preserving the sandboxed iframe path outside Tauri.
- Keep each Agent tab's native WebView mounted, update its bounds and visibility when switching tabs, and close it only when the owning tab is removed.
- Deduplicate asynchronous WebView creation across React StrictMode effect replay and keep late-opening WebViews hidden when their tab has already become inactive.
- Add desktop E2E coverage that writes localStorage, closes the Agent tab, reopens Wegent, and verifies the value is restored from the shared persistent website data store.
- Document that all Wegent application tabs share the fixed data-store identifier and persist the complete origin storage rather than mirroring individual keys.

## Why

Wegent was previously hosted in a cross-origin iframe inside the Wework main WebView. Its website storage lifecycle did not match the native embedded-browser store, so onboarding and other local preferences could be lost when the Agent page was recreated.

The first native implementation also exposed a React StrictMode race: duplicate asynchronous opens could be followed by cleanup that closed the surviving child WebView, leaving the Agent tab white.

## Impact

Wegent localStorage, cookies, and IndexedDB now use the existing persistent native WebView data store on desktop. This applies to every key for the Wegent origin, including onboarding state, without Wework-specific key allowlists or host-side storage mirroring.

## Validation

- `pnpm --filter wework test` — 266 files, 2652 tests passed
- `pnpm --dir wework typecheck`
- Prettier and ESLint on all changed TypeScript, test, E2E, and documentation files
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --segment workspace-tabs`
- Isolated real-Tauri verification with `pnpm --filter wework ai:verify start`: native Wegent WebView created and completed loading with a non-empty page
- Pre-push Wework ESLint, TypeScript, and unit-test checks
