### PR TITLE
fix(wework): 设置页在小窗口下已归档项被标题栏裁切

### DIFF
--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -359,6 +359,17 @@ describe('ConnectionsSettingsPage', () => {
     expect(screen.getByTestId('worktrees-settings-page')).toBeInTheDocument()
   })
 
+  test('settings page fills its container instead of the full viewport', async () => {
+    window.history.pushState({}, '', '/settings')
+    api.getAllDevices.mockResolvedValue([])
+
+    render(<ConnectionsSettingsPage onBack={vi.fn()} />)
+
+    const settingsPage = await screen.findByTestId('wework-settings-page')
+    expect(settingsPage).toHaveClass('h-full')
+    expect(settingsPage).not.toHaveClass('h-screen')
+  })
+
   test('does not duplicate titlebar clearance beneath the Tauri app chrome', () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -1388,7 +1388,7 @@ export function ConnectionsSettingsPage({
     <div
       data-testid="wework-settings-page"
       className={cn(
-        'relative flex h-screen min-w-0 flex-1 overflow-hidden text-text-primary',
+        'relative flex h-full min-w-0 flex-1 overflow-hidden text-text-primary',
         background.imagePath && (background.inMain || background.inSidebar || background.inTopBar)
           ? 'bg-transparent'
           : 'bg-background'


### PR DESCRIPTION
## 问题
小窗口下打开设置，侧边栏底部（Hooks/已归档任务）被窗口下边缘裁掉。滚动后仍无法完整显示已归档项，且滚动会弹回。

## 根因
设置页根节点使用 `h-screen`（100vh），但在 Tauri 主窗口里它渲染在 ChromeTitlebar（约 39px）下方，页面底部约 39px 超出可视区域被 overflow-hidden 裁掉。已归档是导航最后一项，正好落在被裁区域：导航盒子底部始终在窗口下边缘之下约 23px，无论怎么滚动都无法完整显示。

## 修复
[ConnectionsSettingsPage.tsx](wework/src/components/settings/ConnectionsSettingsPage.tsx) 根节点由 `h-screen` 改为 `h-full`，让设置页填满标题栏下方的容器。各挂载点（DesktopWorkbenchLayout、SitesPage/PluginsPage 等辅助页面）的父容器均有确定高度，`h-full` 均正确。

## 验证
- 隔离 Tauri 会话实测：修复前导航底部 y=743（窗口 720），修复后 y=695，已归档项完整可见且可点击进入；滚动到底部后 scrollTop 稳定不回弹。
- 新增回归测试断言设置页使用 `h-full` 而非 `h-screen`。
- 44 个相关单测通过；pre-push 全量 ESLint/TypeScript/单测通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the settings page layout so it fills its parent container correctly, preventing viewport-height sizing issues.

* **Tests**
  * Added regression coverage to verify the settings page uses the intended full-height layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->