### PR TITLE
fix(wework): explain offline plugin installs

### DIFF
--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -271,6 +271,7 @@ pub trait RuntimeWorkHandler: Send + Sync {
 
 pub trait BackendConnectionHandler: Send + Sync {
     fn configure_backend<'a>(&'a self, params: Value) -> BoxFuture<'a, Result<Value, AppIpcError>>;
+    fn backend_status<'a>(&'a self) -> BoxFuture<'a, Result<Value, AppIpcError>>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -439,6 +440,16 @@ impl AppIpcServer {
                 ));
             };
             return handler.configure_backend(params).await;
+        }
+
+        if method == "executor.backend.status" {
+            let Some(handler) = &self.backend_connection_handler else {
+                return Err(AppIpcError::new(
+                    "backend_connection_unavailable",
+                    "Backend connection handler is not available",
+                ));
+            };
+            return handler.backend_status().await;
         }
 
         if method == "device.execute_command" {

--- a/executor/src/local/backend.rs
+++ b/executor/src/local/backend.rs
@@ -6,7 +6,10 @@ use std::{
     env,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     time::Duration,
 };
 
@@ -130,6 +133,7 @@ pub struct LocalBackendRunner<
     extension_handler: Option<Arc<dyn DeviceExtensionHandler>>,
     cancellations: LocalCancellationRegistry,
     runtime_event_forwarder: Option<JoinHandle<()>>,
+    connection_status: Arc<AtomicBool>,
 }
 
 impl<T, R> Drop for LocalBackendRunner<T, R>
