### PR TITLE
fix(wework): remove legacy executor migration

### DIFF
--- a/docs/en/wework/developer-guide/wework-local-data-directory.md
+++ b/docs/en/wework/developer-guide/wework-local-data-directory.md
@@ -22,24 +22,4 @@ The default Executor Home is `~/.wework` and contains:
 - `device-config.json` and `device_id`: local device identity.
 
 The `WEGENT_EXECUTOR_HOME` environment variable overrides the default Executor
-Home. When it is set explicitly, Wework does not run the default-directory
-migration, which keeps isolated sessions, tests, and custom deployments intact.
-
-## Legacy Directory Migration
-
-On the first start with the default directory, Wework automatically migrates
-legacy data into `~/.wework`:
-
-1. `~/.wegent-executor` is migrated first.
-2. The older `~/.wecode/wegent-executor` is merged afterwards.
-
-Migration rules:
-
-- When `~/.wework` does not exist, the legacy directory is renamed as a whole,
-  preserving file attributes, directory structure, and symbolic links.
-- When both directories exist, non-conflicting content is merged recursively;
-  files already in `~/.wework` always win.
-- Conflicting legacy entries are archived under
-  `~/.wework/.legacy-migration-conflicts/<source>/` instead of being overwritten.
-- After migration, the legacy directory is removed and old paths are never read
-  at runtime.
+Home. This is useful for isolated sessions, tests, and custom deployments.

--- a/docs/zh/wework/developer-guide/wework-local-data-directory.md
+++ b/docs/zh/wework/developer-guide/wework-local-data-directory.md
@@ -21,18 +21,4 @@ Wework 的本地运行时数据统一存放在用户主目录下的 `~/.wework`�
 - `device-config.json`、`device_id`：本机设备标识。
 
 `WEGENT_EXECUTOR_HOME` 环境变量可以覆盖默认 Executor Home。显式设置该变量时，
-Wework 不会对默认目录执行迁移，用于隔离会话、测试和自定义部署。
-
-## 旧目录迁移
-
-首次以默认目录启动时，Wework 会自动把旧数据迁移到 `~/.wework`：
-
-1. 优先迁移 `~/.wegent-executor`。
-2. 再合并更早的 `~/.wecode/wegent-executor`。
-
-迁移规则：
-
-- `~/.wework` 不存在时，直接重命名整个旧目录，保留文件属性、目录结构和软链接。
-- 新旧目录同时存在时，递归合并不冲突的内容；`~/.wework` 中的现有文件始终优先。
-- 同名冲突的旧内容归档到 `~/.wework/.legacy-migration-conflicts/<来源>/`，不会覆盖或丢失数据。
-- 迁移完成后旧目录会被移除，运行期不再读取旧路径。
+适用于隔离会话、测试和自定义部署。

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -2617,7 +2617,6 @@ fn default_executor_home(app: &tauri::AppHandle) -> Result<std::path::PathBuf, S
         .path()
         .home_dir()
         .map_err(|error| format!("Failed to locate home directory: {error}"))?;
-    local_executor::migrate_legacy_executor_homes(&home)?;
     Ok(home.join(".wework"))
 }
 
