### PR TITLE
fix(wework): restore filtered user questions

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -262,6 +262,15 @@ The server-provided `messageIndex` is the only ordering authority for the persis
 
 While the current pane has a live turn that the transcript has not covered yet, the UI may keep displaying that pane's stream projection as a whole. Once the Provider covers the same turn, the pane switches to the transcript as a whole instead of taking the union of both message sets. Transcript-page deduplication uses only stable Provider message ids and must not infer identity from content, role, or subtask.
 
+Codex may filter the initial user input from the Provider transcript `items`,
+while Wework still retains the visible text that the user submitted in
+`RuntimeTaskLink.userMessagePresentations`. When the executor restores such a
+message, it must bind it to the next Provider turn on the timeline and write
+the canonical `turnId` and `subtaskId`. If the user input and the first
+assistant message share a timestamp, the user input must remain first.
+Canonical `turns` are the frontend transcript's only input, so restoring a
+message only in the compatibility `messages` array is insufficient.
+
 ## Guidance Message Order
 
 Running Codex LocalTasks can send a queued message as native guidance. Guidance is user input inside the current turn, not a new follow-up turn, so the UI must insert the local user message inside the active assistant as soon as guidance sending starts:

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -225,6 +225,13 @@ Wework 的聊天 UI 不能把持续输出的完整正文长期保存在 React st
 
 当前 pane 的实时 turn 尚未被 transcript 覆盖时，可以继续整体展示该 pane 的 stream 投影；Provider 覆盖同一 turn 后应整体切换到 transcript，而不是对两组消息做并集。消息分页去重只使用 Provider 的稳定 message id，不根据内容、角色或 subtask 猜测身份。
 
+Codex 可能从 Provider transcript 的 `items` 中过滤初始用户输入，但 Wework 仍会在
+`RuntimeTaskLink.userMessagePresentations` 中保存用户实际提交的可见文本。executor
+补回这类消息时，必须把它归属到时间线上紧随其后的 Provider turn，并同时写入规范
+`turnId`/`subtaskId`；用户输入与首个 assistant 消息时间戳相同时，用户输入必须排在
+assistant 之前。canonical `turns` 是前端 transcript 的唯一输入，不能只把补回消息
+留在兼容 `messages` 数组中。
+
 ## 引导消息顺序
 
 运行中的 Codex LocalTask 支持把队列消息作为原生引导发送。引导是当前 turn 内的用户输入，不是新的 follow-up turn，所以 UI 必须在发送开始时就把本地用户消息插入到当前 assistant 中间：

--- a/executor/src/runtime_work/handler/helpers/transcript.rs
+++ b/executor/src/runtime_work/handler/helpers/transcript.rs
@@ -541,7 +541,24 @@ fn attach_user_message_presentations(messages: &mut Vec<Value>, presentations: V
                 }
                 let created_at =
                     timestamp_ms_field(&presentation, "createdAt").unwrap_or_else(now_ms);
-                let synthetic = json!({
+                let index = messages
+                    .iter()
+                    .position(|message| {
+                        timestamp_ms_field(message, "createdAt")
+                            .is_some_and(|message_at| message_at >= created_at)
+                    })
+                    .unwrap_or(messages.len());
+                let turn_id = string_field(&presentation, "turnId")
+                    .or_else(|| string_field(&presentation, "turn_id"))
+                    .or_else(|| {
+                        messages[index..].iter().find_map(|message| {
+                            string_field(message, "turnId")
+                                .or_else(|| string_field(message, "turn_id"))
+                                .or_else(|| string_field(message, "subtaskId"))
+                                .or_else(|| string_field(message, "subtask_id"))
+                        })
+                    });
+                let mut synthetic = json!({
                     "id": client_user_message_id,
                     "clientUserMessageId": client_user_message_id,
                     "role": "user",
@@ -550,13 +567,10 @@ fn attach_user_message_presentations(messages: &mut Vec<Value>, presentations: V
                     "createdAt": created_at,
                     "source": presentation.get("source").cloned(),
                 });
-                let index = messages
-                    .iter()
-                    .position(|message| {
-                        timestamp_ms_field(message, "createdAt")
-                            .is_some_and(|message_at| message_at > created_at)
-                    })
-                    .unwrap_or(messages.len());
+                if let Some(turn_id) = turn_id {
+                    synthetic["turnId"] = Value::String(turn_id.clone());
+                    synthetic["subtaskId"] = Value::String(turn_id);
+                }
                 messages.insert(index, synthetic);
                 index
             }

--- a/executor/src/runtime_work/handler/helpers/transcript.rs
+++ b/executor/src/runtime_work/handler/helpers/transcript.rs
@@ -545,7 +545,11 @@ fn attach_user_message_presentations(messages: &mut Vec<Value>, presentations: V
                     .iter()
                     .position(|message| {
                         timestamp_ms_field(message, "createdAt")
-                            .is_some_and(|message_at| message_at >= created_at)
+                            .is_some_and(|message_at| {
+                                message_at > created_at
+                                    || (message_at == created_at
+                                        && string_field(message, "role").as_deref() != Some("user"))
+                            })
                     })
                     .unwrap_or(messages.len());
                 let turn_id = string_field(&presentation, "turnId")

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -1148,21 +1148,48 @@ fn transcript_restores_a_missing_user_message_before_an_equal_timestamp_response
         "turnId": "turn-1",
         "role": "assistant",
         "content": "Done",
-        "createdAt": 100
+        "createdAt": 1_780_000_000_000_i64
     })];
