### PR TITLE
feat(backend): support API key auth for task share endpoint

### DIFF
--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -711,7 +711,7 @@ def get_pipeline_stage_info(
 @router.post("/{task_id}/share", response_model=TaskShareResponse)
 def share_task(
     task_id: int,
-    current_user: User = Depends(security.get_current_user),
+    current_user: User = Depends(security.get_current_user_flexible_for_executor),
     db: Session = Depends(get_db),
 ):
     """


### PR DESCRIPTION
Switch share_task dependency from get_current_user to get_current_user_flexible_for_executor so the endpoint accepts personal API keys (X-API-Key header or Bearer wg-*) in addition to JWT bearer tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task sharing now supports flexible executor authentication in addition to standard user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->