### PR TITLE
fix(wework): render visualize content references

### DIFF
--- a/docs/en/wegent/user-guide/coding/managing-code-tasks.md
+++ b/docs/en/wegent/user-guide/coding/managing-code-tasks.md
@@ -251,10 +251,10 @@ Export task conversation history and code changes:
 
 When Codex creates an HTML visualization in the task workspace and references it in its response, Wework displays the chart or interactive page directly in that response. You do not need to copy a file path or open a separate browser.
 
-- Wework loads only HTML files created or modified in the current response's file changes. Deleted, reverted, or unlisted files are never loaded inline.
+- Wework supports the latest visualize content reference, such as `visualize{"path":"/absolute/path/visualizations/chart.html"}`. The absolute path does not need to appear in the current response's file changes, but it must point to an HTML file inside a `visualizations` directory.
+- The legacy `::codex-inline-vis{file="chart.html"}` directive remains supported. Legacy directives resolve relative paths or unique file names only from files created or modified in the current response, including fragments organized by date and thread under `.codex/visualizations/`.
 - The visualization runs in a script-isolated iframe and cannot access the Wework page.
-- Only relative workspace paths ending in `.html`, `.htm`, or `.xhtml` are accepted. Parent traversal, absolute paths, and directives inside code fences remain normal text.
-- A Codex visualization directive may reference only the file name. Wework resolves a unique matching file from the current response's file changes, including fragments organized by date and thread under `.codex/visualizations/`.
+- Only `.html`, `.htm`, or `.xhtml` files are accepted. Malformed references, paths containing parent traversal, and directives inside code fences remain normal text.
 - Wework wraps HTML fragments in a UTF-8 visualization host, supplies the Codex visualization theme variables, and automatically sizes the iframe to the fragment content.
 
 ## Cleaning Stale Runtimes

--- a/docs/zh/wegent/user-guide/coding/managing-code-tasks.md
+++ b/docs/zh/wegent/user-guide/coding/managing-code-tasks.md
@@ -251,10 +251,10 @@ graph LR
 
 当 Codex 在任务工作区中生成 HTML 可视化文件并在回复中引用它时，Wework 会在该回复内直接显示图表或交互页面，无需复制文件路径或另开浏览器。
 
-- 仅加载当前回复文件变更中创建或修改的 HTML 文件；删除、回滚或未在变更摘要中的文件不会被内联加载。
+- Wework 支持最新的 visualize 内容引用，例如 `visualize{"path":"/绝对路径/visualizations/chart.html"}`。该绝对路径无需出现在当前回复的文件变更摘要中，但必须指向 `visualizations` 目录内的 HTML 文件。
+- 旧版 `::codex-inline-vis{file="chart.html"}` 指令仍然可用。旧版指令只会从当前回复创建或修改的文件中解析相对路径或唯一同名文件，包括 `.codex/visualizations/` 下按日期和会话组织的片段。
 - 可视化在脚本隔离的 iframe 中运行，无法访问 Wework 页面。
-- 只接受工作区内的相对 `.html`、`.htm` 或 `.xhtml` 文件路径；带父目录跳转、绝对路径或位于代码块内的指令按普通文本显示。
-- Codex 可视化指令可以只引用文件名。Wework 会在当前回复的文件变更中解析唯一同名文件，因此可以加载 `.codex/visualizations/` 下按日期和会话组织的可视化片段。
+- 只接受 `.html`、`.htm` 或 `.xhtml` 文件。格式错误、包含父目录跳转的路径，以及位于代码块内的指令按普通文本显示。
 - Wework 使用 UTF-8 的可视化宿主包装 HTML 片段，提供 Codex 可视化主题变量，并根据片段内容自动调整 iframe 高度。
 
 ## 清理过期运行时

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
@@ -9,6 +11,9 @@ const TOOL_COMPLETION = '本地分支落后于 main，CI 跑的提交是 719f996
 const LEGACY_CONVERSATION_PROMPT = 'WEWORK_DESKTOP_E2E_LEGACY_CONVERSATION_INITIAL'
 const LEGACY_CONVERSATION_COMPLETION = 'WEWORK_DESKTOP_E2E_LEGACY_CONVERSATION_COMPLETE'
 const LEGACY_TRANSCRIPT_ITEM_ID = 'wework-desktop-e2e-legacy-assistant-text'
