### PR TITLE
fix(wework): focus composer when editing queued message

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -805,6 +805,11 @@ describe('ChatInput', () => {
     await waitFor(() =>
       expect(screen.getByTestId('chat-message-input')).toHaveTextContent('先检查引导条里的文本')
     )
+
+    const editor = screen.getByTestId('chat-message-input')
+    expect(editor).toHaveFocus()
+    await userEvent.type(editor, '，继续')
+    expect(editor).toHaveTextContent('先检查引导条里的文本，继续')
   })
 
   test('shows lightweight interrupt action while guidance is sending', async () => {

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -618,6 +618,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
   useImperativeHandle(
     ref,
     () => ({
+      focus: () => composerRef.current?.focus(),
       getValue: () => composerRef.current?.getValue() ?? value,
       setValue: (nextValue, selectionOffset) =>
         composerRef.current?.setValue(nextValue, selectionOffset),
@@ -631,6 +632,11 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     const next = buildRefinedPluginPrompt(composerRef.current?.getValue() ?? value, prompt)
     composerRef.current?.setValue(next)
     onChange(next)
+  }
+
+  const handleEditQueuedMessage = (id: string) => {
+    onEditQueuedMessage?.(id)
+    composerRef.current?.focus()
   }
 
   const displayedGoal = visibleRuntimeGoal(goal)
@@ -803,7 +809,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
       onCancelQueuedMessage={onCancelQueuedMessage}
       onSendQueuedAsGuidance={onSendQueuedAsGuidance}
       onInterruptAndSendQueuedMessage={onInterruptAndSendQueuedMessage}
-      onEditQueuedMessage={onEditQueuedMessage}
+      onEditQueuedMessage={onEditQueuedMessage ? handleEditQueuedMessage : undefined}
       onReorderQueuedMessages={onReorderQueuedMessages}
       queuePaused={queuePaused}
       onResumeQueue={onResumeQueue}

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -169,6 +169,12 @@ export const CompactChatComposer = forwardRef<ComposerTextareaHandle, CompactCha
     useImperativeHandle(
       ref,
       () => ({
+        focus: () => {
+          const activeHandle = fullscreenInputOpen
+            ? fullscreenComposerRef.current
+            : composerRef.current
+          activeHandle?.focus()
+        },
         getValue: () => {
           const activeHandle = fullscreenInputOpen
             ? fullscreenComposerRef.current

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -95,6 +95,7 @@ interface ActiveComposerMenu {
 }
 
 export interface ComposerTextareaHandle {
+  focus: () => void
   getValue: () => string
   setValue: (value: string, selectionOffset?: number) => void
 }
@@ -161,6 +162,7 @@ export const ComposerTextarea = forwardRef<ComposerTextareaHandle, ComposerTexta
     useImperativeHandle(
       ref,
       () => ({
+        focus: () => editorRef.current?.focus(),
         getValue: () => editorRef.current?.getSnapshot().value ?? valueRef.current,
         setValue: (nextValue, selectionOffset = nextValue.length) => {
           valueRef.current = nextValue

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -196,6 +196,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
     useImperativeHandle(
       ref,
       () => ({
+        focus: () => composerRef.current?.focus(),
         getValue: () => composerRef.current?.getValue() ?? value,
         setValue: (nextValue, selectionOffset) =>
           composerRef.current?.setValue(nextValue, selectionOffset),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring a queued chat message now automatically focuses the composer.
  * Users can continue typing immediately at the end of the restored message.
  * Focus is directed to the active composer, including fullscreen mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->