### PR TITLE
fix(wework): associate assistant replies with turns

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -468,10 +468,10 @@ The active-conversation capture is also normative:
 - User messages are right-aligned compact neutral bubbles. Assistant content is
   left-aligned prose, not wrapped in a card. Turn metadata and feedback actions
   are quiet and subordinate.
-- The compact turn-navigation rail reflects visible user messages, not the
-  assistant response currently being read. Every user message intersecting the
-  conversation viewport has a dark marker, so multiple markers may be active;
-  assistant-only viewport content does not activate its preceding turn.
+- The compact turn-navigation rail reflects every conversation turn intersecting
+  the viewport. A turn includes its user messages and assistant responses, so
+  assistant-only viewport content still activates the corresponding marker and
+  multiple markers may be active when content from multiple turns is visible.
 - The bottom Composer shares the thread column and stays visible. It uses the
   same input hierarchy as home but without the home project-selector layer.
 - When opening, closing, or resizing a side panel reflows conversation content,

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -1679,7 +1679,7 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
   }
 }
 
-async function verifyTurnNavigationTracksVisibleUserMessages(
+async function verifyTurnNavigationTracksVisibleTurnMessages(
   control,
   turnNumber = TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN + 1
 ) {
@@ -1734,11 +1734,11 @@ async function verifyTurnNavigationTracksVisibleUserMessages(
     'The oldest user row remained mounted, so the turn navigation fixture was not virtualized'
   )
 
-  await control.command('waitFor', `${markerSelector}[data-active="false"]`, {
+  await control.command('waitFor', `${markerSelector}[data-active="true"]`, {
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
-  await captureVerificationScreenshot(control, 'turn-navigation-02-assistant-only-inactive.png')
+  await captureVerificationScreenshot(control, 'turn-navigation-02-assistant-only-active.png')
 }
 
 async function reopenCurrentTurnNavigationTask(
@@ -6802,7 +6802,7 @@ async function verifyBackgroundTaskWindowLifecycle({
     'utf8'
   )
   await reopenCurrentTurnNavigationTask(control, composerSelector, restartDesktopApp)
-  await verifyTurnNavigationTracksVisibleUserMessages(control)
+  await verifyTurnNavigationTracksVisibleTurnMessages(control)
   return taskRowTestId
 }
 
@@ -14237,7 +14237,7 @@ last_updated = "2026-07-30T00:00:00Z"`
         restartDesktopApp,
         TURN_NAVIGATION_ONLY_TURN_COUNT
       )
-      await verifyTurnNavigationTracksVisibleUserMessages(control, 2)
+      await verifyTurnNavigationTracksVisibleTurnMessages(control, 2)
       console.log(`Wework desktop turn-navigation E2E passed. Evidence: ${resultDir}`)
       return
     }

--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -45,12 +45,18 @@ interface UserTurn {
 
 interface MessageTurnMarker extends UserTurn {
   targetTop: number | null
-  targetBottom: number | null
+  visibleTop: number | null
+  visibleBottom: number | null
 }
 
 interface PendingScrollTarget {
   navigationId: string
   messageIndex: number
+}
+
+interface TurnVisibilityBounds {
+  top: number
+  bottom: number
 }
 
 export function MessageTurnNavigation({
@@ -163,10 +169,10 @@ export function MessageTurnNavigation({
       const nextActiveMarkerIds = nextMarkers
         .filter(
           marker =>
-            marker.targetTop !== null &&
-            marker.targetBottom !== null &&
-            marker.targetBottom > viewportTop &&
-            marker.targetTop < viewportBottom
+            marker.visibleTop !== null &&
+            marker.visibleBottom !== null &&
+            marker.visibleBottom > viewportTop &&
+            marker.visibleTop < viewportBottom
         )
         .map(marker => marker.id)
       setActiveMarkerIds(current =>
@@ -190,14 +196,23 @@ export function MessageTurnNavigation({
 
       const scrollerRect = scroller.getBoundingClientRect()
       const anchorByMessageId = getMessageAnchorById(content)
+      const visibilityByTurnId = getTurnVisibilityBounds(
+        userTurns,
+        messagesRef.current,
+        anchorByMessageId,
+        scroller,
+        scrollerRect
+      )
       const nextMarkers = userTurns.map(turn => {
         const anchor = anchorByMessageId.get(turn.id)
+        const visibleBounds = visibilityByTurnId.get(turn.id)
         if (!anchor) {
           return {
             ...turn,
             loaded: false,
             targetTop: null,
-            targetBottom: null,
+            visibleTop: visibleBounds?.top ?? null,
+            visibleBottom: visibleBounds?.bottom ?? null,
           }
         }
 
@@ -207,7 +222,9 @@ export function MessageTurnNavigation({
           ...turn,
           loaded: true,
           targetTop,
-          targetBottom: scroller.scrollTop + anchorRect.bottom - scrollerRect.top,
+          visibleTop: visibleBounds?.top ?? targetTop,
+          visibleBottom:
+            visibleBounds?.bottom ?? scroller.scrollTop + anchorRect.bottom - scrollerRect.top,
         }
       })
 
@@ -261,7 +278,7 @@ export function MessageTurnNavigation({
     if (!scroller || !content) return
 
     // Mounted anchors are recalculated by observers; raw scroll events reuse
-    // their measured bounds to update which user messages intersect the viewport.
+    // their measured bounds to update which conversation turns intersect the viewport.
     const handleScroll = () => updateActiveMarkers(markersRef.current, 'scroll')
     const handleResize = () => scheduleCalculateMarkers('window-resize')
     scroller.addEventListener('scroll', handleScroll, { passive: true })
@@ -772,6 +789,90 @@ function getMessageAnchorById(content: HTMLElement) {
     }
   })
   return anchors
+}
+
+function getTurnVisibilityBounds(
+  turns: UserTurn[],
+  messages: WorkbenchMessage[],
+  anchorByMessageId: ReadonlyMap<string, HTMLElement>,
+  scroller: HTMLDivElement,
+  scrollerRect: DOMRect
+): Map<string, TurnVisibilityBounds> {
+  const boundsByTurnId = new Map<string, TurnVisibilityBounds>()
+  const messagePositionById = buildMessageTimelinePositions(messages)
+
+  anchorByMessageId.forEach((anchor, messageId) => {
+    const messagePosition = messagePositionById.get(messageId)
+    if (messagePosition === undefined) return
+    const turn = findTurnForMessagePosition(turns, messagePosition)
+    if (!turn) return
+
+    const anchorRect = anchor.getBoundingClientRect()
+    const top = scroller.scrollTop + anchorRect.top - scrollerRect.top
+    const bottom = scroller.scrollTop + anchorRect.bottom - scrollerRect.top
+    const current = boundsByTurnId.get(turn.id)
+    boundsByTurnId.set(turn.id, {
+      top: current ? Math.min(current.top, top) : top,
+      bottom: current ? Math.max(current.bottom, bottom) : bottom,
+    })
+  })
+
+  return boundsByTurnId
+}
+
+function buildMessageTimelinePositions(messages: WorkbenchMessage[]): Map<string, number> {
+  const positions = messages.map(message =>
+    Number.isFinite(message.runtimeMessageIndex) ? (message.runtimeMessageIndex as number) : null
+  )
+  if (positions.every(position => position === null)) {
+    return new Map(messages.map((message, index) => [message.id, index]))
+  }
+
+  let segmentStart = 0
+  while (segmentStart < positions.length) {
+    if (positions[segmentStart] !== null) {
+      segmentStart += 1
+      continue
+    }
+
+    let segmentEnd = segmentStart + 1
+    while (segmentEnd < positions.length && positions[segmentEnd] === null) {
+      segmentEnd += 1
+    }
+    const previousPosition = segmentStart > 0 ? positions[segmentStart - 1] : null
+    const nextPosition = segmentEnd < positions.length ? positions[segmentEnd] : null
+    const segmentLength = segmentEnd - segmentStart
+
+    for (let offset = 0; offset < segmentLength; offset += 1) {
+      if (previousPosition !== null && nextPosition !== null) {
+        positions[segmentStart + offset] =
+          previousPosition +
+          ((nextPosition - previousPosition) * (offset + 1)) / (segmentLength + 1)
+      } else if (previousPosition !== null) {
+        positions[segmentStart + offset] = previousPosition + (offset + 1) / (segmentLength + 1)
+      } else if (nextPosition !== null) {
+        positions[segmentStart + offset] =
+          nextPosition - (segmentLength - offset) / (segmentLength + 1)
+      }
+    }
+    segmentStart = segmentEnd
+  }
+
+  return new Map(
+    messages.flatMap((message, index) => {
+      const position = positions[index]
+      return position === null ? [] : [[message.id, position] as const]
+    })
+  )
+}
+
+function findTurnForMessagePosition(turns: UserTurn[], messagePosition: number): UserTurn | null {
+  let currentTurn: UserTurn | null = null
+  for (const turn of turns) {
+    if (turn.messageIndex > messagePosition) break
+    currentTurn = turn
+  }
+  return currentTurn
 }
 
 function equalStringArrays(left: string[], right: string[]) {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ScrollableMessageArea } from './ScrollableMessageArea'
 import { MessageTurnNavigation } from './MessageTurnNavigation'
 import { getConversationScrollSnapshot } from '@/features/workbench/runtimeConversationCache'
+import { projectRuntimeConversationTurns } from '@/features/workbench/runtimeConversationTurns'
 
 function mockRect(element: Element, top: number, bottom: number) {
   element.getBoundingClientRect = vi.fn(
@@ -1474,7 +1475,7 @@ describe('ScrollableMessageArea', () => {
     expect(screen.getAllByTestId('message-turn-navigation-marker')).toHaveLength(2)
   })
 
-  test('does not activate a turn from mounted assistant rows when user rows are virtualized', () => {
+  test('activates a turn from mounted assistant rows when user rows are virtualized', () => {
     const scrollRef = createRef<HTMLDivElement>()
     const contentRef = createRef<HTMLDivElement>()
     const messages = [
@@ -1549,9 +1550,9 @@ describe('ScrollableMessageArea', () => {
       configurable: true,
     })
     mockRect(scroller, 0, 300)
-    mockRect(screen.getByText('First response'), -200, 120)
+    mockRect(screen.getByText('First response'), -500, -400)
     mockRect(screen.getByText('Long second response'), 40, 1_200)
-    mockRect(screen.getByText('Transient response without a transcript index'), 80, 120)
+    mockRect(screen.getByText('Transient response without a transcript index'), 1_300, 1_400)
 
     fireEvent.resize(window)
     flushScheduledTimers()
@@ -1559,16 +1560,16 @@ describe('ScrollableMessageArea', () => {
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(markers).toHaveLength(3)
     expect(markers[0]).toHaveAttribute('data-active', 'false')
-    expect(markers[1]).toHaveAttribute('data-active', 'false')
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
     expect(markers[2]).toHaveAttribute('data-active', 'false')
 
     scroller.scrollTop = 2_900
     fireEvent.scroll(scroller)
 
-    expect(markers[1]).toHaveAttribute('data-active', 'false')
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
   })
 
-  test('does not activate a turn from a page-leading assistant', () => {
+  test('activates a turn from a page-leading assistant', () => {
     const scrollRef = createRef<HTMLDivElement>()
     const contentRef = createRef<HTMLDivElement>()
 
@@ -1649,7 +1650,7 @@ describe('ScrollableMessageArea', () => {
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(markers).toHaveLength(3)
     expect(markers[0]).toHaveAttribute('data-active', 'false')
-    expect(markers[1]).toHaveAttribute('data-active', 'false')
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
     expect(markers[2]).toHaveAttribute('data-active', 'false')
   })
 
@@ -1709,6 +1710,82 @@ describe('ScrollableMessageArea', () => {
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(markers).toHaveLength(3)
     expect(markers[0]).toHaveAttribute('data-active', 'true')
+    expect(markers[1]).toHaveAttribute('data-active', 'true')
+    expect(markers[2]).toHaveAttribute('data-active', 'false')
+  })
+
+  test('tracks the active turn when the loaded page contains only its assistant response', () => {
+    const scrollRef = createRef<HTMLDivElement>()
+    const contentRef = createRef<HTMLDivElement>()
+    const messages = projectRuntimeConversationTurns([
+      {
+        id: 'assistant-only-turn',
+        runtimeMessageIndex: 10,
+        items: [
+          {
+            id: 'assistant-only-item',
+            type: 'assistant_text',
+            content: 'Only the response is loaded on this page',
+            createdAt: '2026-08-09T00:00:00.000Z',
+          },
+        ],
+        status: 'done',
+      },
+    ])
+
+    render(
+      <div ref={scrollRef}>
+        <div ref={contentRef}>
+          <div data-message-id={messages[0].id}>Only the response is loaded on this page</div>
+        </div>
+        <MessageTurnNavigation
+          messages={messages}
+          turnNavigation={[
+            {
+              id: 'previous-user',
+              turnIndex: 4,
+              messageIndex: 8,
+              promptPreview: 'Previous request',
+              responsePreview: 'Previous response',
+            },
+            {
+              id: 'assistant-only-user',
+              turnIndex: 5,
+              messageIndex: 10,
+              promptPreview: 'Request for the loaded response',
+              responsePreview: 'Only the response is loaded on this page',
+            },
+            {
+              id: 'next-user',
+              turnIndex: 6,
+              messageIndex: 12,
+              promptPreview: 'Next request',
+              responsePreview: 'Next response',
+            },
+          ]}
+          scrollRef={scrollRef}
+          contentRef={contentRef}
+        />
+      </div>
+    )
+
+    const scroller = scrollRef.current!
+    Object.defineProperty(scroller, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 4_000, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 2_800,
+      writable: true,
+      configurable: true,
+    })
+    mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('Only the response is loaded on this page'), 40, 1_200)
+
+    fireEvent.resize(window)
+    flushScheduledTimers()
+
+    const markers = screen.getAllByTestId('message-turn-navigation-marker')
+    expect(markers).toHaveLength(3)
+    expect(markers[0]).toHaveAttribute('data-active', 'false')
     expect(markers[1]).toHaveAttribute('data-active', 'true')
     expect(markers[2]).toHaveAttribute('data-active', 'false')
   })

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -915,6 +915,7 @@ describe('runtimeConversationTurns', () => {
     expect(projectRuntimeConversationTurns(merged).at(-1)).toMatchObject({
       content: 'New response',
       status: 'streaming',
+      runtimeMessageIndex: 12,
     })
   })
 

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -662,6 +662,7 @@ function projectRuntimeConversationTurn(turn: RuntimeConversationTurn): Workbenc
       runtimeStatus: isLast ? turn.status : 'done',
       subtaskId: turn.id ?? undefined,
       turnId: turn.id ?? undefined,
+      runtimeMessageIndex: turn.runtimeMessageIndex,
       blocks: blocks.length > 0 ? blocks : undefined,
       fileChanges: isLast ? turn.fileChanges : undefined,
       error: isLast ? turn.error : undefined,


### PR DESCRIPTION
## What changed

- Treat each conversation turn as the combined visible range of its user messages and assistant replies.
- Preserve the runtime turn index on projected assistant messages so assistant-only transcript pages map to the correct navigation marker.
- Update the Wework design contract and desktop E2E expectation to keep a turn active while its assistant response is visible.

## Root cause

The navigation markers measured only mounted user-message anchors. Runtime virtualization and transcript pagination can leave only assistant replies mounted, so no marker was considered active even though the user was still reading that turn.

## Impact

The left-side turn navigation now remains highlighted throughout the whole turn. It also supports pages containing only assistant replies and continues to allow multiple active markers when content from multiple turns intersects the viewport.

## Verification

- `pnpm --filter wework exec vitest run src/features/workbench/runtimeConversationTurns.test.ts src/components/chat/ScrollableMessageArea.test.tsx`
- `pnpm --filter wework typecheck`
- ESLint and Prettier checks for changed files
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --turn-navigation-only`
- Full Wework pre-push checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation navigation markers now represent every visible turn, including assistant responses.
  * Multiple navigation markers can be active simultaneously when several turns appear in the viewport.

* **Bug Fixes**
  * Improved navigation accuracy for assistant-only responses, partially loaded conversations, and virtualized message lists.
  * Turn markers now remain correctly synchronized as messages load and visibility changes.

* **Documentation**
  * Updated the turn-navigation specification to reflect the expanded behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->