### PR TITLE
fix(wework): reclaim stale runtime storage

### DIFF
--- a/docs/en/wework/developer-guide/wework-local-data-directory.md
+++ b/docs/en/wework/developer-guide/wework-local-data-directory.md
@@ -23,3 +23,28 @@ The default Executor Home is `~/.wework` and contains:
 
 The `WEGENT_EXECUTOR_HOME` environment variable overrides the default Executor
 Home. This is useful for isolated sessions, tests, and custom deployments.
+
+## Automatic Cleanup and Retention
+
+Wework runs storage maintenance in the background immediately after launch and
+then every 30 minutes. Maintenance only processes temporary data that Wework
+explicitly owns. It does not age-delete user projects or managed worktrees that
+may still need recovery:
+
+- `app-runtime/wework-<pid>-<timestamp>/`: an isolated Executor instance is
+  deleted after 14 days only when it is inactive. An instance holding
+  `.instance.lock` is always preserved. For legacy lockless directories, Wework
+  also checks the PID embedded in the directory name before deletion. Legacy
+  `wework-dev-*` directories follow the same rules.
+- Files older than 14 days under `logs/`, and files older than 24 hours in
+  feedback staging or the built-in browser temporary directory, are removed in
+  batches. Current-process logs and symbolic links are preserved.
+- Stale `marketplace-add-*` and `marketplace-upgrade-*` directories older than
+  7 days are removed from `codex/.tmp/marketplaces/.staging/`. This covers both
+  `~/.wework/codex` and `~/.wework/apps/<namespace>/codex` without deleting
+  installed marketplaces.
+
+`workspace/worktrees/` contains task data rather than disposable cache. Its
+lifecycle is driven by archived tasks and the Worktree retention settings, with
+a Git snapshot saved before deletion. The storage maintenance thread does not
+delete these directories directly.

--- a/docs/zh/wework/developer-guide/wework-local-data-directory.md
+++ b/docs/zh/wework/developer-guide/wework-local-data-directory.md
@@ -22,3 +22,21 @@ Wework 的本地运行时数据统一存放在用户主目录下的 `~/.wework`�
 
 `WEGENT_EXECUTOR_HOME` 环境变量可以覆盖默认 Executor Home。显式设置该变量时，
 适用于隔离会话、测试和自定义部署。
+
+## 自动清理与保留策略
+
+Wework 启动后会立即在后台执行一次存储维护，之后每 30 分钟重复执行。维护过程只处理
+Wework 明确拥有的临时数据，不会按时间删除用户项目或仍需恢复的托管工作树：
+
+- `app-runtime/wework-<pid>-<timestamp>/`：隔离 Executor 实例超过 14 天且确认不活跃后
+  删除。持有 `.instance.lock` 的实例始终保留；兼容旧版本无锁目录时，还会检查目录名中的
+  PID，避免删除仍在运行的实例。旧版 `wework-dev-*` 目录遵循相同规则。
+- `logs/` 中超过 14 天的日志，以及反馈暂存和内置浏览器临时目录中超过 24 小时的文件，
+  会按批次清理；当前进程日志和符号链接不会删除。
+- `codex/.tmp/marketplaces/.staging/` 中超过 7 天的
+  `marketplace-add-*`、`marketplace-upgrade-*` 中间目录会删除。该规则同时覆盖
+  `~/.wework/codex` 和 `~/.wework/apps/<namespace>/codex`，不会删除已安装的
+  marketplace。
+
+`workspace/worktrees/` 是任务数据，不属于临时缓存。其清理由归档任务和 Worktree 保留
+设置驱动，并在删除前保存 Git 快照；存储维护线程不会直接删除这些目录。

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -643,6 +643,33 @@ pub(crate) fn local_executor_home_path() -> Result<PathBuf, String> {
     ))
 }
 
