### PR TITLE
feat(external-tasks): add API for sharing external tasks with API key

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -16,6 +16,7 @@ from app.api.endpoints import (
     device_chat_tasks,
     devices,
     dingtalk_docs,
+    external_tasks,
     feedback,
     groups,
     health,
@@ -264,6 +265,11 @@ api_router.include_router(
     knowledge_open.router,
     prefix="/knowledge",
     tags=["knowledge-open"],
+)
+api_router.include_router(
+    external_tasks.router,
+    prefix="/external/tasks",
+    tags=["external-tasks"],
 )
 # Unified share endpoints (Team, Task, KnowledgeBase)
 api_router.include_router(share.router, prefix="/share", tags=["share"])

--- a/backend/app/api/endpoints/external_tasks.py
+++ b/backend/app/api/endpoints/external_tasks.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""External task APIs for API-key based integrations."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core import security
+from app.models.user import User
+from app.schemas.shared_task import TaskShareResponse
+from app.services.shared_task import shared_task_service
+from app.services.task_member_service import task_member_service
+
+router = APIRouter()
+
+
+@router.post("/{task_id}/share", response_model=TaskShareResponse)
+def share_task_with_api_key(
+    task_id: int,
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
+    db: Session = Depends(get_db),
+) -> TaskShareResponse:
+    """Generate a task share link for the task owner."""
+    if not task_member_service.is_task_owner(
+        db=db,
+        task_id=task_id,
+        user_id=current_user.id,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found or you don't have permission",
+        )
+
+    return shared_task_service.share_task(
+        db=db,
+        task_id=task_id,
+        user_id=current_user.id,
+    )

--- a/backend/tests/api/endpoints/test_external_tasks_api.py
+++ b/backend/tests/api/endpoints/test_external_tasks_api.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.api_key import KEY_TYPE_PERSONAL, APIKey
+from app.models.task import TaskResource
+from app.models.user import User
+
+
+def _create_task(
+    db: Session,
+    *,
+    user_id: int,
+    task_id: int,
+    state: int = TaskResource.STATE_ACTIVE,
+) -> TaskResource:
+    task = TaskResource(
+        id=task_id,
+        user_id=user_id,
+        kind="Task",
+        name=f"task-{task_id}",
+        namespace="default",
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Task",
+            "metadata": {"name": f"task-{task_id}", "namespace": "default"},
+            "spec": {"title": f"task-{task_id}", "prompt": ""},
+            "status": {"state": "Available", "status": "COMPLETED"},
+        },
+        is_active=state,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def _create_user(db: Session, username: str) -> User:
+    user = User(
+        user_name=username,
+        password_hash="test",
+        email=f"{username}@example.com",
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _create_personal_api_key(db: Session, user_id: int, raw_key: str) -> APIKey:
+    api_key = APIKey(
+        user_id=user_id,
+        key_hash=hashlib.sha256(raw_key.encode()).hexdigest(),
+        key_prefix=f"{raw_key[:8]}...",
+        name="External Task Test Key",
+        key_type=KEY_TYPE_PERSONAL,
+        expires_at=datetime.utcnow() + timedelta(days=1),
+        is_active=True,
+    )
+    db.add(api_key)
+    db.commit()
+    db.refresh(api_key)
+    return api_key
+
+
+def test_external_task_share_accepts_owner_personal_api_key(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+) -> None:
+    task = _create_task(test_db, user_id=test_user.id, task_id=91001)
+    raw_key = "wg-external-task-share-owner"
+    _create_personal_api_key(test_db, test_user.id, raw_key)
+
+    response = test_client.post(
+        f"/api/external/tasks/{task.id}/share",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["share_url"]
+    assert body["share_token"]
+
+
+def test_external_task_share_rejects_non_owner_personal_api_key(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+) -> None:
+    task = _create_task(test_db, user_id=test_user.id, task_id=91002)
+    other_user = _create_user(test_db, "external-task-share-other")
+    raw_key = "wg-external-task-share-other"
+    _create_personal_api_key(test_db, other_user.id, raw_key)
+
+    response = test_client.post(
+        f"/api/external/tasks/{task.id}/share",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 404
+
+
+def test_external_task_share_rejects_inactive_owner_task(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+) -> None:
+    task = _create_task(
+        test_db,
+        user_id=test_user.id,
+        task_id=91003,
+        state=TaskResource.STATE_DELETED,
+    )
+    raw_key = "wg-external-task-share-inactive"
+    _create_personal_api_key(test_db, test_user.id, raw_key)
+
+    response = test_client.post(
+        f"/api/external/tasks/{task.id}/share",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an external task API endpoint for task owners to generate share links using an API key or task token.
  * Added support for sharing active tasks through the external tasks API.

* **Bug Fixes**
  * Prevented unauthorized users and requests for missing, inactive, or deleted tasks from generating share links.

* **Tests**
  * Added coverage for successful owner authorization and rejected unauthorized or inactive-task requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->