### PR TITLE
fix(wework): close model menu after selection

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -532,6 +532,8 @@ recipe closely:
 - desktop project, quick-phrase, model, execution-mode, and branch selectors
   use the same `text-sm` role at regular weight; mobile variants may retain
   their larger touch-oriented typography;
+- selecting a model is a terminal menu action and closes the model selector;
+  reasoning and speed adjustments keep it open for consecutive changes;
 - on the home screen only, render the project selector as a separate background
   layer above the input surface, with the foreground Composer overlapping its
   lower edge; do not merge the selector into an internal top toolbar;

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -552,6 +552,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('model-switch-warning-dialog')).toHaveTextContent(
       'Switching to Second Model may change how the existing context is understood.'
     )
+    expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
     expect(setSelectedModel).not.toHaveBeenCalled()
 
     await userEvent.click(screen.getByTestId('model-switch-warning-cancel-button'))

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1477,7 +1477,7 @@ describe('ChatInput', () => {
     expect(screen.queryByTestId('project-work-button')).not.toBeInTheDocument()
   })
 
-  test('opens the desktop model menu with real model options', async () => {
+  test('opens the desktop model menu with real model options and closes it after selection', async () => {
     const model: UnifiedModel = {
       name: 'overseas-gpt-5.5',
       type: 'user',
@@ -1588,8 +1588,9 @@ describe('ChatInput', () => {
     await userEvent.click(screen.getByTestId('model-option-overseas-gpt-5.5'))
 
     expect(setSelectedModel).toHaveBeenCalledWith(model)
-    expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-selector-menu')).not.toBeInTheDocument()
 
+    await userEvent.click(screen.getByTestId('model-selector-button'))
     await userEvent.hover(screen.getByTestId('model-control-menu-reasoning'))
 
     expect(screen.getByTestId('model-control-reasoning-high')).toBeInTheDocument()
@@ -2296,7 +2297,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
   })
 
-  test('keeps the desktop model menu open after selecting a model opened by external signal', async () => {
+  test('closes the desktop model menu after selecting a model opened by external signal', async () => {
     const model: UnifiedModel = {
       name: 'ali-qwen3-coder-plus',
       type: 'user',
@@ -2333,7 +2334,7 @@ describe('ChatInput', () => {
     await userEvent.click(screen.getByTestId('model-option-ali-qwen3-coder-plus'))
 
     expect(setSelectedModel).toHaveBeenCalledWith(model)
-    expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-selector-menu')).not.toBeInTheDocument()
   })
 
   test('keeps the desktop model submenu inside the viewport near the bottom edge', async () => {

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -677,9 +677,10 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
       !isSameModel(controls.activeModel, model)
     ) {
       setPendingModelSelection({ model, options })
-      return
+      return false
     }
     applyModelSelection(model, options)
+    return true
   }
 
   const confirmModelSelection = () => {

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -90,7 +90,7 @@ interface CompactChatComposerProps {
   selectedModel?: UnifiedModel | null
   activeModel?: UnifiedModel | null
   selectedModelOptions?: ModelOptions
-  onSelectModel?: (model: UnifiedModel | null) => void
+  onSelectModel?: (model: UnifiedModel | null) => boolean | void
   onBlockedModelSelect?: (model: UnifiedModel, message?: string) => void
   isModelSelectionReady?: boolean
   isStreaming?: boolean

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -28,7 +28,7 @@ interface ComposerToolbarProps {
   onModelSelectorOpenChange?: (open: boolean) => void
   isModelSelectionReady: boolean
   contextUsage?: RuntimeContextUsage
-  onSelectModel: (model: UnifiedModel | null) => void
+  onSelectModel: (model: UnifiedModel | null) => boolean | void
   onSelectModelAndOptions?: (model: UnifiedModel, options: ModelOptions) => void
   onSelectModelOption: (optionId: string, value: string) => void
   onBlockedModelSelect?: (model: UnifiedModel, message?: string) => void

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -158,10 +158,11 @@ export function ModelSelector({
   )
   const handleSelectModel = useCallback(
     (model: UnifiedModel | null) => {
-      onSelectModel(model)
-      if (isMobile) {
+      const selectionApplied = onSelectModel(model)
+      if (isMobile && selectionApplied !== false) {
         closeMenu()
       }
+      return selectionApplied
     },
     [closeMenu, isMobile, onSelectModel]
   )
@@ -571,8 +572,9 @@ export function ModelSelector({
               onBlockedModelSelect?.(model, disabledMessage)
               return
             }
-            handleSelectModel(model)
-            closeMenu()
+            if (handleSelectModel(model) !== false) {
+              closeMenu()
+            }
           }}
           className={[
             `flex h-8 w-full items-center gap-2 rounded-lg ${indented ? 'pl-5 pr-2' : 'px-2'} text-left text-sm leading-[18px]`,

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -572,6 +572,7 @@ export function ModelSelector({
               return
             }
             handleSelectModel(model)
+            closeMenu()
           }}
           className={[
             `flex h-8 w-full items-center gap-2 rounded-lg ${indented ? 'pl-5 pr-2' : 'px-2'} text-left text-sm leading-[18px]`,

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -71,7 +71,7 @@ interface ProjectChatComposerProps {
   uploadingFiles: Map<string, { file: File; progress: number }>
   attachmentErrors: Map<string, string>
   contextUsage?: RuntimeContextUsage
-  onSelectModel: (model: UnifiedModel | null) => void
+  onSelectModel: (model: UnifiedModel | null) => boolean | void
   onSelectModelAndOptions?: (model: UnifiedModel, options: ModelOptions) => void
   onSelectModelOption: (optionId: string, value: string) => void
   onBlockedModelSelect?: (model: UnifiedModel, message?: string) => void

--- a/wework/src/components/chat/composer/model-selector-types.ts
+++ b/wework/src/components/chat/composer/model-selector-types.ts
@@ -6,7 +6,7 @@ export interface ModelSelectorProps {
   selectedModelOptions: ModelOptions
   nextTurn?: boolean
   disabled: boolean
-  onSelectModel: (model: UnifiedModel | null) => void
+  onSelectModel: (model: UnifiedModel | null) => boolean | void
   onSelectModelAndOptions?: (model: UnifiedModel, options: ModelOptions) => void
   onSelectModelOption: (optionId: string, value: string) => void
   onBlockedModelSelect?: (model: UnifiedModel, message?: string) => void


### PR DESCRIPTION
## What changed

- Close the desktop model selector after choosing an enabled model.
- Keep reasoning and speed controls open for consecutive adjustments.
- Update regression coverage for normal and externally opened selectors.
- Document the interaction contract in the Wework design specification.

## Root cause

The shared model selection handler only closed the selector on mobile, so desktop model choices updated state while leaving both menu levels visible.

## Validation

- Focused ChatInput model-menu tests
- Reasoning-option menu persistence regression test
- Pre-push ESLint
- Pre-push TypeScript checks
- Pre-push Wework unit test suite

## Desktop verification

An isolated real-Tauri session was attempted twice. The app remained in local-runtime initialization because the isolated executor did not emit its ready event; logs were retained under `wework/test-results/ai-verify/` and no product-code failure was observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The desktop model selector now closes automatically after you choose an available model.
  * The selector remains open when adjusting reasoning and speed settings consecutively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->