### PR TITLE
docs(wework): prevent accidental full Vitest runs

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -22,9 +22,17 @@ Run focused tests before committing:
 
 ```bash
 pnpm --filter wework test
+pnpm --filter wework test <test-file>
 pnpm --filter wework exec prettier --check <changed-files>
 pnpm --filter wework exec eslint <changed-files>
 ```
+
+- Pass Vitest file paths and filters directly after `test`. Never insert an
+  extra `--` (for example, do not run
+  `pnpm --filter wework test -- <test-file>`), because Vitest can ignore the
+  intended filter and collect the full suite. When running a focused test,
+  confirm the initial collection output matches the requested files and stop
+  the run immediately if it starts collecting unrelated tests.
 
 Direct debug Cargo builds create marked, unavailable stubs for ignored bundled
 sidecars when their real binaries have not been prepared. Do not prepare DWS


### PR DESCRIPTION
## What changed

- Document the correct focused Vitest invocation for Wework.
- Explicitly prohibit the extra `--` separator that can cause Vitest to collect the full suite.
- Require checking the initial collection scope and stopping unexpected broad runs.

## Why

Wework focused test commands have repeatedly included an extra `--`. Vitest can then ignore the intended file filter and run all 340 test files, wasting substantial local and CI time.

## Impact

Contributors and coding agents now have an explicit safe command and an early guard against accidental full-suite runs.

## Validation

- `pnpm --filter wework exec prettier --check AGENTS.md`
- `git diff --check`
- Pre-push ESLint, TypeScript, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded testing guidance with direct test-file execution instructions.
  * Added Prettier and ESLint verification steps.
  * Clarified Vitest file-path and filter usage, including checks to prevent unrelated tests from running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->