### PR TITLE
test(backend): speed up CI password hashing

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.core.config import Settings
-from app.core.security import create_access_token, get_password_hash
+from app.core.security import create_access_token, get_password_hash, pwd_context
 from app.db.base import Base
 
 # Import all models to ensure they are registered with same Base instance
@@ -28,6 +28,16 @@ from app.models.kind import Kind
 from app.models.skill_binary import SkillBinary
 from app.models.subtask import Subtask
 from app.models.user import User
+
+
+@pytest.fixture(scope="session", autouse=True)
+def use_fast_test_password_hashing() -> Generator[None, None, None]:
+    """Use the minimum bcrypt work factor while exercising password behavior."""
+
+    original_rounds = pwd_context.handler("bcrypt").default_rounds
+    pwd_context.update(bcrypt__rounds=4)
+    yield
+    pwd_context.update(bcrypt__rounds=original_rounds)
 
 
 class FakeIMSessionRedisClient:

--- a/backend/tests/services/test_plugin_marketplace_v2.py
+++ b/backend/tests/services/test_plugin_marketplace_v2.py
@@ -1819,6 +1819,10 @@ def test_reconnect_sync_clears_materialized_uninstall_state(test_db, test_user):
 
 
 def test_upstream_sync_is_incremental_and_records_failure(test_db, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.plugin_marketplace_service.validate_upstream_url",
+        lambda _url: None,
+    )
     service = PluginMarketplaceService()
     package = _plugin_zip("2.0.0")
     stored_packages: dict[str, bytes] = {}
@@ -1886,6 +1890,10 @@ def test_upstream_sync_is_incremental_and_records_failure(test_db, monkeypatch):
 def test_upstream_archive_is_scanned_before_plugin_package_selection(
     test_db, monkeypatch
 ):
+    monkeypatch.setattr(
+        "app.services.plugin_marketplace_service.validate_upstream_url",
+        lambda _url: None,
+    )
     service = PluginMarketplaceService()
     package = _plugin_zip("2.0.0")
     stored_packages: dict[str, bytes] = {}


### PR DESCRIPTION
## What changed

- Use bcrypt cost 4 only during backend pytest sessions, preserving hashing and verification behavior while avoiding production-strength CPU work in fixtures.
- Mock upstream URL validation in two marketplace tests so unit tests do not depend on external DNS.

## Why

Recent merge-group runs showed Test Backend taking 8-13 minutes, with dependency installation under 10 seconds and nearly all time spent in pytest. Repeated bcrypt hashing in test fixtures was the main CPU hotspot.

## Validation

- Full backend suite with coverage: 4694 passed, 1 skipped in 418.84s (421.92s wall clock).
- Baseline full backend suite with coverage: 4694 passed, 1 skipped in 762.31s (778.13s wall clock).
- Improvement: 356.21s / 45.8% wall-clock reduction locally.
- Black and isort checks for changed files.