@@ -2706,10 +2705,6 @@ fn get_local_executor_device_id(expected_backend_url: Option<String>) -> Option<
         candidates.push(executor_home.join("device_id"));
     }
     if let Some(home) = dirs::home_dir() {
-        if let Err(error) = local_executor::migrate_legacy_executor_homes(&home) {
-            log::warn!("Failed to migrate legacy Wework home: {error}");
-            return None;
-        }
         if let Some(device_id) = read_device_config(home.join(".wework").join("device-config.json"))
         {
             return Some(device_id);

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -55,9 +55,6 @@ const LOCAL_EXECUTOR_RUNTIME_DIR_NAME: &str = "app-runtime";
 const LOCAL_EXECUTOR_LOG_TAIL_BYTES: u64 = 200 * 1024;
 const LOCAL_EXECUTOR_LOG_TAIL_LINES: usize = 20;
 const WEWORK_HOME_DIR: &str = ".wework";
-const LEGACY_EXECUTOR_HOME_DIR: &str = ".wegent-executor";
-const LEGACY_WECODE_HOME_DIR: &str = ".wecode";
-const LEGACY_MIGRATION_CONFLICTS_DIR: &str = ".legacy-migration-conflicts";
 const LOCAL_EXECUTOR_READY_TIMEOUT_SECS: u64 = if cfg!(debug_assertions) {
     if cfg!(windows) {
         180
@@ -632,7 +629,6 @@ pub(crate) fn local_executor_home_path() -> Result<PathBuf, String> {
     }
 
     let home = dirs::home_dir().ok_or_else(|| "Home directory is not available".to_string())?;
-    migrate_legacy_executor_homes(&home)?;
     Ok(default_local_executor_home_path(
         &home,
         LOCAL_EXECUTOR_NAMESPACE,
@@ -644,204 +640,6 @@ fn default_local_executor_home_path(home: &Path, namespace: Option<&str>) -> Pat
     namespace
         .filter(|value| !value.is_empty())
         .map_or(root.clone(), |value| root.join("apps").join(value))
-}
-
-pub(crate) fn migrate_legacy_executor_homes(home: &Path) -> Result<(), String> {
-    let destination = home.join(WEWORK_HOME_DIR);
-    for (source, label) in [
-        (
-            home.join(LEGACY_EXECUTOR_HOME_DIR),
-            LEGACY_EXECUTOR_HOME_DIR,
-        ),
-        (
-            home.join(LEGACY_WECODE_HOME_DIR)
-                .join(LEGACY_EXECUTOR_HOME_DIR),
-            "wecode-wegent-executor",
-        ),
-    ] {
-        migrate_legacy_executor_home(&source, &destination, label)?;
-    }
-    Ok(())
-}
-
-fn migrate_legacy_executor_home(
-    source: &Path,
-    destination: &Path,
-    legacy_label: &str,
-) -> Result<(), String> {
-    let source_metadata = match fs::symlink_metadata(source) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(format!(
-                "Failed to inspect legacy Wework directory {}: {error}",
-                source.display()
-            ));
-        }
-    };
-    let source_is_symlink = source_metadata.file_type().is_symlink();
-    if !source.is_dir() {
-        log::warn!(
-            "Skipping legacy Wework migration because {} is not a directory",
-            source.display()
-        );
-        return Ok(());
-    }
-
-    match fs::symlink_metadata(destination) {
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            if !source_is_symlink {
-                fs::rename(source, destination).map_err(|error| {
-                    format!(
-                        "Failed to migrate {} to {}: {error}",
-                        source.display(),
-                        destination.display()
-                    )
-                })?;
-                log::info!(
-                    "Migrated legacy Wework directory {} to {}",
-                    source.display(),
-                    destination.display()
-                );
-                return Ok(());
-            }
-
-            fs::create_dir_all(destination)
-                .map_err(|error| format!("Failed to create {}: {error}", destination.display()))?;
-            merge_legacy_executor_directory(
-                source,
-                destination,
-                &destination
-                    .join(LEGACY_MIGRATION_CONFLICTS_DIR)
-                    .join(legacy_label),
-            )?;
-            remove_empty_legacy_executor_home(source, source_is_symlink)?;
-            log::info!(
-                "Migrated linked legacy Wework directory {} to {}",
-                source.display(),
-                destination.display()
-            );
-            return Ok(());
-        }
-        Ok(metadata) if !metadata.is_dir() => {
-            return Err(format!(
-                "Wework home is not a directory: {}",
-                destination.display()
-            ));
-        }
-        Ok(_) => {}
-        Err(error) => {
-            return Err(format!(
-                "Failed to inspect Wework home {}: {error}",
-                destination.display()
-            ));
-        }
-    }
-
-    merge_legacy_executor_directory(
-        source,
-        destination,
-        &destination
-            .join(LEGACY_MIGRATION_CONFLICTS_DIR)
-            .join(legacy_label),
-    )?;
-    remove_empty_legacy_executor_home(source, source_is_symlink)?;
-    Ok(())
-}
-
-fn remove_empty_legacy_executor_home(source: &Path, source_is_symlink: bool) -> Result<(), String> {
-    if fs::read_dir(source)
-        .map_err(|error| format!("Failed to read {}: {error}", source.display()))?
-        .next()
-        .is_some()
-    {
-        return Ok(());
-    }
-
-    if source_is_symlink {
-        fs::remove_file(source)
-    } else {
-        fs::remove_dir(source)
-    }
-    .map_err(|error| format!("Failed to remove {}: {error}", source.display()))
-}
-
-fn merge_legacy_executor_directory(
-    source: &Path,
-    destination: &Path,
-    conflict_destination: &Path,
-) -> Result<(), String> {
-    for entry in fs::read_dir(source)
-        .map_err(|error| format!("Failed to read {}: {error}", source.display()))?
-    {
-        let entry = entry.map_err(|error| error.to_string())?;
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        match fs::symlink_metadata(&destination_path) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                fs::rename(&source_path, &destination_path).map_err(|error| {
-                    format!(
-                        "Failed to migrate {} to {}: {error}",
-                        source_path.display(),
-                        destination_path.display()
-                    )
-                })?;
-            }
-            Ok(destination_metadata)
-                if entry
-                    .file_type()
-                    .map_err(|error| {
-                        format!("Failed to inspect {}: {error}", source_path.display())
-                    })?
-                    .is_dir()
-                    && destination_metadata.is_dir() =>
-            {
-                merge_legacy_executor_directory(
-                    &source_path,
-                    &destination_path,
-                    &conflict_destination.join(entry.file_name()),
-                )?;
-                if fs::read_dir(&source_path)
-                    .map_err(|error| format!("Failed to read {}: {error}", source_path.display()))?
-                    .next()
-                    .is_none()
-                {
-                    fs::remove_dir(&source_path).map_err(|error| {
-                        format!("Failed to remove {}: {error}", source_path.display())
-                    })?;
-                }
-            }
-            Ok(_) => {
-                fs::create_dir_all(conflict_destination).map_err(|error| {
-                    format!(
-                        "Failed to create {}: {error}",
-                        conflict_destination.display()
-                    )
-                })?;
-                let conflict_path = conflict_destination.join(entry.file_name());
-                fs::rename(&source_path, &conflict_path).map_err(|error| {
-                    format!(
-                        "Failed to preserve conflicting legacy Wework entry {} at {}: {error}",
-                        source_path.display(),
-                        conflict_path.display()
-                    )
-                })?;
-                log::warn!(
-                    "Preserved conflicting legacy Wework entry {} at {} because {} already exists",
-                    source_path.display(),
-                    conflict_path.display(),
-                    destination_path.display(),
-                );
-            }
-            Err(error) => {
-                return Err(format!(
-                    "Failed to inspect Wework migration destination {}: {error}",
-                    destination_path.display()
-                ));
-            }
-        }
-    }
-    Ok(())
 }
 
 fn local_executor_log_path() -> Result<PathBuf, String> {
@@ -4788,119 +4586,31 @@ BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
         );
     }
 
