### PR TITLE
test(wework): split slow desktop e2e checkpoints

### DIFF
--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 core_segments=(
   workspace-tabs
   priority-filter
+  automation-lifecycle
+  model-routing
   core-task-flow
   window-lifecycle
   goal-lifecycle
@@ -100,6 +102,13 @@ classify_wework_path() {
       select_target "core:priority-filter"
       return
       ;;
+    wework/src/pages/AutomationsPage* | \
+      wework/src/features/automations/* | \
+      wework/src/features/todo/ProjectAutomationView.tsx | \
+      wework/src/types/automation.ts)
+      select_target "core:automation-lifecycle"
+      return
+      ;;
     # The main sidebar also owns project creation, chats, and attachments.
     wework/src/components/layout/DesktopSidebar.tsx)
       select_target "core:priority-filter"
@@ -181,6 +190,7 @@ classify_wework_path() {
       wework/src/features/local-runtime/* | \
       wework/src/stream/*)
       select_target "core:core-task-flow"
+      select_target "core:model-routing"
       return
       ;;
 

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -264,7 +264,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 
 full_desktop_expected='wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-workspace-tabs","name":"Core / workspace-tabs","command":"e2e:desktop","segment":"workspace-tabs"},{"id":"core-priority-filter","name":"Core / priority-filter","command":"e2e:desktop","segment":"priority-filter"},{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"core-window-lifecycle","name":"Core / window-lifecycle","command":"e2e:desktop","segment":"window-lifecycle"},{"id":"core-goal-lifecycle","name":"Core / goal-lifecycle","command":"e2e:desktop","segment":"goal-lifecycle"},{"id":"core-supervisor-lifecycle","name":"Core / supervisor-lifecycle","command":"e2e:desktop","segment":"supervisor-lifecycle"},{"id":"core-resilience","name":"Core / resilience","command":"e2e:desktop","segment":"resilience"},{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"},{"id":"core-workspace-attachments","name":"Core / workspace-attachments","command":"e2e:desktop","segment":"workspace-attachments"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"},{"id":"core-embedded-browser","name":"Core / embedded-browser","command":"e2e:desktop","segment":"embedded-browser"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-workspace-tabs","name":"Core / workspace-tabs","command":"e2e:desktop","segment":"workspace-tabs"},{"id":"core-priority-filter","name":"Core / priority-filter","command":"e2e:desktop","segment":"priority-filter"},{"id":"core-automation-lifecycle","name":"Core / automation-lifecycle","command":"e2e:desktop","segment":"automation-lifecycle"},{"id":"core-model-routing","name":"Core / model-routing","command":"e2e:desktop","segment":"model-routing"},{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"},{"id":"core-window-lifecycle","name":"Core / window-lifecycle","command":"e2e:desktop","segment":"window-lifecycle"},{"id":"core-goal-lifecycle","name":"Core / goal-lifecycle","command":"e2e:desktop","segment":"goal-lifecycle"},{"id":"core-supervisor-lifecycle","name":"Core / supervisor-lifecycle","command":"e2e:desktop","segment":"supervisor-lifecycle"},{"id":"core-resilience","name":"Core / resilience","command":"e2e:desktop","segment":"resilience"},{"id":"core-conversation-state","name":"Core / conversation-state","command":"e2e:desktop","segment":"conversation-state"},{"id":"core-workspace-attachments","name":"Core / workspace-attachments","command":"e2e:desktop","segment":"workspace-attachments"},{"id":"core-rendering-extensions","name":"Core / rendering-extensions","command":"e2e:desktop","segment":"rendering-extensions"},{"id":"core-embedded-browser","name":"Core / embedded-browser","command":"e2e:desktop","segment":"embedded-browser"}]}
 wework_desktop_other_e2e=true
 wework_desktop_other_e2e_matrix={"include":[{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""},{"id":"cloud","name":"Cloud","command":"e2e:desktop:cloud","segment":""}]}'
 
@@ -291,6 +291,22 @@ wework_desktop_core_e2e_matrix={"include":[{"id":"core-core-task-flow","name":"C
 wework_desktop_other_e2e=true
 wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-skill-mention-rendering","name":"Plugins / skill-mention-rendering","command":"e2e:desktop:plugins","segment":"skill-mention-rendering"}]}' \
   "wework/src/components/chat/composer/ComposerMentionMenu.tsx"
+
+assert_desktop_case "model settings select task launch and model routing coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-model-routing","name":"Core / model-routing","command":"e2e:desktop","segment":"model-routing"},{"id":"core-core-task-flow","name":"Core / core-task-flow","command":"e2e:desktop","segment":"core-task-flow"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
+  "wework/src/features/model-settings/localModelSettings.ts"
+
+assert_desktop_case "automation files select only automation lifecycle coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-automation-lifecycle","name":"Core / automation-lifecycle","command":"e2e:desktop","segment":"automation-lifecycle"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
+  "wework/src/features/automations/AutomationDetailWorkspace.tsx"
 
 assert_desktop_case "browser E2E changes avoid desktop jobs" \
   'wework_desktop_e2e=false

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -114,10 +114,12 @@ Matrix submissions use a 10-second timeout. If the composer already displays a s
 The main desktop flow's short-conversation layout regression stores `short-conversation-00-ready.png`, `short-conversation-01-prompt-filled.png`, `short-conversation-02-completed-top-aligned.png`, and `short-conversation-layout-metrics.json`. The final screenshot and metrics are captured after switching away and reopening the conversation. The gate requires the first message to remain within `160px` of the message viewport's top edge. For focused local diagnosis, run `node wework/e2e/desktop/task-flow.e2e.mjs --short-conversation-only`; the same check remains part of the regular `e2e:desktop` flow rather than a separate CI entrypoint.
 
 The main desktop runner also supports execution through ordered checkpoints.
-The checkpoints are `workspace-tabs`, `core-task-flow`, `window-lifecycle`,
-`goal-lifecycle`, `resilience`, `conversation-state`, `workspace-attachments`,
-`rendering-extensions`, and `embedded-browser`. `--segment <checkpoint>` performs common startup
-and project initialization, then runs only the selected checkpoint.
+The checkpoints are `workspace-tabs`, `priority-filter`, `telemetry-consent`,
+`automation-lifecycle`, `model-routing`, `core-task-flow`, `window-lifecycle`,
+`goal-lifecycle`, `supervisor-lifecycle`, `resilience`, `conversation-state`,
+`workspace-attachments`, `rendering-extensions`, `browser-multi-tabs`, and
+`embedded-browser`. `--segment <checkpoint>` performs common startup and project
+initialization, then runs only the selected checkpoint.
 `--from-segment <checkpoint>` starts there and continues through every later
 checkpoint. When upstream checkpoints are skipped, each checkpoint establishes
 its own minimal fixtures instead of depending on tasks or UI state created only
@@ -139,10 +141,21 @@ feature coverage is registered. Segment commands are also useful for focused
 local iteration:
 
 ```bash
+pnpm --filter wework e2e:desktop -- --segment automation-lifecycle
+pnpm --filter wework e2e:desktop -- --segment model-routing
 pnpm --filter wework e2e:desktop -- --segment window-lifecycle
 pnpm --filter wework e2e:desktop -- --from-segment window-lifecycle
 pnpm --filter wework e2e:desktop -- --segment workspace-attachments
 ```
+
+`automation-lifecycle` independently covers automation creation, immediate
+execution, pinning and continuing an existing task, and scheduled continuation.
+`model-routing` independently covers all six local protocol-switch directions,
+cross-provider retry, the vision sidecar, and the local model protocol matrix.
+Both checkpoints establish their own minimal fixtures, so they no longer extend
+the critical path for task creation, follow-up, and background plans in
+`core-task-flow`. An unsegmented complete desktop run still executes these
+scenarios, so splitting them does not reduce coverage.
 
 The plugin desktop suite reuses the same segment options while keeping its
 separate Codex Home initialization environment. Its ordered segments are
@@ -179,7 +192,7 @@ Optional `WEWORK_E2E_EXECUTOR_BIN` and `WEWORK_E2E_APP_BIN` reuse already-built 
 
 On macOS, desktop E2E launches a temporary `.app` bundle in the background through `open -g`. The test-only `WEWORK_E2E_BACKGROUND_WINDOW=1` setting keeps the Tauri main window hidden, prohibits application activation, and hides its Dock icon. Background throttling is disabled for the hidden WebView, so DOM control, timers, and snapshots continue to work. After the controller connects, the runner also asserts that the test application is not the current foreground process, preventing focus-stealing regressions. Only the desktop E2E runner injects this variable; normal development and production launches are unchanged.
 
-The cloud-project scenario starts a real Backend, Redis, and a real Executor registered as a remote device. It exercises real authentication, device RPC, task persistence, and project deletion while covering project creation, task execution, conversation restoration, follow-up, and project removal. The scenario also verifies all three model protocols through the Backend proxy for cloud Model CRDs, plus local-executor use of Codex and cloud models under the same connected account. Only provider model endpoints are simulated; Backend HTTP and WebSocket APIs must not be mocked. Project cleanup must wait until the task is no longer running; rendered assistant text does not mean the final task state has been persisted. Python 3.11, `uv`, and `redis-server` are required to run this scenario.
+The cloud-project scenario starts a real Backend, Redis, and a real Executor registered as a remote device. It exercises real authentication, device RPC, task persistence, and project deletion while covering project creation, task execution, conversation restoration, follow-up, and project removal. The scenario also verifies all three model protocols through the Backend proxy for cloud Model CRDs, plus local-executor use of Codex and cloud models under the same connected account. Only provider model endpoints are simulated; Backend HTTP and WebSocket APIs must not be mocked. To shorten cold startup, the Executor build runs in parallel with Backend, Redis, and database preparation, while remote Executor registration runs in parallel with the Tauri application build. Application startup still waits for both prerequisite groups to finish. Project cleanup must wait until the task is no longer running; rendered assistant text does not mean the final task state has been persisted. Python 3.11, `uv`, and `redis-server` are required to run this scenario.
 
 Before validating local-executor models for a connected account, the cloud scenario selects its isolated directory through the current Projects → Local project entrypoint and confirms the name in the local-project creation dialog. Desktop E2E coverage must follow this primary product flow instead of relying on the removed existing-project test entrypoint.
 

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -114,9 +114,11 @@ node e2e/utils/mock-connector-upstream-server.mjs
 主桌面流程的短对话布局回归会保存 `short-conversation-00-ready.png`、`short-conversation-01-prompt-filled.png`、`short-conversation-02-completed-top-aligned.png` 和 `short-conversation-layout-metrics.json`。最后一个截图和 metrics 均在切走并重新打开对话后生成；门禁要求首条消息距离消息视口顶部不超过 `160px`。本地排查该回归时可直接运行 `node wework/e2e/desktop/task-flow.e2e.mjs --short-conversation-only`，但该检查同时属于常规 `e2e:desktop` 主流程，不是独立 CI 入口。
 
 主桌面 runner 也支持按有序 checkpoint 分段执行。当前 checkpoint 依次为
-`workspace-tabs`、`core-task-flow`、`window-lifecycle`、`goal-lifecycle`、
-`resilience`、`conversation-state`、`workspace-attachments`、
-`rendering-extensions` 和 `embedded-browser`。
+`workspace-tabs`、`priority-filter`、`telemetry-consent`、
+`automation-lifecycle`、`model-routing`、`core-task-flow`、
+`window-lifecycle`、`goal-lifecycle`、`supervisor-lifecycle`、`resilience`、
+`conversation-state`、`workspace-attachments`、`rendering-extensions`、
+`browser-multi-tabs` 和 `embedded-browser`。
 `--segment <checkpoint>` 在公共启动和项目初始化后只运行指定 checkpoint；
 `--from-segment <checkpoint>` 从指定 checkpoint 开始并继续执行所有后续
 checkpoint。跳过上游时，每个 checkpoint 会自行建立最小前置 fixture，不依赖只有
@@ -134,10 +136,18 @@ merge queue 会验证最终进入 `main` 的合并提交，因此合入后不再
 必须同步登记对应 segment。分段命令也可用于本地快速迭代：
 
 ```bash
+pnpm --filter wework e2e:desktop -- --segment automation-lifecycle
+pnpm --filter wework e2e:desktop -- --segment model-routing
 pnpm --filter wework e2e:desktop -- --segment window-lifecycle
 pnpm --filter wework e2e:desktop -- --from-segment window-lifecycle
 pnpm --filter wework e2e:desktop -- --segment workspace-attachments
 ```
+
+`automation-lifecycle` 独立覆盖自动化创建、立即执行、固定既有任务以及定时继续
+会话；`model-routing` 独立覆盖六种本地协议切换方向、跨 provider 重试、视觉
+sidecar 和本地模型协议矩阵。两者都建立自身最小 fixture，因此不会拉长
+`core-task-flow` 的任务创建、追问和后台计划关键路径。无参数运行完整桌面流程时，
+这些场景仍会执行，不会因为分段而减少覆盖。
 
 插件桌面套件也复用同一套分段参数，但保持独立的 Codex Home 初始化环境。插件
 segment 依次为 `plugin-lifecycle`、`skill-mention-rendering` 和
@@ -170,7 +180,7 @@ CODEX_BIN=/absolute/path/to/codex pnpm --filter wework e2e:desktop
 
 在 macOS 上，桌面 E2E 会通过临时 `.app` bundle 和 `open -g` 在后台启动。测试专用的 `WEWORK_E2E_BACKGROUND_WINDOW=1` 会让 Tauri 保持主窗口隐藏、禁止应用激活并隐藏 Dock 图标；隐藏 WebView 会关闭后台节流，因此 DOM 控制、计时器和截图仍正常工作。runner 在连接控制器后还会断言测试应用不是当前前台进程，防止窗口抢焦点行为回归。该环境变量只由桌面 E2E runner 注入，不改变正常开发或生产启动行为。
 
-云端项目场景会启动真实 Backend、Redis 和一个注册为远端设备的真实 Executor，通过真实鉴权、设备 RPC、任务持久化和项目删除接口完成创建项目、执行任务、恢复会话、连续追问与删除项目验证。场景同时验证云端 Model CRD 经 backend 代理转发三种模型协议，以及同一云端账号下的 Codex/云端模型在本机 executor 中执行。测试只模拟 provider 模型端点；不得模拟 Backend HTTP 或 WebSocket 接口。清理项目之前必须等待任务的运行状态结束；助手文本已经渲染并不代表任务状态已经完成持久化。运行该场景需要 Python 3.11、`uv` 和 `redis-server`。
+云端项目场景会启动真实 Backend、Redis 和一个注册为远端设备的真实 Executor，通过真实鉴权、设备 RPC、任务持久化和项目删除接口完成创建项目、执行任务、恢复会话、连续追问与删除项目验证。场景同时验证云端 Model CRD 经 backend 代理转发三种模型协议，以及同一云端账号下的 Codex/云端模型在本机 executor 中执行。测试只模拟 provider 模型端点；不得模拟 Backend HTTP 或 WebSocket 接口。为缩短冷启动时间，Executor 构建与 Backend/Redis/数据库准备并行，远端 Executor 注册与 Tauri 应用构建并行；应用启动前仍必须同时等待两组前置任务完成。清理项目之前必须等待任务的运行状态结束；助手文本已经渲染并不代表任务状态已经完成持久化。运行该场景需要 Python 3.11、`uv` 和 `redis-server`。
 
 云端场景在验证连接账号下的本机执行模型之前，会通过当前“项目 → 本地项目”入口选择隔离目录，并在本地项目创建对话框中确认名称。桌面 E2E 应复用这个产品主流程，不得继续依赖已经移除的“已有项目”测试入口。
 

--- a/wework/e2e/desktop/checkpoints.mjs
+++ b/wework/e2e/desktop/checkpoints.mjs
@@ -2,6 +2,8 @@ export const DESKTOP_CHECKPOINTS = [
   'workspace-tabs',
   'priority-filter',
   'telemetry-consent',
+  'automation-lifecycle',
+  'model-routing',
   'core-task-flow',
   'window-lifecycle',
   'goal-lifecycle',

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -8981,14 +8981,13 @@ async function verifyGoalRestartRecoveryLifecycle({
 }
 
 class RealCloudEnvironment {
-  constructor({ codexBinary, executorBinary, modelServerUrl, workspacePath }) {
+  constructor({ codexBinary, modelServerUrl, workspacePath }) {
     this.codexBinary = codexBinary
-    this.executorBinary = executorBinary
     this.modelServerUrl = modelServerUrl
     this.workspacePath = workspacePath
   }
 
-  async start() {
+  async startBackend() {
     this.redisPort = await reservePort()
     this.backendPort = await reservePort()
     this.backendUrl = `http://127.0.0.1:${this.backendPort}`
@@ -9052,7 +9051,9 @@ class RealCloudEnvironment {
     assert.ok(this.authToken, 'Real cloud backend did not return an authentication token')
     await this.seedCloudProtocolModels()
     await this.seedCloudVisionSidecarModels()
+  }
 
+  async startRemoteExecutor(executorBinary) {
     const remoteHome = join(resultDir, 'cloud-executor-home')
     this.remoteCodexHome = join(remoteHome, 'codex')
     await writeCodexConfig(this.remoteCodexHome, this.modelServerUrl)
@@ -9080,7 +9081,7 @@ class RealCloudEnvironment {
       DEVICE_SESSION_GATEWAY_PORT: '0',
     }
     delete remoteEnv.WEGENT_APP_IPC_DEVICE_ID
-    this.remoteExecutor = spawn(this.executorBinary, [], {
+    this.remoteExecutor = spawn(executorBinary, [], {
       cwd: weworkDir,
       env: remoteEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -14130,6 +14131,158 @@ async function verifyModelProtocolMatrix({
   }
 }
 
+async function verifyLocalModelRouting({
+  composerSelector,
+  control,
+  modelSwitchVerification,
+  newConversationSelector,
+  projectRowSelector,
+  setPhase,
+  workspacePath,
+}) {
+  for (const [switchIndex, switchCase] of LOCAL_MODEL_SWITCH_CASES.entries()) {
+    setPhase(`local-model-switch-${switchCase.id}`)
+    const sourceModel = LOCAL_MODEL_CASES.find(
+      model => model.protocol === switchCase.sourceProtocol
+    )
+    const targetModel = LOCAL_MODEL_CASES.find(
+      model => model.protocol === switchCase.targetProtocol
+    )
+    assert.ok(sourceModel, `Missing ${switchCase.sourceProtocol} local switch source`)
+    assert.ok(targetModel, `Missing ${switchCase.targetProtocol} local switch target`)
+    for (const model of LOCAL_MODEL_CASES) {
+      control.localProtocolStates.set(model.protocol, { stage: 'initial', requests: [] })
+    }
+    control.localProtocolStates.set(sourceModel.protocol, {
+      stage: 'model_switch_source',
+      requests: [],
+    })
+    control.localProtocolStates.set(targetModel.protocol, {
+      stage: 'model_switch_target',
+      requests: [],
+    })
+    await rm(join(workspacePath, LOCAL_MODEL_SWITCH_ARTIFACT), { force: true })
+    await control.command('clickWhenEnabled', newConversationSelector)
+    await control.command('waitFor', composerSelector, {
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    })
+    await selectE2EModel(control, sourceModel.optionIds, sourceModel.labels)
+    await sendPrompt(control, composerSelector, LOCAL_MODEL_SWITCH_INITIAL_PROMPT)
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: LOCAL_MODEL_SWITCH_INITIAL_COMPLETE,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    await sendPrompt(control, composerSelector, LOCAL_MODEL_SWITCH_FOLLOW_UP_PROMPT)
+    await control.command('waitFor', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR, {
+      visible: true,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    const sourceRequestsBeforeSwitch = control.localProtocolStates.get(sourceModel.protocol)
+      ?.requests.length
+    assert.ok(
+      sourceRequestsBeforeSwitch && sourceRequestsBeforeSwitch >= 3,
+      `${switchCase.id} did not complete its source tool loop and failed follow-up`
+    )
+    if (switchIndex === 0) {
+      await prepareCompletedTurnScreenshot(control)
+      await captureVerificationScreenshot(control, 'model-switch-retry-01-failed.png')
+    }
+    await control.command('scrollIntoView', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR)
+    await control.command('clickWhenEnabled', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR, {
+      stableMs: COMPOSER_READY_STABILITY_MS,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    await control.command('waitFor', '[data-testid="model-selector-menu"]', {
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    if (switchIndex === 0) {
+      await captureVerificationScreenshot(
+        control,
+        'model-switch-retry-02-picker-open.png',
+        '[data-testid="model-selector-menu"]'
+      )
+    }
+    await selectE2EModel(control, targetModel.optionIds, targetModel.labels)
+    if (switchIndex === 0) {
+      await captureVerificationScreenshot(control, 'model-switch-retry-03-target-selected.png')
+    }
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: LOCAL_MODEL_SWITCH_COMPLETE,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    assert.equal(
+      await readFile(join(workspacePath, LOCAL_MODEL_SWITCH_ARTIFACT), 'utf8'),
+      LOCAL_MODEL_SWITCH_ARTIFACT_CONTENT,
+      `${switchCase.id} did not execute its source tool call before switching`
+    )
+    const sourceSwitchState = control.localProtocolStates.get(sourceModel.protocol)
+    const targetSwitchState = control.localProtocolStates.get(targetModel.protocol)
+    assert.equal(
+      sourceSwitchState?.requests.length,
+      sourceRequestsBeforeSwitch,
+      `${switchCase.id} retried through the old custom model`
+    )
+    assert.equal(
+      targetSwitchState?.stage,
+      'model_switch_target_complete',
+      `${switchCase.id} did not complete the automatic same-conversation retry`
+    )
+    await waitForE2EModelLabel(control, targetModel.labels)
+    await waitForSnapshot(
+      control,
+      snapshot => !/下一轮|Next/.test(snapshot.text),
+      `${switchCase.id} left the applied model marked as next-turn only`,
+      DEFAULT_STEP_TIMEOUT_MS,
+      '[data-testid="model-selector-button"]'
+    )
+    modelSwitchVerification.push({
+      direction: switchCase.id,
+      sourceProtocol: sourceModel.protocol,
+      targetProtocol: targetModel.protocol,
+      sourceRequestCount: sourceSwitchState.requests.length,
+      targetRequestCount: targetSwitchState.requests.length,
+      targetHistoryVerified: targetSwitchState.historyVerified === true,
+      toolArtifactVerified: true,
+      completed: true,
+    })
+    if (switchIndex === 0) {
+      await prepareCompletedTurnScreenshot(control)
+      await captureVerificationScreenshot(control, 'model-switch-retry-04-completed.png')
+    }
+  }
+
+  setPhase('provider-switch-retry')
+  await verifyCrossProviderSwitchRetry(control, composerSelector)
+  setPhase('local-vision-sidecar')
+  await verifyVisionSidecar({
+    composerSelector,
+    control,
+    modelCase: LOCAL_VISION_SIDECAR_CASE,
+    projectRowSelector,
+  })
+  await writeFile(
+    join(resultDir, 'model-switch-protocol-verification.json'),
+    `${JSON.stringify(modelSwitchVerification, null, 2)}\n`,
+    'utf8'
+  )
+  assert.deepEqual(
+    modelSwitchVerification.map(result => result.direction),
+    LOCAL_MODEL_SWITCH_CASES.map(result => result.id),
+    'The model-routing E2E did not verify all six protocol directions'
+  )
+  if (MODEL_SWITCH_ONLY) return
+
+  setPhase('local-model-protocol-matrix')
+  await verifyModelProtocolMatrix({
+    cases: LOCAL_CUSTOM_MODEL_PROTOCOL_MATRIX_CASES,
+    composerSelector,
+    control,
+    newConversationSelector: `${projectRowSelector} [data-testid="project-new-conversation-button"]`,
+    screenshotPrefix: 'local-matrix',
+    workspacePath,
+  })
+}
+
 async function waitForMatrixStage(control, model, ...expectedStages) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < MODEL_PROTOCOL_MATRIX_TIMEOUT_MS) {
@@ -14233,17 +14386,19 @@ async function main() {
     assert.ok(codexVersion.length > 0, 'Real Codex did not return a version')
     console.log(`Using real Codex: ${codexVersion}`)
     const appIdentifier = `io.wecode.wework.e2e.run${process.pid}`
-    const executorBinary = await buildExecutor()
+    let executorBinary
     if (CLOUD_ONLY) {
       cloudEnvironment = new RealCloudEnvironment({
         codexBinary,
-        executorBinary,
         modelServerUrl: control.url,
         workspacePath,
       })
-      await cloudEnvironment.start()
+      const [builtExecutor] = await Promise.all([buildExecutor(), cloudEnvironment.startBackend()])
+      executorBinary = builtExecutor
+    } else {
+      executorBinary = await buildExecutor()
     }
-    const desktopApp = await buildDesktopApp(
+    const desktopAppPromise = buildDesktopApp(
       control.controlUrl,
       cloudEnvironment?.backendUrl ?? control.url,
       cloudEnvironment?.authToken ?? desktopScenario?.authToken ?? 'wework-desktop-e2e-cloud-token',
@@ -14251,6 +14406,14 @@ async function main() {
       control.url,
       codexBinary
     )
+    const desktopApp = cloudEnvironment
+      ? (
+          await Promise.all([
+            desktopAppPromise,
+            cloudEnvironment.startRemoteExecutor(executorBinary),
+          ])
+        )[0]
+      : await desktopAppPromise
     const appBinary = desktopApp.binaryPath
     appBundlePath = desktopApp.appBundlePath
     const resolvedAppCodexBinary = desktopApp.codexBinaryPath ?? codexBinary
@@ -14702,10 +14865,14 @@ last_updated = "2026-07-30T00:00:00Z"`
       return
     }
 
-    if (AUTOMATION_ONLY) {
+    if (DESKTOP_SEGMENT === 'automation-lifecycle' || AUTOMATION_ONLY) {
       phase = 'automation-lifecycle'
       await verifyAutomationLifecycle(control, executorHome, homePath)
-      console.log(`Wework desktop automation E2E passed. Evidence: ${resultDir}`)
+      console.log(
+        AUTOMATION_ONLY
+          ? `Wework desktop automation E2E passed. Evidence: ${resultDir}`
+          : `Wework desktop automation-lifecycle checkpoint passed. Evidence: ${resultDir}`
+      )
       return
     }
 
@@ -14801,6 +14968,46 @@ last_updated = "2026-07-30T00:00:00Z"`
       return
     }
 
+    if (DESKTOP_SEGMENT === 'model-routing' || MODEL_SWITCH_ONLY) {
+      phase = 'model-routing-project'
+      await createSingleRootLocalProject(control, workspacePath, 'workspace')
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
+        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      })
+      const projectSnapshot = await waitForSnapshot(
+        control,
+        snapshot => snapshot.testIds.some(testId => testId.startsWith('project-menu-')),
+        'The model-routing project was not shown in the sidebar'
+      )
+      const projectMenuTestId = projectSnapshot.testIds.find(testId =>
+        testId.startsWith('project-menu-')
+      )
+      assert.ok(projectMenuTestId, 'The model-routing project identity was not found')
+      const projectId = projectMenuTestId.slice('project-menu-'.length)
+      await verifyLocalModelRouting({
+        composerSelector: ACTIVE_COMPOSER_SELECTOR,
+        control,
+        modelSwitchVerification,
+        newConversationSelector: `[data-testid="project-row-${projectId}"] [data-testid="project-new-conversation-button"]`,
+        projectRowSelector: `[data-testid="project-row-${projectId}"]`,
+        setPhase: value => {
+          phase = value
+        },
+        workspacePath,
+      })
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      console.log(
+        MODEL_SWITCH_ONLY
+          ? `Wework desktop six-way model-switch E2E passed. Evidence: ${resultDir}`
+          : `Wework desktop model-routing checkpoint passed. Evidence: ${resultDir}`
+      )
+      return
+    }
+
     if (shouldRunDesktopCheckpoint('workspace-tabs')) {
       phase = 'workspace-tab-isolation'
       await verifyWorkspaceTabIsolation(control)
@@ -14834,8 +15041,10 @@ last_updated = "2026-07-30T00:00:00Z"`
         phase = 'workspace-document-tabs'
         await verifyWorkspaceDocumentTabs(control)
 
-        phase = 'automation-lifecycle'
-        await verifyAutomationLifecycle(control, executorHome, homePath)
+        if (shouldRunDesktopCheckpoint('automation-lifecycle')) {
+          phase = 'automation-lifecycle'
+          await verifyAutomationLifecycle(control, executorHome, homePath)
+        }
 
         phase = 'cloud-work-page'
         await verifyCloudWorkPage(control)
@@ -15179,6 +15388,33 @@ last_updated = "2026-07-30T00:00:00Z"`
       await verifyBackgroundTaskPlanRestoration({ composerSelector, control })
       console.log(`Wework background task-plan E2E passed. Evidence: ${resultDir}`)
       return
+    }
+
+    if (shouldRunDesktopCheckpoint('model-routing')) {
+      await verifyLocalModelRouting({
+        composerSelector,
+        control,
+        modelSwitchVerification,
+        newConversationSelector: `${projectRowSelector} [data-testid="project-new-conversation-button"]`,
+        projectRowSelector,
+        setPhase: value => {
+          phase = value
+        },
+        workspacePath,
+      })
+      await writeFile(
+        join(resultDir, 'model-requests.json'),
+        `${JSON.stringify(control.modelRequests, null, 2)}\n`,
+        'utf8'
+      )
+      if (MODEL_SWITCH_ONLY) {
+        console.log(`Wework desktop six-way model-switch E2E passed. Evidence: ${resultDir}`)
+        return
+      }
+      if (shouldStopAfterDesktopCheckpoint('model-routing')) {
+        console.log(`Wework desktop model-routing checkpoint passed. Evidence: ${resultDir}`)
+        return
+      }
     }
 
     let taskRowTestId
@@ -15584,165 +15820,6 @@ last_updated = "2026-07-30T00:00:00Z"`
           control,
           projectRowSelector,
           taskRowTestId,
-        })
-
-        for (const [switchIndex, switchCase] of LOCAL_MODEL_SWITCH_CASES.entries()) {
-          phase = `local-model-switch-${switchCase.id}`
-          const sourceModel = LOCAL_MODEL_CASES.find(
-            model => model.protocol === switchCase.sourceProtocol
-          )
-          const targetModel = LOCAL_MODEL_CASES.find(
-            model => model.protocol === switchCase.targetProtocol
-          )
-          assert.ok(sourceModel, `Missing ${switchCase.sourceProtocol} local switch source`)
-          assert.ok(targetModel, `Missing ${switchCase.targetProtocol} local switch target`)
-          for (const model of LOCAL_MODEL_CASES) {
-            control.localProtocolStates.set(model.protocol, { stage: 'initial', requests: [] })
-          }
-          control.localProtocolStates.set(sourceModel.protocol, {
-            stage: 'model_switch_source',
-            requests: [],
-          })
-          control.localProtocolStates.set(targetModel.protocol, {
-            stage: 'model_switch_target',
-            requests: [],
-          })
-          await rm(join(workspacePath, LOCAL_MODEL_SWITCH_ARTIFACT), { force: true })
-          await control.command('click', '[data-testid="new-chat-button"]')
-          await control.command('waitFor', composerSelector, {
-            timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
-          })
-          await selectE2EModel(control, sourceModel.optionIds, sourceModel.labels)
-          await sendPrompt(control, composerSelector, LOCAL_MODEL_SWITCH_INITIAL_PROMPT)
-          await control.command('waitFor', '[data-testid="message-assistant"]', {
-            text: LOCAL_MODEL_SWITCH_INITIAL_COMPLETE,
-            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-          })
-          await sendPrompt(control, composerSelector, LOCAL_MODEL_SWITCH_FOLLOW_UP_PROMPT)
-          await control.command('waitFor', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR, {
-            visible: true,
-            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-          })
-          const sourceRequestsBeforeSwitch = control.localProtocolStates.get(sourceModel.protocol)
-            ?.requests.length
-          assert.ok(
-            sourceRequestsBeforeSwitch && sourceRequestsBeforeSwitch >= 3,
-            `${switchCase.id} did not complete its source tool loop and failed follow-up`
-          )
-          if (switchIndex === 0) {
-            await prepareCompletedTurnScreenshot(control)
-            await captureVerificationScreenshot(control, 'model-switch-retry-01-failed.png')
-          }
-          await control.command('scrollIntoView', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR)
-          await control.command('clickWhenEnabled', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR, {
-            stableMs: COMPOSER_READY_STABILITY_MS,
-            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-          })
-          await control.command('waitFor', '[data-testid="model-selector-menu"]', {
-            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-          })
-          if (switchIndex === 0) {
-            await captureVerificationScreenshot(
-              control,
-              'model-switch-retry-02-picker-open.png',
-              '[data-testid="model-selector-menu"]'
-            )
-          }
-          await selectE2EModel(control, targetModel.optionIds, targetModel.labels)
-          if (switchIndex === 0) {
-            await captureVerificationScreenshot(
-              control,
-              'model-switch-retry-03-target-selected.png'
-            )
-          }
-          await control.command('waitFor', '[data-testid="message-assistant"]', {
-            text: LOCAL_MODEL_SWITCH_COMPLETE,
-            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-          })
-          assert.equal(
-            await readFile(join(workspacePath, LOCAL_MODEL_SWITCH_ARTIFACT), 'utf8'),
-            LOCAL_MODEL_SWITCH_ARTIFACT_CONTENT,
-            `${switchCase.id} did not execute its source tool call before switching`
-          )
-          const sourceSwitchState = control.localProtocolStates.get(sourceModel.protocol)
-          const targetSwitchState = control.localProtocolStates.get(targetModel.protocol)
-          assert.equal(
-            sourceSwitchState?.requests.length,
-            sourceRequestsBeforeSwitch,
-            `${switchCase.id} retried through the old custom model`
-          )
-          assert.equal(
-            targetSwitchState?.stage,
-            'model_switch_target_complete',
-            `${switchCase.id} did not complete the automatic same-conversation retry`
-          )
-          await waitForE2EModelLabel(control, targetModel.labels)
-          await waitForSnapshot(
-            control,
-            snapshot => !/下一轮|Next/.test(snapshot.text),
-            `${switchCase.id} left the applied model marked as next-turn only`,
-            DEFAULT_STEP_TIMEOUT_MS,
-            '[data-testid="model-selector-button"]'
-          )
-          modelSwitchVerification.push({
-            direction: switchCase.id,
-            sourceProtocol: sourceModel.protocol,
-            targetProtocol: targetModel.protocol,
-            sourceRequestCount: sourceSwitchState.requests.length,
-            targetRequestCount: targetSwitchState.requests.length,
-            targetHistoryVerified: targetSwitchState.historyVerified === true,
-            toolArtifactVerified: true,
-            completed: true,
-          })
-          if (switchIndex === 0) {
-            await prepareCompletedTurnScreenshot(control)
-            await captureVerificationScreenshot(control, 'model-switch-retry-04-completed.png')
-          }
-        }
-        phase = 'provider-switch-retry'
-        await verifyCrossProviderSwitchRetry(control, composerSelector)
-        phase = 'local-vision-sidecar'
-        await verifyVisionSidecar({
-          composerSelector,
-          control,
-          modelCase: LOCAL_VISION_SIDECAR_CASE,
-          projectRowSelector,
-        })
-        await writeFile(
-          join(resultDir, 'model-switch-protocol-verification.json'),
-          `${JSON.stringify(modelSwitchVerification, null, 2)}\n`,
-          'utf8'
-        )
-        if (MODEL_SWITCH_ONLY) {
-          assert.deepEqual(
-            modelSwitchVerification.map(result => result.direction),
-            LOCAL_MODEL_SWITCH_CASES.map(result => result.id),
-            'The focused model-switch E2E did not verify all six protocol directions'
-          )
-          await writeFile(
-            join(resultDir, 'model-requests.json'),
-            `${JSON.stringify(control.modelRequests, null, 2)}\n`,
-            'utf8'
-          )
-          console.log(`Wework desktop six-way model-switch E2E passed. Evidence: ${resultDir}`)
-          return
-        }
-
-        phase = 'local-model-protocol-matrix'
-        await verifyModelProtocolMatrix({
-          cases: LOCAL_CUSTOM_MODEL_PROTOCOL_MATRIX_CASES,
-          composerSelector,
-          control,
-          newConversationSelector: `${projectRowSelector} [data-testid="project-new-conversation-button"]`,
-          screenshotPrefix: 'local-matrix',
-          workspacePath,
-        })
-
-        await ensureTaskRowVisible(control, taskRowTestId)
-        await control.command('click', `[data-testid="${taskRowTestId}"]`)
-        await control.command('waitFor', '[data-testid="model-selector-button"]', {
-          text: DEFAULT_MODEL_LABEL,
-          timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
         })
       }
 

--- a/wework/e2e/desktop/task-flow.e2e.mjs
+++ b/wework/e2e/desktop/task-flow.e2e.mjs
@@ -14970,17 +14970,26 @@ last_updated = "2026-07-30T00:00:00Z"`
 
     if (DESKTOP_SEGMENT === 'model-routing' || MODEL_SWITCH_ONLY) {
       phase = 'model-routing-project'
+      const projectMenusBeforeModelRouting = new Set(
+        JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
+          testId.startsWith('project-menu-')
+        )
+      )
       await createSingleRootLocalProject(control, workspacePath, 'workspace')
       await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
         timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
       })
       const projectSnapshot = await waitForSnapshot(
         control,
-        snapshot => snapshot.testIds.some(testId => testId.startsWith('project-menu-')),
+        snapshot =>
+          snapshot.testIds.some(
+            testId =>
+              testId.startsWith('project-menu-') && !projectMenusBeforeModelRouting.has(testId)
+          ),
         'The model-routing project was not shown in the sidebar'
       )
-      const projectMenuTestId = projectSnapshot.testIds.find(testId =>
-        testId.startsWith('project-menu-')
+      const projectMenuTestId = projectSnapshot.testIds.find(
+        testId => testId.startsWith('project-menu-') && !projectMenusBeforeModelRouting.has(testId)
       )
       assert.ok(projectMenuTestId, 'The model-routing project identity was not found')
       const projectId = projectMenuTestId.slice('project-menu-'.length)
@@ -15407,10 +15416,6 @@ last_updated = "2026-07-30T00:00:00Z"`
         `${JSON.stringify(control.modelRequests, null, 2)}\n`,
         'utf8'
       )
-      if (MODEL_SWITCH_ONLY) {
-        console.log(`Wework desktop six-way model-switch E2E passed. Evidence: ${resultDir}`)
-        return
-      }
       if (shouldStopAfterDesktopCheckpoint('model-routing')) {
         console.log(`Wework desktop model-routing checkpoint passed. Evidence: ${resultDir}`)
         return


### PR DESCRIPTION
## What changed

- split the automation lifecycle out of `core-task-flow` into an independently bootstrapped `automation-lifecycle` checkpoint
- split local model switching, provider retry, vision sidecar, and protocol matrix coverage into a `model-routing` checkpoint
- classify automation and model-routing changes to the smallest relevant desktop E2E matrix jobs
- run cloud Backend preparation in parallel with Executor compilation, then run remote Executor registration in parallel with the Tauri build
- document the updated checkpoint order and cloud startup dependencies in Chinese and English

## Why

Recent successful CI runs showed `core-task-flow` taking roughly 6.5–7 minutes and the cloud desktop suite taking roughly 10.5–11 minutes. Model routing accounted for about three minutes of the serialized core flow, while cloud startup performed independent build and service-preparation work sequentially.

The new checkpoints preserve the existing assertions and establish their own minimal fixtures, allowing GitHub Actions to execute the slow sections in parallel. The unsegmented complete desktop flow still executes every scenario.

## Impact

- the core task-flow critical path no longer includes automation or the local model protocol matrix
- automation and model-related changes select focused CI jobs
- cloud cold-start work overlaps without changing application startup prerequisites
- no E2E assertions are skipped or weakened

## Validation

- `bash .github/scripts/test-classify-ci-changes.sh`
- `pnpm --filter wework exec prettier --check e2e/desktop/task-flow.e2e.mjs e2e/desktop/checkpoints.mjs`
- `pnpm --filter wework exec eslint e2e/desktop/task-flow.e2e.mjs e2e/desktop/checkpoints.mjs`
- `pnpm --filter wework test` — 344 files, 3325 tests passed
- pre-push ESLint, TypeScript, and unit-test checks passed
- focused real-Tauri `model-routing` checkpoint passed locally

Local macOS runs of longer desktop flows also exposed an existing harness issue where the WebView control client can stop polling after otherwise successful UI commands. Failures occurred at unrelated actions in separate runs; Linux GitHub Actions remains the authoritative full desktop validation environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded desktop end-to-end coverage for automation lifecycle and model routing scenarios.
  * Added validation for model switching, provider retries, vision workflows, request history, and automation execution.
  * Improved cloud test startup coordination to reduce setup delays and improve reliability.

* **Documentation**
  * Updated English and Chinese guides with new test checkpoints, focused commands, coverage details, and parallel startup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->