### PR TITLE
fix(executor): preserve Kimi K3 root tool schema

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
@@ -41,6 +41,7 @@ When a cloud Model CRD uses OpenAI Chat Completions and its provider model name 
 - It sends Kimi's supported `thinking` field instead of the generic `reasoning_effort` field.
 - It preserves `reasoning_content` across multi-turn messages and tool calls.
 - It preserves namespace tool identity through a reversible mapping so same-named tools still route to the correct executor.
+- It retains the top-level `type: "object"` on function parameters, equivalently nests a root `anyOf` constraint under `allOf`, and fills object types on `anyOf` branches to satisfy Kimi tool-schema validation.
 
 An explicit Anthropic Messages configuration is never overridden. Operators must select OpenAI Chat Completions in the Model CRD through `protocol` or `apiFormat`. Leaving only `env.model=claude` without protocol metadata continues to route requests as Anthropic Messages to `/v1/messages`.
 

--- a/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
@@ -41,6 +41,7 @@ provider `base_url` 可以是服务根地址、带版本前缀的 API base，或
 - 使用 Kimi 支持的 `thinking` 字段，而不是通用的 `reasoning_effort`。
 - 在多轮消息和工具调用中保留 `reasoning_content`。
 - 可逆地保留 namespace tool 的身份，确保同名工具仍能路由到正确的执行器。
+- 保留 function parameters 顶层的 `type: "object"`，将顶层 `anyOf` 约束等价地下沉到 `allOf`，并为 `anyOf` 对象分支补齐类型，满足 Kimi 的工具 schema 校验。
 
 显式配置的 Anthropic Messages 不会被自动改写。运维人员必须在 Model CRD 中通过 `protocol` 或 `apiFormat` 明确选择 OpenAI Chat Completions；如果只保留 `env.model=claude` 且没有协议元数据，请求仍会按 Anthropic Messages 路由到 `/v1/messages`。
 

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -460,15 +460,15 @@ fn normalize_function_parameters(parameters: Option<&Value>, kimi_k3_compat: boo
         _ => json!({"type": "object", "properties": {}}),
     };
     if kimi_k3_compat {
-        // Moonshot requires anyOf branches to own their types instead of the parent schema.
+        // Moonshot requires function parameters to declare an object type, while anyOf
+        // schemas must declare types only on their branches.
         normalize_kimi_k3_schema(&mut normalized);
+        nest_root_any_of_constraint(&mut normalized);
     }
     let object = normalized
         .as_object_mut()
         .expect("normalized function parameters must be an object");