-    let presentations = vec![json!({
-        "clientUserMessageId": "client-user-1",
-        "content": "Fix the issue",
-        "createdAt": 100,
-        "ensureVisible": true,
-        "references": []
-    })];
+    let presentations = vec![
+        json!({
+            "clientUserMessageId": "client-user-1",
+            "content": "First instruction",
+            "createdAt": 1_780_000_000_000_i64,
+            "ensureVisible": true,
+            "references": []
+        }),
+        json!({
+            "clientUserMessageId": "client-user-2",
+            "content": "Second instruction",
+            "createdAt": 1_780_000_000_000_i64,
+            "ensureVisible": true,
+            "references": []
+        }),
+    ];
 
     attach_user_message_presentations(&mut provider_messages, presentations);
 
     assert_eq!(provider_messages[0]["role"], "user");
+    assert_eq!(provider_messages[0]["content"], "First instruction");
     assert_eq!(provider_messages[0]["turnId"], "turn-1");
-    assert_eq!(provider_messages[1]["role"], "assistant");
+    assert_eq!(provider_messages[0]["subtaskId"], "turn-1");
+    assert_eq!(provider_messages[1]["role"], "user");
+    assert_eq!(provider_messages[1]["content"], "Second instruction");
+    assert_eq!(provider_messages[2]["role"], "assistant");
+
+    let turns =
+        transcript_canonical_turns(&provider_messages, TranscriptTurnItemSource::CodexItems);
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0]["items"][0]["type"], "user_message");
+    assert_eq!(
+        turns[0]["items"][0]["message"]["content"],
+        "First instruction"
+    );
+    assert_eq!(turns[0]["items"][1]["type"], "user_message");
+    assert_eq!(
+        turns[0]["items"][1]["message"]["content"],
+        "Second instruction"
+    );
 }
 
 #[test]

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -1109,6 +1109,7 @@ fn transcript_does_not_attach_presentation_to_an_unmatched_client_user_message_i
 fn transcript_restores_a_missing_supervisor_generated_user_message() {
     let mut provider_messages = vec![json!({
         "id": "assistant-1",
+        "turnId": "turn-1",
         "role": "assistant",
         "content": "Corrected",
         "createdAt": 200
@@ -1129,6 +1130,38 @@ fn transcript_restores_a_missing_supervisor_generated_user_message() {
 
     assert_eq!(provider_messages[0]["role"], "user");
     assert_eq!(provider_messages[0]["content"], "Use Japanese");
+    assert_eq!(provider_messages[0]["turnId"], "turn-1");
+    assert_eq!(provider_messages[0]["subtaskId"], "turn-1");
+    assert_eq!(provider_messages[1]["role"], "assistant");
+
+    let turns =
+        transcript_canonical_turns(&provider_messages, TranscriptTurnItemSource::CodexItems);
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0]["items"][0]["type"], "user_message");
+    assert_eq!(turns[0]["items"][0]["message"]["content"], "Use Japanese");
+}
+
+#[test]
+fn transcript_restores_a_missing_user_message_before_an_equal_timestamp_response() {
+    let mut provider_messages = vec![json!({
+        "id": "assistant-1",
+        "turnId": "turn-1",
+        "role": "assistant",
+        "content": "Done",
+        "createdAt": 100
+    })];
+    let presentations = vec![json!({
+        "clientUserMessageId": "client-user-1",
+        "content": "Fix the issue",
+        "createdAt": 100,
+        "ensureVisible": true,
+        "references": []
+    })];
+
+    attach_user_message_presentations(&mut provider_messages, presentations);
+
+    assert_eq!(provider_messages[0]["role"], "user");
+    assert_eq!(provider_messages[0]["turnId"], "turn-1");
     assert_eq!(provider_messages[1]["role"], "assistant");
 }
 


### PR DESCRIPTION
## Summary

- restore locally retained user questions when Codex filters them from provider transcript items
- bind restored questions to the following canonical turn so Wework renders them after transcript reload
- preserve user-before-assistant ordering when timestamps are equal
- document the canonical transcript ownership rule in Chinese and English

## Root cause

Wework retained the visible submitted question in `RuntimeTaskLink.userMessagePresentations` and restored it into the compatibility `messages` array. The synthetic message had no `turnId`, so canonical turn construction dropped it. The frontend consumes canonical `turns`, leaving only the assistant response visible.

ChatGPT models the initial user input as turn-owned input independently from provider work items. This change closes the equivalent ownership gap in Wework by assigning restored input to the next provider turn.

## Validation

- `cargo fmt --check --manifest-path executor/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml runtime_work::handler::tests:: --lib` (70 passed)
- focused app-runtime transcript contract tests (2 passed)
- pre-push `cargo test --all-features --lib` (passed)
- pre-push `cargo clippy` (passed)
- broader `cargo test --manifest-path executor/Cargo.toml` passed the executor library suite (716 passed, 1 ignored) and all runtime transcript/send/workspace contracts reached before an unrelated `app_sidecar_reserves_stdout_for_jsonl_before_backend_startup` test produced no output for more than three minutes; that local full-suite run was stopped

## Desktop verification

`pnpm --filter wework ai:verify start` was attempted twice in isolated sessions (60 seconds and 180 seconds). Both timed out before the WebView connected and produced no app/executor logs, so real-Tauri interaction verification could not begin. Both isolated sessions were stopped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored user messages now appear in the correct order, including before assistant responses with identical timestamps.
  * Restored messages are associated with the appropriate conversation turn and task.
  * Restored messages now consistently appear in the primary conversation transcript.

* **Documentation**
  * Added English and Chinese guidance describing transcript restoration and ordering behavior.

* **Tests**
  * Added coverage for turn association, canonical transcript placement, and same-timestamp message ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->