### PR TITLE
chore(ci): sign and notarize Wework macOS builds

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -198,9 +198,7 @@ jobs:
             echo ""
             echo "## macOS Distribution Notes"
             echo ""
-            echo "Wework macOS DMG build."
-            echo ""
-            echo "This build is ad-hoc signed and not Apple notarized. On first launch, click Done if macOS shows a Move to Trash warning, then force-open it from System Settings > Privacy & Security > Open Anyway."
+            echo "Wework macOS DMG build, signed with an Apple Developer ID Application certificate and notarized by Apple."
             echo ""
             echo "## Windows Distribution Notes"
             echo ""
@@ -222,7 +220,7 @@ jobs:
   build-macos:
     name: Build macOS ${{ matrix.arch }}
     runs-on: macos-14
-    timeout-minutes: 45
+    timeout-minutes: 90
     needs: prepare-release
 
     strategy:
@@ -349,6 +347,74 @@ jobs:
           cargo_lock_path.write_text(cargo_lock, encoding="utf-8")
           PY
 
+      - name: Import Apple signing certificate
+        shell: bash
+        env:
+          MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          for required_name in \
+            MACOS_CERTIFICATE_BASE64 \
+            MACOS_CERTIFICATE_PASSWORD \
+            MACOS_SIGNING_IDENTITY \
+            APPLE_TEAM_ID; do
+            if [ -z "${!required_name:-}" ]; then
+              echo "Missing GitHub secret: $required_name" >&2
+              exit 1
+            fi
+          done
+
+          certificate_path="$RUNNER_TEMP/wework-signing-certificate.p12"
+          keychain_path="$RUNNER_TEMP/wework-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          cleanup_certificate() {
+            rm -f "$certificate_path"
+          }
+          trap cleanup_certificate EXIT
+
+          printf '%s' "$MACOS_CERTIFICATE_BASE64" | base64 -D > "$certificate_path"
+          chmod 0600 "$certificate_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$certificate_path" \
+            -k "$keychain_path" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+
+          imported_identity="$(
+            security find-identity -v -p codesigning "$keychain_path" \
+              | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' \
+              | head -n 1
+          )"
+          if [ -z "$imported_identity" ]; then
+            echo "The imported p12 does not contain a Developer ID Application identity." >&2
+            exit 1
+          fi
+          if [ "$imported_identity" != "$MACOS_SIGNING_IDENTITY" ]; then
+            echo "The imported signing identity does not match MACOS_SIGNING_IDENTITY." >&2
+            exit 1
+          fi
+          if [[ "$imported_identity" != *"($APPLE_TEAM_ID)" ]]; then
+            echo "The imported signing identity does not belong to APPLE_TEAM_ID." >&2
+            exit 1
+          fi
+
+          echo "MACOS_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"
+          echo "MACOS_SIGNING_IDENTITY=$imported_identity" >> "$GITHUB_ENV"
+
       - name: Build Wework app bundle
         working-directory: wework
         env:
@@ -370,6 +436,12 @@ jobs:
             exit 1
           fi
 
+          source scripts/lib/wework-macos-signing.sh
+          wework_sign_prepared_codex_macos_binaries \
+            "$PWD" \
+            "${{ matrix.rust_target }}" \
+            "$MACOS_SIGNING_IDENTITY"
+
           config_override="$(mktemp "$PWD/src-tauri/tauri.ci.XXXXXX.json")"
           cleanup() {
             rm -f "$config_override"
@@ -380,7 +452,7 @@ jobs:
           VERSION="${{ needs.prepare-release.outputs.version }}" \
           UPDATER_ENDPOINT="https://github.com/${GH_REPO}/releases/download/wework-updater/{{target}}-{{arch}}.json" \
           UPDATER_PUBKEY="$TAURI_UPDATER_PUBKEY" \
-          SIGNING_IDENTITY="-" \
+          SIGNING_IDENTITY="$MACOS_SIGNING_IDENTITY" \
           ENABLE_INSECURE_TRANSPORT="false" \
           node scripts/generate-release-config.mjs
           pnpm exec tauri build \
@@ -388,6 +460,80 @@ jobs:
             --bundles app,dmg \
             --features release-devtools \
             --config "$config_override"
+
+      - name: Sign and notarize macOS disk image
+        shell: bash
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+
+          for required_name in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER; do
+            if [ -z "${!required_name:-}" ]; then
+              echo "Missing GitHub secret: $required_name" >&2
+              exit 1
+            fi
+          done
+
+          dmg_source="$(find "wework/src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f | sort | tail -1)"
+          if [ -z "$dmg_source" ]; then
+            echo "No .dmg bundle found for signing and notarization." >&2
+            exit 1
+          fi
+
+          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          notary_result_path="$RUNNER_TEMP/notary-result-${{ matrix.arch }}.json"
+          cleanup_notary_key() {
+            rm -f "$api_key_path"
+          }
+          trap cleanup_notary_key EXIT
+
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
+          chmod 0600 "$api_key_path"
+
+          codesign --force \
+            --timestamp \
+            --keychain "$MACOS_KEYCHAIN_PATH" \
+            --sign "$MACOS_SIGNING_IDENTITY" \
+            "$dmg_source"
+          codesign --verify --strict --verbose=2 "$dmg_source"
+
+          set +e
+          xcrun notarytool submit "$dmg_source" \
+            --key "$api_key_path" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait \
+            --output-format json > "$notary_result_path"
+          notary_exit_code=$?
+          set -e
+
+          cat "$notary_result_path"
+          if ! jq -e . "$notary_result_path" >/dev/null; then
+            echo "Apple notarization returned an invalid response." >&2
+            exit 1
+          fi
+          submission_id="$(jq -r '.id // empty' "$notary_result_path")"
+          notary_status="$(jq -r '.status // empty' "$notary_result_path")"
+          if [ "$notary_exit_code" -ne 0 ] || [ "$notary_status" != "Accepted" ]; then
+            if [ -n "$submission_id" ]; then
+              xcrun notarytool log "$submission_id" \
+                --key "$api_key_path" \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER" || true
+            fi
+            echo "Apple notarization did not accept the DMG." >&2
+            exit 1
+          fi
+
+          xcrun stapler staple "$dmg_source"
+          xcrun stapler validate "$dmg_source"
+          {
+            echo "APPLE_NOTARY_SUBMISSION_ID=$submission_id"
+            echo "APPLE_NOTARY_STATUS=$notary_status"
+          } >> "$GITHUB_ENV"
 
       - name: Verify and collect release assets
         id: package
