### PR TITLE
fix(wework): keep guidance above composer

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -553,6 +553,10 @@ recipe closely:
   Short threads therefore fill the viewport while long and virtualized threads
   grow naturally. Keep bottom following stable across delayed virtual
   measurements, but stop following immediately after an explicit user scroll.
+- When guidance or another runtime event inserts, removes, or reorders messages
+  inside a virtualized thread, remeasure mounted rows from the first changed
+  index. The virtual container must include every rendered row so no message can
+  appear below or behind the sticky composer.
 
 The Composer is not a green brand block, a thick outlined form, or a card with
 an exaggerated shadow.

--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -720,6 +720,20 @@ async function verifyForegroundGuidanceScroll({ composerSelector, control, retur
       scroller,
     })}`
   )
+  const composerMetrics = JSON.parse(
+    await control.command(
+      'getElementMetrics',
+      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-floating-composer-card"]`
+    )
+  ).at(-1)
+  assert.ok(composerMetrics, 'The conversation composer was not rendered after guidance')
+  assert.ok(
+    guidanceMessage.bottom <= composerMetrics.top + 2,
+    `The newly applied guidance message rendered below the composer: ${JSON.stringify({
+      guidanceMessage,
+      composer: composerMetrics,
+    })}`
+  )
   await captureVerificationScreenshot(control, 'guidance-scroll-01-message-visible.png')
 
   control.releaseGuidanceScrollCompletion()

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -226,6 +226,7 @@ export const MessageList = memo(function MessageList({
   const { t } = useTranslation('common')
   const listRef = useRef<HTMLDivElement>(null)
   const layoutWidthUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const previousVisibleMessageIdsRef = useRef<string[]>([])
   const [isTextSelectionActive, setIsTextSelectionActive] = useState(false)
   const [textSelection, setTextSelection] = useState<MessageTextSelection | null>(null)
   const [layoutWidth, setLayoutWidth] = useState(0)
@@ -337,6 +338,33 @@ export const MessageList = memo(function MessageList({
     if (!virtualMessages) return
     onVirtualLayoutChange?.()
   }, [onVirtualLayoutChange, virtualMessages, virtualTotalSize])
+
+  useLayoutEffect(() => {
+    const previousIds = previousVisibleMessageIdsRef.current
+    const nextIds = visibleMessages.map(message => message.id)
+    previousVisibleMessageIdsRef.current = nextIds
+    if (!virtualMessages || previousIds.length === 0) return
+
+    const firstDifferentIndex = nextIds.findIndex((id, index) => previousIds[index] !== id)
+    if (firstDifferentIndex < 0 && previousIds.length === nextIds.length) return
+    const changedIndex =
+      firstDifferentIndex >= 0 ? firstDifferentIndex : Math.min(previousIds.length, nextIds.length)
+
+    const virtualItemsByIndex = new Map(
+      messageVirtualizer.getVirtualItems().map(item => [item.index, item])
+    )
+    listRef.current?.querySelectorAll<HTMLElement>('[data-index]').forEach(row => {
+      const index = Number(row.dataset.index)
+      if (!Number.isInteger(index) || index < changedIndex) return
+
+      const virtualItem = virtualItemsByIndex.get(index)
+      if (!virtualItem) return
+      const measuredSize = Math.ceil(row.getBoundingClientRect().height)
+      if (virtualItem.size !== measuredSize) {
+        messageVirtualizer.resizeItem(index, measuredSize)
+      }
+    })
+  }, [messageVirtualizer, virtualMessages, visibleMessages])
 
   useLayoutEffect(() => {
     if (

--- a/wework/src/components/chat/MessageList.virtualization.test.tsx
+++ b/wework/src/components/chat/MessageList.virtualization.test.tsx
@@ -51,6 +51,8 @@ vi.mock('@tanstack/react-virtual', () => ({
           index,
           key: options.getItemKey(index),
           start: index * 120,
+          size: 100,
+          end: index * 120 + 100,
         })),
       measureElement: measureElementMock,
       resizeItem: resizeItemMock,
@@ -196,6 +198,49 @@ describe('MessageList Tauri virtualization', () => {
         anchorTo: 'end',
       })
     )
+  })
+
+  test('remeasures mounted rows after guidance changes the message sequence', () => {
+    const messages = buildMessages(3, 'guidance-layout')
+    const guidanceMessage = {
+      ...buildMessages(1, 'mid-turn-guidance')[0],
+      id: 'guidance-message',
+      runtimeGuidance: true,
+    }
+    const props = {
+      messages: [messages[0], guidanceMessage, messages[2]],
+      scrollElementRef: { current: createScrollElement(200) },
+    }
+    const view = render(<MessageList {...props} />)
+    const guidanceRow = screen.getByText('mid-turn-guidance message 0').closest('[data-index]')
+    expect(guidanceRow).not.toBeNull()
+    vi.spyOn(guidanceRow!, 'getBoundingClientRect').mockReturnValue({
+      bottom: 180,
+      height: 180,
+      left: 0,
+      right: 800,
+      top: 0,
+      width: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+    resizeItemMock.mockClear()
+
+    const assistantContinuation = {
+      ...buildMessages(1, 'assistant-continuation')[0],
+      id: 'assistant-continuation',
+      role: 'assistant' as const,
+      status: 'streaming' as const,
+    }
+    view.rerender(
+      <MessageList
+        {...props}
+        messages={[messages[0], assistantContinuation, guidanceMessage, messages[2]]}
+      />
+    )
+
+    expect(resizeItemMock).toHaveBeenCalledWith(2, 180)
   })
 
   test('deduplicates a streaming message that is also a forced navigation target', () => {


### PR DESCRIPTION
## What changed

- remeasure mounted virtual message rows after an insertion, removal, or reorder changes message indexes
- add a focused virtualization regression test for mid-turn guidance insertion
- extend the desktop guidance E2E flow with a geometry assertion that guidance remains above the sticky composer
- document the virtual conversation layout invariant in `wework/DESIGN.md`

## Root cause

Applied runtime guidance splits the active turn and inserts messages into the middle of the virtualized transcript. The list only synchronously remeasured a non-final streaming assistant row, so rows whose indexes shifted could retain stale estimated sizes. The virtual container could then end before the final rendered row, allowing the sticky composer to stop in the middle of the transcript.

## Impact

Runtime guidance and its following assistant continuation now remain in the conversation flow above the desktop composer.

## Validation

- `pnpm --filter wework test src/components/chat/MessageList.test.tsx src/components/chat/MessageList.virtualization.test.tsx` (149 tests passed)
- focused Prettier and ESLint checks
- `node --check wework/e2e/desktop/modules/conversation-navigation.mjs`
- pre-push Wework ESLint, TypeScript, and full unit test checks
- isolated real-Tauri verification of foreground runtime guidance and sticky composer placement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation scrolling when messages are inserted, removed, or reordered.
  * Ensured newly displayed guidance messages remain visible above the floating composer.
  * Updated virtualized message lists to accurately recalculate row heights after streaming content changes.

* **Tests**
  * Added regression coverage for message insertion and rendered-height recalculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->