### PR TITLE
fix(wework): use consistent opaque window surfaces

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -89,6 +89,21 @@ To validate local updater behavior, serve the script output directory:
 python3 -m http.server 8787 --directory src-tauri/target/release/local-update-server
 ```
 
+## Window Surfaces
+
+The Wework main window and detached workspace windows must use opaque Tauri
+windows that are fully covered by the WebView theme surface. Do not enable
+`transparent`, `windowEffects`, or native vibrancy materials for these windows.
+Transparent window edges are composed differently across macOS versions and
+graphics environments, which can expose the desktop or appear as translucent
+or gray borders.
+
+The system drag panel and Popout Window are separate lightweight overlays and
+are not covered by this rule. Changes to ordinary window backgrounds, title
+bars, or creation options must verify both the main window and detached
+workspace windows and retain automated assertions that prevent native
+transparency from being re-enabled.
+
 ## Tauri Dependency Upgrades
 
 Update the Rust core dependencies and frontend toolchain together so development, testing, and release builds do not use different Tauri versions:

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -89,6 +89,17 @@ scripts/release-mac-app.sh --target local --version 0.1.99 --notes "Local verifi
 python3 -m http.server 8787 --directory src-tauri/target/release/local-update-server
 ```
 
+## 窗口表面
+
+Wework 主窗口和独立工作区窗口必须使用不透明的 Tauri 窗口，并由 WebView
+中的主题表面色完整覆盖。不要为这些窗口启用 `transparent`、`windowEffects`
+或原生 vibrancy 材质；不同 macOS 版本和图形环境对透明窗口边缘的合成结果不一致，
+可能显示为透出桌面、半透明描边或灰色边框。
+
+系统拖拽面板和 Popout Window 是独立的轻量浮层，不受该约束。修改普通窗口的背景、
+标题栏或创建参数时，需要同时验证主窗口和独立工作区窗口，并保留自动化断言，确保
+两者不会重新启用原生透明效果。
+
 ## Tauri 依赖升级
 
 升级 Tauri 时需要同时维护 Rust 核心依赖和前端工具链，避免开发、测试与发布使用不同版本：

