### PR TITLE
fix(wework): compile browser data clearing on Windows

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -10,6 +10,7 @@ declare -A changed=(
   [knowledge_engine]=false
   [frontend]=false
   [wework]=false
+  [wework_rust]=false
   [wegent_cli]=false
   [platform_e2e]=false
   [wework_e2e]=false
@@ -88,6 +89,11 @@ classify_path() {
       changed[platform_e2e]=true
       changed[wework_e2e]=true
       ;;
+    wework/src-tauri/*)
+      changed[wework]=true
+      changed[wework_rust]=true
+      changed[wework_e2e]=true
+      ;;
     wework/*)
       changed[wework]=true
       changed[wework_e2e]=true
@@ -114,6 +120,6 @@ else
 fi
 
 output_file="${GITHUB_OUTPUT:-/dev/stdout}"
-for key in backend executor executor_manager shared knowledge_engine frontend wework wegent_cli platform_e2e wework_e2e; do
+for key in backend executor executor_manager shared knowledge_engine frontend wework wework_rust wegent_cli platform_e2e wework_e2e; do
   printf '%s=%s\n' "$key" "${changed[$key]}" >> "$output_file"
 done

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -124,6 +124,7 @@ shared=false
 knowledge_engine=false
 frontend=false
 wework=false
+wework_rust=false
 wegent_cli=false
 platform_e2e=false
 wework_e2e=false
@@ -136,6 +137,10 @@ wework_expected="${all_false/wework=false/wework=true}"
 wework_expected="${wework_expected/wework_e2e=false/wework_e2e=true}"
 assert_case "wework only" "$wework_expected" "wework/src/App.tsx"
 
+wework_rust_expected="${wework_expected/wework_rust=false/wework_rust=true}"
+assert_case "wework Rust only" "$wework_rust_expected" \
+  "wework/src-tauri/src/lib.rs"
+
 shared_expected=$(
   cat <<'EOF'
 backend=true
@@ -145,6 +150,7 @@ shared=true
 knowledge_engine=true
 frontend=false
 wework=false
+wework_rust=false
 wegent_cli=true
 platform_e2e=true
 wework_e2e=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,6 +388,36 @@ jobs:
           flags: wework
           name: wework-coverage
 
+  check-wework-windows-rust:
+    name: Check Wework Windows Rust
+    needs: changes
+    if: needs.changes.outputs.wework == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-wework-windows-rust-check-v1-${{ hashFiles('wework/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wework-windows-rust-check-v1-
+
+      - name: Check Wework Rust for Windows
+        working-directory: ./wework/src-tauri
+        run: cargo check --locked --target x86_64-pc-windows-msvc
+
   test-wegent-cli:
     name: Test wegent CLI
     needs: changes
@@ -530,7 +560,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [changes, test-backend, test-executor, test-executor-manager, test-shared, test-knowledge-engine, test-frontend, test-wework, test-wegent-cli, test-wegent-cli-integration]
+    needs: [changes, test-backend, test-executor, test-executor-manager, test-shared, test-knowledge-engine, test-frontend, test-wework, check-wework-windows-rust, test-wegent-cli, test-wegent-cli-integration]
     if: always()
 
     steps:
@@ -555,5 +585,6 @@ jobs:
           assert_result "${{ needs.changes.outputs.knowledge_engine }}" "${{ needs.test-knowledge-engine.result }}" "Knowledge Engine tests"
           assert_result "${{ needs.changes.outputs.frontend }}" "${{ needs.test-frontend.result }}" "Frontend tests"
           assert_result "${{ needs.changes.outputs.wework }}" "${{ needs.test-wework.result }}" "Wework tests"
+          assert_result "${{ needs.changes.outputs.wework }}" "${{ needs.check-wework-windows-rust.result }}" "Wework Windows Rust check"
           assert_result "${{ needs.changes.outputs.wegent_cli }}" "${{ needs.test-wegent-cli.result }}" "wegent CLI tests"
           assert_result "${{ needs.changes.outputs.wegent_cli }}" "${{ needs.test-wegent-cli-integration.result }}" "wegent CLI integration tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       knowledge_engine: ${{ steps.classify.outputs.knowledge_engine }}
       frontend: ${{ steps.classify.outputs.frontend }}
       wework: ${{ steps.classify.outputs.wework }}
+      wework_rust: ${{ steps.classify.outputs.wework_rust }}
       wegent_cli: ${{ steps.classify.outputs.wegent_cli }}
 
     steps:
@@ -391,7 +392,7 @@ jobs:
   check-wework-windows-rust:
     name: Check Wework Windows Rust
     needs: changes
-    if: needs.changes.outputs.wework == 'true'
+    if: needs.changes.outputs.wework_rust == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
 
@@ -585,6 +586,6 @@ jobs:
           assert_result "${{ needs.changes.outputs.knowledge_engine }}" "${{ needs.test-knowledge-engine.result }}" "Knowledge Engine tests"
           assert_result "${{ needs.changes.outputs.frontend }}" "${{ needs.test-frontend.result }}" "Frontend tests"
           assert_result "${{ needs.changes.outputs.wework }}" "${{ needs.test-wework.result }}" "Wework tests"
-          assert_result "${{ needs.changes.outputs.wework }}" "${{ needs.check-wework-windows-rust.result }}" "Wework Windows Rust check"
+          assert_result "${{ needs.changes.outputs.wework_rust }}" "${{ needs.check-wework-windows-rust.result }}" "Wework Windows Rust check"
           assert_result "${{ needs.changes.outputs.wegent_cli }}" "${{ needs.test-wegent-cli.result }}" "wegent CLI tests"
           assert_result "${{ needs.changes.outputs.wegent_cli }}" "${{ needs.test-wegent-cli-integration.result }}" "wegent CLI integration tests"

--- a/wework/src-tauri/src/embedded_browser/data_clearing.rs
+++ b/wework/src-tauri/src/embedded_browser/data_clearing.rs
@@ -8,7 +8,7 @@ use tauri::{LogicalPosition, LogicalSize, Manager, Webview, WebviewUrl, Wry};
 use tokio::{sync::oneshot, time::timeout};
 
 #[cfg(target_os = "windows")]
-use webview2_com::{Microsoft::Web::WebView2::Win32::*, *};
+use webview2_com::{ClearBrowsingDataCompletedHandler, Microsoft::Web::WebView2::Win32::*};
 #[cfg(target_os = "windows")]
 use windows::core::Interface;
 
@@ -252,14 +252,12 @@ async fn clear_platform_webview_data(
             };
             let kinds = windows_data_kinds(data_kinds);
             let completion_sender = Arc::clone(&sender);
-            let handler = ClearBrowsingDataCompletedHandler::create(Box::new(
-                move |result: windows::core::Result<()>| -> windows::core::Result<()> {
-                    let completion = result
-                        .map_err(|error| format!("Failed to clear embedded browser data: {error}"));
-                    send_clear_completion(&completion_sender, completion);
-                    Ok(())
-                },
-            ));
+            let handler = ClearBrowsingDataCompletedHandler::create(Box::new(move |result| {
+                let completion = result
+                    .map_err(|error| format!("Failed to clear embedded browser data: {error}"));
+                send_clear_completion(&completion_sender, completion);
+                Ok(())
+            }));
             if let Err(error) = unsafe { profile.ClearBrowsingData(kinds, &handler) } {
                 send_clear_completion(
                     &sender,

--- a/wework/src-tauri/src/embedded_browser/data_clearing.rs
+++ b/wework/src-tauri/src/embedded_browser/data_clearing.rs
@@ -252,12 +252,14 @@ async fn clear_platform_webview_data(
             };
             let kinds = windows_data_kinds(data_kinds);
             let completion_sender = Arc::clone(&sender);
-            let handler = ClearBrowsingDataCompletedHandler::create(Box::new(move |result| {
-                let completion = result
-                    .map_err(|error| format!("Failed to clear embedded browser data: {error}"));
-                send_clear_completion(&completion_sender, completion);
-                Ok(())
-            }));
+            let handler = ClearBrowsingDataCompletedHandler::create(Box::new(
+                move |result: windows::core::Result<()>| -> windows::core::Result<()> {
+                    let completion = result
+                        .map_err(|error| format!("Failed to clear embedded browser data: {error}"));
+                    send_clear_completion(&completion_sender, completion);
+                    Ok(())
+                },
+            ));
             if let Err(error) = unsafe { profile.ClearBrowsingData(kinds, &handler) } {
                 send_clear_completion(
                     &sender,


### PR DESCRIPTION
## Summary

- fix the Windows WebView2 data-clearing callback to preserve the required `windows::core::Result` boundary
- add a Windows Rust check for Wework `src-tauri` changes before packaging
- classify the check separately as `wework_rust` so TypeScript-only Wework changes do not run it

## Root cause

The WebView2 completion callback inferred `webview2_com::Error` while the application completion channel uses `String`, causing Windows-only `E0277` and `E0308` compilation failures during the release bundle build.

## Validation

- `cargo check` in `wework/src-tauri`
- `cargo test data_clearing --lib` in `wework/src-tauri`
- `rustfmt --edition 2021 --check wework/src-tauri/src/embedded_browser/data_clearing.rs`
- `bash .github/scripts/test-classify-ci-changes.sh`
- `actionlint .github/workflows/test.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows browsing-data clearing callback handling while preserving existing completion and error behavior.

* **Chores**
  * Added dedicated Windows Rust validation to CI, including dependency caching and locked checks.
  * Updated change detection so Rust-specific updates trigger the appropriate validation workflows.
  * Expanded automated tests to cover the new change classification and CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->