### PR TITLE
fix: clear agent selection on close

### DIFF
--- a/frontend/src/__tests__/features/tasks/utils/task-query-params.test.ts
+++ b/frontend/src/__tests__/features/tasks/utils/task-query-params.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  removeTaskQueryParams,
+  removeTeamQueryParam,
+} from '@/features/tasks/utils/task-query-params'
+
+describe('task query params', () => {
+  it('removes teamId while preserving other query parameters', () => {
+    const params = new URLSearchParams('teamId=42&agent=code')
+
+    expect(removeTeamQueryParam(params)).toBe(true)
+    expect(params.toString()).toBe('agent=code')
+  })
+
+  it('reports when no teamId was removed', () => {
+    expect(removeTeamQueryParam(new URLSearchParams('agent=code'))).toBe(false)
+  })
+
+  it('removes all supported task ID aliases', () => {
+    const params = new URLSearchParams('taskId=1&task_id=2&taskid=3&teamId=42')
+
+    expect(removeTaskQueryParams(params)).toBe(true)
+    expect(params.toString()).toBe('teamId=42')
+  })
+})

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -75,7 +75,10 @@ import type { UnifiedMessage } from '@wegent/chat-core'
 import type { ArtifactPromptRequest } from '@/types/knowledge-artifact'
 import type { KnowledgeCapabilityDraftRequest } from '@/types/knowledge-capability'
 import { getFirstSearchParam, getSearchParam, stringifySearchParams } from '@/lib/search-params'
-import { removeTaskQueryParams } from '@/features/tasks/utils/task-query-params'
+import {
+  removeTaskQueryParams,
+  removeTeamQueryParam,
+} from '@/features/tasks/utils/task-query-params'
 
 /**
  * Threshold in pixels for determining when to collapse selectors.
@@ -499,6 +502,7 @@ function ChatAreaContent({
   // Track initialization and last synced task for team selection
   const hasInitializedTeamRef = useRef(false)
   const lastSyncedTaskIdRef = useRef<number | null>(null)
+  const ignoredTeamIdParamRef = useRef<string | null>(null)
 
   // Filter teams by bind_mode based on current visible agent mode.
   const filteredTeams = useMemo(
@@ -514,6 +518,9 @@ function ChatAreaContent({
   // Team selection logic - using default team from server configuration
   useEffect(() => {
     if (filteredTeams.length === 0) return
+    if (!teamIdFromUrl) {
+      ignoredTeamIdParamRef.current = null
+    }
 
     // Extract team ID from task detail
     const detailTeamId = selectedTaskDetail?.team
@@ -560,7 +567,7 @@ function ChatAreaContent({
 
     // Case 2a: teamId URL param present - select specific team regardless of initialization state
     // This handles navigation after accepting a share invite (/chat?teamId=xxx)
-    if (!taskIdFromUrl && teamIdFromUrl) {
+    if (!taskIdFromUrl && teamIdFromUrl && teamIdFromUrl !== ignoredTeamIdParamRef.current) {
       const targetTeamId = Number(teamIdFromUrl)
       const teamFromUrl =
         filteredTeams.find(t => t.id === targetTeamId) || teams.find(t => t.id === targetTeamId)
@@ -897,6 +904,19 @@ function ChatAreaContent({
   const quickPresetAttachmentIdsRef = useRef<Set<number>>(new Set())
   const selectedContextsRef = useRef(chatState.selectedContexts)
   selectedContextsRef.current = chatState.selectedContexts
+
+  const handleRestoreDefaultTeam = useCallback(() => {
+    const url = new URL(window.location.href)
+    ignoredTeamIdParamRef.current = teamIdFromUrl
+    if (removeTeamQueryParam(url.searchParams)) {
+      window.history.replaceState(
+        window.history.state,
+        '',
+        `${url.pathname}${url.search}${url.hash}`
+      )
+    }
+    restoreDefaultTeam()
+  }, [restoreDefaultTeam, teamIdFromUrl])
 
   const shouldConfirmPendingReplacement =
     runtimeTaskStatus === 'PENDING' &&
@@ -1645,7 +1665,7 @@ function ChatAreaContent({
     onExternalApiParamsChange: chatState.handleExternalApiParamsChange,
     onAppModeChange: chatState.handleAppModeChange,
     // Only enable restore when default team exists
-    onRestoreDefaultTeam: chatState.defaultTeam ? chatState.restoreDefaultTeam : undefined,
+    onRestoreDefaultTeam: chatState.defaultTeam ? handleRestoreDefaultTeam : undefined,
     isUsingDefaultTeam: chatState.isUsingDefaultTeam,
     taskType: effectiveTaskType,
     teamModeFilter,

--- a/frontend/src/features/tasks/utils/task-query-params.ts
+++ b/frontend/src/features/tasks/utils/task-query-params.ts
@@ -5,6 +5,7 @@
 type SearchParamsReader = Pick<URLSearchParams, 'get'>
 
 export const TASK_QUERY_KEYS = ['taskId', 'task_id', 'taskid'] as const
+export const TEAM_QUERY_KEY = 'teamId'
 
 export function getTaskQueryParam(searchParams: SearchParamsReader): string | null {
   for (const key of TASK_QUERY_KEYS) {
@@ -23,4 +24,10 @@ export function removeTaskQueryParams(searchParams: URLSearchParams): boolean {
     }
   }
   return removed
+}
+
+export function removeTeamQueryParam(searchParams: URLSearchParams): boolean {
+  if (!searchParams.has(TEAM_QUERY_KEY)) return false
+  searchParams.delete(TEAM_QUERY_KEY)
+  return true
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring the default team now correctly removes the `teamId` URL parameter.
  * Prevented previously selected team settings in the URL from being reapplied after restoring the default team.
  * Improved handling of task-related URL parameters while preserving unrelated parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->