### PR TITLE
chore(wework): upgrade bundled Codex to 0.147.0

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -528,7 +528,7 @@ jobs:
       - name: Prepare bundled sidecars
         working-directory: ./wework
         run: |
-          pnpm run prepare:codex
+          pnpm run prepare:codex --materialize
           pnpm run prepare:dws
           codex_bin="$(find -L "$PWD/src-tauri/binaries/codex" -type f -path '*/bin/codex' -perm -u+x -print -quit)"
           test -n "$codex_bin"

--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -14,11 +14,17 @@ The Wework macOS app uses the Tauri updater for automatic upgrades. Local or sta
 - The updater manifest includes both `darwin-aarch64` and `darwin-x86_64`; both platform entries can point to the same universal archive.
 - `src-tauri/tauri.conf.json` does not store the update service URL or updater public key. Both the local release script and GitHub Actions use `wework/scripts/generate-release-config.mjs` to create a temporary Tauri config that injects release parameters while preserving the complete `bundle.resources` list from the base config. Tauri config overrides replace resource arrays as a whole, so release paths must not maintain a separate incomplete resources list.
 - Updater private keys and publish tokens are read only from environment variables or local files and must not be committed.
-- Codex CLI is not compiled locally. Before building, `wework/scripts/prepare-codex-binary.mjs` downloads the npm tarball pinned by `wework/codex-binaries.lock.json`, verifies its SHA256, and bundles it as a Tauri resource.
+- Codex CLI is not compiled locally. Before building, `wework/scripts/prepare-codex-binary.mjs` downloads the npm tarball pinned by `wework/codex-binaries.lock.json`, verifies its SHA-512 integrity, and bundles it as a Tauri resource.
 
 ## Bundled Codex Binary
 
 The Wework desktop package includes Codex CLI directly, so users do not need to install it on first launch. The version and per-platform tarball checksums are pinned in `wework/codex-binaries.lock.json`.
+
+The current pin is stable Codex `0.147.0`. An upgrade must update every
+supported platform's npm package version, official registry tarball URL, and
+SHA-512 integrity value together; do not replace the binary inside an already
+signed app bundle. Prepare the sidecar again through a release build, then
+package and code-sign the application.
 
 Local builds prepare the Codex binary for the current target automatically:
 

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -14,11 +14,15 @@ Wework macOS 应用使用 Tauri updater 支持自动升级。本地或独立发�
 - updater manifest 同时写入 `darwin-aarch64` 和 `darwin-x86_64`，两个平台可以指向同一个 universal archive。
 - `src-tauri/tauri.conf.json` 不保存发布服务地址或 updater 公钥。本地发布脚本和 GitHub Actions 都通过 `wework/scripts/generate-release-config.mjs` 生成临时 Tauri config，在注入发布参数的同时完整保留基础配置中的 `bundle.resources`。Tauri config 覆盖会整体替换资源数组，因此发布路径不能单独维护一份不完整的 resources 列表。
 - updater 私钥和发布 token 只通过环境变量或本机文件读取，不提交到仓库。
-- Codex CLI 不在本地编译。构建前通过 `wework/scripts/prepare-codex-binary.mjs` 按 `wework/codex-binaries.lock.json` 下载 npm tarball，校验 SHA256 后打进 Tauri resources。
+- Codex CLI 不在本地编译。构建前通过 `wework/scripts/prepare-codex-binary.mjs` 按 `wework/codex-binaries.lock.json` 下载 npm tarball，校验 SHA-512 integrity 后打进 Tauri resources。
 
 ## Bundled Codex 二进制
 
 Wework 桌面包会直接附带 Codex CLI，避免用户在首次运行时再安装。版本和每个平台的 tarball 校验值由 `wework/codex-binaries.lock.json` 固定。
+
+当前固定版本为稳定版 Codex `0.147.0`。升级时必须同时更新所有支持平台的 npm
+包版本、官方 registry tarball 地址与 SHA-512 integrity 值；不能直接替换已签名
+应用包中的二进制。请通过发布构建重新准备 sidecar、打包并代码签名。
 
 本地构建会自动准备当前目标平台的 Codex：
 

