### PR TITLE
fix(ci): harden flaky workflow setup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -195,7 +195,8 @@ jobs:
           --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
-          --health-retries=3
+          --health-start-period=45s
+          --health-retries=6
 
       redis:
         image: redis:7-alpine

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -38,15 +38,14 @@ jobs:
           path: trusted-policy
           persist-credentials: false
 
-      - name: Checkout pull request merge tree
+      - name: Checkout pull request head tree
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.repository }}
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: policy-target
           persist-credentials: false
-          allow-unsafe-pr-checkout: true
 
       - name: Checkout merge group
         if: github.event_name == 'merge_group'

--- a/docs/en/wegent/developer-guide/testing.md
+++ b/docs/en/wegent/developer-guide/testing.md
@@ -258,6 +258,22 @@ validates the branch after a PR is opened. A newer commit to the same PR or to
 always appear and verify that every selected job actually succeeded. Skipped,
 unrelated modules do not make the summary fail.
 
+CI reliability depends on these invariants:
+
+- The platform E2E MySQL service must allow enough startup grace for its first
+  initialization. Its health-check `start-period` should cover a cold start on
+  a shared runner before the interval and retry count determine failure; reruns
+  must not hide initialization timeouts.
+- Repository Policy jobs triggered by `pull_request_target` must run policy
+  scripts from the trusted base checkout, while checking out the scan target by
+  the PR head repository and immutable head SHA. Do not depend on
+  `refs/pull/<number>/merge`, which can be replaced or removed while a PR is
+  synchronized, and never execute code supplied by the PR in the policy job.
+- When final text and related controls render independently in desktop E2E,
+  wait for each target element before reading attributes or asserting state.
+  Visible final text does not imply that associated disclosure controls or
+  timelines have mounted.
+
 ### CI Cache Ownership
 
 Large caches are prewarmed and owned by `main`. Pull requests and merge-queue

--- a/docs/zh/wegent/developer-guide/testing.md
+++ b/docs/zh/wegent/developer-guide/testing.md
@@ -253,6 +253,18 @@ Wework 浏览器和桌面 E2E，以及 Wework macOS 内存门禁，适合路径�
 `lint-summary` 始终存在，并验证所有被分类为必需的任务确实成功，未执行的无关模块
 不会导致汇总任务误报失败。
 
+CI 稳定性依赖以下约束：
+
+- 平台 E2E 的 MySQL 服务必须为首次初始化保留启动宽限。健康检查的
+  `start-period` 应覆盖共享 runner 上的冷启动，再通过检查间隔和重试次数判断失败；
+  不要依赖重跑掩盖初始化超时。
+- `pull_request_target` 触发的 Repository Policy 必须从受信任的 base checkout
+  运行策略脚本，但扫描目标应按 PR head 仓库和不可变的 head SHA 检出。不要依赖
+  `refs/pull/<number>/merge`，因为 PR 同步提交时这个短生命周期引用可能被替换或删除；
+  策略任务也不得执行 PR 提供的代码。
+- 桌面 E2E 遇到异步独立渲染的最终文本和附属控件时，必须分别等待目标元素出现后再
+  读取属性或断言状态。看到最终文本不代表折叠控件、时间线等关联 UI 已完成挂载。
+
 ### CI 缓存所有权
 
 大型缓存由 `main` 分支统一预热。PR 和 merge queue 可以恢复 `main` 缓存，但不会

