### PR TITLE
fix(wework): support multiple terminals in right sidebar

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5306,6 +5306,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('toggle-bottom-workspace-panel-button')).toBeInTheDocument()
     expect(screen.getByTestId('right-workspace-launcher')).toBeInTheDocument()
     expect(screen.getByTestId('right-workspace-review-option')).toHaveTextContent('审查')
+    expect(screen.getByTestId('right-workspace-terminal-option')).toHaveTextContent('终端')
     expect(screen.getByTestId('right-workspace-browser-option')).toHaveTextContent('浏览器')
     expect(screen.getByTestId('right-workspace-file-option')).toHaveTextContent('文件')
     await userEvent.click(screen.getByTestId('right-workspace-file-option'))
@@ -5810,6 +5811,77 @@ describe('DesktopWorkbenchLayout', () => {
         'workspace-cloud-device',
         '/workspace/project'
       )
+    )
+    expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
+  })
+
+  test('opens multiple terminal tabs in the right workspace panel', async () => {
+    startDeviceTerminalSessionMock
+      .mockResolvedValueOnce({
+        session_id: 'terminal-1',
+        url: '',
+        transport: 'socketio',
+        device_id: 'workspace-cloud-device',
+        path: '/workspace/project',
+      })
+      .mockResolvedValueOnce({
+        session_id: 'terminal-2',
+        url: '',
+        transport: 'socketio',
+        device_id: 'workspace-cloud-device',
+        path: '/workspace/project',
+      })
+    renderWorkspacePanelLayout()
+
+    await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
+    await userEvent.click(screen.getByTestId('right-workspace-terminal-option'))
+
+    expect(screen.queryByTestId('right-workspace-launcher')).not.toBeInTheDocument()
+    expect(screen.getByTestId('right-workspace-terminal-tab')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(screen.getByTestId('bottom-workspace-panel')).toHaveAttribute('aria-hidden', 'true')
+    await waitFor(() =>
+      expect(startDeviceTerminalSessionMock).toHaveBeenCalledWith(
+        'workspace-cloud-device',
+        '/workspace/project'
+      )
+    )
+    expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
+
+    await userEvent.click(screen.getByTestId('right-workspace-new-tab-button'))
+    await userEvent.click(
+      within(screen.getByTestId('right-workspace-new-tab-menu')).getByTestId(
+        'right-workspace-terminal-option'
+      )
+    )
+
+    await waitFor(() => expect(startDeviceTerminalSessionMock).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('right-workspace-terminal-tab')).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+    expect(screen.getByTestId('right-workspace-terminal-tab-2')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(screen.getAllByTestId('remote-terminal')).toHaveLength(2)
+    expect(screen.getAllByTestId('remote-terminal')[0]).toHaveAttribute(
+      'data-session-id',
+      'terminal-1'
+    )
+    expect(screen.getAllByTestId('remote-terminal')[1]).toHaveAttribute(
+      'data-session-id',
+      'terminal-2'
+    )
+
+    await userEvent.click(screen.getByTestId('right-workspace-terminal-tab-2-close-button'))
+
+    expect(screen.queryByTestId('right-workspace-terminal-tab-2')).not.toBeInTheDocument()
+    expect(screen.getByTestId('right-workspace-terminal-tab')).toHaveAttribute(
+      'aria-selected',
+      'true'
     )
     expect(screen.getByTestId('remote-terminal')).toHaveAttribute('data-session-id', 'terminal-1')
   })

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -77,6 +77,7 @@ import {
   type RightWorkspaceHarnessTab,
   type RightWorkspacePanelTab,
   type RightWorkspacePanelView,
+  type RightWorkspaceTerminalTab,
 } from './workspace-panels/RightWorkspacePanel'
 import { WorkspacePanelActions } from './workspace-panels/WorkspacePanelActions'
 import {
@@ -342,8 +343,8 @@ function rightPanelTabType(
 ): 'review' | 'terminal' | 'browser' | 'chat' | 'files' | 'desktop' | 'other' {
   if (tab.startsWith('chat:')) return 'chat'
   if (isRightWorkspaceBrowserTab(tab)) return 'browser'
-  if (isRightWorkspaceHarnessTab(tab)) return 'terminal'
-  if (tab === 'review' || tab === 'terminal' || tab === 'files') return tab
+  if (isRightWorkspaceHarnessTab(tab) || isRightWorkspaceTerminalTab(tab)) return 'terminal'
+  if (tab === 'review' || tab === 'files') return tab
   return 'other'
 }
 
@@ -353,6 +354,31 @@ function isRightWorkspaceBrowserTab(tab: RightWorkspacePanelView): tab is RightW
 
 function isRightWorkspaceHarnessTab(tab: RightWorkspacePanelView): tab is RightWorkspaceHarnessTab {
   return tab.startsWith('harness:')
+}
+
+function isRightWorkspaceTerminalTab(
+  tab: RightWorkspacePanelView
+): tab is RightWorkspaceTerminalTab {
+  return tab.startsWith('terminal:')
+}
+
+function getRightWorkspaceTerminalNumericSuffix(tab: RightWorkspaceTerminalTab): number {
+  const parsed = Number.parseInt(tab.slice('terminal:'.length), 10)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function normalizeRightWorkspacePanelTab(
+  tab: RightWorkspacePanelTab | 'browser' | 'terminal'
+): RightWorkspacePanelTab {
+  if (tab === 'browser') return 'browser:1'
+  if (tab === 'terminal') return 'terminal:1'
+  return tab
+}
+
+function normalizeRightWorkspacePanelView(
+  view: RightWorkspacePanelView | 'browser' | 'terminal'
+): RightWorkspacePanelView {
+  return view === 'launcher' ? view : normalizeRightWorkspacePanelTab(view)
 }
 
 function getRightWorkspaceHarnessSessionId(tab: RightWorkspaceHarnessTab) {
@@ -1236,16 +1262,27 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       initialBlankBrowserMigration?.rightPanelView ??
       initialWorkspaceState?.rightPanelView ??
       'launcher'
-    return (restoredView as RightWorkspacePanelView | 'browser') === 'browser'
-      ? 'browser:1'
-      : restoredView
+    return normalizeRightWorkspacePanelView(
+      restoredView as RightWorkspacePanelView | 'browser' | 'terminal'
+    )
   })
   const [rightPanelTabs, setRightPanelTabs] = useState<RightWorkspacePanelTab[]>(() => {
     const restoredTabs = (initialBlankBrowserMigration?.rightPanelTabs ??
       initialWorkspaceState?.rightPanelTabs ??
-      []) as Array<RightWorkspacePanelTab | 'browser'>
-    return restoredTabs.map(tab => (tab === 'browser' ? 'browser:1' : tab))
+      []) as Array<RightWorkspacePanelTab | 'browser' | 'terminal'>
+    return restoredTabs.map(normalizeRightWorkspacePanelTab)
   })
+  const terminalTabSequence = useRef(
+    Math.max(
+      0,
+      ...rightPanelTabs
+        .filter(isRightWorkspaceTerminalTab)
+        .map(getRightWorkspaceTerminalNumericSuffix),
+      isRightWorkspaceTerminalTab(rightPanelView)
+        ? getRightWorkspaceTerminalNumericSuffix(rightPanelView)
+        : 0
+    )
+  )
   const [rightPanelImmediateLayout, setRightPanelImmediateLayout] = useState(false)
   const [selectedFileWorkspaceTargetKey, setSelectedFileWorkspaceTargetKey] = useState<
     string | null
@@ -1293,6 +1330,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const allocateBrowserTab = useCallback((): RightWorkspaceBrowserTab => {
     browserTabSequence.current += 1
     return `browser:${browserTabSequence.current}` as RightWorkspaceBrowserTab
+  }, [])
+  const allocateTerminalTab = useCallback((): RightWorkspaceTerminalTab => {
+    terminalTabSequence.current += 1
+    return `terminal:${terminalTabSequence.current}` as RightWorkspaceTerminalTab
   }, [])
   const createBrowserTabState = useCallback(
     (
@@ -1515,7 +1556,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     fileWorkspaceDirty ||
     rightPanelTabs.some(
       tab =>
-        tab === 'terminal' || isRightWorkspaceBrowserTab(tab) || isRightWorkspaceHarnessTab(tab)
+        isRightWorkspaceTerminalTab(tab) ||
+        isRightWorkspaceBrowserTab(tab) ||
+        isRightWorkspaceHarnessTab(tab)
     )
   useEffect(() => {
     onPaneResourceRetained(paneKey, 'right-panel', hasPersistentRightPanelResource)
@@ -2947,8 +2990,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     openBrowserTab()
   }, [openBrowserTab])
   const selectTerminalView = useCallback(() => {
-    openRightPanelTab('terminal')
-  }, [openRightPanelTab])
+    openRightPanelTab(allocateTerminalTab())
+  }, [allocateTerminalTab, openRightPanelTab])
   const selectChatView = useCallback(() => {
     openTemporaryChatTab()
   }, [openTemporaryChatTab])

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -61,14 +61,15 @@ function getRightWorkspaceShortcuts(platform: ReturnType<typeof getPlatform>) {
 export type RightWorkspaceChatTab = `chat:${string}`
 export type RightWorkspaceBrowserTab = `browser:${string}`
 export type RightWorkspaceHarnessTab = `harness:${string}`
+export type RightWorkspaceTerminalTab = `terminal:${string}`
 export type RightWorkspacePanelTab =
   | 'review'
-  | 'terminal'
   | 'files'
   | 'plan'
   | RightWorkspaceChatTab
   | RightWorkspaceBrowserTab
   | RightWorkspaceHarnessTab
+  | RightWorkspaceTerminalTab
 export type RightWorkspacePanelView = 'launcher' | RightWorkspacePanelTab
 
 function isRightWorkspaceChatTab(tab: RightWorkspacePanelView): tab is RightWorkspaceChatTab {
@@ -83,6 +84,12 @@ function isRightWorkspaceHarnessTab(tab: RightWorkspacePanelView): tab is RightW
   return tab.startsWith('harness:')
 }
 
+function isRightWorkspaceTerminalTab(
+  tab: RightWorkspacePanelView
+): tab is RightWorkspaceTerminalTab {
+  return tab.startsWith('terminal:')
+}
+
 function getRightWorkspaceHarnessSessionId(tab: RightWorkspaceHarnessTab) {
   return tab.slice('harness:'.length)
 }
@@ -93,6 +100,10 @@ function getRightWorkspaceChatTabSuffix(tab: RightWorkspaceChatTab) {
 
 function getRightWorkspaceBrowserTabSuffix(tab: RightWorkspaceBrowserTab) {
   return tab.slice('browser:'.length)
+}
+
+function getRightWorkspaceTerminalTabSuffix(tab: RightWorkspaceTerminalTab) {
+  return tab.slice('terminal:'.length)
 }
 
 export interface RightWorkspaceBrowserState {
@@ -492,6 +503,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
             allowTemporaryChat={allowTemporaryChat}
             workspaceActions={workspaceActions}
             onSelectReview={onSelectReview}
+            onSelectTerminal={onSelectTerminal}
             onSelectBrowser={onSelectBrowser}
             onSelectFiles={onSelectFiles}
             onSelectChat={onSelectChat}
@@ -508,18 +520,6 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
             focusFilePath={review.focusFilePath}
             viewOptions={reviewViewOptions}
             onRefresh={onRefreshReview}
-          />
-        ) : !isRightWorkspaceChatTab(activeView) && activeView === 'terminal' ? (
-          <WorkspacePanelCards
-            showWorkbenchBackground={showWorkbenchBackground}
-            currentProject={currentProject}
-            devices={devices}
-            workspaceTarget={workspaceTarget}
-            defaultOpenTool="terminal"
-            hideTerminalChrome
-            preferLocalTerminal={preferLocalTerminal}
-            terminalContextTitle={terminalContextTitle}
-            workspaceSessionApi={workspaceSessionApi}
           />
         ) : !isRightWorkspaceChatTab(activeView) && activeView === 'plan' ? (
           <PlanWorkspacePanel content={planContent ?? ''} />
@@ -570,6 +570,25 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
                   ? 'right-workspace-chat-panel'
                   : `right-workspace-chat-panel-${getRightWorkspaceChatTabSuffix(tab)}`
               }
+            />
+          </div>
+        ))}
+        {openTabs.filter(isRightWorkspaceTerminalTab).map(tab => (
+          <div
+            key={tab}
+            className={cn('min-h-0 flex-1 flex-col', activeView === tab ? 'flex' : 'hidden')}
+          >
+            <WorkspacePanelCards
+              showWorkbenchBackground={showWorkbenchBackground}
+              currentProject={currentProject}
+              devices={devices}
+              workspaceTarget={workspaceTarget}
+              defaultOpenTool="terminal"
+              hideTerminalChrome
+              preferLocalTerminal={preferLocalTerminal}
+              terminalContextTitle={terminalContextTitle}
+              workspaceSessionApi={workspaceSessionApi}
+              panelActive={visible && activeView === tab}
             />
           </div>
         ))}
@@ -752,6 +771,7 @@ function RightWorkspaceLauncher({
   allowTemporaryChat,
   workspaceActions,
   onSelectReview,
+  onSelectTerminal,
   onSelectBrowser,
   onSelectFiles,
   onSelectChat,
@@ -761,6 +781,7 @@ function RightWorkspaceLauncher({
   allowTemporaryChat: boolean
   workspaceActions: WorkspaceAddMenuItem[]
   onSelectReview: () => void
+  onSelectTerminal: () => void
   onSelectBrowser: () => void
   onSelectFiles: () => void
   onSelectChat: () => void
@@ -792,6 +813,12 @@ function RightWorkspaceLauncher({
           shortcut={getRightWorkspaceShortcuts(platform).review}
           onClick={onSelectReview}
           disabled={!canOpenReview}
+        />
+        <RightWorkspaceLauncherItem
+          data-testid="right-workspace-terminal-option"
+          icon={SquareTerminal}
+          label={t('workbench.terminal', '终端')}
+          onClick={onSelectTerminal}
         />
         <RightWorkspaceLauncherItem
           data-testid="right-workspace-browser-option"
@@ -864,7 +891,12 @@ function getRightWorkspaceTabLabel(
   harnessSessionsById: Map<string, LocalHarnessWorkbenchSession>
 ) {
   if (tab === 'review') return t('workbench.workspace_tab_review', '审查')
-  if (tab === 'terminal') return t('workbench.terminal', '终端')
+  if (isRightWorkspaceTerminalTab(tab)) {
+    const suffix = getRightWorkspaceTerminalTabSuffix(tab)
+    return suffix === '1'
+      ? t('workbench.terminal', '终端')
+      : `${t('workbench.terminal', '终端')} ${suffix}`
+  }
   if (isRightWorkspaceBrowserTab(tab)) {
     return browserStates[tab]?.title || t('workbench.browser_new_tab', '新选项卡')
   }
@@ -880,7 +912,12 @@ function getRightWorkspaceTabLabel(
 }
 
 function getRightWorkspaceTabTestId(tab: RightWorkspacePanelTab) {
-  if (tab === 'terminal') return 'right-workspace-terminal-tab'
+  if (isRightWorkspaceTerminalTab(tab)) {
+    const suffix = getRightWorkspaceTerminalTabSuffix(tab)
+    return suffix === '1'
+      ? 'right-workspace-terminal-tab'
+      : `right-workspace-terminal-tab-${suffix}`
+  }
   if (tab === 'files') return 'right-workspace-file-tab'
   if (isRightWorkspaceChatTab(tab)) {
     return `right-workspace-chat-tab-${getRightWorkspaceChatTabSuffix(tab)}`
@@ -896,7 +933,7 @@ function getRightWorkspaceTabTestId(tab: RightWorkspacePanelTab) {
 
 function getRightWorkspaceTabIcon(tab: RightWorkspacePanelTab) {
   if (tab === 'review') return FileDiff
-  if (tab === 'terminal') return SquareTerminal
+  if (isRightWorkspaceTerminalTab(tab)) return SquareTerminal
   if (isRightWorkspaceBrowserTab(tab)) return Globe2
   if (isRightWorkspaceChatTab(tab)) return MessageCircle
   if (isRightWorkspaceHarnessTab(tab)) return SquareTerminal


### PR DESCRIPTION
## Summary

- add Terminal to the right workspace launcher
- create a new independent right-side Terminal tab for every Terminal action
- preserve inactive Terminal sessions while switching tabs
- migrate the legacy persisted `terminal` tab state to `terminal:1`

## Root cause

The right workspace modeled Terminal as a singleton tab with the fixed ID `terminal`. Opening Terminal again called the generic tab opener, which deduplicated the existing ID and only selected the current tab. As a result, clicking Terminal a second time appeared to do nothing.

## User impact

Users can now open multiple Terminal sessions in the right sidebar. Tabs are labeled `终端`, `终端 2`, and so on; they can be switched and closed independently. The existing bottom Terminal shortcut and panel behavior are unchanged.

## Validation

- focused `DesktopWorkbenchLayout` Vitest coverage: 4 passed
- Wework TypeScript typecheck
- ESLint on changed files
- pre-push Wework ESLint, TypeScript, and full unit test suite
- isolated real Tauri verification:
  - opened the first right-side Terminal
  - opened `终端 2`
  - switched between both tabs
  - closed `终端 2` and confirmed the first Terminal remained selected

Task: WEWORKC2FA61-221
