### PR TITLE
fix(wework): preserve markdown table layout in code blocks

### DIFF
--- a/wework/src/components/chat/MarkdownCodeBlock.test.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import '@/styles/globals.css'
 import { MarkdownCodeBlock } from './MarkdownCodeBlock'
 
 const trackMock = vi.fn()
@@ -28,5 +29,20 @@ describe('MarkdownCodeBlock', () => {
         source: 'chat',
       })
     )
+  })
+
+  test('keeps Markdown table tokens inline', () => {
+    render(
+      <MarkdownCodeBlock lang="markdown">
+        {'| name | type | port_list |\n| --- | --- | --- |\n| media | mysql | 5104 |'}
+      </MarkdownCodeBlock>
+    )
+
+    const tableTokens = screen.getByTestId('markdown-code-block').querySelectorAll('.token.table')
+
+    expect(tableTokens.length).toBeGreaterThan(0)
+    tableTokens.forEach(token => {
+      expect(token).toHaveStyle({ display: 'inline' })
+    })
   })
 })

--- a/wework/src/components/chat/MarkdownCodeBlock.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.tsx
@@ -128,7 +128,7 @@ export function MarkdownCodeBlock({
       data-testid="markdown-code-block"
       data-scroll-anchor
       className={[
-        'max-w-full select-none overflow-hidden rounded-lg border border-[#3c424a] bg-[#2f2f2f] text-left shadow-sm',
+        'markdown-code-block max-w-full select-none overflow-hidden rounded-lg border border-[#3c424a] bg-[#2f2f2f] text-left shadow-sm',
         compact ? 'mb-1.5' : 'mb-3 mt-2',
       ].join(' ')}
     >

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -472,6 +472,11 @@ button:disabled {
 }
 
 @layer components {
+  /* Prism uses "table" as a Markdown token class, which collides with Tailwind's display utility. */
+  .markdown-code-block .token.table {
+    display: inline;
+  }
+
   .heading-xl {
     font-size: var(--text-xl);
     font-weight: 500;


### PR DESCRIPTION
## What changed

- scope the Markdown code block container with a dedicated class
- force Prism Markdown table tokens to remain inline despite Tailwind's `.table` display utility
- add a regression test that loads the real global stylesheet and verifies table token layout

## Root cause

Prism marks Markdown table tokens with the class `table`. Tailwind also emits a global `.table { display: table }` utility, so each syntax-highlighted token became a table-level box and appeared on a separate visual line. The copied source remained correct because the underlying text was unchanged.

## Impact

Fenced Markdown source now preserves table rows visually while keeping syntax highlighting, copying, horizontal scrolling, and optional wrapping behavior unchanged.

## Validation

- `pnpm --filter wework test src/components/chat/MarkdownCodeBlock.test.tsx src/components/chat/blocks/ToolBlockItem.test.tsx`
- `pnpm --filter wework exec prettier --check src/components/chat/MarkdownCodeBlock.tsx src/components/chat/MarkdownCodeBlock.test.tsx src/styles/globals.css`
- `pnpm --filter wework exec eslint src/components/chat/MarkdownCodeBlock.tsx src/components/chat/MarkdownCodeBlock.test.tsx`
- pre-push Wework ESLint, TypeScript, and full unit test suite
- isolated real-Tauri verification with a model-generated fenced Markdown table
