### PR TITLE
fix(ci): continue when sccache is unavailable

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -11,11 +11,20 @@ runs:
   using: composite
   steps:
     - name: Install sccache
+      id: install
+      continue-on-error: true
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba
       with:
         version: ${{ inputs.version }}
 
+    - name: Report unavailable sccache
+      if: steps.install.outcome != 'success'
+      shell: bash
+      run: |
+        echo "::warning::sccache is unavailable; continuing without Rust compiler caching"
+
     - name: Export GitHub Actions cache credentials
+      if: steps.install.outcome == 'success'
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
       with:
         script: |
@@ -30,6 +39,7 @@ runs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', runtimeToken)
 
     - name: Configure Rust compiler cache
+      if: steps.install.outcome == 'success'
       shell: bash
       run: |
         {

--- a/.github/scripts/test-ci-cache-policy.sh
+++ b/.github/scripts/test-ci-cache-policy.sh
@@ -165,12 +165,17 @@ sccache_action="$action_dir/setup-sccache/action.yml"
 # Environment variables are matched literally in action source.
 # shellcheck disable=SC2016
 if ! grep -Fq 'SCCACHE_BASEDIRS=$GITHUB_WORKSPACE' "$sccache_action" ||
+  ! grep -Fq 'continue-on-error: true' "$sccache_action" ||
+  [[ "$(grep -Fc "if: steps.install.outcome == 'success'" \
+    "$sccache_action")" -ne 2 ]] ||
+  ! grep -Fq "if: steps.install.outcome != 'success'" "$sccache_action" ||
+  ! grep -Fq 'continuing without Rust compiler caching' "$sccache_action" ||
   ! grep -Fq 'GitHub Actions cache credentials are unavailable for sccache' \
     "$sccache_action" ||
   ! grep -Fq 'SCCACHE_GHA_VERSION=wegent-sccache-v1-' "$sccache_action" ||
   ! grep -Fq 'SCCACHE_GHA_RW_MODE=READ_ONLY' "$sccache_action" ||
   ! grep -Fq 'refs/heads/main' "$sccache_action"; then
-  fail "sccache must normalize paths and allow writes only from main"
+  fail "sccache must degrade safely and allow cache writes only from main"
 fi
 
 if ! grep -Fq 'name: Warm Wework macOS Rust Cache' "$warmup_workflow" ||

--- a/docs/en/wegent/developer-guide/testing.md
+++ b/docs/en/wegent/developer-guide/testing.md
@@ -315,7 +315,10 @@ runs may restore the default-branch cache, but they do not save another copy:
 - Rust unit tests, the Windows check, release and snapshot binaries, and the
   macOS memory gate use sccache. The `main` warmup runs the same desktop
   `--build-only` flow on `macos-14`; non-`main` jobs access the shared compiler
-  cache in read-only mode.
+  cache in read-only mode. sccache is an optional acceleration layer: when its
+  release download is temporarily unavailable, jobs must warn and continue
+  with uncached Rust compilation instead of skipping or blocking the real
+  check.
 - Wework Desktop Core E2E retains its `main`-owned Cargo target cache because
   several desktop jobs must reuse the same complete binary output.
 - Platform E2E, Release, and Snapshot Docker BuildKit caches live in

--- a/docs/zh/wegent/developer-guide/testing.md
+++ b/docs/zh/wegent/developer-guide/testing.md
@@ -299,7 +299,9 @@ CI 稳定性依赖以下约束：
   通过仓库内的 `package-lock.json` 锁定完整依赖图和包完整性。
 - Rust 单测、Windows check、发布、快照和 macOS 内存门禁通过 sccache 复用编译器
   输出。`main` 预热会在 `macos-14` 上执行与内存门禁一致的桌面
-  `--build-only`，非 `main` 任务以只读模式访问共享 sccache。
+  `--build-only`，非 `main` 任务以只读模式访问共享 sccache。sccache 只是可选
+  加速层；当 release 下载暂时不可用时，任务必须发出告警并继续执行无缓存 Rust
+  编译，不能跳过或阻断实际检查。
 - Wework Desktop Core E2E 继续使用 `main` 拥有的 Cargo target cache，因为它需要
   在多个桌面 job 之间复用同一套完整二进制产物。
 - 平台 E2E、Release 和 Snapshot 的 Docker BuildKit cache 存放在对应 GHCR 镜像的


### PR DESCRIPTION
## What changed

- treat the shared sccache installer as an optional CI acceleration layer
- continue Rust checks without `RUSTC_WRAPPER` when the release download fails
- emit an explicit warning and skip cache credential/configuration steps after installation failure
- document and test the cache degradation policy in Chinese and English

## Why

A Windows Rust check on August 12, 2026 failed before compilation because the sccache release download hit a socket hang up followed by repeated HTTP 503 responses. Compiler caching must not become a prerequisite for the real Rust check.

## Validation

- `bash .github/scripts/test-ci-cache-policy.sh`
- `pnpm exec prettier --check .github/actions/setup-sccache/action.yml docs/zh/wegent/developer-guide/testing.md docs/en/wegent/developer-guide/testing.md`
- `git diff --check`
- pre-push quality checks
