### PR TITLE
fix(wework): recover blank terminal rendering

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -678,6 +678,11 @@ semantics for all three.
   active task and unsent composer input.
 - Opening the bottom workspace panel starts or restores its Terminal directly;
   it must not show an IDE launcher or require an intermediate tool choice.
+- Terminal sessions may remain mounted while the bottom panel is hidden so the
+  shell session and scrollback survive panel restoration. Only the active
+  terminal should be fitted and resized; after activation, window focus, or
+  document visibility restoration, refresh the buffered xterm rows so the
+  existing session remains visible.
 - Workspace IDEs and native editors launch only from the titlebar “Open
   location” control, including its local-editor picker and remote code-server
   behavior.

--- a/wework/e2e/desktop/scenarios/local-terminal.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/local-terminal.scenario.mjs
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
-const TERMINAL_CARD_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-terminal-card"]`
 const EMBEDDED_TERMINAL_SELECTOR = '[data-testid="embedded-local-terminal"]'
 const BOTTOM_TERMINAL_TAB_SELECTOR = '[data-testid="bottom-workspace-terminal-tab"]'
 
 async function createLocalProject(control, workspacePath, timeoutMs) {
+  await control.command('waitFor', '[data-testid="project-work-button"]', { timeoutMs })
   await control.command('click', '[data-testid="project-work-button"]')
   await control.command('click', '[data-testid="add-local-project-option"]')
   await control.command('waitFor', '[data-testid="device-folder-path-input"]', { timeoutMs })
@@ -48,19 +48,32 @@ export function createDesktopScenario({
         await createLocalProject(control, workspacePath, uiTimeoutMs)
       }
 
-      await control.command('waitFor', TERMINAL_CARD_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await capture(control, 'local-terminal-00-card-visible.png')
-      await control.command('click', TERMINAL_CARD_SELECTOR)
-
+      await control.command('click', '[data-testid="toggle-bottom-workspace-panel-button"]')
       await control.command('waitFor', EMBEDDED_TERMINAL_SELECTOR, { timeoutMs: uiTimeoutMs })
       await control.command('waitFor', BOTTOM_TERMINAL_TAB_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await capture(control, 'local-terminal-01-session-started.png')
+      await capture(control, 'local-terminal-00-session-started.png')
 
       const snapshot = JSON.parse(await control.command('snapshot', 'body'))
       assert.ok(
         snapshot.testIds.includes('embedded-local-terminal'),
         'The embedded local terminal element was not rendered'
       )
+
+      await control.command('click', '[data-testid="close-bottom-workspace-panel-button"]')
+      await control.command(
+        'waitFor',
+        '[data-testid="bottom-workspace-panel"][aria-hidden="true"]',
+        {
+          stableMs: 300,
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await control.command('click', '[data-testid="toggle-bottom-workspace-panel-button"]')
+      await control.command('waitFor', EMBEDDED_TERMINAL_SELECTOR, {
+        visible: true,
+        timeoutMs: uiTimeoutMs,
+      })
+      await capture(control, 'local-terminal-01-session-restored.png')
     },
 
     diagnostics() {

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -19,6 +19,7 @@ import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermSelectionGuard } from './xtermSelectionGuard'
+import { installXtermRenderRecovery, refreshXterm } from './xtermRenderRecovery'
 
 interface EmbeddedLocalTerminalProps {
   sessionId: string
@@ -144,9 +145,10 @@ export function EmbeddedLocalTerminal({
     })
 
     const fitAndResize = () => {
-      if (disposed || !container.isConnected) return
+      if (disposed || !activeRef.current || !container.isConnected) return
       try {
         fitAddon.fit()
+        refreshXterm(terminal)
         syncTerminalSize()
       } catch (error) {
         console.error('Failed to resize local terminal:', error)
@@ -165,6 +167,7 @@ export function EmbeddedLocalTerminal({
 
     const resizeObserver = new ResizeObserver(fitAndResize)
     resizeObserver.observe(container)
+    const removeRenderRecovery = installXtermRenderRecovery(fitAndResize)
     requestAnimationFrame(fitAndResize)
 
     void listenLocalTerminalOutput(payload => {
@@ -205,6 +208,7 @@ export function EmbeddedLocalTerminal({
     return () => {
       disposed = true
       unobserveTheme()
+      removeRenderRecovery()
       resizeObserver.disconnect()
       dataDisposable.dispose()
       titleDisposable.dispose()
@@ -229,6 +233,7 @@ export function EmbeddedLocalTerminal({
       try {
         applyTerminalTheme(terminal, container, getTerminalTheme(), showWorkbenchBackground)
         fitAddon.fit()
+        refreshXterm(terminal)
         terminal.focus()
         if (terminal.rows > 0 && terminal.cols > 0) {
           const lastSize = lastSizeRef.current

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -19,6 +19,7 @@ const testState = vi.hoisted(() => ({
     open: ReturnType<typeof vi.fn>
     dispose: ReturnType<typeof vi.fn>
     focus: ReturnType<typeof vi.fn>
+    refresh: ReturnType<typeof vi.fn>
     options: { theme?: unknown }
   }>,
   webLinksAddonInstances: [] as Array<{
@@ -74,6 +75,7 @@ vi.mock('@xterm/xterm', () => ({
       open: vi.fn(),
       dispose: vi.fn(),
       focus: vi.fn(),
+      refresh: vi.fn(),
       options: {},
     }
     testState.terminalInstances.push(terminal)
@@ -270,6 +272,25 @@ describe('RemoteTerminal', () => {
     )
 
     expect(client.resize).toHaveBeenCalledTimes(1)
+  })
+
+  test('refreshes buffered rows when activated and when the window regains focus', () => {
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
+    })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    render(
+      <RemoteTerminal sessionId="terminal-1" clientFactory={createRemoteTerminalClient} active />
+    )
+    const terminal = testState.terminalInstances[0]
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 23)
+
+    terminal.refresh.mockClear()
+    window.dispatchEvent(new Event('focus'))
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 23)
   })
 
   test('catches rejected active terminal size syncs', async () => {

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -17,6 +17,7 @@ import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
 import { installXtermSelectionGuard } from './xtermSelectionGuard'
+import { installXtermRenderRecovery, refreshXterm } from './xtermRenderRecovery'
 
 interface RemoteTerminalProps {
   sessionId: string
@@ -222,9 +223,10 @@ export function RemoteTerminal({
     })
 
     const fitAndResize = () => {
-      if (disposed || !container.isConnected) return
+      if (disposed || !activeRef.current || !container.isConnected) return
       try {
         fitAddon.fit()
+        refreshXterm(terminal)
       } catch (error) {
         console.error('Failed to resize remote terminal:', error)
         return
@@ -248,6 +250,7 @@ export function RemoteTerminal({
 
     const resizeObserver = new ResizeObserver(fitAndResize)
     resizeObserver.observe(container)
+    const removeRenderRecovery = installXtermRenderRecovery(fitAndResize)
 
     void client
       .attach()
@@ -269,6 +272,7 @@ export function RemoteTerminal({
         if (disposed) return
         disposed = true
         unobserveTheme()
+        removeRenderRecovery()
         resizeObserver.disconnect()
         dataDisposable.dispose()
         titleDisposable.dispose()
@@ -311,6 +315,7 @@ export function RemoteTerminal({
       try {
         applyTerminalTheme(terminal, container, getTerminalTheme(), showWorkbenchBackground)
         fitAddon.fit()
+        refreshXterm(terminal)
         terminal.focus()
       } catch (error) {
         console.error('Failed to activate remote terminal:', error)

--- a/wework/src/components/layout/workspace-panels/xtermRenderRecovery.ts
+++ b/wework/src/components/layout/workspace-panels/xtermRenderRecovery.ts
@@ -1,0 +1,35 @@
+import type { Terminal } from '@xterm/xterm'
+
+export function refreshXterm(terminal: Terminal): void {
+  if (terminal.rows <= 0) return
+  terminal.refresh(0, terminal.rows - 1)
+}
+
+export function installXtermRenderRecovery(onRecover: () => void): () => void {
+  let frameId: number | null = null
+
+  const scheduleRecovery = () => {
+    if (frameId !== null) return
+
+    frameId = window.requestAnimationFrame(() => {
+      frameId = null
+      onRecover()
+    })
+  }
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible') {
+      scheduleRecovery()
+    }
+  }
+
+  window.addEventListener('focus', scheduleRecovery)
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+
+  return () => {
+    window.removeEventListener('focus', scheduleRecovery)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+    if (frameId !== null) {
+      window.cancelAnimationFrame(frameId)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Refresh xterm buffered rows when a terminal is activated or the window/document becomes visible again.
- Avoid fitting and resizing terminals while they are inactive and hidden.
- Add a real Tauri regression that closes and reopens the bottom terminal panel.
- Document the terminal rendering invariant in `wework/DESIGN.md`.

## Root cause
The xterm buffer and PTY session remained alive, but WebKit could lose the renderer output after hidden-panel, focus, or visibility transitions. Activation only called `fit()`, which did not force the existing buffer to paint again.

## Validation
- `pnpm --filter wework test -- RemoteTerminal.test.tsx` (268 files, 2663 tests passed)
- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework e2e:desktop:local-terminal` (real Tauri; start, close, reopen, and visual evidence verified)
- Push quality hook: ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering when reopening panels, switching terminals, restoring window focus, or returning to the app.
  * Preserved hidden terminal sessions so shell state and scrollback remain available.
  * Ensured terminal sizing and display updates apply correctly to the active session.

* **Tests**
  * Added coverage verifying terminal content refreshes after activation and window focus.
  * Updated end-to-end checks for closing and reopening the terminal panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->