### PR TITLE
fix(plugins): repair Windows DingTalk authorization

### DIFF
--- a/executor/src/runtime_work/local_connector_auth.rs
+++ b/executor/src/runtime_work/local_connector_auth.rs
@@ -238,12 +238,10 @@ fn resolve_plugin_root_candidates(
         ));
     }
 
-    let home = env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| AppIpcError::new("internal_error", "HOME is not set"))?;
-    let executor_home = env::var_os("WEGENT_EXECUTOR_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".wegent-executor"));
+    let executor_home = resolve_executor_home(
+        env::var_os("WEGENT_EXECUTOR_HOME").map(PathBuf::from),
+        dirs::home_dir(),
+    )?;
 
     let mut candidates: Vec<PathBuf> = Vec::new();
     let store_plugins = executor_home.join("capabilities/store/plugins");
@@ -284,6 +282,15 @@ fn resolve_plugin_root_candidates(
         ));
     }
     Ok(candidates)
+}
+
+fn resolve_executor_home(
+    configured_executor_home: Option<PathBuf>,
+    platform_home: Option<PathBuf>,
+) -> Result<PathBuf, AppIpcError> {
+    configured_executor_home
+        .or_else(|| platform_home.map(|home| home.join(".wegent-executor")))
+        .ok_or_else(|| AppIpcError::new("internal_error", "Home directory is not available"))
 }
 
 fn has_plugin_manifest(path: &Path) -> bool {
@@ -919,6 +926,15 @@ mod tests {
             Some(value) => env::set_var("WEGENT_CODEX_HOME", value),
             None => env::remove_var("WEGENT_CODEX_HOME"),
         }
+    }
+
+    #[test]
+    fn resolve_executor_home_uses_runtime_path_without_platform_home() {
+        let executor_home = PathBuf::from("runtime/executor-home");
+
+        let resolved = resolve_executor_home(Some(executor_home.clone()), None).unwrap();
+
+        assert_eq!(resolved, executor_home);
     }
 
     #[test]

