### PR TITLE
fix(wework): keep viewed images out of message artifacts

### DIFF
--- a/docs/en/wegent/developer-guide/runtime-local-work.md
+++ b/docs/en/wegent/developer-guide/runtime-local-work.md
@@ -255,6 +255,7 @@ The runtime owns persistence for newly created tasks:
 - Codex app-server input supports `input_text`, `input_image`, and `localImage` prompt blocks. Backend attachment-id download and sandbox-path rewriting remain separate from local-first attachments: local App mode sends same-device attachment records through executor IPC, while cloud/Backend paths continue to use uploaded attachment ids.
 - If Codex response completion includes `file_changes` or `fileChanges`, the executor stores it on the current assistant message's `fileChanges` field, and later transcript refreshes continue to show the same file changes card.
 - Codex app-server `imageGeneration` items must not be treated as ordinary text tool output. The executor stores the complete image result in the tool block `render_payload`, together with the revised prompt and generated-file path, and Wework renders the image directly from that payload. Image data must bypass the regular tool-output truncation window or the base64 will be corrupted during live display or transcript restoration.
+- `view_image` only indicates that the model inspected an existing workspace image. Wework shows that image inside the expandable tool details but must not add it to the generated-image gallery at the end of the assistant message; only `imageGeneration` results are final image artifacts.
 
 Project-backed creation uses a runtime workspace reference:
 

--- a/docs/zh/wegent/developer-guide/runtime-local-work.md
+++ b/docs/zh/wegent/developer-guide/runtime-local-work.md
@@ -253,6 +253,7 @@ Wework 在调用 create 前先生成客户端侧 `localTaskId`，并在请求体
 - Codex app-server 输入支持 `input_text`、`input_image` 和 `localImage` prompt block 映射。Backend 附件 id 下载与沙箱路径重写仍和 local-first 附件分离：本地 App 模式通过 executor IPC 发送同设备附件记录，云端/Backend 路径继续使用上传后的附件 ID。
 - Codex 回复完成时如果 Responses `response.completed` 中带有 `file_changes` 或 `fileChanges`，executor 会把它保存到当前 assistant message 的 `fileChanges` 字段，后续 transcript 刷新继续展示同一张文件变更卡片。
 - Codex app-server 的 `imageGeneration` item 不能作为普通文本工具输出处理。executor 将完整图片结果保存到 tool block 的 `render_payload`，同时保留提示词和生成文件路径；Wework 使用该载荷直接展示图片。图片数据不能经过普通工具输出的截断窗口，否则实时消息或 transcript 恢复后会得到损坏的 base64。
