### PR TITLE
fix(executor): normalize Kimi K3 anyOf tool schemas

### DIFF
--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -176,7 +176,7 @@ fn responses_to_chat_with_namespace_mode(
     }
     apply_reasoning_options(body, &mut result, kimi_k3_compat);
 
-    let tools = chat_tools(body, &context);
+    let tools = chat_tools(body, &context, kimi_k3_compat);
     if !tools.is_empty() {
         result.insert("tools".to_owned(), Value::Array(tools));
         if let Some(choice) = body.get("tool_choice") {
@@ -372,7 +372,7 @@ fn unique_wire_name(context: &ToolContext, preferred: String) -> String {
     unreachable!("an unused tool name suffix must exist")
 }
 
-fn chat_tools(body: &Value, context: &ToolContext) -> Vec<Value> {
+fn chat_tools(body: &Value, context: &ToolContext, kimi_k3_compat: bool) -> Vec<Value> {
     let mut converted = Vec::new();
     for tool in body
         .get("tools")
@@ -390,18 +390,25 @@ fn chat_tools(body: &Value, context: &ToolContext) -> Vec<Value> {
                 .into_iter()
                 .flatten()
             {
-                if let Some(converted_tool) = chat_tool(inner_tool, Some(namespace), context) {
+                if let Some(converted_tool) =
+                    chat_tool(inner_tool, Some(namespace), context, kimi_k3_compat)
+                {
                     converted.push(converted_tool);
                 }
             }
-        } else if let Some(converted_tool) = chat_tool(tool, None, context) {
+        } else if let Some(converted_tool) = chat_tool(tool, None, context, kimi_k3_compat) {
             converted.push(converted_tool);
         }
     }
     converted
 }
 
-fn chat_tool(tool: &Value, namespace: Option<&str>, context: &ToolContext) -> Option<Value> {
+fn chat_tool(
+    tool: &Value,
+    namespace: Option<&str>,
+    context: &ToolContext,
+    kimi_k3_compat: bool,
+) -> Option<Value> {
     let name = tool.get("name")?.as_str()?;
     let wire_name = context.wire_name(namespace, name)?;
     if context.is_custom(wire_name) {
@@ -439,7 +446,7 @@ fn chat_tool(tool: &Value, namespace: Option<&str>, context: &ToolContext) -> Op
     }
     function.insert(
         "parameters".to_owned(),
-        normalize_function_parameters(tool.get("parameters")),
+        normalize_function_parameters(tool.get("parameters"), kimi_k3_compat),
     );
     if let Some(strict) = tool.get("strict") {
         function.insert("strict".to_owned(), strict.clone());
@@ -447,18 +454,92 @@ fn chat_tool(tool: &Value, namespace: Option<&str>, context: &ToolContext) -> Op
     Some(json!({"type": "function", "function": function}))
 }
 
-fn normalize_function_parameters(parameters: Option<&Value>) -> Value {
+fn normalize_function_parameters(parameters: Option<&Value>, kimi_k3_compat: bool) -> Value {
     let mut normalized = match parameters {
         Some(Value::Object(parameters)) => Value::Object(parameters.clone()),
         _ => json!({"type": "object", "properties": {}}),
     };
+    if kimi_k3_compat {
+        // Moonshot requires anyOf branches to own their types instead of the parent schema.
+        normalize_kimi_k3_schema(&mut normalized);
+    }
     let object = normalized
         .as_object_mut()
         .expect("normalized function parameters must be an object");
-    if object.get("type").and_then(Value::as_str) != Some("object") {
+    if (!kimi_k3_compat || !has_fully_typed_any_of(object))
+        && object.get("type").and_then(Value::as_str) != Some("object")
+    {
         object.insert("type".to_owned(), Value::String("object".to_owned()));
     }
     normalized
+}
+
+fn normalize_kimi_k3_schema(schema: &mut Value) {
+    match schema {
+        Value::Object(object) => {
+            for (keyword, value) in object.iter_mut() {
+                if !matches!(
+                    keyword.as_str(),
+                    "const" | "default" | "enum" | "example" | "examples"
+                ) {
+                    normalize_kimi_k3_schema(value);
+                }
+            }
+            move_compatible_parent_type_to_any_of(object);
+        }
+        Value::Array(values) => {
+            for value in values {
+                normalize_kimi_k3_schema(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn move_compatible_parent_type_to_any_of(schema: &mut Map<String, Value>) {
+    let Some(parent_type) = schema.get("type").cloned() else {
+        return;
+    };
+    let can_move = schema
+        .get("anyOf")
+        .and_then(Value::as_array)
+        .is_some_and(|branches| {
+            !branches.is_empty()
+                && branches.iter().all(|branch| {
+                    branch.as_object().is_some_and(|branch| {
+                        branch
+                            .get("type")
+                            .map_or(true, |branch_type| branch_type == &parent_type)
+                    })
+                })
+        });
+    if !can_move {
+        return;
+    }
+    if let Some(branches) = schema.get_mut("anyOf").and_then(Value::as_array_mut) {
+        for branch in branches {
+            branch
+                .as_object_mut()
+                .expect("compatible anyOf branches must be objects")
+                .entry("type".to_owned())
+                .or_insert_with(|| parent_type.clone());
+        }
+    }
+    schema.remove("type");
+}
+
+fn has_fully_typed_any_of(schema: &Map<String, Value>) -> bool {
+    schema
+        .get("anyOf")
+        .and_then(Value::as_array)
+        .is_some_and(|branches| {
+            !branches.is_empty()
+                && branches.iter().all(|branch| {
+                    branch
+                        .get("type")
+                        .is_some_and(|branch_type| !branch_type.is_null())
+                })
+        })
 }
 
 fn responses_tools(tools: &[Value], context: &ToolContext) -> Vec<Value> {
@@ -2119,6 +2200,29 @@ mod tests {
     use super::*;
     use futures_util::StreamExt;
 
+    fn typed_any_of_parameters() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "project_id": {"type": "string"},
+                "title": {"type": "string"},
+                "metadata": {
+                    "type": "object",
+                    "anyOf": [
+                        {"type": "object", "required": ["label"]},
+                        {"required": ["description"]}
+                    ]
+                }
+            },
+            "required": ["project_id"],
+            "anyOf": [
+                {"type": "object", "required": ["title"]},
+                {"type": "object", "required": ["metadata"]}
+            ],
+            "additionalProperties": false
+        })
+    }
+
     #[test]
     fn converts_responses_request_with_history_and_custom_tool() {
         let input = json!({
@@ -2386,6 +2490,56 @@ mod tests {
             converted["tools"][0]["function"]["parameters"]["type"],
             "object"
         );
+    }
+
+    #[test]
+    fn normalizes_typed_any_of_schemas_for_kimi_k3() {
+        let input = json!({
+            "model": "kimi-k3",
+            "tools": [{
+                "type": "namespace",
+                "name": "wegent_apps",
+                "tools": [{
+                    "type": "function",
+                    "name": "wegent_sites__update_site_metadata",
+                    "parameters": typed_any_of_parameters()
+                }]
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let parameters = &converted["tools"][0]["function"]["parameters"];
+
+        assert!(parameters.get("type").is_none());
+        assert!(parameters["properties"]["metadata"].get("type").is_none());
+        assert!(parameters["anyOf"]
+            .as_array()
+            .expect("root anyOf")
+            .iter()
+            .all(|branch| branch["type"] == "object"));
+        assert!(parameters["properties"]["metadata"]["anyOf"]
+            .as_array()
+            .expect("nested anyOf")
+            .iter()
+            .all(|branch| branch["type"] == "object"));
+    }
+
+    #[test]
+    fn preserves_typed_any_of_schema_for_non_kimi_chat_models() {
+        let input = json!({
+            "model": "gpt-compatible-model",
+            "tools": [{
+                "type": "function",
+                "name": "update_site_metadata",
+                "parameters": typed_any_of_parameters()
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let parameters = &converted["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(parameters["properties"]["metadata"]["type"], "object");
     }
 
     #[test]

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -2200,7 +2200,16 @@ mod tests {
         let body = serde_json::to_vec(&json!({
             "model": "cloud-model-resource-name",
             "reasoning": {"effort": "low"},
-            "input": "hello"
+            "input": "hello",
+            "tools": [{
+                "type": "function",
+                "name": "update_site_metadata",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "anyOf": [{"type": "object", "required": ["title"]}]
+                }
+            }]
         }))
         .expect("request body");
 
@@ -2217,6 +2226,13 @@ mod tests {
         assert_eq!(prepared["model"], "cloud-model-resource-name");
         assert_eq!(prepared["thinking"], json!({"type": "enabled"}));
         assert!(prepared.get("reasoning_effort").is_none());
+        assert!(prepared["tools"][0]["function"]["parameters"]
+            .get("type")
+            .is_none());
+        assert_eq!(
+            prepared["tools"][0]["function"]["parameters"]["anyOf"][0]["type"],
+            "object"
+        );
         assert!(matches!(conversion, Some(Conversion::Chat(_))));
     }
 


### PR DESCRIPTION
## Summary

- normalize JSON Schema anyOf nodes for Kimi K3 Chat Completions requests
- move a compatible parent type into untyped anyOf branches and remove the rejected parent type
- keep non-Kimi Chat and Anthropic request conversion unchanged
- cover namespace tools, nested schemas, missing branch types, and routing-model detection

## Problem

Moonshot rejects function parameter schemas that define type on the parent of anyOf, even though the schema is valid JSON Schema. This occurs with generated tools such as update_site_metadata and prevents the request from reaching Kimi K3.

## Solution

Apply a Kimi K3-only recursive normalization during Responses-to-Chat tool conversion. The transformation preserves schema constraints and only moves a parent type when all existing branch types are compatible. Data-bearing keywords such as enum, const, default, example, and examples are not traversed.

The root parameter normalizer also avoids restoring type: object when the normalized anyOf branches are already fully typed.

## Validation

- cargo fmt --all -- --check
- cargo test --lib server::local_model_proxy::chat::tests (50 passed)
- routing-model integration test (1 passed)
- cargo test --lib server::local_model_proxy:: (134 passed, 1 ignored)
- cargo clippy --lib -- -D warnings
- cargo test --lib (628 passed, 1 ignored)
- pre-push cargo test --all-features --lib
- pre-push cargo clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Kimi K3 tool schemas, including nested `anyOf` parameter definitions.
  * Preserved existing tool parameter behavior for other models.
  * Maintained specialized reasoning support for Kimi requests.
  * Added coverage to verify schema conversion and compatibility across model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->