### PR TITLE
chore(ci): use standard executor runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
     name: Test Executor
     needs: changes
     if: needs.changes.outputs.executor == 'true'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read


### PR DESCRIPTION
## What changed

Updated the `Test Executor` GitHub Actions job to use the standard `ubuntu-latest` runner.

## Why

The workflow referenced the custom `ubuntu-latest-m` label; this normalizes it with the ordinary hosted runner configuration.

## Impact

Executor unit-test CI now runs on the standard Ubuntu runner.

## Validation

- Confirmed no `ubuntu-latest-m` references remain under `.github`.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test environment to use an available runner, improving the reliability of automated test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->