### PR TITLE
fix(wework): show scheduled label in workspace tab

### DIFF
--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -533,7 +533,7 @@ function AppShell() {
       auxiliaryRoutes: {
         plugins: t('workbench.workspace_tab_plugins', '插件'),
         sites: t('workbench.workspace_tab_sites', '应用'),
-        automations: t('workbench.workspace_tab_automations', '自动化'),
+        automations: t('workbench.automation', '已安排'),
         cloud: t('workbench.workspace_tab_cloud', '云端工作'),
         apps: t('workbench.workspace_tab_apps', '应用'),
       },

--- a/wework/src/components/topnav/ChromeTitlebar.test.tsx
+++ b/wework/src/components/topnav/ChromeTitlebar.test.tsx
@@ -25,7 +25,7 @@ const labels = {
   auxiliaryRoutes: {
     plugins: '插件',
     sites: '站点',
-    automations: '自动化',
+    automations: '已安排',
     cloud: '云端工作',
     apps: '应用',
   },

--- a/wework/src/features/workspace-tabs/WorkspaceTabStrip.test.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabStrip.test.tsx
@@ -18,7 +18,7 @@ const labels = {
   auxiliaryRoutes: {
     plugins: '插件',
     sites: '站点',
-    automations: '自动化',
+    automations: '已安排',
     cloud: '云端工作',
     apps: '应用',
   },

--- a/wework/src/features/workspace-tabs/WorkspaceTabsContext.test.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabsContext.test.tsx
@@ -13,7 +13,7 @@ const labels = {
   auxiliaryRoutes: {
     plugins: '插件',
     sites: '站点',
-    automations: '自动化',
+    automations: '已安排',
     cloud: '云端工作',
     apps: '应用',
   },

--- a/wework/src/features/workspace-tabs/workspaceTabs.test.ts
+++ b/wework/src/features/workspace-tabs/workspaceTabs.test.ts
@@ -15,7 +15,7 @@ const labels = {
   auxiliaryRoutes: {
     plugins: '插件',
     sites: '站点',
-    automations: '自动化',
+    automations: '已安排',
     cloud: '云端工作',
     apps: '应用',
   },
@@ -61,6 +61,9 @@ describe('workspaceTabs', () => {
 
   test('uses localized labels for auxiliary routes', () => {
     expect(createWorkspaceTab('auxiliary', labels, { contentRoute: '/plugins' }).title).toBe('插件')
+    expect(createWorkspaceTab('auxiliary', labels, { contentRoute: '/automations' }).title).toBe(
+      '已安排'
+    )
     expect(createWorkspaceTab('auxiliary', labels, { contentRoute: '/cloud-work' }).title).toBe(
       '云端工作'
     )

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -391,7 +391,6 @@
     "workspace_tab_auxiliary": "Workspace",
     "workspace_tab_plugins": "Plugins",
     "workspace_tab_sites": "Applications",
-    "workspace_tab_automations": "Automations",
     "workspace_tab_cloud": "Cloud work",
     "workspace_tab_apps": "Apps",
     "workspace_tab_close": "Close {{title}}",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -390,7 +390,6 @@
     "workspace_tab_auxiliary": "工作区",
     "workspace_tab_plugins": "插件",
     "workspace_tab_sites": "应用",
-    "workspace_tab_automations": "自动化",
     "workspace_tab_cloud": "云端工作",
     "workspace_tab_apps": "应用",
     "workspace_tab_close": "关闭 {{title}}",


### PR DESCRIPTION
## What changed

- Reuse the existing Scheduled/已安排 navigation label for the `/automations` workspace tab.
- Remove the duplicate workspace-tab translation key that had drifted to 自动化/Automations.
- Add regression coverage for the `/automations` tab title.

## Root cause

The sidebar and workspace tab used separate translation keys for the same destination. The sidebar displayed 已安排, while the tab-specific translation still displayed 自动化.

## User impact

After clicking 已安排 in Wework, the top workspace tab now consistently displays 已安排.

## Validation

- Focused workspace-tab tests: 4 files, 19 tests passed.
- Full Wework unit suite: 335 files, 3240 tests passed.
- Pre-push ESLint, TypeScript, and unit tests passed.
- Prettier and `git diff --check` passed.
- Verified in an isolated real Tauri session by clicking 已安排 and asserting the top tab text.

Task: WEWORKC2FA61-97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed the automations workspace tab from “自动化” to “已安排” in Chinese.
  * Removed the outdated English and Chinese localization entries for the previous label.

* **Tests**
  * Updated workspace navigation tests to reflect the new tab label.
  * Added coverage confirming the localized automations tab title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->