### PR TITLE
fix(wework): stabilize on-demand app tools

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/en/wework/developer-guide/wework-cloud-model-proxy.md
@@ -70,6 +70,17 @@ Codex can group child tools under a `type: "namespace"` tool when it sends an Op
 
 The mapping is request-scoped protocol context. It is not persisted in model configuration and does not guess a namespace from the returned tool name. Tools with the same child name in different namespaces therefore continue to route to the correct executor.
 
+### On-Demand App Tool Expansion
+
+Wework must not inject the complete schemas of every App and browser child tool into the first model request of a new conversation. The Codex launch configuration enables Remote Apps and `tool_search`; the model searches for a required namespace first, and only tools returned by that search are added to later model requests:
+
+- Responses models with native Codex `tool_search` and namespace-tool support use the native protocol without redundant executor conversion.
+- For models using OpenAI Chat Completions, Anthropic Messages, or another protocol without namespace tools, the executor expands only namespaces matched by the current `tool_search` result. Tools from unmatched Apps must not enter the request.
+- The executor converts the active tool list, historical tool calls, tool results, and explicit `tool_choice` together, then restores the original namespace identity before returning events to Codex.
+- An ordinary message carries only the compact `tool_search` entry point. Adding Apps or browser tools must not make the initial request grow linearly with all tool schemas.
+
+Protocol-conversion E2E coverage must include Responses, Chat Completions, and Anthropic Messages. It verifies that the initial request contains no expanded namespace, only searched tools appear afterward, tool calls and results round-trip, and the initial serialized tool payload stays under a fixed size limit.
+
 ## Security Benefits
 
 - The Wework desktop client and local executor never receive the real provider `api_key`.

--- a/docs/en/wework/developer-guide/wework-embedded-browser.md
+++ b/docs/en/wework/developer-guide/wework-embedded-browser.md
@@ -60,6 +60,10 @@ Browser instances are bound by pane/task label:
 
 This binding keeps the browser the user sees and the browser the agent controls as the same object.
 
+A programmatic first open must treat "the panel was requested" and "the native WebView is ready for navigation" as separate phases. The bridge stores pending navigation with a request ID and executes it only after the browser host for that task has nonzero visible bounds and reaches the ready state. If the frontend listener registers after the request, it recovers the event from the pending-request snapshot. The tool may report success only after the native WebView has navigated to the requested URL, not merely because the right panel or a blank WebView was created.
+
+Close requests triggered by task switching or component unmounting must include the expected native label. A stale pane may close only the WebView it created; it must not close an instance that was relabeled or adopted by a replacement pane. An inactive task may prepare a hidden ready browser, but it cannot display that browser over the active task.
+
 ## Main-interface overlays and address synchronization
 
 The embedded browser is a separate native WebView, so the main React WebView cannot cover it with `z-index`. When a dialog, menu, listbox, or system-level overlay intersects the browser bounds, the browser panel must make the native WebView invisible and restore it after the overlay is removed or no longer intersects. Add `data-embedded-browser-occlusion` when a custom overlay cannot be identified through a semantic role or shared layer class; do not duplicate native visibility calls across feature components.
@@ -108,6 +112,8 @@ cargo test --manifest-path executor/Cargo.toml browser_mcp
 cargo test --manifest-path wework/src-tauri/Cargo.toml embedded_browser
 pnpm --filter wework e2e:desktop:embedded-browser
 ```
+
+`e2e:desktop:embedded-browser` must issue the first bridge `open` from a newly created local task and verify that it completes before the tool timeout, creates exactly one visible native host, and preserves the requested URL. A test that covers only a second open or manually exposes the browser panel first does not exercise the first-open race.
 
 When the browser change touches Tauri commands, native WebView behavior, IPC, or the Agent action path, also start an isolated real Tauri session with `pnpm --filter wework ai:verify start` and record evidence for opening a page, inspect, actions, and screenshot. If the full E2E is too slow locally, document why it was not run and make sure CI runs `e2e:desktop:embedded-browser`.
 

--- a/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-model-proxy.md
@@ -70,6 +70,17 @@ Codex 向 OpenAI Responses API 发送工具时，可以使用 `type: "namespace"
 
 这个映射属于单次模型请求的协议上下文，不写入模型配置，也不依赖根据工具名猜测 namespace。不同 namespace 中的同名工具仍能准确路由到各自的执行器。
 
+### App 工具按需展开
+
+Wework 不应在新会话的第一次模型请求中注入所有 App 和浏览器子工具的完整 schema。Codex 启动配置只启用 Remote Apps 和 `tool_search`，由模型先搜索需要的 namespace，再把搜索结果中的子工具加入后续模型请求：
+
+- 原生支持 Codex `tool_search` 和 namespace tools 的 Responses 模型直接使用原协议，executor 不重复转换。
+- OpenAI Chat Completions、Anthropic Messages 等不支持 namespace tools 的模型由 executor 在协议边界展开本次 `tool_search` 已命中的 namespace。未命中的 App 工具不能出现在请求中。
+- executor 必须同时转换当前工具列表、历史 tool call、tool result 和显式 `tool_choice`，并在返回 Codex 前恢复原 namespace 身份。
+- 普通消息只携带精简的 `tool_search` 入口；新增 App 或浏览器工具时，不得让首次请求大小随全部工具 schema 线性增长。
+
+协议转换 E2E 必须覆盖 Responses、Chat Completions 和 Anthropic Messages，验证首次请求未展开 namespace、搜索后只出现命中的工具、工具调用与结果可以往返，并对首次工具 JSON 大小设置上限。
+
 ## 安全收益
 
 - Wework 桌面端和本地 executor 永远不会拿到真实 provider `api_key`。

--- a/docs/zh/wework/developer-guide/wework-embedded-browser.md
+++ b/docs/zh/wework/developer-guide/wework-embedded-browser.md
@@ -60,6 +60,10 @@ Agent 面向模型暴露的是浏览器动作工具，而不是底层 WebKit API
 
 这种绑定保证“用户看到的浏览器”和“agent 控制的浏览器”是同一个对象。
 
+程序化首次打开必须把“面板已请求打开”和“原生 WebView 已可导航”视为两个不同阶段。bridge 应保存带 request ID 的待处理导航，等任务对应的浏览器宿主获得非零可见尺寸并进入 ready 状态后再执行；监听器晚于请求注册时，前端必须通过待处理请求快照恢复事件。只有原生 WebView 已导航到请求地址后才能向工具返回成功，不能仅因右侧面板或空白 WebView 已创建就报告成功。
+
+任务切换或组件卸载时，关闭请求必须携带预期的原生 label。过期 pane 只能关闭自己创建的 WebView，不能关闭已经迁移或由新 pane 接管的实例。非活跃任务可以提前创建隐藏且 ready 的浏览器，但不能显示在当前任务上方。
+
 ## 主界面浮层与地址栏同步
 
 嵌入式浏览器是独立的原生 WebView，不能通过主 React WebView 的 `z-index` 覆盖。当主界面的 dialog、menu、listbox 或系统级浮层与浏览器区域相交时，浏览器面板必须把原生 WebView 设为不可见；浮层移除或不再相交后再恢复显示。自定义浮层无法通过语义 role 或共享层级类识别时，应添加 `data-embedded-browser-occlusion`，不要在各业务组件中重复调用原生显示命令。