@@ -138,6 +142,7 @@ where
     R: TaskRunner,
 {
     fn drop(&mut self) {
+        self.connection_status.store(false, Ordering::Release);
         if let Some(forwarder) = self.runtime_event_forwarder.take() {
             forwarder.abort();
         }
@@ -244,7 +249,13 @@ where
             extension_handler: None,
             cancellations: LocalCancellationRegistry::default(),
             runtime_event_forwarder: None,
+            connection_status: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn with_connection_status(mut self, connection_status: Arc<AtomicBool>) -> Self {
+        self.connection_status = connection_status;
+        self
     }
 
     pub fn with_task_controller<C>(mut self, controller: C) -> Self
@@ -343,6 +354,7 @@ where
     }
 
     pub async fn run_forever(self) -> Result<(), String> {
+        self.connection_status.store(false, Ordering::Release);
         self.register_handlers();
         let _session_gateway = if self.start_session_gateway {
             match &self.session_handler {
@@ -361,14 +373,17 @@ where
         loop {
             match self.connect_and_register().await {
                 Ok(()) => {
+                    self.connection_status.store(true, Ordering::Release);
                     write_executor_log_line(&local_backend_registered_log_line(
                         &self.client.config.backend_url,
                         &self.client.config.device_id,
                     ));
                     retry_delay = self.client.config.reconnect_delay;
                     self.heartbeat_until_reconnect().await;
+                    self.connection_status.store(false, Ordering::Release);
                 }
                 Err(error) => {
+                    self.connection_status.store(false, Ordering::Release);
                     write_executor_error_line(&local_backend_connection_failure_log_line(
                         &self.client.config.backend_url,
                         &error,

--- a/executor/src/local/backend/connection_controller.rs
+++ b/executor/src/local/backend/connection_controller.rs
@@ -5,7 +5,10 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex as StdMutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex as StdMutex,
+    },
 };
 
 use serde_json::{json, Value};
@@ -32,6 +35,7 @@ pub struct LocalBackendConnectionController {
     /// runtime-work handler so App-IPC task runs can resolve backend
     /// credentials without relying on the executor process environment.
     connection_snapshot: Arc<StdMutex<Option<ConnectionConfig>>>,
+    connection_status: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -75,6 +79,7 @@ impl LocalBackendConnectionController {
             runtime_event_tx,
             state: Arc::new(Mutex::new(LocalBackendConnectionState::default())),
             connection_snapshot,
+            connection_status: Arc::new(AtomicBool::new(false)),
         };
         controller.replace_connection(initial_connection).await;
         controller
@@ -94,6 +99,7 @@ impl LocalBackendConnectionController {
         }
 
         if let Some(task) = state.task.take() {
+            self.connection_status.store(false, Ordering::Release);
             task.abort();
         }
         if let Some(transport) = state.transport.take() {
@@ -125,7 +131,8 @@ impl LocalBackendConnectionController {
                     LocalBackendConfig::from_device_config(config),
                     transport.clone(),
                 )
-            };
+            }
+            .with_connection_status(Arc::clone(&self.connection_status));
             state.transport = Some(transport);
             state.task = Some(tokio::spawn(async move {
                 if let Err(error) = runner.run_forever().await {
@@ -179,6 +186,20 @@ impl BackendConnectionHandler for LocalBackendConnectionController {
                 "connected": connection.is_some(),
                 "backend_url": connection.as_ref().map(|value| &value.backend_url),
                 "socket_url": connection.as_ref().map(resolved_socket_url),
+            }))
+        })
+    }
+
+    fn backend_status<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, AppIpcError>> + Send + 'a>> {
+        Box::pin(async move {
+            let state = self.state.lock().await;
+            Ok(json!({
+                "configured": state.connection.is_some(),
+                "connected": self.connection_status.load(Ordering::Acquire),
+                "backend_url": state.connection.as_ref().map(|value| &value.backend_url),
+                "socket_url": state.connection.as_ref().map(resolved_socket_url),
             }))
         })
     }
@@ -263,7 +284,10 @@ mod tests {
     use serde_json::json;
 
     use super::{connection_from_params, normalized_connection, LocalBackendConnectionController};
-    use crate::config::device::{ConnectionConfig, DeviceConfig};
+    use crate::{
+        config::device::{ConnectionConfig, DeviceConfig},
+        local::app_ipc::BackendConnectionHandler,
+    };
 
     #[tokio::test]
     async fn publishes_the_initial_connection_to_the_shared_snapshot() {
@@ -279,14 +303,23 @@ mod tests {
 
         let controller = LocalBackendConnectionController::start(config).await;
         let snapshot = controller.connection_snapshot();
-        let guard = snapshot.lock().unwrap();
-        let connection = guard
-            .as_ref()
-            .expect("initial connection should be published");
+        {
+            let guard = snapshot.lock().unwrap();
+            let connection = guard
+                .as_ref()
+                .expect("initial connection should be published");
 
-        assert_eq!(connection.backend_url, "https://backend.example.com");
-        assert_eq!(connection.auth_token, "wg-token");
-        assert_eq!(connection.runtime_auth_token, "runtime-wg-token");
+            assert_eq!(connection.backend_url, "https://backend.example.com");
+            assert_eq!(connection.auth_token, "wg-token");
+            assert_eq!(connection.runtime_auth_token, "runtime-wg-token");
+        }
+
+        let status = controller
+            .backend_status()
+            .await
+            .expect("backend status should be available");
+        assert_eq!(status["configured"], true);
+        assert_eq!(status["connected"], false);
     }
 
     #[test]

--- a/wework/src/components/plugins/PluginOperationNotice.tsx
+++ b/wework/src/components/plugins/PluginOperationNotice.tsx
@@ -6,6 +6,8 @@ export type PluginOperationNoticeState = {
   kind: 'authorization' | 'success' | 'error'
   message: string
   iconUrl?: string | null
+  actionLabel?: string
+  onAction?: () => void
 }
 
 export function PluginOperationNotice({
@@ -36,6 +38,16 @@ export function PluginOperationNotice({
         )}
       </span>
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{notice.message}</span>
+      {notice.actionLabel && notice.onAction ? (
+        <button
+          type="button"
+          data-testid="plugin-operation-notice-action"
+          className="plugin-operation-notice-action"
+          onClick={notice.onAction}
+        >
+          {notice.actionLabel}
+        </button>
+      ) : null}
       <button
         type="button"
         data-testid="plugin-operation-notice-dismiss"

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -9,6 +9,10 @@ import {
 } from '@/api/local/codexPlugins'
 import { clearPluginDeviceAutoSyncAttempts } from '@/features/plugins/pluginDeviceAutoSync'
 import {
+  resetLocalExecutorCloudConnectionStatus,
+  setLocalExecutorCloudConnectionStatus,
+} from '@/features/cloud-connection/localExecutorCloudConnectionStatus'
+import {
   clearPluginMarketplaceCache,
   setPluginMarketplaceCache,
 } from '@/features/plugins/pluginMarketplaceCache'
@@ -1061,7 +1065,44 @@ describe('PluginsWorkspace', () => {
     clearPluginDeviceAutoSyncAttempts()
     clearLocalCodexPluginsReadStateCache()
     resetLocalExecutorStateForTests()
+    resetLocalExecutorCloudConnectionStatus()
+    setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: true })
+    window.history.replaceState({}, '', '/')
     mockSystemSkillsFetch()
+  })
+
+  test('keeps the user on the plugin page when the current device is disconnected', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: false })
+    mockCodexAppServerInvoke()
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await userEvent.click(await screen.findByTestId('plugin-marketplace-install-101'))
+
+    expect(screen.queryByTestId('install-plugin-dialog')).not.toBeInTheDocument()
+    expect(screen.getByTestId('plugin-operation-notice')).toHaveTextContent(
+      '当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。'
+    )
+    expect(screen.getByTestId('plugin-operation-notice')).toHaveAttribute(
+      'data-notice-kind',
+      'error'
+    )
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([input]) => String(input).includes('/plugins/marketplace/101/install'))
+    ).toBe(false)
+    expect(window.location.pathname).toBe('/')
+
+    await userEvent.click(screen.getByTestId('plugin-operation-notice-action'))
+
+    expect(window.location.pathname).toBe('/settings/connections')
+    expect(screen.queryByTestId('plugin-operation-notice')).not.toBeInTheDocument()
   })
 
   test('renders a Codex-style plugin marketplace page', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -183,6 +183,7 @@ function mockCodexAppServerInvoke(
       pluginDisplayNames?: string[]
     }>
     deviceId?: string
+    backendConnected?: boolean | (() => boolean)
     cloudLinks?: Array<{
       localPluginName: string
       cloudPluginId: number
@@ -236,6 +237,13 @@ function mockCodexAppServerInvoke(
     const request = args as {
       method?: string
       params?: { method?: string; params?: Record<string, unknown> }
+    }
+    if (request.method === 'executor.backend.status') {
+      const connected =
+        typeof options.backendConnected === 'function'
+          ? options.backendConnected()
+          : options.backendConnected !== false
+      return Promise.resolve({ configured: true, connected })
     }
     if (request.method !== 'codex.app_server_request') return Promise.resolve(undefined)
 
@@ -1078,7 +1086,7 @@ describe('PluginsWorkspace', () => {
     })
     vi.mocked(isTauri).mockReturnValue(true)
     setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: false })
-    mockCodexAppServerInvoke()
+    mockCodexAppServerInvoke({ backendConnected: false })
 
     render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
 
@@ -1103,6 +1111,37 @@ describe('PluginsWorkspace', () => {
 
     expect(window.location.pathname).toBe('/settings/connections')
     expect(screen.queryByTestId('plugin-operation-notice')).not.toBeInTheDocument()
+  })
+
+  test('rechecks the device connection before confirming a cloud install', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    let backendConnected = true
+    mockCodexAppServerInvoke({
+      deviceId: 'current-device',
+      backendConnected: () => backendConnected,
+    })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await userEvent.click(await screen.findByTestId('plugin-marketplace-install-101'))
+    expect(await screen.findByTestId('install-plugin-dialog')).toBeInTheDocument()
+
+    backendConnected = false
+    await userEvent.click(screen.getByTestId('install-plugin-dialog-confirm'))
+
+    expect(await screen.findByTestId('plugin-operation-notice')).toHaveTextContent(
+      '当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。'
+    )
+    expect(screen.queryByTestId('install-plugin-dialog')).not.toBeInTheDocument()
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([input]) => String(input).includes('/plugins/marketplace/101/install'))
+    ).toBe(false)
   })
 
   test('renders a Codex-style plugin marketplace page', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -36,7 +36,7 @@ import { getRuntimeConfig } from '@/config/runtime'
 import { getErrorMessage } from '@/lib/error-message'
 import { navigateTo } from '@/lib/navigation'
 import { openCloudAuthorizationWindow } from '@/lib/cloud-authorization-window'
-import { useLocalExecutorCloudConnectionStatus } from '@/features/cloud-connection/localExecutorCloudConnectionStatus'
+import { refreshLocalExecutorCloudConnectionStatus } from '@/features/cloud-connection/localExecutorCloudConnectionStatus'
 import {
   notifyLocalPluginSkillsChanged,
   queuePluginPromptTrial,
@@ -1285,11 +1285,6 @@ export function PluginsWorkspace({
   pluginReference = null,
 }: PluginsWorkspaceProps) {
   const { t } = useTranslation('common')
-  const runtimeCloudConnection = useLocalExecutorCloudConnectionStatus()
-  const runtimeCloudConnected =
-    runtimeCloudConnection.connected &&
-    runtimeCloudConnection.apiBaseUrl.replace(/\/+$/, '') ===
-      (cloudApiBaseUrl ?? '').replace(/\/+$/, '')
   const appearanceMode = useOptionalAppearance()?.resolvedMode ?? 'light'
   const [query, setQuery] = useState('')
   const [searchResultWindow, setSearchResultWindow] = useState({ query: '', limit: 0 })
@@ -2336,7 +2331,31 @@ export function PluginsWorkspace({
     [cloudApiBaseUrl, cloudToken]
   )
 
-  const installMarketplacePlugin = (item: PluginMarketplaceItem, promptAfterInstall?: string) => {
+  const showDeviceDisconnectedNotice = (itemId: string | number) => {
+    setPluginOperationNotice({
+      id: `install-device-disconnected-${itemId}`,
+      kind: 'error',
+      message: t(
+        'workbench.plugins_install_device_disconnected',
+        '当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。'
+      ),
+      actionLabel: t('workbench.plugins_open_connection_settings', '连接设置'),
+      onAction: () => {
+        setPluginOperationNotice(null)
+        navigateTo('/settings/connections')
+      },
+    })
+  }
+
+  const hasLiveRuntimeCloudConnection = async () => {
+    if (!cloudApiBaseUrl || !currentDeviceId) return false
+    return refreshLocalExecutorCloudConnectionStatus(cloudApiBaseUrl)
+  }
+
+  const installMarketplacePlugin = async (
+    item: PluginMarketplaceItem,
+    promptAfterInstall?: string
+  ) => {
     const installLock = resolveMarketplacePluginLock(item)
     if (installLock) {
       setPluginOperationNotice({
@@ -2359,20 +2378,8 @@ export function PluginsWorkspace({
       return
     }
 
-    if (!installFromLocal && (!runtimeCloudConnected || !currentDeviceId)) {
-      setPluginOperationNotice({
-        id: `install-device-disconnected-${item.id}`,
-        kind: 'error',
-        message: t(
-          'workbench.plugins_install_device_disconnected',
-          '当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。'
-        ),
-        actionLabel: t('workbench.plugins_open_connection_settings', '连接设置'),
-        onAction: () => {
-          setPluginOperationNotice(null)
-          navigateTo('/settings/connections')
-        },
-      })
+    if (!installFromLocal && !(await hasLiveRuntimeCloudConnection())) {
+      showDeviceDisconnectedNotice(item.id)
       return
     }
 
@@ -2558,15 +2565,22 @@ export function PluginsWorkspace({
         }
         return preparedItem
       })
-      .then(preparedItem =>
-        installFromLocal
-          ? localPluginApi
-              .installAvailablePlugin(preparedItem.id, localMarketplaceId!)
-              .then(plugin => ({ plugin, preparedItem }))
-          : pluginApi
-              .installMarketplacePlugin(preparedItem.id, currentDeviceId)
-              .then(response => ({ plugin: response.plugin, preparedItem }))
-      )
+      .then(async preparedItem => {
+        if (installFromLocal) {
+          const plugin = await localPluginApi.installAvailablePlugin(
+            preparedItem.id,
+            localMarketplaceId!
+          )
+          return { plugin, preparedItem }
+        }
+        if (!(await hasLiveRuntimeCloudConnection())) {
+          throw Object.assign(new Error('Current device is disconnected'), {
+            code: 'PLUGIN_DEVICE_DISCONNECTED',
+          })
+        }
+        const response = await pluginApi.installMarketplacePlugin(preparedItem.id, currentDeviceId)
+        return { plugin: response.plugin, preparedItem }
+      })
       .then(async ({ plugin, preparedItem }) => {
         await ensureLocalConnectorsAfterInstall(preparedItem, plugin)
         return plugin
@@ -2683,6 +2697,11 @@ export function PluginsWorkspace({
         }
       })
       .catch((error: unknown) => {
+        if (Reflect.get(error as object, 'code') === 'PLUGIN_DEVICE_DISCONNECTED') {
+          setPluginMarketplaceState(previous => ({ ...previous, error: null }))
+          showDeviceDisconnectedNotice(item.id)
+          return
+        }
         const rawErrorMessage = getErrorMessage(
           error,
           t('workbench.plugins_install_failed', '安装失败，请稍后重试')

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -36,6 +36,7 @@ import { getRuntimeConfig } from '@/config/runtime'
 import { getErrorMessage } from '@/lib/error-message'
 import { navigateTo } from '@/lib/navigation'
 import { openCloudAuthorizationWindow } from '@/lib/cloud-authorization-window'
+import { useLocalExecutorCloudConnectionStatus } from '@/features/cloud-connection/localExecutorCloudConnectionStatus'
 import {
   notifyLocalPluginSkillsChanged,
   queuePluginPromptTrial,
@@ -1284,6 +1285,11 @@ export function PluginsWorkspace({
   pluginReference = null,
 }: PluginsWorkspaceProps) {
   const { t } = useTranslation('common')
+  const runtimeCloudConnection = useLocalExecutorCloudConnectionStatus()
+  const runtimeCloudConnected =
+    runtimeCloudConnection.connected &&
+    runtimeCloudConnection.apiBaseUrl.replace(/\/+$/, '') ===
+      (cloudApiBaseUrl ?? '').replace(/\/+$/, '')
   const appearanceMode = useOptionalAppearance()?.resolvedMode ?? 'light'
   const [query, setQuery] = useState('')
   const [searchResultWindow, setSearchResultWindow] = useState({ query: '', limit: 0 })
@@ -2343,14 +2349,30 @@ export function PluginsWorkspace({
 
     const installFromLocal = isLocalMarketplaceItem(item)
 
-    // 检查是否已登录（未登录时没有 deviceId 或 token）
-    if (!installFromLocal && (!cloudToken || !currentDeviceId)) {
+    if (!installFromLocal && !cloudToken) {
       const shouldLogin = window.confirm(
         t('workbench.plugins_login_required', '安装插件需要登录 Wegent 账户。是否前往登录？')
       )
       if (shouldLogin) {
         navigateTo('/settings/connections')
       }
+      return
+    }
+
+    if (!installFromLocal && (!runtimeCloudConnected || !currentDeviceId)) {
+      setPluginOperationNotice({
+        id: `install-device-disconnected-${item.id}`,
+        kind: 'error',
+        message: t(
+          'workbench.plugins_install_device_disconnected',
+          '当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。'
+        ),
+        actionLabel: t('workbench.plugins_open_connection_settings', '连接设置'),
+        onAction: () => {
+          setPluginOperationNotice(null)
+          navigateTo('/settings/connections')
+        },
+      })
       return
     }
 

--- a/wework/src/features/cloud-connection/LocalExecutorCloudBridge.test.tsx
+++ b/wework/src/features/cloud-connection/LocalExecutorCloudBridge.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   listApps: vi.fn(),
   request: vi.fn().mockResolvedValue({}),
   notifySkillsChanged: vi.fn(),
+  backendConnected: true,
 }))
 
 vi.mock('./cloudConnectionAvailability', () => ({
@@ -47,7 +48,15 @@ describe('LocalExecutorCloudBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetLocalExecutorCloudConnectionStatus()
+    mocks.backendConnected = true
     mocks.connect.mockResolvedValue({ running: true, ready: true })
+    mocks.request.mockImplementation((method: string) =>
+      Promise.resolve(
+        method === 'executor.backend.status'
+          ? { configured: true, connected: mocks.backendConnected }
+          : {}
+      )
+    )
     mocks.issueToken.mockResolvedValue({
       access_token: 'scoped-connector-token',
       token_type: 'bearer',
@@ -145,6 +154,65 @@ describe('LocalExecutorCloudBridge', () => {
       expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
         'disconnected'
       )
+    )
+  })
+
+  test('publishes a later WebSocket disconnect', async () => {
+    render(
+      <>
+        <LocalExecutorCloudBridge
+          apiBaseUrl="https://backend.example.com/api"
+          backendUrl="https://backend.example.com"
+          socketBaseUrl="wss://socket.example.com"
+          isConnected
+          token="token-a"
+        />
+        <ConnectionStatusProbe />
+      </>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
+        'connected:https://backend.example.com/api'
+      )
+    )
+
+    mocks.backendConnected = false
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
+          'disconnected'
+        ),
+      { timeout: 2_000 }
+    )
+  })
+
+  test('clears the published connection when the bridge unmounts', async () => {
+    const view = render(
+      <>
+        <LocalExecutorCloudBridge
+          apiBaseUrl="https://backend.example.com/api"
+          backendUrl="https://backend.example.com"
+          socketBaseUrl="wss://socket.example.com"
+          isConnected
+          token="token-a"
+        />
+        <ConnectionStatusProbe />
+      </>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
+        'connected:https://backend.example.com/api'
+      )
+    )
+
+    view.unmount()
+    render(<ConnectionStatusProbe />)
+
+    expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
+      'disconnected'
     )
   })
 

--- a/wework/src/features/cloud-connection/LocalExecutorCloudBridge.test.tsx
+++ b/wework/src/features/cloud-connection/LocalExecutorCloudBridge.test.tsx
@@ -1,6 +1,10 @@
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { LocalExecutorCloudBridge } from './LocalExecutorCloudBridge'
+import {
+  resetLocalExecutorCloudConnectionStatus,
+  useLocalExecutorCloudConnectionStatus,
+} from './localExecutorCloudConnectionStatus'
 
 const mocks = vi.hoisted(() => ({
   connect: vi.fn().mockResolvedValue({ running: true, ready: true }),
@@ -42,6 +46,8 @@ vi.mock('@/features/plugins/pluginTrial', () => ({
 describe('LocalExecutorCloudBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetLocalExecutorCloudConnectionStatus()
+    mocks.connect.mockResolvedValue({ running: true, ready: true })
     mocks.issueToken.mockResolvedValue({
       access_token: 'scoped-connector-token',
       token_type: 'bearer',
@@ -91,6 +97,56 @@ describe('LocalExecutorCloudBridge', () => {
     })
     return { promise, resolve, reject }
   }
+
+  function ConnectionStatusProbe() {
+    const status = useLocalExecutorCloudConnectionStatus()
+    return (
+      <span data-testid="local-executor-cloud-connection-status">
+        {status.connected ? `connected:${status.apiBaseUrl}` : 'disconnected'}
+      </span>
+    )
+  }
+
+  test('publishes whether the executor WebSocket connection succeeded', async () => {
+    const view = render(
+      <>
+        <LocalExecutorCloudBridge
+          apiBaseUrl="https://backend.example.com/api"
+          backendUrl="https://backend.example.com"
+          socketBaseUrl="wss://socket.example.com"
+          isConnected
+          token="token-a"
+        />
+        <ConnectionStatusProbe />
+      </>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
+        'connected:https://backend.example.com/api'
+      )
+    )
+
+    mocks.connect.mockRejectedValueOnce(new Error('socket unavailable'))
+    view.rerender(
+      <>
+        <LocalExecutorCloudBridge
+          apiBaseUrl="https://offline.example.com/api"
+          backendUrl="https://offline.example.com"
+          socketBaseUrl="wss://offline.example.com"
+          isConnected
+          token="token-b"
+        />
+        <ConnectionStatusProbe />
+      </>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('local-executor-cloud-connection-status')).toHaveTextContent(
+        'disconnected'
+      )
+    )
+  })
 
   test('updates backend connection whenever the cloud target changes', async () => {
     const view = render(

--- a/wework/src/features/cloud-connection/LocalExecutorCloudBridge.tsx
+++ b/wework/src/features/cloud-connection/LocalExecutorCloudBridge.tsx
@@ -10,6 +10,7 @@ import {
   type LocalExecutorCloudConnection,
 } from './localExecutorCloudConnection'
 import { isCloudConnectionUiAvailable } from './cloudConnectionAvailability'
+import { setLocalExecutorCloudConnectionStatus } from './localExecutorCloudConnectionStatus'
 
 const CONNECTOR_AUTHORIZATION_CHANGED_EVENT = 'wegent:connector-authorization-changed'
 
@@ -94,7 +95,16 @@ export function LocalExecutorCloudBridge({
         ) {
           scheduleRefresh(result.runtimeAuthTokenExpiresIn)
         }
+        setLocalExecutorCloudConnectionStatus({
+          apiBaseUrl: result.connected ? apiBaseUrl || '' : '',
+          connected: result.connected,
+        })
       } catch (error) {
+        if (!isCurrentConnectionAttempt()) return
+        setLocalExecutorCloudConnectionStatus({
+          apiBaseUrl: apiBaseUrl || '',
+          connected: false,
+        })
         if (connected) {
           console.error('[CloudConnection] Failed to connect runtime task service to cloud', error)
           scheduleRetry()
@@ -107,6 +117,10 @@ export function LocalExecutorCloudBridge({
       }
     }
 
+    setLocalExecutorCloudConnectionStatus({
+      apiBaseUrl: apiBaseUrl || '',
+      connected: false,
+    })
     void applyConnection()
     return () => {
       cancelled = true

--- a/wework/src/features/cloud-connection/LocalExecutorCloudBridge.tsx
+++ b/wework/src/features/cloud-connection/LocalExecutorCloudBridge.tsx
@@ -10,7 +10,10 @@ import {
   type LocalExecutorCloudConnection,
 } from './localExecutorCloudConnection'
 import { isCloudConnectionUiAvailable } from './cloudConnectionAvailability'
-import { setLocalExecutorCloudConnectionStatus } from './localExecutorCloudConnectionStatus'
+import {
+  refreshLocalExecutorCloudConnectionStatus,
+  setLocalExecutorCloudConnectionStatus,
+} from './localExecutorCloudConnectionStatus'
 
 const CONNECTOR_AUTHORIZATION_CHANGED_EVENT = 'wegent:connector-authorization-changed'
 
@@ -57,6 +60,7 @@ export function LocalExecutorCloudBridge({
     const connected = Boolean(backendUrl && socketBaseUrl && authToken)
     let cancelled = false
     let refreshTimer: ReturnType<typeof setTimeout> | null = null
+    let statusTimer: ReturnType<typeof setTimeout> | null = null
     const isCurrentConnectionAttempt = () =>
       !cancelled && connectionGenerationRef.current === generation
 
@@ -73,6 +77,13 @@ export function LocalExecutorCloudBridge({
       if (!isCurrentConnectionAttempt() || !connected) return
       if (refreshTimer) clearTimeout(refreshTimer)
       refreshTimer = setTimeout(() => void applyConnection(), 30_000)
+    }
+
+    const refreshConnectionStatus = async () => {
+      if (!isCurrentConnectionAttempt() || !connected || !apiBaseUrl) return
+      await refreshLocalExecutorCloudConnectionStatus(apiBaseUrl)
+      if (!isCurrentConnectionAttempt()) return
+      statusTimer = setTimeout(() => void refreshConnectionStatus(), 1_000)
     }
 
     const applyConnection = async () => {
@@ -95,10 +106,12 @@ export function LocalExecutorCloudBridge({
         ) {
           scheduleRefresh(result.runtimeAuthTokenExpiresIn)
         }
-        setLocalExecutorCloudConnectionStatus({
-          apiBaseUrl: result.connected ? apiBaseUrl || '' : '',
-          connected: result.connected,
-        })
+        if (result.connected && apiBaseUrl) {
+          if (statusTimer) clearTimeout(statusTimer)
+          void refreshConnectionStatus()
+        } else {
+          setLocalExecutorCloudConnectionStatus({ apiBaseUrl: apiBaseUrl || '', connected: false })
+        }
       } catch (error) {
         if (!isCurrentConnectionAttempt()) return
         setLocalExecutorCloudConnectionStatus({
@@ -126,6 +139,8 @@ export function LocalExecutorCloudBridge({
       cancelled = true
       connectionGenerationRef.current += 1
       if (refreshTimer) clearTimeout(refreshTimer)
+      if (statusTimer) clearTimeout(statusTimer)
+      setLocalExecutorCloudConnectionStatus({ apiBaseUrl: apiBaseUrl || '', connected: false })
     }
   }, [apiBaseUrl, configuredBackendUrl, isConnected, socketBaseUrl, token])
 

--- a/wework/src/features/cloud-connection/localExecutorCloudConnectionStatus.ts
+++ b/wework/src/features/cloud-connection/localExecutorCloudConnectionStatus.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from 'react'
+
+export interface LocalExecutorCloudConnectionStatus {
+  apiBaseUrl: string
+  connected: boolean
+  revision: number
+}
+
+const EMPTY_STATUS: LocalExecutorCloudConnectionStatus = {
+  apiBaseUrl: '',
+  connected: false,
+  revision: 0,
+}
+
+let status = EMPTY_STATUS
+const listeners = new Set<() => void>()
+
+export function setLocalExecutorCloudConnectionStatus(
+  next: Omit<LocalExecutorCloudConnectionStatus, 'revision'>
+): void {
+  status = { ...next, revision: status.revision + 1 }
+  for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot(): LocalExecutorCloudConnectionStatus {
+  return status
+}
+
+export function useLocalExecutorCloudConnectionStatus(): LocalExecutorCloudConnectionStatus {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+export function resetLocalExecutorCloudConnectionStatus(): void {
+  status = EMPTY_STATUS
+  for (const listener of listeners) listener()
+}

--- a/wework/src/features/cloud-connection/localExecutorCloudConnectionStatus.ts
+++ b/wework/src/features/cloud-connection/localExecutorCloudConnectionStatus.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react'
+import { requestLocalExecutor } from '@/tauri/localExecutor'
 
 export interface LocalExecutorCloudConnectionStatus {
   apiBaseUrl: string
@@ -33,6 +34,23 @@ function getSnapshot(): LocalExecutorCloudConnectionStatus {
 
 export function useLocalExecutorCloudConnectionStatus(): LocalExecutorCloudConnectionStatus {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+export async function refreshLocalExecutorCloudConnectionStatus(
+  apiBaseUrl: string
+): Promise<boolean> {
+  try {
+    const response = await requestLocalExecutor<{
+      configured?: boolean
+      connected?: boolean
+    }>('executor.backend.status')
+    const connected = response.configured === true && response.connected === true
+    setLocalExecutorCloudConnectionStatus({ apiBaseUrl, connected })
+    return connected
+  } catch {
+    setLocalExecutorCloudConnectionStatus({ apiBaseUrl, connected: false })
+    return false
+  }
 }
 
 export function resetLocalExecutorCloudConnectionStatus(): void {

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -1260,6 +1260,8 @@
     "plugins_syncing_installation": "Syncing...",
     "plugins_installed": "Installed",
     "plugins_login_required": "Installing plugins requires a Wegent account. Go to login?",
+    "plugins_install_device_disconnected": "This device is not connected to the cloud, so the plugin cannot be installed right now. Restore the connection and try again.",
+    "plugins_open_connection_settings": "Connection settings",
     "plugins_uninstall": "Uninstall",
     "plugins_update": "Update",
     "plugins_update_confirm": "This update syncs to the current device. If it fails, the installed version on this device stays unchanged. Continue?",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -1259,6 +1259,8 @@
     "plugins_syncing_installation": "同步中...",
     "plugins_installed": "已安装",
     "plugins_login_required": "安装插件需要登录 Wegent 账户。是否前往登录？",
+    "plugins_install_device_disconnected": "当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。",
+    "plugins_open_connection_settings": "连接设置",
     "plugins_uninstall": "卸载",
     "plugins_update": "更新",
     "plugins_update_confirm": "更新将同步到当前设备。若失败，本机将保留当前已安装版本。是否继续？",

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -1372,6 +1372,20 @@ button.plugin-operation-notice-dismiss {
   color: rgb(var(--color-text-muted));
 }
 
+button.plugin-operation-notice-action {
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  padding: 5px 7px;
+  color: rgb(var(--color-text-primary));
+  font-weight: 600;
+}
+
+button.plugin-operation-notice-action:hover {
+  background: rgb(var(--color-text-primary) / 0.07);
+}
+
 button.plugin-operation-notice-dismiss:hover {
   background: rgb(var(--color-text-primary) / 0.07);
   color: rgb(var(--color-text-primary));
@@ -1391,6 +1405,7 @@ button.plugin-market-icon-button:focus-visible,
 button.plugin-market-filter:focus-visible,
 button.plugin-installed-strip-item:focus-visible,
 button.plugin-installed-overflow-button:focus-visible,
+button.plugin-operation-notice-action:focus-visible,
 button.plugin-operation-notice-dismiss:focus-visible,
 button.plugin-detail-action-primary:focus-visible,
 button.plugin-detail-action-secondary:focus-visible,


### PR DESCRIPTION
## What changed

- track the local executor's live backend WebSocket registration state through App IPC
- revalidate the device connection before opening the install flow and again before sending the install request
- show an actionable disconnected notice with a link to connection settings
- reset and poll connection status across bridge lifecycle changes
- add coverage for initial disconnection, disconnect-after-dialog-open, polling, and cleanup

## Why

Marketplace installation previously treated accepted backend configuration as an active WebSocket connection. When the backend was unavailable or disconnected after configuration, clicking Install could appear to do nothing or proceed with stale state.

## Impact

Users now receive a clear prompt when the current device is offline, and no cloud installation request is sent until the executor has a live backend connection. Local plugin installation behavior is unchanged.

## Validation

- `pnpm test src/components/plugins/PluginsWorkspace.test.tsx src/features/cloud-connection/LocalExecutorCloudBridge.test.tsx` (86 tests)
- `pnpm --filter wework typecheck`
- `cargo test local::backend::connection_controller::tests --lib` (4 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `pnpm --filter wework e2e:desktop:plugins`
- repository pre-push quality gate
- Bugbot, Security Review, and CodeRabbit review findings addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live cloud connection status tracking for local devices.
  * Cloud plugin installations now verify connectivity before and during installation.
  * Disconnected devices receive an actionable notice with a link to connection settings.
  * Added support for optional actions in plugin operation notices.

* **Bug Fixes**
  * Prevented cloud installation requests when connectivity is unavailable or lost.
  * Improved connection status updates after connection failures or disconnects.

* **Localization**
  * Added English and Simplified Chinese messages for disconnected-device installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->