### PR TITLE
test(wework): stabilize file panel anchor e2e

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -39,6 +39,7 @@ E2E tests use real backend requests. Do not skip, silently fail, or replace a fa
 - Reuse the existing `e2e:desktop` command and its established CI variants. Do not add a package script or GitHub Actions command for each scenario; extend the desktop runner or its scenario discovery instead. Add a new command only when the test requires a genuinely different CI environment or job boundary.
 - Register long main-runner sections in the ordered desktop checkpoint list. `--segment <checkpoint>` must run that checkpoint alone after common bootstrap; `--from-segment <checkpoint>` must run it and every later checkpoint. Each checkpoint must create its own minimal fixtures when an earlier checkpoint is skipped, and must never silently rely on task IDs, model state, or UI state produced only by a previous checkpoint.
 - Ordinary desktop E2E UI actions and waits use the shared 10-second step timeout. Pass an explicit `timeoutMs` only for a genuinely slow operation such as application startup, workbench reconnection, or a deliberately held model response; do not restore a broad 120-second default.
+- In virtualized content, do not rely on test-added DOM attributes across scrolling or rendering updates. Locate the element with stable product selectors and text first, wait for layout to settle, then add any temporary marker needed by later assertions.
 - E2E coverage complements, but never replaces, verification in the real Tauri application.
 
 ## Real desktop verification

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -15049,15 +15049,19 @@ last_updated = "2026-07-30T00:00:00Z"`
       const conversationScrollerSelector = '[data-testid="desktop-workbench-content"]'
       await control.command('waitFor', filePanelAnchorScopeSelector, {
         text: FILE_PANEL_ANCHOR_MARKER,
+        stableMs: COMPOSER_READY_STABILITY_MS,
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
+      await control.command('scrollIntoViewAsUser', filePanelAnchorScopeSelector, {
+        text: FILE_PANEL_ANCHOR_MARKER,
+        value: 'start',
+      })
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
       await control.command('markElementWithText', filePanelAnchorScopeSelector, {
         text: FILE_PANEL_ANCHOR_MARKER,
         value: 'file-panel-anchor',
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
-      await control.command('scrollIntoViewAsUser', filePanelAnchorSelector, { value: 'start' })
-      await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
       const { element: filePanelAnchorBeforeOpen, scroller: filePanelScrollerBeforeOpen } =
         await waitForElementInsideScroller(
           control,


### PR DESCRIPTION
## Summary

- stabilize the desktop `conversation-state` file-panel anchor regression check
- locate and scroll to the anchor through stable product selectors and text before adding the temporary E2E marker
- document the virtualized-content rule for future Wework desktop E2E coverage

## Root cause

The test added `data-e2e-anchor-id` before scrolling a virtualized conversation. A rendering update could replace that DOM node between commands, removing the test-only attribute even though the response and README link were rendered correctly. The next command then failed to find the temporary selector.

## Impact

The test now waits for stable content, scrolls using the durable `[data-scroll-anchor]` selector plus marker text, lets layout settle, and only then adds the temporary marker used by the remaining assertions.

## Validation

- `node --check wework/e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework e2e:desktop -- --segment conversation-state`
- pre-push Wework ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for file-panel anchor behavior by waiting for layout stabilization before scrolling and validating anchor markers.
  * Added guidance for testing virtualized content using stable selectors, text, and post-render checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->