### PR TITLE
fix(wework): add local terminal lifecycle diagnostics

### DIFF
--- a/docs/en/wework/workbench.md
+++ b/docs/en/wework/workbench.md
@@ -40,7 +40,7 @@ Select **+** in the bottom tab bar to choose **Terminal**, **IDE**, or **Desktop
 
 When diagnosing a terminal that does not repaint after a task switch, frontend logs record the terminal type, task and session identifiers, activation phase, xterm row and column count, container dimensions, and hidden state. They never record terminal output, commands, or workspace paths.
 
-To diagnose `[Terminal connection failed]`, use the same session identifier across three log groups: `Closing local terminal session` identifies whether panel unmount, workspace-target change, or an explicit user close removed the session; `Local terminal connection failed` identifies output-listener, exit-listener, or native-attach failure; and `Tauri local terminal attach` reports native states such as a missing session, closed attach channel, already attached, or successful attach. These logs never include terminal input, output, or workspace paths.
+To diagnose `[Terminal connection failed]`, correlate `Local terminal start`, `Local terminal connection`, `Tauri local terminal attach`, and `Local terminal close` logs by session identifier. The logs include the host process, child process, task, workspace path, connection stage, and close reason so output-listener, exit-listener, native-attach, missing-session, and intentional-close cases can be distinguished. They never include terminal input, output, executed commands, or environment-variable contents.
 
 ## Expand the right workspace
 

--- a/docs/zh/wework/workbench.md
+++ b/docs/zh/wework/workbench.md
@@ -40,7 +40,7 @@ Wework 桌面版使用顶部标签页承载任务、项目空间、智能体和�
 
 排查切换任务后终端未重绘时，前端日志会记录终端类型、任务与会话标识、激活阶段、xterm 行列数、容器尺寸和隐藏状态；不会记录终端输出、命令或工作区路径。
 
-排查 `[Terminal connection failed]` 时，按同一个会话标识查看三类日志：`Closing local terminal session` 说明会话是因面板卸载、工作区目标变化还是用户主动关闭而被移除；`Local terminal connection failed` 会标明失败发生在输出监听、退出监听或原生 attach；`Tauri local terminal attach` 会记录会话不存在、attach 通道已关闭、已附着或 attach 成功等原生状态。上述日志不记录终端输入、输出或工作区路径。
+排查 `[Terminal connection failed]` 时，按同一个会话标识串联 `Local terminal start`、`Local terminal connection`、`Tauri local terminal attach` 和 `Local terminal close` 日志。日志会记录宿主进程、子进程、任务、工作区路径、连接阶段和关闭原因，从而区分输出监听、退出监听、原生 attach、会话不存在和主动关闭等情况。上述日志不记录终端输入、输出、执行命令或环境变量内容。
 
 ## 展开右侧工作区
 