-    #[test]
-    fn migrates_legacy_executor_homes_into_wework_home() {
-        let home = import_test_root("legacy-executor-home");
-        let current_legacy_home = home.join(LEGACY_EXECUTOR_HOME_DIR);
-        let wecode_legacy_home = home
-            .join(LEGACY_WECODE_HOME_DIR)
-            .join(LEGACY_EXECUTOR_HOME_DIR);
-        fs::create_dir_all(current_legacy_home.join("workspace/chats")).unwrap();
-        fs::create_dir_all(wecode_legacy_home.join("capabilities")).unwrap();
-        fs::write(
-            current_legacy_home.join("device-config.json"),
-            "{\"device_id\":\"current-device\"}",
-        )
-        .unwrap();
-        fs::write(
-            current_legacy_home.join("workspace/chats/current.md"),
-            "current",
-        )
-        .unwrap();
-        fs::write(wecode_legacy_home.join("capabilities/legacy.md"), "legacy").unwrap();
-
-        migrate_legacy_executor_homes(&home).unwrap();
-
-        let destination = home.join(WEWORK_HOME_DIR);
-        assert_eq!(
-            fs::read_to_string(destination.join("device-config.json")).unwrap(),
-            "{\"device_id\":\"current-device\"}"
-        );
-        assert_eq!(
-            fs::read_to_string(destination.join("workspace/chats/current.md")).unwrap(),
-            "current"
-        );
-        assert_eq!(
-            fs::read_to_string(destination.join("capabilities/legacy.md")).unwrap(),
-            "legacy"
-        );
-        assert!(!current_legacy_home.exists());
-        assert!(!wecode_legacy_home.exists());
-        let _ = fs::remove_dir_all(home);
-    }
-
-    #[test]
-    fn preserves_conflicting_legacy_entries_without_using_legacy_home() {
-        let home = import_test_root("legacy-executor-conflict");
-        let destination = home.join(WEWORK_HOME_DIR);
-        let legacy_home = home.join(LEGACY_EXECUTOR_HOME_DIR);
-        fs::create_dir_all(&destination).unwrap();
-        fs::create_dir_all(&legacy_home).unwrap();
-        fs::write(destination.join("device-config.json"), "current").unwrap();
-        fs::write(legacy_home.join("device-config.json"), "legacy").unwrap();
-
-        migrate_legacy_executor_homes(&home).unwrap();
-
-        assert_eq!(
-            fs::read_to_string(destination.join("device-config.json")).unwrap(),
-            "current"
-        );
-        assert_eq!(
-            fs::read_to_string(
-                destination
-                    .join(LEGACY_MIGRATION_CONFLICTS_DIR)
-                    .join(LEGACY_EXECUTOR_HOME_DIR)
-                    .join("device-config.json")
-            )
-            .unwrap(),
-            "legacy"
-        );
-        assert!(!legacy_home.exists());
-        let _ = fs::remove_dir_all(home);
-    }
-
-    #[test]
-    fn ignores_non_directory_legacy_executor_home() {
-        let home = import_test_root("non-directory-legacy-executor-home");
-        let legacy_home = home.join(LEGACY_EXECUTOR_HOME_DIR);
-        fs::create_dir_all(&home).unwrap();
-        fs::write(&legacy_home, "not a directory").unwrap();
-
-        migrate_legacy_executor_homes(&home).unwrap();
-
-        assert_eq!(fs::read_to_string(&legacy_home).unwrap(), "not a directory");
-        assert!(!home.join(WEWORK_HOME_DIR).exists());
-        let _ = fs::remove_dir_all(home);
-    }
-
     #[cfg(unix)]
     #[test]
