### PR TITLE
fix: quick launch mode routing

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -688,6 +688,22 @@ def _get_user_quick_access_team_ids(current_user: User) -> list[int]:
     return quick_access_config.get("teams", [])
 
 
+def _get_team_recommended_mode(team_data: dict) -> str:
+    spec = team_data.get("spec", {})
+    bind_mode = spec.get("bind_mode")
+    if isinstance(bind_mode, list):
+        has_chat = "chat" in bind_mode
+        has_code = "code" in bind_mode
+        if has_chat and has_code:
+            return "both"
+        if has_code:
+            return "code"
+        return "chat"
+
+    recommended_mode = team_data.get("recommended_mode") or spec.get("recommended_mode")
+    return recommended_mode if recommended_mode in {"chat", "code", "both"} else "both"
+
+
 def _build_favorite_agent(team_id: int) -> Optional[QuickLaunchFavoriteAgent]:
     team_data = kind_service.get_team_by_id(team_id)
     if not team_data:
@@ -704,7 +720,8 @@ def _build_favorite_agent(team_id: int) -> Optional[QuickLaunchFavoriteAgent]:
         title=title,
         description=spec.get("description"),
         icon=spec.get("icon"),
-        recommended_mode=spec.get("recommended_mode", "both"),
+        bind_mode=spec.get("bind_mode") or [],
+        recommended_mode=_get_team_recommended_mode(team_data),
         agent_type=team_data.get("agent_type"),
         quick_phrases=normalize_quick_phrases(spec.get("quick_phrases")),
         input_presets=input_presets_from_phrases(spec.get("quick_phrases")),
