### PR TITLE
fix(wework): archive tasks without triggering a cloud sync

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2807,6 +2807,39 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('device-status')).toHaveTextContent('online')
   })
 
+  test('does not trigger a cloud sync for socket device events', async () => {
+    let streamHandlers: ChatStreamHandlers = {}
+    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
+      streamHandlers = handlers
+      return vi.fn()
+    })
+    const cloudListRuntimeWork = vi.fn().mockResolvedValue({
+      projects: [],
+      chats: [],
+      totalTasks: 0,
+    })
+    const services = createWorkbenchServices({
+      chatStream: {
+        subscribe,
+      } as unknown as WorkbenchServices['chatStream'],
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([createDevice()]),
+        listRuntimeWork: cloudListRuntimeWork,
+      },
+    })
+
+    renderWorkbench(<DeviceStatusProbe />, services)
+
+    await waitFor(() => expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      streamHandlers.onDeviceSlotUpdate?.({ device_id: 'device-1' })
+    })
+
+    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
+  })
+
   test('keeps the last confirmed online state when an offline event refresh fails', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -6610,9 +6610,11 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() =>
       expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('Remote task')
     )
+    runtimeWorkApi.listRuntimeWork.mockClear()
     await userEvent.click(screen.getByText('archive remote task'))
 
     await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
+    expect(runtimeWorkApi.listRuntimeWork).toHaveBeenCalledTimes(1)
     await waitFor(() =>
       expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
     )
@@ -6690,8 +6692,9 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
 
+    expect(typeof streamHandlers.onRuntimeGoalCleared).toBe('function')
     await act(async () => {
-      streamHandlers.onRuntimeGoalCleared?.({
+      streamHandlers.onRuntimeGoalCleared!({
         deviceId: 'remote-device',
         taskId: 'remote-task',
       })

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -6618,6 +6618,89 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
   })
 
+  test('does not trigger a cloud sync for stream events on an archived task', async () => {
+    const remoteRuntimeWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { key: 'remote-project', name: 'Remote Wegent' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: '10.201.3.200',
+              deviceStatus: 'online',
+              available: true,
+              workspacePath: '/srv/Wegent',
+              workspaceSource: 'remote',
+              remoteHostId: 'remote-device',
+              tasks: [
+                {
+                  taskId: 'remote-task',
+                  workspacePath: '/srv/Wegent',
+                  title: 'Remote task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        },
+      ],
+      chats: [],
+      totalTasks: 1,
+    }
+    let streamHandlers: ChatStreamHandlers = {}
+    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
+      if (hasRuntimeStreamHandler(handlers)) streamHandlers = handlers
+      return vi.fn()
+    })
+    const cloudListRuntimeWork = vi.fn().mockResolvedValue(remoteRuntimeWork)
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue({ projects: [], chats: [], totalTasks: 0 }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      chatStream: {
+        subscribe,
+      } as unknown as WorkbenchServices['chatStream'],
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([
+          createDevice({
+            id: 2,
+            device_id: 'remote-device',
+            name: '10.201.3.200',
+            status: 'online',
+            is_default: false,
+            device_type: 'remote',
+          }),
+        ]),
+        listRuntimeWork: cloudListRuntimeWork,
+      },
+    })
+
+    renderWorkbench(<ArchiveRemoteRuntimeTaskProbe />, services)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('Remote task')
+    )
+    await userEvent.click(screen.getByText('archive remote task'))
+    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
+    )
+    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      streamHandlers.onRuntimeGoalCleared?.({
+        deviceId: 'remote-device',
+        taskId: 'remote-task',
+      })
+    })
+
+    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
+  })
+
   test('renders streaming runtime task chunks when the socket connects after chat start', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1365,6 +1365,9 @@ function ArchiveRemoteRuntimeTaskProbe() {
       >
         archive remote task
       </button>
+      <button type="button" onClick={() => void workbench.refreshWorkLists()}>
+        refresh work lists
+      </button>
     </div>
   )
 }
@@ -6476,7 +6479,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(screen.getByTestId('archive-result')).toHaveTextContent('archived'))
   })
 
