### PR TITLE
fix(wework): attach local terminal before streaming output

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -683,6 +683,12 @@ semantics for all three.
   terminal should be fitted and resized; after activation, window focus, or
   document visibility restoration, refresh the buffered xterm rows so the
   existing session remains visible.
+- PTY output must not be streamed before the renderer is ready to receive it.
+  A terminal session starts reading from the PTY only after the embedded
+  terminal registers its output listeners and explicitly attaches via
+  `attach_local_terminal`; the embedded component reuses the underlying xterm
+  resource while the session stays mounted and defers disposal so re-mounts do
+  not drop early shell output.
 - Workspace IDEs and native editors launch only from the titlebar “Open
   location” control, including its local-editor picker and remote code-server
   behavior.

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -4603,6 +4603,7 @@ pub fn run() {
             embedded_browser::embedded_browser_resume_download,
             embedded_browser::embedded_browser_set_agent_control_paused,
             embedded_browser::embedded_browser_set_bounds,
+            local_terminal::attach_local_terminal,
             local_terminal::close_local_terminal,
             workbench_background::import_workbench_background,
             workbench_background::remove_workbench_background,

--- a/wework/src-tauri/src/local_terminal.rs
+++ b/wework/src-tauri/src/local_terminal.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{mpsc, Mutex};
 use tauri::{Emitter, State};
 
 use crate::process_environment;
@@ -23,6 +23,8 @@ struct LocalTerminalSession {
     writer: Box<dyn Write + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
     child_pid: Option<u32>,
+    attach_sender: Option<mpsc::SyncSender<()>>,
+    attached: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -239,12 +241,15 @@ fn start_pty_shell(
         .map_err(|error| format!("Failed to spawn shell: {error}"))?;
     drop(pair.slave);
 
+    let (attach_sender, attach_receiver) = mpsc::sync_channel(1);
     let session_id = next_session_id(state);
     let session = LocalTerminalSession {
         master: pair.master,
         writer,
         child_pid: child.process_id(),
         child,
+        attach_sender: Some(attach_sender),
+        attached: false,
     };
     state
         .sessions
@@ -255,7 +260,9 @@ fn start_pty_shell(
     let output_session_id = session_id.clone();
     let exit_session_id = session_id.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_millis(80));
+        if attach_receiver.recv().is_err() {
+            return;
+        }
         let mut buffer = [0_u8; 8192];
         let mut pending_utf8 = Vec::new();
         loop {
@@ -286,6 +293,33 @@ fn start_pty_shell(
     });
 
     Ok(session_id)
+}
+
+#[tauri::command]
+pub fn attach_local_terminal(
+    state: State<'_, LocalTerminalState>,
+    session_id: String,
+) -> Result<(), String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "Failed to lock local terminal state".to_string())?;
+    let session = sessions
+        .get_mut(&session_id)
+        .ok_or_else(|| format!("Local terminal session not found: {session_id}"))?;
+    if session.attached {
+        return Ok(());
+    }
+    let attach_sender = session
+        .attach_sender
+        .take()
+        .ok_or_else(|| format!("Local terminal session cannot be attached: {session_id}"))?;
+
+    attach_sender
+        .send(())
+        .map_err(|_| format!("Failed to attach local terminal session: {session_id}"))?;
+    session.attached = true;
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -2,12 +2,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { useEffect, useRef } from 'react'
-import {
-  listenLocalTerminalExit,
-  listenLocalTerminalOutput,
-  resizeLocalTerminal,
-  writeLocalTerminal,
-} from '@/lib/local-terminal'
+import { connectLocalTerminal, resizeLocalTerminal, writeLocalTerminal } from '@/lib/local-terminal'
 import {
   applyTerminalTheme,
   createTerminalThemeScheduler,
@@ -38,6 +33,22 @@ interface EmbeddedLocalTerminalProps {
   showWorkbenchBackground?: boolean
 }
 
+interface LocalTerminalResource {
+  sessionId: string
+  showWorkbenchBackground: boolean
+  dispose: () => void
+}
+
+function matchesLocalTerminalResource(
+  resource: LocalTerminalResource,
+  sessionId: string,
+  showWorkbenchBackground: boolean
+): boolean {
+  return (
+    resource.sessionId === sessionId && resource.showWorkbenchBackground === showWorkbenchBackground
+  )
+}
+
 export function EmbeddedLocalTerminal({
   sessionId,
   active,
@@ -60,6 +71,8 @@ export function EmbeddedLocalTerminal({
   const onTitleChangeRef = useRef(onTitleChange)
   const lastSizeRef = useRef<{ rows: number; cols: number } | null>(null)
   const appearanceRef = useRef(appearance)
+  const resourceRef = useRef<LocalTerminalResource | null>(null)
+  const cleanupTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
     appearanceRef.current = appearance
@@ -108,6 +121,21 @@ export function EmbeddedLocalTerminal({
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
+
+    if (cleanupTimerRef.current !== null) {
+      window.clearTimeout(cleanupTimerRef.current)
+      cleanupTimerRef.current = null
+    }
+    const currentResource = resourceRef.current
+    if (
+      currentResource &&
+      matchesLocalTerminalResource(currentResource, sessionId, showWorkbenchBackground)
+    ) {
+      return () => {
+        cleanupTimerRef.current = window.setTimeout(currentResource.dispose, 0)
+      }
+    }
+    currentResource?.dispose()
 
     const terminalAppearance = appearanceRef.current
     const terminal = new Terminal({
@@ -185,54 +213,70 @@ export function EmbeddedLocalTerminal({
     const removeRenderRecovery = installXtermRenderRecovery(fitAndResize)
     requestAnimationFrame(fitAndResize)
 
-    void listenLocalTerminalOutput(payload => {
-      if (!disposed && payload.session_id === sessionId) {
-        const context = contextRef.current
-        appendRuntimeTerminalContext({
-          sessionId,
-          taskId: context.taskId,
-          workspacePath: context.workspacePath,
-          cwd: context.cwd,
-          title: context.title,
-          kind: 'local',
-          data: payload.data,
-        })
-        terminal.write(payload.data)
-        scheduleThemeSync()
+    void connectLocalTerminal(
+      sessionId,
+      payload => {
+        if (!disposed && payload.session_id === sessionId) {
+          const context = contextRef.current
+          appendRuntimeTerminalContext({
+            sessionId,
+            taskId: context.taskId,
+            workspacePath: context.workspacePath,
+            cwd: context.cwd,
+            title: context.title,
+            kind: 'local',
+            data: payload.data,
+          })
+          terminal.write(payload.data)
+          scheduleThemeSync()
+        }
+      },
+      payload => {
+        if (!disposed && payload.session_id === sessionId) {
+          onExitRef.current?.()
+        }
       }
-    }).then(unlisten => {
-      if (disposed) {
-        unlisten()
-      } else {
-        unlisteners.push(unlisten)
-      }
-    })
+    )
+      .then(unlisten => {
+        if (disposed) {
+          unlisten()
+        } else {
+          unlisteners.push(unlisten)
+        }
+      })
+      .catch(error => {
+        if (!disposed) {
+          console.error('Failed to attach local terminal:', error)
+          terminal.writeln('\r\n[Terminal connection failed]')
+        }
+      })
 
-    void listenLocalTerminalExit(payload => {
-      if (!disposed && payload.session_id === sessionId) {
-        onExitRef.current?.()
-      }
-    }).then(unlisten => {
-      if (disposed) {
-        unlisten()
-      } else {
-        unlisteners.push(unlisten)
-      }
-    })
+    const resource: LocalTerminalResource = {
+      sessionId,
+      showWorkbenchBackground,
+      dispose: () => {
+        if (disposed) return
+        disposed = true
+        unobserveTheme()
+        removeRenderRecovery()
+        resizeObserver.disconnect()
+        dataDisposable.dispose()
+        titleDisposable.dispose()
+        selectionGuard.dispose()
+        inputFallback.dispose()
+        unlisteners.forEach(unlisten => unlisten())
+        terminal.dispose()
+        if (resourceRef.current === resource) {
+          terminalRef.current = null
+          fitAddonRef.current = null
+          resourceRef.current = null
+        }
+      },
+    }
+    resourceRef.current = resource
 
     return () => {
-      disposed = true
-      unobserveTheme()
-      removeRenderRecovery()
-      resizeObserver.disconnect()
-      dataDisposable.dispose()
-      titleDisposable.dispose()
-      selectionGuard.dispose()
-      inputFallback.dispose()
-      unlisteners.forEach(unlisten => unlisten())
-      terminal.dispose()
-      terminalRef.current = null
-      fitAddonRef.current = null
+      cleanupTimerRef.current = window.setTimeout(resource.dispose, 0)
     }
   }, [sessionId, showWorkbenchBackground])
 

--- a/wework/src/lib/local-terminal.test.ts
+++ b/wework/src/lib/local-terminal.test.ts
@@ -4,6 +4,7 @@ import { listen } from '@tauri-apps/api/event'
 import i18n from '@/i18n'
 import {
   closeLocalTerminal,
+  connectLocalTerminal,
   getLocalExecutorDeviceId,
   isLocalTerminalAvailable,
   listenLocalTerminalExit,
@@ -346,5 +347,45 @@ describe('local-terminal', () => {
 
     expect(listenMock).toHaveBeenCalledWith('local-terminal-output', expect.any(Function))
     expect(listenMock).toHaveBeenCalledWith('local-terminal-exit', expect.any(Function))
+  })
+
+  test('attaches an embedded local terminal after listeners are ready', async () => {
+    const calls: string[] = []
+    const outputUnlisten = vi.fn()
+    const exitUnlisten = vi.fn()
+    listenMock.mockImplementation(async event => {
+      calls.push(`listen:${event}`)
+      return event === 'local-terminal-output' ? outputUnlisten : exitUnlisten
+    })
+    invokeMock.mockImplementation(async command => {
+      calls.push(`invoke:${command}`)
+      return undefined
+    })
+
+    const unlisten = await connectLocalTerminal('local-terminal-1', vi.fn(), vi.fn())
+
+    expect(calls).toEqual([
+      'listen:local-terminal-output',
+      'listen:local-terminal-exit',
+      'invoke:attach_local_terminal',
+    ])
+
+    unlisten()
+    expect(outputUnlisten).toHaveBeenCalledOnce()
+    expect(exitUnlisten).toHaveBeenCalledOnce()
+  })
+
+  test('removes local terminal listeners when attach fails', async () => {
+    const outputUnlisten = vi.fn()
+    const exitUnlisten = vi.fn()
+    listenMock.mockResolvedValueOnce(outputUnlisten).mockResolvedValueOnce(exitUnlisten)
+    invokeMock.mockRejectedValue(new Error('attach failed'))
+
+    await expect(connectLocalTerminal('local-terminal-1', vi.fn(), vi.fn())).rejects.toThrow(
+      'attach failed'
+    )
+
+    expect(outputUnlisten).toHaveBeenCalledOnce()
+    expect(exitUnlisten).toHaveBeenCalledOnce()
   })
 })

--- a/wework/src/lib/local-terminal.ts
+++ b/wework/src/lib/local-terminal.ts
@@ -244,6 +244,12 @@ export async function writeLocalTerminal(sessionId: string, data: string): Promi
   })
 }
 
+export async function attachLocalTerminal(sessionId: string): Promise<void> {
+  await invoke('attach_local_terminal', {
+    sessionId,
+  })
+}
+
 export async function resizeLocalTerminal(
   sessionId: string,
   rows: number,
@@ -276,4 +282,28 @@ export function listenLocalTerminalExit(
   return listen<LocalTerminalExitPayload>('local-terminal-exit', event => {
     handler(event.payload)
   })
+}
+
+export async function connectLocalTerminal(
+  sessionId: string,
+  onOutput: (payload: LocalTerminalOutputPayload) => void,
+  onExit: (payload: LocalTerminalExitPayload) => void
+): Promise<UnlistenFn> {
+  const outputUnlisten = await listenLocalTerminalOutput(onOutput)
+  try {
+    const exitUnlisten = await listenLocalTerminalExit(onExit)
+    try {
+      await attachLocalTerminal(sessionId)
+      return () => {
+        outputUnlisten()
+        exitUnlisten()
+      }
+    } catch (error) {
+      exitUnlisten()
+      throw error
+    }
+  } catch (error) {
+    outputUnlisten()
+    throw error
+  }
 }


### PR DESCRIPTION
## Problem

The embedded local terminal can render blank. The Rust side started streaming PTY output after a fixed 80 ms sleep, but the renderer may take longer to register its xterm listeners (especially when the bottom panel mounts or restores later). Shell output emitted during that window is dropped before xterm attaches, leaving the terminal white and unresponsive.

## Fix

Replace the fixed sleep with an explicit attach handshake:

- Rust: `start_pty_shell` no longer waits a fixed duration; the reader thread blocks on an `mpsc` channel and only starts streaming after the frontend calls the new `attach_local_terminal` command.
- Frontend: `connectLocalTerminal` registers the output/exit listeners first, then invokes `attach_local_terminal`, so no output is lost between session start and listener registration. `EmbeddedLocalTerminal` reuses the existing xterm resource across panel re-mounts and defers disposal, avoiding attach/cleanup races.

## Verification

- `local-terminal.test.ts` passes (20 tests, including 2 new tests covering listener ordering and attach failure cleanup).
- Pre-push quality checks pass: ESLint, TypeScript, unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local terminal startup to prevent early output from being lost.
  * Preserved terminal content and resources when embedded terminals are remounted.
  * Improved cleanup when terminal connection or attachment fails.

* **Tests**
  * Added coverage for listener registration, attachment failures, and cleanup behavior.

* **Documentation**
  * Documented terminal attachment and lifecycle requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->