@@ -743,7 +760,8 @@ def _build_system_function(
     return QuickLaunchFunctionResponse(
         **function_data,
         name=metadata.get("name", f"team-{config.team_id}"),
-        recommended_mode=team_data.get("recommended_mode") or "both",
+        bind_mode=spec.get("bind_mode") or [],
+        recommended_mode=_get_team_recommended_mode(team_data),
     )
 
 

--- a/backend/app/schemas/quick_launch.py
+++ b/backend/app/schemas/quick_launch.py
@@ -211,6 +211,7 @@ class QuickLaunchFunctionConfig(InputPresetMixin):
 class QuickLaunchFunctionResponse(QuickLaunchFunctionConfig):
     type: Literal["system_function"] = "system_function"
     name: str
+    bind_mode: list[str] = Field(default_factory=list)
     recommended_mode: Literal["chat", "code", "both"] = "both"
 
 
@@ -222,6 +223,7 @@ class QuickLaunchFavoriteAgent(QuickPhraseMixin, InputPresetMixin):
     title: str
     description: Optional[str] = None
     icon: Optional[str] = None
+    bind_mode: list[str] = Field(default_factory=list)
     recommended_mode: Optional[Literal["chat", "code", "both"]] = "both"
     agent_type: Optional[str] = None
 

--- a/backend/tests/api/endpoints/test_user_quick_launch.py
+++ b/backend/tests/api/endpoints/test_user_quick_launch.py
@@ -88,10 +88,10 @@ async def test_quick_launch_returns_system_functions_and_favorite_agents(monkeyp
         return {
             "id": team_id,
             "metadata": {"name": f"team-{team_id}", "displayName": f"Team {team_id}"},
-            "recommended_mode": "chat",
             "spec": {
                 "description": f"Description {team_id}",
                 "icon": "sparkles",
+                "bind_mode": ["code"],
                 "quick_phrases": [f"agent phrase {team_id}"],
             },
             "agent_type": "claude",
@@ -114,7 +114,8 @@ async def test_quick_launch_returns_system_functions_and_favorite_agents(monkeyp
     assert response.system_functions[0].name == "team-101"
     assert response.system_functions[0].description == "Description 101"
     assert response.system_functions[0].icon == "sparkles"
-    assert response.system_functions[0].recommended_mode == "chat"
+    assert response.system_functions[0].bind_mode == ["code"]
+    assert response.system_functions[0].recommended_mode == "code"
     assert response.system_functions[0].input_presets[0].id == "roadmap"
     assert (
         response.system_functions[0].input_presets[0].prompt
@@ -138,6 +139,8 @@ async def test_quick_launch_returns_system_functions_and_favorite_agents(monkeyp
     ].options.selected_skill_names == ["ppt"]
     assert response.favorite_agents[0].team_id == 202
     assert response.favorite_agents[0].title == "Team 202"
+    assert response.favorite_agents[0].bind_mode == ["code"]
+    assert response.favorite_agents[0].recommended_mode == "code"
     assert response.favorite_agents[0].quick_phrases == ["agent phrase 202"]
     assert response.favorite_agents[0].input_presets[0].prompt == "agent phrase 202"
 

--- a/frontend/src/__tests__/features/resource-library/FeaturedScenarios.test.tsx
+++ b/frontend/src/__tests__/features/resource-library/FeaturedScenarios.test.tsx
@@ -35,6 +35,7 @@ jest.mock('@/apis/user', () => ({
           title: 'Coding Agent',
           description: 'Build software',
           recommended_mode: 'code',
+          bind_mode: [],
           enabled: true,
           order: 2,
           input_presets: [
@@ -42,6 +43,30 @@ jest.mock('@/apis/user', () => ({
             { id: 'test', title: 'Write tests' },
             { id: 'explain', title: 'Explain this module' },
           ],
+        },
+        {
+          type: 'system_function',
+          id: 'image',
+          team_id: 3,
+          name: 'image',
+          title: 'Image Agent',
+          recommended_mode: 'chat',
+          bind_mode: ['image'],
+          enabled: true,
+          order: 3,
+          input_presets: [{ id: 'draw', title: 'Draw an image' }],
+        },
+        {
+          type: 'system_function',
+          id: 'video',
+          team_id: 4,
+          name: 'video',
+          title: 'Video Agent',
+          recommended_mode: 'chat',
+          bind_mode: ['video'],
+          enabled: true,
+          order: 4,
+          input_presets: [{ id: 'create', title: 'Create a video' }],
         },
       ],
       favorite_agents: [],
@@ -131,6 +156,26 @@ describe('FeaturedScenarios', () => {
     fireEvent.click(screen.getByTestId('featured-agent-coder-example-review'))
     expect(mockPush).toHaveBeenCalledWith(
       '/chat?teamId=2&quickLauncher=system%3Acoder&quickPreset=review&agent=code'
+    )
+
+    fireEvent.click(screen.getByTestId('featured-agent-image-example-draw'))
+    expect(mockPush).toHaveBeenCalledWith(
+      '/chat?teamId=3&quickLauncher=system%3Aimage&quickPreset=draw&mode=image'
+    )
+
+    fireEvent.click(screen.getByTestId('featured-agent-image-open'))
+    expect(mockPush).toHaveBeenCalledWith(
+      '/chat?teamId=3&quickLauncher=system%3Aimage&showPresets=1&mode=image'
+    )
+
+    fireEvent.click(screen.getByTestId('featured-agent-video-example-create'))
+    expect(mockPush).toHaveBeenCalledWith(
+      '/chat?teamId=4&quickLauncher=system%3Avideo&quickPreset=create&mode=video'
+    )
+
+    fireEvent.click(screen.getByTestId('featured-agent-video-open'))
+    expect(mockPush).toHaveBeenCalledWith(
+      '/chat?teamId=4&quickLauncher=system%3Avideo&showPresets=1&mode=video'
     )
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/chat/ChatArea.queue-message-handler.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/ChatArea.queue-message-handler.test.tsx
@@ -217,6 +217,30 @@ jest.mock('@/features/tasks/components/chat/QuickAccessCards', () => ({
       </button>
       <button
         type="button"
+        data-testid="quick-preset-title-trigger"
+        onClick={() =>
+          props.onPresetSelect?.({
+            launcher: {
+              key: 'system:quick_site',
+              type: 'system_function',
+              title: 'Quick Site',
+              team: { id: 12 },
+              targetPage: 'chat',
+              inputPresets: [],
+            },
+            preset: {
+              id: 'internal_vote',
+              title: 'Build an internal voting site',
+              prompt: null,
+              source_attachment_ids: [],
+            },
+          })
+        }
+      >
+        Quick preset without prompt
+      </button>
+      <button
+        type="button"
         data-testid="quick-team-trigger"
         onClick={() =>
           props.onTeamSelect({
@@ -393,6 +417,24 @@ describe('ChatArea queue message handler mounting', () => {
   it('mounts QueueMessageHandler for chat mode', () => {
     render(<ChatArea teams={[]} isTeamsLoading={false} taskType="chat" showRepositorySelector />)
     expect(screen.getByTestId('queue-message-handler')).toBeInTheDocument()
+  })
+
+  it('keeps the selected team and code mode after consuming a quick launch preset', async () => {
+    mockSearchParams = new URLSearchParams({
+      teamId: '12',
+      quickLauncher: 'system:quick_site',
+      quickPreset: 'internal_vote',
+      agent: 'code',
+    })
+    mockRouterReplace.mockImplementationOnce((href: string) => {
+      mockSearchParams = new URL(href, 'http://localhost').searchParams
+    })
+
+    render(<ChatArea teams={[]} isTeamsLoading={false} taskType="code" showRepositorySelector />)
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith('/chat?teamId=12&agent=code')
+    })
   })
 
   it('renders chat mode when search params are unavailable', () => {
@@ -718,6 +760,14 @@ describe('ChatArea queue message handler mounting', () => {
         expect.objectContaining({ focusInputAtEndSignal: 1 })
       )
     })
+  })
+
+  it('uses the preset title when the preset prompt is empty', () => {
+    render(<ChatArea teams={[]} isTeamsLoading={false} taskType="chat" showRepositorySelector />)
+
+    fireEvent.click(screen.getByTestId('quick-preset-title-trigger'))
+
+    expect(mockSetTaskInputMessage).toHaveBeenCalledWith('Build an internal voting site')
   })
 
   it('prepares and displays quick launch preset attachments', async () => {

--- a/frontend/src/__tests__/features/tasks/components/chat/quick-launch/launch-intent.test.ts
+++ b/frontend/src/__tests__/features/tasks/components/chat/quick-launch/launch-intent.test.ts
@@ -1,0 +1,24 @@
+import {
+  parseQuickLaunchIntent,
+  removeQuickLaunchQueryParams,
+} from '@/features/tasks/components/chat/quick-launch/launch-intent'
+
+describe('quick launch intent', () => {
+  it('keeps the selected team after consuming a preset', () => {
+    const params = new URLSearchParams({
+      teamId: '42',
+      quickLauncher: 'system:quick-site',
+      quickPreset: 'internal-vote',
+      agent: 'code',
+    })
+
+    expect(parseQuickLaunchIntent(params)).toEqual({
+      teamId: 42,
+      launcherKey: 'system:quick-site',
+      presetId: 'internal-vote',
+      showPresets: false,
+    })
+
+    expect(removeQuickLaunchQueryParams(params).toString()).toBe('teamId=42&agent=code')
+  })
+})

--- a/frontend/src/features/resource-library/components/FeaturedScenarios.tsx
+++ b/frontend/src/features/resource-library/components/FeaturedScenarios.tsx
@@ -9,7 +9,10 @@ import { useRouter } from 'next/navigation'
 import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
 
 import { userApis } from '@/apis/user'
-import { buildTeamTargetHref } from '@/features/tasks/components/selector/team-selector-utils'
+import {
+  buildTeamTargetHref,
+  getBindModesTargetPage,
+} from '@/features/tasks/components/selector/team-selector-utils'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { QuickLaunchFunction } from '@/types/api'
@@ -44,7 +47,11 @@ function getAgentHref(agent: QuickLaunchFunction, presetId?: string) {
   } else if (agent.input_presets.length > 0) {
     params.set('showPresets', '1')
   }
-  const targetPage = agent.recommended_mode === 'code' ? 'code' : 'chat'
+  const targetPage = agent.bind_mode?.length
+    ? getBindModesTargetPage(agent.bind_mode, 'all')
+    : agent.recommended_mode === 'code'
+      ? 'code'
+      : 'chat'
   return buildTeamTargetHref(targetPage, params)
 }
 

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -1635,7 +1635,7 @@ function ChatAreaContent({
         skillSelector.setSelectedSkillNames(options.selected_skill_names)
       }
 
-      const prompt = preset.prompt?.trim()
+      const prompt = preset.prompt?.trim() || preset.title.trim()
       if (prompt) {
         handleQuickPhraseSelect(prompt)
       }

--- a/frontend/src/features/tasks/components/chat/quick-launch/launch-intent.ts
+++ b/frontend/src/features/tasks/components/chat/quick-launch/launch-intent.ts
@@ -69,7 +69,6 @@ export function parseQuickLaunchIntent(searchParams: URLSearchParams): QuickLaun
 
 export function removeQuickLaunchQueryParams(searchParams: URLSearchParams): URLSearchParams {
   const nextParams = new URLSearchParams(searchParams.toString())
-  nextParams.delete(QUICK_LAUNCH_QUERY.teamId)
   nextParams.delete(QUICK_LAUNCH_QUERY.launcher)
   nextParams.delete(QUICK_LAUNCH_QUERY.preset)
   nextParams.delete(QUICK_LAUNCH_QUERY.showPresets)

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -729,6 +729,7 @@ export interface QuickLaunchFunction {
   cover?: string | null
   team_id: number
   name: string
+  bind_mode?: TaskType[]
   recommended_mode?: 'chat' | 'code' | 'both'
   enabled: boolean
   order: number
@@ -743,6 +744,7 @@ export interface QuickLaunchFavoriteAgent {
   title: string
   description?: string | null
   icon?: string | null
+  bind_mode?: TaskType[]
   recommended_mode?: 'chat' | 'code' | 'both'
   agent_type?: string | null
   quick_phrases: string[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-launch items now support chat, code, or combined modes.
  * Featured scenarios open in the appropriate mode, including image and video experiences.
  * Quick-launch presets without prompts now use their title as the chat input.

* **Bug Fixes**
  * Selecting a preset preserves the chosen team and code mode.
  * Quick-launch navigation now removes only relevant launch parameters, preserving team selection.
  * Improved fallback behavior when mode information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->