--- a/executor/src/runtime_work/local_connector_auth.rs
+++ b/executor/src/runtime_work/local_connector_auth.rs
@@ -461,6 +461,22 @@ fn browser_auth_sessions() -> &'static Mutex<HashMap<String, BrowserAuthSession>
     BROWSER_AUTH_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+async fn active_browser_auth_state(plugin_key: &str, connector_slug: &str) -> Option<Value> {
+    let state = {
+        let sessions = browser_auth_sessions().lock().await;
+        sessions
+            .values()
+            .find(|session| {
+                session.plugin_key == plugin_key
+                    && session.connector_slug == connector_slug
+                    && !session.task.is_finished()
+            })
+            .map(|session| Arc::clone(&session.state))
+    }?;
+    let response = state.lock().await.clone();
+    Some(response)
+}
+
 async fn start_browser_auth(
     payload: Value,
     plugin_root: PathBuf,
@@ -473,6 +489,9 @@ async fn start_browser_auth(
         .or_else(|| string_field(&payload, "connector_slug"))
         .or_else(|| string_field(&payload, "slug"))
         .ok_or_else(|| AppIpcError::new("bad_request", "connectorSlug is required"))?;
+    if let Some(state) = active_browser_auth_state(&plugin_key, &connector_slug).await {
+        return Ok(state);
+    }
     let session_id = Uuid::new_v4().to_string();
     let state = Arc::new(Mutex::new(browser_session_state(
         "preparing",
@@ -865,6 +884,43 @@ mod tests {
         assert!(missing
             .windows(2)
             .any(|pair| pair == ["--wait-seconds", "0"]));
+    }
+
+    #[tokio::test]
+    async fn reuses_active_browser_auth_session_state() {
+        let plugin_key = format!("plugin-{}", Uuid::new_v4());
+        let connector_slug = "browser-auth".to_owned();
+        let session_id = Uuid::new_v4().to_string();
+        let state = Arc::new(tokio::sync::Mutex::new(browser_session_state(
+            "waiting_browser",
+            "Complete authorization in the browser",
+            &session_id,
+        )));
+        let task = tokio::spawn(async { std::future::pending::<()>().await });
+        browser_auth_sessions().lock().await.insert(
+            session_id.clone(),
+            BrowserAuthSession {
+                plugin_key: plugin_key.clone(),
+                connector_slug: connector_slug.clone(),
+                state,
+                task,
+            },
+        );
+
+        let reused = active_browser_auth_state(&plugin_key, &connector_slug)
+            .await
+            .expect("active session");
+
+        assert_eq!(
+            reused.get("sessionId").and_then(Value::as_str),
+            Some(session_id.as_str())
+        );
+        let session = browser_auth_sessions()
+            .lock()
+            .await
+            .remove(&session_id)
+            .expect("inserted session");
+        session.task.abort();
     }
 
     #[test]

--- a/executor/src/runtime_work/local_connector_auth/tools.rs
+++ b/executor/src/runtime_work/local_connector_auth/tools.rs
@@ -275,13 +275,10 @@ async fn resolve_managed_tool(
 }
 
 fn executor_home() -> Result<PathBuf, AppIpcError> {
-    if let Some(path) = env::var_os("WEGENT_EXECUTOR_HOME") {
-        return Ok(PathBuf::from(path));
-    }
-    env::var_os("HOME")
-        .map(PathBuf::from)
-        .map(|home| home.join(".wegent-executor"))
-        .ok_or_else(|| AppIpcError::new("internal_error", "HOME is not set"))
+    super::resolve_executor_home(
+        env::var_os("WEGENT_EXECUTOR_HOME").map(PathBuf::from),
+        dirs::home_dir(),
+    )
 }
 
 fn current_tool_target() -> Result<String, AppIpcError> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,8 +752,8 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
       dingtalk-workspace-cli:
-        specifier: 1.0.54
-        version: 1.0.54
+        specifier: 1.0.58
+        version: 1.0.58
       eslint:
         specifier: ^10.3.0
         version: 10.4.1(jiti@1.21.7)
@@ -5067,8 +5067,8 @@ packages:
   dingbat-to-unicode@1.0.1:
     resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
 
-  dingtalk-workspace-cli@1.0.54:
-    resolution: {integrity: sha512-R1gNPwc7yVgU5VKbyI7FaYNjh2L2+/yBo7cdqEdrBP35Xcnm0yOjJcRbk/EEq31Sk60feSBoQ3RtKVhxwduW+Q==}
+  dingtalk-workspace-cli@1.0.58:
+    resolution: {integrity: sha512-9sYkNwfBuT/FM6IYgLEZCJZJItUq6/5dP7+rWXQt/Mbhxty8HPK7rxNepUbmhjfRPI34ZFMT6PSnetfvkTTO3g==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -13690,7 +13690,7 @@ snapshots:
 
   dingbat-to-unicode@1.0.1: {}
 
-  dingtalk-workspace-cli@1.0.54: {}
+  dingtalk-workspace-cli@1.0.58: {}
 
   direction@2.0.1: {}
 

--- a/wework/e2e/desktop/modules/plugin-flows.mjs
+++ b/wework/e2e/desktop/modules/plugin-flows.mjs
@@ -691,6 +691,15 @@ async function verifyMarketplacePluginLifecycle({
   await control.command('waitFor', actionsSelector, {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
+  await waitForSnapshot(
+    control,
+    snapshot =>
+      snapshot.testIds.includes(`plugin-marketplace-actions-${pluginId}`) &&
+      snapshot.testIds.some(
+        testId => testId.startsWith('plugins-installed-strip-item-') && testId.includes(PLUGIN_NAME)
+      ),
+    'The installed marketplace card and installed strip became inconsistent'
+  )
   await control.command('click', actionsSelector)
   const trySelector = `[data-testid="plugin-marketplace-try-${pluginId}"]`
   await control.command('waitFor', trySelector, {

--- a/wework/package.json
+++ b/wework/package.json
@@ -133,7 +133,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-istanbul": "^4.1.8",
     "autoprefixer": "^10.5.0",
-    "dingtalk-workspace-cli": "1.0.54",
+    "dingtalk-workspace-cli": "1.0.58",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/wework/src/api/local/localConnectorAuth.test.ts
+++ b/wework/src/api/local/localConnectorAuth.test.ts
@@ -48,6 +48,14 @@ describe('localConnectorAuthHealth cache', () => {
     await expect(localConnectorAuthHealth(target)).resolves.toEqual({ status: 'ok' })
     expect(mocks.requestLocalExecutor).toHaveBeenCalledTimes(1)
   })
+
+  test('bypasses a cached result while waiting for a fresh local installation', async () => {
+    const target = { pluginKey: 'dingtalk', connectorSlug: 'dingtalk' }
+    await localConnectorAuthHealth(target)
+    await localConnectorAuthHealth(target, { bypassCache: true })
+
+    expect(mocks.requestLocalExecutor).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('local connector kinds', () => {

--- a/wework/src/api/local/localConnectorAuth.ts
+++ b/wework/src/api/local/localConnectorAuth.ts
@@ -37,6 +37,10 @@ export interface LocalConnectorAuthTarget {
   pluginRoot?: string | null
 }
 
+interface LocalConnectorAuthHealthOptions {
+  bypassCache?: boolean
+}
+
 /** Short TTL so send preflight does not re-probe an already-healthy connector. */
 const OK_HEALTH_TTL_MS = 120_000
 const okHealthCache = new Map<string, number>()
@@ -63,10 +67,13 @@ async function callLocalConnectorAuth(
   })
 }
 
-export function localConnectorAuthHealth(target: LocalConnectorAuthTarget) {
+export function localConnectorAuthHealth(
+  target: LocalConnectorAuthTarget,
+  options: LocalConnectorAuthHealthOptions = {}
+) {
   const key = healthCacheKey(target)
   const cachedAt = okHealthCache.get(key)
-  if (cachedAt != null && Date.now() - cachedAt < OK_HEALTH_TTL_MS) {
+  if (!options.bypassCache && cachedAt != null && Date.now() - cachedAt < OK_HEALTH_TTL_MS) {
     return Promise.resolve({ status: 'ok' as const satisfies LocalConnectorAuthStatus })
   }
   return callLocalConnectorAuth('health', target).then(result => {

--- a/wework/src/components/plugins/LocalConnectorAuthDialog.test.tsx
+++ b/wework/src/components/plugins/LocalConnectorAuthDialog.test.tsx
@@ -109,4 +109,13 @@ describe('LocalConnectorAuthDialog browser oauth', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
     await waitFor(() => expect(authMocks.cancel).toHaveBeenCalledWith(executorTarget, 'session-2'))
   })
+
+  test('shows a string executor error once', async () => {
+    authMocks.start.mockRejectedValue('internal_error: HOME is not set')
+
+    render(<LocalConnectorAuthDialog open target={target} onSuccess={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByTestId('local-connector-auth-retry')
+    expect(screen.getAllByText('internal_error: HOME is not set')).toHaveLength(1)
+  })
 })

--- a/wework/src/components/plugins/LocalConnectorAuthDialog.test.tsx
+++ b/wework/src/components/plugins/LocalConnectorAuthDialog.test.tsx
@@ -110,6 +110,25 @@ describe('LocalConnectorAuthDialog browser oauth', () => {
     await waitFor(() => expect(authMocks.cancel).toHaveBeenCalledWith(executorTarget, 'session-2'))
   })
 
+  test('keeps the executor session alive when the dialog is remounted by its host', async () => {
+    authMocks.start.mockResolvedValue({
+      status: 'waiting_browser',
+      sessionId: 'session-remount',
+    })
+    authMocks.poll.mockImplementation(() => new Promise(() => undefined))
+
+    const view = render(
+      <LocalConnectorAuthDialog open target={target} onSuccess={vi.fn()} onCancel={vi.fn()} />
+    )
+
+    await waitFor(() => expect(authMocks.start).toHaveBeenCalled())
+    view.unmount()
+    render(<LocalConnectorAuthDialog open target={target} onSuccess={vi.fn()} onCancel={vi.fn()} />)
+
+    await waitFor(() => expect(authMocks.start).toHaveBeenCalledTimes(2))
+    expect(authMocks.cancel).not.toHaveBeenCalled()
+  })
+
   test('shows a string executor error once', async () => {
     authMocks.start.mockRejectedValue('internal_error: HOME is not set')
 

--- a/wework/src/components/plugins/LocalConnectorAuthDialog.test.tsx
+++ b/wework/src/components/plugins/LocalConnectorAuthDialog.test.tsx
@@ -136,5 +136,7 @@ describe('LocalConnectorAuthDialog browser oauth', () => {
 
     await screen.findByTestId('local-connector-auth-retry')
     expect(screen.getAllByText('internal_error: HOME is not set')).toHaveLength(1)
+    expect(screen.getByTestId('local-connector-auth-browser-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('local-connector-auth-browser-loading')).not.toBeInTheDocument()
   })
 })

--- a/wework/src/components/plugins/LocalConnectorAuthDialog.tsx
+++ b/wework/src/components/plugins/LocalConnectorAuthDialog.tsx
@@ -123,8 +123,9 @@ export function LocalConnectorAuthDialog({
               )}
             </div>
           )}
-          <p className="text-center text-sm text-foreground">{statusText}</p>
-          {error ? <p className="text-center text-sm text-destructive">{error}</p> : null}
+          <p className={cn('text-center text-sm', error ? 'text-destructive' : 'text-foreground')}>
+            {statusText}
+          </p>
         </div>
 
         <div className="mt-4 flex justify-end gap-2">

--- a/wework/src/components/plugins/LocalConnectorAuthDialog.tsx
+++ b/wework/src/components/plugins/LocalConnectorAuthDialog.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Loader2, QrCode, RefreshCw, X } from 'lucide-react'
+import { AlertCircle, ExternalLink, Loader2, QrCode, RefreshCw, X } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type {
@@ -98,10 +98,24 @@ export function LocalConnectorAuthDialog({
               className="flex h-56 w-56 flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-background"
               data-testid="local-connector-auth-browser"
             >
-              {status?.status === 'waiting_browser' ? (
-                <ExternalLink className="h-8 w-8 text-muted-foreground" />
+              {error ? (
+                <AlertCircle
+                  className="h-8 w-8 text-destructive"
+                  aria-hidden="true"
+                  data-testid="local-connector-auth-browser-error"
+                />
+              ) : status?.status === 'waiting_browser' ? (
+                <ExternalLink
+                  className="h-8 w-8 text-muted-foreground"
+                  aria-hidden="true"
+                  data-testid="local-connector-auth-browser-waiting"
+                />
               ) : (
-                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                <Loader2
+                  className="h-8 w-8 animate-spin text-muted-foreground"
+                  aria-hidden="true"
+                  data-testid="local-connector-auth-browser-loading"
+                />
               )}
               <span className="text-sm text-muted-foreground">
                 {t('workbench.plugins_local_browser_device_only', '凭据仅保存在此设备')}

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -7,6 +7,7 @@ import {
   clearLocalCodexPluginsReadStateCache,
   createLocalCodexPluginApi,
 } from '@/api/local/codexPlugins'
+import { clearLocalConnectorAuthHealthCache } from '@/api/local/localConnectorAuth'
 import { clearPluginDeviceAutoSyncAttempts } from '@/features/plugins/pluginDeviceAutoSync'
 import {
   resetLocalExecutorCloudConnectionStatus,
@@ -190,6 +191,7 @@ function mockCodexAppServerInvoke(
       cloudReleaseId: number
     }>
     unlinkError?: Error
+    localConnectorAuthHealth?: () => Promise<unknown>
   } = {}
 ) {
   const marketplaces = [...(options.marketplaces ?? [])]
@@ -244,6 +246,9 @@ function mockCodexAppServerInvoke(
           ? options.backendConnected()
           : options.backendConnected !== false
       return Promise.resolve({ configured: true, connected })
+    }
+    if (request.method === 'runtime.local_connector_auth.health') {
+      return options.localConnectorAuthHealth?.() ?? Promise.resolve({ status: 'ok' })
     }
     if (request.method !== 'codex.app_server_request') return Promise.resolve(undefined)
 
@@ -387,6 +392,7 @@ function mockSystemSkillsFetch(
     installedMarketplaceLogo: string
     marketplaceCount: number
     marketplaceConnectorSlug: string
+    marketplaceConnectorLocal: boolean
     marketplaceHasSkill: boolean
     marketplaceVisibility: 'personal' | 'workspace' | 'public'
     marketplaceSourceProvider: 'codex' | 'wegent'
@@ -651,6 +657,16 @@ function mockSystemSkillsFetch(
             {
               slug: overrides.marketplaceConnectorSlug,
               authPolicy: 'on_install',
+              ...(overrides.marketplaceConnectorLocal
+                ? {
+                    localAuth: {
+                      kind: 'browser_oauth',
+                      health: ['scripts/local-auth.sh', 'health'],
+                      start: ['scripts/local-auth.sh', 'login'],
+                      poll: [],
+                    },
+                  }
+                : {}),
             },
           ]
         : [],
@@ -1072,6 +1088,7 @@ describe('PluginsWorkspace', () => {
     clearPluginMarketplaceCache()
     clearPluginDeviceAutoSyncAttempts()
     clearLocalCodexPluginsReadStateCache()
+    clearLocalConnectorAuthHealthCache()
     resetLocalExecutorStateForTests()
     resetLocalExecutorCloudConnectionStatus()
     setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: true })
@@ -1982,6 +1999,50 @@ describe('PluginsWorkspace', () => {
       expect.objectContaining({ method: 'POST' })
     )
     expect(telemetryMocks.track).toHaveBeenCalledWith('plugin_installed', { source: 'cloud' })
+  })
+
+  test('waits for a cloud plugin to reach the local executor before starting local auth', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    mockSystemSkillsFetch({
+      marketplaceName: 'dingtalk',
+      marketplaceDisplayName: '钉钉',
+      marketplaceConnectorSlug: 'dingtalk',
+      marketplaceConnectorLocal: true,
+    })
+    let postInstallHealthCalls = 0
+    mockCodexAppServerInvoke({
+      deviceId: 'current-device',
+      localConnectorAuthHealth: () => {
+        const installRequested = vi
+          .mocked(fetch)
+          .mock.calls.some(([input]) => String(input).includes('/plugins/marketplace/101/install'))
+        if (!installRequested) {
+          return Promise.reject(
+            new Error("plugin_not_installed: Installed plugin 'dingtalk' was not found")
+          )
+        }
+        postInstallHealthCalls += 1
+        if (postInstallHealthCalls === 1) {
+          return Promise.reject(
+            new Error("plugin_not_installed: Installed plugin 'dingtalk' was not found")
+          )
+        }
+        return Promise.resolve({ status: 'ok' })
+      },
+    })
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await screen.findByTestId('plugin-marketplace-install-101')
+    await installPluginFromMarketCard('plugin-marketplace-install-101')
+
+    const notice = await screen.findByTestId('plugin-operation-notice', {}, { timeout: 4_000 })
+    await waitFor(() => expect(notice).toHaveTextContent('钉钉 已安装'), { timeout: 4_000 })
+    expect(postInstallHealthCalls).toBeGreaterThanOrEqual(2)
+    expect(screen.queryByTestId('local-connector-auth-dialog')).not.toBeInTheDocument()
   })
 
   test('shows a lightweight notice while browser authorization is pending', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -58,6 +58,10 @@ import {
 } from '@/features/plugins/marketplaceSearch'
 import { logoutLocalConnectorsForPlugin } from '@/features/plugins/logoutLocalQrConnectors'
 import {
+  LocalConnectorPluginSyncTimeoutError,
+  waitForLocalConnectorAuthAvailability,
+} from '@/features/plugins/waitForLocalConnectorAuthAvailability'
+import {
   getPluginMarketplaceCache,
   pluginMarketplaceCacheKey,
   sameInstalledPlugins,
@@ -2733,7 +2737,8 @@ export function PluginsWorkspace({
         })
         const syncSettled =
           /failed to synchronize/i.test(rawErrorMessage) ||
-          /PLUGIN_DEVICE_SYNC_FAILED/i.test(rawErrorMessage)
+          /PLUGIN_DEVICE_SYNC_FAILED/i.test(rawErrorMessage) ||
+          error instanceof LocalConnectorPluginSyncTimeoutError
         // Older backends 502 after Kind create; refresh so the row can show the
         // account install instead of leaving a permanent pink sync banner.
         if (syncSettled) {
@@ -3018,9 +3023,10 @@ export function PluginsWorkspace({
         localAuth: connector.localAuth ?? null,
       }
       try {
-        const health = await localConnectorAuthHealth(target)
+        const health = await waitForLocalConnectorAuthAvailability(target)
         if (health.status === 'ok') continue
-      } catch {
+      } catch (error) {
+        if (error instanceof LocalConnectorPluginSyncTimeoutError) throw error
         // Fall through to local login when health or tool discovery fails.
       }
       try {

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -1448,6 +1448,7 @@ export function PluginsWorkspace({
         ? marketplaceCacheKeyValue
         : null
   )
+  const marketplaceStateCacheKeyRef = useRef(marketplaceCacheKeyValue)
   const installedPluginsRef = useRef(installedPlugins)
   installedPluginsRef.current = installedPlugins
   const marketplacesRef = useRef(marketplaces)
@@ -1480,6 +1481,17 @@ export function PluginsWorkspace({
       cloudMarketplaceAvailable,
       t('workbench.plugins_wework_cloud_marketplace', 'Wework 云端市场')
     )
+    const nextMarketplaceState: PluginMarketplaceState = {
+      items,
+      isLoading: items.length === 0,
+      error: null,
+    }
+    // Effects for the new account run in the same commit. Publish the rebuilt
+    // refs before marking them as owned by the new cache key so no async catalog
+    // merge can retain state from the previous account.
+    installedPluginsRef.current = nextInstalled
+    pluginMarketplaceStateRef.current = nextMarketplaceState
+    marketplaceStateCacheKeyRef.current = marketplaceCacheKeyValue
     setMarketplaces(nextMarketplaces)
     setSelectedMarketplaceKey(cached?.selectedMarketplaceKey || rememberedMarketplaceKey())
     setInstalledPlugins(nextInstalled)
@@ -1491,11 +1503,7 @@ export function PluginsWorkspace({
     setCanSharePersonalPlugins(cached?.canSharePersonalPlugins ?? true)
     setIsMarketplaceRefreshing(false)
     setIsOpenAiOfficialCatalogLoading(!hasOpenAiOfficialCatalog(items))
-    setPluginMarketplaceState({
-      items,
-      isLoading: items.length === 0,
-      error: null,
-    })
+    setPluginMarketplaceState(nextMarketplaceState)
     setSelectedPluginId(null)
     setSelectedMarketplacePluginId(null)
     setPluginShareState(null)
@@ -3330,6 +3338,7 @@ export function PluginsWorkspace({
         ),
         previousInstalled: installedPluginsRef.current,
         nextInstalled: nextInstalledRaw,
+        previousStateMatchesScope: marketplaceStateCacheKeyRef.current === marketplaceCacheKeyValue,
       })
       const heldBack = holdBackInFlightMarketplaceInstalls({
         items: retained.items,
@@ -3511,6 +3520,7 @@ export function PluginsWorkspace({
         ),
         previousInstalled: installedPluginsRef.current,
         nextInstalled: nextInstalledRaw,
+        previousStateMatchesScope: marketplaceStateCacheKeyRef.current === marketplaceCacheKeyValue,
       })
       const heldBack = holdBackInFlightMarketplaceInstalls({
         items: retained.items,
@@ -3605,6 +3615,7 @@ export function PluginsWorkspace({
         ),
         previousInstalled: installedPluginsRef.current,
         nextInstalled: nextInstalledRaw,
+        previousStateMatchesScope: marketplaceStateCacheKeyRef.current === marketplaceCacheKeyValue,
       })
       const heldBack = holdBackInFlightMarketplaceInstalls({
         items: retained.items,
@@ -3717,6 +3728,8 @@ export function PluginsWorkspace({
           ),
           previousInstalled: installedPluginsRef.current,
           nextInstalled: nextInstalledRaw,
+          previousStateMatchesScope:
+            marketplaceStateCacheKeyRef.current === marketplaceCacheKeyValue,
         })
         const heldBack = holdBackInFlightMarketplaceInstalls({
           items: retained.items,

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -90,7 +90,7 @@ import type {
 } from '@/types/api'
 import { connectorDisplayName } from './connectorDisplayName'
 import { holdBackInFlightMarketplaceInstalls } from './holdBackInFlightMarketplaceInstalls'
-import { retainMarketplaceInstallHints } from './retainMarketplaceInstallHints'
+import { retainMarketplaceInstalledState } from './retainMarketplaceInstallHints'
 import { type InstalledPluginItem } from './PluginManagementRows'
 import { PluginCreateMenu } from './PluginCreateMenu'
 import { PluginImportDialog } from './PluginImportDialog'
@@ -3311,22 +3311,28 @@ export function PluginsWorkspace({
           ),
         diskPersonalItemsForMerge
       )
-      const heldBack = holdBackInFlightMarketplaceInstalls({
-        items: mergeMarketplaceCatalog(
-          cloudItems,
-          localRows,
-          nextInstalledRaw.map(plugin => plugin.raw)
-        ),
-        installed: nextInstalledRaw,
-        installingIds: installingMarketplacePluginIdsRef.current,
-        authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
-      })
-      const nextInstalled = heldBack.installed
       const previousMarketplaceItems =
         pluginMarketplaceStateRef.current.items.length > 0
           ? pluginMarketplaceStateRef.current.items
           : (getPluginMarketplaceCache(marketplaceCacheKeyValue)?.marketplaceItems ?? [])
-      const mergedItems = retainMarketplaceInstallHints(previousMarketplaceItems, heldBack.items)
+      const retained = retainMarketplaceInstalledState({
+        previousItems: previousMarketplaceItems,
+        nextItems: mergeMarketplaceCatalog(
+          cloudItems,
+          localRows,
+          nextInstalledRaw.map(plugin => plugin.raw)
+        ),
+        previousInstalled: installedPluginsRef.current,
+        nextInstalled: nextInstalledRaw,
+      })
+      const heldBack = holdBackInFlightMarketplaceInstalls({
+        items: retained.items,
+        installed: retained.installed,
+        installingIds: installingMarketplacePluginIdsRef.current,
+        authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
+      })
+      const nextInstalled = heldBack.installed
+      const mergedItems = heldBack.items
       setInstalledPlugins(previous =>
         sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
       )
@@ -3490,21 +3496,24 @@ export function PluginsWorkspace({
       // Prefer in-flight cloud rows, then this key's durable cache — never stale
       // previous-account React state after a cache miss / account switch.
       const cloudItems = cloudItemsForMerge ?? cachedCloudItems
-      const heldBack = holdBackInFlightMarketplaceInstalls({
-        items: mergeMarketplaceCatalog(
+      const retained = retainMarketplaceInstalledState({
+        previousItems: pluginMarketplaceStateRef.current.items,
+        nextItems: mergeMarketplaceCatalog(
           cloudItems,
           localRows,
           nextInstalledRaw.map(plugin => plugin.raw)
         ),
-        installed: nextInstalledRaw,
+        previousInstalled: installedPluginsRef.current,
+        nextInstalled: nextInstalledRaw,
+      })
+      const heldBack = holdBackInFlightMarketplaceInstalls({
+        items: retained.items,
+        installed: retained.installed,
         installingIds: installingMarketplacePluginIdsRef.current,
         authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
       })
       const nextInstalled = heldBack.installed
-      const mergedItems = retainMarketplaceInstallHints(
-        pluginMarketplaceStateRef.current.items,
-        heldBack.items
-      )
+      const mergedItems = heldBack.items
       // Publish installed rows even when the catalog is still empty — cloud
       // listInstalledPlugins often arrives before marketplace rows.
       if (localStateForMerge || cloudInstalledForMerge) {
@@ -3581,13 +3590,19 @@ export function PluginsWorkspace({
         localState.installedPlugins,
         localState.deviceId || currentDeviceIdRef.current || ''
       ).map(toInstalledPluginItem)
-      const heldBack = holdBackInFlightMarketplaceInstalls({
-        items: mergeMarketplaceCatalog(
+      const retained = retainMarketplaceInstalledState({
+        previousItems: pluginMarketplaceStateRef.current.items,
+        nextItems: mergeMarketplaceCatalog(
           pluginMarketplaceStateRef.current.items.filter(item => !isCodexCatalogItem(item)),
           localRows,
           nextInstalledRaw.map(plugin => plugin.raw)
         ),
-        installed: nextInstalledRaw,
+        previousInstalled: installedPluginsRef.current,
+        nextInstalled: nextInstalledRaw,
+      })
+      const heldBack = holdBackInFlightMarketplaceInstalls({
+        items: retained.items,
+        installed: retained.installed,
         installingIds: installingMarketplacePluginIdsRef.current,
         authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
       })
@@ -3596,7 +3611,7 @@ export function PluginsWorkspace({
         sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
       )
       setPluginMarketplaceState(previous => {
-        const nextItems = retainMarketplaceInstallHints(previous.items, heldBack.items)
+        const nextItems = heldBack.items
         if (sameMarketplaceItems(previous.items, nextItems) && !previous.error) {
           return previous
         }
@@ -3687,19 +3702,26 @@ export function PluginsWorkspace({
           localInstalledForMerge,
           localStateForMerge?.deviceId || deviceIdHint || currentDeviceIdRef.current || ''
         ).map(toInstalledPluginItem)
-        const heldBack = holdBackInFlightMarketplaceInstalls({
-          items: mergeMarketplaceCatalog(
+        const retained = retainMarketplaceInstalledState({
+          previousItems: pluginMarketplaceStateRef.current.items,
+          nextItems: mergeMarketplaceCatalog(
             cloudItems,
             localRows,
             nextInstalledRaw.map(plugin => plugin.raw)
           ),
-          installed: nextInstalledRaw,
+          previousInstalled: installedPluginsRef.current,
+          nextInstalled: nextInstalledRaw,
+        })
+        const heldBack = holdBackInFlightMarketplaceInstalls({
+          items: retained.items,
+          installed: retained.installed,
           installingIds: installingMarketplacePluginIdsRef.current,
           authPluginKey: pendingLocalConnectorAuthRef.current?.target.pluginKey,
         })
-        const mergedItems = retainMarketplaceInstallHints(
-          pluginMarketplaceStateRef.current.items,
-          heldBack.items
+        const nextInstalled = heldBack.installed
+        const mergedItems = heldBack.items
+        setInstalledPlugins(previous =>
+          sameInstalledPlugins(previous, nextInstalled) ? previous : nextInstalled
         )
         setPluginMarketplaceState(previous =>
           sameMarketplaceItems(previous.items, mergedItems)

--- a/wework/src/components/plugins/retainMarketplaceInstallHints.test.ts
+++ b/wework/src/components/plugins/retainMarketplaceInstallHints.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import type { PluginMarketplaceItem } from '@/types/api'
-import { retainMarketplaceInstallHints } from './retainMarketplaceInstallHints'
+import type { InstalledPlugin } from '@/types/api'
+import type { InstalledPluginItem } from './PluginManagementRows'
+import {
+  retainMarketplaceInstalledState,
+  retainMarketplaceInstallHints,
+} from './retainMarketplaceInstallHints'
 
 function item(overrides: Partial<PluginMarketplaceItem> = {}): PluginMarketplaceItem {
   return {
@@ -33,6 +38,60 @@ function item(overrides: Partial<PluginMarketplaceItem> = {}): PluginMarketplace
   }
 }
 
+function installedItem(): InstalledPluginItem {
+  const raw: InstalledPlugin = {
+    apiVersion: 'agent.wecode.io/v1',
+    kind: 'InstalledPlugin',
+    metadata: {
+      name: 'github',
+      namespace: 'openai-curated-remote',
+      labels: { id: 'github@openai-curated-remote' },
+    },
+    spec: {
+      source: {
+        type: 'local',
+        providerKey: 'openai-curated-remote',
+        pluginKey: 'github',
+        catalogItemId: 'github@openai-curated-remote',
+        marketplace: 'openai-curated-remote',
+      },
+      origin: 'market',
+      installState: 'installed',
+      enabled: true,
+      displayName: 'GitHub',
+      description: '',
+      componentStates: {},
+      components: {
+        skills: [],
+        commands: [],
+        agents: [],
+        hooks: [],
+        mcps: [],
+        lsps: [],
+        monitors: [],
+        bins: [],
+      },
+      interface: null,
+      packageRef: null,
+      sourcePayload: null,
+    },
+    status: { state: 'enabled' },
+  }
+  return {
+    id: 'github@openai-curated-remote',
+    name: 'GitHub',
+    description: '',
+    enabled: true,
+    version: '0.1.8',
+    origin: 'market',
+    sourceLabel: 'OpenAI',
+    distribution: 'official',
+    updateAvailable: false,
+    componentCounts: {},
+    raw,
+  }
+}
+
 describe('retainMarketplaceInstallHints', () => {
   test('keeps an optimistic install when the next catalog snapshot lags', () => {
     const previous = [
@@ -61,5 +120,44 @@ describe('retainMarketplaceInstallHints', () => {
     const previous = [item({ installed: false, installedPluginId: null })]
     const next = [item({ installed: false, installedPluginId: null })]
     expect(retainMarketplaceInstallHints(previous, next)).toEqual(next)
+  })
+
+  test('retains the matching installed row with an optimistic marketplace hint', () => {
+    const previousItem = item({
+      installed: true,
+      installedLocally: true,
+      installedPluginId: 'github@openai-curated-remote',
+      enabled: true,
+    })
+    const plugin = installedItem()
+
+    const retained = retainMarketplaceInstalledState({
+      previousItems: [previousItem],
+      nextItems: [item()],
+      previousInstalled: [plugin],
+      nextInstalled: [],
+    })
+
+    expect(retained.items[0]?.installed).toBe(true)
+    expect(retained.installed).toEqual([plugin])
+  })
+
+  test('clears a stale installed card when no installed row can be retained', () => {
+    const retained = retainMarketplaceInstalledState({
+      previousItems: [
+        item({
+          installed: true,
+          installedLocally: true,
+          installedPluginId: 'github@openai-curated-remote',
+          enabled: true,
+        }),
+      ],
+      nextItems: [item()],
+      previousInstalled: [],
+      nextInstalled: [],
+    })
+
+    expect(retained.items[0]?.installed).toBe(false)
+    expect(retained.installed).toEqual([])
   })
 })

--- a/wework/src/components/plugins/retainMarketplaceInstallHints.test.ts
+++ b/wework/src/components/plugins/retainMarketplaceInstallHints.test.ts
@@ -136,6 +136,7 @@ describe('retainMarketplaceInstallHints', () => {
       nextItems: [item()],
       previousInstalled: [plugin],
       nextInstalled: [],
+      previousStateMatchesScope: true,
     })
 
     expect(retained.items[0]?.installed).toBe(true)
@@ -155,9 +156,31 @@ describe('retainMarketplaceInstallHints', () => {
       nextItems: [item()],
       previousInstalled: [],
       nextInstalled: [],
+      previousStateMatchesScope: true,
     })
 
     expect(retained.items[0]?.installed).toBe(false)
+    expect(retained.installed).toEqual([])
+  })
+
+  test('does not retain installed state from a different cache scope', () => {
+    const previousItem = item({
+      installed: true,
+      installedLocally: true,
+      installedPluginId: 'github@openai-curated-remote',
+      enabled: true,
+    })
+    const nextItem = item()
+
+    const retained = retainMarketplaceInstalledState({
+      previousItems: [previousItem],
+      nextItems: [nextItem],
+      previousInstalled: [installedItem()],
+      nextInstalled: [],
+      previousStateMatchesScope: false,
+    })
+
+    expect(retained.items).toEqual([nextItem])
     expect(retained.installed).toEqual([])
   })
 })

--- a/wework/src/components/plugins/retainMarketplaceInstallHints.ts
+++ b/wework/src/components/plugins/retainMarketplaceInstallHints.ts
@@ -1,4 +1,5 @@
 import type { PluginMarketplaceItem } from '@/types/api'
+import type { InstalledPluginItem } from './PluginManagementRows'
 
 /**
  * Progressive catalog paints can briefly reuse a stale cache snapshot after a
@@ -35,4 +36,46 @@ export function retainMarketplaceInstallHints(
       },
     }
   })
+}
+
+/**
+ * Keep the installed strip and marketplace actions on the same snapshot when a
+ * post-install catalog refresh temporarily lags behind the optimistic update.
+ */
+export function retainMarketplaceInstalledState(input: {
+  previousItems: PluginMarketplaceItem[]
+  nextItems: PluginMarketplaceItem[]
+  previousInstalled: InstalledPluginItem[]
+  nextInstalled: InstalledPluginItem[]
+}): { items: PluginMarketplaceItem[]; installed: InstalledPluginItem[] } {
+  const hintedItems = retainMarketplaceInstallHints(input.previousItems, input.nextItems)
+  const nextItemsById = new Map(input.nextItems.map(item => [String(item.id), item]))
+  const retainedPluginIds = new Set(
+    hintedItems.flatMap(item => {
+      const next = nextItemsById.get(String(item.id))
+      const retained = item.installed && !next?.installed && item.installedPluginId != null
+      return retained ? [String(item.installedPluginId)] : []
+    })
+  )
+  if (retainedPluginIds.size === 0) {
+    return { items: hintedItems, installed: input.nextInstalled }
+  }
+
+  const installed = [...input.nextInstalled]
+  const installedIds = new Set(installed.map(plugin => String(plugin.id)))
+  for (const plugin of input.previousInstalled) {
+    const id = String(plugin.id)
+    if (!retainedPluginIds.has(id) || installedIds.has(id)) continue
+    installed.push(plugin)
+    installedIds.add(id)
+  }
+  const items = hintedItems.map(item => {
+    const next = nextItemsById.get(String(item.id))
+    const retainedId =
+      item.installed && !next?.installed && item.installedPluginId != null
+        ? String(item.installedPluginId)
+        : null
+    return retainedId && !installedIds.has(retainedId) && next ? next : item
+  })
+  return { items, installed }
 }

--- a/wework/src/components/plugins/retainMarketplaceInstallHints.ts
+++ b/wework/src/components/plugins/retainMarketplaceInstallHints.ts
@@ -47,7 +47,11 @@ export function retainMarketplaceInstalledState(input: {
   nextItems: PluginMarketplaceItem[]
   previousInstalled: InstalledPluginItem[]
   nextInstalled: InstalledPluginItem[]
+  previousStateMatchesScope: boolean
 }): { items: PluginMarketplaceItem[]; installed: InstalledPluginItem[] } {
+  if (!input.previousStateMatchesScope) {
+    return { items: input.nextItems, installed: input.nextInstalled }
+  }
   const hintedItems = retainMarketplaceInstallHints(input.previousItems, input.nextItems)
   const nextItemsById = new Map(input.nextItems.map(item => [String(item.id), item]))
   const retainedPluginIds = new Set(

--- a/wework/src/features/plugins/useLocalConnectorAuthSession.ts
+++ b/wework/src/features/plugins/useLocalConnectorAuthSession.ts
@@ -13,6 +13,7 @@ import {
 export type LocalConnectorAuthTranslate = TFunction
 
 function startErrorMessage(startError: unknown, fallback: string): string {
+  if (typeof startError === 'string' && startError.trim()) return startError
   if (startError instanceof Error) return startError.message
   if (
     typeof startError === 'object' &&

--- a/wework/src/features/plugins/useLocalConnectorAuthSession.ts
+++ b/wework/src/features/plugins/useLocalConnectorAuthSession.ts
@@ -81,6 +81,7 @@ export function useLocalConnectorAuthSession({
   const tRef = useRef(t)
   const sessionRef = useRef(0)
   const activeAuthSessionRef = useRef<string | null>(null)
+  const cancelRequestedRef = useRef(false)
   const cancelledAuthSessionsRef = useRef(new Set<string>())
 
   useEffect(() => {
@@ -123,6 +124,7 @@ export function useLocalConnectorAuthSession({
     const browserMode = targetUsesBrowser
 
     const start = async () => {
+      cancelRequestedRef.current = false
       setBusy(true)
       setError(null)
       setStatus(null)
@@ -131,7 +133,7 @@ export function useLocalConnectorAuthSession({
         // executor reading the installed plugin manifest by pluginKey/slug.
         const started = await localConnectorAuthStart(authTarget)
         if (!isCurrent()) {
-          if (started.sessionId) {
+          if (cancelRequestedRef.current && started.sessionId) {
             cancelAuthSession(authTarget, started.sessionId)
           }
           return
@@ -214,12 +216,6 @@ export function useLocalConnectorAuthSession({
       }
       if (startTimer) clearTimeout(startTimer)
       if (pollTimer) clearTimeout(pollTimer)
-      if (authSessionId) {
-        cancelAuthSession(authTarget, authSessionId)
-        if (activeAuthSessionRef.current === authSessionId) {
-          activeAuthSessionRef.current = null
-        }
-      }
     }
   }, [
     enabled,
@@ -237,6 +233,7 @@ export function useLocalConnectorAuthSession({
   }, [])
 
   const cancelActiveSession = useCallback(() => {
+    cancelRequestedRef.current = true
     const sessionId = activeAuthSessionRef.current
     activeAuthSessionRef.current = null
     if (!sessionId) return

--- a/wework/src/features/plugins/waitForLocalConnectorAuthAvailability.test.ts
+++ b/wework/src/features/plugins/waitForLocalConnectorAuthAvailability.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  LocalConnectorPluginSyncTimeoutError,
+  waitForLocalConnectorAuthAvailability,
+} from './waitForLocalConnectorAuthAvailability'
+
+const target = {
+  pluginKey: 'dingtalk',
+  connectorSlug: 'dingtalk',
+}
+
+describe('waitForLocalConnectorAuthAvailability', () => {
+  test('waits for an installed plugin to become visible before probing authorization', async () => {
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("plugin_not_installed: Installed plugin 'dingtalk' was not found")
+      )
+      .mockRejectedValueOnce(
+        new Error("plugin_not_installed: Installed plugin 'dingtalk' was not found")
+      )
+      .mockResolvedValue({ status: 'need_login' })
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      waitForLocalConnectorAuthAvailability(target, {
+        maxAttempts: 3,
+        retryIntervalMs: 25,
+        probe,
+        wait,
+      })
+    ).resolves.toEqual({ status: 'need_login' })
+
+    expect(probe).toHaveBeenCalledTimes(3)
+    expect(wait).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenNthCalledWith(1, 25)
+  })
+
+  test('does not hide a real local authorization command error', async () => {
+    const probe = vi.fn().mockRejectedValue(new Error('localAuth command returned empty output'))
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(waitForLocalConnectorAuthAvailability(target, { probe, wait })).rejects.toThrow(
+      'localAuth command returned empty output'
+    )
+
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(wait).not.toHaveBeenCalled()
+  })
+
+  test('returns a typed timeout after the local install never appears', async () => {
+    const probe = vi
+      .fn()
+      .mockRejectedValue(new Error('plugin_not_installed: Installed plugin was not found'))
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      waitForLocalConnectorAuthAvailability(target, {
+        maxAttempts: 2,
+        probe,
+        wait,
+      })
+    ).rejects.toBeInstanceOf(LocalConnectorPluginSyncTimeoutError)
+
+    expect(probe).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledTimes(1)
+  })
+})

--- a/wework/src/features/plugins/waitForLocalConnectorAuthAvailability.ts
+++ b/wework/src/features/plugins/waitForLocalConnectorAuthAvailability.ts
@@ -1,0 +1,66 @@
+import {
+  localConnectorAuthHealth,
+  type LocalConnectorAuthResult,
+  type LocalConnectorAuthTarget,
+} from '@/api/local/localConnectorAuth'
+
+const DEFAULT_MAX_ATTEMPTS = 31
+const DEFAULT_RETRY_INTERVAL_MS = 1_000
+
+type HealthProbe = (target: LocalConnectorAuthTarget) => Promise<LocalConnectorAuthResult>
+type Wait = (delayMs: number) => Promise<void>
+
+interface WaitForLocalConnectorAuthAvailabilityOptions {
+  maxAttempts?: number
+  retryIntervalMs?: number
+  probe?: HealthProbe
+  wait?: Wait
+}
+
+export class LocalConnectorPluginSyncTimeoutError extends Error {
+  readonly code = 'PLUGIN_LOCAL_SYNC_TIMEOUT'
+
+  constructor(pluginKey: string) {
+    super(`Installed plugin '${pluginKey}' did not become available on this device`)
+    this.name = 'LocalConnectorPluginSyncTimeoutError'
+  }
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function isLocalConnectorPluginUnavailableError(error: unknown): boolean {
+  return /(?:^|\b)plugin_not_installed(?:\b|:)/i.test(errorText(error))
+}
+
+function waitForDelay(delayMs: number): Promise<void> {
+  return new Promise(resolve => window.setTimeout(resolve, delayMs))
+}
+
+export async function waitForLocalConnectorAuthAvailability(
+  target: LocalConnectorAuthTarget,
+  options: WaitForLocalConnectorAuthAvailabilityOptions = {}
+): Promise<LocalConnectorAuthResult> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)
+  const retryIntervalMs = Math.max(0, options.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS)
+  const probe =
+    options.probe ??
+    ((currentTarget: LocalConnectorAuthTarget) =>
+      localConnectorAuthHealth(currentTarget, { bypassCache: true }))
+  const wait = options.wait ?? waitForDelay
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await probe(target)
+    } catch (error) {
+      if (!isLocalConnectorPluginUnavailableError(error)) throw error
+      if (attempt === maxAttempts) {
+        throw new LocalConnectorPluginSyncTimeoutError(target.pluginKey)
+      }
+      await wait(retryIntervalMs)
+    }
+  }
+
+  throw new LocalConnectorPluginSyncTimeoutError(target.pluginKey)
+}


### PR DESCRIPTION
## Summary

- resolve Windows local connector and managed-tool paths from the explicit executor home instead of requiring the Unix-only `HOME` variable
- preserve browser OAuth callback output and session state, stop the authorization spinner after terminal failures, and expose retryable diagnostics
- wait for local plugin installation and connector availability before starting authorization, while keeping marketplace card and installed-strip state consistent
- upgrade the bundled DingTalk DWS CLI from 1.0.54 to 1.0.58 for the corrected Windows OAuth persistence flow

## Root cause

Windows GUI processes commonly do not expose `HOME`, so the local connector resolver could fail before DWS launched the browser. The authorization UI could also restart or outlive the local auth session, losing the browser callback or leaving the dialog spinning after a terminal error.

Installation and authorization were separate asynchronous flows. Starting authorization before the local connector became available caused a race, while progressive marketplace refreshes could temporarily retain the card's optimistic installed hint without the corresponding installed row.

The bundled DWS 1.0.54 did not include the final Windows credential-persistence handling. This PR now bundles DWS 1.0.58, and the companion DingTalk plugin PR polls the persisted authenticated state after the OAuth callback.

## Validation

- Windows acceptance test with the locally installed DingTalk plugin 0.2.9 and bundled DWS 1.0.58: browser OAuth completed and the persisted login state was recognized
- focused executor local connector authorization tests
- focused Wework plugin UI and marketplace state tests
- `pnpm --filter wework e2e:desktop:plugins`
- GitHub Repository Policy, Lint, Tests, Platform E2E, Wework E2E, and CodeRabbit checks passed

Companion plugin change: https://github.com/wecode-ai/wework-plugins/pull/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace plugin listings now preserve installation status during catalog refreshes.
  * Authentication dialogs show clearer errors and offer retry options.
  * Active authentication sessions are reused when dialogs reopen.
  * Local plugin installation now waits for executor availability and reports sync timeouts.

* **Bug Fixes**
  * Improved executor home-directory resolution and authentication cancellation handling.
  * Marketplace installation flows now wait for installation results.
  * Health checks can bypass cached results when a fresh status is needed.

* **Tests**
  * Added coverage for authentication, installation state, availability checks, and marketplace flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->