@@ -108,6 +112,8 @@ cargo test --manifest-path executor/Cargo.toml browser_mcp
 cargo test --manifest-path wework/src-tauri/Cargo.toml embedded_browser
 pnpm --filter wework e2e:desktop:embedded-browser
 ```
+
+`e2e:desktop:embedded-browser` 必须从新建本地任务执行第一次 bridge `open`，验证它在工具超时前完成、只产生一个可见原生宿主，并保留请求 URL。仅验证第二次打开或手工先展开浏览器面板不能覆盖首次打开竞态。
 
 浏览器涉及 Tauri 命令、原生 WebView、IPC 或 Agent 操作链路时，还应使用 `pnpm --filter wework ai:verify start` 启动隔离真实 Tauri 会话，并记录打开页面、inspect、动作和截图的验证证据。完整 E2E 太慢时，合并前至少要说明未运行的原因，并确保 CI 中的 `e2e:desktop:embedded-browser` 会覆盖该场景。
 

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -3170,11 +3170,6 @@ fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
         "features.non_prefixed_mcp_tool_names=true".to_owned(),
         format!(
             "{}={}",
-            toml_key_path(&["features", "code_mode", "direct_only_tool_namespaces",]),
-            toml_json_value(&json!([WEWORK_BROWSER_MCP_SERVER_NAME]))
-        ),
-        format!(
-            "{}={}",
             toml_key_path(&["mcp_servers", WEWORK_BROWSER_MCP_SERVER_NAME, "command"]),
             toml_value(&command.display().to_string())
         ),

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -2207,10 +2207,7 @@ fn codex_launch_config_includes_cdp_browser_mcp_server() {
         ])
     );
     assert_eq!(config["features.non_prefixed_mcp_tool_names"], true);
-    assert_eq!(
-        config["features.code_mode.direct_only_tool_namespaces"],
-        json!([WEWORK_BROWSER_MCP_SERVER_NAME])
-    );
+    assert!(!config.contains_key("features.code_mode.direct_only_tool_namespaces"));
     assert_eq!(
         config["mcp_servers.wework_browser.command"],
         env::current_exe().unwrap().display().to_string()

--- a/executor/src/browser_mcp/tests.rs
+++ b/executor/src/browser_mcp/tests.rs
@@ -114,6 +114,24 @@ async fn action_tool_schema_guides_index_ref_followup_actions() {
         .and_then(Value::as_str)
         .unwrap()
         .contains("browser_inspect"));
+    assert!(fill.pointer("/inputSchema/properties/url").is_none());
+    assert!(click.pointer("/inputSchema/properties/text").is_none());
+}
+
+#[tokio::test]
+async fn browser_tool_schemas_stay_compact() {
+    let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+    let response = handle_request(&reqwest::Client::new(), &request, 1, Instant::now())
+        .await
+        .unwrap();
+    let tools = response["result"]["tools"].as_array().unwrap();
+    let encoded = serde_json::to_vec(tools).unwrap();
+
+    assert!(
+        encoded.len() < 16 * 1024,
+        "browser tool schemas must remain compact, got {} bytes",
+        encoded.len()
+    );
 }
 
 #[test]

--- a/executor/src/browser_mcp/tests.rs
+++ b/executor/src/browser_mcp/tests.rs
@@ -52,6 +52,30 @@ async fn exposes_expected_browser_tools() {
 }
 
 #[tokio::test]
+async fn browser_open_schema_only_advertises_supported_arguments() {
+    let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+    let response = handle_request(&reqwest::Client::new(), &request, 1, Instant::now())
+        .await
+        .unwrap();
+    let browser_open = response["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["name"] == "browser_open")
+        .expect("browser_open tool");
+    let properties = browser_open["inputSchema"]["properties"]
+        .as_object()
+        .expect("browser_open properties");
+
+    assert_eq!(properties.keys().collect::<Vec<_>>(), vec!["url"]);
+    assert_eq!(browser_open["inputSchema"]["required"], json!(["url"]));
+    assert_eq!(
+        browser_open["inputSchema"]["additionalProperties"],
+        json!(false)
+    );
+}
+
+#[tokio::test]
 async fn action_tool_schema_guides_index_ref_followup_actions() {
     let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
     let response = handle_request(&reqwest::Client::new(), &request, 1, Instant::now())

--- a/executor/src/browser_mcp/tools.rs
+++ b/executor/src/browser_mcp/tools.rs
@@ -6,58 +6,104 @@ pub(crate) fn tools() -> Vec<Value> {
             "browser_open",
             "Open or navigate the Wework built-in browser to a URL.",
             &["url"],
+            &["url"],
         ),
         tool(
             "browser_inspect",
             "Return a compact structured page tree with numbered elements. Reuse known targets and inspect again only after page changes, unknown/stale targets, or for a final-page summary.",
+            &[
+                "mode",
+                "interactiveOnly",
+                "includeTextBlocks",
+                "includeHidden",
+                "maxNodes",
+                "maxTextChars",
+                "maxNameChars",
+                "maxValueChars",
+                "viewportMargin",
+                "timeoutMs",
+                "includeJson",
+            ],
             &[],
         ),
         tool(
             "browser_navigate",
             "Alias of browser_open for opening pages in Wegent's Wework desktop app.",
             &["url"],
+            &["url"],
         ),
         tool(
             "browser_open_and_inspect",
             "Open a URL, wait for page readiness, then return structured page inspection.",
+            &[
+                "url",
+                "condition",
+                "pollMs",
+                "quietMs",
+                "timeoutMs",
+                "inspectOptions",
+                "inspectTimeoutMs",
+                "includeJson",
+            ],
             &["url"],
         ),
         tool(
             "browser_snapshot",
             "Deprecated text-only page read. Use browser_inspect for structured page inspection and browser_take_screenshot for screenshots.",
+            &["includeJson"],
             &[],
         ),
         tool(
             "browser_click",
             "Click an element by inspect index/ref or a specific CSS selector. A requested click is complete only when this action succeeds.",
+            &["ref", "index", "inspectId", "selector", "timeoutMs", "includeJson"],
             &[],
         ),
         tool(
             "browser_click_coordinates",
             "Click viewport coordinates. Prefer an inspected index/ref when available.",
+            &["x", "y", "includeJson"],
             &["x", "y"],
         ),
         tool(
             "browser_type",
             "Append text to an editable element by inspect index/ref or CSS selector.",
+            &[
+                "ref",
+                "index",
+                "inspectId",
+                "selector",
+                "text",
+                "timeoutMs",
+                "includeJson",
+            ],
             &["text"],
         ),
         tool(
             "browser_fill",
             "Replace an editable element's value by inspect index/ref or CSS selector. Continue any separately requested click or submit action after filling.",
+            &[
+                "ref",
+                "index",
+                "inspectId",
+                "selector",
+                "text",
+                "timeoutMs",
+                "includeJson",
+            ],
             &["text"],
         ),
-        tool(
+        combined_target_tool(
             "browser_click_and_inspect",
             "Click an element, wait for page stability, then return structured page inspection.",
             &[],
         ),
-        tool(
+        combined_target_tool(
             "browser_fill_and_inspect",
             "Fill an editable element, wait for page stability, then return structured page inspection.",
             &["text"],
         ),
-        tool(
+        combined_target_tool(
             "browser_type_and_inspect",
             "Type into an editable element, wait for page stability, then return structured page inspection.",
             &["text"],
@@ -65,150 +111,197 @@ pub(crate) fn tools() -> Vec<Value> {
         tool(
             "browser_press_key",
             "Press a keyboard key on the target or focused element.",
+            &[
+                "ref",
+                "index",
+                "inspectId",
+                "selector",
+                "key",
+                "timeoutMs",
+                "includeJson",
+            ],
             &["key"],
         ),
-        tool("browser_hover", "Hover an element.", &[]),
-        tool("browser_focus", "Focus an element.", &[]),
-        tool("browser_scroll", "Scroll the current page.", &[]),
+        target_tool("browser_hover", "Hover an element."),
+        target_tool("browser_focus", "Focus an element."),
         tool(
-            "browser_scroll_into_view",
-            "Scroll an element into view.",
+            "browser_scroll",
+            "Scroll the current page.",
+            &[
+                "x",
+                "y",
+                "direction",
+                "amount",
+                "mode",
+                "timeoutMs",
+                "includeJson",
+            ],
             &[],
         ),
-        tool("browser_select_option", "Select option values.", &[]),
-        tool("browser_set_checked", "Set checkbox or radio checked state.", &[]),
-        tool("browser_wait_for", "Wait for page state.", &[]),
+        target_tool(
+            "browser_scroll_into_view",
+            "Scroll an element into view.",
+        ),
+        tool(
+            "browser_select_option",
+            "Select option values.",
+            &[
+                "ref",
+                "index",
+                "inspectId",
+                "selector",
+                "value",
+                "values",
+                "by",
+                "timeoutMs",
+                "includeJson",
+            ],
+            &[],
+        ),
+        tool(
+            "browser_set_checked",
+            "Set checkbox or radio checked state.",
+            &[
+                "ref",
+                "index",
+                "inspectId",
+                "selector",
+                "checked",
+                "timeoutMs",
+                "includeJson",
+            ],
+            &["checked"],
+        ),
+        tool(
+            "browser_wait_for",
+            "Wait for page state.",
+            &[
+                "text",
+                "selector",
+                "url",
+                "urlIncludes",
+                "urlMatches",
+                "titleIncludes",
+                "expression",
+                "waitUntil",
+                "condition",
+                "pollMs",
+                "quietMs",
+                "timeoutMs",
+                "includeJson",
+            ],
+            &[],
+        ),
         tool(
             "browser_wait_and_inspect",
             "Wait for page state, then return structured page inspection.",
+            &[
+                "text",
+                "selector",
+                "url",
+                "urlIncludes",
+                "urlMatches",
+                "titleIncludes",
+                "expression",
+                "waitUntil",
+                "condition",
+                "pollMs",
+                "quietMs",
+                "timeoutMs",
+                "inspectOptions",
+                "inspectTimeoutMs",
+                "includeJson",
+            ],
             &[],
         ),
         tool(
             "browser_resize",
             "Resize the embedded browser viewport.",
             &[],
+            &[],
         ),
         tool(
             "browser_take_screenshot",
             "Capture a screenshot only when the user explicitly requests one.",
             &[],
+            &[],
         ),
         tool(
             "browser_capabilities",
             "Report current embedded WKWebView browser capabilities and limits.",
+            &["includeJson"],
             &[],
         ),
         tool(
             "browser_native_input_probe",
             "Probe AppKit native input availability for the embedded browser.",
+            &["x", "y", "key", "text", "kind", "screenshotId", "includeJson"],
             &[],
         ),
         tool(
             "browser_ax_probe",
             "Probe macOS accessibility-tree availability for the embedded browser.",
+            &["mode", "maxNodes", "includeJson"],
             &[],
         ),
         tool(
             "browser_present_probe",
             "Report panel/popout WebView presentation and reparent capability.",
+            &["includeJson"],
             &[],
         ),
         tool(
             "browser_evaluate",
             "Evaluate read-only JavaScript for diagnostics. Use dedicated tools for page actions.",
-            &[],
+            &["expression", "includeJson"],
+            &["expression"],
         ),
     ]
 }
 
-fn tool(name: &str, description: &str, required: &[&str]) -> Value {
-    let mut properties = Map::new();
-    for key in [
-        "url",
-        "ref",
-        "element",
-        "text",
-        "value",
-        "key",
-        "selector",
-        "expression",
-        "function",
-        "fn",
-        "kind",
-        "screenshotId",
-        "inspectId",
-        "waitUntil",
-        "urlIncludes",
-        "urlMatches",
-        "titleIncludes",
-        "mode",
-        "by",
-        "direction",
-    ] {
-        properties.insert(key.to_owned(), json!({ "type": "string" }));
-    }
-    properties.insert(
-        "ref".to_owned(),
-        json!({
-            "type": "string",
-            "description": "Opaque element ref from browser_inspect, preferred for action targets."
-        }),
-    );
-    properties.insert(
-        "selector".to_owned(),
-        json!({
-            "type": "string",
-            "description": "CSS selector target. Prefer inspect ref or index; use a specific selector with the same action tool when a fresh ref/index is unavailable or resolves the wrong element."
-        }),
-    );
-    properties.insert(
-        "text".to_owned(),
-        json!({
-            "type": "string",
-            "description": "Text to type or fill into the target element."
-        }),
-    );
-    properties.insert(
-        "value".to_owned(),
-        json!({
-            "type": "string",
-            "description": "Alternative text/value argument for fill/select tools."
-        }),
-    );
-    for key in [
-        "x",
-        "y",
-        "amount",
-        "time",
-        "timeMs",
-        "timeoutMs",
-        "width",
-        "height",
-    ] {
-        properties.insert(key.to_owned(), json!({ "type": "number" }));
-    }
-    properties.insert(
-        "index".to_owned(),
-        json!({
-            "type": "integer",
-            "minimum": 0,
-            "description": "Element index from the latest browser_inspect result, for example 0 for [0] textbox."
-        }),
-    );
-    properties.insert("condition".to_owned(), json!({ "type": "object" }));
-    properties.insert("inspectOptions".to_owned(), json!({ "type": "object" }));
-    for key in [
-        "interactiveOnly",
-        "includeTextBlocks",
-        "includeHidden",
-        "checked",
-    ] {
-        properties.insert(key.to_owned(), json!({ "type": "boolean" }));
-    }
-    properties.insert(
-        "values".to_owned(),
-        json!({ "type": "array", "items": { "type": "string" } }),
-    );
+fn target_tool(name: &str, description: &str) -> Value {
+    tool(
+        name,
+        description,
+        &[
+            "ref",
+            "index",
+            "inspectId",
+            "selector",
+            "timeoutMs",
+            "includeJson",
+        ],
+        &[],
+    )
+}
+
+fn combined_target_tool(name: &str, description: &str, required: &[&str]) -> Value {
+    tool(
+        name,
+        description,
+        &[
+            "ref",
+            "index",
+            "inspectId",
+            "selector",
+            "text",
+            "condition",
+            "pollMs",
+            "quietMs",
+            "timeoutMs",
+            "inspectOptions",
+            "inspectTimeoutMs",
+            "includeJson",
+        ],
+        required,
+    )
+}
+
+fn tool(name: &str, description: &str, properties: &[&str], required: &[&str]) -> Value {
+    let properties = properties
+        .iter()
+        .map(|name| ((*name).to_owned(), property_schema(name)))
+        .collect::<Map<String, Value>>();
     json!({
         "name": name,
         "description": description,
@@ -216,7 +309,37 @@ fn tool(name: &str, description: &str, required: &[&str]) -> Value {
             "type": "object",
             "properties": properties,
             "required": required,
-            "additionalProperties": true
+            "additionalProperties": false
         }
     })
+}
+
+fn property_schema(name: &str) -> Value {
+    match name {
+        "ref" => json!({
+            "type": "string",
+            "description": "Opaque element ref from browser_inspect."
+        }),
+        "index" => json!({
+            "type": "integer",
+            "minimum": 0,
+            "description": "Element index from the latest browser_inspect result."
+        }),
+        "selector" => json!({
+            "type": "string",
+            "description": "CSS selector when no fresh inspect ref/index is available; use it with the same action tool."
+        }),
+        "text" => json!({ "type": "string" }),
+        "value" => json!({ "type": "string" }),
+        "values" => json!({ "type": "array", "items": { "type": "string" } }),
+        "checked" | "interactiveOnly" | "includeTextBlocks" | "includeHidden" | "includeJson" => {
+            json!({ "type": "boolean" })
+        }
+        "x" | "y" | "amount" | "maxNodes" | "maxTextChars" | "maxNameChars" | "maxValueChars"
+        | "viewportMargin" | "pollMs" | "quietMs" | "timeoutMs" | "inspectTimeoutMs" => {
+            json!({ "type": "number" })
+        }
+        "condition" | "inspectOptions" => json!({ "type": "object" }),
+        _ => json!({ "type": "string" }),
+    }
 }

--- a/executor/src/server/local_model_proxy/anthropic.rs
+++ b/executor/src/server/local_model_proxy/anthropic.rs
@@ -678,7 +678,19 @@ mod tests {
                     "call_id": "search_1",
                     "execution": "client",
                     "status": "completed",
-                    "tools": [{"namespace": "github", "name": "create_issue"}]
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "github",
+                        "tools": [{
+                            "type": "function",
+                            "name": "create_issue",
+                            "description": "Create an issue",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"title": {"type": "string"}}
+                            }
+                        }]
+                    }]
                 }
             ],
             "tools": [{
@@ -696,6 +708,7 @@ mod tests {
         let (converted, _) = responses_to_anthropic(&input).expect("request should convert");
 
         assert_eq!(converted["tools"][0]["name"], "tool_search");
+        assert_eq!(converted["tools"][1]["name"], "create_issue");
         assert_eq!(
             converted["tools"][0]["input_schema"]["required"],
             json!(["query"])

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -138,7 +138,8 @@ fn responses_to_chat_with_namespace_mode(
 ) -> Result<(Value, ToolContext), String> {
     let mut result = Map::new();
     copy_field(body, &mut result, "model", "model");
-    let context = build_tool_context(body, preserve_namespace);
+    let tools = effective_tools(body);
+    let context = build_tool_context(&tools, preserve_namespace);
     let mut messages = Vec::new();
 
     if let Some(instructions) = body.get("instructions") {
@@ -182,9 +183,9 @@ fn responses_to_chat_with_namespace_mode(
     }
     apply_reasoning_options(body, &mut result, kimi_k3_compat);
 
-    let tools = chat_tools(body, &context, kimi_k3_compat);
-    if !tools.is_empty() {
-        result.insert("tools".to_owned(), Value::Array(tools));
+    let converted_tools = chat_tools(&tools, &context, kimi_k3_compat);
+    if !converted_tools.is_empty() {
+        result.insert("tools".to_owned(), Value::Array(converted_tools));
         if let Some(choice) = body.get("tool_choice") {
             if choice != "auto" {
                 result.insert("tool_choice".to_owned(), chat_tool_choice(choice, &context));
@@ -200,12 +201,77 @@ fn copy_field(body: &Value, result: &mut Map<String, Value>, source: &str, targe
     }
 }
 
-fn build_tool_context(body: &Value, preserve_namespace: bool) -> ToolContext {
-    let tools = body
+fn effective_tools(body: &Value) -> Vec<Value> {
+    let mut tools = body
         .get("tools")
         .and_then(Value::as_array)
-        .map(Vec::as_slice)
+        .cloned()
         .unwrap_or_default();
+    for searched_tool in body
+        .get("input")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("tool_search_output"))
+        .flat_map(|item| {
+            item.get("tools")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+    {
+        merge_effective_tool(&mut tools, searched_tool);
+    }
+    tools
+}
+
+fn merge_effective_tool(tools: &mut Vec<Value>, searched_tool: &Value) {
+    let searched_type = searched_tool.get("type").and_then(Value::as_str);
+    if searched_type != Some("namespace") {
+        if !matches!(searched_type, Some("function" | "custom" | "tool_search")) {
+            return;
+        }
+        let searched_name = searched_tool.get("name").and_then(Value::as_str);
+        if !tools.iter().any(|tool| {
+            tool.get("type") == searched_tool.get("type")
+                && tool.get("name").and_then(Value::as_str) == searched_name
+        }) {
+            tools.push(searched_tool.clone());
+        }
+        return;
+    }
+
+    let Some(namespace) = searched_tool.get("name").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(existing) = tools.iter_mut().find(|tool| {
+        tool.get("type").and_then(Value::as_str) == Some("namespace")
+            && tool.get("name").and_then(Value::as_str) == Some(namespace)
+    }) else {
+        tools.push(searched_tool.clone());
+        return;
+    };
+    let Some(existing_tools) = existing.get_mut("tools").and_then(Value::as_array_mut) else {
+        *existing = searched_tool.clone();
+        return;
+    };
+    for inner_tool in searched_tool
+        .get("tools")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let inner_name = inner_tool.get("name").and_then(Value::as_str);
+        if !existing_tools
+            .iter()
+            .any(|tool| tool.get("name").and_then(Value::as_str) == inner_name)
+        {
+            existing_tools.push(inner_tool.clone());
+        }
+    }
+}
+
+fn build_tool_context(tools: &[Value], preserve_namespace: bool) -> ToolContext {
     let name_counts = tool_name_counts(tools);
 
     let mut context = ToolContext::default();
@@ -390,14 +456,9 @@ fn unique_wire_name(context: &ToolContext, preferred: String) -> String {
     unreachable!("an unused tool name suffix must exist")
 }
 
-fn chat_tools(body: &Value, context: &ToolContext, kimi_k3_compat: bool) -> Vec<Value> {
+fn chat_tools(tools: &[Value], context: &ToolContext, kimi_k3_compat: bool) -> Vec<Value> {
     let mut converted = Vec::new();
-    for tool in body
-        .get("tools")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-    {
+    for tool in tools {
         if tool.get("type").and_then(Value::as_str) == Some("tool_search") {
             if let Some(converted_tool) = chat_tool_search(tool, context, kimi_k3_compat) {
                 converted.push(converted_tool);
@@ -742,12 +803,18 @@ pub(super) fn responses_to_responses(
     native_namespace_tools: bool,
 ) -> Result<(Value, ToolContext), String> {
     let mut result = body.clone();
-    let context = build_tool_context(&result, true);
+    let effective_tools = effective_tools(&result);
+    let context = build_tool_context(&effective_tools, true);
     let bridge_tool_search = !native_tool_search;
     let bridge_namespace_tools = !native_namespace_tools;
 
     if let Some(tools) = result.get("tools").and_then(Value::as_array) {
         if !tools.is_empty() {
+            let tools = if bridge_namespace_tools {
+                effective_tools.as_slice()
+            } else {
+                tools.as_slice()
+            };
             result["tools"] = Value::Array(responses_tools(
                 tools,
                 &context,
@@ -2774,7 +2841,19 @@ mod tests {
                     "call_id": "search_1",
                     "execution": "client",
                     "status": "completed",
-                    "tools": [{"namespace": "github", "name": "create_issue"}]
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "github",
+                        "tools": [{
+                            "type": "function",
+                            "name": "create_issue",
+                            "description": "Create an issue",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"title": {"type": "string"}}
+                            }
+                        }]
+                    }]
                 }
             ],
             "tools": [{
@@ -2793,6 +2872,10 @@ mod tests {
 
         assert_eq!(converted["tools"][0]["type"], "function");
         assert_eq!(converted["tools"][0]["function"]["name"], "tool_search");
+        assert_eq!(
+            converted["tools"][1]["function"]["name"],
+            "github__create_issue"
+        );
         assert_eq!(
             converted["messages"][1]["tool_calls"][0]["function"]["name"],
             "tool_search"
@@ -3736,7 +3819,19 @@ mod tests {
                     "call_id": "search_1",
                     "execution": "client",
                     "status": "completed",
-                    "tools": [{"namespace": "github", "name": "create_issue"}]
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "github",
+                        "tools": [{
+                            "type": "function",
+                            "name": "create_issue",
+                            "description": "Create an issue",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"title": {"type": "string"}}
+                            }
+                        }]
+                    }]
                 },
                 {
                     "type": "function_call",
@@ -3756,17 +3851,6 @@ mod tests {
                         "properties": {"query": {"type": "string"}},
                         "required": ["query"]
                     }
-                },
-                {
-                    "type": "namespace",
-                    "name": "github",
-                    "description": "GitHub App",
-                    "tools": [{
-                        "type": "function",
-                        "name": "create_issue",
-                        "description": "Create an issue",
-                        "parameters": {"type": "object", "properties": {"title": {"type": "string"}}}
-                    }]
                 }
             ]
         });

--- a/executor/src/server/local_model_proxy/mod.rs
+++ b/executor/src/server/local_model_proxy/mod.rs
@@ -3770,9 +3770,10 @@ mod tests {
                                             == Some("app_1")
                                 })
                             });
-                            let loaded_app = body["tools"].as_array().is_some_and(|tools| {
-                                tools.iter().any(|tool| {
-                                    tool.get("type").and_then(Value::as_str) == Some("namespace")
+                            let loaded_app = body["input"].as_array().is_some_and(|items| {
+                                items.iter().any(|item| {
+                                    item.get("type").and_then(Value::as_str)
+                                        == Some("tool_search_output")
                                 })
                             });
                             request_tx.send(body).expect("request receiver");
@@ -3874,11 +3875,10 @@ mod tests {
             second_upstream["tools"]
                 .as_array()
                 .expect("second tools")
-                .iter()
-                .filter(|tool| tool.get("type").and_then(Value::as_str) == Some("namespace"))
-                .count(),
+                .len(),
             1
         );
+        assert_eq!(second_upstream["tools"][0]["type"], "tool_search");
         let second_response = String::from_utf8_lossy(&second_response);
         assert!(second_response.contains("\"namespace\":\"github\""));
         assert!(second_response.contains("\"name\":\"create_issue\""));
@@ -4283,7 +4283,7 @@ mod tests {
     }
 
     fn app_tool_search_request(include_loaded_app: bool) -> Value {
-        let mut tools = vec![json!({
+        let tools = vec![json!({
             "type": "tool_search",
             "execution": "client",
             "description": "Search available Apps",
@@ -4311,24 +4311,23 @@ mod tests {
                     "call_id": "search_1",
                     "execution": "client",
                     "status": "completed",
-                    "tools": [{"namespace": "github", "name": "create_issue"}]
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "github",
+                        "description": "GitHub App",
+                        "tools": [{
+                            "type": "function",
+                            "name": "create_issue",
+                            "description": "Create a GitHub issue",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"title": {"type": "string"}},
+                                "required": ["title"]
+                            }
+                        }]
+                    }]
                 }),
             ]);
-            tools.push(json!({
-                "type": "namespace",
-                "name": "github",
-                "description": "GitHub App",
-                "tools": [{
-                    "type": "function",
-                    "name": "create_issue",
-                    "description": "Create a GitHub issue",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"title": {"type": "string"}},
-                        "required": ["title"]
-                    }
-                }]
-            }));
         }
         json!({
             "model": "third-party-chat",

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -510,21 +510,42 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
           rightPanelShellWidth,
         })}`
       )