-    fn migrates_legacy_executor_directory_symlink_into_wework_home() {
-        let home = import_test_root("linked-legacy-executor-home");
-        let linked_target = import_test_root("linked-legacy-executor-target");
-        let legacy_home = home.join(LEGACY_EXECUTOR_HOME_DIR);
-        fs::create_dir_all(&home).unwrap();
-        fs::create_dir_all(linked_target.join("workspace/chats")).unwrap();
-        fs::write(linked_target.join("workspace/chats/current.md"), "current").unwrap();
-        std::os::unix::fs::symlink(&linked_target, &legacy_home).unwrap();
+    fn default_executor_home_does_not_migrate_legacy_directory() {
+        let _guard = env_lock();
+        let home = import_test_root("legacy-executor-home-is-untouched");
+        let legacy_home = home.join(".wegent-executor");
+        let previous_home = std::env::var_os("HOME");
+        let previous_executor_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
+        fs::create_dir_all(&legacy_home).unwrap();
+        fs::write(legacy_home.join("device-config.json"), "legacy").unwrap();
+        std::env::set_var("HOME", &home);
+        std::env::remove_var(LOCAL_EXECUTOR_HOME_ENV);
 
-        migrate_legacy_executor_homes(&home).unwrap();
+        let executor_home = local_executor_home_path().unwrap();
 
-        let destination = home.join(WEWORK_HOME_DIR);
+        restore_env("HOME", previous_home);
+        restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_executor_home);
+
+        assert_eq!(executor_home, home.join(WEWORK_HOME_DIR));
         assert_eq!(
-            fs::read_to_string(destination.join("workspace/chats/current.md")).unwrap(),
-            "current"
+            fs::read_to_string(legacy_home.join("device-config.json")).unwrap(),
+            "legacy"
         );
-        assert!(fs::symlink_metadata(&destination).unwrap().is_dir());
-        assert!(!fs::symlink_metadata(&destination)
-            .unwrap()
-            .file_type()
-            .is_symlink());
-        assert!(fs::symlink_metadata(&legacy_home).is_err());
-        assert!(linked_target.is_dir());
-        assert!(fs::read_dir(&linked_target).unwrap().next().is_none());
+        assert!(!executor_home.exists());
         let _ = fs::remove_dir_all(home);
-        let _ = fs::remove_dir_all(linked_target);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- remove Wework's automatic migration from `~/.wegent-executor` and `~/.wecode/wegent-executor` to `~/.wework`
- keep local attachment and device-ID lookup on the configured or default Wework home only
- update the local-data-directory guides and add a regression test that verifies legacy data remains untouched

## Why

Wework should not move or merge data owned by the standalone executor during local-runtime startup.

## Validation

- `cargo test --manifest-path wework/src-tauri/Cargo.toml local_executor::tests::default_executor_home_does_not_migrate_legacy_directory --lib`
- `pnpm --filter wework exec vitest run src/lib/workspace-target.test.ts`
- pre-push Wework ESLint, TypeScript, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English and Chinese guidance for `WEGENT_EXECUTOR_HOME`, highlighting isolated sessions, testing, and custom deployments.
  * Removed documentation about legacy directory migration and migration rules.

* **Bug Fixes**
  * Removed automatic migration of legacy executor-home directories.
  * Existing home and configuration locations are now used directly without migration warnings.
  * Preserved existing legacy directories without modifying them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->