### PR TITLE
fix(wework): expand sidebar from hover preview

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2552,14 +2552,12 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('desktop-sidebar-preview-panel')).toHaveStyle({ width: '240px' })
     expect(main).not.toHaveClass('ml-1.5')
 
-    fireEvent.pointerEnter(preview)
+    await userEvent.click(within(preview).getByTestId('collapse-sidebar-button'))
 
-    expect(preview).toHaveClass('translate-x-0', 'opacity-100')
-
-    fireEvent.pointerLeave(preview)
-
-    expect(preview).toHaveClass('pointer-events-none', '-translate-x-full', 'opacity-100')
-    expect(main).not.toHaveClass('ml-1.5')
+    expect(screen.getByTestId('desktop-sidebar')).toHaveStyle({ width: '240px' })
+    expect(screen.getByTestId('desktop-sidebar')).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.queryByTestId('desktop-sidebar-preview')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('desktop-sidebar-hover-edge')).not.toBeInTheDocument()
   })
 
   test('keeps sidebar controls out of the page chrome in Tauri', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -555,12 +555,14 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
     hideResizeHandle = false,
     onPointerEnter,
     onPointerLeave,
+    onToggleSidebar,
   }: {
     collapsed: boolean
     containerTestId?: string
     hideResizeHandle?: boolean
     onPointerEnter?: PointerEventHandler<HTMLElement>
     onPointerLeave?: PointerEventHandler<HTMLElement>
+    onToggleSidebar?: () => void
   }) => (
     <DesktopSidebar
       user={state.user}
@@ -587,7 +589,7 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
       onResizeStateChange={setSidebarResizing}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
-      onToggleSidebar={() => updateSidebarCollapsed(!collapsed)}
+      onToggleSidebar={onToggleSidebar ?? (() => updateSidebarCollapsed(!collapsed))}
       onNewChat={onNewChat}
       onStartStandaloneChat={onStartStandaloneChat}
       onOpenSearch={() => setSearchOpen(true)}
@@ -680,6 +682,7 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
                 hideResizeHandle: true,
                 onPointerEnter: openSidebarPreview,
                 onPointerLeave: closeSidebarPreview,
+                onToggleSidebar: () => updateSidebarCollapsed(false),
               })}
             </div>
           </>


### PR DESCRIPTION
## Summary

- Make the hover-preview sidebar's toggle expand the persistent sidebar.
- Add regression coverage for collapsing the sidebar, opening the left-edge preview, and restoring the persistent sidebar from the preview control.

## Root cause

The preview rendered an expanded sidebar and reused the generic toggle callback. That callback inverted the preview's render state, so it kept the persistent sidebar collapsed and removed the preview instead of restoring the sidebar.

## User impact

Users can now pin the sidebar open directly from its left-edge hover preview.

## Validation

- `pnpm --filter wework test -- DesktopWorkbenchLayout.test.tsx`
- Prettier, ESLint, and typography checks through Husky
- Real isolated Tauri verification of the collapse → hover preview → restore flow
