### PR TITLE
ci(e2e): cache Playwright browsers across jobs

### DIFF
--- a/.github/scripts/install-playwright-browser.sh
+++ b/.github/scripts/install-playwright-browser.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly max_attempts="${PLAYWRIGHT_INSTALL_MAX_ATTEMPTS:-3}"
+readonly timeout_seconds="${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-180}"
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  echo "Installing Playwright Chromium (attempt $attempt/$max_attempts)"
+
+  if timeout \
+    --signal=TERM \
+    --kill-after=15s \
+    "${timeout_seconds}s" \
+    pnpm exec playwright install chromium; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -eq "$max_attempts" ]]; then
+    echo "Playwright Chromium installation failed after $max_attempts attempts" >&2
+    exit 1
+  fi
+
+  sleep $((attempt * 5))
+done

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,6 +49,8 @@ jobs:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && needs.changes.outputs.platform_e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      playwright_version: ${{ steps.playwright-version.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -79,6 +81,23 @@ jobs:
       - name: Install frontend dependencies
         if: steps.frontend-node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: ./frontend
+        run: echo "version=$(pnpm exec playwright --version | sed 's/^Version //')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./frontend
+        run: ../.github/scripts/install-playwright-browser.sh
 
       - name: Cache Next.js build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -294,16 +313,15 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-chromium-${{ needs.build-frontend-e2e.outputs.playwright_version }}
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browser
         working-directory: ./frontend
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        run: ../.github/scripts/install-playwright-browser.sh
 
-      - name: Install Playwright dependencies (cached)
+      - name: Install Playwright system dependencies
         working-directory: ./frontend
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
 
       - name: Run database migrations
@@ -619,16 +637,15 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-chromium-${{ needs.build-frontend-e2e.outputs.playwright_version }}
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browser
         working-directory: ./frontend
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        run: ../.github/scripts/install-playwright-browser.sh
 
-      - name: Install Playwright dependencies (cached)
+      - name: Install Playwright system dependencies
         working-directory: ./frontend
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
 
       - name: Download executor E2E runtime

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -211,6 +211,13 @@ browsers, and the executor job's Claude Code CLI. Dependency install steps are
 skipped only on exact cache hits; partial restore-key matches still run install
 commands to reconcile dependencies before saving a fresh cache.
 
+Playwright browser binaries are prepared once in `build-frontend-e2e` before the
+sharded browser/API jobs and the executor E2E job start. The cache key contains
+the runner OS and resolved Playwright version, so unrelated lockfile changes do
+not invalidate the browser cache. A cache miss uses
+`.github/scripts/install-playwright-browser.sh`, which retries interrupted or
+slow downloads up to three times with a three-minute per-attempt timeout.
+
 ### Sharded CI Users
 
 The CI workflow runs Playwright tests across multiple shards. Each shard uses an


### PR DESCRIPTION
## What changed

- Prepare the Playwright Chromium cache once in `build-frontend-e2e` before browser shards and executor E2E start.
- Key the browser cache by runner OS and resolved Playwright version instead of the whole lockfile.
- Share the same cache and retry path between sharded E2E and executor E2E jobs.
- Retry slow or interrupted browser downloads up to three times with a three-minute timeout per attempt.
- Document the CI browser cache behavior in `frontend/e2e/README.md`.

## Root cause

The four matrix jobs checked the cache concurrently before any job reached the post-job cache-save phase, so every shard downloaded Chromium. The previous key also changed whenever any dependency in `pnpm-lock.yaml` changed.

## Validation

- `actionlint -shellcheck= .github/workflows/e2e-tests.yml`
- `bash -n .github/scripts/install-playwright-browser.sh`
- `shellcheck .github/scripts/install-playwright-browser.sh`
- `git diff --check`
- Pre-push ESLint, TypeScript check, and frontend unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated browser test setup with version-specific browser caching.
  * Added retry and timeout handling to make browser installation more reliable in continuous integration.
  * Streamlined browser and system dependency installation across end-to-end test jobs.

* **Documentation**
  * Documented browser preparation, caching behavior, and retry handling for end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->