### PR TITLE
feat: fix(image): update image URL handling to use attachment URLs

### DIFF
--- a/backend/app/services/execution/agents/image/image_agent.py
+++ b/backend/app/services/execution/agents/image/image_agent.py
@@ -19,6 +19,7 @@ import uuid
 from typing import List, Optional
 
 from app.core.shutdown import shutdown_manager
+from app.services.context import context_service
 from shared.models import EventType, ExecutionEvent, ExecutionRequest
 from shared.prompts.constants import USER_QUESTION_MARKER, extract_user_question
 
@@ -208,7 +209,6 @@ class ImageAgent(PollingAgent):
                 # Get image URL (either direct URL or convert from base64)
                 image_url = image.url
                 if not image_url and image.b64_json:
-                    # For base64, we'll store it directly
                     output_format = model_config.get("imageConfig", {}).get(
                         "output_format"
                     ) or ("png" if protocol == "gpt-image" else "jpeg")
@@ -216,9 +216,6 @@ class ImageAgent(PollingAgent):
                     image_url = f"data:image/{mime_subtype};base64,{image.b64_json}"
 
                 if image_url:
-                    image_urls.append(image_url)
-
-                    # Upload as attachment
                     attachment_id = await self._upload_attachment(
                         image_url=image_url,
                         image_size=image.size,
@@ -228,8 +225,11 @@ class ImageAgent(PollingAgent):
                         index=i,
                     )
                     attachment_ids.append(attachment_id)
+                    image_urls.append(
+                        context_service.build_attachment_url(attachment_id)
+                    )
 
-            # Emit final image block with actual image data
+            # Emit final image block with persisted attachment URLs
             final_image_block = {
                 "id": image_block_id,
                 "type": "image",

--- a/backend/tests/services/execution/agents/image/test_image_agent.py
+++ b/backend/tests/services/execution/agents/image/test_image_agent.py
@@ -383,7 +383,7 @@ class TestImageAgent:
                 await agent.execute(sample_request, mock_emitter)
 
         # Assert
-        # Verify DONE event was emitted with data URL
+        # Verify upload receives the provider data URL while DONE uses the attachment URL
         done_calls = [
             call
             for call in mock_emitter.emit.call_args_list
@@ -392,8 +392,9 @@ class TestImageAgent:
         assert len(done_calls) == 1
         done_event = done_calls[0][0][0]
         image_urls = done_event.result["blocks"][0]["image_urls"]
-        assert len(image_urls) == 1
-        assert image_urls[0].startswith("data:image/jpeg;base64,")
+        assert image_urls == ["/api/attachments/999/download"]
+        uploaded_url = mock_upload.await_args.kwargs["image_url"]
+        assert uploaded_url.startswith("data:image/jpeg;base64,")
 
     @pytest.mark.asyncio
     async def test_execute_with_multiple_images(
@@ -445,8 +446,12 @@ class TestImageAgent:
         done_event = done_calls[0][0][0]
         image_block = done_event.result["blocks"][0]
         assert image_block["image_count"] == 3
-        assert len(image_block["image_urls"]) == 3
-        assert len(image_block["image_attachment_ids"]) == 3
+        assert image_block["image_urls"] == [
+            "/api/attachments/1001/download",
+            "/api/attachments/1002/download",
+            "/api/attachments/1003/download",
+        ]
+        assert image_block["image_attachment_ids"] == [1001, 1002, 1003]
 
     def test_agent_name(self):
         """Test agent name property."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated images now appear with stable attachment download links in completed results.
  * Image uploads continue to support data URL inputs while exposing the correct persisted image URLs.
  * Improved handling of results containing multiple generated images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->