--- a/wework/src-tauri/src/local_terminal.rs
+++ b/wework/src-tauri/src/local_terminal.rs
@@ -176,17 +176,46 @@ pub fn start_local_terminal(
     rows: Option<u16>,
     cols: Option<u16>,
     env: Option<HashMap<String, String>>,
+    task_id: Option<String>,
+    workspace_path: Option<String>,
 ) -> Result<String, String> {
+    log::info!(
+        "Tauri local terminal start requested: host_pid={}, task_id={:?}, workspace_path={:?}, cwd={:?}",
+        std::process::id(),
+        task_id,
+        workspace_path,
+        cwd
+    );
     #[cfg(target_os = "macos")]
     {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-        start_pty_shell(app, &state, cwd, rows, cols, env, shell)
+        start_pty_shell(
+            app,
+            &state,
+            cwd,
+            rows,
+            cols,
+            env,
+            shell,
+            task_id,
+            workspace_path,
+        )
     }
 
     #[cfg(target_os = "windows")]
     {
         let shell = resolve_windows_shell();
-        start_pty_shell(app, &state, cwd, rows, cols, env, shell)
+        start_pty_shell(
+            app,
+            &state,
+            cwd,
+            rows,
+            cols,
+            env,
+            shell,
+            task_id,
+            workspace_path,
+        )
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -197,6 +226,8 @@ pub fn start_local_terminal(
         let _ = rows;
         let _ = cols;
         let _ = env;
+        let _ = task_id;
+        let _ = workspace_path;
         Err("Local terminal is supported only on macOS and Windows".to_string())
     }
 }
@@ -209,8 +240,11 @@ fn start_pty_shell(
     cols: Option<u16>,
     env: Option<HashMap<String, String>>,
     shell: String,
+    task_id: Option<String>,
+    workspace_path: Option<String>,
 ) -> Result<String, String> {
     let cwd = normalized_cwd(cwd)?;
+    let diagnostic_cwd = cwd.clone();
     let size = PtySize {
         rows: rows.unwrap_or(24).max(1),
         cols: cols.unwrap_or(80).max(1),
@@ -239,6 +273,7 @@ fn start_pty_shell(
         .slave
         .spawn_command(command)
         .map_err(|error| format!("Failed to spawn shell: {error}"))?;
+    let child_pid = child.process_id();
     drop(pair.slave);
 
     let (attach_sender, attach_receiver) = mpsc::sync_channel(1);
@@ -246,7 +281,7 @@ fn start_pty_shell(
     let session = LocalTerminalSession {
         master: pair.master,
         writer,
-        child_pid: child.process_id(),
+        child_pid,
         child,
         attach_sender: Some(attach_sender),
         attached: false,
@@ -256,6 +291,15 @@ fn start_pty_shell(
         .lock()
         .map_err(|_| "Failed to lock local terminal state".to_string())?
         .insert(session_id.clone(), session);
+    log::info!(
+        "Tauri local terminal start succeeded: host_pid={}, child_pid={:?}, session_id={}, task_id={:?}, workspace_path={:?}, cwd={:?}",
+        std::process::id(),
+        child_pid,
+        session_id,
+        task_id,
+        workspace_path,
+        diagnostic_cwd
+    );
 
     let output_session_id = session_id.clone();
     let exit_session_id = session_id.clone();
@@ -299,29 +343,53 @@ fn start_pty_shell(
 pub fn attach_local_terminal(
     state: State<'_, LocalTerminalState>,
     session_id: String,
+    task_id: Option<String>,
+    workspace_path: Option<String>,
 ) -> Result<(), String> {
-    log::info!("Tauri local terminal attach requested: session_id={session_id}");
+    log::info!(
+        "Tauri local terminal attach requested: host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+        std::process::id(),
+        session_id,
+        task_id,
+        workspace_path
+    );
     let mut sessions = state.sessions.lock().map_err(|_| {
         log::warn!(
-            "Tauri local terminal attach failed: reason=state_lock, session_id={session_id}"
+            "Tauri local terminal attach failed: reason=state_lock, host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path
         );
         "Failed to lock local terminal state".to_string()
     })?;
     let Some(session) = sessions.get_mut(&session_id) else {
         log::warn!(
-            "Tauri local terminal attach failed: reason=session_not_found, session_id={session_id}"
+            "Tauri local terminal attach failed: reason=session_not_found, host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path
         );
         return Err(format!("Local terminal session not found: {session_id}"));
     };
     if session.attached {
         log::info!(
-            "Tauri local terminal attach skipped: reason=already_attached, session_id={session_id}"
+            "Tauri local terminal attach skipped: reason=already_attached, host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path
         );
         return Ok(());
     }
     let Some(attach_sender) = session.attach_sender.take() else {
         log::warn!(
-            "Tauri local terminal attach failed: reason=attach_sender_missing, session_id={session_id}"
+            "Tauri local terminal attach failed: reason=attach_sender_missing, host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path
         );
         return Err(format!(
             "Local terminal session cannot be attached: {session_id}"
@@ -330,14 +398,24 @@ pub fn attach_local_terminal(
 
     if attach_sender.send(()).is_err() {
         log::warn!(
-            "Tauri local terminal attach failed: reason=attach_receiver_closed, session_id={session_id}"
+            "Tauri local terminal attach failed: reason=attach_receiver_closed, host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path
         );
         return Err(format!(
             "Failed to attach local terminal session: {session_id}"
         ));
     }
     session.attached = true;
-    log::info!("Tauri local terminal attach succeeded: session_id={session_id}");
+    log::info!(
+        "Tauri local terminal attach succeeded: host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}",
+        std::process::id(),
+        session_id,
+        task_id,
+        workspace_path
+    );
     Ok(())
 }
 
@@ -420,6 +498,9 @@ pub fn resize_local_terminal(
 pub fn close_local_terminal(
     state: State<'_, LocalTerminalState>,
     session_id: String,
+    task_id: Option<String>,
+    workspace_path: Option<String>,
+    reason: Option<String>,
 ) -> Result<(), String> {
     let mut sessions = state
         .sessions
@@ -427,15 +508,32 @@ pub fn close_local_terminal(
         .map_err(|_| "Failed to lock local terminal state".to_string())?;
     if let Some(mut session) = sessions.remove(&session_id) {
         log::info!(
-            "Tauri local terminal close requested: sender_pid={}, session_id={session_id}",
-            std::process::id()
+            "Tauri local terminal close requested: host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}, reason={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path,
+            reason
         );
         if let Err(error) = session.child.kill() {
             log::warn!(
-                "Tauri local terminal kill failed: sender_pid={}, session_id={session_id}, error={error}",
-                std::process::id()
+                "Tauri local terminal kill failed: host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}, reason={:?}, error={error}",
+                std::process::id(),
+                session_id,
+                task_id,
+                workspace_path,
+                reason
             );
         }
+    } else {
+        log::warn!(
+            "Tauri local terminal close skipped: reason=session_not_found, host_pid={}, session_id={}, task_id={:?}, workspace_path={:?}, close_reason={:?}",
+            std::process::id(),
+            session_id,
+            task_id,
+            workspace_path,
+            reason
+        );
     }
 
     Ok(())

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -7776,9 +7776,11 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/Users/me/Wegent',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/Users/me/Wegent',
+        })
+      )
     )
     expect(startTerminalSessionMock).not.toHaveBeenCalled()
     expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
@@ -7830,9 +7832,11 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/Users/me/Wegent',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/Users/me/Wegent',
+        })
+      )
     )
     expect(startTerminalSessionMock).not.toHaveBeenCalled()
     expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
@@ -7934,9 +7938,11 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/Users/me/Wegent',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/Users/me/Wegent',
+        })
+      )
     )
     expect(startTerminalSessionMock).not.toHaveBeenCalled()
     expect(localPathExistsMock).toHaveBeenCalledWith('/Users/me/Wegent')
@@ -7961,14 +7967,16 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/Users/me/Wegent/.worktrees/a',
-        env: {
-          WEWORK_PARENT_TITLE: 'Task A',
-          WEWORK_PARENT_PROJECT: 'Wegent',
-          WEWORK_PARENT_WORKSPACE: '/Users/me/Wegent/.worktrees/a',
-        },
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/Users/me/Wegent/.worktrees/a',
+          env: {
+            WEWORK_PARENT_TITLE: 'Task A',
+            WEWORK_PARENT_PROJECT: 'Wegent',
+            WEWORK_PARENT_WORKSPACE: '/Users/me/Wegent/.worktrees/a',
+          },
+        })
+      )
     )
     await waitFor(() => {
       const terminals = visibleLocalTerminals()
@@ -7988,14 +7996,16 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/Users/me/Wegent/.worktrees/b',
-        env: {
-          WEWORK_PARENT_TITLE: 'Task B',
-          WEWORK_PARENT_PROJECT: 'Wegent',
-          WEWORK_PARENT_WORKSPACE: '/Users/me/Wegent/.worktrees/b',
-        },
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/Users/me/Wegent/.worktrees/b',
+          env: {
+            WEWORK_PARENT_TITLE: 'Task B',
+            WEWORK_PARENT_PROJECT: 'Wegent',
+            WEWORK_PARENT_WORKSPACE: '/Users/me/Wegent/.worktrees/b',
+          },
+        })
+      )
     )
     await waitFor(() => {
       const terminals = visibleLocalTerminals()

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -235,6 +235,10 @@ export function EmbeddedLocalTerminal({
         if (!disposed && payload.session_id === sessionId) {
           onExitRef.current?.()
         }
+      },
+      {
+        taskId: contextRef.current.taskId,
+        workspacePath: contextRef.current.workspacePath,
       }
     )
       .then(unlisten => {

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -453,9 +453,11 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/projects/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/projects/project38',
+        })
+      )
     )
     expect(getLocalExecutorDeviceIdMock).toHaveBeenCalledWith('/api')
     expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
