### PR TITLE
chore: control run for wework cloud e2e

### DIFF
--- a/wework/src/lib/device-selection.ts
+++ b/wework/src/lib/device-selection.ts
@@ -1,3 +1,4 @@
+// Control run for the Wework desktop cloud E2E. No behavior change.
 import { isWeWorkExecutorVersionCompatible } from './device-capabilities'
 
 export interface SelectableDevice {
@@ -22,9 +23,11 @@ export function isCloudDevice(device: SelectableDevice): boolean {
 }
 
 export function isWeWorkSelectableStandaloneDevice(device: SelectableDevice): boolean {
-  return isClaudeCodeDevice(device) &&
+  return (
+    isClaudeCodeDevice(device) &&
     isOnlineDevice(device) &&
     isWeWorkExecutorVersionCompatible(device.executor_version)
+  )
 }
 
 export function sortStandaloneDevices<T extends SelectableDevice>(devices: T[]): T[] {
@@ -47,7 +50,7 @@ export function sortStandaloneDevices<T extends SelectableDevice>(devices: T[]):
 
 export function getPreferredStandaloneDeviceId(
   devices: SelectableDevice[],
-  currentDeviceId?: string | null,
+  currentDeviceId?: string | null
 ): string | null {
   const currentDevice = currentDeviceId
     ? devices.find(device => device.device_id === currentDeviceId)


### PR DESCRIPTION
Control experiment for the failing `Wework Desktop E2E (Cloud)` check on PR #2550.

- Base: main (`8ac761739`)
- Change: one comment line in `wework/src/lib/device-selection.ts` — no behavior change.
- Purpose: determine whether the Cloud E2E duplicate-project-row failure reproduces without the device-selection change from #2550.

This draft PR will be closed after the check result is recorded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a control-run note for the Wework desktop cloud end-to-end test process.

* **Style**
  * Reformatted device-selection logic without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->