### PR TITLE
fix(plugins): accelerate marketplace loading and harden install state

### DIFF
--- a/backend/app/services/plugin_marketplace_service.py
+++ b/backend/app/services/plugin_marketplace_service.py
@@ -99,6 +99,15 @@ class PublishedRelease:
     created: bool
 
 
+@dataclass(frozen=True)
+class _UserPluginAccessContext:
+    """Preloaded namespace membership used by marketplace list access checks."""
+
+    namespace_ids: set[str]
+    namespace_names: list[str]
+    namespace_names_by_id: dict[str, str]
+
+
 class PluginMarketplaceService:
     """Own the cloud marketplace while leaving runtime installation to Codex."""
 
@@ -304,8 +313,12 @@ class PluginMarketplaceService:
             if owner_ids
             else {}
         )
-        grants_by_plugin_id = self._load_grants_by_plugin_ids(
-            db, [plugin.id for plugin in rows]
+        plugin_ids = [plugin.id for plugin in rows]
+        grants_by_plugin_id = self._load_grants_by_plugin_ids(db, plugin_ids)
+        access_context = self._load_user_plugin_access_context(
+            db,
+            user_id=user_id,
+            grants_by_plugin_id=grants_by_plugin_id,
         )
         installed_kind_ids = [row.id for row in installed_by_plugin_id.values()]
         device_rows_by_kind_id: dict[int, PluginDeviceInstallation] = {}
@@ -322,7 +335,13 @@ class PluginMarketplaceService:
 
         items: list[PluginMarketplaceItem] = []
         for plugin in rows:
-            if not self._can_access_plugin(db, plugin=plugin, user_id=user_id):
+            if not self._can_access_plugin(
+                db,
+                plugin=plugin,
+                user_id=user_id,
+                grants=grants_by_plugin_id.get(plugin.id, []),
+                access_context=access_context,
+            ):
                 continue
             if listing_type and plugin.listing_type != listing_type:
                 continue
@@ -1880,7 +1899,13 @@ class PluginMarketplaceService:
         return plugin
 
     def _can_access_plugin(
-        self, db: Session, *, plugin: Plugin, user_id: int | None
+        self,
+        db: Session,
+        *,
+        plugin: Plugin,
+        user_id: int | None,
+        grants: list[ResourceMember] | None = None,
+        access_context: _UserPluginAccessContext | None = None,
     ) -> bool:
         """Apply optional direct-user or department grants to workspace plugins.
 
@@ -1888,6 +1913,8 @@ class PluginMarketplaceService:
             db: Database session
             plugin: Plugin to check access for
             user_id: User ID, or None for unauthenticated access
+            grants: Optional preloaded approved plugin grants
+            access_context: Optional preloaded user/namespace membership
 
         Returns:
             True if user can access plugin, False otherwise
@@ -1908,17 +1935,19 @@ class PluginMarketplaceService:
         # Owner can always access their own plugins
         if plugin.owner_user_id == user_id:
             return True
-        plugin_type_values = (ResourceType.PLUGIN.value, ResourceType.PLUGIN.name)
-        approved_values = (MemberStatus.APPROVED.value, MemberStatus.APPROVED.name)
-        grants = (
-            db.query(ResourceMember)
-            .filter(
-                ResourceMember.resource_type.in_(plugin_type_values),
-                ResourceMember.resource_id == plugin.id,
-                ResourceMember.status.in_(approved_values),
+
+        if grants is None:
+            plugin_type_values = (ResourceType.PLUGIN.value, ResourceType.PLUGIN.name)
+            approved_values = (MemberStatus.APPROVED.value, MemberStatus.APPROVED.name)
+            grants = (
+                db.query(ResourceMember)
+                .filter(
+                    ResourceMember.resource_type.in_(plugin_type_values),
+                    ResourceMember.resource_id == plugin.id,
+                    ResourceMember.status.in_(approved_values),
+                )
+                .all()
             )
-            .all()
-        )
         if not grants:
             return plugin.visibility == "workspace"
         if any(
@@ -1931,6 +1960,42 @@ class PluginMarketplaceService:
         }
         if not granted_namespace_ids:
             return False
+
+        if access_context is None:
+            access_context = self._load_user_plugin_access_context(
+                db,
+                user_id=user_id,
+                grants_by_plugin_id={plugin.id: grants},
+            )
+        if access_context is None:
+            return False
+        if access_context.namespace_ids & granted_namespace_ids:
+            return True
+        if not access_context.namespace_names:
+            return False
+        granted_names = [
+            access_context.namespace_names_by_id[namespace_id]
+            for namespace_id in granted_namespace_ids
+            if namespace_id in access_context.namespace_names_by_id
+        ]
+        return any(
+            member_name == granted_name or member_name.startswith(f"{granted_name}/")
+            for member_name in access_context.namespace_names
+            for granted_name in granted_names
+        )
+
+    def _load_user_plugin_access_context(
+        self,
+        db: Session,
+        *,
+        user_id: int | None,
+        grants_by_plugin_id: dict[int, list[ResourceMember]],
+    ) -> _UserPluginAccessContext | None:
+        """Load user namespace membership once for a marketplace list/access pass."""
+        if user_id is None:
+            return None
+
+        approved_values = (MemberStatus.APPROVED.value, MemberStatus.APPROVED.name)
         user_namespaces = (
             db.query(Namespace.id, Namespace.name)
             .join(
@@ -1948,29 +2013,31 @@ class PluginMarketplaceService:
             )
             .all()
         )
-        direct_ids = {str(row.id) for row in user_namespaces}
-        if direct_ids & granted_namespace_ids:
-            return True
-        user_namespace_names = [row.name for row in user_namespaces]
-        if not user_namespace_names:
-            return False
-        granted_names = [
-            row.name
-            for row in db.query(Namespace.name)
-            .filter(
-                Namespace.id.in_(
-                    int(namespace_id)
-                    for namespace_id in granted_namespace_ids
-                    if namespace_id.isdigit()
-                ),
-                Namespace.is_active.is_(True),
-            )
-            .all()
-        ]
-        return any(
-            member_name == granted_name or member_name.startswith(f"{granted_name}/")
-            for member_name in user_namespace_names
-            for granted_name in granted_names
+        granted_namespace_ids = {
+            grant.entity_id
+            for grants in grants_by_plugin_id.values()
+            for grant in grants
+            if grant.entity_type == "namespace"
+        }
+        namespace_names_by_id: dict[str, str] = {}
+        if granted_namespace_ids:
+            namespace_names_by_id = {
+                str(row.id): row.name
+                for row in db.query(Namespace.id, Namespace.name)
+                .filter(
+                    Namespace.id.in_(
+                        int(namespace_id)
+                        for namespace_id in granted_namespace_ids
+                        if namespace_id.isdigit()
+                    ),
+                    Namespace.is_active.is_(True),
+                )
+                .all()
+            }
+        return _UserPluginAccessContext(
+            namespace_ids={str(row.id) for row in user_namespaces},
+            namespace_names=[row.name for row in user_namespaces],
+            namespace_names_by_id=namespace_names_by_id,
         )
 
     def get_plugin_access(

--- a/backend/tests/services/test_plugin_marketplace_v2.py
+++ b/backend/tests/services/test_plugin_marketplace_v2.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.orm import Session
 
 from app.api.endpoints.installed_plugins import (
     _can_publish,
@@ -932,8 +933,8 @@ def test_plugin_visibility_requires_an_approved_grant(test_db, test_user):
 
 
 def test_list_plugins_batches_grant_lookups_instead_of_per_plugin_queries(
-    test_db, test_user
-):
+    test_db: Session, test_user: User
+) -> None:
     owner = User(
         user_name="other-plugin-owner",
         password_hash=test_user.password_hash,
@@ -985,8 +986,13 @@ def test_list_plugins_batches_grant_lookups_instead_of_per_plugin_queries(
     statements: list[str] = []
 
     def before_cursor_execute(
-        _conn, _cursor, statement, _parameters, _context, _executemany
-    ):
+        _conn: object,
+        _cursor: object,
+        statement: str | bytes,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
         statements.append(str(statement))
 
     bind = test_db.get_bind()

--- a/backend/tests/services/test_plugin_marketplace_v2.py
+++ b/backend/tests/services/test_plugin_marketplace_v2.py
@@ -931,6 +931,85 @@ def test_plugin_visibility_requires_an_approved_grant(test_db, test_user):
     ] == [plugin.id]
 
 
+def test_list_plugins_batches_grant_lookups_instead_of_per_plugin_queries(
+    test_db, test_user
+):
+    owner = User(
+        user_name="other-plugin-owner",
+        password_hash=test_user.password_hash,
+        email="other-plugin-owner@example.com",
+        is_active=True,
+        git_info=None,
+    )
+    test_db.add(owner)
+    test_db.flush()
+    for index in range(12):
+        plugin = Plugin(
+            slug=f"personal-{index}",
+            name=f"personal-{index}",
+            display_name=f"Personal {index}",
+            keywords_json=[],
+            interface_json={},
+            visibility="personal",
+            status="published",
+            owner_user_id=owner.id,
+        )
+        test_db.add(plugin)
+        test_db.flush()
+        release = PluginRelease(
+            plugin_id=plugin.id,
+            version="1.0.0",
+            manifest_json={"name": plugin.name, "version": "1.0.0"},
+            interface_json={},
+            storage_key=f"plugins/{plugin.slug}.zip",
+            sha256=f"{index:064d}",
+            size_bytes=10,
+            status="ready",
+            scan_status="passed",
+            scan_report_json={},
+        )
+        test_db.add(release)
+        test_db.flush()
+        plugin.latest_release_id = release.id
+        test_db.add(
+            ResourceMember.create(
+                resource_type="Plugin",
+                resource_id=plugin.id,
+                entity_type="user",
+                entity_id=str(owner.id),
+                status=MemberStatus.APPROVED.value,
+            )
+        )
+    test_db.commit()
+
+    statements: list[str] = []
+
+    def before_cursor_execute(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ):
+        statements.append(str(statement))
+
+    bind = test_db.get_bind()
+    from sqlalchemy import event
+
+    event.listen(bind, "before_cursor_execute", before_cursor_execute)
+    try:
+        service = PluginMarketplaceService()
+        items = service.list_plugins(test_db, user_id=test_user.id).items
+    finally:
+        event.remove(bind, "before_cursor_execute", before_cursor_execute)
+
+    assert items == []
+    plugin_grant_lookups = [
+        statement
+        for statement in statements
+        if "resource_members" in statement.lower()
+        and "resource_id" in statement.lower()
+    ]
+    # One batched grants query, plus at most one user-namespace membership query.
+    assert len(plugin_grant_lookups) <= 2
+
+
 def test_restricted_submission_is_owner_only_until_access_is_granted(
     test_db, test_user, monkeypatch
 ):

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -5080,6 +5080,9 @@ async function verifyMarketplacePluginLifecycle({
       'The installed plugin card did not reappear under its marketplace tab'
     )
   }
+  await control.command('waitFor', actionsSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
   await control.command('click', actionsSelector)
   const trySelector = `[data-testid="plugin-marketplace-try-${pluginId}"]`
   await control.command('waitFor', trySelector, {

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -4916,6 +4916,7 @@ pub fn run() {
             local_executor::local_executor_migrate_native_codex_home,
             local_executor::local_executor_package_plugin,
             local_executor::local_executor_read_plugin_cloud_links,
+            local_executor::local_executor_list_personal_marketplace_plugins,
             local_executor::local_executor_read_plugin_manifest,
             local_executor::local_executor_read_codex_local_config,
             local_executor::local_executor_read_log,

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -555,6 +555,27 @@ pub struct BundledPluginMarketplace {
     plugin_count: usize,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonalMarketplacePluginSummary {
+    name: String,
+    version: Option<String>,
+    display_name: Option<String>,
+    description: Option<String>,
+    logo: Option<String>,
+    category: Option<String>,
+    plugin_path: String,
+    installed: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonalMarketplaceListResult {
+    marketplace_id: String,
+    marketplace_path: String,
+    plugins: Vec<PersonalMarketplacePluginSummary>,
+}
+
 struct LocalExecutorLogTail {
     path: String,
     content: String,
@@ -3724,6 +3745,264 @@ pub async fn local_executor_read_plugin_cloud_links(
     .map_err(|error| format!("Failed to join plugin cloud link read task: {error}"))?
 }
 
+fn optional_trimmed_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn personal_plugin_summary_from_root(
+    name: &str,
+    plugin_root: &Path,
+    installed: bool,
+) -> PersonalMarketplacePluginSummary {
+    let plugin_path = plugin_root.display().to_string();
+    let manifest_path = [
+        plugin_root.join(".codex-plugin/plugin.json"),
+        plugin_root.join(".claude-plugin/plugin.json"),
+    ]
+    .into_iter()
+    .find(|path| path.is_file());
+    let mut summary = PersonalMarketplacePluginSummary {
+        name: name.to_string(),
+        version: None,
+        display_name: None,
+        description: None,
+        logo: None,
+        category: None,
+        plugin_path,
+        installed,
+    };
+    if let Some(manifest_path) = manifest_path {
+        if let Ok(content) = fs::read_to_string(&manifest_path) {
+            if let Ok(manifest) = serde_json::from_str::<Value>(&content) {
+                summary.version = optional_trimmed_string(manifest.get("version"));
+                summary.description = optional_trimmed_string(manifest.get("description")).or_else(
+                    || {
+                        optional_trimmed_string(
+                            manifest
+                                .get("interface")
+                                .and_then(|interface| interface.get("shortDescription")),
+                        )
+                    },
+                );
+                summary.display_name = optional_trimmed_string(
+                    manifest
+                        .get("interface")
+                        .and_then(|interface| interface.get("displayName")),
+                );
+                summary.logo = optional_trimmed_string(
+                    manifest
+                        .get("interface")
+                        .and_then(|interface| interface.get("logo")),
+                );
+                summary.category = optional_trimmed_string(
+                    manifest
+                        .get("interface")
+                        .and_then(|interface| interface.get("category")),
+                );
+            }
+        }
+    }
+    summary
+}
+
+fn enrich_personal_plugin_summary(
+    existing: &mut PersonalMarketplacePluginSummary,
+    candidate: PersonalMarketplacePluginSummary,
+) {
+    if existing.display_name.is_none() {
+        existing.display_name = candidate.display_name;
+    }
+    if existing.description.is_none() {
+        existing.description = candidate.description;
+    }
+    if existing.version.is_none() {
+        existing.version = candidate.version;
+    }
+    if existing.logo.is_none() {
+        existing.logo = candidate.logo;
+    }
+    if existing.category.is_none() {
+        existing.category = candidate.category;
+    }
+    if candidate.installed {
+        existing.installed = true;
+        // Prefer the concrete installed tree when marketplace.json only had a stub.
+        if existing.plugin_path.is_empty()
+            || !Path::new(&existing.plugin_path)
+                .join(".codex-plugin/plugin.json")
+                .is_file()
+        {
+            existing.plugin_path = candidate.plugin_path;
+        }
+    }
+}
+
+fn latest_cached_personal_plugin_root(plugin_dir: &Path) -> Option<PathBuf> {
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    let entries = fs::read_dir(plugin_dir).ok()?;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let has_manifest = path.join(".codex-plugin/plugin.json").is_file()
+            || path.join(".claude-plugin/plugin.json").is_file();
+        if !has_manifest {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        match &best {
+            Some((best_modified, _)) if modified <= *best_modified => {}
+            _ => best = Some((modified, path)),
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+fn list_personal_marketplace_plugins(
+    marketplace_path: &Path,
+) -> Result<PersonalMarketplaceListResult, String> {
+    let root = marketplace_root_from_path(marketplace_path);
+    let marketplace_path_display = root.display().to_string();
+    let mut by_name: std::collections::BTreeMap<String, PersonalMarketplacePluginSummary> =
+        std::collections::BTreeMap::new();
+
+    let manifest_path = root.join(".agents/plugins/marketplace.json");
+    if manifest_path.is_file() {
+        for name in marketplace_plugin_names(&manifest_path)? {
+            let plugin_root = root.join("plugins").join(&name);
+            by_name.insert(
+                name.clone(),
+                personal_plugin_summary_from_root(&name, &plugin_root, false),
+            );
+        }
+    }
+
+    if let Ok(entries) = fs::read_dir(root.join("plugins")) {
+        for entry in entries.filter_map(Result::ok) {
+            let plugin_root = entry.path();
+            if !plugin_root.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            if name.starts_with('.') {
+                continue;
+            }
+            let has_manifest = plugin_root.join(".codex-plugin/plugin.json").is_file()
+                || plugin_root.join(".claude-plugin/plugin.json").is_file();
+            if !has_manifest {
+                continue;
+            }
+            let summary = personal_plugin_summary_from_root(&name, &plugin_root, true);
+            match by_name.get_mut(&name) {
+                Some(existing) => enrich_personal_plugin_summary(existing, summary),
+                None => {
+                    by_name.insert(name, summary);
+                }
+            }
+        }
+    }
+
+    // Codex materializes installed personal plugins under CODEX_HOME/plugins/cache/
+    // even when the source marketplace.json stays empty.
+    for codex_home in personal_plugin_cache_codex_homes() {
+        let cache_root = codex_home
+            .join("plugins")
+            .join("cache")
+            .join(WEWORK_PERSONAL_MARKETPLACE_ID);
+        if let Ok(entries) = fs::read_dir(&cache_root) {
+            for entry in entries.filter_map(Result::ok) {
+                let plugin_dir = entry.path();
+                if !plugin_dir.is_dir() {
+                    continue;
+                }
+                let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+                    continue;
+                };
+                if name.starts_with('.') {
+                    continue;
+                }
+                let Some(plugin_root) = latest_cached_personal_plugin_root(&plugin_dir) else {
+                    continue;
+                };
+                let summary = personal_plugin_summary_from_root(&name, &plugin_root, true);
+                match by_name.get_mut(&name) {
+                    Some(existing) => enrich_personal_plugin_summary(existing, summary),
+                    None => {
+                        by_name.insert(name, summary);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PersonalMarketplaceListResult {
+        marketplace_id: WEWORK_PERSONAL_MARKETPLACE_ID.to_string(),
+        marketplace_path: marketplace_path_display,
+        plugins: by_name.into_values().collect(),
+    })
+}
+
+fn default_personal_marketplace_path() -> Result<PathBuf, String> {
+    Ok(local_executor_runtime_home_path()?
+        .join("capabilities")
+        .join("bundled-marketplaces")
+        .join(WEWORK_PERSONAL_MARKETPLACE_ID))
+}
+
+fn personal_plugin_cache_codex_homes() -> Vec<PathBuf> {
+    let mut homes = Vec::new();
+    if let Ok(executor_home) = local_executor_home_path() {
+        if let Ok(codex_home) = wework_codex_home_path(&executor_home.display().to_string()) {
+            homes.push(codex_home);
+        }
+    }
+    if let Ok(managed) = managed_codex_home_paths() {
+        for path in managed {
+            if !homes.iter().any(|existing| existing == &path) {
+                homes.push(path);
+            }
+        }
+    }
+    homes
+}
+
+fn resolve_personal_marketplace_path(marketplace_path: &str) -> Result<PathBuf, String> {
+    let trimmed = marketplace_path.trim();
+    if !trimmed.is_empty() {
+        return Ok(PathBuf::from(trimmed));
+    }
+    default_personal_marketplace_path()
+}
+
+/// Lists personal marketplace plugins from disk without calling Codex plugin/list.
+#[tauri::command]
+pub async fn local_executor_list_personal_marketplace_plugins(
+    marketplace_path: String,
+) -> Result<PersonalMarketplaceListResult, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let path = resolve_personal_marketplace_path(&marketplace_path)?;
+        let listed = list_personal_marketplace_plugins(&path)?;
+        log::info!(
+            "Listed personal marketplace plugins from disk: path={}, count={}",
+            listed.marketplace_path,
+            listed.plugins.len()
+        );
+        Ok(listed)
+    })
+    .await
+    .map_err(|error| format!("Failed to join personal marketplace list task: {error}"))?
+}
+
 #[tauri::command]
 pub async fn local_executor_import_external_content(
     options: ExternalContentImportOptions,
@@ -3929,6 +4208,116 @@ mod tests {
         } else {
             std::env::remove_var(key);
         }
+    }
+
+    #[test]
+    fn lists_personal_marketplace_plugins_from_disk_without_codex() {
+        let _guard = env_lock();
+        let previous_home = std::env::var_os("HOME");
+        let previous_executor_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
+        let previous_codex_home = std::env::var_os(WEGENT_CODEX_HOME_ENV);
+        let fake_home = import_test_root("list-personal-marketplace-user-home");
+        let executor_home = fake_home.join(".wework");
+        let codex_home = executor_home.join("codex");
+        fs::create_dir_all(&codex_home).unwrap();
+        std::env::set_var("HOME", &fake_home);
+        std::env::set_var(LOCAL_EXECUTOR_HOME_ENV, &executor_home);
+        std::env::set_var(WEGENT_CODEX_HOME_ENV, &codex_home);
+
+        let root = import_test_root("list-personal-marketplace");
+        let marketplace_manifest = root.join(".agents/plugins/marketplace.json");
+        let notes_manifest = root.join("plugins/notes/.codex-plugin/plugin.json");
+        let tasks_manifest = root.join("plugins/tasks/.codex-plugin/plugin.json");
+        fs::create_dir_all(marketplace_manifest.parent().unwrap()).unwrap();
+        fs::create_dir_all(notes_manifest.parent().unwrap()).unwrap();
+        fs::create_dir_all(tasks_manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &marketplace_manifest,
+            r#"{"name":"wework-personal","plugins":[{"name":"tasks"},{"name":"notes"}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            notes_manifest,
+            r#"{"name":"notes","version":"1.2.0","interface":{"displayName":"Notes","shortDescription":"Take notes","category":"Productivity","logo":"./logo.png"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            tasks_manifest,
+            r#"{"name":"tasks","version":"0.1.0","description":"Track tasks"}"#,
+        )
+        .unwrap();
+
+        let listed = list_personal_marketplace_plugins(&root).unwrap();
+        assert_eq!(listed.marketplace_id, "wework-personal");
+        assert_eq!(listed.plugins.len(), 2);
+        assert_eq!(listed.plugins[0].name, "notes");
+        assert_eq!(listed.plugins[0].display_name.as_deref(), Some("Notes"));
+        assert_eq!(listed.plugins[0].version.as_deref(), Some("1.2.0"));
+        assert!(listed.plugins[0].installed);
+        assert_eq!(listed.plugins[1].name, "tasks");
+        assert_eq!(listed.plugins[1].description.as_deref(), Some("Track tasks"));
+
+        restore_env("HOME", previous_home);
+        restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_executor_home);
+        restore_env(WEGENT_CODEX_HOME_ENV, previous_codex_home);
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(fake_home);
+    }
+
+    #[test]
+    fn lists_personal_plugins_from_codex_cache_when_marketplace_json_is_empty() {
+        let _guard = env_lock();
+        let previous_home = std::env::var_os("HOME");
+        let previous_executor_home = std::env::var_os(LOCAL_EXECUTOR_HOME_ENV);
+        let previous_codex_home = std::env::var_os(WEGENT_CODEX_HOME_ENV);
+        let fake_home = import_test_root("list-personal-cache-user-home");
+        let executor_home = fake_home.join(".wework");
+        fs::create_dir_all(executor_home.join("codex")).unwrap();
+        std::env::set_var("HOME", &fake_home);
+        std::env::set_var(LOCAL_EXECUTOR_HOME_ENV, &executor_home);
+        std::env::remove_var(WEGENT_CODEX_HOME_ENV);
+
+        let marketplace_root = import_test_root("list-personal-cache-marketplace");
+        let marketplace_manifest = marketplace_root.join(".agents/plugins/marketplace.json");
+        fs::create_dir_all(marketplace_manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &marketplace_manifest,
+            r#"{"name":"wework-personal","interface":{"displayName":"WeWork Personal Marketplace"},"plugins":[]}"#,
+        )
+        .unwrap();
+
+        let cached_plugin = executor_home
+            .join("codex/plugins/cache/wework-personal/dev-tools/0.1.0/.codex-plugin/plugin.json");
+        fs::create_dir_all(cached_plugin.parent().unwrap()).unwrap();
+        fs::write(
+            &cached_plugin,
+            r#"{"name":"dev-tools","version":"0.1.0","interface":{"displayName":"Dev Tools","shortDescription":"Tools"}}"#,
+        )
+        .unwrap();
+
+        let listed = list_personal_marketplace_plugins(&marketplace_root).unwrap();
+        assert_eq!(listed.plugins.len(), 1);
+        assert_eq!(listed.plugins[0].name, "dev-tools");
+        assert_eq!(listed.plugins[0].display_name.as_deref(), Some("Dev Tools"));
+        assert!(listed.plugins[0].installed);
+
+        let listed_default =
+            list_personal_marketplace_plugins(&resolve_personal_marketplace_path("").unwrap())
+                .unwrap();
+        assert!(
+            listed_default
+                .plugins
+                .iter()
+                .any(|plugin| plugin.name == "dev-tools"),
+            "empty marketplacePath should still resolve cache via default home"
+        );
+
+        restore_env("HOME", previous_home);
+        restore_env(LOCAL_EXECUTOR_HOME_ENV, previous_executor_home);
+        restore_env(WEGENT_CODEX_HOME_ENV, previous_codex_home);
+        let _ = fs::remove_dir_all(executor_home);
+        let _ = fs::remove_dir_all(marketplace_root);
+        let _ = fs::remove_dir_all(fake_home);
     }
 
     #[test]

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -3876,12 +3876,24 @@ fn list_personal_marketplace_plugins(
 
     let manifest_path = root.join(".agents/plugins/marketplace.json");
     if manifest_path.is_file() {
-        for name in marketplace_plugin_names(&manifest_path)? {
-            let plugin_root = root.join("plugins").join(&name);
-            by_name.insert(
-                name.clone(),
-                personal_plugin_summary_from_root(&name, &plugin_root, false),
-            );
+        // Invalid marketplace.json must not abort directory/cache scans — those
+        // still return installable personal plugins for first paint.
+        match marketplace_plugin_names(&manifest_path) {
+            Ok(names) => {
+                for name in names {
+                    let plugin_root = root.join("plugins").join(&name);
+                    by_name.insert(
+                        name.clone(),
+                        personal_plugin_summary_from_root(&name, &plugin_root, false),
+                    );
+                }
+            }
+            Err(error) => {
+                eprintln!(
+                    "[Wework] personal marketplace.json skipped at {}: {error}",
+                    manifest_path.display()
+                );
+            }
         }
     }
 

--- a/wework/src/api/local/codexPlugins.readStateCache.test.ts
+++ b/wework/src/api/local/codexPlugins.readStateCache.test.ts
@@ -530,4 +530,93 @@ describe('local codex plugin readState cache', () => {
       )
     ).toHaveLength(1)
   })
+
+  test('listInstalledPlugins refreshes via plugin/installed when peek is stale', async () => {
+    const api = createLocalCodexPluginApi()
+    await api.readState({ mergeAllMarketplaces: true })
+
+    const installedResponse = (pluginName: string) => ({
+      marketplaces: [
+        {
+          ...personalMarketplace,
+          plugins: [
+            {
+              name: pluginName,
+              id: pluginName,
+              installed: true,
+              enabled: true,
+              interface: { displayName: pluginName },
+            },
+          ],
+        },
+      ],
+    })
+
+    mocks.requestLocalExecutor.mockClear()
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          throw new Error('plugin/list must not run for listInstalledPlugins')
+        }
+        if (params.method === 'plugin/installed') {
+          return installedResponse('dingtalk')
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const first = await api.listInstalledPlugins()
+    expect(first.items.map(item => item.metadata.name)).toEqual(['dingtalk'])
+
+    mocks.requestLocalExecutor.mockClear()
+    const second = await api.listInstalledPlugins()
+    expect(second.items.map(item => item.metadata.name)).toEqual(['dingtalk'])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/installed'
+      )
+    ).toHaveLength(0)
+
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now + 61_000)
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          throw new Error('plugin/list must not run for listInstalledPlugins')
+        }
+        if (params.method === 'plugin/installed') {
+          return installedResponse('lark')
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const third = await api.listInstalledPlugins()
+    expect(third.items.map(item => item.metadata.name)).toEqual(['lark'])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/installed'
+      )
+    ).toHaveLength(1)
+  })
 })

--- a/wework/src/api/local/codexPlugins.readStateCache.test.ts
+++ b/wework/src/api/local/codexPlugins.readStateCache.test.ts
@@ -619,4 +619,64 @@ describe('local codex plugin readState cache', () => {
       )
     ).toHaveLength(1)
   })
+
+  test('listInstalledPlugins does not persist membership-only snapshot to durable cache', async () => {
+    const api = createLocalCodexPluginApi()
+    await api.readState({ mergeAllMarketplaces: true })
+
+    const durableKey = 'wework.plugins.codexReadState.v1'
+    const durableBefore = window.localStorage.getItem(durableKey)
+    expect(durableBefore).toBeTruthy()
+
+    const installedResponse = (pluginName: string) => ({
+      marketplaces: [
+        {
+          ...personalMarketplace,
+          plugins: [
+            {
+              name: pluginName,
+              id: pluginName,
+              installed: true,
+              enabled: true,
+              interface: { displayName: pluginName },
+            },
+          ],
+        },
+      ],
+    })
+
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now + 61_000)
+    mocks.requestLocalExecutor.mockClear()
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          throw new Error('plugin/list must not run for listInstalledPlugins')
+        }
+        if (params.method === 'plugin/installed') {
+          return installedResponse('dingtalk')
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const listed = await api.listInstalledPlugins()
+    expect(listed.items.map(item => item.metadata.name)).toEqual(['dingtalk'])
+    // Memory is refreshed for this session…
+    expect(
+      peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.installedPlugins.map(
+        item => item.metadata.name
+      )
+    ).toEqual(['dingtalk'])
+    // …but durable localStorage must keep the fuller readState snapshot.
+    expect(window.localStorage.getItem(durableKey)).toBe(durableBefore)
+  })
 })

--- a/wework/src/api/local/codexPlugins.readStateCache.test.ts
+++ b/wework/src/api/local/codexPlugins.readStateCache.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { InstalledPlugin } from '@/types/api'
-import { clearLocalCodexPluginsReadStateCache, createLocalCodexPluginApi } from './codexPlugins'
+import {
+  clearLocalCodexPluginsReadStateCache,
+  createLocalCodexPluginApi,
+  peekLocalCodexPluginsReadState,
+  warmLocalCodexPluginsReadState,
+} from './codexPlugins'
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
@@ -151,5 +156,378 @@ describe('local codex plugin readState cache', () => {
       cloudPluginId: 71,
       cloudReleaseId: 82,
     })
+  })
+
+  test('search query reuses the unfiltered readState TTL cache', async () => {
+    const githubPlugin = {
+      name: 'github',
+      version: '1.0.0',
+      description: 'GitHub integration',
+      interface: { displayName: 'GitHub' },
+    }
+    const slackPlugin = {
+      name: 'slack',
+      version: '1.0.0',
+      description: 'Slack integration',
+      interface: { displayName: 'Slack' },
+    }
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          return {
+            marketplaces: [
+              {
+                ...personalMarketplace,
+                plugins: [githubPlugin, slackPlugin],
+              },
+            ],
+          }
+        }
+        if (params.method === 'plugin/installed') {
+          return { marketplaces: [personalMarketplace] }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const api = createLocalCodexPluginApi()
+    const warm = await api.readState({ mergeAllMarketplaces: true })
+    expect(warm.marketplaceItems.map(item => item.name)).toEqual(['github', 'slack'])
+
+    const searched = await api.readState({ mergeAllMarketplaces: true, q: 'github' })
+    expect(searched.marketplaceItems.map(item => item.name)).toEqual(['github'])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/list'
+      ).length
+    ).toBe(1)
+
+    const cleared = await api.readState({ mergeAllMarketplaces: true, q: '' })
+    expect(cleared.marketplaceItems.map(item => item.name)).toEqual(['github', 'slack'])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/list'
+      ).length
+    ).toBe(1)
+  })
+
+  test('concurrent readState calls share one plugin/list request', async () => {
+    let resolveList: ((value: unknown) => void) | null = null
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          expect(params).toEqual(
+            expect.objectContaining({
+              method: 'plugin/list',
+              params: expect.objectContaining({
+                marketplaceKinds: ['local'],
+              }),
+            })
+          )
+          return await new Promise(resolve => {
+            resolveList = resolve
+          })
+        }
+        if (params.method === 'plugin/installed') {
+          return { marketplaces: [personalMarketplace] }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const api = createLocalCodexPluginApi()
+    const first = api.readState({ mergeAllMarketplaces: true })
+    const second = api.readState({ mergeAllMarketplaces: true })
+
+    await vi.waitFor(() => {
+      expect(
+        mocks.requestLocalExecutor.mock.calls.filter(
+          ([method, params]) =>
+            method === 'codex.app_server_request' &&
+            (params as { method?: string }).method === 'plugin/list'
+        ).length
+      ).toBe(1)
+    })
+
+    expect(resolveList).not.toBeNull()
+    resolveList!({ marketplaces: [personalMarketplace] })
+    await Promise.all([first, second])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/list'
+      ).length
+    ).toBe(1)
+  })
+
+  test('stale readState returns cache immediately and refreshes plugin/list in background', async () => {
+    const api = createLocalCodexPluginApi()
+    const warm = await api.readState({ mergeAllMarketplaces: true })
+    expect(warm.deviceId).toBe('local-device')
+
+    let resolveList: ((value: unknown) => void) | null = null
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          return await new Promise(resolve => {
+            resolveList = resolve
+          })
+        }
+        if (params.method === 'plugin/installed') {
+          return { marketplaces: [personalMarketplace] }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now + 61_000)
+
+    const stalePromise = api.readState({ mergeAllMarketplaces: true })
+    const stale = await stalePromise
+    expect(stale.deviceId).toBe('local-device')
+    await vi.waitFor(() => {
+      expect(resolveList).not.toBeNull()
+    })
+
+    resolveList!({
+      marketplaces: [
+        {
+          ...personalMarketplace,
+          plugins: [
+            {
+              name: 'github',
+              version: '1.0.0',
+              description: 'GitHub',
+              interface: { displayName: 'GitHub' },
+            },
+          ],
+        },
+      ],
+    })
+    await vi.waitFor(() => {
+      expect(
+        peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.marketplaceItems.map(
+          item => item.name
+        )
+      ).toEqual(['github'])
+    })
+  })
+
+  test('peekLocalCodexPluginsReadState hydrates from localStorage after memory clear', async () => {
+    const api = createLocalCodexPluginApi()
+    await api.readState({ mergeAllMarketplaces: true })
+    const warmed = peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })
+    expect(warmed?.deviceId).toBe('local-device')
+
+    // Simulate an app restart that loses module memory but keeps localStorage.
+    const raw = window.localStorage.getItem('wework.plugins.codexReadState.v1')
+    expect(raw).toBeTruthy()
+    clearLocalCodexPluginsReadStateCache()
+    window.localStorage.setItem('wework.plugins.codexReadState.v1', raw!)
+
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId).toBe(
+      'local-device'
+    )
+  })
+
+  test('migrates a legacy sessionStorage snapshot into localStorage', async () => {
+    const api = createLocalCodexPluginApi()
+    await api.readState({ mergeAllMarketplaces: true })
+    const raw = window.localStorage.getItem('wework.plugins.codexReadState.v1')
+    expect(raw).toBeTruthy()
+
+    clearLocalCodexPluginsReadStateCache()
+    window.sessionStorage.setItem('wework.plugins.codexReadState.v1', raw!)
+
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId).toBe(
+      'local-device'
+    )
+    expect(window.localStorage.getItem('wework.plugins.codexReadState.v1')).toBeTruthy()
+    expect(window.sessionStorage.getItem('wework.plugins.codexReadState.v1')).toBeNull()
+  })
+
+  test('warmLocalCodexPluginsReadState shares the same plugin/list inflight as readState', async () => {
+    let resolveList: ((value: unknown) => void) | null = null
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          return await new Promise(resolve => {
+            resolveList = resolve
+          })
+        }
+        if (params.method === 'plugin/installed') {
+          return { marketplaces: [personalMarketplace] }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const warmPromise = warmLocalCodexPluginsReadState()
+    expect(warmPromise).not.toBeNull()
+    const readPromise = createLocalCodexPluginApi().readState({ mergeAllMarketplaces: true })
+
+    await vi.waitFor(() => {
+      expect(
+        mocks.requestLocalExecutor.mock.calls.filter(
+          ([method, params]) =>
+            method === 'codex.app_server_request' &&
+            (params as { method?: string }).method === 'plugin/list'
+        ).length
+      ).toBe(1)
+    })
+
+    resolveList!({ marketplaces: [personalMarketplace] })
+    await Promise.all([warmPromise, readPromise])
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId).toBe(
+      'local-device'
+    )
+  })
+
+  test('listInstalledPlugins uses plugin/installed and never waits on plugin/list', async () => {
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          throw new Error('plugin/list must not run for listInstalledPlugins')
+        }
+        if (params.method === 'plugin/installed') {
+          return {
+            marketplaces: [
+              {
+                ...personalMarketplace,
+                plugins: [
+                  {
+                    name: 'dev-tools',
+                    id: 'dev-tools',
+                    installed: true,
+                    enabled: true,
+                    interface: { displayName: 'Dev Tools' },
+                  },
+                ],
+              },
+            ],
+          }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const api = createLocalCodexPluginApi()
+    const listed = await api.listInstalledPlugins()
+    expect(listed.items.map(item => item.metadata.name)).toEqual(['dev-tools'])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/list'
+      )
+    ).toHaveLength(0)
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/installed'
+      )
+    ).toHaveLength(1)
+  })
+
+  test('listInstalledPlugins ignores durable peek with empty installedPlugins', async () => {
+    const api = createLocalCodexPluginApi()
+    // Warm durable cache with a catalog that has no installs yet.
+    await api.readState({ mergeAllMarketplaces: true })
+    expect(
+      peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.installedPlugins
+    ).toEqual([])
+
+    mocks.requestLocalExecutor.mockClear()
+    mocks.requestLocalExecutor.mockImplementation(
+      async (
+        method: string,
+        params: {
+          method?: string
+        }
+      ) => {
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/list') {
+          throw new Error('plugin/list must not run for listInstalledPlugins')
+        }
+        if (params.method === 'plugin/installed') {
+          return {
+            marketplaces: [
+              {
+                ...personalMarketplace,
+                plugins: [
+                  {
+                    name: 'dingtalk',
+                    id: 'dingtalk',
+                    installed: true,
+                    enabled: true,
+                    interface: { displayName: '钉钉' },
+                  },
+                ],
+              },
+            ],
+          }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const listed = await api.listInstalledPlugins()
+    expect(listed.items.map(item => item.metadata.name)).toEqual(['dingtalk'])
+    expect(
+      mocks.requestLocalExecutor.mock.calls.filter(
+        ([method, params]) =>
+          method === 'codex.app_server_request' &&
+          (params as { method?: string }).method === 'plugin/installed'
+      )
+    ).toHaveLength(1)
   })
 })

--- a/wework/src/api/local/codexPlugins.readStateCache.test.ts
+++ b/wework/src/api/local/codexPlugins.readStateCache.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest'
 import type { InstalledPlugin } from '@/types/api'
 import {
   clearLocalCodexPluginsReadStateCache,
@@ -118,6 +118,10 @@ describe('local codex plugin readState cache', () => {
       if (command === 'local_executor_link_plugin_release') return null
       throw new Error(`Unexpected invoke ${command}`)
     })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   test('linkPersonalPluginRelease drops TTL cache so the next readState reloads', async () => {

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -1722,16 +1722,28 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
     },
     async listInstalledPlugins() {
       if (!isTauriRuntime()) return { items: [] }
-      const peeked =
-        peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true }) ||
-        peekLocalCodexPluginsReadState()
-      // Durable readState can exist with an empty installedPlugins list (e.g. warm
-      // catalog before installs, or a stale localStorage snapshot). Never treat that
-      // as authoritative for composer — plugin/installed is cheap (~50–150ms).
-      if (peeked && peeked.installedPlugins.length > 0) {
+      const mergeParams = { mergeAllMarketplaces: true as const }
+      const peeked = peekLocalCodexPluginsReadState(mergeParams) || peekLocalCodexPluginsReadState()
+      // Only trust a non-empty install list while the readState snapshot is still
+      // fresh. Durable localStorage can keep installs for days after uninstall.
+      const peekedIsFresh =
+        Boolean(peeked) &&
+        (isLocalCodexPluginsReadStateFresh(mergeParams) || isLocalCodexPluginsReadStateFresh())
+      if (peeked && peeked.installedPlugins.length > 0 && peekedIsFresh) {
         return { items: peeked.installedPlugins }
       }
       const loaded = await loadInstalledPluginsOnly()
+      if (cachedState) {
+        cachedState = {
+          ...cachedState,
+          installedPlugins: loaded.installedPlugins,
+          deviceId: loaded.deviceId || cachedState.deviceId,
+        }
+        cachedStateAt = Date.now()
+        if (cachedStateParamsKey) {
+          persistReadStateSnapshot(cachedStateParamsKey, cachedState, cachedStateAt)
+        }
+      }
       return { items: loaded.installedPlugins }
     },
     async listSkills(params = {}) {

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -1334,11 +1334,15 @@ async function readState(
   if (!params.refresh && cachedState && cachedStateParamsKey === paramsKey) {
     const loadPromise = loadReadStateSnapshot(params, paramsKey)
     inflightReadState.set(paramsKey, loadPromise)
-    void loadPromise.finally(() => {
-      if (inflightReadState.get(paramsKey) === loadPromise) {
-        inflightReadState.delete(paramsKey)
-      }
-    })
+    void loadPromise
+      .catch(error => {
+        console.warn('[Wework] background local Codex plugin refresh failed', error)
+      })
+      .finally(() => {
+        if (inflightReadState.get(paramsKey) === loadPromise) {
+          inflightReadState.delete(paramsKey)
+        }
+      })
     return withFilteredMarketplaceItems(cachedState, params.query)
   }
 

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -1740,9 +1740,8 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
           deviceId: loaded.deviceId || cachedState.deviceId,
         }
         cachedStateAt = Date.now()
-        if (cachedStateParamsKey) {
-          persistReadStateSnapshot(cachedStateParamsKey, cachedState, cachedStateAt)
-        }
+        // Keep the update in memory only. Persisting would write a membership-only
+        // snapshot into the 7-day durable cache and can clobber a fuller readState.
       }
       return { items: loaded.installedPlugins }
     },

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -292,12 +292,33 @@ interface CodexSkillsListEntry {
 }
 
 const SELECTED_MARKETPLACE_STORAGE_KEY = 'wework.plugins.selectedCodexMarketplace'
-const READ_STATE_TTL_MS = 15_000
+/** Durable across app restarts so OpenAI/local tabs can paint before plugin/list (~10s). */
+const READ_STATE_LOCAL_STORAGE_KEY = 'wework.plugins.codexReadState.v1'
+/** Legacy same-session key; migrated once into localStorage then removed. */
+const READ_STATE_SESSION_STORAGE_KEY = 'wework.plugins.codexReadState.v1'
+/** Serve memory/local cache without hitting Codex while fresher than this. */
+const READ_STATE_FRESH_TTL_MS = 60_000
+/** Keep a durable snapshot so cold app launches can paint before plugin/list (~10s). */
+const READ_STATE_DURABLE_TTL_MS = 7 * 24 * 60 * 60_000
 let cachedState: LocalCodexPluginsState | null = null
 let cachedStateGeneration = 0
 let nextReadStateGeneration = 1
 let cachedStateAt = 0
 let cachedStateParamsKey = ''
+const inflightReadState = new Map<string, Promise<LocalCodexPluginsState>>()
+let didHydrateReadStateSession = false
+let warmupReadStatePromise: Promise<LocalCodexPluginsState> | null = null
+
+type PersistedReadStateEntry = {
+  paramsKey: string
+  cachedAt: number
+  state: LocalCodexPluginsState
+}
+
+type PersistedReadStateStore = {
+  version: 1
+  entries: Record<string, PersistedReadStateEntry>
+}
 
 /** Clears the short-lived readState cache. Intended for tests and explicit invalidation. */
 export function clearLocalCodexPluginsReadStateCache(): void {
@@ -305,18 +326,176 @@ export function clearLocalCodexPluginsReadStateCache(): void {
   cachedStateGeneration = 0
   cachedStateAt = 0
   cachedStateParamsKey = ''
+  inflightReadState.clear()
+  didHydrateReadStateSession = false
+  warmupReadStatePromise = null
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(READ_STATE_LOCAL_STORAGE_KEY)
+    window.sessionStorage.removeItem(READ_STATE_SESSION_STORAGE_KEY)
+  }
 }
 
 function readStateParamsKey(params: {
-  query?: string
   marketplaceId?: string
   mergeAllMarketplaces?: boolean
 }): string {
+  // Search query is applied in-memory after load; keep it out of the cache key so
+  // typing/clearing search reuses the same plugin/list + plugin/installed snapshot.
   return [
-    params.query?.trim() || '',
     params.marketplaceId?.trim() || '',
     params.mergeAllMarketplaces ? 'all' : 'selected',
   ].join('|')
+}
+
+function parsePersistedReadStateStore(raw: string | null): PersistedReadStateStore | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as PersistedReadStateStore
+    if (parsed?.version !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function readPersistedReadStateStore(): PersistedReadStateStore {
+  if (typeof window === 'undefined') return { version: 1, entries: {} }
+  const fromLocal = parsePersistedReadStateStore(
+    window.localStorage.getItem(READ_STATE_LOCAL_STORAGE_KEY)
+  )
+  if (fromLocal) return fromLocal
+
+  // One-time migration from the previous same-session snapshot.
+  const fromSession = parsePersistedReadStateStore(
+    window.sessionStorage.getItem(READ_STATE_SESSION_STORAGE_KEY)
+  )
+  if (fromSession) {
+    writePersistedReadStateStore(fromSession)
+    try {
+      window.sessionStorage.removeItem(READ_STATE_SESSION_STORAGE_KEY)
+    } catch {
+      // Ignore storage failures; memory cache still works for the session.
+    }
+    return fromSession
+  }
+  return { version: 1, entries: {} }
+}
+
+function writePersistedReadStateStore(store: PersistedReadStateStore): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(READ_STATE_LOCAL_STORAGE_KEY, JSON.stringify(store))
+  } catch {
+    // Ignore quota / private-mode failures; memory cache still works for the session.
+  }
+}
+
+function persistReadStateSnapshot(
+  paramsKey: string,
+  state: LocalCodexPluginsState,
+  cachedAt: number
+) {
+  const store = readPersistedReadStateStore()
+  store.entries[paramsKey] = { paramsKey, cachedAt, state }
+  writePersistedReadStateStore(store)
+}
+
+function hydrateReadStateCacheFromSession(): void {
+  if (didHydrateReadStateSession) return
+  didHydrateReadStateSession = true
+  if (cachedState) return
+  const store = readPersistedReadStateStore()
+  const entry = Object.values(store.entries).sort(
+    (left, right) => right.cachedAt - left.cachedAt
+  )[0]
+  if (!entry) return
+  if (Date.now() - entry.cachedAt > READ_STATE_DURABLE_TTL_MS) return
+  cachedState = entry.state
+  cachedStateAt = entry.cachedAt
+  cachedStateParamsKey = entry.paramsKey
+  cachedStateGeneration = Math.max(cachedStateGeneration, 1)
+}
+
+function rememberReadStateSnapshot(
+  paramsKey: string,
+  state: LocalCodexPluginsState,
+  generation: number
+): void {
+  if (generation < cachedStateGeneration) return
+  cachedState = state
+  cachedStateGeneration = generation
+  cachedStateAt = Date.now()
+  cachedStateParamsKey = paramsKey
+  persistReadStateSnapshot(paramsKey, state, cachedStateAt)
+}
+
+/** Returns the last local Codex marketplace snapshot without waiting on plugin/list. */
+export function peekLocalCodexPluginsReadState(
+  params: {
+    marketplaceId?: string
+    mergeAllMarketplaces?: boolean
+  } = {}
+): LocalCodexPluginsState | null {
+  hydrateReadStateCacheFromSession()
+  const paramsKey = readStateParamsKey(params)
+  if (cachedState && cachedStateParamsKey === paramsKey) return cachedState
+  const persisted = readPersistedReadStateStore().entries[paramsKey]
+  if (!persisted) return null
+  if (Date.now() - persisted.cachedAt > READ_STATE_DURABLE_TTL_MS) return null
+  cachedState = persisted.state
+  cachedStateAt = persisted.cachedAt
+  cachedStateParamsKey = paramsKey
+  return cachedState
+}
+
+export function isLocalCodexPluginsReadStateFresh(
+  params: {
+    marketplaceId?: string
+    mergeAllMarketplaces?: boolean
+  } = {}
+): boolean {
+  const peeked = peekLocalCodexPluginsReadState(params)
+  if (!peeked) return false
+  return Date.now() - cachedStateAt < READ_STATE_FRESH_TTL_MS
+}
+
+/**
+ * Optionally warms Codex plugin/list into the durable cache.
+ * Do not call this during app startup or chat: plugin/list (~10s) shares the Codex
+ * app-server with turns and will stall send/response. Prefer localStorage peek +
+ * loading the marketplace only when the Plugins page opens.
+ */
+export function warmLocalCodexPluginsReadState(): Promise<LocalCodexPluginsState> | null {
+  if (!isTauriRuntime()) return null
+  if (!warmupReadStatePromise) {
+    warmupReadStatePromise = readState({ mergeAllMarketplaces: true })
+      .then(state => {
+        console.info('[Wework] warmed local Codex plugin catalog', {
+          marketplaceCount: state.marketplaces.length,
+          itemCount: state.marketplaceItems.length,
+        })
+        return state
+      })
+      .catch(error => {
+        console.warn('[Wework] warm local Codex plugin catalog failed', error)
+        warmupReadStatePromise = null
+        throw error
+      })
+  }
+  return warmupReadStatePromise
+}
+
+function withFilteredMarketplaceItems(
+  state: LocalCodexPluginsState,
+  query?: string
+): LocalCodexPluginsState {
+  if (!query?.trim()) return state
+  return {
+    ...state,
+    marketplaceItems: filterPluginItems(state.marketplaceItems, query),
+  }
 }
 
 async function codexAppServerRequest<T>(
@@ -324,10 +503,33 @@ async function codexAppServerRequest<T>(
   params: Record<string, unknown> = {}
 ): Promise<T> {
   await ensureLocalExecutorStarted()
-  return requestLocalExecutor<T>('codex.app_server_request', {
-    method,
-    params,
-  })
+  const startedAt = Date.now()
+  try {
+    const result = await requestLocalExecutor<T>('codex.app_server_request', {
+      method,
+      params,
+    })
+    const elapsedMs = Date.now() - startedAt
+    // plugin/list and plugin/installed have been ~10s in production; keep a focused
+    // breadcrumb so we can tell which nested method is still slow after local-kinds.
+    if (method.startsWith('plugin/') || elapsedMs >= 1_000) {
+      console.info('[Wework] codex.app_server_request', {
+        method,
+        elapsedMs,
+        marketplaceKinds: params.marketplaceKinds ?? null,
+      })
+    }
+    return result
+  } catch (error) {
+    const elapsedMs = Date.now() - startedAt
+    console.warn('[Wework] codex.app_server_request failed', {
+      method,
+      elapsedMs,
+      marketplaceKinds: params.marketplaceKinds ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
 }
 
 function selectedMarketplaceId(): string {
@@ -517,6 +719,107 @@ function emptyComponents(): InstalledPluginComponents {
     monitors: [],
     bins: [],
   }
+}
+
+type PersonalMarketplacePluginSummary = {
+  name: string
+  version?: string | null
+  displayName?: string | null
+  description?: string | null
+  logo?: string | null
+  category?: string | null
+  pluginPath: string
+  installed?: boolean
+}
+
+type PersonalMarketplaceListResult = {
+  marketplaceId: string
+  marketplacePath: string
+  plugins: PersonalMarketplacePluginSummary[]
+}
+
+function toDiskPersonalMarketplaceItem(
+  plugin: PersonalMarketplacePluginSummary,
+  marketplacePath: string
+): PluginMarketplaceItem {
+  const displayName = plugin.displayName?.trim() || plugin.name
+  const description = plugin.description?.trim() || ''
+  const installed = Boolean(plugin.installed)
+  return {
+    id: `personal-disk:${plugin.name}`,
+    remotePluginId: plugin.name,
+    name: plugin.name,
+    displayName,
+    description,
+    version: plugin.version ?? null,
+    author: null,
+    visibility: 'personal',
+    featured: false,
+    installed,
+    installedPluginId: installed ? `${plugin.name}@${WEWORK_PERSONAL_MARKETPLACE_ID}` : null,
+    installedLocally: installed,
+    enabled: installed,
+    sourceType: 'marketplace',
+    interface: {
+      displayName,
+      shortDescription: description,
+      logo: plugin.logo ?? null,
+      category: plugin.category ?? null,
+    },
+    components: emptyComponents(),
+    manifest: {
+      name: plugin.name,
+      marketplaceId: WEWORK_PERSONAL_MARKETPLACE_ID,
+      marketplacePath,
+      source: {
+        source: 'local',
+        path: plugin.pluginPath || `./plugins/${plugin.name}`,
+      },
+    },
+    ownerUserId: 0,
+    sourceProvider: 'user',
+    sourceLabel: i18n.t('workbench.plugins_source_personal_share'),
+  }
+}
+
+/**
+ * Lists wework-personal plugins from disk. Avoids Codex plugin/list (~10s reconcile)
+ * so the personal-created tab can paint before app-server finishes.
+ *
+ * Does not wait for local executor startup: the Tauri command only reads disk and
+ * resolves a default marketplace path when the in-memory bundled path is missing.
+ */
+export async function listPersonalMarketplacePluginsFromDisk(): Promise<PluginMarketplaceItem[]> {
+  if (!isTauriRuntime()) {
+    console.info('[Wework] personal marketplace disk list skipped', { reason: 'not-tauri' })
+    return []
+  }
+  const marketplacePath = getInitializedBundledPluginMarketplace()?.path?.trim() || ''
+  const listed = await invoke<PersonalMarketplaceListResult>(
+    'local_executor_list_personal_marketplace_plugins',
+    { marketplacePath }
+  ).catch(error => {
+    console.warn('[Wework] list personal marketplace from disk failed', error)
+    return null
+  })
+  if (!listed) return []
+  if (!listed.plugins.length) {
+    console.info('[Wework] personal marketplace disk list empty', {
+      marketplacePath: listed.marketplacePath || marketplacePath || null,
+    })
+    return []
+  }
+  console.info('[Wework] personal marketplace disk list', {
+    marketplacePath: listed.marketplacePath || marketplacePath || null,
+    count: listed.plugins.length,
+    names: listed.plugins.map(plugin => plugin.name),
+  })
+  return listed.plugins.map(plugin =>
+    toDiskPersonalMarketplaceItem(
+      plugin,
+      listed.marketplacePath || marketplacePath || WEWORK_PERSONAL_MARKETPLACE_ID
+    )
+  )
 }
 
 function pluginDescription(summary: CodexPluginSummary, detail?: CodexPluginDetail | null): string {
@@ -1006,27 +1309,76 @@ async function readState(
   } = {}
 ): Promise<LocalCodexPluginsState> {
   if (!isTauriRuntime()) return emptyState
+  hydrateReadStateCacheFromSession()
   const paramsKey = readStateParamsKey(params)
   if (
     !params.refresh &&
     cachedState &&
     cachedStateParamsKey === paramsKey &&
-    Date.now() - cachedStateAt < READ_STATE_TTL_MS
+    Date.now() - cachedStateAt < READ_STATE_FRESH_TTL_MS
   ) {
-    return cachedState
+    return withFilteredMarketplaceItems(cachedState, params.query)
   }
+
+  const existingInflight = !params.refresh ? inflightReadState.get(paramsKey) : undefined
+  if (existingInflight) {
+    // Stale-while-revalidate: if we already have a snapshot, paint it now while the
+    // in-flight plugin/list (~10s) finishes. Callers that need a hard refresh pass
+    // refresh: true and wait on the network path below.
+    if (!params.refresh && cachedState && cachedStateParamsKey === paramsKey) {
+      return withFilteredMarketplaceItems(cachedState, params.query)
+    }
+    return withFilteredMarketplaceItems(await existingInflight, params.query)
+  }
+
+  if (!params.refresh && cachedState && cachedStateParamsKey === paramsKey) {
+    const loadPromise = loadReadStateSnapshot(params, paramsKey)
+    inflightReadState.set(paramsKey, loadPromise)
+    void loadPromise.finally(() => {
+      if (inflightReadState.get(paramsKey) === loadPromise) {
+        inflightReadState.delete(paramsKey)
+      }
+    })
+    return withFilteredMarketplaceItems(cachedState, params.query)
+  }
+
+  const loadPromise = loadReadStateSnapshot(params, paramsKey)
+  inflightReadState.set(paramsKey, loadPromise)
+  try {
+    const state = await loadPromise
+    return withFilteredMarketplaceItems(state, params.query)
+  } finally {
+    if (inflightReadState.get(paramsKey) === loadPromise) {
+      inflightReadState.delete(paramsKey)
+    }
+  }
+}
+
+async function loadReadStateSnapshot(
+  params: {
+    marketplaceId?: string
+    mergeAllMarketplaces?: boolean
+    refresh?: boolean
+    skipPersonalReconcile?: boolean
+  },
+  paramsKey: string
+): Promise<LocalCodexPluginsState> {
   const generation = nextReadStateGeneration++
   const executorStatus = await ensureLocalExecutorStarted()
   await ensureBundledPluginMarketplaceRegistered()
   const requestedMarketplaceId = params.mergeAllMarketplaces
     ? ''
     : params.marketplaceId?.trim() || selectedMarketplaceId()
+  // Restrict to local marketplace kinds so Codex skips remote GitHub refresh
+  // (often ~10s timeout). Cached OpenAI curated plugins under the local Codex
+  // home still appear; cloud Wework catalog is loaded separately by the UI.
   const [availableResponse, installedResponse] = await Promise.all([
     codexAppServerRequest<{
       marketplaces: CodexPluginMarketplaceEntry[]
       featuredPluginIds?: string[]
     }>('plugin/list', {
       cwds: null,
+      marketplaceKinds: ['local'],
     }),
     codexAppServerRequest<{ marketplaces: CodexPluginMarketplaceEntry[] }>('plugin/installed', {
       cwds: null,
@@ -1054,11 +1406,8 @@ async function readState(
         marketplacePath: personalMarketplace.path,
       }).catch(() => [] as LocalPluginCloudLink[])
     : []
-  const availableMarketplaceItems = filterPluginItems(
-    selectedMarketplaces.flatMap(marketplace =>
-      marketplace.plugins.map(plugin => toMarketplaceItem(marketplace, plugin))
-    ),
-    params.query
+  const availableMarketplaceItems = selectedMarketplaces.flatMap(marketplace =>
+    marketplace.plugins.map(plugin => toMarketplaceItem(marketplace, plugin))
   )
   // plugin/installed is authoritative for membership; summaries sometimes omit
   // `installed`/`enabled`. Also fold in plugin/list rows marked installed so a
@@ -1086,19 +1435,53 @@ async function readState(
     deviceId: executorStatus.deviceId?.trim() ?? '',
   }
   if (generation >= cachedStateGeneration) {
-    cachedState = state
-    cachedStateGeneration = generation
-    cachedStateAt = Date.now()
-    cachedStateParamsKey = paramsKey
+    // Always cache the unfiltered catalog so search queries can reuse it.
+    rememberReadStateSnapshot(paramsKey, state, generation)
     rememberSelectedMarketplaceId(selectedId)
   }
   if (!params.skipPersonalReconcile) {
     const migrated = await reconcileCodexPersonalPlugins(state)
     if (migrated) {
-      return readState({ ...params, skipPersonalReconcile: true, refresh: true })
+      return loadReadStateSnapshot(
+        { ...params, skipPersonalReconcile: true, refresh: true },
+        paramsKey
+      )
     }
   }
   return state
+}
+
+async function loadInstalledPluginsOnly(): Promise<{
+  installedPlugins: InstalledPlugin[]
+  deviceId: string
+}> {
+  const executorStatus = await ensureLocalExecutorStarted()
+  const installedResponse = await codexAppServerRequest<{
+    marketplaces: CodexPluginMarketplaceEntry[]
+  }>('plugin/installed', {
+    cwds: null,
+    installSuggestionPluginNames: null,
+  })
+  const bundled = getInitializedBundledPluginMarketplace()
+  const personalPath =
+    bundled?.path && isLocalMarketplacePath(bundled.path) ? bundled.path.trim() : ''
+  const cloudLinks = personalPath
+    ? await invoke<LocalPluginCloudLink[]>('local_executor_read_plugin_cloud_links', {
+        marketplacePath: personalPath,
+      }).catch(() => [] as LocalPluginCloudLink[])
+    : []
+  // Composer / auth gates only need membership. Never call plugin/list here — it
+  // reconciles for ~10s and stalls Codex turns on the shared app-server.
+  const installedPlugins = applyPluginCloudLinks(
+    preferWeworkPersonalInstalled(
+      mergeInstalledPluginSummaries(installedResponse.marketplaces, installedResponse.marketplaces)
+    ),
+    cloudLinks
+  )
+  return {
+    installedPlugins,
+    deviceId: executorStatus.deviceId?.trim() ?? '',
+  }
 }
 
 export function createLocalCodexPluginApi(): LocalCodexPluginApi {
@@ -1338,8 +1721,18 @@ export function createLocalCodexPluginApi(): LocalCodexPluginApi {
       )
     },
     async listInstalledPlugins() {
-      const state = await readState()
-      return { items: state.installedPlugins }
+      if (!isTauriRuntime()) return { items: [] }
+      const peeked =
+        peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true }) ||
+        peekLocalCodexPluginsReadState()
+      // Durable readState can exist with an empty installedPlugins list (e.g. warm
+      // catalog before installs, or a stale localStorage snapshot). Never treat that
+      // as authoritative for composer — plugin/installed is cheap (~50–150ms).
+      if (peeked && peeked.installedPlugins.length > 0) {
+        return { items: peeked.installedPlugins }
+      }
+      const loaded = await loadInstalledPluginsOnly()
+      return { items: loaded.installedPlugins }
     },
     async listSkills(params = {}) {
       if (!isTauriRuntime()) return []

--- a/wework/src/api/local/listPersonalMarketplaceFromDisk.test.ts
+++ b/wework/src/api/local/listPersonalMarketplaceFromDisk.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { listPersonalMarketplacePluginsFromDisk } from './codexPlugins'
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  ensureLocalExecutorStarted: vi.fn(),
+  getInitializedBundledPluginMarketplace: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mocks.invoke(...args),
+}))
+
+vi.mock('@/lib/runtime-environment', () => ({
+  isTauriRuntime: () => true,
+}))
+
+vi.mock('@/tauri/localExecutor', () => ({
+  ensureLocalExecutorStarted: () => mocks.ensureLocalExecutorStarted(),
+  ensureBundledPluginMarketplaceRegistered: vi.fn(),
+  getInitializedBundledPluginMarketplace: () => mocks.getInitializedBundledPluginMarketplace(),
+  requestLocalExecutor: vi.fn(),
+  resetLocalExecutorStateForTests: vi.fn(),
+}))
+
+describe('listPersonalMarketplacePluginsFromDisk', () => {
+  beforeEach(() => {
+    mocks.invoke.mockReset()
+    mocks.ensureLocalExecutorStarted.mockReset()
+    mocks.getInitializedBundledPluginMarketplace.mockReset()
+    mocks.ensureLocalExecutorStarted.mockResolvedValue({ deviceId: 'local-device' })
+    mocks.getInitializedBundledPluginMarketplace.mockReturnValue({
+      id: 'wework-personal',
+      path: '/tmp/wework-personal',
+      pluginCount: 1,
+    })
+  })
+
+  test('maps disk personal plugins without calling Codex plugin/list', async () => {
+    mocks.invoke.mockResolvedValue({
+      marketplaceId: 'wework-personal',
+      marketplacePath: '/tmp/wework-personal',
+      plugins: [
+        {
+          name: 'notes',
+          version: '1.2.0',
+          displayName: 'Notes',
+          description: 'Take notes',
+          logo: './logo.png',
+          category: 'Productivity',
+          pluginPath: '/tmp/wework-personal/plugins/notes',
+          installed: true,
+        },
+      ],
+    })
+
+    const items = await listPersonalMarketplacePluginsFromDisk()
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      name: 'notes',
+      displayName: 'Notes',
+      visibility: 'personal',
+      sourceProvider: 'user',
+      installed: true,
+      installedLocally: true,
+      manifest: expect.objectContaining({ marketplaceId: 'wework-personal' }),
+    })
+    expect(mocks.ensureLocalExecutorStarted).not.toHaveBeenCalled()
+    expect(mocks.invoke).toHaveBeenCalledWith('local_executor_list_personal_marketplace_plugins', {
+      marketplacePath: '/tmp/wework-personal',
+    })
+    expect(
+      mocks.invoke.mock.calls.some(
+        ([command, args]) =>
+          command === 'local_executor_request' &&
+          (args as { method?: string })?.method === 'codex.app_server_request'
+      )
+    ).toBe(false)
+  })
+
+  test('invokes disk list with empty marketplacePath when bundled path is unavailable', async () => {
+    mocks.getInitializedBundledPluginMarketplace.mockReturnValue(null)
+    mocks.invoke.mockResolvedValue({
+      marketplaceId: 'wework-personal',
+      marketplacePath: '/Users/test/.wework/capabilities/bundled-marketplaces/wework-personal',
+      plugins: [
+        {
+          name: 'dev-tools',
+          version: '0.1.0',
+          displayName: 'Dev Tools',
+          description: 'Tools',
+          pluginPath: '/Users/test/.wework/codex/plugins/cache/wework-personal/dev-tools/0.1.0',
+          installed: true,
+        },
+      ],
+    })
+
+    const items = await listPersonalMarketplacePluginsFromDisk()
+    expect(items).toHaveLength(1)
+    expect(items[0]?.name).toBe('dev-tools')
+    expect(mocks.invoke).toHaveBeenCalledWith('local_executor_list_personal_marketplace_plugins', {
+      marketplacePath: '',
+    })
+  })
+})

--- a/wework/src/components/chat/composer/ComposerToolbar.test.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.test.tsx
@@ -72,7 +72,7 @@ describe('ComposerToolbar', () => {
     expect(screen.getByTestId('quick-phrase-layout')).toHaveTextContent('icon')
   })
 
-  it('collapses the plugin picker trigger to an icon once a conversation has started', () => {
+  it('keeps the expanded plugin picker until the toolbar itself is compact', () => {
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       width: 600,

--- a/wework/src/components/chat/composer/PluginPickerMenu.tsx
+++ b/wework/src/components/chat/composer/PluginPickerMenu.tsx
@@ -43,6 +43,44 @@ function paintComposerApps(items: LocalDeviceApp[]): LocalDeviceApp[] {
   return enabledComposerApps(items.length > 0 ? items : getComposerApps())
 }
 
+function ComposerPluginPreviewIcons({
+  apps,
+  appearanceMode,
+}: {
+  apps: LocalDeviceApp[]
+  appearanceMode: 'light' | 'dark'
+}) {
+  return (
+    <span
+      className="flex -space-x-1"
+      data-testid="composer-plugin-preview-icons"
+      aria-hidden="true"
+    >
+      {apps.slice(0, 3).map(app => {
+        const logo = resolvePluginLogoUrl({
+          pluginKey: composerAppPluginKey(app),
+          logo: app.logoUrl,
+          logoDark: app.logoUrlDark,
+          appearanceMode,
+        })
+        return (
+          <span
+            key={app.id}
+            data-testid={`composer-plugin-preview-icon-${app.id}`}
+            className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/30 bg-background"
+          >
+            {logo ? (
+              <img src={logo} alt="" className="h-full w-full object-contain" />
+            ) : (
+              <Boxes className="h-4 w-4" />
+            )}
+          </span>
+        )
+      })}
+    </span>
+  )
+}
+
 export function PluginPickerMenu({
   disabled = false,
   iconOnly = false,
@@ -202,33 +240,7 @@ export function PluginPickerMenu({
           ) : (
             <>
               <span className="font-medium">{t('workbench.composer_plugins', '插件')}</span>
-              <span
-                className="flex -space-x-1"
-                data-testid="composer-plugin-preview-icons"
-                aria-hidden="true"
-              >
-                {apps.slice(0, 3).map(app => {
-                  const logo = resolvePluginLogoUrl({
-                    pluginKey: composerAppPluginKey(app),
-                    logo: app.logoUrl,
-                    logoDark: app.logoUrlDark,
-                    appearanceMode,
-                  })
-                  return (
-                    <span
-                      key={app.id}
-                      data-testid={`composer-plugin-preview-icon-${app.id}`}
-                      className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/30 bg-background"
-                    >
-                      {logo ? (
-                        <img src={logo} alt="" className="h-full w-full object-contain" />
-                      ) : (
-                        <Boxes className="h-4 w-4" />
-                      )}
-                    </span>
-                  )
-                })}
-              </span>
+              <ComposerPluginPreviewIcons apps={apps} appearanceMode={appearanceMode} />
               {apps.length > 3 && (
                 <span className="text-xs text-text-muted">+{apps.length - 3}</span>
               )}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2379,7 +2379,6 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                                     onDraftEdit={paneSession.clearError}
                                     onSubmit={submitPaneInput}
                                     disabled={composerDisabled}
-                                    pluginPickerIconOnly={hasConversation}
                                     submitDisabled={paneSession.status.isSubmitting}
                                     error={paneSession.error}
                                     disabledReason={inlineComposerDisabledReason}

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -3016,7 +3016,9 @@ describe('PluginsWorkspace', () => {
     expect(await screen.findByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
 
     resolveLocalList?.({ marketplaces: [] })
-    expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+    })
   })
 
   test('paints cloud installed strip even when marketplace catalog is still empty', async () => {
@@ -3056,7 +3058,9 @@ describe('PluginsWorkspace', () => {
       status: 200,
       json: () => Promise.resolve({ items: [] }),
     })
-    expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+    })
   })
 
   test('sends remote plugin id for remote marketplace install', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -5,7 +5,11 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { authorizeWegentConnector, listWegentConnectorApps } from '@/api/cloud/connectorApps'
 import { clearLocalCodexPluginsReadStateCache } from '@/api/local/codexPlugins'
 import { clearPluginDeviceAutoSyncAttempts } from '@/features/plugins/pluginDeviceAutoSync'
-import { clearPluginMarketplaceCache } from '@/features/plugins/pluginMarketplaceCache'
+import {
+  clearPluginMarketplaceCache,
+  setPluginMarketplaceCache,
+} from '@/features/plugins/pluginMarketplaceCache'
+import { resetLocalExecutorStateForTests } from '@/tauri/localExecutor'
 import '@/i18n'
 import { PluginsWorkspace } from './PluginsWorkspace'
 
@@ -993,6 +997,7 @@ describe('PluginsWorkspace', () => {
     clearPluginMarketplaceCache()
     clearPluginDeviceAutoSyncAttempts()
     clearLocalCodexPluginsReadStateCache()
+    resetLocalExecutorStateForTests()
     mockSystemSkillsFetch()
   })
 
@@ -1215,17 +1220,25 @@ describe('PluginsWorkspace', () => {
     render(<PluginsWorkspace />)
 
     expect(await screen.findByText('Documents')).toBeInTheDocument()
+    const marketplaceFetchesBeforeSearch = vi
+      .mocked(fetch)
+      .mock.calls.filter(([url]) => String(url).startsWith('/api/plugins/marketplace')).length
 
     await userEvent.type(screen.getByTestId('plugins-search-input'), 'missing')
 
     expect(await screen.findByText('没有匹配的插件')).toBeInTheDocument()
     expect(screen.queryByText('Documents')).not.toBeInTheDocument()
-    await waitFor(() =>
-      expect(fetch).toHaveBeenCalledWith(
-        '/api/plugins/marketplace?q=missing',
-        expect.objectContaining({ method: 'GET' })
-      )
-    )
+    // Search is client-side over the already-loaded catalog; typing must not refetch.
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(([url]) => String(url).startsWith('/api/plugins/marketplace')).length
+    ).toBe(marketplaceFetchesBeforeSearch)
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).includes('/api/plugins/marketplace?q='))
+    ).toBe(false)
   })
 
   test('filters marketplace plugins by the prototype distribution tabs', async () => {
@@ -1627,21 +1640,17 @@ describe('PluginsWorkspace', () => {
     render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
 
     expect(await screen.findByText('Superpowers')).toBeInTheDocument()
-    await userEvent.click(
-      screen.getByTestId('plugin-marketplace-actions-openai-official:superpowers-local-id')
-    )
-    await userEvent.click(
-      screen.getByTestId('plugin-marketplace-uninstall-openai-official:superpowers-local-id')
-    )
+    await userEvent.click(screen.getByTestId('plugin-marketplace-actions-superpowers-local-id'))
+    await userEvent.click(screen.getByTestId('plugin-marketplace-uninstall-superpowers-local-id'))
     expect(screen.getByTestId('plugin-uninstall-confirm-button')).toBeInTheDocument()
     await userEvent.click(screen.getByTestId('plugin-uninstall-confirm-button'))
 
     expectCodexAppServerRequest('plugin/uninstall', { pluginId: 'superpowers-local-id' })
     expect(
-      await screen.findByTestId('plugin-marketplace-install-openai-official:superpowers-local-id')
+      await screen.findByTestId('plugin-marketplace-install-superpowers-local-id')
     ).toHaveTextContent('安装')
     expect(
-      screen.queryByTestId('plugin-marketplace-actions-openai-official:superpowers-local-id')
+      screen.queryByTestId('plugin-marketplace-actions-superpowers-local-id')
     ).not.toBeInTheDocument()
   })
 
@@ -2117,7 +2126,7 @@ describe('PluginsWorkspace', () => {
     expectCodexAppServerRequest('plugin/list', { cwds: null })
   })
 
-  test('renders Codex upstream marketplaces after the cloud marketplace', async () => {
+  test('treats the OpenAI curated remote marketplace as a built-in source', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
       value: {},
@@ -2137,12 +2146,65 @@ describe('PluginsWorkspace', () => {
     expect(await screen.findByTestId('plugins-marketplace-tab-default')).toHaveTextContent(
       'Wework 云端市场'
     )
-    expect(screen.getByTestId('plugins-marketplace-tab-openai-curated-remote')).toHaveTextContent(
-      'OpenAI 官方市场'
-    )
+    expect(
+      screen.queryByTestId('plugins-marketplace-tab-openai-curated-remote')
+    ).not.toBeInTheDocument()
     expectCodexAppServerRequest('plugin/list', {
       cwds: null,
     })
+  })
+
+  test('keeps openai-curated plugins under the OpenAI official filter', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockCodexAppServerInvoke({
+      marketplaces: [
+        {
+          name: 'openai-curated',
+          displayName: 'Codex official',
+          path: 'https://github.com/openai/plugins',
+          plugins: [
+            {
+              id: 'linear',
+              name: 'linear',
+              displayName: 'Linear',
+              description: 'Official Linear plugin',
+            },
+          ],
+        },
+        {
+          name: 'awesome-codex-plugins',
+          displayName: 'Awesome Codex Plugins',
+          path: 'https://github.com/example/awesome-codex-plugins',
+          plugins: [
+            {
+              id: 'superpowers',
+              name: 'superpowers',
+              displayName: 'SuperPowers',
+              description: 'Community plugin',
+            },
+          ],
+        },
+      ],
+    })
+
+    render(<PluginsWorkspace cloudMarketplaceAvailable={false} />)
+
+    expect(await screen.findByText('Linear')).toBeInTheDocument()
+    expect(screen.getByText('SuperPowers')).toBeInTheDocument()
+    expect(screen.queryByTestId('plugins-marketplace-tab-openai-curated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Codex official')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('plugins-distribution-tab-official'))
+    expect(screen.getByText('Linear')).toBeInTheDocument()
+    expect(screen.queryByText('SuperPowers')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('plugins-marketplace-tab-awesome-codex-plugins'))
+    expect(screen.getByText('SuperPowers')).toBeInTheDocument()
+    expect(screen.queryByText('Linear')).not.toBeInTheDocument()
   })
 
   test('merges plugins from all local Codex marketplaces into one catalog', async () => {
@@ -2418,6 +2480,495 @@ describe('PluginsWorkspace', () => {
     expect(await screen.findByTestId('plugins-marketplace-loading')).toBeInTheDocument()
     expect(screen.queryByTestId('plugins-no-marketplace-welcome')).not.toBeInTheDocument()
     expect(screen.queryByTestId('plugins-publish-empty-button')).not.toBeInTheDocument()
+  })
+
+  test('paints local Codex plugins before a slow cloud marketplace responds', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockCodexAppServerInvoke({
+      deviceId: 'local-device',
+      marketplaces: [
+        {
+          name: 'openai-curated',
+          displayName: 'Codex official',
+          path: 'https://github.com/openai/plugins',
+          plugins: [
+            {
+              id: 'linear',
+              name: 'linear',
+              displayName: 'Linear',
+              description: 'Official Linear plugin',
+            },
+          ],
+        },
+      ],
+    })
+
+    let resolveMarketplace: ((value: Response) => void) | null = null
+    const pendingMarketplace = new Promise<Response>(resolve => {
+      resolveMarketplace = resolve
+    })
+    const previousFetch = vi.mocked(fetch)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        const requestUrl = new URL(url, 'http://localhost')
+        if (requestUrl.pathname === '/api/plugins/marketplace') {
+          return pendingMarketplace
+        }
+        return previousFetch(url, init)
+      })
+    )
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    expect(await screen.findByText('Linear')).toBeInTheDocument()
+    expect(screen.queryByTestId('plugins-marketplace-loading')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cloud Only Plugin')).not.toBeInTheDocument()
+
+    resolveMarketplace?.({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [
+          {
+            id: 999,
+            remotePluginId: 'cloud-only',
+            name: 'cloud-only',
+            displayName: 'Cloud Only Plugin',
+            description: 'Cloud catalog plugin',
+            version: '1.0.0',
+            author: 'Wegent',
+            visibility: 'public',
+            featured: false,
+            installed: false,
+            enabled: false,
+            installedPluginId: null,
+            sourceType: 'marketplace',
+            sourceProvider: 'wegent',
+            sourceLabel: 'Wework',
+            ownerUserId: 1,
+            interface: {
+              displayName: 'Cloud Only Plugin',
+              shortDescription: 'Cloud catalog plugin',
+              logo: null,
+              composerIcon: null,
+              brandColor: null,
+              category: 'Productivity',
+              defaultPrompt: [],
+              homepageUrl: null,
+              supportUrl: null,
+              categories: ['productivity'],
+              tags: [],
+            },
+            components: {
+              skills: [],
+              commands: [],
+              apps: [],
+              agents: [],
+              hooks: [],
+              mcps: [],
+              lsps: [],
+              monitors: [],
+              bins: [],
+              connectors: [],
+            },
+            manifest: {},
+            latestReleaseId: 1,
+          },
+        ],
+      }),
+    } as Response)
+
+    expect(await screen.findByText('Cloud Only Plugin')).toBeInTheDocument()
+    expect(screen.getByText('Linear')).toBeInTheDocument()
+  })
+
+  test('paints personal-created plugins from disk before Codex plugin/list returns', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockCodexAppServerInvoke({
+      deviceId: 'local-device',
+      marketplaces: [],
+    })
+
+    let resolveLocalList: ((value: unknown) => void) | null = null
+    const pendingLocalList = new Promise(resolve => {
+      resolveLocalList = resolve
+    })
+    const previousInvoke = vi.mocked(invoke).getMockImplementation()
+    vi.mocked(invoke).mockImplementation((command: string, args?: unknown) => {
+      if (command === 'local_executor_initialize_bundled_plugin_marketplace') {
+        return Promise.resolve({
+          id: 'wework-personal',
+          path: '/tmp/wework-personal',
+          pluginCount: 1,
+        })
+      }
+      if (command === 'local_executor_list_personal_marketplace_plugins') {
+        return Promise.resolve({
+          marketplaceId: 'wework-personal',
+          marketplacePath: '/tmp/wework-personal',
+          plugins: [
+            {
+              name: 'my-notes',
+              version: '0.1.0',
+              displayName: 'My Notes',
+              description: 'Personal notes plugin',
+              logo: null,
+              category: 'Productivity',
+              pluginPath: '/tmp/wework-personal/plugins/my-notes',
+            },
+          ],
+        })
+      }
+      if (command === 'local_executor_request') {
+        const request = args as {
+          method?: string
+          params?: { method?: string }
+        }
+        if (
+          request.method === 'codex.app_server_request' &&
+          request.params?.method === 'plugin/list'
+        ) {
+          return pendingLocalList
+        }
+      }
+      return previousInvoke?.(command, args) as Promise<unknown>
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await userEvent.click(await screen.findByTestId('plugins-distribution-tab-personal'))
+    expect(await screen.findByText('My Notes')).toBeInTheDocument()
+    expect(screen.queryByTestId('plugins-marketplace-loading')).not.toBeInTheDocument()
+
+    resolveLocalList?.({ marketplaces: [] })
+  })
+
+  test('paints disk personal plugins even when a cloud marketplace cache already exists', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    setPluginMarketplaceCache({
+      cacheKey: '/api|cloud-token',
+      marketplaceItems: [
+        {
+          id: 42,
+          remotePluginId: '42',
+          name: 'cloud-docs',
+          displayName: 'Cloud Docs',
+          description: 'Cloud only',
+          version: '1.0.0',
+          author: null,
+          visibility: 'public',
+          featured: false,
+          installed: false,
+          enabled: false,
+          sourceType: 'marketplace',
+          sourceProvider: 'wegent',
+          latestReleaseId: 7,
+          components: {
+            skills: [],
+            commands: [],
+            apps: [],
+            agents: [],
+            mcps: [],
+            hooks: [],
+            lsps: [],
+            monitors: [],
+            bins: [],
+          },
+          manifest: {},
+          ownerUserId: 1,
+        },
+      ],
+      installedPlugins: [],
+      marketplaces: [
+        {
+          key: 'cloud:default',
+          id: 'default',
+          name: 'Wework 云端市场',
+          kind: 'cloud',
+        },
+      ],
+      selectedMarketplaceKey: 'cloud:default',
+      deviceId: 'local-device',
+      canPublish: true,
+      canSharePersonalPlugins: true,
+      fetchedAt: Date.now(),
+    })
+    mockCodexAppServerInvoke({
+      deviceId: 'local-device',
+      marketplaces: [],
+    })
+
+    let resolveLocalList: ((value: unknown) => void) | null = null
+    const pendingLocalList = new Promise(resolve => {
+      resolveLocalList = resolve
+    })
+    const previousInvoke = vi.mocked(invoke).getMockImplementation()
+    vi.mocked(invoke).mockImplementation((command: string, args?: unknown) => {
+      if (command === 'local_executor_list_personal_marketplace_plugins') {
+        return Promise.resolve({
+          marketplaceId: 'wework-personal',
+          marketplacePath: '/tmp/wework-personal',
+          plugins: [
+            {
+              name: 'cached-notes',
+              version: '0.1.0',
+              displayName: 'Cached Notes',
+              description: 'Should paint despite catalog cache',
+              logo: null,
+              category: 'Productivity',
+              pluginPath: '/tmp/wework-personal/plugins/cached-notes',
+              installed: true,
+            },
+          ],
+        })
+      }
+      if (command === 'local_executor_request') {
+        const request = args as {
+          method?: string
+          params?: { method?: string }
+        }
+        if (
+          request.method === 'codex.app_server_request' &&
+          request.params?.method === 'plugin/list'
+        ) {
+          return pendingLocalList
+        }
+      }
+      return previousInvoke?.(command, args) as Promise<unknown>
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await userEvent.click(await screen.findByTestId('plugins-distribution-tab-personal'))
+    expect(await screen.findByText('Cached Notes')).toBeInTheDocument()
+    expect(screen.queryByTestId('plugins-marketplace-loading')).not.toBeInTheDocument()
+
+    resolveLocalList?.({ marketplaces: [] })
+  })
+
+  test('paints cloud marketplace plugins before a slow local Codex readState responds', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockCodexAppServerInvoke({
+      deviceId: 'local-device',
+      marketplaces: [
+        {
+          name: 'openai-curated',
+          displayName: 'Codex official',
+          path: 'https://github.com/openai/plugins',
+          plugins: [
+            {
+              id: 'linear',
+              name: 'linear',
+              displayName: 'Linear',
+              description: 'Official Linear plugin',
+            },
+          ],
+        },
+      ],
+    })
+
+    let resolveLocalList: ((value: unknown) => void) | null = null
+    const pendingLocalList = new Promise(resolve => {
+      resolveLocalList = resolve
+    })
+    const previousInvoke = vi.mocked(invoke).getMockImplementation()
+    vi.mocked(invoke).mockImplementation((command: string, args?: unknown) => {
+      if (command === 'local_executor_request') {
+        const request = args as {
+          method?: string
+          params?: { method?: string }
+        }
+        if (
+          request.method === 'codex.app_server_request' &&
+          request.params?.method === 'plugin/list'
+        ) {
+          return pendingLocalList
+        }
+      }
+      return previousInvoke?.(command, args) as Promise<unknown>
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    expect(await screen.findByText('Documents')).toBeInTheDocument()
+    expect(screen.queryByTestId('plugins-marketplace-loading')).not.toBeInTheDocument()
+    expect(screen.queryByText('Linear')).not.toBeInTheDocument()
+
+    resolveLocalList?.({
+      marketplaces: [
+        {
+          name: 'openai-curated',
+          path: 'https://github.com/openai/plugins',
+          interface: { displayName: 'Codex official' },
+          plugins: [
+            {
+              id: 'linear',
+              remotePluginId: 'linear',
+              localVersion: '1.0.0',
+              name: 'linear',
+              installed: false,
+              enabled: false,
+              installPolicy: 'AVAILABLE',
+              authPolicy: 'ON_USE',
+              interface: {
+                displayName: 'Linear',
+                shortDescription: 'Official Linear plugin',
+                longDescription: 'Official Linear plugin',
+                logo: null,
+                composerIcon: null,
+                brandColor: null,
+                category: 'Productivity',
+                defaultPrompt: [],
+                homepageUrl: null,
+                supportUrl: null,
+                categories: ['productivity'],
+                tags: [],
+              },
+              components: {
+                skills: [],
+                commands: [],
+                apps: [],
+                agents: [],
+                hooks: [],
+                mcps: [],
+                lsps: [],
+                monitors: [],
+                bins: [],
+                connectors: [],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(await screen.findByText('Linear')).toBeInTheDocument()
+    expect(screen.getByText('Documents')).toBeInTheDocument()
+    expectCodexAppServerRequest('plugin/list', { marketplaceKinds: ['local'] })
+  })
+
+  test('paints local installed strip when Codex readState arrives after cloud catalog', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockCodexAppServerInvoke({
+      deviceId: 'local-device',
+      installedPluginNames: ['linear'],
+      marketplaces: [
+        {
+          name: 'openai-curated',
+          displayName: 'Codex official',
+          path: 'https://github.com/openai/plugins',
+          plugins: [
+            {
+              id: 'linear',
+              name: 'linear',
+              displayName: 'Linear',
+              description: 'Official Linear plugin',
+            },
+          ],
+        },
+      ],
+    })
+
+    let resolveLocalList: ((value: unknown) => void) | null = null
+    const pendingLocalList = new Promise(resolve => {
+      resolveLocalList = resolve
+    })
+    const previousInvoke = vi.mocked(invoke).getMockImplementation()
+    vi.mocked(invoke).mockImplementation((command: string, args?: unknown) => {
+      if (command === 'local_executor_request') {
+        const request = args as {
+          method?: string
+          params?: { method?: string; params?: Record<string, unknown> }
+        }
+        if (
+          request.method === 'codex.app_server_request' &&
+          request.params?.method === 'plugin/list'
+        ) {
+          return pendingLocalList
+        }
+      }
+      return previousInvoke?.(command, args) as Promise<unknown>
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    expect(await screen.findByText('Documents')).toBeInTheDocument()
+    expect(screen.getByTestId('plugins-installed-strip-empty')).toBeInTheDocument()
+
+    resolveLocalList?.({
+      marketplaces: [
+        {
+          name: 'openai-curated',
+          path: 'https://github.com/openai/plugins',
+          interface: { displayName: 'Codex official' },
+          plugins: [
+            {
+              id: 'linear',
+              remotePluginId: 'linear',
+              localVersion: '1.0.0',
+              name: 'linear',
+              installed: true,
+              enabled: true,
+              installPolicy: 'AVAILABLE',
+              authPolicy: 'ON_USE',
+              interface: {
+                displayName: 'Linear',
+                shortDescription: 'Official Linear plugin',
+                longDescription: 'Official Linear plugin',
+                logo: null,
+                composerIcon: null,
+                brandColor: null,
+                category: 'Productivity',
+                defaultPrompt: [],
+                homepageUrl: null,
+                supportUrl: null,
+                categories: ['productivity'],
+                tags: [],
+              },
+              components: {
+                skills: [],
+                commands: [],
+                apps: [],
+                agents: [],
+                hooks: [],
+                mcps: [],
+                lsps: [],
+                monitors: [],
+                bins: [],
+                connectors: [],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    await userEvent.click(await screen.findByTestId('plugins-distribution-tab-official'))
+    expect(await screen.findByText('Linear')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByTestId('plugins-installed-strip-empty')).not.toBeInTheDocument()
+    })
   })
 
   test('sends remote plugin id for remote marketplace install', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -3019,6 +3019,46 @@ describe('PluginsWorkspace', () => {
     expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
   })
 
+  test('paints cloud installed strip even when marketplace catalog is still empty', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    clearPluginMarketplaceCache()
+    clearLocalCodexPluginsReadStateCache()
+    mockSystemSkillsFetch({
+      marketplaceInstalled: true,
+      marketplaceDeviceState: 'installed',
+    })
+    mockCodexAppServerInvoke({ deviceId: 'local-device', marketplaces: [] })
+
+    let resolveMarketplace: ((value: unknown) => void) | null = null
+    const pendingMarketplace = new Promise(resolve => {
+      resolveMarketplace = resolve
+    })
+    const previousFetch = vi.mocked(fetch).getMockImplementation()
+    vi.mocked(fetch).mockImplementation((input, init) => {
+      const requestUrl = new URL(String(input), 'http://localhost')
+      if (requestUrl.pathname === '/api/plugins/marketplace') {
+        return pendingMarketplace as Promise<Response>
+      }
+      return previousFetch?.(input, init) as Promise<Response>
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    // Installed strip must paint from /plugins/installed even before marketplace rows arrive.
+    expect(await screen.findByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+
+    resolveMarketplace?.({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ items: [] }),
+    })
+    expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+  })
+
   test('sends remote plugin id for remote marketplace install', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -1701,6 +1701,10 @@ describe('PluginsWorkspace', () => {
     render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
 
     await userEvent.click(await screen.findByTestId('plugins-installed-strip-item-101'))
+    // Prefer the marketplace-enriched detail path (same as list → detail).
+    expect(screen.getByText('Create and edit documents')).toBeInTheDocument()
+    expect(screen.getByText('AI 使用向导')).toBeInTheDocument()
+    expect(screen.getByText('Documents App')).toBeInTheDocument()
     await userEvent.click(screen.getByTestId('plugin-detail-toggle-101'))
 
     expect(window.location.pathname).toBe('/')
@@ -2969,6 +2973,50 @@ describe('PluginsWorkspace', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('plugins-installed-strip-empty')).not.toBeInTheDocument()
     })
+  })
+
+  test('paints cloud installed strip before Codex plugin/list finishes', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    clearPluginMarketplaceCache()
+    clearLocalCodexPluginsReadStateCache()
+    mockSystemSkillsFetch({
+      marketplaceInstalled: true,
+      marketplaceDeviceState: 'installed',
+    })
+    mockCodexAppServerInvoke({ deviceId: 'local-device' })
+
+    let resolveLocalList: ((value: unknown) => void) | null = null
+    const pendingLocalList = new Promise(resolve => {
+      resolveLocalList = resolve
+    })
+    const previousInvoke = vi.mocked(invoke).getMockImplementation()
+    vi.mocked(invoke).mockImplementation((command: string, args?: unknown) => {
+      if (command === 'local_executor_request') {
+        const request = args as {
+          method?: string
+          params?: { method?: string }
+        }
+        if (
+          request.method === 'codex.app_server_request' &&
+          request.params?.method === 'plugin/list'
+        ) {
+          return pendingLocalList
+        }
+      }
+      return previousInvoke?.(command, args) as Promise<unknown>
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    // Wework/cloud installs must not wait on Codex plugin/list (~10s) or the strip flashes.
+    expect(await screen.findByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
+
+    resolveLocalList?.({ marketplaces: [] })
+    expect(screen.getByTestId('plugins-installed-strip-item-101')).toBeInTheDocument()
   })
 
   test('sends remote plugin id for remote marketplace install', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -2487,15 +2487,20 @@ export function PluginsWorkspace({
         localRows,
         nextInstalled.map(plugin => plugin.raw)
       )
-      if (mergedItems.length === 0 && !hasCachedCatalog) return
-
-      // Publish installed rows when either side has data. Preserving prior cloud rows
-      // above stops a Codex-only peek from flashing away Wework/official icons.
+      // Publish installed rows even when the catalog is still empty — cloud
+      // listInstalledPlugins often arrives before marketplace rows.
       if (localStateForMerge || cloudInstalledForMerge) {
         setInstalledPlugins(previous =>
           sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
         )
       }
+      if (mergedItems.length === 0 && !hasCachedCatalog) {
+        if (localStateForMerge || cloudInstalledForMerge) {
+          setIsMarketplaceRefreshing(options.keepRefreshing)
+        }
+        return
+      }
+
       setPluginMarketplaceState({
         items: mergedItems,
         isLoading: false,

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -68,6 +68,7 @@ import type {
   PluginAccessUpdateRequest,
   PluginMarketplaceItem,
 } from '@/types/api'
+import { holdBackInFlightMarketplaceInstalls } from './holdBackInFlightMarketplaceInstalls'
 import { type InstalledPluginItem } from './PluginManagementRows'
 import { PluginCreateMenu } from './PluginCreateMenu'
 import { PluginDetailView } from './PluginDetailView'
@@ -966,6 +967,8 @@ export function PluginsWorkspace({
   const [installingMarketplacePluginIds, setInstallingMarketplacePluginIds] = useState<
     Set<string | number>
   >(() => new Set())
+  const installingMarketplacePluginIdsRef = useRef(installingMarketplacePluginIds)
+  installingMarketplacePluginIdsRef.current = installingMarketplacePluginIds
   const [uninstallingPluginIds, setUninstallingPluginIds] = useState<Set<string | number>>(
     () => new Set()
   )
@@ -985,6 +988,8 @@ export function PluginsWorkspace({
     resolve: () => void
     reject: (error: Error) => void
   } | null>(null)
+  const pendingLocalConnectorAuthRef = useRef(pendingLocalConnectorAuth)
+  pendingLocalConnectorAuthRef.current = pendingLocalConnectorAuth
   const [localConnectorAuthBySlug, setLocalConnectorAuthBySlug] = useState<
     Record<string, 'connected' | 'disconnected'>
   >({})
@@ -2258,13 +2263,15 @@ export function PluginsWorkspace({
       lastMarketplaceRefreshTickRef.current = marketplaceRefreshTick
     }
 
-    if (!hasCachedCatalog || isExplicitRefresh) {
+    if (!hasCachedCatalog) {
       setPluginMarketplaceState(previous => ({
         ...previous,
-        isLoading: !hasCachedCatalog || isExplicitRefresh,
+        isLoading: true,
         error: null,
       }))
     } else {
+      // Keep the current catalog mounted while revalidating (including explicit
+      // post-install refresh). Flipping isLoading made action buttons vanish mid-click.
       setIsMarketplaceRefreshing(true)
       setPluginMarketplaceState(previous => ({ ...previous, error: null }))
     }
@@ -2330,7 +2337,7 @@ export function PluginsWorkspace({
       capabilities: { canPublish: boolean; canSharePersonalPlugins?: boolean },
       options?: { preferExistingOnSameSignature?: boolean }
     ) => {
-      const nextInstalled = mergeInstalledPlugins(
+      const nextInstalledRaw = mergeInstalledPlugins(
         cloudInstalled,
         localState?.installedPlugins ?? installedPluginsRef.current.map(plugin => plugin.raw),
         localState?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
@@ -2343,11 +2350,18 @@ export function PluginsWorkspace({
           ),
         diskPersonalItemsForMerge
       )
-      const mergedItems = mergeMarketplaceCatalog(
-        cloudItems,
-        localRows,
-        nextInstalled.map(plugin => plugin.raw)
-      )
+      const heldBack = holdBackInFlightMarketplaceInstalls({
+        items: mergeMarketplaceCatalog(
+          cloudItems,
+          localRows,
+          nextInstalledRaw.map(plugin => plugin.raw)
+        ),
+        installed: nextInstalledRaw,
+        installingIds: installingMarketplacePluginIdsRef.current,
+        authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
+      })
+      const nextInstalled = heldBack.installed
+      const mergedItems = heldBack.items
 
       setInstalledPlugins(previous =>
         sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
@@ -2430,7 +2444,14 @@ export function PluginsWorkspace({
         )
         if (seeded.length > 0) {
           setMarketplaces(seeded)
-          setSelectedMarketplaceKey(current => current || cloudMarketplaceKey())
+          const cloudKey = cloudMarketplaceAvailable ? cloudMarketplaceKey() : ''
+          setSelectedMarketplaceKey(
+            current =>
+              current ||
+              (cloudKey && seeded.some(option => option.key === cloudKey) ? cloudKey : '') ||
+              seeded[0]?.key ||
+              ''
+          )
         }
       }
       if (
@@ -2451,8 +2472,13 @@ export function PluginsWorkspace({
         )
         if (seeded.length > 0) {
           setMarketplaces(seeded)
+          const cloudKey = cloudMarketplaceAvailable ? cloudMarketplaceKey() : ''
           setSelectedMarketplaceKey(
-            current => current || cloudMarketplaceKey() || seeded[0]?.key || ''
+            current =>
+              current ||
+              (cloudKey && seeded.some(option => option.key === cloudKey) ? cloudKey : '') ||
+              seeded[0]?.key ||
+              ''
           )
         }
       }
@@ -2477,16 +2503,23 @@ export function PluginsWorkspace({
         (cloudMarketplaceAvailable
           ? previousInstalledRaw.filter(plugin => typeof plugin.spec.pluginId === 'number')
           : [])
-      const nextInstalled = mergeInstalledPlugins(
+      const nextInstalledRaw = mergeInstalledPlugins(
         cloudInstalled,
         localStateForMerge?.installedPlugins ?? previousInstalledRaw,
         localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
       ).map(toInstalledPluginItem)
-      const mergedItems = mergeMarketplaceCatalog(
-        cloudItems,
-        localRows,
-        nextInstalled.map(plugin => plugin.raw)
-      )
+      const heldBack = holdBackInFlightMarketplaceInstalls({
+        items: mergeMarketplaceCatalog(
+          cloudItems,
+          localRows,
+          nextInstalledRaw.map(plugin => plugin.raw)
+        ),
+        installed: nextInstalledRaw,
+        installingIds: installingMarketplacePluginIdsRef.current,
+        authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
+      })
+      const nextInstalled = heldBack.installed
+      const mergedItems = heldBack.items
       // Publish installed rows even when the catalog is still empty — cloud
       // listInstalledPlugins often arrives before marketplace rows.
       if (localStateForMerge || cloudInstalledForMerge) {
@@ -2536,7 +2569,7 @@ export function PluginsWorkspace({
             (cached?.marketplaceItems ?? []).filter(isLocalMarketplaceItem),
           diskPersonalItems
         )
-        const nextInstalled = mergeInstalledPlugins(
+        const nextInstalledRaw = mergeInstalledPlugins(
           cloudInstalledForMerge ??
             (cloudMarketplaceAvailable
               ? installedPluginsRef.current
@@ -2547,11 +2580,17 @@ export function PluginsWorkspace({
             installedPluginsRef.current.map(plugin => plugin.raw),
           localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
         ).map(toInstalledPluginItem)
-        const mergedItems = mergeMarketplaceCatalog(
-          cloudItems,
-          localRows,
-          nextInstalled.map(plugin => plugin.raw)
-        )
+        const heldBack = holdBackInFlightMarketplaceInstalls({
+          items: mergeMarketplaceCatalog(
+            cloudItems,
+            localRows,
+            nextInstalledRaw.map(plugin => plugin.raw)
+          ),
+          installed: nextInstalledRaw,
+          installingIds: installingMarketplacePluginIdsRef.current,
+          authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
+        })
+        const mergedItems = heldBack.items
         setPluginMarketplaceState(previous =>
           sameMarketplaceItems(previous.items, mergedItems)
             ? previous

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -13,7 +13,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { MacOSTitleBarDragRegion } from '@/components/layout/MacOSTitleBarDragRegion'
 import { createHttpClient } from '@/api/http'
-import { createLocalCodexPluginApi } from '@/api/local/codexPlugins'
+import {
+  createLocalCodexPluginApi,
+  isLocalCodexPluginsReadStateFresh,
+  listPersonalMarketplacePluginsFromDisk,
+  peekLocalCodexPluginsReadState,
+  type LocalCodexMarketplace,
+} from '@/api/local/codexPlugins'
 import { createPluginApi } from '@/api/plugins'
 import { authorizeWegentConnector, listWegentConnectorApps } from '@/api/cloud/connectorApps'
 import { track } from '@/telemetry/client'
@@ -37,6 +43,8 @@ import {
 } from '@/features/plugins/pluginTrial'
 import { isWegentCloudMarketplace, type PluginReference } from '@/features/plugins/pluginNavigation'
 import { isBuiltInMarketplaceId } from '@/features/plugins/marketplaceIdentity'
+import { WEWORK_PERSONAL_MARKETPLACE_ID } from '@/features/plugins/builtinPlugins'
+import { rankMarketplaceSearchResults } from '@/features/plugins/marketplaceSearch'
 import { logoutLocalConnectorsForPlugin } from '@/features/plugins/logoutLocalQrConnectors'
 import {
   getPluginMarketplaceCache,
@@ -60,7 +68,6 @@ import type {
   PluginAccessUpdateRequest,
   PluginMarketplaceItem,
 } from '@/types/api'
-import type { LocalCodexMarketplace } from '@/api/local/codexPlugins'
 import { type InstalledPluginItem } from './PluginManagementRows'
 import { PluginCreateMenu } from './PluginCreateMenu'
 import { PluginDetailView } from './PluginDetailView'
@@ -79,6 +86,7 @@ import {
 } from './installedPluginMerge'
 import {
   isLocalMarketplaceItem,
+  mergeDiskPersonalIntoLocalRows,
   mergeMarketplaceCatalog,
   shouldShowInstalledMarketplaceActions,
 } from './marketplaceCatalogMerge'
@@ -1034,7 +1042,6 @@ export function PluginsWorkspace({
       error: null,
     })
   )
-  const [debouncedQuery, setDebouncedQuery] = useState('')
   const [deviceAutoSyncSettled, setDeviceAutoSyncSettled] = useState(() =>
     hasSettledPluginDeviceAutoSync(currentDeviceId)
   )
@@ -1117,13 +1124,6 @@ export function PluginsWorkspace({
   const hasMarketplace = selectedMarketplace !== null
 
   const normalizedQuery = query.trim().toLowerCase()
-
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setDebouncedQuery(normalizedQuery)
-    }, 300)
-    return () => window.clearTimeout(timeoutId)
-  }, [normalizedQuery])
 
   const applyLocalMarketplaceState = useCallback(
     (state: Awaited<ReturnType<typeof localPluginApi.readState>>) => {
@@ -2287,26 +2287,40 @@ export function PluginsWorkspace({
     }
 
     const deviceIdHint = cached?.deviceId || currentDeviceIdRef.current || undefined
-    const localPromise = localPluginApi.readState({
-      q: debouncedQuery || undefined,
-      mergeAllMarketplaces: true,
-      refresh: isExplicitRefresh,
-    })
+    const localReadParams = { mergeAllMarketplaces: true as const }
+    const peekedLocalState = !isExplicitRefresh
+      ? peekLocalCodexPluginsReadState(localReadParams)
+      : null
+    const localStateIsFresh =
+      Boolean(peekedLocalState) && isLocalCodexPluginsReadStateFresh(localReadParams)
+    // Catalog loads stay query-agnostic; search filters client-side from the cached list.
+    // OpenAI/personal catalogs come from Codex plugin/list (~10s). Reuse a durable peek
+    // for first paint, then refresh in the background when the snapshot is stale.
+    const localPromise = localStateIsFresh
+      ? Promise.resolve(peekedLocalState!)
+      : localPluginApi.readState({
+          ...localReadParams,
+          refresh: isExplicitRefresh || Boolean(peekedLocalState),
+        })
     // Use a known device id when available (cache / prior load). Otherwise start cloud
     // immediately for progressive first paint; a device-scoped pass follows once local
     // resolves the device id.
     const cloudPromise = cloudMarketplaceAvailable
       ? pluginApi.listMarketplacePlugins({
-          q: debouncedQuery || undefined,
-          deviceId: deviceIdHint,
+          deviceId: deviceIdHint || peekedLocalState?.deviceId,
         })
       : Promise.resolve({ items: [] as PluginMarketplaceItem[] })
     const installedPromise = pluginApi
-      .listInstalledPlugins(deviceIdHint)
+      .listInstalledPlugins(deviceIdHint || peekedLocalState?.deviceId)
       .catch(() => ({ items: [] as InstalledPlugin[] }))
     const capabilitiesPromise = pluginApi
       .getCapabilities()
       .catch(() => ({ canPublish: false, canSharePersonalPlugins: true }))
+
+    const defaultCapabilities = {
+      canPublish: Boolean(cached?.canPublish),
+      canSharePersonalPlugins: Boolean(cached?.canSharePersonalPlugins ?? true),
+    }
 
     const applyCatalogSnapshot = (
       cloudItems: PluginMarketplaceItem[],
@@ -2321,11 +2335,13 @@ export function PluginsWorkspace({
         localState?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
       ).map(toInstalledPluginItem)
 
-      const localRows =
+      const localRows = mergeDiskPersonalIntoLocalRows(
         localState?.marketplaceItems ??
-        (getPluginMarketplaceCache(marketplaceCacheKeyValue)?.marketplaceItems ?? []).filter(
-          isLocalMarketplaceItem
-        )
+          (getPluginMarketplaceCache(marketplaceCacheKeyValue)?.marketplaceItems ?? []).filter(
+            isLocalMarketplaceItem
+          ),
+        diskPersonalItemsForMerge
+      )
       const mergedItems = mergeMarketplaceCatalog(
         cloudItems,
         localRows,
@@ -2368,15 +2384,233 @@ export function PluginsWorkspace({
       })
     }
 
+    // Paint whichever side arrives first so a slow Codex plugin/list (~10s remote
+    // refresh) cannot block an already-fast cloud marketplace response, and vice versa.
+    let catalogSettled = false
+    let localStateForMerge: Awaited<ReturnType<typeof localPluginApi.readState>> | null = null
+    let cloudItemsForMerge: PluginMarketplaceItem[] | null = null
+    let cloudInstalledForMerge: InstalledPlugin[] | null = null
+    let diskPersonalItemsForMerge: PluginMarketplaceItem[] | null = null
+
+    const paintPartialCatalog = (options: {
+      cloudItems?: PluginMarketplaceItem[]
+      cloudInstalled?: InstalledPlugin[]
+      localState?: Awaited<ReturnType<typeof localPluginApi.readState>> | null
+      diskPersonalItems?: PluginMarketplaceItem[]
+      keepRefreshing: boolean
+    }) => {
+      if (!isCurrent || catalogSettled) return
+      const localState = options.localState ?? null
+      if (localState) {
+        localStateForMerge = localState
+        setCurrentDeviceId(localState.deviceId)
+        applyLocalMarketplaceState(localState)
+        const selectedKey = localState.selectedMarketplaceId
+          ? localMarketplaceKey(localState.selectedMarketplaceId)
+          : ''
+        initialMarketplaceLoadKeyRef.current = selectedKey
+      }
+      if (options.cloudItems) {
+        cloudItemsForMerge = options.cloudItems
+      }
+      if (options.cloudInstalled) {
+        cloudInstalledForMerge = options.cloudInstalled
+      }
+      if (options.diskPersonalItems) {
+        diskPersonalItemsForMerge = options.diskPersonalItems
+      }
+      // Cloud can arrive before Codex marketplaces; seed the cloud tab so the catalog
+      // is not replaced by the empty "cloud unavailable" empty-state.
+      if (options.cloudItems && !localStateForMerge && marketplacesRef.current.length === 0) {
+        const seeded = toMarketplaceOptions(
+          [],
+          cloudMarketplaceAvailable,
+          t('workbench.plugins_wework_cloud_marketplace', 'Wework 云端市场')
+        )
+        if (seeded.length > 0) {
+          setMarketplaces(seeded)
+          setSelectedMarketplaceKey(current => current || cloudMarketplaceKey())
+        }
+      }
+      if (
+        options.diskPersonalItems?.length &&
+        !localStateForMerge &&
+        marketplacesRef.current.length === 0
+      ) {
+        const seeded = toMarketplaceOptions(
+          [
+            {
+              id: WEWORK_PERSONAL_MARKETPLACE_ID,
+              name: t('workbench.plugins_distribution_personal', '个人创建'),
+              path: '',
+            },
+          ],
+          cloudMarketplaceAvailable,
+          t('workbench.plugins_wework_cloud_marketplace', 'Wework 云端市场')
+        )
+        if (seeded.length > 0) {
+          setMarketplaces(seeded)
+          setSelectedMarketplaceKey(
+            current => current || cloudMarketplaceKey() || seeded[0]?.key || ''
+          )
+        }
+      }
+
+      const cloudItems =
+        cloudItemsForMerge ??
+        (getPluginMarketplaceCache(marketplaceCacheKeyValue)?.marketplaceItems ?? []).filter(
+          item => !isLocalMarketplaceItem(item)
+        )
+      const localRows = mergeDiskPersonalIntoLocalRows(
+        localStateForMerge?.marketplaceItems ??
+          (getPluginMarketplaceCache(marketplaceCacheKeyValue)?.marketplaceItems ?? []).filter(
+            isLocalMarketplaceItem
+          ),
+        diskPersonalItemsForMerge
+      )
+      const cloudInstalled = cloudInstalledForMerge ?? []
+      const nextInstalled = mergeInstalledPlugins(
+        cloudInstalled,
+        localStateForMerge?.installedPlugins ??
+          installedPluginsRef.current.map(plugin => plugin.raw),
+        localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
+      ).map(toInstalledPluginItem)
+      const mergedItems = mergeMarketplaceCatalog(
+        cloudItems,
+        localRows,
+        nextInstalled.map(plugin => plugin.raw)
+      )
+      if (mergedItems.length === 0 && !hasCachedCatalog) return
+
+      // Always publish installed rows once either side has data. Previously we only
+      // updated when cloudInstalledForMerge was set, so a local-first paint left the
+      // installed strip empty until the final settle.
+      if (localStateForMerge || cloudInstalledForMerge) {
+        setInstalledPlugins(previous =>
+          sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
+        )
+      }
+      setPluginMarketplaceState({
+        items: mergedItems,
+        isLoading: false,
+        error: null,
+      })
+      setMarketplaceLoadingMessage('')
+      setIsMarketplaceRefreshing(options.keepRefreshing)
+    }
+
+    if (peekedLocalState && !hasCachedCatalog) {
+      paintPartialCatalog({
+        localState: peekedLocalState,
+        keepRefreshing: !localStateIsFresh || cloudMarketplaceAvailable,
+      })
+    }
+
+    const personalDiskPromise = listPersonalMarketplacePluginsFromDisk().catch(error => {
+      console.warn('[Wework] personal marketplace disk paint failed', error)
+      return [] as PluginMarketplaceItem[]
+    })
+    void personalDiskPromise.then(diskPersonalItems => {
+      if (!isCurrent) return
+      if (diskPersonalItems.length === 0) return
+      diskPersonalItemsForMerge = diskPersonalItems
+      if (catalogSettled) {
+        // Final snapshot may have landed before disk I/O; merge personal rows now.
+        const cached = getPluginMarketplaceCache(marketplaceCacheKeyValue)
+        const cloudItems =
+          cloudItemsForMerge ??
+          (cached?.marketplaceItems ?? []).filter(item => !isLocalMarketplaceItem(item))
+        const localRows = mergeDiskPersonalIntoLocalRows(
+          localStateForMerge?.marketplaceItems ??
+            (cached?.marketplaceItems ?? []).filter(isLocalMarketplaceItem),
+          diskPersonalItems
+        )
+        const nextInstalled = mergeInstalledPlugins(
+          cloudInstalledForMerge ?? [],
+          localStateForMerge?.installedPlugins ??
+            installedPluginsRef.current.map(plugin => plugin.raw),
+          localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
+        ).map(toInstalledPluginItem)
+        const mergedItems = mergeMarketplaceCatalog(
+          cloudItems,
+          localRows,
+          nextInstalled.map(plugin => plugin.raw)
+        )
+        setPluginMarketplaceState(previous =>
+          sameMarketplaceItems(previous.items, mergedItems)
+            ? previous
+            : { items: mergedItems, isLoading: false, error: null }
+        )
+        return
+      }
+      // Always paint disk personal rows, even when a cloud cache already filled the
+      // catalog. Skipping here left "个人创建" waiting on Codex plugin/list (~10s).
+      paintPartialCatalog({
+        diskPersonalItems,
+        localState: localStateForMerge,
+        keepRefreshing: true,
+      })
+    })
+
+    void localPromise
+      .then(localState => {
+        if (hasCachedCatalog) {
+          localStateForMerge = localState
+          return
+        }
+        // Peek already painted this snapshot; wait for a refreshed result when stale.
+        if (peekedLocalState && localState === peekedLocalState && !localStateIsFresh) {
+          localStateForMerge = localState
+          return
+        }
+        paintPartialCatalog({
+          localState,
+          diskPersonalItems: diskPersonalItemsForMerge ?? undefined,
+          keepRefreshing: cloudMarketplaceAvailable,
+        })
+      })
+      .catch(() => undefined)
+
+    void Promise.allSettled([cloudPromise, installedPromise, capabilitiesPromise]).then(
+      ([cloudResult, installedResult, capabilitiesResult]) => {
+        if (!isCurrent || catalogSettled) return
+        if (hasCachedCatalog) return
+        const cloudItems = cloudResult.status === 'fulfilled' ? cloudResult.value.items : []
+        const cloudInstalled =
+          installedResult.status === 'fulfilled' ? installedResult.value.items : []
+        if (cloudResult.status === 'rejected' && cloudItems.length === 0) return
+
+        if (capabilitiesResult.status === 'fulfilled') {
+          setCanPublish(Boolean(capabilitiesResult.value.canPublish))
+          setCanSharePersonalPlugins(
+            Boolean(capabilitiesResult.value.canSharePersonalPlugins ?? true)
+          )
+        }
+        paintPartialCatalog({
+          cloudItems,
+          cloudInstalled,
+          localState: localStateForMerge,
+          diskPersonalItems: diskPersonalItemsForMerge ?? undefined,
+          keepRefreshing: true,
+        })
+      }
+    )
+
     void Promise.allSettled([
       localPromise,
       cloudPromise,
       installedPromise,
       capabilitiesPromise,
-    ]).then(([localResult, cloudResult, installedResult, capabilitiesResult]) => {
+      personalDiskPromise,
+    ]).then(([localResult, cloudResult, installedResult, capabilitiesResult, diskResult]) => {
       if (!isCurrent) return
+      catalogSettled = true
       setMarketplaceLoadingMessage('')
       setIsMarketplaceRefreshing(false)
+
+      if (diskResult.status === 'fulfilled' && diskResult.value.length > 0) {
+        diskPersonalItemsForMerge = diskResult.value
+      }
 
       if (localResult.status === 'rejected' && cloudResult.status === 'rejected') {
         const error = localResult.reason instanceof Error ? localResult.reason : cloudResult.reason
@@ -2390,14 +2624,12 @@ export function PluginsWorkspace({
         return
       }
 
-      const localState = localResult.status === 'fulfilled' ? localResult.value : null
+      const localState = localResult.status === 'fulfilled' ? localResult.value : localStateForMerge
       const cloudItems = cloudResult.status === 'fulfilled' ? cloudResult.value.items : []
       const cloudInstalled =
         installedResult.status === 'fulfilled' ? installedResult.value.items : []
       const capabilities =
-        capabilitiesResult.status === 'fulfilled'
-          ? capabilitiesResult.value
-          : { canPublish: false, canSharePersonalPlugins: true }
+        capabilitiesResult.status === 'fulfilled' ? capabilitiesResult.value : defaultCapabilities
 
       if (localState) {
         setCurrentDeviceId(localState.deviceId)
@@ -2420,7 +2652,6 @@ export function PluginsWorkspace({
         void Promise.all([
           pluginApi
             .listMarketplacePlugins({
-              q: debouncedQuery || undefined,
               deviceId: resolvedDeviceId,
             })
             .catch(() => ({ items: [] as PluginMarketplaceItem[] })),
@@ -2450,7 +2681,6 @@ export function PluginsWorkspace({
   }, [
     applyLocalMarketplaceState,
     cloudMarketplaceAvailable,
-    debouncedQuery,
     localPluginApi,
     marketplaceCacheKeyValue,
     marketplaceRefreshTick,
@@ -2482,7 +2712,6 @@ export function PluginsWorkspace({
         try {
           const [cloud, installed] = await Promise.all([
             pluginApi.listMarketplacePlugins({
-              q: debouncedQuery || undefined,
               deviceId,
             }),
             pluginApi
@@ -2536,7 +2765,6 @@ export function PluginsWorkspace({
     cloudMarketplaceAvailable,
     cloudToken,
     currentDeviceId,
-    debouncedQuery,
     marketplaceCacheKeyValue,
     pluginApi,
     pluginMarketplaceState.isLoading,
@@ -2550,7 +2778,6 @@ export function PluginsWorkspace({
     const revalidateCloudMarketplace = () => {
       void pluginApi
         .listMarketplacePlugins({
-          q: debouncedQuery || undefined,
           deviceId: currentDeviceId || undefined,
         })
         .then(response => {
@@ -2596,13 +2823,7 @@ export function PluginsWorkspace({
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       window.clearInterval(intervalId)
     }
-  }, [
-    cloudMarketplaceAvailable,
-    currentDeviceId,
-    debouncedQuery,
-    marketplaceCacheKeyValue,
-    pluginApi,
-  ])
+  }, [cloudMarketplaceAvailable, currentDeviceId, marketplaceCacheKeyValue, pluginApi])
 
   const selectedPlugin = useMemo(
     () =>
@@ -2759,20 +2980,24 @@ export function PluginsWorkspace({
     () => marketplaces.filter(isUserAddedMarketplace),
     [marketplaces]
   )
-  const visibleMarketplaceItems = useMemo(
-    () =>
-      pluginMarketplaceState.items.filter(item => {
-        if (marketplaceSourceFilterKey) {
-          const marketplaceId = marketplaceSourceFilterKey.slice('local:'.length)
-          return localMarketplaceIdFromItem(item) === marketplaceId
-        }
-        return (
-          marketplaceDistributionFilter === 'all' ||
-          marketplacePluginDistribution(item) === marketplaceDistributionFilter
-        )
-      }),
-    [marketplaceDistributionFilter, marketplaceSourceFilterKey, pluginMarketplaceState.items]
-  )
+  const visibleMarketplaceItems = useMemo(() => {
+    const filteredItems = pluginMarketplaceState.items.filter(item => {
+      if (marketplaceSourceFilterKey) {
+        const marketplaceId = marketplaceSourceFilterKey.slice('local:'.length)
+        return localMarketplaceIdFromItem(item) === marketplaceId
+      }
+      return (
+        marketplaceDistributionFilter === 'all' ||
+        marketplacePluginDistribution(item) === marketplaceDistributionFilter
+      )
+    })
+    return rankMarketplaceSearchResults(filteredItems, normalizedQuery)
+  }, [
+    marketplaceDistributionFilter,
+    marketplaceSourceFilterKey,
+    normalizedQuery,
+    pluginMarketplaceState.items,
+  ])
   const displayedMarketplaceItems = visibleMarketplaceItems.slice(0, marketplaceVisibleCount)
   const hiddenMarketplaceItems = visibleMarketplaceItems.slice(marketplaceVisibleCount)
   const marketplaceRevealNames = hiddenMarketplaceItems

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -84,6 +84,7 @@ import {
   isCloudManagedInstalledPlugin,
   mergeInstalledPlugins,
 } from './installedPluginMerge'
+import { findMarketplaceItemForInstalled } from './findMarketplaceItemForInstalled'
 import {
   isLocalMarketplaceItem,
   mergeDiskPersonalIntoLocalRows,
@@ -2468,11 +2469,17 @@ export function PluginsWorkspace({
           ),
         diskPersonalItemsForMerge
       )
-      const cloudInstalled = cloudInstalledForMerge ?? []
+      const previousInstalledRaw = installedPluginsRef.current.map(plugin => plugin.raw)
+      // Local-first paint must not blank cloud installs already on the strip. Until
+      // listInstalledPlugins returns, keep prior cloud-managed rows (spec.pluginId).
+      const cloudInstalled =
+        cloudInstalledForMerge ??
+        (cloudMarketplaceAvailable
+          ? previousInstalledRaw.filter(plugin => typeof plugin.spec.pluginId === 'number')
+          : [])
       const nextInstalled = mergeInstalledPlugins(
         cloudInstalled,
-        localStateForMerge?.installedPlugins ??
-          installedPluginsRef.current.map(plugin => plugin.raw),
+        localStateForMerge?.installedPlugins ?? previousInstalledRaw,
         localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
       ).map(toInstalledPluginItem)
       const mergedItems = mergeMarketplaceCatalog(
@@ -2482,9 +2489,8 @@ export function PluginsWorkspace({
       )
       if (mergedItems.length === 0 && !hasCachedCatalog) return
 
-      // Always publish installed rows once either side has data. Previously we only
-      // updated when cloudInstalledForMerge was set, so a local-first paint left the
-      // installed strip empty until the final settle.
+      // Publish installed rows when either side has data. Preserving prior cloud rows
+      // above stops a Codex-only peek from flashing away Wework/official icons.
       if (localStateForMerge || cloudInstalledForMerge) {
         setInstalledPlugins(previous =>
           sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
@@ -2526,7 +2532,12 @@ export function PluginsWorkspace({
           diskPersonalItems
         )
         const nextInstalled = mergeInstalledPlugins(
-          cloudInstalledForMerge ?? [],
+          cloudInstalledForMerge ??
+            (cloudMarketplaceAvailable
+              ? installedPluginsRef.current
+                  .map(plugin => plugin.raw)
+                  .filter(plugin => typeof plugin.spec.pluginId === 'number')
+              : []),
           localStateForMerge?.installedPlugins ??
             installedPluginsRef.current.map(plugin => plugin.raw),
           localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
@@ -2570,6 +2581,19 @@ export function PluginsWorkspace({
         })
       })
       .catch(() => undefined)
+
+    // Paint the installed strip as soon as account installs arrive — do not wait on
+    // marketplace catalog or Codex plugin/list. That is what made Wework/official
+    // icons flash in after OpenAI/local peeks.
+    void installedPromise.then(installed => {
+      if (!isCurrent || catalogSettled) return
+      paintPartialCatalog({
+        cloudInstalled: installed.items,
+        localState: localStateForMerge,
+        diskPersonalItems: diskPersonalItemsForMerge ?? undefined,
+        keepRefreshing: true,
+      })
+    })
 
     void Promise.allSettled([cloudPromise, installedPromise, capabilitiesPromise]).then(
       ([cloudResult, installedResult, capabilitiesResult]) => {
@@ -3180,6 +3204,16 @@ export function PluginsWorkspace({
     setSelectedMarketplacePluginId(item.id)
   }
 
+  const openInstalledPluginDetail = (plugin: InstalledPluginItem) => {
+    const marketplaceItem = findMarketplaceItemForInstalled(plugin, pluginMarketplaceState.items)
+    if (marketplaceItem) {
+      openMarketplacePluginDetail(marketplaceItem)
+      return
+    }
+    setSelectedMarketplacePluginId(null)
+    setSelectedPluginId(plugin.id)
+  }
+
   if (selectedPlugin) {
     const ownedMarketplace = findOwnedMarketplacePlugin(selectedPlugin)
     const packableCreated =
@@ -3768,8 +3802,9 @@ export function PluginsWorkspace({
                 >
                   <div className="plugin-installed-icons-track">
                     {installedStripPlugins.map(plugin => {
-                      const marketplaceItem = pluginMarketplaceState.items.find(
-                        item => String(item.id) === String(plugin.id)
+                      const marketplaceItem = findMarketplaceItemForInstalled(
+                        plugin,
+                        pluginMarketplaceState.items
                       )
                       const logo = resolvePluginLogo({
                         pluginKey: String(plugin.raw.spec.source?.pluginKey || plugin.id),
@@ -3790,7 +3825,7 @@ export function PluginsWorkspace({
                           data-tooltip={plugin.name}
                           aria-label={plugin.name}
                           className="plugin-installed-strip-item"
-                          onClick={() => setSelectedPluginId(plugin.id)}
+                          onClick={() => openInstalledPluginDetail(plugin)}
                         >
                           <span
                             className={[
@@ -3825,8 +3860,9 @@ export function PluginsWorkspace({
                           {hiddenInstalledPlugins
                             .slice(0, INSTALLED_STRIP_OVERFLOW_PREVIEW_COUNT)
                             .map(plugin => {
-                              const marketplaceItem = pluginMarketplaceState.items.find(
-                                item => String(item.id) === String(plugin.id)
+                              const marketplaceItem = findMarketplaceItemForInstalled(
+                                plugin,
+                                pluginMarketplaceState.items
                               )
                               const logo = resolvePluginLogo({
                                 pluginKey: String(plugin.raw.spec.source?.pluginKey || plugin.id),

--- a/wework/src/components/plugins/findMarketplaceItemForInstalled.test.ts
+++ b/wework/src/components/plugins/findMarketplaceItemForInstalled.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest'
+import type { InstalledPlugin, PluginMarketplaceItem } from '@/types/api'
+import type { InstalledPluginItem } from './PluginManagementRows'
+import { findMarketplaceItemForInstalled } from './findMarketplaceItemForInstalled'
+
+const components = {
+  skills: [],
+  commands: [],
+  agents: [],
+  hooks: [],
+  mcps: [],
+  lsps: [],
+  monitors: [],
+  bins: [],
+}
+
+function marketplaceItem(
+  overrides: Partial<PluginMarketplaceItem> & Pick<PluginMarketplaceItem, 'id' | 'name'>
+): PluginMarketplaceItem {
+  return {
+    remotePluginId: String(overrides.id),
+    displayName: overrides.displayName ?? overrides.name,
+    description: '',
+    featured: false,
+    installed: false,
+    installedPluginId: null,
+    enabled: false,
+    sourceType: 'marketplace',
+    visibility: 'public',
+    ownerUserId: 0,
+    components,
+    manifest: {},
+    ...overrides,
+  }
+}
+
+function installedItem(
+  overrides: Partial<InstalledPluginItem> & {
+    id: string | number
+    pluginKey: string
+    pluginId?: number
+    marketplace?: string
+    origin?: 'created' | 'market'
+  }
+): InstalledPluginItem {
+  const raw: InstalledPlugin = {
+    apiVersion: 'wegent.ai/v1',
+    kind: 'InstalledPlugin',
+    metadata: { name: overrides.pluginKey, namespace: overrides.marketplace ?? 'default' },
+    spec: {
+      source: {
+        type: overrides.origin === 'created' ? 'local' : 'marketplace',
+        providerKey: overrides.marketplace ?? 'wegent-market',
+        pluginKey: overrides.pluginKey,
+        marketplace: overrides.marketplace ?? 'wegent',
+      },
+      origin: overrides.origin ?? 'market',
+      pluginId: overrides.pluginId,
+      installState: 'installed',
+      enabled: true,
+      displayName: overrides.name ?? overrides.pluginKey,
+      description: '',
+      componentStates: {},
+      components,
+      interface: null,
+      packageRef: null,
+      sourcePayload: {},
+    },
+    status: { state: 'enabled' },
+  }
+  return {
+    id: overrides.id,
+    name: overrides.name ?? overrides.pluginKey,
+    description: '',
+    enabled: true,
+    version: '1.0.0',
+    origin: overrides.origin ?? 'market',
+    sourceLabel: 'Wegent',
+    distribution: 'public',
+    updateAvailable: false,
+    componentCounts: {},
+    raw,
+    ...overrides,
+  }
+}
+
+describe('findMarketplaceItemForInstalled', () => {
+  test('matches by installedPluginId first', () => {
+    const items = [
+      marketplaceItem({ id: 4, name: 'dingtalk', installedPluginId: '62' }),
+      marketplaceItem({ id: 9, name: 'dingtalk', installedPluginId: '99' }),
+    ]
+    const plugin = installedItem({
+      id: '62',
+      pluginKey: 'dingtalk',
+      pluginId: 9,
+      marketplace: 'wegent',
+    })
+    expect(findMarketplaceItemForInstalled(plugin, items)?.id).toBe(4)
+  })
+
+  test('matches by cloud pluginId when installedPluginId is absent', () => {
+    const items = [marketplaceItem({ id: 4, name: 'dingtalk', latestReleaseId: 6 })]
+    const plugin = installedItem({
+      id: '62',
+      pluginKey: 'other-name',
+      pluginId: 4,
+      marketplace: 'wegent',
+    })
+    expect(findMarketplaceItemForInstalled(plugin, items)?.id).toBe(4)
+  })
+
+  test('matches by pluginKey and marketplace alias', () => {
+    const items = [
+      marketplaceItem({
+        id: 'dingtalk@wework',
+        name: 'dingtalk',
+        latestReleaseId: null,
+        manifest: { marketplaceId: 'wework' },
+      }),
+    ]
+    const plugin = installedItem({
+      id: 'local-1',
+      pluginKey: 'dingtalk',
+      marketplace: 'wegent',
+    })
+    expect(findMarketplaceItemForInstalled(plugin, items)?.id).toBe('dingtalk@wework')
+  })
+
+  test('returns null for personal plugins with no catalog row', () => {
+    const items = [marketplaceItem({ id: 4, name: 'dingtalk', latestReleaseId: 6 })]
+    const plugin = installedItem({
+      id: 'notes@wework-personal',
+      pluginKey: 'notes',
+      marketplace: 'wework-personal',
+      origin: 'created',
+    })
+    expect(findMarketplaceItemForInstalled(plugin, items)).toBeNull()
+  })
+})

--- a/wework/src/components/plugins/findMarketplaceItemForInstalled.ts
+++ b/wework/src/components/plugins/findMarketplaceItemForInstalled.ts
@@ -1,0 +1,59 @@
+import type { PluginMarketplaceItem } from '@/types/api'
+import { isWegentCloudMarketplace } from '@/features/plugins/pluginNavigation'
+import type { InstalledPluginItem } from './PluginManagementRows'
+import { installedPluginMarketplaceId, marketplaceItemMarketplaceId } from './pluginDistribution'
+
+function normalizedMarketplaceId(value: string | null | undefined): string {
+  const trimmed = (value ?? '').trim().toLowerCase()
+  if (!trimmed) return ''
+  return isWegentCloudMarketplace(trimmed) ? 'wegent' : trimmed
+}
+
+function pluginKey(plugin: InstalledPluginItem): string {
+  return String(plugin.raw.spec.source.pluginKey || plugin.raw.metadata.name || '')
+    .trim()
+    .toLowerCase()
+}
+
+/**
+ * Resolve the marketplace catalog row for an installed plugin so the installed
+ * strip can open the same enriched detail path as the market list.
+ *
+ * Match order: installedPluginId → cloud pluginId → pluginKey@marketplace.
+ */
+export function findMarketplaceItemForInstalled(
+  plugin: InstalledPluginItem,
+  items: PluginMarketplaceItem[]
+): PluginMarketplaceItem | null {
+  if (items.length === 0) return null
+
+  const installedId = String(plugin.id)
+  const byInstalledPluginId = items.find(
+    item =>
+      item.installedPluginId !== null &&
+      item.installedPluginId !== undefined &&
+      String(item.installedPluginId) === installedId
+  )
+  if (byInstalledPluginId) return byInstalledPluginId
+
+  const cloudPluginId = plugin.raw.spec.pluginId
+  if (typeof cloudPluginId === 'number') {
+    const byPluginId = items.find(item => String(item.id) === String(cloudPluginId))
+    if (byPluginId) return byPluginId
+  }
+
+  const key = pluginKey(plugin)
+  const marketplace = normalizedMarketplaceId(installedPluginMarketplaceId(plugin.raw))
+  if (!key || !marketplace) return null
+
+  return (
+    items.find(item => {
+      const itemKey = item.name.trim().toLowerCase()
+      if (itemKey !== key) return false
+      const itemMarketplace =
+        normalizedMarketplaceId(marketplaceItemMarketplaceId(item)) ||
+        (item.latestReleaseId != null ? 'wegent' : '')
+      return itemMarketplace === marketplace
+    }) ?? null
+  )
+}

--- a/wework/src/components/plugins/holdBackInFlightMarketplaceInstalls.test.ts
+++ b/wework/src/components/plugins/holdBackInFlightMarketplaceInstalls.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest'
+import type { InstalledPlugin, PluginMarketplaceItem } from '@/types/api'
+import type { InstalledPluginItem } from './PluginManagementRows'
+import { holdBackInFlightMarketplaceInstalls } from './holdBackInFlightMarketplaceInstalls'
+
+function marketplaceItem(overrides: Partial<PluginMarketplaceItem> = {}): PluginMarketplaceItem {
+  return {
+    id: 'desktop-e2e-marketplace:desktop-e2e-plugin@desktop-e2e-marketplace',
+    name: 'desktop-e2e-plugin',
+    displayName: 'Desktop E2E Plugin',
+    description: '',
+    version: '0.1.0',
+    author: null,
+    installed: true,
+    installedLocally: true,
+    installedPluginId: 'desktop-e2e-plugin@desktop-e2e-marketplace',
+    enabled: true,
+    updateAvailable: false,
+    latestReleaseId: null,
+    components: {
+      skills: [],
+      commands: [],
+      agents: [],
+      hooks: [],
+      mcps: [],
+      lsps: [],
+      monitors: [],
+      bins: [],
+      connectors: [],
+    },
+    manifest: { marketplaceId: 'desktop-e2e-marketplace' },
+    interface: null,
+    ...overrides,
+  }
+}
+
+function installedItem(name: string): InstalledPluginItem {
+  const raw: InstalledPlugin = {
+    apiVersion: 'agent.wecode.io/v1',
+    kind: 'InstalledPlugin',
+    metadata: {
+      name,
+      namespace: 'desktop-e2e-marketplace',
+      labels: { id: `${name}@desktop-e2e-marketplace` },
+    },
+    spec: {
+      source: {
+        type: 'local',
+        providerKey: 'desktop-e2e-marketplace',
+        pluginKey: name,
+        catalogItemId: `${name}@desktop-e2e-marketplace`,
+        marketplace: 'desktop-e2e-marketplace',
+      },
+      origin: 'market',
+      installState: 'installed',
+      enabled: true,
+      displayName: name,
+      description: '',
+      componentStates: {},
+      components: {
+        skills: [],
+        commands: [],
+        agents: [],
+        hooks: [],
+        mcps: [],
+        lsps: [],
+        monitors: [],
+        bins: [],
+      },
+      interface: null,
+      packageRef: null,
+      sourcePayload: null,
+    },
+    status: { state: 'enabled' },
+  }
+  return {
+    id: `${name}@desktop-e2e-marketplace`,
+    name,
+    description: '',
+    enabled: true,
+    version: '0.1.0',
+    origin: 'market',
+    sourceLabel: 'Desktop E2E Marketplace',
+    distribution: 'external',
+    updateAvailable: false,
+    componentCounts: {},
+    raw,
+  }
+}
+
+describe('holdBackInFlightMarketplaceInstalls', () => {
+  test('clears installed card and strip rows while marketplace install is in flight', () => {
+    const item = marketplaceItem()
+    const held = holdBackInFlightMarketplaceInstalls({
+      items: [item, marketplaceItem({ id: 'other', name: 'other-plugin', installed: true })],
+      installed: [installedItem('desktop-e2e-plugin'), installedItem('other-plugin')],
+      installingIds: new Set([item.id]),
+      authPluginKey: null,
+    })
+
+    expect(held.items.find(entry => entry.id === item.id)?.installed).toBe(false)
+    expect(held.items.find(entry => entry.name === 'other-plugin')?.installed).toBe(true)
+    expect(held.installed.map(entry => entry.name)).toEqual(['other-plugin'])
+  })
+
+  test('also holds back rows matching the pending local-auth plugin key', () => {
+    const held = holdBackInFlightMarketplaceInstalls({
+      items: [marketplaceItem()],
+      installed: [installedItem('desktop-e2e-plugin')],
+      installingIds: new Set(),
+      authPluginKey: 'desktop-e2e-plugin',
+    })
+
+    expect(held.items[0]?.installed).toBe(false)
+    expect(held.installed).toEqual([])
+  })
+})

--- a/wework/src/components/plugins/holdBackInFlightMarketplaceInstalls.ts
+++ b/wework/src/components/plugins/holdBackInFlightMarketplaceInstalls.ts
@@ -1,0 +1,46 @@
+import type { PluginMarketplaceItem } from '@/types/api'
+import type { InstalledPluginItem } from './PluginManagementRows'
+
+/**
+ * While install+local-auth is in flight, Codex already reports the plugin as
+ * installed. Background catalog paints must not surface strip/actions yet —
+ * that races auth and can cancel/uninstall mid-dialog.
+ */
+export function holdBackInFlightMarketplaceInstalls(input: {
+  items: PluginMarketplaceItem[]
+  installed: InstalledPluginItem[]
+  installingIds: Set<string | number>
+  authPluginKey: string | null | undefined
+}): { items: PluginMarketplaceItem[]; installed: InstalledPluginItem[] } {
+  const authKey = input.authPluginKey?.trim().toLowerCase() || ''
+  if (input.installingIds.size === 0 && !authKey) {
+    return { items: input.items, installed: input.installed }
+  }
+
+  const blockedNames = new Set<string>()
+  if (authKey) blockedNames.add(authKey)
+  const items = input.items.map(item => {
+    const blocked =
+      input.installingIds.has(item.id) ||
+      (authKey !== '' && item.name.trim().toLowerCase() === authKey)
+    if (!blocked) return item
+    blockedNames.add(item.name.trim().toLowerCase())
+    return {
+      ...item,
+      installed: false,
+      installedLocally: false,
+      installedPluginId: null,
+    }
+  })
+
+  if (blockedNames.size === 0) {
+    return { items, installed: input.installed }
+  }
+
+  const installed = input.installed.filter(plugin => {
+    const pluginKey = (plugin.raw.spec.source.pluginKey || plugin.name).trim().toLowerCase()
+    const name = plugin.name.trim().toLowerCase()
+    return !blockedNames.has(pluginKey) && !blockedNames.has(name)
+  })
+  return { items, installed }
+}

--- a/wework/src/components/plugins/marketplaceCatalogMerge.test.ts
+++ b/wework/src/components/plugins/marketplaceCatalogMerge.test.ts
@@ -128,6 +128,44 @@ describe('mergeMarketplaceCatalog', () => {
     expect(shouldShowInstalledMarketplaceActions(localCatalogPlugin(), false)).toBe(true)
     expect(shouldShowInstalledMarketplaceActions(cloudPlugin(), false)).toBe(false)
   })
+
+  test('marks a cloud row installed from account InstalledPlugin when catalog lags', () => {
+    const cloudInstalled: InstalledPlugin = {
+      apiVersion: 'wegent.ai/v1',
+      kind: 'InstalledPlugin',
+      metadata: { name: 'weibo-api-wiki', namespace: 'default', labels: { id: '267433' } },
+      spec: {
+        source: {
+          type: 'marketplace',
+          providerKey: 'wegent-market',
+          pluginKey: 'weibo-api-wiki',
+          marketplace: 'wegent',
+        },
+        pluginId: 4,
+        releaseId: 6,
+        installState: 'installed',
+        enabled: true,
+        displayName: '微博小程序H5开发助手',
+        description: '',
+        componentStates: {},
+        components,
+        interface: null,
+        packageRef: null,
+        sourcePayload: {},
+      },
+      status: { state: 'enabled' },
+    }
+
+    const merged = mergeMarketplaceCatalog([cloudPlugin()], [], [cloudInstalled])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({
+      id: 4,
+      installed: true,
+      installedPluginId: '267433',
+      enabled: true,
+    })
+    expect(shouldShowInstalledMarketplaceActions(merged[0], true)).toBe(true)
+  })
 })
 
 describe('mergeDiskPersonalIntoLocalRows', () => {

--- a/wework/src/components/plugins/marketplaceCatalogMerge.test.ts
+++ b/wework/src/components/plugins/marketplaceCatalogMerge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import type { InstalledPlugin, PluginMarketplaceItem } from '@/types/api'
 import {
+  mergeDiskPersonalIntoLocalRows,
   mergeMarketplaceCatalog,
   shouldShowInstalledMarketplaceActions,
 } from './marketplaceCatalogMerge'
@@ -126,5 +127,105 @@ describe('mergeMarketplaceCatalog', () => {
   test('keeps local installed actions available while signed out', () => {
     expect(shouldShowInstalledMarketplaceActions(localCatalogPlugin(), false)).toBe(true)
     expect(shouldShowInstalledMarketplaceActions(cloudPlugin(), false)).toBe(false)
+  })
+})
+
+describe('mergeDiskPersonalIntoLocalRows', () => {
+  test('uses disk personal rows when Codex local rows are empty', () => {
+    const disk = [{ ...localCatalogPlugin(), id: 'personal-disk:notes', name: 'notes' }]
+    expect(mergeDiskPersonalIntoLocalRows([], disk)).toEqual(disk)
+  })
+
+  test('keeps Codex rows and appends disk-only personal plugins', () => {
+    const diskOnly = {
+      ...localCatalogPlugin(),
+      id: 'personal-disk:notes',
+      name: 'notes',
+      displayName: 'Notes',
+    }
+    const merged = mergeDiskPersonalIntoLocalRows(
+      [localCatalogPlugin()],
+      [localCatalogPlugin(), diskOnly]
+    )
+    expect(merged.map(item => item.name).sort()).toEqual(['dev-tools', 'notes'])
+  })
+
+  test('collapses Codex and disk copies of the same personal plugin', () => {
+    const codex = {
+      ...localCatalogPlugin(),
+      id: 'dev-tools',
+      description: 'Use developer tools in Codex.',
+      author: 'Local developer',
+      installed: false,
+      installedPluginId: null,
+      installedLocally: false,
+    }
+    const disk = {
+      ...localCatalogPlugin(),
+      id: 'personal-disk:dev-tools',
+      description: 'Developer tools plugin with IP geolocation lookup.',
+      author: null,
+      sourceLabel: '个人分享',
+      installed: true,
+      installedLocally: true,
+      installedPluginId: 'dev-tools@wework-personal',
+    }
+    const merged = mergeDiskPersonalIntoLocalRows([codex], [disk])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({
+      id: 'dev-tools',
+      description: 'Use developer tools in Codex.',
+      author: 'Local developer',
+      installed: true,
+      installedLocally: true,
+      installedPluginId: 'dev-tools@wework-personal',
+    })
+  })
+
+  test('collapses personal and wework-personal aliases for the same plugin name', () => {
+    const legacyPersonal = {
+      ...localCatalogPlugin(),
+      id: 'dev-tools@personal',
+      manifest: { marketplaceId: 'personal' },
+      installed: false,
+      installedPluginId: null,
+      installedLocally: false,
+    }
+    const disk = {
+      ...localCatalogPlugin(),
+      id: 'personal-disk:dev-tools',
+      installed: true,
+      installedLocally: true,
+      installedPluginId: 'dev-tools@wework-personal',
+    }
+    const merged = mergeDiskPersonalIntoLocalRows([legacyPersonal], [disk])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.installed).toBe(true)
+  })
+})
+
+describe('mergeMarketplaceCatalog personal dedupe', () => {
+  test('keeps a single personal slot when Codex and disk rows both arrive', () => {
+    const codex = {
+      ...localCatalogPlugin(),
+      id: 'dev-tools',
+      author: 'Local developer',
+      installed: false,
+      installedPluginId: null,
+    }
+    const disk = {
+      ...localCatalogPlugin(),
+      id: 'personal-disk:dev-tools',
+      installed: true,
+      installedLocally: true,
+      installedPluginId: 'dev-tools@wework-personal',
+    }
+    const merged = mergeMarketplaceCatalog([], [codex, disk], [])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({
+      id: 'dev-tools',
+      installed: true,
+      installedPluginId: 'dev-tools@wework-personal',
+    })
   })
 })

--- a/wework/src/components/plugins/marketplaceCatalogMerge.ts
+++ b/wework/src/components/plugins/marketplaceCatalogMerge.ts
@@ -1,4 +1,5 @@
 import type { InstalledPlugin, PluginMarketplaceItem } from '@/types/api'
+import { isPersonalMarketplaceId } from '@/features/plugins/builtinPlugins'
 import { isBuiltInMarketplaceId } from '@/features/plugins/marketplaceIdentity'
 import { marketplaceItemMarketplaceId } from './pluginDistribution'
 import { linkedCloudPluginId, localPluginId } from './installedPluginMerge'
@@ -6,6 +7,75 @@ import { linkedCloudPluginId, localPluginId } from './installedPluginMerge'
 export function isLocalMarketplaceItem(item: PluginMarketplaceItem): boolean {
   if (item.latestReleaseId != null) return false
   return marketplaceItemMarketplaceId(item) !== null
+}
+
+function isDiskPersonalMarketplaceItem(item: PluginMarketplaceItem): boolean {
+  return String(item.id).startsWith('personal-disk:')
+}
+
+/**
+ * Collapse wework-personal / personal aliases so disk bypass and Codex plugin/list
+ * do not paint the same created plugin twice.
+ */
+export function localMarketplaceDedupeKey(item: PluginMarketplaceItem): string {
+  const name = item.name.trim().toLowerCase()
+  const marketplaceId = marketplaceItemMarketplaceId(item)
+  if (marketplaceId && isPersonalMarketplaceId(marketplaceId)) {
+    return `personal:${name}`
+  }
+  return `${(marketplaceId || 'unknown').toLowerCase()}:${name}`
+}
+
+function withDiskInstallHints(
+  primary: PluginMarketplaceItem,
+  disk: PluginMarketplaceItem
+): PluginMarketplaceItem {
+  if (!disk.installed && !disk.installedLocally) return primary
+  return {
+    ...primary,
+    installed: true,
+    installedLocally: true,
+    installedPluginId: primary.installedPluginId || disk.installedPluginId,
+    enabled: primary.enabled || disk.enabled,
+  }
+}
+
+function preferLocalMarketplaceItem(
+  current: PluginMarketplaceItem,
+  candidate: PluginMarketplaceItem
+): PluginMarketplaceItem {
+  const currentIsDisk = isDiskPersonalMarketplaceItem(current)
+  const candidateIsDisk = isDiskPersonalMarketplaceItem(candidate)
+  if (currentIsDisk && !candidateIsDisk) {
+    return withDiskInstallHints(candidate, current)
+  }
+  if (!currentIsDisk && candidateIsDisk) {
+    return withDiskInstallHints(current, candidate)
+  }
+  if (candidate.installed && !current.installed) return candidate
+  return current
+}
+
+/** Prefer Codex/local rows; keep disk-personal extras that are not in the primary list yet. */
+export function mergeDiskPersonalIntoLocalRows(
+  localRows: PluginMarketplaceItem[],
+  diskPersonalItems: PluginMarketplaceItem[] | null | undefined
+): PluginMarketplaceItem[] {
+  if (!diskPersonalItems?.length) return localRows
+  if (!localRows.length) return diskPersonalItems
+
+  const byKey = new Map<string, PluginMarketplaceItem>()
+  for (const item of localRows) {
+    const key = localMarketplaceDedupeKey(item)
+    const existing = byKey.get(key)
+    byKey.set(key, existing ? preferLocalMarketplaceItem(existing, item) : item)
+  }
+  for (const item of diskPersonalItems) {
+    const key = localMarketplaceDedupeKey(item)
+    const existing = byKey.get(key)
+    byKey.set(key, existing ? preferLocalMarketplaceItem(existing, item) : item)
+  }
+  return Array.from(byKey.values())
 }
 
 export function shouldShowInstalledMarketplaceActions(
@@ -52,13 +122,19 @@ export function mergeMarketplaceCatalog(
     const marketplaceId = marketplaceItemMarketplaceId(item)
     if (marketplaceId && !isBuiltInMarketplaceId(marketplaceId)) {
       const key = `local:${marketplaceId.toLowerCase()}:${item.name.toLowerCase()}`
-      if (!merged.has(key)) merged.set(key, item)
+      const existing = merged.get(key)
+      merged.set(key, existing ? preferLocalMarketplaceItem(existing, item) : item)
       continue
     }
     // Built-in local mirrors of a cloud listing are already represented above.
     if (cloudNames.has(item.name.toLowerCase())) continue
-    const key = `local-builtin:${(marketplaceId || 'unknown').toLowerCase()}:${item.name.toLowerCase()}`
-    if (!merged.has(key)) merged.set(key, item)
+    // Personal aliases (wework-personal / personal) share one catalog slot.
+    const key =
+      marketplaceId && isPersonalMarketplaceId(marketplaceId)
+        ? `local-personal:${item.name.toLowerCase()}`
+        : `local-builtin:${(marketplaceId || 'unknown').toLowerCase()}:${item.name.toLowerCase()}`
+    const existing = merged.get(key)
+    merged.set(key, existing ? preferLocalMarketplaceItem(existing, item) : item)
   }
   return Array.from(merged.values())
 }

--- a/wework/src/components/plugins/marketplaceCatalogMerge.ts
+++ b/wework/src/components/plugins/marketplaceCatalogMerge.ts
@@ -91,10 +91,17 @@ export function mergeMarketplaceCatalog(
   installedPlugins: InstalledPlugin[]
 ): PluginMarketplaceItem[] {
   const localPublishedInstalls = new Map<string, InstalledPlugin>()
+  const cloudManagedInstalls = new Map<string, InstalledPlugin>()
   for (const plugin of installedPlugins) {
     const cloudPluginId = linkedCloudPluginId(plugin)
     if (cloudPluginId !== null && localPluginId(plugin) !== null) {
       localPublishedInstalls.set(String(cloudPluginId), plugin)
+    }
+    // Account installs from /installed-plugins carry spec.pluginId == catalog id.
+    // After install, a marketplace refresh can still return installed:false on the
+    // cloud row; overlay from the installed list so the card shows "..." immediately.
+    if (typeof plugin.spec.pluginId === 'number') {
+      cloudManagedInstalls.set(String(plugin.spec.pluginId), plugin)
     }
   }
 
@@ -102,17 +109,20 @@ export function mergeMarketplaceCatalog(
   const cloudNames = new Set<string>()
   for (const item of cloudItems) {
     const localInstall = localPublishedInstalls.get(String(item.id))
+    const cloudInstall = localInstall ? undefined : cloudManagedInstalls.get(String(item.id))
+    const matchedInstall = localInstall ?? cloudInstall
     // Cloud catalog ids are unique; never collapse distinct plugins by display name.
     merged.set(`cloud:${item.id}`, {
       ...item,
-      ...(localInstall
+      ...(matchedInstall
         ? {
             installed: true,
-            installedPluginId: localPluginId(localInstall),
-            installedLocally: true,
-            enabled: localInstall.spec.enabled,
-            updateAvailable: false,
-            currentDeviceInstallation: null,
+            installedPluginId: localPluginId(matchedInstall) ?? item.installedPluginId,
+            installedLocally: Boolean(localInstall) || Boolean(item.installedLocally),
+            enabled: matchedInstall.spec.enabled,
+            updateAvailable:
+              item.updateAvailable || matchedInstall.spec.installState === 'update_available',
+            currentDeviceInstallation: localInstall ? null : item.currentDeviceInstallation,
           }
         : {}),
     })

--- a/wework/src/features/plugins/loadComposerPluginApps.ts
+++ b/wework/src/features/plugins/loadComposerPluginApps.ts
@@ -77,6 +77,11 @@ export async function loadComposerPluginApps(
       pluginKeys: installedPlugins.map(
         plugin => plugin.spec.source?.pluginKey || plugin.metadata.name
       ),
+      pluginStates: installedPlugins.map(plugin => ({
+        key: plugin.spec.source?.pluginKey || plugin.metadata.name,
+        enabled: plugin.spec.enabled,
+        installState: plugin.spec.installState,
+      })),
     })
   }
 

--- a/wework/src/features/plugins/marketplaceIdentity.test.ts
+++ b/wework/src/features/plugins/marketplaceIdentity.test.ts
@@ -7,9 +7,20 @@ import {
 
 describe('marketplaceIdentity', () => {
   test('recognizes OpenAI official marketplace ids', () => {
+    expect(isOpenAiOfficialMarketplaceId('openai-api-curated')).toBe(true)
     expect(isOpenAiOfficialMarketplaceId('openai-bundled')).toBe(true)
+    expect(isOpenAiOfficialMarketplaceId('openai-curated')).toBe(true)
+    expect(isOpenAiOfficialMarketplaceId('openai-curated-remote')).toBe(true)
+    expect(isOpenAiOfficialMarketplaceId('openai-official')).toBe(true)
     expect(isOpenAiOfficialMarketplaceId('OpenAI-Primary-Runtime')).toBe(true)
     expect(isOpenAiOfficialMarketplaceId('awesome-codex-plugins')).toBe(false)
+  })
+
+  test('treats OpenAI official marketplaces as built-ins', () => {
+    expect(isBuiltInMarketplaceId('openai-curated')).toBe(true)
+    expect(isBuiltInMarketplaceId('openai-curated-remote')).toBe(true)
+    expect(isBuiltInMarketplaceId('openai-official')).toBe(true)
+    expect(isBuiltInMarketplaceId('awesome-codex-plugins')).toBe(false)
   })
 
   test('recognizes the internal wegent marketplace and other built-ins', () => {

--- a/wework/src/features/plugins/marketplaceIdentity.ts
+++ b/wework/src/features/plugins/marketplaceIdentity.ts
@@ -2,9 +2,14 @@ import { CODEX_PERSONAL_MARKETPLACE_ID, WEWORK_PERSONAL_MARKETPLACE_ID } from '.
 
 export const INTERNAL_DEVICE_MARKETPLACE_ID = 'wegent'
 
+// Keep in sync with executor plugin_source_priority official OpenAI sources.
+// Do not use an openai-* prefix match; that is too broad for non-marketplace ids.
 const OPENAI_OFFICIAL_MARKETPLACE_IDS = new Set([
   'openai-api-curated',
   'openai-bundled',
+  'openai-curated',
+  'openai-curated-remote',
+  'openai-official',
   'openai-primary-runtime',
 ])
 

--- a/wework/src/features/plugins/marketplaceSearch.test.ts
+++ b/wework/src/features/plugins/marketplaceSearch.test.ts
@@ -58,6 +58,32 @@ describe('marketplaceSearch', () => {
     ).toBeNull()
   })
 
+  test('marketplaceSearchScore matches description and interface blurbs', () => {
+    expect(
+      marketplaceSearchScore(
+        marketplaceItem({
+          id: 1,
+          name: 'office',
+          displayName: 'Office Kit',
+          description: 'Manage DingTalk documents and calendars',
+        }),
+        'dingtalk'
+      )
+    ).toBe(100)
+
+    expect(
+      marketplaceSearchScore(
+        marketplaceItem({
+          id: 2,
+          name: 'notes',
+          displayName: 'Notes',
+          interface: { shortDescription: 'Capture meeting notes in Feishu' },
+        }),
+        'feishu'
+      )
+    ).toBe(100)
+  })
+
   test('rankMarketplaceSearchResults returns all items for empty query', () => {
     const items = [marketplaceItem({ id: 1, name: 'a' }), marketplaceItem({ id: 2, name: 'b' })]
     expect(rankMarketplaceSearchResults(items, '  ')).toEqual(items)

--- a/wework/src/features/plugins/marketplaceSearch.test.ts
+++ b/wework/src/features/plugins/marketplaceSearch.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import type { PluginMarketplaceItem } from '@/types/api'
+import {
+  marketplaceSearchScore,
+  normalizeMarketplaceSearchQuery,
+  rankMarketplaceSearchResults,
+} from './marketplaceSearch'
+
+function marketplaceItem(
+  overrides: Partial<PluginMarketplaceItem> & Pick<PluginMarketplaceItem, 'id' | 'name'>
+): PluginMarketplaceItem {
+  return {
+    remotePluginId: String(overrides.id),
+    displayName: overrides.displayName ?? overrides.name,
+    description: '',
+    featured: false,
+    installed: false,
+    enabled: false,
+    sourceType: 'marketplace',
+    visibility: 'public',
+    ownerUserId: 0,
+    components: {
+      skills: [],
+      commands: [],
+      agents: [],
+      hooks: [],
+      mcps: [],
+      lsps: [],
+      monitors: [],
+      bins: [],
+    },
+    manifest: {},
+    ...overrides,
+  }
+}
+
+describe('marketplaceSearch', () => {
+  test('normalizeMarketplaceSearchQuery trims and lowercases', () => {
+    expect(normalizeMarketplaceSearchQuery('  GitHub  ')).toBe('github')
+  })
+
+  test('rankMarketplaceSearchResults prefers exact name matches', () => {
+    const items = [
+      marketplaceItem({ id: 1, name: 'tools', displayName: 'GitHub Tools' }),
+      marketplaceItem({ id: 2, name: 'github', displayName: 'GitHub' }),
+      marketplaceItem({ id: 3, name: 'slack', displayName: 'Slack' }),
+    ]
+
+    expect(rankMarketplaceSearchResults(items, 'github').map(item => item.id)).toEqual([2, 1])
+  })
+
+  test('marketplaceSearchScore returns null when nothing matches', () => {
+    expect(
+      marketplaceSearchScore(
+        marketplaceItem({ id: 1, name: 'slack', displayName: 'Slack' }),
+        'github'
+      )
+    ).toBeNull()
+  })
+
+  test('rankMarketplaceSearchResults returns all items for empty query', () => {
+    const items = [marketplaceItem({ id: 1, name: 'a' }), marketplaceItem({ id: 2, name: 'b' })]
+    expect(rankMarketplaceSearchResults(items, '  ')).toEqual(items)
+  })
+})

--- a/wework/src/features/plugins/marketplaceSearch.ts
+++ b/wework/src/features/plugins/marketplaceSearch.ts
@@ -1,0 +1,92 @@
+import type { PluginMarketplaceItem } from '@/types/api'
+
+const EXACT_NAME_SCORE = 400
+const NAME_PREFIX_SCORE = 300
+const NAME_CONTAINS_SCORE = 200
+const AUTHOR_OR_TAG_SCORE = 100
+
+interface MarketplaceSearchablePlugin {
+  name: string
+  displayName?: string | null
+  author?: string | null
+  ownerDisplayName?: string | null
+  manifest?: Record<string, unknown> | null
+  interface?: {
+    developerName?: string | null
+    category?: string | null
+  } | null
+}
+
+export function normalizeMarketplaceSearchQuery(value: string): string {
+  return value.trim().normalize('NFKC').toLocaleLowerCase()
+}
+
+function normalizedValues(values: Array<string | null | undefined>): string[] {
+  return values.map(value => normalizeMarketplaceSearchQuery(value ?? '')).filter(Boolean)
+}
+
+function valueContainsQuery(value: string, query: string): boolean {
+  return value.includes(query)
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === 'string') return value.trim() ? [value] : []
+  if (!Array.isArray(value)) return []
+  return value.filter(
+    (entry): entry is string => typeof entry === 'string' && Boolean(entry.trim())
+  )
+}
+
+function itemTags(item: MarketplaceSearchablePlugin): string[] {
+  const interfaceRecord = item.interface as Record<string, unknown> | null | undefined
+  const manifest = item.manifest ?? {}
+  return [
+    item.interface?.category,
+    ...stringValues(interfaceRecord?.tags),
+    ...stringValues(interfaceRecord?.keywords),
+    ...stringValues(interfaceRecord?.categories),
+    ...stringValues(manifest.tags),
+    ...stringValues(manifest.keywords),
+    ...stringValues(manifest.categories),
+  ].filter((value): value is string => Boolean(value))
+}
+
+export function marketplaceSearchScore(
+  item: MarketplaceSearchablePlugin,
+  query: string
+): number | null {
+  const normalizedQuery = normalizeMarketplaceSearchQuery(query)
+  if (!normalizedQuery) return 0
+
+  const names = normalizedValues([item.displayName, item.name])
+  if (names.some(name => name === normalizedQuery)) return EXACT_NAME_SCORE
+  if (names.some(name => name.startsWith(normalizedQuery))) return NAME_PREFIX_SCORE
+  if (names.some(name => valueContainsQuery(name, normalizedQuery))) return NAME_CONTAINS_SCORE
+
+  const authorAndTags = normalizedValues([
+    item.author,
+    item.ownerDisplayName,
+    item.interface?.developerName,
+    ...itemTags(item),
+  ])
+  return authorAndTags.some(value => valueContainsQuery(value, normalizedQuery))
+    ? AUTHOR_OR_TAG_SCORE
+    : null
+}
+
+export function rankMarketplaceSearchResults(
+  items: PluginMarketplaceItem[],
+  query: string
+): PluginMarketplaceItem[] {
+  const normalizedQuery = normalizeMarketplaceSearchQuery(query)
+  if (!normalizedQuery) return items
+
+  return items
+    .map((item, index) => ({ item, index, score: marketplaceSearchScore(item, normalizedQuery) }))
+    .filter(
+      (entry): entry is { item: PluginMarketplaceItem; index: number; score: number } =>
+        entry.score !== null
+    )
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .map(entry => entry.item)
+}

--- a/wework/src/features/plugins/marketplaceSearch.ts
+++ b/wework/src/features/plugins/marketplaceSearch.ts
@@ -8,12 +8,15 @@ const AUTHOR_OR_TAG_SCORE = 100
 interface MarketplaceSearchablePlugin {
   name: string
   displayName?: string | null
+  description?: string | null
   author?: string | null
   ownerDisplayName?: string | null
   manifest?: Record<string, unknown> | null
   interface?: {
     developerName?: string | null
     category?: string | null
+    shortDescription?: string | null
+    longDescription?: string | null
   } | null
 }
 
@@ -62,6 +65,15 @@ export function marketplaceSearchScore(
   if (names.some(name => name === normalizedQuery)) return EXACT_NAME_SCORE
   if (names.some(name => name.startsWith(normalizedQuery))) return NAME_PREFIX_SCORE
   if (names.some(name => valueContainsQuery(name, normalizedQuery))) return NAME_CONTAINS_SCORE
+
+  const descriptions = normalizedValues([
+    item.description,
+    item.interface?.shortDescription,
+    item.interface?.longDescription,
+  ])
+  if (descriptions.some(value => valueContainsQuery(value, normalizedQuery))) {
+    return AUTHOR_OR_TAG_SCORE
+  }
 
   const authorAndTags = normalizedValues([
     item.author,

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1752,7 +1752,6 @@ export function WorkbenchProvider({
         let apps = await loadComposerPluginApps({
           listCodexApps: () => localPluginApi.listApps(),
           readLocalInstalledPlugins: async () => {
-            const response = await localPluginApi.listInstalledPlugins()
             currentComposerDeviceId =
               peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId ||
               peekLocalCodexPluginsReadState()?.deviceId ||
@@ -1765,7 +1764,16 @@ export function WorkbenchProvider({
                 currentComposerDeviceId = null
               }
             }
-            return response.items
+            try {
+              const response = await localPluginApi.listInstalledPlugins()
+              currentComposerDeviceId =
+                peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId ||
+                peekLocalCodexPluginsReadState()?.deviceId ||
+                currentComposerDeviceId
+              return response.items
+            } catch {
+              return []
+            }
           },
           listCloudInstalledPlugins: () =>
             cloudPluginApi

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -27,7 +27,7 @@ import { requestNewChatComposerFocus } from '@/lib/workbenchComposerFocus'
 import { installLocalWorkspaceOpenListener } from '@/tauri/localWorkspaceOpen'
 import { installMainRuntimeWorkChangedListener } from '@/tauri/runtimeWorkSync'
 import { disposeTauriListener } from '@/tauri/disposeTauriListener'
-import { createLocalCodexPluginApi } from '@/api/local/codexPlugins'
+import { createLocalCodexPluginApi, peekLocalCodexPluginsReadState } from '@/api/local/codexPlugins'
 import { createHttpClient } from '@/api/http'
 import { createPluginApi } from '@/api/plugins'
 import { listWegentInstalledConnectorApps } from '@/api/cloud/connectorApps'
@@ -39,7 +39,7 @@ import {
 } from '@/components/chat/composer/composerAppsSnapshot'
 import { isSystemApplicationConnectorSlug } from '@/features/plugins/builtinPlugins'
 import { loadComposerPluginApps } from '@/features/plugins/loadComposerPluginApps'
-import { requestLocalExecutor } from '@/tauri/localExecutor'
+import { ensureLocalExecutorStarted, requestLocalExecutor } from '@/tauri/localExecutor'
 import type {
   LocalDeviceApp,
   LocalDeviceSkill,
@@ -1745,16 +1745,28 @@ export function WorkbenchProvider({
 
       const loadGeneration = localAppsLoadGenerationRef.current
       const loadPromise = (async () => {
-        // Cloud installs must not depend on Codex readState succeeding — that was
-        // wiping the toolbar plugin button whenever local plugin state failed.
+        // Composer only needs installed membership. Never await Codex plugin/list
+        // here — it reconciles for ~10s and stalls turns on the shared app-server
+        // (regression vs fix/wework stop-blocking-send-on-plugin-prep).
         let currentComposerDeviceId: string | null = null
         let apps = await loadComposerPluginApps({
           listCodexApps: () => localPluginApi.listApps(),
-          readLocalInstalledPlugins: () =>
-            localPluginApi.readState().then(state => {
-              currentComposerDeviceId = state.deviceId
-              return state.installedPlugins
-            }),
+          readLocalInstalledPlugins: async () => {
+            const response = await localPluginApi.listInstalledPlugins()
+            currentComposerDeviceId =
+              peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId ||
+              peekLocalCodexPluginsReadState()?.deviceId ||
+              null
+            if (!currentComposerDeviceId) {
+              try {
+                const status = await ensureLocalExecutorStarted()
+                currentComposerDeviceId = status.deviceId?.trim() || null
+              } catch {
+                currentComposerDeviceId = null
+              }
+            }
+            return response.items
+          },
           listCloudInstalledPlugins: () =>
             cloudPluginApi
               .listInstalledPlugins(currentComposerDeviceId ?? undefined)


### PR DESCRIPTION
## Summary
- Speed up Wework plugin marketplace first paint: durable peek, progressive catalog merge, disk-backed personal marketplace listing, and batched backend access checks (avoid N+1).
- Harden install/detail consistency: account `pluginId` drives marketplace card `installed`, installed-strip opens enriched marketplace detail, and cloud installs paint before slow Codex `plugin/list`.
- Fix review regressions: paint installed strip even when catalog is still empty; keep `plugin/installed` refreshes in memory only so they do not clobber the durable readState snapshot.

## Test plan
- [ ] Open Plugins marketplace cold: OpenAI/personal tabs paint from peek/disk without waiting ~10s on `plugin/list`
- [ ] With cloud plugins already installed: installed strip shows before marketplace catalog finishes
- [ ] Install a cloud plugin: card switches to installed; strip and detail stay consistent
- [ ] Open an installed-strip item: detail uses marketplace-enriched content when available
- [ ] Composer plugin picker still lists apps without blocking on `plugin/list`
- [ ] `pnpm --filter wework exec vitest run` on marketplace-related tests
- [ ] `cd backend && uv run pytest tests/services/test_plugin_marketplace_v2.py`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Personal marketplace plugins now appear directly from local storage with installation status and metadata.
  - Marketplace results load progressively from local, installed, and cloud sources.
  - Search ranks matches across names, descriptions, authors, developers, and tags.
  - Installed plugins more reliably link to marketplace details.
  - Plugin data loads faster with caching, background refresh, and request deduplication.

- **Bug Fixes**
  - Improved handling of duplicate personal marketplace entries and official marketplace identification.
  - Marketplace installation states now remain accurate while installs or authorization are in progress.
  - Composer warnings now include plugin names, enabled status, and installation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->