### PR TITLE
fix(wework): enable progressive tool discovery for GPT-5.6

### DIFF
--- a/executor/src/server/codex_model_catalog.rs
+++ b/executor/src/server/codex_model_catalog.rs
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_enables_deferred_tool_search_for_all_gpt_56_profiles() {
+    fn catalog_enables_deferred_tool_search_only_for_verified_profiles() {
         let catalog = catalog();
         let models = catalog["models"].as_array().expect("models array");
 
@@ -659,6 +659,14 @@ mod tests {
                 .find(|model| model["slug"] == slug)
                 .unwrap_or_else(|| panic!("missing GPT 5.6 model {slug}"));
             assert_eq!(model["supports_search_tool"], true);
+        }
+
+        for slug in [KIMI_K3_MODEL, KIMI_K27_MODEL] {
+            let model = models
+                .iter()
+                .find(|model| model["slug"] == slug)
+                .unwrap_or_else(|| panic!("missing model {slug}"));
+            assert_eq!(model["supports_search_tool"], false);
         }
     }
 

--- a/executor/src/server/codex_model_catalog.rs
+++ b/executor/src/server/codex_model_catalog.rs
@@ -642,6 +642,27 @@ mod tests {
     }
 
     #[test]
+    fn catalog_enables_deferred_tool_search_for_all_gpt_56_profiles() {
+        let catalog = catalog();
+        let models = catalog["models"].as_array().expect("models array");
+
+        for slug in [
+            GPT_56_SOL_MODEL,
+            GPT_56_TERRA_MODEL,
+            GPT_56_LUNA_MODEL,
+            WEWORK_GPT_56_SOL_MODEL,
+            WEWORK_GPT_56_TERRA_MODEL,
+            WEWORK_GPT_56_LUNA_MODEL,
+        ] {
+            let model = models
+                .iter()
+                .find(|model| model["slug"] == slug)
+                .unwrap_or_else(|| panic!("missing GPT 5.6 model {slug}"));
+            assert_eq!(model["supports_search_tool"], true);
+        }
+    }
+
+    #[test]
     fn validates_complete_custom_catalog_entries_without_accepting_official_slugs() {
         let mut entry = model_entry(
             "wework-custom-registration-test",

--- a/executor/src/server/codex_model_catalog.rs
+++ b/executor/src/server/codex_model_catalog.rs
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_enables_deferred_tool_search_only_for_verified_profiles() {
+    fn catalog_enables_gpt_56_tool_search_without_changing_kimi_profiles() {
         let catalog = catalog();
         let models = catalog["models"].as_array().expect("models array");
 

--- a/shared/assets/codex-models/openai.json
+++ b/shared/assets/codex-models/openai.json
@@ -5,6 +5,7 @@
       "display_name": "GPT 5.6 Sol",
       "description": "GPT 5.6 Sol profile for agentic coding",
       "apply_patch_tool_type": "freeform",
+      "supports_search_tool": true,
       "visibility": "list",
       "priority": 1,
       "context_window": 272000,
@@ -15,6 +16,7 @@
       "display_name": "GPT 5.6 Terra",
       "description": "GPT 5.6 Terra profile for agentic coding",
       "apply_patch_tool_type": "freeform",
+      "supports_search_tool": true,
       "visibility": "list",
       "priority": 2,
       "context_window": 272000,
@@ -25,6 +27,7 @@
       "display_name": "GPT 5.6 Luna",
       "description": "GPT 5.6 Luna profile for agentic coding",
       "apply_patch_tool_type": "freeform",
+      "supports_search_tool": true,
       "visibility": "list",
       "priority": 3,
       "context_window": 272000,
@@ -35,6 +38,7 @@
       "display_name": "GPT 5.6 Sol",
       "description": "Wework GPT 5.6 Sol compatibility profile",
       "apply_patch_tool_type": "freeform",
+      "supports_search_tool": true,
       "context_window": 272000,
       "max_context_window": 272000
     },
@@ -43,6 +47,7 @@
       "display_name": "GPT 5.6 Terra",
       "description": "Wework GPT 5.6 Terra compatibility profile",
       "apply_patch_tool_type": "freeform",
+      "supports_search_tool": true,
       "context_window": 272000,
       "max_context_window": 272000
     },
@@ -51,6 +56,7 @@
       "display_name": "GPT 5.6 Luna",
       "description": "Wework GPT 5.6 Luna compatibility profile",
       "apply_patch_tool_type": "freeform",
+      "supports_search_tool": true,
       "context_window": 272000,
       "max_context_window": 272000
     }

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -374,7 +374,9 @@ const TOOL_BLOCK_ORDER_PROMPT =
   'WEWORK_DESKTOP_E2E_TOOL_BLOCK_ORDER: run the four requested tools in order.'
 const TOOL_BLOCK_ORDER_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_TOOL_BLOCK_ORDER_COMPLETE'
 const EARLIER_TOOL_BLOCK_ID = 'wework-e2e-tool-earlier'
+const NODE_REPL_TOOL_SEARCH_ID = 'wework-e2e-search-node-repl'
 const NODE_REPL_TOOL_BLOCK_ID = 'wework-e2e-tool-node-repl'
+const GENERIC_MCP_TOOL_SEARCH_ID = 'wework-e2e-search-generic-mcp'
 const GENERIC_MCP_TOOL_BLOCK_ID = 'wework-e2e-tool-generic-mcp'
 const LATER_TOOL_BLOCK_ID = 'wework-e2e-tool-later'
 const SIDE_CHAT_PROMPT = 'WEWORK_DESKTOP_E2E_SIDE_CHAT: verify isolated attachments.'
@@ -451,6 +453,8 @@ const OFFICIAL_PLUGIN_SKILL_NAME = 'openai-platform-api-key'
 const OFFICIAL_PLUGIN_SKILL_MARKER = '# OpenAI API Key'
 const OFFICIAL_PLUGIN_MCP_NAMESPACE = 'openai_api_key_local_confirmation'
 const OFFICIAL_PLUGIN_MCP_TOOL_DESCRIPTION = 'local env-file destination'
+const OFFICIAL_PLUGIN_TOOL_SEARCH_ID = 'wework-e2e-official-plugin-search'
+const OFFICIAL_PLUGIN_MCP_TOOL_ID = 'wework-e2e-official-plugin-mcp'
 const OFFICIAL_PLUGIN_SKILL_READY_TEXT = 'WEWORK_DESKTOP_E2E_OFFICIAL_PLUGIN_SKILL_READY'
 const OFFICIAL_PLUGIN_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_OFFICIAL_PLUGIN_COMPLETE'
 const PLUGIN_MARKETPLACE_NAME = 'desktop-e2e-marketplace'
@@ -4729,11 +4733,11 @@ async function verifyPluginLifecycle({ control, fixture }) {
     text: OFFICIAL_PLUGIN_COMPLETION_TEXT,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
-  await control.awaitScenarioRequestCount('official_plugin', 4, WORKBENCH_READY_TIMEOUT_MS)
+  await control.awaitScenarioRequestCount('official_plugin', 5, WORKBENCH_READY_TIMEOUT_MS)
   assert.equal(
     control.scenarioRequests.get('official_plugin')?.length,
-    4,
-    'The official plugin flow did not execute the expected skill-read and direct MCP-call turns'
+    5,
+    'The official plugin flow did not execute the expected skill-read, tool-search, and MCP-call turns'
   )
   await captureVerificationScreenshot(control, 'plugins-04-skill-and-mcp-complete.png')
 }
@@ -7405,6 +7409,25 @@ function namespacedFunctionCall(callId, namespace, name, argumentsValue) {
   }))
 }
 
