### PR TITLE
feat(quick-access): add search functionality for all agents in favori…

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
@@ -35,6 +35,7 @@ jest.mock('@/hooks/useTranslation', () => ({
         'common:teams.more': 'More',
         'common:teams.select_team': 'Select team',
         'common:teams.search_team': 'Search team',
+        'common:teams.search_all_agents': 'Search all agents...',
         'common:teams.no_match': 'No match',
         'common:teams.reorder_quick_access': 'Drag to reorder',
         'teams.create_first_team': 'Create Agent',
@@ -756,6 +757,51 @@ describe('QuickAccessCards', () => {
     expect(await screen.findByTestId('quick-access-more-team-system-team')).toHaveTextContent(
       'System Team Display'
     )
+  })
+
+  test('searches all agents directly from the favorites view', async () => {
+    renderQuickAccessCards(
+      [
+        makeTeam({ id: 2, name: 'favorite-team' }),
+        makeTeam({
+          id: 3,
+          name: 'other-team',
+          displayName: 'Other Agent',
+          bind_mode: ['image'],
+        }),
+      ],
+      {
+        system_version: 2,
+        system_team_ids: [],
+        user_version: 2,
+        show_system_recommended: false,
+        teams: [
+          {
+            id: 2,
+            name: 'favorite-team',
+            display_name: 'Favorite Agent',
+            is_system: false,
+            recommended_mode: 'chat',
+          },
+        ],
+      }
+    )
+
+    fireEvent.click(await screen.findByText('More'))
+
+    expect(screen.queryByTestId('quick-access-more-team-other-team')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Search all agents...'), {
+      target: { value: 'Other Agent' },
+    })
+
+    expect(await screen.findByTestId('quick-access-more-team-other-team')).toHaveTextContent(
+      'Other Agent'
+    )
+
+    fireEvent.click(screen.getByTestId('quick-access-more-team-other-team'))
+
+    expect(routerPush).toHaveBeenCalledWith('/chat?teamId=3&mode=image')
   })
 
   test('shows generation agents in all agents and switches to their mode', async () => {

--- a/frontend/src/features/tasks/components/chat/QuickAccessCards.tsx
+++ b/frontend/src/features/tasks/components/chat/QuickAccessCards.tsx
@@ -161,7 +161,10 @@ export function QuickAccessCards({
   const hasTeamsOutsideQuickAccess = allSelectableTeams.some(
     team => !quickAccessTeamIds.has(team.id)
   )
-  const morePopoverTeams = showAllTeamsInMore ? allSelectableTeams : displayTeams
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const isSearchingAllTeams = normalizedSearchQuery.length > 0
+  const isShowingAllTeams = showAllTeamsInMore || isSearchingAllTeams
+  const morePopoverTeams = isShowingAllTeams ? allSelectableTeams : displayTeams
   const favoriteQuickAccessTeamIds = quickAccessTeams
     .filter(team => !team.is_system && !systemRecommendedQuickAccessIdSet.has(team.id))
     .map(team => team.id)
@@ -179,10 +182,9 @@ export function QuickAccessCards({
 
   // Filter teams by search query for the more popover
   const filteredTeamsBySearch = morePopoverTeams.filter(team => {
-    const normalizedSearch = searchQuery.toLowerCase()
     return (
-      getTeamDisplayName(team).toLowerCase().includes(normalizedSearch) ||
-      team.name.toLowerCase().includes(normalizedSearch)
+      getTeamDisplayName(team).toLowerCase().includes(normalizedSearchQuery) ||
+      team.name.toLowerCase().includes(normalizedSearchQuery)
     )
   })
 
@@ -195,7 +197,7 @@ export function QuickAccessCards({
   }
 
   const handleSelectTeamFromMore = (team: Team) => {
-    if (showAllTeamsInMore) {
+    if (isShowingAllTeams) {
       const targetPage = getTeamTargetPage(team, 'all')
       const currentPage = getCurrentTargetPageByMode(currentMode)
       if (targetPage !== currentPage) {
@@ -424,9 +426,7 @@ export function QuickAccessCards({
     const popoverDescription = showAllTeamsInMore
       ? t('common:teams.all_agents_description')
       : t('common:teams.quick_access_description')
-    const searchPlaceholder = showAllTeamsInMore
-      ? t('common:teams.search_all_agents')
-      : t('common:teams.search_quick_access')
+    const searchPlaceholder = t('common:teams.search_all_agents')
 
     return (
       <Popover open={morePopoverOpen} onOpenChange={handleMorePopoverOpenChange}>
@@ -487,7 +487,7 @@ export function QuickAccessCards({
               favoriteUpdatingTeamId={favoriteUpdatingTeamId}
               onToggleFavorite={handleToggleFavorite}
               optionTestIdPrefix="quick-access-more-team"
-              showReorderHandle={!showAllTeamsInMore}
+              showReorderHandle={!isShowingAllTeams}
               canReorder={displayTeams.length > 1}
               dragOverTeamId={dragOverTeamId}
               onTeamDragStart={handleQuickAccessDragStart}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -360,7 +360,6 @@
     "quick_access_back": "Back to favorites",
     "all_agents_title": "All agents",
     "all_agents_description": "Choose from all available agents.",
-    "search_quick_access": "Search favorite agents...",
     "search_all_agents": "Search all agents...",
     "new_team": "New Team",
     "search_placeholder": "Search team...",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -360,7 +360,6 @@
     "quick_access_back": "返回常用智能体",
     "all_agents_title": "全部智能体",
     "all_agents_description": "从所有可用的智能体中选择。",
-    "search_quick_access": "搜索常用智能体...",
     "search_all_agents": "搜索全部智能体...",
     "new_team": "新建智能体",
     "search_placeholder": "搜索智能体...",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search in the “More teams” view now includes all available agents, not just favorites.
  * Search queries are trimmed and normalized for more reliable results.
  * Selecting a searched agent navigates directly to its image mode.

* **UI Improvements**
  * Updated search wording to clarify that all agents are included.
  * Reordering controls are hidden while searching or viewing all teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->