@@ -476,9 +478,11 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/projects/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/projects/project38',
+        })
+      )
     )
     expect(localPathExistsMock).toHaveBeenCalledWith('/workspace/projects/project38')
     expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
@@ -497,9 +501,11 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/projects/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/projects/project38',
+        })
+      )
     )
     expect(localPathExistsMock).toHaveBeenCalledWith('/workspace/projects/project38')
     expect(startProjectTerminalMock).not.toHaveBeenCalled()
@@ -507,7 +513,6 @@ describe('WorkspacePanelCards', () => {
   })
 
   test('closes local terminal sessions when the workspace panel unmounts', async () => {
-    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     const { unmount } = render(<WorkspacePanelCards currentProject={project} devices={[]} />)
 
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
@@ -515,15 +520,14 @@ describe('WorkspacePanelCards', () => {
 
     unmount()
 
-    expect(closeLocalTerminalMock).toHaveBeenCalledWith('local-terminal-1')
-    expect(consoleInfo).toHaveBeenCalledWith('Closing local terminal session', {
-      sessionId: 'local-terminal-1',
+    expect(closeLocalTerminalMock).toHaveBeenCalledWith('local-terminal-1', {
       reason: 'workspace-panel-unmount',
+      taskId: undefined,
+      workspacePath: '/workspace/projects/project38',
     })
   })
 
   test('closes local terminal sessions when the workspace target changes', async () => {
-    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     const nextProject = {
       ...project,
       id: 8,
@@ -543,10 +547,10 @@ describe('WorkspacePanelCards', () => {
 
     rerender(<WorkspacePanelCards currentProject={nextProject} devices={[]} />)
 
-    expect(closeLocalTerminalMock).toHaveBeenCalledWith('local-terminal-1')
-    expect(consoleInfo).toHaveBeenCalledWith('Closing local terminal session', {
-      sessionId: 'local-terminal-1',
+    expect(closeLocalTerminalMock).toHaveBeenCalledWith('local-terminal-1', {
       reason: 'workspace-target-changed',
+      taskId: undefined,
+      workspacePath: '/workspace/projects/project38',
     })
     expect(screen.queryByTestId('embedded-local-terminal')).not.toBeInTheDocument()
   })
@@ -573,9 +577,11 @@ describe('WorkspacePanelCards', () => {
     pathCheck.resolve(true)
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/projects/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/projects/project38',
+        })
+      )
     )
     expect(startProjectTerminalMock).not.toHaveBeenCalled()
   })
@@ -596,9 +602,11 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/worktrees/8/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/worktrees/8/project38',
+        })
+      )
     )
     expect(localPathExistsMock).toHaveBeenCalledWith('/workspace/worktrees/8/project38')
   })