--- a/executor/src/runtime_work/handler/helpers/transcript.rs
+++ b/executor/src/runtime_work/handler/helpers/transcript.rs
@@ -1,12 +1,13 @@
 fn cached_transcript_response(
     link: &RuntimeTaskLink,
-    messages: Vec<Value>,
+    mut messages: Vec<Value>,
     context_usage: Option<Value>,
     running: bool,
     limit: Option<usize>,
     before_cursor: Option<&str>,
     after_cursor: Option<&str>,
 ) -> Value {
+    remove_superseded_transcript_turns(&mut messages, &link.runtime_handle);
     transcript_response(TranscriptResponseInput {
         local_task_id: link.local_task_id.clone(),
         workspace_path: link.workspace_path.clone(),
@@ -20,6 +21,34 @@ fn cached_transcript_response(
         full_content: false,
         turn_item_source: TranscriptTurnItemSource::CachedMessages,
     })
+}
+
+pub(super) fn remove_superseded_transcript_turns(
+    messages: &mut Vec<Value>,
+    runtime_handle: &Value,
+) {
+    let superseded_turn_ids = runtime_handle
+        .get("supersededTranscriptTurnIds")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|turn_id| !turn_id.is_empty())
+        .collect::<Vec<_>>();
+    if superseded_turn_ids.is_empty() {
+        return;
+    }
+
+    messages.retain(|message| {
+        string_field(message, "turnId")
+            .or_else(|| string_field(message, "turn_id"))
+            .or_else(|| string_field(message, "subtaskId"))
+            .or_else(|| string_field(message, "subtask_id"))
+            .map_or(true, |turn_id| {
+                !superseded_turn_ids.contains(&turn_id.as_str())
+            })
+    });
 }
 
 #[derive(Clone, Copy)]

--- a/executor/src/runtime_work/handler/queries.rs
+++ b/executor/src/runtime_work/handler/queries.rs
@@ -289,6 +289,7 @@ impl RuntimeWorkRpcHandler {
         let mut messages = transcript_messages;
         if let Some(link) = local_link.as_ref() {
             attach_user_message_presentations(&mut messages, user_message_presentations(link));
+            remove_superseded_transcript_turns(&mut messages, &link.runtime_handle);
         }
         let running = local_execution_running;
         let message_count = messages.len();

--- a/executor/src/runtime_work/handler/tasks.rs
+++ b/executor/src/runtime_work/handler/tasks.rs
@@ -438,6 +438,34 @@ impl RuntimeWorkRpcHandler {
         });
     }
 
+    pub(super) fn record_superseded_runtime_transcript_turn(
+        &self,
+        local_task_id: &str,
+        turn_id: &str,
+    ) {
+        self.store.update_task(local_task_id, |link| {
+            let Some(runtime_handle) = link.runtime_handle.as_object_mut() else {
+                link.runtime_handle = json!({
+                    "supersededTranscriptTurnIds": [turn_id],
+                });
+                return;
+            };
+            let turn_ids = runtime_handle
+                .entry("supersededTranscriptTurnIds")
+                .or_insert_with(|| json!([]));
+            let Some(turn_ids) = turn_ids.as_array_mut() else {
+                *turn_ids = json!([turn_id]);
+                return;
+            };
+            if !turn_ids
+                .iter()
+                .any(|existing| existing.as_str() == Some(turn_id))
+            {
+                turn_ids.push(Value::String(turn_id.to_owned()));
+            }
+        });
+    }
+
     pub(super) async fn send_message(&self, payload: Value) -> Result<Value, AppIpcError> {
         let local_task_id = runtime_task_id(&payload)
             .ok_or_else(|| AppIpcError::new("bad_request", "taskId is required"))?;
@@ -549,6 +577,9 @@ impl RuntimeWorkRpcHandler {
             &request,
             &payload,
         );
+        if let Some(turn_id) = retry_source_turn_id(&payload) {
+            self.record_superseded_runtime_transcript_turn(&local_task_id, &turn_id);
+        }
         self.schedule_worktree_prune();
         let link_for_send = existing_link.as_ref().or(recovered_link.as_ref());
         let ephemeral = request.ephemeral || link_for_send.is_some_and(|link| link.ephemeral);
@@ -1142,6 +1173,12 @@ fn synthetic_transcript_turn_id_base(value: &str) -> Option<&str> {
         return None;
     }
     Some(turn_id)
+}
+
+fn retry_source_turn_id(payload: &Value) -> Option<String> {
+    string_field(payload, "retrySourceTurnId")
+        .or_else(|| string_field(payload, "retry_source_turn_id"))
+        .filter(|turn_id| !turn_id.trim().is_empty())
 }
 
 #[cfg(test)]

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -333,6 +333,65 @@ fn linked_failed_codex_turn_does_not_create_cached_transcript() {
 }
 
 #[test]
