### PR TITLE
Fix/wiki tables not null

### DIFF
--- a/backend/app/api/endpoints/knowledge_code_wiki.py
+++ b/backend/app/api/endpoints/knowledge_code_wiki.py
@@ -321,9 +321,20 @@ def create_code_wiki(
                 KnowledgeService._get_knowledge_base_record(db, settled),
                 KnowledgeService.get_document_count(db, settled),
             )
+
+        # Reaching here means the constraint that failed was not the one this
+        # handler is about, so the database's own account of it is the only thing
+        # that can say what went wrong. It used to be discarded in favour of
+        # "already exists" -- a cause nobody had checked, and one that sent two
+        # separate investigations looking for a duplicate name that did not exist.
+        logger.exception(
+            "[code_wiki] create failed for %s (owner %s): unexpected constraint",
+            source.source_url,
+            current_user.id,
+        )
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Knowledge base with name '{data.name}' already exists",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not create the code wiki; see the server log",
         ) from e
     except ValueError as e:
         db.rollback()

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -35,10 +35,14 @@ class WikiProject(WikiBase):
     project_type = Column(String(50), nullable=False, default="git", index=True)
     source_type = Column(String(50), nullable=False, default="github", index=True)
     source_url = Column(String(500), nullable=False)
-    source_id = Column(String(100), nullable=True)
-    source_domain = Column(String(100), nullable=True)
-    description = Column(Text)
-    ext = Column(JSON, comment="Project extension data")
+    # NOT NULL with an empty default, matching `wiki_tables.sql`, which every
+    # deployment is built from. Declared nullable here, the ORM-created schema used by
+    # tests accepted a NULL that production refuses -- so an insert that omitted one
+    # of these passed every test and failed on the first real database.
+    source_id = Column(String(100), nullable=False, default="", server_default="")
+    source_domain = Column(String(100), nullable=False, default="", server_default="")
+    description = Column(Text, nullable=False, default="")
+    ext = Column(JSON, nullable=False, default=dict, comment="Project extension data")
     # The code wiki this row registers, or 0 for a legacy wiki project. One row per
     # (repository, wiki): a code wiki belongs to its creator, so a repository may
     # have several, one per person who built one.
@@ -122,7 +126,7 @@ class WikiGeneration(WikiBase):
         default=WikiGenerationStatus.PENDING,
         index=True,
     )
-    ext = Column(JSON, comment="Extension fields")
+    ext = Column(JSON, nullable=False, default=dict, comment="Extension fields")
     created_at = Column(DateTime, default=func.now(), index=True)
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
     completed_at = Column(DateTime, nullable=False, default="1970-01-01 00:00:00")
@@ -154,7 +158,7 @@ class WikiContent(WikiBase):
     title = Column(String(500), nullable=False)
     content = Column(Text, nullable=False)
     parent_id = Column(Integer, nullable=False, default=0)
-    ext = Column(JSON, comment="Content extension data")
+    ext = Column(JSON, nullable=False, default=dict, comment="Content extension data")
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
 

--- a/backend/app/services/knowledge/code_wiki/registry.py
+++ b/backend/app/services/knowledge/code_wiki/registry.py
@@ -52,6 +52,11 @@ def claim_repository(
         source_type=source.source_type,
         source_url=source.source_url,
         source_domain=source.source_domain,
+        # Empty rather than left out. `wiki_tables.sql` declares this NOT NULL with
+        # an empty default, and an omitted column is sent as an explicit NULL, which
+        # overrides that default and fails the insert. A repository resolved from its
+        # URL has no platform id to record, and "" is how the legacy rows say so.
+        source_id="",
         description="",
         ext={},
         kind_id=kind_id,

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -268,7 +268,14 @@ class KnowledgeService:
         )
 
         if existing_by_name:
-            raise ValueError(f"Knowledge base with name '{data.name}' already exists")
+            # Named for the check that fired. The two below say the same sentence
+            # otherwise, so an "already exists" gave no way to tell which of them
+            # matched -- or, when neither had, that the message came from somewhere
+            # else entirely.
+            raise ValueError(
+                f"Knowledge base with name '{data.name}' already exists "
+                f"(kind {kb_name})"
+            )
 
         # Also check by display name in spec to prevent duplicates
         existing_by_display = (
@@ -286,7 +293,8 @@ class KnowledgeService:
             kb_spec = kb.json.get("spec", {})
             if kb_spec.get("name") == data.name:
                 raise ValueError(
-                    f"Knowledge base with name '{data.name}' already exists"
+                    f"Knowledge base with name '{data.name}' already exists "
+                    f"(knowledge base {kb.id})"
                 )
 
         # Build CRD structure

--- a/backend/app/services/wiki_service.py
+++ b/backend/app/services/wiki_service.py
@@ -183,7 +183,11 @@ class WikiService:
                         parent_id=(
                             section.parent_id if section.parent_id is not None else 0
                         ),
-                        ext=section.ext or None,
+                        # ``{}`` rather than ``None``: `wiki_tables.sql` declares
+                        # this NOT NULL, and every page with a path is rescued by
+                        # ``set_page_path`` below -- which left a path-less write as
+                        # the one shape that reached production as a NULL.
+                        ext=section.ext or {},
                         created_at=now,
                         updated_at=now,
                     )

