### PR TITLE
feat(wework): gate task completion notifications on window focus

### DIFF
--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -313,6 +313,8 @@ const LOCAL_WORKSPACE_OPEN_REQUESTED_EVENT: &str = "wework-open-local-workspace-
 #[cfg(desktop)]
 const CLOSE_TO_TRAY_HINT_REQUESTED_EVENT: &str = "wework-close-to-tray-hint-requested";
 #[cfg(desktop)]
+const MAIN_WINDOW_FOCUS_CHANGED_EVENT: &str = "wework-main-window-focus-changed";
+#[cfg(desktop)]
 const TRAY_MENU_OPEN_ID: &str = "open";
 #[cfg(desktop)]
 const TRAY_MENU_SETTINGS_ID: &str = "settings";
@@ -3009,6 +3011,16 @@ fn schedule_frontend_resume_probe<R: tauri::Runtime>(app: &tauri::AppHandle<R>) 
 }
 
 #[cfg(desktop)]
+fn emit_main_window_focus_changed<R: tauri::Runtime>(window: &tauri::Window<R>, focused: bool) {
+    if window.label() != MAIN_WINDOW_LABEL {
+        return;
+    }
+    if let Err(error) = window.app_handle().emit(MAIN_WINDOW_FOCUS_CHANGED_EVENT, focused) {
+        log::warn!("Failed to emit main window focus changed event: {error}");
+    }
+}
+
+#[cfg(desktop)]
 fn handle_main_window_focus_for_frontend_recovery<R: tauri::Runtime>(
     window: &tauri::Window<R>,
     focused: bool,
@@ -4755,6 +4767,7 @@ pub fn run() {
             {
                 if let tauri::WindowEvent::Focused(focused) = event {
                     handle_main_window_focus_for_frontend_recovery(window, *focused);
+                    emit_main_window_focus_changed(window, *focused);
                 }
                 if hide_main_window_on_close(window, event) {
                     return;

--- a/wework/src/features/workbench/runtimeTaskReminders.ts
+++ b/wework/src/features/workbench/runtimeTaskReminders.ts
@@ -17,6 +17,7 @@ import {
 } from '@/components/layout/runtimeTaskSidebarHelpers'
 import { getRuntimeTaskNotificationText } from './runtimeTaskNotificationContent'
 import { sendRuntimeTaskCompletionNotification } from './runtimeTaskSystemNotifications'
+import { isMainWindowFocused, subscribeMainWindowFocus } from '@/tauri/windowFocus'
 import type {
   RuntimeTaskLifecycleStore,
   RuntimeTaskLifecycleStoreSnapshot,
@@ -122,6 +123,13 @@ export function useRuntimeTaskReminders({
   const [preferences, setPreferences] = useState<AppPreferences>(defaultAppPreferences)
   const notifiedTaskKeysRef = useRef<Set<string>>(new Set())
   const previousUnreadTaskKeysRef = useRef<ReadonlySet<string>>(new Set())
+  const windowFocusedRef = useRef(isMainWindowFocused())
+
+  useEffect(() => {
+    return subscribeMainWindowFocus(focused => {
+      windowFocusedRef.current = focused
+    })
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -159,6 +167,7 @@ export function useRuntimeTaskReminders({
       notifiedTaskKeysRef.current.delete(key)
     }
     if (!preferences.taskCompletionNotificationsEnabled) return
+    if (windowFocusedRef.current) return
     for (const item of newlyUnreadItems) {
       if (notifiedTaskKeysRef.current.has(item.key)) continue
       notifiedTaskKeysRef.current.add(item.key)

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -1653,7 +1653,7 @@
     "general_settings_prevent_sleep_while_tasks_running_description": "Prevent idle system sleep while any task is running, then restore the system's normal sleep policy after all tasks finish.",
     "general_settings_system_tray_title": "System tray",
     "general_settings_task_completion_notifications": "Send a system notification when a task completes",
-    "general_settings_task_completion_notifications_description": "Send an operating system notification through the system notification plugin when a background task completes.",
+    "general_settings_task_completion_notifications_description": "Only notify when away: send an operating system notification when a background task completes and the Wework window is not focused.",
     "general_settings_tray_display_content": "Tray display content",
     "general_settings_tray_display_content_description": "Choose which statuses appear in the tray icon and menu.",
     "general_settings_tray_unread": "Unread tasks",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -1652,7 +1652,7 @@
     "general_settings_prevent_sleep_while_tasks_running_description": "有任务运行时阻止电脑因空闲自动休眠；所有任务结束后恢复系统原本的休眠策略。",
     "general_settings_system_tray_title": "系统托盘",
     "general_settings_task_completion_notifications": "任务完成时发送系统通知",
-    "general_settings_task_completion_notifications_description": "后台任务完成后，通过系统通知插件发送操作系统通知。",
+    "general_settings_task_completion_notifications_description": "仅在窗口失焦时提醒：后台任务完成后，若 Wework 窗口未处于焦点状态，通过系统通知发送提醒。",
     "general_settings_tray_display_content": "托盘显示内容",
     "general_settings_tray_display_content_description": "选择托盘图标和菜单里展示的状态。",
     "general_settings_tray_unread": "未读任务",

--- a/wework/src/tauri/windowFocus.ts
+++ b/wework/src/tauri/windowFocus.ts
@@ -1,0 +1,47 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { isTauriRuntime } from '@/lib/runtime-environment'
+import { disposeTauriListener } from './disposeTauriListener'
+
+export const WEWORK_MAIN_WINDOW_FOCUS_CHANGED_EVENT = 'wework-main-window-focus-changed'
+
+const listeners = new Set<(focused: boolean) => void>()
+let currentFocused = true
+let initialized = false
+let unlistenPromise: Promise<UnlistenFn> | null = null
+
+function ensureListenerInstalled() {
+  if (initialized || !isTauriRuntime() || getCurrentWindow().label !== 'main') {
+    return
+  }
+  initialized = true
+  unlistenPromise = listen<boolean>(WEWORK_MAIN_WINDOW_FOCUS_CHANGED_EVENT, event => {
+    const focused = event.payload
+    if (focused === currentFocused) return
+    currentFocused = focused
+    for (const listener of listeners) {
+      listener(focused)
+    }
+  }).catch(error => {
+    initialized = false
+    console.error('[Wework] Failed to install window focus listener', error)
+    return () => {}
+  })
+}
+
+export function isMainWindowFocused(): boolean {
+  return currentFocused
+}
+
+export function subscribeMainWindowFocus(callback: (focused: boolean) => void): () => void {
+  listeners.add(callback)
+  ensureListenerInstalled()
+  return () => {
+    listeners.delete(callback)
+    if (listeners.size === 0 && unlistenPromise) {
+      void unlistenPromise.then(unlisten => disposeTauriListener(unlisten, 'window focus'))
+      unlistenPromise = null
+      initialized = false
+    }
+  }
+}

--- a/wework/src/tauri/windowFocus.ts
+++ b/wework/src/tauri/windowFocus.ts
@@ -11,7 +11,16 @@ let initialized = false
 let unlistenPromise: Promise<UnlistenFn> | null = null
 
 function ensureListenerInstalled() {
-  if (initialized || !isTauriRuntime() || getCurrentWindow().label !== 'main') {
+  if (initialized || !isTauriRuntime()) {
+    return
+  }
+  let label: string
+  try {
+    label = getCurrentWindow().label
+  } catch {
+    return
+  }
+  if (label !== 'main') {
     return
   }
   initialized = true


### PR DESCRIPTION
## 背景

现有 `taskCompletionNotificationsEnabled` 开关打开后，任务完成时**无条件**发送 OS 系统通知——即使用户正盯着 Wework 窗口也会弹通知，造成打扰。

## 改动

将通知语义从"总是通知"改为"仅离开时通知"：任务完成时，只有主窗口不在焦点状态才发送系统通知。

### 改动清单

**Rust 侧** — `src-tauri/src/lib.rs`

- 新增 `wework-main-window-focus-changed` 事件常量
- 新增 `emit_main_window_focus_changed` 函数，在 `on_window_event` 的 `Focused` 分支中调用，将 `focused: bool` emit 给前端
- 只对 `main` 窗口生效，popout 窗口不触发

**前端基础设施** — `src/tauri/windowFocus.ts`（新文件）

- 轻量 pub/sub 模块，惰性安装 Tauri event listener
- `isMainWindowFocused()`：同步读当前窗口焦点状态
- `subscribeMainWindowFocus(callback)`：订阅焦点变化，最后一个订阅者取消时自动清理 listener

**通知门控** — `src/features/workbench/runtimeTaskReminders.ts`

- 新增 `windowFocusedRef`，通过 `subscribeMainWindowFocus` 实时更新
- 在发通知的 effect 中，`taskCompletionNotificationsEnabled` 检查之后加 `if (windowFocusedRef.current) return`——窗口有焦点时跳过通知

**i18n** — zh-CN / en

- 更新 `general_settings_task_completion_notifications_description` 描述为"仅在窗口失焦时提醒"

### 不涉及 backend

OS 系统通知路径：executor → backend WS 转发 → 前端判断 → `@tauri-apps/plugin-notification` 弹通知。backend 只是中转，门控逻辑在前端，无需改 backend。

## 测试

- ESLint: PASSED
- TypeScript: PASSED
- Unit Tests: PASSED (3332 tests)
- pre-commit / pre-push hooks: PASSED

## 后续

锁屏检测（macOS `NSWorkspaceDidLockNotification` / Windows `WM_WTSSESSION_CHANGE` / Linux D-Bus）作为第二期增强，可在 Rust 侧加平台特定监听后同样 emit 事件到前端，前端门控逻辑无需再改。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task-completion notifications now respect the Wework window’s focus state.
  * Notifications are suppressed while the main window is focused and shown when you are away.

* **Documentation**
  * Updated English and Chinese notification descriptions to clarify when task-completion alerts are delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->