### PR TITLE
fix(wework): repair IM continuation and away notifications

### DIFF
--- a/backend/app/api/endpoints/runtime_work.py
+++ b/backend/app/api/endpoints/runtime_work.py
@@ -27,6 +27,8 @@ from app.schemas.runtime_work import (
     RuntimeGlobalIMNotificationUpdateRequest,
     RuntimeGuidanceRequest,
     RuntimeGuidanceResponse,
+    RuntimeIMNotificationPresenceResponse,
+    RuntimeIMNotificationPresenceUpdateRequest,
     RuntimeIMNotificationSettingsResponse,
     RuntimeSendRequest,
     RuntimeSendResponse,
@@ -354,6 +356,26 @@ async def update_global_im_notification_endpoint(
     set_span_attribute("runtime.im_notifications.global.enabled", request.enabled)
     return await runtime_work_service.update_global_im_notification(
         db=db,
+        user_id=current_user.id,
+        request=request,
+    )
+
+
+@router.put(
+    "/im-notifications/presence",
+    response_model=RuntimeIMNotificationPresenceResponse,
+    response_model_by_alias=True,
+)
+@trace_async("runtime_work.im_notifications.presence.update", "runtime_work.api")
+async def update_im_notification_presence_endpoint(
+    request: RuntimeIMNotificationPresenceUpdateRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Refresh one Wework client's foreground or away presence."""
+
+    set_span_attribute("user.id", current_user.id)
+    set_span_attribute("runtime.im_notifications.presence.away", request.away)
+    return await runtime_work_service.update_im_notification_presence(
         user_id=current_user.id,
         request=request,
     )

--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -637,6 +637,30 @@ class RuntimeGlobalIMNotificationUpdateRequest(BaseModel):
     session_key: Optional[str] = Field(default=None, alias="sessionKey")
 
 
+class RuntimeIMNotificationPresenceUpdateRequest(BaseModel):
+    """Refresh one Wework client's foreground or away presence."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    client_id: str = Field(
+        ...,
+        alias="clientId",
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9._:-]+$",
+    )
+    away: bool
+
+
+class RuntimeIMNotificationPresenceResponse(BaseModel):
+    """Aggregated away state after refreshing one Wework client."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    away: bool
+    ttl_seconds: int = Field(..., alias="ttlSeconds")
+
+
 class RuntimeTaskIMNotificationSubscriptionRequest(BaseModel):
     """Subscribe a runtime task to one or more private IM sessions."""
 

--- a/backend/app/services/im/notification_dispatcher.py
+++ b/backend/app/services/im/notification_dispatcher.py
@@ -188,6 +188,8 @@ class IMNotificationDispatcher:
         settings = await im_session_service.get_global_notification_settings(user_id)
         if not settings.enabled or not settings.session_key:
             return []
+        if not await im_session_service.is_user_away_for_im_notifications(user_id):
+            return []
         session = await im_session_service.get_session(settings.session_key)
         if session is None or session.user_id != user_id:
             return []

--- a/backend/app/services/im/session_service.py
+++ b/backend/app/services/im/session_service.py
@@ -6,6 +6,7 @@
 
 import hashlib
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Sequence
@@ -21,9 +22,13 @@ PENDING_STATE_TTL_MINUTES = 15
 PRIVATE_SESSION_KEY_PREFIX = "channel:private_session:"
 USER_PRIVATE_SESSIONS_PREFIX = "channel:user_private_sessions:"
 USER_GLOBAL_NOTIFICATION_PREFIX = "channel:user_global_notification:"
+USER_IM_NOTIFICATION_PRESENCE_PREFIX = "channel:user_im_notification_presence:"
 USER_RUNTIME_TASK_SUBSCRIPTIONS_PREFIX = "channel:user_runtime_task_subscriptions:"
 RUNTIME_TASK_REPLY_TARGET_PREFIX = "channel:runtime_task_reply_target:"
 RUNTIME_TASK_REPLY_TARGET_TTL_SECONDS = 7 * 24 * 60 * 60
+IM_NOTIFICATION_PRESENCE_TTL_SECONDS = 90
+IM_NOTIFICATION_PRESENCE_ACTIVE = "active"
+IM_NOTIFICATION_PRESENCE_AWAY = "away"
 
 CHANNEL_LABELS = {
     "dingtalk": "钉钉",
@@ -204,6 +209,57 @@ class IMSessionService:
         )
         await self._save_global_notification_settings(user_id, settings)
         return settings
+
+    async def update_im_notification_presence(
+        self,
+        *,
+        user_id: int,
+        client_id: str,
+        away: bool,
+    ) -> bool:
+        """Refresh one client presence and return the aggregated away state."""
+
+        key = self._im_notification_presence_key(user_id)
+        active_member = self._im_notification_presence_member(
+            client_id,
+            IM_NOTIFICATION_PRESENCE_ACTIVE,
+        )
+        away_member = self._im_notification_presence_member(
+            client_id,
+            IM_NOTIFICATION_PRESENCE_AWAY,
+        )
+        next_member = away_member if away else active_member
+        now = time.time()
+        client = await cache_manager._get_client()
+        try:
+            await client.zrem(key, active_member, away_member)
+            await client.zadd(
+                key,
+                {next_member: now + IM_NOTIFICATION_PRESENCE_TTL_SECONDS},
+            )
+            members = await self._fresh_im_notification_presence_members(
+                client,
+                key,
+                now,
+            )
+        finally:
+            await client.aclose()
+        return self._presence_members_are_away(members)
+
+    async def is_user_away_for_im_notifications(self, user_id: int) -> bool:
+        """Return whether no fresh Wework client is currently foregrounded."""
+
+        key = self._im_notification_presence_key(user_id)
+        client = await cache_manager._get_client()
+        try:
+            members = await self._fresh_im_notification_presence_members(
+                client,
+                key,
+                time.time(),
+            )
+        finally:
+            await client.aclose()
+        return self._presence_members_are_away(members)
 
     async def subscribe_runtime_task_notification(
         self,
@@ -468,6 +524,27 @@ class IMSessionService:
 
     def _global_notification_key(self, user_id: int) -> str:
         return f"{USER_GLOBAL_NOTIFICATION_PREFIX}{user_id}"
+
+    def _im_notification_presence_key(self, user_id: int) -> str:
+        return f"{USER_IM_NOTIFICATION_PRESENCE_PREFIX}{user_id}"
+
+    def _im_notification_presence_member(self, client_id: str, state: str) -> str:
+        return f"{client_id}\0{state}"
+
+    async def _fresh_im_notification_presence_members(
+        self,
+        client: Any,
+        key: str,
+        now: float,
+    ) -> list[Any]:
+        await client.zremrangebyscore(key, "-inf", now)
+        return await client.zrevrange(key, 0, -1)
+
+    def _presence_members_are_away(self, members: Sequence[Any]) -> bool:
+        return not any(
+            _decode_member(member).endswith(f"\0{IM_NOTIFICATION_PRESENCE_ACTIVE}")
+            for member in members
+        )
 
     def _runtime_task_subscriptions_key(self, user_id: int) -> str:
         return f"{USER_RUNTIME_TASK_SUBSCRIPTIONS_PREFIX}{user_id}"

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -50,6 +50,8 @@ from app.schemas.runtime_work import (
     RuntimeGlobalIMNotificationUpdateRequest,
     RuntimeGuidanceRequest,
     RuntimeGuidanceResponse,
+    RuntimeIMNotificationPresenceResponse,
+    RuntimeIMNotificationPresenceUpdateRequest,
     RuntimeIMNotificationSession,
     RuntimeIMNotificationSettingsResponse,
     RuntimeProjectRef,
@@ -86,7 +88,10 @@ from app.services.device.command_service import execute_configured_device_comman
 from app.services.device.runtime_rpc_service import RuntimeRpcError, runtime_rpc_service
 from app.services.device_service import device_service
 from app.services.im.notification_dispatcher import im_notification_dispatcher
-from app.services.im.session_service import im_session_service
+from app.services.im.session_service import (
+    IM_NOTIFICATION_PRESENCE_TTL_SECONDS,
+    im_session_service,
+)
 from app.services.object_storage import object_storage_presign_service
 from app.services.runtime_work_kind_store import (
     deactivate_device_workspace_kind,
@@ -624,24 +629,35 @@ async def _dispatch_runtime_send(
     request: RuntimeSendRequest,
     rpc_method: str,
 ) -> RuntimeSendResponse:
-    """Send a runtime task message with a best-effort executionRequest payload.
+    """Send a runtime task message with the required execution request.
 
     The executor requires ``executionRequest`` to spawn a new turn (it carries
     model config, user info, skills, etc.). The Wework frontend builds this
     client-side for direct local sends; the IM continuation path flows through
-    the backend RPC, so we synthesize a minimal request here from the default
-    task-mode team. Failures to build the request are non-fatal — the payload
-    is still forwarded so existing tasks that don't need a fresh turn (e.g.
-    request-user-input responses) keep working.
+    the backend RPC, so we build it here from the default task-mode team.
+    Request-user-input responses use a dedicated executor channel and do not
+    spawn a new turn, so they intentionally omit ``executionRequest``.
     """
-    execution_request = _safe_build_runtime_send_execution_request(
-        db=db,
-        user_id=user_id,
-        address=address,
-        message=request.message,
-        attachment_ids=request.attachment_ids,
-    )
-    if execution_request is not None:
+    if request.request_user_input_response is None:
+        try:
+            execution_request = _build_runtime_send_execution_request(
+                db=db,
+                user_id=user_id,
+                address=address,
+                message=request.message,
+                attachment_ids=request.attachment_ids,
+                additional_context=request.additional_context,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.exception(
+                "[RuntimeWork] Failed to build executionRequest for runtime send"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to build runtime execution request",
+            ) from exc
         payload["executionRequest"] = execution_request.to_dict()
     try:
         result = await runtime_rpc_service.call(
@@ -788,6 +804,24 @@ async def update_global_im_notification(
         session_key=request.session_key,
     )
     return await get_im_notification_settings(db=db, user_id=user_id)
+
+
+async def update_im_notification_presence(
+    *,
+    user_id: int,
+    request: RuntimeIMNotificationPresenceUpdateRequest,
+) -> RuntimeIMNotificationPresenceResponse:
+    """Refresh Wework foreground presence for away-only global IM delivery."""
+
+    away = await im_session_service.update_im_notification_presence(
+        user_id=user_id,
+        client_id=request.client_id,
+        away=request.away,
+    )
+    return RuntimeIMNotificationPresenceResponse(
+        away=away,
+        ttlSeconds=IM_NOTIFICATION_PRESENCE_TTL_SECONDS,
+    )
 
 
 async def subscribe_runtime_task_im_notification(
@@ -3894,6 +3928,7 @@ def _build_runtime_send_execution_request(
     address: RuntimeTaskAddress,
     message: str,
     attachment_ids: list[int],
+    additional_context: Optional[dict[str, dict[str, Any]]] = None,
 ):
     """Build an executor request for an IM continuation send.
 
@@ -3904,98 +3939,33 @@ def _build_runtime_send_execution_request(
     through the backend RPC, so we synthesize one here from the default
     task-mode team — the same agent the workbench uses.
     """
-    from app.services.execution import TaskRequestBuilder
-
-    user = _get_user(db, user_id)
     team = _get_task_mode_team(db, user_id)
     if team is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Default task-mode team is not configured",
         )
-    task_id, subtask_id = _runtime_execution_ids()
     target = RuntimeTaskTarget(
         device_id=address.device_id,
         workspace_path=address.workspace_path or "",
         project=None,
         workspace_source="local_path",
     )
-    request = SimpleNamespace(
-        message=message,
-        additional_context=None,
-        additional_skills=[],
-        attachment_ids=attachment_ids,
-        model_id=None,
-        model_type=None,
-        model_options={},
+    request = RuntimeTaskCreateRequest(
+        deviceId=address.device_id,
+        workspacePath=address.workspace_path,
+        teamId=team.id,
         runtime="codex",
+        message=message,
+        attachmentIds=attachment_ids,
+        additionalContext=additional_context,
     )
-    task = _runtime_task_context(
+    return _build_runtime_execution_request(
+        db=db,
         user_id=user_id,
-        task_id=task_id,
         request=request,
         target=target,
-        team=team,
     )
-    subtask = _runtime_assistant_context(
-        user_id=user_id,
-        task_id=task_id,
-        subtask_id=subtask_id,
-        request=request,
-        team=team,
-    )
-    payload = _runtime_execution_payload(request)
-    runtime_model_config, override_model_name, force_override = _runtime_model_override(
-        db,
-        user_id,
-        request,
-    )
-    execution_request = TaskRequestBuilder(db).build(
-        subtask=subtask,
-        task=task,
-        user=user,
-        team=team,
-        message=_message_with_application_context(message, None),
-        preload_skills=request.additional_skills,
-        override_model_name=override_model_name,
-        force_override=force_override,
-        runtime_model_config=runtime_model_config,
-        web_runtime_guidance=True,
-    )
-    _apply_runtime_task_target(execution_request, target)
-    _apply_runtime_model_options(db, execution_request, user, payload)
-    _apply_runtime_attachments(db, execution_request, user_id, attachment_ids)
-    return execution_request
-
-
-def _safe_build_runtime_send_execution_request(
-    *,
-    db: Session,
-    user_id: int,
-    address: RuntimeTaskAddress,
-    message: str,
-    attachment_ids: list[int],
-):
-    """Best-effort wrapper around _build_runtime_send_execution_request.
-
-    Returns ``None`` on failure so the send payload is still forwarded
-    without an ``executionRequest`` — the executor can handle cases that
-    don't need a fresh turn (e.g. request-user-input responses).
-    """
-    try:
-        return _build_runtime_send_execution_request(
-            db=db,
-            user_id=user_id,
-            address=address,
-            message=message,
-            attachment_ids=attachment_ids,
-        )
-    except Exception:
-        logger.warning(
-            "[RuntimeWork] Failed to build executionRequest for runtime send",
-            exc_info=True,
-        )
-        return None
 
 
 def _ensure_owned_device(db: Session, user_id: int, device_id: str) -> None:

--- a/backend/tests/api/endpoints/test_runtime_work_api.py
+++ b/backend/tests/api/endpoints/test_runtime_work_api.py
@@ -779,6 +779,33 @@ def test_runtime_global_im_notification_endpoint_dispatches_payload(
     assert payload.session_key == "session-1"
 
 
+def test_runtime_im_notification_presence_endpoint_dispatches_payload(
+    test_client,
+    test_token,
+    monkeypatch,
+):
+    from app.api.endpoints import runtime_work
+
+    service_mock = AsyncMock(return_value={"away": False, "ttlSeconds": 90})
+    monkeypatch.setattr(
+        runtime_work.runtime_work_service,
+        "update_im_notification_presence",
+        service_mock,
+    )
+
+    response = test_client.put(
+        "/api/runtime-work/im-notifications/presence",
+        headers=_auth_headers(test_token),
+        json={"clientId": "desktop-client-1", "away": False},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"away": False, "ttlSeconds": 90}
+    request = service_mock.await_args.kwargs["request"]
+    assert request.client_id == "desktop-client-1"
+    assert request.away is False
+
+
 def test_runtime_task_im_notification_subscribe_endpoint_dispatches_address(
     test_client,
     test_token,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -71,6 +71,20 @@ class FakeIMSessionRedisClient:
                 del zset[member]
         return removed
 
+    async def zremrangebyscore(
+        self,
+        key: str,
+        minimum: str | float,
+        maximum: str | float,
+    ) -> int:
+        lower = float("-inf") if minimum == "-inf" else float(minimum)
+        upper = float("inf") if maximum == "+inf" else float(maximum)
+        zset = self._cache.zsets.get(key, {})
+        expired = [member for member, score in zset.items() if lower <= score <= upper]
+        for member in expired:
+            del zset[member]
+        return len(expired)
+
     async def aclose(self) -> None:
         return None
 

--- a/backend/tests/services/im/test_notification_dispatcher.py
+++ b/backend/tests/services/im/test_notification_dispatcher.py
@@ -234,6 +234,42 @@ async def test_runtime_task_update_uses_global_im_notification_target(
 
 
 @pytest.mark.asyncio
+async def test_runtime_task_update_suppresses_global_target_while_client_is_active(
+    test_db: Session,
+    test_user,
+) -> None:
+    session = _create_session(
+        user_id=test_user.id,
+        channel_id=9412,
+        channel_type="telegram",
+        sender_id="100200300",
+    )
+    await im_session_service.save_session(session)
+    await im_session_service.enable_global_notification(test_db, session=session)
+    await im_session_service.update_im_notification_presence(
+        user_id=test_user.id,
+        client_id="wework-client",
+        away=False,
+    )
+
+    result = await im_notification_dispatcher.send_runtime_task_update(
+        test_db,
+        user_id=test_user.id,
+        address={
+            "deviceId": "device-1",
+            "localTaskId": "codex-thread-1",
+        },
+        title="Native Codex task",
+        status="updated",
+        content="Foreground update",
+        source="codex_watcher",
+    )
+
+    assert result["sent"] == 0
+    assert result["results"] == []
+
+
+@pytest.mark.asyncio
 async def test_runtime_task_update_uses_subscribed_native_codex_task(
     test_db: Session,
     test_user,
@@ -257,6 +293,11 @@ async def test_runtime_task_update_uses_subscribed_native_codex_task(
         "workspacePath": "/repo/Wegent",
     }
     await im_session_service.save_session(session)
+    await im_session_service.update_im_notification_presence(
+        user_id=test_user.id,
+        client_id="wework-client",
+        away=False,
+    )
     await im_session_service.subscribe_runtime_task_notification(
         test_db,
         session=session,

--- a/backend/tests/services/im/test_session_service.py
+++ b/backend/tests/services/im/test_session_service.py
@@ -142,3 +142,36 @@ async def test_bind_active_task_sets_task_mode_and_clears_pending_state(
     assert session.state == IMSessionState.IDLE
     assert session.active_task_id == 7001
     assert session.pending_payload == {}
+
+
+@pytest.mark.asyncio
+async def test_im_notification_presence_aggregates_clients_and_expires(
+    fake_im_session_cache,
+    test_user: User,
+) -> None:
+    assert await im_session_service.is_user_away_for_im_notifications(test_user.id)
+
+    away = await im_session_service.update_im_notification_presence(
+        user_id=test_user.id,
+        client_id="client-a",
+        away=True,
+    )
+    assert away is True
+
+    away = await im_session_service.update_im_notification_presence(
+        user_id=test_user.id,
+        client_id="client-b",
+        away=False,
+    )
+    assert away is False
+
+    away = await im_session_service.update_im_notification_presence(
+        user_id=test_user.id,
+        client_id="client-b",
+        away=True,
+    )
+    assert away is True
+
+    key = f"channel:user_im_notification_presence:{test_user.id}"
+    fake_im_session_cache.zsets[key] = {"client-a\0active": 0}
+    assert await im_session_service.is_user_away_for_im_notifications(test_user.id)

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -1784,8 +1784,8 @@ async def test_send_runtime_message_normalizes_runtime_rpc_failure_without_task_
     monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
     monkeypatch.setattr(
         runtime_work_service,
-        "_safe_build_runtime_send_execution_request",
-        lambda **kwargs: None,
+        "_build_runtime_send_execution_request",
+        lambda **kwargs: SimpleNamespace(to_dict=lambda: {"prompt": kwargs["message"]}),
     )
 
     response = await runtime_work_service.send_runtime_message(
@@ -1823,6 +1823,7 @@ async def test_send_runtime_message_normalizes_runtime_rpc_failure_without_task_
                     "value": "terminal output",
                 }
             },
+            "executionRequest": {"prompt": "continue"},
         },
         timeout_seconds=600,
     )
@@ -1997,8 +1998,8 @@ async def test_send_runtime_message_forwards_ready_attachments_without_task_rows
     monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
     monkeypatch.setattr(
         runtime_work_service,
-        "_safe_build_runtime_send_execution_request",
-        lambda **kwargs: None,
+        "_build_runtime_send_execution_request",
+        lambda **kwargs: SimpleNamespace(to_dict=lambda: {"prompt": kwargs["message"]}),
     )
 
     response = await runtime_work_service.send_runtime_message(
@@ -3869,6 +3870,12 @@ def test_runtime_model_override_falls_back_to_request_model_id_for_unknown_model
 
 def _runtime_team_with_bot(test_db, user_id: int) -> Kind:
     """Create a minimal Team + Bot + Shell + Ghost for runtime request building."""
+    model = _codex_provider_model(
+        test_db,
+        user_id,
+        name="codex-model",
+        api_model_id="gpt-test",
+    )
     shell = Kind(
         user_id=user_id,
         kind="Shell",
@@ -3913,6 +3920,7 @@ def _runtime_team_with_bot(test_db, user_id: int) -> Kind:
             "spec": {
                 "ghostRef": {"name": "ghost", "namespace": "default"},
                 "shellRef": {"name": "ClaudeCode", "namespace": "default"},
+                "modelRef": {"name": model.name, "namespace": model.namespace},
             },
             "status": {"state": "Available"},
         },
@@ -3941,6 +3949,136 @@ def _runtime_team_with_bot(test_db, user_id: int) -> Kind:
     test_db.commit()
     test_db.refresh(team)
     return team
+
+
+def test_build_runtime_send_execution_request_uses_complete_create_request(
+    test_db,
+    test_user,
+    monkeypatch,
+):
+    from app.schemas.runtime_work import RuntimeTaskAddress
+    from app.services import runtime_work_service
+
+    team = _runtime_team_with_bot(test_db, test_user.id)
+    monkeypatch.setattr(
+        runtime_work_service.settings,
+        "DEFAULT_TEAM_TASK",
+        f"{team.name}#{team.namespace}",
+    )
+
+    execution_request = runtime_work_service._build_runtime_send_execution_request(
+        db=test_db,
+        user_id=test_user.id,
+        address=RuntimeTaskAddress(
+            deviceId="device-1",
+            workspacePath="/repo/Wegent",
+            localTaskId="codex-1",
+        ),
+        message="continue",
+        attachment_ids=[],
+        additional_context={
+            "wework.terminal.current": {
+                "kind": "application",
+                "value": "terminal output",
+            }
+        },
+    )
+
+    assert execution_request.team_id == team.id
+    assert execution_request.project_workspace_path == "/repo/Wegent"
+    assert execution_request.device_id == "device-1"
+    assert execution_request.prompt.endswith("continue")
+    assert "terminal output" in execution_request.prompt
+
+
+@pytest.mark.asyncio
+async def test_send_runtime_message_does_not_dispatch_when_request_build_fails(
+    test_db,
+    test_user,
+    monkeypatch,
+):
+    from app.schemas.runtime_work import RuntimeSendRequest, RuntimeTaskAddress
+    from app.services import runtime_work_service
+
+    monkeypatch.setattr(
+        runtime_work_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: object(),
+    )
+
+    def fail_build(**kwargs):
+        raise AttributeError("missing request field")
+
+    monkeypatch.setattr(
+        runtime_work_service,
+        "_build_runtime_send_execution_request",
+        fail_build,
+    )
+    rpc = AsyncMock()
+    monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await runtime_work_service.send_runtime_message(
+            db=test_db,
+            user_id=test_user.id,
+            request=RuntimeSendRequest(
+                address=RuntimeTaskAddress(
+                    deviceId="device-1",
+                    localTaskId="codex-1",
+                ),
+                message="continue",
+            ),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Failed to build runtime execution request"
+    rpc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_runtime_request_user_input_response_omits_execution_request(
+    test_db,
+    test_user,
+    monkeypatch,
+):
+    from app.schemas.runtime_work import RuntimeSendRequest, RuntimeTaskAddress
+    from app.services import runtime_work_service
+
+    monkeypatch.setattr(
+        runtime_work_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: object(),
+    )
+
+    def unexpected_build(**kwargs):
+        raise AssertionError("request-user-input response must not build a new turn")
+
+    monkeypatch.setattr(
+        runtime_work_service,
+        "_build_runtime_send_execution_request",
+        unexpected_build,
+    )
+    rpc = AsyncMock(return_value={"success": True, "accepted": True})
+    monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+
+    response = await runtime_work_service.send_runtime_message(
+        db=test_db,
+        user_id=test_user.id,
+        request=RuntimeSendRequest(
+            address=RuntimeTaskAddress(
+                deviceId="device-1",
+                localTaskId="codex-1",
+            ),
+            message="option-a",
+            requestUserInputResponse={"answers": {"choice": "option-a"}},
+        ),
+    )
+
+    assert response.accepted is True
+    rpc.assert_awaited_once()
+    payload = rpc.await_args.kwargs["payload"]
+    assert payload["requestUserInputResponse"] == {"answers": {"choice": "option-a"}}
+    assert "executionRequest" not in payload
 
 
 def test_build_runtime_execution_request_resolves_crd_model_id(

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ core-graphics = "0.25.0"
 block2 = "0.6.2"
 objc2 = "0.6.3"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["block2", "libc", "NSAttributedString", "NSBitmapImageRep", "NSColor", "NSEvent", "NSFont", "NSFontDescriptor", "NSGraphics", "NSGraphicsContext", "NSImage", "NSImageRep", "NSOpenPanel", "NSPanel", "NSPasteboard", "NSResponder", "NSRunningApplication", "NSSavePanel", "NSScreen", "NSStringDrawing", "NSView", "NSWindow", "NSWorkspace"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSAttributedString", "NSData", "NSDate", "NSDictionary", "NSDistributedNotificationCenter", "NSError", "NSNotification", "NSObject", "NSSet", "NSString", "NSURLCache", "std"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSAttributedString", "NSData", "NSDate", "NSDictionary", "NSDistributedNotificationCenter", "NSError", "NSNotification", "NSObject", "NSOperation", "NSSet", "NSString", "NSURLCache", "std"] }
 objc2-web-kit = { version = "0.3.2", default-features = false, features = ["WKWebView", "WKWebViewConfiguration", "WKWebsiteDataRecord", "WKWebsiteDataStore", "block2", "objc2-app-kit", "std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod process_environment;
 #[cfg(desktop)]
 mod storage_maintenance;
 mod system_drag;
+mod system_lock;
 mod system_sleep;
 mod todo_store;
 mod workbench_background;
@@ -3115,7 +3116,10 @@ fn emit_main_window_focus_changed<R: tauri::Runtime>(window: &tauri::Window<R>, 
     if window.label() != MAIN_WINDOW_LABEL {
         return;
     }
-    if let Err(error) = window.app_handle().emit(MAIN_WINDOW_FOCUS_CHANGED_EVENT, focused) {
+    if let Err(error) = window
+        .app_handle()
+        .emit(MAIN_WINDOW_FOCUS_CHANGED_EVENT, focused)
+    {
         log::warn!("Failed to emit main window focus changed event: {error}");
     }
 }
@@ -4907,6 +4911,7 @@ pub fn run() {
         .manage(local_terminal::LocalTerminalState::default())
         .manage(popout_window::PopoutWindowState::default())
         .manage(system_drag::SystemDragState::default())
+        .manage(system_lock::SystemLockState::default())
         .manage(system_sleep::SystemSleepState::default())
         .on_window_event(|window, event| {
             #[cfg(desktop)]
@@ -4968,6 +4973,8 @@ pub fn run() {
             }
             #[cfg(desktop)]
             system_drag::setup(app.handle().clone());
+            #[cfg(desktop)]
+            system_lock::setup(app.handle().clone());
             #[cfg(desktop)]
             appshots::setup(app.handle());
             #[cfg(desktop)]
@@ -5120,6 +5127,8 @@ pub fn run() {
             system_drag::dismiss_system_drag_panel,
             system_drag::log_system_drag_debug,
             system_drag::take_pending_system_drag_drops,
+            #[cfg(desktop)]
+            system_lock::get_system_session_locked,
             local_terminal::get_local_terminal_snapshot,
             local_terminal::list_local_harnesses,
             local_terminal::list_local_harness_sessions,

--- a/wework/src-tauri/src/system_lock.rs
+++ b/wework/src-tauri/src/system_lock.rs
@@ -1,0 +1,82 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tauri::{Emitter, Manager};
+
+pub const SYSTEM_SESSION_LOCK_CHANGED_EVENT: &str = "wework-system-session-lock-changed";
+
+#[derive(Default)]
+pub struct SystemLockState {
+    locked: AtomicBool,
+}
+
+impl SystemLockState {
+    fn update<R: tauri::Runtime>(&self, app: &tauri::AppHandle<R>, locked: bool) {
+        if self.locked.swap(locked, Ordering::SeqCst) == locked {
+            return;
+        }
+        if let Err(error) = app.emit(SYSTEM_SESSION_LOCK_CHANGED_EVENT, locked) {
+            log::warn!("Failed to emit system session lock changed event: {error}");
+        }
+    }
+
+    fn is_locked(&self) -> bool {
+        self.locked.load(Ordering::SeqCst)
+    }
+}
+
+#[tauri::command]
+pub fn get_system_session_locked(state: tauri::State<'_, SystemLockState>) -> bool {
+    state.is_locked()
+}
+
+#[cfg(target_os = "macos")]
+pub fn setup(app: tauri::AppHandle) {
+    use block2::RcBlock;
+    use objc2_app_kit::{
+        NSWorkspace, NSWorkspaceSessionDidBecomeActiveNotification,
+        NSWorkspaceSessionDidResignActiveNotification,
+    };
+
+    let center = NSWorkspace::sharedWorkspace().notificationCenter();
+    let locked_app = app.clone();
+    let locked_handler = RcBlock::new(move |_| {
+        locked_app
+            .state::<SystemLockState>()
+            .update(&locked_app, true);
+    });
+    let unlocked_app = app;
+    let unlocked_handler = RcBlock::new(move |_| {
+        unlocked_app
+            .state::<SystemLockState>()
+            .update(&unlocked_app, false);
+    });
+
+    // NSNotificationCenter retains both registrations for its own lifetime.
+    unsafe {
+        center.addObserverForName_object_queue_usingBlock(
+            Some(NSWorkspaceSessionDidResignActiveNotification),
+            None,
+            None,
+            &locked_handler,
+        );
+        center.addObserverForName_object_queue_usingBlock(
+            Some(NSWorkspaceSessionDidBecomeActiveNotification),
+            None,
+            None,
+            &unlocked_handler,
+        );
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn setup(_app: tauri::AppHandle) {}
+
+#[cfg(test)]
+mod tests {
+    use super::SystemLockState;
+
+    #[test]
+    fn lock_state_defaults_to_unlocked() {
+        assert!(!SystemLockState::default().is_locked());
+    }
+}

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -40,6 +40,9 @@ import { useCloudConnection } from '@/features/cloud-connection/useCloudConnecti
 import { LocalExecutorCloudBridge } from '@/features/cloud-connection/LocalExecutorCloudBridge'
 import { cn } from '@/lib/utils'
 import { createLocalAppServices } from '@/api/local/localServices'
+import { createHttpClient } from '@/api/http'
+import { createRuntimeWorkApi } from '@/api/runtimeWork'
+import { useAwayImNotificationPresence } from '@/features/workbench/awayImNotificationPresence'
 import { applyLanguagePreference } from '@/i18n/languagePreference'
 import {
   KEYBINDINGS_CHANGED_EVENT,
@@ -450,7 +453,11 @@ function AppShell() {
   const { activeAppKey, navigateToApp } = useChromeTabs(path)
   const isTauri = isTauriRuntime()
   const isPopoutWindow = isPopoutWindowRuntime()
-  const isWorkspaceWindow = isTauri && getCurrentWindow().label?.startsWith('workspace-') === true
+  const currentWindowLabel = isTauri ? getCurrentWindow().label : null
+  const isMainWindow = currentWindowLabel === 'main'
+  const isWorkspaceWindow = currentWindowLabel?.startsWith('workspace-') === true
+  const cloudApiBaseUrl = cloudConnection.apiBaseUrl
+  const cloudToken = cloudConnection.token
   const titlebarOverlaysContent = false
   const showChromeTitlebar = isTauri && !isPopoutWindow
   const workspaceTabStorageScope = useMemo(
@@ -474,6 +481,20 @@ function AppShell() {
   )
   const [workbenchStartupReady, setWorkbenchStartupReady] = useState(false)
   const [workbenchStartupRevealTimedOut, setWorkbenchStartupRevealTimedOut] = useState(false)
+  const updateImNotificationPresence = useMemo(() => {
+    if (!cloudApiBaseUrl || !cloudToken) return undefined
+    return createRuntimeWorkApi(
+      createHttpClient({
+        baseUrl: cloudApiBaseUrl,
+        getToken: () => cloudToken,
+        redirectOnUnauthorized: false,
+      })
+    ).updateImNotificationPresence
+  }, [cloudApiBaseUrl, cloudToken])
+  useAwayImNotificationPresence({
+    enabled: isMainWindow && hasTauriIpc() && cloudConnection.isConnected,
+    updatePresence: updateImNotificationPresence,
+  })
   const openWeworkForAppshot = useCallback(() => {
     navigateToApp('wework')
   }, [navigateToApp])

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -34,6 +34,7 @@ import type {
   RuntimeRollbackRequest,
   RuntimeFileChangesRevertRequest,
   RuntimeGlobalIMNotificationUpdateRequest,
+  RuntimeIMNotificationPresenceUpdateRequest,
   RuntimeLocalProjectUpsertRequest,
   RuntimeSendRequest,
   RuntimeTaskAddress,
@@ -766,6 +767,9 @@ export function createHybridWorkbenchServices(
     },
     updateGlobalImNotification(data: RuntimeGlobalIMNotificationUpdateRequest) {
       return cloudServices.runtimeWorkApi!.updateGlobalImNotification(data)
+    },
+    updateImNotificationPresence(data: RuntimeIMNotificationPresenceUpdateRequest) {
+      return cloudServices.runtimeWorkApi!.updateImNotificationPresence(data)
     },
     subscribeRuntimeTaskNotifications(data: RuntimeTaskIMNotificationSubscriptionRequest) {
       return cloudServices.runtimeWorkApi!.subscribeRuntimeTaskNotifications(data)

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -2585,6 +2585,9 @@ export function createRuntimeWorkApiFromIpc(
     updateGlobalImNotification() {
       return cloudConnectionRequired('updateGlobalImNotification')
     },
+    updateImNotificationPresence() {
+      return cloudConnectionRequired('updateImNotificationPresence')
+    },
     subscribeRuntimeTaskNotifications() {
       return cloudConnectionRequired('subscribeRuntimeTaskNotifications')
     },

--- a/wework/src/api/runtimeWork.test.ts
+++ b/wework/src/api/runtimeWork.test.ts
@@ -345,6 +345,7 @@ describe('createRuntimeWorkApi', () => {
       runtimeTaskSubscriptions: [],
     })
     await api.updateGlobalImNotification({ enabled: true, sessionKey: 'session-a' })
+    await api.updateImNotificationPresence({ clientId: 'desktop-client-1', away: false })
     await api.subscribeRuntimeTaskNotifications({
       address: {
         deviceId: 'device-1',
@@ -362,7 +363,11 @@ describe('createRuntimeWorkApi', () => {
       enabled: true,
       sessionKey: 'session-a',
     })
-    expect(put).toHaveBeenNthCalledWith(2, '/runtime-work/im-notifications/runtime-task', {
+    expect(put).toHaveBeenNthCalledWith(2, '/runtime-work/im-notifications/presence', {
+      clientId: 'desktop-client-1',
+      away: false,
+    })
+    expect(put).toHaveBeenNthCalledWith(3, '/runtime-work/im-notifications/runtime-task', {
       address: {
         deviceId: 'device-1',
         taskId: 'codex-1',

--- a/wework/src/api/runtimeWork.ts
+++ b/wework/src/api/runtimeWork.ts
@@ -10,6 +10,8 @@ import type {
   DeviceWorkspacePrepareResponse,
   DeviceWorkspaceUpsert,
   RuntimeGlobalIMNotificationUpdateRequest,
+  RuntimeIMNotificationPresenceResponse,
+  RuntimeIMNotificationPresenceUpdateRequest,
   RuntimeGuidanceRequest,
   RuntimeGuidanceResponse,
   RuntimeInterruptAndSendRequest,
@@ -256,6 +258,11 @@ export function createRuntimeWorkApi(client: HttpClient) {
       data: RuntimeGlobalIMNotificationUpdateRequest
     ): Promise<RuntimeIMNotificationSettingsResponse> {
       return client.put('/runtime-work/im-notifications/global', data)
+    },
+    updateImNotificationPresence(
+      data: RuntimeIMNotificationPresenceUpdateRequest
+    ): Promise<RuntimeIMNotificationPresenceResponse> {
+      return client.put('/runtime-work/im-notifications/presence', data)
     },
     subscribeRuntimeTaskNotifications(
       data: RuntimeTaskIMNotificationSubscriptionRequest

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1136,7 +1136,7 @@ function GlobalImNotificationBell({
                 <p className="mt-1 text-xs leading-5 text-text-secondary">
                   {t(
                     'workbench.away_im_reminder_description',
-                    '所有任务进展会推送到 IM，不会改变任务的 IM 会话归属。'
+                    '锁屏或 Wework 未聚焦时，任务进展会推送到 IM，不会改变任务的 IM 会话归属。'
                   )}
                 </p>
               </div>

--- a/wework/src/features/workbench/awayImNotificationPresence.test.tsx
+++ b/wework/src/features/workbench/awayImNotificationPresence.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  getImNotificationPresenceClientId,
+  isAwayForImNotifications,
+  useAwayImNotificationPresence,
+} from './awayImNotificationPresence'
+
+const focusState = vi.hoisted(() => ({
+  focused: true,
+  listener: null as ((focused: boolean) => void) | null,
+}))
+
+const lockState = vi.hoisted(() => ({
+  locked: false,
+  listener: null as ((locked: boolean) => void) | null,
+}))
+
+vi.mock('@/tauri/windowFocus', () => ({
+  isMainWindowFocused: () => focusState.focused,
+  subscribeMainWindowFocus: (listener: (focused: boolean) => void) => {
+    focusState.listener = listener
+    return () => {
+      focusState.listener = null
+    }
+  },
+}))
+
+vi.mock('@/tauri/systemLock', () => ({
+  isSystemSessionLocked: () => lockState.locked,
+  subscribeSystemSessionLock: (listener: (locked: boolean) => void) => {
+    lockState.listener = listener
+    return () => {
+      lockState.listener = null
+    }
+  },
+}))
+
+describe('away IM notification presence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    focusState.focused = true
+    focusState.listener = null
+    lockState.locked = false
+    lockState.listener = null
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('treats either lost focus or hidden visibility as away', () => {
+    expect(isAwayForImNotifications(true, 'visible', false)).toBe(false)
+    expect(isAwayForImNotifications(false, 'visible', false)).toBe(true)
+    expect(isAwayForImNotifications(true, 'hidden', false)).toBe(true)
+    expect(isAwayForImNotifications(true, 'visible', true)).toBe(true)
+  })
+
+  test('keeps one stable installation client id', () => {
+    expect(getImNotificationPresenceClientId()).toBe(getImNotificationPresenceClientId())
+  })
+
+  test('reports foreground initially and away after focus is lost', async () => {
+    const updatePresence = vi.fn().mockResolvedValue({ away: false, ttlSeconds: 90 })
+    renderHook(() =>
+      useAwayImNotificationPresence({
+        enabled: true,
+        updatePresence,
+      })
+    )
+
+    await waitFor(() => expect(updatePresence).toHaveBeenCalledTimes(1))
+    expect(updatePresence.mock.calls[0][0]).toMatchObject({ away: false })
+
+    act(() => {
+      focusState.listener?.(false)
+    })
+
+    await waitFor(() => expect(updatePresence).toHaveBeenCalledTimes(2))
+    expect(updatePresence.mock.calls[1][0]).toMatchObject({ away: true })
+  })
+
+  test('reports away when the native system session locks', async () => {
+    const updatePresence = vi.fn().mockResolvedValue({ away: false, ttlSeconds: 90 })
+    renderHook(() =>
+      useAwayImNotificationPresence({
+        enabled: true,
+        updatePresence,
+      })
+    )
+
+    await waitFor(() => expect(updatePresence).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      lockState.listener?.(true)
+    })
+
+    await waitFor(() => expect(updatePresence).toHaveBeenCalledTimes(2))
+    expect(updatePresence.mock.calls[1][0]).toMatchObject({ away: true })
+  })
+
+  test('does not report while cloud presence synchronization is disabled', () => {
+    const updatePresence = vi.fn()
+    renderHook(() =>
+      useAwayImNotificationPresence({
+        enabled: false,
+        updatePresence,
+      })
+    )
+
+    expect(updatePresence).not.toHaveBeenCalled()
+  })
+})

--- a/wework/src/features/workbench/awayImNotificationPresence.ts
+++ b/wework/src/features/workbench/awayImNotificationPresence.ts
@@ -1,0 +1,97 @@
+import { useEffect } from 'react'
+import type {
+  RuntimeIMNotificationPresenceResponse,
+  RuntimeIMNotificationPresenceUpdateRequest,
+} from '@/types/api'
+import { isMainWindowFocused, subscribeMainWindowFocus } from '@/tauri/windowFocus'
+import { isSystemSessionLocked, subscribeSystemSessionLock } from '@/tauri/systemLock'
+
+const CLIENT_ID_STORAGE_KEY = 'wework:im-notification-presence-client-id'
+export const IM_NOTIFICATION_PRESENCE_HEARTBEAT_MS = 30_000
+
+type PresenceUpdater = (
+  data: RuntimeIMNotificationPresenceUpdateRequest
+) => Promise<RuntimeIMNotificationPresenceResponse>
+
+function randomClientId(): string {
+  const randomUuid = globalThis.crypto?.randomUUID?.()
+  if (randomUuid) return `wework-${randomUuid}`
+  return `wework-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export function getImNotificationPresenceClientId(): string {
+  try {
+    const existing = globalThis.localStorage?.getItem(CLIENT_ID_STORAGE_KEY)?.trim()
+    if (existing) return existing
+    const created = randomClientId()
+    globalThis.localStorage?.setItem(CLIENT_ID_STORAGE_KEY, created)
+    return created
+  } catch {
+    return randomClientId()
+  }
+}
+
+export function isAwayForImNotifications(
+  focused: boolean,
+  visibilityState: DocumentVisibilityState,
+  systemLocked: boolean
+): boolean {
+  return systemLocked || !focused || visibilityState !== 'visible'
+}
+
+export function useAwayImNotificationPresence({
+  enabled,
+  updatePresence,
+}: {
+  enabled: boolean
+  updatePresence?: PresenceUpdater
+}) {
+  useEffect(() => {
+    if (!enabled || !updatePresence) return
+
+    const clientId = getImNotificationPresenceClientId()
+    let focused = isMainWindowFocused()
+    let systemLocked = isSystemSessionLocked()
+    let lastQueuedAway: boolean | null = null
+    let queue = Promise.resolve()
+
+    const enqueue = (force = false) => {
+      const away = isAwayForImNotifications(focused, document.visibilityState, systemLocked)
+      if (!force && away === lastQueuedAway) return
+      lastQueuedAway = away
+      queue = queue
+        .catch(() => undefined)
+        .then(() => updatePresence({ clientId, away }))
+        .then(() => undefined)
+        .catch(error => {
+          console.warn('[Wework] Failed to synchronize away IM notification presence', error)
+        })
+    }
+
+    const unsubscribeFocus = subscribeMainWindowFocus(nextFocused => {
+      focused = nextFocused
+      enqueue()
+    })
+    const unsubscribeSystemLock = subscribeSystemSessionLock(nextLocked => {
+      systemLocked = nextLocked
+      enqueue()
+    })
+    const handleVisibilityChange = () => enqueue()
+    const handlePageHide = () => {
+      focused = false
+      enqueue()
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('pagehide', handlePageHide)
+    enqueue(true)
+    const heartbeat = window.setInterval(() => enqueue(true), IM_NOTIFICATION_PRESENCE_HEARTBEAT_MS)
+
+    return () => {
+      unsubscribeFocus()
+      unsubscribeSystemLock()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('pagehide', handlePageHide)
+      window.clearInterval(heartbeat)
+    }
+  }, [enabled, updatePresence])
+}

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -739,7 +739,7 @@
     "continue_im_failed": "Failed to continue in IM",
     "away_im_reminder_title": "Away reminder",
     "away_im_reminder_on": "Away reminder is on",
-    "away_im_reminder_description": "All task progress will be pushed to IM without changing any task's IM session ownership.",
+    "away_im_reminder_description": "Task progress is pushed to IM while the screen is locked or Wework is not focused, without changing any task's IM session ownership.",
     "away_im_reminder_target": "Deliver to",
     "away_im_reminder_no_target": "No IM session selected",
     "away_im_reminder_enable": "Turn on away reminder",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -738,7 +738,7 @@
     "continue_im_failed": "继续到私聊失败",
     "away_im_reminder_title": "离开电脑提醒",
     "away_im_reminder_on": "离开电脑提醒已开启",
-    "away_im_reminder_description": "所有任务进展会推送到 IM，不会改变任务的 IM 会话归属。",
+    "away_im_reminder_description": "锁屏或 Wework 未聚焦时，任务进展会推送到 IM，不会改变任务的 IM 会话归属。",
     "away_im_reminder_target": "投递到",
     "away_im_reminder_no_target": "未选择 IM 会话",
     "away_im_reminder_enable": "开启离开电脑提醒",

--- a/wework/src/tauri/systemLock.ts
+++ b/wework/src/tauri/systemLock.ts
@@ -1,0 +1,59 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { isTauriRuntime } from '@/lib/runtime-environment'
+import { disposeTauriListener } from './disposeTauriListener'
+
+export const WEWORK_SYSTEM_SESSION_LOCK_CHANGED_EVENT = 'wework-system-session-lock-changed'
+
+const listeners = new Set<(locked: boolean) => void>()
+let currentLocked = false
+let initialized = false
+let unlistenPromise: Promise<UnlistenFn> | null = null
+
+function publishLocked(locked: boolean) {
+  if (locked === currentLocked) return
+  currentLocked = locked
+  for (const listener of listeners) {
+    listener(locked)
+  }
+}
+
+function ensureListenerInstalled() {
+  if (initialized || !isTauriRuntime()) return
+
+  try {
+    if (getCurrentWindow().label !== 'main') return
+  } catch {
+    return
+  }
+
+  initialized = true
+  void invoke<boolean>('get_system_session_locked')
+    .then(publishLocked)
+    .catch(error => console.error('[Wework] Failed to read system session lock state', error))
+  unlistenPromise = listen<boolean>(WEWORK_SYSTEM_SESSION_LOCK_CHANGED_EVENT, event => {
+    publishLocked(event.payload)
+  }).catch(error => {
+    initialized = false
+    console.error('[Wework] Failed to install system session lock listener', error)
+    return () => {}
+  })
+}
+
+export function isSystemSessionLocked(): boolean {
+  return currentLocked
+}
+
+export function subscribeSystemSessionLock(callback: (locked: boolean) => void): () => void {
+  listeners.add(callback)
+  ensureListenerInstalled()
+  return () => {
+    listeners.delete(callback)
+    if (listeners.size === 0 && unlistenPromise) {
+      void unlistenPromise.then(unlisten => disposeTauriListener(unlisten, 'system session lock'))
+      unlistenPromise = null
+      initialized = false
+    }
+  }
+}

--- a/wework/src/tauri/windowFocus.ts
+++ b/wework/src/tauri/windowFocus.ts
@@ -10,27 +10,34 @@ let currentFocused = true
 let initialized = false
 let unlistenPromise: Promise<UnlistenFn> | null = null
 
+function publishFocused(focused: boolean) {
+  if (focused === currentFocused) return
+  currentFocused = focused
+  for (const listener of listeners) {
+    listener(focused)
+  }
+}
+
 function ensureListenerInstalled() {
   if (initialized || !isTauriRuntime()) {
     return
   }
-  let label: string
+  let currentWindow: ReturnType<typeof getCurrentWindow>
   try {
-    label = getCurrentWindow().label
+    currentWindow = getCurrentWindow()
   } catch {
     return
   }
-  if (label !== 'main') {
+  if (currentWindow.label !== 'main') {
     return
   }
   initialized = true
+  void currentWindow
+    .isFocused()
+    .then(publishFocused)
+    .catch(error => console.error('[Wework] Failed to read main window focus', error))
   unlistenPromise = listen<boolean>(WEWORK_MAIN_WINDOW_FOCUS_CHANGED_EVENT, event => {
-    const focused = event.payload
-    if (focused === currentFocused) return
-    currentFocused = focused
-    for (const listener of listeners) {
-      listener(focused)
-    }
+    publishFocused(event.payload)
   }).catch(error => {
     initialized = false
     console.error('[Wework] Failed to install window focus listener', error)

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -963,6 +963,16 @@ export interface RuntimeGlobalIMNotificationUpdateRequest {
   sessionKey?: string | null
 }
 
+export interface RuntimeIMNotificationPresenceUpdateRequest {
+  clientId: string
+  away: boolean
+}
+
+export interface RuntimeIMNotificationPresenceResponse {
+  away: boolean
+  ttlSeconds: number
+}
+
 export interface RuntimeTaskIMNotificationSubscriptionRequest {
   address: RuntimeTaskAddress
   sessionKeys: string[]


### PR DESCRIPTION
## Summary

- build a complete `executionRequest` for IM private-chat continuations before dispatching the runtime RPC
- keep request-user-input responses on their dedicated path without creating a new execution request
- report main-window focus and macOS session lock state to the Backend with a TTL-based client presence heartbeat
- send global fallback IM notifications only while every fresh Wework client is away, without changing active-session or task-subscription priority

## Root cause

The IM continuation path crossed the Backend RPC boundary without the complete execution request required to start a new executor turn. The previous best-effort builder could silently forward a payload without `executionRequest`, which surfaced as `executionRequest is required` when replying from IM.

Separately, the global IM reminder stored only an enabled flag and target session. It had no Wework foreground or lock-screen state, so the fallback session was used continuously after the reminder was enabled.

## User impact

- replies sent from the selected IM private chat can continue the existing Codex task
- global task progress is sent to the selected IM session when the main Wework window is unfocused or the macOS session is locked
- returning to a foreground Wework window suppresses only the global fallback; explicit IM task ownership and per-task subscriptions remain unchanged
- stale or disconnected clients expire after 90 seconds and cannot permanently suppress notifications

Project tasks:

- `1026076_1#82237` — 修复私聊续跑请求构造
- `1026076_1#82238` — 按离开状态推送IM通知

## Validation

- `uv run pytest tests/services/im/test_session_service.py tests/services/im/test_notification_dispatcher.py tests/api/endpoints/test_runtime_work_api.py tests/services/test_runtime_work_service.py -q` — 93 passed
- focused Wework Vitest suite — 114 passed
- `pnpm --filter wework test src/App.plugins.test.tsx` — 27 passed
- `pnpm --filter wework typecheck`
- `cargo fmt --all --check`
- `cargo test system_lock::tests --lib`
- repository pre-push quality checks, including the complete Wework unit-test suite, ESLint, TypeScript, Cargo tests, Clippy, formatting, and Alembic multi-head validation

Not run: local Wework desktop E2E or an isolated real-Tauri session, by request. The native lock-screen path still requires desktop-environment acceptance testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic IM notification presence tracking based on window focus, visibility, and screen-lock status.
  * Notifications now reflect whether the desktop app is active or away, with presence refreshed automatically.
  * Added support for querying system lock status and synchronizing presence across desktop sessions.
* **Bug Fixes**
  * Runtime updates now require a valid execution request before being sent.
  * Prevented unnecessary task notifications while the app is active.
* **Documentation**
  * Clarified when away notifications are delivered in English, Chinese, and sidebar descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->