### PR TITLE
fix(connectors): restore Sites user context headers

### DIFF
--- a/backend/app/services/connector_runtime.py
+++ b/backend/app/services/connector_runtime.py
@@ -479,7 +479,7 @@ class ConnectorRuntimeService:
                     f"Connector '{app.slug}' authorization is unavailable",
                 )
             headers["Authorization"] = f"Bearer {access_token}"
-        if user and app.forward_user_context_headers:
+        if user:
             headers["X-Wegent-Username"] = user.user_name
             headers["X-Wegent-User-Id"] = str(user.id)
         return {

--- a/backend/tests/services/test_connector_runtime.py
+++ b/backend/tests/services/test_connector_runtime.py
@@ -237,14 +237,13 @@ async def test_mcp_session_initializes_streamable_http_transport(
 
 
 @pytest.mark.asyncio
-async def test_server_config_sends_trusted_user_headers(
+async def test_server_config_sends_trusted_user_headers_without_opt_in(
     test_db: Session, test_user: User
 ) -> None:
     app = _app(
         slug="sites",
         name="Sites",
         provider_headers_encrypted=_encrypt_json({"X-Provider": "configured"}),
-        forward_user_context_headers=True,
     )
 
     config = await ConnectorRuntimeService._server_config(test_db, app, test_user)
@@ -257,7 +256,7 @@ async def test_server_config_sends_trusted_user_headers(
 
 
 @pytest.mark.asyncio
-async def test_oauth_server_config_uses_user_token_without_identity_headers(
+async def test_oauth_server_config_uses_user_token_with_identity_headers(
     test_db: Session,
     test_user: User,
 ) -> None:
@@ -276,7 +275,11 @@ async def test_oauth_server_config_uses_user_token_without_identity_headers(
 
     config = await ConnectorRuntimeService._server_config(test_db, app, test_user)
 
-    assert config["headers"] == {"Authorization": "Bearer github-user-token"}
+    assert config["headers"] == {
+        "Authorization": "Bearer github-user-token",
+        "X-Wegent-Username": test_user.user_name,
+        "X-Wegent-User-Id": str(test_user.id),
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore forwarding of authenticated Wegent username and user ID on connector runtime requests so existing Sites connectors receive the required context
- update runtime tests to cover connectors without the forwarding opt-in and OAuth-backed connectors

## Risk
- identity headers are now forwarded to all connector runtimes, including OAuth-backed external connectors

## Test plan
- [x] `cd backend && uv run pytest tests/services/test_connector_runtime.py`
- [x] pre-push Black, isort, syntax, settings, and Alembic checks

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trusted user identity information is now forwarded automatically when available, without requiring an additional configuration setting.
  * OAuth connections now consistently include the user’s identity details alongside authentication information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->