### PR TITLE
fix(wework): keep image previews loaded across session event updates

### DIFF
--- a/wework/src/components/chat/AttachmentImagePreview.test.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Attachment } from '@/types/api'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
@@ -24,6 +24,19 @@ function remoteAttachment(id: number): Attachment {
     status: 'ready',
     file_extension: '.png',
     created_at: '2026-08-07T00:00:00.000Z',
+  }
+}
+
+function localPathAttachment(id: number, localPath: string): Attachment {
+  return {
+    id,
+    filename: `image-${id}.png`,
+    file_size: 1,
+    mime_type: 'image/png',
+    status: 'ready',
+    file_extension: '.png',
+    created_at: '2026-08-07T00:00:00.000Z',
+    local_path: localPath,
   }
 }
 
@@ -117,5 +130,47 @@ describe('AttachmentImagePreview', () => {
 
     expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
     expect(screen.getByTestId('preview-loading')).toBeInTheDocument()
+  })
+
+  test('lightbox loads the selected attachment when equal ids differ by local_path', async () => {
+    const first = localPathAttachment(1, '/a.png')
+    const second = localPathAttachment(1, '/b.png')
+    render(
+      <AttachmentImagePreview
+        attachment={first}
+        galleryAttachments={[first, second]}
+        galleryIndex={0}
+        buttonTestId="preview-button"
+        imageTestId="preview-image"
+        loadingTestId="preview-loading"
+        errorTestId="preview-error"
+        imageClassName="h-20 w-20"
+        placeholderClassName="h-20 w-20"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-image')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('preview-button'))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+        'src',
+        'asset://localhost/a.png'
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('attachment-image-next'))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+        'src',
+        'asset://localhost/b.png'
+      )
+    })
   })
 })

--- a/wework/src/components/chat/AttachmentImagePreview.test.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.test.tsx
@@ -1,0 +1,121 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Attachment } from '@/types/api'
+import { AttachmentImagePreview } from './AttachmentImagePreview'
+
+const tauriCoreMock = vi.hoisted(() => ({
+  convertFileSrc: vi.fn((path: string) => `asset://localhost/${path.replace(/^\/+/, '')}`),
+  invoke: vi.fn(),
+  isTauri: vi.fn(() => false),
+}))
+
+vi.mock('@tauri-apps/api/core', () => tauriCoreMock)
+
+interface PendingFetch {
+  resolve: (response: Response) => void
+}
+
+function remoteAttachment(id: number): Attachment {
+  return {
+    id,
+    filename: `image-${id}.png`,
+    file_size: 1,
+    mime_type: 'image/png',
+    status: 'ready',
+    file_extension: '.png',
+    created_at: '2026-08-07T00:00:00.000Z',
+  }
+}
+
+function previewElement(attachment: Attachment) {
+  return (
+    <AttachmentImagePreview
+      attachment={attachment}
+      buttonTestId="preview-button"
+      imageTestId="preview-image"
+      loadingTestId="preview-loading"
+      errorTestId="preview-error"
+      imageClassName="h-20 w-20"
+      placeholderClassName="h-20 w-20"
+    />
+  )
+}
+
+describe('AttachmentImagePreview', () => {
+  const originalCreateObjectUrl = URL.createObjectURL
+  let pendingFetches: PendingFetch[]
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    pendingFetches = []
+    fetchMock = vi.fn(() => {
+      let resolveFetch: (response: Response) => void = () => {}
+      const promise = new Promise<Response>(resolve => {
+        resolveFetch = resolve
+      })
+      pendingFetches.push({ resolve: resolveFetch })
+      return promise
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    URL.createObjectURL = vi.fn(
+      () => 'blob:attachment-preview'
+    ) as unknown as typeof URL.createObjectURL
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectUrl
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  async function settleNextFetch() {
+    const pending = pendingFetches.shift()
+    if (!pending) throw new Error('No pending fetch to settle')
+    await act(async () => {
+      pending.resolve(
+        new Response('preview', {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        })
+      )
+    })
+  }
+
+  test('keeps the loaded preview when session events recreate the attachment object with the same content', async () => {
+    const { rerender } = render(previewElement(remoteAttachment(1)))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+    await settleNextFetch()
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-image')).toBeInTheDocument()
+    })
+
+    // Runtime turn/block projections produce a fresh attachment object with
+    // the same id and preview source on every session event.
+    rerender(previewElement(remoteAttachment(1)))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('preview-image')).toBeInTheDocument()
+    expect(screen.queryByTestId('preview-loading')).not.toBeInTheDocument()
+  })
+
+  test('resets to the loading state when the attachment content identity actually changes', async () => {
+    const { rerender } = render(previewElement(remoteAttachment(1)))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+    await settleNextFetch()
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-image')).toBeInTheDocument()
+    })
+
+    rerender(previewElement(remoteAttachment(2)))
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByTestId('preview-loading')).toBeInTheDocument()
+  })
+})

--- a/wework/src/components/chat/AttachmentImagePreview.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.tsx
@@ -49,6 +49,10 @@ function clampIndex(value: number, length: number): number {
   return Math.min(length - 1, Math.max(0, value))
 }
 
