### PR TITLE
fix(wework): let fullscreen shell follow viewport

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -233,6 +233,9 @@ async function waitForVisibleSingleElement(control, selector, timeoutMs, message
     appShellHeight: await control.command('getInlineStyle', '[data-testid="app-shell"]', {
       value: 'height',
     }),
+    tauriViewportHeight: await control.command('getAttribute', '[data-testid="app-shell"]', {
+      value: 'data-tauri-viewport-height',
+    }),
     routeHost: JSON.parse(
       await control.command('getElementMetrics', '[data-testid="app-route-host"]')
     ),

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -233,9 +233,6 @@ async function waitForVisibleSingleElement(control, selector, timeoutMs, message
     appShellHeight: await control.command('getInlineStyle', '[data-testid="app-shell"]', {
       value: 'height',
     }),
-    tauriViewportHeight: await control.command('getAttribute', '[data-testid="app-shell"]', {
-      value: 'data-tauri-viewport-height',
-    }),
     routeHost: JSON.parse(
       await control.command('getElementMetrics', '[data-testid="app-route-host"]')
     ),

--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -29,12 +29,6 @@ vi.mock('@tauri-apps/api/window', () => ({
     toggleMaximize: vi.fn(),
     close: vi.fn(),
     isMaximized: vi.fn().mockResolvedValue(false),
-    innerSize: vi.fn().mockResolvedValue({
-      width: 1280,
-      height: 720,
-      toLogical: vi.fn().mockReturnValue({ width: 1280, height: 720 }),
-    }),
-    scaleFactor: vi.fn().mockResolvedValue(1),
     onResized: vi.fn().mockResolvedValue(vi.fn()),
   }),
 }))
@@ -305,9 +299,7 @@ describe('App center route', () => {
     const appShell = screen.getByTestId('app-shell')
     expect(appShell).toHaveClass('fixed', 'inset-0')
     expect(appShell).not.toHaveClass('h-dvh', 'h-screen')
-    await waitFor(() => {
-      expect(appShell).toHaveStyle({ width: '1280px', height: '720px' })
-    })
+    expect(appShell).not.toHaveAttribute('style')
     expect(routeHost).toHaveClass('flex-1', 'min-h-0')
     expect(routeHost).not.toHaveClass('h-0')
     expect(screen.getByTestId('workbench-page')).toBeInTheDocument()

--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -29,7 +29,14 @@ vi.mock('@tauri-apps/api/window', () => ({
     toggleMaximize: vi.fn(),
     close: vi.fn(),
     isMaximized: vi.fn().mockResolvedValue(false),
+    innerSize: vi.fn().mockResolvedValue({
+      width: 1280,
+      height: 720,
+      toLogical: vi.fn().mockReturnValue({ width: 1280, height: 720 }),
+    }),
+    scaleFactor: vi.fn().mockResolvedValue(1),
     onResized: vi.fn().mockResolvedValue(vi.fn()),
+    onScaleChanged: vi.fn().mockResolvedValue(vi.fn()),
   }),
 }))
 
@@ -299,7 +306,9 @@ describe('App center route', () => {
     const appShell = screen.getByTestId('app-shell')
     expect(appShell).toHaveClass('fixed', 'inset-0')
     expect(appShell).not.toHaveClass('h-dvh', 'h-screen')
-    expect(appShell).not.toHaveAttribute('style')
+    await waitFor(() => {
+      expect(appShell).toHaveStyle({ width: '1280px', height: '720px' })
+    })
     expect(routeHost).toHaveClass('flex-1', 'min-h-0')
     expect(routeHost).not.toHaveClass('h-0')
     expect(screen.getByTestId('workbench-page')).toBeInTheDocument()

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -25,7 +25,14 @@ vi.mock('@tauri-apps/api/window', () => ({
     toggleMaximize: vi.fn(),
     close: vi.fn(),
     isMaximized: vi.fn().mockResolvedValue(false),
+    innerSize: vi.fn().mockResolvedValue({
+      width: 1280,
+      height: 720,
+      toLogical: vi.fn().mockReturnValue({ width: 1280, height: 720 }),
+    }),
+    scaleFactor: vi.fn().mockResolvedValue(1),
     onResized: vi.fn().mockResolvedValue(vi.fn()),
+    onScaleChanged: vi.fn().mockResolvedValue(vi.fn()),
   }),
 }))
 

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -25,12 +25,6 @@ vi.mock('@tauri-apps/api/window', () => ({
     toggleMaximize: vi.fn(),
     close: vi.fn(),
     isMaximized: vi.fn().mockResolvedValue(false),
-    innerSize: vi.fn().mockResolvedValue({
-      width: 1280,
-      height: 720,
-      toLogical: vi.fn().mockReturnValue({ width: 1280, height: 720 }),
-    }),
-    scaleFactor: vi.fn().mockResolvedValue(1),
     onResized: vi.fn().mockResolvedValue(vi.fn()),
   }),
 }))

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -94,11 +94,6 @@ import { setActiveWorkspaceTabPortalOwner } from '@/components/topnav/workspaceT
 const WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS = 6000
 const POPOUT_WINDOW_LABEL = 'popout-window'
 
