### PR TITLE
test(wework): harden cloud terminal e2e workspace roots

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -2294,6 +2294,8 @@ async function waitForSnapshot(
       testId.startsWith('runtime-local-task-') ||
       testId.startsWith('composer-plugin-') ||
       testId.startsWith('plugin-trial-') ||
+      testId.startsWith('workspace-') ||
+      testId.startsWith('bottom-workspace-') ||
       [
         'goal-status-bar',
         'pause-response-button',
@@ -8392,6 +8394,7 @@ class RealCloudEnvironment {
       DEVICE_TYPE: 'cloud',
       BIND_SHELL: 'claudecode',
       LOCAL_WORKSPACE_ROOT: dirname(this.workspacePath),
+      WEGENT_WORKSPACE_ROOTS: this.workspacePath,
       WEWORK_E2E_MODEL_API_KEY: MODEL_API_KEY,
       DEVICE_SESSION_GATEWAY_HOST: '127.0.0.1',
       DEVICE_SESSION_GATEWAY_PORT: '0',


### PR DESCRIPTION
## 问题

Wework 云端桌面 E2E 偶发在首次打开项目终端时失败。远端 executor 返回 `Project path is outside allowed workspace roots`，导致终端卡片进入“启动失败”状态，测试最终以等待终端窗口超时结束。

## 根因

测试创建的云端项目 workspace 位于临时结果目录中，但远端 executor 只通过 `LOCAL_WORKSPACE_ROOT` 间接获得较宽泛的目录边界，没有使用 executor 为额外工作区提供的显式 allow-list 配置。环境状态异常时，session 路径校验可能无法确认该 workspace。

同时，通用快照超时诊断没有保留 workspace 面板相关的 test ID，失败日志只显示 composer 控件，掩盖了实际的终端启动失败状态。

## 修改

- 启动测试用远端 executor 时，通过 `WEGENT_WORKSPACE_ROOTS` 显式声明本次云端 workspace。
- 快照超时诊断保留 `workspace-*` 和 `bottom-workspace-*` test ID，便于直接识别终端、launcher 和底部面板状态。

## 影响

云端桌面 E2E 的终端路径边界配置变得确定，不再依赖隐式目录覆盖；若终端流程再次失败，CI 日志也会包含直接相关的 UI 状态。

## 验证

- `node --check wework/e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework e2e:desktop:cloud`
  - 18 个模型协议组合全部通过
  - 云端项目创建、首次终端启动、历史终端恢复及任务流程通过
- pre-push Wework ESLint、TypeScript 和全量单测通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop end-to-end diagnostics now retain workspace-related test identifiers in snapshots.
  * Cloud execution now consistently uses the configured workspace path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->