### PR TITLE
test(wework): capture goal recovery e2e diagnostics

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -8097,7 +8097,20 @@ async function verifyGoalRestartRecoveryLifecycle({
       !snapshot.testIds.includes(goalUnreadTestId) &&
       snapshot.text.includes(GOAL_RESTART_INITIAL_TEXT),
     'The user did not see the Goal working before Wework restarted'
-  )
+  ).catch(async error => {
+    const debugSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}; workbench debug: ${JSON.stringify(
+        {
+          currentRuntimeTask: debugSnapshot.workbench?.currentRuntimeTask ?? null,
+          lifecycleCurrentTaskRunning: debugSnapshot.workbench?.lifecycleCurrentTaskRunning ?? null,
+          goal: debugSnapshot.pane?.goal ?? null,
+          goalContinuing: debugSnapshot.pane?.goalContinuing ?? null,
+          goalDraftActive: debugSnapshot.pane?.goalDraftActive ?? null,
+        }
+      )}`
+    )
+  })
   await captureVerificationScreenshot(control, 'goal-restart-01-working-before-restart.png')
 
   await control.command('click', '[data-testid="new-chat-button"]')


### PR DESCRIPTION
## Summary

- Capture the active runtime task, lifecycle task, and pane Goal state whenever the Goal restart recovery E2E visibility assertion fails.
- Preserve the strict `goal-status-bar` assertion instead of masking a missing Goal state.

## Why

The merge-queue failure showed the task still running while `goal-status-bar` was absent. The archived test snapshot omitted the pane Goal state, so it could not distinguish a missing, completed, or misbound Goal. These diagnostics make a recurrence actionable.

## Validation

- `node --check wework/e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework e2e:desktop -- --segment goal-lifecycle` (passed in a real Tauri run)
- Pre-push ESLint, TypeScript, and unit tests (passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostics for Goal-restart readiness test failures.
  * Failure messages now include relevant runtime task, lifecycle, goal, continuation, and draft-state details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->