+function attachmentPreviewIdentity(attachment: Attachment): string {
+  return `${attachment.id}:${attachment.local_preview_url ?? attachment.local_path ?? ''}`
+}
+
 async function loadAttachmentImageUrl(
   attachment: Attachment
 ): Promise<{ url: string; objectUrl: string | null }> {
@@ -186,7 +190,7 @@ export function AttachmentImagePreview({
   const [zoom, setZoom] = useState(1)
   const [shouldLoadPreview, setShouldLoadPreview] = useState(false)
   const previewContainerRef = useRef<HTMLElement | null>(null)
-  const previewIdentity = `${attachment.id}:${attachment.local_preview_url ?? attachment.local_path ?? ''}`
+  const previewIdentity = attachmentPreviewIdentity(attachment)
   const attachmentRef = useRef(attachment)
   const setPreviewContainerRef = useCallback((element: HTMLElement | null) => {
     previewContainerRef.current = element
@@ -283,8 +287,7 @@ export function AttachmentImagePreview({
     const currentAttachment = attachmentRef.current
     const selectedAttachment = gallery[nextIndex] ?? currentAttachment
     const reusablePreviewUrl =
-      selectedAttachment.id === currentAttachment.id &&
-      selectedAttachment.local_preview_url === currentAttachment.local_preview_url
+      attachmentPreviewIdentity(selectedAttachment) === attachmentPreviewIdentity(currentAttachment)
         ? previewUrl
         : null
 

--- a/wework/src/components/chat/AttachmentImagePreview.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.tsx
@@ -187,9 +187,13 @@ export function AttachmentImagePreview({
   const [shouldLoadPreview, setShouldLoadPreview] = useState(false)
   const previewContainerRef = useRef<HTMLElement | null>(null)
   const previewIdentity = `${attachment.id}:${attachment.local_preview_url ?? attachment.local_path ?? ''}`
+  const attachmentRef = useRef(attachment)
   const setPreviewContainerRef = useCallback((element: HTMLElement | null) => {
     previewContainerRef.current = element
   }, [])
+  useEffect(() => {
+    attachmentRef.current = attachment
+  }, [attachment])
   const gallery = useMemo(
     () => (galleryAttachments?.length ? galleryAttachments : [attachment]),
     [attachment, galleryAttachments]
@@ -235,6 +239,7 @@ export function AttachmentImagePreview({
 
     let isMounted = true
     let objectUrl: string | null = null
+    const targetAttachment = attachmentRef.current
 
     async function loadPreview() {
       setPreviewUrl(null)
@@ -244,7 +249,7 @@ export function AttachmentImagePreview({
       setZoom(1)
 
       try {
-        const loaded = await loadAttachmentImageUrl(attachment)
+        const loaded = await loadAttachmentImageUrl(targetAttachment)
         objectUrl = loaded.objectUrl
         if (isMounted) {
           setPreviewUrl(loaded.url)
@@ -253,7 +258,7 @@ export function AttachmentImagePreview({
         }
       } catch {
         if (isMounted) {
-          rememberFailedAttachmentPreview(attachment)
+          rememberFailedAttachmentPreview(targetAttachment)
           setHasError(true)
         }
       }
@@ -267,7 +272,7 @@ export function AttachmentImagePreview({
         URL.revokeObjectURL(objectUrl)
       }
     }
-  }, [attachment, shouldLoadPreview])
+  }, [previewIdentity, shouldLoadPreview])
 
   useEffect(() => {
     if (!isLightboxOpen || disableLightbox) return
@@ -275,10 +280,11 @@ export function AttachmentImagePreview({
     let isMounted = true
     let objectUrl: string | null = null
     const nextIndex = clampIndex(lightboxIndex, gallery.length)
-    const selectedAttachment = gallery[nextIndex] ?? attachment
+    const currentAttachment = attachmentRef.current
+    const selectedAttachment = gallery[nextIndex] ?? currentAttachment
     const reusablePreviewUrl =
-      selectedAttachment.id === attachment.id &&
-      selectedAttachment.local_preview_url === attachment.local_preview_url
+      selectedAttachment.id === currentAttachment.id &&
+      selectedAttachment.local_preview_url === currentAttachment.local_preview_url
         ? previewUrl
         : null
 
@@ -321,7 +327,7 @@ export function AttachmentImagePreview({
         URL.revokeObjectURL(objectUrl)
       }
     }
-  }, [attachment, disableLightbox, gallery, isLightboxOpen, lightboxIndex, previewUrl])
+  }, [disableLightbox, gallery, isLightboxOpen, lightboxIndex, previewIdentity, previewUrl])
 
   useEffect(() => {
     if (!isLightboxOpen || disableLightbox) return


### PR DESCRIPTION
## 问题

会话事件更新时，若当前 turn/run 中带有图片（用户消息附件、`view_image`/`image_generation` 生成的图片），图片预览会频繁回到 loading 占位状态，导致会话消息区域跳动。

## 根因

`AttachmentImagePreview` 的预览加载 effect 依赖 `attachment` 对象引用。会话事件流式更新会通过 turn 投影、block 更新、快照合并等路径重建消息/附件对象（内容相同、引用全新），每次都会触发 effect 重新执行，把 `previewUrl` 重置为 `null` 并回到 loading。

## 修复

- 预览与灯箱加载 effect 改为以稳定内容标识（`id + local_preview_url/local_path`）为依赖，通过 ref 读取最新 attachment，避免对象引用变化导致重复加载；
- 图片内容真正变化时标识仍会变化，加载逻辑照常重新触发。

## 验证

- 新增回归单测：对象引用变化但内容相同 → 不重新加载、不回到 loading；内容标识变化 → 正常重置为 loading；
- wework 全量单测通过（308 文件 / 2994 用例），eslint、prettier 干净；
- 已用 `ai:verify` 在隔离的真实 Tauri 会话中启动确认工作台正常渲染。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment image previews to consistently display the latest selected image.
  * Prevented stale attachment data from affecting preview loading and lightbox behavior.
  * Preserved already loaded previews for equivalent attachments, avoiding unnecessary reloads.
  * Fixed preview loading and refreshing when attachments share an ID but have different local files.
  * Improved lightbox navigation between attachments with distinct preview content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->