### PR TITLE
test(wework): preserve sleep assertion identity

### DIFF
--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -6465,9 +6465,13 @@ async function verifyBackgroundTaskWindowLifecycle({
     'Timed out waiting for the streaming response to start'
   )
   const sleepInhibitorEvidence = []
+  let runningAssertionIds = []
   if (process.platform === 'darwin') {
-    const assertionIds = await waitForMacosSleepAssertion(app.pid, true)
-    sleepInhibitorEvidence.push({ stage: 'task-running', assertionIds })
+    runningAssertionIds = await waitForMacosSleepAssertion(app.pid, true)
+    sleepInhibitorEvidence.push({
+      stage: 'task-running',
+      assertionIds: runningAssertionIds,
+    })
   }
   const runningTaskSnapshot = await waitForSnapshot(
     control,
@@ -6524,6 +6528,11 @@ async function verifyBackgroundTaskWindowLifecycle({
       'Closing to tray terminated the executor process'
     )
     const backgroundAssertionIds = await waitForMacosSleepAssertion(app.pid, true)
+    assert.deepEqual(
+      backgroundAssertionIds,
+      runningAssertionIds,
+      'The macOS sleep assertion changed while the task remained active'
+    )
     sleepInhibitorEvidence.push({
       stage: 'window-closed-to-tray',
       assertionIds: backgroundAssertionIds,


### PR DESCRIPTION
## What changed

- retain the macOS sleep assertion IDs observed when the task starts
- assert that closing the Wework window to the tray preserves the same assertion IDs

## Why

This follows up on the review feedback from #2554. The previous E2E check proved that an assertion existed before and after closing to the tray, but it could not detect an incorrect release-and-recreate cycle while the task remained active.

## Validation

- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs`
- pre-push Wework ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced desktop task-flow coverage for macOS sleep-prevention behavior.
  * Verified that closing the window to the tray preserves active task protections and associated lifecycle evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->