-      const openResult = await bridgeCall({
-        action: 'open',
-        url: fixtureUrl,
-        timeoutMs: 8_000,
-      })
-      assert.equal(openResult.ok, true, `Bridge open failed: ${JSON.stringify(openResult)}`)
-      await control.command('waitFor', BROWSER_INPUT_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await waitForControlValue(
-        control,
-        BROWSER_INPUT_SELECTOR,
-        fixtureUrl,
-        uiTimeoutMs,
-        'Bridge open did not show the fixture URL in the browser panel'
-      )
-      await control.command('waitFor', BROWSER_NATIVE_VIEW_SELECTOR, { timeoutMs: uiTimeoutMs })
+      for (let reopenAttempt = 1; reopenAttempt <= 2; reopenAttempt += 1) {
+        const closeResult = await bridgeCall({ action: 'close', timeoutMs: 8_000 })
+        assert.equal(
+          closeResult.ok,
+          true,
+          `Bridge close before reopen ${reopenAttempt} failed: ${JSON.stringify(closeResult)}`
+        )
+        const reopenStartedAt = Date.now()
+        const reopenResult = await bridgeCall({
+          action: 'open',
+          url: fixtureUrl,
+          timeoutMs: 8_000,
+        })
+        assert.equal(
+          reopenResult.ok,
+          true,
+          `Bridge reopen ${reopenAttempt} failed: ${JSON.stringify(reopenResult)}`
+        )
+        assert.ok(
+          Date.now() - reopenStartedAt < 8_000,
+          `Bridge reopen ${reopenAttempt} only completed after its tool timeout`
+        )
+        await waitForVisibleSingleElement(
+          control,
+          BROWSER_NATIVE_VIEW_SELECTOR,
+          8_000,
+          `Bridge reopen ${reopenAttempt} did not make exactly one active host visible`
+        )
+        await waitForControlValue(
+          control,
+          BROWSER_INPUT_SELECTOR,
+          fixtureUrl,
+          uiTimeoutMs,
+          `Bridge reopen ${reopenAttempt} did not preserve its URL in the browser panel`
+        )
+      }
       const readyWait = await bridgeCall({
         action: 'waitFor',
         options: { condition: { textVisible: READY_TEXT } },

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -6,9 +6,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
-const RIGHT_PANEL_TOGGLE_SELECTOR =
-  '[data-workspace-tab-portal-owner]:not([hidden]) [data-testid="toggle-right-workspace-panel-button"]'
-const RIGHT_BROWSER_OPTION_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-browser-option"]`
 const BROWSER_INPUT_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-url-input"]`
 const BROWSER_AGENT_STATUS_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-status"]`
 const BROWSER_AGENT_PAUSE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-pause-button"]`
@@ -25,6 +22,9 @@ const CLICKED_TEXT = 'clicked: Alpha Beta'
 const DIRECT_FILLED_TEXT = 'filled: Gamma Delta'
 const DIRECT_CLICKED_TEXT = 'clicked: Gamma Delta'
 const DIRECT_DELETED_TEXT = 'deleted: Gamma Delta'
+const EMBEDDED_BROWSER_SETUP_PROMPT =
+  'WEWORK_DESKTOP_E2E_EMBEDDED_BROWSER_SETUP: create a local task before opening the browser.'
+const EMBEDDED_BROWSER_SETUP_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_EMBEDDED_BROWSER_SETUP_COMPLETE'
 const HOVER_TEXT = 'hovered'
 const SELECT_TEXT = 'selected: finance'
 const CHECKED_TEXT = 'checked: true'
@@ -41,7 +41,7 @@ const BROWSER_MORE_BUTTON_SELECTOR = '[data-testid="workspace-browser-more-butto
 const BROWSER_CLEAR_DATA_SELECTOR = '[data-testid="workspace-browser-clear-data-item"]'
 const BROWSER_CLEAR_COOKIES_SELECTOR = '[data-testid="workspace-browser-clear-cookies-item"]'
 const BROWSER_CLEAR_CACHE_SELECTOR = '[data-testid="workspace-browser-clear-cache-item"]'
-const BROWSER_NATIVE_VIEW_SELECTOR = '[data-testid="workspace-browser-native-view"]'
+const BROWSER_NATIVE_VIEW_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-native-view"]`
 const BROWSER_CLEAR_STARTED_TEXT = '开始清除浏览数据'
 const BROWSER_CLEAR_COMPLETED_TEXT = '浏览数据已清除'
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -214,7 +214,59 @@ async function waitForControlValue(control, selector, expected, timeoutMs, messa
   throw new Error(message)
 }
 
-async function withBrowserMcp(identity, callback) {
+async function waitForVisibleSingleElement(control, selector, timeoutMs, message) {
+  const startedAt = Date.now()
+  let metrics = []
+  while (Date.now() - startedAt < timeoutMs) {
+    metrics = JSON.parse(await control.command('getElementMetrics', selector))
+    if (metrics.length === 1 && metrics[0].width > 1 && metrics[0].height > 1) {
+      return metrics[0]
+    }
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+  const diagnostics = {
+    activeWorkbench: JSON.parse(
+      await control.command('getElementMetrics', ACTIVE_WORKBENCH_SELECTOR)
+    ),
+    browserHost: metrics,
+    browserPanel: JSON.parse(
+      await control.command(
+        'getElementMetrics',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-panel"]`
+      )
+    ),
+    rightPanelShell: JSON.parse(
+      await control.command(
+        'getElementMetrics',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`
+      )
+    ),
+    rightPanelShellAriaHidden: await control.command(
+      'getAttribute',
+      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`,
+      { value: 'aria-hidden' }
+    ),
+    rightPanelShellWidth: await control.command(
+      'getInlineStyle',
+      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`,
+      { value: 'width' }
+    ),
+  }
+  throw new Error(`${message}: ${JSON.stringify(diagnostics)}`)
+}
+
+async function waitForRuntimeTaskId(control, timeoutMs) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const snapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    const taskId = snapshot.workbench?.currentRuntimeTask?.taskId
+    if (taskId) return taskId
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error('Timed out waiting for the embedded-browser setup to create a local task')
+}
+
+async function withBrowserMcp(identity, label, callback) {
   const executorPath =
     process.env.WEWORK_E2E_EXECUTOR_BIN ||
     join(
@@ -231,7 +283,7 @@ async function withBrowserMcp(identity, callback) {
       WEWORK_EMBEDDED_BROWSER_BRIDGE_URL: identity.baseUrl,
       WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN: identity.token,
       WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE: identity.runtimePath,
-      WEWORK_EMBEDDED_BROWSER_LABEL: BROWSER_LABEL,
+      WEWORK_EMBEDDED_BROWSER_LABEL: label,
     },
     stdio: ['pipe', 'pipe', 'pipe'],
   })
@@ -366,10 +418,70 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
     async verify(control) {
       const fixtureUrl = `${control.url}${FIXTURE_PATH}`
       const redirectUrl = `${control.url}${REDIRECT_PATH}`
-      await control.command('waitFor', RIGHT_PANEL_TOGGLE_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await control.command('click', RIGHT_PANEL_TOGGLE_SELECTOR)
-      await control.command('click', RIGHT_BROWSER_OPTION_SELECTOR)
+      control.setScenario('embedded_browser_setup')
+      await control.command(
+        'waitFor',
+        '[data-testid="chat-message-input"][contenteditable="true"]',
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await control.command('fill', '[data-testid="chat-message-input"][contenteditable="true"]', {
+        value: EMBEDDED_BROWSER_SETUP_PROMPT,
+      })
+      await control.command('press', '[data-testid="chat-message-input"][contenteditable="true"]', {
+        key: 'Enter',
+      })
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: EMBEDDED_BROWSER_SETUP_COMPLETION_TEXT,
+        timeoutMs: uiTimeoutMs,
+      })
+      const taskId = await waitForRuntimeTaskId(control, uiTimeoutMs)
+      const browserLabel = await control.command(
+        'getAttribute',
+        `${ACTIVE_WORKBENCH_SELECTOR} [data-embedded-browser-label]`,
+        { value: 'data-embedded-browser-label' }
+      )
+      assert.equal(
+        browserLabel,
+        `workspace-browser-${taskId.replace(/[^a-zA-Z0-9_-]/g, '-')}`,
+        'The fresh local task did not expose its task-scoped embedded browser label'
+      )
+      const bridgeIdentity = await waitForBridgeIdentity(executorHome, uiTimeoutMs)
+      const bridgeCall = payload => callBridge(bridgeIdentity, { label: browserLabel, ...payload })
+      const firstOpenStartedAt = Date.now()
+      const firstOpenPromise = bridgeCall({
+        action: 'open',
+        url: fixtureUrl,
+        timeoutMs: 8_000,
+      })
+      const [firstOpenResult] = await Promise.all([
+        firstOpenPromise,
+        waitForVisibleSingleElement(
+          control,
+          BROWSER_NATIVE_VIEW_SELECTOR,
+          8_000,
+          'The first bridge open did not make exactly one active host visible'
+        ),
+      ])
+      assert.equal(
+        firstOpenResult.ok,
+        true,
+        `The first bridge open from a fresh task failed: ${JSON.stringify(firstOpenResult)}`
+      )
+      assert.ok(
+        Date.now() - firstOpenStartedAt < 8_000,
+        'The first bridge open only completed after its tool timeout'
+      )
       await control.command('waitFor', BROWSER_INPUT_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await waitForControlValue(
+        control,
+        BROWSER_INPUT_SELECTOR,
+        fixtureUrl,
+        uiTimeoutMs,
+        'The first bridge open did not preserve its URL in the browser panel'
+      )
+      await control.command('waitFor', BROWSER_NATIVE_VIEW_SELECTOR, { timeoutMs: uiTimeoutMs })
       await control.command('finishAnimations', 'body')
       const browserPanelMetrics = JSON.parse(
         await control.command(
@@ -398,21 +510,6 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
           rightPanelShellWidth,
         })}`
       )
-      await control.command('fill', BROWSER_INPUT_SELECTOR, { value: fixtureUrl })
-      await waitForControlValue(
-        control,
-        BROWSER_INPUT_SELECTOR,
-        fixtureUrl,
-        uiTimeoutMs,
-        'Browser URL input did not receive fixture URL before submit'
-      )
-      await control.command('submit', BROWSER_INPUT_SELECTOR)
-      const bridgeIdentity = await waitForBridgeIdentity(executorHome, uiTimeoutMs)
-      const bridgeCall = payload => callBridge(bridgeIdentity, payload)
-      // A bridge open adopts the pane-derived label created by the UI submit
-      // (the frontend relabels the existing webview to the fixed bridge
-      // label), so later bridge calls and agent-state events resolve to the
-      // same logical browser.
       const openResult = await bridgeCall({
         action: 'open',
         url: fixtureUrl,
@@ -532,7 +629,7 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
       assert.equal(cacheResourceRequests, 2, 'Cache clear did not force a resource request')
 
       await writeStaleBridgeRuntime(bridgeIdentity)
-      const mcpResult = await withBrowserMcp(bridgeIdentity, async callTool => {
+      const mcpResult = await withBrowserMcp(bridgeIdentity, browserLabel, async callTool => {
         const openText = await callTool('browser_open_and_inspect', {
           url: redirectUrl,
           inspectOptions: { interactiveOnly: false, includeTextBlocks: true, maxNodes: 80 },

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -175,20 +175,20 @@ async function writeStaleBridgeRuntime(identity) {
   )
 }
 
-async function callBridge(identity, payload) {
-  const body = await callBridgeResponse(identity, payload)
+async function callBridge(identity, payload, label = BROWSER_LABEL) {
+  const body = await callBridgeResponse(identity, payload, label)
   assert.equal(body.ok, true, `Bridge action failed: ${JSON.stringify(body)}`)
   return body.data
 }
 
-async function callBridgeResponse(identity, payload) {
+async function callBridgeResponse(identity, payload, label = BROWSER_LABEL) {
   const response = await fetch(`${identity.baseUrl}/browser`, {
     method: 'POST',
     headers: {
       authorization: `Bearer ${identity.token}`,
       'content-type': 'application/json',
     },
-    body: JSON.stringify({ label: BROWSER_LABEL, ...payload }),
+    body: JSON.stringify({ label, ...payload }),
   })
   const body = await response.json()
   assert.equal(response.ok, true, `Bridge HTTP failed: ${JSON.stringify(body)}`)
@@ -878,9 +878,13 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         assert.ok(screenshotResult.path.endsWith('.png'))
       } else {
         assert.equal(capabilities.screenshot.viewport, false)
-        const screenshotResponse = await callBridgeResponse(bridgeIdentity, {
-          action: 'screenshot',
-        })
+        const screenshotResponse = await callBridgeResponse(
+          bridgeIdentity,
+          {
+            action: 'screenshot',
+          },
+          browserLabel
+        )
         assert.equal(screenshotResponse.ok, false)
         assert.equal(
           screenshotResponse.error,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -97,6 +97,9 @@ const GUIDANCE_SCROLL_RESPONSE = [
 const GUIDANCE_SCROLL_MESSAGE = 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_MESSAGE'
 const GUIDANCE_SCROLL_PRE_TOOL_TEXT = 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_PRE_TOOL_TEXT'
 const GUIDANCE_SCROLL_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_GUIDANCE_SCROLL_COMPLETE'
+const EMBEDDED_BROWSER_SETUP_PROMPT =
+  'WEWORK_DESKTOP_E2E_EMBEDDED_BROWSER_SETUP: create a local task before opening the browser.'
+const EMBEDDED_BROWSER_SETUP_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_EMBEDDED_BROWSER_SETUP_COMPLETE'
 const QUEUE_DIRECT_INITIAL = 'WEWORK_DESKTOP_E2E_QUEUE_DIRECT_INITIAL'
 const QUEUE_DIRECT_FIRST = 'WEWORK_DESKTOP_E2E_QUEUE_DIRECT_FIRST'
 const QUEUE_DIRECT_SECOND = 'WEWORK_DESKTOP_E2E_QUEUE_DIRECT_SECOND'
@@ -7864,17 +7867,40 @@ function selectMcpTool(request, namespaceName, toolName, argumentsValue) {
   return { namespace: namespace.name, name: tool.name, arguments: argumentsValue }
 }
 
+function selectConvertedTool(request, toolName, argumentsValue) {
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  const names = tools.map(tool => tool?.name ?? tool?.function?.name).filter(Boolean)
+  const name = names.find(
+    candidate => candidate === toolName || candidate.endsWith(`__${toolName}`)
+  )
+  assert.ok(name, `Converted request did not expose ${toolName}: ${names.join(', ')}`)
+  return { name, arguments: argumentsValue }
+}
+
 function selectToolSearch(request, query) {
   const tools = Array.isArray(request.tools) ? request.tools : []
+  const toolNames = tools.map(tool => tool?.name ?? tool?.function?.name).filter(Boolean)
   const searchTools = tools.filter(
     tool =>
-      tool?.type === 'tool_search' || (tool?.type === 'function' && tool.name === 'tool_search')
+      tool?.type === 'tool_search' ||
+      (tool?.type === 'function' &&
+        (tool?.name === 'tool_search' || tool?.function?.name === 'tool_search'))
   )
   assert.equal(searchTools.length, 1, 'Real Codex did not advertise exactly one tool_search tool')
   assert.equal(
     tools.some(tool => tool?.type === 'namespace'),
     false,
     'Real Codex eagerly advertised namespace tools before tool_search'
+  )
+  assert.equal(
+    toolNames.some(name => name.startsWith('browser_')),
+    false,
+    `Real Codex eagerly advertised Wework browser tools before tool_search: ${toolNames.join(', ')}`
+  )
+  const encodedTools = Buffer.byteLength(JSON.stringify(tools))
+  assert.ok(
+    encodedTools < 32 * 1024,
+    `Real Codex first-turn tool payload exceeded 32 KiB: ${encodedTools} bytes`
   )
   return { query, limit: 8 }
 }
@@ -8916,6 +8942,7 @@ class DesktopE2EServer {
     this.matrixCase = null
     this.matrixState = null
     this.toolLessPrewarmHandled = false
+    this.embeddedBrowserSetupToolLessPrewarmHandled = false
     this.viewImageToolLessPrewarmHandled = false
     this.memoryToolLessPrewarmHandled = false
     this.cloudToolLessPrewarmHandled = false
@@ -9190,6 +9217,7 @@ class DesktopE2EServer {
     assert.ok(
       [
         'initial',
+        'embedded_browser_setup',
         'follow_up',
         'running_fork_follow_up',
         'fork_follow_up',
@@ -10072,6 +10100,16 @@ class DesktopE2EServer {
     }
 
     if (
+      this.scenario === 'embedded_browser_setup' &&
+      !this.embeddedBrowserSetupToolLessPrewarmHandled &&
+      !requestAdvertisesShellTool(body)
+    ) {
+      this.embeddedBrowserSetupToolLessPrewarmHandled = true
+      this.writeSse(response, [responseCreated(responseId), responseCompleted(responseId)])
+      return
+    }
+
+    if (
       this.scenario === 'view_image' &&
       this.viewImageStage === 'initial' &&
       !this.viewImageToolLessPrewarmHandled &&
@@ -10261,6 +10299,20 @@ class DesktopE2EServer {
         ...functionCall('wework-e2e-tool-call', tool.name, tool.arguments),
         ...functionCall('wework-e2e-view-image', image.name, image.arguments),
         customToolCall('wework-e2e-apply-patch', 'apply_patch', patch),
+        responseCompleted(responseId),
+      ])
+      return
+    }
+
+    if (this.scenario === 'embedded_browser_setup') {
+      this.recordScenarioRequest('embedded_browser_setup', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(EMBEDDED_BROWSER_SETUP_PROMPT),
+        'The embedded-browser setup request lost its local-task prompt'
+      )
+      this.writeSse(response, [
+        responseCreated(responseId),
+        assistantMessage(EMBEDDED_BROWSER_SETUP_COMPLETION_TEXT),
         responseCompleted(responseId),
       ])
       return
@@ -11738,14 +11790,27 @@ class DesktopE2EServer {
         excludes: [followUpPrompt],
       })
       this.assertLocalApplyPatchTool(model, body)
-      this.assertLocalNamespaceTools(model, body)
-      if (model.protocol !== 'responses') {
-        state.stage = 'awaiting_namespace_tool_output'
-        this.writeLocalNamespaceToolCall(response, model)
-        return
+      const argumentsValue = selectToolSearch(body, 'Wework browser open')
+      state.stage = 'awaiting_browser_search_output'
+      this.writeLocalToolSearchCall(response, model, argumentsValue)
+      return
+    }
+    if (state.stage === 'awaiting_browser_search_output') {
+      this.assertLocalConversation(model, body, {
+        includes: [],
+        excludes: [followUpPrompt],
+      })
+      this.assertLocalApplyPatchTool(model, body)
+      const browserArguments = {
+        timeoutMs: 5000,
+        url: this.url,
+        waitUntil: 'domcontentloaded',
       }
-      state.stage = 'awaiting_tool_output'
-      this.writeLocalToolCall(response, model, localProtocolPatch(model))
+      selectMcpTool(body, 'wework_browser', 'browser_open', browserArguments)
+      const browserTool = selectConvertedTool(body, 'browser_open', browserArguments)
+      this.assertLocalNamespaceTools(model, body)
+      state.stage = 'awaiting_namespace_tool_output'
+      this.writeLocalNamespaceToolCall(response, model, browserTool)
       return
     }
     if (state.stage === 'awaiting_namespace_tool_output') {
@@ -11955,14 +12020,13 @@ class DesktopE2EServer {
   }
 
   assertLocalNamespaceTools(model, body) {
-    if (model.protocol === 'responses') return
     const tools = Array.isArray(body.tools) ? body.tools : []
     const names = tools
       .map(candidate => candidate?.name ?? candidate?.function?.name)
       .filter(Boolean)
 
     assert.ok(
-      names.includes('browser_snapshot'),
+      names.some(name => name === 'browser_open' || name.endsWith('__browser_open')),
       `${model.protocol} did not flatten the wework_browser namespace: ${names.join(', ')}`
     )
     assert.equal(
@@ -11975,33 +12039,54 @@ class DesktopE2EServer {
   assertLocalNamespaceToolOutput(model, body) {
     const serialized = JSON.stringify(body)
     assert.equal(
-      serialized.includes('unsupported function call: browser_snapshot'),
+      serialized.includes('unsupported function call: browser_open'),
       false,
       `${model.protocol} did not restore the wework_browser namespace on the tool call`
     )
 
+    if (model.protocol === 'responses') {
+      const call = body.input?.find(
+        item =>
+          item?.type === 'function_call' &&
+          (item?.name === 'browser_open' || item?.name?.endsWith('__browser_open'))
+      )
+      assert.ok(call, 'Responses lost the flattened browser_open call history')
+      assert.ok(
+        body.input?.some(
+          item => item?.type === 'function_call_output' && item?.call_id === call?.call_id
+        ),
+        'Responses lost the namespaced browser_open result'
+      )
+      return
+    }
     if (model.protocol === 'chat') {
       const call = body.messages
         ?.flatMap(message => message?.tool_calls ?? [])
-        .find(candidate => candidate?.function?.name === 'browser_snapshot')
-      assert.ok(call, 'Chat lost the flattened browser_snapshot call history')
+        .find(
+          candidate =>
+            candidate?.function?.name === 'browser_open' ||
+            candidate?.function?.name?.endsWith('__browser_open')
+        )
+      assert.ok(call, 'Chat lost the flattened browser_open call history')
       assert.ok(
         body.messages?.some(
           message => message?.role === 'tool' && message?.tool_call_id === call?.id
         ),
-        'Chat lost the namespaced browser_snapshot result'
+        'Chat lost the namespaced browser_open result'
       )
       return
     }
 
     const blocks = body.messages?.flatMap(message => message?.content ?? []) ?? []
     const call = blocks.find(
-      block => block?.type === 'tool_use' && block?.name === 'browser_snapshot'
+      block =>
+        block?.type === 'tool_use' &&
+        (block?.name === 'browser_open' || block?.name?.endsWith('__browser_open'))
     )
-    assert.ok(call, 'Anthropic lost the flattened browser_snapshot call history')
+    assert.ok(call, 'Anthropic lost the flattened browser_open call history')
     assert.ok(
       blocks.some(block => block?.type === 'tool_result' && block?.tool_use_id === call?.id),
-      'Anthropic lost the namespaced browser_snapshot result'
+      'Anthropic lost the namespaced browser_open result'
     )
   }
 
@@ -12197,13 +12282,40 @@ class DesktopE2EServer {
     this.writeAnthropicToolCall(response, patch)
   }
 
-  writeLocalNamespaceToolCall(response, model) {
-    const callId = `${model.protocol}-local-browser-snapshot`
-    if (model.protocol === 'chat') {
-      this.writeChatToolCall(response, {}, callId, 'browser_snapshot')
+  writeLocalToolSearchCall(response, model, argumentsValue) {
+    const callId = `${model.protocol}-local-browser-search`
+    if (model.protocol === 'responses') {
+      const id = `local-${model.protocol}-browser-search`
+      this.writeSse(response, [
+        responseCreated(id),
+        ...functionCall(callId, 'tool_search', argumentsValue),
+        responseCompleted(id),
+      ])
       return
     }
-    this.writeAnthropicToolCall(response, {}, callId, 'browser_snapshot')
+    if (model.protocol === 'chat') {
+      this.writeChatToolCall(response, argumentsValue, callId, 'tool_search')
+      return
+    }
+    this.writeAnthropicToolCall(response, argumentsValue, callId, 'tool_search')
+  }
+
+  writeLocalNamespaceToolCall(response, model, tool) {
+    const callId = `${model.protocol}-local-browser-open`
+    if (model.protocol === 'responses') {
+      const id = `local-${model.protocol}-browser-open`
+      this.writeSse(response, [
+        responseCreated(id),
+        ...functionCall(callId, tool.name, tool.arguments),
+        responseCompleted(id),
+      ])
+      return
+    }
+    if (model.protocol === 'chat') {
+      this.writeChatToolCall(response, tool.arguments, callId, tool.name)
+      return
+    }
+    this.writeAnthropicToolCall(response, tool.arguments, callId, tool.name)
   }
 
   writeLocalAssistantMessage(response, model, text) {

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -7886,7 +7886,7 @@ function selectToolSearch(request, query) {
     'Real Codex eagerly advertised namespace tools before tool_search'
   )
   assert.equal(
-    toolNames.some(name => name.startsWith('browser_')),
+    toolNames.some(name => /(^|__)browser_/.test(name)),
     false,
     `Real Codex eagerly advertised Wework browser tools before tool_search: ${toolNames.join(', ')}`
   )
@@ -11794,11 +11794,7 @@ class DesktopE2EServer {
         excludes: [followUpPrompt],
       })
       this.assertLocalApplyPatchTool(model, body)
-      const browserArguments = {
-        timeoutMs: 5000,
-        url: this.url,
-        waitUntil: 'domcontentloaded',
-      }
+      const browserArguments = { url: this.url }
       selectMcpTool(body, 'wework_browser', 'browser_open', browserArguments)
       const browserTool = selectConvertedTool(body, 'browser_open', browserArguments)
       this.assertLocalNamespaceTools(model, body)

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -7176,18 +7176,11 @@ async function verifySideChatAttachmentIsolation({
   await control.command('click', '[data-testid="right-workspace-chat-option"]')
   await control.command('waitFor', sideComposerSelector, { timeoutMs: DEFAULT_STEP_TIMEOUT_MS })
 
-  const workbenchWidth = Number.parseFloat(
-    await control.command('getStyle', ACTIVE_WORKBENCH_SELECTOR, { value: 'width' })
-  )
-  const panelWidthStyle = await control.command('getInlineStyle', rightPanelShellSelector, {
-    value: 'width',
-  })
-  const chatWidthMatch = panelWidthStyle.match(/^calc\(100% - ([\d.]+)px\)$/)
-  assert.ok(chatWidthMatch, `Unexpected right-panel width style: ${panelWidthStyle}`)
-  const panelWidth = workbenchWidth - Number.parseFloat(chatWidthMatch[1])
-  assert.ok(
-    panelWidth >= 400 && panelWidth <= 440,
-    `The temporary-chat-only right panel was ${panelWidth}px wide instead of about 420px`
+  await waitForElementWidth(
+    control,
+    rightPanelShellSelector,
+    width => width >= 400 && width <= 440,
+    'The temporary-chat-only right panel'
   )
   await captureVerificationScreenshot(control, '01-side-chat-compact-width.png')
 

--- a/wework/src-tauri/src/embedded_browser.rs
+++ b/wework/src-tauri/src/embedded_browser.rs
@@ -540,11 +540,10 @@ fn should_replay_browser_open_request(
     attempt: u64,
     readiness: Option<EmbeddedBrowserReadiness>,
 ) -> bool {
-    attempt > 0
-        && readiness.is_none()
-        && attempt
-            .checked_mul(BRIDGE_OPEN_WAIT_INTERVAL_MS)
-            .is_some_and(|elapsed_ms| elapsed_ms % BRIDGE_OPEN_REQUEST_REPLAY_INTERVAL_MS == 0)
+    let replay_stride = BRIDGE_OPEN_REQUEST_REPLAY_INTERVAL_MS
+        .div_ceil(BRIDGE_OPEN_WAIT_INTERVAL_MS)
+        .max(1);
+    attempt > 0 && readiness.is_none() && attempt % replay_stride == 0
 }
 
 fn relabel_logical_entry<T>(
@@ -1391,16 +1390,16 @@ pub async fn embedded_browser_open(
             .lock()
             .map_err(|_| "Embedded browser state lock poisoned".to_string())?;
         match webviews.get(&label) {
-            Some(entry) if entry.readiness() == EmbeddedBrowserReadiness::Ready => {
-                Some(entry.clone())
+            Some(entry) if matches!(&entry.phase, EmbeddedBrowserPhase::Opening) => {
+                return Err(EMBEDDED_BROWSER_NOT_READY_ERROR.to_string());
             }
-            Some(_) => return Err(EMBEDDED_BROWSER_NOT_READY_ERROR.to_string()),
+            Some(entry) => Some(entry.clone()),
             None => None,
         }
     };
 
     if let Some(entry) = existing {
-        let webview = entry.ready_webview()?;
+        let webview = entry.available_webview()?;
         apply_webview_bounds(&webview, normalized_bounds)?;
         log_embedded_browser_diagnostic(
             &state,
@@ -1451,6 +1450,11 @@ pub async fn embedded_browser_open(
         update_entry_for_native_label(&state, &entry.native_label, |entry| {
             entry.url = Some(url.clone());
             entry.title = initial_title_for_entry;
+            entry.phase = if bridge_ready {
+                EmbeddedBrowserPhase::Ready(webview.clone())
+            } else {
+                EmbeddedBrowserPhase::Hidden(webview.clone())
+            };
         })?;
         log_embedded_browser_diagnostic(
             &state,

--- a/wework/src-tauri/src/embedded_browser.rs
+++ b/wework/src-tauri/src/embedded_browser.rs
@@ -73,6 +73,7 @@ const BRIDGE_READ_TIMEOUT_MS: u64 = 5_000;
 const BRIDGE_EVAL_TIMEOUT_MS: u64 = 10_000;
 const BRIDGE_OPEN_WAIT_TIMEOUT_MS: u64 = 15_000;
 const BRIDGE_OPEN_WAIT_INTERVAL_MS: u64 = 100;
+const BRIDGE_OPEN_REQUEST_REPLAY_INTERVAL_MS: u64 = 500;
 const EMBEDDED_BROWSER_PLACEHOLDER_URL: &str = "about:blank";
 const EMBEDDED_BROWSER_OPEN_REQUEST_EVENT: &str = "wework:embedded-browser-open-request";
 const EMBEDDED_BROWSER_DOWNLOAD_EVENT: &str = "wework:embedded-browser-download";
@@ -93,6 +94,7 @@ const EMBEDDED_BROWSER_WAIT_SCRIPT: &str = include_str!("embedded_browser_wait.j
 static EMBEDDED_BROWSER_DOWNLOAD_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static EMBEDDED_BROWSER_BRIDGE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static EMBEDDED_BROWSER_NATIVE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static EMBEDDED_BROWSER_OPEN_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static EMBEDDED_BROWSER_SCREENSHOT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static EMBEDDED_BROWSER_POPUP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 
@@ -103,6 +105,7 @@ pub struct EmbeddedBrowserState {
     preview_sources: Arc<Mutex<HashMap<String, String>>>,
     agent_control_paused: Arc<Mutex<HashMap<String, bool>>>,
     agent_approvals: Arc<Mutex<HashMap<String, EmbeddedBrowserApprovalState>>>,
+    pending_open_requests: Arc<Mutex<HashMap<String, EmbeddedBrowserOpenRequest>>>,
     lifecycle: Arc<AsyncMutex<()>>,
 }
 
@@ -118,6 +121,7 @@ struct EmbeddedBrowserEntry {
 #[derive(Clone)]
 enum EmbeddedBrowserPhase {
     Opening,
+    Hidden(Webview<Wry>),
     Ready(Webview<Wry>),
 }
 
@@ -138,6 +142,7 @@ impl EmbeddedBrowserEntry {
     fn readiness(&self) -> EmbeddedBrowserReadiness {
         match &self.phase {
             EmbeddedBrowserPhase::Opening => EmbeddedBrowserReadiness::Opening,
+            EmbeddedBrowserPhase::Hidden(_) => EmbeddedBrowserReadiness::Opening,
             EmbeddedBrowserPhase::Ready(_) => EmbeddedBrowserReadiness::Ready,
         }
     }
@@ -145,6 +150,17 @@ impl EmbeddedBrowserEntry {
     fn ready_webview(&self) -> Result<Webview<Wry>, String> {
         match &self.phase {
             EmbeddedBrowserPhase::Ready(webview) => Ok(webview.clone()),
+            EmbeddedBrowserPhase::Opening | EmbeddedBrowserPhase::Hidden(_) => {
+                Err(EMBEDDED_BROWSER_NOT_READY_ERROR.to_string())
+            }
+        }
+    }
+
+    fn available_webview(&self) -> Result<Webview<Wry>, String> {
+        match &self.phase {
+            EmbeddedBrowserPhase::Hidden(webview) | EmbeddedBrowserPhase::Ready(webview) => {
+                Ok(webview.clone())
+            }
             EmbeddedBrowserPhase::Opening => Err(EMBEDDED_BROWSER_NOT_READY_ERROR.to_string()),
         }
     }
@@ -207,7 +223,8 @@ struct EmbeddedBrowserBridgeResponse {
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct EmbeddedBrowserOpenRequest {
+pub struct EmbeddedBrowserOpenRequest {
+    request_id: u64,
     url: String,
     label: String,
 }
@@ -482,6 +499,18 @@ fn ready_logical_entry<'a, T>(
     }
 }
 
+fn available_logical_entry<'a, T>(
+    entries: &'a HashMap<String, T>,
+    logical_label: &str,
+    available: impl Fn(&T) -> bool,
+) -> Result<&'a T, String> {
+    match entries.get(logical_label) {
+        Some(entry) if available(entry) => Ok(entry),
+        Some(_) => Err(EMBEDDED_BROWSER_NOT_READY_ERROR.to_string()),
+        None => Err("Embedded browser is not open".to_string()),
+    }
+}
+
 fn browser_open_action(readiness: Option<EmbeddedBrowserReadiness>) -> EmbeddedBrowserOpenAction {
     match readiness {
         Some(EmbeddedBrowserReadiness::Ready) => EmbeddedBrowserOpenAction::Ready,
@@ -490,18 +519,32 @@ fn browser_open_action(readiness: Option<EmbeddedBrowserReadiness>) -> EmbeddedB
     }
 }
 
-fn wait_for_browser_ready(
+fn wait_for_browser_ready_with_observer(
     mut readiness: impl FnMut() -> Result<Option<EmbeddedBrowserReadiness>, String>,
     attempts: u64,
     interval: Duration,
+    mut observer: impl FnMut(u64, Option<EmbeddedBrowserReadiness>) -> Result<(), String>,
 ) -> Result<(), String> {
-    for _ in 0..attempts {
-        if readiness()? == Some(EmbeddedBrowserReadiness::Ready) {
+    for attempt in 0..attempts {
+        let current_readiness = readiness()?;
+        if current_readiness == Some(EmbeddedBrowserReadiness::Ready) {
             return Ok(());
         }
+        observer(attempt, current_readiness)?;
         thread::sleep(interval);
     }
     Err("Timed out waiting for Wework to open the embedded browser tab".to_string())
+}
+
+fn should_replay_browser_open_request(
+    attempt: u64,
+    readiness: Option<EmbeddedBrowserReadiness>,
+) -> bool {
+    attempt > 0
+        && readiness.is_none()
+        && attempt
+            .checked_mul(BRIDGE_OPEN_WAIT_INTERVAL_MS)
+            .is_some_and(|elapsed_ms| elapsed_ms % BRIDGE_OPEN_REQUEST_REPLAY_INTERVAL_MS == 0)
 }
 
 fn relabel_logical_entry<T>(
@@ -629,6 +672,20 @@ fn get_entry(state: &EmbeddedBrowserState, label: &str) -> Result<EmbeddedBrowse
     ready_logical_entry(&webviews, label, EmbeddedBrowserEntry::readiness).cloned()
 }
 
+fn get_available_entry(
+    state: &EmbeddedBrowserState,
+    label: &str,
+) -> Result<EmbeddedBrowserEntry, String> {
+    let webviews = state
+        .webviews
+        .lock()
+        .map_err(|_| "Embedded browser state lock poisoned".to_string())?;
+    available_logical_entry(&webviews, label, |entry| {
+        !matches!(entry.phase, EmbeddedBrowserPhase::Opening)
+    })
+    .cloned()
+}
+
 fn update_entry_for_native_label(
     state: &EmbeddedBrowserState,
     native_label: &str,
@@ -661,9 +718,14 @@ fn mark_entry_ready_for_native_label(
     state: &EmbeddedBrowserState,
     native_label: &str,
     webview: Webview<Wry>,
+    bridge_ready: bool,
 ) -> Result<(), String> {
     let updated = update_entry_for_native_label(state, native_label, |entry| {
-        entry.phase = EmbeddedBrowserPhase::Ready(webview);
+        entry.phase = if bridge_ready {
+            EmbeddedBrowserPhase::Ready(webview)
+        } else {
+            EmbeddedBrowserPhase::Hidden(webview)
+        };
     })?;
     updated
         .then_some(())
@@ -713,7 +775,7 @@ fn page_state_for_label(
     state: &EmbeddedBrowserState,
     label: &str,
 ) -> Result<EmbeddedBrowserPageState, String> {
-    let entry = get_entry(state, label)?;
+    let entry = get_available_entry(state, label)?;
     Ok(EmbeddedBrowserPageState {
         #[cfg(target_os = "macos")]
         invalid_tls_certificate: crate::embedded_browser_tls::invalid_tls_certificate(
@@ -919,20 +981,44 @@ fn request_browser_open(
     label: &str,
     url: &str,
 ) -> Result<(), String> {
-    match browser_open_action(entry_readiness(state, label)?) {
+    let request_id = match browser_open_action(entry_readiness(state, label)?) {
         EmbeddedBrowserOpenAction::Ready => return Ok(()),
-        EmbeddedBrowserOpenAction::WaitForReady => {}
+        EmbeddedBrowserOpenAction::WaitForReady => state
+            .pending_open_requests
+            .lock()
+            .map_err(|_| "Embedded browser pending request lock poisoned".to_string())?
+            .get(label)
+            .map(|request| request.request_id),
         EmbeddedBrowserOpenAction::RequestOpen => {
-            app.emit(
-                EMBEDDED_BROWSER_OPEN_REQUEST_EVENT,
-                EmbeddedBrowserOpenRequest {
-                    url: url.to_string(),
-                    label: label.to_string(),
-                },
-            )
-            .map_err(|error| format!("Failed to request embedded browser open: {error}"))?;
+            let request = EmbeddedBrowserOpenRequest {
+                request_id: EMBEDDED_BROWSER_OPEN_REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+                url: url.to_string(),
+                label: label.to_string(),
+            };
+            let request_id = request.request_id;
+            state
+                .pending_open_requests
+                .lock()
+                .map_err(|_| "Embedded browser pending request lock poisoned".to_string())?
+                .insert(label.to_string(), request.clone());
+            if let Err(error) = app.emit(EMBEDDED_BROWSER_OPEN_REQUEST_EVENT, request) {
+                if let Ok(mut requests) = state.pending_open_requests.lock() {
+                    requests.remove(label);
+                }
+                return Err(format!("Failed to request embedded browser open: {error}"));
+            }
+            log_embedded_browser_diagnostic(
+                state,
+                label,
+                "open_request_emitted",
+                json!({
+                    "requestedUrl": url,
+                    "requestId": request_id,
+                }),
+            );
+            Some(request_id)
         }
-    }
+    };
 
     log_embedded_browser_diagnostic(
         state,
@@ -940,23 +1026,58 @@ fn request_browser_open(
         "open_waiting_for_ready",
         json!({
             "requestedUrl": url,
+            "requestId": request_id,
         }),
     );
-    if let Err(error) = wait_for_browser_ready(
+    if let Err(error) = wait_for_browser_ready_with_observer(
         || entry_readiness(state, label),
         BRIDGE_OPEN_WAIT_TIMEOUT_MS / BRIDGE_OPEN_WAIT_INTERVAL_MS,
         Duration::from_millis(BRIDGE_OPEN_WAIT_INTERVAL_MS),
+        |attempt, readiness| {
+            if !should_replay_browser_open_request(attempt, readiness) {
+                return Ok(());
+            }
+            let request = state
+                .pending_open_requests
+                .lock()
+                .map_err(|_| "Embedded browser pending request lock poisoned".to_string())?
+                .get(label)
+                .cloned();
+            let Some(request) = request else {
+                return Ok(());
+            };
+            app.emit(EMBEDDED_BROWSER_OPEN_REQUEST_EVENT, request.clone())
+                .map_err(|error| format!("Failed to replay embedded browser open: {error}"))?;
+            log_embedded_browser_diagnostic(
+                state,
+                label,
+                "open_request_replayed",
+                json!({
+                    "requestedUrl": url,
+                    "requestId": request.request_id,
+                    "elapsedMs": attempt * BRIDGE_OPEN_WAIT_INTERVAL_MS,
+                }),
+            );
+            Ok(())
+        },
     ) {
+        if let Ok(mut requests) = state.pending_open_requests.lock() {
+            requests.remove(label);
+        }
         log_embedded_browser_diagnostic(
             state,
             label,
             "open_wait_timeout",
             json!({
                 "requestedUrl": url,
+                "requestId": request_id,
                 "error": error,
             }),
         );
         return Err(error);
+    }
+    if let Ok(mut requests) = state.pending_open_requests.lock() {
+        requests.remove(label);
     }
     log_embedded_browser_diagnostic(
         state,
@@ -964,9 +1085,21 @@ fn request_browser_open(
         "open_ready",
         json!({
             "requestedUrl": url,
+            "requestId": request_id,
         }),
     );
     Ok(())
+}
+
+#[tauri::command]
+pub fn embedded_browser_pending_open_requests(
+    state: tauri::State<'_, EmbeddedBrowserState>,
+) -> Result<Vec<EmbeddedBrowserOpenRequest>, String> {
+    let requests = state
+        .pending_open_requests
+        .lock()
+        .map_err(|_| "Embedded browser pending request lock poisoned".to_string())?;
+    Ok(requests.values().cloned().collect())
 }
 
 fn eval_json(
@@ -1067,13 +1200,14 @@ fn handle_bridge_request(
             Ok(json!({ "ok": true }))
         }
         "close" => {
-            close_embedded_browser_entry(state, &label)?;
-            app.emit_to(
-                MAIN_WINDOW_LABEL,
-                EMBEDDED_BROWSER_CLOSE_EVENT,
-                json!({ "label": label }),
-            )
-            .map_err(|error| format!("Failed to notify embedded browser close: {error}"))?;
+            if let Some(native_label) = close_embedded_browser_entry(state, &label, None)? {
+                app.emit_to(
+                    MAIN_WINDOW_LABEL,
+                    EMBEDDED_BROWSER_CLOSE_EVENT,
+                    json!({ "label": label, "nativeLabel": native_label }),
+                )
+                .map_err(|error| format!("Failed to notify embedded browser close: {error}"))?;
+            }
             Ok(json!({ "ok": true }))
         }
         "back" => eval_json(
@@ -1237,8 +1371,12 @@ pub async fn embedded_browser_open(
     url: String,
     bounds: EmbeddedBrowserBounds,
     label: Option<String>,
+    visible: Option<bool>,
+    ready_when_hidden: Option<bool>,
 ) -> Result<EmbeddedBrowserPageState, String> {
     let label = browser_label(label);
+    let visible = visible.unwrap_or(true);
+    let bridge_ready = visible || ready_when_hidden.unwrap_or(true);
     let _lifecycle = state.lifecycle.lock().await;
     let display_url = resolve_browser_navigation_url(&state, &url)?;
     let initial_title = browser_url(&url)
@@ -1287,10 +1425,16 @@ pub async fn embedded_browser_open(
             );
             return Err(message);
         }
-        if let Err(error) = webview
-            .show()
-            .map_err(|error| format!("Failed to show embedded browser: {error}"))
-        {
+        let visibility_result = if visible {
+            webview
+                .show()
+                .map_err(|error| format!("Failed to show embedded browser: {error}"))
+        } else {
+            webview
+                .hide()
+                .map_err(|error| format!("Failed to hide embedded browser: {error}"))
+        };
+        if let Err(error) = visibility_result {
             log_embedded_browser_diagnostic(
                 &state,
                 &label,
@@ -1676,10 +1820,16 @@ pub async fn embedded_browser_open(
         }
     }
 
-    if let Err(error) = webview
-        .show()
-        .map_err(|error| format!("Failed to show embedded browser: {error}"))
-    {
+    let visibility_result = if visible {
+        webview
+            .show()
+            .map_err(|error| format!("Failed to show embedded browser: {error}"))
+    } else {
+        webview
+            .hide()
+            .map_err(|error| format!("Failed to hide embedded browser: {error}"))
+    };
+    if let Err(error) = visibility_result {
         log_embedded_browser_diagnostic(
             &state,
             &label,
@@ -1705,12 +1855,18 @@ pub async fn embedded_browser_open(
     log_embedded_browser_diagnostic(
         &state,
         &label,
-        "open_visible",
+        if visible {
+            "open_visible"
+        } else {
+            "open_hidden"
+        },
         json!({
             "nativeLabel": &native_label,
         }),
     );
-    if let Err(error) = mark_entry_ready_for_native_label(&state, &native_label, webview.clone()) {
+    if let Err(error) =
+        mark_entry_ready_for_native_label(&state, &native_label, webview.clone(), bridge_ready)
+    {
         log_embedded_browser_diagnostic(
             &state,
             &label,
@@ -1736,11 +1892,20 @@ pub async fn embedded_browser_open(
     log_embedded_browser_diagnostic(
         &state,
         &label,
-        "open_ready",
+        if bridge_ready {
+            "open_ready"
+        } else {
+            "open_waiting_for_visible_bounds"
+        },
         json!({
             "nativeLabel": &native_label,
         }),
     );
+    if bridge_ready {
+        if let Ok(mut requests) = state.pending_open_requests.lock() {
+            requests.remove(&label);
+        }
+    }
 
     Ok(EmbeddedBrowserPageState {
         #[cfg(target_os = "macos")]
@@ -1764,6 +1929,7 @@ pub fn embedded_browser_set_bounds(
     bounds: EmbeddedBrowserBounds,
     visible: bool,
     label: Option<String>,
+    ready_when_hidden: Option<bool>,
 ) -> Result<(), String> {
     let label = browser_label(label);
     let normalized_bounds = normalize_bounds(bounds);
@@ -1773,15 +1939,16 @@ pub fn embedded_browser_set_bounds(
             .lock()
             .map_err(|_| "Embedded browser state lock poisoned".to_string())?;
         match webviews.get(&label) {
-            Some(entry) if entry.readiness() == EmbeddedBrowserReadiness::Ready => {
-                Some(entry.ready_webview()?)
-            }
-            Some(_) => return Err(EMBEDDED_BROWSER_NOT_READY_ERROR.to_string()),
+            Some(entry) => Some((
+                entry.native_label.clone(),
+                entry.available_webview()?,
+                entry.readiness(),
+            )),
             None => None,
         }
     };
 
-    let Some(webview) = webview else {
+    let Some((native_label, webview, readiness)) = webview else {
         return Ok(());
     };
 
@@ -1794,6 +1961,23 @@ pub fn embedded_browser_set_bounds(
         webview
             .hide()
             .map_err(|error| format!("Failed to hide embedded browser: {error}"))?;
+    }
+    if (visible || ready_when_hidden.unwrap_or(false))
+        && readiness != EmbeddedBrowserReadiness::Ready
+    {
+        mark_entry_ready_for_native_label(&state, &native_label, webview, true)?;
+        if let Ok(mut requests) = state.pending_open_requests.lock() {
+            requests.remove(&label);
+        }
+        log_embedded_browser_diagnostic(
+            &state,
+            &label,
+            "bounds_visible_ready",
+            json!({
+                "nativeLabel": native_label,
+                "visible": visible,
+            }),
+        );
     }
     Ok(())
 }
@@ -1983,29 +2167,48 @@ pub async fn embedded_browser_close(
     app: tauri::AppHandle,
     state: tauri::State<'_, EmbeddedBrowserState>,
     label: Option<String>,
+    expected_native_label: Option<String>,
 ) -> Result<(), String> {
     let label = browser_label(label);
     let _lifecycle = state.lifecycle.lock().await;
-    close_embedded_browser_entry(&state, &label)?;
-    app.emit_to(
-        MAIN_WINDOW_LABEL,
-        EMBEDDED_BROWSER_CLOSE_EVENT,
-        json!({ "label": label }),
-    )
-    .map_err(|error| format!("Failed to notify embedded browser close: {error}"))?;
+    let closed_native_label =
+        close_embedded_browser_entry(&state, &label, expected_native_label.as_deref())?;
+    log::info!(
+        "Embedded browser close label={} expected_native_label={:?} closed_native_label={:?}",
+        label,
+        expected_native_label,
+        closed_native_label
+    );
+    if let Some(native_label) = closed_native_label {
+        app.emit_to(
+            MAIN_WINDOW_LABEL,
+            EMBEDDED_BROWSER_CLOSE_EVENT,
+            json!({ "label": label, "nativeLabel": native_label }),
+        )
+        .map_err(|error| format!("Failed to notify embedded browser close: {error}"))?;
+    }
     Ok(())
 }
 
-fn close_embedded_browser_entry(state: &EmbeddedBrowserState, label: &str) -> Result<(), String> {
+fn close_embedded_browser_entry(
+    state: &EmbeddedBrowserState,
+    label: &str,
+    expected_native_label: Option<&str>,
+) -> Result<Option<String>, String> {
     let entry = {
         let webviews = state
             .webviews
             .lock()
             .map_err(|_| "Embedded browser state lock poisoned".to_string())?;
-        webviews.get(label).cloned()
+        webviews
+            .get(label)
+            .filter(|entry| {
+                expected_native_label.is_none_or(|expected| entry.native_label == expected)
+            })
+            .cloned()
     };
     if let Some(entry) = entry {
-        let webview = entry.ready_webview()?;
+        let webview = entry.available_webview()?;
         #[cfg(target_os = "macos")]
         crate::embedded_browser_tls::unregister_invalid_tls_handler(&webview);
         webview
@@ -2021,8 +2224,10 @@ fn close_embedded_browser_entry(state: &EmbeddedBrowserState, label: &str) -> Re
             &entry.native_label,
             |current| current.native_label.as_str(),
         );
+        clear_label_agent_state(state, label)?;
+        return Ok(Some(entry.native_label));
     }
-    clear_label_agent_state(state, label)
+    Ok(None)
 }
 
 #[tauri::command]

--- a/wework/src-tauri/src/embedded_browser/tests.rs
+++ b/wework/src-tauri/src/embedded_browser/tests.rs
@@ -10,16 +10,17 @@ use std::{
 };
 
 use super::{
-    bridge_navigation_url, bridge_request_authorized, browser_file_url_from_path,
-    browser_open_action, browser_webview_url, consume_approved_agent_risk,
-    directory_entry_modified_unix_seconds, directory_listing_html, download_event_owner,
-    file_url_path, format_directory_entry_modified, format_file_size, loaded_browser_url,
-    local_file_browser_title, logical_owner_for_native_label, merge_request_option,
-    native_webview_label, read_http_request, ready_logical_entry, register_agent_approval,
-    register_preview_source, relabel_logical_entry, remove_logical_entry_if_native_matches,
-    resolve_browser_navigation_url, script_browser_action, script_resolve_inspect_target,
-    script_semantic_inspect, should_block_local_file_preview, should_record_loaded_url,
-    update_logical_entry_if_native_matches, wait_for_browser_ready, DirectoryEntry,
+    available_logical_entry, bridge_navigation_url, bridge_request_authorized,
+    browser_file_url_from_path, browser_open_action, browser_webview_url,
+    consume_approved_agent_risk, directory_entry_modified_unix_seconds, directory_listing_html,
+    download_event_owner, file_url_path, format_directory_entry_modified, format_file_size,
+    loaded_browser_url, local_file_browser_title, logical_owner_for_native_label,
+    merge_request_option, native_webview_label, read_http_request, ready_logical_entry,
+    register_agent_approval, register_preview_source, relabel_logical_entry,
+    remove_logical_entry_if_native_matches, resolve_browser_navigation_url, script_browser_action,
+    script_resolve_inspect_target, script_semantic_inspect, should_block_local_file_preview,
+    should_record_loaded_url, should_replay_browser_open_request,
+    update_logical_entry_if_native_matches, wait_for_browser_ready_with_observer, DirectoryEntry,
     EmbeddedBrowserBridgeRequest, EmbeddedBrowserDownloadPayload, EmbeddedBrowserOpenAction,
     EmbeddedBrowserPageState, EmbeddedBrowserReadiness, EmbeddedBrowserState,
     EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV, EMBEDDED_BROWSER_NOT_READY_ERROR,
@@ -328,6 +329,29 @@ fn opening_route_is_hidden_from_public_access_but_available_to_native_callbacks(
 }
 
 #[test]
+fn hidden_route_exposes_page_state_without_becoming_bridge_ready() {
+    let entries = HashMap::from([(
+        "workspace-browser".to_string(),
+        (
+            "https://example.test/",
+            EmbeddedBrowserReadiness::Opening,
+            true,
+        ),
+    )]);
+
+    assert_eq!(
+        ready_logical_entry(&entries, "workspace-browser", |entry| entry.1).unwrap_err(),
+        EMBEDDED_BROWSER_NOT_READY_ERROR
+    );
+    assert_eq!(
+        available_logical_entry(&entries, "workspace-browser", |entry| entry.2)
+            .unwrap()
+            .0,
+        "https://example.test/"
+    );
+}
+
+#[test]
 fn bridge_open_waits_for_an_opening_route_without_requesting_again() {
     assert_eq!(
         browser_open_action(Some(EmbeddedBrowserReadiness::Opening)),
@@ -344,6 +368,22 @@ fn bridge_open_waits_for_an_opening_route_without_requesting_again() {
 }
 
 #[test]
+fn bridge_replays_pending_open_requests_only_while_no_route_is_registered() {
+    assert!(!should_replay_browser_open_request(0, None));
+    assert!(!should_replay_browser_open_request(4, None));
+    assert!(should_replay_browser_open_request(5, None));
+    assert!(should_replay_browser_open_request(10, None));
+    assert!(!should_replay_browser_open_request(
+        5,
+        Some(EmbeddedBrowserReadiness::Opening)
+    ));
+    assert!(!should_replay_browser_open_request(
+        5,
+        Some(EmbeddedBrowserReadiness::Ready)
+    ));
+}
+
+#[test]
 fn bridge_waits_for_ready_instead_of_accepting_an_opening_registration() {
     let readiness = Arc::new(Mutex::new(EmbeddedBrowserReadiness::Opening));
     let waiter_readiness = Arc::clone(&readiness);
@@ -352,7 +392,7 @@ fn bridge_waits_for_ready_instead_of_accepting_an_opening_registration() {
 
     let waiter = thread::spawn(move || {
         let mut first_check = true;
-        wait_for_browser_ready(
+        wait_for_browser_ready_with_observer(
             || {
                 if first_check {
                     first_check = false;
@@ -362,6 +402,7 @@ fn bridge_waits_for_ready_instead_of_accepting_an_opening_registration() {
             },
             100,
             Duration::from_millis(1),
+            |_, _| Ok(()),
         )
     });
 

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -4883,6 +4883,7 @@ pub fn run() {
             embedded_browser::embedded_browser_go_forward,
             embedded_browser::embedded_browser_navigate,
             embedded_browser::embedded_browser_open,
+            embedded_browser::embedded_browser_pending_open_requests,
             embedded_browser::embedded_browser_pause_download,
             embedded_browser::embedded_browser_page_state,
             embedded_browser::embedded_browser_reload,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4711,10 +4711,11 @@ describe('DesktopWorkbenchLayout', () => {
     expect(rightPanelShell).toHaveClass(
       'overflow-hidden',
       'opacity-0',
-      'transition-[width,opacity]',
+      'transition-opacity',
       'duration-[240ms]',
       'ease-[cubic-bezier(0.2,0,0,1)]'
     )
+    expect(rightPanelShell).not.toHaveClass('transition-[width,opacity]')
     expect(rightPanelShell).toHaveStyle({ width: '0px' })
     expect(screen.queryByTestId('right-workspace-panel')).not.toBeInTheDocument()
     expect(screen.getByTestId('desktop-floating-composer-layer')).toHaveClass(

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -18,6 +18,7 @@ import type {
   WorkbenchPaneContextValue,
 } from '@/features/workbench/workbenchContextTypes'
 import { openExternalUrl } from '@/lib/external-links'
+import { requestEmbeddedBrowserOpen } from '@/lib/embedded-browser'
 import {
   closeLocalTerminal,
   getLocalPathKind,
@@ -8049,6 +8050,48 @@ describe('DesktopWorkbenchLayout', () => {
       'src',
       'https://example.com/'
     )
+  })
+
+  test('does not reuse a migrated default browser label after switching panes', async () => {
+    const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {
+        transformCallback: vi.fn(() => 1),
+        unregisterCallback: vi.fn(),
+        invoke: vi.fn(async (command: string) => {
+          if (command === 'embedded_browser_pending_open_requests') return []
+          if (command === 'embedded_browser_open') {
+            return { nativeLabel: 'embedded-browser-native-test', title: null, url: null }
+          }
+          return null
+        }),
+      },
+    })
+    Object.defineProperty(window, '__TAURI_EVENT_PLUGIN_INTERNALS__', {
+      configurable: true,
+      value: { unregisterListener: vi.fn() },
+    })
+    const { rerender, unmount } = render(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
+    const browserHost = () =>
+      screen.getByTestId('desktop-workbench-main').querySelector('[data-embedded-browser-label]')
+
+    await waitFor(() => {
+      expect(requestEmbeddedBrowserOpen('https://example.com/')).toBe(true)
+    })
+    await waitFor(() => {
+      expect(browserHost()).toHaveAttribute('data-embedded-browser-label', 'workspace-browser')
+    })
+
+    rerender(<DesktopWorkbenchLayout {...propsForTask(taskB)} />)
+
+    expect(browserHost()).toHaveAttribute(
+      'data-embedded-browser-label',
+      'workspace-browser-runtime-b'
+    )
+
+    unmount()
+    await new Promise(resolve => setTimeout(resolve, 1_100))
   })
 
   test('preserves the open file when switching runtime tasks', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4290,7 +4290,7 @@ describe('DesktopWorkbenchLayout', () => {
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
     await waitFor(() => {
       expect(content).toHaveStyle({ width: '420px' })
-      expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
+      expect(rightPanelShell).toHaveStyle({ width: '580px' })
     })
     expect(panel).toHaveClass('min-w-0', 'flex-1', 'basis-0')
     expect(panel).toHaveClass('transition-[opacity,transform]', 'duration-300', 'ease-out')
@@ -4305,7 +4305,7 @@ describe('DesktopWorkbenchLayout', () => {
     fireEvent.pointerUp(document)
 
     expect(content).toHaveStyle({ width: '580px' })
-    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 580px)' })
+    expect(rightPanelShell).toHaveStyle({ width: '420px' })
     expect(screen.getByTestId('workspace-file-tree')).toHaveClass('w-[240px]')
   })
 
@@ -4357,7 +4357,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await waitFor(() => {
       expect(content).toHaveStyle({ width: '420px' })
-      expect(panelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
+      expect(panelShell).toHaveStyle({ width: '580px' })
     })
     expect(screen.getByTestId('right-workspace-resize-handle')).toBeInTheDocument()
     expect(screen.getByTestId('project-chat-composer')).toBeInTheDocument()
@@ -4532,7 +4532,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await waitFor(() => {
       expect(content).toHaveStyle({ width: '420px' })
-      expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
+      expect(rightPanelShell).toHaveStyle({ width: '580px' })
     })
 
     fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 422 })
@@ -4541,7 +4541,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(content).toHaveClass('transition-none')
     expect(rightPanelShell).toHaveClass('transition-none')
     expect(content).toHaveStyle({ width: '700px' })
-    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 700px)' })
+    expect(rightPanelShell).toHaveStyle({ width: '300px' })
 
     fireEvent.pointerMove(document, { clientX: 902 })
 
@@ -4557,7 +4557,7 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
     expect(content).toHaveStyle({ width: '420px' })
-    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
+    expect(rightPanelShell).toHaveStyle({ width: '580px' })
     expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
   })
 
@@ -4735,7 +4735,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() => {
       expect(content).toHaveStyle({ width: '420px' })
       expect(topBar).toHaveStyle({ width: '420px' })
-      expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
+      expect(rightPanelShell).toHaveStyle({ width: '580px' })
     })
     expect(rightPanelShell).toHaveClass('opacity-100')
     expect(screen.queryByTestId('workbench-topbar-right-actions')).not.toBeInTheDocument()
@@ -4839,7 +4839,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() => {
       expect(screen.getByTestId('desktop-workbench-content')).toHaveStyle({ width: '580px' })
       expect(screen.getByTestId('right-workspace-panel-shell')).toHaveStyle({
-        width: 'calc(100% - 580px)',
+        width: '420px',
       })
     })
 
@@ -5132,9 +5132,7 @@ describe('DesktopWorkbenchLayout', () => {
       expect(screen.getByTestId('titlebar-actions')).toHaveStyle({
         right: '0px',
       })
-      expect(screen.getByTestId('titlebar-right-workspace-zone')).toHaveStyle({
-        width: 'calc(100% - 420px - 0px - 5rem)',
-      })
+      expect(screen.getByTestId('titlebar-right-workspace-zone').style.width).toContain('580px')
       expect(screen.getByTestId('right-workspace-resize-handle')).toHaveClass(
         'after:bg-transparent'
       )

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -96,6 +96,7 @@ import { getPlatform } from '@/lib/platform'
 import { getLocalPathKind } from '@/lib/local-terminal'
 import { navigateTo } from '@/lib/navigation'
 import {
+  browserDiagnosticUrl,
   DEFAULT_EMBEDDED_BROWSER_LABEL,
   listenEmbeddedBrowserOpenRequests,
   markEmbeddedBrowserLabelTransferred,
@@ -320,7 +321,14 @@ interface PendingBlankBrowserMigration {
 let latestBlankBrowserMigration: PendingBlankBrowserMigration | null = null
 
 function logEmbeddedBrowserOpenRoute(stage: string, detail: Record<string, unknown>) {
-  const message = `[Wework] Embedded browser open route ${JSON.stringify({ stage, ...detail })}`
+  const sanitizedDetail = {
+    ...detail,
+    ...(typeof detail.url === 'string' ? { url: browserDiagnosticUrl(detail.url) } : {}),
+  }
+  const message = `[Wework] Embedded browser open route ${JSON.stringify({
+    stage,
+    ...sanitizedDetail,
+  })}`
   console.info(message)
   if (!isTauriRuntime()) return
   void writeInfoLog(message).catch(() => {
@@ -2005,6 +2013,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       if (request.label && request.label !== current.embeddedBrowserLabel) {
         if (request.label !== DEFAULT_EMBEDDED_BROWSER_LABEL) {
           logEmbeddedBrowserOpenRoute('request_ignored_label_mismatch', routeDetail)
+          return
+        }
+        if (!current.paneActive) {
+          logEmbeddedBrowserOpenRoute('request_ignored_inactive_default_label', routeDetail)
           return
         }
         logEmbeddedBrowserOpenRoute('default_label_migrated', routeDetail)

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { info as writeInfoLog } from '@tauri-apps/plugin-log'
 import {
   ArrowLeftRight,
   ChevronRight,
@@ -317,6 +318,15 @@ interface PendingBlankBrowserMigration {
 }
 
 let latestBlankBrowserMigration: PendingBlankBrowserMigration | null = null
+
+function logEmbeddedBrowserOpenRoute(stage: string, detail: Record<string, unknown>) {
+  const message = `[Wework] Embedded browser open route ${JSON.stringify({ stage, ...detail })}`
+  console.info(message)
+  if (!isTauriRuntime()) return
+  void writeInfoLog(message).catch(() => {
+    // Diagnostics must not affect browser routing.
+  })
+}
 
 function findSelectedAssistantPlanContent(
   messages: WorkbenchMessage[],
@@ -1340,6 +1350,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     () =>
       initialBlankBrowserMigration?.rightPanelTabs ?? initialWorkspaceState?.rightPanelTabs ?? []
   )
+  const [rightPanelImmediateLayout, setRightPanelImmediateLayout] = useState(false)
   const [selectedFileWorkspaceTargetKey, setSelectedFileWorkspaceTargetKey] = useState<
     string | null
   >(() => initialWorkspaceState?.selectedFileWorkspaceTargetKey ?? null)
@@ -1452,6 +1463,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     onCollapse: closeRightPanel,
     defaultPanelWidth: onlyTemporaryChatOpen ? TEMPORARY_CHAT_PANEL_DEFAULT_WIDTH : undefined,
   })
+  const rightPanelTransitionDisabled = rightSplitResizing || rightPanelImmediateLayout
   const chatColumnWidth = rightPanelOpen && !rightPanelExpanded ? rightSplitChatWidth : '100%'
   const availableChatColumnWidth = rightPanelOpen ? rightSplitChatWidth : workbenchContentWidth
   const environmentInfoDocked =
@@ -1485,14 +1497,15 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   }, [currentRuntimeTask, environmentInfoDocked, onEnvironmentInfoOverlayOpenChange])
 
   const paneTitleWidth = rightPanelOpen ? chatColumnWidth : '100%'
+  const rightPanelWidth = Math.max(0, workbenchContentWidth - rightSplitChatWidth)
   const rightPanelShellWidth = rightPanelOpen
     ? rightPanelExpanded
       ? '100%'
-      : `calc(100% - ${rightSplitChatWidth}px)`
+      : `${rightPanelWidth}px`
     : '0px'
   const rightPanelTabBarRightOffset = '0px'
   const rightPanelTabBarWidth = rightPanelOpen
-    ? `calc(${rightPanelExpanded ? '100%' : `100% - ${rightSplitChatWidth}px`} - ${rightPanelTabBarRightOffset} - ${COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE})`
+    ? `calc(${rightPanelExpanded ? '100%' : `${rightPanelWidth}px`} - ${rightPanelTabBarRightOffset} - ${COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE})`
     : '0px'
   const effectiveRightPanelTabs = useMemo<RightWorkspacePanelTab[]>(() => {
     const canBrowseFiles = Boolean(workspaceProject || openFileRequest?.target)
@@ -1881,13 +1894,28 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     [paneSession]
   )
   const openRightPanelTab = useCallback(
-    (tab: RightWorkspacePanelTab) => {
+    (tab: RightWorkspacePanelTab, options?: { immediateLayout?: boolean }) => {
+      if (options?.immediateLayout) setRightPanelImmediateLayout(true)
       setRightPanelOpen(true)
       setRightPanelTabs(current => (current.includes(tab) ? current : [...current, tab]))
       setRightPanelView(tab)
     },
     [setRightPanelOpen, setRightPanelTabs, setRightPanelView]
   )
+  useEffect(() => {
+    if (!rightPanelImmediateLayout || !rightPanelOpen) return
+
+    let secondFrame = 0
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => {
+        setRightPanelImmediateLayout(false)
+      })
+    })
+    return () => {
+      cancelAnimationFrame(firstFrame)
+      if (secondFrame) cancelAnimationFrame(secondFrame)
+    }
+  }, [rightPanelImmediateLayout, rightPanelOpen])
   const selectRightPanelTab = useCallback(
     (tab: RightWorkspacePanelTab) => {
       setRightPanelOpen(true)
@@ -1931,32 +1959,92 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const embeddedBrowserListenerStateRef = useRef({
     embeddedBrowserLabel,
     openRightPanelTab,
+    paneActive,
+    paneKey,
+    rightPanelOpen,
+    rightPanelTabs,
+    rightPanelView,
+    workbenchVisible,
   })
   useEffect(() => {
     embeddedBrowserListenerStateRef.current = {
       embeddedBrowserLabel,
       openRightPanelTab,
+      paneActive,
+      paneKey,
+      rightPanelOpen,
+      rightPanelTabs,
+      rightPanelView,
+      workbenchVisible,
     }
-  }, [embeddedBrowserLabel, openRightPanelTab])
+  }, [
+    embeddedBrowserLabel,
+    openRightPanelTab,
+    paneActive,
+    paneKey,
+    rightPanelOpen,
+    rightPanelTabs,
+    rightPanelView,
+    workbenchVisible,
+  ])
   useEffect(() => {
-    if (!paneActive) return
     const listener = listenEmbeddedBrowserOpenRequests(request => {
       const current = embeddedBrowserListenerStateRef.current
+      const routeDetail = {
+        requestId: request.requestId,
+        requestLabel: request.label,
+        currentLabel: current.embeddedBrowserLabel,
+        url: request.url,
+        paneActive: current.paneActive,
+        paneKey: current.paneKey,
+        rightPanelOpen: current.rightPanelOpen,
+        rightPanelTabs: current.rightPanelTabs,
+        rightPanelView: current.rightPanelView,
+        workbenchVisible: current.workbenchVisible,
+      }
       if (request.label && request.label !== current.embeddedBrowserLabel) {
-        if (request.label !== DEFAULT_EMBEDDED_BROWSER_LABEL) return
+        if (request.label !== DEFAULT_EMBEDDED_BROWSER_LABEL) {
+          logEmbeddedBrowserOpenRoute('request_ignored_label_mismatch', routeDetail)
+          return
+        }
+        logEmbeddedBrowserOpenRoute('default_label_migrated', routeDetail)
         setMigratedEmbeddedBrowserLabel(request.label)
       }
-      setEmbeddedBrowserOpenRequest(previous => ({
+      logEmbeddedBrowserOpenRoute('request_routed', routeDetail)
+      setEmbeddedBrowserOpenRequest({
         ...request,
-        id: (previous?.id ?? 0) + 1,
-      }))
-      current.openRightPanelTab('browser')
+        id: request.requestId,
+      })
+      current.openRightPanelTab('browser', { immediateLayout: true })
     })
 
     return () => {
       void listener?.then(unlisten => unlisten())
     }
-  }, [paneActive])
+  }, [])
+  useEffect(() => {
+    if (!embeddedBrowserOpenRequest) return
+    logEmbeddedBrowserOpenRoute('request_state_committed', {
+      requestId: embeddedBrowserOpenRequest.requestId,
+      requestLabel: embeddedBrowserOpenRequest.label,
+      currentLabel: embeddedBrowserLabel,
+      paneActive,
+      paneKey,
+      rightPanelOpen,
+      rightPanelTabs,
+      rightPanelView,
+      workbenchVisible,
+    })
+  }, [
+    embeddedBrowserLabel,
+    embeddedBrowserOpenRequest,
+    paneActive,
+    paneKey,
+    rightPanelOpen,
+    rightPanelTabs,
+    rightPanelView,
+    workbenchVisible,
+  ])
   const openAssistantPlan = useCallback(
     (request: AssistantPlanOpenRequest) => {
       setSelectedAssistantPlan({
@@ -2456,7 +2544,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         className={cn(
           'pointer-events-none absolute left-0 top-0 z-chrome flex h-11 min-w-0 truncate items-center pr-7 text-sm font-medium leading-none text-text-primary',
           sidebarCollapsed ? 'pl-[14rem]' : 'pl-4',
-          rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+          rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
         )}
         style={{ width: paneTitleWidth }}
       >
@@ -2562,7 +2650,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           data-testid="workbench-pane-task-title"
           className={cn(
             'pointer-events-none relative z-0 flex h-full min-w-0 flex-1 items-center truncate pl-4 text-sm font-medium leading-none text-text-primary',
-            rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+            rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
           )}
         >
           <span className="block min-w-0 truncate">{runtimeTaskTitle}</span>
@@ -2583,7 +2671,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         aria-hidden="true"
         className={cn(
           'shrink-0',
-          rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+          rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
         )}
         style={{
           width: `calc(${rightPanelTabBarWidth} + ${COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE})`,
@@ -2595,7 +2683,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           'pointer-events-none absolute top-0 z-chrome flex h-full min-w-0 items-center overflow-hidden',
           background.imagePath && background.inTopBar ? 'bg-transparent' : 'bg-background/95',
           rightPanelOpen && !rightPanelExpanded ? 'border-l border-border/60' : undefined,
-          rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+          rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
         )}
         style={{
           right: COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE,
@@ -2613,7 +2701,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         data-testid="titlebar-actions"
         className={cn(
           'pointer-events-auto absolute top-0 z-chrome flex h-full min-w-[5rem] items-center justify-end gap-1 pr-2',
-          rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+          rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
         )}
         style={{
           right: '0px',
@@ -2653,6 +2741,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   return (
     <main
       ref={workbenchMainRef}
+      data-embedded-browser-label={embeddedBrowserLabel}
       className={cn(
         'absolute inset-x-0 bottom-0 flex min-w-0 flex-1 flex-col overflow-hidden',
         hasMainBackground ? 'bg-background/20' : 'bg-background',
@@ -2685,7 +2774,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               'absolute left-0 top-0 z-chrome h-11 overflow-visible border-b border-border/50 pr-7',
               background.imagePath && background.inTopBar ? 'bg-background/20' : 'bg-background/95',
               isTauri && sidebarCollapsed ? 'pl-[14rem]' : 'pl-4',
-              rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
+              rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
             )}
             style={{ width: chatColumnWidth }}
             left={topBarLeftContent}
@@ -2712,7 +2801,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             hasConversation
               ? 'overflow-x-hidden overflow-y-auto [overflow-anchor:none]'
               : 'overflow-hidden',
-            rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
+            rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
             showPageTopBar && 'pt-11'
           )}
           style={{ width: chatColumnWidth }}
@@ -3115,7 +3204,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             aria-controls="right-workspace-panel-shell"
             className={cn(
               'absolute bottom-[-6px] top-0 z-critical w-1.5 -translate-x-1/2 cursor-col-resize bg-transparent after:absolute after:bottom-0 after:left-1/2 after:top-0 after:w-px after:-translate-x-1/2 after:bg-transparent after:transition-colors after:duration-150 after:ease-out hover:after:bg-primary/40',
-              rightSplitResizing ? 'transition-none' : RIGHT_PANEL_HANDLE_TRANSITION_CLASS
+              rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_HANDLE_TRANSITION_CLASS
             )}
             style={{ left: rightSplitChatWidth }}
             onPointerDown={handleRightSplitResizeStart}
@@ -3132,7 +3221,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               : hasMainBackground
                 ? 'bg-background/20'
                 : 'bg-background',
-            rightSplitResizing ? 'transition-none' : RIGHT_PANEL_SHELL_TRANSITION_CLASS,
+            rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_SHELL_TRANSITION_CLASS,
             rightPanelOpen
               ? cn(
                   'pointer-events-auto opacity-100',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1397,8 +1397,16 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     selectedFileWorkspaceTargetKey,
     selectedWorkspaceFile,
   ])
-  const [migratedEmbeddedBrowserLabel, setMigratedEmbeddedBrowserLabel] = useState<string | null>(
-    () => initialBlankBrowserMigration?.browserLabel ?? null
+  const [migratedEmbeddedBrowser, setMigratedEmbeddedBrowser] = useState<{
+    label: string
+    paneKey: string
+  } | null>(() =>
+    initialBlankBrowserMigration
+      ? {
+          label: initialBlankBrowserMigration.browserLabel,
+          paneKey,
+        }
+      : null
   )
   const temporaryChatTabSequence = useRef(0)
   const [embeddedBrowserOpenRequest, setEmbeddedBrowserOpenRequest] = useState<
@@ -1539,6 +1547,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const defaultEmbeddedBrowserLabel = currentRuntimeTask?.taskId
     ? `workspace-browser-${sanitizeEmbeddedBrowserLabelSegment(currentRuntimeTask.taskId)}`
     : `workspace-browser-${sanitizeEmbeddedBrowserLabelSegment(paneKey)}`
+  const migratedEmbeddedBrowserLabel =
+    migratedEmbeddedBrowser?.paneKey === paneKey ? migratedEmbeddedBrowser.label : null
   const embeddedBrowserLabel = migratedEmbeddedBrowserLabel ?? defaultEmbeddedBrowserLabel
   const activeDeviceId =
     currentRuntimeTask?.deviceId ??
@@ -1688,7 +1698,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     )
       .then(() => {
         if (!disposed) {
-          setMigratedEmbeddedBrowserLabel(null)
+          setMigratedEmbeddedBrowser(null)
         }
       })
       .catch(error => {
@@ -2020,7 +2030,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           return
         }
         logEmbeddedBrowserOpenRoute('default_label_migrated', routeDetail)
-        setMigratedEmbeddedBrowserLabel(request.label)
+        setMigratedEmbeddedBrowser({
+          label: request.label,
+          paneKey: current.paneKey,
+        })
       }
       logEmbeddedBrowserOpenRoute('request_routed', routeDetail)
       setEmbeddedBrowserOpenRequest({

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -161,7 +161,7 @@ const DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS = 'bottom-4 z-popover bg-background/
 const RIGHT_PANEL_WIDTH_TRANSITION_CLASS =
   'transition-[width] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[width]'
 const RIGHT_PANEL_SHELL_TRANSITION_CLASS =
-  'transition-[width,opacity] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[width,opacity]'
+  'transition-opacity duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[opacity]'
 const RIGHT_PANEL_HANDLE_TRANSITION_CLASS =
   'transition-[left] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[left]'
 const DOCKED_ENVIRONMENT_INFO_WIDTH = 320

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -1165,7 +1165,12 @@ describe('WorkspaceBrowserPanel', () => {
     render(
       <WorkspaceBrowserPanel
         active
-        openRequest={{ id: 1, label: 'workspace-browser', url: 'https://example.test/' }}
+        openRequest={{
+          id: 1,
+          requestId: 1,
+          label: 'workspace-browser',
+          url: 'https://example.test/',
+        }}
       />
     )
 
@@ -1184,6 +1189,195 @@ describe('WorkspaceBrowserPanel', () => {
       )
     })
     expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://example.test/')
+  })
+
+  test('opens hidden immediately when the active browser host is not measurable yet', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValueOnce({
+        bottom: 0,
+        height: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      })
+      .mockReturnValue({
+        bottom: 420,
+        height: 300,
+        left: 500,
+        right: 900,
+        top: 120,
+        width: 400,
+        x: 500,
+        y: 120,
+        toJSON: () => ({}),
+      })
+    render(
+      <WorkspaceBrowserPanel
+        active
+        openRequest={{
+          id: 1,
+          requestId: 1,
+          label: 'workspace-browser',
+          url: 'https://example.test/',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledWith(
+        'https://example.test/',
+        {
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+        },
+        'workspace-browser',
+        false,
+        false
+      )
+    })
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenCalledWith(
+        {
+          x: 500,
+          y: 120,
+          width: 400,
+          height: 300,
+        },
+        true,
+        'workspace-browser'
+      )
+    })
+  })
+
+  test('opens an external request in a hidden browser while the panel is inactive', async () => {
+    mockBrowserHostRect()
+    const openRequest = {
+      id: 1,
+      requestId: 1,
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+    }
+    const view = render(<WorkspaceBrowserPanel active={false} openRequest={openRequest} />)
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledWith(
+        'https://example.test/',
+        {
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+        },
+        'workspace-browser',
+        false,
+        true
+      )
+    })
+    expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1)
+
+    view.rerender(<WorkspaceBrowserPanel active openRequest={openRequest} />)
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenCalledWith(
+        {
+          x: 500,
+          y: 120,
+          width: 400,
+          height: 300,
+        },
+        true,
+        'workspace-browser'
+      )
+    })
+  })
+
+  test('keeps an in-flight external open alive when panel activity changes', async () => {
+    mockBrowserHostRect()
+    let resolveOpen:
+      | ((value: { nativeLabel: string; title: null; url: string }) => void)
+      | undefined
+    embeddedBrowserMocks.openEmbeddedBrowser.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveOpen = resolve
+        })
+    )
+    const openRequest = {
+      id: 1,
+      requestId: 1,
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+    }
+    const view = render(<WorkspaceBrowserPanel active openRequest={openRequest} />)
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1)
+    })
+
+    view.rerender(<WorkspaceBrowserPanel active={false} openRequest={openRequest} />)
+    view.rerender(<WorkspaceBrowserPanel active openRequest={openRequest} />)
+
+    await act(async () => {
+      resolveOpen?.({
+        nativeLabel: 'workspace-browser-native-1',
+        title: null,
+        url: 'https://example.test/',
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://example.test/')
+    })
+    expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledTimes(1)
+    expect(embeddedBrowserMocks.closeEmbeddedBrowser).not.toHaveBeenCalled()
+  })
+
+  test('does not close a reused logical label when an uninitialized panel unmounts', () => {
+    const view = render(
+      <WorkspaceBrowserPanel active={false} label="workspace-browser-runtime-1" />
+    )
+
+    view.unmount()
+
+    expect(embeddedBrowserMocks.closeEmbeddedBrowser).not.toHaveBeenCalled()
+  })
+
+  test('closes an owned native browser by identity when the panel unmounts', async () => {
+    const view = render(<WorkspaceBrowserPanel active label="workspace-browser-runtime-1" />)
+    await screen.findByTestId('workspace-browser-native-view')
+
+    view.unmount()
+
+    expect(embeddedBrowserMocks.closeEmbeddedBrowser).toHaveBeenCalledWith(
+      'workspace-browser-runtime-1',
+      'workspace-browser-native-1'
+    )
+  })
+
+  test('ignores a stale close event for a replacement native browser', async () => {
+    let handleClose!: (event: { label: string; nativeLabel: string }) => void
+    embeddedBrowserMocks.listenEmbeddedBrowserCloseRequests.mockImplementation(handler => {
+      handleClose = handler
+      return Promise.resolve(vi.fn())
+    })
+    render(<WorkspaceBrowserPanel active label="workspace-browser-runtime-1" />)
+    await screen.findByTestId('workspace-browser-native-view')
+
+    act(() => {
+      handleClose({
+        label: 'workspace-browser-runtime-1',
+        nativeLabel: 'embedded-browser-native-stale',
+      })
+    })
+
+    expect(screen.getByTestId('workspace-browser-native-view')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://example.com/')
   })
 
   test('does not overwrite the address draft while page-state polling continues', async () => {
@@ -1590,7 +1784,12 @@ describe('WorkspaceBrowserPanel', () => {
     rerender(
       <WorkspaceBrowserPanel
         active
-        openRequest={{ id: 1, label: 'workspace-browser', url: extensionUrl }}
+        openRequest={{
+          id: 1,
+          requestId: 1,
+          label: 'workspace-browser',
+          url: extensionUrl,
+        }}
         onAddCodeComment={onAddCodeComment}
       />
     )

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -1355,6 +1355,54 @@ export function WorkspaceBrowserPanel({
     nativeBrowserOpeningRef.current = true
 
     setStatus('loading')
+    const revealHiddenBrowser = async (visible: boolean) => {
+      if (visible || !active) return
+      const visibleBounds = await waitForVisibleBrowserHost(
+        () => browserHostRef.current,
+        isAbandoned,
+        () => activeRef.current,
+        detail =>
+          logBrowserOpenDiagnostic('host_waiting', {
+            ...detail,
+            label: openingLabel,
+            requestId,
+            url: openingUrl,
+          })
+      )
+      if (visibleBounds) {
+        await setEmbeddedBrowserBounds(visibleBounds, true, openingLabel)
+        logBrowserOpenDiagnostic('host_visible', {
+          bounds: visibleBounds,
+          label: openingLabel,
+          requestId,
+          url: openingUrl,
+        })
+        return
+      }
+      await setEmbeddedBrowserBounds({ x: 0, y: 0, width: 1, height: 1 }, false, openingLabel, true)
+    }
+    const recoverBrowserFromPageState = async () => {
+      const recoveryDelays = [0, 120, 300, 600]
+      for (const delay of recoveryDelays) {
+        if (delay > 0) {
+          await new Promise<void>(resolve => window.setTimeout(resolve, delay))
+        }
+        try {
+          const pageState = await readEmbeddedBrowserPageState(openingLabel)
+          if (isAbandoned()) return true
+          adoptNativeLabel(pageState.nativeLabel, openingLabel)
+          setInvalidTlsCertificate(pageState.invalidTlsCertificate ?? null)
+          nativeBrowserOpenRef.current = true
+          updatePageUrl(pageState.url || openingUrl)
+          schedulePostOpenBoundsSync(activeRef.current)
+          setStatus('ready')
+          return true
+        } catch {
+          // No existing browser state to recover yet.
+        }
+      }
+      return false
+    }
     const openWhenHostIsReady = async () => {
       try {
         const host = browserHostRef.current
@@ -1399,36 +1447,7 @@ export function WorkspaceBrowserPanel({
         setInvalidTlsCertificate(pageState.invalidTlsCertificate ?? null)
         nativeBrowserOpenRef.current = true
         updatePageUrl(pageState.url || openingUrl)
-        if (!visible && active) {
-          const visibleBounds = await waitForVisibleBrowserHost(
-            () => browserHostRef.current,
-            isAbandoned,
-            () => activeRef.current,
-            detail =>
-              logBrowserOpenDiagnostic('host_waiting', {
-                ...detail,
-                label: openingLabel,
-                requestId,
-                url: openingUrl,
-              })
-          )
-          if (visibleBounds) {
-            await setEmbeddedBrowserBounds(visibleBounds, true, openingLabel)
-            logBrowserOpenDiagnostic('host_visible', {
-              bounds: visibleBounds,
-              label: openingLabel,
-              requestId,
-              url: openingUrl,
-            })
-          } else {
-            await setEmbeddedBrowserBounds(
-              { x: 0, y: 0, width: 1, height: 1 },
-              false,
-              openingLabel,
-              true
-            )
-          }
-        }
+        await revealHiddenBrowser(visible)
         schedulePostOpenBoundsSync(activeRef.current)
         if (readyTimer !== null) window.clearTimeout(readyTimer)
         setStatus('ready')
@@ -1463,25 +1482,7 @@ export function WorkspaceBrowserPanel({
         })
         if (!abandoned) {
           if (readyTimer !== null) window.clearTimeout(readyTimer)
-          const recoveryDelays = [0, 120, 300, 600]
-          for (const delay of recoveryDelays) {
-            if (delay > 0) {
-              await new Promise<void>(resolve => window.setTimeout(resolve, delay))
-            }
-            try {
-              const pageState = await readEmbeddedBrowserPageState(openingLabel)
-              if (isAbandoned()) return
-              adoptNativeLabel(pageState.nativeLabel, openingLabel)
-              setInvalidTlsCertificate(pageState.invalidTlsCertificate ?? null)
-              nativeBrowserOpenRef.current = true
-              updatePageUrl(pageState.url || openingUrl)
-              schedulePostOpenBoundsSync(activeRef.current)
-              setStatus('ready')
-              return
-            } catch {
-              // No existing browser state to recover yet.
-            }
-          }
+          if (await recoverBrowserFromPageState()) return
           setStatus('error')
           setError(t('workbench.browser_open_failed'))
         }

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -78,8 +78,8 @@ import { track } from '@/telemetry/client'
 const EMBEDDED_BROWSER_READY_TIMEOUT_MS = 800
 const EMBEDDED_BROWSER_STATE_INTERVAL_MS = 1000
 const EMBEDDED_BROWSER_BOUNDS_DEBOUNCE_MS = 80
-const EMBEDDED_BROWSER_HOST_BOUNDS_TIMEOUT_MS = 5000
-const EMBEDDED_BROWSER_HOST_BOUNDS_INTERVAL_MS = 50
+const EMBEDDED_BROWSER_VISIBLE_HOST_TIMEOUT_MS = 12_000
+const EMBEDDED_BROWSER_VISIBLE_HOST_INTERVAL_MS = 50
 const EMBEDDED_BROWSER_POST_OPEN_SYNC_DELAYS_MS = [0, 120, 300, 600]
 const BROWSER_CLEAR_STARTED_NOTICE_MIN_MS = 350
 const BROWSER_ANNOTATION_LOG_PREFIX = '[Wework][BrowserAnnotation]'
@@ -104,6 +104,15 @@ interface WorkspaceBrowserPanelProps {
 type BrowserStatus = 'idle' | 'loading' | 'ready' | 'error'
 type BrowserDownload = EmbeddedBrowserDownloadEvent
 type BrowserAgentState = EmbeddedBrowserAgentStateEvent
+type BrowserOpenDiagnosticStage =
+  | 'request_consumed'
+  | 'host_ready'
+  | 'host_waiting'
+  | 'host_visible'
+  | 'native_open_started'
+  | 'native_open_succeeded'
+  | 'native_open_failed'
+  | 'lifecycle_cancelled'
 type BrowserAnnotationRect = { x: number; y: number; width: number; height: number }
 type BrowserAnnotationTarget = {
   inspectId?: string
@@ -188,44 +197,58 @@ function getElementBounds(element: HTMLElement): EmbeddedBrowserBounds | null {
   }
 }
 
-function waitForElementBounds(
+async function waitForVisibleBrowserHost(
   getElement: () => HTMLElement | null,
-  isDisposed: () => boolean
-): Promise<EmbeddedBrowserBounds> {
-  return new Promise((resolve, reject) => {
-    const startedAt = Date.now()
-    let timer: number | null = null
-    const finish = (callback: () => void) => {
-      if (timer !== null) {
-        window.clearTimeout(timer)
-        timer = null
-      }
-      callback()
+  isAbandoned: () => boolean,
+  isActive: () => boolean,
+  onPending: (detail: Record<string, unknown>) => void
+): Promise<EmbeddedBrowserBounds | null> {
+  const startedAt = Date.now()
+  let lastDiagnosticAt = 0
+  while (!isAbandoned()) {
+    if (!isActive()) return null
+    const element = getElement()
+    const bounds = element ? getElementBounds(element) : null
+    if (bounds) return bounds
+    const now = Date.now()
+    if (now - lastDiagnosticAt >= 1_000) {
+      const pane = element?.closest<HTMLElement>('[data-active-workbench-pane]')
+      const rect = element?.getBoundingClientRect()
+      onPending({
+        elapsedMs: now - startedAt,
+        hostConnected: element?.isConnected ?? false,
+        hostExists: Boolean(element),
+        hostRect: rect ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height } : null,
+        paneActive: pane?.dataset.activeWorkbenchPane ?? null,
+        paneHidden: pane?.hidden ?? null,
+      })
+      lastDiagnosticAt = now
     }
-
-    const check = () => {
-      if (isDisposed()) {
-        finish(() => reject(new Error('Embedded browser open was cancelled')))
-        return
-      }
-
-      const element = getElement()
-      const bounds = element ? getElementBounds(element) : null
-      if (bounds) {
-        finish(() => resolve(bounds))
-        return
-      }
-
-      if (Date.now() - startedAt >= EMBEDDED_BROWSER_HOST_BOUNDS_TIMEOUT_MS) {
-        finish(() => reject(new Error('Timed out waiting for embedded browser host bounds')))
-        return
-      }
-
-      timer = window.setTimeout(check, EMBEDDED_BROWSER_HOST_BOUNDS_INTERVAL_MS)
+    if (now - startedAt >= EMBEDDED_BROWSER_VISIBLE_HOST_TIMEOUT_MS) {
+      throw new Error('Timed out waiting to show the embedded browser')
     }
+    await new Promise<void>(resolve =>
+      window.setTimeout(resolve, EMBEDDED_BROWSER_VISIBLE_HOST_INTERVAL_MS)
+    )
+  }
+  throw new Error('Embedded browser open was cancelled')
+}
 
-    timer = window.setTimeout(check, 0)
-  })
+function browserOpenErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+function logBrowserOpenDiagnostic(
+  stage: BrowserOpenDiagnosticStage,
+  detail: Record<string, unknown>
+) {
+  console.info('[Wework] Embedded browser open diagnostic', JSON.stringify({ stage, ...detail }))
 }
 
 function observeElementIfPresent(observer: ResizeObserver, element: Element | null) {
@@ -727,6 +750,7 @@ export function WorkspaceBrowserPanel({
   const appearance = useOptionalAppearance()?.appearance ?? defaultAppearance
   const browserHostRef = useRef<HTMLDivElement | null>(null)
   const nativeBrowserOpenRef = useRef(false)
+  const nativeBrowserOpeningRef = useRef(false)
   const currentUrlRef = useRef<string | null>(null)
   const activePageUrlRef = useRef<string | null>(null)
   const addressEditingRef = useRef(false)
@@ -743,6 +767,7 @@ export function WorkspaceBrowserPanel({
   const pageStateRequestGenerationRef = useRef(0)
   const previousCodeCommentCountRef = useRef(codeCommentCount)
   const handledOpenRequestIdRef = useRef<number | null>(null)
+  const activeOpenRequestIdRef = useRef<number | null>(null)
   const syncBoundsTimerRef = useRef<number | null>(null)
   const syncBoundsAnimationFrameRef = useRef<number | null>(null)
   const postOpenSyncTimerRefs = useRef<number[]>([])
@@ -813,15 +838,18 @@ export function WorkspaceBrowserPanel({
 
   useLayoutEffect(() => {
     mountedRef.current = true
-    currentLabelRef.current = label
-    activeRef.current = active
-    pageStateRequestGenerationRef.current += 1
-    annotationRequestGenerationRef.current += 1
     return () => {
       mountedRef.current = false
       pageStateRequestGenerationRef.current += 1
       annotationRequestGenerationRef.current += 1
     }
+  }, [])
+
+  useLayoutEffect(() => {
+    currentLabelRef.current = label
+    activeRef.current = active
+    pageStateRequestGenerationRef.current += 1
+    annotationRequestGenerationRef.current += 1
   }, [active, label])
 
   useEffect(() => {
@@ -920,6 +948,21 @@ export function WorkspaceBrowserPanel({
   useEffect(() => {
     const listener = listenEmbeddedBrowserCloseRequests(event => {
       if (!activeRef.current || event.label !== currentLabelRef.current) return
+      if (nativeLabelRef.current && event.nativeLabel !== nativeLabelRef.current) {
+        console.info(
+          '[Wework] Embedded browser close ignored',
+          JSON.stringify({
+            currentNativeLabel: nativeLabelRef.current,
+            eventNativeLabel: event.nativeLabel,
+            label: event.label,
+          })
+        )
+        return
+      }
+      console.info(
+        '[Wework] Embedded browser close consumed',
+        JSON.stringify({ label: event.label, nativeLabel: event.nativeLabel })
+      )
       nativeBrowserOpenRef.current = false
       nativeLabelRef.current = null
       adoptedDownloadOwnerLabelRef.current = null
@@ -1297,45 +1340,128 @@ export function WorkspaceBrowserPanel({
   }, [currentUrl])
 
   useEffect(() => {
-    if (!active || !embeddedBrowserAvailable || !currentUrl) return
+    if (!embeddedBrowserAvailable || !currentUrl) return
     if (nativeBrowserOpenRef.current) {
       schedulePostOpenBoundsSync(active)
       return
     }
+    if (nativeBrowserOpeningRef.current) return
 
-    let disposed = false
     let readyTimer: number | null = null
+    const requestId = activeOpenRequestIdRef.current
+    const openingLabel = label
+    const openingUrl = currentUrl
+    const isAbandoned = () => !mountedRef.current || currentLabelRef.current !== openingLabel
+    nativeBrowserOpeningRef.current = true
 
     setStatus('loading')
     const openWhenHostIsReady = async () => {
       try {
-        const bounds = await waitForElementBounds(
-          () => browserHostRef.current,
-          () => disposed
-        )
-        if (disposed) return
+        const host = browserHostRef.current
+        const measuredBounds = active && host ? getElementBounds(host) : null
+        const visible = measuredBounds !== null
+        const bounds = measuredBounds ?? { x: 0, y: 0, width: 1, height: 1 }
+        if (isAbandoned()) return
 
+        logBrowserOpenDiagnostic('host_ready', {
+          active,
+          bounds,
+          label: openingLabel,
+          requestId,
+          url: openingUrl,
+          visible,
+        })
         readyTimer = window.setTimeout(() => {
-          if (!disposed) setStatus('ready')
+          if (!isAbandoned()) setStatus('ready')
         }, EMBEDDED_BROWSER_READY_TIMEOUT_MS)
 
-        const pageState = await openEmbeddedBrowser(currentUrl, bounds, label)
-        if (disposed) {
-          if (!mountedRef.current || !activeRef.current || currentLabelRef.current !== label) {
-            await closeEmbeddedBrowser(label).catch(() => undefined)
-          }
+        logBrowserOpenDiagnostic('native_open_started', {
+          active,
+          label: openingLabel,
+          requestId,
+          url: openingUrl,
+          visible,
+        })
+        const pageState = visible
+          ? await openEmbeddedBrowser(openingUrl, bounds, openingLabel)
+          : await openEmbeddedBrowser(openingUrl, bounds, openingLabel, false, !active)
+        if (isAbandoned()) {
+          await closeEmbeddedBrowser(openingLabel).catch(() => undefined)
+          logBrowserOpenDiagnostic('lifecycle_cancelled', {
+            active,
+            label: openingLabel,
+            requestId,
+            url: openingUrl,
+          })
           return
         }
-        adoptNativeLabel(pageState.nativeLabel, label)
+        adoptNativeLabel(pageState.nativeLabel, openingLabel)
         setInvalidTlsCertificate(pageState.invalidTlsCertificate ?? null)
         nativeBrowserOpenRef.current = true
-        updatePageUrl(pageState.url || currentUrl)
-        schedulePostOpenBoundsSync(active)
+        updatePageUrl(pageState.url || openingUrl)
+        if (!visible && active) {
+          const visibleBounds = await waitForVisibleBrowserHost(
+            () => browserHostRef.current,
+            isAbandoned,
+            () => activeRef.current,
+            detail =>
+              logBrowserOpenDiagnostic('host_waiting', {
+                ...detail,
+                label: openingLabel,
+                requestId,
+                url: openingUrl,
+              })
+          )
+          if (visibleBounds) {
+            await setEmbeddedBrowserBounds(visibleBounds, true, openingLabel)
+            logBrowserOpenDiagnostic('host_visible', {
+              bounds: visibleBounds,
+              label: openingLabel,
+              requestId,
+              url: openingUrl,
+            })
+          } else {
+            await setEmbeddedBrowserBounds(
+              { x: 0, y: 0, width: 1, height: 1 },
+              false,
+              openingLabel,
+              true
+            )
+          }
+        }
+        schedulePostOpenBoundsSync(activeRef.current)
         if (readyTimer !== null) window.clearTimeout(readyTimer)
         setStatus('ready')
+        logBrowserOpenDiagnostic('native_open_succeeded', {
+          active,
+          label: openingLabel,
+          nativeLabel: pageState.nativeLabel,
+          requestId,
+          url: pageState.url || openingUrl,
+        })
       } catch (error) {
-        console.error('Failed to open embedded browser:', error)
-        if (!disposed) {
+        const message = browserOpenErrorMessage(error)
+        const abandoned = isAbandoned()
+        console.error(
+          '[Wework] Embedded browser open failed',
+          JSON.stringify({
+            active,
+            disposed: abandoned,
+            error: message,
+            label: openingLabel,
+            requestId,
+            url: openingUrl,
+          })
+        )
+        logBrowserOpenDiagnostic('native_open_failed', {
+          active,
+          disposed: abandoned,
+          error: message,
+          label: openingLabel,
+          requestId,
+          url: openingUrl,
+        })
+        if (!abandoned) {
           if (readyTimer !== null) window.clearTimeout(readyTimer)
           const recoveryDelays = [0, 120, 300, 600]
           for (const delay of recoveryDelays) {
@@ -1343,13 +1469,13 @@ export function WorkspaceBrowserPanel({
               await new Promise<void>(resolve => window.setTimeout(resolve, delay))
             }
             try {
-              const pageState = await readEmbeddedBrowserPageState(label)
-              if (disposed) return
-              adoptNativeLabel(pageState.nativeLabel, label)
+              const pageState = await readEmbeddedBrowserPageState(openingLabel)
+              if (isAbandoned()) return
+              adoptNativeLabel(pageState.nativeLabel, openingLabel)
               setInvalidTlsCertificate(pageState.invalidTlsCertificate ?? null)
               nativeBrowserOpenRef.current = true
-              updatePageUrl(pageState.url || currentUrl)
-              schedulePostOpenBoundsSync(active)
+              updatePageUrl(pageState.url || openingUrl)
+              schedulePostOpenBoundsSync(activeRef.current)
               setStatus('ready')
               return
             } catch {
@@ -1359,15 +1485,13 @@ export function WorkspaceBrowserPanel({
           setStatus('error')
           setError(t('workbench.browser_open_failed'))
         }
+      } finally {
+        if (readyTimer !== null) window.clearTimeout(readyTimer)
+        nativeBrowserOpeningRef.current = false
       }
     }
 
     void openWhenHostIsReady()
-
-    return () => {
-      disposed = true
-      if (readyTimer !== null) window.clearTimeout(readyTimer)
-    }
   }, [
     active,
     adoptNativeLabel,
@@ -1600,9 +1724,21 @@ export function WorkspaceBrowserPanel({
     return () => {
       nativeBrowserOpenRef.current = false
       if (consumeEmbeddedBrowserLabelTransfer(label)) return
+      const nativeLabel = nativeLabelRef.current
       nativeLabelRef.current = null
       adoptedDownloadOwnerLabelRef.current = null
-      void closeEmbeddedBrowser(label).catch(() => undefined)
+      if (!nativeLabel) {
+        console.info(
+          '[Wework] Embedded browser cleanup skipped',
+          JSON.stringify({ label, reason: 'no_native_identity' })
+        )
+        return
+      }
+      console.info(
+        '[Wework] Embedded browser cleanup requested',
+        JSON.stringify({ label, nativeLabel })
+      )
+      void closeEmbeddedBrowser(label, nativeLabel).catch(() => undefined)
     }
   }, [label])
 
@@ -1806,8 +1942,16 @@ export function WorkspaceBrowserPanel({
     if (openRequest.label && openRequest.label !== label) return
     if (handledOpenRequestIdRef.current === openRequest.id) return
     handledOpenRequestIdRef.current = openRequest.id
+    activeOpenRequestIdRef.current = openRequest.id
+    logBrowserOpenDiagnostic('request_consumed', {
+      active,
+      label,
+      requestId: openRequest.id,
+      requestLabel: openRequest.label,
+      url: openRequest.url,
+    })
     openBrowserUrl(openRequest.url)
-  }, [label, openBrowserUrl, openRequest?.id, openRequest?.label, openRequest?.url])
+  }, [active, label, openBrowserUrl, openRequest?.id, openRequest?.label, openRequest?.url])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -4,6 +4,7 @@ import {
   EMBEDDED_BROWSER_AGENT_STATE_EVENT,
   EMBEDDED_BROWSER_PAGE_STATE_CHANGE_EVENT,
   clearEmbeddedBrowserData,
+  closeEmbeddedBrowser,
   evalEmbeddedBrowserJson,
   listenEmbeddedBrowserAgentState,
   listenEmbeddedBrowserOpenRequests,
@@ -81,6 +82,17 @@ describe('embedded-browser', () => {
     })
   })
 
+  test('closes only the expected native browser identity', async () => {
+    invokeMock.mockResolvedValue(undefined)
+
+    await closeEmbeddedBrowser('workspace-browser-task-1', 'embedded-browser-native-7')
+
+    expect(invokeMock).toHaveBeenCalledWith('embedded_browser_close', {
+      expectedNativeLabel: 'embedded-browser-native-7',
+      label: 'workspace-browser-task-1',
+    })
+  })
+
   test('clears selected embedded browser data through Tauri', async () => {
     invokeMock.mockResolvedValue(1)
 
@@ -151,31 +163,61 @@ describe('embedded-browser', () => {
   })
 
   test('routes frontend open requests to the active embedded browser listener', async () => {
+    invokeMock.mockResolvedValue([])
     const handler = vi.fn()
     const unlisten = listenEmbeddedBrowserOpenRequests(handler)
 
     expect(requestEmbeddedBrowserOpen('http://localhost:3000')).toBe(true)
     expect(handler).toHaveBeenCalledWith({
+      requestId: expect.any(Number),
       label: 'workspace-browser',
       url: 'http://localhost:3000/',
     })
     expect(requestEmbeddedBrowserOpen('asset://localhost/Users/me/workspace/trend.html')).toBe(true)
     expect(handler).toHaveBeenCalledWith({
+      requestId: expect.any(Number),
       label: 'workspace-browser',
       url: 'asset://localhost/Users/me/workspace/trend.html',
     })
     expect(requestEmbeddedBrowserOpen('file:///Users/me/workspace/report.html')).toBe(true)
     expect(handler).toHaveBeenCalledWith({
+      requestId: expect.any(Number),
       label: 'workspace-browser',
       url: 'file:///Users/me/workspace/report.html',
     })
     expect(requestEmbeddedBrowserOpen('/Users/me/workspace/report.html')).toBe(true)
     expect(handler).toHaveBeenCalledWith({
+      requestId: expect.any(Number),
       label: 'workspace-browser',
       url: 'file:///Users/me/workspace/report.html',
     })
     expect(requestEmbeddedBrowserOpen('ftp://localhost/resource')).toBe(false)
     expect(handler).toHaveBeenCalledTimes(4)
+
+    const release = await unlisten
+    release?.()
+  })
+
+  test('recovers an open request created before the native listener is ready', async () => {
+    invokeMock.mockResolvedValue([
+      {
+        requestId: 42,
+        label: 'workspace-browser-task-1',
+        url: 'https://example.test/',
+      },
+    ])
+    const handler = vi.fn()
+
+    const unlisten = listenEmbeddedBrowserOpenRequests(handler)
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledWith({
+        requestId: 42,
+        label: 'workspace-browser-task-1',
+        url: 'https://example.test/',
+      })
+    })
+    expect(invokeMock).toHaveBeenCalledWith('embedded_browser_pending_open_requests')
 
     const release = await unlisten
     release?.()

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import {
   EMBEDDED_BROWSER_AGENT_STATE_EVENT,
   EMBEDDED_BROWSER_PAGE_STATE_CHANGE_EVENT,
+  browserDiagnosticUrl,
   clearEmbeddedBrowserData,
   closeEmbeddedBrowser,
   evalEmbeddedBrowserJson,
@@ -41,6 +42,16 @@ describe('embedded-browser', () => {
   beforeEach(() => {
     invokeMock.mockReset()
     eventMocks.listen.mockClear()
+  })
+
+  test('removes query strings and fragments from diagnostic URLs', () => {
+    expect(browserDiagnosticUrl('https://example.test/path?token=secret#details')).toBe(
+      'https://example.test/path'
+    )
+    expect(browserDiagnosticUrl('file:///Users/me/report.html?token=secret#details')).toBe(
+      'file:///Users/me/report.html'
+    )
+    expect(browserDiagnosticUrl('not a URL')).toBe('<invalid-url>')
   })
 
   test('unwraps successful eval result values', async () => {
@@ -173,6 +184,7 @@ describe('embedded-browser', () => {
       label: 'workspace-browser',
       url: 'http://localhost:3000/',
     })
+    expect(handler.mock.calls[0]?.[0].requestId).toBeLessThan(0)
     expect(requestEmbeddedBrowserOpen('asset://localhost/Users/me/workspace/trend.html')).toBe(true)
     expect(handler).toHaveBeenCalledWith({
       requestId: expect.any(Number),

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -6,9 +6,11 @@ import { isTauriRuntime } from './runtime-environment'
 export const DEFAULT_EMBEDDED_BROWSER_LABEL = 'workspace-browser'
 const transferredBrowserLabels = new Set<string>()
 const embeddedBrowserOpenRequestHandlers = new Set<(request: EmbeddedBrowserOpenRequest) => void>()
+let embeddedBrowserFrontendOpenRequestSequence = 1
 let embeddedBrowserOpenRequestUnlistenPromise: Promise<UnlistenFn> | null = null
 let embeddedBrowserOpenRequestUnlisten: UnlistenFn | null = null
 let embeddedBrowserOpenRequestReleaseTimer: ReturnType<typeof setTimeout> | null = null
+let embeddedBrowserOpenRequestHandlerSequence = 1
 export const EMBEDDED_BROWSER_OPEN_REQUEST_EVENT = 'wework:embedded-browser-open-request'
 export const EMBEDDED_BROWSER_DOWNLOAD_EVENT = 'wework:embedded-browser-download'
 export const EMBEDDED_BROWSER_LOCAL_FILE_PREVIEW_EVENT =
@@ -41,12 +43,25 @@ export interface EmbeddedBrowserPageState {
 }
 
 export interface EmbeddedBrowserOpenRequest {
+  requestId: number
   url: string
   label: string
 }
 
+function logEmbeddedBrowserOpenTransport(stage: string, detail: Record<string, unknown> = {}) {
+  console.info(
+    '[Wework] Embedded browser open transport',
+    JSON.stringify({
+      stage,
+      handlerCount: embeddedBrowserOpenRequestHandlers.size,
+      ...detail,
+    })
+  )
+}
+
 export interface EmbeddedBrowserCloseRequest {
   label: string
+  nativeLabel: string
 }
 
 export type EmbeddedBrowserDataKind = 'cookies' | 'cache'
@@ -215,24 +230,30 @@ export function consumeEmbeddedBrowserLabelTransfer(
 export async function openEmbeddedBrowser(
   url: string,
   bounds: EmbeddedBrowserBounds,
-  label = DEFAULT_EMBEDDED_BROWSER_LABEL
+  label = DEFAULT_EMBEDDED_BROWSER_LABEL,
+  visible = true,
+  readyWhenHidden = true
 ): Promise<EmbeddedBrowserPageState> {
   return invoke<EmbeddedBrowserPageState>('embedded_browser_open', {
     ...browserArgs(label),
     url,
     bounds,
+    visible,
+    readyWhenHidden,
   })
 }
 
 export async function setEmbeddedBrowserBounds(
   bounds: EmbeddedBrowserBounds,
   visible: boolean,
-  label = DEFAULT_EMBEDDED_BROWSER_LABEL
+  label = DEFAULT_EMBEDDED_BROWSER_LABEL,
+  readyWhenHidden = false
 ): Promise<void> {
   await invoke('embedded_browser_set_bounds', {
     ...browserArgs(label),
     bounds,
     visible,
+    readyWhenHidden,
   })
 }
 
@@ -312,8 +333,14 @@ export async function relabelEmbeddedBrowser(
   })
 }
 
-export async function closeEmbeddedBrowser(label = DEFAULT_EMBEDDED_BROWSER_LABEL): Promise<void> {
-  await invoke('embedded_browser_close', browserArgs(label))
+export async function closeEmbeddedBrowser(
+  label = DEFAULT_EMBEDDED_BROWSER_LABEL,
+  expectedNativeLabel?: string
+): Promise<void> {
+  await invoke('embedded_browser_close', {
+    ...browserArgs(label),
+    expectedNativeLabel: expectedNativeLabel ?? null,
+  })
 }
 
 export async function clearEmbeddedBrowserData(kinds?: EmbeddedBrowserDataKind[]): Promise<number> {
@@ -331,7 +358,11 @@ export function requestEmbeddedBrowserOpen(
   const normalizedUrl = normalizeBrowserUrl(url, window.location.href)
   if (!normalizedUrl) return false
 
-  const request = { url: normalizedUrl, label }
+  const request = {
+    requestId: embeddedBrowserFrontendOpenRequestSequence++,
+    url: normalizedUrl,
+    label,
+  }
   embeddedBrowserOpenRequestHandlers.forEach(handler => handler(request))
   return true
 }
@@ -346,19 +377,29 @@ export function listenEmbeddedBrowserOpenRequests(
   if (embeddedBrowserOpenRequestReleaseTimer !== null) {
     clearTimeout(embeddedBrowserOpenRequestReleaseTimer)
     embeddedBrowserOpenRequestReleaseTimer = null
+    logEmbeddedBrowserOpenTransport('native_listener_release_cancelled')
   }
 
+  const handlerId = embeddedBrowserOpenRequestHandlerSequence++
   embeddedBrowserOpenRequestHandlers.add(handler)
+  logEmbeddedBrowserOpenTransport('handler_registered', { handlerId })
 
   if (!embeddedBrowserOpenRequestUnlistenPromise) {
+    logEmbeddedBrowserOpenTransport('native_listener_registering', { handlerId })
     embeddedBrowserOpenRequestUnlistenPromise = listen<EmbeddedBrowserOpenRequest>(
       EMBEDDED_BROWSER_OPEN_REQUEST_EVENT,
       event => {
+        logEmbeddedBrowserOpenTransport('native_event_received', {
+          requestId: event.payload.requestId,
+          label: event.payload.label,
+          url: event.payload.url,
+        })
         embeddedBrowserOpenRequestHandlers.forEach(currentHandler => currentHandler(event.payload))
       }
     )
       .then(unlisten => {
         embeddedBrowserOpenRequestUnlisten = unlisten
+        logEmbeddedBrowserOpenTransport('native_listener_registered', { handlerId })
         if (
           embeddedBrowserOpenRequestHandlers.size === 0 &&
           embeddedBrowserOpenRequestReleaseTimer === null
@@ -366,6 +407,9 @@ export function listenEmbeddedBrowserOpenRequests(
           embeddedBrowserOpenRequestUnlisten?.()
           embeddedBrowserOpenRequestUnlisten = null
           embeddedBrowserOpenRequestUnlistenPromise = null
+          logEmbeddedBrowserOpenTransport('native_listener_released_after_registration', {
+            handlerId,
+          })
         }
         return unlisten
       })
@@ -376,14 +420,42 @@ export function listenEmbeddedBrowserOpenRequests(
       })
   }
 
+  void embeddedBrowserOpenRequestUnlistenPromise
+    .then(() => invoke<EmbeddedBrowserOpenRequest[]>('embedded_browser_pending_open_requests'))
+    .then(requests => {
+      logEmbeddedBrowserOpenTransport('pending_snapshot_received', {
+        handlerId,
+        requests: requests.map(request => ({
+          requestId: request.requestId,
+          label: request.label,
+        })),
+      })
+      requests.forEach(request => {
+        logEmbeddedBrowserOpenTransport('pending_request_dispatched', {
+          handlerId,
+          requestId: request.requestId,
+          label: request.label,
+        })
+        handler(request)
+      })
+    })
+    .catch(error => {
+      console.error('[Wework] Failed to recover embedded browser open requests', error)
+    })
+
   return Promise.resolve(() => {
     embeddedBrowserOpenRequestHandlers.delete(handler)
+    logEmbeddedBrowserOpenTransport('handler_unregistered', { handlerId })
     if (embeddedBrowserOpenRequestHandlers.size > 0) return
     if (embeddedBrowserOpenRequestReleaseTimer !== null) return
 
+    logEmbeddedBrowserOpenTransport('native_listener_release_scheduled', { handlerId })
     embeddedBrowserOpenRequestReleaseTimer = setTimeout(() => {
       embeddedBrowserOpenRequestReleaseTimer = null
-      if (embeddedBrowserOpenRequestHandlers.size > 0) return
+      if (embeddedBrowserOpenRequestHandlers.size > 0) {
+        logEmbeddedBrowserOpenTransport('native_listener_release_skipped', { handlerId })
+        return
+      }
 
       const currentUnlisten = embeddedBrowserOpenRequestUnlisten
       const pendingUnlisten = embeddedBrowserOpenRequestUnlistenPromise
@@ -391,10 +463,14 @@ export function listenEmbeddedBrowserOpenRequests(
       embeddedBrowserOpenRequestUnlistenPromise = null
       if (currentUnlisten) {
         currentUnlisten()
+        logEmbeddedBrowserOpenTransport('native_listener_released', { handlerId })
         return
       }
       if (pendingUnlisten) {
-        void pendingUnlisten.then(unlisten => unlisten())
+        void pendingUnlisten.then(unlisten => {
+          unlisten()
+          logEmbeddedBrowserOpenTransport('pending_native_listener_released', { handlerId })
+        })
       }
     }, 1000)
   })

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -6,7 +6,8 @@ import { isTauriRuntime } from './runtime-environment'
 export const DEFAULT_EMBEDDED_BROWSER_LABEL = 'workspace-browser'
 const transferredBrowserLabels = new Set<string>()
 const embeddedBrowserOpenRequestHandlers = new Set<(request: EmbeddedBrowserOpenRequest) => void>()
-let embeddedBrowserFrontendOpenRequestSequence = 1
+const EMBEDDED_BROWSER_FRONTEND_REQUEST_ID_START = -1
+let embeddedBrowserFrontendOpenRequestSequence = EMBEDDED_BROWSER_FRONTEND_REQUEST_ID_START
 let embeddedBrowserOpenRequestUnlistenPromise: Promise<UnlistenFn> | null = null
 let embeddedBrowserOpenRequestUnlisten: UnlistenFn | null = null
 let embeddedBrowserOpenRequestReleaseTimer: ReturnType<typeof setTimeout> | null = null
@@ -22,6 +23,15 @@ export const EMBEDDED_BROWSER_INVALID_TLS_CERTIFICATE_EVENT =
 export const EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT = 'wework:debug-panel-visibility-change'
 export const EMBEDDED_BROWSER_OCCLUSION_EVENT = 'wework:embedded-browser-occlusion-change'
 export const EMBEDDED_BROWSER_AGENT_STATE_EVENT = 'wework:embedded-browser-agent-state'
+
+export function browserDiagnosticUrl(value: string): string {
+  try {
+    const url = new URL(value)
+    return `${url.protocol}//${url.host}${url.pathname}`
+  } catch {
+    return '<invalid-url>'
+  }
+}
 
 export interface EmbeddedBrowserOcclusionChange {
   id: string
@@ -359,7 +369,7 @@ export function requestEmbeddedBrowserOpen(
   if (!normalizedUrl) return false
 
   const request = {
-    requestId: embeddedBrowserFrontendOpenRequestSequence++,
+    requestId: embeddedBrowserFrontendOpenRequestSequence--,
     url: normalizedUrl,
     label,
   }


### PR DESCRIPTION
## Summary

- stop eagerly injecting every Remote App and browser schema into ordinary new-session requests
- preserve native Codex tool_search for supported Responses models and expand searched namespaces at the Executor boundary for Chat Completions and Anthropic models
- make the Wework built-in browser first programmatic open wait for the task-scoped native WebView to become ready and navigate before reporting success
- add request replay, identity-aware close behavior, focused lifecycle diagnostics, and architecture documentation

## Impact

- ordinary messages keep a compact tool payload instead of growing with all configured Apps
- non-official models retain the same on-demand App capability through reversible protocol conversion
- the first browser_open from a fresh local task no longer loses its URL, falsely succeeds, or waits until the tool timeout

## Validation

- Wework ESLint, TypeScript, and 3,188 unit tests passed
- Executor fmt, clippy, and 695 library tests passed
- Tauri embedded-browser tests passed (36 tests)
- desktop embedded-browser E2E passed on Codex 0.147.0, including fresh local-task first open under the timeout with one visible native host and preserved URL
- desktop core-task-flow E2E passed on Codex 0.147.0, including Responses, Chat Completions, and Anthropic tool_search / namespace / browser_open round trips
- isolated real Tauri AI verification opened and controlled the requested page successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Browser tools now load on demand after discovery, reducing initial request sizes.
  - Embedded browsers can open in the background and become visible when ready.
- **Bug Fixes**
  - Improved recovery for browser requests received before the interface is ready.
  - Prevented stale or relabeled browser panes from closing accidentally.
  - Preserved tool calls, results, and selections across supported model protocols.
- **Improvements**
  - Browser tools now expose only valid, tool-specific options and reject unsupported properties.
  - Added safeguards for initial request and browser-tool schema sizes.
- **Tests**
  - Expanded coverage for tool discovery, browser startup, navigation, and protocol compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->