### PR TITLE
refactor(wework): migrate local runtime home to ~/.wework

### DIFF
--- a/docs/en/wework/developer-guide/wework-local-data-directory.md
+++ b/docs/en/wework/developer-guide/wework-local-data-directory.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 22
+---
+
+# Local Data Directory
+
+Wework stores its local runtime data under `~/.wework` in the user's home
+directory. The legacy `~/.wecode/wegent-executor` and `~/.wegent-executor`
+locations are no longer used.
+
+## Directory Layout
+
+The default Executor Home is `~/.wework` and contains:
+
+- `codex/`: Wework's isolated Codex home (overridable with `WEGENT_CODEX_HOME`).
+- `workspace/projects/` and `workspace/worktrees/`: local projects and managed worktrees.
+- `workspace/chats/`: local task conversations.
+- `workspace/attachments/draft/`: local attachment drafts.
+- `capabilities/bundled-marketplaces/`: bundled plugin marketplace cache.
+- `logs/`: Executor logs such as `logs/executor.log`.
+- `runtime/`: per-process state such as the bridge identity.
+- `device-config.json` and `device_id`: local device identity.
+
+The `WEGENT_EXECUTOR_HOME` environment variable overrides the default Executor
+Home. When it is set explicitly, Wework does not run the default-directory
+migration, which keeps isolated sessions, tests, and custom deployments intact.
+
+## Legacy Directory Migration
+
+On the first start with the default directory, Wework automatically migrates
+legacy data into `~/.wework`:
+
+1. `~/.wegent-executor` is migrated first.
+2. The older `~/.wecode/wegent-executor` is merged afterwards.
+
+Migration rules:
+
+- When `~/.wework` does not exist, the legacy directory is renamed as a whole,
+  preserving file attributes, directory structure, and symbolic links.
+- When both directories exist, non-conflicting content is merged recursively;
+  files already in `~/.wework` always win.
+- Conflicting legacy entries are archived under
+  `~/.wework/.legacy-migration-conflicts/<source>/` instead of being overwritten.
+- After migration, the legacy directory is removed and old paths are never read
+  at runtime.