-interface ViewportSize {
-  width: number
-  height: number
-}
-
 function isPopoutWindowRuntime() {
   if (!isTauriRuntime()) return false
   try {
@@ -442,65 +437,6 @@ function browserWorkspaceTabStorageScope(): string {
   return `browser:${window.name}`
 }
 
-function useTauriViewportSize(isTauri: boolean): ViewportSize | null {
-  const [viewportSize, setViewportSize] = useState<ViewportSize | null>(() => {
-    if (!isTauri || window.innerWidth <= 0 || window.innerHeight <= 0) return null
-    return { width: window.innerWidth, height: window.innerHeight }
-  })
-
-  useEffect(() => {
-    if (!isTauri) return undefined
-
-    const appWindow = getCurrentWindow()
-    let disposed = false
-    let unlisten: (() => void) | undefined
-
-    const applyPhysicalSize = async (
-      physicalSize: Awaited<ReturnType<typeof appWindow.innerSize>>
-    ) => {
-      const scaleFactor = await appWindow.scaleFactor()
-      const logicalSize = physicalSize.toLogical(scaleFactor)
-      if (disposed || logicalSize.width <= 0 || logicalSize.height <= 0) return
-      setViewportSize(current =>
-        current?.width === logicalSize.width && current.height === logicalSize.height
-          ? current
-          : { width: logicalSize.width, height: logicalSize.height }
-      )
-    }
-
-    void appWindow
-      .innerSize()
-      .then(applyPhysicalSize)
-      .catch(error => {
-        console.error('[Wework] Failed to read the Tauri viewport size:', error)
-      })
-
-    void appWindow
-      .onResized(({ payload }) => {
-        void applyPhysicalSize(payload).catch(error => {
-          console.error('[Wework] Failed to update the Tauri viewport size:', error)
-        })
-      })
-      .then(unlistenFn => {
-        if (disposed) {
-          unlistenFn()
-          return
-        }
-        unlisten = unlistenFn
-      })
-      .catch(error => {
-        console.error('[Wework] Failed to listen for Tauri viewport changes:', error)
-      })
-
-    return () => {
-      disposed = true
-      unlisten?.()
-    }
-  }, [isTauri])
-
-  return viewportSize
-}
-
 function AppShell() {
   const { t } = useTranslation('common')
   const { pathname: path, search } = useCurrentLocation()
@@ -515,7 +451,6 @@ function AppShell() {
   }
   const { activeAppKey, navigateToApp } = useChromeTabs(path)
   const isTauri = isTauriRuntime()
-  const tauriViewportSize = useTauriViewportSize(isTauri)
   const isPopoutWindow = isPopoutWindowRuntime()
   const isWorkspaceWindow = isTauri && getCurrentWindow().label?.startsWith('workspace-') === true
   const titlebarOverlaysContent = false
@@ -732,7 +667,6 @@ function AppShell() {
     >
       <div
         data-testid="app-shell"
-        data-tauri-viewport-height={tauriViewportSize?.height}
         className={cn(
           isTauri ? 'fixed inset-0' : 'h-dvh',
           isPopoutWindow
@@ -742,14 +676,6 @@ function AppShell() {
               : 'overflow-hidden bg-surface',
           titlebarOverlaysContent ? 'relative' : 'flex flex-col'
         )}
-        style={
-          tauriViewportSize
-            ? {
-                width: `${tauriViewportSize.width}px`,
-                height: `${tauriViewportSize.height}px`,
-              }
-            : undefined
-        }
       >
         {showChromeTitlebar && (
           <ChromeTitlebar

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -90,6 +90,7 @@ import { TelemetryBridge } from '@/telemetry/TelemetryBridge'
 import { track, useTelemetryEnabled } from '@/telemetry/client'
 import { WorkspaceTabPortalOwner } from '@/components/topnav/TitlebarActionsPortal'
 import { setActiveWorkspaceTabPortalOwner } from '@/components/topnav/workspaceTabPortalOwnership'
+import { useTauriViewportSize } from '@/hooks/useTauriViewportSize'
 
 const WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS = 6000
 const POPOUT_WINDOW_LABEL = 'popout-window'
@@ -451,6 +452,7 @@ function AppShell() {
   }
   const { activeAppKey, navigateToApp } = useChromeTabs(path)
   const isTauri = isTauriRuntime()
+  const tauriViewportSize = useTauriViewportSize(isTauri)
   const isPopoutWindow = isPopoutWindowRuntime()
   const isWorkspaceWindow = isTauri && getCurrentWindow().label?.startsWith('workspace-') === true
   const titlebarOverlaysContent = false
@@ -667,6 +669,7 @@ function AppShell() {
     >
       <div
         data-testid="app-shell"
+        data-tauri-viewport-height={tauriViewportSize?.height}
         className={cn(
           isTauri ? 'fixed inset-0' : 'h-dvh',
           isPopoutWindow
@@ -676,6 +679,14 @@ function AppShell() {
               : 'overflow-hidden bg-surface',
           titlebarOverlaysContent ? 'relative' : 'flex flex-col'
         )}
+        style={
+          tauriViewportSize
+            ? {
+                width: `${tauriViewportSize.width}px`,
+                height: `${tauriViewportSize.height}px`,
+              }
+            : undefined
+        }
       >
         {showChromeTitlebar && (
           <ChromeTitlebar

--- a/wework/src/App.viewport.test.tsx
+++ b/wework/src/App.viewport.test.tsx
@@ -1,0 +1,73 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { useTauriViewportSize } from '@/hooks/useTauriViewportSize'
+
+function physicalSize(width: number, height: number) {
+  return {
+    width,
+    height,
+    toLogical: (scaleFactor: number) => ({
+      width: width / scaleFactor,
+      height: height / scaleFactor,
+    }),
+  }
+}
+
+const windowMocks = vi.hoisted(() => ({
+  innerSize: vi.fn(),
+  scaleFactor: vi.fn(),
+  onResized: vi.fn(),
+  onScaleChanged: vi.fn(),
+  resizeHandler: null as ((event: { payload: ReturnType<typeof physicalSize> }) => void) | null,
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    innerSize: windowMocks.innerSize,
+    scaleFactor: windowMocks.scaleFactor,
+    onResized: windowMocks.onResized,
+    onScaleChanged: windowMocks.onScaleChanged,
+  }),
+}))
+
+beforeEach(() => {
+  windowMocks.resizeHandler = null
+  windowMocks.innerSize.mockReset().mockResolvedValue(physicalSize(1280, 720))
+  windowMocks.scaleFactor.mockReset().mockResolvedValue(1)
+  windowMocks.onResized.mockReset().mockImplementation(async handler => {
+    windowMocks.resizeHandler = handler
+    return vi.fn()
+  })
+  windowMocks.onScaleChanged.mockReset().mockResolvedValue(vi.fn())
+})
+
+test('keeps the latest native viewport size when resize conversions finish out of order', async () => {
+  const { result } = renderHook(() => useTauriViewportSize(true))
+
+  await waitFor(() => {
+    expect(windowMocks.resizeHandler).not.toBeNull()
+    expect(result.current).toEqual({ width: 1280, height: 720 })
+  })
+
+  let resolveStaleScaleFactor: ((scaleFactor: number) => void) | undefined
+  const staleScaleFactor = new Promise<number>(resolve => {
+    resolveStaleScaleFactor = resolve
+  })
+  windowMocks.scaleFactor.mockReturnValueOnce(staleScaleFactor).mockResolvedValueOnce(1)
+
+  act(() => {
+    windowMocks.resizeHandler?.({ payload: physicalSize(1504, 929) })
+    windowMocks.resizeHandler?.({ payload: physicalSize(1728, 1084) })
+  })
+
+  await waitFor(() => {
+    expect(result.current).toEqual({ width: 1728, height: 1084 })
+  })
+
+  await act(async () => {
+    resolveStaleScaleFactor?.(1)
+    await staleScaleFactor
+  })
+
+  expect(result.current).toEqual({ width: 1728, height: 1084 })
+})

--- a/wework/src/hooks/useTauriViewportSize.ts
+++ b/wework/src/hooks/useTauriViewportSize.ts
@@ -1,0 +1,77 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { useEffect, useState } from 'react'
+
+interface ViewportSize {
+  width: number
+  height: number
+}
+
+export function useTauriViewportSize(isTauri: boolean): ViewportSize | null {
+  const [viewportSize, setViewportSize] = useState<ViewportSize | null>(() => {
+    if (!isTauri || window.innerWidth <= 0 || window.innerHeight <= 0) return null
+    return { width: window.innerWidth, height: window.innerHeight }
+  })
+
+  useEffect(() => {
+    if (!isTauri) return undefined
+
+    const appWindow = getCurrentWindow()
+    let disposed = false
+    let latestUpdate = 0
+    let unlistenResize: (() => void) | undefined
+    let unlistenScale: (() => void) | undefined
+
+    const applyPhysicalSize = async (
+      physicalSize:
+        | Awaited<ReturnType<typeof appWindow.innerSize>>
+        | ReturnType<typeof appWindow.innerSize>,
+      scaleFactor: number | ReturnType<typeof appWindow.scaleFactor>
+    ) => {
+      const update = ++latestUpdate
+      const [resolvedSize, resolvedScaleFactor] = await Promise.all([physicalSize, scaleFactor])
+      if (disposed || update !== latestUpdate) return
+
+      const logicalSize = resolvedSize.toLogical(resolvedScaleFactor)
+      if (logicalSize.width <= 0 || logicalSize.height <= 0) return
+      setViewportSize(current =>
+        current?.width === logicalSize.width && current.height === logicalSize.height
+          ? current
+          : { width: logicalSize.width, height: logicalSize.height }
+      )
+    }
+
+    void Promise.all([
+      appWindow.onResized(({ payload }) => {
+        void applyPhysicalSize(payload, appWindow.scaleFactor()).catch(error => {
+          console.error('[Wework] Failed to update the Tauri viewport size:', error)
+        })
+      }),
+      appWindow.onScaleChanged(({ payload }) => {
+        void applyPhysicalSize(payload.size, payload.scaleFactor)
+      }),
+    ])
+      .then(([unlistenResizeFn, unlistenScaleFn]) => {
+        if (disposed) {
+          unlistenResizeFn()
+          unlistenScaleFn()
+          return
+        }
+        unlistenResize = unlistenResizeFn
+        unlistenScale = unlistenScaleFn
+        void applyPhysicalSize(appWindow.innerSize(), appWindow.scaleFactor()).catch(error => {
+          console.error('[Wework] Failed to read the Tauri viewport size:', error)
+        })
+      })
+      .catch(error => {
+        console.error('[Wework] Failed to listen for Tauri viewport changes:', error)
+      })
+
+    return () => {
+      disposed = true
+      unlistenResize?.()
+      unlistenScale?.()
+    }
+  }, [isTauri])
+
+  return viewportSize
+}


### PR DESCRIPTION
## Summary

- preserve native window sizing for Linux/WebKit startup stability
- discard stale asynchronous resize conversions when a newer native resize arrives
- handle native display scale-factor changes explicitly
- add regression coverage for out-of-order resize completion

## Root cause

The app shell converts Tauri physical window sizes to logical CSS sizes. macOS
fullscreen emits a sequence of resize updates, and each conversion previously
awaited the scale factor without guarding against out-of-order completion. An
older conversion could therefore overwrite the final fullscreen size, leaving
blank space on the right and bottom.

The native size mirror cannot simply be removed: Linux WebKit under Xvfb can
start with a one-pixel CSS viewport even though the native window is
`1280 × 720`. The fix keeps native sizing as the source of truth while assigning
each conversion a monotonically increasing update number; only the newest
conversion may update React state.

## Validation

- Wework pre-push ESLint, TypeScript, and unit tests
- Wework full Vitest suite: 335 files, 3240 tests
- focused viewport/App tests: 3 files, 38 tests
- Prettier and ESLint on changed files
- isolated real-Tauri verification:
  - normal window: `1280 × 720`
  - fullscreen viewport and app shell: `1728 × 1084`
  - restored window: `1280 × 720`

Related task: WEWORKC2FA61-95


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport sizing across window resize and scale-factor changes.
  * Prevented outdated or invalid size updates from overriding the latest dimensions.
  * Added safer handling when viewport information cannot be read.

* **Tests**
  * Added coverage for resize events, scale-factor changes, initialization, and stale update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->