### PR TITLE
feat: 普通“新建任务”（侧边栏的独立会话）现在只会选择本地设备，不会再从云设备/本地设备里挑。

### DIFF
--- a/wework/src/components/chat/composer/project-work-bar-utils.ts
+++ b/wework/src/components/chat/composer/project-work-bar-utils.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeDeviceWorkspace,
 } from '@/types/api'
 import { supportsGitWorktreeExecution } from '@/lib/projectClassification'
+import { isLocalStandaloneDevice } from '@/lib/device-selection'
 
 const PROJECT_MENU_VIEWPORT_MARGIN = 16
 const PROJECT_MENU_VERTICAL_PADDING = 12
@@ -62,9 +63,7 @@ export function getProjectDeviceId(project: ProjectWithTasks): string | undefine
   return project.config?.execution?.deviceId ?? project.config?.device_id
 }
 
-export function isLocalStandaloneDevice(device: DeviceInfo): boolean {
-  return device.device_type !== 'cloud' && device.device_type !== 'remote'
-}
+export { isLocalStandaloneDevice }
 
 export function isLocalProjectWorkspaceDevice(device: DeviceInfo | undefined): boolean {
   return Boolean(device && isLocalStandaloneDevice(device))

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -4526,4 +4526,42 @@ describe('DesktopSidebar', () => {
     expect(screen.queryByTestId('project-item-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('runtime-local-task-row-standalone-task')).toBeInTheDocument()
   })
+
+  test('does not render a standalone project row when the path is already represented on another device', () => {
+    const workspacePath = '/Users/alice/repo'
+
+    renderSidebar({
+      projects: [],
+      devices: [localDevice({ device_id: 'device-1', name: 'Local Mac' })],
+      standaloneDeviceId: 'device-1',
+      standaloneWorkspacePath: workspacePath,
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, key: 'cloud-project', name: 'Repo' },
+            totalTasks: 0,
+            deviceWorkspaces: [
+              {
+                id: 10,
+                projectId: 7,
+                deviceId: 'device-cloud',
+                deviceName: 'Cloud Device',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath,
+                workspaceKind: 'workspace',
+                mapped: true,
+                tasks: [],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 0,
+      },
+    })
+
+    expect(screen.getAllByTestId('project-item-button')).toHaveLength(1)
+    expect(screen.getByTestId('project-item-button')).toHaveTextContent('Repo')
+  })
 })

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -350,14 +350,19 @@ function getSidebarPathBasename(path: string): string {
   return parts.at(-1) ?? normalizedPath
 }
 
+/**
+ * Whether any project or chat already represents the workspace path.
+ *
+ * The standalone row must not duplicate a workspace that is already visible
+ * under another device route: the same path can be opened as both a local and
+ * an aliased cloud project, and the workbench deduplicates them into one row.
+ */
 function runtimeWorkHasWorkspace(
   runtimeWork: RuntimeWorkListResponse | null | undefined,
-  deviceId: string,
   workspacePath: string
 ): boolean {
   const normalizedPath = normalizeSidebarWorkspacePath(workspacePath)
   const hasMatchingWorkspace = (workspace: RuntimeDeviceWorkspace) =>
-    workspace.deviceId === deviceId &&
     normalizeSidebarWorkspacePath(workspace.workspacePath) === normalizedPath
 
   return (
@@ -376,7 +381,7 @@ function standaloneRuntimeProjectWork(
   const normalizedDeviceId = deviceId?.trim()
   const normalizedWorkspacePath = workspacePath ? normalizeSidebarWorkspacePath(workspacePath) : ''
   if (!normalizedDeviceId || !normalizedWorkspacePath) return null
-  if (runtimeWorkHasWorkspace(runtimeWork, normalizedDeviceId, normalizedWorkspacePath)) {
+  if (runtimeWorkHasWorkspace(runtimeWork, normalizedWorkspacePath)) {
     return null
   }
 

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -847,6 +847,9 @@ function ProjectSendProbe() {
           .map(projectWork => projectWork.project.name)
           .join('|') ?? ''}
       </span>
+      <span data-testid="runtime-project-count">
+        {workbench.state.runtimeWork?.projects.length ?? 0}
+      </span>
       <span data-testid="runtime-chat-workspaces">
         {workbench.state.runtimeWork?.chats.map(workspace => workspace.workspacePath).join('|') ??
           ''}
@@ -994,6 +997,14 @@ function ProjectSendProbe() {
         }
       >
         open cloud standalone workspace
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void workbench.openStandaloneWorkspace('device-local', '/workspace/cloud', 'Cloud Repo')
+        }
+      >
+        open local workspace over cloud path
       </button>
       <button type="button" onClick={() => paneSession.setInput('修复 CI')}>
         set input
@@ -6093,6 +6104,115 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(runtimeWorkApi.listRuntimeWork.mock.calls.length).toBeGreaterThan(1))
     expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('device-cloud')
     expect(screen.getByTestId('standalone-workspace-path')).toHaveTextContent('/workspace/cloud')
+  })
+
+  test('deduplicates a fresh local project over an aliased cloud workspace after refresh', async () => {
+    const localDevice = createDevice({
+      id: 31,
+      device_id: 'device-local',
+      name: 'This Mac',
+      device_type: 'local',
+    })
+    const cloudDevice = createDevice({
+      id: 32,
+      device_id: 'device-cloud',
+      name: 'Cloud Device',
+      device_type: 'cloud',
+    })
+    const localRuntimeWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { key: 'local-project', name: 'Cloud Repo' },
+          deviceWorkspaces: [
+            {
+              id: null,
+              projectId: null,
+              deviceId: 'device-local',
+              deviceName: 'This Mac',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/cloud',
+              mapped: true,
+              available: true,
+              tasks: [
+                {
+                  taskId: 'local-task-1',
+                  workspacePath: '/workspace/cloud',
+                  title: 'Local task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        },
+      ],
+      chats: [],
+      totalTasks: 1,
+    }
+    const cloudRuntimeWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { id: 50, key: 'cloud-project', name: 'Cloud Repo' },
+          deviceWorkspaces: [
+            {
+              id: 51,
+              projectId: 50,
+              deviceId: 'device-cloud',
+              deviceName: 'Cloud Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/cloud',
+              mapped: true,
+              available: true,
+              tasks: [],
+            },
+          ],
+          totalTasks: 0,
+        },
+      ],
+      chats: [],
+      totalTasks: 0,
+    }
+    const cloudListDevices = vi
+      .fn()
+      .mockResolvedValueOnce([cloudDevice])
+      .mockResolvedValue([{ ...cloudDevice, app_device_id: 'device-local' }])
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(localRuntimeWork),
+      openRuntimeWorkspace: vi.fn().mockImplementation(async ({ deviceId, workspacePath }) => ({
+        accepted: true,
+        deviceId,
+        workspacePath,
+        runtime: 'codex',
+      })),
+    })
+    const services = createWorkbenchServices({
+      deviceApi: {
+        listDevices: vi.fn().mockResolvedValue([localDevice, cloudDevice]),
+      } as Partial<WorkbenchServices['deviceApi']> as WorkbenchServices['deviceApi'],
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      cloudBackgroundApi: {
+        listTeams: vi.fn().mockResolvedValue([]),
+        listDevices: cloudListDevices,
+        listRuntimeWork: vi.fn().mockResolvedValue(cloudRuntimeWork),
+      },
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(screen.getByText('open cloud standalone workspace'))
+    await waitFor(() => expect(runtimeWorkApi.openRuntimeWorkspace).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('device-cloud')
+
+    await userEvent.click(screen.getByText('open local workspace over cloud path'))
+    await waitFor(() => expect(runtimeWorkApi.openRuntimeWorkspace).toHaveBeenCalledTimes(2))
+
+    await userEvent.click(screen.getByText('refresh work lists'))
+    await waitFor(() => expect(runtimeWorkApi.listRuntimeWork.mock.calls.length).toBeGreaterThan(1))
+    await waitFor(() => expect(cloudListDevices.mock.calls.length).toBeGreaterThan(1))
+
+    // The local and cloud copies of the same workspace must collapse into one project.
+    expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('device-local')
   })
 
   test('opens a standalone runtime project first without refreshing the runtime list', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -983,6 +983,18 @@ function ProjectSendProbe() {
       >
         open cli local-device workspace
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          void workbench.openStandaloneWorkspace(
+            'device-cloud',
+            '/workspace/cloud',
+            'Cloud Workspace'
+          )
+        }
+      >
+        open cloud standalone workspace
+      </button>
       <button type="button" onClick={() => paneSession.setInput('修复 CI')}>
         set input
       </button>
@@ -6039,6 +6051,48 @@ describe('WorkbenchProvider runtime tasks', () => {
         message: '修复 CI',
       })
     )
+  })
+
+  test('keeps the opened cloud standalone workspace device after a work list refresh', async () => {
+    const cloudDevice = createDevice({
+      id: 21,
+      device_id: 'device-cloud',
+      name: 'Cloud Device',
+      device_type: 'cloud',
+    })
+    const localDevice = createDevice({
+      id: 22,
+      device_id: 'device-local',
+      name: 'This Mac',
+      device_type: 'local',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(createRuntimeWork({ projects: [] })),
+      openRuntimeWorkspace: vi.fn().mockResolvedValue({
+        accepted: true,
+        deviceId: 'device-cloud',
+        workspacePath: '/workspace/cloud',
+        runtime: 'codex',
+      }),
+    })
+    const services = createWorkbenchServices({
+      deviceApi: {
+        listDevices: vi.fn().mockResolvedValue([cloudDevice, localDevice]),
+      } as Partial<WorkbenchServices['deviceApi']> as WorkbenchServices['deviceApi'],
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(screen.getByText('open cloud standalone workspace'))
+    await waitFor(() => expect(runtimeWorkApi.openRuntimeWorkspace).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('device-cloud')
+    expect(screen.getByTestId('standalone-workspace-path')).toHaveTextContent('/workspace/cloud')
+
+    await userEvent.click(screen.getByText('refresh work lists'))
+    await waitFor(() => expect(runtimeWorkApi.listRuntimeWork.mock.calls.length).toBeGreaterThan(1))
+    expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('device-cloud')
+    expect(screen.getByTestId('standalone-workspace-path')).toHaveTextContent('/workspace/cloud')
   })
 
   test('opens a standalone runtime project first without refreshing the runtime list', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -5888,6 +5888,11 @@ describe('WorkbenchProvider runtime tasks', () => {
 
   test('creates a conversation workspace when sending without a selected project', async () => {
     vi.setSystemTime(new Date('2026-06-25T09:30:00.000Z'))
+    const localDevice = createDevice({
+      device_id: 'device-1',
+      device_type: 'local',
+      is_default: true,
+    })
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(createRuntimeWork({ projects: [], chats: [] })),
       createRuntimeTask: vi.fn().mockResolvedValue({
@@ -5900,6 +5905,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     })
     const services = createWorkbenchServices({
       deviceApi: {
+        listDevices: vi.fn().mockResolvedValue([localDevice]),
         getHomeDirectory: vi.fn().mockResolvedValue('/Users/alice'),
         createDirectory: vi.fn().mockResolvedValue(undefined),
       } as Partial<WorkbenchServices['deviceApi']> as WorkbenchServices['deviceApi'],

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -46,6 +46,25 @@ import {
 } from './remoteRuntimeWorkCache'
 import { normalizeRuntimeWorkspacePath, runtimeProjectUiId } from '@/lib/runtime-project'
 
+/**
+ * Resolve the standalone device after a device or runtime-work refresh.
+ *
+ * While a standalone workspace is open its device must be preserved verbatim:
+ * the workspace may belong to a cloud or remote device that the standalone-task
+ * preference intentionally excludes. Re-picking a local device here would
+ * render a phantom local project row next to the real remote workspace.
+ */
+function resolveStandaloneDeviceIdForRefresh(
+  devices: DeviceInfo[],
+  standaloneDeviceId: string | null | undefined,
+  standaloneWorkspacePath: string | null | undefined
+): string | null {
+  if (standaloneWorkspacePath && standaloneDeviceId) {
+    return standaloneDeviceId
+  }
+  return getPreferredStandaloneDeviceId(devices, standaloneDeviceId)
+}
+
 interface UseWorkbenchDataRefreshOptions {
   user: User
   state: WorkbenchState
@@ -315,6 +334,7 @@ export function useWorkbenchDataRefresh({
       options?: {
         projects: ProjectWithTasks[]
         standaloneDeviceId: string | null
+        standaloneWorkspacePath?: string | null
         trigger?: 'bootstrap' | 'manual-refresh' | 'device-event'
         isCancelled?: () => boolean
       }
@@ -390,9 +410,10 @@ export function useWorkbenchDataRefresh({
           dispatch({
             type: 'devices_refreshed',
             devices,
-            standaloneDeviceId: getPreferredStandaloneDeviceId(
+            standaloneDeviceId: resolveStandaloneDeviceIdForRefresh(
               devices,
-              options?.standaloneDeviceId ?? null
+              options?.standaloneDeviceId ?? null,
+              options?.standaloneWorkspacePath
             ),
           })
         }
@@ -480,9 +501,10 @@ export function useWorkbenchDataRefresh({
           projects: options?.projects ?? [],
           devices,
           runtimeWork,
-          standaloneDeviceId: getPreferredStandaloneDeviceId(
+          standaloneDeviceId: resolveStandaloneDeviceIdForRefresh(
             devices,
-            options?.standaloneDeviceId ?? null
+            options?.standaloneDeviceId ?? null,
+            options?.standaloneWorkspacePath
           ),
         })
       } finally {
@@ -641,15 +663,17 @@ export function useWorkbenchDataRefresh({
         projects: state.projects,
         devices: visibleDevices,
         runtimeWork,
-        standaloneDeviceId: getPreferredStandaloneDeviceId(
+        standaloneDeviceId: resolveStandaloneDeviceIdForRefresh(
           visibleDevices,
-          state.standaloneDeviceId
+          state.standaloneDeviceId,
+          state.standaloneWorkspacePath
         ),
       })
       if (options?.syncCloud !== false) {
         void refreshCloudBackgroundData(devices, localRuntimeWork, {
           projects: state.projects,
           standaloneDeviceId: state.standaloneDeviceId,
+          standaloneWorkspacePath: state.standaloneWorkspacePath,
           trigger: 'manual-refresh',
         }).catch(() => undefined)
       }
@@ -666,6 +690,7 @@ export function useWorkbenchDataRefresh({
       state.projects,
       state.runtimeWork,
       state.standaloneDeviceId,
+      state.standaloneWorkspacePath,
     ]
   )
 
@@ -746,11 +771,16 @@ export function useWorkbenchDataRefresh({
       dispatch({
         type: 'devices_refreshed',
         devices,
-        standaloneDeviceId: getPreferredStandaloneDeviceId(devices, state.standaloneDeviceId),
+        standaloneDeviceId: resolveStandaloneDeviceIdForRefresh(
+          devices,
+          state.standaloneDeviceId,
+          state.standaloneWorkspacePath
+        ),
       })
       void refreshCloudBackgroundData(devices, state.runtimeWork ?? EMPTY_RUNTIME_WORK, {
         projects: state.projects,
         standaloneDeviceId: state.standaloneDeviceId,
+        standaloneWorkspacePath: state.standaloneWorkspacePath,
         trigger: 'manual-refresh',
       }).catch(() => undefined)
     },
@@ -761,6 +791,7 @@ export function useWorkbenchDataRefresh({
       state.projects,
       state.runtimeWork,
       state.standaloneDeviceId,
+      state.standaloneWorkspacePath,
     ]
   )
 

--- a/wework/src/lib/device-selection.test.ts
+++ b/wework/src/lib/device-selection.test.ts
@@ -5,6 +5,20 @@ import {
 } from './device-selection'
 
 describe('device-selection', () => {
+  function selectableDevice(
+    overrides: Partial<Parameters<typeof isWeWorkSelectableStandaloneDevice>[0]> = {}
+  ) {
+    return {
+      device_id: 'device-1',
+      name: 'Device',
+      status: 'online',
+      device_type: 'local',
+      bind_shell: 'claudecode',
+      executor_version: '1.8.5',
+      ...overrides,
+    }
+  }
+
   test('does not select an online standalone device below the WeWork executor version', () => {
     const devices = [
       {
@@ -27,5 +41,50 @@ describe('device-selection', () => {
 
     expect(isWeWorkSelectableStandaloneDevice(devices[0])).toBe(false)
     expect(getPreferredStandaloneDeviceId(devices, 'old-device')).toBe('new-device')
+  })
+
+  test('prefers the local device when cloud and local devices are both selectable', () => {
+    const devices = [
+      selectableDevice({ device_id: 'cloud-device', name: 'Cloud Device', device_type: 'cloud' }),
+      selectableDevice({ device_id: 'local-device', name: 'Local Device', device_type: 'local' }),
+    ]
+
+    expect(getPreferredStandaloneDeviceId(devices)).toBe('local-device')
+  })
+
+  test('does not fall back to a remembered cloud device while a local device is selectable', () => {
+    const devices = [
+      selectableDevice({ device_id: 'cloud-device', name: 'Cloud Device', device_type: 'cloud' }),
+      selectableDevice({ device_id: 'local-device', name: 'Local Device', device_type: 'local' }),
+    ]
+
+    expect(getPreferredStandaloneDeviceId(devices, 'cloud-device')).toBe('local-device')
+  })
+
+  test('returns null when only cloud devices are selectable', () => {
+    const devices = [
+      selectableDevice({ device_id: 'cloud-device', name: 'Cloud Device', device_type: 'cloud' }),
+      selectableDevice({
+        device_id: 'remote-device',
+        name: 'Remote Device',
+        device_type: 'remote',
+      }),
+    ]
+
+    expect(getPreferredStandaloneDeviceId(devices)).toBeNull()
+  })
+
+  test('does not select a local device below the WeWork executor version when a cloud device is compatible', () => {
+    const devices = [
+      selectableDevice({ device_id: 'cloud-device', name: 'Cloud Device', device_type: 'cloud' }),
+      selectableDevice({
+        device_id: 'old-local-device',
+        name: 'Old Local Device',
+        device_type: 'local',
+        executor_version: '1.8.4',
+      }),
+    ]
+
+    expect(getPreferredStandaloneDeviceId(devices)).toBeNull()
   })
 })

--- a/wework/src/lib/device-selection.ts
+++ b/wework/src/lib/device-selection.ts
@@ -21,10 +21,17 @@ export function isCloudDevice(device: SelectableDevice): boolean {
   return device.device_type === 'cloud'
 }
 
+export function isLocalStandaloneDevice(device: Pick<SelectableDevice, 'device_type'>): boolean {
+  return device.device_type !== 'cloud' && device.device_type !== 'remote'
+}
+
 export function isWeWorkSelectableStandaloneDevice(device: SelectableDevice): boolean {
-  return isClaudeCodeDevice(device) &&
+  return (
+    isLocalStandaloneDevice(device) &&
+    isClaudeCodeDevice(device) &&
     isOnlineDevice(device) &&
     isWeWorkExecutorVersionCompatible(device.executor_version)
+  )
 }
 
 export function sortStandaloneDevices<T extends SelectableDevice>(devices: T[]): T[] {
@@ -37,9 +44,9 @@ export function sortStandaloneDevices<T extends SelectableDevice>(devices: T[]):
     const rightCompatible = isWeWorkExecutorVersionCompatible(right.executor_version) ? 0 : 1
     if (leftCompatible !== rightCompatible) return leftCompatible - rightCompatible
 
-    const leftCloud = isOnlineDevice(left) && isCloudDevice(left) ? 0 : 1
-    const rightCloud = isOnlineDevice(right) && isCloudDevice(right) ? 0 : 1
-    if (leftCloud !== rightCloud) return leftCloud - rightCloud
+    const leftLocal = isLocalStandaloneDevice(left) ? 0 : 1
+    const rightLocal = isLocalStandaloneDevice(right) ? 0 : 1
+    if (leftLocal !== rightLocal) return leftLocal - rightLocal
 
     return (left.name || left.device_id).localeCompare(right.name || right.device_id)
   })
@@ -47,7 +54,7 @@ export function sortStandaloneDevices<T extends SelectableDevice>(devices: T[]):
 
 export function getPreferredStandaloneDeviceId(
   devices: SelectableDevice[],
-  currentDeviceId?: string | null,
+  currentDeviceId?: string | null
 ): string | null {
   const currentDevice = currentDeviceId
     ? devices.find(device => device.device_id === currentDeviceId)


### PR DESCRIPTION
## 背景

普通“新建任务”（侧边栏的独立会话）是本地编码会话，应当固定跑在本机设备上。此前设备选择会在云设备 / 本地设备之间挑选，甚至可能回退到记忆中的云设备，导致任务被分配到云设备上执行。

## 改动

- `wework/src/lib/device-selection.ts`：抽出 `isLocalStandaloneDevice`（排除 `cloud` / `remote`），`isWeWorkSelectableStandaloneDevice` 只接受本地独立设备；`sortStandaloneDevices` 排序改为本地设备优先，不再把云设备排在前面；有可用本地设备时不再回退到历史云设备。
- `wework/src/components/chat/composer/project-work-bar-utils.ts`：复用 `device-selection` 里的 `isLocalStandaloneDevice`，删除重复实现。
- `wework/src/features/workbench/useWorkbenchDataRefresh.ts`：设备/runtime-work 刷新时，若存在已打开的 standalone workspace，保留其设备（例如云端工作区），不再被本地优先规则改写成本地设备。
- `wework/src/components/layout/DesktopSidebar.tsx`：standalone 项目行不再与已存在的同路径工作区重复渲染；同路径的本地项目与（别名后的）云端项目只显示一行。
- 新增/更新单测：覆盖“本地设备优先”“不回落云设备”“仅有云/远程设备时返回 null”“本地设备低于 WeWork executor 版本时不选”“打开云端工作区后刷新仍保留云设备”“同路径已存在其他设备工作区时不渲染 standalone 行”等场景。

## 影响

用户从侧边栏新建独立会话时，任务只会选择本地设备，行为与“本地编码”语义一致；已打开的云端/远程工作区不受影响，也不会出现重复项目行。

## 验证

- 相关单测：`device-selection`、`WorkbenchProvider`、`DesktopSidebar` 共 253 个用例全部通过
- Prettier / ESLint 检查通过
- 对照实验：不含本改动（main + 注释）的 Cloud E2E 两次通过，含本改动的 Cloud E2E 暴露重复项目行回归；修复后 CI 重新验证中
- 真实 Tauri 桌面验证（`ai:verify`）尚未在本会话执行，合入前可补跑


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved device selection to prioritize compatible local devices.
  * Local standalone devices are now identified consistently across the app.
  * Cloud workspaces are handled more reliably when no local device is available.
  * Device selection now better accounts for online status and compatibility.
  * Preserved the selected workspace and path during refreshes.
  * Prevented duplicate project entries when the same workspace path is already represented.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->