### PR TITLE
fix(executor): avoid blocking runtime event relay

### DIFF
--- a/executor/src/local/backend.rs
+++ b/executor/src/local/backend.rs
@@ -79,7 +79,6 @@ const TERMINAL_EXIT_EVENT: &str = "terminal:exit";
 const TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const RUNTIME_RPC_EVENT: &str = "runtime:rpc";
 const RUNTIME_EVENT_EVENT: &str = "runtime:event";
-const RUNTIME_EVENT_ACK_TIMEOUT: Duration = Duration::from_secs(10);
 const DEVICE_UPGRADE_EVENT: &str = "device:upgrade";
 const DEVICE_RUN_EXTENSION_EVENT: &str = "device:run_extension";
 const APP_IPC_DEVICE_ID_ENV: &str = "WEGENT_APP_IPC_DEVICE_ID";
@@ -312,9 +311,7 @@ where
             loop {
                 match events.recv().await {
                     Ok(event) => {
-                        if let Err(error) = client
-                            .call_raw_event(RUNTIME_EVENT_EVENT, event, RUNTIME_EVENT_ACK_TIMEOUT)
-                            .await
+                        if let Err(error) = client.emit_raw_event(RUNTIME_EVENT_EVENT, event).await
                         {
                             write_executor_error_line(&format_executor_log(
                                 "runtime event relay failed",

--- a/executor/src/local/backend/client.rs
+++ b/executor/src/local/backend/client.rs
@@ -115,15 +115,6 @@ where
         self.transport.emit(event, payload).await
     }
 
-    pub async fn call_raw_event(
-        &self,
-        event: &str,
-        payload: Value,
-        timeout: Duration,
-    ) -> Result<Value, String> {
-        self.transport.call(event, payload, timeout).await
-    }
-
     pub fn set_running_task_ids<I>(&self, task_ids: I)
     where
         I: IntoIterator<Item = String>,

--- a/executor/tests/local_backend_contract.rs
+++ b/executor/tests/local_backend_contract.rs
@@ -518,7 +518,7 @@ async fn local_backend_relays_events_from_shared_app_runtime_handler() {
 
     timeout(Duration::from_secs(3), async {
         loop {
-            if !transport.calls().is_empty() {
+            if !transport.emits().is_empty() {
                 return;
             }
             tokio::task::yield_now().await;
@@ -527,10 +527,10 @@ async fn local_backend_relays_events_from_shared_app_runtime_handler() {
     .await
     .unwrap();
 
-    let calls = transport.calls();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].event, "runtime:event");
-    assert_eq!(calls[0].payload["event"], "runtime.task.completed");
+    let emits = transport.emits();
+    assert_eq!(emits.len(), 1);
+    assert_eq!(emits[0].event, "runtime:event");
+    assert_eq!(emits[0].payload["event"], "runtime.task.completed");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- relay runtime events with Socket.IO emit semantics instead of waiting synchronously for an acknowledgement
- remove the now-unused acknowledgement call helper and timeout
- update the executor contract test to verify emitted events

## Root cause

The cloud desktop supervisor scenario stalled because the executor runtime event forwarder waited up to 10 seconds for each backend acknowledgement. The backend acknowledges only after synchronous project-chat persistence, so one delayed acknowledgement blocked all later streaming and completion events in the serial forwarder.

## Verification

- `cargo fmt`
- `cargo test --test local_backend_contract local_backend_relays_events_from_shared_app_runtime_handler`
- pre-push Rust library tests and Clippy

A local desktop E2E attempt did not reach the supervisor scenario because setup failed while filling the device folder path amid stale historical E2E app processes; no E2E test logic was changed.

No documentation update is needed because this restores the existing non-blocking event-relay contract and does not change user-facing behavior or architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime event delivery by sending events without waiting for acknowledgments.
  * Reduced the chance of delays or timeouts when forwarding runtime events.
* **Tests**
  * Updated runtime event validation to confirm that events are emitted and contain the expected payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->