+const VISUALIZATION_PROMPT = 'WEWORK_DESKTOP_E2E_ABSOLUTE_VISUALIZATION'
+const VISUALIZATION_TITLE = 'Absolute visualization E2E'
+const VISUALIZATION_MARKER = 'WEWORK_DESKTOP_E2E_VISUALIZATION_VISIBLE'
 const PHASE_FLIP_PROMPT = 'WEWORK_DESKTOP_E2E_PROCESS_TO_FALLBACK_FINAL'
 const PHASE_FLIP_TEXT = 'WEWORK_DESKTOP_E2E_FALLBACK_FINAL_FROM_PROCESS'
 const TIMER_PROMPT = 'WEWORK_DESKTOP_E2E_RUNNING_TIMER_PERSISTS'
@@ -329,6 +334,10 @@ function requestContainsLegacyConversationPrompt(body) {
   return JSON.stringify(body.input ?? []).includes(LEGACY_CONVERSATION_PROMPT)
 }
 
+function requestContainsVisualizationPrompt(body) {
+  return JSON.stringify(body.input ?? []).includes(VISUALIZATION_PROMPT)
+}
+
 function requestContainsTimerPrompt(body) {
   return JSON.stringify(body.input ?? []).includes(TIMER_PROMPT)
 }
@@ -522,6 +531,17 @@ async function waitForProjectBranch(control, timeoutMs) {
     await new Promise(resolve => setTimeout(resolve, 100))
   }
   throw new Error('The streaming-text project branch did not finish loading')
