### PR TITLE
feat(wework): collapse composer plugin picker to an icon in conversation

### DIFF
--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -130,6 +130,7 @@ export interface ChatInputProps {
   onCompositionEnd?: () => void
   onSubmit: (valueOverride?: string, options?: ChatSubmitOptions) => void | Promise<void>
   disabled: boolean
+  pluginPickerIconOnly?: boolean
   submitDisabled?: boolean
   error?: string | null
   disabledReason?: string
@@ -515,6 +516,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     onCompositionEnd,
     onSubmit,
     disabled,
+    pluginPickerIconOnly = false,
     submitDisabled = false,
     error,
     disabledReason,
@@ -818,6 +820,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
         <ProjectChatComposer
           ref={composerRef}
           {...composerProps}
+          pluginPickerIconOnly={pluginPickerIconOnly}
           models={controls.models}
           selectedModel={controls.selectedModel}
           activeModel={controls.activeModel}

--- a/wework/src/components/chat/composer/AddContextMenu.tsx
+++ b/wework/src/components/chat/composer/AddContextMenu.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { CloudProject } from '@/api/deliveries'
 import { useTranslation } from '@/hooks/useTranslation'
+import { Tooltip } from '@/components/ui/tooltip'
 import type { ComposerCloudMentionCandidate } from './composerMentionCandidates'
 import { useAnchoredPortalMenu } from './useAnchoredPortalMenu'
 import { useOutsideClick } from './useOutsideClick'
@@ -272,18 +273,24 @@ export function AddContextMenu({
           </div>,
           document.body
         )}
-      <button
-        ref={triggerRef}
-        type="button"
-        data-testid="add-context-button"
-        onClick={() => !disabled && setOpen(current => !current)}
-        disabled={disabled}
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full p-0 text-text-primary hover:bg-background/70 disabled:cursor-not-allowed disabled:opacity-50"
-        aria-expanded={open}
-        aria-label={t('workbench.add_context', '添加上下文')}
+      <Tooltip
+        label={t('workbench.add_context', '添加上下文')}
+        align="start"
+        testId="composer-add-context-tooltip"
       >
-        <Plus className="h-5 w-5" strokeWidth={1.5} />
-      </button>
+        <button
+          ref={triggerRef}
+          type="button"
+          data-testid="add-context-button"
+          onClick={() => !disabled && setOpen(current => !current)}
+          disabled={disabled}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full p-0 text-text-primary hover:bg-background/70 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-expanded={open}
+          aria-label={t('workbench.add_context', '添加上下文')}
+        >
+          <Plus className="h-5 w-5" strokeWidth={1.5} />
+        </button>
+      </Tooltip>
     </div>
   )
 }

--- a/wework/src/components/chat/composer/ComposerToolbar.test.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.test.tsx
@@ -71,4 +71,54 @@ describe('ComposerToolbar', () => {
     expect(screen.getByTestId('composer-toolbar')).toHaveAttribute('data-compact', 'true')
     expect(screen.getByTestId('quick-phrase-layout')).toHaveTextContent('icon')
   })
+
+  it('collapses the plugin picker trigger to an icon once a conversation has started', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 600,
+      height: 32,
+      top: 0,
+      right: 600,
+      bottom: 32,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+
+    const { rerender } = render(
+      <ComposerToolbar
+        canSend={false}
+        models={[]}
+        selectedModel={null}
+        selectedModelOptions={{}}
+        isModelSelectionReady
+        onSelectModel={vi.fn()}
+        onSelectModelOption={vi.fn()}
+        onFileSelect={vi.fn()}
+        onQuickPhraseSelect={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('composer-plugin-picker-button')).toHaveClass('h-8')
+
+    rerender(
+      <ComposerToolbar
+        canSend={false}
+        models={[]}
+        selectedModel={null}
+        selectedModelOptions={{}}
+        isModelSelectionReady
+        pluginPickerIconOnly
+        onSelectModel={vi.fn()}
+        onSelectModelOption={vi.fn()}
+        onFileSelect={vi.fn()}
+        onQuickPhraseSelect={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('composer-plugin-picker-button')).toHaveClass('h-7')
+  })
 })

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -4,6 +4,7 @@ import type { CloudProject } from '@/api/deliveries'
 import { ActionMenu } from '@/components/common/ActionMenu'
 import type { ComposerSubmitOptions } from './ComposerTextarea'
 import { useTranslation } from '@/hooks/useTranslation'
