### PR TITLE
fix(wework): keep Windows sidebar dark in dark mode

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -219,7 +219,7 @@ describe('DesktopSidebar', () => {
     expect(sidebar).toHaveClass('bg-[rgb(var(--color-sidebar-unfocused))]')
   })
 
-  test('keeps the shared right border on Windows', () => {
+  test('keeps the shared right border and forces an opaque sidebar on Windows', () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
       value: {},
@@ -232,6 +232,10 @@ describe('DesktopSidebar', () => {
     renderSidebar()
     const sidebar = screen.getByTestId('desktop-sidebar')
     expect(sidebar).toHaveClass('border-r')
+    // Windows WebView2 cannot render a translucent window, so the sidebar opts
+    // out of the translucent background. The dark-theme CSS in globals.css must
+    // keep this opaque background dark instead of falling back to light.
+    expect(sidebar).toHaveAttribute('data-sidebar-translucent', 'false')
   })
 
   test('uses the project action model for right click and global-state pinning', async () => {

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -247,7 +247,8 @@
   --color-sidebar-unfocused: 246 246 246;
 }
 
-[data-theme='dark'][data-sidebar-translucent='false'] {
+[data-theme='dark'][data-sidebar-translucent='false'],
+[data-theme='dark'] [data-sidebar-translucent='false'] {
   --color-sidebar: 33 33 33;
   --color-sidebar-unfocused: 40 40 40;
 }


### PR DESCRIPTION
## Summary
- Fix the Windows wework sidebar falling back to a light/white background in dark mode.
- Root cause: the CSS rule `[data-theme='dark'][data-sidebar-translucent='false']` required both attributes on the same element, but `data-theme` lives on `<html>` while `data-sidebar-translucent='false'` lives on the sidebar `<aside>` (Windows Tauri only). The rule never matched, so the opaque light background `rgb(243 243 243)` won over the dark value inherited from `<html>`.
- Fix: add a descendant selector `[data-theme='dark'] [data-sidebar-translucent='false']` so the opaque Windows sidebar stays dark in dark mode.

## Test plan
- [ ] CSS cascade verified with real Chromium: dark + Windows aside resolves to `rgb(33 33 33)`; light-mode and non-Windows behavior unchanged (6 other scenarios identical)
- [ ] wework unit tests pass (307 files / 3016 tests)
- [ ] prettier + eslint pass on changed files
- [ ] Windows: manually confirm the sidebar renders dark in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar appearance in dark mode when translucency is disabled.
  * Ensured Windows uses an opaque sidebar background consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->