### PR TITLE
fix(wework): show thinking between streamed items

### DIFF
--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -270,13 +270,16 @@ impl CodexNotificationEventMapper {
                     self.remember_subagent_item(notification.params);
                     return;
                 }
-                emit_tool_start(
+                let emitted_tool = emit_tool_start(
                     event_tx,
                     device_id,
                     local_task_id,
                     request,
                     notification.params,
                 );
+                if !emitted_tool {
+                    self.finish_process_text_before_item(&emit_context, notification.params);
+                }
             }
             "item/tool/requestUserInput" => {
                 emit_request_user_input(
@@ -1073,6 +1076,35 @@ impl CodexNotificationEventMapper {
         self.process_text = None;
     }
 
+    fn finish_process_text_before_item(
+        &mut self,
+        emit_context: &EventEmitContext<'_>,
+        params: &Value,
+    ) {
+        let next_item_id = notification_item_id(params);
+        let Some(process_text) = self.process_text.as_ref() else {
+            return;
+        };
+        if process_text.item_id == next_item_id {
+            return;
+        }
+
+        emit_response_event(
+            emit_context.event_tx,
+            emit_context.device_id,
+            "response.block.updated",
+            emit_context.local_task_id,
+            emit_context.request,
+            json!({
+                "block_id": process_text.id,
+                "updates": {
+                    "status": "done",
+                }
+            }),
+        );
+        self.reset_process_text();
+    }
+
     fn remember_subagent_item(&mut self, params: &Value) {
         if let Some(item_id) = notification_item_id(params) {
             self.subagent_item_ids.insert(item_id);
@@ -1308,7 +1340,7 @@ fn emit_tool_start(
     local_task_id: &str,
     request: &ExecutionRequest,
     params: &Value,
-) {
+) -> bool {
     if let Some(block) = workbench_block_from_notification(
         params,
         &request.subtask_id,
@@ -1324,7 +1356,9 @@ fn emit_tool_start(
             request,
             json!({"block": block}),
         );
+        return true;
     }
+    false
 }
 
 fn emit_request_user_input(
@@ -2458,6 +2492,72 @@ mod tests {
             created["payload"]["data"]["block"]["id"]
         );
         assert_eq!(updated["payload"]["data"]["updates"]["status"], "done");
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn completes_streamed_process_text_when_the_next_codex_item_starts() {
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let request = ExecutionRequest {
+            task_id: "7".to_owned(),
+            subtask_id: "8".to_owned(),
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+
+        for message in [
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "msg-commentary",
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": ""
+                    }
+                }
+            }),
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "itemId": "msg-commentary",
+                    "delta": "I will inspect."
+                }
+            }),
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "reasoning-1",
+                        "type": "reasoning"
+                    }
+                }
+            }),
+        ] {
+            mapper.map(
+                &Some(event_tx.clone()),
+                "device-1",
+                "local-1",
+                &request,
+                message,
+            );
+        }
+
+        let created = event_rx
+            .try_recv()
+            .expect("streamed process text should be emitted");
+        let completed = event_rx
+            .try_recv()
+            .expect("the next item should settle the process text");
+
+        assert_eq!(created["event"], "response.block.created");
+        assert_eq!(created["payload"]["data"]["block"]["status"], "streaming");
+        assert_eq!(completed["event"], "response.block.updated");
+        assert_eq!(
+            completed["payload"]["data"]["block_id"],
+            created["payload"]["data"]["block"]["id"]
+        );
+        assert_eq!(completed["payload"]["data"]["updates"]["status"], "done");
         assert!(event_rx.try_recv().is_err());
     }
 
