### PR TITLE
fix(wework): fix continue-to-private-chat for local runtime tasks

### DIFF
--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -688,10 +688,11 @@ async def bind_runtime_task_to_im_sessions(
             session=session,
             runtime_task=runtime_task,
         )
+    task_title = await _runtime_task_title_for_address(user_id=user_id, address=address)
     notification = await im_notification_dispatcher.send_task_switched(
         db,
         sessions,
-        address.local_task_id,
+        task_title or address.local_task_id,
     )
     return BindRuntimeTaskIMSessionsResponse(
         address=address,
@@ -2179,6 +2180,41 @@ def _workspace_path_for_runtime_task(
             if isinstance(task_path, str) and task_path.strip():
                 return normalize_workspace_path(task_path)
             return workspace_path
+    return None
+
+
+async def _runtime_task_title_for_address(
+    *,
+    user_id: int,
+    address: RuntimeTaskAddress,
+) -> Optional[str]:
+    """Best-effort resolution of a runtime task title for notifications."""
+
+    try:
+        result = await runtime_rpc_service.call(
+            user_id=user_id,
+            device_id=address.device_id,
+            method="runtime.tasks.list",
+            payload={},
+            timeout_seconds=RUNTIME_LIST_TIMEOUT_SECONDS,
+        )
+    except RuntimeRpcError:
+        return None
+    if result.get("success") is False:
+        return None
+    expected_task_id = str(address.local_task_id).strip()
+    if not expected_task_id:
+        return None
+    for workspace in _iter_runtime_workspaces(result):
+        for task in workspace["tasks"]:
+            if not isinstance(task, dict):
+                continue
+            task_id = str(task.get("taskId") or "")
+            if task_id.strip() != expected_task_id:
+                continue
+            title = task.get("title")
+            if isinstance(title, str) and title.strip():
+                return title.strip()
     return None
 
 

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -759,7 +759,7 @@ export function createHybridWorkbenchServices(
       return runtimeApi(data.deviceId).restoreWorktree(data)
     },
     bindRuntimeTaskImSessions(data) {
-      return routeByAddress(data.address).bindRuntimeTaskImSessions(data)
+      return cloudServices.runtimeWorkApi!.bindRuntimeTaskImSessions(data)
     },
     getImNotificationSettings() {
       return cloudServices.runtimeWorkApi!.getImNotificationSettings()
@@ -768,10 +768,10 @@ export function createHybridWorkbenchServices(
       return cloudServices.runtimeWorkApi!.updateGlobalImNotification(data)
     },
     subscribeRuntimeTaskNotifications(data: RuntimeTaskIMNotificationSubscriptionRequest) {
-      return routeByAddress(data.address).subscribeRuntimeTaskNotifications(data)
+      return cloudServices.runtimeWorkApi!.subscribeRuntimeTaskNotifications(data)
     },
     unsubscribeRuntimeTaskNotifications(address: RuntimeTaskAddress) {
-      return routeByAddress(address).unsubscribeRuntimeTaskNotifications(address)
+      return cloudServices.runtimeWorkApi!.unsubscribeRuntimeTaskNotifications(address)
     },
     archiveRuntimeTask(address: RuntimeTaskAddress) {
       const request = routeByAddress(address).archiveRuntimeTask(address)


### PR DESCRIPTION
## Summary

Fix two P0 bugs that block the core flow of continuing a Wework local runtime task in an IM private chat (e.g. DingTalk).

## Problem 1: Local-first mode bind always fails

`hybridServices.ts` routed `bindRuntimeTaskImSessions` by device address via `routeByAddress`. For local-device tasks, this routed to `localServices.runtimeWorkApi`, which rejects with `cloudConnectionRequired('bindRuntimeTaskImSessions')`.

IM session state (Redis) and notification dispatch are backend-only operations — they should never be routed to local services.

**Fix:** Route `bindRuntimeTaskImSessions`, `subscribeRuntimeTaskNotifications`, and `unsubscribeRuntimeTaskNotifications` directly through `cloudServices.runtimeWorkApi`, matching the existing pattern for `getImNotificationSettings` and `updateGlobalImNotification`.

## Problem 2: DingTalk notification shows task ID instead of title

`bind_runtime_task_to_im_sessions` passed `address.local_task_id` (e.g. `"runtime-1"`) as the `task_title` to `send_task_switched`. Users received "已切换到任务「runtime-1」" — unreadable.

**Fix:** Added `_runtime_task_title_for_address` which best-effort resolves the real title via `runtime.tasks.list` RPC. Falls back to `local_task_id` if the RPC fails or the title is empty, so binding is never blocked by title resolution.

## End-to-end flow after fix

1. User clicks "继续到私聊" → dialog lists IM private sessions (backend Redis)
2. User selects DingTalk session → `POST /runtime-work/im-sessions` (now reaches backend, not rejected by local services)
3. Backend binds session + sends DingTalk notification with real task title
4. User replies in DingTalk → message routed to `_execute_private_im_continue_runtime_task` → `runtime_work_service.send_runtime_message` → local executor

## Testing

- TypeScript: `tsc --noEmit` — 0 errors
- Frontend unit tests: `hybridServices.test.ts` (32), `runtimeWork.test.ts` (11), `DesktopWorkbenchLayout.test.tsx` (168), `MobileWorkbenchLayout.test.tsx` (25), `ContinueInImDialog.test.tsx` (7), `WorkbenchProvider.test.tsx` (152) — all pass
- Backend: `py_compile` — OK

## Changed files

- `wework/src/api/hybrid/hybridServices.ts` — route IM session bind/subscribe/unsubscribe through cloud services
- `backend/app/services/runtime_work_service.py` — resolve runtime task title for notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switch notifications now display the associated task title when available.
  * Notifications fall back to the task ID when a title cannot be retrieved.

* **Bug Fixes**
  * Improved runtime task and instant messaging session binding for more reliable notification delivery.
  * Added graceful handling when task information is unavailable or cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->