+import { Tooltip } from '@/components/ui/tooltip'
 import type { LocalDeviceApp, ModelOptions, RuntimeContextUsage, UnifiedModel } from '@/types/api'
 import { AddContextMenu } from './AddContextMenu'
 import type { ComposerCloudMentionCandidate } from './composerMentionCandidates'
@@ -18,6 +19,7 @@ import type { QuickPhrase } from '@/tauri/appPreferences'
 interface ComposerToolbarProps {
   canSend: boolean
   disabled?: boolean
+  pluginPickerIconOnly?: boolean
   models: UnifiedModel[]
   selectedModel: UnifiedModel | null
   activeModel?: UnifiedModel | null
@@ -61,6 +63,7 @@ const NARROW_MODEL_SELECTOR_MAX_WIDTH = 160
 export function ComposerToolbar({
   canSend,
   disabled = false,
+  pluginPickerIconOnly = false,
   models,
   selectedModel,
   activeModel,
@@ -146,7 +149,7 @@ export function ComposerToolbar({
         <QuickPhraseMenu disabled={disabled} onSelect={onQuickPhraseSelect} />
         <PluginPickerMenu
           disabled={disabled}
-          iconOnly={compact}
+          iconOnly={compact || pluginPickerIconOnly}
           onListLocalApps={onListLocalApps}
         />
         {leadingContext}
@@ -194,25 +197,37 @@ export function ComposerToolbar({
           <PopoutWorkspaceMenu {...projectWorkMenuContext} disabled={disabled} />
         ) : null}
         {isStreaming && !canSend ? (
-          <button
-            type="button"
-            data-testid="pause-response-button"
-            onClick={onPause}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1f1f1f] p-0 text-white hover:bg-[#333]"
-            aria-label={t('workbench.pause_response', '暂停回复')}
+          <Tooltip
+            label={t('workbench.pause_response', '暂停回复')}
+            align="end"
+            testId="composer-pause-tooltip"
           >
-            <span className="h-3.5 w-3.5 rounded-sm bg-current" aria-hidden="true" />
-          </button>
+            <button
+              type="button"
+              data-testid="pause-response-button"
+              onClick={onPause}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1f1f1f] p-0 text-white hover:bg-[#333]"
+              aria-label={t('workbench.pause_response', '暂停回复')}
+            >
+              <span className="h-3.5 w-3.5 rounded-sm bg-current" aria-hidden="true" />
+            </button>
+          </Tooltip>
         ) : isStreaming && canSend ? (
           <div className="flex items-center rounded-full bg-[#1f1f1f] text-white">
-            <button
-              type="submit"
-              data-testid={sendButtonTestId}
-              className="flex h-8 w-8 items-center justify-center rounded-l-full hover:bg-[#333]"
-              aria-label={t('workbench.send_after_turn', '当前回复结束后发送')}
+            <Tooltip
+              label={t('workbench.send_after_turn', '当前回复结束后发送')}
+              align="end"
+              testId="composer-send-after-turn-tooltip"
             >
-              <ArrowUp className="h-4 w-4" />
-            </button>
+              <button
+                type="submit"
+                data-testid={sendButtonTestId}
+                className="flex h-8 w-8 items-center justify-center rounded-l-full hover:bg-[#333]"
+                aria-label={t('workbench.send_after_turn', '当前回复结束后发送')}
+              >
+                <ArrowUp className="h-4 w-4" />
+              </button>
+            </Tooltip>
             <ActionMenu
               ariaLabel={t('workbench.choose_send_mode', '选择发送方式')}
               testId="send-mode-menu-button"
@@ -262,15 +277,21 @@ export function ComposerToolbar({
             />
           </div>
         ) : (
-          <button
-            type="submit"
-            data-testid={sendButtonTestId}
-            disabled={!canSend}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1f1f1f] p-0 text-white disabled:cursor-not-allowed disabled:bg-text-muted/45 disabled:text-background"
-            aria-label={t('workbench.send_message', '发送消息')}
+          <Tooltip
+            label={t('workbench.send_message', '发送消息')}
+            align="end"
+            testId="composer-send-tooltip"
           >
-            <ArrowUp className="h-4 w-4" />
-          </button>
+            <button
+              type="submit"
+              data-testid={sendButtonTestId}
+              disabled={!canSend}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1f1f1f] p-0 text-white disabled:cursor-not-allowed disabled:bg-text-muted/45 disabled:text-background"
+              aria-label={t('workbench.send_message', '发送消息')}
+            >
+              <ArrowUp className="h-4 w-4" />
+            </button>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/wework/src/components/chat/composer/PluginPickerMenu.test.tsx
+++ b/wework/src/components/chat/composer/PluginPickerMenu.test.tsx
@@ -119,6 +119,20 @@ describe('PluginPickerMenu', () => {
     window.removeEventListener(SHOW_PLUGIN_TRIAL_GUIDE_EVENT, onShowGuide)
   })
 
+  test('renders a single icon trigger when iconOnly is set', async () => {
+    const onListLocalApps = vi.fn().mockResolvedValue([githubApp, superpowersApp, echoIdApp])
+
+    render(<PluginPickerMenu iconOnly onListLocalApps={onListLocalApps} />)
+
+    const trigger = screen.getByTestId('composer-plugin-picker-button')
+    expect(trigger).toHaveClass('h-7', 'w-7', 'rounded-lg')
+    expect(trigger).not.toHaveTextContent('插件')
+    expect(screen.queryByTestId(/composer-plugin-preview-icon-/)).not.toBeInTheDocument()
+
+    await userEvent.click(trigger)
+    expect(await screen.findByTestId('composer-plugin-picker-item-github')).toBeInTheDocument()
+  })
+
   test('orders available plugins by usage count then recent selection', async () => {
     recordPluginUsage('EchoID')
     recordPluginUsage('EchoID')

--- a/wework/src/components/chat/composer/PluginPickerMenu.tsx
+++ b/wework/src/components/chat/composer/PluginPickerMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/features/plugins/pluginTrial'
 import { composerAppPluginKey } from '@/features/plugins/composerPluginMetadata'
 import { useTranslation } from '@/hooks/useTranslation'
+import { Tooltip } from '@/components/ui/tooltip'
 import { navigateTo } from '@/lib/navigation'
 import type { LocalDeviceApp } from '@/types/api'
 import { resolvePluginLogoUrl } from '@/components/plugins/plugin-assets'
@@ -163,70 +164,78 @@ export function PluginPickerMenu({
 
   return (
     <div ref={rootRef} className="relative">
-      <button
-        type="button"
-        data-testid="composer-plugin-picker-button"
-        disabled={disabled}
-        aria-expanded={open}
-        aria-label={t('workbench.composer_plugins', '插件')}
-        className={[
-          'flex items-center text-sm text-text-secondary transition-colors hover:bg-muted hover:text-text-primary disabled:opacity-40',
-          iconOnly
-            ? 'h-7 w-7 justify-center rounded-lg px-0'
-            : 'h-8 gap-1.5 rounded-xl bg-muted px-2',
-        ].join(' ')}
-        onClick={() => {
-          if (disabled) return
-          if (!open) {
-            // Ask slash to re-publish first — `/` may already have apps in React
-            // state while this menu's store was emptied by HMR or a failed refresh.
-            requestComposerAppsSync()
-            if (!applySharedApps()) {
-              if (onListLocalApps) {
-                setLoading(true)
-                setReloadToken(token => token + 1)
+      <Tooltip
+        label={t('workbench.composer_plugins', '插件')}
+        align="start"
+        testId="composer-plugin-picker-tooltip"
+      >
+        <button
+          type="button"
+          data-testid="composer-plugin-picker-button"
+          disabled={disabled}
+          aria-expanded={open}
+          aria-label={t('workbench.composer_plugins', '插件')}
+          className={[
+            'flex items-center text-sm text-text-secondary transition-colors hover:bg-muted hover:text-text-primary disabled:opacity-40',
+            iconOnly
+              ? 'h-7 w-7 justify-center rounded-lg px-0'
+              : 'h-8 gap-1.5 rounded-xl bg-muted px-2',
+          ].join(' ')}
+          onClick={() => {
+            if (disabled) return
+            if (!open) {
+              // Ask slash to re-publish first — `/` may already have apps in React
+              // state while this menu's store was emptied by HMR or a failed refresh.
+              requestComposerAppsSync()
+              if (!applySharedApps()) {
+                if (onListLocalApps) {
+                  setLoading(true)
+                  setReloadToken(token => token + 1)
+                }
               }
             }
-          }
-          setOpen(!open)
-        }}
-      >
-        {iconOnly ? (
-          <Puzzle className="h-4 w-4" />
-        ) : (
-          <>
-            <span className="font-medium">{t('workbench.composer_plugins', '插件')}</span>
-            <span
-              className="flex -space-x-1"
-              data-testid="composer-plugin-preview-icons"
-              aria-hidden="true"
-            >
-              {apps.slice(0, 3).map(app => {
-                const logo = resolvePluginLogoUrl({
-                  pluginKey: composerAppPluginKey(app),
-                  logo: app.logoUrl,
-                  logoDark: app.logoUrlDark,
-                  appearanceMode,
-                })
-                return (
-                  <span
-                    key={app.id}
-                    data-testid={`composer-plugin-preview-icon-${app.id}`}
-                    className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/30 bg-background"
-                  >
-                    {logo ? (
-                      <img src={logo} alt="" className="h-full w-full object-contain" />
-                    ) : (
-                      <Boxes className="h-4 w-4" />
-                    )}
-                  </span>
-                )
-              })}
-            </span>
-            {apps.length > 3 && <span className="text-xs text-text-muted">+{apps.length - 3}</span>}
-          </>
-        )}
-      </button>
+            setOpen(!open)
+          }}
+        >
+          {iconOnly ? (
+            <Puzzle className="h-4 w-4" />
+          ) : (
+            <>
+              <span className="font-medium">{t('workbench.composer_plugins', '插件')}</span>
+              <span
+                className="flex -space-x-1"
+                data-testid="composer-plugin-preview-icons"
+                aria-hidden="true"
+              >
+                {apps.slice(0, 3).map(app => {
+                  const logo = resolvePluginLogoUrl({
+                    pluginKey: composerAppPluginKey(app),
+                    logo: app.logoUrl,
+                    logoDark: app.logoUrlDark,
+                    appearanceMode,
+                  })
+                  return (
+                    <span
+                      key={app.id}
+                      data-testid={`composer-plugin-preview-icon-${app.id}`}
+                      className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/30 bg-background"
+                    >
+                      {logo ? (
+                        <img src={logo} alt="" className="h-full w-full object-contain" />
+                      ) : (
+                        <Boxes className="h-4 w-4" />
+                      )}
+                    </span>
+                  )
+                })}
+              </span>
+              {apps.length > 3 && (
+                <span className="text-xs text-text-muted">+{apps.length - 3}</span>
+              )}
+            </>
+          )}
+        </button>
+      </Tooltip>
 
       {open && (
         <div

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -53,6 +53,7 @@ interface ProjectChatComposerProps {
   onCompositionEnd?: () => void
   onSubmit: (submittedValue?: string, options?: ComposerSubmitOptions) => void
   disabled: boolean
+  pluginPickerIconOnly?: boolean
   submitDisabled?: boolean
   disabledReason?: string
   placeholder: string
@@ -122,6 +123,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
       onCompositionEnd,
       onSubmit,
       disabled,
+      pluginPickerIconOnly = false,
       submitDisabled = false,
       disabledReason,
       placeholder,
@@ -413,6 +415,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
             canSend={canSend}
             sendButtonTestId={submitButtonTestId}
             disabled={disabled}
+            pluginPickerIconOnly={pluginPickerIconOnly}
             models={models}
             selectedModel={selectedModel}
             activeModel={activeModel}

--- a/wework/src/components/chat/composer/QuickPhraseMenu.tsx
+++ b/wework/src/components/chat/composer/QuickPhraseMenu.tsx
@@ -4,6 +4,7 @@ import { convertFileSrc } from '@tauri-apps/api/core'
 import { createPortal } from 'react-dom'
 import { useTranslation } from '@/hooks/useTranslation'
 import { track } from '@/telemetry/client'
+import { Tooltip } from '@/components/ui/tooltip'
 import { navigateTo } from '@/lib/navigation'
 import { getAppPreferences, updateAppPreferences, type QuickPhrase } from '@/tauri/appPreferences'
 import { useQuickPhrases } from '@/hooks/useQuickPhrases'
@@ -220,22 +221,28 @@ export function QuickPhraseMenu({ disabled, compact, onSelect }: QuickPhraseMenu
 
   return (
     <div ref={rootRef} className="relative shrink-0">
-      <button
-        ref={triggerRef}
-        type="button"
-        data-testid="quick-phrase-button"
-        disabled={disabled}
-        onClick={() => setOpen(value => !value)}
-        className={
-          compact
-            ? 'flex h-11 w-11 items-center justify-center rounded-full text-text-primary hover:bg-muted disabled:opacity-40'
-            : 'flex h-8 w-8 items-center justify-center rounded-lg text-text-primary hover:bg-muted disabled:opacity-40'
-        }
-        aria-label={t('workbench.quick_phrases', '快捷短语')}
-        aria-expanded={open}
+      <Tooltip
+        label={t('workbench.quick_phrases', '快捷短语')}
+        align="start"
+        testId="composer-quick-phrase-tooltip"
       >
-        <MessageSquareText className="h-4 w-4 text-text-primary" strokeWidth={1.5} />
-      </button>
+        <button
+          ref={triggerRef}
+          type="button"
+          data-testid="quick-phrase-button"
+          disabled={disabled}
+          onClick={() => setOpen(value => !value)}
+          className={
+            compact
+              ? 'flex h-11 w-11 items-center justify-center rounded-full text-text-primary hover:bg-muted disabled:opacity-40'
+              : 'flex h-8 w-8 items-center justify-center rounded-lg text-text-primary hover:bg-muted disabled:opacity-40'
+          }
+          aria-label={t('workbench.quick_phrases', '快捷短语')}
+          aria-expanded={open}
+        >
+          <MessageSquareText className="h-4 w-4 text-text-primary" strokeWidth={1.5} />
+        </button>
+      </Tooltip>
       {open &&
         typeof document !== 'undefined' &&
         createPortal(

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1791,7 +1791,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [projectMenuOpenSignal, setProjectMenuOpenSignal] = useState(0)
   const [projectMenuAnchorElement, setProjectMenuAnchorElement] =
     useState<HTMLButtonElement | null>(null)
-  const hasConversation = paneMessages.length > 0 || currentRuntimeTask
+  const hasConversation = paneMessages.length > 0 || Boolean(currentRuntimeTask)
   const hasMainBackground = Boolean(background.imagePath && background.inMain)
   const activeDevice = findWorkbenchDevice(devices, activeDeviceId)
   const activeDeviceSupportsGoal = Boolean(activeDevice && isClaudeCodeDevice(activeDevice))
@@ -2862,6 +2862,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                                     onChange={paneSession.setInput}
                                     onSubmit={submitPaneInput}
                                     disabled={composerDisabled}
+                                    pluginPickerIconOnly={hasConversation}
                                     submitDisabled={paneSession.status.isSubmitting}
                                     error={paneSession.error}
                                     disabledReason={inlineComposerDisabledReason}

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -535,6 +535,7 @@ export function TemporaryChatPanel({
             onChange={setInput}
             onSubmit={send}
             disabled={false}
+            pluginPickerIconOnly
             error={error}
             placeholder={placeholder}
             variant="desktop"

--- a/wework/src/components/ui/tooltip.test.tsx
+++ b/wework/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,57 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { Tooltip } from './tooltip'
+
+describe('Tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('shows the label on hover after the delay and hides on pointer leave', () => {
+    render(
+      <Tooltip label="添加上下文" testId="composer-tooltip">
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+    const wrapper = screen.getByRole('button').parentElement as HTMLElement
+    const tooltip = screen.getByTestId('composer-tooltip')
+    expect(tooltip).toHaveClass('opacity-0')
+
+    fireEvent.pointerEnter(wrapper)
+    act(() => {
+      vi.advanceTimersByTime(699)
+    })
+    expect(tooltip).toHaveClass('opacity-0')
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(tooltip).toHaveClass('opacity-100')
+    expect(tooltip).toHaveTextContent('添加上下文')
+
+    fireEvent.pointerLeave(wrapper)
+    expect(tooltip).toHaveClass('opacity-0')
+  })
+
+  test('hides on Escape while focused', () => {
+    render(
+      <Tooltip label="插件" testId="composer-tooltip">
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+    const wrapper = screen.getByRole('button').parentElement as HTMLElement
+    const tooltip = screen.getByTestId('composer-tooltip')
+
+    fireEvent.focus(wrapper)
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    expect(tooltip).toHaveClass('opacity-100')
+
+    fireEvent.keyDown(wrapper, { key: 'Escape' })
+    expect(tooltip).toHaveClass('opacity-0')
+  })
+})

--- a/wework/src/components/ui/tooltip.tsx
+++ b/wework/src/components/ui/tooltip.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface TooltipProps {
+  label: string
+  side?: 'top' | 'bottom'
+  align?: 'start' | 'center' | 'end'
+  testId?: string
+  children: ReactNode
+}
+
+const SHOW_DELAY_MS = 700
+
+const sidePosition = {
+  top: 'bottom-full mb-2',
+  bottom: 'top-full mt-2',
+}
+
+const alignPosition = {
+  start: 'left-0',
+  center: 'left-1/2 -translate-x-1/2',
+  end: 'right-0',
+}
+
+export function Tooltip({ label, side = 'top', align = 'center', testId, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+  const showTimerRef = useRef<number | null>(null)
+
+  const clearShowTimer = () => {
+    if (showTimerRef.current !== null) {
+      window.clearTimeout(showTimerRef.current)
+      showTimerRef.current = null
+    }
+  }
+
+  const scheduleShow = () => {
+    clearShowTimer()
+    showTimerRef.current = window.setTimeout(() => {
+      setVisible(true)
+      showTimerRef.current = null
+    }, SHOW_DELAY_MS)
+  }
+
+  const hide = () => {
+    clearShowTimer()
+    setVisible(false)
+  }
+
+  useEffect(() => clearShowTimer, [])
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === 'Escape') hide()
+  }
+
+  return (
+    <span
+      className="group relative inline-flex shrink-0"
+      onPointerEnter={scheduleShow}
+      onPointerLeave={hide}
+      onFocus={scheduleShow}
+      onBlur={hide}
+      onClickCapture={hide}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+      <span
+        role="tooltip"
+        data-testid={testId}
+        className={cn(
+          'pointer-events-none absolute z-system-popover max-w-[20rem] whitespace-nowrap rounded-lg border border-border/70 bg-popover/95 px-2 py-1 text-sm leading-5 text-text-primary shadow-[0_10px_28px_rgba(0,0,0,0.18)] backdrop-blur-md transition-opacity duration-100',
+          visible ? 'opacity-100' : 'opacity-0',
+          sidePosition[side],
+          alignPosition[align]
+        )}
+      >
+        {label}
+      </span>
+    </span>
+  )
+}


### PR DESCRIPTION
## 背景

进入对话后，composer 里的插件入口仍然以展开形式显示“插件”文字和最多 3 个插件预览图标（超出显示 +N），占据工具栏空间。需求是：默认状态保持展开不变，只有开始对话以后才收成一个图标。

## 改动

- `ComposerToolbar` 新增 `pluginPickerIconOnly` 透传开关：进入对话（`hasConversation`）或临时对话面板时，把 `PluginPickerMenu` 收成单个 Puzzle 图标；默认（空启动台）仍保持“插件 + 预览图标”的展开形式。
- 图标收起后，为 composer 里纯图标按钮补齐 hover tooltip（添加上下文、快捷短语、插件、发送/暂停回复），新增共享 `Tooltip` 组件（700ms 延迟，符合 `DESIGN.md` 6.6）。
- 单元测试：`PluginPickerMenu` iconOnly 渲染、`ComposerToolbar` 对话后收起、`Tooltip` hover/Escape 行为。

## 影响

- 用户：进入对话后工具栏更紧凑，插件入口变成图标，hover 可看到名称提示；默认首页行为不变。

## 验证

- wework 相关单测全部通过。
- 真实 Tauri 会话（ai-verify）：默认空启动台保持“插件 + 预览图标 +N”；发送消息进入对话后按钮变为 28×28 图标且无预览列表；hover 插件图标显示“插件”tooltip。
- pre-push：ESLint / TypeScript / 单测全部通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to chat composer controls, including context, plugins, quick phrases, pause, and send actions.
  * Added compact icon-only plugin picker support for desktop and temporary chat composers.
  * Tooltips now support accessible hover and keyboard interactions.

* **Tests**
  * Added coverage for tooltip behavior and compact plugin picker presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->