### PR TITLE
fix(wework): show quick phrases trigger as icon only by default

### DIFF
--- a/wework/src/components/chat/composer/ComposerToolbar.test.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.test.tsx
@@ -5,9 +5,7 @@ import { ComposerToolbar } from './ComposerToolbar'
 let resizeCallback: ResizeObserverCallback | null = null
 
 vi.mock('./QuickPhraseMenu', () => ({
-  QuickPhraseMenu: ({ iconOnly }: { iconOnly?: boolean }) => (
-    <span data-testid="quick-phrase-layout">{iconOnly ? 'icon' : 'label'}</span>
-  ),
+  QuickPhraseMenu: () => <span data-testid="quick-phrase-layout">icon</span>,
 }))
 
 vi.mock('./ModelSelector', () => ({
@@ -61,7 +59,7 @@ describe('ComposerToolbar', () => {
     )
 
     expect(screen.getByTestId('composer-toolbar')).toHaveAttribute('data-compact', 'false')
-    expect(screen.getByTestId('quick-phrase-layout')).toHaveTextContent('label')
+    expect(screen.getByTestId('quick-phrase-layout')).toHaveTextContent('icon')
 
     act(() => {
       resizeCallback?.(

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -143,7 +143,7 @@ export function ComposerToolbar({
           selectedCloudProjectId={selectedCloudProjectId}
           onSelectCloudProject={onSelectCloudProject}
         />
-        <QuickPhraseMenu disabled={disabled} iconOnly={compact} onSelect={onQuickPhraseSelect} />
+        <QuickPhraseMenu disabled={disabled} onSelect={onQuickPhraseSelect} />
         <PluginPickerMenu
           disabled={disabled}
           iconOnly={compact}

--- a/wework/src/components/chat/composer/QuickPhraseMenu.test.tsx
+++ b/wework/src/components/chat/composer/QuickPhraseMenu.test.tsx
@@ -44,15 +44,14 @@ describe('QuickPhraseMenu', () => {
     expect(screen.queryByTestId('quick-phrase-menu')).not.toBeInTheDocument()
   })
 
-  test('uses subdued regular text for the trigger and menu options', () => {
+  test('uses an icon-only trigger and subdued regular text for menu options', () => {
     render(<QuickPhraseMenu onSelect={vi.fn()} />)
 
-    expect(screen.getByTestId('quick-phrase-button')).toHaveClass(
-      'font-normal',
-      'text-text-primary'
-    )
+    const button = screen.getByTestId('quick-phrase-button')
+    expect(button).not.toHaveTextContent('快捷短语')
+    expect(button).toHaveClass('h-8', 'w-8', 'text-text-primary')
 
-    fireEvent.click(screen.getByTestId('quick-phrase-button'))
+    fireEvent.click(button)
 
     const menu = screen.getByTestId('quick-phrase-menu')
     expect(menu).toHaveClass('text-text-primary')
@@ -87,15 +86,6 @@ describe('QuickPhraseMenu', () => {
 
     fireEvent.pointerEnter(stash)
     expect(screen.getByTestId('quick-phrase-stash-preview')).toHaveTextContent('两张图片')
-  })
-
-  test('renders icon-only without label when iconOnly is true', () => {
-    render(<QuickPhraseMenu iconOnly onSelect={vi.fn()} />)
-
-    const button = screen.getByTestId('quick-phrase-button')
-    expect(button).not.toHaveTextContent('快捷短语')
-    expect(button.className).toContain('h-8')
-    expect(button.className).toContain('w-8')
   })
 
   test('renders compact circular button without label when compact is true', () => {

--- a/wework/src/components/chat/composer/QuickPhraseMenu.tsx
+++ b/wework/src/components/chat/composer/QuickPhraseMenu.tsx
@@ -12,7 +12,6 @@ import { useOutsideClick } from './useOutsideClick'
 interface QuickPhraseMenuProps {
   disabled?: boolean
   compact?: boolean
-  iconOnly?: boolean
   onSelect: (phrase: QuickPhrase) => void
 }
 
@@ -152,7 +151,7 @@ function StashPreview({ phrase }: { phrase: QuickPhrase }) {
   )
 }
 
-export function QuickPhraseMenu({ disabled, compact, iconOnly, onSelect }: QuickPhraseMenuProps) {
+export function QuickPhraseMenu({ disabled, compact, onSelect }: QuickPhraseMenuProps) {
   const { t } = useTranslation('common')
   const phrases = useQuickPhrases()
   const [open, setOpen] = useState(false)
@@ -228,17 +227,12 @@ export function QuickPhraseMenu({ disabled, compact, iconOnly, onSelect }: Quick
         className={
           compact
             ? 'flex h-11 w-11 items-center justify-center rounded-full text-text-primary hover:bg-muted disabled:opacity-40'
-            : iconOnly
-              ? 'flex h-8 w-8 items-center justify-center rounded-lg text-text-primary hover:bg-muted disabled:opacity-40'
-              : 'flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm font-normal text-text-primary hover:bg-muted disabled:opacity-40'
+            : 'flex h-8 w-8 items-center justify-center rounded-lg text-text-primary hover:bg-muted disabled:opacity-40'
         }
         aria-label={t('workbench.quick_phrases', '快捷短语')}
         aria-expanded={open}
       >
         <MessageSquareText className="h-4 w-4 text-text-primary" strokeWidth={1.5} />
-        {!compact && !iconOnly && (
-          <span className="text-text-primary">{t('workbench.quick_phrases', '快捷短语')}</span>
-        )}
       </button>
       {open &&
         typeof document !== 'undefined' &&


### PR DESCRIPTION
## What changed

The quick-phrases trigger in the Wework composer is now icon-only by default. The
desktop toolbar no longer passes an `iconOnly` flag to `QuickPhraseMenu`, and the
component no longer renders a text label; the `iconOnly` prop was removed
entirely.

## Why

The quick-phrase trigger should stay visually quiet in the composer toolbar:
only its icon is shown by default, matching the compact/mobile variant and the
Codex composer recipe in `wework/DESIGN.md`. The accessible name remains on the
button (`aria-label`), so screen readers are unaffected.

## Impact

Users see a smaller, icon-only quick-phrases control in the desktop composer
instead of an icon plus the "Quick phrases" label. Opening the menu and
selecting, searching, or managing phrases works exactly as before.

## Validation

- Updated `QuickPhraseMenu` and `ComposerToolbar` unit tests (menu behavior,
  icon-only trigger, keyboard and stash flows).
- `pnpm --filter wework` ESLint, TypeScript, and unit tests all passed in the
  pre-push quality gate; focused tests and Prettier passed before push.