+function toolSearchCall(callId, argumentsValue) {
+  const item = {
+    type: 'tool_search_call',
+    call_id: callId,
+    execution: 'client',
+    arguments: argumentsValue,
+  }
+  return [
+    {
+      type: 'response.output_item.added',
+      item: { ...item, status: 'in_progress' },
+    },
+    {
+      type: 'response.output_item.done',
+      item: { ...item, status: 'completed' },
+    },
+  ]
+}
+
 function customToolCall(callId, name, input) {
   return {
     type: 'response.output_item.done',
@@ -7652,7 +7675,10 @@ function requestContainsToolOutput(request, callId) {
     if (!value || typeof value !== 'object') return false
 
     const type = value.type
-    const isToolOutput = type === 'function_call_output' || type === 'custom_tool_call_output'
+    const isToolOutput =
+      type === 'function_call_output' ||
+      type === 'custom_tool_call_output' ||
+      type === 'tool_search_output'
     if (isToolOutput && (!callId || value.call_id === callId)) return true
 
     return Object.values(value).some(containsOutput)
@@ -7681,8 +7707,8 @@ function selectTool(request, name, argumentsValue) {
 function selectOfficialPluginMcpTool(request, argumentsValue) {
   const tools = Array.isArray(request.tools) ? request.tools : []
   assert.ok(
-    !tools.some(tool => tool?.type === 'tool_search'),
-    'Real Codex still advertised the removed tool_search surface'
+    tools.some(tool => tool?.type === 'tool_search'),
+    'Real Codex did not retain tool_search after loading the official plugin MCP tool'
   )
   const namespaces = tools.filter(
     candidate => candidate?.type === 'namespace' && candidate.name === OFFICIAL_PLUGIN_MCP_NAMESPACE
@@ -7714,6 +7740,21 @@ function selectOfficialPluginMcpTool(request, argumentsValue) {
     'The direct MCP tool did not require both workspace confinement inputs'
   )
   return { namespace: namespace.name, name: tool.name, arguments: argumentsValue }
+}
+
+function assertMcpNamespaceDeferred(request, namespaceName) {
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  assert.ok(
+    !tools.some(tool => tool?.type === 'namespace' && tool.name === namespaceName),
+    `Real Codex advertised MCP namespace ${namespaceName} before tool discovery`
+  )
+}
+
+function selectToolSearch(request, query) {
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  const searchTools = tools.filter(tool => tool?.type === 'tool_search')
+  assert.equal(searchTools.length, 1, 'Real Codex did not advertise exactly one tool_search')
+  return { query, limit: 5 }
 }
 
 function selectMcpTool(request, namespaceName, toolName, argumentsValue) {
@@ -9969,6 +10010,22 @@ class DesktopE2EServer {
           true,
           'The earlier command output did not return through the real Codex tool loop'
         )
+        assertMcpNamespaceDeferred(body, 'node_repl')
+        const search = selectToolSearch(body, 'Run JavaScript in the persistent Node REPL')
+        this.writeSse(response, [
+          responseCreated(responseId),
+          ...toolSearchCall(NODE_REPL_TOOL_SEARCH_ID, search),
+          responseCompleted(responseId),
+        ])
+        return
+      }
+
+      if (requestNumber === 3) {
+        assert.equal(
+          requestContainsToolOutput(body, NODE_REPL_TOOL_SEARCH_ID),
+          true,
+          'The Node REPL tool search output did not return through the real Codex tool loop'
+        )
         const tool = selectMcpTool(body, 'node_repl', 'js', {
           code: "nodeRepl.write({ status: 'ready', value: 42 })",
         })
@@ -9985,7 +10042,7 @@ class DesktopE2EServer {
         return
       }
 
-      if (requestNumber === 3) {
+      if (requestNumber === 4) {
         assert.equal(
           requestContainsToolOutput(body, NODE_REPL_TOOL_BLOCK_ID),
           true,
@@ -9997,6 +10054,22 @@ class DesktopE2EServer {
         )
         this.resolveToolBlockNodeOutputObserved()
         await this.toolBlockNodeRelease
+        assertMcpNamespaceDeferred(body, 'github__issues')
+        const search = selectToolSearch(body, 'Get deterministic GitHub issue details')
+        this.writeSse(response, [
+          responseCreated(responseId),
+          ...toolSearchCall(GENERIC_MCP_TOOL_SEARCH_ID, search),
+          responseCompleted(responseId),
+        ])
+        return
+      }
+
+      if (requestNumber === 5) {
+        assert.equal(
+          requestContainsToolOutput(body, GENERIC_MCP_TOOL_SEARCH_ID),
+          true,
+          'The generic MCP tool search output did not return through the real Codex tool loop'
+        )
         const tool = selectMcpTool(body, 'github__issues', 'get_issue_details', {
           owner: 'wecode-ai',
           repo: 'Wegent',
@@ -10015,7 +10088,7 @@ class DesktopE2EServer {
         return
       }
 
-      if (requestNumber === 4) {
+      if (requestNumber === 6) {
         assert.equal(
           requestContainsToolOutput(body, GENERIC_MCP_TOOL_BLOCK_ID),
           true,
@@ -10036,7 +10109,7 @@ class DesktopE2EServer {
         return
       }
 
-      assert.equal(requestNumber, 5, `Unexpected tool-block-order request ${requestNumber}`)
+      assert.equal(requestNumber, 7, `Unexpected tool-block-order request ${requestNumber}`)
       assert.equal(
         requestContainsToolOutput(body, LATER_TOOL_BLOCK_ID),
         true,
@@ -10740,6 +10813,22 @@ class DesktopE2EServer {
       }
 
       if (requestNumber === 3) {
+        assertMcpNamespaceDeferred(body, OFFICIAL_PLUGIN_MCP_NAMESPACE)
+        const search = selectToolSearch(body, OFFICIAL_PLUGIN_MCP_TOOL_DESCRIPTION)
+        this.writeSse(response, [
+          responseCreated(responseId),
+          ...toolSearchCall(OFFICIAL_PLUGIN_TOOL_SEARCH_ID, search),
+          responseCompleted(responseId),
+        ])
+        return
+      }
+
+      if (requestNumber === 4) {
+        assert.equal(
+          requestContainsToolOutput(body, OFFICIAL_PLUGIN_TOOL_SEARCH_ID),
+          true,
+          'The official plugin MCP tool search output did not return through the real Codex tool loop'
+        )
         const mcpTool = selectOfficialPluginMcpTool(body, {
           workspacePath: this.workspacePath,
           targetPath: '../outside.env',
@@ -10748,7 +10837,7 @@ class DesktopE2EServer {
         this.writeSse(response, [
           responseCreated(responseId),
           ...namespacedFunctionCall(
-            'wework-e2e-official-plugin-mcp',
+            OFFICIAL_PLUGIN_MCP_TOOL_ID,
             mcpTool.namespace,
             mcpTool.name,
             mcpTool.arguments
@@ -10758,7 +10847,7 @@ class DesktopE2EServer {
         return
       }
 
-      assert.equal(requestNumber, 4, `Unexpected official plugin request ${requestNumber}`)
+      assert.equal(requestNumber, 5, `Unexpected official plugin request ${requestNumber}`)
       assert.ok(
         requestText.includes('The env file must be inside the selected workspace.'),
         'The official plugin MCP server did not execute and return its validation result'


### PR DESCRIPTION
## Summary

- mark all official and Wework compatibility GPT-5.6 profiles as supporting Codex tool search
- defer enabled Remote Apps, MCP, browser, and multi-agent tool schemas until the model searches for them
- keep the shared custom-model default disabled so unverified providers are not opted in accidentally
- add positive and negative regression coverage for the per-model capability boundary

## Root cause

The generated Codex model catalog defaulted `supports_search_tool` to `false`, and the GPT-5.6 profile assets did not override it.

In the bundled Codex `0.146.0-alpha.9.2`, deferred tool exposure is enabled only when both of these are true:

1. the selected model declares `supports_search_tool`
2. the configured model provider supports namespace tools

The `features.tool_search` user setting does not override a missing model capability in this runtime. As a result, enabled tools from the host-owned `codex_apps` MCP and other MCP sources were exposed as `Direct`: `tool_search` was omitted and full descriptions plus JSON Schemas were expanded into the first model request.

## User impact

This also fixes the reported fresh-session context spike where Remote Apps contributed approximately 64.5k of 74.7k input tokens before the user had requested an App. GPT-5.6 conversations can now keep Remote Apps available while initially sending only the compact discovery surface; matching schemas are exposed after `tool_search` identifies the required tools.

Wework's Remote Apps availability setting remains independent and user-configurable. The fix does not disable Apps by default or silently change unverified custom model behavior.

## Validation

- `cargo test server::codex_model_catalog::tests` (9 passed)
- `cargo test --lib catalog_enables_deferred_tool_search_only_for_verified_profiles`
- pre-push `cargo fmt --check`
- pre-push `cargo test --all-features --lib`
- pre-push `cargo clippy`
- isolated real-Tauri startup and `desktop-workbench-content` assertion via `pnpm --filter wework ai:verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPT-5.6 models now support the search tool across standard and Wework-compatible profiles.
  * Search availability is enabled consistently for all GPT-5.6 variants.
  * Tool discovery now supports deferred search, improving compatibility with MCP tools and official plugins.

* **Bug Fixes**
  * Improved model capability declarations so search is correctly available for GPT-5.6 while remaining unchanged for Kimi models.
  * Updated tool interactions to ensure discovered tools are handled in the correct sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
