### PR TITLE
fix(ci): isolate Playwright version output

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -85,7 +85,9 @@ jobs:
       - name: Resolve Playwright version
         id: playwright-version
         working-directory: ./frontend
-        run: echo "version=$(pnpm exec playwright --version | sed 's/^Version //')" >> "$GITHUB_OUTPUT"
+        run: |
+          version="$(pnpm exec playwright --version | sed -n 's/^Version //p')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/docs/en/wegent/developer-guide/testing.md
+++ b/docs/en/wegent/developer-guide/testing.md
@@ -250,6 +250,21 @@ validates the branch after a PR is opened. A newer commit to the same PR or to
 always appear and verify that every selected job actually succeeded. Skipped,
 unrelated modules do not make the summary fail.
 
+### Writing GitHub Actions Outputs
+
+Every line written to `$GITHUB_OUTPUT` must use the `name=value` format. Do not
+write the substituted output of a command that can emit progress or diagnostic
+messages directly to that file. Extract the needed value first, then write the
+output. For example, to resolve the Playwright version:
+
+```bash
+version="$(pnpm exec playwright --version | sed -n 's/^Version //p')"
+echo "version=$version" >> "$GITHUB_OUTPUT"
+```
+
+This prevents package-manager supply-chain checks or other auxiliary logs from
+invalidating the workflow output format.
+
 ### Workflow Jobs
 
 Regular PR checks must cover module tests; E2E jobs do not replace them:

--- a/docs/zh/wegent/developer-guide/testing.md
+++ b/docs/zh/wegent/developer-guide/testing.md
@@ -246,6 +246,19 @@ Wework 浏览器和桌面 E2E，以及 Wework macOS 内存门禁，适合路径�
 `lint-summary` 始终存在，并验证所有被分类为必需的任务确实成功，未执行的无关模块
 不会导致汇总任务误报失败。
 
+### 写入 GitHub Actions 输出
+
+写入 `$GITHUB_OUTPUT` 时，每一行必须是 `name=value` 格式。不要把会输出进度或诊断
+信息的命令替换结果直接写入该文件；先只提取所需的值，再写入输出。例如，解析
+Playwright 版本时：
+
+```bash
+version="$(pnpm exec playwright --version | sed -n 's/^Version //p')"
+echo "version=$version" >> "$GITHUB_OUTPUT"
+```
+
+这样包管理器的供应链检查或其他辅助日志不会使工作流输出格式失效。
+
 ### 工作流任务
 
 常规 PR 测试必须覆盖各模块测试，不能用 E2E 任务代替：


### PR DESCRIPTION
## What changed

- Extract only the Playwright version before writing the GitHub Actions output.
- Document the safe `$GITHUB_OUTPUT` pattern in Chinese and English testing guides.

## Why

`pnpm exec playwright --version` can emit supply-chain verification logs alongside the version. The previous command wrote those logs to `$GITHUB_OUTPUT`, which requires every line to use `name=value` syntax, causing the E2E artifact build to fail.

## Validation

- Simulated noisy pnpm output and verified that only `version=1.60.0` is emitted.
- Ran `git diff --check`.
- Pre-push quality checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guidance for safely writing GitHub Actions outputs.
  * Documented the required `name=value` format and how to avoid mixing diagnostic logs with output values.

* **Chores**
  * Improved Playwright version handling in automated end-to-end test workflows without changing the resulting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->