### PR TITLE
fix(wework): install local plugins from item marketplace

### DIFF
--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -140,7 +140,10 @@ export interface LocalCodexPluginApi {
   deleteMarketplace(id: string): Promise<LocalCodexPluginsState>
   reorderMarketplaces(ids: string[]): Promise<LocalCodexPluginsState>
   upsertMarketplace(data: { id?: string; path: string }): Promise<LocalCodexPluginsState>
-  installAvailablePlugin(pluginId: string | number): Promise<InstalledPlugin>
+  installAvailablePlugin(
+    pluginId: string | number,
+    marketplaceId?: string
+  ): Promise<InstalledPlugin>
   updateInstalledPlugin(
     id: string | number,
     data: InstalledPluginUpdateRequest
@@ -1347,14 +1350,23 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
       rememberSelectedMarketplaceId(response.marketplaceName)
       return readState({ marketplaceId: response.marketplaceName, refresh: true })
     },
-    async installAvailablePlugin(pluginId) {
-      const currentState = cachedState ?? (await readState())
-      const item = currentState.marketplaceItems.find(item => String(item.id) === String(pluginId))
-      if (!item) throw new Error('Codex plugin not found in current marketplace')
-      const marketplace = currentState.marketplaces.find(
-        marketplace => marketplace.id === currentState.selectedMarketplaceId
+    async installAvailablePlugin(pluginId, marketplaceId) {
+      const currentState = await readState({ mergeAllMarketplaces: true })
+      const requestedMarketplaceId = marketplaceId?.trim()
+      const item = currentState.marketplaceItems.find(
+        item =>
+          String(item.id) === String(pluginId) &&
+          (!requestedMarketplaceId || item.manifest?.marketplaceId === requestedMarketplaceId)
       )
-      if (!marketplace) throw new Error('Codex marketplace not selected')
+      if (!item) throw new Error('Codex plugin not found in current marketplace')
+      const itemMarketplaceId =
+        typeof item.manifest?.marketplaceId === 'string' ? item.manifest.marketplaceId.trim() : ''
+      const resolvedMarketplaceId = requestedMarketplaceId || itemMarketplaceId
+      if (!resolvedMarketplaceId) throw new Error('Codex plugin marketplace is missing')
+      const marketplace = currentState.marketplaces.find(
+        marketplace => marketplace.id === resolvedMarketplaceId
+      )
+      if (!marketplace) throw new Error('Codex plugin marketplace not found')
       const localMarketplace = isLocalMarketplacePath(marketplace.path)
       await codexAppServerRequest('plugin/install', {
         marketplacePath: localMarketplace ? marketplace.path : null,
@@ -1362,7 +1374,7 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
         pluginName: pluginInstallName(item, localMarketplace),
       })
       const state = await readState({
-        marketplaceId: currentState.selectedMarketplaceId,
+        marketplaceId: resolvedMarketplaceId,
         refresh: true,
       })
       const installed = state.installedPlugins.find(plugin => {

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -2234,6 +2234,48 @@ describe('PluginsWorkspace', () => {
     })
   })
 
+  test('installs from the item marketplace after another marketplace was selected', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockCodexAppServerInvoke({
+      marketplaces: [
+        {
+          name: 'target-marketplace',
+          displayName: 'Target',
+          path: '/Users/test/.codex/plugins/marketplaces/target',
+          plugins: [
+            {
+              ...defaultCodexPlugin,
+              id: 'target-plugin',
+              name: 'target-plugin',
+            },
+          ],
+        },
+        {
+          name: 'other-marketplace',
+          displayName: 'Other',
+          path: '/Users/test/.codex/plugins/marketplaces/other',
+        },
+      ],
+    })
+    const { createLocalCodexPluginApi } = await import('@/api/local/codexPlugins')
+    const localPluginApi = createLocalCodexPluginApi()
+
+    await localPluginApi.selectMarketplace('other-marketplace')
+    await localPluginApi.installAvailablePlugin(
+      'target-marketplace:target-plugin',
+      'target-marketplace'
+    )
+
+    expectCodexAppServerRequest('plugin/install', {
+      marketplacePath: '/Users/test/.codex/plugins/marketplaces/target',
+      pluginName: 'target-plugin',
+    })
+  })
+
   test('disables an installed plugin without uninstalling it', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -1655,9 +1655,7 @@ export function PluginsWorkspace({
     const request = ensureMarketplaceConnectors(item)
       .then(() =>
         installFromLocal
-          ? localPluginApi
-              .selectMarketplace(localMarketplaceId!)
-              .then(() => localPluginApi.installAvailablePlugin(item.id))
+          ? localPluginApi.installAvailablePlugin(item.id, localMarketplaceId!)
           : pluginApi
               .installMarketplacePlugin(item.id, currentDeviceId)
               .then(response => response.plugin)


### PR DESCRIPTION
## What changed

- Carry the clicked local plugin item's marketplace ID into installation.
- Resolve the install target from all marketplace entries rather than mutable selected-marketplace cache.
- Add a regression test for switching marketplaces before installing a plugin.

## Root cause

The install handler discarded the clicked item's marketplace and looked it up in shared cached state. A concurrent marketplace refresh could leave that cache on another marketplace, causing `Codex plugin not found in current marketplace` before the app-server `plugin/install` request.

## Validation

- `pnpm --filter wework typecheck`
- `pnpm --filter wework exec vitest run src/components/plugins/PluginsWorkspace.test.tsx`
- `pnpm --filter wework e2e:desktop:plugins`
- pre-push ESLint, TypeScript, and unit tests