### PR TITLE
fix(wework): keep guidance after completed content

### DIFF
--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -341,6 +341,20 @@ function requestContainsToolOutput(body) {
   return JSON.stringify(body.input ?? []).includes('function_call_output')
 }
 
+async function waitForRuntimePaneReadyToSend(control, timeoutMs) {
+  const startedAt = Date.now()
+  let lastStatus = null
+  while (Date.now() - startedAt < timeoutMs) {
+    const snapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    lastStatus = snapshot.pane?.status ?? null
+    if (lastStatus?.isBusy === false && lastStatus.canSendQueuedMessage === true) return
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(
+    `The stopped runtime turn did not settle before follow-up: ${JSON.stringify(lastStatus)}`
+  )
+}
+
 function selectShellTool(body, workspacePath, command = 'pwd', timeoutMs = 1_000) {
   const tools = Array.isArray(body.tools) ? body.tools : []
   const names = new Set(tools.map(tool => tool?.name).filter(Boolean))
@@ -616,11 +630,14 @@ export function createDesktopScenario({
     await control.command('waitFor', '[data-testid="assistant-stopped-notice"]', {
       timeoutMs: uiTimeoutMs,
     })
+    await waitForRuntimePaneReadyToSend(control, uiTimeoutMs)
     for (let index = 1; index <= ORDER_FOLLOW_UP_COUNT; index += 1) {
       const prompt = `${ORDER_FOLLOW_UP_PREFIX}_${index}`
       const completion = `${ORDER_COMPLETION_PREFIX}_${index}`
       await control.command('fill', COMPOSER_SELECTOR, { value: prompt })
-      await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
+      await control.command('clickWhenEnabled', '[data-testid="send-message-button"]', {
+        timeoutMs: uiTimeoutMs,
+      })
       await control.command('waitFor', ASSISTANT_CONTENT_SELECTOR, {
         text: completion,
         timeoutMs: uiTimeoutMs,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -95,6 +95,7 @@ const GUIDANCE_SCROLL_RESPONSE = [
   ),
 ].join('\n\n')
 const GUIDANCE_SCROLL_MESSAGE = 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_MESSAGE'
+const GUIDANCE_SCROLL_PRE_TOOL_TEXT = 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_PRE_TOOL_TEXT'
 const GUIDANCE_SCROLL_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_COMPLETE'
 const QUEUE_DIRECT_INITIAL = 'WEWORK_DESKTOP_E2E_QUEUE_DIRECT_INITIAL'
 const QUEUE_DIRECT_FIRST = 'WEWORK_DESKTOP_E2E_QUEUE_DIRECT_FIRST'
@@ -1561,6 +1562,11 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
     text: 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_RESPONSE',
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await control.command('markElementWithText', '[data-testid="message-assistant"]', {
+    text: 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_RESPONSE',
+    value: 'guidance-scroll-setup-assistant',
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
 
   const scrollerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`
   await waitForOverflowMetrics(
@@ -1598,6 +1604,24 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
     text: GUIDANCE_SCROLL_MESSAGE,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: GUIDANCE_SCROLL_PRE_TOOL_TEXT,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('markElementWithText', '[data-testid="message-assistant"]', {
+    text: GUIDANCE_SCROLL_PRE_TOOL_TEXT,
+    value: 'guidance-scroll-pre-tool-assistant',
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  const assistantAfterGuidanceText = await control.command(
+    'getText',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]:not([data-e2e-anchor-id])`
+  )
+  assert.equal(
+    assistantAfterGuidanceText.includes(GUIDANCE_SCROLL_PRE_TOOL_TEXT),
+    false,
+    'The final text from before guidance was duplicated after the guidance message'
+  )
 
   const { element: guidanceMessage, scroller } = await waitForElementInsideScroller(
     control,
@@ -10028,10 +10052,12 @@ class DesktopE2EServer {
         const tool = selectShellTool(body, this.workspacePath)
         this.guidanceScrollStage = 'awaiting_tool_output'
         await this.guidanceScrollToolRelease
+        const preToolMessage = assistantMessage(GUIDANCE_SCROLL_PRE_TOOL_TEXT)
         this.writeSse(response, [
           responseCreated(responseId),
+          preToolMessage,
           ...functionCall('wework-e2e-guidance-scroll-tool', tool.name, tool.arguments),
-          responseCompleted(responseId),
+          responseCompleted(responseId, [preToolMessage.item]),
         ])
         return
       }
@@ -13543,6 +13569,21 @@ last_updated = "2026-07-30T00:00:00Z"`
       return
     }
 
+    if (GUIDANCE_SCROLL_ONLY) {
+      phase = 'guidance-scroll'
+      await verifyForegroundGuidanceScroll({
+        composerSelector: ACTIVE_COMPOSER_SELECTOR,
+        control,
+      })
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(`Wework guidance scroll desktop E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
     if (RATE_LIMIT_ONLY) {
       phase = 'rate-limit-recovery'
       await control.command('click', '[data-testid="new-chat-button"]')
@@ -14087,18 +14128,6 @@ last_updated = "2026-07-30T00:00:00Z"`
     if (shouldRunDesktopCheckpoint('core-task-flow')) {
       phase = 'project-space-default-association-setup'
       associatedTaskTabTestId = await configureDefaultProjectSpaceAssociation(control, projectId)
-    }
-
-    if (GUIDANCE_SCROLL_ONLY) {
-      phase = 'guidance-scroll'
-      await verifyForegroundGuidanceScroll({ composerSelector, control })
-      await writeFile(
-        join(resultDir, 'model-requests.json'),
-        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-        'utf8'
-      )
-      console.log(`Wework guidance scroll desktop E2E passed. Evidence: ${resultDir}`)
-      return
     }
 
     if (MIXED_TOOL_TURNS_ONLY) {

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1443,15 +1443,6 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         )
       )
 
-      const optimisticTurnId = activeAssistantMessage?.subtaskId
-      if (optimisticTurnId) {
-        appendOptimisticRuntimeConversationGuidance(
-          currentRuntimeTask,
-          optimisticTurnId,
-          queuedMessage
-        )
-      }
-
       try {
         const additionalContext = readRuntimeTerminalAdditionalContext(currentRuntimeTask)
         const messageAttachments = queuedMessage.attachments ?? []
@@ -1467,7 +1458,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         })
         if (result.sent) {
           markRuntimeTerminalAdditionalContextDelivered(additionalContext)
-          if (result.turnId && result.turnId !== optimisticTurnId) {
+          if (result.turnId) {
             appendOptimisticRuntimeConversationGuidance(
               currentRuntimeTask,
               result.turnId,
@@ -1510,7 +1501,6 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     },
     [
       currentRuntimeTask,
-      activeAssistantMessage?.subtaskId,
       paneStatus.isBusy,
       sendRuntimeMessage,
       sendRuntimePaneGuidance,

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -9995,7 +9995,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(sendRuntimeMessage).not.toHaveBeenCalled()
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('sending:继续修')
     expect(screen.getByTestId('runtime-open-messages').textContent).toBe(
-      'first message|working\n\nbefore |继续修|'
+      'first message|working\n\nbefore '
     )
     expect(screen.getByTestId('runtime-open-blocks')).not.toHaveTextContent(
       'tool:conversation_guidance:done'
@@ -10999,6 +10999,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       message: '执行ls',
       clientGuidanceId: expect.stringMatching(/^queued-runtime-pane-/),
     })
+    expect(screen.getByTestId('runtime-open-messages')).not.toHaveTextContent('执行ls')
     await act(async () => {
       streamHandlers.onGuidanceApplied?.({
         taskId: 'runtime-a',

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -261,6 +261,64 @@ describe('runtimeConversationTurns', () => {
     })
   })
 
+  test('keeps a completed final text block before subsequently applied guidance', () => {
+    const guidance = {
+      ...userMessage('guidance-1', 'Use the new name'),
+      role: 'user' as const,
+      runtimeGuidance: true,
+    }
+    const turns = reduceRuntimeConversationTurns(
+      [
+        {
+          id: 'turn-1',
+          items: [
+            {
+              id: 'tool-1',
+              type: 'block',
+              block: requestBlock('tool-1', 'turn-1'),
+            },
+            {
+              id: 'final-process-text',
+              type: 'block',
+              block: {
+                id: 'final-process-text',
+                subtaskId: 'turn-1',
+                type: 'text',
+                content: '推荐改成“应用构建”。',
+                status: 'done',
+                createdAt: Date.parse('2026-08-06T06:00:00.000Z'),
+              },
+            },
+            {
+              id: guidance.id,
+              type: 'user_message',
+              message: guidance,
+            },
+          ],
+          status: 'streaming',
+        },
+      ],
+      {
+        type: 'assistant_done',
+        subtaskId: 'turn-1',
+        content: '推荐改成“应用构建”。',
+      }
+    )
+
+    expect(turns[0].items.map(item => item.id)).toEqual([
+      'tool-1',
+      'runtime-final:turn-1',
+      'guidance-1',
+    ])
+    expect(
+      projectRuntimeConversationTurns(turns).map(message => [message.role, message.content])
+    ).toEqual([
+      ['assistant', '推荐改成“应用构建”。'],
+      ['user', 'Use the new name'],
+      ['assistant', ''],
+    ])
+  })
+
   test('keeps streamed final text when terminal content is already present', () => {
     const turns = reduceRuntimeConversationTurns(
       [

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -528,11 +528,7 @@ function applyCompletedAssistantContent(
   )
   if (hasStreamedAssistantText) return items
   const matchingProcessTextIndex = items.findLastIndex(
-    (item, index) =>
-      index > lastUserIndex &&
-      item.type === 'block' &&
-      item.block.type === 'text' &&
-      item.block.content === content
+    item => item.type === 'block' && item.block.type === 'text' && item.block.content === content
   )
   if (matchingProcessTextIndex >= 0) {
     return replaceAt(items, matchingProcessTextIndex, {


### PR DESCRIPTION
## What changed

- Wait for the runtime guidance result before projecting a guidance message into a conversation turn.
- Promote matching streamed final content in place even when guidance arrived afterward.
- Extend the existing desktop guidance-scroll flow with the interleaving that previously misplaced or duplicated final text.

## Why

The UI guessed a target turn from a stale assistant message, and final-content reconciliation only searched after the last user item. When guidance arrived between streamed tool/text content and the completion event, the completed assistant text could be inserted on the wrong side of the guidance message.

## Impact

Guidance now appears only in the runtime-confirmed turn and stays after all content that belongs to the preceding assistant response.

## Validation

- `pnpm --filter wework test src/features/workbench/runtimeConversationTurns.test.ts src/features/workbench/runtimeConversationCache.test.ts src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --guidance-scroll-only`
- Pre-push Wework ESLint, TypeScript, and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime guidance so it appears reliably in the conversation after being applied.
  * Prevented assistant guidance and completed responses from appearing more than once.
  * Improved conversation ordering when guidance follows a completed process.
  * Ensured final assistant content correctly replaces temporary process content, including after earlier user messages.

* **Tests**
  * Added focused verification for guidance scrolling, response duplication, and conversation ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->