@@ -621,9 +629,11 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/runtime/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/runtime/project38',
+        })
+      )
     )
     expect(startProjectTerminalMock).not.toHaveBeenCalled()
   })
@@ -766,9 +776,11 @@ describe('WorkspacePanelCards', () => {
     await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
-      expect(startLocalTerminalMock).toHaveBeenCalledWith({
-        cwd: '/workspace/projects/project38',
-      })
+      expect(startLocalTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/workspace/projects/project38',
+        })
+      )
     )
     expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
       'data-session-id',

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -89,9 +89,13 @@ function createAvailableTools(): WorkspaceToolAvailability {
   }
 }
 
-function closeLocalTerminalWithReason(sessionId: string, reason: LocalTerminalCloseReason) {
-  console.info('Closing local terminal session', { sessionId, reason })
-  void closeLocalTerminal(sessionId)
+function closeLocalTerminalWithReason(
+  sessionId: string,
+  reason: LocalTerminalCloseReason,
+  taskId?: string | null,
+  workspacePath?: string | null
+) {
+  void closeLocalTerminal(sessionId, { reason, taskId, workspacePath })
 }
 
 export function WorkspacePanelCards({
@@ -135,6 +139,7 @@ export function WorkspacePanelCards({
   })
   const projectDeviceId = getProjectDeviceId(currentProject)
   const workspaceSource = workspaceTarget?.source
+  const activeWorkspaceTaskId = workspaceTarget?.taskId
   const activeWorkspaceDeviceId = workspaceTarget?.deviceId ?? projectDeviceId
   const activeWorkspacePath =
     workspaceTarget?.path ?? (currentProject ? getProjectLocalPath(currentProject) : undefined)
@@ -247,7 +252,12 @@ export function WorkspacePanelCards({
     return () => {
       terminalSessionsRef.current.forEach(session => {
         if (session.terminal_kind === 'local') {
-          closeLocalTerminalWithReason(session.session_id, 'workspace-panel-unmount')
+          closeLocalTerminalWithReason(
+            session.session_id,
+            'workspace-panel-unmount',
+            session.diagnostic_task_id,
+            session.cwd
+          )
         }
       })
     }
@@ -264,7 +274,12 @@ export function WorkspacePanelCards({
 
     terminalSessionsRef.current.forEach(session => {
       if (session.terminal_kind === 'local') {
-        closeLocalTerminalWithReason(session.session_id, 'workspace-target-changed')
+        closeLocalTerminalWithReason(
+          session.session_id,
+          'workspace-target-changed',
+          session.diagnostic_task_id,
+          session.cwd
+        )
       }
     })
     terminalSessionsRef.current = []
@@ -378,6 +393,10 @@ export function WorkspacePanelCards({
             projectName: currentProject?.name,
             workspacePath: activeWorkspacePath,
           }),
+          diagnosticContext: {
+            taskId: activeWorkspaceTaskId,
+            workspacePath: activeWorkspacePath,
+          },
         })
         const sessionDeviceId =
           activeWorkspaceDeviceId ?? resolvedLocalTerminalCheck.executorDeviceId ?? 'local'
@@ -393,6 +412,7 @@ export function WorkspacePanelCards({
             url: '',
             transport: 'socketio',
             cwd: activeWorkspacePath,
+            diagnostic_task_id: activeWorkspaceTaskId ?? undefined,
           },
         ])
         setActiveTerminalSessionId(sessionId)
@@ -484,6 +504,7 @@ export function WorkspacePanelCards({
     setProjectError,
     terminalContextTitle,
     useDeviceTerminalSession,
+    activeWorkspaceTaskId,
     workspaceSessionApi,
   ])
 
@@ -524,7 +545,12 @@ export function WorkspacePanelCards({
   const handleCloseTerminalSession = (sessionId: string) => {
     const session = terminalSessions.find(session => session.session_id === sessionId)
     if (session?.terminal_kind === 'local') {
-      closeLocalTerminalWithReason(sessionId, 'user-closed-session')
+      closeLocalTerminalWithReason(
+        sessionId,
+        'user-closed-session',
+        session.diagnostic_task_id,
+        session.cwd
+      )
     }
 
     removeTerminalSession(sessionId)

--- a/wework/src/components/layout/workspace-panels/workspace-panel-tools.ts
+++ b/wework/src/components/layout/workspace-panels/workspace-panel-tools.ts
@@ -17,6 +17,7 @@ export type WorkspacePanelMenuActions = Record<WorkspacePanelMenuTool, Workspace
 export type WorkspaceTerminalSessionBase = ProjectDeviceSessionResponse & {
   cwd?: string
   title?: string
+  diagnostic_task_id?: string
 }
 
 export type WorkspaceTerminalSession =

--- a/wework/src/lib/local-terminal.test.ts
+++ b/wework/src/lib/local-terminal.test.ts
@@ -193,12 +193,22 @@ describe('local-terminal', () => {
     invokeMock.mockResolvedValue('local-terminal-1')
 
     await expect(
-      startLocalTerminal({ cwd: ' /Users/me/project ', rows: 30, cols: 100 })
+      startLocalTerminal({
+        cwd: ' /Users/me/project ',
+        rows: 30,
+        cols: 100,
+        diagnosticContext: {
+          taskId: ' runtime-1 ',
+          workspacePath: ' /Users/me/project ',
+        },
+      })
     ).resolves.toBe('local-terminal-1')
     expect(invokeMock).toHaveBeenCalledWith('start_local_terminal', {
       cwd: '/Users/me/project',
       rows: 30,
       cols: 100,
+      taskId: 'runtime-1',
+      workspacePath: '/Users/me/project',
     })
   })
 
@@ -229,6 +239,8 @@ describe('local-terminal', () => {
       cwd: '/Users/me/project',
       rows: undefined,
       cols: undefined,
+      taskId: null,
+      workspacePath: null,
       env: {
         WEWORK_PARENT_TITLE: 'Task A',
       },
@@ -320,7 +332,11 @@ describe('local-terminal', () => {
 
     await writeLocalTerminal('local-terminal-1', 'pwd\r')
     await resizeLocalTerminal('local-terminal-1', 40, 120)
-    await closeLocalTerminal('local-terminal-1')
+    await closeLocalTerminal('local-terminal-1', {
+      taskId: 'runtime-1',
+      workspacePath: '/Users/me/project',
+      reason: 'user-closed-session',
+    })
 
     expect(invokeMock).toHaveBeenCalledWith('write_local_terminal', {
       sessionId: 'local-terminal-1',
@@ -333,6 +349,9 @@ describe('local-terminal', () => {
     })
     expect(invokeMock).toHaveBeenCalledWith('close_local_terminal', {
       sessionId: 'local-terminal-1',
+      taskId: 'runtime-1',
+      workspacePath: '/Users/me/project',
+      reason: 'user-closed-session',
     })
   })
 
@@ -362,13 +381,21 @@ describe('local-terminal', () => {
       return undefined
     })
 
-    const unlisten = await connectLocalTerminal('local-terminal-1', vi.fn(), vi.fn())
+    const unlisten = await connectLocalTerminal('local-terminal-1', vi.fn(), vi.fn(), {
+      taskId: ' runtime-1 ',
+      workspacePath: ' /Users/me/project ',
+    })
 
     expect(calls).toEqual([
       'listen:local-terminal-output',
       'listen:local-terminal-exit',
       'invoke:attach_local_terminal',
     ])
+    expect(invokeMock).toHaveBeenCalledWith('attach_local_terminal', {
+      sessionId: 'local-terminal-1',
+      taskId: 'runtime-1',
+      workspacePath: '/Users/me/project',
+    })
 
     unlisten()
     expect(outputUnlisten).toHaveBeenCalledOnce()
@@ -391,6 +418,9 @@ describe('local-terminal', () => {
     expect(consoleError).toHaveBeenCalledWith('Local terminal connection failed', {
       sessionId: 'local-terminal-1',
       stage: 'attach',
+      taskId: null,
+      workspacePath: null,
+      reason: null,
       error: 'attach failed',
     })
   })

--- a/wework/src/lib/local-terminal.ts
+++ b/wework/src/lib/local-terminal.ts
@@ -56,6 +56,13 @@ export interface StartLocalTerminalOptions {
   rows?: number
   cols?: number
   env?: Record<string, string | null | undefined>
+  diagnosticContext?: LocalTerminalDiagnosticContext
+}
+
+export interface LocalTerminalDiagnosticContext {
+  taskId?: string | null
+  workspacePath?: string | null
+  reason?: string | null
 }
 
 export interface LocalTerminalOutputPayload {
@@ -72,6 +79,7 @@ export async function startLocalTerminal({
   rows,
   cols,
   env,
+  diagnosticContext,
 }: StartLocalTerminalOptions = {}): Promise<string> {
   if (!isLocalTerminalAvailable()) {
     throw new Error(i18n.t('localRuntime:local_terminal_unavailable'))
@@ -79,21 +87,45 @@ export async function startLocalTerminal({
 
   const trimmedCwd = cwd?.trim()
   const normalizedEnv = normalizeLocalTerminalEnv(env)
+  const context = normalizeLocalTerminalDiagnosticContext(diagnosticContext)
   const payload: {
     cwd: string | null
     rows?: number
     cols?: number
     env?: Record<string, string>
+    taskId: string | null
+    workspacePath: string | null
   } = {
     cwd: trimmedCwd || null,
     rows,
     cols,
+    taskId: context.taskId,
+    workspacePath: context.workspacePath,
   }
   if (normalizedEnv) {
     payload.env = normalizedEnv
   }
 
-  return invoke<string>('start_local_terminal', payload)
+  console.info('Local terminal start requested', {
+    cwd: trimmedCwd || null,
+    ...context,
+  })
+  try {
+    const sessionId = await invoke<string>('start_local_terminal', payload)
+    console.info('Local terminal start succeeded', {
+      sessionId,
+      cwd: trimmedCwd || null,
+      ...context,
+    })
+    return sessionId
+  } catch (error) {
+    console.error('Local terminal start failed', {
+      cwd: trimmedCwd || null,
+      ...context,
+      error: formatLocalTerminalError(error),
+    })
+    throw error
+  }
 }
 
 function normalizeLocalTerminalEnv(env?: Record<string, string | null | undefined>) {
@@ -107,6 +139,20 @@ function normalizeLocalTerminalEnv(env?: Record<string, string | null | undefine
   })
 
   return entries.length > 0 ? Object.fromEntries(entries) : null
+}
+
+function normalizeLocalTerminalDiagnosticContext(
+  context?: LocalTerminalDiagnosticContext
+): Required<LocalTerminalDiagnosticContext> {
+  return {
+    taskId: context?.taskId?.trim() || null,
+    workspacePath: context?.workspacePath?.trim() || null,
+    reason: context?.reason?.trim() || null,
+  }
+}
+
+function formatLocalTerminalError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 export interface OpenLocalWorkspaceOptions {
@@ -244,9 +290,15 @@ export async function writeLocalTerminal(sessionId: string, data: string): Promi
   })
 }
 
-export async function attachLocalTerminal(sessionId: string): Promise<void> {
+export async function attachLocalTerminal(
+  sessionId: string,
+  diagnosticContext?: LocalTerminalDiagnosticContext
+): Promise<void> {
+  const context = normalizeLocalTerminalDiagnosticContext(diagnosticContext)
   await invoke('attach_local_terminal', {
     sessionId,
+    taskId: context.taskId,
+    workspacePath: context.workspacePath,
   })
 }
 
@@ -262,10 +314,28 @@ export async function resizeLocalTerminal(
   })
 }
 
-export async function closeLocalTerminal(sessionId: string): Promise<void> {
-  await invoke('close_local_terminal', {
-    sessionId,
-  })
+export async function closeLocalTerminal(
+  sessionId: string,
+  diagnosticContext?: LocalTerminalDiagnosticContext
+): Promise<void> {
+  const context = normalizeLocalTerminalDiagnosticContext(diagnosticContext)
+  console.info('Local terminal close requested', { sessionId, ...context })
+  try {
+    await invoke('close_local_terminal', {
+      sessionId,
+      taskId: context.taskId,
+      workspacePath: context.workspacePath,
+      reason: context.reason,
+    })
+    console.info('Local terminal close succeeded', { sessionId, ...context })
+  } catch (error) {
+    console.error('Local terminal close failed', {
+      sessionId,
+      ...context,
+      error: formatLocalTerminalError(error),
+    })
+    throw error
+  }
 }
 
 export function listenLocalTerminalOutput(
@@ -289,43 +359,64 @@ type LocalTerminalConnectionStage = 'listen-output' | 'listen-exit' | 'attach'
 function logLocalTerminalConnectionFailure(
   sessionId: string,
   stage: LocalTerminalConnectionStage,
+  diagnosticContext: LocalTerminalDiagnosticContext | undefined,
   error: unknown
 ) {
+  const context = normalizeLocalTerminalDiagnosticContext(diagnosticContext)
   console.error('Local terminal connection failed', {
     sessionId,
     stage,
-    error: error instanceof Error ? error.message : String(error),
+    ...context,
+    error: formatLocalTerminalError(error),
   })
 }
 
 export async function connectLocalTerminal(
   sessionId: string,
   onOutput: (payload: LocalTerminalOutputPayload) => void,
-  onExit: (payload: LocalTerminalExitPayload) => void
+  onExit: (payload: LocalTerminalExitPayload) => void,
+  diagnosticContext?: LocalTerminalDiagnosticContext
 ): Promise<UnlistenFn> {
+  const context = normalizeLocalTerminalDiagnosticContext(diagnosticContext)
+  console.info('Local terminal connection requested', { sessionId, ...context })
   let outputUnlisten: UnlistenFn
   try {
     outputUnlisten = await listenLocalTerminalOutput(onOutput)
+    console.info('Local terminal connection stage succeeded', {
+      sessionId,
+      stage: 'listen-output',
+      ...context,
+    })
   } catch (error) {
-    logLocalTerminalConnectionFailure(sessionId, 'listen-output', error)
+    logLocalTerminalConnectionFailure(sessionId, 'listen-output', context, error)
     throw error
   }
 
   let exitUnlisten: UnlistenFn
   try {
     exitUnlisten = await listenLocalTerminalExit(onExit)
+    console.info('Local terminal connection stage succeeded', {
+      sessionId,
+      stage: 'listen-exit',
+      ...context,
+    })
   } catch (error) {
     outputUnlisten()
-    logLocalTerminalConnectionFailure(sessionId, 'listen-exit', error)
+    logLocalTerminalConnectionFailure(sessionId, 'listen-exit', context, error)
     throw error
   }
 
   try {
-    await attachLocalTerminal(sessionId)
+    await attachLocalTerminal(sessionId, context)
+    console.info('Local terminal connection stage succeeded', {
+      sessionId,
+      stage: 'attach',
+      ...context,
+    })
   } catch (error) {
     outputUnlisten()
     exitUnlisten()
-    logLocalTerminalConnectionFailure(sessionId, 'attach', error)
+    logLocalTerminalConnectionFailure(sessionId, 'attach', context, error)
     throw error
   }
 


### PR DESCRIPTION
## What changed

- correlate local terminal start, listener registration, native attach, and close events by session ID
- include host PID, child PID, task ID, workspace path, connection stage, and close reason in diagnostics
- preserve the originating task context when cached terminals are closed after task switches
- document the troubleshooting workflow in Chinese and English
- update unit coverage for the expanded terminal diagnostic context

## Why

`[Terminal connection failed]` previously identified only a broad listener or attach stage. The available logs could not determine which host process owned the PTY, whether the session had already been removed, or why it was closed. This change provides an end-to-end lifecycle evidence chain without logging terminal input, output, commands, or environment-variable contents.

## Validation

- pre-push ESLint: passed
- pre-push TypeScript build: passed
- pre-push Wework unit tests: 3218 passed
- Rust local terminal tests: 2 passed
- isolated real-Tauri launch attempted; UI verification was blocked because the isolated local executor rebuild lost its build lock and never emitted ready. Evidence: `wework/test-results/ai-verify/2026-08-09T13-23-26-322Z-84632/` (local artifact, not committed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local terminal connection failure diagnostics with correlated session, task, and workspace details.
  * Added clearer logging for terminal startup, connection stages, attachment, and closure outcomes.
  * Missing terminal sessions now produce a warning when closure is attempted.

* **Documentation**
  * Updated English and Chinese troubleshooting guidance to reflect enhanced diagnostics and clarify that terminal content and environment variables are not logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->