-    if (!kimi_k3_compat || !has_fully_typed_any_of(object))
-        && object.get("type").and_then(Value::as_str) != Some("object")
-    {
+    if object.get("type").and_then(Value::as_str) != Some("object") {
         object.insert("type".to_owned(), Value::String("object".to_owned()));
     }
     normalized
@@ -528,18 +528,30 @@ fn move_compatible_parent_type_to_any_of(schema: &mut Map<String, Value>) {
     schema.remove("type");
 }
 
-fn has_fully_typed_any_of(schema: &Map<String, Value>) -> bool {
-    schema
+fn nest_root_any_of_constraint(schema: &mut Value) {
+    let Some(object) = schema.as_object_mut() else {
+        return;
+    };
+    if object.get("allOf").is_some_and(|value| !value.is_array()) {
+        return;
+    }
+    let Some(any_of) = object
         .get("anyOf")
         .and_then(Value::as_array)
-        .is_some_and(|branches| {
-            !branches.is_empty()
-                && branches.iter().all(|branch| {
-                    branch
-                        .get("type")
-                        .is_some_and(|branch_type| !branch_type.is_null())
-                })
-        })
+        .filter(|branches| !branches.is_empty())
+        .cloned()
+    else {
+        return;
+    };
+    object.remove("anyOf");
+    let constraint = json!({"anyOf": any_of});
+    match object.get_mut("allOf") {
+        Some(Value::Array(all_of)) => all_of.push(constraint),
+        Some(_) => unreachable!("non-array allOf was rejected above"),
+        None => {
+            object.insert("allOf".to_owned(), Value::Array(vec![constraint]));
+        }
+    }
 }
 
 fn responses_tools(tools: &[Value], context: &ToolContext) -> Vec<Value> {
@@ -2510,9 +2522,10 @@ mod tests {
         let (converted, _) = responses_to_chat(&input).expect("request should convert");
         let parameters = &converted["tools"][0]["function"]["parameters"];
 
-        assert!(parameters.get("type").is_none());
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("anyOf").is_none());
         assert!(parameters["properties"]["metadata"].get("type").is_none());
-        assert!(parameters["anyOf"]
+        assert!(parameters["allOf"][0]["anyOf"]
             .as_array()
             .expect("root anyOf")
             .iter()

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -462,16 +462,21 @@ fn normalize_function_parameters(parameters: Option<&Value>, kimi_k3_compat: boo
     if kimi_k3_compat {
         // Moonshot requires function parameters to declare an object type, while anyOf
         // schemas must declare types only on their branches.
+        ensure_function_parameters_object_type(&mut normalized);
         normalize_kimi_k3_schema(&mut normalized);
         nest_root_any_of_constraint(&mut normalized);
     }
-    let object = normalized
+    ensure_function_parameters_object_type(&mut normalized);
+    normalized
+}
+
+fn ensure_function_parameters_object_type(schema: &mut Value) {
+    let object = schema
         .as_object_mut()
         .expect("normalized function parameters must be an object");
     if object.get("type").and_then(Value::as_str) != Some("object") {
         object.insert("type".to_owned(), Value::String("object".to_owned()));
     }
-    normalized
 }
 
 fn normalize_kimi_k3_schema(schema: &mut Value) {
@@ -2535,6 +2540,56 @@ mod tests {
             .expect("nested anyOf")
             .iter()
             .all(|branch| branch["type"] == "object"));
+    }
+
+    #[test]
+    fn normalizes_untyped_root_any_of_schema_for_kimi_k3() {
+        let input = json!({
+            "model": "kimi-k3",
+            "tools": [{
+                "type": "function",
+                "name": "update_site_metadata",
+                "parameters": {
+                    "anyOf": [{"required": ["title"]}]
+                }
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let parameters = &converted["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("anyOf").is_none());
+        assert_eq!(parameters["allOf"][0]["anyOf"][0]["type"], "object");
+    }
+
+    #[test]
+    fn preserves_existing_root_all_of_when_nesting_any_of_for_kimi_k3() {
+        let existing_constraint = json!({
+            "type": "object",
+            "required": ["project_id"]
+        });
+        let input = json!({
+            "model": "kimi-k3",
+            "tools": [{
+                "type": "function",
+                "name": "update_site_metadata",
+                "parameters": {
+                    "type": "object",
+                    "allOf": [existing_constraint.clone()],
+                    "anyOf": [{"required": ["title"]}]
+                }
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let parameters = &converted["tools"][0]["function"]["parameters"];
+        let all_of = parameters["allOf"].as_array().expect("root allOf");
+
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(all_of.len(), 2);
+        assert_eq!(all_of[0], existing_constraint);
+        assert_eq!(all_of[1]["anyOf"][0]["type"], "object");
     }
 
     #[test]

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -2226,11 +2226,12 @@ mod tests {
         assert_eq!(prepared["model"], "cloud-model-resource-name");
         assert_eq!(prepared["thinking"], json!({"type": "enabled"}));
         assert!(prepared.get("reasoning_effort").is_none());
-        assert!(prepared["tools"][0]["function"]["parameters"]
-            .get("type")
-            .is_none());
         assert_eq!(
-            prepared["tools"][0]["function"]["parameters"]["anyOf"][0]["type"],
+            prepared["tools"][0]["function"]["parameters"]["type"],
+            "object"
+        );
+        assert_eq!(
+            prepared["tools"][0]["function"]["parameters"]["allOf"][0]["anyOf"][0]["type"],
             "object"
         );
         assert!(matches!(conversion, Some(Conversion::Chat(_))));


### PR DESCRIPTION
## Summary

- keep `tools.function.parameters.type` as `object` for Kimi K3 Chat Completions requests
- move a root `anyOf` constraint under `allOf` while retaining equivalent JSON Schema semantics
- continue moving compatible nested schema types into their `anyOf` branches
- remove the obsolete branch that allowed function parameters without a top-level type
- document the Kimi K3 tool-schema normalization behavior

## Root cause

Moonshot's Kimi K3 schema validator applies two constraints simultaneously: function parameters must declare a top-level `type: "object"`, while a schema that directly contains `anyOf` must declare types in the `anyOf` items instead of on that parent schema. The previous normalization moved the root type into the branches, satisfying the second constraint but failing the first.

This change preserves the required function-parameter type and nests only the root `anyOf` constraint under `allOf`. Nested `anyOf` schemas retain the existing Kimi-specific branch-type normalization.

## Validation

- `cargo fmt --manifest-path executor/Cargo.toml --check`
- `cargo test --manifest-path executor/Cargo.toml --lib server::local_model_proxy` (134 passed, 1 external-model test ignored by design)
- pre-push `cargo test --all-features --lib`
- pre-push `cargo clippy`
- verified end to end against the configured Moonshot Kimi K3 Chat Completions service in Wework


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kimi K3 tool-schema compatibility by consistently preserving object parameter types.
  * Normalized schemas with root-level alternatives to ensure valid Chat Completions requests.
  * Improved handling of object types within alternative schema branches.
  * Preserved existing schema constraints during normalization.

* **Documentation**
  * Updated English and Chinese developer guides with Kimi K3 tool-schema compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->