### PR TITLE
fix(ci): keep Wegent releases from becoming latest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -159,6 +159,9 @@ jobs:
       - name: Test CI cache policy
         run: .github/scripts/test-ci-cache-policy.sh
 
+      - name: Test Wegent release policy
+        run: scripts/test-publish-image-release-policy.sh
+
       - name: Test repository policy workflow
         run: scripts/test-repository-policy-workflow.sh
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1185,6 +1185,7 @@ jobs:
           body: ${{ steps.release-notes.outputs.body }}
           draft: false
           prerelease: false
+          make_latest: false
           files: |
             ./executor-binaries/wegent-executor-macos-arm64
             ./executor-binaries/wegent-executor-macos-amd64

--- a/scripts/test-publish-image-release-policy.sh
+++ b/scripts/test-publish-image-release-policy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$PROJECT_ROOT/.github/workflows/publish-image.yml"
+
+release_step="$(
+    awk '
+        /^      - name: Create GitHub Release$/ {
+            in_step = 1
+        }
+        in_step && /^      - name:/ && $0 !~ /Create GitHub Release$/ {
+            exit
+        }
+        in_step {
+            print
+        }
+    ' "$WORKFLOW"
+)"
+
+if [ -z "$release_step" ]; then
+    echo "Create GitHub Release step was not found."
+    exit 1
+fi
+
+if ! grep -Fq "make_latest: false" <<< "$release_step"; then
+    echo "Wegent releases must not be marked as the latest GitHub release."
+    exit 1
+fi
+
+echo "publish-image release policy regression test passed"


### PR DESCRIPTION
## Summary

- configure the Wegent GitHub Release action with `make_latest: false`
- add a regression test for the release policy
- run the policy test in the repository lint workflow

## Root cause

The release workflow relied on the GitHub Release action default, so publishing a Wegent release could automatically move the repository's Latest release marker.

## Impact

Wegent releases continue to publish versioned GitHub Releases and assets, but they no longer become the repository's Latest release. Container image tags, including image `latest` tags, are unchanged.

## Validation

- `scripts/test-publish-image-release-policy.sh`
- `scripts/test-publish-image-standalone-gate.sh`
- `.github/scripts/test-classify-ci-changes.sh`
- `.github/scripts/test-ci-cache-policy.sh`
- `scripts/test-repository-policy-workflow.sh`
- `actionlint .github/workflows/publish-image.yml .github/workflows/lint.yml`
- `git diff --check`

Task: WEWORKC2FA61-135