### PR TITLE
fix(wework): restore conversation mentions after switching

### DIFF
--- a/executor/src/runtime_work/transcript/message_projection.rs
+++ b/executor/src/runtime_work/transcript/message_projection.rs
@@ -291,10 +291,38 @@ fn strip_leading_application_context(content: &str) -> &str {
     if !trimmed.starts_with(APPLICATION_CONTEXT_OPEN) {
         return trimmed;
     }
-    let Some(close_index) = trimmed.find(APPLICATION_CONTEXT_CLOSE) else {
+    let Some(close_index) = matching_application_context_close_index(trimmed) else {
         return trimmed;
     };
     trimmed[close_index + APPLICATION_CONTEXT_CLOSE.len()..].trim_start()
+}
+
+fn matching_application_context_close_index(content: &str) -> Option<usize> {
+    let mut depth = 1;
+    let mut offset = APPLICATION_CONTEXT_OPEN.len();
+
+    while offset < content.len() {
+        let next_open = content[offset..]
+            .find(APPLICATION_CONTEXT_OPEN)
+            .map(|index| offset + index);
+        let next_close = content[offset..]
+            .find(APPLICATION_CONTEXT_CLOSE)
+            .map(|index| offset + index)?;
+
+        if let Some(next_open) = next_open.filter(|index| *index < next_close) {
+            depth += 1;
+            offset = next_open + APPLICATION_CONTEXT_OPEN.len();
+            continue;
+        }
+
+        depth -= 1;
+        if depth == 0 {
+            return Some(next_close);
+        }
+        offset = next_close + APPLICATION_CONTEXT_CLOSE.len();
+    }
+
+    None
 }
 
 pub(crate) fn merge_missing_user_message_metadata(target: &mut Value, source: &Value) {

--- a/executor/src/runtime_work/transcript/tests_core.rs
+++ b/executor/src/runtime_work/transcript/tests_core.rs
@@ -3,6 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::*;
+
+#[test]
+fn visible_user_request_skips_nested_application_context_from_referenced_conversations() {
+    let content = concat!(
+        "<application_context>\n",
+        "[referencedConversations]\n",
+        "[{\"role\":\"user\",\"content\":\"<application_context>\\n",
+        "[source]\\nstate\\n</application_context>\\n\\nOriginal question\"}]\n",
+        "</application_context>\n\n",
+        "Continue with the referenced conversation"
+    );
+
+    assert_eq!(
+        normalized_user_request_content(content),
+        "Continue with the referenced conversation"
+    );
+}
+
 #[test]
 fn transcript_restores_failed_turn_without_assistant_output() {
     let thread = json!({

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -2747,6 +2747,11 @@ last_updated = "2026-07-30T00:00:00Z"`
         control,
         otherTaskRowTestId: secondTaskRowTestId,
       })
+      if (desktopScenario) {
+        phase = 'conversation-mention-switch-restore'
+        desktopScenarioVerified = true
+        await desktopScenario.verify(control)
+      }
       if (shouldStopAfterDesktopCheckpoint('conversation-state')) {
         console.log(`Wework desktop conversation-state checkpoint passed. Evidence: ${resultDir}`)
         return

--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -10,6 +10,7 @@ import { DESKTOP_CHECKPOINTS } from './checkpoints.mjs'
 const HEARTBEAT_INTERVAL_MS = 30_000
 const DEFAULT_PARALLEL_CHECKPOINTS = 3
 const CHECKPOINT_SCENARIO_MODULES = {
+  'conversation-state': './scenarios/conversation-mention.scenario.mjs',
   'embedded-browser': './scenarios/embedded-browser-agent.scenario.mjs',
   'local-harness': './scenarios/local-terminal.scenario.mjs',
   'browser-multi-tabs': './scenarios/embedded-browser-multi-tabs.scenario.mjs',

--- a/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
@@ -134,6 +134,7 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
 
     async verify(control) {
       active = true
+      await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
       const initialTaskRows = new Set(
         JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>

--- a/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
@@ -95,6 +95,7 @@ async function waitForNewTaskRow(control, knownTaskRows, timeoutMs) {
 
 export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
   const capture = (control, name) => captureScreenshot(control, name, ACTIVE_WORKBENCH_SELECTOR)
+  let active = false
   let sourceRequest = null
   let targetRequest = null
 
@@ -102,6 +103,7 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
     codexConfigToml: '\n[features]\nplugins = false\n',
 
     async handleHttp(request, response, url) {
+      if (!active) return false
       if (request.method !== 'POST' || !['/v1/responses', '/responses'].includes(url.pathname)) {
         return false
       }
@@ -131,6 +133,7 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
     },
 
     async verify(control) {
+      active = true
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
       const initialTaskRows = new Set(
         JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>

--- a/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
@@ -113,12 +113,12 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
       const responseId = `wework-conversation-mention-${Date.now()}`
       let completion = ''
 
-      if (serialized.includes(SOURCE_PROMPT) && !serialized.includes('<application_context>')) {
-        sourceRequest = body
-        completion = SOURCE_COMPLETION
-      } else if (serialized.includes('wework-conversation://')) {
+      if (serialized.includes('wework-conversation://')) {
         targetRequest = body
         completion = TARGET_COMPLETION
+      } else if (serialized.includes(SOURCE_PROMPT)) {
+        sourceRequest = body
+        completion = SOURCE_COMPLETION
       }
 
       response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })

--- a/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/conversation-mention.scenario.mjs
@@ -80,6 +80,19 @@ async function selectConversationOption(control, timeoutMs) {
   throw new Error('The referenced conversation could not be selected from the @ menu')
 }
 
+async function waitForNewTaskRow(control, knownTaskRows, timeoutMs) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const snapshot = JSON.parse(await control.command('snapshot', 'body'))
+    const taskRow = snapshot.testIds.find(
+      testId => testId.startsWith('runtime-local-task-row-') && !knownTaskRows.has(testId)
+    )
+    if (taskRow) return taskRow
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error('The conversation mention task row did not appear')
+}
+
 export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
   const capture = (control, name) => captureScreenshot(control, name, ACTIVE_WORKBENCH_SELECTOR)
   let sourceRequest = null
@@ -119,6 +132,11 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
 
     async verify(control) {
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      const initialTaskRows = new Set(
+        JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
+          testId.startsWith('runtime-local-task-row-')
+        )
+      )
       await control.command('fill', COMPOSER_SELECTOR, { value: SOURCE_PROMPT })
       await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
       await control.command('waitFor', '[data-testid="message-assistant"]', {
@@ -126,9 +144,15 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         timeoutMs: uiTimeoutMs,
       })
       assert.ok(sourceRequest, 'The source conversation was not sent through the real runtime')
+      const sourceTaskRow = await waitForNewTaskRow(control, initialTaskRows, uiTimeoutMs)
 
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      const sourceOnlyTaskRows = new Set(
+        JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
+          testId.startsWith('runtime-local-task-row-')
+        )
+      )
       await control.command('fill', COMPOSER_SELECTOR, {
         value: '@WEWORK_CONVERSATION_REFERENCE_SOURCE',
       })
@@ -149,6 +173,7 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         text: TARGET_COMPLETION,
         timeoutMs: uiTimeoutMs,
       })
+      const targetTaskRow = await waitForNewTaskRow(control, sourceOnlyTaskRows, uiTimeoutMs)
 
       assert.ok(targetRequest, 'Selecting the conversation mention did not send a model request')
       const serializedTarget = JSON.stringify(targetRequest)
@@ -169,6 +194,33 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         'The referenced conversation content was not delivered to the model'
       )
       await capture(control, 'conversation-mention-03-sent.png')
+
+      await control.command('click', `[data-testid="${sourceTaskRow}"]`)
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: SOURCE_COMPLETION,
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', `[data-testid="${targetTaskRow}"]`)
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: TARGET_COMPLETION,
+        timeoutMs: uiTimeoutMs,
+      })
+      const restoredSnapshot = JSON.parse(
+        await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
+      )
+      assert.ok(
+        !restoredSnapshot.text.includes(SOURCE_COMPLETION),
+        'Switching back exposed the referenced assistant response in the user message'
+      )
+      assert.ok(
+        !restoredSnapshot.text.includes('untrusted background context'),
+        'Switching back exposed the serialized referenced-conversation context'
+      )
+      assert.ok(
+        !restoredSnapshot.text.includes('{"role":"assistant"'),
+        'Switching back rendered referenced-conversation JSON as user-visible text'
+      )
+      await capture(control, 'conversation-mention-04-restored.png')
     },
 
     diagnostics() {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -804,6 +804,18 @@ describe('ScrollableMessageArea', () => {
               '<application_context>',
               '[wework.terminal.current]',
               'Wework terminal context',
+              '[referencedConversations]',
+              JSON.stringify([
+                {
+                  role: 'user',
+                  content:
+                    '<application_context>\\n[source]\\nstate\\n</application_context>\\n\\nReferenced question',
+                },
+                {
+                  role: 'assistant',
+                  content: 'Referenced answer that must stay hidden',
+                },
+              ]),
               '</application_context>',
               '',
               '第二条用户需求',
@@ -890,6 +902,7 @@ describe('ScrollableMessageArea', () => {
     expect(screen.getAllByText('第一条回复摘要')).toHaveLength(2)
     expect(screen.getAllByText('第二条用户需求')).toHaveLength(2)
     expect(screen.queryByText(/application_context/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Referenced answer that must stay hidden/)).not.toBeInTheDocument()
   })
 
   test('renders message navigation in an overlay outside the external scroller', () => {

--- a/wework/src/lib/runtime-user-message.test.ts
+++ b/wework/src/lib/runtime-user-message.test.ts
@@ -32,6 +32,26 @@ describe('runtime user message', () => {
     ).toBe('Continue fixing')
   })
 
+  test('removes the complete wrapper when referenced conversations contain nested contexts', () => {
+    const referencedConversation = JSON.stringify([
+      {
+        role: 'user',
+        content:
+          '<application_context>\\n[source]\\nsource state\\n</application_context>\\n\\nOriginal question',
+      },
+    ])
+    const content = [
+      '<application_context>',
+      '[referencedConversations]',
+      referencedConversation,
+      '</application_context>',
+      '',
+      'Continue with the referenced conversation',
+    ].join('\n')
+
+    expect(visibleRuntimeUserMessage(content)).toBe('Continue with the referenced conversation')
+  })
+
   test('preserves malformed context instead of dropping user content', () => {
     expect(visibleRuntimeUserMessage('<application_context>\nuser text')).toBe(
       '<application_context>\nuser text'

--- a/wework/src/lib/runtime-user-message.ts
+++ b/wework/src/lib/runtime-user-message.ts
@@ -28,8 +28,31 @@ function stripLeadingApplicationContext(content: string): string {
   const trimmed = content.trimStart()
   if (!trimmed.startsWith(APPLICATION_CONTEXT_OPEN)) return trimmed.trim()
 
-  const closeIndex = trimmed.indexOf(APPLICATION_CONTEXT_CLOSE)
+  const closeIndex = matchingApplicationContextCloseIndex(trimmed)
   if (closeIndex < 0) return trimmed.trim()
 
   return trimmed.slice(closeIndex + APPLICATION_CONTEXT_CLOSE.length).trim()
+}
+
+function matchingApplicationContextCloseIndex(content: string): number {
+  let depth = 1
+  let offset = APPLICATION_CONTEXT_OPEN.length
+
+  while (offset < content.length) {
+    const nextOpen = content.indexOf(APPLICATION_CONTEXT_OPEN, offset)
+    const nextClose = content.indexOf(APPLICATION_CONTEXT_CLOSE, offset)
+    if (nextClose < 0) return -1
+
+    if (nextOpen >= 0 && nextOpen < nextClose) {
+      depth += 1
+      offset = nextOpen + APPLICATION_CONTEXT_OPEN.length
+      continue
+    }
+
+    depth -= 1
+    if (depth === 0) return nextClose
+    offset = nextClose + APPLICATION_CONTEXT_CLOSE.length
+  }
+
+  return -1
 }


### PR DESCRIPTION
## Summary

- parse nested `<application_context>` blocks by matching the outer closing tag in both Wework and executor transcript projection
- prevent referenced conversation JSON and assistant content from leaking into restored user messages after switching conversations
- add unit, component, Rust regression coverage and register the conversation mention desktop scenario in the CI-covered `conversation-state` checkpoint

## Verification

- `pnpm --filter wework test src/lib/runtime-user-message.test.ts src/components/chat/ScrollableMessageArea.test.tsx` (66 tests passed)
- `cargo test --manifest-path executor/Cargo.toml visible_user_request_skips_nested_application_context_from_referenced_conversations`
- `cargo fmt --manifest-path executor/Cargo.toml -- --check`
- package-local Prettier, ESLint, and Node syntax checks
- pre-push checks: Wework ESLint, TypeScript, unit tests; Executor fmt, lib tests, Clippy

## Desktop E2E note

`conversation-state` was attempted twice locally. Both runs failed before the conversation mention scenario started, in the existing local-project initialization flow (`confirm-local-project-create-button`, then `confirm-device-folder-picker-button`). In both evidence states, `desktopScenario.receivedSourceRequest=false`; the existing E2E flow was not modified to mask these unrelated failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented referenced conversation details, assistant responses, and background context from appearing in user-visible messages.
  * Improved handling of nested application context blocks while preserving surrounding request text.
  * Preserved content safely when context markers are incomplete or malformed.

* **Tests**
  * Added coverage for nested context removal, restored conversations, task reopening, and message rendering.
  * Expanded desktop conversation-state checkpoint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->