### PR TITLE
fix(wework): dismiss completed task plan notice

### DIFF
--- a/wework/src/components/chat/composer/TaskPlanProgress.test.tsx
+++ b/wework/src/components/chat/composer/TaskPlanProgress.test.tsx
@@ -1,0 +1,58 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { TaskPlanProgress } from './TaskPlanProgress'
+
+describe('TaskPlanProgress', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('dismisses a completed plan while keeping active progress visible', () => {
+    vi.useFakeTimers()
+    const activePlan = {
+      plan: [{ step: 'Implement the fix', status: 'inProgress' as const }],
+    }
+    const completedPlan = {
+      plan: [{ step: 'Implement the fix', status: 'completed' as const }],
+    }
+    const { rerender } = render(<TaskPlanProgress plan={activePlan} />)
+
+    act(() => {
+      vi.advanceTimersByTime(2200)
+    })
+    expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument()
+
+    rerender(<TaskPlanProgress plan={completedPlan} />)
+    expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(2200)
+    })
+    expect(screen.queryByTestId('runtime-plan-progress-button')).not.toBeInTheDocument()
+
+    rerender(<TaskPlanProgress plan={activePlan} />)
+    expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument()
+  })
+
+  test('cancels the dismissal when a new active plan arrives', () => {
+    vi.useFakeTimers()
+    const completedPlan = {
+      plan: [{ step: 'Inspect the result', status: 'completed' as const }],
+    }
+    const activePlan = {
+      plan: [{ step: 'Handle follow-up work', status: 'inProgress' as const }],
+    }
+    const { rerender } = render(<TaskPlanProgress plan={completedPlan} />)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    rerender(<TaskPlanProgress plan={activePlan} />)
+
+    act(() => {
+      vi.advanceTimersByTime(2200)
+    })
+    expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument()
+    expect(screen.getByTestId('runtime-plan-popover')).toHaveTextContent('Handle follow-up work')
+  })
+})

--- a/wework/src/components/chat/composer/TaskPlanProgress.test.tsx
+++ b/wework/src/components/chat/composer/TaskPlanProgress.test.tsx
@@ -30,7 +30,27 @@ describe('TaskPlanProgress', () => {
     })
     expect(screen.queryByTestId('runtime-plan-progress-button')).not.toBeInTheDocument()
 
+    rerender(
+      <TaskPlanProgress
+        plan={{
+          ...completedPlan,
+          plan: completedPlan.plan.map(step => ({ ...step })),
+        }}
+      />
+    )
+    expect(screen.queryByTestId('runtime-plan-progress-button')).not.toBeInTheDocument()
+
     rerender(<TaskPlanProgress plan={activePlan} />)
+    expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument()
+
+    rerender(
+      <TaskPlanProgress
+        plan={{
+          ...completedPlan,
+          plan: completedPlan.plan.map(step => ({ ...step })),
+        }}
+      />
+    )
     expect(screen.getByTestId('runtime-plan-progress-button')).toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/composer/TaskPlanProgress.tsx
