### PR TITLE
fix(wework): prevent deleted cloud projects from returning

### DIFF
--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -516,6 +516,7 @@ class RuntimeWorkspaceRemoveRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     device_id: str = Field(..., alias="deviceId", min_length=1)
+    project_key: Optional[str] = Field(default=None, alias="projectKey")
     workspace_path: str = Field(..., alias="workspacePath", min_length=1)
     runtime: RuntimeName = "codex"
 

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -1324,15 +1324,19 @@ async def remove_runtime_workspace(
     device_id = request.device_id.strip()
     workspace_path = normalize_workspace_path(request.workspace_path)
     _ensure_owned_device(db, user_id, device_id)
+    payload = {
+        "runtime": request.runtime,
+        "workspacePath": workspace_path,
+    }
+    project_key = request.project_key.strip() if request.project_key else ""
+    if project_key:
+        payload["projectKey"] = project_key
     try:
         result = await runtime_rpc_service.call(
             user_id=user_id,
             device_id=device_id,
             method="runtime.workspaces.remove",
-            payload={
-                "runtime": request.runtime,
-                "workspacePath": workspace_path,
-            },
+            payload=payload,
             timeout_seconds=RUNTIME_WORKSPACE_OPEN_TIMEOUT_SECONDS,
         )
     except RuntimeRpcError as exc:

--- a/backend/tests/api/endpoints/test_runtime_work_api.py
+++ b/backend/tests/api/endpoints/test_runtime_work_api.py
@@ -699,6 +699,7 @@ def test_runtime_workspace_remove_endpoint_dispatches_request(
         headers=_auth_headers(test_token),
         json={
             "deviceId": "device-1",
+            "projectKey": "remote-project-id",
             "workspacePath": "/Users/crystal/Documents/hello-0",
             "runtime": "codex",
         },
@@ -708,6 +709,7 @@ def test_runtime_workspace_remove_endpoint_dispatches_request(
     assert response.json()["accepted"] is True
     request = service_mock.await_args.kwargs["request"]
     assert request.device_id == "device-1"
+    assert request.project_key == "remote-project-id"
     assert request.workspace_path == "/Users/crystal/Documents/hello-0"
 
 

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -2354,6 +2354,7 @@ async def test_remove_runtime_workspace_dispatches_to_owned_device(
         user_id=test_user.id,
         request=RuntimeWorkspaceRemoveRequest(
             deviceId="device-1",
+            projectKey=" remote-project-id ",
             workspacePath="/Users/crystal/Documents/hello-0/",
             runtime="codex",
         ),
@@ -2367,6 +2368,7 @@ async def test_remove_runtime_workspace_dispatches_to_owned_device(
         method="runtime.workspaces.remove",
         payload={
             "runtime": "codex",
+            "projectKey": "remote-project-id",
             "workspacePath": "/Users/crystal/Documents/hello-0",
         },
         timeout_seconds=60,

--- a/executor/src/runtime_work/codex_global_state.rs
+++ b/executor/src/runtime_work/codex_global_state.rs
@@ -22,9 +22,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use super::{
+    remote_projects::{remote_project_items, upsert_remote_project_payload},
     store::runtime_work_dir,
     util::{normalize_workspace_path, now_ms, path_is_within, workspace_label},
 };
+
+pub(crate) use super::remote_projects::CodexGlobalRemoteProject;
 
 const CODEX_GLOBAL_STATE_FILENAME: &str = ".codex-global-state.json";
 const CODEX_GLOBAL_STATE_OPLOG_FILENAME: &str = ".codex-global-state.oplog.jsonl";
@@ -51,6 +54,7 @@ const OPLOG_KIND_REMOVE: &str = "remove";
 const OPLOG_KIND_REORDER_PROJECT: &str = "reorder_project";
 const OPLOG_KIND_PIN_PROJECT: &str = "pin_project";
 const OPLOG_KIND_UPSERT_REMOTE_PROJECT: &str = "upsert_remote_project";
+const OPLOG_KIND_UPSERT_REMOTE_PROJECTS: &str = "upsert_remote_projects";
 const OPLOG_KIND_UPSERT_LOCAL_PROJECT: &str = "upsert_local_project";
 const OPLOG_KIND_ACTIVATE_PROJECT: &str = "activate_project";
 const OPLOG_KIND_PROJECT_APPEARANCE: &str = "project_appearance";
@@ -78,14 +82,6 @@ pub(crate) struct CodexGlobalProject {
     pub active: bool,
     pub appearance: Option<Value>,
     pub default_project_space: Option<Value>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CodexGlobalRemoteProject {
-    pub id: String,
-    pub host_id: String,
-    pub remote_path: String,
-    pub label: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -148,6 +144,12 @@ struct CodexGlobalStateOplogRecord {
     label: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     roots: Vec<String>,
+    #[serde(
+        rename = "remoteProjects",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    remote_projects: Vec<CodexGlobalRemoteProject>,
     #[serde(rename = "updatedAt")]
     updated_at: i64,
 }
@@ -169,6 +171,7 @@ impl Default for CodexGlobalStateOplogRecord {
             clear_default_project_space: false,
             label: None,
             roots: Vec::new(),
+            remote_projects: Vec::new(),
             updated_at: 0,
         }
     }
@@ -323,27 +326,32 @@ pub(crate) fn set_codex_global_project_appearance(
 pub(crate) fn sync_codex_global_remote_projects(
     projects: &[CodexGlobalRemoteProject],
 ) -> Result<(), String> {
-    for project in projects {
-        let Some(project_key) = clean_text(&project.id) else {
-            continue;
-        };
-        let Some(remote_host_id) = clean_text(&project.host_id) else {
-            continue;
-        };
-        let remote_path = normalize_workspace_path(&project.remote_path);
-        if remote_path.is_empty() {
-            continue;
-        }
-        append_codex_global_state_op_record(&CodexGlobalStateOplogRecord {
-            kind: OPLOG_KIND_UPSERT_REMOTE_PROJECT.to_owned(),
-            workspace_path: remote_path,
-            project_key: Some(project_key),
-            remote_host_id: Some(remote_host_id),
-            label: project.label.as_deref().and_then(clean_text),
-            updated_at: now_ms(),
-            ..Default::default()
-        })?;
+    let remote_projects = projects
+        .iter()
+        .filter_map(|project| {
+            let id = clean_text(&project.id)?;
+            let host_id = clean_text(&project.host_id)?;
+            let remote_path = normalize_workspace_path(&project.remote_path);
+            if remote_path.is_empty() {
+                return None;
+            }
+            Some(CodexGlobalRemoteProject {
+                id,
+                host_id,
+                remote_path,
+                label: project.label.as_deref().and_then(clean_text),
+            })
+        })
+        .collect::<Vec<_>>();
+    if remote_projects.is_empty() {
+        return Ok(());
     }
+    append_codex_global_state_op_record(&CodexGlobalStateOplogRecord {
+        kind: OPLOG_KIND_UPSERT_REMOTE_PROJECTS.to_owned(),
+        remote_projects,
+        updated_at: now_ms(),
+        ..Default::default()
+    })?;
     flush_or_watch_codex_global_state_oplog();
     refresh_codex_global_project_cache();
     Ok(())
@@ -799,11 +807,20 @@ fn apply_codex_global_state_ops(
                 {
                     upsert_remote_project_payload(
                         payload,
-                        project_key,
-                        remote_host_id,
-                        &op.workspace_path,
-                        op.label.as_deref(),
+                        &CodexGlobalRemoteProject {
+                            id: project_key.to_owned(),
+                            host_id: remote_host_id.to_owned(),
+                            remote_path: op.workspace_path.clone(),
+                            label: op.label.clone(),
+                        },
                     );
+                    upsert_project_order(payload, project_key);
+                }
+            }
+            OPLOG_KIND_UPSERT_REMOTE_PROJECTS => {
+                for project in &op.remote_projects {
+                    upsert_remote_project_payload(payload, project);
+                    upsert_project_order(payload, &project.id);
                 }
             }
             OPLOG_KIND_RENAME => {
@@ -1230,50 +1247,6 @@ fn remote_projects_from_payload(payload: &Map<String, Value>) -> Vec<CodexGlobal
         .collect()
 }
 
-fn upsert_remote_project_payload(
-    payload: &mut Map<String, Value>,
-    project_key: &str,
-    remote_host_id: &str,
-    remote_path: &str,
-    label: Option<&str>,
-) {
-    let projects = payload
-        .entry(REMOTE_PROJECTS_KEY.to_owned())
-        .or_insert_with(|| Value::Array(Vec::new()));
-    if !projects.is_array() {
-        *projects = Value::Array(Vec::new());
-    }
-    let projects = projects
-        .as_array_mut()
-        .expect("remote projects is an array");
-    let index = projects.iter().position(|project| {
-        project.get("id").and_then(clean_string).as_deref() == Some(project_key)
-    });
-    let project = index
-        .and_then(|index| projects.get_mut(index))
-        .and_then(Value::as_object_mut);
-    let mut project = project.cloned().unwrap_or_default();
-    project.insert("id".to_owned(), Value::String(project_key.to_owned()));
-    project.insert(
-        "hostId".to_owned(),
-        Value::String(remote_host_id.to_owned()),
-    );
-    project.insert(
-        "remotePath".to_owned(),
-        Value::String(remote_path.to_owned()),
-    );
-    if let Some(label) = label.and_then(clean_text) {
-        project.insert("label".to_owned(), Value::String(label));
-    }
-    let project = Value::Object(project);
-    if let Some(index) = index {
-        projects[index] = project;
-    } else {
-        projects.push(project);
-    }
-    upsert_project_order(payload, project_key);
-}
-
 fn activate_project_payload(
     payload: &mut Map<String, Value>,
     project_key: &str,
@@ -1297,40 +1270,6 @@ fn activate_project_payload(
         Value::Array(vec![Value::String(workspace_path.to_owned())]),
     );
     payload.remove(ACTIVE_REMOTE_PROJECT_ID_KEY);
-}
-
-struct RemoteProjectItem {
-    key: String,
-    host_id: String,
-    remote_path: String,
-    label: Option<String>,
-}
-
-fn remote_project_items(value: Option<&Value>) -> Vec<RemoteProjectItem> {
-    value
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|item| {
-            let key = clean_string(item.get("id")?)?;
-            let host_id = clean_string(item.get("hostId").or_else(|| item.get("host_id"))?)?;
-            let remote_path = normalize_path_or_raw(&clean_string(
-                item.get("remotePath").or_else(|| item.get("remote_path"))?,
-            )?);
-            if remote_path.is_empty() {
-                return None;
-            }
-            Some(RemoteProjectItem {
-                key,
-                host_id,
-                remote_path,
-                label: item
-                    .get("label")
-                    .or_else(|| item.get("name"))
-                    .and_then(clean_string),
-            })
-        })
-        .collect()
 }
 
 fn local_project_from_path(
@@ -1821,8 +1760,9 @@ mod tests {
         OPLOG_KIND_ACTIVATE_PROJECT, OPLOG_KIND_PIN_PROJECT, OPLOG_KIND_PIN_THREAD,
         OPLOG_KIND_PROJECT_APPEARANCE, OPLOG_KIND_REORDER_PROJECT, OPLOG_KIND_REORDER_THREAD,
         OPLOG_KIND_UPSERT_LOCAL_PROJECT, OPLOG_KIND_UPSERT_REMOTE_PROJECT,
-        SELECTED_REMOTE_HOST_ID_KEY,
+        OPLOG_KIND_UPSERT_REMOTE_PROJECTS, SELECTED_REMOTE_HOST_ID_KEY,
     };
+    use crate::runtime_work::remote_projects::CodexGlobalRemoteProject;
     use serde_json::{json, Map, Value};
 
     fn payload(value: Value) -> Map<String, Value> {
@@ -2092,5 +2032,68 @@ mod tests {
 
         remove_codex_global_project_payload(&mut payload, "remote-id", "/srv");
         assert_eq!(payload["remote-projects"], json!([]));
+    }
+
+    #[test]
+    fn remote_project_batch_preserves_projects_missing_from_the_update() {
+        let mut payload = payload(json!({
+            "local-projects": {"local": {"id": "local", "name": "Local"}},
+            "project-writable-roots": {"local": [{"kind": "local", "path": "/repo"}]},
+            "remote-projects": [
+                {"id": "removed", "hostId": "old-host", "remotePath": "/old"},
+                {"id": "retained", "hostId": "old-host", "remotePath": "/retained", "label": "Old"}
+            ],
+            "project-order": ["local", "removed", "retained"],
+            "pinned-project-ids": ["removed", "retained"],
+            "project-appearances": {"removed": {"color": "red"}},
+            "sidebar-project-thread-orders": {"removed": {"threadIds": ["t1"]}},
+            "thread-project-assignments": {"t1": {"projectId": "removed"}}
+        }));
+        let operation = CodexGlobalStateOplogRecord {
+            kind: OPLOG_KIND_UPSERT_REMOTE_PROJECTS.to_owned(),
+            remote_projects: vec![CodexGlobalRemoteProject {
+                id: "retained".to_owned(),
+                host_id: "new-host".to_owned(),
+                remote_path: "/retained".to_owned(),
+                label: Some("Current".to_owned()),
+            }],
+            ..Default::default()
+        };
+
+        apply_codex_global_state_ops(&mut payload, &[operation]);
+
+        assert_eq!(
+            payload["remote-projects"],
+            json!([
+                {"id": "removed", "hostId": "old-host", "remotePath": "/old"},
+                {
+                    "id": "retained",
+                    "hostId": "new-host",
+                    "remotePath": "/retained",
+                    "label": "Current"
+                }
+            ])
+        );
+        assert_eq!(
+            payload["project-order"],
+            json!(["retained", "local", "removed"])
+        );
+        assert_eq!(
+            payload["pinned-project-ids"],
+            json!(["removed", "retained"])
+        );
+        assert_eq!(
+            payload["project-appearances"]["removed"],
+            json!({"color": "red"})
+        );
+        assert_eq!(
+            payload["sidebar-project-thread-orders"]["removed"],
+            json!({"threadIds": ["t1"]})
+        );
+        assert_eq!(
+            payload["thread-project-assignments"]["t1"],
+            json!({"projectId": "removed"})
+        );
+        assert!(payload["local-projects"]["local"].is_object());
     }
 }

--- a/executor/src/runtime_work/mod.rs
+++ b/executor/src/runtime_work/mod.rs
@@ -13,6 +13,7 @@ pub mod fork_transfer;
 mod handler;
 pub(crate) mod local_connector_auth;
 mod notification_mapping;
+mod remote_projects;
 mod response;
 mod runtime_handle_messages;
 mod store;

--- a/executor/src/runtime_work/remote_projects.rs
+++ b/executor/src/runtime_work/remote_projects.rs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use super::util::normalize_workspace_path;
+
+const REMOTE_PROJECTS_KEY: &str = "remote-projects";
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodexGlobalRemoteProject {
+    pub(crate) id: String,
+    pub(crate) host_id: String,
+    pub(crate) remote_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) label: Option<String>,
+}
+
+pub(crate) struct RemoteProjectItem {
+    pub(crate) key: String,
+    pub(crate) host_id: String,
+    pub(crate) remote_path: String,
+    pub(crate) label: Option<String>,
+}
+
+pub(crate) fn remote_project_items(value: Option<&Value>) -> Vec<RemoteProjectItem> {
+    value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            let key = clean_string(item.get("id")?)?;
+            let host_id = clean_string(item.get("hostId").or_else(|| item.get("host_id"))?)?;
+            let remote_path = normalize_workspace_path(&clean_string(
+                item.get("remotePath").or_else(|| item.get("remote_path"))?,
+            )?);
+            if remote_path.is_empty() {
+                return None;
+            }
+            Some(RemoteProjectItem {
+                key,
+                host_id,
+                remote_path,
+                label: item
+                    .get("label")
+                    .or_else(|| item.get("name"))
+                    .and_then(clean_string),
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn upsert_remote_project_payload(
+    payload: &mut Map<String, Value>,
+    project: &CodexGlobalRemoteProject,
+) {
+    let projects = payload
+        .entry(REMOTE_PROJECTS_KEY.to_owned())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !projects.is_array() {
+        *projects = Value::Array(Vec::new());
+    }
+    let projects = projects
+        .as_array_mut()
+        .expect("remote projects is an array");
+    let index = projects.iter().position(|item| {
+        item.get("id").and_then(clean_string).as_deref() == Some(project.id.as_str())
+    });
+    let existing = index
+        .and_then(|index| projects.get_mut(index))
+        .and_then(Value::as_object_mut);
+    let mut item = existing.cloned().unwrap_or_default();
+    item.insert("id".to_owned(), Value::String(project.id.clone()));
+    item.insert("hostId".to_owned(), Value::String(project.host_id.clone()));
+    item.insert(
+        "remotePath".to_owned(),
+        Value::String(project.remote_path.clone()),
+    );
+    if let Some(label) = project.label.as_deref().and_then(clean_text) {
+        item.insert("label".to_owned(), Value::String(label));
+    }
+    let item = Value::Object(item);
+    if let Some(index) = index {
+        projects[index] = item;
+    } else {
+        projects.push(item);
+    }
+}
+
+fn clean_string(value: &Value) -> Option<String> {
+    value.as_str().and_then(clean_text)
+}
+
+fn clean_text(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}

--- a/wework/e2e/desktop/modules/desktop-build-flows.mjs
+++ b/wework/e2e/desktop/modules/desktop-build-flows.mjs
@@ -812,18 +812,27 @@ async function verifyCloudProjectFlow(
   await control.command('press', '[data-testid="device-folder-path-input"]', { key: 'Enter' })
   await waitForFolderPathReady(control, replacementWorkspacePath)
   await control.command('clickWhenEnabled', '[data-testid="confirm-device-folder-picker-button"]')
-  await waitForSnapshot(
+  const replacementProjectSnapshot = await waitForSnapshot(
     control,
     snapshot => snapshot.testIds.filter(testId => testId.startsWith('project-menu-')).length === 1,
     'The duplicate regression cloud project was not created'
   )
-  const replacementProjectSnapshot = JSON.parse(
-    await control.command('getWorkbenchDebugSnapshot', 'body')
+  const replacementProjectMenuTestId = replacementProjectSnapshot.testIds.find(testId =>
+    testId.startsWith('project-menu-')
+  )
+  assert.ok(replacementProjectMenuTestId, 'The replacement cloud project identity was not found')
+  const replacementProjectId = replacementProjectMenuTestId.slice('project-menu-'.length)
+  assert.notEqual(
+    replacementProjectId,
+    currentProjectId,
+    'Creating another cloud project restored the removed project identity'
   )
   assert.equal(
-    replacementProjectSnapshot.workbench?.currentProject?.config?.workspace?.localPath,
-    replacementWorkspacePath,
-    'Creating another cloud project restored the removed workspace instead of selecting the replacement'
+    (
+      await control.command('getText', `[data-testid="project-title-${replacementProjectId}"]`)
+    ).trim(),
+    'replacement-workspace',
+    'Creating another cloud project restored the removed project instead of the replacement'
   )
 
   await cloudEnvironment.aliasCloudDeviceToCurrentApp()
@@ -837,19 +846,28 @@ async function verifyCloudProjectFlow(
   await captureVerificationScreenshot(control, 'cloud-08-local-project-deduplicated.png')
 
   await restartDesktopApp()
-  await waitForSnapshot(
+  const restartedProjectSnapshot = await waitForSnapshot(
     control,
     snapshot => snapshot.testIds.filter(testId => testId.startsWith('project-menu-')).length === 1,
     'Restarting Wework changed the deduplicated local and cloud project into multiple rows',
     WORKBENCH_READY_TIMEOUT_MS
   )
-  const restartedProjectSnapshot = JSON.parse(
-    await control.command('getWorkbenchDebugSnapshot', 'body')
+  const restartedProjectMenuTestId = restartedProjectSnapshot.testIds.find(testId =>
+    testId.startsWith('project-menu-')
+  )
+  assert.ok(restartedProjectMenuTestId, 'The restarted replacement project identity was not found')
+  const restartedProjectId = restartedProjectMenuTestId.slice('project-menu-'.length)
+  assert.notEqual(
+    restartedProjectId,
+    currentProjectId,
+    'Restarting Wework restored the removed project identity'
   )
   assert.equal(
-    restartedProjectSnapshot.workbench?.currentProject?.config?.workspace?.localPath,
-    replacementWorkspacePath,
-    'Restarting Wework restored the removed workspace instead of the replacement'
+    (
+      await control.command('getText', `[data-testid="project-title-${restartedProjectId}"]`)
+    ).trim(),
+    'replacement-workspace',
+    'Restarting Wework restored the removed project instead of the replacement'
   )
   await captureVerificationScreenshot(control, 'cloud-09-local-project-deduplicated-restart.png')
 }

--- a/wework/e2e/desktop/modules/desktop-build-flows.mjs
+++ b/wework/e2e/desktop/modules/desktop-build-flows.mjs
@@ -790,6 +790,8 @@ async function verifyCloudProjectFlow(
   )
   await captureVerificationScreenshot(control, 'cloud-07-project-removed.png')
 
+  const replacementWorkspacePath = join(dirname(workspacePath), 'replacement-workspace')
+  await mkdir(replacementWorkspacePath, { recursive: true })
   await control.command('click', '[data-testid="projects-create-button"]')
   await control.command('click', '[data-testid="project-create-remote-option"]')
   await control.command('waitFor', '[data-testid="standalone-remote-device-select"]', {
@@ -805,19 +807,27 @@ async function verifyCloudProjectFlow(
     'The duplicate regression remote picker did not load the cloud executor home'
   )
   await control.command('fill', '[data-testid="device-folder-path-input"]', {
-    value: workspacePath,
+    value: replacementWorkspacePath,
   })
   await control.command('press', '[data-testid="device-folder-path-input"]', { key: 'Enter' })
-  await waitForFolderPathReady(control, workspacePath)
+  await waitForFolderPathReady(control, replacementWorkspacePath)
   await control.command('clickWhenEnabled', '[data-testid="confirm-device-folder-picker-button"]')
   await waitForSnapshot(
     control,
     snapshot => snapshot.testIds.filter(testId => testId.startsWith('project-menu-')).length === 1,
     'The duplicate regression cloud project was not created'
   )
+  const replacementProjectSnapshot = JSON.parse(
+    await control.command('getWorkbenchDebugSnapshot', 'body')
+  )
+  assert.equal(
+    replacementProjectSnapshot.workbench?.currentProject?.config?.workspace?.localPath,
+    replacementWorkspacePath,
+    'Creating another cloud project restored the removed workspace instead of selecting the replacement'
+  )
 
   await cloudEnvironment.aliasCloudDeviceToCurrentApp()
-  await createSingleRootLocalProject(control, workspacePath, 'workspace')
+  await createSingleRootLocalProject(control, replacementWorkspacePath, 'replacement-workspace')
   await waitForSnapshot(
     control,
     snapshot => snapshot.testIds.filter(testId => testId.startsWith('project-menu-')).length === 1,
@@ -832,6 +842,14 @@ async function verifyCloudProjectFlow(
     snapshot => snapshot.testIds.filter(testId => testId.startsWith('project-menu-')).length === 1,
     'Restarting Wework changed the deduplicated local and cloud project into multiple rows',
     WORKBENCH_READY_TIMEOUT_MS
+  )
+  const restartedProjectSnapshot = JSON.parse(
+    await control.command('getWorkbenchDebugSnapshot', 'body')
+  )
+  assert.equal(
+    restartedProjectSnapshot.workbench?.currentProject?.config?.workspace?.localPath,
+    replacementWorkspacePath,
+    'Restarting Wework restored the removed workspace instead of the replacement'
   )
   await captureVerificationScreenshot(control, 'cloud-09-local-project-deduplicated-restart.png')
 }

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -339,6 +339,14 @@ function createServices() {
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe('createHybridWorkbenchServices', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -640,6 +648,78 @@ describe('createHybridWorkbenchServices', () => {
     const devices = await services.deviceApi.listDevices()
 
     expect(devices.map(device => device.device_id)).toEqual(['local-device', 'cloud-device'])
+  })
+
+  it('drops remembered cloud devices after an authoritative empty background sync', async () => {
+    const services = createServices()
+
+    await services.cloudBackgroundApi?.listDevices?.()
+    mocks.cloudListDevices.mockResolvedValue([])
+    await services.cloudBackgroundApi?.listDevices?.()
+    const devices = await services.deviceApi.listDevices()
+
+    expect(devices.map(device => device.device_id)).toEqual(['local-device'])
+  })
+
+  it('does not let an older cloud device response overwrite a newer snapshot', async () => {
+    const olderDevices = deferred<
+      Array<{
+        id: number
+        device_id: string
+        name: string
+        status: 'online'
+        is_default: boolean
+        device_type: 'cloud'
+        bind_shell: 'claudecode'
+      }>
+    >()
+    mocks.cloudListDevices
+      .mockReset()
+      .mockImplementationOnce(() => olderDevices.promise)
+      .mockResolvedValueOnce([
+        {
+          id: 2,
+          device_id: 'new-cloud-device',
+          name: 'New Cloud Executor',
+          status: 'online',
+          is_default: false,
+          device_type: 'cloud',
+          bind_shell: 'claudecode',
+        },
+      ])
+    const services = createServices()
+
+    const olderRequest = services.cloudBackgroundApi!.listDevices!({
+      signal: new AbortController().signal,
+    })
+    await services.cloudBackgroundApi!.listDevices!({ signal: new AbortController().signal })
+    olderDevices.resolve([
+      {
+        id: 1,
+        device_id: 'old-cloud-device',
+        name: 'Old Cloud Executor',
+        status: 'online',
+        is_default: false,
+        device_type: 'cloud',
+        bind_shell: 'claudecode',
+      },
+    ])
+    await olderRequest
+
+    const devices = await services.deviceApi.listDevices()
+    expect(devices.map(device => device.device_id)).toEqual(['local-device', 'new-cloud-device'])
+  })
+
+  it('reuses one cloud device snapshot across a background refresh', async () => {
+    const services = createServices()
+    const controller = new AbortController()
+
+    await Promise.all([
+      services.cloudBackgroundApi!.listDevices!({ signal: controller.signal }),
+      services.cloudBackgroundApi!.listRuntimeWork!({ signal: controller.signal }),
+    ])
+
+    expect(mocks.cloudListDevices).toHaveBeenCalledTimes(1)
   })
 
   it('routes Worktree settings to the selected local or cloud device', async () => {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -33,7 +33,7 @@ import type {
   ArchivedConversationsListResponse,
   DeleteDeviceWorkspaceRequest,
   DeviceCommandResponse,
-  DeviceInfo,
+  DeviceInfo as RuntimeDeviceInfo,
   DeviceWorkspacePrepareRequest,
   RuntimeArchivedConversationCleanupResponse,
   RuntimeCompactRequest,
@@ -60,6 +60,7 @@ import type {
   User,
 } from '@/types/api'
 import type { Automation } from '@/types/automation'
+import type { DeviceInfo } from '@/types/devices'
 
 const LOCAL_DEVICE_ID = 'local-device'
 const CLOUD_BACKGROUND_CACHE_TTL_MS = 30_000
@@ -340,6 +341,10 @@ export function createHybridWorkbenchServices(
   const localRuntimeInstanceIds = new Set<string>()
   const localRuntimeProjectKeys = new Set<string>()
   let rememberedCloudDevices: DeviceInfo[] = []
+  let rememberedCloudDevicesRevision = 0
+  let nextCloudDevicesRevision = 1
+  let unscopedCloudDevicesRequest: Promise<DeviceInfo[]> | null = null
+  const cloudDevicesRequestsBySignal = new WeakMap<AbortSignal, Promise<DeviceInfo[]>>()
   let rememberedCloudModels: UnifiedModel[] = []
   let cloudModelsLoaded = false
   let cloudModelsRequest: Promise<void> | null = null
@@ -357,8 +362,10 @@ export function createHybridWorkbenchServices(
       }
     })
   }
-  const rememberCloudDevices = (devices: DeviceInfo[]) => {
-    rememberedCloudDevices = mergeDeviceLists(rememberedCloudDevices, devices)
+  const rememberCloudDevices = (devices: DeviceInfo[], revision: number) => {
+    if (revision < rememberedCloudDevicesRevision) return
+    rememberedCloudDevices = devices
+    rememberedCloudDevicesRevision = revision
   }
   const loadCloudModelsInBackground = () => {
     if (cloudModelsLoaded || cloudModelsRequest) return
@@ -498,7 +505,9 @@ export function createHybridWorkbenchServices(
     rememberLocalDevices(devices)
     return devices
   }
-  const listCloudDevices = async (signal?: AbortSignal) => {
+  const fetchCloudDevices = async (signal?: AbortSignal) => {
+    const revision = nextCloudDevicesRevision
+    nextCloudDevicesRevision += 1
     const devices = (
       signal
         ? await cloudServices.deviceApi.listDevices({ signal })
@@ -507,12 +516,29 @@ export function createHybridWorkbenchServices(
       device =>
         (isCloudDevice(device) || isRemoteDevice(device)) && !isAppDeviceRegistration(device)
     )
-    rememberCloudDevices(devices)
+    rememberCloudDevices(devices, revision)
     return devices
+  }
+  const listCloudDevices = (signal?: AbortSignal): Promise<DeviceInfo[]> => {
+    if (signal) {
+      const existing = cloudDevicesRequestsBySignal.get(signal)
+      if (existing) return existing
+      const request = fetchCloudDevices(signal)
+      cloudDevicesRequestsBySignal.set(signal, request)
+      return request
+    }
+    if (unscopedCloudDevicesRequest) return unscopedCloudDevicesRequest
+    const request = fetchCloudDevices().finally(() => {
+      if (unscopedCloudDevicesRequest === request) {
+        unscopedCloudDevicesRequest = null
+      }
+    })
+    unscopedCloudDevicesRequest = request
+    return request
   }
   const listKnownDevices = async (signal?: AbortSignal) =>
     mergeDeviceLists(await listLocalDevices(signal), rememberedCloudDevices)
-  const resolveExecutorDevice = async (deviceId: string): Promise<DeviceInfo | null> => {
+  const resolveExecutorDevice = async (deviceId: string): Promise<RuntimeDeviceInfo | null> => {
     const knownDevice = (await listKnownDevices()).find(device => device.device_id === deviceId)
     if (knownDevice) return knownDevice
 

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -6576,6 +6576,7 @@ describe('WorkbenchProvider runtime tasks', () => {
   test('does not restore a removed runtime project from an in-flight cloud refresh', async () => {
     const cloudRuntimeWork = deferred<RuntimeWorkListResponse>()
     const staleRuntimeWork = createRuntimeWork()
+    writeCachedRemoteRuntimeWork(1, staleRuntimeWork)
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(staleRuntimeWork),
     })
@@ -6597,6 +6598,10 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() =>
       expect(screen.getByTestId('mutation-project-order')).toHaveTextContent(/^$/)
     )
+    expect(
+      JSON.parse(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.1') ?? '{}')
+        .runtimeWork.projects
+    ).toEqual([])
 
     await act(async () => {
       cloudRuntimeWork.resolve({ projects: [], chats: [], totalTasks: 0 })
@@ -6661,6 +6666,7 @@ describe('WorkbenchProvider runtime tasks', () => {
   })
 
   test('renames and removes remote projects from both the remote executor and local Codex index', async () => {
+    const initialRemoteProjectSync = deferred<{ accepted: boolean; deviceId: string }>()
     const remoteRuntimeWork = createRuntimeWork({
       projects: [
         {
@@ -6695,6 +6701,10 @@ describe('WorkbenchProvider runtime tasks', () => {
     })
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(remoteRuntimeWork),
+      syncRuntimeRemoteProjects: vi
+        .fn()
+        .mockImplementationOnce(() => initialRemoteProjectSync.promise)
+        .mockResolvedValue({ accepted: true, deviceId: 'local-device' }),
     })
     const services = createWorkbenchServices({
       deviceApi: {
@@ -6723,7 +6733,19 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     renderWorkbench(<RuntimeProjectMutationProbe />, services)
 
+    await waitFor(() => expect(runtimeWorkApi.syncRuntimeRemoteProjects).toHaveBeenCalledTimes(1))
     await userEvent.click(await screen.findByText('rename runtime project'))
+    await waitFor(() => expect(runtimeWorkApi.renameRuntimeWorkspace).toHaveBeenCalledTimes(1))
+    expect(runtimeWorkApi.renameRuntimeWorkspace).toHaveBeenNthCalledWith(1, {
+      deviceId: 'remote-device',
+      projectKey: '/srv/project-alpha',
+      workspacePath: '/srv/project-alpha',
+      runtime: 'codex',
+      name: 'Hello project',
+    })
+    await act(async () => {
+      initialRemoteProjectSync.resolve({ accepted: true, deviceId: 'local-device' })
+    })
     await waitFor(() => expect(runtimeWorkApi.renameRuntimeWorkspace).toHaveBeenCalledTimes(2))
     expect(runtimeWorkApi.renameRuntimeWorkspace).toHaveBeenNthCalledWith(1, {
       deviceId: 'remote-device',
@@ -6754,6 +6776,65 @@ describe('WorkbenchProvider runtime tasks', () => {
       workspacePath: '/srv/project-alpha',
       runtime: 'codex',
     })
+    expect(runtimeWorkApi.syncRuntimeRemoteProjects).not.toHaveBeenCalledWith({
+      deviceId: 'local-device',
+      projects: [],
+    })
+  })
+
+  test('does not treat a local-only empty remote view as an authoritative deletion', async () => {
+    const remoteRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: {
+            id: 7,
+            key: '/srv/project-alpha',
+            sidebarStateKey: 'remote-project-id',
+            name: 'Wegent',
+            kind: 'remote',
+            source: 'remote_project',
+            stateDeviceId: 'local-device',
+          },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'remote-device',
+              remoteHostId: 'remote-device',
+              workspacePath: '/srv/project-alpha',
+              workspaceSource: 'remote',
+              mapped: true,
+              available: false,
+              tasks: [],
+            },
+          ],
+          totalTasks: 0,
+        },
+      ],
+      totalTasks: 0,
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(remoteRuntimeWork),
+    })
+    const services = createWorkbenchServices({
+      deviceApi: {
+        listDevices: vi
+          .fn()
+          .mockResolvedValue([
+            createDevice({ device_id: 'local-device', device_type: 'local' }),
+            createDevice({ device_id: 'remote-device', device_type: 'remote', is_default: false }),
+          ]),
+      } as Partial<WorkbenchServices['deviceApi']> as WorkbenchServices['deviceApi'],
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimeProjectMutationProbe />, services)
+
+    await waitFor(() => expect(runtimeWorkApi.listRuntimeWork).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(screen.getByTestId('mutation-project-order')).toHaveTextContent(/^$/)
+    )
+    expect(runtimeWorkApi.syncRuntimeRemoteProjects).not.toHaveBeenCalled()
   })
 
   test('archives a worktree task without prompting and preserves a snapshot', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -258,6 +258,7 @@ export function WorkbenchProvider({
     }
   }, [dispatch, state.user?.id, workbenchIdentity])
   const remoteProjectSyncSignatureRef = useRef('')
+  const remoteProjectMutationQueueRef = useRef<Promise<void>>(Promise.resolve())
   const projectActivationSignatureRef = useRef('')
   const lastProjectRestoreAttemptedRef = useRef(false)
   const projectSelectionStartedRef = useRef(false)
@@ -781,23 +782,47 @@ export function WorkbenchProvider({
     [state.devices]
   )
 
+  const enqueueRemoteProjectStateMutation = useCallback(
+    <T,>(mutation: () => Promise<T>): Promise<T> => {
+      const run = remoteProjectMutationQueueRef.current.catch(() => undefined).then(mutation)
+      remoteProjectMutationQueueRef.current = run.then(
+        () => undefined,
+        () => undefined
+      )
+      return run
+    },
+    []
+  )
+
   useEffect(() => {
     const projects = getRuntimeRemoteProjectRegistrations(
       state.runtimeWork,
       localRuntimeStateDeviceId
     ).sort((left, right) => left.id.localeCompare(right.id))
-    if (!localRuntimeStateDeviceId || projects.length === 0) return
+    if (!localRuntimeStateDeviceId || projects.length === 0) {
+      remoteProjectSyncSignatureRef.current = ''
+      return
+    }
     const signature = JSON.stringify({ deviceId: localRuntimeStateDeviceId, projects })
     if (remoteProjectSyncSignatureRef.current === signature) return
     remoteProjectSyncSignatureRef.current = signature
-    void executorClient.runtime
-      .syncRuntimeRemoteProjects({ deviceId: localRuntimeStateDeviceId, projects })
-      .then(() => refreshWorkLists())
-      .catch(error => {
+    void enqueueRemoteProjectStateMutation(() =>
+      executorClient.runtime
+        .syncRuntimeRemoteProjects({ deviceId: localRuntimeStateDeviceId, projects })
+        .then(() => refreshWorkLists())
+    ).catch(error => {
+      if (remoteProjectSyncSignatureRef.current === signature) {
         remoteProjectSyncSignatureRef.current = ''
-        console.warn('[Wework] Failed to sync remote projects into Codex global state', error)
-      })
-  }, [executorClient, localRuntimeStateDeviceId, refreshWorkLists, state.runtimeWork])
+      }
+      console.warn('[Wework] Failed to sync remote projects into Codex global state', error)
+    })
+  }, [
+    enqueueRemoteProjectStateMutation,
+    executorClient,
+    localRuntimeStateDeviceId,
+    refreshWorkLists,
+    state.runtimeWork,
+  ])
 
   useEffect(() => {
     if (lastProjectRestoreAttemptedRef.current || !state.runtimeWork) return
@@ -1373,6 +1398,7 @@ export function WorkbenchProvider({
     markRuntimeProjectRemoved,
     clearRuntimeProjectRemoval,
     rememberExecutionDevice,
+    enqueueRemoteProjectStateMutation,
   })
   const runtimeMessaging = useWorkbenchRuntimeMessaging({
     state,

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -11,6 +11,7 @@ import type {
   User,
 } from '@/types/api'
 import type { DockerRemoteDeviceCommandResponse } from '@/types/devices'
+import { isCloudDevice, isRemoteDevice } from '@/lib/device-capabilities'
 import type { CloudRuntimeState, CloudWorkCheckKey, WorkbenchState } from '@/types/workbench'
 import {
   EMPTY_CLOUD_RUNTIME_STATE,
@@ -67,6 +68,10 @@ function resolveStandaloneDeviceIdForRefresh(
     return standaloneDeviceId
   }
   return getPreferredStandaloneDeviceId(devices, standaloneDeviceId)
+}
+
+function localDeviceSnapshot(devices: DeviceInfo[]): DeviceInfo[] {
+  return devices.filter(device => !isCloudDevice(device) && !isRemoteDevice(device))
 }
 
 interface UseWorkbenchDataRefreshOptions {
@@ -429,7 +434,8 @@ export function useWorkbenchDataRefresh({
           devicesResult?.status === 'fulfilled'
         ) {
           const devices = resolveDeviceListWithCache(
-            mergeDeviceLists(baseDevices, devicesResult.value)
+            mergeDeviceLists(localDeviceSnapshot(baseDevices), devicesResult.value),
+            { useCacheFallback: false }
           )
           dispatch({
             type: 'devices_refreshed',
@@ -475,10 +481,10 @@ export function useWorkbenchDataRefresh({
         if (filteredRuntimeWorkResult?.status === 'fulfilled') {
           releaseConfirmedArchivedRuntimeTasks(
             mergeRuntimeWorkLists(latestLocalRuntimeWork, filteredRuntimeWorkResult.value, {
-              devices: [
-                ...baseDevices,
-                ...(devicesResult?.status === 'fulfilled' ? devicesResult.value : []),
-              ],
+              devices:
+                devicesResult?.status === 'fulfilled'
+                  ? [...localDeviceSnapshot(baseDevices), ...devicesResult.value]
+                  : baseDevices,
             })
           )
         }
@@ -516,7 +522,11 @@ export function useWorkbenchDataRefresh({
         updateCloudRuntimeState(nextCloudState)
 
         const devices = resolveDeviceListWithCache(
-          selectVisibleDevices(baseDevices, nextCloudState)
+          selectVisibleDevices(
+            devicesResult?.status === 'fulfilled' ? localDeviceSnapshot(baseDevices) : baseDevices,
+            nextCloudState
+          ),
+          { useCacheFallback: devicesResult?.status !== 'fulfilled' }
         )
         const runtimeWork = selectVisibleRuntimeWork(
           latestLocalRuntimeWork,
@@ -581,7 +591,9 @@ export function useWorkbenchDataRefresh({
       }
 
       const rawDevices = devicesResult.status === 'fulfilled' ? devicesResult.value : []
-      const devices = resolveDeviceListWithCache(rawDevices)
+      const devices = resolveDeviceListWithCache(rawDevices, {
+        useCacheFallback: devicesResult.status !== 'fulfilled',
+      })
       const standaloneDeviceId = getRememberedStandaloneDeviceId(user, devices)
 
       // Do not force-clear currentProject / runtimeWork here. CLI `wework <path>` may
@@ -664,9 +676,10 @@ export function useWorkbenchDataRefresh({
         }),
         executorClient.runtime.listRuntimeWork().catch(() => undefined),
       ])
-      const devices = resolveDeviceListWithCache(devicesResult)
+      const devices = resolveDeviceListWithCache(devicesResult, { useCacheFallback: false })
       const visibleDevices = resolveDeviceListWithCache(
-        selectVisibleDevices(devices, cloudRuntimeStateRef.current)
+        selectVisibleDevices(devices, cloudRuntimeStateRef.current),
+        { useCacheFallback: false }
       )
       const filteredRuntimeWorkResult = runtimeWorkResult
         ? applyRuntimeTaskTitleOverrides(filterRemovedRuntimeProjects(runtimeWorkResult), true)
@@ -742,7 +755,7 @@ export function useWorkbenchDataRefresh({
           throw error
         }
       }
-      return resolveDeviceListWithCache(devices)
+      return resolveDeviceListWithCache(devices, { useCacheFallback: false })
     },
     [executorClient]
   )
@@ -768,10 +781,14 @@ export function useWorkbenchDataRefresh({
       }
       cachedRemoteRuntimeWorkRef.current = {
         ...cachedRemoteRuntimeWorkRef.current,
-        runtimeWork: removeRuntimeProject(
-          cachedRemoteRuntimeWorkRef.current.runtimeWork,
-          projectId,
-          normalizedWorkspace
+        runtimeWork: writeCachedRemoteRuntimeWork(
+          user.id,
+          removeRuntimeProject(
+            cachedRemoteRuntimeWorkRef.current.runtimeWork,
+            projectId,
+            normalizedWorkspace
+          ),
+          devicesRef.current
         ),
       }
       updateCloudRuntimeState(
@@ -782,7 +799,7 @@ export function useWorkbenchDataRefresh({
         )
       )
     },
-    [updateCloudRuntimeState]
+    [updateCloudRuntimeState, user.id]
   )
 
   const clearRuntimeProjectRemoval = useCallback(

--- a/wework/src/features/workbench/useWorkbenchProjectActions.ts
+++ b/wework/src/features/workbench/useWorkbenchProjectActions.ts
@@ -54,6 +54,7 @@ interface UseWorkbenchProjectActionsOptions {
   ) => void
   clearRuntimeProjectRemoval: (workspace: { deviceId: string; workspacePath: string }) => void
   rememberExecutionDevice: (deviceId: string) => void
+  enqueueRemoteProjectStateMutation: <T>(mutation: () => Promise<T>) => Promise<T>
 }
 
 export function useWorkbenchProjectActions({
@@ -66,6 +67,7 @@ export function useWorkbenchProjectActions({
   markRuntimeProjectRemoved,
   clearRuntimeProjectRemoval,
   rememberExecutionDevice,
+  enqueueRemoteProjectStateMutation,
 }: UseWorkbenchProjectActionsOptions) {
   const createProject = useCallback(
     async (data: CreateProjectRequest, options: ProjectMutationOptions = {}) => {
@@ -150,13 +152,20 @@ export function useWorkbenchProjectActions({
         const runtimeProject = state.runtimeWork?.projects.find(
           item => runtimeProjectUiId(item.project) === projectId
         )?.project
-        const response = await executorClient.runtime.renameRuntimeWorkspace({
-          deviceId: runtimeWorkspace.deviceId,
-          projectKey: runtimeProject?.key,
-          workspacePath: runtimeWorkspace.workspacePath,
-          runtime: 'codex',
-          name,
-        })
+        const renamePrimaryProject = () =>
+          executorClient.runtime.renameRuntimeWorkspace({
+            deviceId: runtimeWorkspace.deviceId,
+            projectKey: runtimeProject?.key,
+            workspacePath: runtimeWorkspace.workspacePath,
+            runtime: 'codex',
+            name,
+          })
+        const primaryTargetsRemoteProjectState =
+          Boolean(runtimeProject?.sidebarStateKey) &&
+          runtimeProject?.stateDeviceId === runtimeWorkspace.deviceId
+        const response = primaryTargetsRemoteProjectState
+          ? await enqueueRemoteProjectStateMutation(renamePrimaryProject)
+          : await renamePrimaryProject()
         if (!response.accepted) {
           const message = response.error || 'Failed to rename runtime workspace'
           dispatch({ type: 'error_set', error: message })
@@ -165,15 +174,18 @@ export function useWorkbenchProjectActions({
         if (
           runtimeProject?.sidebarStateKey &&
           runtimeProject.stateDeviceId &&
-          runtimeProject.stateDeviceId !== runtimeWorkspace.deviceId
+          (runtimeProject.stateDeviceId !== runtimeWorkspace.deviceId ||
+            runtimeProject.sidebarStateKey !== runtimeProject.key)
         ) {
-          await executorClient.runtime.renameRuntimeWorkspace({
-            deviceId: runtimeProject.stateDeviceId,
-            projectKey: runtimeProject.sidebarStateKey,
-            workspacePath: runtimeWorkspace.workspacePath,
-            runtime: 'codex',
-            name,
-          })
+          await enqueueRemoteProjectStateMutation(() =>
+            executorClient.runtime.renameRuntimeWorkspace({
+              deviceId: runtimeProject.stateDeviceId!,
+              projectKey: runtimeProject.sidebarStateKey,
+              workspacePath: runtimeWorkspace.workspacePath,
+              runtime: 'codex',
+              name,
+            })
+          )
         }
         await refreshWorkLists()
         return
@@ -181,7 +193,14 @@ export function useWorkbenchProjectActions({
       await services.projectApi.updateProject(projectId, { name })
       await refreshWorkLists()
     },
-    [dispatch, executorClient, refreshWorkLists, services.projectApi, state.runtimeWork]
+    [
+      dispatch,
+      enqueueRemoteProjectStateMutation,
+      executorClient,
+      refreshWorkLists,
+      services.projectApi,
+      state.runtimeWork,
+    ]
   )
 
   const updateLocalRuntimeProject = useCallback(
@@ -221,12 +240,19 @@ export function useWorkbenchProjectActions({
       const runtimeProject = state.runtimeWork?.projects.find(
         item => runtimeProjectUiId(item.project) === projectId
       )?.project
-      const response = await executorClient.runtime.removeRuntimeWorkspace({
-        deviceId: runtimeWorkspace.deviceId,
-        projectKey: runtimeProject?.key,
-        workspacePath: runtimeWorkspace.workspacePath,
-        runtime: 'codex',
-      })
+      const removePrimaryProject = () =>
+        executorClient.runtime.removeRuntimeWorkspace({
+          deviceId: runtimeWorkspace.deviceId,
+          projectKey: runtimeProject?.key,
+          workspacePath: runtimeWorkspace.workspacePath,
+          runtime: 'codex',
+        })
+      const primaryTargetsRemoteProjectState =
+        Boolean(runtimeProject?.sidebarStateKey) &&
+        runtimeProject?.stateDeviceId === runtimeWorkspace.deviceId
+      const response = primaryTargetsRemoteProjectState
+        ? await enqueueRemoteProjectStateMutation(removePrimaryProject)
+        : await removePrimaryProject()
       if (!response.accepted) {
         const message = response.error || 'Failed to remove runtime workspace'
         dispatch({ type: 'error_set', error: message })
@@ -235,14 +261,17 @@ export function useWorkbenchProjectActions({
       if (
         runtimeProject?.sidebarStateKey &&
         runtimeProject.stateDeviceId &&
-        runtimeProject.stateDeviceId !== runtimeWorkspace.deviceId
+        (runtimeProject.stateDeviceId !== runtimeWorkspace.deviceId ||
+          runtimeProject.sidebarStateKey !== runtimeProject.key)
       ) {
-        await executorClient.runtime.removeRuntimeWorkspace({
-          deviceId: runtimeProject.stateDeviceId,
-          projectKey: runtimeProject.sidebarStateKey,
-          workspacePath: runtimeWorkspace.workspacePath,
-          runtime: 'codex',
-        })
+        await enqueueRemoteProjectStateMutation(() =>
+          executorClient.runtime.removeRuntimeWorkspace({
+            deviceId: runtimeProject.stateDeviceId!,
+            projectKey: runtimeProject.sidebarStateKey,
+            workspacePath: runtimeWorkspace.workspacePath,
+            runtime: 'codex',
+          })
+        )
       }
 
       const standaloneDeviceId = state.standaloneDeviceId?.trim()
@@ -271,6 +300,7 @@ export function useWorkbenchProjectActions({
     },
     [
       dispatch,
+      enqueueRemoteProjectStateMutation,
       executorClient,
       markRuntimeProjectRemoved,
       refreshWorkLists,

--- a/wework/src/features/workbench/workbenchCloudStatus.test.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { DeviceInfo, RuntimeDeviceWorkspace, RuntimeWorkListResponse } from '@/types/api'
 import {
   EMPTY_CLOUD_RUNTIME_STATE,
   filterDisconnectedRemoteRuntimeWork,
   finishCloudRuntimeSync,
   mergeRuntimeWorkLists,
+  readCachedDeviceList,
+  resolveDeviceListWithCache,
   selectCloudWorkStatus,
   selectProjectCreatableDevices,
   selectRuntimeWorkView,
@@ -154,6 +156,26 @@ describe('mergeRuntimeWorkLists', () => {
     }
 
     expect(mergeRuntimeWorkLists(localWork, cloudWork).chats).toEqual([])
+  })
+})
+
+describe('resolveDeviceListWithCache', () => {
+  beforeEach(() => sessionStorage.clear())
+
+  test('accepts an authoritative empty device list and clears stale cache', () => {
+    const cachedDevice = device({ device_id: 'stale-device' })
+    resolveDeviceListWithCache([cachedDevice])
+
+    expect(readCachedDeviceList()).toHaveLength(1)
+    expect(resolveDeviceListWithCache([], { useCacheFallback: false })).toEqual([])
+    expect(readCachedDeviceList()).toEqual([])
+  })
+
+  test('retains cached devices when the caller explicitly permits fallback', () => {
+    const cachedDevice = device({ device_id: 'cached-device' })
+    resolveDeviceListWithCache([cachedDevice])
+
+    expect(resolveDeviceListWithCache([]).map(item => item.device_id)).toEqual(['cached-device'])
   })
 })
 

--- a/wework/src/features/workbench/workbenchCloudStatus.ts
+++ b/wework/src/features/workbench/workbenchCloudStatus.ts
@@ -481,11 +481,23 @@ function writeCachedDeviceList(devices: DeviceInfo[]) {
   }
 }
 
-export function resolveDeviceListWithCache(devices: DeviceInfo[]): DeviceInfo[] {
+export function resolveDeviceListWithCache(
+  devices: DeviceInfo[],
+  options: { useCacheFallback?: boolean } = {}
+): DeviceInfo[] {
   const claudeCodeDevices = filterClaudeCodeDevices(devices)
   if (claudeCodeDevices.length > 0) {
     writeCachedDeviceList(claudeCodeDevices)
     return claudeCodeDevices
+  }
+
+  if (options.useCacheFallback === false) {
+    try {
+      window.sessionStorage.removeItem(DEVICE_LIST_CACHE_KEY)
+    } catch {
+      // The authoritative empty result still applies when storage is unavailable.
+    }
+    return devices
   }
 
   const cachedDevices = readCachedDeviceList()


### PR DESCRIPTION
## Summary

- persist remote-project deletion across Wework runtime and local caches
- serialize remote-project sync with rename/remove mutations to prevent stale writes
- treat device snapshots and remote project registration updates as authoritative without deleting projects hidden by local-only views
- add backend, executor, Wework, and desktop regression coverage

## Root cause

Cloud projects are represented in the live runtime list, the Wework cached remote-work snapshot, and the local Codex global sidebar state. The delete request did not consistently forward the sidebar `projectKey`, while background synchronization could race with deletion and write stale registrations back. Older device-list responses and non-authoritative empty views could also preserve or restore stale state.

## Impact

Deleted cloud projects no longer reappear after another project is created or after Wework restarts. Local projects, remote-project ordering, pinned state, appearance, and thread assignments remain unchanged. Cloud device discovery requests are deduplicated within a refresh.

## Validation

- Wework ESLint, TypeScript, and unit tests
- backend Black, isort, syntax checks, and 82 focused runtime-work tests
- executor `cargo fmt --check`, `cargo test --all-features --lib`, and `cargo clippy`
- Alembic multi-head check
- focused Wework regression suite: 217 tests
- desktop E2E scenario updated to delete one workspace, create a different workspace, and verify it before and after restart

## Task

- `vGopFCzLWw` — 修复云设备项目删除后重现


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime workspace removal now supports specifying a project key.
  - Remote project updates are synchronized in batches for improved consistency.

- **Bug Fixes**
  - Fixed removed workspaces reappearing after app restarts.
  - Improved retention of remote project settings such as paths, ordering, pinning, and metadata.
  - Prevented stale cloud device information from overwriting newer results.
  - Empty authoritative device results now clear outdated cached devices.
  - Serialized project changes to prevent conflicting remote updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->