-  test('does not restore an archived remote task from the previous cloud snapshot', async () => {
+  test('archives a remote task locally without triggering a cloud sync', async () => {
     const remoteRuntimeWork: RuntimeWorkListResponse = {
       projects: [
         {
@@ -6540,9 +6543,11 @@ describe('WorkbenchProvider runtime tasks', () => {
     await userEvent.click(screen.getByText('archive remote task'))
 
     await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
-    await waitFor(() => expect(cloudListRuntimeWork).toHaveBeenCalledTimes(2))
     expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
+    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
 
+    await userEvent.click(screen.getByText('refresh work lists'))
+    await waitFor(() => expect(cloudListRuntimeWork).toHaveBeenCalledTimes(2))
     postArchiveCloudWork.resolve({ projects: [], chats: [], totalTasks: 0 })
     await waitFor(() =>
       expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -6554,6 +6554,70 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
   })
 
+  test('keeps an archived remote task hidden when the local list refresh fails', async () => {
+    const remoteRuntimeWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { key: 'remote-project', name: 'Remote Wegent' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: '10.201.3.200',
+              deviceStatus: 'online',
+              available: true,
+              workspacePath: '/srv/Wegent',
+              workspaceSource: 'remote',
+              remoteHostId: 'remote-device',
+              tasks: [
+                {
+                  taskId: 'remote-task',
+                  workspacePath: '/srv/Wegent',
+                  title: 'Remote task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        },
+      ],
+      chats: [],
+      totalTasks: 1,
+    }
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockRejectedValue(new Error('local list unavailable')),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([
+          createDevice({
+            id: 2,
+            device_id: 'remote-device',
+            name: '10.201.3.200',
+            status: 'online',
+            is_default: false,
+            device_type: 'remote',
+          }),
+        ]),
+        listRuntimeWork: vi.fn().mockResolvedValue(remoteRuntimeWork),
+      },
+    })
+
+    renderWorkbench(<ArchiveRemoteRuntimeTaskProbe />, services)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('Remote task')
+    )
+    await userEvent.click(screen.getByText('archive remote task'))
+
+    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
+    )
+  })
+
   test('renders streaming runtime task chunks when the socket connects after chat start', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2517,6 +2517,71 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
   })
 
+  test('does not leave cloud work stuck syncing when a sync is superseded', async () => {
+    const runtimeWork = deferred<RuntimeWorkListResponse>()
+    const services = createWorkbenchServices({
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([]),
+        listRuntimeWork: vi.fn(() => runtimeWork.promise),
+      },
+    })
+
+    renderWorkbench(
+      <>
+        <CloudWorkStatusProbe />
+        <BootstrapProbe />
+      </>,
+      services
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cloud-work-availability')).toHaveTextContent('syncing')
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Refresh devices' }))
+    await act(async () => {
+      runtimeWork.resolve({ projects: [], chats: [], totalTasks: 0 })
+      await runtimeWork.promise
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cloud-work-availability')).not.toHaveTextContent('syncing')
+    )
+  })
+
+  test('does not leave cloud work stuck syncing when a task is archived mid-sync', async () => {
+    const runtimeWork = deferred<RuntimeWorkListResponse>()
+    const runtimeWorkApi = createRuntimeWorkApiMock()
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: vi.fn().mockResolvedValue([]),
+        listRuntimeWork: vi.fn(() => runtimeWork.promise),
+      },
+    })
+
+    renderWorkbench(
+      <>
+        <CloudWorkStatusProbe />
+        <ArchiveRemoteRuntimeTaskProbe />
+      </>,
+      services
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cloud-work-availability')).toHaveTextContent('syncing')
+    )
+
+    await userEvent.click(screen.getByText('archive remote task'))
+    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cloud-work-availability')).not.toHaveTextContent('syncing')
+    )
+  })
+
   test('restores cached remote task summaries when the device is offline at startup', async () => {
     writeCachedRemoteRuntimeWork(1, {
       projects: [

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2872,39 +2872,6 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('device-status')).toHaveTextContent('online')
   })
 
-  test('does not trigger a cloud sync for socket device events', async () => {
-    let streamHandlers: ChatStreamHandlers = {}
-    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
-      streamHandlers = handlers
-      return vi.fn()
-    })
-    const cloudListRuntimeWork = vi.fn().mockResolvedValue({
-      projects: [],
-      chats: [],
-      totalTasks: 0,
-    })
-    const services = createWorkbenchServices({
-      chatStream: {
-        subscribe,
-      } as unknown as WorkbenchServices['chatStream'],
-      cloudBackgroundApi: {
-        listTeams: vi.fn().mockResolvedValue([]),
-        listDevices: vi.fn().mockResolvedValue([createDevice()]),
-        listRuntimeWork: cloudListRuntimeWork,
-      },
-    })
-
-    renderWorkbench(<DeviceStatusProbe />, services)
-
-    await waitFor(() => expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1))
-
-    await act(async () => {
-      streamHandlers.onDeviceSlotUpdate?.({ device_id: 'device-1' })
-    })
-
-    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
-  })
-
   test('keeps the last confirmed online state when an offline event refresh fails', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
@@ -6716,90 +6683,6 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() =>
       expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
     )
