### PR TITLE
fix(backend): enforce AI assignee column constraints

### DIFF
--- a/backend/alembic/versions/20260804_a1f4c8d9e2b7_add_loop_item_ai_assignee.py
+++ b/backend/alembic/versions/20260804_a1f4c8d9e2b7_add_loop_item_ai_assignee.py
@@ -15,18 +15,21 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "loop_items",
-        sa.Column("assignee_agent_id", sa.String(length=64), nullable=True),
-    )
-    op.create_index(
-        "ix_loop_items_assignee_agent_id",
-        "loop_items",
-        ["assignee_agent_id"],
-        unique=False,
+    op.execute(
+        sa.text(
+            "ALTER TABLE loop_items "
+            "ADD COLUMN assignee_agent_id VARCHAR(64) NOT NULL DEFAULT '' "
+            "COMMENT 'Assigned project chat agent ID; empty when unassigned', "
+            "ADD INDEX idx_loop_items_assignee_agent_id (assignee_agent_id)"
+        )
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_loop_items_assignee_agent_id", table_name="loop_items")
-    op.drop_column("loop_items", "assignee_agent_id")
+    op.execute(
+        sa.text(
+            "ALTER TABLE loop_items "
+            "DROP INDEX idx_loop_items_assignee_agent_id, "
+            "DROP COLUMN assignee_agent_id"
+        )
+    )

--- a/backend/app/models/delivery.py
+++ b/backend/app/models/delivery.py
@@ -93,7 +93,13 @@ class LoopNode(Base):
     device_id = Column(String(100), nullable=True)
     is_default = Column(Boolean, nullable=True)
     task_user_id = Column(Integer, nullable=True)
-    assignee_agent_id = Column(String(64), nullable=True, index=True)
+    assignee_agent_id = Column(
+        String(64),
+        nullable=False,
+        default="",
+        server_default="",
+        comment="Assigned project chat agent ID; empty when unassigned",
+    )
     task_id = Column(String(255), nullable=True)
     task_title = Column(String(255), nullable=True)
     backend_task_id = Column(
@@ -132,6 +138,7 @@ class LoopNode(Base):
         Index("idx_loop_items_project_type", "cloud_project_id", "resource_type"),
         Index("idx_loop_items_parent_type", "parent_id", "resource_type", "sort_order"),
         Index("idx_loop_items_project_path", "cloud_project_id", "path"),
+        Index("idx_loop_items_assignee_agent_id", "assignee_agent_id"),
         {"mysql_engine": "InnoDB", "mysql_charset": "utf8mb4"},
     )
 

--- a/backend/app/services/loop_items/external_provider.py
+++ b/backend/app/services/loop_items/external_provider.py
@@ -784,7 +784,7 @@ class ExternalLoopItemProvider:
             )
         else:
             row.assignee_user_id = int(assignee_id) if assignee_id else 0
-            row.assignee_agent_id = None
+            row.assignee_agent_id = ""
             loop_item_service._write_assignment_change(
                 metadata, user_id, "user", assignee_id or None, assignee_name
             )

--- a/backend/app/services/loop_items/service.py
+++ b/backend/app/services/loop_items/service.py
@@ -500,6 +500,7 @@ class LoopItemService:
         payload = values.model_dump()
         tags = payload.pop("tags")
         agent_id = payload.get("assignee_agent_id")
+        payload["assignee_agent_id"] = agent_id or ""
         task_metadata: dict = {}
         if agent_id:
             agent = db.get(ProjectChatAgent, agent_id)
@@ -851,6 +852,7 @@ class LoopItemService:
         updates = values.model_dump(exclude={"version"}, exclude_unset=True)
         if "assignee_agent_id" in values.model_fields_set:
             agent_id = values.assignee_agent_id
+            updates["assignee_agent_id"] = agent_id or ""
             if agent_id:
                 agent = db.get(ProjectChatAgent, agent_id)
                 if (
@@ -864,7 +866,7 @@ class LoopItemService:
                     )
                 updates["assignee_user_id"] = None
         elif "assignee_user_id" in values.model_fields_set and values.assignee_user_id:
-            updates["assignee_agent_id"] = None
+            updates["assignee_agent_id"] = ""
         if "parent_id" in values.model_fields_set:
             self._validate_parent_change(db, item, values.parent_id)
         if "tags" in values.model_fields_set:
@@ -1034,7 +1036,7 @@ class LoopItemService:
                 )
             assignee_updates = {
                 "assignee_user_id": target_user_id,
-                "assignee_agent_id": None,
+                "assignee_agent_id": "",
             }
             target = db.get(User, target_user_id)
             self._write_assignment_change(

--- a/backend/tests/services/test_external_loop_item_execution.py
+++ b/backend/tests/services/test_external_loop_item_execution.py
@@ -198,7 +198,7 @@ def test_assign_user_on_gitlab_creates_index_row_without_execution(
     row = test_db.get(LoopItem, _item_id(project))
     assert row is not None
     assert row.assignee_user_id == member.id
-    assert row.assignee_agent_id is None
+    assert row.assignee_agent_id == ""
     assert _active_execution(test_db, _item_id(project)) is None
 
 

--- a/backend/tests/services/test_loop_item_assignment.py
+++ b/backend/tests/services/test_loop_item_assignment.py
@@ -164,7 +164,7 @@ def test_assign_to_member_records_chain(test_db: Session, test_user: User) -> No
     )
 
     assert updated.assignee_user_id == member.id
-    assert updated.assignee_agent_id is None
+    assert updated.assignee_agent_id == ""
     metadata = updated.metadata_json or {}
     assert metadata["assignment_history"][-1]["to_type"] == "user"
     assert metadata["assignment_history"][-1]["to_name"] == "assignee"


### PR DESCRIPTION
## Summary

- make `loop_items.assignee_agent_id` non-null with program and database defaults
- normalize unassigned persisted values to an empty string while preserving API `null` compatibility
- update the original migration to satisfy MySQL DDL governance requirements

## Root cause

The deployed backend model selected `loop_items.assignee_agent_id`, but the preview database had not applied the migration. The original migration was also rejected by the database review gate because the new column was nullable, had no default or comment, used an `ix_` index prefix, and emitted multiple table alteration statements.

## Changes

- add the column and `idx_loop_items_assignee_agent_id` index in one `ALTER TABLE`
- declare `NOT NULL DEFAULT ''` and add a column comment
- keep SQLAlchemy's program-side default and align its explicit index metadata
- write `''` instead of `NULL` when tasks are assigned to users or unassigned from robots
- update persisted-value assertions

## Validation

- `uv run pytest tests/services/test_loop_item_assignment.py tests/services/test_external_loop_item_execution.py tests/api/test_cloud_projects_api.py -q` — 42 passed
- generated and inspected MySQL upgrade and downgrade SQL
- pre-push Black, isort, Python syntax, settings configuration, and Alembic single-head checks passed

No user-facing documentation update is needed because the API continues to expose an unassigned robot as `null`.