+fn retry_supersedes_the_previous_transcript_turn() {
+    let index_path = temp_runtime_work_index_path("retry-supersedes-transcript");
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(index_path.clone());
+    handler.upsert_local_task(RuntimeTaskLink::new_pending(
+        "task-1".to_owned(),
+        "/tmp/project".to_owned(),
+        "Task".to_owned(),
+    ));
+
+    handler.record_superseded_runtime_transcript_turn("task-1", "failed-turn");
+
+    let task = handler
+        .local_task_link("task-1")
+        .expect("task should remain stored");
+    let mut messages = vec![
+        json!({
+            "id": "failed-user",
+            "role": "user",
+            "turnId": "failed-turn",
+            "content": "Retry me",
+        }),
+        json!({
+            "id": "failed-assistant",
+            "role": "assistant",
+            "turnId": "failed-turn",
+            "status": "failed",
+            "content": "",
+        }),
+        json!({
+            "id": "retry-user",
+            "role": "user",
+            "turnId": "retry-turn",
+            "content": "Retry me",
+        }),
+        json!({
+            "id": "retry-assistant",
+            "role": "assistant",
+            "turnId": "retry-turn",
+            "status": "done",
+            "content": "Completed",
+        }),
+    ];
+
+    remove_superseded_transcript_turns(&mut messages, &task.runtime_handle);
+
+    assert_eq!(messages.len(), 2);
+    assert!(messages
+        .iter()
+        .all(|message| message["turnId"] == "retry-turn"));
+    assert_eq!(
+        task.runtime_handle["supersededTranscriptTurnIds"],
+        json!(["failed-turn"])
+    );
+
+    let _ = fs::remove_file(index_path);
+}
+
+#[test]
 fn syncing_an_active_goal_does_not_start_an_idle_task() {
     let index_path = temp_runtime_work_index_path("sync-active-goal");
     let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");

--- a/wework/codex-binaries.lock.json
+++ b/wework/codex-binaries.lock.json
@@ -1,40 +1,40 @@
 {
-  "codexVersion": "0.146.0-alpha.9.2",
+  "codexVersion": "0.147.0",
   "registry": "https://registry.npmjs.org",
   "targets": {
     "aarch64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.146.0-alpha.9.2-darwin-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-alpha.9.2-darwin-arm64.tgz",
-      "integrity": "sha512-cPZDgtNo14mt6hpbIbczXdIysupSjKMFDm3bfr2QDFIf7o7LIMKZEHe8b3XqDmFm91b8OpSbasDCQGTh6iLgqg==",
+      "version": "0.147.0-darwin-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
       "binaryPath": "vendor/aarch64-apple-darwin/bin/codex"
     },
     "x86_64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.146.0-alpha.9.2-darwin-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-alpha.9.2-darwin-x64.tgz",
-      "integrity": "sha512-leUh89x4rhaSKj/Dn3ZudOT5aoh8ExJiov/f2bHU7/TiYS+TmNHIduYtnr1wk21b4LrL+yzvjChTHzj2LZgMFg==",
+      "version": "0.147.0-darwin-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
       "binaryPath": "vendor/x86_64-apple-darwin/bin/codex"
     },
     "x86_64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.146.0-alpha.9.2-linux-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-alpha.9.2-linux-x64.tgz",
-      "integrity": "sha512-sfkKbuzpK6r4QabE4j2d6mmpiui7l4uRb7OBopftoYKFi57DQW4ADsMZ7KJP4qicbaAYBtEbHNQFxNzJCGyzWg==",
+      "version": "0.147.0-linux-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
       "binaryPath": "vendor/x86_64-unknown-linux-musl/bin/codex"
     },
     "aarch64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.146.0-alpha.9.2-linux-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-alpha.9.2-linux-arm64.tgz",
