### PR TITLE
fix(wework): preserve multimodal tool outputs

### DIFF
--- a/executor/src/server/codex_model_catalog.rs
+++ b/executor/src/server/codex_model_catalog.rs
@@ -538,6 +538,7 @@ mod tests {
             .is_some_and(|instructions| instructions.len() > 10_000
                 && !instructions.contains("based on GPT-5")));
         assert_eq!(models[0]["context_window"], 1_048_576);
+        assert_eq!(models[0]["auto_compact_token_limit"], 786_432);
         assert_eq!(models[0]["default_reasoning_level"], "low");
         assert_eq!(models[0]["supports_parallel_tool_calls"], false);
         assert_eq!(models[0]["supports_search_tool"], true);

--- a/executor/src/server/local_model_proxy/anthropic.rs
+++ b/executor/src/server/local_model_proxy/anthropic.rs
@@ -14,7 +14,7 @@ use crate::logging::log_executor_event;
 
 use super::{
     chat::{self, ToolContext},
-    DEFAULT_MAX_OUTPUT_TOKENS,
+    vision, DEFAULT_MAX_OUTPUT_TOKENS,
 };
 
 pub(super) fn responses_to_anthropic(body: &Value) -> Result<(Value, ToolContext), String> {
@@ -44,10 +44,7 @@ pub(super) fn responses_to_anthropic(body: &Value) -> Result<(Value, ToolContext
             Some("system") => system.push(text_value(message.get("content"))),
             Some("tool") => append_tool_result(message, &mut messages),
             Some("assistant") => messages.push(assistant_message(message)),
-            _ => messages.push(json!({
-                "role": "user",
-                "content": anthropic_content(message.get("content"))
-            })),
+            _ => append_user_content(anthropic_content(message.get("content")), &mut messages),
         }
     }
     if !system.is_empty() {
@@ -123,16 +120,24 @@ fn append_tool_result(message: &Value, messages: &mut Vec<Value>) {
         "tool_use_id": message.get("tool_call_id").cloned().unwrap_or(Value::Null),
         "content": text_value(message.get("content"))
     });
