### PR TITLE
fix(wework): prevent quota menu text overlap

### DIFF
--- a/wework/src/components/layout/DesktopSettingsMenu.test.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.test.tsx
@@ -336,5 +336,7 @@ describe('DesktopSettingsMenu', () => {
     )
     expect(await screen.findByText('1,126.7 / 1,042 元')).toBeInTheDocument()
     expect(screen.getByText('已用 108.13% · 剩余 -84.7 元')).toBeInTheDocument()
+    expect(screen.getByText('1,126.7 / 1,042 元')).toHaveClass('break-words')
+    expect(screen.getByText('已用 108.13% · 剩余 -84.7 元')).toHaveClass('break-words')
   })
 })

--- a/wework/src/components/layout/DesktopSettingsMenu.tsx
+++ b/wework/src/components/layout/DesktopSettingsMenu.tsx
@@ -363,14 +363,14 @@ export function DesktopSettingsMenu({
           ) : null}
           {!wegentQuotaLoading && !wegentQuotaError ? (
             wegentUsage.status === 'available' ? (
-              <div className="space-y-0.5 text-xs leading-5 text-text-secondary">
-                <div className="flex items-start justify-between gap-3">
-                  <span className="min-w-0 whitespace-nowrap">{wegentUsage.sourceText}</span>
-                  <span className="shrink-0 whitespace-nowrap font-semibold text-text-primary">
+              <div className="space-y-1 text-xs leading-5 text-text-secondary">
+                <div className="min-w-0">
+                  <div>{wegentUsage.sourceText}</div>
+                  <div className="break-words font-semibold text-text-primary">
                     {wegentUsage.value}
-                  </span>
+                  </div>
                 </div>
-                <div className="text-text-muted">{wegentUsage.detail}</div>
+                <div className="break-words text-text-muted">{wegentUsage.detail}</div>
               </div>
             ) : (
               <div className="py-1 text-sm leading-[18px] text-text-secondary">


### PR DESCRIPTION
## Summary

- Stack the cloud quota source, amount, and usage details in the desktop settings menu.
- Allow long localized quota values to wrap instead of overlapping in narrow sidebars.
- Add a regression assertion for the wrapping behavior.

## Root cause

The source label and a non-wrapping quota amount were forced into the same flex row. When the sidebar was narrow, the source label overflowed into the amount.

## Impact

Cloud-account users can read quota details at all supported sidebar widths without text overlap.

## Validation

- `pnpm --filter wework test -- DesktopSettingsMenu.test.tsx`
- `pnpm --filter wework exec prettier --check src/components/layout/DesktopSettingsMenu.tsx src/components/layout/DesktopSettingsMenu.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopSettingsMenu.tsx src/components/layout/DesktopSettingsMenu.test.tsx`
- Isolated real-Tauri verification using `pnpm --filter wework ai:verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of Wegent usage information by allowing long values and details to wrap cleanly.
  * Adjusted the layout and spacing for clearer usage details in the desktop settings menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->