### PR TITLE
fix(wework): copy visible user message text

### DIFF
--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -3326,6 +3326,37 @@ describe('MessageList', () => {
     expect(screen.queryByText(/My request for Codex/)).not.toBeInTheDocument()
   })
 
+  test('copies only the visible request from Codex user messages with file mentions', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboardWriteText(writeText)
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'codex-image-mention-copy',
+            role: 'user',
+            content: [
+              '# Files mentioned by the user:',
+              '',
+              '## image.png: /Users/me/.wework/workspace/attachments/draft/image.png',
+              '',
+              '## My request for Codex:',
+              '分析下这个图片',
+            ].join('\n'),
+            status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.pointerEnter(screen.getByTestId('message-hover-region'))
+    await userEvent.click(screen.getByTestId('copy-message-button'))
+
+    expect(writeText).toHaveBeenCalledWith('分析下这个图片')
+  })
+
   test('renders Codex local non-image file mentions as compact file chips', () => {
     const onOpenWorkspaceFile = vi.fn()
 

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1175,6 +1175,7 @@ function UserMessage({
       {!editing && (
         <MessageHoverActions
           message={message}
+          copyContent={displayContent}
           align="right"
           visible={areHoverActionsVisible}
           onEdit={editable ? onStartEdit : undefined}
@@ -1509,12 +1510,14 @@ function MessageImageAttachmentPreview({
 
 function MessageHoverActions({
   message,
+  copyContent = message.content,
   align,
   visible,
   onEdit,
   onFork,
 }: {
   message: WorkbenchMessage
+  copyContent?: string
   align: 'left' | 'right'
   visible: boolean
   onEdit?: () => void
@@ -1536,7 +1539,7 @@ function MessageHoverActions({
     if (event.detail > 0) {
       event.currentTarget.blur()
     }
-    void copyText(message.content).then(() => {
+    void copyText(copyContent).then(() => {
       setCopied(true)
       resetCopiedAfterHideRef.current = false
     })


### PR DESCRIPTION
## What changed

- Copy the normalized, visible user-message text instead of the raw runtime payload.
- Keep assistant-message copying unchanged.
- Add regression coverage for Codex user messages that include hidden file-mention metadata.

## Why

Wework renders only the request portion of Codex user messages, but the copy action previously used the original `message.content`. Messages with attachments therefore copied hidden `Files mentioned by the user` and `My request for Codex` wrapper text.

## Impact

Copying a user message now matches the text shown in the message bubble and edit form.

## Validation

- `pnpm --filter wework test -- MessageList.test.tsx --run` (334 files, 3219 tests passed)
- `pnpm --filter wework exec prettier --check src/components/chat/MessageList.tsx src/components/chat/MessageList.test.tsx`
- `pnpm --filter wework exec eslint src/components/chat/MessageList.tsx src/components/chat/MessageList.test.tsx`
- Pre-push Wework ESLint, TypeScript, and unit-test checks passed
- Isolated Tauri session started, but UI verification was blocked before the workbench loaded by a preview-backend HTTP 500 from `/v1/cloud-projects`; the session was stopped and cleaned up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Copying messages with file mentions now copies only the visible request text, excluding internal file metadata.
  - Message copy actions now consistently use the displayed, normalized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->