-      "integrity": "sha512-7yz6Eak6uYmkvbNxz6ziv7eZ+7q8iFey1Tj8T1Enn4Bg2FBeR+h393a5onrVMEJccnLniUciTTXkEP70/nM6Pg==",
+      "version": "0.147.0-linux-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
       "binaryPath": "vendor/aarch64-unknown-linux-musl/bin/codex"
     },
     "x86_64-pc-windows-msvc": {
       "package": "@openai/codex",
-      "version": "0.146.0-alpha.9.2-win32-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-alpha.9.2-win32-x64.tgz",
-      "integrity": "sha512-HkCs04T65klWgiBEKJDefXdMVc75zkRYc8Gr1PGHZXRtD1Kzi+mFrzAwrpLiJijX+CC/o7XXZ1C99pp3fgr8bA==",
+      "version": "0.147.0-win32-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
       "binaryPath": "vendor/x86_64-pc-windows-msvc/bin/codex.exe"
     }
   }

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -183,8 +183,14 @@ const RECONNECT_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_RECONNECT_COMPLETE'
 const MEMORY_PROMPT = 'WEWORK_DESKTOP_E2E_MEMORY: run a tool and stream the report.'
 const MEMORY_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_MEMORY_COMPLETE'
 const CONCURRENT_MEMORY_TASK_COUNT = 10
