### PR TITLE
fix(wework): sync API model reasoning settings

### DIFF
--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -111,6 +111,7 @@ describe('createLocalAppServices', () => {
             ui: expect.objectContaining({
               family: 'model-interface:%E6%9C%AC%E5%9C%B0%E6%8E%A8%E7%90%86',
               familyLabel: '本地推理',
+              reasoningEfforts: [],
             }),
           }),
           runtime: { family: 'openai.openai-responses', provider: 'local' },

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -289,7 +289,7 @@ function localModelConfigToUnifiedModel(config: LocalModelConfig): UnifiedModel 
         family,
         ...(group ? { familyLabel: group } : {}),
         modelLabel: config.displayName,
-        ...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+        reasoningEfforts,
         ...(defaultReasoningEffort ? { defaultReasoningEffort } : {}),
         controls: ['speed'],
         sortOrder: 20,

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1830,6 +1830,221 @@ describe('ChatInput', () => {
     }
   })
 
+  test('uses the current API model efforts without switching to same-id Codex Auth', async () => {
+    const apiModel: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      provider: 'local',
+      displayName: 'API Sol',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          modelLabel: 'API Sol',
+          reasoningEfforts: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+          defaultReasoningEffort: 'minimal',
+          controls: ['speed'],
+        },
+      },
+    }
+    const officialModel: UnifiedModel = {
+      name: 'gpt-5.6-sol',
+      type: 'runtime',
+      provider: 'local',
+      displayName: 'GPT 5.6 Sol',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'codex-official',
+        ui: {
+          family: 'codex-official',
+          modelLabel: 'GPT 5.6 Sol',
+          reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'ultra'],
+          defaultReasoningEffort: 'medium',
+          controls: ['speed'],
+        },
+      },
+    }
+    const setSelectedModel = vi.fn()
+    const setSelectedModelAndOptions = vi.fn()
+    const setSelectedModelOption = vi.fn()
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [officialModel, apiModel],
+          selectedModel: apiModel,
+          selectedModelOptions: { reasoning: 'xhigh', speed: 'standard' },
+          setSelectedModel,
+          setSelectedModelAndOptions,
+          setSelectedModelOption,
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+    await userEvent.hover(screen.getByTestId('model-control-menu-reasoning'))
+
+    const submenu = screen.getByTestId('model-selector-submenu')
+    expect(within(submenu).getByTestId('model-control-reasoning-minimal')).toHaveTextContent(
+      'Minimal'
+    )
+    expect(within(submenu).getByTestId('model-control-reasoning-low')).toHaveTextContent('Low')
+    expect(within(submenu).getByTestId('model-control-reasoning-xhigh')).toHaveTextContent(
+      'Extra high'
+    )
+    expect(within(submenu).getByTestId('model-control-reasoning-max')).toHaveTextContent('Maximum')
+    expect(within(submenu).getByTestId('model-control-reasoning-ultra')).toHaveTextContent('Ultra')
+    expect(within(submenu).queryByTestId('model-control-reasoning-none')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('model-advanced-toggle'))
+
+    expect(screen.getByTestId('model-advanced-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-reasoning-minimal')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-reasoning-max')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-reasoning-ultra')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-power-setting-gpt-5-6-sol-low')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('model-control-reasoning-max'))
+
+    expect(setSelectedModelOption).toHaveBeenCalledWith('reasoning', 'max')
+    expect(setSelectedModel).not.toHaveBeenCalled()
+    expect(setSelectedModelAndOptions).not.toHaveBeenCalled()
+  })
+
+  test('hides the API advanced slider when fewer than two efforts are configured', async () => {
+    const apiModel: UnifiedModel = {
+      name: 'local-model:single-effort',
+      type: 'runtime',
+      provider: 'local',
+      displayName: 'Single effort API',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          modelLabel: 'Single effort API',
+          reasoningEfforts: ['minimal'],
+          defaultReasoningEffort: 'minimal',
+          controls: ['speed'],
+        },
+      },
+    }
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [apiModel],
+          selectedModel: apiModel,
+          selectedModelOptions: { reasoning: 'minimal', speed: 'standard' },
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+
+    expect(screen.queryByTestId('model-advanced-toggle')).not.toBeInTheDocument()
+    await userEvent.hover(screen.getByTestId('model-control-menu-reasoning'))
+    expect(screen.getByTestId('model-control-reasoning-minimal')).toBeInTheDocument()
+  })
+
+  test('shows the API advanced slider when exactly two efforts are configured', async () => {
+    const apiModel: UnifiedModel = {
+      name: 'local-model:two-efforts',
+      type: 'runtime',
+      provider: 'local',
+      displayName: 'Two effort API',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          modelLabel: 'Two effort API',
+          reasoningEfforts: ['minimal', 'max'],
+          defaultReasoningEffort: 'minimal',
+          controls: ['speed'],
+        },
+      },
+    }
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [apiModel],
+          selectedModel: apiModel,
+          selectedModelOptions: { reasoning: 'minimal', speed: 'standard' },
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+    await userEvent.click(screen.getByTestId('model-advanced-toggle'))
+
+    expect(screen.getByTestId('model-advanced-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-reasoning-minimal')).toBeInTheDocument()
+    expect(screen.getByTestId('model-control-reasoning-max')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-control-reasoning-low')).not.toBeInTheDocument()
+  })
+
+  test('does not treat a same-id API model as the default Codex reset target', async () => {
+    const apiSol: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      provider: 'local',
+      displayName: 'API Sol',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['minimal'],
+          defaultReasoningEffort: 'minimal',
+          controls: ['speed'],
+        },
+      },
+    }
+    const selectedApi: UnifiedModel = {
+      ...apiSol,
+      name: 'local-model:selected-api',
+      displayName: 'Selected API',
+      modelId: 'another-model',
+    }
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [apiSol, selectedApi],
+          selectedModel: selectedApi,
+          selectedModelOptions: { reasoning: 'minimal', speed: 'standard' },
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+
+    expect(screen.getByTestId('model-reset-default-button')).toBeDisabled()
+  })
+
   test('renders the advertised ultra effort with purple summary and slider treatment', async () => {
     const model: UnifiedModel = {
       name: 'gpt-5.6-sol',

--- a/wework/src/components/chat/composer/ModelPowerSlider.tsx
+++ b/wework/src/components/chat/composer/ModelPowerSlider.tsx
@@ -4,6 +4,7 @@ import {
   type ModelControlConfig,
   getControlsForModel,
   getModelDisplayLabel,
+  isSameModelSelection,
   normalizeModelOptionValue,
 } from '@/lib/model-ui'
 import type { ModelOptions, UnifiedModel } from '@/types/api'
@@ -67,9 +68,7 @@ export function ModelPowerSlider({
       const setting = powerSettings.find(candidate => candidate.id === settingId)
       if (!setting) return
 
-      const sameModel =
-        setting.model.name === selectedModel?.name && setting.model.type === selectedModel?.type
-      if (sameModel) {
+      if (isSameModelSelection(setting.model, selectedModel)) {
         onSelectModelOption('reasoning', setting.reasoningEffort)
         return
       }

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -11,6 +11,7 @@ import {
   getSelectedModelDisplayLabel,
   groupModelsByFamily,
   inferModelFamily,
+  isModelInterfaceModel,
   normalizeModelOptionValue,
 } from '@/lib/model-ui'
 import { cn } from '@/lib/utils'
@@ -384,12 +385,19 @@ export function ModelSelector({
   const selectedReasoningValue =
     normalizeModelOptionValue('reasoning', selectedModelOptions.reasoning) ??
     reasoningControl?.defaultValue
+  const selectedReasoningOption = reasoningControl?.options.find(
+    option => option.value === selectedReasoningValue
+  )
   const ultraLabel =
-    selectedReasoningValue === 'ultra' ? t('workbench.intelligence_ultra', 'Extra High') : undefined
+    selectedReasoningValue === 'ultra' && selectedReasoningOption
+      ? selectedReasoningOption.labelKey
+        ? t(selectedReasoningOption.labelKey, selectedReasoningOption.label)
+        : selectedReasoningOption.label
+      : undefined
   const supportsReasoningControl = Boolean(reasoningControl)
   const speedControl = controlsBelowModels.find(control => control.id === 'speed')
   const fastModeState = desktopFastModeState(speedControl, selectedModelOptions)
-  const desktopReasoningControl = desktopModelControl(reasoningControl)
+  const desktopReasoningControl = desktopModelControl(reasoningControl, selectedModel)
   const desktopControls = [desktopReasoningControl, speedControl].filter(
     (control): control is ModelControlConfig =>
       Boolean(control && !DESKTOP_HIDDEN_CONTROL_IDS.has(control.id))
@@ -397,10 +405,19 @@ export function ModelSelector({
   const desktopModels = useMemo(() => familyGroups.flatMap(group => group.models), [familyGroups])
   const defaultModel = useMemo(() => findCodexDefaultModel(desktopModels), [desktopModels])
   const powerSettings = useMemo(() => getCodexModelPowerSettings(desktopModels), [desktopModels])
-  const selectedPowerSettingAvailable = powerSettings.some(setting =>
+  const codexPowerSettingAvailable = powerSettings.some(setting =>
     isSelectedPowerSetting(setting, selectedModel, selectedModelOptions.reasoning)
   )
-  const powerViewOpen = advancedOpen && selectedPowerSettingAvailable
+  const currentModelSliderAvailable = Boolean(
+    isModelInterfaceModel(selectedModel) && (desktopReasoningControl?.options.length ?? 0) >= 2
+  )
+  const advancedReasoningMode = codexPowerSettingAvailable
+    ? 'codex-power'
+    : currentModelSliderAvailable
+      ? 'current-model'
+      : null
+  const advancedReasoningAvailable = advancedReasoningMode !== null
+  const powerViewOpen = advancedOpen && advancedReasoningAvailable
   const activeControl =
     activeDesktopSubmenu?.type === 'control'
       ? desktopControls.find(control => control.id === activeDesktopSubmenu.id)
@@ -922,7 +939,7 @@ export function ModelSelector({
                   <div className="mx-2 my-1 border-t border-border" />
                 </>
               ) : null}
-              {selectedPowerSettingAvailable ? (
+              {advancedReasoningAvailable ? (
                 <ModelAdvancedHeader
                   disabled={!reasoningControl}
                   interacting={powerSliderInteracting}
@@ -967,16 +984,26 @@ export function ModelSelector({
                   data-enter-animation="advanced"
                   className={styles.advancedPanel}
                 >
-                  <ModelPowerSlider
-                    control={desktopReasoningControl}
-                    models={desktopModels}
-                    selectedModel={selectedModel}
-                    selectedModelOptions={selectedModelOptions}
-                    onSelectModel={handleSelectModel}
-                    onSelectModelAndOptions={onSelectModelAndOptions}
-                    onSelectModelOption={handleSelectModelOption}
-                    onInteractionChange={setPowerSliderInteracting}
-                  />
+                  {advancedReasoningMode === 'codex-power' ? (
+                    <ModelPowerSlider
+                      control={desktopReasoningControl}
+                      models={desktopModels}
+                      selectedModel={selectedModel}
+                      selectedModelOptions={selectedModelOptions}
+                      onSelectModel={handleSelectModel}
+                      onSelectModelAndOptions={onSelectModelAndOptions}
+                      onSelectModelOption={handleSelectModelOption}
+                      onInteractionChange={setPowerSliderInteracting}
+                    />
+                  ) : (
+                    <ReasoningSlider
+                      control={desktopReasoningControl}
+                      selectedModelOptions={selectedModelOptions}
+                      onSelectOption={handleSelectModelOption}
+                      clearSubmenuOnHover={false}
+                      onInteractionChange={setPowerSliderInteracting}
+                    />
+                  )}
                 </div>
               ) : null}
             </div>

--- a/wework/src/components/chat/composer/model-selector-utils.ts
+++ b/wework/src/components/chat/composer/model-selector-utils.ts
@@ -1,6 +1,9 @@
 import {
   type ModelControlConfig,
   getControlsForModel,
+  isCodexOfficialModel,
+  isModelInterfaceModel,
+  isSameModelSelection,
   normalizeModelOptionValue,
 } from '@/lib/model-ui'
 import type { ModelCompatibilityDisabledReason, ModelOptions, UnifiedModel } from '@/types/api'
@@ -46,7 +49,9 @@ function normalizedModelId(model: UnifiedModel): string {
 }
 
 export function isCodexDefaultModel(model: UnifiedModel | null): boolean {
-  return Boolean(model && normalizedModelId(model) === CODEX_DEFAULT_MODEL_ID)
+  return Boolean(
+    model && isCodexOfficialModel(model) && normalizedModelId(model) === CODEX_DEFAULT_MODEL_ID
+  )
 }
 
 export function findCodexDefaultModel(models: UnifiedModel[]): UnifiedModel | null {
@@ -60,7 +65,9 @@ function resolvePowerSettings(
   return definitions.flatMap(definition => {
     const model = models.find(
       candidate =>
-        !candidate.compatibilityDisabled && normalizedModelId(candidate) === definition.modelId
+        !candidate.compatibilityDisabled &&
+        isCodexOfficialModel(candidate) &&
+        normalizedModelId(candidate) === definition.modelId
     )
     if (!model) return []
 
@@ -95,15 +102,16 @@ export function isSelectedPowerSetting(
 ): boolean {
   return Boolean(
     selectedModel &&
-    normalizedModelId(selectedModel) === setting.modelId &&
+    isSameModelSelection(selectedModel, setting.model) &&
     normalizeModelOptionValue('reasoning', reasoningEffort) === setting.reasoningEffort
   )
 }
 
 export function desktopModelControl(
-  control: ModelControlConfig | undefined
+  control: ModelControlConfig | undefined,
+  model: UnifiedModel | null
 ): ModelControlConfig | undefined {
-  if (!control || control.id !== 'reasoning') {
+  if (!control || control.id !== 'reasoning' || isModelInterfaceModel(model)) {
     return control
   }
 

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -650,7 +650,14 @@ describe('ConnectionsSettingsPage', () => {
     await userEvent.click(screen.getByTestId('local-model-input-modality-image'))
     await userEvent.click(screen.getByTestId('local-model-image-generation-checkbox'))
     await userEvent.click(screen.getByTestId('local-model-reasoning-level-high'))
-    await userEvent.selectOptions(screen.getByTestId('local-model-default-reasoning-input'), 'high')
+    const defaultReasoningSelect = screen.getByTestId('local-model-default-reasoning-input')
+    expect(
+      within(defaultReasoningSelect).getByRole('option', {
+        name: '高',
+      })
+    ).toHaveAttribute('value', 'high')
+    expect(within(defaultReasoningSelect).queryByRole('option', { name: 'high' })).toBeNull()
+    await userEvent.selectOptions(defaultReasoningSelect, 'high')
     await userEvent.click(screen.getByTestId('local-model-advanced-capabilities-toggle'))
     await userEvent.click(screen.getByTestId('local-model-advanced-section-metadata'))
     await userEvent.type(screen.getByTestId('local-model-speed-tiers-input'), 'fast')

--- a/wework/src/components/settings/CustomModelCapabilitiesForm.tsx
+++ b/wework/src/components/settings/CustomModelCapabilitiesForm.tsx
@@ -394,9 +394,12 @@ export function CustomModelCapabilitiesForm({
             <option value="">{t('workbench.local_model_automatic_option', '自动')}</option>
             {structuredItems(entry.supported_reasoning_levels).map(item => {
               const effort = stringValue(item.effort)
+              const knownOption = REASONING_LEVEL_OPTIONS.find(option => option.effort === effort)
               return effort ? (
                 <option key={effort} value={effort}>
-                  {effort}
+                  {knownOption
+                    ? t(`workbench.local_model_reasoning_${knownOption.labelKey}`)
+                    : effort}
                 </option>
               ) : null
             })}

--- a/wework/src/features/workbench/useWorkbenchModels.ts
+++ b/wework/src/features/workbench/useWorkbenchModels.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   getDefaultModelOptions,
   inferModelFamily,
+  isSameModelSelection,
   isSupportedModelFamily,
   normalizeModelOptions,
 } from '@/lib/model-ui'
@@ -176,6 +177,43 @@ export function useWorkbenchModels({
     [scopeKey]
   )
 
+  const reconcileSelectedModels = useCallback((nextModels: UnifiedModel[]) => {
+    const selectedModelPatch: Record<string, UnifiedModel> = {}
+    const selectedOptionsPatch: Record<string, ModelOptions> = {}
+
+    for (const [selectedScopeKey, currentModel] of Object.entries(selectedModelRef.current)) {
+      if (!currentModel) continue
+      const refreshedModel = nextModels.find(model => isSameModelSelection(model, currentModel))
+      if (!refreshedModel) continue
+
+      if (refreshedModel !== currentModel) {
+        selectedModelPatch[selectedScopeKey] = refreshedModel
+      }
+
+      const currentOptions = selectedModelOptionsRef.current[selectedScopeKey] ?? {}
+      const normalizedOptions = normalizeModelOptions(refreshedModel, currentOptions)
+      if (!areModelOptionsEqual(currentOptions, normalizedOptions)) {
+        selectedOptionsPatch[selectedScopeKey] = normalizedOptions
+      }
+    }
+
+    if (Object.keys(selectedModelPatch).length > 0) {
+      selectedModelRef.current = {
+        ...selectedModelRef.current,
+        ...selectedModelPatch,
+      }
+      setSelectedModelByScope(current => ({ ...current, ...selectedModelPatch }))
+    }
+
+    if (Object.keys(selectedOptionsPatch).length > 0) {
+      selectedModelOptionsRef.current = {
+        ...selectedModelOptionsRef.current,
+        ...selectedOptionsPatch,
+      }
+      setSelectedModelOptionsByScope(current => ({ ...current, ...selectedOptionsPatch }))
+    }
+  }, [])
+
   useEffect(() => {
     let cancelled = false
 
@@ -186,6 +224,7 @@ export function useWorkbenchModels({
         const response = await api.listModels()
         if (!cancelled) {
           const filtered = response.data.filter(isSupportedModelFamily)
+          reconcileSelectedModels(filterModel ? filtered.filter(filterModel) : filtered)
           setAvailableModels(filtered)
         }
       } catch (nextError) {
@@ -207,7 +246,7 @@ export function useWorkbenchModels({
       window.removeEventListener(LOCAL_MODEL_SETTINGS_CHANGED_EVENT, loadModels)
       window.removeEventListener(WORKBENCH_MODELS_CHANGED_EVENT, loadModels)
     }
-  }, [api])
+  }, [api, filterModel, reconcileSelectedModels])
 
   useEffect(() => {
     if (!selectionReady) {

--- a/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
+++ b/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
@@ -78,6 +78,229 @@ describe('workbench project chat hooks', () => {
     await waitFor(() => expect(result.current.models).toEqual([codexModel, localModel]))
   })
 
+  test('refreshes the selected model metadata while preserving supported options', async () => {
+    const originalModel: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      displayName: 'API Sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['low', 'high'],
+          defaultReasoningEffort: 'low',
+        },
+      },
+    }
+    const refreshedModel: UnifiedModel = {
+      ...originalModel,
+      displayName: 'API Sol Updated',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['minimal', 'high', 'max'],
+          defaultReasoningEffort: 'max',
+        },
+      },
+    }
+    const onSelectionChange = vi.fn()
+    const api = {
+      listModels: vi
+        .fn()
+        .mockResolvedValueOnce({ data: [originalModel] })
+        .mockResolvedValueOnce({ data: [refreshedModel] }),
+    }
+    const { result } = renderHook(() =>
+      useWorkbenchModels({
+        api,
+        locked: false,
+        selectionConfig: {
+          modelName: originalModel.name,
+          modelType: originalModel.type,
+          options: { reasoning: 'high' },
+        },
+        onSelectionChange,
+      })
+    )
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(originalModel))
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
+    })
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(refreshedModel))
+    expect(result.current.selectedModelOptions).toEqual({ reasoning: 'high' })
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the refreshed model default when the selected option is removed', async () => {
+    const originalModel: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['low', 'high'],
+          defaultReasoningEffort: 'low',
+        },
+      },
+    }
+    const refreshedModel: UnifiedModel = {
+      ...originalModel,
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['minimal', 'max'],
+          defaultReasoningEffort: 'max',
+        },
+      },
+    }
+    const onSelectionChange = vi.fn()
+    const api = {
+      listModels: vi
+        .fn()
+        .mockResolvedValueOnce({ data: [originalModel] })
+        .mockResolvedValueOnce({ data: [refreshedModel] }),
+    }
+    const { result } = renderHook(() =>
+      useWorkbenchModels({
+        api,
+        locked: false,
+        selectionConfig: {
+          modelName: originalModel.name,
+          modelType: originalModel.type,
+          options: { reasoning: 'high' },
+        },
+        onSelectionChange,
+      })
+    )
+
+    await waitFor(() => expect(result.current.selectedModelOptions).toEqual({ reasoning: 'high' }))
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
+    })
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(refreshedModel))
+    expect(result.current.selectedModelOptions).toEqual({ reasoning: 'max' })
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the first refreshed option when the configured default is invalid', async () => {
+    const originalModel: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['high'],
+          defaultReasoningEffort: 'high',
+        },
+      },
+    }
+    const refreshedModel: UnifiedModel = {
+      ...originalModel,
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['minimal', 'max'],
+          defaultReasoningEffort: 'high',
+        },
+      },
+    }
+    const api = {
+      listModels: vi
+        .fn()
+        .mockResolvedValueOnce({ data: [originalModel] })
+        .mockResolvedValueOnce({ data: [refreshedModel] }),
+    }
+    const { result } = renderHook(() =>
+      useWorkbenchModels({
+        api,
+        locked: false,
+        selectionConfig: {
+          modelName: originalModel.name,
+          modelType: originalModel.type,
+          options: { reasoning: 'high' },
+        },
+      })
+    )
+
+    await waitFor(() => expect(result.current.selectedModelOptions).toEqual({ reasoning: 'high' }))
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
+    })
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(refreshedModel))
+    expect(result.current.selectedModelOptions).toEqual({ reasoning: 'minimal' })
+  })
+
+  test('clears removed controls for every cached model selection scope', async () => {
+    const originalModel: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: ['minimal', 'max'],
+          defaultReasoningEffort: 'minimal',
+        },
+      },
+    }
+    const refreshedModel: UnifiedModel = {
+      ...originalModel,
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: [],
+        },
+      },
+    }
+    const api = {
+      listModels: vi
+        .fn()
+        .mockResolvedValueOnce({ data: [originalModel] })
+        .mockResolvedValueOnce({ data: [refreshedModel] }),
+    }
+    const { result, rerender } = renderHook(
+      ({ scopeKey }: { scopeKey: string }) =>
+        useWorkbenchModels({
+          api,
+          locked: false,
+          scopeKey,
+          persistSelection: false,
+        }),
+      { initialProps: { scopeKey: 'blank:1' } }
+    )
+
+    await waitFor(() => expect(result.current.models).toEqual([originalModel]))
+    act(() => {
+      result.current.setSelectionForScope('blank:1', originalModel, { reasoning: 'max' })
+      result.current.setSelectionForScope('runtime:task-1', originalModel, { reasoning: 'minimal' })
+    })
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
+    })
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(refreshedModel))
+    expect(result.current.selectedModelOptions).toEqual({})
+
+    rerender({ scopeKey: 'runtime:task-1' })
+
+    expect(result.current.selectedModel).toBe(refreshedModel)
+    expect(result.current.selectedModelOptions).toEqual({})
+  })
+
   test('reloads models after a background cloud model refresh', async () => {
     const localModel: UnifiedModel = { name: 'local-model', type: 'runtime' }
     const cloudModel: UnifiedModel = { name: 'cloud-model', type: 'public' }

--- a/wework/src/lib/model-ui.test.ts
+++ b/wework/src/lib/model-ui.test.ts
@@ -6,6 +6,9 @@ import {
   getControlsForModel,
   groupModelsByFamily,
   inferModelFamily,
+  isCodexOfficialModel,
+  isModelInterfaceModel,
+  isSameModelSelection,
   isSupportedModelFamily,
   normalizeModelOptions,
 } from './model-ui'
@@ -396,5 +399,95 @@ describe('model-ui', () => {
     expect(normalizeModelOptions(model, { reasoning: 'ultra' })).toEqual({
       reasoning: 'medium',
     })
+  })
+
+  test('uses every model-interface reasoning effort in its advertised order', () => {
+    const model: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      displayName: 'API Sol',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: [
+            'minimal',
+            'low',
+            'medium',
+            'high',
+            'xhigh',
+            'max',
+            'ultra',
+            'custom-heavy',
+          ],
+          defaultReasoningEffort: 'minimal',
+        },
+      },
+    }
+
+    const reasoningControl = getControlsForModel(model).find(control => control.id === 'reasoning')
+
+    expect(reasoningControl).toMatchObject({
+      defaultValue: 'minimal',
+      options: [
+        { value: 'minimal', label: 'Minimal' },
+        { value: 'low', label: 'Low' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'high', label: 'High' },
+        { value: 'xhigh', label: 'Extra high' },
+        { value: 'max', label: 'Maximum' },
+        { value: 'ultra', label: 'Ultra' },
+        { value: 'custom-heavy', label: 'custom-heavy' },
+      ],
+    })
+    expect(normalizeModelOptions(model, { reasoning: 'max' })).toEqual({
+      reasoning: 'max',
+    })
+    expect(getSelectedModelDisplayLabel(model, { reasoning: 'ultra' })).toBe('API Sol Ultra')
+  })
+
+  test('omits model-interface reasoning when the model explicitly advertises no efforts', () => {
+    const model: UnifiedModel = {
+      name: 'local-model:no-reasoning',
+      type: 'runtime',
+      displayName: 'No reasoning API',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: {
+          family: 'model-interface',
+          reasoningEfforts: [],
+        },
+      },
+    }
+
+    expect(getControlsForModel(model).map(control => control.id)).not.toContain('reasoning')
+  })
+
+  test('keeps same-id API and Codex Auth models as distinct selections', () => {
+    const official: UnifiedModel = {
+      name: 'gpt-5.6-sol',
+      type: 'runtime',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'codex-official',
+        ui: { family: 'codex-official' },
+      },
+    }
+    const api: UnifiedModel = {
+      name: 'local-model:api-sol',
+      type: 'runtime',
+      modelId: 'gpt-5.6-sol',
+      config: {
+        weworkModelKind: 'model-interface',
+        ui: { family: 'model-interface', reasoningEfforts: ['low', 'high'] },
+      },
+    }
+
+    expect(isCodexOfficialModel(official)).toBe(true)
+    expect(isCodexOfficialModel(api)).toBe(false)
+    expect(isModelInterfaceModel(api)).toBe(true)
+    expect(isSameModelSelection(official, api)).toBe(false)
+    expect(isSameModelSelection(api, { ...api })).toBe(true)
   })
 })

