### PR TITLE
fix(frontend): preserve project context when switching agents

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/selector/TeamSelectorButton.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/TeamSelectorButton.test.tsx
@@ -10,6 +10,7 @@ import { userApis } from '@/apis/user'
 
 const mockRefresh = jest.fn()
 const mockPush = jest.fn()
+let mockSearchParams = new URLSearchParams()
 let mockQuickAccessTeams: number[] = []
 let mockQuickAccessVersion: number | undefined = 7
 
@@ -17,6 +18,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  useSearchParams: () => mockSearchParams,
 }))
 
 jest.mock('@/hooks/useTranslation', () => ({
@@ -130,6 +132,7 @@ describe('TeamSelectorButton', () => {
     mockRefresh.mockResolvedValue(undefined)
     mockQuickAccessTeams = []
     mockQuickAccessVersion = 7
+    mockSearchParams = new URLSearchParams()
   })
 
   it('deduplicates system and personal teams with the same identity', async () => {
@@ -207,6 +210,30 @@ describe('TeamSelectorButton', () => {
 
     expect(mockPush).toHaveBeenCalledWith('/chat?teamId=2&mode=image')
     expect(setSelectedTeam).not.toHaveBeenCalled()
+  })
+
+  it('preserves project context when switching to an agent on another page', async () => {
+    mockSearchParams = new URLSearchParams({
+      projectId: '2180',
+      deviceId: 'cloud-device',
+      taskId: '99',
+    })
+    const taskTeam = makeTeam({ id: 1, name: 'task-agent', bind_mode: ['task'] })
+    const chatTeam = makeTeam({ id: 2, name: 'chat-agent', bind_mode: ['chat'] })
+
+    render(
+      <TeamSelectorButton
+        selectedTeam={taskTeam}
+        setSelectedTeam={jest.fn()}
+        teams={[taskTeam, chatTeam]}
+        disabled={false}
+        currentMode="task"
+      />
+    )
+
+    fireEvent.click(await screen.findByTestId('team-option-chat-agent'))
+
+    expect(mockPush).toHaveBeenCalledWith('/chat?teamId=2&projectId=2180&deviceId=cloud-device')
   })
 
   it('shows five recent teams and fills missing entries by update time', async () => {

--- a/frontend/src/__tests__/features/tasks/components/selector/team-selector-popover-width.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/team-selector-popover-width.test.tsx
@@ -15,6 +15,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: jest.fn(),
   }),
+  useSearchParams: () => new URLSearchParams(),
 }))
 
 jest.mock('@/hooks/useTranslation', () => ({

--- a/frontend/src/features/tasks/components/selector/TeamSelectorButton.tsx
+++ b/frontend/src/features/tasks/components/selector/TeamSelectorButton.tsx
@@ -13,7 +13,7 @@
 'use client'
 
 import React, { useMemo, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Cog6ToothIcon, SparklesIcon, Squares2X2Icon } from '@heroicons/react/24/outline'
 import { ActionButton } from '@/components/ui/action-button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -71,6 +71,7 @@ export default function TeamSelectorButton({
 }: TeamSelectorButtonProps) {
   const { t } = useTranslation('tasks')
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [open, setOpen] = useState(false)
   const [wizardOpen, setWizardOpen] = useState(false)
   const {
@@ -101,7 +102,12 @@ export default function TeamSelectorButton({
     const targetPage = getTeamTargetPage(team, 'all')
     const currentPage = getCurrentTargetPageByMode(currentMode)
     if (targetPage !== currentPage) {
-      router.push(buildTeamTargetHref(targetPage, new URLSearchParams({ teamId: String(team.id) })))
+      const targetParams = new URLSearchParams({ teamId: String(team.id) })
+      for (const param of ['projectId', 'deviceId', 'device_id']) {
+        const value = searchParams.get(param)
+        if (value) targetParams.set(param, value)
+      }
+      router.push(buildTeamTargetHref(targetPage, targetParams))
       setOpen(false)
       return
     }


### PR DESCRIPTION
## Summary

- preserve `projectId` and execution device query parameters when switching to an agent that routes to another page
- avoid carrying the previous `taskId` into the new conversation
- add regression coverage for project-context navigation and update an existing navigation mock

## Root cause

Cross-mode agent selection constructed a new URL from only the selected `teamId`. Because project conversations derive their context from `projectId` in the URL, routing from `/devices/chat` to `/chat` silently dropped the project and device context.

## Impact

Users can switch agents from a workspace project conversation without losing the selected project or execution device. Model selection behavior remains unchanged and continues to follow the selected agent's saved or bound model.

## Validation

- targeted selector tests: 12 passed
- pre-push ESLint: passed
- pre-push TypeScript check: passed
- full frontend unit suite: passed

## Task

- `vjGmem92d3` — 修复切换智能体丢失项目上下文


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved project and device context when switching between task and chat destinations.
  * Retained the selected team while navigating between team target pages.
  * Excluded task-specific parameters when moving to chat.

* **Tests**
  * Added coverage to verify query parameters are preserved correctly during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->