+    append_user_content(Value::Array(vec![block]), messages);
+}
+
+fn append_user_content(content: Value, messages: &mut Vec<Value>) {
+    let Value::Array(content) = content else {
+        messages.push(json!({"role": "user", "content": content}));
+        return;
+    };
     if let Some(last) = messages
         .last_mut()
         .filter(|value| value.get("role").and_then(Value::as_str) == Some("user"))
     {
-        if let Some(content) = last.get_mut("content").and_then(Value::as_array_mut) {
-            content.push(block);
+        if let Some(existing) = last.get_mut("content").and_then(Value::as_array_mut) {
+            existing.extend(content);
             return;
         }
     }
-    messages.push(json!({"role": "user", "content": [block]}));
+    messages.push(json!({"role": "user", "content": Value::Array(content)}));
 }
 
 fn anthropic_content(content: Option<&Value>) -> Value {
@@ -155,12 +160,7 @@ fn image_block(value: Option<&Value>) -> Option<Value> {
     let url = value
         .and_then(|value| value.get("url").or(Some(value)))
         .and_then(Value::as_str)?;
-    let data = url.strip_prefix("data:")?;
-    let (media_type, encoded) = data.split_once(";base64,")?;
-    Some(json!({
-        "type": "image",
-        "source": {"type": "base64", "media_type": media_type, "data": encoded}
-    }))
+    Some(vision::anthropic_image_block(url))
 }
 
 fn anthropic_tool_choice(choice: &Value) -> Value {
@@ -630,6 +630,97 @@ mod tests {
         assert_eq!(
             converted["messages"][1]["content"][0]["content"],
             "{\"id\":\"prj_1\",\"title\":\"Palette\"}"
+        );
+    }
+
+    #[test]
+    fn converts_tool_output_images_to_anthropic_image_blocks() {
+        let input = json!({
+            "model": "kimi-k3",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "image_1",
+                    "name": "view_image",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "image_1",
+                    "output": [
+                        {"type": "text", "text": "Rendered preview"},
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,aGVsbG8="
+                        }
+                    ]
+                }
+            ],
+            "tools": [{
+                "type": "function",
+                "name": "view_image",
+                "parameters": {"type": "object"}
+            }]
+        });
+
+        let (converted, _) = responses_to_anthropic(&input).expect("request should convert");
+        let messages = converted["messages"].as_array().expect("messages");
+
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[1]["content"][0]["type"], "tool_result");
+        assert_eq!(messages[1]["content"][0]["content"], "Rendered preview");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(
+            messages[1]["content"][1]["text"],
+            "Image output from tool view_image:"
+        );
+        assert_eq!(messages[1]["content"][2]["type"], "image");
+        assert_eq!(
+            messages[1]["content"][2]["source"]["media_type"],
+            "image/png"
+        );
+        assert_eq!(messages[1]["content"][2]["source"]["data"], "aGVsbG8=");
+        assert!(!messages[1]["content"][0]["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("aGVsbG8=")));
+    }
+
+    #[test]
+    fn converts_user_input_images_to_anthropic_image_blocks() {
+        let input = json!({
+            "model": "kimi-k3",
+            "input": [{
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this image"},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/jpeg;base64,dXNlci1pbWFnZQ=="
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/image.png"
+                    }
+                ]
+            }]
+        });
+
+        let (converted, _) = responses_to_anthropic(&input).expect("request should convert");
+
+        assert_eq!(converted["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(converted["messages"][0]["content"][1]["type"], "image");
+        assert_eq!(
+            converted["messages"][0]["content"][1]["source"]["media_type"],
+            "image/jpeg"
+        );
+        assert_eq!(
+            converted["messages"][0]["content"][1]["source"]["data"],
+            "dXNlci1pbWFnZQ=="
+        );
+        assert_eq!(converted["messages"][0]["content"][2]["type"], "image");
+        assert_eq!(
+            converted["messages"][0]["content"][2]["source"],
+            json!({"type": "url", "url": "https://example.com/image.png"})
         );
     }
 

--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -869,13 +869,45 @@ fn convert_responses_input_items(
         _ => return Ok(input.clone()),
     };
 
-    let mut call_id_to_identity: HashMap<String, ToolIdentity> = HashMap::new();
+    let call_id_to_identity = responses_call_identities(items, context);
+
+    let mut converted = Vec::new();
+    let mut pending_tool_image_content = Vec::new();
+    for item in items {
+        let item_type = item.get("type").and_then(Value::as_str);
+        if !is_tool_output_item(item_type) {
+            flush_tool_image_content_to_responses(&mut converted, &mut pending_tool_image_content);
+        }
+        let mut converted_item = convert_responses_input_item(
+            item,
+            context,
+            &call_id_to_identity,
+            convert_custom_tools,
+            bridge_tool_search,
+            bridge_namespace_tools,
+        )?;
+        move_responses_tool_output_images(
+            item,
+            &mut converted_item,
+            &call_id_to_identity,
+            &mut pending_tool_image_content,
+        );
+        converted.push(converted_item);
+    }
+    flush_tool_image_content_to_responses(&mut converted, &mut pending_tool_image_content);
+    Ok(Value::Array(converted))
+}
+
+fn responses_call_identities(
+    items: &[Value],
+    context: &ToolContext,
+) -> HashMap<String, ToolIdentity> {
+    let mut identities = HashMap::new();
     for item in items {
         let Some(call_id) = item.get("call_id").and_then(Value::as_str) else {
             continue;
         };
-        let item_type = item.get("type").and_then(Value::as_str);
-        let (namespace, name) = match item_type {
+        let (namespace, name) = match item.get("type").and_then(Value::as_str) {
             Some("tool_search_call") => (None, TOOL_SEARCH_NAME),
             Some("custom_tool_call") | Some("function_call") => (
                 item.get("namespace").and_then(Value::as_str),
@@ -883,26 +915,53 @@ fn convert_responses_input_items(
             ),
             _ => continue,
         };
-        let Some(wire_name) = context.wire_name(namespace, name) else {
+        let Some(identity) = context
+            .wire_name(namespace, name)
+            .and_then(|wire_name| context.identity(wire_name))
+        else {
             continue;
         };
-        if let Some(identity) = context.identity(wire_name) {
-            call_id_to_identity.insert(call_id.to_owned(), identity.clone());
-        }
+        identities.insert(call_id.to_owned(), identity.clone());
     }
+    identities
+}
 
-    let mut converted = Vec::new();
-    for item in items {
-        converted.push(convert_responses_input_item(
-            item,
-            context,
-            &call_id_to_identity,
-            convert_custom_tools,
-            bridge_tool_search,
-            bridge_namespace_tools,
-        )?);
+fn move_responses_tool_output_images(
+    item: &Value,
+    converted_item: &mut Value,
+    call_id_to_identity: &HashMap<String, ToolIdentity>,
+    pending_tool_image_content: &mut Vec<Value>,
+) {
+    if !matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("function_call_output") | Some("custom_tool_call_output")
+    ) {
+        return;
     }
-    Ok(Value::Array(converted))
+    let mut output = item
+        .get("output")
+        .map(split_tool_output)
+        .unwrap_or_default();
+    if output.images.is_empty() {
+        return;
+    }
+    let tool_name = item
+        .get("call_id")
+        .and_then(Value::as_str)
+        .and_then(|call_id| call_id_to_identity.get(call_id))
+        .map(|identity| identity.name.as_str());
+    append_tool_image_content(pending_tool_image_content, tool_name, output.images);
+    if output.text.is_empty() {
+        output.text = tool_image_output_notice().to_owned();
+    }
+    converted_item["output"] = Value::String(output.text);
+}
+
+fn is_tool_output_item(item_type: Option<&str>) -> bool {
+    matches!(
+        item_type,
+        Some("function_call_output") | Some("custom_tool_call_output") | Some("tool_search_output")
+    )
 }
 
 fn convert_responses_input_item(
@@ -1031,9 +1090,16 @@ fn append_input(
     let mut pending_calls = Vec::new();
     let mut pending_reasoning = String::new();
     let mut call_names = BTreeMap::new();
+    let mut pending_tool_image_content = Vec::new();
     let mut last_assistant_index = None;
 
     for item in items {
+        let item_type = item.get("type").and_then(Value::as_str);
+        if !is_tool_output_item(item_type)
+            && flush_tool_image_content_to_chat(messages, &mut pending_tool_image_content)
+        {
+            last_assistant_index = None;
+        }
         match item.get("type").and_then(Value::as_str) {
             Some("reasoning") => {
                 append_text(&mut pending_reasoning, &reasoning_text(item));
@@ -1082,25 +1148,12 @@ fn append_input(
                 {
                     last_assistant_index = Some(index);
                 }
-                let call_id = item
-                    .get("call_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                let output =
-                    if item.get("type").and_then(Value::as_str) == Some("tool_search_output") {
-                        serde_json::to_string(&json!({
-                            "tools": item.get("tools").cloned().unwrap_or_else(|| json!([]))
-                        }))
-                        .unwrap_or_else(|_| "{\"tools\":[]}".to_owned())
-                    } else {
-                        item.get("output").map(tool_output_text).unwrap_or_default()
-                    };
-                let output = if call_names.get(call_id).map(String::as_str) == Some("apply_patch") {
-                    friendly_apply_patch_output(&output)
-                } else {
-                    output
-                };
-                messages.push(json!({"role": "tool", "tool_call_id": call_id, "content": output}));
+                append_chat_tool_output(
+                    item,
+                    &call_names,
+                    messages,
+                    &mut pending_tool_image_content,
+                );
             }
             _ => {
                 if let Some(index) =
@@ -1148,12 +1201,52 @@ fn append_input(
     if let Some(index) = flush_calls(messages, &mut pending_calls, &mut pending_reasoning) {
         last_assistant_index = Some(index);
     }
+    if flush_tool_image_content_to_chat(messages, &mut pending_tool_image_content) {
+        last_assistant_index = None;
+    }
     attach_pending_reasoning_to_previous_assistant(
         messages,
         last_assistant_index,
         &mut pending_reasoning,
     );
     Ok(())
+}
+
+fn append_chat_tool_output(
+    item: &Value,
+    call_names: &BTreeMap<String, String>,
+    messages: &mut Vec<Value>,
+    pending_tool_image_content: &mut Vec<Value>,
+) {
+    let call_id = item
+        .get("call_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let mut output = if item.get("type").and_then(Value::as_str) == Some("tool_search_output") {
+        ToolOutput {
+            text: serde_json::to_string(&json!({
+                "tools": item.get("tools").cloned().unwrap_or_else(|| json!([]))
+            }))
+            .unwrap_or_else(|_| "{\"tools\":[]}".to_owned()),
+            images: Vec::new(),
+        }
+    } else {
+        item.get("output")
+            .map(split_tool_output)
+            .unwrap_or_default()
+    };
+    let tool_name = call_names.get(call_id).map(String::as_str);
+    if tool_name == Some("apply_patch") {
+        output.text = friendly_apply_patch_output(&output.text);
+    }
+    let has_images = !output.images.is_empty();
+    if has_images {
+        append_tool_image_content(pending_tool_image_content, tool_name, output.images);
+    }
+    if has_images && output.text.is_empty() {
+        output.text = tool_image_output_notice().to_owned();
+    }
+    messages.push(json!({"role": "tool", "tool_call_id": call_id, "content": output.text}));
 }
 
 pub(super) fn friendly_apply_patch_output(output: &str) -> String {
@@ -1354,15 +1447,94 @@ fn text_value(value: &Value) -> String {
     }
 }
 
-fn tool_output_text(value: &Value) -> String {
+#[derive(Debug, Default)]
+struct ToolOutput {
+    text: String,
+    images: Vec<Value>,
+}
+
+fn split_tool_output(value: &Value) -> ToolOutput {
     let structured_content = value
         .get("structuredContent")
         .or_else(|| value.get("structured_content"))
         .filter(|value| !value.is_null());
-    if let Some(structured_content) = structured_content {
-        return json_string(Some(structured_content));
+    let content = value
+        .as_array()
+        .or_else(|| value.get("content").and_then(Value::as_array));
+    let images = content
+        .into_iter()
+        .flatten()
+        .filter(|part| is_tool_output_image(part))
+        .cloned()
+        .collect::<Vec<_>>();
+    let text = if let Some(structured_content) = structured_content {
+        json_string(Some(structured_content))
+    } else if let Some(content) = content {
+        content
+            .iter()
+            .filter(|part| !is_tool_output_image(part))
+            .map(text_value)
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        text_value(value)
+    };
+    ToolOutput { text, images }
+}
+
+fn is_tool_output_image(part: &Value) -> bool {
+    if part.get("type").and_then(Value::as_str) != Some("input_image") {
+        return false;
     }
-    text_value(value)
+    part.get("image_url").is_some_and(|image_url| {
+        image_url
+            .as_str()
+            .or_else(|| image_url.get("url").and_then(Value::as_str))
+            .is_some_and(|url| !url.is_empty())
+    })
+}
+
+fn tool_image_output_notice() -> &'static str {
+    "[Image output attached in the following user message.]"
+}
+
+fn append_tool_image_content(
+    pending_content: &mut Vec<Value>,
+    tool_name: Option<&str>,
+    images: Vec<Value>,
+) {
+    let label = tool_name
+        .filter(|name| !name.is_empty())
+        .map(|name| format!("Image output from tool {name}:"))
+        .unwrap_or_else(|| "Image output from tool:".to_owned());
+    pending_content.push(json!({"type": "input_text", "text": label}));
+    pending_content.extend(images);
+}
+
+fn flush_tool_image_content_to_chat(
+    messages: &mut Vec<Value>,
+    pending_content: &mut Vec<Value>,
+) -> bool {
+    if pending_content.is_empty() {
+        return false;
+    }
+    let content = chat_content(&Value::Array(std::mem::take(pending_content)));
+    messages.push(json!({
+        "role": "user",
+        "content": content
+    }));
+    true
+}
+
+fn flush_tool_image_content_to_responses(input: &mut Vec<Value>, pending_content: &mut Vec<Value>) {
+    if !pending_content.is_empty() {
+        input.push(json!({
+            "type": "message",
+            "role": "user",
+            "content": std::mem::take(pending_content)
+        }));
+    }
 }
 
 fn json_string(value: Option<&Value>) -> String {
@@ -2729,6 +2901,121 @@ mod tests {
     }
 
     #[test]
+    fn moves_tool_output_images_to_a_multimodal_user_message() {
+        let input = json!({
+            "model": "kimi-k3",
+            "input": [
+                {"type": "function_call", "call_id": "image_1", "name": "view_image", "arguments": "{}"},
+                {"type": "function_call", "call_id": "text_1", "name": "exec_command", "arguments": "{}"},
+                {
+                    "type": "function_call_output",
+                    "call_id": "image_1",
+                    "output": [{
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,aGVsbG8="
+                    }]
+                },
+                {"type": "function_call_output", "call_id": "text_1", "output": "done"}
+            ],
+            "tools": [
+                {"type": "function", "name": "view_image", "parameters": {"type": "object"}},
+                {"type": "function", "name": "exec_command", "parameters": {"type": "object"}}
+            ]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+        let messages = converted["messages"].as_array().expect("messages");
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "image_1");
+        assert_eq!(
+            messages[1]["content"],
+            "[Image output attached in the following user message.]"
+        );
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "text_1");
+        assert_eq!(messages[2]["content"], "done");
+        assert_eq!(messages[3]["role"], "user");
+        assert_eq!(
+            messages[3]["content"][0]["text"],
+            "Image output from tool view_image:"
+        );
+        assert_eq!(messages[3]["content"][1]["type"], "image_url");
+        assert_eq!(
+            messages[3]["content"][1]["image_url"]["url"],
+            "data:image/png;base64,aGVsbG8="
+        );
+        assert!(!messages[1]["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("aGVsbG8=")));
+    }
+
+    #[test]
+    fn converts_user_input_images_to_chat_image_parts() {
+        let input = json!({
+            "model": "kimi-k3",
+            "input": [{
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this image"},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,dXNlci1pbWFnZQ=="
+                    }
+                ]
+            }]
+        });
+
+        let (converted, _) = responses_to_chat(&input).expect("request should convert");
+
+        assert_eq!(converted["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(converted["messages"][0]["content"][1]["type"], "image_url");
+        assert_eq!(
+            converted["messages"][0]["content"][1]["image_url"]["url"],
+            "data:image/png;base64,dXNlci1pbWFnZQ=="
+        );
+    }
+
+    #[test]
+    fn preserves_tool_text_and_structured_content_while_extracting_images() {
+        let mixed = split_tool_output(&json!([
+            {"type": "text", "text": "Rendered preview"},
+            {"type": "input_image", "image_url": "data:image/png;base64,bWl4ZWQ="}
+        ]));
+        assert_eq!(mixed.text, "Rendered preview");
+        assert_eq!(mixed.images.len(), 1);
+
+        let structured = split_tool_output(&json!({
+            "content": [
+                {"type": "text", "text": "Human-readable fallback"},
+                {"type": "input_image", "image_url": "data:image/jpeg;base64,cHJldmlldw=="}
+            ],
+            "structuredContent": {
+                "width": 1280,
+                "business_value": {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,bm90LWEtYmxvY2s="
+                }
+            }
+        }));
+        assert_eq!(
+            structured.text,
+            "{\"business_value\":{\"image_url\":\"data:image/png;base64,bm90LWEtYmxvY2s=\",\"type\":\"input_image\"},\"width\":1280}"
+        );
+        assert_eq!(structured.images.len(), 1);
+        assert_eq!(
+            structured.images[0]["image_url"],
+            "data:image/jpeg;base64,cHJldmlldw=="
+        );
+
+        let malformed = split_tool_output(&json!([{"type": "input_image"}]));
+        assert_eq!(malformed.text, "{\"type\":\"input_image\"}");
+        assert!(malformed.images.is_empty());
+    }
+
+    #[test]
     fn keeps_assistant_text_and_tool_calls_in_one_chat_message() {
         let input = json!({
             "model": "kimi-for-coding",
@@ -3800,6 +4087,63 @@ mod tests {
             "{\"input\":\"*** Begin Patch\\n*** End Patch\"}"
         );
         assert_eq!(converted["input"][2]["type"], "function_call_output");
+    }
+
+    #[test]
+    fn responses_to_responses_moves_tool_images_after_all_tool_results() {
+        let input = json!({
+            "model": "wework-gpt-5.6-sol",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,dXNlci1pbWFnZQ=="
+                    }]
+                },
+                {"type": "function_call", "call_id": "image_1", "name": "view_image", "arguments": "{}"},
+                {"type": "function_call", "call_id": "text_1", "name": "exec_command", "arguments": "{}"},
+                {
+                    "type": "function_call_output",
+                    "call_id": "image_1",
+                    "output": [{
+                        "type": "input_image",
+                        "image_url": "data:image/jpeg;base64,dG9vbC1pbWFnZQ=="
+                    }]
+                },
+                {"type": "function_call_output", "call_id": "text_1", "output": "done"}
+            ],
+            "tools": [
+                {"type": "function", "name": "view_image", "parameters": {"type": "object"}},
+                {"type": "function", "name": "exec_command", "parameters": {"type": "object"}}
+            ]
+        });
+
+        let (converted, _) =
+            responses_to_responses(&input, false, true, true).expect("request should convert");
+        let converted_input = converted["input"].as_array().expect("input");
+
+        assert_eq!(converted_input.len(), 6);
+        assert_eq!(
+            converted_input[0]["content"][0]["image_url"],
+            "data:image/png;base64,dXNlci1pbWFnZQ=="
+        );
+        assert_eq!(converted_input[3]["type"], "function_call_output");
+        assert_eq!(converted_input[3]["output"], tool_image_output_notice());
+        assert_eq!(converted_input[4]["type"], "function_call_output");
+        assert_eq!(converted_input[4]["output"], "done");
+        assert_eq!(converted_input[5]["role"], "user");
+        assert_eq!(converted_input[5]["content"][0]["type"], "input_text");
+        assert_eq!(
+            converted_input[5]["content"][0]["text"],
+            "Image output from tool view_image:"
+        );
+        assert_eq!(converted_input[5]["content"][1]["type"], "input_image");
+        assert_eq!(
+            converted_input[5]["content"][1]["image_url"],
+            "data:image/jpeg;base64,dG9vbC1pbWFnZQ=="
+        );
     }
 
     #[test]

--- a/executor/src/server/local_model_proxy/vision.rs
+++ b/executor/src/server/local_model_proxy/vision.rs
@@ -494,7 +494,7 @@ Output only the description.{suffix}"
     )
 }
 
-fn anthropic_image_block(image_url: &str) -> Value {
+pub(super) fn anthropic_image_block(image_url: &str) -> Value {
     if let Some((media_type, data)) = parse_data_url(image_url) {
         json!({
             "type": "image",

--- a/shared/assets/codex-models/kimi.json
+++ b/shared/assets/codex-models/kimi.json
@@ -22,6 +22,7 @@
       ],
       "context_window": 1048576,
       "max_context_window": 1048576,
+      "auto_compact_token_limit": 786432,
       "truncation_policy": {
         "mode": "tokens",
         "limit": 10000

--- a/wework/src/features/model-settings/localModelProviders.test.ts
+++ b/wework/src/features/model-settings/localModelProviders.test.ts
@@ -59,7 +59,10 @@ describe('localModelProviders', () => {
         webSearchMode: 'disabled',
         contextWindow: 1_000_000,
         modelDefaults: {
-          'kimi-k3': { contextWindow: 1_000_000 },
+          'kimi-k3': {
+            contextWindow: 1_048_576,
+            codexCatalogModelId: 'wework-kimi-k3',
+          },
           'kimi-k2.6': { contextWindow: 262_144 },
           'moonshot-v1-8k': { contextWindow: 8_192 },
           'moonshot-v1-32k': { contextWindow: 32_768 },

--- a/wework/src/features/model-settings/localModelProviders.ts
+++ b/wework/src/features/model-settings/localModelProviders.ts
@@ -9,6 +9,7 @@ import {
   KIMI_CODING_CONTEXT_WINDOW,
   KIMI_K27_CATALOG_MODEL_ID,
   KIMI_K3_CATALOG_MODEL_ID,
+  KIMI_K3_CONTEXT_WINDOW,
   type LocalModelApiFormat,
   type LocalModelConfig,
   type LocalModelToolProfile,
@@ -134,7 +135,11 @@ export const LOCAL_MODEL_PROVIDER_PROFILES: LocalModelProviderProfile[] = [
     webSearchMode: 'disabled',
     imageGenerationEnabled: false,
     modelDefaults: {
-      'kimi-k3': { contextWindow: 1_000_000, inputModalities: ['text', 'image'] },
+      'kimi-k3': {
+        contextWindow: KIMI_K3_CONTEXT_WINDOW,
+        codexCatalogModelId: KIMI_K3_CATALOG_MODEL_ID,
+        inputModalities: ['text', 'image'],
+      },
       'kimi-k2.7-code': { contextWindow: 262_144 },
       'kimi-k2.7-code-highspeed': { contextWindow: 262_144 },
       'kimi-k2.6': { contextWindow: 262_144 },

--- a/wework/src/features/model-settings/localModelSettings.test.ts
+++ b/wework/src/features/model-settings/localModelSettings.test.ts
@@ -379,6 +379,36 @@ describe('localModelSettings', () => {
     ])
   })
 
+  test('migrates Kimi Open Platform K3 configs to the buffered catalog profile', () => {
+    localStorage.setItem(
+      'wework.localModelSettings.v1',
+      JSON.stringify([
+        {
+          id: 'existing-kimi-k3',
+          providerProfileId: 'kimi',
+          displayName: 'Kimi K3',
+          modelId: 'kimi-k3',
+          baseUrl: 'https://api.moonshot.cn/v1',
+          apiFormat: 'openai-chat-completions',
+          contextWindow: 1_000_000,
+          webSearchMode: 'disabled',
+          imageGenerationEnabled: false,
+          enabled: true,
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ])
+    )
+
+    expect(listLocalModelConfigs()).toEqual([
+      expect.objectContaining({
+        id: 'existing-kimi-k3',
+        contextWindow: 1_048_576,
+        codexCatalogModelId: 'wework-kimi-k3',
+        catalogReady: true,
+      }),
+    ])
+  })
+
   test('migrates managed DeepSeek Flash configs to the native Responses API', () => {
     localStorage.setItem(
       'wework.localModelSettings.v1',

--- a/wework/src/features/model-settings/localModelSettings.ts
+++ b/wework/src/features/model-settings/localModelSettings.ts
@@ -4,6 +4,7 @@ import {
 } from './localModelCatalog'
 
 export const KIMI_CODING_CONTEXT_WINDOW = 262_144
+export const KIMI_K3_CONTEXT_WINDOW = 1_048_576
 export const KIMI_K3_CATALOG_MODEL_ID = 'wework-kimi-k3'
 export const KIMI_K27_CATALOG_MODEL_ID = 'wework-kimi-k2-7'
 export const DEEPSEEK_V4_FLASH_MODEL_ID = 'deepseek-v4-flash'
@@ -219,8 +220,10 @@ function normalizeStoredLocalModelConfig(config: LocalModelConfig): LocalModelCo
         })
       : undefined)
   const needsCatalogMigration = isCustomProvider && !legacyConfig.catalogEntry
-  const kimiCatalogModelId =
-    providerProfileId === 'kimi-coding'
+  const isKimiOpenPlatformK3 = providerProfileId === 'kimi' && legacyConfig.modelId === 'kimi-k3'
+  const kimiCatalogModelId = isKimiOpenPlatformK3
+    ? KIMI_K3_CATALOG_MODEL_ID
+    : providerProfileId === 'kimi-coding'
       ? legacyConfig.modelId === 'k3'
         ? KIMI_K3_CATALOG_MODEL_ID
         : legacyConfig.modelId === 'kimi-for-coding' ||
@@ -247,7 +250,9 @@ function normalizeStoredLocalModelConfig(config: LocalModelConfig): LocalModelCo
     ...(providerCatalogModelId
       ? {
           contextWindow: kimiCatalogModelId
-            ? KIMI_CODING_CONTEXT_WINDOW
+            ? isKimiOpenPlatformK3
+              ? KIMI_K3_CONTEXT_WINDOW
+              : KIMI_CODING_CONTEXT_WINDOW
             : DEEPSEEK_V4_CONTEXT_WINDOW,
         }
       : legacyConfig.contextWindow


### PR DESCRIPTION
## Summary

- Move image blocks out of tool-result text and into native user multimodal messages for Chat Completions, Anthropic Messages, and Responses upstreams.
- Preserve tool call/result pairing, structured output, and parallel tool-result ordering while avoiding base64 text tokenization.
- Set Kimi K3 automatic compaction to 786,432 tokens (75%) and migrate Kimi Open Platform K3 configs to the buffered built-in profile.

## Root cause

Image tool results were serialized as plain tool text in the Chat compatibility path. Large data URLs were therefore tokenized as text, allowing a request to jump past the model context limit before Codex could trigger its next compaction check.

## Validation

- `cargo test --lib` (726 passed, 1 external-model test ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm lint`
- `pnpm typecheck`
- Provider/settings tests (40 passed)
- Full pre-push Wework and Executor checks

The live Kimi profile smoke test was not run because it requires `KIMI_API_KEY`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of images in tool results and user messages across supported model providers.
  - Preserved text and structured content while extracting images for multimodal requests.
  - Added support for remote and data URL images.
  - Updated Kimi K3 configuration with a 1,048,576-token context window and automatic compaction settings.
  - Existing Kimi K3 configurations are migrated to the updated catalog profile.

- **Bug Fixes**
  - Improved ordering and handling of consecutive tool outputs containing images.
  - Added clearer behavior for image-only tool results and malformed image content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->