+}
+
+async function waitForVisualizationBlob(control, selector, timeoutMs) {
+  const startedAt = Date.now()
+  let source = ''
+  while (Date.now() - startedAt < timeoutMs) {
+    source = await control.command('getAttribute', selector, { value: 'src' })
+    if (source.startsWith('blob:')) return source
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`The absolute visualization did not load through the asset protocol: ${source}`)
 }
 
 async function createLocalProject(control, workspacePath, timeoutMs) {
@@ -826,6 +846,24 @@ export function createDesktopScenario({
         return true
       }
 
+      if (requestContainsVisualizationPrompt(body)) {
+        const visualizationPath = join(workspacePath, 'visualizations', 'absolute-reference.html')
+        const contentReference = `visualize${JSON.stringify({
+          path: visualizationPath,
+          mode: 'wide',
+          title: VISUALIZATION_TITLE,
+        })}`
+        response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
+        response.end(
+          sse([
+            responseCreated(responseId),
+            assistantMessage(contentReference),
+            responseCompleted(responseId),
+          ])
+        )
+        return true
+      }
+
       const historyTurn = findHistoryTurn(body)
       if (historyTurn) {
         response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
@@ -869,6 +907,52 @@ export function createDesktopScenario({
         active = false
         return
       }
+      const visualizationDirectory = join(workspacePath, 'visualizations')
+      const visualizationPath = join(visualizationDirectory, 'absolute-reference.html')
+      await mkdir(visualizationDirectory, { recursive: true })
+      await writeFile(
+        visualizationPath,
+        `<section style="padding:24px;font:600 18px system-ui;color:#2563eb">${VISUALIZATION_MARKER}</section>`,
+        'utf8'
+      )
+      await control.command('fill', COMPOSER_SELECTOR, { value: VISUALIZATION_PROMPT })
+      await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
+      const visualizationSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="codex-inline-visualization"]`
+      const visualizationFrameSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="codex-inline-visualization-frame"]`
+      await control.command('waitFor', visualizationFrameSelector, { timeoutMs: uiTimeoutMs })
+      await waitForVisualizationBlob(control, visualizationFrameSelector, uiTimeoutMs)
+      assert.equal(
+        await control.command('getAttribute', visualizationSelector, {
+          value: 'data-visualization-mode',
+        }),
+        'wide',
+        'The visualize content reference did not preserve wide mode'
+      )
+      assert.equal(
+        await control.command('getAttribute', visualizationFrameSelector, { value: 'title' }),
+        VISUALIZATION_TITLE,
+        'The visualize content reference did not preserve its title'
+      )
+      assert.equal(
+        await control.command('getAttribute', visualizationFrameSelector, { value: 'sandbox' }),
+        'allow-scripts',
+        'The visualization iframe lost its sandbox'
+      )
+      const visualizationSnapshot = JSON.parse(
+        await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
+      )
+      assert.ok(
+        !visualizationSnapshot.text.includes('visualize'),
+        'The raw visualize content reference remained visible'
+      )
+      await capture(control, 'streaming-text-00-absolute-visualization.png')
+      if (process.env.WEWORK_E2E_VISUALIZATION_ONLY === 'true') {
+        active = false
+        return
+      }
+
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
       const knownLegacyTaskRows = new Set(
         JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
           testId.startsWith('runtime-local-task-row-')

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -48,7 +48,7 @@ interface AssistantMarkdownProps {
 
 type AssistantMarkdownPart =
   | { kind: 'markdown'; content: string; windowed: boolean }
-  | { kind: 'visualization'; file: string }
+  | { kind: 'visualization'; file: string; mode?: 'wide'; title?: string }
 
 export const AssistantMarkdown = memo(function AssistantMarkdown({
   content,
@@ -211,6 +211,8 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
             key={`${part.file}-${index}`}
             file={part.file}
             fileChanges={fileChanges}
+            mode={part.mode}
+            title={part.title}
           />
         ) : part.windowed ? (
           <WindowedMarkdownChunk

--- a/wework/src/components/chat/CodexInlineVisualizationHost.test.tsx
+++ b/wework/src/components/chat/CodexInlineVisualizationHost.test.tsx
@@ -11,6 +11,29 @@ afterEach(() => {
 })
 
 describe('CodexInlineVisualizationHost', () => {
+  test('loads an absolute ChatGPT visualize path without file change metadata', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<div>可视化内容</div>'))
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:absolute-visualization')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    render(
+      <CodexInlineVisualizationHost
+        file="/tmp/codex/visualizations/latency.html"
+        mode="wide"
+        title="Latency"
+      />
+    )
+
+    const host = screen.getByTestId('codex-inline-visualization')
+    const frame = screen.getByTestId('codex-inline-visualization-frame')
+    expect(host).toHaveAttribute('data-visualization-mode', 'wide')
+    expect(frame).toHaveAttribute('title', 'Latency')
+    await waitFor(() => expect(frame).toHaveAttribute('src', 'blob:absolute-visualization'))
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'asset://localhost/tmp/codex/visualizations/latency.html'
+    )
+  })
+
   test('loads the unique nested fragment as a UTF-8 sandbox document and resizes safely', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('<h2>月度趋势</h2><svg style="stroke:var(--viz-series-1)"></svg>')

--- a/wework/src/components/chat/CodexInlineVisualizationHost.tsx
+++ b/wework/src/components/chat/CodexInlineVisualizationHost.tsx
@@ -58,9 +58,13 @@ h3, h4, h5, h6 { font-size: calc(var(--font-size-base) * 1.2857142857); font-wei
 export function CodexInlineVisualizationHost({
   file,
   fileChanges,
+  mode,
+  title,
 }: {
   file: string
   fileChanges?: TurnFileChangesSummary
+  mode?: 'wide'
+  title?: string
 }) {
   const sourcePath = resolveVisualizationPath(file, fileChanges)
   const sourceUrl = sourcePath ? localHtmlBrowserUrl(sourcePath) : null
@@ -105,11 +109,12 @@ export function CodexInlineVisualizationHost({
     <div
       data-scroll-anchor
       data-testid="codex-inline-visualization"
+      data-visualization-mode={mode ?? 'inline'}
       className="mb-3 overflow-hidden rounded-xl border border-border bg-background"
     >
       <iframe
         ref={frameRef}
-        title={file}
+        title={title ?? file}
         src={frameUrl}
         sandbox="allow-scripts"
         style={{ height: frameHeight }}
@@ -168,6 +173,7 @@ function resolveVisualizationPath(
   file: string,
   fileChanges?: TurnFileChangesSummary
 ): string | null {
+  if (isAbsoluteVisualizationPath(file)) return file
   if (!fileChanges || fileChanges.status !== 'active') return null
   const normalizedFile = file.replace(/\\/g, '/')
   const exactMatch = fileChanges.files.find(
@@ -186,4 +192,9 @@ function resolveVisualizationPath(
   } catch {
     return null
   }
+}
+
+function isAbsoluteVisualizationPath(file: string): boolean {
+  const normalized = file.trim().replace(/\\/g, '/')
+  return normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized)
 }

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -70,6 +70,39 @@ describe('MessageList', () => {
     )
   })
 
+  test('renders a ChatGPT visualize content reference from its absolute path', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<div>可视化内容</div>'))
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:chatgpt-visualization')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-chatgpt-visualization',
+            role: 'assistant',
+            content: [
+              '已生成可视化。',
+              '',
+              'visualize{"path":"/tmp/codex/visualizations/latency.html","title":"Latency"}',
+            ].join('\n'),
+            status: 'done',
+            createdAt: '2026-08-12T10:00:00Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('已生成可视化。')).toBeInTheDocument()
+    expect(screen.queryByText('visualize')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('codex-inline-visualization-frame')).toHaveAttribute(
+        'src',
+        'blob:chatgpt-visualization'
+      )
+    )
+  })
+
   test('offers conversation actions for text selected inside one message body', async () => {
     const onAddSelectionToConversation = vi.fn()
     const onAskSelectionInSidebar = vi.fn()

--- a/wework/src/lib/codex-directives.test.ts
+++ b/wework/src/lib/codex-directives.test.ts
@@ -64,11 +64,32 @@ describe('stripCodexUiDirectives', () => {
     ])
   })
 
+  test('parses ChatGPT visualize content references with absolute paths', () => {
+    const content = [
+      '这里是可视化结果。',
+      '',
+      'visualize{"path":"/tmp/codex/visualizations/latency.html","mode":"wide","title":"Latency"}',
+    ].join('\n')
+
+    expect(splitCodexInlineVisualizations(content)).toEqual([
+      { kind: 'markdown', content: '这里是可视化结果。\n' },
+      {
+        kind: 'visualization',
+        file: '/tmp/codex/visualizations/latency.html',
+        mode: 'wide',
+        title: 'Latency',
+      },
+    ])
+  })
+
   test('preserves malformed, unsafe, and code-fenced visualization directives as markdown', () => {
     const content = [
       '::codex-inline-vis{file="../private.html"}',
+      'visualize{"path":"/tmp/private.html"}',
+      'visualize{"path":"relative/visualizations/trend.html"}',
       '```text',
       '::codex-inline-vis{file="trend.html"}',
+      'visualize{"path":"/tmp/visualizations/trend.html"}',
       '```',
       '::codex-inline-vis{file="trend.txt"}',
     ].join('\n')

--- a/wework/src/lib/codex-directives.ts
+++ b/wework/src/lib/codex-directives.ts
@@ -19,10 +19,11 @@ const CODEX_UI_DIRECTIVE_LINE_PATTERN = new RegExp(
 )
 const CODEX_INLINE_VISUALIZATION_PATTERN =
   /^\s*::codex-inline-vis\{\s*file=(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)')\s*\}\s*$/
+const VISUALIZE_CONTENT_REFERENCE_PATTERN = /^\s*visualize(\{.*\})\s*$/
 
 export type CodexInlineVisualizationPart =
   | { kind: 'markdown'; content: string }
-  | { kind: 'visualization'; file: string }
+  | { kind: 'visualization'; file: string; mode?: 'wide'; title?: string }
 
 export function splitCodexInlineVisualizations(content: string): CodexInlineVisualizationPart[] {
   const parts: CodexInlineVisualizationPart[] = []
@@ -42,20 +43,14 @@ export function splitCodexInlineVisualizations(content: string): CodexInlineVisu
       continue
     }
 
-    const match = inCodeFence ? null : line.match(CODEX_INLINE_VISUALIZATION_PATTERN)
-    if (!match) {
-      markdownLines.push(line)
-      continue
-    }
-
-    const file = unescapeDirectiveValue(match[1] ?? match[2] ?? '')
-    if (!isSafeInlineVisualizationFile(file)) {
+    const visualization = inCodeFence ? null : parseInlineVisualization(line)
+    if (!visualization) {
       markdownLines.push(line)
       continue
     }
 
     flushMarkdown()
-    parts.push({ kind: 'visualization', file })
+    parts.push(visualization)
   }
 
   flushMarkdown()
@@ -99,7 +94,39 @@ function unescapeDirectiveValue(value: string): string {
   return value.replace(/\\([\\"'])/g, '$1')
 }
 
-function isSafeInlineVisualizationFile(file: string): boolean {
+function parseInlineVisualization(line: string): CodexInlineVisualizationPart | null {
+  const legacyMatch = line.match(CODEX_INLINE_VISUALIZATION_PATTERN)
+  if (legacyMatch) {
+    const file = unescapeDirectiveValue(legacyMatch[1] ?? legacyMatch[2] ?? '')
+    return isSafeLegacyVisualizationFile(file) ? { kind: 'visualization', file } : null
+  }
+
+  const contentReferenceMatch = line.match(VISUALIZE_CONTENT_REFERENCE_PATTERN)
+  if (!contentReferenceMatch) return null
+
+  try {
+    const payload = JSON.parse(contentReferenceMatch[1]) as unknown
+    if (!isRecord(payload) || typeof payload.path !== 'string') return null
+
+    const file = payload.path.trim()
+    if (!isSafeAbsoluteVisualizationFile(file)) return null
+    if (payload.mode !== undefined && payload.mode !== 'wide') return null
+    if (payload.title !== undefined && typeof payload.title !== 'string') return null
+
+    return {
+      kind: 'visualization',
+      file,
+      ...(payload.mode === 'wide' ? { mode: 'wide' as const } : {}),
+      ...(typeof payload.title === 'string' && payload.title.trim()
+        ? { title: payload.title.trim() }
+        : {}),
+    }
+  } catch {
+    return null
+  }
+}
+
+function isSafeLegacyVisualizationFile(file: string): boolean {
   const normalized = file.trim().replace(/\\/g, '/')
   return (
     normalized.length > 0 &&
@@ -107,4 +134,18 @@ function isSafeInlineVisualizationFile(file: string): boolean {
     !normalized.split('/').some(segment => segment === '..') &&
     /\.(?:html?|xhtml)$/i.test(normalized)
   )
+}
+
+function isSafeAbsoluteVisualizationFile(file: string): boolean {
+  const normalized = file.replace(/\\/g, '/')
+  return (
+    (normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized)) &&
+    normalized.split('/').includes('visualizations') &&
+    !normalized.split('/').some(segment => segment === '..') &&
+    /\.(?:html?|xhtml)$/i.test(normalized)
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }


### PR DESCRIPTION
## 问题

Wework 只识别旧版 `::codex-inline-vis{file="..."}` 指令，并依赖当前回复的文件变更记录解析相对路径。最新 visualize 技能使用 `visualize{"path":"..."}` 内容引用并返回绝对路径，因此回复中只显示引用文本，未展示可视化内容。

## 修改

- 解析最新 visualize JSON 内容引用，支持 `path`、`title` 和 `mode`
- 安全加载 `visualizations` 目录中的绝对 HTML 路径
- 保留旧版 inline visualization 指令兼容性
- 将标题和宽屏模式传递到 iframe 宿主
- 补充解析器、宿主和消息列表集成测试
- 更新中英文 Wework 使用文档

## 验证

- 预推送完整检查：ESLint、TypeScript、Wework unit tests 全部通过
- Wework production build 通过
- 真实 Tauri 会话中由 Codex 生成最新 visualize 内容引用，Wework 成功展示可见柱状图
- 已逐步检查项目选择、提示词提交、生成中状态、最终可视化和可视化元素截图


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for absolute-path visualization references, including Unix and Windows-style paths.
  * Added optional wide display mode and custom titles for inline visualizations.
  * Retained support for legacy visualization directives.

* **Bug Fixes**
  * Improved validation for file types, path safety, malformed references, and missing file metadata.

* **Documentation**
  * Updated English and Chinese guides with the latest visualization syntax and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->