--- a/docs/zh/wework/developer-guide/wework-local-data-directory.md
+++ b/docs/zh/wework/developer-guide/wework-local-data-directory.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 22
+---
+
+# 本地数据目录
+
+Wework 的本地运行时数据统一存放在用户主目录下的 `~/.wework`，不再使用
+`~/.wecode/wegent-executor` 或 `~/.wegent-executor`。
+
+## 目录结构
+
+默认 Executor Home 为 `~/.wework`，主要内容包括：
+
+- `codex/`：Wework 独立的 Codex home（可通过 `WEGENT_CODEX_HOME` 覆盖）。
+- `workspace/projects/`、`workspace/worktrees/`：本地项目与托管工作树。
+- `workspace/chats/`：本地任务会话。
+- `workspace/attachments/draft/`：本地附件草稿。
+- `capabilities/bundled-marketplaces/`：内置插件市场缓存。
+- `logs/`：Executor 日志（例如 `logs/executor.log`）。
+- `runtime/`：运行时桥接等进程内状态。
+- `device-config.json`、`device_id`：本机设备标识。
+
+`WEGENT_EXECUTOR_HOME` 环境变量可以覆盖默认 Executor Home。显式设置该变量时，
+Wework 不会对默认目录执行迁移，用于隔离会话、测试和自定义部署。
+
+## 旧目录迁移
+
+首次以默认目录启动时，Wework 会自动把旧数据迁移到 `~/.wework`：
+
+1. 优先迁移 `~/.wegent-executor`。
+2. 再合并更早的 `~/.wecode/wegent-executor`。
+
+迁移规则：
+
+- `~/.wework` 不存在时，直接重命名整个旧目录，保留文件属性、目录结构和软链接。
+- 新旧目录同时存在时，递归合并不冲突的内容；`~/.wework` 中的现有文件始终优先。
+- 同名冲突的旧内容归档到 `~/.wework/.legacy-migration-conflicts/<来源>/`，不会覆盖或丢失数据。
+- 迁移完成后旧目录会被移除，运行期不再读取旧路径。

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -1900,20 +1900,10 @@ fn read_executor_process_device_id(expected_backend_url: Option<&str>) -> Option
                 })
             })
             .or_else(|| {
-                process_env_value(&tokens, "WECODE_HOME").and_then(|home| {
-                    read_device_config_for_backend(
-                        std::path::PathBuf::from(home)
-                            .join("wegent-executor")
-                            .join("device-config.json"),
-                        expected_backend_url,
-                    )
-                })
-            })
-            .or_else(|| {
                 process_env_value(&tokens, "HOME").and_then(|home| {
                     read_device_config_for_backend(
                         std::path::PathBuf::from(home)
-                            .join(".wegent-executor")
+                            .join(".wework")
                             .join("device-config.json"),
                         expected_backend_url,
                     )
@@ -2434,7 +2424,8 @@ fn default_executor_home(app: &tauri::AppHandle) -> Result<std::path::PathBuf, S
         .path()
         .home_dir()
         .map_err(|error| format!("Failed to locate home directory: {error}"))?;
-    Ok(home.join(".wegent-executor"))
+    local_executor::migrate_legacy_executor_homes(&home)?;
+    Ok(home.join(".wework"))
 }
 
 fn executor_home_attachment_root(executor_home: &std::path::Path) -> std::path::PathBuf {
@@ -2522,19 +2513,15 @@ fn get_local_executor_device_id(expected_backend_url: Option<String>) -> Option<
         candidates.push(executor_home.join("device_id"));
     }
     if let Some(home) = dirs::home_dir() {
-        if let Some(device_id) = read_device_config(
-            home.join(".wecode")
-                .join("wegent-executor")
-                .join("device-config.json"),
-        ) {
-            return Some(device_id);
+        if let Err(error) = local_executor::migrate_legacy_executor_homes(&home) {
+            log::warn!("Failed to migrate legacy Wework home: {error}");
+            return None;
         }
-        if let Some(device_id) =
-            read_device_config(home.join(".wegent-executor").join("device-config.json"))
+        if let Some(device_id) = read_device_config(home.join(".wework").join("device-config.json"))
         {
             return Some(device_id);
         }
-        candidates.push(home.join(".wegent-executor").join("device_id"));
+        candidates.push(home.join(".wework").join("device_id"));
     }
 
     for path in candidates {
@@ -4093,8 +4080,8 @@ mod tests {
     #[test]
     fn places_local_attachment_drafts_under_executor_home() {
         assert_eq!(
-            executor_home_attachment_root(std::path::Path::new("/Users/me/.wegent-executor")),
-            std::path::PathBuf::from("/Users/me/.wegent-executor/workspace/attachments/draft")
+            executor_home_attachment_root(std::path::Path::new("/Users/me/.wework")),
+            std::path::PathBuf::from("/Users/me/.wework/workspace/attachments/draft")
         );
     }
 

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -54,6 +54,10 @@ const LOCAL_EXECUTOR_SIGNAL_AUDIT_FILE_NAME: &str = "wework-executor-signal-audi
 const LOCAL_EXECUTOR_RUNTIME_DIR_NAME: &str = "app-runtime";
 const LOCAL_EXECUTOR_LOG_TAIL_BYTES: u64 = 200 * 1024;
 const LOCAL_EXECUTOR_LOG_TAIL_LINES: usize = 20;
+const WEWORK_HOME_DIR: &str = ".wework";
+const LEGACY_EXECUTOR_HOME_DIR: &str = ".wegent-executor";
+const LEGACY_WECODE_HOME_DIR: &str = ".wecode";
+const LEGACY_MIGRATION_CONFLICTS_DIR: &str = ".legacy-migration-conflicts";
 const LOCAL_EXECUTOR_READY_TIMEOUT_SECS: u64 = if cfg!(debug_assertions) {
     if cfg!(windows) {
         180
@@ -628,6 +632,7 @@ pub(crate) fn local_executor_home_path() -> Result<PathBuf, String> {
     }
 
     let home = dirs::home_dir().ok_or_else(|| "Home directory is not available".to_string())?;
+    migrate_legacy_executor_homes(&home)?;
     Ok(default_local_executor_home_path(
         &home,
         LOCAL_EXECUTOR_NAMESPACE,
@@ -635,10 +640,177 @@ pub(crate) fn local_executor_home_path() -> Result<PathBuf, String> {
 }
 
 fn default_local_executor_home_path(home: &Path, namespace: Option<&str>) -> PathBuf {
-    let root = home.join(".wegent-executor");
+    let root = home.join(WEWORK_HOME_DIR);
     namespace
         .filter(|value| !value.is_empty())
         .map_or(root.clone(), |value| root.join("apps").join(value))
+}
+
+pub(crate) fn migrate_legacy_executor_homes(home: &Path) -> Result<(), String> {
+    let destination = home.join(WEWORK_HOME_DIR);
+    for (source, label) in [
+        (
+            home.join(LEGACY_EXECUTOR_HOME_DIR),
+            LEGACY_EXECUTOR_HOME_DIR,
+        ),
+        (
+            home.join(LEGACY_WECODE_HOME_DIR)
+                .join(LEGACY_EXECUTOR_HOME_DIR),
+            "wecode-wegent-executor",
+        ),
+    ] {
+        migrate_legacy_executor_home(&source, &destination, label)?;
+    }
+    Ok(())
+}
+
+fn migrate_legacy_executor_home(
+    source: &Path,
+    destination: &Path,
+    legacy_label: &str,
+) -> Result<(), String> {
+    let source_metadata = match fs::symlink_metadata(source) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "Failed to inspect legacy Wework directory {}: {error}",
+                source.display()
+            ));
+        }
+    };
+    if !source_metadata.is_dir() {
+        return Err(format!(
+            "Legacy Wework directory is not a directory: {}",
+            source.display()
+        ));
+    }
+
+    match fs::symlink_metadata(destination) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::rename(source, destination).map_err(|error| {
+                format!(
+                    "Failed to migrate {} to {}: {error}",
+                    source.display(),
+                    destination.display()
+                )
+            })?;
+            log::info!(
+                "Migrated legacy Wework directory {} to {}",
+                source.display(),
+                destination.display()
+            );
+            return Ok(());
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(format!(
+                "Wework home is not a directory: {}",
+                destination.display()
+            ));
+        }
+        Ok(_) => {}
+        Err(error) => {
+            return Err(format!(
+                "Failed to inspect Wework home {}: {error}",
+                destination.display()
+            ));
+        }
+    }
+
+    merge_legacy_executor_directory(
+        source,
+        destination,
+        &destination
+            .join(LEGACY_MIGRATION_CONFLICTS_DIR)
+            .join(legacy_label),
+    )?;
+    if fs::read_dir(source)
+        .map_err(|error| format!("Failed to read {}: {error}", source.display()))?
+        .next()
+        .is_none()
+    {
+        fs::remove_dir(source)
+            .map_err(|error| format!("Failed to remove {}: {error}", source.display()))?;
+    }
+    Ok(())
+}
+
+fn merge_legacy_executor_directory(
+    source: &Path,
+    destination: &Path,
+    conflict_destination: &Path,
+) -> Result<(), String> {
+    for entry in fs::read_dir(source)
+        .map_err(|error| format!("Failed to read {}: {error}", source.display()))?
+    {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        match fs::symlink_metadata(&destination_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::rename(&source_path, &destination_path).map_err(|error| {
+                    format!(
+                        "Failed to migrate {} to {}: {error}",
+                        source_path.display(),
+                        destination_path.display()
+                    )
+                })?;
+            }
+            Ok(destination_metadata)
+                if entry
+                    .file_type()
+                    .map_err(|error| {
+                        format!("Failed to inspect {}: {error}", source_path.display())
+                    })?
+                    .is_dir()
+                    && destination_metadata.is_dir() =>
+            {
+                merge_legacy_executor_directory(
+                    &source_path,
+                    &destination_path,
+                    &conflict_destination.join(entry.file_name()),
+                )?;
+                if fs::read_dir(&source_path)
+                    .map_err(|error| format!("Failed to read {}: {error}", source_path.display()))?
+                    .next()
+                    .is_none()
+                {
+                    fs::remove_dir(&source_path).map_err(|error| {
+                        format!("Failed to remove {}: {error}", source_path.display())
+                    })?;
+                }
+            }
+            Ok(_) => {
+                fs::create_dir_all(conflict_destination).map_err(|error| {
+                    format!(
+                        "Failed to create {}: {error}",
+                        conflict_destination.display()
+                    )
+                })?;
+                let conflict_path = conflict_destination.join(entry.file_name());
+                fs::rename(&source_path, &conflict_path).map_err(|error| {
+                    format!(
+                        "Failed to preserve conflicting legacy Wework entry {} at {}: {error}",
+                        source_path.display(),
+                        conflict_path.display()
+                    )
+                })?;
+                log::warn!(
+                    "Preserved conflicting legacy Wework entry {} at {} because {} already exists",
+                    source_path.display(),
+                    conflict_path.display(),
+                    destination_path.display(),
+                );
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Failed to inspect Wework migration destination {}: {error}",
+                    destination_path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn local_executor_log_path() -> Result<PathBuf, String> {
@@ -4577,12 +4749,83 @@ BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
 
         assert_eq!(
             default_local_executor_home_path(home, None),
-            PathBuf::from("/tmp/wework-test-home/.wegent-executor")
+            PathBuf::from("/tmp/wework-test-home/.wework")
         );
         assert_eq!(
             default_local_executor_home_path(home, Some("com.example.demo-wework")),
-            PathBuf::from("/tmp/wework-test-home/.wegent-executor/apps/com.example.demo-wework")
+            PathBuf::from("/tmp/wework-test-home/.wework/apps/com.example.demo-wework")
         );
+    }
+
+    #[test]
+    fn migrates_legacy_executor_homes_into_wework_home() {
+        let home = import_test_root("legacy-executor-home");
+        let current_legacy_home = home.join(LEGACY_EXECUTOR_HOME_DIR);
+        let wecode_legacy_home = home
+            .join(LEGACY_WECODE_HOME_DIR)
+            .join(LEGACY_EXECUTOR_HOME_DIR);
+        fs::create_dir_all(current_legacy_home.join("workspace/chats")).unwrap();
+        fs::create_dir_all(wecode_legacy_home.join("capabilities")).unwrap();
+        fs::write(
+            current_legacy_home.join("device-config.json"),
+            "{\"device_id\":\"current-device\"}",
+        )
+        .unwrap();
+        fs::write(
+            current_legacy_home.join("workspace/chats/current.md"),
+            "current",
+        )
+        .unwrap();
+        fs::write(wecode_legacy_home.join("capabilities/legacy.md"), "legacy").unwrap();
+
+        migrate_legacy_executor_homes(&home).unwrap();
+
+        let destination = home.join(WEWORK_HOME_DIR);
+        assert_eq!(
+            fs::read_to_string(destination.join("device-config.json")).unwrap(),
+            "{\"device_id\":\"current-device\"}"
+        );
+        assert_eq!(
+            fs::read_to_string(destination.join("workspace/chats/current.md")).unwrap(),
+            "current"
+        );
+        assert_eq!(
+            fs::read_to_string(destination.join("capabilities/legacy.md")).unwrap(),
+            "legacy"
+        );
+        assert!(!current_legacy_home.exists());
+        assert!(!wecode_legacy_home.exists());
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn preserves_conflicting_legacy_entries_without_using_legacy_home() {
+        let home = import_test_root("legacy-executor-conflict");
+        let destination = home.join(WEWORK_HOME_DIR);
+        let legacy_home = home.join(LEGACY_EXECUTOR_HOME_DIR);
+        fs::create_dir_all(&destination).unwrap();
+        fs::create_dir_all(&legacy_home).unwrap();
+        fs::write(destination.join("device-config.json"), "current").unwrap();
+        fs::write(legacy_home.join("device-config.json"), "legacy").unwrap();
+
+        migrate_legacy_executor_homes(&home).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("device-config.json")).unwrap(),
+            "current"
+        );
+        assert_eq!(
+            fs::read_to_string(
+                destination
+                    .join(LEGACY_MIGRATION_CONFLICTS_DIR)
+                    .join(LEGACY_EXECUTOR_HOME_DIR)
+                    .join("device-config.json")
+            )
+            .unwrap(),
+            "legacy"
+        );
+        assert!(!legacy_home.exists());
+        let _ = fs::remove_dir_all(home);
     }
 
     #[cfg(unix)]

--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -92,7 +92,7 @@ vi.mock('@/features/local-runtime/CodexHomeInitializer', () => ({
 vi.mock('@/api/local/codexPlugins', () => ({
   createLocalCodexPluginApi: () => ({
     codexHomeMigrationStatus: vi.fn().mockResolvedValue({
-      weworkCodexHome: '/Users/test/.wegent-executor/codex',
+      weworkCodexHome: '/Users/test/.wework/codex',
       nativeCodexHome: '/Users/test/.codex',
       weworkCodexHomeExists: true,
       nativeCodexHomeExists: true,

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -71,7 +71,7 @@ vi.mock('@/api/local/codexPlugins', async importOriginal => {
     createLocalCodexPluginApi: () => ({
       ...actual.createLocalCodexPluginApi(),
       codexHomeMigrationStatus: vi.fn().mockResolvedValue({
-        weworkCodexHome: '/Users/test/.wegent-executor/codex',
+        weworkCodexHome: '/Users/test/.wework/codex',
         nativeCodexHome: '/Users/test/.codex',
         weworkCodexHomeExists: true,
         nativeCodexHomeExists: true,

--- a/wework/src/api/local/localAttachments.test.ts
+++ b/wework/src/api/local/localAttachments.test.ts
@@ -20,7 +20,7 @@ describe('local attachment API', () => {
 
   test('stores uploaded files under executor home instead of the active project workspace', async () => {
     tauriMocks.invoke.mockResolvedValue(
-      '/Users/me/.wegent-executor/workspace/attachments/draft/123/photo.png'
+      '/Users/me/.wework/workspace/attachments/draft/123/photo.png'
     )
     const file = new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' })
     const progress = vi.fn()
@@ -44,7 +44,7 @@ describe('local attachment API', () => {
     expect(progress).toHaveBeenNthCalledWith(1, 0)
     expect(progress).toHaveBeenNthCalledWith(2, 100)
     expect(attachment.local_path).toBe(
-      '/Users/me/.wegent-executor/workspace/attachments/draft/123/photo.png'
+      '/Users/me/.wework/workspace/attachments/draft/123/photo.png'
     )
   })
 })

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -541,9 +541,8 @@ describe('createLocalAppServices', () => {
           status: 'ready',
           file_extension: '.png',
           created_at: '2026-06-29T00:00:00.000Z',
-          local_path: '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard.png',
-          local_preview_url:
-            '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard.png',
+          local_path: '/Users/me/.wework/workspace/attachments/draft/-45/clipboard.png',
+          local_preview_url: '/Users/me/.wework/workspace/attachments/draft/-45/clipboard.png',
         },
       ],
     })
@@ -580,9 +579,8 @@ describe('createLocalAppServices', () => {
           status: 'ready',
           file_extension: '.png',
           created_at: '2026-06-29T00:00:00.000Z',
-          local_path: '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard.png',
-          local_preview_url:
-            '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard.png',
+          local_path: '/Users/me/.wework/workspace/attachments/draft/-45/clipboard.png',
+          local_preview_url: '/Users/me/.wework/workspace/attachments/draft/-45/clipboard.png',
         },
       ],
       executionRequest: expect.objectContaining({
@@ -645,9 +643,8 @@ describe('createLocalAppServices', () => {
             mime_type: 'image/png',
             subtask_id: expect.any(String),
             file_extension: '.png',
-            local_path: '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard.png',
-            local_preview_url:
-              '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard.png',
+            local_path: '/Users/me/.wework/workspace/attachments/draft/-45/clipboard.png',
+            local_preview_url: '/Users/me/.wework/workspace/attachments/draft/-45/clipboard.png',
           },
         ],
       }),
@@ -688,7 +685,7 @@ describe('createLocalAppServices', () => {
           }
         }
         if (method === 'runtime.worktrees.prepare') {
-          const path = `/Users/me/.wegent-executor/workspace/worktrees/${data.worktreeId}/project`
+          const path = `/Users/me/.wework/workspace/worktrees/${data.worktreeId}/project`
           return { success: true, path, worktree: { path } }
         }
         if (method === 'runtime.tasks.create') {
@@ -732,7 +729,7 @@ describe('createLocalAppServices', () => {
     )?.[1]
     const worktreePath = String(createPayload.workspacePath)
     expect(worktreePath).toMatch(
-      /^\/Users\/me\/\.wegent-executor\/workspace\/worktrees\/runtime-\d+\/project$/
+      /^\/Users\/me\/\.wework\/workspace\/worktrees\/runtime-\d+\/project$/
     )
     expect(response?.workspacePath).toBe(worktreePath)
     expect(response?.runtimeHandle).toEqual({
@@ -786,7 +783,7 @@ describe('createLocalAppServices', () => {
           }
         }
         if (method === 'runtime.worktrees.prepare') {
-          const path = `/Users/me/.wegent-executor/workspace/worktrees/${data.worktreeId}/project`
+          const path = `/Users/me/.wework/workspace/worktrees/${data.worktreeId}/project`
           return { success: true, path, worktree: { path } }
         }
         if (method === 'runtime.tasks.create') {
@@ -884,9 +881,8 @@ describe('createLocalAppServices', () => {
           status: 'ready',
           file_extension: '.png',
           created_at: '2026-06-29T00:00:00.000Z',
-          local_path: '/Users/me/.wegent-executor/workspace/attachments/draft/-46/follow-up.png',
-          local_preview_url:
-            '/Users/me/.wegent-executor/workspace/attachments/draft/-46/follow-up.png',
+          local_path: '/Users/me/.wework/workspace/attachments/draft/-46/follow-up.png',
+          local_preview_url: '/Users/me/.wework/workspace/attachments/draft/-46/follow-up.png',
         },
       ],
     })
@@ -918,9 +914,8 @@ describe('createLocalAppServices', () => {
             status: 'ready',
             file_extension: '.png',
             created_at: '2026-06-29T00:00:00.000Z',
-            local_path: '/Users/me/.wegent-executor/workspace/attachments/draft/-46/follow-up.png',
-            local_preview_url:
-              '/Users/me/.wegent-executor/workspace/attachments/draft/-46/follow-up.png',
+            local_path: '/Users/me/.wework/workspace/attachments/draft/-46/follow-up.png',
+            local_preview_url: '/Users/me/.wework/workspace/attachments/draft/-46/follow-up.png',
           },
         ],
         executionRequest: expect.objectContaining({
@@ -966,10 +961,8 @@ describe('createLocalAppServices', () => {
               mime_type: 'image/png',
               subtask_id: expect.any(String),
               file_extension: '.png',
-              local_path:
-                '/Users/me/.wegent-executor/workspace/attachments/draft/-46/follow-up.png',
-              local_preview_url:
-                '/Users/me/.wegent-executor/workspace/attachments/draft/-46/follow-up.png',
+              local_path: '/Users/me/.wework/workspace/attachments/draft/-46/follow-up.png',
+              local_preview_url: '/Users/me/.wework/workspace/attachments/draft/-46/follow-up.png',
             },
           ],
         }),

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -3150,7 +3150,7 @@ describe('MessageList', () => {
       status: 'ready',
       file_extension: '.png',
       created_at: '2026-06-26T15:33:00.000+08:00',
-      local_path: '/Users/me/.wegent-executor/workspace/attachments/draft/42/historical.png',
+      local_path: '/Users/me/.wework/workspace/attachments/draft/42/historical.png',
     }
 
     render(
@@ -3170,7 +3170,7 @@ describe('MessageList', () => {
 
     expect(await screen.findByTestId('message-image-preview')).toHaveAttribute(
       'src',
-      'asset://localhost/Users/me/.wegent-executor/workspace/attachments/draft/42/historical.png'
+      'asset://localhost/Users/me/.wework/workspace/attachments/draft/42/historical.png'
     )
     expect(fetch).not.toHaveBeenCalled()
   })
@@ -3273,7 +3273,7 @@ describe('MessageList', () => {
             content: [
               '# Files mentioned by the user:',
               '',
-              '## image.png: /Users/yunpeng7/.wegent-executor/workspace/attachments/10406026969952/0/image.png',
+              '## image.png: /Users/yunpeng7/.wework/workspace/attachments/10406026969952/0/image.png',
               '',
               '## My request for Codex:',
               '分析下这个图片',
@@ -3287,7 +3287,7 @@ describe('MessageList', () => {
 
     expect(await screen.findByTestId('message-local-image-preview')).toHaveAttribute(
       'src',
-      'asset://localhost/Users/yunpeng7/.wegent-executor/workspace/attachments/10406026969952/0/image.png'
+      'asset://localhost/Users/yunpeng7/.wework/workspace/attachments/10406026969952/0/image.png'
     )
     expect(screen.getByTestId('user-message-content')).toHaveTextContent('分析下这个图片')
     expect(screen.queryByText(/Files mentioned by the user/)).not.toBeInTheDocument()
@@ -3375,7 +3375,7 @@ describe('MessageList', () => {
             content: [
               '# Files mentioned by the user:',
               '',
-              '## image.png: /Users/yunpeng7/.wegent-executor/workspace/attachments/10406026969952/0/image.png',
+              '## image.png: /Users/yunpeng7/.wework/workspace/attachments/10406026969952/0/image.png',
               '',
               '## My request for Codex:',
               '分析下这个图片',
@@ -3771,7 +3771,7 @@ describe('MessageList', () => {
       created_at: '2026-05-25T15:09:00.000+08:00',
       text_preview: '{ "event_type": "http_exchange", "id": "e9972aac" }',
       local_path:
-        '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard-text-1783070360990.txt',
+        '/Users/me/.wework/workspace/attachments/draft/-45/clipboard-text-1783070360990.txt',
     }
 
     render(
@@ -3805,7 +3805,7 @@ describe('MessageList', () => {
 
     await waitFor(() =>
       expect(onOpenWorkspaceFile).toHaveBeenCalledWith(
-        '/Users/me/.wegent-executor/workspace/attachments/draft/-45/clipboard-text-1783070360990.txt'
+        '/Users/me/.wework/workspace/attachments/draft/-45/clipboard-text-1783070360990.txt'
       )
     )
   })

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1710,7 +1710,7 @@ describe('DesktopSidebar', () => {
 
   test('renders chat runtime tasks as conversations instead of workspace groups', async () => {
     const onOpenRuntimeTask = vi.fn()
-    const chatPath = '/Users/alice/.wecode/wegent-executor/workspace/chats/2026-06-20/hi-1'
+    const chatPath = '/Users/alice/.wework/workspace/chats/2026-06-20/hi-1'
 
     renderSidebar({
       projects: [],

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5763,9 +5763,9 @@ describe('DesktopWorkbenchLayout', () => {
     const user = userEvent.setup()
     const workspacePanelState = createCloudWorkspacePanelState()
     const localDevice = createLocalSkillDevice()
-    const imagePath = '/Users/me/.wegent-executor/workspace/attachments/draft/42/result.png'
+    const imagePath = '/Users/me/.wework/workspace/attachments/draft/42/result.png'
     const listWorkspaceEntries = vi.fn().mockResolvedValue({
-      path: '/Users/me/.wegent-executor/workspace/attachments/draft/42',
+      path: '/Users/me/.wework/workspace/attachments/draft/42',
       entries: [],
     })
     const readWorkspaceFileChunk = vi.fn().mockResolvedValue({
@@ -5815,7 +5815,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
     expect(listWorkspaceEntries).toHaveBeenCalledWith(
       localDevice.device_id,
-      '/Users/me/.wegent-executor/workspace/attachments/draft/42'
+      '/Users/me/.wework/workspace/attachments/draft/42'
     )
     expect(readWorkspaceFileChunk).toHaveBeenCalledWith(localDevice.device_id, imagePath, 0)
   })

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -1478,7 +1478,7 @@ describe('MobileWorkbenchLayout', () => {
 
   test('renders chat runtime tasks as conversations in the mobile drawer', async () => {
     const onOpenRuntimeTask = vi.fn()
-    const chatPath = '/Users/alice/.wecode/wegent-executor/workspace/chats/2026-06-20/hi-1'
+    const chatPath = '/Users/alice/.wework/workspace/chats/2026-06-20/hi-1'
 
     render(
       <MobileWorkbenchLayout

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -142,7 +142,7 @@ function isRuntimeChatPath(path: string) {
     if (parts[index] !== 'workspace' || parts[index + 1] !== 'chats') continue
     const previous = parts[index - 1]
     if (!previous) return true
-    return previous === 'wegent-executor' || previous === '.wegent-executor'
+    return previous === '.wework'
   }
   return parts[0] === 'workspace' && parts[1] === 'chats'
 }

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -175,7 +175,7 @@ function mockCodexAppServerInvoke(
   vi.mocked(invoke).mockImplementation((command: string, args?: unknown) => {
     if (command === 'local_executor_codex_home_migration_status') {
       return Promise.resolve({
-        weworkCodexHome: '/Users/test/.wegent-executor/codex',
+        weworkCodexHome: '/Users/test/.wework/codex',
         nativeCodexHome: '/Users/test/.codex',
         weworkCodexHomeExists: true,
         nativeCodexHomeExists: false,
@@ -184,7 +184,7 @@ function mockCodexAppServerInvoke(
     }
     if (command === 'local_executor_migrate_native_codex_home') {
       return Promise.resolve({
-        weworkCodexHome: '/Users/test/.wegent-executor/codex',
+        weworkCodexHome: '/Users/test/.wework/codex',
         nativeCodexHome: '/Users/test/.codex',
         weworkCodexHomeExists: true,
         nativeCodexHomeExists: true,
@@ -1900,7 +1900,7 @@ describe('PluginsWorkspace', () => {
         {
           name: 'wework-personal',
           displayName: 'Personal',
-          path: '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal',
+          path: '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal',
           plugins: [
             {
               id: '202',
@@ -2136,7 +2136,7 @@ describe('PluginsWorkspace', () => {
     vi.mocked(invoke).mockImplementation((command: string) => {
       if (command === 'local_executor_codex_home_migration_status') {
         return Promise.resolve({
-          weworkCodexHome: '/Users/test/.wegent-executor/codex',
+          weworkCodexHome: '/Users/test/.wework/codex',
           nativeCodexHome: '/Users/test/.codex',
           weworkCodexHomeExists: true,
           nativeCodexHomeExists: false,

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -235,14 +235,14 @@ describe('ConnectionsSettingsPage', () => {
       disk: [],
     })
     localCodexPluginApiMock.readCodexLocalConfig.mockResolvedValue({
-      codexHome: '/Users/crystal/.wegent-executor/codex',
-      configPath: '/Users/crystal/.wegent-executor/codex/config.toml',
+      codexHome: '/Users/crystal/.wework/codex',
+      configPath: '/Users/crystal/.wework/codex/config.toml',
       remoteAppsEnabled: false,
     })
     localCodexPluginApiMock.updateCodexLocalConfig.mockImplementation(patch =>
       Promise.resolve({
-        codexHome: '/Users/crystal/.wegent-executor/codex',
-        configPath: '/Users/crystal/.wegent-executor/codex/config.toml',
+        codexHome: '/Users/crystal/.wework/codex',
+        configPath: '/Users/crystal/.wework/codex/config.toml',
         remoteAppsEnabled: Boolean(patch.remoteAppsEnabled),
       })
     )

--- a/wework/src/components/settings/GeneralSettingsPage.test.tsx
+++ b/wework/src/components/settings/GeneralSettingsPage.test.tsx
@@ -122,7 +122,7 @@ describe('GeneralSettingsPage', () => {
     importExternalContentMock.mockResolvedValue({
       source: 'codex',
       sourcePath: '/Users/test/.codex',
-      destinationPath: '/Users/test/.wegent-executor/codex',
+      destinationPath: '/Users/test/.wework/codex',
       importedEntries: ['config.toml'],
     })
     getAppPreferencesMock.mockResolvedValue(defaultPreferences)
@@ -348,7 +348,7 @@ describe('GeneralSettingsPage', () => {
       .mockResolvedValueOnce({
         source: 'codex',
         sourcePath: '/Users/test/.codex',
-        destinationPath: '/Users/test/.wegent-executor/codex',
+        destinationPath: '/Users/test/.wework/codex',
         importedEntries: ['config.toml'],
       })
     render(<GeneralSettingsPage />)

--- a/wework/src/components/settings/WorktreesSettingsPage.test.tsx
+++ b/wework/src/components/settings/WorktreesSettingsPage.test.tsx
@@ -38,14 +38,14 @@ describe('WorktreesSettingsPage', () => {
     getWorktreeSettings.mockResolvedValue({
       deviceId: 'local-device',
       worktreeRoot: '',
-      resolvedWorktreeRoot: '/Users/me/.wecode/wegent-executor/workspace/worktrees',
+      resolvedWorktreeRoot: '/Users/me/.wework/workspace/worktrees',
       autoCleanupEnabled: true,
       keepCount: 15,
     })
     updateWorktreeSettings.mockImplementation(async data => ({
       deviceId: 'local-device',
       worktreeRoot: '',
-      resolvedWorktreeRoot: '/Users/me/.wecode/wegent-executor/workspace/worktrees',
+      resolvedWorktreeRoot: '/Users/me/.wework/workspace/worktrees',
       autoCleanupEnabled: data.autoCleanupEnabled ?? true,
       keepCount: data.keepCount ?? 15,
     }))
@@ -56,7 +56,7 @@ describe('WorktreesSettingsPage', () => {
         {
           deviceId: 'local-device',
           worktreeId: 'runtime-1',
-          path: '/Users/me/.wecode/wegent-executor/workspace/worktrees/runtime-1/repo',
+          path: '/Users/me/.wework/workspace/worktrees/runtime-1/repo',
           repositoryName: 'repo',
           sourcePath: '/Users/me/repo',
           state: 'active',
@@ -64,7 +64,7 @@ describe('WorktreesSettingsPage', () => {
             {
               deviceId: 'local-device',
               taskId: 'runtime-1',
-              workspacePath: '/Users/me/.wecode/wegent-executor/workspace/worktrees/runtime-1/repo',
+              workspacePath: '/Users/me/.wework/workspace/worktrees/runtime-1/repo',
               title: 'Fix settings',
               status: 'active',
               running: false,
@@ -132,7 +132,7 @@ describe('WorktreesSettingsPage', () => {
         {
           deviceId: 'local-device',
           worktreeId: 'runtime-restorable',
-          path: '/Users/me/.wecode/wegent-executor/workspace/worktrees/restorable/repo',
+          path: '/Users/me/.wework/workspace/worktrees/restorable/repo',
           repositoryName: 'repo',
           sourcePath: '/Users/me/repo',
           state: 'restorable',
@@ -174,7 +174,7 @@ describe('WorktreesSettingsPage', () => {
     await waitFor(() =>
       expect(deleteWorktree).toHaveBeenCalledWith({
         deviceId: 'local-device',
-        path: '/Users/me/.wecode/wegent-executor/workspace/worktrees/runtime-1/repo',
+        path: '/Users/me/.wework/workspace/worktrees/runtime-1/repo',
         preserveSnapshot: true,
       })
     )

--- a/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/CodexHomeInitializer.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@/api/local/codexPlugins', () => ({
 }))
 
 const migrationStatus = {
-  weworkCodexHome: '/Users/test/.wegent-executor/codex',
+  weworkCodexHome: '/Users/test/.wework/codex',
   nativeCodexHome: '/Users/test/.codex',
   weworkCodexHomeExists: true,
   nativeCodexHomeExists: true,

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -277,7 +277,7 @@ describe('LocalRuntimeInitializer', () => {
         })
     )
     readLogMock.mockResolvedValue({
-      path: '~/.wegent-executor/logs/executor.log',
+      path: '~/.wework/logs/executor.log',
       content: 'executor waiting for stdio via Tauri runtime detail',
       truncated: true,
       lineCount: 20,
@@ -288,7 +288,7 @@ describe('LocalRuntimeInitializer', () => {
       sidecarSource: 'configured',
       sidecarPath: '/Applications/Wework.app/Contents/MacOS/wegent-executor',
       currentDir: '/Applications/Wework.app/Contents/MacOS',
-      executorHome: '~/.wegent-executor',
+      executorHome: '~/.wework',
       backendUrl: 'https://cloud.example.com',
       socketUrl: 'wss://socket.example.com',
       hasBackendAuthToken: true,
@@ -361,9 +361,7 @@ describe('LocalRuntimeInitializer', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Current working directory: /Applications/Wework.app/Contents/MacOS')
     )
-    expect(writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Executor home: ~/.wegent-executor')
-    )
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Executor home: ~/.wework'))
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Backend URL: https://cloud.example.com')
     )
@@ -391,7 +389,7 @@ describe('LocalRuntimeInitializer', () => {
     vi.useFakeTimers()
     ensureMock.mockImplementation(() => new Promise(() => undefined))
     readLogMock.mockResolvedValue({
-      path: '~/.wegent-executor/logs/executor.log',
+      path: '~/.wework/logs/executor.log',
       content: 'executor native clipboard path',
       truncated: false,
       lineCount: 1,
@@ -402,7 +400,7 @@ describe('LocalRuntimeInitializer', () => {
       sidecarSource: 'bundled',
       sidecarPath: 'wegent-executor',
       currentDir: '/tmp/wework',
-      executorHome: '~/.wegent-executor',
+      executorHome: '~/.wework',
       backendUrl: null,
       socketUrl: null,
       hasBackendAuthToken: false,
@@ -514,7 +512,7 @@ describe('LocalRuntimeInitializer', () => {
     )
 
     expect(await screen.findByTestId('local-runtime-error')).toHaveTextContent('stdio unavailable')
-    expect(screen.getByText('~/.wegent-executor/logs/executor.log')).toBeInTheDocument()
+    expect(screen.getByText('~/.wework/logs/executor.log')).toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('local-runtime-retry-button'))
 

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -31,8 +31,8 @@ import {
 
 function getLocalExecutorLogDisplayPath(): string {
   return getPlatform() === 'win'
-    ? '%USERPROFILE%\\.wegent-executor\\logs\\executor.log'
-    : '~/.wegent-executor/logs/executor.log'
+    ? '%USERPROFILE%\\.wework\\logs\\executor.log'
+    : '~/.wework/logs/executor.log'
 }
 const LOCAL_RUNTIME_SLOW_STARTUP_MS = 10000
 

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -218,8 +218,7 @@ function createTurnFileChanges(): TurnFileChangesSummary {
   }
 }
 
-const LOCAL_IMAGE_ATTACHMENT_PATH =
-  '/Users/me/.wegent-executor/workspace/attachments/draft/-45/photo.png'
+const LOCAL_IMAGE_ATTACHMENT_PATH = '/Users/me/.wework/workspace/attachments/draft/-45/photo.png'
 
 function createImageAttachment(overrides: Partial<Attachment> = {}): Attachment {
   return {

--- a/wework/src/lib/device-workspace-path.test.ts
+++ b/wework/src/lib/device-workspace-path.test.ts
@@ -22,8 +22,8 @@ describe('device workspace path helpers', () => {
   })
 
   test('resolves executor workspace root from project workspace root', () => {
-    expect(executorWorkspaceRoot('/Users/me/.wegent-executor/workspace/projects')).toBe(
-      '/Users/me/.wegent-executor/workspace'
+    expect(executorWorkspaceRoot('/Users/me/.wework/workspace/projects')).toBe(
+      '/Users/me/.wework/workspace'
     )
     expect(executorWorkspaceRoot('/workspace')).toBe('/workspace')
   })
@@ -31,10 +31,10 @@ describe('device workspace path helpers', () => {
   test('builds managed worktree paths beside executor projects', () => {
     expect(
       buildManagedWorktreePath({
-        projectWorkspaceRoot: '/Users/me/.wegent-executor/workspace/projects',
+        projectWorkspaceRoot: '/Users/me/.wework/workspace/projects',
         sourceWorkspacePath: '/Users/me/project',
         worktreeId: 42,
       })
-    ).toBe('/Users/me/.wegent-executor/workspace/worktrees/42/project')
+    ).toBe('/Users/me/.wework/workspace/worktrees/42/project')
   })
 })

--- a/wework/src/lib/workspace-target.test.ts
+++ b/wework/src/lib/workspace-target.test.ts
@@ -54,16 +54,22 @@ describe('resolveWorkspaceTarget', () => {
 
     expect(
       createLocalAttachmentWorkspaceTarget(
-        '/Users/me/.wegent-executor/workspace/attachments/draft/42/result.png',
+        '/Users/me/.wework/workspace/attachments/draft/42/result.png',
         devices
       )
     ).toMatchObject({
       deviceId: 'device-local-real',
-      path: '/Users/me/.wegent-executor/workspace/attachments/draft/42',
+      path: '/Users/me/.wework/workspace/attachments/draft/42',
       workspaceSource: 'local',
     })
     expect(
       createLocalAttachmentWorkspaceTarget('/workspace/project/result.png', devices)
+    ).toBeNull()
+    expect(
+      createLocalAttachmentWorkspaceTarget(
+        '/Users/me/.wegent-executor/workspace/attachments/draft/42/result.png',
+        devices
+      )
     ).toBeNull()
   })
 

--- a/wework/src/lib/workspace-target.ts
+++ b/wework/src/lib/workspace-target.ts
@@ -68,7 +68,7 @@ export function createLocalAttachmentWorkspaceTarget(
 ): WorkspaceTarget | null {
   const normalizedPath = filePath.trim().replace(/\\/g, '/')
   const isLocalAttachment =
-    normalizedPath.includes('/.wegent-executor/workspace/attachments/') ||
+    normalizedPath.includes('/.wework/workspace/attachments/') ||
     normalizedPath.includes('/.wegent/attachments/')
   return isLocalAttachment ? createLocalFileWorkspaceTarget(normalizedPath, devices) : null
 }

--- a/wework/src/tauri/localExecutor.test.ts
+++ b/wework/src/tauri/localExecutor.test.ts
@@ -40,7 +40,7 @@ describe('localExecutor', () => {
       if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {
         return Promise.resolve({
           id: 'wework-personal',
-          path: '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal',
+          path: '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal',
           pluginCount: 0,
         })
       }
@@ -71,7 +71,7 @@ describe('localExecutor', () => {
     })
     expect(getInitializedBundledPluginMarketplace()).toEqual({
       id: 'wework-personal',
-      path: '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal',
+      path: '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal',
       pluginCount: 0,
     })
     expect(invokeMock.mock.calls).toEqual([
@@ -86,7 +86,7 @@ describe('localExecutor', () => {
       if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {
         return Promise.resolve({
           id: 'wework-personal',
-          path: '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal',
+          path: '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal',
           pluginCount: 0,
         })
       }
@@ -109,7 +109,7 @@ describe('localExecutor', () => {
   })
 
   test('keeps an initialized bundled marketplace without adding it again', async () => {
-    const path = '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal'
+    const path = '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal'
     invokeMock.mockImplementation(command => {
       if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {
         return Promise.resolve({ id: 'wework-personal', path, pluginCount: 0 })
@@ -137,8 +137,7 @@ describe('localExecutor', () => {
   })
 
   test('does not start bundled marketplace registration before reporting ready', async () => {
-    const path =
-      '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal-background'
+    const path = '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal-background'
     let finishMarketplaceRegistration: (value: { marketplaceName: string }) => void = () =>
       undefined
     const marketplaceRegistration = new Promise<{ marketplaceName: string }>(resolve => {
@@ -194,8 +193,7 @@ describe('localExecutor', () => {
   })
 
   test('repairs a stale bundled marketplace using local-only discovery', async () => {
-    const path =
-      '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal-repaired'
+    const path = '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal-repaired'
     let addAttempts = 0
     invokeMock.mockImplementation(command => {
       if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {
@@ -259,8 +257,7 @@ describe('localExecutor', () => {
   })
 
   test('defers bundled marketplace registration until it is explicitly requested', async () => {
-    const path =
-      '/Users/test/.wegent-executor/capabilities/bundled-marketplaces/wework-personal-deferred'
+    const path = '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal-deferred'
     let shouldPromptMigration = true
     invokeMock.mockImplementation(command => {
       if (command === LOCAL_EXECUTOR_COMMANDS.initializeBundledPluginMarketplace) {


### PR DESCRIPTION
## 概述

将 Wework 本地运行时数据目录从 `~/.wecode/wegent-executor` 和 `~/.wegent-executor` 统一迁移到 `~/.wework`，并增加旧目录的一次性迁移逻辑。

## 变更内容

- 默认 Executor Home 改为 `~/.wework`，隔离实例目录为 `~/.wework/apps/<namespace>`。
- Codex 隔离目录、日志、附件、工作树、聊天工作区、设备标识等运行时数据全部落在新目录下。
- 启动时自动迁移旧目录：
  - 优先迁移 `~/.wegent-executor`，再合并更早的 `~/.wecode/wegent-executor`。
  - 新目录不存在时直接重命名整个目录，保留文件属性、目录结构和软链接。
  - 新旧目录同时存在时递归合并不冲突内容，`~/.wework` 现有文件始终优先。
  - 同名冲突的旧内容归档到 `~/.wework/.legacy-migration-conflicts/<来源>/`，不覆盖、不丢失数据。
  - 显式设置 `WEGENT_EXECUTOR_HOME` 时不触发迁移，隔离会话、测试和自定义部署不受影响。
- 前端本地附件/聊天路径识别与日志展示同步改为新目录，不再识别旧路径。
- 补充中英文开发者文档，说明新目录结构与迁移规则。

## 验证

- 前端聚焦测试：355 条断言全部通过。
- Rust 单元测试：旧目录合并迁移、冲突归档、默认路径派生等测试通过。
- Prettier、ESLint、TypeScript、`cargo fmt --check` 通过。
- 隔离真实 Tauri 会话启动并完成本地运行时初始化界面验证后已关闭。
- pre-push 质量检查（ESLint、TypeScript、单元测试）全部通过。