+- `view_image` 只表示模型查看了工作区中的现有图片。Wework 在可展开的工具详情中展示该图片，但不能把它加入 assistant 消息末尾的生成图片画廊；只有 `imageGeneration` 结果属于最终图片产物。
 
 Project 场景使用运行时 workspace 引用：
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -2571,6 +2571,14 @@ async function waitForProcessingBlock(
 async function verifyViewImageProcessingBlock(control) {
   const viewImageBlockSelector = '[data-processing-block-id="wework-e2e-view-image"]'
   await waitForProcessingBlock(control, viewImageBlockSelector, 'The view_image processing block')
+  const generatedImageGalleryCount = Number(
+    await control.command('getElementCount', '[data-testid="generated-image-gallery"]')
+  )
+  assert.equal(
+    generatedImageGalleryCount,
+    0,
+    'The view_image result incorrectly rendered as a final generated-image artifact'
+  )
   await control.command('scrollIntoView', '[data-testid="processing-live-preview"]')
   await control.command(
     'waitFor',

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -304,6 +304,42 @@ describe('MessageList', () => {
     expect(screen.getByTestId('attachment-image-zoom-value')).toHaveTextContent('125%')
   })
 
+  test('does not render viewed images as final message artifacts', () => {
+    const imageUrl = 'data:image/png;base64,aW1hZ2U='
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-view-image',
+            role: 'assistant',
+            content: 'The screenshot is visible in the tool details.',
+            status: 'done',
+            createdAt: '2026-08-08T10:00:01Z',
+            blocks: [
+              {
+                id: 'view-image-1',
+                subtaskId: '1',
+                type: 'tool',
+                toolName: 'view_image',
+                toolInput: { path: '/tmp/screenshot.png' },
+                toolOutput: { image_url: imageUrl },
+                renderPayload: {
+                  dataUrl: imageUrl,
+                },
+                status: 'done',
+                createdAt: Date.now(),
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByTestId('generated-image-gallery')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('generated-image')).not.toBeInTheDocument()
+  })
+
   test('uses browser-native content visibility without message window placeholders', () => {
     render(
       <MessageList

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -2225,59 +2225,22 @@ function generatedImageAttachment(image: GeneratedImageArtifact, index: number):
 
 function getGeneratedImages(blocks: ProcessingBlock[]): GeneratedImageArtifact[] {
   return blocks.flatMap(block => {
-    if (block.type !== 'tool') return []
-    if (block.toolName === 'image_generation') {
-      const payload = block.renderPayload
-      if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return []
-      const imageBase64 = Reflect.get(payload, 'imageBase64')
-      if (typeof imageBase64 !== 'string' || !imageBase64.trim()) return []
-      const revisedPrompt = Reflect.get(payload, 'revisedPrompt')
-      return [
-        {
-          id: block.id,
-          src: imageBase64.startsWith('data:')
-            ? imageBase64
-            : `data:image/png;base64,${imageBase64}`,
-          alt:
-            typeof revisedPrompt === 'string' && revisedPrompt.trim()
-              ? revisedPrompt
-              : 'Generated image',
-        },
-      ]
-    }
-
-    if (block.toolName !== 'view_image') return []
+    if (block.type !== 'tool' || block.toolName !== 'image_generation') return []
     const payload = block.renderPayload
-    const toolInput =
-      typeof Reflect.get(block, 'toolInput') === 'object' && Reflect.get(block, 'toolInput')
-        ? (Reflect.get(block, 'toolInput') as Record<string, unknown>)
-        : null
-    const candidates: Array<unknown> = [
-      payload && typeof payload === 'object' ? Reflect.get(payload, 'dataUrl') : null,
-      payload && typeof payload === 'object' ? Reflect.get(payload, 'imageBase64') : null,
-      payload && typeof payload === 'object' ? Reflect.get(payload, 'src') : null,
-      toolInput?.dataUrl,
-      toolInput?.imageBase64,
-      toolInput?.path,
-      toolInput?.file_path,
-      toolInput?.image_path,
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return []
+    const imageBase64 = Reflect.get(payload, 'imageBase64')
+    if (typeof imageBase64 !== 'string' || !imageBase64.trim()) return []
+    const revisedPrompt = Reflect.get(payload, 'revisedPrompt')
+    return [
+      {
+        id: block.id,
+        src: imageBase64.startsWith('data:') ? imageBase64 : `data:image/png;base64,${imageBase64}`,
+        alt:
+          typeof revisedPrompt === 'string' && revisedPrompt.trim()
+            ? revisedPrompt
+            : 'Generated image',
+      },
     ]
-    for (const candidate of candidates) {
-      if (typeof candidate !== 'string' || !candidate.trim()) continue
-      const src = candidate.startsWith('data:')
-        ? candidate
-        : candidate.startsWith('/') || candidate.includes('://')
-          ? candidate
-          : `data:image/png;base64,${candidate}`
-      return [
-        {
-          id: block.id,
-          src,
-          alt: 'Viewed image',
-        },
-      ]
-    }
-    return []
   })
 }
 


### PR DESCRIPTION
## What changed

- Keep `view_image` results inside expandable tool details instead of rendering them again in the assistant message's generated-image gallery.
- Preserve `image_generation` as the only tool source for final generated-image artifacts.
- Add component and desktop E2E regression coverage.
- Document the rendering boundary in the Chinese and English runtime-local-work guides.

## Why

`MessageList` collected both `image_generation` and `view_image` blocks as final image artifacts. Since `view_image` already renders its preview inside the tool details, the same inspected image remained duplicated at the bottom of the assistant turn.

## Impact

Images inspected through `view_image` remain available in tool details, while the bottom-of-message gallery is reserved for images generated as final output.

## Validation

- `pnpm --filter wework exec vitest run src/components/chat/MessageList.test.tsx`
- `pnpm --filter wework typecheck`
- Prettier and ESLint on changed source, test, E2E, and documentation files
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --view-image-only`
- Full pre-push Wework ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images viewed through the image-viewing tool no longer appear incorrectly in the final generated-image gallery.
  * Final image galleries now include only images produced by image-generation actions.
  * Viewed images remain available in expandable tool details and previews.

* **Tests**
  * Added coverage to verify correct image display behavior for viewed images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->