### PR TITLE
fix(wework): show device name instead of IP in sidebar project list

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -2308,7 +2308,18 @@ describe('DesktopSidebar', () => {
 
   test('keeps an unavailable remote-only project visible with its IP and gray status', () => {
     renderSidebar({
-      devices: [localDevice()],
+      devices: [
+        localDevice(),
+        localDevice({
+          id: 2,
+          device_id: 'remote-device',
+          name: 'Remote Host',
+          status: 'offline',
+          is_default: false,
+          device_type: 'remote',
+          client_ip: '10.201.3.200',
+        }),
+      ],
       runtimeWork: {
         projects: [
           {
@@ -2317,7 +2328,7 @@ describe('DesktopSidebar', () => {
               {
                 id: 91,
                 deviceId: 'remote-device',
-                deviceName: '10.201.3.200',
+                deviceName: 'Remote Host',
                 deviceStatus: 'offline',
                 available: false,
                 workspacePath: '/home/ubuntu/workspace/Wegent',
@@ -2350,7 +2361,7 @@ describe('DesktopSidebar', () => {
 
     expect(screen.getByText('Remote Wegent')).toBeInTheDocument()
     expect(screen.getByTestId('project-remote-folder-icon-7')).toBeInTheDocument()
-    expect(screen.getByTestId('project-device-status-7')).toHaveTextContent('10.201.3.200')
+    expect(screen.getByTestId('project-device-status-7')).toHaveTextContent('Remote Host')
     expect(screen.getByTestId('project-device-status-7-dot')).toHaveClass(
       'bg-[rgb(var(--color-sidebar-text-muted))]',
       'opacity-55'
@@ -2467,7 +2478,7 @@ describe('DesktopSidebar', () => {
       },
     })
 
-    expect(screen.getByTestId('project-device-status-7')).toHaveTextContent('10.201.3.200')
+    expect(screen.getByTestId('project-device-status-7')).toHaveTextContent('Remote Host')
     expect(screen.getByTestId('project-device-status-7-dot')).toHaveStyle({
       backgroundColor: '#1FD660',
     })

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -630,6 +630,8 @@ function hasCloudRuntimeRoute(device?: DeviceInfo): boolean {
 }
 
 function getDeviceRouteLabel(deviceState: SidebarDeviceState): string {
+  const deviceName = deviceState.device?.name?.trim()
+  if (deviceName) return deviceName
   return getDeviceNetworkLabel(deviceState.device) || deviceState.deviceId
 }
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -3792,7 +3792,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     const projectRow = screen.getByTestId('project-row-7')
     expect(within(projectRow).getByTestId('project-device-status-7')).toHaveTextContent(
-      '192.0.2.10'
+      'Online Device'
     )
     expect(within(projectRow).getByTestId('project-new-conversation-button')).not.toBeDisabled()
   })
@@ -3844,7 +3844,7 @@ describe('DesktopWorkbenchLayout', () => {
     const status = within(screen.getByTestId('project-row-7')).getByTestId(
       'project-device-status-7'
     )
-    expect(status).toHaveTextContent('127.0.0.1')
+    expect(status).toHaveTextContent('Remote Device')
     expect(status).not.toHaveTextContent('9d317900')
   })
 


### PR DESCRIPTION
## Problem

The sidebar project list displayed the device's network address (IP) instead of its name:
- Cloud devices showed their device ID (e.g. `yunpeng7-executor-0bb4`)
- Remote Docker devices showed `127.0.0.1` (loopback IP from local port mapping)

## Root cause

`ProjectDeviceInlineStatus` in `DesktopSidebar.tsx` calls `getDeviceRouteLabel`, which prioritized `runtime_transfer_host` / `client_ip` over `device.name`. For cloud devices the IP is often unavailable, so it fell back to `deviceId`; for remote Docker devices the reported IP is the loopback address.

## Fix

Prioritize `device.name` in `getDeviceRouteLabel`, falling back to the network label or deviceId only when no name is available. This is consistent with the existing `getStandaloneDeviceLabel` and `getSidebarDeviceName` helpers in the same file.

```diff
 function getDeviceRouteLabel(deviceState: SidebarDeviceState): string {
+  const deviceName = deviceState.device?.name?.trim()
+  if (deviceName) return deviceName
   return getDeviceNetworkLabel(deviceState.device) || deviceState.deviceId
 }
```

## Testing
- Updated 4 existing test assertions across `DesktopSidebar.test.tsx` and `DesktopWorkbenchLayout.test.tsx` to expect device names instead of IPs.
- All 307 test files (2999 tests) pass, ESLint and TypeScript checks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device status labels in the desktop sidebar and workbench now show the device’s display name when available, making remote and cloud project locations easier to identify.
  * Labels continue to use a network address or device identifier when no display name is available.
* **Tests**
  * Updated coverage to verify device-name labels and unavailable-project status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->