-  })
-
-  test('does not trigger a cloud sync for stream events on an archived task', async () => {
-    const remoteRuntimeWork: RuntimeWorkListResponse = {
-      projects: [
-        {
-          project: { key: 'remote-project', name: 'Remote Wegent' },
-          deviceWorkspaces: [
-            {
-              deviceId: 'remote-device',
-              deviceName: '10.201.3.200',
-              deviceStatus: 'online',
-              available: true,
-              workspacePath: '/srv/Wegent',
-              workspaceSource: 'remote',
-              remoteHostId: 'remote-device',
-              tasks: [
-                {
-                  taskId: 'remote-task',
-                  workspacePath: '/srv/Wegent',
-                  title: 'Remote task',
-                  runtime: 'codex',
-                },
-              ],
-            },
-          ],
-          totalTasks: 1,
-        },
-      ],
-      chats: [],
-      totalTasks: 1,
-    }
-    let streamHandlers: ChatStreamHandlers = {}
-    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
-      if (hasRuntimeStreamHandler(handlers)) streamHandlers = handlers
-      return vi.fn()
-    })
-    const cloudListRuntimeWork = vi.fn().mockResolvedValue(remoteRuntimeWork)
-    const runtimeWorkApi = createRuntimeWorkApiMock({
-      listRuntimeWork: vi.fn().mockResolvedValue({ projects: [], chats: [], totalTasks: 0 }),
-    })
-    const services = createWorkbenchServices({
-      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
-      chatStream: {
-        subscribe,
-      } as unknown as WorkbenchServices['chatStream'],
-      cloudBackgroundApi: {
-        listTeams: vi.fn().mockResolvedValue([]),
-        listDevices: vi.fn().mockResolvedValue([
-          createDevice({
-            id: 2,
-            device_id: 'remote-device',
-            name: '10.201.3.200',
-            status: 'online',
-            is_default: false,
-            device_type: 'remote',
-          }),
-        ]),
-        listRuntimeWork: cloudListRuntimeWork,
-      },
-    })
-
-    renderWorkbench(<ArchiveRemoteRuntimeTaskProbe />, services)
-
-    await waitFor(() =>
-      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('Remote task')
-    )
-    await userEvent.click(screen.getByText('archive remote task'))
-    await waitFor(() => expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1))
-    await waitFor(() =>
-      expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
-    )
-    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
-
-    expect(typeof streamHandlers.onRuntimeGoalCleared).toBe('function')
-    await act(async () => {
-      streamHandlers.onRuntimeGoalCleared!({
-        deviceId: 'remote-device',
-        taskId: 'remote-task',
-      })
-    })
-
-    expect(cloudListRuntimeWork).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('archive-remote-task-titles')).toHaveTextContent('')
   })
 
   test('renders streaming runtime task chunks when the socket connects after chat start', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -532,7 +532,7 @@ export function WorkbenchProvider({
     remoteProjectSyncSignatureRef.current = signature
     void executorClient.runtime
       .syncRuntimeRemoteProjects({ deviceId: localRuntimeStateDeviceId, projects })
-      .then(refreshWorkLists)
+      .then(() => refreshWorkLists())
       .catch(error => {
         remoteProjectSyncSignatureRef.current = ''
         console.warn('[Wework] Failed to sync remote projects into Codex global state', error)

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1215,7 +1215,7 @@ export function WorkbenchProvider({
   )
   const stableRefreshWorkLists = useStableEvent(refreshWorkLists)
   const refreshRuntimeWorkLists = useStableEvent((address: RuntimeTaskAddress) => {
-    void stableRefreshWorkLists({ syncCloud: false }).catch(error => {
+    void stableRefreshWorkLists().catch(error => {
       console.warn('[Wework] Runtime work list refresh failed', {
         deviceId: address.deviceId,
         taskId: address.taskId,

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1215,7 +1215,7 @@ export function WorkbenchProvider({
   )
   const stableRefreshWorkLists = useStableEvent(refreshWorkLists)
   const refreshRuntimeWorkLists = useStableEvent((address: RuntimeTaskAddress) => {
-    void stableRefreshWorkLists().catch(error => {
+    void stableRefreshWorkLists({ syncCloud: false }).catch(error => {
       console.warn('[Wework] Runtime work list refresh failed', {
         deviceId: address.deviceId,
         taskId: address.taskId,

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -14,6 +14,8 @@ import type { CloudRuntimeState, CloudWorkCheckKey, WorkbenchState } from '@/typ
 import {
   EMPTY_CLOUD_RUNTIME_STATE,
   EMPTY_RUNTIME_WORK,
+  abandonCloudRuntimeSync,
+  clearCloudRuntimeSync,
   filterDisconnectedRemoteRuntimeWork,
   finishCloudRuntimeSync,
   mergeDeviceLists,
@@ -93,14 +95,11 @@ function removeRuntimeTasksFromCloudState(
           runtimeWork: removeRuntimeTasks(snapshot.runtimeWork, addresses),
         }
       : null
-  return {
+  return clearCloudRuntimeSync({
     ...state,
-    availability:
-      state.inFlightRevision == null ? state.availability : state.lastGood ? 'stale' : 'idle',
     current: removeFromSnapshot(state.current),
     lastGood: removeFromSnapshot(state.lastGood),
-    inFlightRevision: null,
-  }
+  })
 }
 
 function removeRuntimeProjectFromCloudState(
@@ -336,7 +335,6 @@ export function useWorkbenchDataRefresh({
       try {
         if (cloudRuntimeStateRef.current.inFlightRevision != null) {
           if (options?.trigger !== 'manual-refresh' || !backgroundApi?.listDevices) return
-          const inFlightRevision = cloudRuntimeStateRef.current.inFlightRevision
           const inFlightBackgroundApi = backgroundApi
           const devicesResult = await timedWorkbenchBootstrapRequest(
             'cloudDevices',
@@ -348,7 +346,6 @@ export function useWorkbenchDataRefresh({
             !isCurrentRefresh() ||
             options?.isCancelled?.() ||
             devicesResult.status !== 'fulfilled' ||
-            cloudRuntimeStateRef.current.inFlightRevision !== inFlightRevision ||
             cloudBackgroundApiRef.current !== inFlightBackgroundApi
           ) {
             return
@@ -437,6 +434,9 @@ export function useWorkbenchDataRefresh({
           cloudRuntimeStateRef.current.inFlightRevision !== revision ||
           cloudBackgroundApiRef.current !== backgroundApi
         ) {
+          if (revision != null) {
+            updateCloudRuntimeState(abandonCloudRuntimeSync(cloudRuntimeStateRef.current, revision))
+          }
           return
         }
 

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -623,64 +623,72 @@ export function useWorkbenchDataRefresh({
     user,
   ])
 
-  const refreshWorkLists = useCallback(async () => {
-    const [devicesResult, runtimeWorkResult] = await Promise.all([
-      executorClient.commands.listDevices().catch(error => {
-        const cachedDevices = readCachedDeviceList()
-        if (cachedDevices.length === 0) throw error
-        return cachedDevices
-      }),
-      executorClient.runtime.listRuntimeWork().catch(() => undefined),
-    ])
-    const devices = resolveDeviceListWithCache(devicesResult)
-    const visibleDevices = resolveDeviceListWithCache(
-      selectVisibleDevices(devices, cloudRuntimeStateRef.current)
-    )
-    const filteredRuntimeWorkResult = runtimeWorkResult
-      ? filterRemovedRuntimeProjects(runtimeWorkResult)
-      : undefined
-    if (filteredRuntimeWorkResult) {
-      localRuntimeWorkRef.current = filteredRuntimeWorkResult
-    }
-    const localRuntimeWork = filteredRuntimeWorkResult ?? state.runtimeWork ?? EMPTY_RUNTIME_WORK
-    if (filteredRuntimeWorkResult && !services.cloudBackgroundApi?.listRuntimeWork) {
-      releaseConfirmedArchivedRuntimeTasks(filteredRuntimeWorkResult)
-    }
-    const runtimeWork = filteredRuntimeWorkResult
-      ? selectVisibleRuntimeWork(localRuntimeWork, cloudRuntimeStateRef.current, visibleDevices)
-      : hasCloudBackgroundApi
-        ? localRuntimeWork
-        : filterDisconnectedRemoteRuntimeWork(localRuntimeWork)
-    debugRuntimeSidebarState('refresh-resolved', {
-      source: filteredRuntimeWorkResult ? 'executor' : 'current-state',
-      executorTaskIds: summarizeRuntimeWorkTaskIds(filteredRuntimeWorkResult ?? null),
-      visibleTaskIds: summarizeRuntimeWorkTaskIds(runtimeWork),
-    })
-    dispatch({
-      type: 'lists_refreshed',
-      projects: state.projects,
-      devices: visibleDevices,
-      runtimeWork,
-      standaloneDeviceId: getPreferredStandaloneDeviceId(visibleDevices, state.standaloneDeviceId),
-    })
-    void refreshCloudBackgroundData(devices, localRuntimeWork, {
-      projects: state.projects,
-      standaloneDeviceId: state.standaloneDeviceId,
-      trigger: 'manual-refresh',
-    }).catch(() => undefined)
-  }, [
-    dispatch,
-    executorClient,
-    filterRemovedRuntimeProjects,
-    refreshCloudBackgroundData,
-    hasCloudBackgroundApi,
-    releaseConfirmedArchivedRuntimeTasks,
-    selectVisibleRuntimeWork,
-    services.cloudBackgroundApi,
-    state.projects,
-    state.runtimeWork,
-    state.standaloneDeviceId,
-  ])
+  const refreshWorkLists = useCallback(
+    async (options?: { syncCloud?: boolean }) => {
+      const [devicesResult, runtimeWorkResult] = await Promise.all([
+        executorClient.commands.listDevices().catch(error => {
+          const cachedDevices = readCachedDeviceList()
+          if (cachedDevices.length === 0) throw error
+          return cachedDevices
+        }),
+        executorClient.runtime.listRuntimeWork().catch(() => undefined),
+      ])
+      const devices = resolveDeviceListWithCache(devicesResult)
+      const visibleDevices = resolveDeviceListWithCache(
+        selectVisibleDevices(devices, cloudRuntimeStateRef.current)
+      )
+      const filteredRuntimeWorkResult = runtimeWorkResult
+        ? filterRemovedRuntimeProjects(runtimeWorkResult)
+        : undefined
+      if (filteredRuntimeWorkResult) {
+        localRuntimeWorkRef.current = filteredRuntimeWorkResult
+      }
+      const localRuntimeWork = filteredRuntimeWorkResult ?? state.runtimeWork ?? EMPTY_RUNTIME_WORK
+      if (filteredRuntimeWorkResult && !services.cloudBackgroundApi?.listRuntimeWork) {
+        releaseConfirmedArchivedRuntimeTasks(filteredRuntimeWorkResult)
+      }
+      const runtimeWork = filteredRuntimeWorkResult
+        ? selectVisibleRuntimeWork(localRuntimeWork, cloudRuntimeStateRef.current, visibleDevices)
+        : hasCloudBackgroundApi
+          ? localRuntimeWork
+          : filterDisconnectedRemoteRuntimeWork(localRuntimeWork)
+      debugRuntimeSidebarState('refresh-resolved', {
+        source: filteredRuntimeWorkResult ? 'executor' : 'current-state',
+        executorTaskIds: summarizeRuntimeWorkTaskIds(filteredRuntimeWorkResult ?? null),
+        visibleTaskIds: summarizeRuntimeWorkTaskIds(runtimeWork),
+      })
+      dispatch({
+        type: 'lists_refreshed',
+        projects: state.projects,
+        devices: visibleDevices,
+        runtimeWork,
+        standaloneDeviceId: getPreferredStandaloneDeviceId(
+          visibleDevices,
+          state.standaloneDeviceId
+        ),
+      })
+      if (options?.syncCloud !== false) {
+        void refreshCloudBackgroundData(devices, localRuntimeWork, {
+          projects: state.projects,
+          standaloneDeviceId: state.standaloneDeviceId,
+          trigger: 'manual-refresh',
+        }).catch(() => undefined)
+      }
+    },
+    [
+      dispatch,
+      executorClient,
+      filterRemovedRuntimeProjects,
+      refreshCloudBackgroundData,
+      hasCloudBackgroundApi,
+      releaseConfirmedArchivedRuntimeTasks,
+      selectVisibleRuntimeWork,
+      services.cloudBackgroundApi,
+      state.projects,
+      state.runtimeWork,
+      state.standaloneDeviceId,
+    ]
+  )
 
   const loadDevicesForRefresh = useCallback(
     async (options?: { useCacheFallback?: boolean }): Promise<DeviceInfo[]> => {

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -766,18 +766,20 @@ export function useWorkbenchDataRefresh({
   )
 
   const refreshDevices = useCallback(
-    async (options?: { useCacheFallback?: boolean }) => {
+    async (options?: { useCacheFallback?: boolean; syncCloud?: boolean }) => {
       const devices = await loadDevicesForRefresh(options)
       dispatch({
         type: 'devices_refreshed',
         devices,
         standaloneDeviceId: getPreferredStandaloneDeviceId(devices, state.standaloneDeviceId),
       })
-      void refreshCloudBackgroundData(devices, state.runtimeWork ?? EMPTY_RUNTIME_WORK, {
-        projects: state.projects,
-        standaloneDeviceId: state.standaloneDeviceId,
-        trigger: 'manual-refresh',
-      }).catch(() => undefined)
+      if (options?.syncCloud !== false) {
+        void refreshCloudBackgroundData(devices, state.runtimeWork ?? EMPTY_RUNTIME_WORK, {
+          projects: state.projects,
+          standaloneDeviceId: state.standaloneDeviceId,
+          trigger: 'manual-refresh',
+        }).catch(() => undefined)
+      }
     },
     [
       dispatch,

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -36,6 +36,7 @@ import {
   runtimeWorkContainsTask,
 } from './workbenchRuntimeHelpers'
 import type { WorkbenchServices } from './workbenchServices'
+import type { RefreshWorkLists } from './workbenchContextTypes'
 import {
   readCachedRemoteRuntimeWork,
   reconcileCachedRemoteRuntimeWork,
@@ -623,8 +624,8 @@ export function useWorkbenchDataRefresh({
     user,
   ])
 
-  const refreshWorkLists = useCallback(
-    async (options?: { syncCloud?: boolean }) => {
+  const refreshWorkLists: RefreshWorkLists = useCallback(
+    async options => {
       const [devicesResult, runtimeWorkResult] = await Promise.all([
         executorClient.commands.listDevices().catch(error => {
           const cachedDevices = readCachedDeviceList()
@@ -649,9 +650,12 @@ export function useWorkbenchDataRefresh({
       }
       const runtimeWork = filteredRuntimeWorkResult
         ? selectVisibleRuntimeWork(localRuntimeWork, cloudRuntimeStateRef.current, visibleDevices)
-        : hasCloudBackgroundApi
-          ? localRuntimeWork
-          : filterDisconnectedRemoteRuntimeWork(localRuntimeWork)
+        : removeRuntimeTasks(
+            hasCloudBackgroundApi
+              ? localRuntimeWork
+              : filterDisconnectedRemoteRuntimeWork(localRuntimeWork),
+            archivedRuntimeTaskAddressesRef.current
+          )
       debugRuntimeSidebarState('refresh-resolved', {
         source: filteredRuntimeWorkResult ? 'executor' : 'current-state',
         executorTaskIds: summarizeRuntimeWorkTaskIds(filteredRuntimeWorkResult ?? null),

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -766,20 +766,18 @@ export function useWorkbenchDataRefresh({
   )
 
   const refreshDevices = useCallback(
-    async (options?: { useCacheFallback?: boolean; syncCloud?: boolean }) => {
+    async (options?: { useCacheFallback?: boolean }) => {
       const devices = await loadDevicesForRefresh(options)
       dispatch({
         type: 'devices_refreshed',
         devices,
         standaloneDeviceId: getPreferredStandaloneDeviceId(devices, state.standaloneDeviceId),
       })
-      if (options?.syncCloud !== false) {
-        void refreshCloudBackgroundData(devices, state.runtimeWork ?? EMPTY_RUNTIME_WORK, {
-          projects: state.projects,
-          standaloneDeviceId: state.standaloneDeviceId,
-          trigger: 'manual-refresh',
-        }).catch(() => undefined)
-      }
+      void refreshCloudBackgroundData(devices, state.runtimeWork ?? EMPTY_RUNTIME_WORK, {
+        projects: state.projects,
+        standaloneDeviceId: state.standaloneDeviceId,
+        trigger: 'manual-refresh',
+      }).catch(() => undefined)
     },
     [
       dispatch,

--- a/wework/src/features/workbench/useWorkbenchDeviceUpgrades.ts
+++ b/wework/src/features/workbench/useWorkbenchDeviceUpgrades.ts
@@ -24,7 +24,7 @@ interface UseWorkbenchDeviceUpgradesOptions {
   dispatch: Dispatch<WorkbenchAction>
   executorClient: ExecutorClient
   services: WorkbenchServices
-  refreshDevices: (options?: { useCacheFallback?: boolean }) => Promise<void>
+  refreshDevices: (options?: { useCacheFallback?: boolean; syncCloud?: boolean }) => Promise<void>
 }
 
 export function useWorkbenchDeviceUpgrades({
@@ -118,7 +118,7 @@ export function useWorkbenchDeviceUpgrades({
 
   useEffect(() => {
     const refreshDevicesAfterEvent = () => {
-      void refreshDevices({ useCacheFallback: false }).catch(() => undefined)
+      void refreshDevices({ useCacheFallback: false, syncCloud: false }).catch(() => undefined)
     }
     const handleDeviceOnline = (payload: unknown) => {
       const deviceId = getDeviceEventId(payload)

--- a/wework/src/features/workbench/useWorkbenchDeviceUpgrades.ts
+++ b/wework/src/features/workbench/useWorkbenchDeviceUpgrades.ts
@@ -24,7 +24,7 @@ interface UseWorkbenchDeviceUpgradesOptions {
   dispatch: Dispatch<WorkbenchAction>
   executorClient: ExecutorClient
   services: WorkbenchServices
-  refreshDevices: (options?: { useCacheFallback?: boolean; syncCloud?: boolean }) => Promise<void>
+  refreshDevices: (options?: { useCacheFallback?: boolean }) => Promise<void>
 }
 
 export function useWorkbenchDeviceUpgrades({
@@ -118,7 +118,7 @@ export function useWorkbenchDeviceUpgrades({
 
   useEffect(() => {
     const refreshDevicesAfterEvent = () => {
-      void refreshDevices({ useCacheFallback: false, syncCloud: false }).catch(() => undefined)
+      void refreshDevices({ useCacheFallback: false }).catch(() => undefined)
     }
     const handleDeviceOnline = (payload: unknown) => {
       const deviceId = getDeviceEventId(payload)

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -41,6 +41,7 @@ import type {
   ArchiveRuntimeTaskOptions,
   ArchiveRuntimeTaskResult,
   ArchiveRuntimeConversationsResult,
+  RefreshWorkLists,
 } from './workbenchContextTypes'
 import { evictRuntimeConversation } from './runtimeConversationCache'
 import type { RuntimeTaskLifecycleStore } from './runtimeTaskLifecycle'
@@ -53,7 +54,7 @@ interface UseWorkbenchRuntimeTasksOptions {
   services: WorkbenchServices
   lifecycleStore: RuntimeTaskLifecycleStore
   markRuntimeTasksArchived: (addresses: RuntimeTaskAddress[]) => void
-  refreshWorkLists: () => Promise<void>
+  refreshWorkLists: RefreshWorkLists
 }
 
 const runtimeTranscriptRequests = new Map<string, Promise<RuntimePaneTranscript>>()
@@ -265,7 +266,7 @@ export function useWorkbenchRuntimeTasks({
           findRuntimeTaskWorktrees(state.runtimeWork, archivedAddresses)
         )
         clearCurrentRuntimeTaskIfArchived(archivedAddresses)
-        await refreshWorkLists()
+        await refreshWorkLists({ syncCloud: false })
       }
       const failedResult = results.find(result => !result.response?.accepted)
       if (!failedResult) return { status: 'archived' }

--- a/wework/src/features/workbench/workbenchCloudStatus.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.ts
@@ -103,6 +103,46 @@ function cloneChecks(
   }
 }
 
+function resetSyncingChecks(
+  checks: Record<CloudWorkCheckKey, SyncCheckState>,
+  previous: CloudRuntimeSnapshot | null
+): Record<CloudWorkCheckKey, SyncCheckState> {
+  const next = cloneChecks(checks)
+  ;(Object.keys(next) as CloudWorkCheckKey[]).forEach(key => {
+    if (next[key].status === 'syncing') {
+      next[key] = previous?.checks[key] ?? EMPTY_SYNC_CHECKS[key]
+    }
+  })
+  return next
+}
+
+export function abandonCloudRuntimeSync(
+  state: CloudRuntimeState,
+  revision: number
+): CloudRuntimeState {
+  if (state.inFlightRevision !== revision) return state
+  return {
+    ...state,
+    availability: state.lastGood ? 'stale' : 'idle',
+    inFlightRevision: null,
+    current: state.current
+      ? { ...state.current, checks: resetSyncingChecks(state.current.checks, state.lastGood) }
+      : state.current,
+  }
+}
+
+export function clearCloudRuntimeSync(state: CloudRuntimeState): CloudRuntimeState {
+  if (state.inFlightRevision == null) return state
+  return {
+    ...state,
+    availability: state.lastGood ? 'stale' : 'idle',
+    inFlightRevision: null,
+    current: state.current
+      ? { ...state.current, checks: resetSyncingChecks(state.current.checks, state.lastGood) }
+      : state.current,
+  }
+}
+
 function syncCheckResult<T>(
   result: PromiseSettledResult<T> | undefined,
   previous: SyncCheckState,

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -73,6 +73,8 @@ export type ArchiveRuntimeTaskResult = {
   status: 'archived' | 'dirty_worktree' | 'failed'
 }
 
+export type RefreshWorkLists = (options?: { syncCloud?: boolean }) => Promise<void>
+
 export type ArchiveRuntimeConversationsResult = ArchiveRuntimeTaskResult
 
 export interface SendCurrentInputOptions {
@@ -229,7 +231,7 @@ export interface WorkbenchContextValue {
     address: RuntimeTaskAddress
   ) => Promise<RuntimeTaskIMNotificationSubscriptionResponse>
   rememberExecutionDevice: (deviceId: string) => void
-  refreshWorkLists: () => Promise<void>
+  refreshWorkLists: RefreshWorkLists
   refreshDevices: () => Promise<void>
   getRemoteDeviceStartupCommand: () => Promise<DockerRemoteDeviceCommandResponse>
   upgradeDevice: (deviceId: string) => Promise<void>

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -75,6 +75,11 @@ export type ArchiveRuntimeTaskResult = {
 
 export type RefreshWorkLists = (options?: { syncCloud?: boolean }) => Promise<void>
 
+export type RefreshDevices = (options?: {
+  useCacheFallback?: boolean
+  syncCloud?: boolean
+}) => Promise<void>
+
 export type ArchiveRuntimeConversationsResult = ArchiveRuntimeTaskResult
 
 export interface SendCurrentInputOptions {
@@ -232,7 +237,7 @@ export interface WorkbenchContextValue {
   ) => Promise<RuntimeTaskIMNotificationSubscriptionResponse>
   rememberExecutionDevice: (deviceId: string) => void
   refreshWorkLists: RefreshWorkLists
-  refreshDevices: () => Promise<void>
+  refreshDevices: RefreshDevices
   getRemoteDeviceStartupCommand: () => Promise<DockerRemoteDeviceCommandResponse>
   upgradeDevice: (deviceId: string) => Promise<void>
   createProject: (

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -75,11 +75,6 @@ export type ArchiveRuntimeTaskResult = {
 
 export type RefreshWorkLists = (options?: { syncCloud?: boolean }) => Promise<void>
 
-export type RefreshDevices = (options?: {
-  useCacheFallback?: boolean
-  syncCloud?: boolean
-}) => Promise<void>
-
 export type ArchiveRuntimeConversationsResult = ArchiveRuntimeTaskResult
 
 export interface SendCurrentInputOptions {
@@ -237,7 +232,7 @@ export interface WorkbenchContextValue {
   ) => Promise<RuntimeTaskIMNotificationSubscriptionResponse>
   rememberExecutionDevice: (deviceId: string) => void
   refreshWorkLists: RefreshWorkLists
-  refreshDevices: RefreshDevices
+  refreshDevices: () => Promise<void>
   getRemoteDeviceStartupCommand: () => Promise<DockerRemoteDeviceCommandResponse>
   upgradeDevice: (deviceId: string) => Promise<void>
   createProject: (


### PR DESCRIPTION
## 背景

在 Wework 桌面端归档任务后，侧边栏“云端工作”会变成“同步中”，且长时间不恢复。

## 根因（日志定位）

归档本身不会主动触发云端同步，真正的问题是**状态机被归档打断后卡死**：

1. 归档成功后 `removeRuntimeTasksFromCloudState` 会把 `inFlightRevision` 置空——如果当时有一个云端同步正在进行（例如启动引导同步），它的完成校验就会失效，`finishCloudRuntimeSync` 提前返回，导致同步的 `syncing` 检查状态永远不更新。
2. `refreshCloudBackgroundData` 在同步被后续刷新取代（请求被 abort）时同样提前返回，不清理 `inFlightRevision`、不恢复 `syncing` 状态。
3. 结果：`云端工作` 的可用性检查永久停留在 `syncing`，即“同步中”卡死，直到下一次完整同步成功才覆盖。用户每次归档后看到的“同步中”正是被归档打断后卡住的旧状态。

## 修改

- 归档成功后只做本地剔除：`refreshWorkLists({ syncCloud: false })`，不再触发云端后台同步。
- 新增 `clearCloudRuntimeSync` / `abandonCloudRuntimeSync`：任何打断/取代同步的路径（归档、被新刷新取代）都会清空 `inFlightRevision`，并把 `syncing` 检查状态恢复为上一次已知值（有 lastGood 时显示“可用”，否则回到“未检查”），避免永久卡在“同步中”。
- 归档后本地列表刷新失败时，归档任务仍通过 `archivedRuntimeTaskAddressesRef` 保持隐藏（本地剔除的可靠性）。
- 设备刷新分支不再要求 `inFlightRevision` 保持不变，避免被清理逻辑误伤。
- 云端同步仍由显式路径触发：启动引导、手动刷新、用户操作（发送/创建/重命名/删除/取消等），以及运行时流事件/设备事件（与本次问题无关，保持原行为不变）。

## 影响

- 用户：归档任务后“云端工作”不再卡在“同步中”；归档任务立即从列表消失。
- 开发者：仅归档与同步状态机两处行为变化，其余刷新行为不变。

## 验证

- 新增回归测试（去掉对应修复均失败）：
  - 归档打断飞行中的云端同步后，`cloudWorkStatus.availability` 不再停留在 `syncing`；
  - 同步被后续刷新取代后，状态不再卡死；
  - 归档后本地列表刷新失败时归档任务不复活。
- WorkbenchProvider 等 304 个相关测试通过；`tsc -b`、eslint、prettier、pre-push 质量门禁全部通过。
- CI（Lint Wework / Test Wework / 浏览器与桌面 E2E）随 PR 检查运行。
