### PR TITLE
fix(backend): inject executionRequest into runtime send for IM continuation

### DIFF
--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -573,20 +573,14 @@ async def send_runtime_message(
         payload["requestUserInputResponse"] = request.request_user_input_response
     if request.additional_context:
         payload["additionalContext"] = request.additional_context
-    try:
-        result = await runtime_rpc_service.call(
-            user_id=user_id,
-            device_id=address.device_id,
-            method="runtime.tasks.send",
-            payload=payload,
-            timeout_seconds=RUNTIME_SEND_TIMEOUT_SECONDS,
-        )
-    except RuntimeRpcError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=str(exc),
-        ) from exc
-    return _runtime_send_response(result, address.local_task_id)
+    return await _dispatch_runtime_send(
+        db=db,
+        user_id=user_id,
+        address=address,
+        payload=payload,
+        request=request,
+        rpc_method="runtime.tasks.send",
+    )
 
 
 async def interrupt_and_send_runtime_message(
@@ -611,11 +605,49 @@ async def interrupt_and_send_runtime_message(
         payload["source"] = request.source.model_dump()
     if request.additional_context:
         payload["additionalContext"] = request.additional_context
+    return await _dispatch_runtime_send(
+        db=db,
+        user_id=user_id,
+        address=address,
+        payload=payload,
+        request=request,
+        rpc_method="runtime.tasks.interrupt_and_send",
+    )
+
+
+async def _dispatch_runtime_send(
+    *,
+    db: Session,
+    user_id: int,
+    address: RuntimeTaskAddress,
+    payload: dict[str, Any],
+    request: RuntimeSendRequest,
+    rpc_method: str,
+) -> RuntimeSendResponse:
+    """Send a runtime task message with a best-effort executionRequest payload.
+
+    The executor requires ``executionRequest`` to spawn a new turn (it carries
+    model config, user info, skills, etc.). The Wework frontend builds this
+    client-side for direct local sends; the IM continuation path flows through
+    the backend RPC, so we synthesize a minimal request here from the default
+    task-mode team. Failures to build the request are non-fatal — the payload
+    is still forwarded so existing tasks that don't need a fresh turn (e.g.
+    request-user-input responses) keep working.
+    """
+    execution_request = _safe_build_runtime_send_execution_request(
+        db=db,
+        user_id=user_id,
+        address=address,
+        message=request.message,
+        attachment_ids=request.attachment_ids,
+    )
+    if execution_request is not None:
+        payload["executionRequest"] = execution_request.to_dict()
     try:
         result = await runtime_rpc_service.call(
             user_id=user_id,
             device_id=address.device_id,
-            method="runtime.tasks.interrupt_and_send",
+            method=rpc_method,
             payload=payload,
             timeout_seconds=RUNTIME_SEND_TIMEOUT_SECONDS,
         )
@@ -2205,7 +2237,15 @@ async def _runtime_task_title_for_address(
     expected_task_id = str(address.local_task_id).strip()
     if not expected_task_id:
         return None
+    expected_workspace_path = (
+        normalize_workspace_path(address.workspace_path)
+        if address.workspace_path
+        else None
+    )
     for workspace in _iter_runtime_workspaces(result):
+        workspace_path = normalize_workspace_path(workspace["workspacePath"])
+        if expected_workspace_path and workspace_path != expected_workspace_path:
+            continue
         for task in workspace["tasks"]:
             if not isinstance(task, dict):
                 continue
@@ -3824,6 +3864,138 @@ def _get_team(db: Session, user_id: int, team_id: int) -> Kind:
             detail="Team not found",
         )
     return team
+
+
+def _get_task_mode_team(db: Session, user_id: int) -> Optional[Kind]:
+    """Resolve the default task-mode team (e.g. wegent-wework#default).
+
+    Mirrors ``IMChannelHandler._get_task_mode_team`` so the IM continuation
+    path uses the same default agent as the Wework workbench.
+    """
+    from app.services.readers.kinds import KindType, kindReader
+
+    config_value = settings.DEFAULT_TEAM_TASK
+    if not config_value or not config_value.strip():
+        return None
+    parts = config_value.strip().split("#", 1)
+    name = parts[0].strip()
+    namespace = parts[1].strip() if len(parts) > 1 else "default"
+    if not name:
+        return None
+    return kindReader.get_by_name_and_namespace(
+        db, user_id, KindType.TEAM, namespace, name
+    )
+
+
+def _build_runtime_send_execution_request(
+    *,
+    db: Session,
+    user_id: int,
+    address: RuntimeTaskAddress,
+    message: str,
+    attachment_ids: list[int],
+):
+    """Build an executor request for an IM continuation send.
+
+    The executor's ``runtime.tasks.send`` handler requires an
+    ``executionRequest`` to spawn a new turn (model config, user info,
+    skills, workspace, etc.). The Wework frontend constructs this
+    client-side for direct local sends; the IM continuation path flows
+    through the backend RPC, so we synthesize one here from the default
+    task-mode team — the same agent the workbench uses.
+    """
+    from app.services.execution import TaskRequestBuilder
+
+    user = _get_user(db, user_id)
+    team = _get_task_mode_team(db, user_id)
+    if team is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Default task-mode team is not configured",
+        )
+    task_id, subtask_id = _runtime_execution_ids()
+    target = RuntimeTaskTarget(
+        device_id=address.device_id,
+        workspace_path=address.workspace_path or "",
+        project=None,
+        workspace_source="local_path",
+    )
+    request = SimpleNamespace(
+        message=message,
+        additional_context=None,
+        additional_skills=[],
+        attachment_ids=attachment_ids,
+        model_id=None,
+        model_type=None,
+        model_options={},
+        runtime="codex",
+    )
+    task = _runtime_task_context(
+        user_id=user_id,
+        task_id=task_id,
+        request=request,
+        target=target,
+        team=team,
+    )
+    subtask = _runtime_assistant_context(
+        user_id=user_id,
+        task_id=task_id,
+        subtask_id=subtask_id,
+        request=request,
+        team=team,
+    )
+    payload = _runtime_execution_payload(request)
+    runtime_model_config, override_model_name, force_override = _runtime_model_override(
+        db,
+        user_id,
+        request,
+    )
+    execution_request = TaskRequestBuilder(db).build(
+        subtask=subtask,
+        task=task,
+        user=user,
+        team=team,
+        message=_message_with_application_context(message, None),
+        preload_skills=request.additional_skills,
+        override_model_name=override_model_name,
+        force_override=force_override,
+        runtime_model_config=runtime_model_config,
+        web_runtime_guidance=True,
+    )
+    _apply_runtime_task_target(execution_request, target)
+    _apply_runtime_model_options(db, execution_request, user, payload)
+    _apply_runtime_attachments(db, execution_request, user_id, attachment_ids)
+    return execution_request
+
+
+def _safe_build_runtime_send_execution_request(
+    *,
+    db: Session,
+    user_id: int,
+    address: RuntimeTaskAddress,
+    message: str,
+    attachment_ids: list[int],
+):
+    """Best-effort wrapper around _build_runtime_send_execution_request.
+
+    Returns ``None`` on failure so the send payload is still forwarded
+    without an ``executionRequest`` — the executor can handle cases that
+    don't need a fresh turn (e.g. request-user-input responses).
+    """
+    try:
+        return _build_runtime_send_execution_request(
+            db=db,
+            user_id=user_id,
+            address=address,
+            message=message,
+            attachment_ids=attachment_ids,
+        )
+    except Exception:
+        logger.warning(
+            "[RuntimeWork] Failed to build executionRequest for runtime send",
+            exc_info=True,
+        )
+        return None
 
 
 def _ensure_owned_device(db: Session, user_id: int, device_id: str) -> None:

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -1782,6 +1782,11 @@ async def test_send_runtime_message_normalizes_runtime_rpc_failure_without_task_
         }
     )
     monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+    monkeypatch.setattr(
+        runtime_work_service,
+        "_safe_build_runtime_send_execution_request",
+        lambda **kwargs: None,
+    )
 
     response = await runtime_work_service.send_runtime_message(
         db=test_db,
@@ -1990,6 +1995,11 @@ async def test_send_runtime_message_forwards_ready_attachments_without_task_rows
     )
     rpc = AsyncMock(return_value={"success": True, "accepted": True})
     monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+    monkeypatch.setattr(
+        runtime_work_service,
+        "_safe_build_runtime_send_execution_request",
+        lambda **kwargs: None,
+    )
 
     response = await runtime_work_service.send_runtime_message(
         db=test_db,


### PR DESCRIPTION
## Problem

When a user clicks **继续到私聊** (Continue to Private Chat) in Wework and then replies in DingTalk, the executor rejects the message with:

> executionRequest is required

## Root Cause

The executor's `runtime.tasks.send` handler ([tasks.rs:517](https://github.com/wecode-ai/Wegent/blob/main/executor/src/runtime_work/handler/tasks.rs#L517)) requires an `executionRequest` field in the RPC payload to spawn a new turn — it carries model config, user info, skills, workspace, etc.

The Wework frontend builds this client-side via `buildLocalRuntimeExecutionRequest()` for direct local sends. But the IM continuation path (DingTalk reply → `_execute_private_im_continue_runtime_task` → `send_runtime_message`) flows through the backend RPC, which didn't construct or include an `executionRequest`.

## Fix

**`_build_runtime_send_execution_request`** — synthesizes a minimal `ExecutionRequest` from the default task-mode team (`DEFAULT_TEAM_TASK` config, the same agent the Wework workbench uses) via `TaskRequestBuilder`. It resolves:
- User from DB (`_get_user`)
- Team from DB via `DEFAULT_TEAM_TASK` config (same pattern as `IMChannelHandler._get_task_mode_team`)
- Bot/model config from the team's bot via `TaskRequestBuilder.build()`
- Workspace/device from the runtime task address

**`_dispatch_runtime_send`** — shared helper that both `send_runtime_message` and `interrupt_and_send_runtime_message` now route through. It best-effort injects the `executionRequest` into the payload. Failures are non-fatal (logged as warnings) so paths that don't need a fresh turn — e.g. `requestUserInputResponse` — still work without it.

## Also addresses CodeRabbit feedback from #2539

`_runtime_task_title_for_address` now scopes the task lookup by both `workspacePath` and `taskId` to avoid matching a duplicate task ID in a different workspace.

## Testing

- `backend/tests/services/test_runtime_work_service.py` — 54 passed (existing send tests updated to mock the new builder)
- `backend/tests/api/endpoints/test_runtime_work_api.py` — 24 passed
- `wework/src/api/runtimeWork.test.ts` — 11 passed
- Python compile check passes

## Data sources

All data needed for `executionRequest` is in MySQL (User, Team/Bot Kind CRDs) — no in-memory state. Safe across multiple backend instances. This is a follow-up to #2539 which fixed the routing and task title P0s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime messages now include execution details such as task mode, runtime context, model settings, workspace targeting, and attachments when available.
  * Normal and interrupt-and-send messages use consistent processing.

* **Bug Fixes**
  * Message delivery continues even if execution details cannot be created.
  * Task titles are now matched to the correct workspace when workspace information is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->