--- a/backend/app/services/wiki_service.py
+++ b/backend/app/services/wiki_service.py
@@ -169,7 +169,11 @@ class WikiService:
                     content_item.type = section.type
                     content_item.title = section.title
                     content_item.content = section.content
-                    content_item.ext = section.ext or None
+                    # Same reason as the insert below, and the likelier of the two to
+                    # be reached: this branch rewrites a row that already exists, so
+                    # a path-less update of legacy content meets the NOT NULL that
+                    # was there all along.
+                    content_item.ext = section.ext or {}
                     if path:
                         set_page_path(content_item, path)
                     content_item.updated_at = now

--- a/backend/tests/api/test_knowledge_code_wiki.py
+++ b/backend/tests/api/test_knowledge_code_wiki.py
@@ -1367,6 +1367,32 @@ def test_a_code_wiki_and_its_registry_row_are_created_together(
     assert rows[0].source_url == source.source_url
 
 
+def test_the_registry_row_leaves_no_column_null_that_production_forbids(
+    test_db: Session, test_user: User, kind_services_use_test_db
+):
+    """The row this writes has to satisfy `wiki_tables.sql`, not just the ORM.
+
+    `source_id` is declared NOT NULL with an empty default there, and every
+    deployment is built from it -- but the schema these tests run against is created
+    from the model, where it was nullable. Omitting the column sends an explicit NULL,
+    which overrides the default, so the insert passed here and failed on the first
+    real database with "Column 'source_id' cannot be null".
+
+    Asserted as "not None" rather than by inspecting the schema: what production
+    refuses is the value, and pinning the value is what stops it coming back.
+    """
+    from app.models.wiki import WikiProject
+    from app.services.knowledge.orchestrator import knowledge_orchestrator
+
+    result = knowledge_orchestrator.create_code_wiki(
+        db=test_db, user=test_user, name="repo wiki", source=_source()
+    )
+
+    (row,) = test_db.query(WikiProject).filter(WikiProject.kind_id == result.id).all()
+    for column in ("source_id", "source_domain", "description", "ext", "project_name"):
+        assert getattr(row, column) is not None, column
+
+
 def test_a_failed_registration_leaves_no_knowledge_base_behind(
     test_db: Session, test_user: User, kind_services_use_test_db
 ):

--- a/backend/tests/services/knowledge/code_wiki/test_content_write.py
+++ b/backend/tests/services/knowledge/code_wiki/test_content_write.py
@@ -180,6 +180,29 @@ def test_a_rejected_write_leaves_the_version_unchanged(
     assert {page_path_of(page) for page in _pages(test_db, generation.id)} == {"index"}
 
 
+def test_a_path_less_write_never_leaves_ext_null(
+    test_db: Session, generation: WikiGeneration
+):
+    """`wiki_tables.sql` declares ``ext`` NOT NULL, and both branches here used to
+    write ``None`` when a section carried no ext of its own.
+
+    A page with a path is rescued by ``set_page_path``, which rewrites ``ext`` as a
+    dict -- so a path-less write is the only shape that reaches the column unrescued.
+    Covered on both branches: the insert, and the update that rewrites a row which
+    already exists. The second is the likelier one, because it meets a constraint the
+    row was already stored under.
+    """
+    _write(test_db, generation, _section(None, "Overview", "v1"))
+    (created,) = _pages(test_db, generation.id)
+    assert created.ext is not None
+
+    _write(test_db, generation, _section(None, "Overview", "v2"))
+
+    (updated,) = _pages(test_db, generation.id)
+    assert updated.content == "v2"
+    assert updated.ext is not None
+
+
 def test_writes_without_a_path_still_match_on_title(
     test_db: Session, generation: WikiGeneration
 ):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code wiki creation reliability by consistently populating project metadata.
  * Unexpected creation errors now return an internal-server error instead of being misreported as duplicate-name conflicts.
  * Duplicate knowledge-base messages now identify the conflicting entry more clearly.
  * Wiki content without optional path information is handled successfully.
  * Improved handling of missing optional metadata and extension details during wiki creation and content updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->