### PR TITLE
test(backend): reduce CI test runtime

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -15,6 +15,7 @@ addopts =
     --strict-markers
     --tb=short
     -n 4
+    --maxschedchunk=1
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any, Generator, Tuple
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -376,12 +377,10 @@ def test_task_token(test_user: User) -> str:
     )
 
 
-@pytest.fixture(scope="function")
-def test_client(test_db: Session) -> TestClient:
-    """
-    Create a test client with database dependency override.
-    """
-    from app.api.dependencies import get_db
+@pytest.fixture(scope="session")
+def test_app() -> FastAPI:
+    """Create the API application once per test worker."""
+
     from app.core.rate_limit import limiter
     from app.main import create_app
 
@@ -391,6 +390,18 @@ def test_client(test_db: Session) -> TestClient:
     # The limiter is initialized at module load time and may have Redis enabled
     # but Redis connections can become stale during parallel test runs
     limiter.enabled = False
+
+    return app
+
+
+@pytest.fixture(scope="function")
+def test_client(
+    test_app: FastAPI,
+    test_db: Session,
+) -> Generator[TestClient, None, None]:
+    """Create an isolated client for the worker's shared application."""
+
+    from app.api.dependencies import get_db
 
     # Override database dependency to always return the same test_db session
     def override_get_db():
@@ -402,9 +413,13 @@ def test_client(test_db: Session) -> TestClient:
             test_db.rollback()
             raise
 
-    app.dependency_overrides[get_db] = override_get_db
-
-    return TestClient(app)
+    original_overrides = test_app.dependency_overrides.copy()
+    test_app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(test_app)
+    yield client
+    client.close()
+    test_app.dependency_overrides.clear()
+    test_app.dependency_overrides.update(original_overrides)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## What changed

- reuse one FastAPI application per pytest-xdist worker while keeping each test client isolated
- restore dependency overrides after every test
- limit xdist load-scheduling chunks to one test to reduce long-tail worker imbalance

## Why

Backend CI spent nearly all of its time in pytest. Logs showed two workers finishing several minutes before the remaining workers, while repeated `create_app()` calls added substantial setup cost to API tests.

## Impact

The test suite keeps the same coverage and per-test database/client isolation. Merge queue force-all behavior is unchanged.

## Validation

- `uv run pytest tests/ --cov=app --cov-report=xml --cov-report=term-missing -q`
  - 4694 passed, 1 skipped
  - 124.27s wall time locally, down from approximately 421.92s
- focused request-state isolation regression: 17 passed
- Black, isort, Python syntax, settings configuration, and Alembic multi-head pre-push checks passed

## Other slow jobs reviewed

- Wework unit coverage: tested Vitest V8 coverage against Istanbul; V8 was slower (190.41s vs 174.19s), so the experiment was reverted
- Cloud desktop E2E: most time is in dynamic cloud-specific app build and the real protocol matrix; no low-risk coverage-preserving shortcut was included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test execution for more consistent scheduling across parallel workers.
  * Streamlined application setup and test-client handling to improve test isolation and reliability.

* **Chores**
  * No end-user-facing functionality or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->