### PR TITLE
fix(ci): reuse Wework desktop Cargo cache

### DIFF
--- a/.github/scripts/classify-ci-cache-warmup.sh
+++ b/.github/scripts/classify-ci-cache-warmup.sh
@@ -63,6 +63,10 @@ classify_path() {
       changed[executor_rust]=true
       changed[wework_target]=true
       ;;
+    docker/wework-e2e/desktop.Dockerfile)
+      changed[docker]=true
+      changed[wework_target]=true
+      ;;
     executor/*)
       changed[docker]=true
       changed[executor_rust]=true

--- a/.github/scripts/test-ci-cache-policy.sh
+++ b/.github/scripts/test-ci-cache-policy.sh
@@ -85,6 +85,11 @@ executor_lock="${executor_lock/executor_rust=false/executor_rust=true}"
 executor_lock="${executor_lock/wework_target=false/wework_target=true}"
 assert_warmup_case "executor lock" "$executor_lock" "executor/Cargo.lock"
 
+desktop_image="${warmup_all_false/docker=false/docker=true}"
+desktop_image="${desktop_image/wework_target=false/wework_target=true}"
+assert_warmup_case "Wework desktop image" "$desktop_image" \
+  "docker/wework-e2e/desktop.Dockerfile"
+
 wework_lock="${warmup_all_false/wework_rust=false/wework_rust=true}"
 wework_lock="${wework_lock/wework_target=false/wework_target=true}"
 assert_warmup_case "Wework lock" "$wework_lock" \
@@ -270,10 +275,19 @@ fi
 
 # GitHub expressions are matched literally in workflow source.
 # shellcheck disable=SC2016
-wework_target_key='wework-desktop-e2e-v2-${{ hashFiles('\''executor/Cargo.lock'\'', '\''wework/src-tauri/Cargo.lock'\'') }}'
+wework_target_key='wework-desktop-e2e-v3-${{ hashFiles('\''docker/wework-e2e/desktop.Dockerfile'\'') }}-${{ hashFiles('\''executor/Cargo.lock'\'', '\''wework/src-tauri/Cargo.lock'\'') }}'
 if ! grep -Fq "$wework_target_key" "$workflow_dir/wework-e2e.yml" ||
   ! grep -Fq "$wework_target_key" "$warmup_workflow"; then
   fail "Wework E2E and warmup must share the desktop Cargo target cache"
+fi
+
+if ! grep -A40 'name: Warm Wework Desktop Cargo Target' "$warmup_workflow" |
+  grep -Fq 'image: ${{ needs.prepare-wework-desktop-image.outputs.desktop_image }}' ||
+  ! grep -A40 'name: Warm Wework Desktop Cargo Target' "$warmup_workflow" |
+    grep -Fq 'HOME: /root' ||
+  grep -A40 'name: Warm Wework Desktop Cargo Target' "$warmup_workflow" |
+    grep -Eq 'install-wework-tauri-system-dependencies|dtolnay/rust-toolchain'; then
+  fail "Wework desktop target warmup must build inside the E2E container"
 fi
 
 printf 'CI cache policy tests passed\n'

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -556,10 +556,12 @@ fi
 
 # GitHub expressions are matched literally in workflow source.
 # shellcheck disable=SC2016
-if ! grep -Fq '${{ runner.os }}-wework-desktop-e2e-v2-' \
+if ! grep -Fq '${{ runner.os }}-wework-desktop-e2e-v3-' \
   <<<"$desktop_cache_key" ||
+  ! grep -Fq "hashFiles('docker/wework-e2e/desktop.Dockerfile')" \
+    <<<"$desktop_cache_key" ||
   grep -Fq '${{ matrix.command }}' <<<"$desktop_cache_key"; then
-  printf 'Wework desktop E2E Cargo cache key must not vary by command\n' >&2
+  printf 'Wework desktop E2E Cargo cache key must follow the desktop image\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/ci-cache-warmup.yml
+++ b/.github/workflows/ci-cache-warmup.yml
@@ -22,6 +22,7 @@ on:
       - ".github/workflows/test.yml"
       - ".github/workflows/wework-e2e.yml"
       - "backend/uv.lock"
+      - "docker/wework-e2e/desktop.Dockerfile"
       - "executor/**"
       - "executor_manager/uv.lock"
       - "frontend/e2e/fixtures/claudecode-executor/**"
@@ -404,12 +405,17 @@ jobs:
             ~/.cargo/git
           key: ${{ steps.wework-cargo-sources-cache.outputs.cache-primary-key }}
 
-  warm-wework-desktop-target:
-    name: Warm Wework Desktop Cargo Target
+  prepare-wework-desktop-image:
+    name: Prepare Wework Desktop E2E Image
     needs: changes
     if: needs.changes.outputs.wework_target == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      desktop_image: ${{ steps.image.outputs.desktop-ref }}
 
     steps:
       - name: Checkout code
@@ -417,39 +423,76 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set APT cache key
-        id: apt-cache-key
+      - name: Resolve Wework desktop E2E image
+        id: image
         run: |
-          week="$(date -u +'%G-%V')"
-          echo "key=apt-$RUNNER_OS-$RUNNER_ARCH-wework-v1-$week" \
+          desktop_digest="$(
+            sha256sum docker/wework-e2e/desktop.Dockerfile | cut -d ' ' -f 1
+          )"
+          echo "desktop-ref=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wegent-wework-e2e:desktop-$desktop_digest" \
             >> "$GITHUB_OUTPUT"
 
-      - name: Restore shared Tauri system packages
-        id: wework-apt-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
-          path: ~/.cache/wework-apt/archives
-          key: ${{ steps.apt-cache-key.outputs.key }}
-          restore-keys: |
-            apt-${{ runner.os }}-${{ runner.arch }}-wework-v1-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Tauri build dependencies
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Check Wework desktop E2E image
+        id: desktop-image-check
         env:
-          DEBIAN_FRONTEND: noninteractive
-        run: .github/scripts/install-wework-tauri-system-dependencies.sh full redis
+          IMAGE: ${{ steps.image.outputs.desktop-ref }}
+        run: |
+          if docker buildx imagetools inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Save shared Tauri system packages
-        if: steps.wework-apt-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Build and publish Wework desktop E2E image
+        if: steps.desktop-image-check.outputs.exists != 'true'
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
-          path: ~/.cache/wework-apt/archives
-          key: ${{ steps.wework-apt-cache.outputs.cache-primary-key }}
+          context: .
+          file: docker/wework-e2e/desktop.Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.desktop-ref }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wegent-wework-e2e:buildcache-desktop
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wegent-wework-e2e:buildcache-desktop,mode=max
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+  warm-wework-desktop-target:
+    name: Warm Wework Desktop Cargo Target
+    needs:
+      - changes
+      - prepare-wework-desktop-image
+    if: needs.changes.outputs.wework_target == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    env:
+      HOME: /root
+    container:
+      image: ${{ needs.prepare-wework-desktop-image.outputs.desktop_image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Node workspace
         uses: ./.github/actions/setup-node-workspace
+        with:
+          setup-toolchain: "false"
 
       - name: Restore shared Wework desktop E2E Cargo dependencies
         id: wework-desktop-cargo-cache
@@ -460,9 +503,9 @@ jobs:
             ~/.cargo/git
             executor/target
             wework/src-tauri/target
-          key: ${{ runner.os }}-wework-desktop-e2e-v2-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-wework-desktop-e2e-v3-${{ hashFiles('docker/wework-e2e/desktop.Dockerfile') }}-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-wework-desktop-e2e-v2-
+            ${{ runner.os }}-wework-desktop-e2e-v3-${{ hashFiles('docker/wework-e2e/desktop.Dockerfile') }}-
 
       - name: Prepare bundled sidecars
         if: steps.wework-desktop-cargo-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -231,9 +231,9 @@ jobs:
             ~/.cargo/git
             executor/target
             wework/src-tauri/target
-          key: ${{ runner.os }}-wework-desktop-e2e-v2-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-wework-desktop-e2e-v3-${{ hashFiles('docker/wework-e2e/desktop.Dockerfile') }}-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-wework-desktop-e2e-v2-
+            ${{ runner.os }}-wework-desktop-e2e-v3-${{ hashFiles('docker/wework-e2e/desktop.Dockerfile') }}-
 
       - name: Prepare bundled sidecars
         working-directory: ./wework
@@ -458,9 +458,9 @@ jobs:
             ~/.cargo/git
             executor/target
             wework/src-tauri/target
-          key: ${{ runner.os }}-wework-desktop-e2e-v2-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-wework-desktop-e2e-v3-${{ hashFiles('docker/wework-e2e/desktop.Dockerfile') }}-${{ hashFiles('executor/Cargo.lock', 'wework/src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-wework-desktop-e2e-v2-
+            ${{ runner.os }}-wework-desktop-e2e-v3-${{ hashFiles('docker/wework-e2e/desktop.Dockerfile') }}-
 
       - name: Prepare bundled sidecars
         working-directory: ./wework


### PR DESCRIPTION
## What changed

- run the Wework desktop Cargo target warmup inside the same immutable desktop E2E container used by consumers
- remove the host-runner Tauri dependency and Rust setup path from that warmup
- version the shared cache as `v3` and bind it to the desktop image Dockerfile plus both Cargo lockfiles
- rebuild the desktop dependency image from the warmup workflow when its content-addressed image is missing
- extend cache policy and change-classification checks for the containerized warmup

## Why

The previous warmup generated Cargo artifacts under `/home/runner/work/...` with Cargo sources under `/home/runner/.cargo`, while desktop E2E consumed them under `/__w/...` and `/root/.cargo` inside a container. The cache archive matched exactly, but Cargo fingerprints and source paths were not reusable, so dependencies were downloaded and compiled again.

## Validation

- `bash .github/scripts/test-ci-cache-policy.sh`
- `bash .github/scripts/test-classify-ci-changes.sh`
- parsed both changed workflow files with Ruby YAML
- `actionlint .github/workflows/ci-cache-warmup.yml .github/workflows/wework-e2e.yml`
- `git diff --check origin/main...HEAD`
