### PR TITLE
fix(wework): collapse plugin picker in conversations

### DIFF
--- a/docs/en/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/en/wework/developer-guide/wework-codex-plugins.md
@@ -86,6 +86,8 @@ Wework includes the current model category in local runtime requests. Official C
 
 ## Chat Runtime
 
+For a new chat, the composer shows the plugin entry with previews for up to three available plugins. After the conversation starts, the entry collapses to a single icon to reduce toolbar usage, while clicking the icon still opens the complete plugin picker. Narrow toolbars use the icon form as well.
+
 When a user selects a skill, app, or plugin in the composer, the editor inserts an indivisible inline mention. The cursor can only stop before or after the mention; copy and submit serialize it as Codex app-server-compatible Markdown:
 
 - Skills use `[$name](/absolute/path/to/SKILL.md)`.

--- a/docs/zh/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-codex-plugins.md
@@ -86,6 +86,8 @@ Wework 会把当前模型类别写入本地运行时请求。Codex 官方模型�
 
 ## 对话运行时
 
+新对话的 Composer 会展开显示插件入口和最多三个可用插件预览；进入会话后，插件入口折叠为单个图标以减少工具栏占用，但点击图标仍会打开完整插件选择器。窄工具栏同样使用图标形态。
+
 用户在输入框中选择 skill、app 或插件时，编辑器插入不可拆分的行内 mention。光标只能停在 mention 前后；复制或提交时，编辑器会把 mention 序列化为 Codex app-server 支持的 markdown 输入：
 
 - skill 使用 `[$name](/absolute/path/to/SKILL.md)`。

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1812,6 +1812,13 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('treats a selected runtime task with an empty transcript as a conversation', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      if (this.getAttribute('data-testid') === 'composer-toolbar') {
+        return createRect({ left: 0, top: 0, width: 600, height: 32 })
+      }
+      return createRect({ left: 0, top: 0, width: 0, height: 0 })
+    })
+
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
@@ -1852,6 +1859,8 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(screen.getByTestId('desktop-floating-composer-layer')).toBeInTheDocument()
     expect(screen.queryByTestId('desktop-empty-composer-frame')).not.toBeInTheDocument()
+    expect(screen.getByTestId('composer-plugin-picker-button')).toHaveClass('h-7', 'w-7')
+    expect(screen.queryByTestId('composer-plugin-preview-icons')).not.toBeInTheDocument()
     const paneTitle = screen.getByTestId('workbench-pane-task-title')
     expect(paneTitle).toHaveTextContent('Fix pane title')
     expect(paneTitle).toHaveClass('truncate', 'text-sm', 'text-text-primary')

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2622,6 +2622,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                                     onDraftEdit={paneSession.clearError}
                                     onSubmit={submitPaneInput}
                                     disabled={composerDisabled}
+                                    pluginPickerIconOnly={hasConversation}
                                     submitDisabled={paneSession.status.isSubmitting}
                                     error={paneSession.error}
                                     disabledReason={inlineComposerDisabledReason}


### PR DESCRIPTION
## What changed

- Restore the conversation composer wiring that collapses the plugin picker to a single icon after a conversation starts.
- Add a layout-level regression assertion for an active runtime task with an empty transcript and a wide toolbar.
- Document the expanded-new-chat and collapsed-active-conversation behavior in Chinese and English.

## Root cause

PR #2549 removed `pluginPickerIconOnly={hasConversation}` from the main conversation composer, so the picker kept rendering the expanded plugin preview chip even after entering a conversation.

## User impact

Active conversations once again use the compact plugin icon while preserving access to the complete plugin picker. New chats still show the expanded preview.

## Validation

- `pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx -t "treats a selected runtime task with an empty transcript as a conversation"`
- `pnpm --filter wework exec prettier --check src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx` (no errors; one pre-existing warning)
- Pre-push Wework ESLint, TypeScript, and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The plugin picker now shows up to three plugin previews when starting a new chat.
  - In active conversations and narrow toolbars, the picker collapses to a compact icon while remaining fully accessible.
- **Documentation**
  - Updated English and Chinese developer guides to describe the plugin picker’s new display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->