### PR TITLE
fix(wework): honor dark theme in search dialog

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -599,6 +599,8 @@ a preferred shape.
 Dialogs use:
 
 - a centered elevated surface with `20px` radius;
+- semantic theme surfaces such as `bg-background` or `bg-popover`; never
+  hardcode a light-only background for a theme-aware dialog;
 - `0.5px` semantic ring, light `lg` shadow, and subtle translucent blur;
 - a restrained scrim (`#00000022` in the audited Electron light treatment);
 - a maximum width of `92vw`;

--- a/wework/src/components/layout/WorkbenchSearchDialog.test.tsx
+++ b/wework/src/components/layout/WorkbenchSearchDialog.test.tsx
@@ -28,6 +28,21 @@ describe('WorkbenchSearchDialog', () => {
     vi.useRealTimers()
   })
 
+  test('uses the themed popover surface instead of a fixed light background', () => {
+    render(
+      <WorkbenchSearchDialog
+        open
+        onClose={vi.fn()}
+        onSearchRuntimeWork={vi.fn().mockResolvedValue({ items: [] })}
+        onOpenRuntimeTask={vi.fn()}
+      />
+    )
+
+    const dialog = screen.getByTestId('workbench-search-dialog')
+    expect(dialog).toHaveClass('bg-popover', 'text-text-primary', 'ring-border')
+    expect(dialog).not.toHaveClass('bg-white')
+  })
+
   test('searches transcripts and opens a runtime task result', async () => {
     const user = userEvent.setup()
     const onSearchRuntimeWork = vi.fn().mockResolvedValue({

--- a/wework/src/components/layout/WorkbenchSearchDialog.tsx
+++ b/wework/src/components/layout/WorkbenchSearchDialog.tsx
@@ -153,7 +153,10 @@ function WorkbenchSearchDialogPanel({
         if (event.target === event.currentTarget) onClose()
       }}
     >
-      <div className="w-full max-w-[520px] overflow-hidden rounded-[18px] bg-white shadow-[0_24px_70px_rgba(15,23,42,0.20)] ring-1 ring-black/5">
+      <div
+        data-testid="workbench-search-dialog"
+        className="w-full max-w-[520px] overflow-hidden rounded-[18px] bg-popover text-text-primary shadow-[0_24px_70px_rgba(15,23,42,0.20)] ring-[0.5px] ring-border"
+      >
         <div className="flex h-14 items-center gap-3 border-b border-border/70 px-4">
           <Search className="h-4 w-4 shrink-0 text-text-muted" />
           <input


### PR DESCRIPTION
## Summary

- replace the search dialog hardcoded white surface with the existing theme-aware popover surface
- use semantic text and ring colors for light and dark themes
- document that theme-aware dialogs must not hardcode light-only backgrounds
- add a regression test for the semantic dialog surface

## Root cause

The search dialog panel used `bg-white`, bypassing the Wework theme tokens. As a result, the panel stayed white while the rest of the workbench switched to dark mode.

## Validation

- `pnpm --filter wework exec prettier --check src/components/layout/WorkbenchSearchDialog.tsx src/components/layout/WorkbenchSearchDialog.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/WorkbenchSearchDialog.tsx src/components/layout/WorkbenchSearchDialog.test.tsx`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework test` — 335 files, 3232 tests passed
- isolated real-Tauri verification in both dark and light themes
- verified search input/results and Escape dismissal
- pre-push ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the search dialog to use theme-aware colors and surfaces, improving appearance across light and dark themes.
  * Replaced the fixed white background and dark outline with adaptive popover styling and a lighter border.

* **Tests**
  * Added coverage to verify the dialog uses themed styling instead of a fixed white background.

* **Documentation**
  * Updated dialog design guidance to require semantic, theme-aware surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->