-const CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB = Number(
-  process.env.WEWORK_E2E_CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB ?? 1280 * 1024
+const CONCURRENT_MEMORY_MAX_PEAK_GROWTH_KIB = Number(
+  process.env.WEWORK_E2E_CONCURRENT_MEMORY_MAX_PEAK_GROWTH_KIB ?? 320 * 1024
+)
+const CONCURRENT_MEMORY_MAX_SETTLED_GROWTH_KIB = Number(
+  process.env.WEWORK_E2E_CONCURRENT_MEMORY_MAX_SETTLED_GROWTH_KIB ?? 256 * 1024
+)
+const CONCURRENT_MEMORY_MAX_SETTLED_SAMPLE_RANGE_KIB = Number(
+  process.env.WEWORK_E2E_CONCURRENT_MEMORY_MAX_SETTLED_SAMPLE_RANGE_KIB ?? 64 * 1024
 )
 const MEMORY_SAMPLE_INTERVAL_MS = 500
 const MEMORY_MAX_PEAK_GROWTH_KIB = Number(
@@ -3453,6 +3459,9 @@ async function waitForBlankConversation(control, composerSelector) {
 async function verifyConcurrentTaskMemory({ composerSelector, control }) {
   assert.equal(process.platform, 'darwin', 'Concurrent memory E2E currently requires macOS')
   control.setScenario('concurrent_memory')
+  const baselineSamples = await captureStableTotalMemorySamples(control, 'baseline')
+  const baseline = medianMemorySample(baselineSamples.slice(-MEMORY_SAMPLE_WINDOW_SIZE))
+  assert.ok(baseline, 'The concurrent memory E2E did not capture a baseline')
   const taskRows = []
   const initialSnapshot = JSON.parse(await control.command('snapshot', 'body'))
   const knownTaskRows = new Set(
@@ -3502,6 +3511,12 @@ async function verifyConcurrentTaskMemory({ composerSelector, control }) {
   const peak = samples.reduce((largest, sample) =>
     sample.physicalFootprintKiB > largest.physicalFootprintKiB ? sample : largest
   )
+  const settledWindow = samples.slice(-MEMORY_SAMPLE_WINDOW_SIZE)
+  const settled = medianMemorySample(settledWindow)
+  assert.ok(settled, 'The concurrent memory E2E did not capture a settled sample window')
+  const peakGrowthKiB = peak.physicalFootprintKiB - baseline.physicalFootprintKiB
+  const settledGrowthKiB = settled.physicalFootprintKiB - baseline.physicalFootprintKiB
+  const settledSampleRangeKiB = memorySampleRangeKiB(settledWindow)
 
   const sidebarSnapshot = JSON.parse(await control.command('snapshot', 'body'))
   const expandTasksButton = sidebarSnapshot.testIds.find(testId =>
@@ -3529,8 +3544,20 @@ async function verifyConcurrentTaskMemory({ composerSelector, control }) {
     `${JSON.stringify(
       {
         taskCount: CONCURRENT_MEMORY_TASK_COUNT,
-        limitPhysicalFootprintKiB: CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB,
-        peak,
+        limits: {
+          maxPeakGrowthKiB: CONCURRENT_MEMORY_MAX_PEAK_GROWTH_KIB,
+          maxSettledGrowthKiB: CONCURRENT_MEMORY_MAX_SETTLED_GROWTH_KIB,
+          maxSettledSampleRangeKiB: CONCURRENT_MEMORY_MAX_SETTLED_SAMPLE_RANGE_KIB,
+        },
+        summary: {
+          baseline,
+          peak,
+          settled,
+          peakGrowthKiB,
+          settledGrowthKiB,
+          settledSampleRangeKiB,
+        },
+        baselineSamples,
         samples,
       },
       null,
@@ -3539,8 +3566,16 @@ async function verifyConcurrentTaskMemory({ composerSelector, control }) {
     'utf8'
   )
   assert.ok(
-    peak.physicalFootprintKiB < CONCURRENT_MEMORY_MAX_PHYSICAL_FOOTPRINT_KIB,
-    `Wework physical footprint reached ${peak.physicalFootprintKiB} KiB with ten concurrent tasks`
+    peakGrowthKiB <= CONCURRENT_MEMORY_MAX_PEAK_GROWTH_KIB,
+    `Wework physical footprint grew by ${peakGrowthKiB} KiB with ten concurrent tasks`
+  )
+  assert.ok(
+    settledGrowthKiB <= CONCURRENT_MEMORY_MAX_SETTLED_GROWTH_KIB,
+    `Wework physical footprint settled ${settledGrowthKiB} KiB above baseline with ten concurrent tasks`
+  )
+  assert.ok(
+    settledSampleRangeKiB <= CONCURRENT_MEMORY_MAX_SETTLED_SAMPLE_RANGE_KIB,
+    `Wework concurrent memory sample range reached ${settledSampleRangeKiB} KiB`
   )
   control.releaseConcurrentMemoryResponses()
 }
@@ -3661,6 +3696,20 @@ async function captureStableMemorySamples(control, phase, minimumSamples, maximu
     }
     samples.push(await captureMemorySample(control, phase))
     if (samples.length < minimumSamples) continue
+    const recent = samples.slice(-MEMORY_SAMPLE_WINDOW_SIZE)
+    if (memorySampleRangeKiB(recent) <= MEMORY_MAX_SAMPLE_RANGE_KIB) break
+  }
+  return samples
+}
+
+async function captureStableTotalMemorySamples(control, phase) {
+  const samples = []
+  while (samples.length < MEMORY_MAX_BASELINE_SAMPLES) {
+    if (samples.length > 0) {
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 1_000))
+    }
+    samples.push(await captureTotalMemorySample(control, phase))
+    if (samples.length < MEMORY_MIN_BASELINE_SAMPLES) continue
     const recent = samples.slice(-MEMORY_SAMPLE_WINDOW_SIZE)
     if (memorySampleRangeKiB(recent) <= MEMORY_MAX_SAMPLE_RANGE_KIB) break
   }
@@ -13972,6 +14021,24 @@ last_updated = "2026-07-30T00:00:00Z"`
       return
     }
 
+    if (MEMORY_ONLY) {
+      phase = 'memory-project'
+      await createSingleRootLocalProject(control, workspacePath, 'workspace')
+      const composerSelector = ACTIVE_COMPOSER_SELECTOR
+      await control.command('waitFor', composerSelector, {
+        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      })
+      phase = 'memory-growth'
+      await selectE2EModel(control)
+      await verifyMemoryGrowth({ composerSelector, control })
+      phase = 'concurrent-memory'
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', composerSelector, { timeoutMs: DEFAULT_STEP_TIMEOUT_MS })
+      await verifyConcurrentTaskMemory({ composerSelector, control })
+      console.log(`Wework desktop memory E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
     if (shouldRunDesktopCheckpoint('workspace-tabs')) {
       phase = 'workspace-tab-isolation'
       await verifyWorkspaceTabIsolation(control)
@@ -14349,18 +14416,6 @@ last_updated = "2026-07-30T00:00:00Z"`
       phase = 'background-task-plan'
       await verifyBackgroundTaskPlanRestoration({ composerSelector, control })
       console.log(`Wework background task-plan E2E passed. Evidence: ${resultDir}`)
-      return
-    }
-
-    if (MEMORY_ONLY) {
-      phase = 'memory-growth'
-      await selectE2EModel(control)
-      await verifyMemoryGrowth({ composerSelector, control })
-      phase = 'concurrent-memory'
-      await control.command('click', '[data-testid="new-chat-button"]')
-      await control.command('waitFor', composerSelector, { timeoutMs: DEFAULT_STEP_TIMEOUT_MS })
-      await verifyConcurrentTaskMemory({ composerSelector, control })
-      console.log(`Wework desktop memory E2E passed. Evidence: ${resultDir}`)
       return
     }
 

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -7092,6 +7092,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       expect.objectContaining({
         address: expect.objectContaining({ taskId: 'runtime-restored' }),
         message: '修复 CI',
+        retrySourceTurnId: 'reused-subtask',
       })
     )
   })

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -1202,6 +1202,7 @@ export function useWorkbenchRuntimeMessaging({
         dispatch({ type: 'error_set', error: '未找到可重试的失败消息' })
         return false
       }
+      const failedMessage = messageSource[failedMessageIndex]
 
       const previousUserMessage =
         retryUserMessageOverride?.role === 'user'
@@ -1229,6 +1230,7 @@ export function useWorkbenchRuntimeMessaging({
           address: state.currentRuntimeTask,
           message: previousUserMessage.content,
           clientUserMessageId: previousUserMessage.id,
+          retrySourceTurnId: failedMessage.turnId ?? failedMessage.subtaskId,
           ...selectedModelExecutionFields(runtimeSelectedModel, runtimeSelectedModelOptions),
           ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
           ...(attachments.length > 0 ? { attachments } : {}),

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -643,6 +643,7 @@ export interface RuntimeSendRequest {
   address: RuntimeTaskAddress
   message: string
   clientUserMessageId?: string
+  retrySourceTurnId?: string
   initialGoal?: RuntimeGoalCreateInput | null
   ephemeral?: boolean
   modelId?: string


### PR DESCRIPTION
## Summary

- upgrade the Wework-bundled Codex sidecar from `0.146.0-alpha.9.2` to stable `0.147.0` for macOS, Linux, and Windows targets
- pin official npm registry tarballs and SHA-512 integrity values for every supported platform
- document the sidecar upgrade process and correct the documented integrity algorithm

## Compatibility

- Wework does not use the removed `codex exec --full-auto` flag.
- The isolated Wework Codex home passes `--strict-config` with the new sidecar.
- The real Tauri verification confirmed the local executor, Codex startup, and app-server request paths remain operational.

## Validation

- `pnpm --filter wework exec vitest run scripts/prepare-codex-binary.test.mjs`
- `pnpm --filter wework exec prettier --check ../docs/zh/wework/developer-guide/wework-macos-release.md ../docs/en/wework/developer-guide/wework-macos-release.md`
- `CODEX_HOME=~/.wework/codex <bundled-codex> --strict-config --version`
- isolated `pnpm --filter wework ai:verify start` flow, including `runtime.codex.ensure_started` and `codex.app_server_request`
- pre-push ESLint, TypeScript, and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the bundled Codex release to version 0.147.0 across supported platforms.
  * Improved retry handling to preserve the latest transcript while removing superseded failed turns.

* **Bug Fixes**
  * Prevented failed user and assistant messages from lingering after a retry.
  * Ensured retry requests correctly identify the original turn.

* **Documentation**
  * Added SHA-512 verification and clarified package, URL, integrity, packaging, and signing requirements for macOS releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->