### PR TITLE
fix(wework): preserve focused vitest filters

### DIFF
--- a/docs/en/wegent/developer-guide/testing.md
+++ b/docs/en/wegent/developer-guide/testing.md
@@ -227,6 +227,27 @@ frontend/src/__tests__/
 └── components/              # Component tests
 ```
 
+## Wework Unit Tests
+
+Run the complete Wework unit test suite from the repository root:
+
+```bash
+pnpm --dir wework test
+```
+
+When debugging one test file, pass its path or file name to the test script.
+The following forms are equivalent and collect only matching Vitest files:
+
+```bash
+pnpm --dir wework test runtimePaneMessages.test.ts
+pnpm --dir wework test -- runtimePaneMessages.test.ts
+```
+
+For compatibility, the test script removes one standalone leading `--`, then
+passes all remaining file filters and Vitest options through unchanged. For a
+focused run, confirm that the reported `Test Files` count matches the intended
+scope so an accidental full-suite run is caught immediately.
+
 ## Wework Desktop Cloud Device Tests
 
 Run the cloud-device feature E2E from the repository root:

--- a/docs/zh/wegent/developer-guide/testing.md
+++ b/docs/zh/wegent/developer-guide/testing.md
@@ -227,6 +227,26 @@ frontend/src/__tests__/
 └── components/              # 组件测试
 ```
 
+## Wework 单元测试
+
+从仓库根目录运行全部 Wework 单元测试：
+
+```bash
+pnpm --dir wework test
+```
+
+调试单个测试文件时，将文件路径或文件名传给测试脚本。以下两种形式等价，都会只
+收集匹配的 Vitest 测试文件：
+
+```bash
+pnpm --dir wework test runtimePaneMessages.test.ts
+pnpm --dir wework test -- runtimePaneMessages.test.ts
+```
+
+测试脚本会兼容性地移除参数开头的一个独立 `--`，再把其余文件过滤条件和 Vitest
+选项原样传递给测试运行器。运行聚焦测试时，应确认输出中的 `Test Files` 数量符合
+预期，避免误跑全量测试。
+
 ## Wework 桌面云设备测试
 
 从仓库根目录运行云设备功能 E2E：

--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -45,12 +45,12 @@ pnpm --filter wework exec prettier --check <changed-files>
 pnpm --filter wework exec eslint <changed-files>
 ```
 
-- Pass Vitest file paths and filters directly after `test`. Never insert an
-  extra `--` (for example, do not run
-  `pnpm --filter wework test -- <test-file>`), because Vitest can ignore the
-  intended filter and collect the full suite. When running a focused test,
-  confirm the initial collection output matches the requested files and stop
-  the run immediately if it starts collecting unrelated tests.
+- Pass Vitest file paths and filters directly after `test`. The test runner
+  also removes one leading `--` for compatibility with generated commands, so
+  both `pnpm --filter wework test <test-file>` and
+  `pnpm --filter wework test -- <test-file>` remain focused. When running a
+  focused test, confirm the initial collection output matches the requested
+  files and stop the run immediately if it starts collecting unrelated tests.
 
 Direct debug Cargo builds create marked, unavailable stubs for ignored bundled
 sidecars when their real binaries have not been prepared. Do not prepare DWS

--- a/wework/package.json
+++ b/wework/package.json
@@ -24,7 +24,7 @@
     "lint:task-lifecycle": "node scripts/check-runtime-task-lifecycle.mjs",
     "typecheck": "tsc -b",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.mjs",
     "test:watch": "vitest",
     "test:kimi-k3-profile": "node scripts/verify-kimi-k3-profile.mjs",
     "e2e": "playwright test",

--- a/wework/scripts/run-vitest.mjs
+++ b/wework/scripts/run-vitest.mjs
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process'
+
+const rawArgs = process.argv.slice(2)
+const vitestArgs = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs
+const result = spawnSync('vitest', ['run', ...vitestArgs], {
+  stdio: 'inherit',
+})
+
+if (result.error) {
+  throw result.error
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal)
+}
+
+process.exit(result.status ?? 1)


### PR DESCRIPTION
## What changed

- route the Wework `test` script through a small Vitest argument normalizer
- remove one standalone leading `--` while preserving all remaining file filters and Vitest options
- document focused Wework unit-test commands in Chinese and English contributor documentation
- update the scoped Wework contributor instructions to describe both supported command forms

## Why

Generated commands commonly use `pnpm --dir wework test -- <test-file>`. Vitest can treat the extra separator in a way that loses the intended file filter and collects the full suite. This makes a targeted unit-test request unexpectedly expensive.

The wrapper normalizes that common command form at the package-script boundary, so both forms remain focused:

```bash
pnpm --dir wework test runtimePaneMessages.test.ts
pnpm --dir wework test -- runtimePaneMessages.test.ts
```

## Impact

Focused Wework test commands no longer depend on callers remembering the package manager's argument-forwarding detail. Existing full-suite and direct-filter commands keep their behavior.

## Validation

- both command forms collected exactly 1 test file and passed all 51 tests in `runtimePaneMessages.test.ts`
- pre-commit Prettier, ESLint, and typography checks passed
- pre-push Wework ESLint passed
- pre-push Wework TypeScript checks passed
- pre-push Wework unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guidance for running the complete test suite and targeted tests.
  * Clarified command-line argument handling and how to verify that focused tests collect only the requested files.
* **Developer Experience**
  * Improved the test command to consistently forward filters and options.
  * Test execution now reports failures reliably, handles interruptions cleanly, and preserves the test runner’s exit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->