### PR TITLE
fix(wework): show runtime send errors

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -6106,8 +6106,10 @@ async function sendPromptUntilScenarioRequest(control, selector, prompt, scenari
 
 async function visibleModelOptionId(control, targetOptionIds) {
   for (const targetOptionId of targetOptionIds) {
+    const targetSelector = `[data-testid="model-selector-submenu"] [data-testid="${targetOptionId}"]`
+    await control.command('scrollIntoView', targetSelector).catch(() => undefined)
     const metrics = await control
-      .command('getElementMetrics', `[data-testid="${targetOptionId}"]`)
+      .command('getElementMetrics', targetSelector)
       .then(value => JSON.parse(value))
       .catch(() => [])
     if (
@@ -6255,10 +6257,11 @@ async function selectE2EModel(
     targetOptionId = await visibleModelOptionId(control, targetOptionIds)
   }
   assert.ok(targetOptionId, `No visible model option matched ${modelOptionIdCandidates(modelIds)}`)
-  await control.command('waitFor', `[data-testid="${targetOptionId}"]`, {
+  const targetSelector = `[data-testid="model-selector-submenu"] [data-testid="${targetOptionId}"]`
+  await control.command('waitFor', targetSelector, {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
-  await control.command('click', `[data-testid="${targetOptionId}"]`)
+  await control.command('click', targetSelector)
   const selectionSnapshot = JSON.parse(await control.command('snapshot', 'body'))
   if (selectionSnapshot.testIds.includes('model-switch-warning-dialog')) {
     await control.command(

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -173,6 +173,11 @@ const TURN_NAVIGATION_ONLY_TURN_COUNT = 3
 const TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN = 6
 const CANCELLATION_PROMPT = 'WEWORK_DESKTOP_E2E_CANCEL: wait until the response is cancelled.'
 const CANCELLATION_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_CANCEL_COMPLETE'
+const SEND_REJECTION_RUNNING_PROMPT =
+  'WEWORK_DESKTOP_E2E_SEND_REJECTION_RUNNING: keep this turn active.'
+const SEND_REJECTION_RETRY_PROMPT =
+  'WEWORK_DESKTOP_E2E_SEND_REJECTION_RETRY: this send must be rejected visibly.'
+const SEND_REJECTION_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_SEND_REJECTION_COMPLETE'
 const RETRY_PROMPT = 'WEWORK_DESKTOP_E2E_RETRY: fail once and then succeed after retry.'
 const RETRY_FAILURE_TEXT = 'WEWORK_DESKTOP_E2E_RETRY_FAILURE'
 const RETRY_CODEX_ERROR_TEXT = "Codex ran out of room in the model's context window."
@@ -440,6 +445,7 @@ const GUIDANCE_BACKGROUND_ONLY = process.argv.includes('--guidance-background-on
 const GUIDANCE_SCROLL_ONLY = process.argv.includes('--guidance-scroll-only')
 const MESSAGE_RESTORATION_ONLY = process.argv.includes('--message-restoration-only')
 const QUEUE_MANAGEMENT_ONLY = process.argv.includes('--queue-management-only')
+const SEND_REJECTION_ONLY = process.argv.includes('--send-rejection-only')
 const TASK_PLAN_ONLY = process.argv.includes('--task-plan-only')
 const BUILD_ONLY = process.argv.includes('--build-only')
 const DESKTOP_SCENARIO_ONLY = process.env.WEWORK_E2E_DESKTOP_SCENARIO_ONLY === 'true'
@@ -536,6 +542,7 @@ function getActiveOnlyModes() {
     ['--guidance-scroll-only', GUIDANCE_SCROLL_ONLY],
     ['--message-restoration-only', MESSAGE_RESTORATION_ONLY],
     ['--queue-management-only', QUEUE_MANAGEMENT_ONLY],
+    ['--send-rejection-only', SEND_REJECTION_ONLY],
     ['--task-plan-only', TASK_PLAN_ONLY],
     ['--build-only', BUILD_ONLY],
     ['WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true', DESKTOP_SCENARIO_ONLY],
@@ -6097,9 +6104,32 @@ async function sendPromptUntilScenarioRequest(control, selector, prompt, scenari
   )
 }
 
-async function revealGroupedModelOption(control, targetOptionId) {
+async function visibleModelOptionId(control, targetOptionIds) {
+  for (const targetOptionId of targetOptionIds) {
+    const metrics = await control
+      .command('getElementMetrics', `[data-testid="${targetOptionId}"]`)
+      .then(value => JSON.parse(value))
+      .catch(() => [])
+    if (
+      metrics.some(
+        metric =>
+          metric.width > 0 &&
+          metric.height > 0 &&
+          metric.bottom > 0 &&
+          metric.right > 0 &&
+          metric.top < 720 &&
+          metric.left < 1280
+      )
+    ) {
+      return targetOptionId
+    }
+  }
+  return null
+}
+
+async function revealGroupedModelOption(control, targetOptionIds) {
   const menu = JSON.parse(await control.command('snapshot', 'body'))
-  if (menu.testIds.includes(targetOptionId)) return true
+  if (await visibleModelOptionId(control, targetOptionIds)) return true
   const familyTestIds = menu.testIds.filter(testId => testId.startsWith('model-family-'))
 
   for (const familyTestId of familyTestIds) {
@@ -6107,8 +6137,7 @@ async function revealGroupedModelOption(control, targetOptionId) {
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     })
     await new Promise(resolvePromise => setTimeout(resolvePromise, 150))
-    const familyMenu = JSON.parse(await control.command('snapshot', 'body'))
-    if (familyMenu.testIds.includes(targetOptionId)) return true
+    if (await visibleModelOptionId(control, targetOptionIds)) return true
   }
 
   return false
@@ -6152,10 +6181,8 @@ async function ensureModelOptionVisible(control, modelIds) {
     await new Promise(resolvePromise => setTimeout(resolvePromise, 150))
     menu = JSON.parse(await control.command('snapshot', 'body'))
     if (hasModelOption(menu, targetOptionIds)) return menu
-    for (const targetOptionId of targetOptionIds) {
-      if (await revealGroupedModelOption(control, targetOptionId)) {
-        return JSON.parse(await control.command('snapshot', 'body'))
-      }
+    if (await revealGroupedModelOption(control, targetOptionIds)) {
+      return JSON.parse(await control.command('snapshot', 'body'))
     }
   }
 
@@ -6213,10 +6240,20 @@ async function selectE2EModel(
   )
   if (labels.some(label => selectedModelLabel.includes(label))) return
 
-  const selectionMenu = await ensureModelOptionVisible(control, modelIds)
-  const targetOptionId = modelOptionIdCandidates(modelIds).find(optionId =>
-    selectionMenu.testIds.includes(optionId)
-  )
+  await ensureModelOptionVisible(control, modelIds)
+  const targetOptionIds = modelOptionIdCandidates(modelIds)
+  let targetOptionId = await visibleModelOptionId(control, targetOptionIds)
+  if (!targetOptionId) {
+    const menu = JSON.parse(await control.command('snapshot', 'body'))
+    if (!menu.testIds.includes('model-selector-menu')) {
+      await control.command('clickWhenEnabled', '[data-testid="model-selector-button"]', {
+        stableMs: 100,
+        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+      })
+    }
+    await revealGroupedModelOption(control, targetOptionIds)
+    targetOptionId = await visibleModelOptionId(control, targetOptionIds)
+  }
   assert.ok(targetOptionId, `No visible model option matched ${modelOptionIdCandidates(modelIds)}`)
   await control.command('waitFor', `[data-testid="${targetOptionId}"]`, {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
@@ -7376,6 +7413,102 @@ async function verifyReconnectRecovery({ composerSelector, control }) {
     'reconnect-03-recovered.png',
     ACTIVE_WORKBENCH_SELECTOR
   )
+}
+
+async function verifyFollowUpSendRejectionNotice({ composerSelector, control }) {
+  control.setScenario('send_rejection')
+  await sendPromptUntilScenarioRequest(
+    control,
+    composerSelector,
+    SEND_REJECTION_RUNNING_PROMPT,
+    'send_rejection'
+  )
+  await control.command('waitFor', '[data-testid="pause-response-button"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await captureVerificationScreenshot(
+    control,
+    'send-rejection-01-running.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+
+  const runningSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+  assert.ok(
+    runningSnapshot.workbench?.currentRuntimeTask,
+    'The send-rejection task did not expose its runtime address'
+  )
+  await control.command('dispatchRuntimeLifecycleEvent', 'body', {
+    value: JSON.stringify({
+      address: runningSnapshot.workbench.currentRuntimeTask,
+      type: 'turn_settled',
+    }),
+  })
+  await waitForWorkbenchDebugState(
+    control,
+    snapshot => snapshot.pane?.status?.isBusy === false,
+    'The send-rejection fixture did not make the composer available'
+  )
+
+  await control.command('fill', composerSelector, { value: SEND_REJECTION_RETRY_PROMPT })
+  await captureVerificationScreenshot(
+    control,
+    'send-rejection-02-retry-ready.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+  await control.command('press', composerSelector, { key: 'Enter' })
+  await control.command('waitFor', '[data-testid="chat-input-error"]', {
+    text: '当前回复仍在进行中，请稍后再发送',
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    stableMs: 300,
+  })
+  const sendError = await control.command('getText', '[data-testid="chat-input-error"]')
+  assert.equal(
+    sendError,
+    '当前回复仍在进行中，请稍后再发送',
+    'The rejected follow-up did not show the localized runtime-busy error'
+  )
+  await control.command('waitFor', composerSelector, {
+    text: SEND_REJECTION_RETRY_PROMPT,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    stableMs: 300,
+  })
+  const userMessages = await control.command(
+    'getText',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"]`
+  )
+  assert.equal(
+    userMessages.includes(SEND_REJECTION_RETRY_PROMPT),
+    false,
+    'The rejected follow-up remained in the conversation'
+  )
+  await captureVerificationScreenshot(
+    control,
+    'send-rejection-03-error-visible.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+  assert.equal(
+    control.scenarioRequests.get('send_rejection')?.length,
+    1,
+    'The rejected follow-up unexpectedly reached the model service'
+  )
+
+  control.releaseSendRejectionResponse()
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: SEND_REJECTION_COMPLETION_TEXT,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('fill', composerSelector, { value: 'retry draft' })
+  await waitForSnapshot(
+    control,
+    snapshot => !snapshot.testIds.includes('chat-input-error'),
+    'Editing the composer did not clear the send error'
+  )
+  await captureVerificationScreenshot(
+    control,
+    'send-rejection-04-recovered.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+  await control.command('fill', composerSelector, { value: '' })
 }
 
 async function verifyRateLimitRecovery({ composerSelector, control }) {
@@ -8990,6 +9123,9 @@ class DesktopE2EServer {
     this.cancellationCompletionRelease = new Promise(resolvePromise => {
       this.releaseCancellationCompletion = resolvePromise
     })
+    this.sendRejectionCompletionRelease = new Promise(resolvePromise => {
+      this.releaseSendRejectionCompletion = resolvePromise
+    })
     this.sideChatQueueRelease = new Promise(resolvePromise => {
       this.resolveSideChatQueueRelease = resolvePromise
     })
@@ -9237,6 +9373,7 @@ class DesktopE2EServer {
         'goal_restart',
         'turn_navigation',
         'cancellation',
+        'send_rejection',
         'guidance_scroll',
         'queue_management',
         'retry',
@@ -9356,6 +9493,10 @@ class DesktopE2EServer {
 
   releaseCancellationResponse() {
     this.releaseCancellationCompletion()
+  }
+
+  releaseSendRejectionResponse() {
+    this.releaseSendRejectionCompletion()
   }
 
   releaseSideChatQueueResponse() {
@@ -11344,6 +11485,27 @@ class DesktopE2EServer {
       if (response.destroyed || response.writableEnded) return
       response.end(
         createSse([assistantMessage(CANCELLATION_COMPLETION_TEXT), responseCompleted(responseId)])
+      )
+      return
+    }
+
+    if (this.scenario === 'send_rejection') {
+      this.recordScenarioRequest('send_rejection', modelRequest)
+      assert.ok(
+        JSON.stringify(body).includes(SEND_REJECTION_RUNNING_PROMPT),
+        'The real Codex request did not contain the send-rejection prompt'
+      )
+      response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      })
+      response.write(createSse([responseCreated(responseId)]))
+      await this.sendRejectionCompletionRelease
+      if (response.destroyed || response.writableEnded) return
+      response.end(
+        createSse([assistantMessage(SEND_REJECTION_COMPLETION_TEXT), responseCompleted(responseId)])
       )
       return
     }
@@ -14171,6 +14333,20 @@ last_updated = "2026-07-30T00:00:00Z"`
       return
     }
 
+    if (SEND_REJECTION_ONLY) {
+      phase = 'send-rejection-project'
+      await createSingleRootLocalProject(control, workspacePath, 'workspace')
+      const composerSelector = ACTIVE_COMPOSER_SELECTOR
+      await control.command('waitFor', composerSelector, {
+        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      })
+      await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
+      phase = 'send-rejection-notice'
+      await verifyFollowUpSendRejectionNotice({ composerSelector, control })
+      console.log(`Wework desktop send-rejection E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
     if (shouldRunDesktopCheckpoint('workspace-tabs')) {
       phase = 'workspace-tab-isolation'
       await verifyWorkspaceTabIsolation(control)
@@ -15210,6 +15386,9 @@ last_updated = "2026-07-30T00:00:00Z"`
     }
 
     if (shouldRunDesktopCheckpoint('resilience')) {
+      phase = 'send-rejection-notice'
+      await verifyFollowUpSendRejectionNotice({ composerSelector, control })
+
       phase = 'queue-management'
       await verifyPausedQueueLifecycle({ composerSelector, control })
 

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -128,7 +128,10 @@ export interface ChatInputProps {
   onChange: (value: string) => void
   onBlur?: () => void
   onCompositionEnd?: () => void
-  onSubmit: (valueOverride?: string, options?: ChatSubmitOptions) => void | Promise<void>
+  onSubmit: (
+    valueOverride?: string,
+    options?: ChatSubmitOptions
+  ) => void | boolean | Promise<void | boolean>
   disabled: boolean
   pluginPickerIconOnly?: boolean
   submitDisabled?: boolean

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -83,6 +83,62 @@ describe('BufferedChatInput', () => {
     expect(onDraftEdit).toHaveBeenCalled()
   })
 
+  test('restores the submitted draft when an async send promise rejects', async () => {
+    let rejectSubmission: (error: Error) => void = () => undefined
+    const unhandledRejection = vi.fn()
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<boolean>((_resolve, reject) => {
+          rejectSubmission = reject
+        })
+    )
+
+    function Harness() {
+      const [value, setValue] = useState('retry rejected promise')
+      return (
+        <BufferedChatInput value={value} onChange={setValue} onSubmit={onSubmit} disabled={false} />
+      )
+    }
+
+    window.addEventListener('unhandledrejection', unhandledRejection)
+    render(<Harness />)
+    await userEvent.click(screen.getByTestId('send-message-button'))
+    rejectSubmission(new Error('send failed'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-message-input')).toHaveValue('retry rejected promise')
+    })
+    await Promise.resolve()
+    expect(unhandledRejection).not.toHaveBeenCalled()
+    window.removeEventListener('unhandledrejection', unhandledRejection)
+  })
+
+  test('keeps a newer draft when an earlier async send promise rejects', async () => {
+    let rejectSubmission: (error: Error) => void = () => undefined
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<boolean>((_resolve, reject) => {
+          rejectSubmission = reject
+        })
+    )
+
+    function Harness() {
+      const [value, setValue] = useState('submitted draft')
+      return (
+        <BufferedChatInput value={value} onChange={setValue} onSubmit={onSubmit} disabled={false} />
+      )
+    }
+
+    render(<Harness />)
+    await userEvent.click(screen.getByTestId('send-message-button'))
+    await userEvent.type(screen.getByTestId('chat-message-input'), 'newer draft')
+    rejectSubmission(new Error('send failed'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-message-input')).toHaveValue('newer draft')
+    })
+  })
+
   test('clears only the draft accepted by an async send', async () => {
     let resolveSubmission: (accepted: boolean) => void = () => undefined
     const onSubmit = vi.fn(

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { BufferedChatInput } from './BufferedChatInput'
 
@@ -43,6 +44,67 @@ describe('BufferedChatInput', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('chat-message-input')).toHaveValue('queued message')
+    })
+  })
+
+  test('keeps the submitted draft when an async send is rejected', async () => {
+    let resolveSubmission: (accepted: boolean) => void = () => undefined
+    const onDraftEdit = vi.fn()
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolveSubmission = resolve
+        })
+    )
+
+    function Harness() {
+      const [value, setValue] = useState('retry this message')
+      return (
+        <BufferedChatInput
+          value={value}
+          onChange={setValue}
+          onDraftEdit={onDraftEdit}
+          onSubmit={onSubmit}
+          disabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    await userEvent.click(screen.getByTestId('send-message-button'))
+    resolveSubmission(false)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-message-input')).toHaveValue('retry this message')
+    })
+    expect(onDraftEdit).not.toHaveBeenCalled()
+
+    await userEvent.type(screen.getByTestId('chat-message-input'), ' updated')
+    expect(onDraftEdit).toHaveBeenCalled()
+  })
+
+  test('clears only the draft accepted by an async send', async () => {
+    let resolveSubmission: (accepted: boolean) => void = () => undefined
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolveSubmission = resolve
+        })
+    )
+
+    function Harness() {
+      const [value, setValue] = useState('accepted message')
+      return (
+        <BufferedChatInput value={value} onChange={setValue} onSubmit={onSubmit} disabled={false} />
+      )
+    }
+
+    render(<Harness />)
+    await userEvent.click(screen.getByTestId('send-message-button'))
+    resolveSubmission(true)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-message-input')).toHaveValue('')
     })
   })
 

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -41,6 +41,9 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const committedValueRef = useRef(value)
   const pendingChangeRef = useRef(onChange)
   const programmaticUpdateDepthRef = useRef(0)
+  const draftEditVersionRef = useRef(0)
+  const scopeKeyRef = useRef(scopeKey)
+  scopeKeyRef.current = scopeKey
 
   const setComposerValue = useCallback((nextValue: string, cursor: number) => {
     programmaticUpdateDepthRef.current += 1
@@ -103,6 +106,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   useEffect(() => {
     if (!insertion || appliedInsertionIdRef.current === insertion.id) return
     appliedInsertionIdRef.current = insertion.id
+    draftEditVersionRef.current += 1
     const currentDraft = draftRef.current
     const nextDraft = currentDraft ? `${currentDraft}\n${insertion.text}` : insertion.text
     draftRef.current = nextDraft
@@ -115,6 +119,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     (nextDraft: string) => {
       draftRef.current = nextDraft
       if (programmaticUpdateDepthRef.current === 0) {
+        draftEditVersionRef.current += 1
         onDraftEdit?.()
       }
       scheduleDraftFlush(nextDraft)
@@ -130,6 +135,8 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const handleSubmit = useCallback(
     (valueOverride?: string, options?: ChatSubmitOptions) => {
       const submittedDraft = valueOverride ?? draftRef.current
+      const submittedDraftEditVersion = draftEditVersionRef.current
+      const submittedScopeKey = scopeKey
       const submission =
         options === undefined ? onSubmit(submittedDraft) : onSubmit(submittedDraft, options)
       if (submittedDraft.trim()) {
@@ -139,15 +146,21 @@ export const BufferedChatInput = memo(function BufferedChatInput({
         setComposerValue('', 0)
         onChange('')
       }
-      void Promise.resolve(submission).then(accepted => {
-        if (accepted !== false || !submittedDraft.trim()) return
+      const restoreSubmittedDraft = () => {
+        if (!submittedDraft.trim()) return
+        if (scopeKeyRef.current !== submittedScopeKey) return
+        if (draftEditVersionRef.current !== submittedDraftEditVersion) return
         if (draftRef.current) return
         draftRef.current = submittedDraft
         cancelPendingFlush()
         setDraftState({ scopeKey, sourceValue: submittedDraft, draft: submittedDraft })
         setComposerValue(submittedDraft, submittedDraft.length)
         onChange(submittedDraft)
-      })
+      }
+      void Promise.resolve(submission).then(accepted => {
+        if (accepted !== false) return
+        restoreSubmittedDraft()
+      }, restoreSubmittedDraft)
     },
     [cancelPendingFlush, onChange, onSubmit, scopeKey, setComposerValue]
   )

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -13,6 +13,7 @@ export interface BufferedChatInputInsertion {
 
 interface BufferedChatInputProps extends ChatInputProps {
   insertion?: BufferedChatInputInsertion | null
+  onDraftEdit?: () => void
 }
 
 const DRAFT_FLUSH_DELAY_MS = 300
@@ -22,6 +23,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   onChange,
   onSubmit,
   insertion,
+  onDraftEdit,
   ...props
 }: BufferedChatInputProps) {
   const scopeKey = props.projectChat?.scopeKey
@@ -38,6 +40,15 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const composerRef = useRef<ChatInputHandle>(null)
   const committedValueRef = useRef(value)
   const pendingChangeRef = useRef(onChange)
+  const programmaticUpdateDepthRef = useRef(0)
+
+  const setComposerValue = useCallback((nextValue: string, cursor: number) => {
+    programmaticUpdateDepthRef.current += 1
+    composerRef.current?.setValue(nextValue, cursor)
+    queueMicrotask(() => {
+      programmaticUpdateDepthRef.current = Math.max(0, programmaticUpdateDepthRef.current - 1)
+    })
+  }, [])
 
   const cancelPendingFlush = useCallback(() => {
     if (flushTimeoutRef.current !== null) {
@@ -74,9 +85,9 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     committedValueRef.current = value
     setDraftState({ scopeKey, sourceValue: value, draft: value })
     if (shouldSetComposer) {
-      composerRef.current?.setValue(value, value.length)
+      setComposerValue(value, value.length)
     }
-  }, [scopeKey, value])
+  }, [scopeKey, setComposerValue, value])
 
   // Flush a pending draft whenever it would be discarded (scope switch or unmount).
   useEffect(() => {
@@ -96,16 +107,19 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     const nextDraft = currentDraft ? `${currentDraft}\n${insertion.text}` : insertion.text
     draftRef.current = nextDraft
     setDraftState({ scopeKey, sourceValue: value, draft: nextDraft })
-    composerRef.current?.setValue(nextDraft, nextDraft.length)
+    setComposerValue(nextDraft, nextDraft.length)
     scheduleDraftFlush(nextDraft)
-  }, [insertion, scheduleDraftFlush, scopeKey, value])
+  }, [insertion, scheduleDraftFlush, scopeKey, setComposerValue, value])
 
   const setDraft = useCallback(
     (nextDraft: string) => {
       draftRef.current = nextDraft
+      if (programmaticUpdateDepthRef.current === 0) {
+        onDraftEdit?.()
+      }
       scheduleDraftFlush(nextDraft)
     },
-    [scheduleDraftFlush]
+    [onDraftEdit, scheduleDraftFlush]
   )
 
   // Flush after the next frame so the editor state settles first.
@@ -116,20 +130,26 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const handleSubmit = useCallback(
     (valueOverride?: string, options?: ChatSubmitOptions) => {
       const submittedDraft = valueOverride ?? draftRef.current
-      if (options === undefined) {
-        void onSubmit(submittedDraft)
-      } else {
-        void onSubmit(submittedDraft, options)
-      }
+      const submission =
+        options === undefined ? onSubmit(submittedDraft) : onSubmit(submittedDraft, options)
       if (submittedDraft.trim()) {
         draftRef.current = ''
         cancelPendingFlush()
         setDraftState({ scopeKey, sourceValue: '', draft: '' })
-        composerRef.current?.setValue('', 0)
+        setComposerValue('', 0)
         onChange('')
       }
+      void Promise.resolve(submission).then(accepted => {
+        if (accepted !== false || !submittedDraft.trim()) return
+        if (draftRef.current) return
+        draftRef.current = submittedDraft
+        cancelPendingFlush()
+        setDraftState({ scopeKey, sourceValue: submittedDraft, draft: submittedDraft })
+        setComposerValue(submittedDraft, submittedDraft.length)
+        onChange(submittedDraft)
+      })
     },
-    [cancelPendingFlush, onChange, onSubmit, scopeKey]
+    [cancelPendingFlush, onChange, onSubmit, scopeKey, setComposerValue]
   )
 
   return (

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -624,7 +624,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
 
   const connectorAuthGate = useLocalConnectorAuthGate({
     messages: paneSession.messages,
-    onResumeSend: input => sendPaneInputWithContext(input),
+    onResumeSend: async input => {
+      await sendPaneInputWithContext(input)
+    },
     onRetryMessage: message => paneSession.retryFailedMessage(message),
   })
 
@@ -636,7 +638,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         if (gate === 'blocked') {
           // Keep composer text so cancel does not discard the draft; resume
           // send still uses pendingInput and clears after a successful send.
-          return
+          return false
         }
       }
       return sendPaneInputWithContext(value, options)
@@ -2372,6 +2374,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                                     insertion={conversationSelectionInsertion}
                                     value={paneSession.input}
                                     onChange={paneSession.setInput}
+                                    onDraftEdit={paneSession.clearError}
                                     onSubmit={submitPaneInput}
                                     disabled={composerDisabled}
                                     pluginPickerIconOnly={hasConversation}
@@ -2533,6 +2536,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                     <BufferedChatInput
                       value={paneSession.input}
                       onChange={paneSession.setInput}
+                      onDraftEdit={paneSession.clearError}
                       onSubmit={submitPaneInput}
                       disabled={composerDisabled}
                       submitDisabled={paneSession.status.isSubmitting}

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -468,6 +468,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                   <BufferedChatInput
                     value={paneSession.input}
                     onChange={paneSession.setInput}
+                    onDraftEdit={paneSession.clearError}
                     onSubmit={submitPaneInput}
                     disabled={composerDisabled}
                     submitDisabled={paneSession.status.isSubmitting}
@@ -574,6 +575,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
               <BufferedChatInput
                 value={paneSession.input}
                 onChange={paneSession.setInput}
+                onDraftEdit={paneSession.clearError}
                 onSubmit={submitPaneInput}
                 disabled={composerDisabled}
                 submitDisabled={paneSession.status.isSubmitting}

--- a/wework/src/components/layout/useWorkbenchPaneSession.test.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  applyRuntimeConversationAction,
+  clearRuntimeConversationCacheForTests,
+  getRuntimeConversationMessages,
+} from '@/features/workbench/runtimeConversationCache'
+import { rollbackRejectedRuntimeConversationTurn } from './useWorkbenchPaneSession'
+
+describe('rollbackRejectedRuntimeConversationTurn', () => {
+  afterEach(clearRuntimeConversationCacheForTests)
+
+  test('removes the old optimistic turn without overwriting a newly active conversation', () => {
+    const submittedTarget = {
+      deviceId: 'device-1',
+      taskId: 'task-a',
+      workspacePath: '/workspace/a',
+    }
+    const activeTarget = {
+      deviceId: 'device-1',
+      taskId: 'task-b',
+      workspacePath: '/workspace/b',
+    }
+    applyRuntimeConversationAction(submittedTarget, {
+      type: 'user_added',
+      message: {
+        id: 'rejected-message',
+        role: 'user',
+        content: 'old conversation draft',
+        status: 'done',
+        createdAt: '2026-08-09T00:00:00.000Z',
+      },
+    })
+    applyRuntimeConversationAction(activeTarget, {
+      type: 'user_added',
+      message: {
+        id: 'active-message',
+        role: 'user',
+        content: 'new conversation',
+        status: 'done',
+        createdAt: '2026-08-09T00:00:01.000Z',
+      },
+    })
+
+    const visibleMessages = rollbackRejectedRuntimeConversationTurn(
+      submittedTarget,
+      activeTarget,
+      'rejected-message'
+    )
+
+    expect(visibleMessages).toBeNull()
+    expect(getRuntimeConversationMessages(submittedTarget)).toEqual([])
+    expect(getRuntimeConversationMessages(activeTarget)).toMatchObject([
+      { id: 'active-message', content: 'new conversation' },
+    ])
+  })
+})

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -199,11 +199,19 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   const [codeCommentContexts, setCodeCommentContexts] = useState<CodeCommentContext[]>([])
   const input = projectChat.input ?? ''
   const scopedSetInput = projectChat.setInput ?? noopSetInput
-  const [error, setError] = useState<string | null>(null)
+  const [localError, setLocalError] = useState<string | null>(null)
+  const error = projectChat.setComposerError ? (projectChat.composerError ?? null) : localError
+  const setError = projectChat.setComposerError ?? setLocalError
+  const clearError = useCallback(() => setError(null), [setError])
   const setInput = useCallback(
     (value: string) => {
       scopedSetInput(value)
-      setError(null)
+    },
+    [scopedSetInput]
+  )
+  const restoreInputAfterFailure = useCallback(
+    (value: string) => {
+      scopedSetInput(value)
     },
     [scopedSetInput]
   )
@@ -903,23 +911,30 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     ): Promise<boolean> => {
       if (!currentRuntimeTask) return false
 
-      lastSubmittedRetryMessageRef.current = createLocalUserMessage(
-        message.content,
-        message.attachments,
-        {
-          id: message.id,
-          createdAt: message.createdAt,
-          runtimeGoalRequest: message.runtimeGoalRequest,
-          codeComments: message.codeComments,
-        }
-      )
-      if (options.appendLocalMessage !== false) {
-        appendLocalUserMessage(message.displayContent ?? message.content, message.attachments, {
-          id: message.id,
-          createdAt: message.createdAt,
-          runtimeGoalRequest: message.runtimeGoalRequest,
-          codeComments: message.codeComments,
-        })
+      const retryMessage = createLocalUserMessage(message.content, message.attachments, {
+        id: message.id,
+        createdAt: message.createdAt,
+        runtimeGoalRequest: message.runtimeGoalRequest,
+        codeComments: message.codeComments,
+      })
+      lastSubmittedRetryMessageRef.current = retryMessage
+      const appendedLocalMessage = options.appendLocalMessage !== false
+      if (appendedLocalMessage) {
+        const visibleMessage =
+          message.displayContent === undefined
+            ? retryMessage
+            : createLocalUserMessage(message.displayContent, message.attachments, {
+                id: message.id,
+                createdAt: message.createdAt,
+                runtimeGoalRequest: message.runtimeGoalRequest,
+                codeComments: message.codeComments,
+              })
+        setMessages(
+          applyRuntimeConversationAction(currentRuntimeTask, {
+            type: 'user_added',
+            message: visibleMessage,
+          })
+        )
       }
       const messageAttachments = message.attachments ?? []
       const attachmentIds = remoteAttachmentIds(messageAttachments)
@@ -943,14 +958,20 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           ...(attachments.length > 0 ? { attachments } : {}),
           ...(Object.keys(additionalContext).length > 0 ? { additionalContext } : {}),
         },
-        { onError: options.onError }
+        { onError: options.onError ?? setError }
       )
       if (sent) {
         markRuntimeTerminalAdditionalContextDelivered(terminalContext)
+      } else if (appendedLocalMessage) {
+        setMessages(
+          removeRuntimeConversationTurn(currentRuntimeTask, {
+            clientUserMessageId: message.id,
+          })
+        )
       }
       return sent
     },
-    [appendLocalUserMessage, currentRuntimeTask, sendRuntimePaneMessage]
+    [currentRuntimeTask, sendRuntimePaneMessage, setError]
   )
 
   const interruptAndSendQueuedMessage = useCallback(
@@ -1038,6 +1059,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       currentRuntimeTask,
       interruptAndSendRuntimePaneMessage,
       queuedMessages,
+      setError,
       setQueuedMessages,
     ]
   )
@@ -1101,7 +1123,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         retryInFlightRef.current = false
       }
     },
-    [currentRuntimeTask, retryRuntimeFailedMessage]
+    [currentRuntimeTask, retryRuntimeFailedMessage, setError]
   )
 
   const sendRequestUserInputResponse = useCallback(
@@ -1251,7 +1273,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         return false
       }
     },
-    [currentRuntimeTask, editLastUserMessage, getRuntimeModelFields, paneStatus.isBusy]
+    [currentRuntimeTask, editLastUserMessage, getRuntimeModelFields, paneStatus.isBusy, setError]
   )
 
   const ignoreRequestUserInput = useCallback(
@@ -1505,11 +1527,12 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       paneStatus.isBusy,
       sendRuntimeMessage,
       sendRuntimePaneGuidance,
+      setError,
       setQueuedMessages,
     ]
   )
 
-  const send: (inputOverride?: string, options?: RuntimePaneSendOptions) => Promise<void> =
+  const send: (inputOverride?: string, options?: RuntimePaneSendOptions) => Promise<boolean> =
     useCallback(
       async (inputOverride, options = {}) => {
         const submittedInput = (inputOverride ?? input).trim()
@@ -1533,16 +1556,15 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         if (goalDraftActive) {
           if (!submittedInput) {
             setError(i18n.t('workbench.goal_objective_required'))
-            return
+            return false
           }
           if (hasCodeComments) {
             setError(i18n.t('workbench.runtime_task_code_comments_not_supported'))
-            return
+            return false
           }
 
           // Errors belong to the previous action; a new goal submission starts fresh.
           setError(null)
-          setInput('')
           if (currentRuntimeTask) {
             const draftGoal = createPendingRuntimeGoal(submittedInput)
             const initialGoal = runtimeGoalCreateInput(draftGoal)
@@ -1565,10 +1587,11 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
                 status: 'active',
               })
               if (!response.accepted) {
-                setInput(submittedInput)
+                currentAttachments.forEach(projectChat.addExistingAttachment)
                 setError(response.error || i18n.t('workbench.goal_set_failed'))
-                return
+                return false
               }
+              setInput('')
               setRuntimeConversationGoal(currentRuntimeTask, response.goal)
               lifecycleStore.goalStatusReceived(currentRuntimeTask, response.goal.status)
               setGoalDraftActive(false)
@@ -1576,23 +1599,32 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
               if (options.guideWhenBusy) {
                 await sendQueuedMessageAsGuidance(queuedMessage)
               }
-              return
+              return true
             }
 
-            const sent = await sendRuntimeMessage(queuedMessage, { initialGoal })
+            let sendError: string | null = null
+            const sent = await sendRuntimeMessage(queuedMessage, {
+              initialGoal,
+              onError: nextError => {
+                sendError = nextError
+              },
+            })
             if (sent) {
+              setInput('')
               setRuntimeConversationGoal(currentRuntimeTask, draftGoal)
               lifecycleStore.goalStatusReceived(currentRuntimeTask, draftGoal.status)
               setGoalDraftActive(false)
               setCodeCommentContexts([])
             } else {
-              setInput(submittedInput)
+              currentAttachments.forEach(projectChat.addExistingAttachment)
+              setError(sendError ?? i18n.t('workbench.project_chat_send_failed'))
             }
-            return
+            return sent
           }
 
           const draftGoal = createPendingRuntimeGoal(submittedInput)
           const initialGoal = runtimeGoalCreateInput(draftGoal)
+          setInput('')
           setPendingGoalState({ goal: draftGoal, targetKey: null, targetIdentityKey: null })
           setGoalDraftActive(false)
           const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments, {
@@ -1605,6 +1637,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             additionalContext: options.additionalContext,
             cloudProjectId: options.cloudProjectId,
             initialSupervisor: options.initialSupervisor,
+            onError: setError,
             onRuntimeTaskOptimisticOpen: (address, context) => {
               options.onRuntimeTaskCreated?.(address)
               setPendingGoalState(current =>
@@ -1635,6 +1668,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             },
           })
           if (sent) {
+            setInput('')
             if (!isRuntimeTaskAddress(sent)) {
               appendLocalUserMessage(submittedInput, currentAttachments, {
                 runtimeGoalRequest: true,
@@ -1655,28 +1689,29 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             if (seededGoalAddress) {
               clearRuntimePaneGoalSeed(seededGoalAddress)
             }
+            restoreInputAfterFailure(submittedInput)
             setGoalDraftActive(true)
             setPendingGoalState(null)
           }
-          return
+          return Boolean(sent)
         }
 
         if (submittedInput === '/compact') {
           if (!currentRuntimeTask) {
             setError('当前对话还没有可压缩的 Codex 线程')
-            return
+            return false
           }
           if (paneStatus.isBusy) {
             setError('当前回复进行中，完成后再压缩上下文')
-            return
+            return false
           }
           if (currentAttachments.length > 0 || hasCodeComments) {
             setError('/compact 不能和附件或代码评论一起发送')
-            return
+            return false
           }
-          setInput('')
-          await compactRuntimePaneTask(currentRuntimeTask, { onError: setError })
-          return
+          const compacted = await compactRuntimePaneTask(currentRuntimeTask, { onError: setError })
+          if (compacted) setInput('')
+          return compacted
         }
 
         const pendingInitialGoal =
@@ -1690,7 +1725,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             additionalContext: options.additionalContext,
             cloudProjectId: options.cloudProjectId,
           })
-          return
+          return true
         }
 
         let resolvedAdditionalContext: RuntimeAdditionalContext | undefined
@@ -1703,16 +1738,16 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         } catch (cause) {
           console.warn('[Wework composer] failed to load referenced conversation', cause)
           setError(i18n.t('workbench.mention_conversation_load_failed'))
-          return
+          return false
         }
 
         // Do not keep an earlier action error visible once the user sends a new message.
         setError(null)
-        setInput('')
         const visibleSubmittedInput =
           effectiveSubmittedInput ||
           (hasCodeComments ? i18n.t('workbench.code_comment_fallback') : '')
         if (!currentRuntimeTask) {
+          setInput('')
           const optimisticMessage = createLocalUserMessage(
             visibleSubmittedInput,
             currentAttachments,
@@ -1787,11 +1822,9 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             projectChat.resetAttachments()
             setCodeCommentContexts([])
           } else {
-            // Restore the draft when send is blocked so the user can retry.
-            // Use scoped setter so we do not clear the pane error reported via onError.
-            scopedSetInput(visibleSubmittedInput)
+            restoreInputAfterFailure(visibleSubmittedInput)
           }
-          return
+          return Boolean(sent)
         }
 
         if (hasCodeComments) {
@@ -1813,22 +1846,32 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
             if (options.interruptWhenBusy) {
               const sent = await interruptAndSendQueuedMessage(queuedMessage)
               if (!sent) {
-                scopedSetInput(visibleSubmittedInput)
                 currentAttachments.forEach(projectChat.addExistingAttachment)
                 setCodeCommentContexts(codeCommentContexts)
+              } else {
+                setInput('')
               }
-              return
+              return sent
             }
             setQueuedMessages(messages => [...messages, queuedMessage])
-            return
+            setInput('')
+            return true
           }
 
-          const sent = await sendRuntimeMessage(queuedMessage)
+          let sendError: string | null = null
+          const sent = await sendRuntimeMessage(queuedMessage, {
+            onError: nextError => {
+              sendError = nextError
+            },
+          })
           if (sent) {
+            setInput('')
             projectChat.resetAttachments()
             setCodeCommentContexts([])
+          } else {
+            setError(sendError ?? i18n.t('workbench.project_chat_send_failed'))
           }
-          return
+          return sent
         }
 
         const queuedMessage: RuntimePaneQueuedMessage = {
@@ -1846,22 +1889,34 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
           if (options.interruptWhenBusy) {
             const sent = await interruptAndSendQueuedMessage(queuedMessage)
             if (!sent) {
-              scopedSetInput(submittedInput)
               currentAttachments.forEach(projectChat.addExistingAttachment)
+            } else {
+              setInput('')
             }
-            return
+            return sent
           }
           setQueuedMessages(messages => [...messages, queuedMessage])
+          setInput('')
           if (options.guideWhenBusy) {
             await sendQueuedMessageAsGuidance(queuedMessage)
           }
-          return
+          return true
         }
 
-        const sent = await sendRuntimeMessage(queuedMessage)
+        let sendError: string | null = null
+        const sent = await sendRuntimeMessage(queuedMessage, {
+          onError: nextError => {
+            sendError = nextError
+          },
+        })
         if (sent) {
+          setInput('')
           setCodeCommentContexts([])
+        } else {
+          currentAttachments.forEach(projectChat.addExistingAttachment)
+          setError(sendError ?? i18n.t('workbench.project_chat_send_failed'))
         }
+        return sent
       },
       [
         appendLocalUserMessage,
@@ -1879,10 +1934,11 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         paneStatus.isBusy,
         projectChat,
         queuedMessages.length,
+        restoreInputAfterFailure,
         sendCurrentInput,
         sendQueuedMessageAsGuidance,
         sendRuntimeMessage,
-        scopedSetInput,
+        setError,
         setInput,
         setQueuedMessages,
         setRuntimeGoal,
@@ -2001,13 +2057,20 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       projectChat.resetAttachments()
       const sent = await interruptAndSendQueuedMessage(combinedMessage)
       if (sent) return
-      scopedSetInput(combinedMessage.displayContent ?? combinedMessage.content)
+      restoreInputAfterFailure(combinedMessage.displayContent ?? combinedMessage.content)
       combinedMessage.attachments?.forEach(projectChat.addExistingAttachment)
       if (combinedMessage.codeComments && combinedMessage.codeComments.length > 0) {
         setCodeCommentContexts(combinedMessage.codeComments)
       }
     },
-    [input, interruptAndSendQueuedMessage, projectChat, queuedMessages, scopedSetInput, setInput]
+    [
+      input,
+      interruptAndSendQueuedMessage,
+      projectChat,
+      queuedMessages,
+      restoreInputAfterFailure,
+      setInput,
+    ]
   )
 
   const compactContext = useCallback(async () => {
@@ -2020,7 +2083,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       return false
     }
     return compactRuntimePaneTask(currentRuntimeTask, { onError: setError })
-  }, [compactRuntimePaneTask, currentRuntimeTask, paneStatus.isBusy])
+  }, [compactRuntimePaneTask, currentRuntimeTask, paneStatus.isBusy, setError])
 
   const setCurrentGoal = useCallback(async () => {
     projectChat.setSelectedModelOption('collaborationMode', 'default')
@@ -2231,6 +2294,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     input,
     setInput,
     error,
+    clearError,
     status: paneStatus,
     sending: paneStatus.isSubmitting,
     waitingForAssistant: paneStatus.isWaitingForAssistantIndicator,

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -963,11 +963,12 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       if (sent) {
         markRuntimeTerminalAdditionalContextDelivered(terminalContext)
       } else if (appendedLocalMessage) {
-        setMessages(
-          removeRuntimeConversationTurn(currentRuntimeTask, {
-            clientUserMessageId: message.id,
-          })
+        const rolledBackMessages = rollbackRejectedRuntimeConversationTurn(
+          currentRuntimeTask,
+          currentRuntimeTaskRef.current,
+          message.id
         )
+        if (rolledBackMessages) setMessages(rolledBackMessages)
       }
       return sent
     },
@@ -2344,6 +2345,21 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
 }
 
 export type WorkbenchPaneSession = ReturnType<typeof useWorkbenchPaneSession>
+
+export function rollbackRejectedRuntimeConversationTurn(
+  target: RuntimeTaskAddress,
+  activeTarget: RuntimeTaskAddress | null,
+  clientUserMessageId: string
+): WorkbenchMessage[] | null {
+  const messages = removeRuntimeConversationTurn(target, { clientUserMessageId })
+  if (
+    !activeTarget ||
+    runtimeTranscriptPaneIdentityKey(activeTarget) !== runtimeTranscriptPaneIdentityKey(target)
+  ) {
+    return null
+  }
+  return messages
+}
 
 function isInterruptedGuidance(message: RuntimePaneQueuedMessage): boolean {
   return message.status === 'sending' && message.deliveryMode === 'guidance'

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -533,6 +533,7 @@ export function TemporaryChatPanel({
           <BufferedChatInput
             value={input}
             onChange={setInput}
+            onDraftEdit={() => setError(null)}
             onSubmit={send}
             disabled={false}
             pluginPickerIconOnly

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1643,6 +1643,7 @@ function FollowUpProbe() {
   return (
     <div>
       <span data-testid="composer-input">{paneSession.input}</span>
+      <span data-testid="pane-session-error">{paneSession.error ?? ''}</span>
       <span data-testid="queued-messages">
         {paneSession.queuedMessages
           .map(message => `${message.status}:${message.content}`)
@@ -7806,6 +7807,91 @@ describe('WorkbenchProvider runtime tasks', () => {
       modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
+  })
+
+  test('shows the runtime rejection in the active pane when a follow-up send fails', async () => {
+    const sendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: false,
+      taskId: 'runtime-a',
+      error: 'runtime task is already running',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <FollowUpProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pane-session-error')).toHaveTextContent(
+        '当前回复仍在进行中，请稍后再发送'
+      )
+    )
+    expect(screen.getByTestId('composer-input')).toHaveTextContent('继续修')
+    expect(screen.getByTestId('runtime-open-messages')).not.toHaveTextContent('继续修')
+    expect(screen.getByTestId('runtime-open-error')).toHaveTextContent('')
+  })
+
+  test('shows model preparation cancellation in the active pane', async () => {
+    const prepareRuntimeModel = vi.fn().mockResolvedValue(false)
+    const sendRuntimeMessage = vi.fn()
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      prepareRuntimeModel,
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <FollowUpProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pane-session-error')).toHaveTextContent('已取消模型配置同步')
+    )
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+    expect(screen.getByTestId('composer-input')).toHaveTextContent('继续修')
+    expect(screen.getByTestId('runtime-open-messages')).not.toHaveTextContent('继续修')
+    expect(screen.getByTestId('runtime-open-error')).toHaveTextContent('')
   })
 
   test('marks an existing runtime task running while a follow-up send is pending', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -339,6 +339,7 @@ export function WorkbenchProvider({
   const [draftInputByScope, setDraftInputByScope] = useState<Record<string, string>>(() =>
     workspaceTabId ? (consumeWorkspaceTabTransfer(workspaceTabId)?.draftInputByScope ?? {}) : {}
   )
+  const [composerErrorByScope, setComposerErrorByScope] = useState<Record<string, string>>({})
   useEffect(() => {
     if (!workspaceTabId) return
     publishWorkspaceTabTransferState(workspaceTabId, { draftInputByScope })
@@ -348,6 +349,7 @@ export function WorkbenchProvider({
   >({})
   const [trialPluginNameByScope, setTrialPluginNameByScope] = useState<Record<string, string>>({})
   const draftInput = draftInputByScope[projectChatScopeKey] ?? ''
+  const composerError = composerErrorByScope[projectChatScopeKey] ?? null
   const trialTemplates = trialTemplatesByScope[projectChatScopeKey] ?? EMPTY_PLUGIN_TRIAL_TEMPLATES
   const trialPluginName = trialPluginNameByScope[projectChatScopeKey] ?? ''
   useEffect(() => {
@@ -399,6 +401,21 @@ export function WorkbenchProvider({
           return next
         })
       }
+    },
+    [projectChatScopeKey]
+  )
+  const setComposerError = useCallback(
+    (error: string | null) => {
+      setComposerErrorByScope(current => {
+        if (error) {
+          if (current[projectChatScopeKey] === error) return current
+          return { ...current, [projectChatScopeKey]: error }
+        }
+        if (!current[projectChatScopeKey]) return current
+        const next = { ...current }
+        delete next[projectChatScopeKey]
+        return next
+      })
     },
     [projectChatScopeKey]
   )
@@ -1901,6 +1918,7 @@ export function WorkbenchProvider({
       selectedModelOptions: modelSelection.selectedModelOptions,
       isModelSelectionReady: modelSelection.isSelectionReady,
       input: draftInput,
+      composerError,
       trialTemplates,
       trialPluginName,
       hasConversationContext: Boolean(state.currentRuntimeTask),
@@ -1920,6 +1938,7 @@ export function WorkbenchProvider({
       getSelectedModelOptions: modelSelection.getSelectedModelOptions,
       onBlockedModelSelect: handleBlockedModelSelect,
       setInput: setDraftInput,
+      setComposerError,
       setSelectedSkills: skillSelection.setSelectedSkills,
       toggleSkill: skillSelection.toggleSkill,
       handleFileSelect: attachmentSelection.handleFileSelect,
@@ -1940,6 +1959,7 @@ export function WorkbenchProvider({
       attachmentSelection.uploadingFiles,
       projectChatScopeKey,
       draftInput,
+      composerError,
       trialTemplates,
       trialPluginName,
       state.currentRuntimeTask,
@@ -1961,6 +1981,7 @@ export function WorkbenchProvider({
       modelSelection.getSelectedModel,
       modelSelection.getSelectedModelOptions,
       setDraftInput,
+      setComposerError,
       skillSelection.selectedSkills,
       skillSelection.setSelectedSkills,
       skillSelection.skills,
@@ -1977,6 +1998,7 @@ export function WorkbenchProvider({
       selectedModelOptions: modelSelection.selectedModelOptions,
       isModelSelectionReady: modelSelection.isSelectionReady,
       input: draftInput,
+      composerError,
       trialTemplates,
       trialPluginName,
       hasConversationContext: Boolean(state.currentRuntimeTask),
@@ -1996,6 +2018,7 @@ export function WorkbenchProvider({
       getSelectedModelOptions: modelSelection.getSelectedModelOptions,
       onBlockedModelSelect: handleBlockedModelSelect,
       setInput: setDraftInput,
+      setComposerError,
       setSelectedSkills: skillSelection.setSelectedSkills,
       toggleSkill: skillSelection.toggleSkill,
       handleFileSelect: attachmentSelection.handleFileSelect,
@@ -2016,6 +2039,7 @@ export function WorkbenchProvider({
       attachmentSelection.uploadingFiles,
       projectChatScopeKey,
       draftInput,
+      composerError,
       trialTemplates,
       trialPluginName,
       state.currentRuntimeTask,
@@ -2036,6 +2060,7 @@ export function WorkbenchProvider({
       modelSelection.getSelectedModel,
       modelSelection.getSelectedModelOptions,
       setDraftInput,
+      setComposerError,
       skillSelection.selectedSkills,
       skillSelection.setSelectedSkills,
       skillSelection.skills,

--- a/wework/src/features/workbench/runtimePaneStatus.ts
+++ b/wework/src/features/workbench/runtimePaneStatus.ts
@@ -1,5 +1,6 @@
 import type { RuntimeTaskAddress } from '@/types/api'
 import type { WorkbenchMessage } from '@/types/workbench'
+import i18n from '@/i18n'
 import type { RuntimeTaskLifecycleSnapshot } from './runtimeTaskLifecycle'
 
 export type RuntimePaneSendPhase = 'idle' | 'submitting' | 'awaiting_assistant'
@@ -23,7 +24,11 @@ export interface RuntimePaneStatus {
 }
 
 export function isRuntimeTaskBusyError(error: string | null): boolean {
-  return error?.toLowerCase().includes('runtime task is already running') === true
+  const normalizedError = error?.trim().toLowerCase()
+  return (
+    normalizedError?.includes('runtime task is already running') === true ||
+    normalizedError === i18n.t('workbench.runtime_task_running_message').trim().toLowerCase()
+  )
 }
 
 export function deriveRuntimePaneStatus({

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -73,6 +73,7 @@ import {
 } from './workbenchRuntimeHelpers'
 import type { WorkbenchRuntimeTasks } from './useWorkbenchRuntimeTasks'
 import { findFileChangesBySubtaskId } from './runtimePaneMessages'
+import { isRuntimeTaskBusyError } from './runtimePaneStatus'
 import type { RuntimeTaskLifecycleStore } from './runtimeTaskLifecycle'
 import {
   inferRuntimeName,
@@ -130,6 +131,13 @@ interface UseWorkbenchRuntimeMessagingOptions {
   skillSelection: RuntimeMessagingSkillSelection
   refreshWorkLists: () => Promise<void>
   rememberExecutionDevice: (deviceId: string) => void
+}
+
+function runtimeSendError(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : fallback
+  return isRuntimeTaskBusyError(message)
+    ? i18n.t('workbench.runtime_task_running_message')
+    : message
 }
 
 export function runtimeThreadId(address?: RuntimeTaskAddress | null): string | null {
@@ -221,7 +229,10 @@ export function useWorkbenchRuntimeMessaging({
           deviceId: request.address.deviceId,
           modelId: request.modelId,
         })
-        if (!prepared) return false
+        if (!prepared) {
+          reportError(i18n.t('workbench.cloud_model_catalog_sync_cancelled'), options)
+          return false
+        }
         lifecycleStore.sendRequested(request.address)
         sendRequested = true
         const response = await executorClient.runtime.sendRuntimeMessage(request)
@@ -247,7 +258,7 @@ export function useWorkbenchRuntimeMessaging({
           addressKeys: Object.keys(request.address as unknown as Record<string, unknown>).sort(),
           error: error instanceof Error ? error.message : String(error),
         })
-        reportError(error instanceof Error ? error.message : '发送失败', options)
+        reportError(runtimeSendError(error, '发送失败'), options)
         return false
       }
     },
@@ -262,7 +273,10 @@ export function useWorkbenchRuntimeMessaging({
           deviceId: request.address.deviceId,
           modelId: request.modelId,
         })
-        if (!prepared) return false
+        if (!prepared) {
+          reportError(i18n.t('workbench.cloud_model_catalog_sync_cancelled'), options)
+          return false
+        }
         lifecycleStore.sendRequested(request.address)
         sendRequested = true
         const response = await executorClient.runtime.interruptAndSendRuntimeMessage(request)
@@ -277,7 +291,7 @@ export function useWorkbenchRuntimeMessaging({
         return true
       } catch (error) {
         if (sendRequested) lifecycleStore.sendRejected(request.address)
-        reportError(error instanceof Error ? error.message : '打断并发送失败', options)
+        reportError(runtimeSendError(error, '打断并发送失败'), options)
         return false
       }
     },

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -165,6 +165,7 @@ export interface WorkbenchContextValue {
     selectedModelOptions: ModelOptions
     isModelSelectionReady: boolean
     input: string
+    composerError?: string | null
     trialTemplates: PluginPathComponent[]
     trialPluginName?: string
     hasConversationContext?: boolean
@@ -184,6 +185,7 @@ export interface WorkbenchContextValue {
     getSelectedModelOptions?: () => ModelOptions
     onBlockedModelSelect: (model: UnifiedModel, message?: string) => void
     setInput: (value: string) => void
+    setComposerError?: (error: string | null) => void
     setSelectedSkills: (skills: SkillRef[]) => void
     toggleSkill: (skill: SkillRef) => void
     handleFileSelect: (files: File | File[]) => Promise<void>


### PR DESCRIPTION
## What changed

- Show runtime follow-up send failures in the active Wework composer instead of only logging them.
- Localize the executor busy rejection and keep model preparation cancellation visible in the pane.
- Roll back the optimistic user turn and restore the submitted draft and attachments when a send is rejected.
- Keep composer errors scoped to the conversation, and clear them only after a real user edit.
- Add unit coverage and a CI-covered real desktop E2E flow with screenshots for running, retry, rejection, and recovery states.

## Root cause

The runtime send path returned `false` after executor rejection without consistently forwarding the error to the active pane. The composer also cleared its buffered draft before the asynchronous result was known, while the optimistic user turn remained in the conversation. Pane-local error state could then be lost or immediately cleared by the programmatic draft restoration.

## User impact

When a follow-up is rejected because the runtime is still executing, users now see a localized inline error, retain the draft for retry, and do not see a ghost user message. Editing the restored draft clears the stale error.

## Validation

- `pnpm --dir wework test` — 332 files / 3199 tests passed
- `pnpm --dir wework typecheck`
- `pnpm --dir wework lint`
- `WEWORK_E2E_CONTROL_SERVER_PORT=43111 WEWORK_E2E_MODEL_SERVER_PORT=43112 pnpm --dir wework e2e:desktop -- --send-rejection-only`
- Pre-push ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved drafted messages, attachments, and comments when sending fails, allowing users to retry without losing work.
  * Added clear, localized messages for busy or cancelled runtime tasks.
  * Cleared pane errors when users edit the draft.
  * Prevented failed submissions from creating duplicate or unintended messages.
  * Improved model selection by reliably identifying visible options.

* **Tests**
  * Added coverage for rejected sends, draft preservation, recovery, runtime errors, and model selection across desktop workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->