--- a/wework/src/lib/model-ui.ts
+++ b/wework/src/lib/model-ui.ts
@@ -49,6 +49,7 @@ interface ModelUiMetadata {
   modelLabel: string
   sortOrder: number
   supportedControls: Set<string>
+  reasoningEffortsDeclared: boolean
   supportedReasoningEfforts: string[]
   defaultReasoningEffort?: string
 }
@@ -77,6 +78,44 @@ const FAMILY_ORDER = [
 ]
 
 const HIDDEN_MODEL_FAMILIES = new Set(['gemini'])
+
+const MODEL_INTERFACE_REASONING_OPTIONS: Record<
+  string,
+  Pick<ModelControlOption, 'label' | 'labelKey'>
+> = {
+  none: {
+    label: 'None',
+    labelKey: 'workbench.local_model_reasoning_none',
+  },
+  minimal: {
+    label: 'Minimal',
+    labelKey: 'workbench.local_model_reasoning_minimal',
+  },
+  low: {
+    label: 'Low',
+    labelKey: 'workbench.local_model_reasoning_low',
+  },
+  medium: {
+    label: 'Medium',
+    labelKey: 'workbench.local_model_reasoning_medium',
+  },
+  high: {
+    label: 'High',
+    labelKey: 'workbench.local_model_reasoning_high',
+  },
+  xhigh: {
+    label: 'Extra high',
+    labelKey: 'workbench.local_model_reasoning_xhigh',
+  },
+  max: {
+    label: 'Maximum',
+    labelKey: 'workbench.local_model_reasoning_max',
+  },
+  ultra: {
+    label: 'Ultra',
+    labelKey: 'workbench.local_model_reasoning_ultra',
+  },
+}
 
 const OPENAI_RESPONSES_CONTROLS: ModelControlConfig[] = [
   {
@@ -210,6 +249,31 @@ function getConfigUi(model: UnifiedModel): Record<string, unknown> {
   return ui && typeof ui === 'object' && !Array.isArray(ui) ? (ui as Record<string, unknown>) : {}
 }
 
+export function getWeworkModelKind(model: UnifiedModel): string {
+  const configuredKind = model.config?.weworkModelKind
+  if (typeof configuredKind === 'string' && configuredKind.trim()) {
+    return configuredKind.trim().toLowerCase()
+  }
+  return inferModelFamily(model)
+}
+
+export function isCodexOfficialModel(model: UnifiedModel | null): boolean {
+  return Boolean(model && getWeworkModelKind(model) === 'codex-official')
+}
+
+export function isModelInterfaceModel(model: UnifiedModel | null): boolean {
+  if (!model) return false
+  const kind = getWeworkModelKind(model)
+  return kind === 'model-interface' || kind.startsWith('model-interface:')
+}
+
+export function isSameModelSelection(
+  left: UnifiedModel | null,
+  right: UnifiedModel | null
+): boolean {
+  return Boolean(left && right && left.type === right.type && left.name === right.name)
+}
+
 function identityTextForModel(model: UnifiedModel): string {
   return [model.name, model.displayName, model.modelId].filter(Boolean).join(' ').toLowerCase()
 }
@@ -341,13 +405,31 @@ function getExplicitSupportedControls(ui: Record<string, unknown>): Set<string> 
 function getSupportedReasoningEfforts(ui: Record<string, unknown>): string[] {
   const values = ui.reasoningEfforts ?? ui.supportedReasoningEfforts
   if (!Array.isArray(values)) return []
-  return values
-    .filter((value): value is string => typeof value === 'string')
-    .map(value => normalizeModelOptionValue('reasoning', value) ?? value)
+  return Array.from(
+    new Set(
+      values
+        .filter((value): value is string => typeof value === 'string')
+        .map(value => normalizeModelOptionValue('reasoning', value) ?? value)
+        .filter(Boolean)
+    )
+  )
+}
+
+function modelInterfaceReasoningOptions(values: string[]): ModelControlOption[] {
+  return values.map((value, index) => {
+    const configured = MODEL_INTERFACE_REASONING_OPTIONS[value]
+    return {
+      value,
+      label: configured?.label ?? value,
+      ...(configured?.labelKey ? { labelKey: configured.labelKey } : {}),
+      order: (index + 1) * 10,
+    }
+  })
 }
 
 export function getModelUiMetadata(model: UnifiedModel): ModelUiMetadata {
   const ui = getConfigUi(model)
+  const reasoningEfforts = ui.reasoningEfforts ?? ui.supportedReasoningEfforts
   const modelLabel =
     typeof ui.modelLabel === 'string' && ui.modelLabel.trim()
       ? ui.modelLabel.trim()
@@ -363,6 +445,7 @@ export function getModelUiMetadata(model: UnifiedModel): ModelUiMetadata {
     modelLabel,
     sortOrder,
     supportedControls: getExplicitSupportedControls(ui),
+    reasoningEffortsDeclared: Array.isArray(reasoningEfforts),
     supportedReasoningEfforts: getSupportedReasoningEfforts(ui),
     defaultReasoningEffort:
       typeof ui.defaultReasoningEffort === 'string'
@@ -380,8 +463,27 @@ export function getControlsForModel(model: UnifiedModel | null): ModelControlCon
       if ((control.scope ?? 'family') === 'family') return true
       return metadata.supportedControls.has(control.id)
     })
-    .map(control => {
-      if (control.id !== 'reasoning') return control
+    .flatMap(control => {
+      if (control.id !== 'reasoning') return [control]
+      if (isModelInterfaceModel(model) && metadata.reasoningEffortsDeclared) {
+        const options = modelInterfaceReasoningOptions(metadata.supportedReasoningEfforts)
+        if (options.length === 0) return []
+        const configuredDefault = metadata.defaultReasoningEffort
+        const defaultValue =
+          configuredDefault && options.some(option => option.value === configuredDefault)
+            ? configuredDefault
+            : options.some(option => option.value === control.defaultValue)
+              ? control.defaultValue
+              : options[0].value
+        return [
+          {
+            ...control,
+            defaultValue,
+            options,
+          },
+        ]
+      }
+
       const supportedValues = new Set(metadata.supportedReasoningEfforts)
       const options = control.options.filter(option => {
         if (supportedValues.size > 0) return supportedValues.has(option.value)
@@ -393,11 +495,13 @@ export function getControlsForModel(model: UnifiedModel | null): ModelControlCon
         : options.some(option => option.value === control.defaultValue)
           ? control.defaultValue
           : options[0]?.value
-      return {
-        ...control,
-        defaultValue: defaultValue ?? control.defaultValue,
-        options,
-      }
+      return [
+        {
+          ...control,
+          defaultValue: defaultValue ?? control.defaultValue,
+          options,
+        },
+      ]
     })
 
   return controls


### PR DESCRIPTION
## Summary

- API 模型严格按照 `supported_reasoning_levels` 展示推理等级，并保持配置顺序。
- 补齐 `none`、`minimal`、`max`、`ultra` 等等级的本地化展示，未知等级保留原始值。
- 设置页“默认推理等级”与“支持的推理等级”复用同一套文案。
- 保存模型能力配置后，当前对话立即使用最新模型元数据，不需要切换模型再切回来。
- API 模型的“高级”滑杆只更新当前模型的 `reasoning`，不会切换到同 ID 的 Codex Auth 模型。
- API 模型少于两个推理等级时隐藏“高级”；两个及以上等级时显示当前模型滑杆。

## Root cause

1. 对话模型选择器使用 Codex 基础等级集合过滤 API 模型配置，并在桌面端无条件移除 `max`。
2. Codex 高级档位只按 `modelId` 匹配，导致同 ID 的 API 模型和 Codex Auth 模型被误认为同一个模型。
3. 设置页默认等级下拉框直接渲染 `effort` 协议值，没有复用左侧的本地化文案。
4. 模型列表刷新后，当前对话仍持有旧 `UnifiedModel` 对象；仅包含 `type + name` 的选择 key 无法感知能力元数据变化。

## Changes

- Codex 专属能力只接受 `weworkModelKind === 'codex-official'`。
- 当前模型身份统一使用运行时选择键 `type + name`。
- API 普通推理菜单和高级滑杆均由当前模型的 `reasoningEfforts` 动态生成。
- API 高级滑杆只调用 `onSelectModelOption('reasoning', effort)`，不调用模型切换接口。
- 本地 API 模型始终输出 `ui.reasoningEfforts`，包括明确声明的空数组。
- 设置页默认等级对已知值使用 `local_model_reasoning_*` 文案，未知值继续显示原始字符串。
- 模型列表刷新后，同步所有缓存会话 scope 中的同身份模型，并按最新能力归一化当前选项。

## Behavior

| 场景                                 | 修复后行为                        |
| ------------------------------------ | --------------------------------- |
| API 模型配置 0 个等级                | 不显示推理强度和高级入口          |
| API 模型配置 1 个等级                | 显示普通推理强度，隐藏高级入口    |
| API 模型配置 2 个及以上等级          | 普通菜单和高级滑杆都按配置展示    |
| 当前等级在保存后仍受支持             | 保持当前等级并立即刷新能力配置    |
| 当前等级在保存后被删除               | 回退到新默认或首个有效等级        |
| 保存后模型不再支持推理               | 清除推理选项并隐藏相关控件        |
| API 与 Codex Auth 使用相同 `modelId` | 保持为两个独立模型                |
| API 高级滑杆调整档位                 | 只改变当前 API 模型的 `reasoning` |
| Codex Auth 高级滑杆                  | 保持现有 Terra/Sol 跨模型行为     |

## Screenshots

### 设置页推理等级

支持等级与默认等级使用一致的中文文案，并完整展示“极低、低、中、高、极高、最大、Ultra”。

<img width="1410" height="508" alt="01-api-model-seven-level-settings png" src="https://github.com/user-attachments/assets/1b059521-b7b2-43da-9e0f-07b7bb773830" />


### API 模型高级推理

高级滑杆选择最高档位后，当前模型仍保持为 `gpt-5.6-sol`，摘要显示 `Ultra`，不会迁移到别的模型。

<img width="688" height="340" alt="04-api-advanced-max-stays-api" src="https://github.com/user-attachments/assets/27faca75-aaa2-4f61-bc0d-257a63a80896" />


## Testing

- Prettier passed.
- ESLint passed.
- TypeScript typecheck passed.
- Focused Vitest passed: 5 files, 238 tests.
- `git diff --check` passed.

Regression coverage includes:

- API reasoning option order, labels, defaults, and unknown values.
- Empty, single-level, and multi-level API reasoning configurations.
- Same-ID API/Codex model identity isolation.
- API advanced slider updates without model switching.
- Current model metadata refresh after saving settings.
- Valid option preservation and invalid option fallback after refresh.
- Clearing reasoning options across cached conversation scopes.

## Compatibility

- No backend API changes.
- No database or configuration migration.
- Legacy models without declared `reasoningEfforts` keep the existing default behavior.
- Codex Auth labels and Terra/Sol advanced slider behavior remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-specific reasoning controls, including dynamic effort options and sliders.
  * Added localized labels for reasoning levels in custom model settings.
  * Improved model refresh handling by preserving valid selections and safely falling back when options change.

* **Bug Fixes**
  * Prevented unrelated models with matching IDs from being treated as the same selection.
  * Ensured models without reasoning options do not display unnecessary controls.
  * Improved consistency when model configurations are refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->