+pub(crate) fn managed_codex_home_paths() -> Result<Vec<PathBuf>, String> {
+    let home = dirs::home_dir().ok_or_else(|| "Home directory is not available".to_string())?;
+    let storage_root = home.join(WEWORK_HOME_DIR);
+    let legacy_codex_home = storage_root.join("codex");
+    let current_codex_home =
+        default_local_executor_home_path(&home, LOCAL_EXECUTOR_NAMESPACE).join("codex");
+    let mut paths = vec![legacy_codex_home];
+    if !paths.contains(&current_codex_home) {
+        paths.push(current_codex_home);
+    }
+    if let Ok(namespaces) = fs::read_dir(storage_root.join("apps")) {
+        for namespace in namespaces.filter_map(Result::ok) {
+            let Ok(metadata) = fs::symlink_metadata(namespace.path()) else {
+                continue;
+            };
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                continue;
+            }
+            let codex_home = namespace.path().join("codex");
+            if !paths.contains(&codex_home) {
+                paths.push(codex_home);
+            }
+        }
+    }
+    Ok(paths)
+}
+
 fn default_local_executor_home_path(home: &Path, namespace: Option<&str>) -> PathBuf {
     let root = home.join(WEWORK_HOME_DIR);
     namespace

--- a/wework/src-tauri/src/storage_maintenance.rs
+++ b/wework/src-tauri/src/storage_maintenance.rs
@@ -9,14 +9,14 @@ use std::{
 use fs2::FileExt;
 use tauri::Manager;
 
-const INITIAL_DELAY: Duration = Duration::from_secs(5 * 60);
 const MAINTENANCE_INTERVAL: Duration = Duration::from_secs(30 * 60);
 const TEMP_FILE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const STAGING_DIRECTORY_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 const LOG_FILE_MAX_AGE: Duration = Duration::from_secs(14 * 24 * 60 * 60);
 const RUNTIME_INSTANCE_MAX_AGE: Duration = Duration::from_secs(14 * 24 * 60 * 60);
 const MAX_REMOVALS_PER_DIRECTORY: usize = 20;
-const MAX_RUNTIME_INSTANCE_REMOVALS: usize = 2;
 const RUNTIME_INSTANCE_LOCK_FILE: &str = ".instance.lock";
+const MARKETPLACE_STAGING_PREFIXES: [&str; 2] = ["marketplace-add-", "marketplace-upgrade-"];
 
 struct RuntimeInstanceLease {
     root: PathBuf,
@@ -33,7 +33,6 @@ pub fn schedule(app: tauri::AppHandle) {
                 None
             }
         };
-        thread::sleep(INITIAL_DELAY);
         loop {
             let now = SystemTime::now();
             if let Some(lease) = &runtime_instance_lease {
@@ -104,6 +103,20 @@ fn run(app: &tauri::AppHandle, now: SystemTime, lease: Option<&RuntimeInstanceLe
         &HashSet::new(),
     );
 
+    match crate::local_executor::managed_codex_home_paths() {
+        Ok(codex_homes) => {
+            for codex_home in codex_homes {
+                cleanup_staging_target(
+                    &codex_home.join(".tmp/marketplaces/.staging"),
+                    now,
+                    STAGING_DIRECTORY_MAX_AGE,
+                    &MARKETPLACE_STAGING_PREFIXES,
+                );
+            }
+        }
+        Err(error) => log::warn!("Failed to locate managed Codex homes: {error}"),
+    }
+
     match crate::app_log_directory(app) {
         Ok(log_directory) => {
             let current_process_suffix = format!("-{}.log", std::process::id());
@@ -123,7 +136,6 @@ fn run(app: &tauri::AppHandle, now: SystemTime, lease: Option<&RuntimeInstanceLe
             &lease.instance,
             now,
             RUNTIME_INSTANCE_MAX_AGE,
-            MAX_RUNTIME_INSTANCE_REMOVALS,
         ) {
             log::warn!(
                 "Runtime instance maintenance skipped {}: {error}",
@@ -148,6 +160,20 @@ fn cleanup_target(
     ) {
         log::warn!(
             "Storage maintenance skipped {}: {error}",
+            directory.display()
+        );
+    }
+}
+
+fn cleanup_staging_target(
+    directory: &Path,
+    now: SystemTime,
+    max_age: Duration,
+    allowed_prefixes: &[&str],
+) {
+    if let Err(error) = cleanup_old_directories(directory, now, max_age, allowed_prefixes) {
+        log::warn!(
+            "Staging directory maintenance skipped {}: {error}",
             directory.display()
         );
     }
@@ -208,12 +234,65 @@ fn cleanup_old_files(
     Ok(removed)
 }
 
+fn cleanup_old_directories(
+    directory: &Path,
+    now: SystemTime,
+    max_age: Duration,
+    allowed_prefixes: &[&str],
+) -> Result<usize, String> {
+    ensure_concrete_absolute_path(directory)?;
+    if !directory.exists() {
+        return Ok(0);
+    }
+    let canonical_directory = fs::canonicalize(directory)
+        .map_err(|error| format!("Failed to resolve {}: {error}", directory.display()))?;
+    let mut candidates = fs::read_dir(directory)
+        .map_err(|error| format!("Failed to inspect {}: {error}", directory.display()))?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path).ok()?;
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                return None;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !allowed_prefixes
+                .iter()
+                .any(|prefix| name.starts_with(prefix))
+            {
+                return None;
+            }
+            let modified = metadata.modified().ok()?;
+            let age = now.duration_since(modified).ok()?;
+            (age >= max_age).then_some((modified, path))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|(modified, _)| *modified);
+
+    let mut removed = 0;
+    for (_, path) in candidates {
+        if let Err(error) = ensure_safe_directory_target(&canonical_directory, &path) {
+            log::warn!("Skipping unsafe staging directory target: {error}");
+            continue;
+        }
+        match fs::remove_dir_all(&path) {
+            Ok(()) => removed += 1,
+            Err(error) => {
+                log::warn!(
+                    "Failed to remove staging directory {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(removed)
+}
+
 fn cleanup_old_runtime_instances(
     root: &Path,
     current_instance: &Path,
     now: SystemTime,
     max_age: Duration,
-    max_removals: usize,
 ) -> Result<usize, String> {
     ensure_concrete_absolute_path(root)?;
     ensure_concrete_absolute_path(current_instance)?;
@@ -247,9 +326,9 @@ fn cleanup_old_runtime_instances(
             _ => continue,
         };
         let name = entry.file_name().to_string_lossy().into_owned();
-        if !is_runtime_instance_name(&name) {
+        let Some(pid) = runtime_instance_pid(&name) else {
             continue;
-        }
+        };
         let canonical_path = match fs::canonicalize(&path) {
             Ok(canonical_path) => canonical_path,
             Err(error) => {
@@ -265,7 +344,7 @@ fn cleanup_old_runtime_instances(
         }
 
         let lock_path = path.join(RUNTIME_INSTANCE_LOCK_FILE);
-        let (modified, lock) = match inactive_instance_lock(&lock_path, &metadata) {
+        let (modified, lock) = match inactive_instance_lock(&lock_path, &metadata, pid) {
             Ok(Some(state)) => state,
             Ok(None) => continue,
             Err(error) => {
@@ -286,7 +365,7 @@ fn cleanup_old_runtime_instances(
     candidates.sort_by_key(|(modified, _, _)| *modified);
 
     let mut removed = 0;
-    for (_, path, lock) in candidates.into_iter().take(max_removals) {
+    for (_, path, lock) in candidates {
         if let Err(error) = ensure_safe_directory_target(&canonical_root, &path) {
             log::warn!("Skipping unsafe runtime instance target: {error}");
             continue;
@@ -308,8 +387,12 @@ fn cleanup_old_runtime_instances(
 fn inactive_instance_lock(
     lock_path: &Path,
     instance_metadata: &fs::Metadata,
+    pid: u32,
 ) -> Result<Option<(SystemTime, Option<File>)>, String> {
     if !lock_path.exists() {
+        if process_is_alive(pid) {
+            return Ok(None);
+        }
         return Ok(Some((
             instance_metadata
                 .modified()
@@ -345,19 +428,54 @@ fn inactive_instance_lock(
     Ok(Some((modified, Some(lock))))
 }
 
-fn is_runtime_instance_name(name: &str) -> bool {
+fn runtime_instance_pid(name: &str) -> Option<u32> {
     let Some(identity) = name.strip_prefix("wework-") else {
-        return false;
+        return None;
     };
+    let identity = identity.strip_prefix("dev-").unwrap_or(identity);
     let Some((pid, timestamp)) = identity.split_once('-') else {
-        return false;
+        return None;
     };
-    !pid.is_empty()
-        && !timestamp.is_empty()
-        && pid.chars().all(|character| character.is_ascii_digit())
-        && timestamp
+    if timestamp.is_empty()
+        || !timestamp
             .chars()
             .all(|character| character.is_ascii_digit())
+    {
+        return None;
+    }
+    pid.parse().ok()
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_ACCESS_DENIED};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    const STILL_ACTIVE: u32 = 259;
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return GetLastError() == ERROR_ACCESS_DENIED;
+        }
+        let mut exit_code = 0;
+        let result = GetExitCodeProcess(handle, &mut exit_code);
+        CloseHandle(handle);
+        result != 0 && exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_is_alive(_pid: u32) -> bool {
+    false
 }
 
 fn ensure_concrete_absolute_path(path: &Path) -> Result<(), String> {
@@ -513,6 +631,42 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_removes_only_old_known_staging_directories() {
+        let root = test_directory("wework-storage-staging");
+        let stale = root.join("marketplace-upgrade-stale");
+        let recent = root.join("marketplace-add-recent");
+        let unknown = root.join("user-marketplace");
+        for directory in [&stale, &recent, &unknown] {
+            fs::create_dir_all(directory).unwrap();
+            fs::write(directory.join("content"), "content").unwrap();
+        }
+        let outside = root.with_extension("outside");
+        fs::create_dir_all(&outside).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, root.join("marketplace-upgrade-linked")).unwrap();
+        let now = SystemTime::now();
+        set_directory_modified(&stale, now - Duration::from_secs(120));
+        set_directory_modified(&recent, now - Duration::from_secs(30));
+        set_directory_modified(&unknown, now - Duration::from_secs(120));
+
+        let removed = cleanup_old_directories(
+            &root,
+            now,
+            Duration::from_secs(60),
+            &MARKETPLACE_STAGING_PREFIXES,
+        )
+        .unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!stale.exists());
+        assert!(recent.is_dir());
+        assert!(unknown.is_dir());
+        assert!(outside.is_dir());
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(outside);
+    }
+
+    #[test]
     fn cleanup_removes_only_old_inactive_runtime_instances() {
         let root = test_directory("wework-runtime-maintenance");
         let current = root.join("wework-10-100");
@@ -537,8 +691,7 @@ mod tests {
         drop(stale_lock);
 
         let removed =
-            cleanup_old_runtime_instances(&root, &current, now, Duration::from_secs(60), 10)
-                .unwrap();
+            cleanup_old_runtime_instances(&root, &current, now, Duration::from_secs(60)).unwrap();
 
         assert_eq!(removed, 1);
         assert!(current.is_dir());
@@ -551,13 +704,21 @@ mod tests {
     }
 
     #[test]
-    fn runtime_cleanup_is_bounded_and_ignores_unknown_directories() {
-        let root = test_directory("wework-runtime-maintenance-bounded");
+    fn runtime_cleanup_drains_stale_instances_and_ignores_unknown_directories() {
+        let root = test_directory("wework-runtime-maintenance-drain");
         let current = root.join("wework-10-100");
         let unknown = root.join("user-data");
+        let legacy = root.join("wework-dev-99-999");
         fs::create_dir_all(&current).unwrap();
         fs::create_dir_all(&unknown).unwrap();
+        fs::create_dir_all(&legacy).unwrap();
         let now = SystemTime::now();
+        let legacy_lock = create_instance_lock_file(&legacy);
+        set_modified(
+            legacy.join(RUNTIME_INSTANCE_LOCK_FILE),
+            now - Duration::from_secs(120),
+        );
+        drop(legacy_lock);
         for index in 0..3 {
             let instance = root.join(format!("wework-{}-{}", index + 20, index + 200));
             fs::create_dir_all(&instance).unwrap();
@@ -570,20 +731,31 @@ mod tests {
         }
 
         let removed =
-            cleanup_old_runtime_instances(&root, &current, now, Duration::from_secs(60), 2)
-                .unwrap();
+            cleanup_old_runtime_instances(&root, &current, now, Duration::from_secs(60)).unwrap();
 
-        assert_eq!(removed, 2);
+        assert_eq!(removed, 4);
         assert!(current.is_dir());
         assert!(unknown.is_dir());
-        assert_eq!(
-            fs::read_dir(&root)
-                .unwrap()
-                .filter_map(Result::ok)
-                .filter(|entry| is_runtime_instance_name(&entry.file_name().to_string_lossy()))
-                .count(),
-            2
-        );
+        assert!(!legacy.exists());
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn runtime_cleanup_preserves_lockless_instance_with_live_pid() {
+        let root = test_directory("wework-runtime-maintenance-live-pid");
+        let current = root.join("wework-10-100");
+        let active = root.join(format!("wework-{}-200", std::process::id()));
+        fs::create_dir_all(&current).unwrap();
+        fs::create_dir_all(&active).unwrap();
+        let now = SystemTime::now();
+        set_directory_modified(&active, now - Duration::from_secs(120));
+
+        let removed =
+            cleanup_old_runtime_instances(&root, &current, now, Duration::from_secs(60)).unwrap();
+
+        assert_eq!(removed, 0);
+        assert!(active.is_dir());
         let _ = fs::remove_dir_all(root);
     }
 
@@ -614,5 +786,10 @@ mod tests {
     fn set_modified(path: PathBuf, modified: SystemTime) {
         let file = fs::OpenOptions::new().write(true).open(path).unwrap();
         file.set_modified(modified).unwrap();
+    }
+
+    fn set_directory_modified(path: &Path, modified: SystemTime) {
+        let directory = fs::OpenOptions::new().read(true).open(path).unwrap();
+        directory.set_modified(modified).unwrap();
     }
 }


### PR DESCRIPTION
## What changed

- run Wework storage maintenance immediately at startup instead of waiting five minutes
- drain every expired inactive isolated runtime while preserving locked instances and legacy lockless instances whose PID is still alive
- recognize legacy `wework-dev-*` runtime directories
- remove stale Codex marketplace add/upgrade staging directories after seven days across legacy and namespaced Wework Codex homes
- document the Wework local-data retention policy in Chinese and English

## Root cause

Runtime maintenance waited five minutes before its first pass and removed at most two runtime instances per pass. Short-lived development sessions therefore created instances faster than maintenance could reclaim them. Legacy development directory names were also excluded permanently.

Codex marketplace staging uses temporary directories, but process termination can leave those directories behind and no Wework startup maintenance reclaimed them.

## Impact

Expired Wework-owned temporary storage now converges on startup without deleting active runtimes, installed marketplaces, user projects, or managed task worktrees.

During investigation, the same safety rules reclaimed 417 expired runtime instances and 12 stale marketplace staging directories from the affected machine, freeing about 9.62 GB.

## Validation

- `cargo test --manifest-path wework/src-tauri/Cargo.toml --lib` — 155 passed
- `pnpm --filter wework test` — 335 files / 3231 tests passed
- pre-push ESLint, TypeScript, and Wework unit checks passed
- isolated real-Tauri session reached the Wework workbench and local executor successfully; the initial cold-start control timeout was followed by a successful snapshot from the same session
