### PR TITLE
fix(wework): clear stale reconnect status after refresh

### DIFF
--- a/wework/e2e/desktop/modules/resilience-flows.mjs
+++ b/wework/e2e/desktop/modules/resilience-flows.mjs
@@ -59,11 +59,6 @@ async function verifyReconnectRecovery({ composerSelector, control }) {
     WORKBENCH_READY_TIMEOUT_MS,
     'The reloaded Wework WebView did not reconnect during response recovery'
   )
-  await control.command(
-    'waitFor',
-    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="runtime-reconnecting-status"]`,
-    { timeoutMs: WORKBENCH_READY_TIMEOUT_MS }
-  )
 
   await withTimeout(
     control.awaitScenarioRequestCount('reconnect', 2),

--- a/wework/e2e/desktop/modules/resilience-flows.mjs
+++ b/wework/e2e/desktop/modules/resilience-flows.mjs
@@ -52,6 +52,19 @@ async function verifyReconnectRecovery({ composerSelector, control }) {
     ACTIVE_WORKBENCH_SELECTOR
   )
 
+  const readyCountBeforeReload = control.readyCount
+  await control.command('reloadMainWindow', 'body')
+  await withTimeout(
+    control.awaitReadyAfter(readyCountBeforeReload),
+    WORKBENCH_READY_TIMEOUT_MS,
+    'The reloaded Wework WebView did not reconnect during response recovery'
+  )
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="runtime-reconnecting-status"]`,
+    { timeoutMs: WORKBENCH_READY_TIMEOUT_MS }
+  )
+
   await withTimeout(
     control.awaitScenarioRequestCount('reconnect', 2),
     DEFAULT_STEP_TIMEOUT_MS,

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -33,6 +33,109 @@ function requestBlock(id: string, turnId: string): ProcessingBlock {
 }
 
 describe('runtimeConversationTurns', () => {
+  test('settles a stale reconnecting block when the turn resumes with new work', () => {
+    let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
+      type: 'block_created',
+      subtaskId: 'turn-1',
+      block: {
+        id: 'reconnecting-turn-1',
+        subtaskId: 'turn-1',
+        type: 'tool',
+        toolName: 'runtime_reconnecting',
+        status: 'streaming',
+        createdAt: 100,
+      },
+    })
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'block_created',
+      subtaskId: 'turn-1',
+      block: {
+        id: 'command-1',
+        subtaskId: 'turn-1',
+        type: 'tool',
+        toolName: 'exec_command',
+        status: 'streaming',
+        createdAt: 200,
+      },
+    })
+
+    expect(turns[0].items).toEqual([
+      expect.objectContaining({
+        id: 'reconnecting-turn-1',
+        block: expect.objectContaining({
+          status: 'done',
+          completedAt: expect.any(Number),
+        }),
+      }),
+      expect.objectContaining({
+        id: 'command-1',
+        block: expect.objectContaining({ status: 'streaming' }),
+      }),
+    ])
+  })
+
+  test('keeps the reconnecting block active until actual turn progress arrives', () => {
+    let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
+      type: 'block_created',
+      subtaskId: 'turn-1',
+      block: {
+        id: 'reconnecting-turn-1',
+        subtaskId: 'turn-1',
+        type: 'tool',
+        toolName: 'runtime_reconnecting',
+        status: 'streaming',
+        createdAt: 100,
+      },
+    })
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      content: '',
+      blocks: [],
+    })
+
+    expect(turns[0].items[0]).toMatchObject({
+      id: 'reconnecting-turn-1',
+      block: { status: 'streaming' },
+    })
+  })
+
+  test('settles a reconnecting block when the turn reaches an error terminal state', () => {
+    let turns = reduceRuntimeConversationTurns([{ id: 'turn-1', items: [], status: 'streaming' }], {
+      type: 'block_created',
+      subtaskId: 'turn-1',
+      block: {
+        id: 'reconnecting-turn-1',
+        subtaskId: 'turn-1',
+        type: 'tool',
+        toolName: 'runtime_reconnecting',
+        status: 'streaming',
+        createdAt: 100,
+      },
+    })
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'assistant_error',
+      subtaskId: 'turn-1',
+      error: 'upstream unavailable',
+    })
+
+    expect(turns[0]).toMatchObject({
+      status: 'failed',
+      items: [
+        {
+          id: 'reconnecting-turn-1',
+          block: {
+            status: 'done',
+            completedAt: expect.any(Number),
+          },
+        },
+      ],
+    })
+  })
+
   test('binds only the exact optimistic user to the real Codex turn id', () => {
     let turns = reduceRuntimeConversationTurns([], {
       type: 'user_added',

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -8,6 +8,8 @@ import type {
   WorkbenchMessage,
 } from '@/types/workbench'
 
+const RUNTIME_RECONNECTING_TOOL_NAME = 'runtime_reconnecting'
+
 export function mergeRuntimeConversationTurns(
   localTurns: RuntimeConversationTurn[],
   snapshotTurns: RuntimeConversationTurn[]
@@ -72,7 +74,10 @@ export function reduceRuntimeConversationTurns(
       return updateStartedTurn(turns, action)
     case 'assistant_chunk':
       return updateTurn(turns, action.subtaskId, turn => {
-        let items = upsertReasoningChunk(turn.items, action.subtaskId, action.reasoningChunk)
+        let items = hasAssistantChunkProgress(action)
+          ? settleRuntimeReconnectingBlocks(turn.items)
+          : turn.items
+        items = upsertReasoningChunk(items, action.subtaskId, action.reasoningChunk)
         items = upsertBlocks(items, action.blocks)
         if (action.content) {
           if (action.itemId) {
@@ -106,7 +111,9 @@ export function reduceRuntimeConversationTurns(
     case 'assistant_done':
       return updateTurn(turns, action.subtaskId, turn => {
         const items = applyCompletedAssistantContent(
-          settleProcessingBlocks(upsertBlocks(turn.items, action.blocks)),
+          settleProcessingBlocks(
+            upsertBlocks(settleRuntimeReconnectingBlocks(turn.items), action.blocks)
+          ),
           turn.id,
           action.itemId,
           action.content
@@ -123,22 +130,28 @@ export function reduceRuntimeConversationTurns(
         }
       })
     case 'assistant_cancelled':
-      return updateTurn(turns, action.subtaskId, turn => ({
-        ...turn,
-        status: 'cancelled',
-        streamingThinkingContent: undefined,
-        completedAt: new Date().toISOString(),
-        stoppedNotice: true,
-      }))
+      return updateTurn(turns, action.subtaskId, turn => {
+        return {
+          ...turn,
+          items: settleRuntimeReconnectingBlocks(turn.items),
+          status: 'cancelled',
+          streamingThinkingContent: undefined,
+          completedAt: new Date().toISOString(),
+          stoppedNotice: true,
+        }
+      })
     case 'assistant_error':
-      return updateTurn(turns, action.subtaskId, turn => ({
-        ...turn,
-        status: 'failed',
-        streamingThinkingContent: undefined,
-        completedAt: new Date().toISOString(),
-        error: action.error,
-        errorType: action.errorType,
-      }))
+      return updateTurn(turns, action.subtaskId, turn => {
+        return {
+          ...turn,
+          items: settleRuntimeReconnectingBlocks(turn.items),
+          status: 'failed',
+          streamingThinkingContent: undefined,
+          completedAt: new Date().toISOString(),
+          error: action.error,
+          errorType: action.errorType,
+        }
+      })
     case 'file_changes_updated':
       return updateTurn(turns, action.subtaskId, turn => ({
         ...turn,
@@ -146,8 +159,11 @@ export function reduceRuntimeConversationTurns(
       }))
     case 'block_created':
       return updateTurn(turns, action.subtaskId, turn => {
+        const currentItems = isRuntimeReconnectingBlock(action.block)
+          ? turn.items
+          : settleRuntimeReconnectingBlocks(turn.items)
         const items = replaceAssistantTextWithBlock(
-          turn.items,
+          currentItems,
           action.replaceAssistantTextItemId,
           action.block
         )
@@ -164,10 +180,18 @@ export function reduceRuntimeConversationTurns(
       })
     case 'block_updated':
       return updateTurn(turns, action.subtaskId, turn => {
+        const currentItems = turn.items.some(
+          item =>
+            item.type === 'block' &&
+            item.id === action.blockId &&
+            isRuntimeReconnectingBlock(item.block)
+        )
+          ? turn.items
+          : settleRuntimeReconnectingBlocks(turn.items)
         const previousBlock = turn.items.find(
           item => item.type === 'block' && item.id === action.blockId
         )
-        const items = turn.items.map(item =>
+        const items = currentItems.map(item =>
           item.type === 'block' && item.id === action.blockId
             ? {
                 ...item,
@@ -784,6 +808,43 @@ function settleProcessingBlocks(items: RuntimeConversationItem[]): RuntimeConver
       } as ProcessingBlock,
     }
   })
+}
+
+function settleRuntimeReconnectingBlocks(
+  items: RuntimeConversationItem[]
+): RuntimeConversationItem[] {
+  // A WebView refresh can miss the dedicated completion event. Any later turn
+  // progress proves the connection recovered, so the transient block must settle.
+  const completedAt = Date.now()
+  return items.map(item => {
+    if (
+      item.type !== 'block' ||
+      !isRuntimeReconnectingBlock(item.block) ||
+      item.block.status === 'done' ||
+      item.block.status === 'error'
+    ) {
+      return item
+    }
+    return {
+      ...item,
+      block: {
+        ...item.block,
+        status: 'done',
+        completedAt: item.block.completedAt ?? completedAt,
+      },
+    }
+  })
+}
+
+function hasAssistantChunkProgress(
+  action: Extract<RuntimePaneMessageAction, { type: 'assistant_chunk' }>
+): boolean {
+  if (action.content || action.reasoningChunk) return true
+  return Boolean(action.blocks?.some(block => !isRuntimeReconnectingBlock(block)))
+}
+
+function isRuntimeReconnectingBlock(block: ProcessingBlock): boolean {
+  return block.type === 'tool' && block.toolName === RUNTIME_RECONNECTING_TOOL_NAME
 }
 
 function assistantTextContent(items: RuntimeConversationItem[]): string {


### PR DESCRIPTION
## What changed

- settle the transient `runtime_reconnecting` block when the same turn emits later progress or reaches a terminal state
- keep the reconnecting indicator active when no actual progress has arrived
- extend the desktop resilience flow to reload the Wework WebView while reconnecting and verify the indicator disappears after recovery

## Root cause

The reconnecting indicator was represented as a transient processing block that normally depended on a dedicated `status: done` update. During a WebView refresh, transcript hydration and live stream events can interleave, so that completion update could be missed while later task events continued normally. The stale block then remained visible indefinitely even though execution had recovered.

## Impact

After refreshing Wework during an active task, the UI now clears the stale “Connection interrupted. Reconnecting…” status as soon as the turn demonstrably resumes or finishes.

## Validation

- `pnpm --filter wework test src/features/workbench/runtimeConversationTurns.test.ts`
- `pnpm --filter wework typecheck`
- focused Prettier and ESLint checks
- pre-push Wework ESLint, TypeScript, and full unit-test checks
- desktop `resilience` checkpoint attempted; the shared bootstrap failed before this scenario because the action on `[data-testid="device-folder-path-input"]` timed out. Evidence: `wework/test-results/desktop-e2e/2026-08-14T06-48-40-758Z-35488`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when the runtime reconnects during an active conversation.
  * Reconnecting status now clears when meaningful progress resumes, work completes, is cancelled, or encounters an error.
  * Preserved the reconnecting state during empty assistant updates until recovery is confirmed.
* **Tests**
  * Added coverage for reconnecting conversations, including recovery, failures, completion timestamps, and active-state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->