@@ -3894,6 +3994,9 @@ mod tests {
             .try_recv()
             .expect("commentary process event should be emitted");
         let tool = event_rx.try_recv().expect("tool event should be emitted");
+        let process_completed = event_rx
+            .try_recv()
+            .expect("the final item should settle commentary");
         let final_text = event_rx
             .try_recv()
             .expect("final process event should be emitted");
@@ -3908,6 +4011,15 @@ mod tests {
         assert_eq!(
             tool["payload"]["data"]["block"]["tool_name"],
             "exec_command"
+        );
+        assert_eq!(process_completed["event"], "response.block.updated");
+        assert_eq!(
+            process_completed["payload"]["data"]["block_id"],
+            process["payload"]["data"]["block"]["id"]
+        );
+        assert_eq!(
+            process_completed["payload"]["data"]["updates"]["status"],
+            "done"
         );
         assert_eq!(final_text["event"], "response.block.created");
         assert_eq!(

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -4665,6 +4665,35 @@ describe('MessageList', () => {
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 
+  test('shows thinking after process text completes while waiting for the next item', () => {
+    const processBlock: ProcessingBlock = {
+      id: 'text-1',
+      subtaskId: 1,
+      type: 'text',
+      content: 'Let me inspect the repository first.',
+      status: 'done',
+      createdAt: 1770000000000,
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+            blocks: [processBlock],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Let me inspect the repository first.')).toBeInTheDocument()
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
+  })
+
   test('collapses tool rows and shows trailing thinking once final text is visible', () => {
     const runningBlock: ProcessingBlock = {
       id: 'call-1',

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -2066,6 +2066,7 @@ function AssistantMessage({
     isStreaming,
     hasProcessingDisplayBlock: hasProcessingDisplayBlock(displayBlocks),
     hasVisibleContent,
+    hasTrailingCompletedProcessText: hasTrailingCompletedProcessText(displayBlocks),
   })
   const webSearchSources = isStreaming
     ? []
@@ -2416,16 +2417,26 @@ function hasProcessingDisplayBlock(blocks: ProcessingBlock[]): boolean {
   return buildProcessingDisplayRows(blocks).length > 0
 }
 
+function hasTrailingCompletedProcessText(blocks: ProcessingBlock[]): boolean {
+  const lastBlock = blocks.at(-1)
+  return lastBlock?.type === 'text' && (lastBlock.status === 'done' || lastBlock.status === 'error')
+}
+
 function shouldShowAssistantThinkingIndicator({
   isStreaming,
   hasProcessingDisplayBlock,
   hasVisibleContent,
+  hasTrailingCompletedProcessText,
 }: {
   isStreaming: boolean
   hasProcessingDisplayBlock: boolean
   hasVisibleContent: boolean
+  hasTrailingCompletedProcessText: boolean
 }): boolean {
-  return isStreaming && (!hasProcessingDisplayBlock || hasVisibleContent)
+  return (
+    isStreaming &&
+    (!hasProcessingDisplayBlock || hasVisibleContent || hasTrailingCompletedProcessText)
+  )
 }
 
 function AssistantErrorCard({


### PR DESCRIPTION
## Summary

- show the existing “正在思考” indicator after completed process text while the assistant turn is still running
- settle streamed process text when a new non-tool Codex item starts, so the UI enters the waiting state immediately
- keep process text streaming across visible tool starts, preserving interleaved commentary and tool output
- add frontend and executor regression coverage for the real item ordering

## Root cause

The frontend hid the global thinking indicator while the trailing process-text block was still marked as streaming. In the failing Codex event order, a new reasoning or final-message item could start before the previous commentary item completed, so the executor left that process-text block streaming and the UI appeared frozen.

## Validation

- `pnpm --filter wework test src/components/chat/MessageList.test.tsx` (140 tests passed)
- `cargo test --manifest-path executor/Cargo.toml --all-features --lib runtime_work::events::tests::` (46 tests passed)
- `cargo test --manifest-path executor/Cargo.toml --all-features --lib` (794 passed, 1 ignored)
- pre-push frontend, Wework, backend formatting/syntax, executor fmt/test/clippy, settings, and Alembic checks
- isolated real-Tauri verification of process text → tool item → final response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the assistant’s thinking indicator during streaming responses.
  * Completed process-text content remains visible while the assistant waits for the next response item.
  * Improved handling of content transitions during streamed responses.

* **Tests**
  * Added regression coverage for process-text visibility and thinking-indicator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->