### PR TITLE
test(wework): stabilize desktop E2E recovery

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -12,6 +12,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  rename,
   rm,
   symlink,
   writeFile,
@@ -7919,8 +7920,13 @@ async function verifyGoalRestartRecoveryLifecycle({
     'Opening the interrupted Goal did not present a stable, user-controlled recovery state',
     WORKBENCH_READY_TIMEOUT_MS
   )
-  const interruptedDebugSnapshot = JSON.parse(
-    await control.command('getWorkbenchDebugSnapshot', 'body')
+  const interruptedDebugSnapshot = await waitForWorkbenchDebugState(
+    control,
+    snapshot =>
+      snapshot.workbench?.currentRuntimeTask?.taskId === goalTaskId &&
+      snapshot.workbench?.lifecycleCurrentTaskRunning === false &&
+      snapshot.pane?.goal?.status === 'active',
+    'The interrupted Goal did not finish hydrating after Wework restarted'
   )
   assert.equal(
     interruptedDebugSnapshot.workbench?.lifecycleCurrentTaskRunning,
@@ -11954,11 +11960,14 @@ async function writeCodexConfig(
   upstreamApiFormat = 'openai-responses'
 ) {
   await mkdir(codexHome, { recursive: true })
+  const configPath = join(codexHome, 'config.toml')
+  const temporaryConfigPath = join(codexHome, `config.toml.${randomUUID()}.tmp`)
   await writeFile(
-    join(codexHome, 'config.toml'),
+    temporaryConfigPath,
     `model_provider = "${MODEL_PROVIDER_ID}"\nmodel = "${DEFAULT_MODEL_ID}"\napproval_policy = "never"\nsandbox_mode = "danger-full-access"\n${scenarioConfigToml}\n[model_providers.${MODEL_PROVIDER_ID}]\nname = "Wework Desktop E2E"\nbase_url = "${modelServerUrl}/v1"\nenv_key = "WEWORK_E2E_MODEL_API_KEY"\nwire_api = "responses"\nupstream_api_format = "${upstreamApiFormat}"\n`,
     'utf8'
   )
+  await rename(temporaryConfigPath, configPath)
 }
 
 function toolDetailsMcpConfigToml() {


### PR DESCRIPTION
## What changed

- Wait for the restored Goal debug state to finish hydrating before asserting its active status after a desktop restart.
- Replace running Codex E2E `config.toml` atomically during protocol-matrix changes.

## Why

Two intermittent desktop E2E failures were caused by test synchronization races. The Goal test read `pane.goal` before its asynchronous hydration completed. The Cloud E2E test overwrote `config.toml` while Codex was reloading its model catalog, allowing a reader to observe a truncated TOML file and lose the canonical model option.

## Impact

Desktop E2E verification now waits for the actual recovered state and never exposes a partially written Codex configuration to concurrent readers. Product behavior is unchanged.

## Validation

- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- `CI=true WEWORK_E2E_SCREENSHOTS=final pnpm --filter wework e2e:desktop -- --segment goal-lifecycle`
- `CI=true WEWORK_E2E_SCREENSHOTS=final pnpm --filter wework e2e:desktop:cloud` (18/18 model protocol matrix cases passed)
- Pre-push ESLint, TypeScript, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interrupted goal recovery by waiting for the workbench state to fully load before continuing.
  * Made configuration updates more reliable by writing them safely and atomically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->