@@ -428,11 +574,12 @@ jobs:
           fi
           codesign --verify --deep --strict --verbose=2 "$app_path"
           codesign --display --verbose=4 "$app_path"
-          if spctl --assess --type execute --verbose "$app_path"; then
-            echo "Gatekeeper accepted the app bundle."
-          else
-            echo "::warning::Gatekeeper rejected this ad-hoc signed, non-notarized build. Users must click Done if macOS shows Move to Trash, then force-open it from System Settings > Privacy & Security > Open Anyway."
-          fi
+          spctl --assess --type execute --verbose=2 "$app_path"
+          spctl --assess \
+            --type open \
+            --context context:primary-signature \
+            --verbose=2 \
+            "$dmg_source"
           cleanup_mount
           trap - EXIT
 
@@ -451,10 +598,10 @@ jobs:
             echo ""
             echo "- DMG: $(basename "$dmg_path")"
             echo "- Updater archive: $(basename "$archive_path")"
-            echo "- This build is ad-hoc signed and not Apple notarized."
-            echo "- If the first launch dialog shows Move to Trash, click Done instead."
-            echo "- Then force-open from System Settings > Privacy & Security > Open Anyway."
-            echo "- If macOS keeps the quarantine flag: \`xattr -dr com.apple.quarantine /Applications/WeWork.app\`"
+            echo "- Signed with an Apple Developer ID Application certificate."
+            echo "- Apple notarization status: $APPLE_NOTARY_STATUS"
+            echo "- Apple notarization submission: $APPLE_NOTARY_SUBMISSION_ID"
+            echo "- Gatekeeper accepted both the application and DMG."
           } >> "$GITHUB_STEP_SUMMARY"
 
           {
@@ -502,6 +649,14 @@ jobs:
             ${{ steps.package.outputs.archive_path }}
             ${{ steps.package.outputs.signature_path }}
           if-no-files-found: error
+
+      - name: Remove temporary signing keychain
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${MACOS_KEYCHAIN_PATH:-}" ] && [ -f "$MACOS_KEYCHAIN_PATH" ]; then
+            security delete-keychain "$MACOS_KEYCHAIN_PATH"
+          fi
 
   build-windows:
     name: Build Windows x64


### PR DESCRIPTION
## What changed

- import the Developer ID Application certificate into an ephemeral CI keychain
- sign bundled Codex executables, the Wework app, and the macOS DMG
- submit each arm64 and x64 DMG to Apple notarization with an App Store Connect API key
- staple and validate the notarization ticket
- make Gatekeeper rejection a hard CI failure
- update generated GitHub Release notes and build summaries for notarized artifacts

## Why

The macOS workflow explicitly used ad-hoc signing and allowed Gatekeeper rejection. Users therefore had to bypass macOS security warnings after downloading release artifacts.

## Impact

macOS release and test artifacts now require valid Apple signing credentials, successful notarization, and successful Gatekeeper assessment. Windows packaging is unchanged.

Repository Actions secrets for the certificate and notarization API credentials have been configured separately and are not present in this change.

## Validation

- `actionlint .github/workflows/wework-app.yml`
- `git diff --check`
- imported the configured p12 into an isolated macOS keychain and verified the expected Developer ID identity
- decoded and validated the configured App Store Connect API private key with OpenSSL
- repository pre-push quality checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS releases are now signed with an Apple Developer ID certificate.
  * macOS disk images are notarized with Apple and validated by Gatekeeper.
  * Release notes now include signing and notarization details.

* **Reliability**
  * Added validation steps to confirm the app and disk image meet macOS security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->