### PR TITLE
fix(ci): share Wework desktop Cargo cache

### DIFF
--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -427,11 +427,38 @@ if ! grep -q "wework_desktop_core_e2e_matrix" "$wework_workflow" ||
   exit 1
 fi
 
+core_cache_step="$(
+  extract_named_workflow_step \
+    <(sed -n \
+      '/^  build-wework-desktop-core-e2e:/,/^  wework-desktop-core-e2e:/p' \
+      "$wework_workflow") \
+    "Restore shared Wework desktop E2E Cargo dependencies"
+)"
 desktop_cache_step="$(
-  extract_named_workflow_step "$wework_workflow" "Cache Cargo dependencies"
+  extract_named_workflow_step \
+    <(sed -n '/^  wework-desktop-e2e:/,/^  wework-e2e-summary:/p' \
+      "$wework_workflow") \
+    "Restore shared Wework desktop E2E Cargo dependencies"
+)"
+core_cache_key="$(
+  sed -n 's/^          key:[[:space:]]*//p' <<<"$core_cache_step"
 )"
 desktop_cache_key="$(
   sed -n 's/^          key:[[:space:]]*//p' <<<"$desktop_cache_step"
+)"
+core_cache_restore_keys="$(
+  awk '
+    /^          restore-keys:/ {
+      in_restore_keys = 1
+      next
+    }
+    in_restore_keys && /^          [[:alnum:]_-]+:/ {
+      exit
+    }
+    in_restore_keys {
+      print
+    }
+  ' <<<"$core_cache_step"
 )"
 desktop_cache_restore_keys="$(
   awk '
@@ -447,11 +474,44 @@ desktop_cache_restore_keys="$(
     }
   ' <<<"$desktop_cache_step"
 )"
+if [[ "$(grep -c \
+  "name: Restore shared Wework desktop E2E Cargo dependencies" \
+  "$wework_workflow")" -ne 2 ]]; then
+  printf 'Wework desktop E2E build jobs must restore the shared Cargo cache\n' >&2
+  exit 1
+fi
+
+if [[ "$core_cache_key" != "$desktop_cache_key" ]] ||
+  [[ "$core_cache_restore_keys" != "$desktop_cache_restore_keys" ]]; then
+  printf 'Wework desktop E2E build jobs must share one Cargo cache key\n' >&2
+  exit 1
+fi
+
 # GitHub expressions are matched literally in workflow source.
 # shellcheck disable=SC2016
-if ! grep -Fq '${{ matrix.command }}' <<<"$desktop_cache_key" ||
-  ! grep -Fq '${{ matrix.command }}' <<<"$desktop_cache_restore_keys"; then
-  printf 'Wework desktop E2E caches must be isolated by E2E command\n' >&2
+if ! grep -Fq '${{ runner.os }}-wework-desktop-e2e-v2-' \
+  <<<"$desktop_cache_key" ||
+  grep -Fq '${{ matrix.command }}' <<<"$desktop_cache_key"; then
+  printf 'Wework desktop E2E Cargo cache key must not vary by command\n' >&2
+  exit 1
+fi
+
+desktop_cache_save_step="$(
+  extract_named_workflow_step \
+    "$wework_workflow" \
+    "Save shared Wework desktop E2E Cargo dependencies"
+)"
+# GitHub expressions are matched literally in workflow source.
+# shellcheck disable=SC2016
+if [[ "$(grep -c \
+  "name: Save shared Wework desktop E2E Cargo dependencies" \
+  "$wework_workflow")" -ne 1 ]] ||
+  ! grep -Fq "if: github.ref == 'refs/heads/main'" \
+    <<<"$desktop_cache_save_step" ||
+  ! grep -Fq \
+    'key: ${{ steps.wework-desktop-cargo-cache.outputs.cache-primary-key }}' \
+    <<<"$desktop_cache_save_step"; then
+  printf 'Only main may save the shared Wework desktop E2E Cargo cache\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -194,18 +194,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Core E2E build Cargo dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Restore shared Wework desktop E2E Cargo dependencies
+        id: wework-desktop-cargo-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             executor/target
             wework/src-tauri/target
-          key: ${{ runner.os }}-wework-desktop-core-build-e2e-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-wework-desktop-e2e-v2-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-wework-desktop-core-build-e2e-
-            ${{ runner.os }}-wework-desktop-
+            ${{ runner.os }}-wework-desktop-e2e-v2-
 
       - name: Prepare bundled sidecars
         working-directory: ./wework
@@ -221,6 +221,17 @@ jobs:
           WEWORK_E2E_CONTROL_SERVER_PORT: "43111"
           WEWORK_E2E_MODEL_SERVER_PORT: "43112"
         run: node wework/e2e/desktop/task-flow.e2e.mjs --build-only
+
+      - name: Save shared Wework desktop E2E Cargo dependencies
+        if: github.ref == 'refs/heads/main' && steps.wework-desktop-cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            executor/target
+            wework/src-tauri/target
+          key: ${{ steps.wework-desktop-cargo-cache.outputs.cache-primary-key }}
 
       - name: Archive Wework desktop Core E2E build
         run: .github/scripts/archive-wework-core-e2e-build.sh
@@ -435,17 +446,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Cargo dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Restore shared Wework desktop E2E Cargo dependencies
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             executor/target
             wework/src-tauri/target
-          key: ${{ runner.os }}-wework-desktop-${{ matrix.command }}-e2e-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-wework-desktop-e2e-v2-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-wework-desktop-${{ matrix.command }}-e2e-
+            ${{ runner.os }}-wework-desktop-e2e-v2-
 
       - name: Prepare bundled sidecars
         working-directory: ./wework


### PR DESCRIPTION
## What changed

- restore one shared Linux Wework desktop E2E Cargo cache in Core, Plugins, and Cloud jobs
- save that cache only from the Core build on `refs/heads/main`
- prevent pull request and merge queue refs from uploading duplicate `target` caches
- replace the command-isolation workflow assertion with shared-cache ownership assertions

## Why

The Core, Plugins, and Cloud jobs cached the same Cargo registry and target
directories under different keys. Each entry was about 1.85 GB, and GitHub
created additional copies for pull request and merge queue refs. The resulting
cache churn evicted the much smaller main-branch APT cache before later CI runs
could restore it.

Keeping a single main-owned cache lets pull request and merge queue jobs restore
the default-branch entry without creating branch-scoped copies.

## Impact

- reduces Wework desktop E2E Cargo cache writes from up to three large entries
  per ref to one repository-wide main entry
- preserves Cargo fingerprint-based rebuild correctness
- allows smaller caches to remain available longer

## Verification

- `bash -n .github/scripts/test-classify-ci-changes.sh`
- `shellcheck .github/scripts/test-classify-ci-changes.sh`
- `actionlint .github/workflows/wework-e2e.yml`
- `.github/scripts/test-classify-ci-changes.sh`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop end-to-end test caching for faster and more consistent build reuse.
  * Ensured core-build and desktop test jobs share compatible caches.
  * Added safeguards to prevent duplicate or incorrectly configured cache saves.
  * Updated caching to use a consistent versioned format across supported jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->