### PR TITLE
fix(wework): preserve Codex session precedence

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -2571,16 +2571,6 @@ function ProjectItem({
       >
         <div className="min-h-0 overflow-hidden">
           <div className="space-y-0.5">
-            {localHarnessSessions.map(session => (
-              <LocalHarnessSessionRow
-                key={session.sessionId}
-                session={session}
-                selected={activeLocalHarnessSessionId === session.sessionId}
-                indentClassName="pl-9"
-                onOpen={onOpenLocalHarnessSession}
-                onClose={onCloseLocalHarnessSession}
-              />
-            ))}
             {runtimeTaskItems.length === 0 && localHarnessSessions.length === 0 ? (
               <div
                 data-testid={`project-local-tasks-empty-${project.id}`}
@@ -2648,6 +2638,16 @@ function ProjectItem({
                     />
                   )}
                 />
+                {localHarnessSessions.map(session => (
+                  <LocalHarnessSessionRow
+                    key={session.sessionId}
+                    session={session}
+                    selected={activeLocalHarnessSessionId === session.sessionId}
+                    indentClassName="pl-9"
+                    onOpen={onOpenLocalHarnessSession}
+                    onClose={onCloseLocalHarnessSession}
+                  />
+                ))}
                 {(hasHiddenRuntimeTasks || canCollapseRuntimeTasks) && (
                   <div className="ml-9 flex h-8 items-center gap-2">
                     {hasHiddenRuntimeTasks ? (
@@ -4094,15 +4094,6 @@ export function DesktopSidebar({
                   </DesktopSidebarSectionHeader>
                   {displayedChatsExpanded && (
                     <div className="space-y-0.5 pb-2">
-                      {standaloneLocalHarnessSessions.map(session => (
-                        <LocalHarnessSessionRow
-                          key={session.sessionId}
-                          session={session}
-                          selected={activeLocalHarnessSessionId === session.sessionId}
-                          onOpen={onOpenLocalHarnessSession}
-                          onClose={onCloseLocalHarnessSession}
-                        />
-                      ))}
                       {standaloneLocalHarnessSessions.length === 0 &&
                       regularChatTaskItems.length === 0 ? (
                         <div
@@ -4169,6 +4160,15 @@ export function DesktopSidebar({
                           )}
                         />
                       ) : null}
+                      {standaloneLocalHarnessSessions.map(session => (
+                        <LocalHarnessSessionRow
+                          key={session.sessionId}
+                          session={session}
+                          selected={activeLocalHarnessSessionId === session.sessionId}
+                          onOpen={onOpenLocalHarnessSession}
+                          onClose={onCloseLocalHarnessSession}
+                        />
+                      ))}
                     </div>
                   )}
                 </section>

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -3519,7 +3519,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('central-harness-close-button')).not.toBeInTheDocument()
   })
 
-  test('keeps Codex and harness session selection exclusive without reopening the loaded task', async () => {
+  test('keeps the loaded Codex session above and selected before a restored harness session', async () => {
     isLocalTerminalAvailableMock.mockReturnValue(true)
     listLocalHarnessSessionsMock.mockResolvedValue([
       {
@@ -3578,29 +3578,54 @@ describe('DesktopWorkbenchLayout', () => {
 
     const harnessRow = await screen.findByTestId('local-harness-session-row-local-harness-restored')
     const codexRow = screen.getByTestId('runtime-local-task-row-runtime-loaded')
+    const sessionRows = [
+      ...screen
+        .getByTestId('runtime-chat-section')
+        .querySelectorAll(
+          '[data-testid^="runtime-local-task-row-"], [data-testid^="local-harness-session-row-"]'
+        ),
+    ]
+    expect(sessionRows.map(row => row.getAttribute('data-testid'))).toEqual([
+      'runtime-local-task-row-runtime-loaded',
+      'local-harness-session-row-local-harness-restored',
+    ])
+    expect(codexRow).toHaveAttribute('aria-current', 'page')
+    expect(harnessRow).not.toHaveAttribute('aria-current')
+
+    await userEvent.click(harnessRow)
+
     expect(harnessRow).toHaveAttribute('aria-current', 'page')
     expect(codexRow).not.toHaveAttribute('aria-current')
 
     await userEvent.click(codexRow)
 
     expect(onOpenRuntimeTask).not.toHaveBeenCalled()
-    expect(screen.getByTestId('runtime-local-task-row-runtime-loaded')).toHaveAttribute(
-      'aria-current',
-      'page'
-    )
+    expect(codexRow).toHaveAttribute('aria-current', 'page')
+    expect(harnessRow).not.toHaveAttribute('aria-current')
+  })
+
+  test('restores a harness session when no Codex session is loaded', async () => {
+    isLocalTerminalAvailableMock.mockReturnValue(true)
+    listLocalHarnessSessionsMock.mockResolvedValue([
+      {
+        session_id: 'local-harness-restored',
+        harness_id: 'opencode',
+        title: 'OpenCode 会话',
+        cwd: '/workspace/project-alpha',
+        created_at: 1234,
+        is_primary: true,
+        project_id: null,
+        active: true,
+        model_key: harnessTestModel.key,
+      },
+    ])
+
+    render(<DesktopWorkbenchLayout {...baseProps} />)
+
     expect(
-      screen.getByTestId('local-harness-session-row-local-harness-restored')
-    ).not.toHaveAttribute('aria-current')
-
-    await userEvent.click(screen.getByTestId('local-harness-session-row-local-harness-restored'))
-
-    expect(screen.getByTestId('local-harness-session-row-local-harness-restored')).toHaveAttribute(
-      'aria-current',
-      'page'
-    )
-    expect(screen.getByTestId('runtime-local-task-row-runtime-loaded')).not.toHaveAttribute(
-      'aria-current'
-    )
+      await screen.findByTestId('local-harness-session-row-local-harness-restored')
+    ).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByTestId('central-harness-terminal')).toBeVisible()
   })
 
   test('reopens the loaded Codex task when switching back from another page', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -153,6 +153,10 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
   const [activeLocalHarnessSessionId, setActiveLocalHarnessSessionId] = useState<string | null>(
     null
   )
+  const currentRuntimeTaskRef = useRef(state.currentRuntimeTask)
+  useEffect(() => {
+    currentRuntimeTaskRef.current = state.currentRuntimeTask
+  }, [state.currentRuntimeTask])
   const loadLocalHarnessSessions = useCallback(async () => {
     const sessions = await listLocalHarnessSessions()
     return sessions.map(session => ({
@@ -178,7 +182,10 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
       .then(restored => {
         if (cancelled) return
         setLocalHarnessSessions(restored)
-        setActiveLocalHarnessSessionId(current => current ?? restored[0]?.sessionId ?? null)
+        setActiveLocalHarnessSessionId(
+          current =>
+            current ?? (currentRuntimeTaskRef.current ? null : (restored[0]?.sessionId ?? null))
+        )
       })
       .catch(error => {
         console.error('Failed to restore local harness sessions:', error)


### PR DESCRIPTION
## What changed

- keep restored Codex sessions above OpenCode/local Harness sessions in project and standalone conversation lists
- preserve the already loaded Codex session when the workbench restores persisted Harness sessions
- retain automatic Harness restoration when no Codex session is loaded
- add regression coverage for ordering, initial selection, and switching between Codex and Harness sessions

## Root cause

Harness rows were rendered before runtime task rows, and the restore effect always selected the first persisted Harness session. This made OpenCode appear above Codex and steal focus whenever the workbench opened.

## Validation

- `pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx src/components/layout/DesktopSidebar.test.tsx` — 280 passed
- `pnpm --filter wework exec eslint src/components/layout/DesktopSidebar.tsx src/components/layout/DesktopWorkbenchLayout.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec prettier --check src/components/layout/DesktopSidebar.tsx src/components/layout/DesktopWorkbenchLayout.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework typecheck`
- pre-push Wework ESLint, TypeScript, and unit test suite passed
- isolated real-Tauri app compiled and launched twice; runtime interaction verification was blocked because the isolated executor did not emit its ready event, leaving the workbench initializer waiting. Logs are retained under `wework/test-results/ai-verify/2026-08-12T09-07-24-592Z-73020/` and `wework/test-results/ai-verify/2026-08-12T09-11-57-046Z-1399/`.
