### PR TITLE
fix(wework): default telemetry in development

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -355,6 +355,7 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          VITE_WEWORK_RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.channel }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
@@ -571,6 +572,7 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+          VITE_WEWORK_RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.channel }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -12456,6 +12456,7 @@ async function buildDesktopApp(
         VITE_WEWORK_E2E_SEED_LOCAL_MODELS: RUNS_PLUGIN_E2E || MEMORY_ONLY ? 'false' : 'true',
         VITE_WEWORK_POSTHOG_HOST: modelServerUrl,
         VITE_WEWORK_POSTHOG_KEY: TELEMETRY_TEST_PROJECT_KEY,
+        VITE_WEWORK_RELEASE_CHANNEL: 'stable',
         VITE_WEWORK_RUNTIME_MODE: 'local-first',
       },
     }

--- a/wework/scripts/release-mac-app.sh
+++ b/wework/scripts/release-mac-app.sh
@@ -505,6 +505,7 @@ BACKEND_PORT="${BACKEND_PORT:-9100}"
 BACKEND_BASE_URL="$(wework_resolve_backend_base_url)"
 
 export VITE_WEGENT_BACKEND_URL="${VITE_WEGENT_BACKEND_URL:-$BACKEND_BASE_URL}"
+export VITE_WEWORK_RELEASE_CHANNEL="${VITE_WEWORK_RELEASE_CHANNEL:-$([ "$TARGET" = "prod" ] && printf 'stable' || printf 'development')}"
 
 download_base_url="$LOCAL_DOWNLOAD_BASE_URL"
 dist_dir="$LOCAL_DIST_DIR"
@@ -546,6 +547,7 @@ elif [ "$TARGET" = "local" ]; then
   echo "Notary profile: not set (local release will skip notarization)"
 fi
 echo "VITE_WEGENT_BACKEND_URL=$VITE_WEGENT_BACKEND_URL"
+echo "VITE_WEWORK_RELEASE_CHANNEL=$VITE_WEWORK_RELEASE_CHANNEL"
 echo "VITE_WEGENT_SOCKET_URL=${VITE_WEGENT_SOCKET_URL:-<backend URL>}"
 echo "VITE_WEWORK_FEEDBACK_URL=${VITE_WEWORK_FEEDBACK_URL:-<disabled>}"
 

--- a/wework/src/telemetry/TelemetryBridge.test.tsx
+++ b/wework/src/telemetry/TelemetryBridge.test.tsx
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   setTelemetryEnabled: vi.fn().mockResolvedValue(undefined),
   track: vi.fn(),
   updateAppPreferences: vi.fn().mockResolvedValue(undefined),