--- a/wework/src-tauri/tauri.conf.json
+++ b/wework/src-tauri/tauri.conf.json
@@ -22,10 +22,7 @@
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "decorations": true,
-        "transparent": true,
-        "windowEffects": {
-          "effects": ["sidebar"]
-        },
+        "transparent": false,
         "dragDropEnabled": false,
         "trafficLightPosition": {
           "x": 19,

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -33,7 +33,6 @@ import { AppIframe } from '@/components/topnav/AppIframe'
 import { useChromeTabs } from '@/components/topnav/useChromeTabs'
 import { APP_TABS } from '@/config/apps'
 import { isTauriRuntime } from '@/lib/runtime-environment'
-import { getPlatform } from '@/lib/platform'
 import { AppUpdateProvider } from '@/features/app-update/AppUpdateProvider'
 import { LocalRuntimeInitializer } from '@/features/local-runtime/LocalRuntimeInitializer'
 import { CodexHomeInitializer } from '@/features/local-runtime/CodexHomeInitializer'
@@ -475,7 +474,6 @@ function AppShell() {
   const isTauri = isTauriRuntime()
   const isPopoutWindow = isPopoutWindowRuntime()
   const isWorkspaceWindow = isTauri && getCurrentWindow().label?.startsWith('workspace-') === true
-  const usesDesktopVibrancy = isTauri && !isPopoutWindow && getPlatform() === 'mac'
   const titlebarOverlaysContent = false
   const showChromeTitlebar = isTauri && !isPopoutWindow
   const workspaceTabStorageScope = useMemo(
@@ -503,15 +501,6 @@ function AppShell() {
   const openWeworkForAppshot = useCallback(() => {
     navigateToApp('wework')
   }, [navigateToApp])
-
-  useEffect(() => {
-    if (!usesDesktopVibrancy) return undefined
-
-    document.documentElement.dataset.desktopVibrancy = 'true'
-    return () => {
-      delete document.documentElement.dataset.desktopVibrancy
-    }
-  }, [usesDesktopVibrancy])
 
   useEffect(() => {
     if (!isTauri || isPopoutWindow) return undefined
@@ -704,9 +693,7 @@ function AppShell() {
             ? 'overflow-visible bg-transparent'
             : isWorkspaceWindow
               ? 'overflow-hidden bg-[rgb(var(--color-titlebar))]'
-              : usesDesktopVibrancy
-                ? 'overflow-hidden bg-transparent'
-                : 'overflow-hidden bg-surface',
+              : 'overflow-hidden bg-surface',
           titlebarOverlaysContent ? 'relative' : 'flex flex-col'
         )}
       >

--- a/wework/src/components/topnav/ChromeTitlebar.test.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.test.tsx
@@ -71,7 +71,14 @@ describe('ChromeTitlebar', () => {
       afterTabs: <button type="button">Update</button>,
     })
 
-    expect(screen.getByTestId('chrome-titlebar')).toHaveClass('h-[38px]')
+    expect(screen.getByTestId('chrome-titlebar')).toHaveClass(
+      'h-[38px]',
+      'bg-[rgb(var(--color-titlebar))]'
+    )
+    expect(screen.getByTestId('chrome-titlebar')).not.toHaveClass(
+      'backdrop-blur-xl',
+      'backdrop-saturate-150'
+    )
     expect(screen.getByTestId('workspace-tab-strip')).toHaveTextContent('任务')
     expect(screen.getByTestId('chrome-titlebar-before-tabs')).toHaveTextContent('Toggle sidebar')
     expect(screen.getByTestId('chrome-titlebar-after-tabs')).toHaveTextContent('Update')

--- a/wework/src/components/topnav/ChromeTitlebar.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.tsx
@@ -46,7 +46,7 @@ export function ChromeTitlebar({
     <div
       data-testid="chrome-titlebar"
       className={cn(
-        'z-titlebar flex h-[38px] shrink-0 items-center bg-[rgb(var(--color-titlebar))] pr-2 backdrop-blur-xl backdrop-saturate-150 select-none',
+        'z-titlebar flex h-[38px] shrink-0 items-center bg-[rgb(var(--color-titlebar))] pr-2 select-none',
         className
       )}
     >

--- a/wework/src/features/workspace-tabs/workspaceWindow.test.ts
+++ b/wework/src/features/workspace-tabs/workspaceWindow.test.ts
@@ -18,10 +18,6 @@ vi.mock('@tauri-apps/api/dpi', () => ({
     ) {}
   },
 }))
-vi.mock('@tauri-apps/api/window', () => ({
-  Effect: { Sidebar: 'sidebar' },
-}))
-
 const tab: WorkspaceTab = {
   id: 'board-project-1',
   kind: 'board',
@@ -73,12 +69,12 @@ describe('openWorkspaceTabWindow', () => {
       expect.objectContaining({
         title: '产品规划',
         visible: false,
-        transparent: true,
-        windowEffects: { effects: ['sidebar'] },
+        transparent: false,
         titleBarStyle: 'overlay',
         tabbingIdentifier: 'io.wecode.wework.workspace',
       })
     )
+    expect(WebviewWindow.mock.calls[0]?.[1]).not.toHaveProperty('windowEffects')
     expect(show).toHaveBeenCalledOnce()
     expect(setFocus).toHaveBeenCalledOnce()
     expect(destroy).not.toHaveBeenCalled()

--- a/wework/src/features/workspace-tabs/workspaceWindow.ts
+++ b/wework/src/features/workspace-tabs/workspaceWindow.ts
@@ -1,6 +1,5 @@
 import type { UnlistenFn } from '@tauri-apps/api/event'
 import { LogicalPosition } from '@tauri-apps/api/dpi'
-import { Effect } from '@tauri-apps/api/window'
 import { getPlatform } from '@/lib/platform'
 import { isTauriRuntime } from '@/lib/runtime-environment'
 import { toBrowserPath } from '@/lib/navigation'
@@ -42,8 +41,7 @@ export async function openWorkspaceTabWindow(tab: WorkspaceTab): Promise<boolean
     focus: true,
     visible: false,
     resizable: true,
-    transparent: platform === 'mac',
-    windowEffects: platform === 'mac' ? { effects: [Effect.Sidebar] } : undefined,
+    transparent: false,
     decorations: platform !== 'win',
     titleBarStyle: platform === 'mac' ? 'overlay' : undefined,
     hiddenTitle: platform === 'mac',

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -15,7 +15,7 @@
   --color-primary-contrast: 255 255 255;
   --color-border: 224 224 224;
   --color-muted: 245 245 245;
-  --color-titlebar: 229 231 234;
+  --color-titlebar: 247 247 248;
   --color-sidebar: 243 243 243 / 0.92;
   --color-sidebar-unfocused: 246 246 246 / 0.88;
   --color-sidebar-active: 26 28 31 / 0.07;
@@ -221,7 +221,7 @@
   --color-primary-contrast: 11 18 20;
   --color-border: 55 61 70;
   --color-muted: 38 42 48;
-  --color-titlebar: 20 22 25;
+  --color-titlebar: 28 31 36;
   --color-sidebar: 33 33 33 / 0.96;
   --color-sidebar-unfocused: 40 40 40 / 0.92;
   --color-sidebar-active: 255 255 255 / 0.1;

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -281,12 +281,6 @@ html[data-system-drag-panel='true'] #root {
   background: transparent;
 }
 
-html[data-desktop-vibrancy='true'],
-html[data-desktop-vibrancy='true'] body,
-html[data-desktop-vibrancy='true'] #root {
-  background: transparent;
-}
-
 button,
 input,
 textarea {

--- a/wework/src/test/macos-window-chrome.test.ts
+++ b/wework/src/test/macos-window-chrome.test.ts
@@ -6,6 +6,8 @@ interface TauriWindowConfig {
   titleBarStyle?: string
   hiddenTitle?: boolean
   decorations?: boolean
+  transparent?: boolean
+  windowEffects?: unknown
   dragDropEnabled?: boolean
   trafficLightPosition?: {
     x: number
@@ -37,6 +39,8 @@ describe('macOS window chrome', () => {
     expect(mainWindow.titleBarStyle).toBe('Overlay')
     expect(mainWindow.hiddenTitle).toBe(true)
     expect(mainWindow.decorations).toBe(true)
+    expect(mainWindow.transparent).toBe(false)
+    expect(mainWindow).not.toHaveProperty('windowEffects')
     expect(mainWindow.trafficLightPosition).toEqual({ x: 19, y: 21 })
   })
 

--- a/wework/src/test/theme-token-guard.test.ts
+++ b/wework/src/test/theme-token-guard.test.ts
@@ -65,6 +65,16 @@ describe('theme token guard', () => {
     expect(source).toContain("darkMode: 'class'")
   })
 
+  test('titlebar and window frame use the same opaque surface colors', () => {
+    const globalsPath = resolve(process.cwd(), 'src/styles/globals.css')
+    const source = readFileSync(globalsPath, 'utf8')
+
+    expect(source.match(/--color-bg-surface: 247 247 248;/g)).toHaveLength(1)
+    expect(source.match(/--color-titlebar: 247 247 248;/g)).toHaveLength(1)
+    expect(source.match(/--color-bg-surface: 28 31 36;/g)).toHaveLength(1)
+    expect(source.match(/--color-titlebar: 28 31 36;/g)).toHaveLength(1)
+  })
+
   test('tailwind exposes semantic z-index layers', () => {
     const tailwindConfigPath = resolve(process.cwd(), 'tailwind.config.js')
     const source = readFileSync(tailwindConfigPath, 'utf8')


### PR DESCRIPTION
## Summary

- disable native transparency and sidebar window effects for the main Wework window and detached workspace windows
- use the application surface color for the titlebar and exposed window frame in both light and dark themes
- remove the obsolete desktop vibrancy and titlebar blur paths
- document the opaque-window contract in the Chinese and English macOS developer guides

## Root cause

The macOS windows enabled Tauri transparency and the native sidebar material while the WebView root was also transparent. macOS versions and graphics environments compose those edges differently, so the frame could expose the desktop, appear translucent, or render gray. Simply disabling native transparency exposed a separate blue-gray titlebar token, so the final fix also aligns the frame and titlebar with the normal application surface.

## Impact

The main window and detached workspace windows now render an opaque, consistent neutral frame across supported systems. The system drag panel and Popout Window remain intentionally transparent lightweight overlays.

## Validation

- Prettier checks passed
- ESLint passed
- TypeScript passed
- Wework unit tests passed in pre-push
- focused window regression suite: 41 tests passed
- isolated real Tauri application built and launched successfully

Task: WEWORKC2FA61-65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized workspace windows with opaque surfaces for improved visual consistency.
  * Removed transparency, blur, saturation, and native window effects from standard desktop windows.
  * Updated light and dark titlebars to match their corresponding surface colors.

* **Documentation**
  * Added guidance on window surface requirements and verification for main and detached workspace windows.

* **Tests**
  * Added coverage to prevent accidental reintroduction of transparent or native window effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->