--- a/frontend/src/features/settings/components/ModelEditDialog.tsx
+++ b/frontend/src/features/settings/components/ModelEditDialog.tsx
@@ -1646,7 +1646,6 @@ const ModelEditDialog: React.FC<ModelEditDialogProps> = ({
                       value={modelIdSearch}
                       onChange={e => setModelIdSearch(e.target.value)}
                       className="h-8"
-                      autoFocus
                     />
                   </div>
                   <div className="p-1" style={{ maxHeight: '200px', overflowY: 'auto' }}>

--- a/scripts/test-repository-policy-workflow.sh
+++ b/scripts/test-repository-policy-workflow.sh
@@ -28,6 +28,32 @@ require_line() {
     fi
 }
 
+reject_line() {
+    local file="$1"
+    local pattern="$2"
+    local description="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "Rejected ${description}: ${pattern}"
+        exit 1
+    fi
+}
+
+require_step_line() {
+    local file="$1"
+    local start_step="$2"
+    local end_step="$3"
+    local pattern="$4"
+    local description="$5"
+    local step
+
+    step="$(sed -n "/- name: ${start_step}/,/- name: ${end_step}/p" "$file")"
+    if ! grep -Fq "$pattern" <<<"$step"; then
+        echo "Expected ${description} in ${start_step}: ${pattern}"
+        exit 1
+    fi
+}
+
 require_file "$POLICY_WORKFLOW"
 require_line "$POLICY_WORKFLOW" "pull_request_target:" "trusted fork PR trigger"
 require_line "$POLICY_WORKFLOW" "merge_group:" "merge queue trigger"
@@ -37,9 +63,17 @@ require_line "$POLICY_WORKFLOW" "path: trusted-policy" "trusted script checkout 
 require_line "$POLICY_WORKFLOW" "path: policy-target" "PR content checkout path"
 # GitHub expressions are matched literally in workflow source.
 # shellcheck disable=SC2016
-require_line "$POLICY_WORKFLOW" 'repository: ${{ github.event.pull_request.head.repo.full_name }}' "PR head repository checkout"
+require_step_line "$POLICY_WORKFLOW" "Checkout pull request head tree" "Checkout merge group" \
+    "if: github.event_name == 'pull_request_target'" "pull request event guard"
 # shellcheck disable=SC2016
-require_line "$POLICY_WORKFLOW" 'ref: ${{ github.event.pull_request.head.sha }}' "immutable PR head SHA checkout"
+require_step_line "$POLICY_WORKFLOW" "Checkout pull request head tree" "Checkout merge group" \
+    'repository: ${{ github.event.pull_request.head.repo.full_name }}' "PR head repository checkout"
+# shellcheck disable=SC2016
+require_step_line "$POLICY_WORKFLOW" "Checkout pull request head tree" "Checkout merge group" \
+    'ref: ${{ github.event.pull_request.head.sha }}' "immutable PR head SHA checkout"
+# shellcheck disable=SC2016
+reject_line "$POLICY_WORKFLOW" 'refs/pull/${{ github.event.pull_request.number }}/merge' "short-lived PR merge ref"
+reject_line "$POLICY_WORKFLOW" "allow-unsafe-pr-checkout" "unsafe checkout input"
 require_line "$POLICY_WORKFLOW" "Checkout merge group" "merge group checkout step"
 # shellcheck disable=SC2016
 require_line "$POLICY_WORKFLOW" 'ref: ${{ github.sha }}' "merge group SHA checkout"

--- a/scripts/test-repository-policy-workflow.sh
+++ b/scripts/test-repository-policy-workflow.sh
@@ -37,11 +37,12 @@ require_line "$POLICY_WORKFLOW" "path: trusted-policy" "trusted script checkout 
 require_line "$POLICY_WORKFLOW" "path: policy-target" "PR content checkout path"
 # GitHub expressions are matched literally in workflow source.
 # shellcheck disable=SC2016
-require_line "$POLICY_WORKFLOW" 'ref: refs/pull/${{ github.event.pull_request.number }}/merge' "PR merge ref checkout"
+require_line "$POLICY_WORKFLOW" 'repository: ${{ github.event.pull_request.head.repo.full_name }}' "PR head repository checkout"
+# shellcheck disable=SC2016
+require_line "$POLICY_WORKFLOW" 'ref: ${{ github.event.pull_request.head.sha }}' "immutable PR head SHA checkout"
 require_line "$POLICY_WORKFLOW" "Checkout merge group" "merge group checkout step"
 # shellcheck disable=SC2016
 require_line "$POLICY_WORKFLOW" 'ref: ${{ github.sha }}' "merge group SHA checkout"
-require_line "$POLICY_WORKFLOW" "allow-unsafe-pr-checkout: true" "reviewed fork PR checkout opt-in"
 require_line "$POLICY_WORKFLOW" "REPOSITORY_POLICY_ROOT: \${{ github.workspace }}/policy-target" "target repository scan root"
 require_line "$POLICY_WORKFLOW" "trusted-policy/scripts/hooks/check-repository-policy.sh" "trusted policy script execution"
 


### PR DESCRIPTION
## Summary

- give the platform E2E MySQL service enough initialization grace before health-check retries count
- scan pull requests by immutable head SHA in Repository Policy instead of the short-lived merge ref
- add positive, scoped, and negative regression assertions for the trusted policy checkout
- wait for the final processing control before reading its state in desktop rendering E2E
- keep the model selector open by removing an inner search input autofocus that scrolled and detached the popover
- document the CI reliability invariants in Chinese and English

## Root-cause evidence

- recent platform E2E failures exhausted the previous 30-second MySQL health window while first-time initialization was still running
- recent Repository Policy failures reported that the PR merge ref no longer existed after synchronize events
- rendering E2E diagnostics showed the final-processing control in the final UI snapshot even though the immediate selector lookup had failed
- PR trace for settings-model showed the model option becoming unstable and detached; screencast frames showed explicit autofocus scrolling the dialog and unmounting the popover

## Verification

- scripts/test-repository-policy-workflow.sh
- actionlint -shellcheck= .github/workflows/e2e-tests.yml .github/workflows/repository-policy.yml
- shellcheck scripts/test-repository-policy-workflow.sh
- node --check wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
- pnpm --filter wework exec prettier --check e2e/desktop/scenarios/streaming-text.scenario.mjs
- pnpm --dir frontend exec prettier --check src/features/settings/components/ModelEditDialog.tsx
- pnpm --dir frontend exec eslint src/features/settings/components/ModelEditDialog.tsx
- pnpm --dir frontend exec tsc --noEmit
- pnpm --dir wework exec prettier --check ../docs/zh/wegent/developer-guide/testing.md ../docs/en/wegent/developer-guide/testing.md
- pnpm --filter wework e2e:desktop -- --segment rendering-extensions
- pre-push Frontend, Wework, Backend format/syntax, settings, and Alembic checks
- GitHub PR CI: 22 successful, 0 failing; all four platform E2E shards and Executor E2E passed