### PR TITLE
fix(wework): preserve sidebar running state after reload

### DIFF
--- a/wework/e2e/desktop/modules/goal-flows.mjs
+++ b/wework/e2e/desktop/modules/goal-flows.mjs
@@ -205,6 +205,45 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     true,
     'Reloading exposed a direct send path while the provider turn was still active'
   )
+  assert.ok(
+    reloadedContinuationDebugSnapshot.workbench?.currentRuntimeTask,
+    'The reloaded Goal did not expose its runtime address for stale transcript recovery'
+  )
+  await control.command('dispatchRuntimeLifecycleEvent', 'body', {
+    value: JSON.stringify({
+      address: reloadedContinuationDebugSnapshot.workbench.currentRuntimeTask,
+      type: 'transcript_received',
+      transcript: {
+        taskId: goalTaskId,
+        messages: [],
+        running: false,
+        turns: [{ id: 'stale-running-state-turn', items: [], status: 'streaming' }],
+      },
+    }),
+  })
+  await waitForSnapshot(
+    control,
+    snapshot =>
+      snapshot.testIds.includes(goalTaskRowTestId) &&
+      snapshot.testIds.includes(goalRunningTestId) &&
+      snapshot.testIds.includes('pause-response-button') &&
+      !snapshot.testIds.includes('send-message-button') &&
+      !snapshot.testIds.includes(goalUnreadTestId),
+    'A stale coarse transcript running flag hid the active turn from the sidebar'
+  )
+  const staleTranscriptDebugSnapshot = await waitForWorkbenchDebugState(
+    control,
+    snapshot =>
+      snapshot.workbench?.lifecycleCurrentTaskRunning === true &&
+      snapshot.pane?.status?.isAssistantStreaming === true &&
+      snapshot.pane?.status?.isBusy === true,
+    'The active turn did not remain authoritative after receiving stale transcript running state'
+  )
+  assert.equal(
+    staleTranscriptDebugSnapshot.pane?.status?.taskExecution?.running,
+    true,
+    'The stale transcript running flag overrode the concrete active turn'
+  )
   await assertConversationTextOccurrences(control, {
     [GOAL_IDLE_INITIAL_TEXT]: 1,
   })

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleProvider.tsx
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleProvider.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from 'react'
 import type { RuntimeTaskAddress } from '@/types/api'
+import type { RuntimePaneTranscript } from '@/types/workbench'
 import { RuntimeTaskLifecycleContext } from './internalContext'
 import type { RuntimeTaskLifecycleStore } from './RuntimeTaskLifecycleStore'
 
@@ -21,10 +22,13 @@ export function RuntimeTaskLifecycleProvider({
           address: RuntimeTaskAddress
           type: string
           turnId?: string | null
+          transcript?: RuntimePaneTranscript
         }>
       ).detail
       if (detail?.type === 'turn_settled') {
         store.turnSettled(detail.address, detail.turnId)
+      } else if (detail?.type === 'transcript_received' && detail.transcript) {
+        store.syncTranscript(detail.address, detail.transcript)
       }
     }
     window.addEventListener(E2E_RUNTIME_LIFECYCLE_EVENT, handleLifecycleEvent)

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
@@ -256,6 +256,26 @@ describe('RuntimeTaskLifecycleStore', () => {
     expect(snapshot?.derived.isTurnActive).toBe(true)
   })
 
+  test('recovers a streaming turn after restart when coarse transcript running state is stale', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+
+    store.syncTranscript(
+      address,
+      transcript({
+        running: false,
+        turns: [{ id: 'restored-turn', items: [], status: 'streaming' }],
+      })
+    )
+
+    const snapshot = store.getTask(address)
+    expect(snapshot?.execution.phase).toBe('running')
+    expect(snapshot?.turn.phase).toBe('streaming')
+    expect(snapshot?.derived.shouldShowSidebarRunning).toBe(true)
+    expect(store.getSnapshot().runningTaskKeys).toEqual(
+      new Set([getRuntimeTaskLifecycleKey(address)])
+    )
+  })
+
   test('treats an explicit executor snapshot as authoritative over a live turn', () => {
     const store = new RuntimeTaskLifecycleStore('test')
 

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
@@ -154,19 +154,17 @@ export class RuntimeTaskLifecycleStore {
       options.preserveActiveTurn === true &&
       (this.getTask(address)?.derived.isRunning ?? false)
 
-    if (transcript.running === true) {
+    if (hasStreamingTurn) {
       this.executorStarted(address)
-    } else if (transcript.running === false && !ignoreStaleIdleTranscript) {
-      this.executorSettled(address)
-    }
-
-    if (hasStreamingTurn && transcript.running !== false) {
       this.dispatch(address, {
         type: 'turn_recovered',
         streaming: true,
         turnId: streamingTurn?.id,
       })
+    } else if (transcript.running === true) {
+      this.executorStarted(address)
     } else if (transcript.running === false && !ignoreStaleIdleTranscript) {
+      this.executorSettled(address)
       this.turnSettled(address)
     }
   }


### PR DESCRIPTION
## Summary

- keep a concrete streaming transcript turn authoritative when the coarse transcript `running` flag is stale
- restore the task lifecycle so the sidebar spinner and composer controls remain consistent after reload
- extend the CI-covered desktop `goal-lifecycle` checkpoint with a stale-transcript regression assertion

## Verification

- `pnpm --filter wework test src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts src/components/layout/DesktopSidebar.test.tsx`
- `pnpm --dir wework exec prettier --check ...`
- focused ESLint on changed TypeScript files
- `pnpm --filter wework typecheck`
- pre-push Wework ESLint, TypeScript, and unit-test suite

## Local desktop E2E note

The local `goal-lifecycle` attempts were interrupted in shared bootstrap checkpoints before reaching this scenario while another worktree was concurrently running a real Tauri desktop E2E instance. The regression is attached to the existing CI-covered checkpoint so GitHub Actions validates it in an isolated environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of active tasks after a reload, including cases where transcript status is stale or reports that execution has stopped.
  - Preserved streaming, busy, and running indicators while an active task continues.
  - Kept recovered tasks visible in the running tasks sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->