### PR TITLE
fix(wework): track visible user message markers

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -468,6 +468,10 @@ The active-conversation capture is also normative:
 - User messages are right-aligned compact neutral bubbles. Assistant content is
   left-aligned prose, not wrapped in a card. Turn metadata and feedback actions
   are quiet and subordinate.
+- The compact turn-navigation rail reflects visible user messages, not the
+  assistant response currently being read. Every user message intersecting the
+  conversation viewport has a dark marker, so multiple markers may be active;
+  assistant-only viewport content does not activate its preceding turn.
 - The bottom Composer shares the thread column and stays visible. It uses the
   same input hierarchy as home but without the home project-selector layer.
 - When opening, closing, or resizing a side panel reflows conversation content,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1673,7 +1673,7 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
 
 async function verifyTurnNavigationTracksVisibleUserMessages(
   control,
-  turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN
+  turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN + 1
 ) {
   const promptText = `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
   const previewSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-preview"]`
@@ -1686,6 +1686,7 @@ async function verifyTurnNavigationTracksVisibleUserMessages(
     value: 'data-turn-index',
   })
   assert.match(turnIndex, /^\d+$/, `Unable to identify the navigation marker for "${promptText}"`)
+  const anchorResponseText = `Virtualized navigation response ${turnNumber}.1`
   const targetResponseText = `Virtualized navigation response ${turnNumber}.6`
   await control.command(
     'scrollToRatioAsUser',
@@ -1693,27 +1694,25 @@ async function verifyTurnNavigationTracksVisibleUserMessages(
     { value: '0' }
   )
   await control.command(
-    'waitFor',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
-    {
-      text: targetResponseText,
-      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-    }
+    'scrollIntoViewAsUser',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"] p`,
+    { text: anchorResponseText }
   )
 
+  const markerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="${turnIndex}"]`
   await control.command(
     'scrollIntoViewAsUser',
     `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`,
     { text: promptText }
   )
-  await control.command(
-    'waitFor',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="${turnIndex}"][data-active="true"]`,
-    {
-      stableMs: COMPOSER_READY_STABILITY_MS,
-      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-    }
-  )
+  await control.command('waitFor', `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`, {
+    text: promptText,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('waitFor', `${markerSelector}[data-active="true"]`, {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
   await captureVerificationScreenshot(control, 'turn-navigation-01-user-visible-active.png')
 
   const assistantText = await control.command(
@@ -1727,14 +1726,10 @@ async function verifyTurnNavigationTracksVisibleUserMessages(
   assert.equal(Number(turnMatch[1]), turnNumber, 'Scrolled to the wrong navigation turn')
   await new Promise(resolvePromise => setTimeout(resolvePromise, 750))
 
-  await control.command(
-    'waitFor',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="${turnIndex}"][data-active="false"]`,
-    {
-      stableMs: COMPOSER_READY_STABILITY_MS,
-      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-    }
-  )
+  await control.command('waitFor', `${markerSelector}[data-active="false"]`, {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
   await captureVerificationScreenshot(control, 'turn-navigation-02-assistant-only-inactive.png')
 }
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -169,6 +169,7 @@ const FILE_PANEL_ANCHOR_RESPONSE = [
 const TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX = 'WEWORK_DESKTOP_E2E_TURN_NAVIGATION'
 const TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX = 'WEWORK_DESKTOP_E2E_TURN_NAVIGATION_COMPLETE'
 const TURN_NAVIGATION_REGRESSION_TURN_COUNT = 30
+const TURN_NAVIGATION_ONLY_TURN_COUNT = 3
 const TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN = 6
 const CANCELLATION_PROMPT = 'WEWORK_DESKTOP_E2E_CANCEL: wait until the response is cancelled.'
 const CANCELLATION_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CANCEL_COMPLETE'
@@ -1670,8 +1671,10 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
   }
 }
 
-async function verifyVirtualizedTurnNavigationActiveMarker(control) {
-  const turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN
+async function verifyTurnNavigationTracksVisibleUserMessages(
+  control,
+  turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN
+) {
   const promptText = `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
   const previewSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-preview"]`
   await control.command('waitFor', previewSelector, {
@@ -1683,7 +1686,7 @@ async function verifyVirtualizedTurnNavigationActiveMarker(control) {
     value: 'data-turn-index',
   })
   assert.match(turnIndex, /^\d+$/, `Unable to identify the navigation marker for "${promptText}"`)
-  const targetResponseText = `Virtualized navigation response ${turnNumber}.1`
+  const targetResponseText = `Virtualized navigation response ${turnNumber}.6`
   await control.command(
     'scrollToRatioAsUser',
     `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`,
@@ -1698,26 +1701,11 @@ async function verifyVirtualizedTurnNavigationActiveMarker(control) {
     }
   )
 
-  const assistantText = await control.command(
+  await control.command(
     'scrollIntoViewAsUser',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
-    { text: targetResponseText }
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`,
+    { text: promptText }
   )
-  const turnMatch = assistantText.match(/Virtualized navigation response (\d+)\.\d+/)
-  assert.ok(turnMatch, `Unable to identify the virtualized navigation turn from "${assistantText}"`)
-
-  assert.equal(Number(turnMatch[1]), turnNumber, 'Scrolled to the wrong navigation turn')
-  await new Promise(resolvePromise => setTimeout(resolvePromise, 750))
-
-  const mountedUserMessages = await control.command(
-    'getText',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`
-  )
-  assert.ok(
-    !mountedUserMessages.includes(promptText),
-    `Turn ${turnNumber} user row remained mounted, so the active-marker regression was not reproduced`
-  )
-
   await control.command(
     'waitFor',
     `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="${turnIndex}"][data-active="true"]`,
@@ -1726,9 +1714,36 @@ async function verifyVirtualizedTurnNavigationActiveMarker(control) {
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     }
   )
+  await captureVerificationScreenshot(control, 'turn-navigation-01-user-visible-active.png')
+
+  const assistantText = await control.command(
+    'scrollIntoViewAsUser',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"] p`,
+    { text: targetResponseText }
+  )
+  const turnMatch = assistantText.match(/Virtualized navigation response (\d+)\.\d+/)
+  assert.ok(turnMatch, `Unable to identify the virtualized navigation turn from "${assistantText}"`)
+
+  assert.equal(Number(turnMatch[1]), turnNumber, 'Scrolled to the wrong navigation turn')
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 750))
+
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="${turnIndex}"][data-active="false"]`,
+    {
+      stableMs: COMPOSER_READY_STABILITY_MS,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    }
+  )
+  await captureVerificationScreenshot(control, 'turn-navigation-02-assistant-only-inactive.png')
 }
 
-async function reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp) {
+async function reopenCurrentTurnNavigationTask(
+  control,
+  composerSelector,
+  restartDesktopApp,
+  expectedTurnCount = TURN_NAVIGATION_REGRESSION_TURN_COUNT
+) {
   const debugSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
   const taskId = debugSnapshot.workbench?.currentRuntimeTask?.taskId
   assert.ok(taskId, 'The turn-navigation fixture did not expose its runtime task ID')
@@ -1749,7 +1764,7 @@ async function reopenCurrentTurnNavigationTask(control, composerSelector, restar
     'waitFor',
     `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
     {
-      text: `${TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX}_${TURN_NAVIGATION_REGRESSION_TURN_COUNT}`,
+      text: `${TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX}_${expectedTurnCount}`,
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     }
   )
@@ -6668,6 +6683,10 @@ async function verifyBackgroundTaskWindowLifecycle({
       `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
       { text: completionText, timeoutMs: DEFAULT_STEP_TIMEOUT_MS }
     )
+    await control.command('waitFor', composerSelector, {
+      stableMs: COMPOSER_READY_STABILITY_MS,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
   }
 
   await control.command('waitFor', '[data-testid="message-turn-navigation-marker"]', {
@@ -6739,7 +6758,7 @@ async function verifyBackgroundTaskWindowLifecycle({
     'utf8'
   )
   await reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp)
-  await verifyVirtualizedTurnNavigationActiveMarker(control)
+  await verifyTurnNavigationTracksVisibleUserMessages(control)
   return taskRowTestId
 }
 
@@ -13972,7 +13991,7 @@ last_updated = "2026-07-30T00:00:00Z"`
       })
       await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
       control.setScenario('turn_navigation')
-      for (let index = 0; index < TURN_NAVIGATION_REGRESSION_TURN_COUNT; index += 1) {
+      for (let index = 0; index < TURN_NAVIGATION_ONLY_TURN_COUNT; index += 1) {
         const turnNumber = index + 1
         await sendPrompt(
           control,
@@ -13987,6 +14006,10 @@ last_updated = "2026-07-30T00:00:00Z"`
             timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
           }
         )
+        await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
+          stableMs: COMPOSER_READY_STABILITY_MS,
+          timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+        })
       }
       console.log(
         'Turn navigation metrics:',
@@ -13995,8 +14018,13 @@ last_updated = "2026-07-30T00:00:00Z"`
       await control.command('waitFor', '[data-testid="message-turn-navigation-marker"]', {
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
-      await reopenCurrentTurnNavigationTask(control, ACTIVE_COMPOSER_SELECTOR, restartDesktopApp)
-      await verifyVirtualizedTurnNavigationActiveMarker(control)
+      await reopenCurrentTurnNavigationTask(
+        control,
+        ACTIVE_COMPOSER_SELECTOR,
+        restartDesktopApp,
+        TURN_NAVIGATION_ONLY_TURN_COUNT
+      )
+      await verifyTurnNavigationTracksVisibleUserMessages(control, 2)
       console.log(`Wework desktop turn-navigation E2E passed. Evidence: ${resultDir}`)
       return
     }

--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -45,6 +45,7 @@ interface UserTurn {
 
 interface MessageTurnMarker extends UserTurn {
   targetTop: number | null
+  targetBottom: number | null
 }
 
 interface PendingScrollTarget {
@@ -64,7 +65,7 @@ export function MessageTurnNavigation({
 }: MessageTurnNavigationProps) {
   const { t } = useTranslation('chat')
   const [markers, setMarkers] = useState<MessageTurnMarker[]>([])
-  const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null)
+  const [activeMarkerIds, setActiveMarkerIds] = useState<string[]>([])
   const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null)
   const [loadingMarkerId, setLoadingMarkerId] = useState<string | null>(null)
   const [pendingScrollTarget, setPendingScrollTarget] = useState<PendingScrollTarget | null>(null)
@@ -148,48 +149,29 @@ export function MessageTurnNavigation({
     turnNavigationRef.current = turnNavigation
   }, [messages, turnNavigation, userTurnsSignature])
 
-  const updateActiveMarker = useCallback(
-    (
-      nextMarkers: MessageTurnMarker[],
-      reason = 'unknown',
-      anchorByMessageId?: ReadonlyMap<string, HTMLElement>
-    ) => {
+  const updateActiveMarkers = useCallback(
+    (nextMarkers: MessageTurnMarker[], reason = 'unknown') => {
       void reason
       const scroller = scrollRef.current
       if (!scroller || nextMarkers.length === 0) {
-        setActiveMarkerId(null)
+        setActiveMarkerIds([])
         return
       }
 
-      const mountedMessageMarker = findActiveMarkerFromMountedMessages(
-        nextMarkers,
-        messagesRef.current,
-        anchorByMessageId,
-        scroller
+      const viewportTop = scroller.scrollTop
+      const viewportBottom = viewportTop + scroller.clientHeight
+      const nextActiveMarkerIds = nextMarkers
+        .filter(
+          marker =>
+            marker.targetTop !== null &&
+            marker.targetBottom !== null &&
+            marker.targetBottom > viewportTop &&
+            marker.targetTop < viewportBottom
+        )
+        .map(marker => marker.id)
+      setActiveMarkerIds(current =>
+        equalStringArrays(current, nextActiveMarkerIds) ? current : nextActiveMarkerIds
       )
-      if (mountedMessageMarker) {
-        setActiveMarkerId(mountedMessageMarker.id)
-        return
-      }
-
-      const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
-      const loadedMarkers = nextMarkers.filter(
-        (marker): marker is MessageTurnMarker & { targetTop: number } => marker.targetTop !== null
-      )
-      if (loadedMarkers.length === 0) {
-        return
-      }
-
-      let activeMarker = loadedMarkers[0]
-      for (const marker of loadedMarkers) {
-        if (marker.targetTop !== null && marker.targetTop <= currentPosition) {
-          activeMarker = marker
-        } else {
-          break
-        }
-      }
-
-      setActiveMarkerId(activeMarker.id)
     },
     [scrollRef]
   )
@@ -202,7 +184,7 @@ export function MessageTurnNavigation({
       if (!scroller || !content || userTurns.length < 2) {
         markersRef.current = []
         setMarkers([])
-        setActiveMarkerId(null)
+        setActiveMarkerIds([])
         return
       }
 
@@ -215,6 +197,7 @@ export function MessageTurnNavigation({
             ...turn,
             loaded: false,
             targetTop: null,
+            targetBottom: null,
           }
         }
 
@@ -224,14 +207,15 @@ export function MessageTurnNavigation({
           ...turn,
           loaded: true,
           targetTop,
+          targetBottom: scroller.scrollTop + anchorRect.bottom - scrollerRect.top,
         }
       })
 
       markersRef.current = nextMarkers
       setMarkers(nextMarkers)
-      updateActiveMarker(nextMarkers, reason, anchorByMessageId)
+      updateActiveMarkers(nextMarkers, reason)
     },
-    [contentRef, scrollRef, updateActiveMarker]
+    [contentRef, scrollRef, updateActiveMarkers]
   )
 
   const scheduleCalculateMarkers = useCallback(
@@ -259,7 +243,6 @@ export function MessageTurnNavigation({
     if (!scroller || !targetMessageId || !anchor) return
 
     scrollToMessageId(scroller, targetMessageId)
-    setActiveMarkerId(targetMessageId)
     setLoadingMarkerId(current => (current === pendingScrollTarget.navigationId ? null : current))
     setPendingScrollTarget(null)
     finishNavigationLoad(onNavigationLoadStateChange)
@@ -278,8 +261,8 @@ export function MessageTurnNavigation({
     if (!scroller || !content) return
 
     // Mounted anchors are recalculated by observers; raw scroll events reuse
-    // measured user targets and preserve the last valid virtualized marker.
-    const handleScroll = () => updateActiveMarker(markersRef.current, 'scroll')
+    // their measured bounds to update which user messages intersect the viewport.
+    const handleScroll = () => updateActiveMarkers(markersRef.current, 'scroll')
     const handleResize = () => scheduleCalculateMarkers('window-resize')
     scroller.addEventListener('scroll', handleScroll, { passive: true })
     window.addEventListener('resize', handleResize)
@@ -309,12 +292,13 @@ export function MessageTurnNavigation({
         timerRef.current = null
       }
     }
-  }, [contentRef, scheduleCalculateMarkers, scrollRef, updateActiveMarker])
+  }, [contentRef, scheduleCalculateMarkers, scrollRef, updateActiveMarkers])
 
   const handleMarkerClick = useCallback(
     async (marker: MessageTurnMarker) => {
       const scroller = scrollRef.current
       if (!scroller) return
+      const activeMarkerId = activeMarkerIds[0] ?? null
 
       const currentAnchor = findMessageAnchor(contentRef, marker.id)
       logTurnNavigation('marker-click', {
@@ -346,7 +330,6 @@ export function MessageTurnNavigation({
           }
         }
         scrollToMessageId(scroller, marker.id, 'smooth')
-        setActiveMarkerId(marker.id)
         return
       }
 
@@ -387,7 +370,7 @@ export function MessageTurnNavigation({
       }
     },
     [
-      activeMarkerId,
+      activeMarkerIds,
       contentRef,
       messages,
       onLoadTurnNavigationItem,
@@ -435,7 +418,7 @@ export function MessageTurnNavigation({
       >
         <div className="relative w-full" style={{ height: `${navigationHeight}px` }}>
           {markers.map((marker, index) => {
-            const isActive = activeMarkerId === marker.id
+            const isActive = activeMarkerIds.includes(marker.id)
             const isLoading = loadingMarkerId === marker.id
             const hoverDistance =
               hoveredMarkerIndex === -1 ? null : Math.abs(index - hoveredMarkerIndex)
@@ -763,70 +746,6 @@ function getMessageAnchorTargetTop(scroller: HTMLDivElement, anchor: HTMLElement
   return Math.max(0, scroller.scrollTop + anchorRect.top - scrollerRect.top)
 }
 
-function findActiveMarkerFromMountedMessages(
-  markers: MessageTurnMarker[],
-  messages: WorkbenchMessage[],
-  anchorByMessageId: ReadonlyMap<string, HTMLElement> | undefined,
-  scroller: HTMLDivElement
-): MessageTurnMarker | null {
-  if (!anchorByMessageId || anchorByMessageId.size === 0) return null
-
-  const messagePositionById = buildMessageTimelinePositions(messages)
-  const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
-  let currentMessageIndex: number | null = null
-  let currentMessageTop = Number.NEGATIVE_INFINITY
-  let firstMountedMessageIndex: number | null = null
-  let firstMountedMessageTop = Number.POSITIVE_INFINITY
-
-  anchorByMessageId.forEach((anchor, messageId) => {
-    const messagePosition = messagePositionById.get(messageId)
-    if (messagePosition === undefined) return
-
-    const targetTop = getMessageAnchorTargetTop(scroller, anchor)
-    if (targetTop < firstMountedMessageTop) {
-      firstMountedMessageTop = targetTop
-      firstMountedMessageIndex = messagePosition
-    }
-    if (targetTop <= currentPosition && targetTop > currentMessageTop) {
-      currentMessageTop = targetTop
-      currentMessageIndex = messagePosition
-    }
-  })
-
-  const viewportMessageIndex = currentMessageIndex ?? firstMountedMessageIndex
-  if (viewportMessageIndex === null) return null
-
-  let activeMarker: MessageTurnMarker | null = null
-  for (const marker of markers) {
-    if (marker.messageIndex > viewportMessageIndex) break
-    activeMarker = marker
-  }
-  return activeMarker
-}
-
-function buildMessageTimelinePositions(messages: WorkbenchMessage[]): Map<string, number> {
-  const positions = new Map<string, number>()
-  let nextMessageIndex: number | null = null
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index]
-    if (Number.isFinite(message.runtimeMessageIndex)) {
-      nextMessageIndex = message.runtimeMessageIndex as number
-      positions.set(message.id, nextMessageIndex)
-      continue
-    }
-
-    // A persisted page can start with an assistant message whose preceding user
-    // message belongs to the previous page. Keep it in the absolute transcript
-    // coordinate system by placing it immediately before the next indexed row.
-    if (nextMessageIndex !== null) {
-      positions.set(message.id, nextMessageIndex - 0.5)
-    }
-  }
-
-  return positions
-}
-
 function getScrollMetrics(scroller: HTMLElement, anchor?: HTMLElement | null) {
   const scrollerRect = scroller.getBoundingClientRect()
   const anchorRect = anchor?.getBoundingClientRect()
@@ -855,6 +774,10 @@ function getMessageAnchorById(content: HTMLElement) {
     }
   })
   return anchors
+}
+
+function equalStringArrays(left: string[], right: string[]) {
+  return left.length === right.length && left.every((value, index) => value === right[index])
 }
 
 function finishNavigationLoad(onNavigationLoadStateChange?: (loading: boolean) => void) {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -1474,7 +1474,7 @@ describe('ScrollableMessageArea', () => {
     expect(screen.getAllByTestId('message-turn-navigation-marker')).toHaveLength(2)
   })
 
-  test('tracks the active turn from a mounted assistant row when the user row is virtualized', () => {
+  test('does not activate a turn from mounted assistant rows when user rows are virtualized', () => {
     const scrollRef = createRef<HTMLDivElement>()
     const contentRef = createRef<HTMLDivElement>()
     const messages = [
@@ -1559,16 +1559,16 @@ describe('ScrollableMessageArea', () => {
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(markers).toHaveLength(3)
     expect(markers[0]).toHaveAttribute('data-active', 'false')
-    expect(markers[1]).toHaveAttribute('data-active', 'true')
+    expect(markers[1]).toHaveAttribute('data-active', 'false')
     expect(markers[2]).toHaveAttribute('data-active', 'false')
 
     scroller.scrollTop = 2_900
     fireEvent.scroll(scroller)
 
-    expect(markers[1]).toHaveAttribute('data-active', 'true')
+    expect(markers[1]).toHaveAttribute('data-active', 'false')
   })
 
-  test('tracks a page-leading assistant without a runtime message index', () => {
+  test('does not activate a turn from a page-leading assistant', () => {
     const scrollRef = createRef<HTMLDivElement>()
     const contentRef = createRef<HTMLDivElement>()
 
@@ -1649,6 +1649,66 @@ describe('ScrollableMessageArea', () => {
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(markers).toHaveLength(3)
     expect(markers[0]).toHaveAttribute('data-active', 'false')
+    expect(markers[1]).toHaveAttribute('data-active', 'false')
+    expect(markers[2]).toHaveAttribute('data-active', 'false')
+  })
+
+  test('activates every user message visible in the viewport', () => {
+    render(
+      <ScrollableMessageArea
+        messages={[
+          {
+            id: 'visible-user-1',
+            role: 'user',
+            content: 'Visible request one',
+            status: 'done',
+            createdAt: '2026-07-31T00:00:00.000Z',
+          },
+          {
+            id: 'visible-assistant',
+            role: 'assistant',
+            content: 'Visible response',
+            status: 'done',
+            createdAt: '2026-07-31T00:00:01.000Z',
+          },
+          {
+            id: 'visible-user-2',
+            role: 'user',
+            content: 'Visible request two',
+            status: 'done',
+            createdAt: '2026-07-31T00:00:02.000Z',
+          },
+          {
+            id: 'hidden-user',
+            role: 'user',
+            content: 'Hidden request',
+            status: 'done',
+            createdAt: '2026-07-31T00:00:03.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 1_000, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 200,
+      writable: true,
+      configurable: true,
+    })
+    mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('Visible request one').closest('[data-message-id]')!, -20, 80)
+    mockRect(screen.getByText('Visible response').closest('[data-message-id]')!, 80, 120)
+    mockRect(screen.getByText('Visible request two').closest('[data-message-id]')!, 200, 80)
+    mockRect(screen.getByText('Hidden request').closest('[data-message-id]')!, 420, 80)
+
+    fireEvent.resize(window)
+    flushScheduledTimers()
+
+    const markers = screen.getAllByTestId('message-turn-navigation-marker')
+    expect(markers).toHaveLength(3)
+    expect(markers[0]).toHaveAttribute('data-active', 'true')
     expect(markers[1]).toHaveAttribute('data-active', 'true')
     expect(markers[2]).toHaveAttribute('data-active', 'false')
   })


### PR DESCRIPTION
## What changed

- activate the left turn-navigation markers from user messages that intersect the conversation viewport
- allow multiple visible user messages to activate multiple markers simultaneously
- stop assistant-only viewport content from activating the preceding user turn
- update focused unit coverage and the real desktop turn-navigation regression flow
- document the interaction rule in `wework/DESIGN.md`

## Root cause

The navigation rail inferred one active turn from every mounted transcript row. When an assistant row was visible, it mapped that row back to the preceding user message, so the marker appeared active even though that user message was outside the viewport.

## Impact

The rail now reflects the user prompts actually visible on screen. Reading a long AI response no longer makes the preceding prompt marker appear selected, and multiple prompts visible in the same viewport are represented accurately.

## Validation

- `pnpm --filter wework exec vitest run src/components/chat/ScrollableMessageArea.test.tsx`
- `pnpm --filter wework exec prettier --check src/components/chat/MessageTurnNavigation.tsx src/components/chat/ScrollableMessageArea.test.tsx e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint src/components/chat/MessageTurnNavigation.tsx src/components/chat/ScrollableMessageArea.test.tsx e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --turn-navigation-only`
- pre-push Wework ESLint, TypeScript, and complete unit-test checks

Real Tauri evidence:

- `turn-navigation-01-user-visible-active.png`: the visible second user message activates its marker
- `turn-navigation-02-assistant-only-inactive.png`: the second marker becomes inactive when only its assistant response remains visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Turn-navigation markers now activate for all visible user-message turns.
  * Assistant-only content no longer activates a preceding turn.
  * Navigation remains accurate while scrolling and when multiple turns are visible.

* **Bug Fixes**
  * Improved turn-marker state when reopening tasks and navigating between messages.

* **Tests**
  * Expanded coverage for scrolling, visible turns, and multi-turn task flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->