+  officialRelease: true,
+  tauriRuntime: false,
 }))
 
 vi.mock('@/features/app-preferences/useAppPreferencesState', () => ({
@@ -18,7 +20,7 @@ vi.mock('@/features/app-preferences/useAppPreferencesState', () => ({
 }))
 
 vi.mock('@/lib/runtime-environment', () => ({
-  isTauriRuntime: () => false,
+  isTauriRuntime: () => mocks.tauriRuntime,
 }))
 
 vi.mock('@tauri-apps/api/window', () => ({
@@ -30,6 +32,10 @@ vi.mock('./client', () => ({
   isTelemetryEnabled: () => mocks.preferences.preferences.telemetryEnabled,
   setTelemetryEnabled: mocks.setTelemetryEnabled,
   track: mocks.track,
+}))
+
+vi.mock('./config', () => ({
+  isOfficialReleaseBuild: () => mocks.officialRelease,
 }))
 
 vi.mock('@/tauri/appPreferences', () => ({
@@ -45,6 +51,8 @@ describe('TelemetryBridge', () => {
     mocks.preferences.loaded = true
     mocks.preferences.preferences.telemetryConsentAsked = true
     mocks.preferences.preferences.telemetryEnabled = true
+    mocks.officialRelease = true
+    mocks.tauriRuntime = false
   })
 
   it('initializes once and starts telemetry again after it is re-enabled', async () => {
@@ -101,5 +109,23 @@ describe('TelemetryBridge', () => {
       })
     })
     expect(mocks.installTelemetry).not.toHaveBeenCalled()
+  })
+
+  it('enables telemetry by default without prompting in development builds', async () => {
+    mocks.officialRelease = false
+    mocks.tauriRuntime = true
+    mocks.preferences.preferences.telemetryConsentAsked = false
+    mocks.preferences.preferences.telemetryEnabled = false
+
+    render(<TelemetryBridge />)
+
+    expect(screen.queryByTestId('telemetry-consent-overlay')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(mocks.installTelemetry).toHaveBeenCalledWith(true)
+      expect(mocks.updateAppPreferences).toHaveBeenCalledWith({
+        telemetryConsentAsked: true,
+        telemetryEnabled: true,
+      })
+    })
   })
 })

--- a/wework/src/telemetry/TelemetryBridge.tsx
+++ b/wework/src/telemetry/TelemetryBridge.tsx
@@ -6,6 +6,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import { updateAppPreferences } from '@/tauri/appPreferences'
 import { useTranslation } from '@/hooks/useTranslation'
 import { TelemetryConsentDialog } from './TelemetryConsentDialog'
+import { isOfficialReleaseBuild } from './config'
 
 function appSurface(): 'main' | 'popout' | 'workspace' {
   const label = isTauriRuntime() ? getCurrentWindow().label : 'main'
@@ -23,11 +24,13 @@ export function TelemetryBridge() {
   const [consentError, setConsentError] = useState<string | null>(null)
   const consentAsked = appPreferences?.preferences.telemetryConsentAsked
   const telemetryEnabled = appPreferences?.preferences.telemetryEnabled
-  const effectiveTelemetryEnabled = consentAsked === true && telemetryEnabled === true
+  const officialRelease = isOfficialReleaseBuild()
+  const effectiveTelemetryEnabled =
+    !officialRelease && consentAsked !== true ? true : telemetryEnabled === true
   const surface = useMemo(() => appSurface(), [])
 
   useEffect(() => {
-    if (!appPreferences?.loaded || !consentAsked || initializedRef.current) {
+    if (!appPreferences?.loaded || (officialRelease && !consentAsked) || initializedRef.current) {
       return
     }
     initializedRef.current = true
@@ -36,10 +39,10 @@ export function TelemetryBridge() {
       startedRef.current = true
       track('app_started', { surface })
     })
-  }, [appPreferences?.loaded, consentAsked, effectiveTelemetryEnabled, surface])
+  }, [appPreferences?.loaded, consentAsked, effectiveTelemetryEnabled, officialRelease, surface])
 
   useEffect(() => {
-    if (!appPreferences?.loaded || !consentAsked) return
+    if (!appPreferences?.loaded || (officialRelease && !consentAsked)) return
     void setTelemetryEnabled(effectiveTelemetryEnabled).then(() => {
       // app_started marks the first point in this session where telemetry is
       // active: either right after app launch or after the user re-enables it.
@@ -47,9 +50,19 @@ export function TelemetryBridge() {
       startedRef.current = true
       track('app_started', { surface })
     })
-  }, [appPreferences?.loaded, consentAsked, effectiveTelemetryEnabled, surface])
+  }, [appPreferences?.loaded, consentAsked, effectiveTelemetryEnabled, officialRelease, surface])
 
-  if (!appPreferences?.loaded || consentAsked || surface !== 'main') {
+  useEffect(() => {
+    if (officialRelease || !isTauriRuntime() || !appPreferences?.loaded || consentAsked === true) {
+      return
+    }
+    void updateAppPreferences({
+      telemetryConsentAsked: true,
+      telemetryEnabled: true,
+    })
+  }, [appPreferences?.loaded, consentAsked, officialRelease])
+
+  if (!appPreferences?.loaded || !officialRelease || consentAsked || surface !== 'main') {
     return null
   }
 

--- a/wework/src/telemetry/config.ts
+++ b/wework/src/telemetry/config.ts
@@ -34,6 +34,11 @@ export function getTelemetryConfig(): TelemetryConfig {
   }
 }
 
+export function isOfficialReleaseBuild(): boolean {
+  const { releaseChannel } = getTelemetryConfig()
+  return releaseChannel === 'stable' || releaseChannel === 'beta'
+}
+
 function architecture(): CommonTelemetryProperties['arch'] {
   const userAgent = (navigator.userAgent || '').toLowerCase()
   if (userAgent.includes('arm64') || userAgent.includes('aarch64')) return 'arm64'


### PR DESCRIPTION
## What changed

- Enable telemetry by default in Wework development builds without showing the startup consent dialog.
- Preserve explicit consent prompts for official `stable` and `beta` release builds.
- Inject the release channel into macOS and Windows CI builds and the production macOS release script.
- Keep automatic preference persistence limited to the real Tauri runtime, avoiding browser-test side effects.

## Why

Development builds previously inherited the privacy-gated default intended for official releases, so telemetry was disabled and a consent dialog appeared on startup. Official release-channel information was also not passed into CI bundles.

## Validation

- `pnpm --filter wework exec vitest run src/telemetry/TelemetryBridge.test.tsx src/App.plugins.test.tsx src/e2e/desktop-process-lifecycle.test.ts`
- `pnpm --filter wework typecheck`
- Real isolated Tauri startup verification: development instance showed no telemetry consent dialog.
- Full pre-push checks: ESLint, TypeScript, and 305 Wework test files / 2968 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development builds now enable telemetry automatically when no consent decision exists.
  * Official stable and beta releases continue to request consent before enabling telemetry.
  * Release channels are applied consistently to macOS and Windows builds.

* **Bug Fixes**
  * Improved telemetry initialization and startup tracking when telemetry is re-enabled.
  * Limited consent prompts to applicable official release screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->