### PR TITLE
fix(wework): preserve accurate tool durations

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -167,6 +167,12 @@ A Codex web search may not include its query action in `item/started`; the final
 
 The Wework presentation layer accepts both Responses API snake_case action names (`open_page`, `find_in_page`) and Codex app-server camelCase names (`openPage`, `findInPage`). Normalize this naming difference at the tool-detail parsing boundary; do not mask missing completion events with UI placeholder content or status fallbacks.
 
+### Tool Call Duration
+
+Tool start time, completion time, and duration come from the Codex item lifecycle forwarded by the executor. This lifecycle is the shared authoritative source for both the live stream and historical transcript. The executor must preserve millisecond-precision `createdAt`, `completedAt`, and `durationMs` fields in started/completed events and transcript projections, and merge the function call, command execution, and output for one invocation into a single block.
+
+Pane caches and React components only restore and present those timing fields. A running local timer may temporarily anchor the start time from its first render to avoid jumps during incremental updates. Once the executor supplies a completion time or duration, the completed presentation must use the current block's authoritative fields. Switching panes, refreshing the transcript, or reusing a component must not retain a local completion time or start anchor from the previous pane state.
+
 ### Tool Activity Preview Scrolling
 
 The collapsed tool activity preview shows at most three rows and follows the latest activity while no tool detail is expanded. Auto-scroll must react both to changes in the tool row count and to the bottom “Thinking” row appearing or disappearing. When a tool completes without changing the row count, the thinking row must remain inside the inner scroll area's visible range. Expanding a detail removes the preview height limit, so forced scrolling must not override the user's reading position in that state.

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -134,6 +134,12 @@ Codex 的网页搜索在 `item/started` 时可能还没有查询动作，在 `it
 
 Wework 展示层兼容 Responses API 的 snake_case 动作名（如 `open_page`、`find_in_page`）和 Codex app-server 的 camelCase 动作名（如 `openPage`、`findInPage`）。动作名差异只能在工具详情解析边界处理，不能通过 UI 占位内容或状态兜底掩盖缺失的完成事件。
 
+### 工具调用时长
+
+工具调用的开始时间、完成时间和时长来自 executor 转发的 Codex item 生命周期，是实时 stream 和历史 transcript 的共同权威来源。executor 必须在 started/completed 事件和 transcript 投影中保留毫秒精度的 `createdAt`、`completedAt` 与 `durationMs`，并把同一调用的 function call、command execution 和 output 合并为一个 block。
+
+pane 缓存和 React 组件只负责恢复与展示这些时间字段。运行中的本地计时器可以临时锚定首次渲染的开始时间，避免增量更新导致跳动；一旦收到 executor 的完成时间或时长，完成态必须按当前 block 的权威字段计算。切换 pane、刷新 transcript 或复用组件都不能继续使用旧 pane 的本地完成时间或开始锚点。
+
 ### 工具活动预览滚动
 
 折叠的工具活动预览最多显示三行，并在用户没有展开工具详情时跟随最新活动。自动滚动必须同时响应工具行数量变化和底部“正在思考”行的出现或消失；工具完成后即使行数不变，“正在思考”也必须保持在内层滚动区域的可见范围内。展开详情时预览解除高度限制，不能用强制滚动覆盖用户阅读位置。

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -88,7 +88,10 @@ use super::{
         user_message_presentations,
     },
     store::{runtime_work_dir, RuntimeWorkStore},
-    transcript::{full_transcript_messages, normalized_user_request_content, transcript_messages},
+    transcript::{
+        full_transcript_messages, normalized_user_request_content, notification_item,
+        transcript_messages,
+    },
     transcript_page::transcript_page,
     util::{
         apply_runtime_payload_metadata, bool_field, cloud_project_id, execution_request, id_field,

--- a/executor/src/runtime_work/handler/notifications.rs
+++ b/executor/src/runtime_work/handler/notifications.rs
@@ -37,14 +37,11 @@ impl RuntimeWorkRpcHandler {
         ) {
             return;
         }
-        let Some(item) = notification
-            .params
-            .get("item")
-            .filter(|item| item.is_object())
-        else {
+        let item = notification_item(notification.params);
+        if !item.is_object() {
             return;
-        };
-        let Some(item_id) = string_field(item, "id") else {
+        }
+        let Some(item_id) = string_field(&item, "id") else {
             return;
         };
         let Ok(mut active_items) = self.active_codex_transcript_items.lock() else {
@@ -62,9 +59,18 @@ impl RuntimeWorkRpcHandler {
             .iter_mut()
             .find(|existing| string_field(existing, "id").as_deref() == Some(item_id.as_str()))
         {
-            *existing = item.clone();
+            let created_at = existing
+                .get("createdAt")
+                .or_else(|| existing.get("created_at"))
+                .cloned();
+            *existing = item;
+            if existing.get("createdAt").is_none() && existing.get("created_at").is_none() {
+                if let (Some(object), Some(created_at)) = (existing.as_object_mut(), created_at) {
+                    object.insert("createdAt".to_owned(), created_at);
+                }
+            }
         } else {
-            transcript.items.push(item.clone());
+            transcript.items.push(item);
         }
     }
 

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -107,6 +107,7 @@ fn active_codex_items_replace_stale_paginated_items() {
             "method": "item/started",
             "params": {
                 "turnId": "turn-1",
+                "startedAtMs": 1_780_000_001_250_i64,
                 "item": {
                     "id": "change-1",
                     "type": "fileChange",
@@ -123,6 +124,7 @@ fn active_codex_items_replace_stale_paginated_items() {
             "method": "item/completed",
             "params": {
                 "turnId": "turn-1",
+                "completedAtMs": 1_780_000_004_750_i64,
                 "item": {
                     "id": "change-1",
                     "type": "fileChange",
@@ -156,6 +158,14 @@ fn active_codex_items_replace_stale_paginated_items() {
     assert_eq!(
         thread["turns"][0]["items"][0]["changes"][0]["path"],
         Value::String("/tmp/result.txt".to_owned())
+    );
+    assert_eq!(
+        thread["turns"][0]["items"][0]["createdAt"],
+        1_780_000_001_250_i64
+    );
+    assert_eq!(
+        thread["turns"][0]["items"][0]["completedAt"],
+        1_780_000_004_750_i64
     );
     let messages = transcript_messages(&thread, "device-1");
     assert_eq!(messages.len(), 1);

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -171,9 +171,15 @@ impl<'a> TurnTranscriptProjector<'a> {
                 .assistant
                 .blocks
                 .push(plan_block(item, self.created_at, self.options)),
-            "commandexecution" | "functioncall" | "customtoolcall" | "dynamictoolcall"
-            | "mcptoolcall" | "mcpcall" | "toolsearchcall" | "websearchcall" | "websearch"
-            | "imagegeneration" | "imageview" | "sleep" | "localshellcall" | "shellcall" => {
+            "commandexecution" => merge_tool_output(
+                &mut self.assistant.blocks,
+                item,
+                self.created_at,
+                self.options,
+            ),
+            "functioncall" | "customtoolcall" | "dynamictoolcall" | "mcptoolcall" | "mcpcall"
+            | "toolsearchcall" | "websearchcall" | "websearch" | "imagegeneration"
+            | "imageview" | "sleep" | "localshellcall" | "shellcall" => {
                 self.push_workbench_block(item)
             }
             "functioncalloutput"
@@ -510,6 +516,14 @@ pub(crate) fn tool_update_from_notification(params: &Value) -> Option<(String, V
         "status": status,
     });
     if let Some(object) = updates.as_object_mut() {
+        if let Some(completed_at) = item_completed_at(&item) {
+            object.insert("completedAt".to_owned(), json!(completed_at));
+        }
+        if let Some(duration_ms) =
+            integer_field(&item, "durationMs").or_else(|| integer_field(&item, "duration_ms"))
+        {
+            object.insert("durationMs".to_owned(), json!(duration_ms.max(0)));
+        }
         insert_tool_output_fields(object, &item, TranscriptBuildOptions::truncated());
         insert_image_generation_render_payload(object, &item);
     }
@@ -526,16 +540,38 @@ pub(crate) fn tool_update_from_notification(params: &Value) -> Option<(String, V
     Some((tool_call_id(&item), updates))
 }
 
-fn notification_item(params: &Value) -> Value {
-    transcript_item(params.get("item").unwrap_or(params))
+pub(crate) fn notification_item(params: &Value) -> Value {
+    let mut item = transcript_item(params.get("item").unwrap_or(params));
+    let Some(object) = item.as_object_mut() else {
+        return item;
+    };
+    if !object.contains_key("createdAt") && !object.contains_key("created_at") {
+        if let Some(started_at) = params
+            .get("startedAtMs")
+            .or_else(|| params.get("started_at_ms"))
+            .cloned()
+        {
+            object.insert("createdAt".to_owned(), started_at);
+        }
+    }
+    if !object.contains_key("completedAt") && !object.contains_key("completed_at") {
+        if let Some(completed_at) = params
+            .get("completedAtMs")
+            .or_else(|| params.get("completed_at_ms"))
+            .cloned()
+        {
+            object.insert("completedAt".to_owned(), completed_at);
+        }
+    }
+    item
 }
 
 fn transcript_item(item: &Value) -> Value {
     let Some(payload) = codex_wrapped_item_payload(item) else {
         return item.clone();
     };
-    if let Some(plan_item) = completed_plan_event_item(item, payload) {
-        return plan_item;
+    if let Some(completed_item) = completed_event_item(item, payload) {
+        return completed_item;
     }
     let Some(payload_object) = payload.as_object() else {
         return item.clone();
@@ -552,14 +588,11 @@ fn transcript_item(item: &Value) -> Value {
     Value::Object(object)
 }
 
-fn completed_plan_event_item(item: &Value, payload: &Value) -> Option<Value> {
+fn completed_event_item(item: &Value, payload: &Value) -> Option<Value> {
     if item_type(item) != "eventmsg" || item_type(payload) != "itemcompleted" {
         return None;
     }
     let nested_item = payload.get("item")?;
-    if item_type(nested_item) != "plan" {
-        return None;
-    }
     let mut object = nested_item.as_object()?.clone();
     copy_missing_fields(
         &mut object,
@@ -585,12 +618,23 @@ fn completed_plan_event_item(item: &Value, payload: &Value) -> Option<Value> {
         ],
     );
     if !object.contains_key("createdAt") && !object.contains_key("created_at") {
+        if let Some(started_at) = payload
+            .get("started_at_ms")
+            .or_else(|| payload.get("startedAtMs"))
+            .or_else(|| payload.get("completed_at_ms"))
+            .or_else(|| payload.get("completedAtMs"))
+            .cloned()
+        {
+            object.insert("createdAt".to_owned(), started_at);
+        }
+    }
+    if !object.contains_key("completedAt") && !object.contains_key("completed_at") {
         if let Some(completed_at) = payload
             .get("completed_at_ms")
             .or_else(|| payload.get("completedAtMs"))
             .cloned()
         {
-            object.insert("createdAt".to_owned(), completed_at);
+            object.insert("completedAt".to_owned(), completed_at);
         }
     }
     Some(Value::Object(object))
@@ -874,9 +918,9 @@ mod message_projection;
 pub(crate) use message_projection::normalized_user_request_content;
 use message_projection::{
     assistant_message_phase_name, collect_assistant_message, file_changes_block, guidance_block,
-    is_internal_turn_abort_message, item_timestamp, normalized_phase_or_status, plan_block,
-    push_accumulated_assistant, push_reasoning_block, push_user_message_once, AssistantEmitContext,
-    AssistantTurnAccumulation,
+    is_internal_turn_abort_message, item_completed_at, item_timestamp, normalized_phase_or_status,
+    plan_block, push_accumulated_assistant, push_reasoning_block, push_user_message_once,
+    AssistantEmitContext, AssistantTurnAccumulation,
 };
 
 #[path = "transcript/tool_projection.rs"]

--- a/executor/src/runtime_work/transcript/message_projection.rs
+++ b/executor/src/runtime_work/transcript/message_projection.rs
@@ -11,7 +11,30 @@ fn apply_turn_completed_at(blocks: &mut [Value], completed_at: Option<i64>) {
     let Some(block) = blocks.last_mut().and_then(Value::as_object_mut) else {
         return;
     };
-    block.insert("timestamp".to_owned(), json!(completed_at));
+    if block.get("type").and_then(Value::as_str) != Some("tool") {
+        block.insert("timestamp".to_owned(), json!(completed_at));
+        return;
+    }
+    let has_completed_at =
+        block.get("completedAt").is_some() || block.get("completed_at").is_some();
+    let duration_ms = block
+        .get("durationMs")
+        .or_else(|| block.get("duration_ms"))
+        .and_then(Value::as_i64)
+        .filter(|duration| *duration >= 0);
+    if !has_completed_at && duration_ms.is_none() {
+        block.insert("timestamp".to_owned(), json!(completed_at));
+        return;
+    }
+    if !has_completed_at {
+        block.insert("completedAt".to_owned(), json!(completed_at));
+    }
+    if let Some(duration_ms) = duration_ms {
+        block.insert(
+            "timestamp".to_owned(),
+            json!(completed_at.saturating_sub(duration_ms)),
+        );
+    }
 }
 
 pub(super) struct AssistantTurnAccumulation {
@@ -666,6 +689,10 @@ pub(super) fn item_timestamp(item: &Value) -> Option<i64> {
     timestamp_ms_field(item, "timestamp")
         .or_else(|| timestamp_ms_field(item, "createdAt"))
         .or_else(|| timestamp_ms_field(item, "created_at"))
+}
+
+pub(super) fn item_completed_at(item: &Value) -> Option<i64> {
+    timestamp_ms_field(item, "completedAt").or_else(|| timestamp_ms_field(item, "completed_at"))
 }
 
 struct AssistantMessageDraft<'a> {

--- a/executor/src/runtime_work/transcript/tests_core.rs
+++ b/executor/src/runtime_work/transcript/tests_core.rs
@@ -172,6 +172,169 @@ fn completed_statusless_tools_are_done() {
 }
 
 #[test]
+fn tool_notifications_preserve_item_lifecycle_timestamps() {
+    let started = json!({
+        "startedAtMs": 1_780_000_001_250_i64,
+        "item": {
+            "id": "call-1",
+            "type": "commandExecution",
+            "command": "sleep 3",
+            "cwd": "/tmp",
+            "status": "inProgress"
+        }
+    });
+    let completed = json!({
+        "completedAtMs": 1_780_000_004_750_i64,
+        "item": {
+            "id": "call-1",
+            "type": "commandExecution",
+            "command": "sleep 3",
+            "cwd": "/tmp",
+            "status": "completed",
+            "durationMs": 3_500
+        }
+    });
+
+    let started_block =
+        workbench_block_from_notification(&started, "turn-1", "device-1", "/tmp", None)
+            .expect("started tool block");
+    let (_, completed_updates) =
+        tool_update_from_notification(&completed).expect("completed tool update");
+
+    assert_eq!(started_block["timestamp"], 1_780_000_001_250_i64);
+    assert_eq!(completed_updates["completedAt"], 1_780_000_004_750_i64);
+    assert_eq!(completed_updates["durationMs"], 3_500);
+}
+
+#[test]
+fn completed_tool_duration_is_not_replaced_with_the_turn_duration() {
+    let thread = json!({
+        "id": "thread-1",
+        "cwd": "/tmp/project",
+        "turns": [{
+            "id": "turn-1",
+            "startedAt": 1_780_000_000,
+            "completedAt": 1_780_000_010,
+            "status": "completed",
+            "items": [{
+                "id": "call-1",
+                "type": "commandExecution",
+                "command": "sleep 3",
+                "cwd": "/tmp/project",
+                "status": "completed",
+                "durationMs": 3_500
+            }]
+        }]
+    });
+
+    let messages = transcript_messages(&thread, "device-1");
+    let block = &messages[0]["blocks"][0];
+
+    assert_eq!(block["tool_name"], "bash");
+    assert_eq!(block["timestamp"], 1_780_000_006_500_i64);
+    assert_eq!(block["completedAt"], 1_780_000_010_000_i64);
+}
+
+#[test]
+fn transcript_restores_precise_tool_timing_from_completed_rollout_events() {
+    let thread = json!({
+        "id": "thread-1",
+        "cwd": "/tmp/project",
+        "turns": [{
+            "id": "turn-1",
+            "startedAt": 1_780_000_000,
+            "completedAt": 1_780_000_020,
+            "status": "completed",
+            "items": [{
+                "type": "event_msg",
+                "payload": {
+                    "type": "item_completed",
+                    "started_at_ms": 1_780_000_001_250_i64,
+                    "completed_at_ms": 1_780_000_016_119_i64,
+                    "item": {
+                        "id": "call-1",
+                        "type": "CommandExecution",
+                        "command": ["sleep", "15"],
+                        "cwd": "/tmp/project",
+                        "status": "completed",
+                        "duration": {
+                            "secs": 14,
+                            "nanos": 869_000_000
+                        }
+                    }
+                }
+            }]
+        }]
+    });
+
+    let messages = transcript_messages(&thread, "device-1");
+    let block = &messages[0]["blocks"][0];
+
+    assert_eq!(block["timestamp"], 1_780_000_001_250_i64);
+    assert_eq!(block["completedAt"], 1_780_000_016_119_i64);
+}
+
+#[test]
+fn transcript_merges_completed_command_timing_into_function_call_block() {
+    let thread = json!({
+        "id": "thread-1",
+        "cwd": "/tmp/project",
+        "turns": [{
+            "id": "turn-1",
+            "startedAt": 1_780_000_000,
+            "completedAt": 1_780_000_020,
+            "status": "completed",
+            "items": [{
+                "type": "response_item",
+                "timestamp": 1_780_000_001_100_i64,
+                "payload": {
+                    "id": "function-call-1",
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"sleep 15\",\"workdir\":\"/tmp/project\"}"
+                }
+            }, {
+                "type": "event_msg",
+                "payload": {
+                    "type": "item_completed",
+                    "started_at_ms": 1_780_000_001_250_i64,
+                    "completed_at_ms": 1_780_000_016_119_i64,
+                    "item": {
+                        "id": "call-1",
+                        "type": "CommandExecution",
+                        "command": ["/bin/zsh", "-lc", "sleep 15"],
+                        "cwd": "/tmp/project",
+                        "status": "completed",
+                        "duration": {
+                            "secs": 14,
+                            "nanos": 869_000_000
+                        }
+                    }
+                }
+            }, {
+                "type": "response_item",
+                "timestamp": 1_780_000_016_120_i64,
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "Chunk ID: test\nWall time: 14.869 seconds\nProcess exited with code 0\nFinal output:\n"
+                }
+            }]
+        }]
+    });
+
+    let messages = transcript_messages(&thread, "device-1");
+    let blocks = messages[0]["blocks"].as_array().expect("assistant blocks");
+
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0]["tool_use_id"], "call-1");
+    assert_eq!(blocks[0]["timestamp"], 1_780_000_001_250_i64);
+    assert_eq!(blocks[0]["completedAt"], 1_780_000_016_119_i64);
+    assert_eq!(blocks[0]["tool_input"]["cmd"], "sleep 15");
+}
+
+#[test]
 fn completed_mcp_tool_updates_preserve_structured_content() {
     let params = json!({
         "item": {

--- a/executor/src/runtime_work/transcript/tool_projection.rs
+++ b/executor/src/runtime_work/transcript/tool_projection.rs
@@ -6,7 +6,12 @@ use super::*;
 use sha2::{Digest, Sha256};
 
 fn command_block(item: &Value, timestamp: i64, options: TranscriptBuildOptions) -> Value {
-    let mut block = new_tool_block(item, timestamp, "bash", Some(command_input(item)));
+    let mut block = new_tool_block(
+        item,
+        item_timestamp(item).unwrap_or(timestamp),
+        "bash",
+        Some(command_input(item)),
+    );
     enrich_tool_block(&mut block, item, options, false);
     block
 }
@@ -18,7 +23,12 @@ pub(super) fn tool_block(item: &Value, timestamp: i64, options: TranscriptBuildO
     ) {
         return command_block(item, timestamp, options);
     }
-    let mut block = new_tool_block(item, timestamp, &tool_name(item), Some(tool_input(item)));
+    let mut block = new_tool_block(
+        item,
+        item_timestamp(item).unwrap_or(timestamp),
+        &tool_name(item),
+        Some(tool_input(item)),
+    );
     enrich_tool_block(&mut block, item, options, true);
     block
 }
@@ -38,18 +48,41 @@ pub(super) fn merge_tool_output(
     }) {
         if let Some(object) = block.as_object_mut() {
             merge_tool_input(object, command_input_from_output(item));
+            merge_tool_timing(object, item);
         }
         enrich_tool_block(block, item, options, true);
         return;
     }
+    if item_type(item) == "commandexecution" {
+        blocks.push(command_block(item, timestamp, options));
+        return;
+    }
     let mut block = new_tool_block(
         item,
-        timestamp,
+        item_timestamp(item).unwrap_or(timestamp),
         &tool_name(item),
         command_input_from_output(item),
     );
     enrich_tool_block(&mut block, item, options, true);
     blocks.push(block);
+}
+
+fn merge_tool_timing(object: &mut Map<String, Value>, item: &Value) {
+    let completed_at = item_completed_at(item);
+    let duration_ms =
+        integer_field(item, "durationMs").or_else(|| integer_field(item, "duration_ms"));
+    if completed_at.is_none() && duration_ms.is_none() {
+        return;
+    }
+    if let Some(timestamp) = item_timestamp(item) {
+        object.insert("timestamp".to_owned(), json!(timestamp));
+    }
+    if let Some(completed_at) = completed_at {
+        object.insert("completedAt".to_owned(), json!(completed_at));
+    }
+    if let Some(duration_ms) = duration_ms {
+        object.insert("durationMs".to_owned(), json!(duration_ms.max(0)));
+    }
 }
 
 fn new_tool_block(
@@ -69,6 +102,16 @@ fn new_tool_block(
     });
     if let (Some(object), Some(tool_input)) = (block.as_object_mut(), tool_input) {
         object.insert("tool_input".to_owned(), tool_input);
+    }
+    if let Some(object) = block.as_object_mut() {
+        if let Some(completed_at) = item_completed_at(item) {
+            object.insert("completedAt".to_owned(), json!(completed_at));
+        }
+        if let Some(duration_ms) =
+            integer_field(item, "durationMs").or_else(|| integer_field(item, "duration_ms"))
+        {
+            object.insert("durationMs".to_owned(), json!(duration_ms.max(0)));
+        }
     }
     block
 }
@@ -294,7 +337,10 @@ fn command_output_ref(item: &Value) -> Option<&str> {
 }
 
 pub(super) fn command_input_from_output(item: &Value) -> Option<Value> {
-    if item_type(item) != "execcommandend" {
+    if !matches!(
+        item_type(item).as_str(),
+        "commandexecution" | "execcommandend"
+    ) {
         return None;
     }
     Some(command_input(item))

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -23,6 +23,7 @@ export interface BaseWorkbenchProcessingBlock {
   status: WorkbenchToolBlockStatus
   createdAt: number
   completedAt?: number
+  durationMs?: number
   contentTruncated?: boolean
   contentOriginalChars?: number
   contentLoadRef?: WorkbenchContentLoadRef
@@ -116,6 +117,8 @@ type ProcessingBlockUpdate = {
   renderPayload?: unknown
   fileChanges?: unknown
   status?: WorkbenchToolBlockStatus
+  completedAt?: number
+  durationMs?: number
 }
 
 const MAX_LIVE_MESSAGE_CONTENT_CHARS = 200_000
@@ -519,10 +522,14 @@ function mergeProcessingBlockUpdate<TFileChanges>(
   block: WorkbenchProcessingBlock<TFileChanges>,
   updates: ProcessingBlockUpdate
 ): WorkbenchProcessingBlock<TFileChanges> {
-  const { toolOutputDelta, ...directUpdates } = updates
+  const { toolOutputDelta, durationMs, ...directUpdates } = updates
   const nextBlock = withBlockCompletionTime(block, {
     ...block,
-    ...directUpdates
+    ...directUpdates,
+    ...(durationMs !== undefined && {
+      durationMs: Math.max(0, durationMs),
+      completedAt: block.createdAt + Math.max(0, durationMs)
+    })
   } as WorkbenchProcessingBlock<TFileChanges>)
 
   if (typeof toolOutputDelta !== 'string' || block.type !== 'tool') {

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -548,9 +548,10 @@ function useToolDuration(startedAt: number, fallbackEndAt: number | undefined, i
     wasRunning.current = isRunning
   }, [isRunning])
 
+  const durationStartedAt = fallbackEndAt === undefined ? anchoredStartedAt : startedAt
   const endedAt = isRunning ? now : (fallbackEndAt ?? completedAt ?? anchoredStartedAt)
   if (!isRunning && completedAt === null && fallbackEndAt === undefined) return ''
-  return `${(Math.max(0, endedAt - anchoredStartedAt) / 1000).toFixed(1)}s`
+  return `${(Math.max(0, endedAt - durationStartedAt) / 1000).toFixed(1)}s`
 }
 
 function fileChangeRowLabel(

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1188,6 +1188,39 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('3.0s')).toBeInTheDocument()
   })
 
+  test('uses restored timestamps after a completed tool block is reused', () => {
+    const { rerender } = render(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            ...completedCommandBlock,
+            createdAt: 1786459157500,
+            completedAt: 1786459172000,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('processing-summary-toggle'))
+    expect(screen.getByText('14.5s')).toBeInTheDocument()
+
+    rerender(
+      <ToolBlocksDisplay
+        blocks={[
+          {
+            ...completedCommandBlock,
+            createdAt: 1786459157131,
+            completedAt: 1786459172000,
+          },
+        ]}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByText('14.9s')).toBeInTheDocument()
+  })
+
   test('shows thinking without an aggregate timer after all tool blocks are done', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-05T00:00:00.000Z'))

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -1089,6 +1089,47 @@ describe('runtimeConversationTurns', () => {
     expect(merged[0].status).toBe('done')
   })
 
+  test('preserves the live tool start when a snapshot falls back to the turn start', () => {
+    const localBlock: ProcessingBlock = {
+      id: 'tool-1',
+      subtaskId: 'turn-1',
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: 'cargo test' },
+      status: 'streaming',
+      createdAt: 1_786_442_820_000,
+    }
+    const snapshotBlock: ProcessingBlock = {
+      ...localBlock,
+      createdAt: 1_786_440_000_000,
+    }
+    const local: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [{ id: localBlock.id, type: 'block', block: localBlock }],
+        status: 'streaming',
+      },
+    ]
+    const snapshot: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [{ id: snapshotBlock.id, type: 'block', block: snapshotBlock }],
+        status: 'streaming',
+      },
+    ]
+
+    const mergedBlock = mergeRuntimeConversationTurns(local, snapshot)[0].items[0]
+
+    expect(mergedBlock).toEqual({
+      id: localBlock.id,
+      type: 'block',
+      block: {
+        ...snapshotBlock,
+        createdAt: localBlock.createdAt,
+      },
+    })
+  })
+
   test('preserves completed tool timing when a conversation snapshot is restored', () => {
     const localBlock: ProcessingBlock = {
       id: 'tool-1',
@@ -1133,6 +1174,50 @@ describe('runtimeConversationTurns', () => {
     })
   })
 
+  test('applies snapshot duration to the preserved live tool start', () => {
+    const localBlock: ProcessingBlock = {
+      id: 'tool-1',
+      subtaskId: 'turn-1',
+      type: 'tool',
+      toolName: 'bash',
+      status: 'streaming',
+      createdAt: 1_786_458_436_531,
+    }
+    const snapshotBlock: ProcessingBlock = {
+      ...localBlock,
+      status: 'done',
+      createdAt: 1_786_458_436_134,
+      completedAt: 1_786_458_451_000,
+      durationMs: 14_866,
+    }
+    const local: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [{ id: localBlock.id, type: 'block', block: localBlock }],
+        status: 'streaming',
+      },
+    ]
+    const snapshot: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [{ id: snapshotBlock.id, type: 'block', block: snapshotBlock }],
+        status: 'done',
+      },
+    ]
+
+    const mergedBlock = mergeRuntimeConversationTurns(local, snapshot)[0].items[0]
+
+    expect(mergedBlock).toEqual({
+      id: localBlock.id,
+      type: 'block',
+      block: {
+        ...snapshotBlock,
+        createdAt: localBlock.createdAt,
+        completedAt: localBlock.createdAt + snapshotBlock.durationMs!,
+      },
+    })
+  })
+
   test('records tool completion time in runtime conversation state', () => {
     vi.useFakeTimers()
     try {
@@ -1173,6 +1258,43 @@ describe('runtimeConversationTurns', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  test('uses the runtime tool duration when completing a streamed block', () => {
+    const createdAt = 1_780_000_001_250
+    let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
+      type: 'block_created',
+      subtaskId: 'turn-1',
+      block: {
+        id: 'tool-1',
+        subtaskId: 'turn-1',
+        type: 'tool',
+        toolName: 'bash',
+        status: 'streaming',
+        createdAt,
+      },
+    })
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'block_updated',
+      subtaskId: 'turn-1',
+      blockId: 'tool-1',
+      updates: {
+        status: 'done',
+        completedAt: createdAt + 3_700,
+        durationMs: 3_500,
+      },
+    })
+
+    expect(turns[0].items[0]).toEqual(
+      expect.objectContaining({
+        type: 'block',
+        block: expect.objectContaining({
+          createdAt,
+          completedAt: createdAt + 3_500,
+        }),
+      })
+    )
   })
 
   test('keeps a live Codex turn failure when the provider snapshot omits the failure', () => {

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -382,15 +382,10 @@ function mergeRuntimeConversationItem(
   snapshot: RuntimeConversationItem
 ): RuntimeConversationItem {
   if (local?.type !== 'block' || snapshot.type !== 'block') return snapshot
-  const localComplete = local.block.status === 'done' || local.block.status === 'error'
-  const snapshotComplete = snapshot.block.status === 'done' || snapshot.block.status === 'error'
-  if (!localComplete || !snapshotComplete || local.block.completedAt === undefined) {
-    return snapshot
-  }
 
   return {
     ...snapshot,
-    block: preserveCompletedProcessingBlockTiming(local.block, snapshot.block),
+    block: preserveProcessingBlockTiming(local.block, snapshot.block),
   }
 }
 
@@ -636,7 +631,7 @@ function upsertBlocks(
       type: 'block',
       block:
         index >= 0 && next[index]?.type === 'block'
-          ? preserveCompletedProcessingBlockTiming(next[index].block, block)
+          ? preserveProcessingBlockTiming(next[index].block, block)
           : block,
     }
     next = index < 0 ? [...next, canonicalItem] : replaceAt(next, index, canonicalItem)
@@ -785,7 +780,15 @@ function mergeProcessingBlockUpdate(
   block: ProcessingBlock,
   updates: Extract<RuntimePaneMessageAction, { type: 'block_updated' }>['updates']
 ): ProcessingBlock {
-  let merged = { ...block, ...updates } as ProcessingBlock
+  const { durationMs, ...directUpdates } = updates
+  let merged = {
+    ...block,
+    ...directUpdates,
+    ...(durationMs !== undefined && {
+      durationMs: Math.max(0, durationMs),
+      completedAt: block.createdAt + Math.max(0, durationMs),
+    }),
+  } as ProcessingBlock
   if (merged.type === 'tool' && block.type === 'tool') {
     merged.toolInput = updates.toolInput ?? block.toolInput
   }
@@ -797,24 +800,31 @@ function mergeProcessingBlockUpdate(
   return merged
 }
 
-function preserveCompletedProcessingBlockTiming(
+function preserveProcessingBlockTiming(
   previous: ProcessingBlock,
   next: ProcessingBlock
 ): ProcessingBlock {
   const previousComplete = previous.status === 'done' || previous.status === 'error'
   const nextComplete = next.status === 'done' || next.status === 'error'
-  if (
-    !previousComplete ||
-    !nextComplete ||
-    previous.completedAt === undefined ||
-    next.completedAt !== undefined
-  ) {
-    return next
+  const createdAt = previousComplete ? next.createdAt : previous.createdAt
+  if (previousComplete && nextComplete && previous.completedAt !== undefined) {
+    if (next.completedAt === undefined) {
+      return {
+        ...next,
+        createdAt: previous.createdAt,
+        completedAt: previous.completedAt,
+        durationMs: next.durationMs ?? previous.durationMs,
+      } as ProcessingBlock
+    }
   }
+  if (createdAt === next.createdAt) return next
   return {
     ...next,
-    createdAt: previous.createdAt,
-    completedAt: previous.completedAt,
+    createdAt,
+    ...(nextComplete &&
+      next.durationMs !== undefined && {
+        completedAt: createdAt + next.durationMs,
+      }),
   } as ProcessingBlock
 }
 

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -91,6 +91,60 @@ describe('runtime transcript status', () => {
     )
   })
 
+  test('restores tool lifecycle timing from the runtime transcript', () => {
+    const [turn] = runtimeTranscriptTurnsToConversationTurns([
+      {
+        id: 'turn-1',
+        status: 'completed',
+        items: [
+          {
+            id: 'block-item-1',
+            type: 'block',
+            block: {
+              id: 'tool-1',
+              type: 'tool',
+              toolName: 'exec_command',
+              status: 'done',
+              timestamp: 1_780_000_001_250,
+              completedAt: 1_780_000_004_750,
+            },
+          },
+          {
+            id: 'block-item-2',
+            type: 'block',
+            block: {
+              id: 'tool-2',
+              type: 'tool',
+              toolName: 'exec_command',
+              status: 'done',
+              timestamp: 1_780_000_010_000,
+              durationMs: 2_500,
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(turn.items).toEqual([
+      expect.objectContaining({
+        id: 'block-item-1',
+        type: 'block',
+        block: expect.objectContaining({
+          createdAt: 1_780_000_001_250,
+          completedAt: 1_780_000_004_750,
+        }),
+      }),
+      expect.objectContaining({
+        id: 'block-item-2',
+        type: 'block',
+        block: expect.objectContaining({
+          createdAt: 1_780_000_010_000,
+          completedAt: 1_780_000_012_500,
+        }),
+      }),
+    ])
+  })
+
   test('does not infer streaming from an active conversation status', () => {
     const [message] = runtimeMessagesToWorkbenchMessages([
       {
@@ -1018,7 +1072,9 @@ describe('createRuntimeTaskStreamHandlers', () => {
       deviceId: 'device-1',
       blockId: 'text-local-task-1-0-1',
       content: 'partial',
-      status: 'streaming',
+      status: 'done',
+      completedAt: 1_780_000_004_750,
+      durationMs: 3_500,
     })
 
     expect(actions).toHaveLength(1)
@@ -1028,7 +1084,9 @@ describe('createRuntimeTaskStreamHandlers', () => {
       blockId: 'text-local-task-1-0-1',
       updates: {
         content: 'partial',
-        status: 'streaming',
+        status: 'done',
+        completedAt: 1_780_000_004_750,
+        durationMs: 3_500,
       },
     })
     expect(warn).not.toHaveBeenCalled()

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -411,6 +411,8 @@ export function createRuntimeTaskStreamHandlers(
         hasToolOutputTruncated: payload.toolOutputTruncated !== undefined,
         hasRenderPayload: payload.renderPayload !== undefined,
         hasFileChanges: payload.fileChanges !== undefined,
+        hasCompletedAt: payload.completedAt !== undefined,
+        hasDurationMs: payload.durationMs !== undefined,
       })
       const fileChanges = normalizeTurnFileChanges(payload.fileChanges)
       if (fileChanges) {
@@ -442,6 +444,8 @@ export function createRuntimeTaskStreamHandlers(
             fileChanges: normalizeTurnFileChanges(payload.fileChanges),
           }),
           ...(payload.status && { status: normalizeWorkbenchBlockStatus(payload.status) }),
+          ...(payload.completedAt !== undefined && { completedAt: payload.completedAt }),
+          ...(payload.durationMs !== undefined && { durationMs: payload.durationMs }),
         },
       })
     },
@@ -999,10 +1003,28 @@ function normalizeProcessingBlock(
     block.timestamp ?? block.created_at ?? block.createdAt,
     fallbackTimestamp
   )
+  const explicitCompletedAt = block.completedAt ?? block.completed_at
+  const durationMs =
+    typeof block.durationMs === 'number' && Number.isFinite(block.durationMs)
+      ? Math.max(0, block.durationMs)
+      : typeof block.duration_ms === 'number' && Number.isFinite(block.duration_ms)
+        ? Math.max(0, block.duration_ms)
+        : undefined
+  const completedAt =
+    durationMs !== undefined
+      ? timestamp + durationMs
+      : explicitCompletedAt !== undefined
+        ? getBlockTimestamp(explicitCompletedAt, timestamp)
+        : undefined
   const status = normalizeWorkbenchBlockStatus(
     typeof block.status === 'string' ? block.status : undefined
   )
-
+  const timing = {
+    status,
+    createdAt: timestamp,
+    completedAt,
+    ...(durationMs !== undefined && { durationMs }),
+  }
   if (block.type === 'tool') {
     const id =
       typeof block.id === 'string'
@@ -1042,8 +1064,7 @@ function normalizeProcessingBlock(
             ? block.tool_output_original_bytes
             : undefined,
       renderPayload: normalizeToolRenderPayload(block),
-      status,
-      createdAt: timestamp,
+      ...timing,
     }
   }
 
@@ -1061,8 +1082,7 @@ function normalizeProcessingBlock(
         ...(typeof block.revised_prompt === 'string' && { revisedPrompt: block.revised_prompt }),
         ...(typeof block.saved_path === 'string' && { savedPath: block.saved_path }),
       },
-      status,
-      createdAt: timestamp,
+      ...timing,
     }
   }
 
@@ -1086,8 +1106,7 @@ function normalizeProcessingBlock(
           : typeof block.content_original_chars === 'number'
             ? block.content_original_chars
             : undefined,
-      status,
-      createdAt: timestamp,
+      ...timing,
     }
   }
 
@@ -1117,8 +1136,7 @@ function normalizeProcessingBlock(
           : typeof block.content_original_chars === 'number'
             ? block.content_original_chars
             : undefined,
-      status,
-      createdAt: timestamp,
+      ...timing,
     }
   }
 
@@ -1148,8 +1166,7 @@ function normalizeProcessingBlock(
           : typeof block.content_original_chars === 'number'
             ? block.content_original_chars
             : undefined,
-      status,
-      createdAt: timestamp,
+      ...timing,
     }
   }
 
@@ -1163,8 +1180,7 @@ function normalizeProcessingBlock(
       subtaskId,
       type: 'file_changes',
       fileChanges,
-      status,
-      createdAt: timestamp,
+      ...timing,
     }
   }
 

--- a/wework/src/stream/responseApiStream.test.ts
+++ b/wework/src/stream/responseApiStream.test.ts
@@ -469,9 +469,11 @@ describe('emitResponseApiEvent', () => {
         data: {
           block_id: 'call-1',
           updates: {
-            status: 'streaming',
+            status: 'done',
             tool_output_delta: 'line 1\n',
             tool_output_truncated: false,
+            completed_at: 1_780_000_004_750,
+            duration_ms: 3_500,
           },
         },
       },
@@ -483,9 +485,11 @@ describe('emitResponseApiEvent', () => {
       subtaskId: '2',
       deviceId: 'device-1',
       blockId: 'call-1',
-      status: 'streaming',
+      status: 'done',
       toolOutputDelta: 'line 1\n',
       toolOutputTruncated: false,
+      completedAt: 1_780_000_004_750,
+      durationMs: 3_500,
     })
   })
 

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -556,6 +556,10 @@ function emitResponseBlockUpdated(
   const toolOutputTruncated = updates.toolOutputTruncated ?? updates.tool_output_truncated
   const toolOutputOriginalBytes =
     updates.toolOutputOriginalBytes ?? updates.tool_output_original_bytes
+  const completedAt =
+    optionalNumberField(updates, 'completedAt') ?? optionalNumberField(updates, 'completed_at')
+  const durationMs =
+    optionalNumberField(updates, 'durationMs') ?? optionalNumberField(updates, 'duration_ms')
   emitBlockUpdated(
     handlers,
     'response.block.updated',
@@ -581,6 +585,8 @@ function emitResponseBlockUpdated(
       ...(typeof updates.status === 'string' && {
         status: updates.status as ChatBlock['status'],
       }),
+      ...(completedAt !== undefined && { completedAt }),
+      ...(durationMs !== undefined && { durationMs }),
     }
   )
 }

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -2275,6 +2275,8 @@ export interface ChatBlock {
   timestamp?: number | string | null
   created_at?: number | string | null
   createdAt?: number | string | null
+  completed_at?: number | string | null
+  completedAt?: number | string | null
 }
 
 export interface ChatBlockCreatedPayload {
@@ -2300,6 +2302,8 @@ export interface ChatBlockUpdatedPayload {
   renderPayload?: unknown
   fileChanges?: TurnFileChangesSummary
   status?: ChatBlock['status'] | 'running'
+  completedAt?: number
+  durationMs?: number
   deviceId?: string
 }
 


### PR DESCRIPTION
## Summary

- preserve millisecond-precision tool lifecycle timing from Codex through executor streams and transcript restoration
- merge command execution completion data into the original tool block instead of creating a competing timing source
- make completed tool rows render the current authoritative timestamps after pane switches or component reuse
- document the tool-duration source-of-truth contract in Chinese and English

## Verification

- `pnpm test src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/stream/responseApiStream.test.ts src/features/workbench/runtimePaneMessages.test.ts src/features/workbench/runtimeConversationTurns.test.ts` (165 passed)
- `cargo test --lib runtime_work::transcript::tests` (47 passed)
- `pnpm run typecheck`
- focused ESLint and Prettier checks
- `pnpm e2e:desktop -- --segment rendering-extensions` (passed, including running/completed tool duration restoration across conversation switches)
- pre-push ESLint, TypeScript, Wework unit tests, `cargo fmt`, `cargo test --all-features --lib`, and `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool activity now displays more accurate start times, completion times, and durations.
  * Completed tool durations remain consistent when reopening, refreshing, or switching panes.
  * Command execution results appear as completed tool outputs with preserved timing details.
  * Running timers reset correctly when viewing different conversation content.
  * Invalid or negative duration values are handled safely.
  * Timing data now preserves millisecond precision where available.

* **Documentation**
  * Added guidance explaining how tool timing is represented for live and historical conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->