+++ b/wework/src/components/chat/composer/TaskPlanProgress.tsx
@@ -6,10 +6,6 @@ import type { RuntimePlanEventPayload, RuntimePlanStep } from '@/types/api'
 const COMPLETED_PLAN_NOTICE_DURATION_MS = 2200
 
 export function TaskPlanProgress({ plan }: { plan?: RuntimePlanEventPayload | null }) {
-  const { t } = useTranslation('common')
-  const [dismissedPlan, setDismissedPlan] = useState<RuntimePlanEventPayload | null>(null)
-  const allCompleted = plan?.plan.every(step => step.status === 'completed') ?? false
-
   useEffect(() => {
     if (import.meta.env.DEV) {
       console.warn('[Wework] Runtime task plan progress rendered', {
@@ -18,18 +14,34 @@ export function TaskPlanProgress({ plan }: { plan?: RuntimePlanEventPayload | nu
     }
   }, [plan])
 
+  if (!plan?.plan.length) return null
+
+  const allCompleted = plan.plan.every(step => step.status === 'completed')
+  if (allCompleted) {
+    return <CompletedTaskPlanProgress key={runtimePlanIdentity(plan)} plan={plan} />
+  }
+  return <TaskPlanProgressContent plan={plan} allCompleted={false} />
+}
+
+function CompletedTaskPlanProgress({ plan }: { plan: RuntimePlanEventPayload }) {
+  const [visible, setVisible] = useState(true)
+
   useEffect(() => {
-    if (!plan?.plan.length || !allCompleted) return
-
-    const timeout = window.setTimeout(
-      () => setDismissedPlan(plan),
-      COMPLETED_PLAN_NOTICE_DURATION_MS
-    )
+    const timeout = window.setTimeout(() => setVisible(false), COMPLETED_PLAN_NOTICE_DURATION_MS)
     return () => window.clearTimeout(timeout)
-  }, [allCompleted, plan])
+  }, [])
 
-  if (!plan?.plan.length || plan === dismissedPlan) return null
+  return visible ? <TaskPlanProgressContent plan={plan} allCompleted /> : null
+}
 
+function TaskPlanProgressContent({
+  plan,
+  allCompleted,
+}: {
+  plan: RuntimePlanEventPayload
+  allCompleted: boolean
+}) {
+  const { t } = useTranslation('common')
   const currentIndex = currentPlanStepIndex(plan.plan)
   const activeStep = plan.plan[currentIndex]
 
@@ -79,6 +91,16 @@ export function TaskPlanProgress({ plan }: { plan?: RuntimePlanEventPayload | nu
       </div>
     </div>
   )
+}
+
+function runtimePlanIdentity(plan: RuntimePlanEventPayload): string {
+  return JSON.stringify({
+    taskId: plan.taskId ?? null,
+    subtaskId: plan.subtaskId ?? null,
+    threadId: plan.threadId ?? null,
+    turnId: plan.turnId ?? null,
+    plan: plan.plan,
+  })
 }
 
 function currentPlanStepIndex(plan: RuntimePlanStep[]): number {

--- a/wework/src/components/chat/composer/TaskPlanProgress.tsx
+++ b/wework/src/components/chat/composer/TaskPlanProgress.tsx
@@ -1,10 +1,14 @@
 import { Check, Circle } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { RuntimePlanEventPayload, RuntimePlanStep } from '@/types/api'
 
+const COMPLETED_PLAN_NOTICE_DURATION_MS = 2200
+
 export function TaskPlanProgress({ plan }: { plan?: RuntimePlanEventPayload | null }) {
   const { t } = useTranslation('common')
+  const [dismissedPlan, setDismissedPlan] = useState<RuntimePlanEventPayload | null>(null)
+  const allCompleted = plan?.plan.every(step => step.status === 'completed') ?? false
 
   useEffect(() => {
     if (import.meta.env.DEV) {
@@ -14,11 +18,20 @@ export function TaskPlanProgress({ plan }: { plan?: RuntimePlanEventPayload | nu
     }
   }, [plan])
 
-  if (!plan?.plan.length) return null
+  useEffect(() => {
+    if (!plan?.plan.length || !allCompleted) return
+
+    const timeout = window.setTimeout(
+      () => setDismissedPlan(plan),
+      COMPLETED_PLAN_NOTICE_DURATION_MS
+    )
+    return () => window.clearTimeout(timeout)
+  }, [allCompleted, plan])
+
+  if (!plan?.plan.length || plan === dismissedPlan) return null
 
   const currentIndex = currentPlanStepIndex(plan.plan)
   const activeStep = plan.plan[currentIndex]
-  const allCompleted = plan.plan.every(step => step.status === 'completed')
 
   return (
     <div data-testid="runtime-plan-progress" className="relative z-0 mb-2 flex justify-center">


### PR DESCRIPTION
## Summary

- keep task-plan progress visible while any step is active or pending
- show the completed state briefly, then dismiss it after 2.2 seconds
- cancel the pending dismissal when a new active plan arrives

## Root cause

`TaskPlanProgress` rendered every non-empty cached plan indefinitely. A fully completed plan therefore remained above the composer even after the assistant turn had finished.

## User impact

The completed-plan notice now behaves as transient completion feedback instead of occupying the composer indefinitely. New task-plan progress still appears normally.

## Verification

- `pnpm --filter wework test` (369 files, 3670 tests)
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- pre-push ESLint, TypeScript, and unit-test checks
- isolated real-Tauri verification: active progress visible, completed notice visible, completed notice absent after 2.2 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed task plans now automatically disappear after a brief delay.
  * Active task progress remains visible while work is ongoing.
  * Newly arriving active plans can prevent pending completion dismissal.

* **Tests**
  * Added coverage for completion dismissal, active progress visibility, and dismissal cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->