### PR TITLE
fix(wework): decouple local project spaces from cloud

### DIFF
--- a/docs/plans/2026-08-15-wework-local-cloud-project-space-decoupling.md
+++ b/docs/plans/2026-08-15-wework-local-cloud-project-space-decoupling.md
@@ -112,6 +112,16 @@ function projectSpaceKey(ref: ProjectSpaceRef): string {
 }
 ```
 
+`ProjectStore` 是持久化和路由身份，`ProjectSpaceLocation` 只是 UI 服务选择使用的
+`"local" | "cloud"` 表达。二者只允许在明确边界转换：
+
+- `projectStoreLocation("local") -> "local"`
+- `projectStoreLocation("backend") -> "cloud"`
+- 从创建位置回写项目身份时，`"local" -> "local"`，`"cloud" -> "backend"`
+
+`projectId` 全程保持字符串语义，不允许通过 `Number(...)` 或其他数值转换推断身份。路由
+解析、缺失 store 的兼容入口和缓存索引最终都必须产出完整 `ProjectSpaceRef`。
+
 以下状态不得继续仅用 `project.id` 索引：
 
 - 当前选中项目
@@ -371,15 +381,14 @@ ProjectSpacesWorkspace
 目标：本地项目自动化不再复用 Backend 项目自动化服务。
 
 当前 `projectAutomationApi` 仅由 Backend Services 创建，而本地 Executor 已有通用
-`automationApi`。实施前需要明确本地项目自动化规则的唯一数据所有者，然后采用以下一种
-主路径：
+`automationApi`。本次采用“本地规则能力尚未支持”的主路径：
 
-1. 如果本地 Executor 已拥有项目自动化规则，则实现本地
-   `ProjectAutomationRulesApi` 适配器，并从本地详情服务注入。
-2. 如果本地 Executor 当前只支持通用自动化，则把项目自动化 UI 改为使用本地
-   `automationApi` 的项目作用域能力。
-3. 如果本地尚未支持该能力，则在本地项目详情中明确隐藏或禁用该功能，并显示“本地项目
-   暂不支持”，不得回退到 Backend。
+- 本地详情服务不注入 Backend `projectAutomationApi`。
+- `ProjectAutomationRulesSection` 在本地 API 缺失时不挂载，不发规则请求。
+- 本地自动化页保留由本地详情服务提供的机器人、执行队列、设备和模型能力。
+- 独立自动化页继续使用本地 Executor 的通用 `automationApi`。
+- 后续若实现本地项目规则，必须先扩展本地 Executor 的项目作用域契约，不得借用 Backend
+  数据所有权。
 
 同时拆分自动化所需的辅助目录：
 

--- a/docs/plans/2026-08-15-wework-local-cloud-project-space-decoupling.md
+++ b/docs/plans/2026-08-15-wework-local-cloud-project-space-decoupling.md
@@ -1,0 +1,652 @@
+---
+sidebar_position: 99
+---
+
+# Wework 本地与云端项目空间解耦修复计划
+
+## 1. 背景
+
+Wework 的项目空间同时支持本地存储和云端存储：
+
+- 本地项目空间的数据由本地 Executor 持有。
+- 云端项目空间的数据由 Backend 持有。
+- 两类项目可以共用界面和领域类型，但不共享数据可用性，也不应共享请求生命周期。
+
+当前实现把本地和云端项目放进同一个项目数组，并在页面运行时根据裸
+`projectId` 查找项目、推断来源和选择 API。项目列表、项目详情和全局聚合视图又由
+同一个 `CloudTodoWorkspace` 组件管理，导致以下问题：
+
+1. 云端不可用时，本地项目列表需要等待云端请求完成才能结束加载状态。
+2. 打开本地项目详情后，部分子功能仍能通过全局 Hybrid Services 发起云端请求。
+3. 项目路由只保存 `projectId`，没有保存项目存储来源，恢复本地详情时必须先加载多个
+   数据源。
+4. 项目列表初始化会预加载每个项目的任务和成员，把列表展示与详情请求绑定。
+5. `apiForProjectId()` 在来源未知时使用 `services.deliveryApi` 或第一个可用 API
+   fallback，可能把本地操作错误路由到云端。
+6. 本地项目自动化详情仍收到云端 `projectAutomationApi`、`teamApi` 等服务，云端故障
+   因而会进入本地详情流程。
+
+这不是单个超时或错误处理缺失的问题，而是项目身份、数据所有权和服务注入边界不完整。
+
+## 2. 修复目标
+
+本次修复需要建立以下硬边界。
+
+### 2.1 项目列表
+
+- 本地项目列表只由本地 API 加载。
+- 本地列表加载完成后立即展示，不等待云端列表。
+- 云端列表作为独立、可选的数据源加载。
+- 云端加载中、失败或断开不能改变本地列表的 loading、error 和可交互状态。
+- 项目列表请求只返回项目摘要，不预加载任务、成员、文件或自动化详情。
+
+### 2.2 项目详情
+
+- 本地项目详情只持有本地项目服务。
+- 本地项目详情的挂载、刷新、切换标签和卸载均不得发起云端请求。
+- 云端项目详情只持有云端项目服务。
+- 项目详情不再根据裸 `projectId` 从混合项目数组中猜测来源。
+- 来源不完整或服务不可用时明确停止请求，不使用其他来源的 API fallback。
+
+### 2.3 全局聚合
+
+- “我的工作”“全局搜索”等确实需要跨来源的功能由独立聚合层负责。
+- 每个来源独立加载、独立失败、独立展示。
+- 本地结果不得等待云端结果。
+- 进入具体项目详情后，不继续运行与该详情无关的跨来源轮询或刷新。
+
+## 3. 非目标
+
+本次修复不做以下工作：
+
+- 不把本地项目迁移到 Backend。
+- 不在云端不可用时提供云端数据的伪本地 fallback。
+- 不通过增加重试次数掩盖错误路由。
+- 不通过缩短云端超时替代数据源解耦。
+- 不改变 Backend 对云端项目空间的授权边界。
+- 不修改现有 E2E 测试来绕过失败；只有日志和调用链证明测试逻辑错误时才调整测试本身。
+
+## 4. 当前错误模型
+
+当前主流程可以概括为：
+
+```text
+CloudTodoWorkspace
+  -> 收集 localApi + cloudApi
+  -> Promise.all 加载两个来源
+  -> 合并为 projects[]
+  -> 只保存 selectedProjectId
+  -> projects.find(project.id === selectedProjectId)
+  -> apiForProjectId(projectId)
+       -> 根据 projects[] 推断 location
+       -> 推断失败时 fallback 到 deliveryApi 或第一个 API
+  -> 把全局 WorkbenchServices 继续传给详情子组件
+```
+
+这个模型存在三个结构性错误：
+
+1. `projectId` 不是完整身份。
+2. 项目来源是运行时推断结果，而不是请求前已知条件。
+3. 详情组件能访问超出自身存储域的服务。
+
+## 5. 目标模型
+
+### 5.1 项目空间身份
+
+所有项目空间选择、路由、缓存和状态索引统一使用完整引用：
+
+```ts
+type ProjectStore = "local" | "backend";
+
+interface ProjectSpaceRef {
+  projectStore: ProjectStore;
+  projectId: string;
+}
+```
+
+统一 key：
+
+```ts
+function projectSpaceKey(ref: ProjectSpaceRef): string {
+  return `${ref.projectStore}:${ref.projectId}`;
+}
+```
+
+以下状态不得继续仅用 `project.id` 索引：
+
+- 当前选中项目
+- 工作区标签页路由
+- 项目任务缓存
+- 项目成员缓存
+- 项目统计缓存
+- 项目菜单状态
+- 重命名、归档和创建任务目标
+- 详情抽屉所属项目
+
+### 5.2 路由
+
+看板路由保存完整项目身份：
+
+```text
+/todo?projectStore=local&projectId=<id>
+/todo?projectStore=backend&projectId=<id>
+```
+
+不再通过加载所有项目来反推 `projectStore`。
+
+旧的、只包含 `projectId` 的持久化标签页不能触发来源猜测或跨来源请求。迁移时应提升工作区
+标签存储版本，并把无法确定来源的旧看板路由恢复到 `/todo` 项目首页。不要保留
+“依次请求本地和云端直到找到项目”的兼容路径。
+
+### 5.3 来源固定的项目上下文
+
+选中项目后创建来源固定的上下文：
+
+```ts
+interface ProjectSpaceContext {
+  ref: ProjectSpaceRef;
+  project: CloudProject;
+  services: ProjectSpaceDetailServices;
+}
+```
+
+详情服务接口按功能声明，而不是传入完整 `WorkbenchServices`：
+
+```ts
+interface ProjectSpaceDetailServices {
+  projectApi: DeliveryApi;
+  projectChatAgentApi?: ProjectChatAgentApi;
+  projectChatClient?: ProjectChatClient;
+  executionApi?: ExecutionListApi;
+  automationApi?: ProjectAutomationRulesApi;
+  deviceApi?: ProjectDeviceApi;
+  modelApi?: ProjectModelApi;
+  teamApi?: ProjectTeamApi;
+}
+```
+
+构造规则：
+
+```text
+projectStore=local
+  -> 只能构造 LocalProjectSpaceDetailServices
+
+projectStore=backend
+  -> 只能构造 CloudProjectSpaceDetailServices
+```
+
+详情组件不再接收整个 Hybrid `WorkbenchServices`，从类型层面移除访问其他存储域的能力。
+
+### 5.4 列表控制器
+
+列表状态按来源拆分：
+
+```ts
+interface ProjectListSourceState {
+  status: "idle" | "loading" | "loaded" | "error";
+  projects: CloudProject[];
+  error: string | null;
+}
+
+interface ProjectListsState {
+  local: ProjectListSourceState;
+  cloud: ProjectListSourceState;
+}
+```
+
+加载顺序：
+
+```text
+挂载项目首页
+  -> 启动本地列表请求
+  -> 本地返回
+  -> 立即展示本地项目
+
+  -> 云端已配置且当前允许加载时，独立启动云端列表请求
+  -> 云端返回后增量展示云端项目
+  -> 云端失败只更新 cloud.error
+```
+
+本地与云端请求之间不得存在 `Promise.all`、共享 loading 或共享 catch/finally。
+
+### 5.5 详情控制器
+
+详情控制器的输入必须是完整 `ProjectSpaceRef`：
+
+```text
+路由 ProjectSpaceRef
+  -> 选择对应来源的列表缓存或 getProject API
+  -> 构造固定来源 ProjectSpaceContext
+  -> 挂载 ProjectSpaceDetail
+  -> 所有详情请求从 context.services 发出
+```
+
+进入本地详情时：
+
+- 不加载云端项目列表。
+- 不调用云端 `listMyWork()`。
+- 不调用云端成员、任务、文件、自动化或执行 API。
+- 不调用会在后台刷新云端目录的混合 model/team/device API。
+- 不为确定项目来源发起探测请求。
+
+### 5.6 全局聚合控制器
+
+跨来源功能使用独立数据源适配器：
+
+```ts
+interface GlobalProjectSource {
+  source: "local" | "cloud";
+  listMyWork(): Promise<CloudMyWorkItem[]>;
+  search(query: ProjectSearchQuery): Promise<ProjectSearchResult[]>;
+}
+```
+
+聚合层分别维护来源状态：
+
+```text
+GlobalMyWork
+  -> local source: loading/loaded/error
+  -> cloud source: idle/loading/loaded/error
+  -> UI 合并已完成来源的结果
+```
+
+项目详情不持有 `GlobalProjectSource[]`。
+
+## 6. 需要删除的错误路径
+
+实施时优先删除以下代码和抽象，再依靠 TypeScript 和测试暴露需要补齐的调用点：
+
+1. 删除详情流程中的 `availableProjectSpaceApis`。
+2. 删除 `apiForProjectId(projectId)`。
+3. 删除项目 API 的 `services.deliveryApi` fallback。
+4. 删除项目 API 的 `availableProjectSpaceApis[0]` fallback。
+5. 删除列表 effect 中为所有项目执行的 `listLoopItems()`。
+6. 删除列表 effect 中为所有项目执行的 `listCloudProjectMembers()`。
+7. 删除本地和云端共用的单一 `loading` 状态。
+8. 删除详情子组件对完整 `WorkbenchServices` 的依赖。
+9. 删除看板路由和页面状态中只保存裸 `projectId` 的路径。
+10. 删除本地项目自动化对 Backend `projectAutomationApi` 的引用。
+11. 删除本地项目自动化对云端 `teamApi.listTeams()` 的引用。
+12. 删除本地详情中 `services.deliveryApi.stopExecution` 优先于来源 API 的路径。
+13. 删除通过请求多个来源来寻找项目的兼容或探测逻辑。
+
+## 7. 分阶段实施计划
+
+### 阶段一：建立完整项目身份
+
+目标：让项目来源在进入页面和发出请求前已经确定。
+
+主要修改：
+
+- 复用并扩展 `projectSpaceRef()`、`projectSpaceKey()`。
+- 将工作区看板标签页的选择状态改为 `ProjectSpaceRef`。
+- 路由增加 `projectStore`。
+- 将 `activeProjectId`、`onActiveProjectChange` 改为完整项目引用。
+- 将项目相关 Map 的 key 改为 `projectSpaceKey`。
+- 提升 Workspace Tabs 持久化结构版本，失效无法确定来源的旧看板详情路由。
+
+预计涉及：
+
+- `wework/src/features/todo/projectSpaceSelection.ts`
+- `wework/src/features/todo/CloudTodoWorkspace.tsx`
+- `wework/src/components/layout/DesktopWorkbenchLayout.tsx`
+- `wework/src/features/workspace-tabs/`
+- `wework/src/lib/navigation.ts`
+
+验收条件：
+
+- 本地和云端存在相同 `projectId` 时仍可分别打开。
+- 恢复本地看板标签页不需要加载云端项目列表。
+- 来源缺失时回到项目首页，不猜测 API。
+
+### 阶段二：拆分项目列表生命周期
+
+目标：本地项目列表独立加载和展示。
+
+主要修改：
+
+- 提取 `useLocalProjectSpaces()`。
+- 提取 `useCloudProjectSpaces()`。
+- 每个 hook 独立维护 status、projects 和 error。
+- 项目首页根据两个来源的已完成结果组合展示。
+- 云端未连接时不启动云端列表 hook。
+- 删除总的 `Promise.all` 和全局 `loading`。
+- 删除项目列表阶段的任务和成员预加载。
+
+预计涉及：
+
+- `wework/src/features/todo/CloudTodoWorkspace.tsx`
+- 新增 `wework/src/features/todo/useLocalProjectSpaces.ts`
+- 新增 `wework/src/features/todo/useCloudProjectSpaces.ts`
+- `wework/src/features/todo/CloudProjectsHome.tsx`
+
+如果拆分后 `CloudTodoWorkspace.tsx` 仍承担列表、详情和所有子功能，应继续拆成：
+
+```text
+ProjectSpacesWorkspace
+  -> ProjectSpacesHome
+  -> ProjectSpaceDetail
+```
+
+验收条件：
+
+- 云端列表 Promise 永不结束时，本地列表仍结束 loading 并可点击。
+- 云端列表失败时，本地项目创建、重命名、归档和打开不受影响。
+- 项目首页初次加载不请求任何项目的任务和成员详情。
+
+### 阶段三：建立来源固定的详情服务
+
+目标：本地详情代码没有发起云端请求的能力。
+
+主要修改：
+
+- 定义 `ProjectSpaceDetailServices`。
+- 分别构造 `createLocalProjectSpaceDetailServices()` 和
+  `createCloudProjectSpaceDetailServices()`。
+- `ProjectSpaceDetail` 只接收 `ProjectSpaceContext`。
+- 看板、文件、成员、管理、任务详情和执行队列均使用 context 中的固定 API。
+- 去掉所有根据项目 ID 重新寻找 API 的逻辑。
+- 去掉详情中的 Hybrid service fallback。
+
+预计涉及：
+
+- `wework/src/features/workbench/workbenchServices.ts`
+- `wework/src/api/local/localServices.ts`
+- `wework/src/api/hybrid/hybridServices.ts`
+- `wework/src/features/todo/CloudTodoWorkspace.tsx`
+- `wework/src/features/todo/CloudFilesView.tsx`
+- `wework/src/features/todo/CloudProjectManageView.tsx`
+- `wework/src/features/todo/TodoEditor.tsx`
+- `wework/src/features/todo/TaskActivityView.tsx`
+- `wework/src/features/todo/ProjectQueueView.tsx`
+
+验收条件：
+
+- 打开本地项目详情后，云端 API mock 的调用次数始终为 0。
+- 切换本地详情中的看板、文件、管理和任务抽屉不会发云端请求。
+- 本地 API 不可用时明确显示本地错误，不尝试云端 API。
+
+### 阶段四：修复本地项目自动化服务
+
+目标：本地项目自动化不再复用 Backend 项目自动化服务。
+
+当前 `projectAutomationApi` 仅由 Backend Services 创建，而本地 Executor 已有通用
+`automationApi`。实施前需要明确本地项目自动化规则的唯一数据所有者，然后采用以下一种
+主路径：
+
+1. 如果本地 Executor 已拥有项目自动化规则，则实现本地
+   `ProjectAutomationRulesApi` 适配器，并从本地详情服务注入。
+2. 如果本地 Executor 当前只支持通用自动化，则把项目自动化 UI 改为使用本地
+   `automationApi` 的项目作用域能力。
+3. 如果本地尚未支持该能力，则在本地项目详情中明确隐藏或禁用该功能，并显示“本地项目
+   暂不支持”，不得回退到 Backend。
+
+同时拆分自动化所需的辅助目录：
+
+- 本地设备目录只列本地设备。
+- 本地模型目录不得触发云端后台刷新。
+- 本地团队目录只提供本地可执行的团队或代理配置。
+- 本地项目不显示只能由 Backend 管理的 Wegent Team 执行模式。
+
+预计涉及：
+
+- `wework/src/features/todo/ProjectAutomationView.tsx`
+- `wework/src/features/todo/ProjectAutomationRulesSection.tsx`
+- `wework/src/api/projectAutomations.ts`
+- `wework/src/api/local/localServices.ts`
+- `wework/src/api/hybrid/hybridServices.ts`
+- 必要时涉及 `executor/src/` 的本地自动化命令
+
+验收条件：
+
+- 打开本地项目自动化标签时云端 HTTP 和云端 Runtime IPC 调用次数均为 0。
+- 云端断开时本地自动化页面不报云端连接错误。
+- 本地不支持的能力明确不可用，不创建 fallback。
+
+### 阶段五：拆分全局聚合视图
+
+目标：跨来源能力不再污染项目详情生命周期。
+
+主要修改：
+
+- 将 `listMyWork()` 从项目详情组件 effect 中移出。
+- 为本地和云端“我的工作”建立独立 source state。
+- 全局搜索按来源独立请求和合并。
+- 离开全局视图时取消对应请求和轮询。
+- 进入项目详情后只保留当前来源的详情刷新。
+
+预计涉及：
+
+- `wework/src/features/todo/CloudTodoWorkspace.tsx`
+- `wework/src/features/todo/CloudMyWorkView.tsx`
+- `wework/src/components/layout/WorkbenchSearchDialog.tsx`
+- 新增全局聚合 hooks 或 controller
+
+验收条件：
+
+- 云端“我的工作”请求挂起时，本地结果可见且可操作。
+- 本地项目详情挂载期间不产生全局云端聚合请求。
+
+### 阶段六：收口独立自动化页面
+
+目标：`/automations` 页面同样按来源独立展示，避免云端设备失败拖垮本地自动化。
+
+主要修改：
+
+- 删除 Hybrid `automationApi.listAutomations()` 中跨设备 `Promise.all` 的全成全败语义。
+- 本地自动化作为主数据源独立加载。
+- 每个云端设备作为独立数据源加载并记录错误。
+- 自动化 ID 的路由映射同时记录 source 和 device ID。
+- 本地自动化操作不通过云端设备发现来确定路由。
+
+预计涉及：
+
+- `wework/src/api/hybrid/hybridServices.ts`
+- `wework/src/pages/AutomationsPage.tsx`
+- `wework/src/types/automation.ts`
+
+验收条件：
+
+- 云端 Runtime IPC 超时 75 秒时，本地自动化列表仍立即可见。
+- 一个云端设备失败不会让本地或其他设备的自动化列表报全局错误。
+- 对本地自动化的查看、修改、启停和立即运行不触发云端请求。
+
+## 8. 测试计划
+
+### 8.1 单元测试
+
+新增或更新以下测试。
+
+#### 项目身份与路由
+
+- `projectSpaceKey()` 能区分相同 ID 的本地和云端项目。
+- 看板路由能够编码和解析 `projectStore + projectId`。
+- 缺少 `projectStore` 的旧详情路由恢复到项目首页。
+- Workspace Tab 恢复本地项目时不需要云端数据。
+
+#### 项目列表
+
+- 本地列表完成、云端列表 pending：本地项目立即展示。
+- 本地列表完成、云端列表 rejected：本地项目仍可交互。
+- 本地列表 rejected、云端列表完成：分别展示本地错误和云端项目。
+- 未连接云端：云端 API 调用次数为 0。
+- 列表加载期间 `listLoopItems()` 和 `listCloudProjectMembers()` 调用次数为 0。
+
+#### 本地项目详情
+
+为所有云端 API 使用严格 mock：
+
+```ts
+const cloudApi = {
+  listCloudProjects: vi.fn(() => {
+    throw new Error("unexpected cloud request");
+  }),
+  // 其余方法同样在调用时抛错
+};
+```
+
+覆盖：
+
+- 打开本地看板。
+- 刷新本地看板。
+- 打开任务详情。
+- 创建、修改、移动、归档任务。
+- 打开文件页。
+- 打开管理页。
+- 打开自动化页。
+- 打开执行队列。
+- 切换和恢复本地项目标签页。
+
+每个场景均断言云端 HTTP、云端 Delivery API 和云端 Runtime IPC 调用次数为 0。
+
+#### 云端项目详情
+
+- 云端项目仍使用 Backend API。
+- 云端详情不会错误使用本地项目 API。
+- 本地和云端同 ID 项目不会串数据。
+
+#### 自动化
+
+- 本地自动化独立加载。
+- 云端设备请求 pending 或 rejected 不影响本地结果。
+- 本地自动化操作不调用云端 Runtime IPC。
+
+### 8.2 组件集成测试
+
+主要扩展：
+
+- `wework/src/features/todo/CloudTodoWorkspace.test.tsx`
+- `wework/src/components/layout/DesktopWorkbenchLayout.test.tsx`
+- `wework/src/features/workspace-tabs/WorkspaceTabsContext.test.tsx`
+- `wework/src/pages/AutomationsPage.test.tsx`
+- `wework/src/api/hybrid/hybridServices.test.ts`
+
+测试必须使用可控 pending Promise，而不是依赖真实计时：
+
+```ts
+const neverResolvingCloudRequest = new Promise<never>(() => undefined);
+```
+
+核心断言不是“最终会恢复”，而是“云端请求未完成时本地功能已经可用”。
+
+### 8.3 Desktop E2E
+
+按照现有 Desktop E2E runner 增加 CI 覆盖的回归场景，不创建本地专用孤立命令。
+
+测试环境：
+
+- 隔离的真实 Tauri 会话。
+- 本地 Executor 正常。
+- 保存一份有效但当前不可达的云端连接配置，或通过测试云端服务稳定模拟连接后断开。
+- 创建至少一个本地项目和一条本地任务。
+
+场景：
+
+1. 云端不可达时启动 Wework。
+2. 打开项目空间首页。
+3. 断言本地项目在普通步骤超时内可见。
+4. 打开本地项目。
+5. 查看、创建和修改本地任务。
+6. 打开本地项目的文件、管理和自动化标签。
+7. 打开独立自动化页面，确认本地自动化可见。
+8. 检查日志，确认上述本地详情操作期间没有云端项目详情请求。
+
+不得通过重试获得通过结果。出现间歇性失败时必须定位并修复。
+
+### 8.4 真实 Tauri 验证
+
+由于修改 Wework UI、服务路由和本地运行时边界，必须使用
+`pnpm --filter wework ai:verify` 完成真实 Tauri 验证。
+
+至少验证：
+
+- 冷启动。
+- 云端断开启动。
+- 本地列表。
+- 本地详情。
+- 本地任务编辑。
+- 本地自动化。
+- 从本地详情返回项目首页。
+- 重新加载和标签页恢复。
+
+保留 `app.log`、`executor.log` 和 Tauri 日志作为请求边界证据。
+
+## 9. 诊断日志
+
+为验证请求边界，可在项目空间 API 入口增加结构化诊断日志，但不得记录 token 或项目内容：
+
+```ts
+console.info("[ProjectSpace] request", {
+  source: "local",
+  operation: "listLoopItems",
+  projectStore: ref.projectStore,
+  projectId: ref.projectId,
+});
+```
+
+测试和真实 Tauri 验证应能够根据日志确认：
+
+- 本地详情只出现 `source=local`。
+- 云端列表失败不会阻塞本地列表完成事件。
+- 项目来源在请求发出前已经确定。
+
+日志用于确认边界，不用于替代类型约束和自动化测试。
+
+## 10. 风险与处理
+
+### 10.1 Workspace Tab 持久化兼容
+
+旧标签页没有 `projectStore`。不要通过同时请求本地和云端来恢复，避免重新引入耦合。通过存储
+版本迁移将旧详情标签恢复到项目首页。
+
+### 10.2 项目 ID 冲突
+
+所有缓存和 UI 状态改用 `projectSpaceKey` 后，必须检查项目卡片 key、详情抽屉、菜单、统计和
+任务缓存，防止残留裸 ID。
+
+### 10.3 本地自动化能力不完整
+
+先确认 Executor 的实际能力。缺少能力时应明确禁用，不得调用 Backend 作为隐式实现。
+
+### 10.4 组件拆分范围
+
+`CloudTodoWorkspace.tsx` 已同时承担过多职责。实施过程中应优先删除混合路径并拆分组件，
+避免继续在大组件内增加条件分支。
+
+### 10.5 云端连接状态
+
+本次解耦不能依赖 `isConnected` 完全准确。即使缓存状态暂时仍是 connected，只要请求边界
+正确，云端故障也只能影响云端数据源。连接状态后续可以独立改进，但不能成为本地正确性的
+前提。
+
+## 11. 完成标准
+
+同时满足以下条件后才算完成：
+
+1. 项目身份统一为 `projectStore + projectId`。
+2. 本地和云端项目列表拥有独立状态和请求生命周期。
+3. 项目列表不再预加载所有项目详情。
+4. `apiForProjectId()` 和跨来源 API fallback 被删除。
+5. 本地项目详情组件无法访问云端项目服务。
+6. 本地项目详情所有功能的云端 API 调用次数为 0。
+7. 本地项目自动化不使用 Backend 项目自动化 API。
+8. 全局聚合视图按来源独立加载和失败。
+9. 独立自动化页面中本地数据不等待云端设备。
+10. 聚焦单元测试、组件测试、Desktop E2E 和真实 Tauri 验证全部通过。
+11. 云端不可达时，本地项目列表和详情在正常交互时间内可用。
+12. 没有通过重试、fallback、静默 catch 或跳过测试掩盖失败。
+
+## 12. 建议提交顺序
+
+为降低评审和回归风险，建议按以下顺序提交：
+
+1. `refactor(wework): scope project space identity by store`
+2. `refactor(wework): split local and cloud project list loading`
+3. `refactor(wework): inject source-bound project detail services`
+4. `fix(wework): keep local project automation offline`
+5. `refactor(wework): isolate cross-source project aggregations`
+6. `fix(wework): load local automations independently from cloud`
+7. `test(wework): cover offline local project boundaries`
+
+每个提交都应保持可编译，并运行对应的聚焦测试。最终提交前运行 Wework 的完整测试和真实
+Tauri 验证。

--- a/wework/e2e/desktop/checkpoints.mjs
+++ b/wework/e2e/desktop/checkpoints.mjs
@@ -4,6 +4,7 @@ export const DESKTOP_CHECKPOINTS = [
   'telemetry-consent',
   'automation-lifecycle',
   'project-automation',
+  'offline-local-project-space',
   'plugin-auto-update',
   'model-routing',
   'permission-modes',

--- a/wework/e2e/desktop/modules/goal-flows.mjs
+++ b/wework/e2e/desktop/modules/goal-flows.mjs
@@ -46,11 +46,7 @@ import {
   withTimeout,
 } from './shared.mjs'
 
-import {
-  captureVerificationScreenshot,
-  waitForAttribute,
-  waitForWorkbenchDebugState,
-} from './workspace-flows.mjs'
+import { captureVerificationScreenshot, waitForWorkbenchDebugState } from './workspace-flows.mjs'
 
 const SUPERVISOR_MODEL_KEY = `public:${CLOUD_PUBLIC_MODEL_NAME}:default:0`
 
@@ -611,16 +607,14 @@ async function verifyTaskSupervisorLifecycle({ composerSelector, control }) {
     SUPERVISOR_MODEL_KEY,
     'The active supervisor did not retain its selected model'
   )
-  await waitForAttribute(
-    control,
-    '[data-testid="task-supervisor-run-now-button"]',
-    'disabled',
-    '',
-    'The immediate supervisor review did not become available'
-  )
-  await control.command('click', '[data-testid="task-supervisor-run-now-button"]')
   await withTimeout(
     control.awaitScenarioRequestCount('supervisor', 4),
+    DEFAULT_STEP_TIMEOUT_MS,
+    'The supervisor did not inspect the completed auto-correction'
+  )
+  await control.command('clickWhenEnabled', '[data-testid="task-supervisor-run-now-button"]')
+  await withTimeout(
+    control.awaitScenarioRequestCount('supervisor', 5),
     DEFAULT_STEP_TIMEOUT_MS,
     'The immediate supervisor review did not reach the evaluator'
   )

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -749,7 +749,7 @@ async function verifyWorkspaceTabIsolation(control) {
     'workspace-tabs-isolation-05-detached-window.png'
   )
 
-  const sourceStorageKey = 'wework.workspaceTabs.v2:main'
+  const sourceStorageKey = 'wework.workspaceTabs.v3:main'
   const sourceTabRemovalStartedAt = Date.now()
   let sourceTabs = []
   while (Date.now() - sourceTabRemovalStartedAt < DEFAULT_STEP_TIMEOUT_MS) {

--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -22,12 +22,14 @@ const CHECKPOINT_SCENARIO_MODULES = {
   'runtime-task-queue': './scenarios/runtime-task-queue.scenario.mjs',
   'split-workbench': './scenarios/split-workbench.scenario.mjs',
   'project-automation': './scenarios/project-automation.scenario.mjs',
+  'offline-local-project-space': './scenarios/offline-local-project-space.scenario.mjs',
 }
 const SCENARIO_ONLY_CHECKPOINTS = new Set([
   'change-request-status',
   'claude-runtime',
   'local-file-preview',
   'local-harness',
+  'offline-local-project-space',
   'runtime-task-queue',
   'split-workbench',
   'temporary-chat',

--- a/wework/e2e/desktop/scenarios/offline-local-project-space.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/offline-local-project-space.scenario.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict'
+
+const PROJECT_NAME = '离线本地项目空间'
+const TASK_NAME = '离线本地任务'
+const UPDATED_TASK_NAME = '离线本地任务（已更新）'
+
+function json(response, status, body) {
+  response.writeHead(status, { 'content-type': 'application/json' })
+  response.end(JSON.stringify(body))
+}
+
+export function createDesktopScenario({ uiTimeoutMs }) {
+  let cloudProjectListFailures = 0
+  const cloudDetailRequests = []
+
+  return {
+    async handleHttp(request, response, url) {
+      if (request.method === 'GET' && url.pathname === '/api/v1/cloud-projects') {
+        cloudProjectListFailures += 1
+        json(response, 503, { detail: 'Desktop E2E cloud project service is unavailable' })
+        return true
+      }
+      if (url.pathname.startsWith('/api/v1/cloud-projects/')) {
+        cloudDetailRequests.push(`${request.method} ${url.pathname}`)
+      }
+      return false
+    },
+
+    async verify(control) {
+      await control.command('waitFor', '[data-testid="workspace-tab-add"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="workspace-tab-add"]')
+      await control.command('waitFor', '[data-testid="workspace-tab-add-menu"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="workspace-tab-add-board"]')
+      await control.command('waitFor', '[data-testid="cloud-todo-workspace"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('waitFor', '[data-testid="cloud-project-add"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+
+      await control.command('click', '[data-testid="cloud-project-add"]')
+      await control.command('waitFor', '[data-testid="cloud-project-name"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('fill', '[data-testid="cloud-project-name"]', {
+        value: PROJECT_NAME,
+      })
+      await control.command('click', '[data-testid="cloud-project-location-local"]')
+      await control.command('click', '[data-testid="cloud-project-task-provider-local"]')
+      await control.command('clickWhenEnabled', '[data-testid="cloud-project-create-confirm"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+
+      await control.command('waitFor', '[data-testid="cloud-todo-column-inbox"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="cloud-todo-add"]')
+      await control.command('waitFor', '[data-testid="cloud-todo-create-panel"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('fill', '[data-testid="cloud-todo-title"]', {
+        value: TASK_NAME,
+      })
+      await control.command('clickWhenEnabled', '[data-testid="cloud-todo-create-confirm"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('waitFor', '[data-testid^="cloud-todo-card-"]', {
+        text: TASK_NAME,
+        timeoutMs: uiTimeoutMs,
+      })
+      const boardSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+      const taskCardTestId = boardSnapshot.testIds.find(
+        testId =>
+          testId.startsWith('cloud-todo-card-') &&
+          ![
+            'cloud-todo-card-add-child-',
+            'cloud-todo-card-assignee-',
+            'cloud-todo-card-archive-',
+            'cloud-todo-card-drop-',
+            'cloud-todo-card-menu-',
+            'cloud-todo-card-more-',
+          ].some(prefix => testId.startsWith(prefix))
+      )
+      assert.ok(taskCardTestId, 'The newly created local task card was not present in the board')
+      await control.command('click', `[data-testid="${taskCardTestId}"]`)
+      await control.command('waitFor', '[data-testid="cloud-todo-detail"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('fill', '[data-testid="cloud-todo-detail-title"]', {
+        value: UPDATED_TASK_NAME,
+      })
+      await control.command('clickWhenEnabled', '[data-testid="cloud-todo-save"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="cloud-todo-detail-close"]')
+      await control.command('waitFor', `[data-testid="${taskCardTestId}"]`, {
+        text: UPDATED_TASK_NAME,
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="cloud-project-files-view"]')
+      await control.command('waitFor', '[data-testid="cloud-files-upload"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="cloud-project-manage-view"]')
+      await control.command('waitFor', '[data-testid="cloud-project-members-toggle"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="cloud-project-automation-view"]')
+      await control.command('waitFor', '[data-testid="project-automation-view"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid^="workspace-tab-select-task-"]')
+      await control.command('waitFor', '[data-testid="automation-button"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="automation-button"]')
+      await control.command('waitFor', '[data-testid="create-automation-button"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+
+      assert.ok(
+        cloudProjectListFailures > 0,
+        'The scenario did not exercise an unavailable cloud project list'
+      )
+      assert.deepEqual(
+        cloudDetailRequests,
+        [],
+        `Local project details unexpectedly called cloud APIs: ${cloudDetailRequests.join(', ')}`
+      )
+    },
+
+    diagnostics() {
+      return { cloudDetailRequests, cloudProjectListFailures }
+    },
+  }
+}

--- a/wework/src/api/backend/backendServices.ts
+++ b/wework/src/api/backend/backendServices.ts
@@ -69,9 +69,14 @@ export function createBackendWorkbenchServices(
     getToken: resolveToken,
   })
 
+  const teamApi = createTeamApi(client)
+  const modelApi = createModelApi(client)
+  const projectChatAgentApi = createProjectChatAgentApi(client)
+  const projectAutomationApi = createProjectAutomationApi(client)
+
   return {
-    teamApi: createTeamApi(client),
-    modelApi: createModelApi(client),
+    teamApi,
+    modelApi,
     skillApi: createSkillApi(client),
     projectApi,
     gitApi: createGitApi(client),
@@ -82,6 +87,17 @@ export function createBackendWorkbenchServices(
     projectSpaceApis: {
       cloud: deliveryApi,
       defaultLocation: 'cloud',
+    },
+    projectSpaceDetailServices: {
+      cloud: {
+        deliveryApi,
+        projectChatClient,
+        projectChatAgentApi,
+        projectAutomationApi,
+        deviceApi,
+        modelApi,
+        teamApi,
+      },
     },
     imSessionApi: createImSessionApi(client),
     runtimeWorkApi,
@@ -100,8 +116,8 @@ export function createBackendWorkbenchServices(
     userApi: createUserApi(client),
     socketClient,
     projectChatClient,
-    projectChatAgentApi: createProjectChatAgentApi(client),
-    projectAutomationApi: createProjectAutomationApi(client),
+    projectChatAgentApi,
+    projectAutomationApi,
     workspaceSessionApi: {
       startProjectTerminal: projectApi.startTerminalSession,
       startProjectCodeServer: projectApi.startCodeServerSession,

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WORKBENCH_AUTOMATIONS_CHANGED_EVENT } from '@/features/workbench/workbenchCloudDataEvents'
 import { createHybridWorkbenchServices } from './hybridServices'
 
 const mocks = vi.hoisted(() => {
@@ -209,6 +210,15 @@ vi.mock('@/api/local/localServices', () => ({
     },
     async createAutomation(data: Record<string, unknown>) {
       return request('runtime.automations.create', data, deviceId)
+    },
+    async updateAutomation(automationId: string, data: Record<string, unknown>) {
+      return request('runtime.automations.update', { automationId, ...data }, deviceId)
+    },
+    async deleteAutomation(automationId: string) {
+      return request('runtime.automations.delete', { automationId }, deviceId)
+    },
+    async toggleAutomation(automationId: string, enabled: boolean) {
+      return request('runtime.automations.toggle', { automationId, enabled }, deviceId)
     },
     listAutomationRuns: vi.fn().mockResolvedValue({ items: [] }),
   }),
@@ -1491,6 +1501,122 @@ describe('createHybridWorkbenchServices', () => {
       {},
       'cloud-device'
     )
+  })
+
+  it('notifies automation consumers only when the cloud cache changes', async () => {
+    const cloudAutomation = {
+      id: 'cloud-automation',
+      source: 'cloud' as const,
+      version: 1,
+      name: 'Cloud automation',
+      description: '',
+      prompt: 'Run remotely',
+      schedule: { type: 'interval' as const, value: 1, unit: 'hours' as const },
+      timezone: 'UTC',
+      enabled: true,
+      conversationMode: 'independent' as const,
+      notificationPolicy: 'all_runs' as const,
+      createdAt: '2026-08-15T00:00:00Z',
+      updatedAt: '2026-08-15T00:00:00Z',
+    }
+    mocks.cloudRuntimeIpcRequest.mockResolvedValue({ items: [cloudAutomation] })
+    const listener = vi.fn()
+    window.addEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, listener)
+    const services = createServices()
+    await services.cloudBackgroundApi?.listDevices?.()
+
+    await services.automationApi?.listAutomations()
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1))
+
+    await services.automationApi?.listAutomations()
+    await vi.waitFor(() => expect(mocks.cloudRuntimeIpcRequest).toHaveBeenCalledTimes(2))
+    expect(listener).toHaveBeenCalledTimes(1)
+    window.removeEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, listener)
+  })
+
+  it('writes cloud automation mutations through to the immediate list cache', async () => {
+    mocks.localAutomationApi.listAutomations.mockResolvedValue({ items: [] })
+    const automation = {
+      id: 'cloud-automation',
+      source: 'cloud' as const,
+      version: 1,
+      name: 'Cloud automation',
+      description: '',
+      prompt: 'Run remotely',
+      schedule: { type: 'interval' as const, value: 1, unit: 'hours' as const },
+      timezone: 'UTC',
+      enabled: true,
+      conversationMode: 'independent' as const,
+      notificationPolicy: 'all_runs' as const,
+      createdAt: '2026-08-15T00:00:00Z',
+      updatedAt: '2026-08-15T00:00:00Z',
+    }
+    mocks.cloudRuntimeIpcRequest.mockImplementation(async method => {
+      if (method === 'runtime.automations.list') return { items: [automation] }
+      return { automation }
+    })
+    const services = createServices()
+    await services.cloudBackgroundApi?.listDevices?.()
+    await services.automationApi?.listAutomations()
+    await vi.waitFor(() =>
+      expect(mocks.cloudRuntimeIpcRequest).toHaveBeenCalledWith(
+        'runtime.automations.list',
+        {},
+        'cloud-device'
+      )
+    )
+
+    const pendingList = new Promise(() => undefined)
+    mocks.cloudRuntimeIpcRequest.mockImplementation(async (method, params) => {
+      if (method === 'runtime.automations.list') return pendingList
+      const version = method === 'runtime.automations.create' ? 1 : 2
+      return {
+        automation: {
+          ...automation,
+          id:
+            method === 'runtime.automations.create'
+              ? 'created-automation'
+              : String((params as { automationId?: string }).automationId),
+          version,
+          enabled:
+            method === 'runtime.automations.toggle'
+              ? Boolean((params as { enabled?: boolean }).enabled)
+              : true,
+        },
+      }
+    })
+    await services.automationApi?.listAutomations()
+
+    await services.automationApi?.createAutomation({
+      ...automation,
+      taskRequest: { deviceId: 'cloud-device' },
+    })
+    expect((await services.automationApi?.listAutomations())?.items.map(item => item.id)).toEqual([
+      'cloud-automation',
+      'created-automation',
+    ])
+
+    await services.automationApi?.updateAutomation('cloud-automation', {
+      name: 'Updated',
+      taskRequest: { deviceId: 'cloud-device' },
+    })
+    expect(
+      (await services.automationApi?.listAutomations())?.items.find(
+        item => item.id === 'cloud-automation'
+      )?.version
+    ).toBe(2)
+
+    await services.automationApi?.toggleAutomation('cloud-automation', false)
+    expect(
+      (await services.automationApi?.listAutomations())?.items.find(
+        item => item.id === 'cloud-automation'
+      )?.enabled
+    ).toBe(false)
+
+    await services.automationApi?.deleteAutomation('cloud-automation')
+    expect((await services.automationApi?.listAutomations())?.items.map(item => item.id)).toEqual([
+      'created-automation',
+    ])
   })
 
   it('routes cloud automations to the selected remote executor', async () => {

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -1522,16 +1522,19 @@ describe('createHybridWorkbenchServices', () => {
     mocks.cloudRuntimeIpcRequest.mockResolvedValue({ items: [cloudAutomation] })
     const listener = vi.fn()
     window.addEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, listener)
-    const services = createServices()
-    await services.cloudBackgroundApi?.listDevices?.()
+    try {
+      const services = createServices()
+      await services.cloudBackgroundApi?.listDevices?.()
 
-    await services.automationApi?.listAutomations()
-    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1))
+      await services.automationApi?.listAutomations()
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1))
 
-    await services.automationApi?.listAutomations()
-    await vi.waitFor(() => expect(mocks.cloudRuntimeIpcRequest).toHaveBeenCalledTimes(2))
-    expect(listener).toHaveBeenCalledTimes(1)
-    window.removeEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, listener)
+      await services.automationApi?.listAutomations()
+      await vi.waitFor(() => expect(mocks.cloudRuntimeIpcRequest).toHaveBeenCalledTimes(2))
+      expect(listener).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, listener)
+    }
   })
 
   it('writes cloud automation mutations through to the immediate list cache', async () => {

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -1447,6 +1447,52 @@ describe('createHybridWorkbenchServices', () => {
     expect(services.workspaceSessionApi).toBe(mocks.cloudWorkspaceSessionApi)
   })
 
+  it('returns local automations without waiting for an unresponsive cloud executor', async () => {
+    mocks.cloudListDevices.mockResolvedValue([
+      {
+        device_id: 'cloud-device',
+        device_type: 'cloud',
+        status: 'online',
+      },
+    ])
+    mocks.localAutomationApi.listAutomations.mockResolvedValue({
+      items: [
+        {
+          id: 'local-automation',
+          source: 'local',
+          version: 1,
+          name: 'Local automation',
+          description: '',
+          prompt: 'Run locally',
+          schedule: { type: 'interval', value: 1, unit: 'hours' },
+          timezone: 'UTC',
+          enabled: true,
+          conversationMode: 'independent',
+          notificationPolicy: 'all_runs',
+          taskRequest: { deviceId: 'local-device' },
+          createdAt: '2026-08-15T00:00:00Z',
+          updatedAt: '2026-08-15T00:00:00Z',
+        },
+      ],
+    })
+    mocks.cloudRuntimeIpcRequest.mockImplementation(method =>
+      method === 'runtime.automations.list'
+        ? new Promise(() => undefined)
+        : Promise.resolve({ items: [] })
+    )
+    const services = createServices()
+    await services.cloudBackgroundApi?.listDevices?.()
+
+    const response = await services.automationApi?.listAutomations()
+
+    expect(response?.items.map(item => item.id)).toEqual(['local-automation'])
+    expect(mocks.cloudRuntimeIpcRequest).toHaveBeenCalledWith(
+      'runtime.automations.list',
+      {},
+      'cloud-device'
+    )
+  })
+
   it('routes cloud automations to the selected remote executor', async () => {
     mocks.cloudRuntimeIpcRequest.mockImplementation(async (method, params) => {
       if (method === 'runtime.automations.create') {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -1011,6 +1011,29 @@ export function createHybridWorkbenchServices(
   const rememberAutomationRoutes = (deviceId: string, automations: Automation[]) => {
     automations.forEach(automation => automationDevices.set(automation.id, deviceId))
   }
+  const sameAutomationVersions = (left: Automation[], right: Automation[]) =>
+    left.length === right.length &&
+    left.every(automation =>
+      right.some(
+        candidate => candidate.id === automation.id && candidate.version === automation.version
+      )
+    )
+  const writeCloudAutomation = (deviceId: string, automation: Automation) => {
+    if (isLocalDeviceId(deviceId)) return
+    const current = rememberedCloudAutomations.get(deviceId) ?? []
+    rememberedCloudAutomations.set(deviceId, [
+      ...current.filter(candidate => candidate.id !== automation.id),
+      automation,
+    ])
+  }
+  const removeCloudAutomation = (deviceId: string, automationId: string) => {
+    if (isLocalDeviceId(deviceId)) return
+    const current = rememberedCloudAutomations.get(deviceId) ?? []
+    rememberedCloudAutomations.set(
+      deviceId,
+      current.filter(automation => automation.id !== automationId)
+    )
+  }
   const refreshCloudAutomationsInBackground = () => {
     rememberedCloudDevices.filter(isUsableDevice).forEach(device => {
       const deviceId = device.device_id
@@ -1018,9 +1041,12 @@ export function createHybridWorkbenchServices(
       const request = automationApiForDevice(deviceId)
         .listAutomations()
         .then(response => {
+          const previous = rememberedCloudAutomations.get(deviceId) ?? []
           rememberAutomationRoutes(deviceId, response.items)
           rememberedCloudAutomations.set(deviceId, response.items)
-          notifyWorkbenchAutomationsChanged()
+          if (!sameAutomationVersions(previous, response.items)) {
+            notifyWorkbenchAutomationsChanged()
+          }
         })
         .catch(error => {
           console.warn('[Wework] Failed to refresh cloud automations in background', {
@@ -1066,18 +1092,21 @@ export function createHybridWorkbenchServices(
       const deviceId = automationMutationDeviceId(data)
       const response = await automationApiForDevice(deviceId).createAutomation(data)
       rememberAutomationRoutes(deviceId, [response.automation])
+      writeCloudAutomation(deviceId, response.automation)
       return response
     },
     async updateAutomation(automationId, data) {
       const deviceId = automationDevices.get(automationId) ?? automationMutationDeviceId(data)
       const response = await automationApiForDevice(deviceId).updateAutomation(automationId, data)
       rememberAutomationRoutes(deviceId, [response.automation])
+      writeCloudAutomation(deviceId, response.automation)
       return response
     },
     async deleteAutomation(automationId) {
       const deviceId = await automationDeviceId(automationId)
       const response = await automationApiForDevice(deviceId).deleteAutomation(automationId)
       automationDevices.delete(automationId)
+      removeCloudAutomation(deviceId, automationId)
       return response
     },
     async toggleAutomation(automationId, enabled) {
@@ -1087,6 +1116,7 @@ export function createHybridWorkbenchServices(
         enabled
       )
       rememberAutomationRoutes(deviceId, [response.automation])
+      writeCloudAutomation(deviceId, response.automation)
       return response
     },
     async runAutomationNow(automationId) {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -15,6 +15,7 @@ import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
 import {
   notifyWorkbenchCloudArchivesChanged,
   notifyWorkbenchCloudSearchResults,
+  notifyWorkbenchAutomationsChanged,
   notifyWorkbenchModelsChanged,
 } from '@/features/workbench/workbenchCloudDataEvents'
 import { requestCloudModelCatalogSync } from '@/features/model-settings/cloudModelCatalogSyncRequest'
@@ -336,6 +337,8 @@ export function createHybridWorkbenchServices(
   })
   const cloudRuntimeApis = new Map<string, NonNullable<WorkbenchServices['runtimeWorkApi']>>()
   const cloudAutomationApis = new Map<string, NonNullable<WorkbenchServices['automationApi']>>()
+  const rememberedCloudAutomations = new Map<string, Automation[]>()
+  const cloudAutomationRequests = new Map<string, Promise<void>>()
   const automationDevices = new Map<string, string>()
   const localDeviceIds = new Set<string>([LOCAL_DEVICE_ID])
   const localRuntimeInstanceIds = new Set<string>()
@@ -1008,6 +1011,29 @@ export function createHybridWorkbenchServices(
   const rememberAutomationRoutes = (deviceId: string, automations: Automation[]) => {
     automations.forEach(automation => automationDevices.set(automation.id, deviceId))
   }
+  const refreshCloudAutomationsInBackground = () => {
+    rememberedCloudDevices.filter(isUsableDevice).forEach(device => {
+      const deviceId = device.device_id
+      if (cloudAutomationRequests.has(deviceId)) return
+      const request = automationApiForDevice(deviceId)
+        .listAutomations()
+        .then(response => {
+          rememberAutomationRoutes(deviceId, response.items)
+          rememberedCloudAutomations.set(deviceId, response.items)
+          notifyWorkbenchAutomationsChanged()
+        })
+        .catch(error => {
+          console.warn('[Wework] Failed to refresh cloud automations in background', {
+            deviceId,
+            error,
+          })
+        })
+        .finally(() => {
+          cloudAutomationRequests.delete(deviceId)
+        })
+      cloudAutomationRequests.set(deviceId, request)
+    })
+  }
   const automationMutationDeviceId = (data: { taskRequest?: RuntimeTaskCreateRequest }) => {
     const deviceId = data.taskRequest?.deviceId?.trim()
     if (!deviceId) throw new Error('Automation target device is required')
@@ -1023,17 +1049,12 @@ export function createHybridWorkbenchServices(
   }
   const automationApi: NonNullable<WorkbenchServices['automationApi']> = {
     async listAutomations() {
-      const cloudDeviceIds = rememberedCloudDevices
-        .filter(device => isUsableDevice(device))
-        .map(device => device.device_id)
-      const deviceIds = [LOCAL_DEVICE_ID, ...cloudDeviceIds]
-      const responses = await Promise.all(
-        deviceIds.map(deviceId => automationApiForDevice(deviceId).listAutomations())
-      )
-      responses.forEach((response, index) =>
-        rememberAutomationRoutes(deviceIds[index], response.items)
-      )
-      return { items: responses.flatMap(response => response.items) }
+      const localResponse = await localServices.automationApi!.listAutomations()
+      rememberAutomationRoutes(LOCAL_DEVICE_ID, localResponse.items)
+      refreshCloudAutomationsInBackground()
+      return {
+        items: [...localResponse.items, ...Array.from(rememberedCloudAutomations.values()).flat()],
+      }
     },
     async getAutomation(automationId) {
       const deviceId = await automationDeviceId(automationId)
@@ -1077,16 +1098,7 @@ export function createHybridWorkbenchServices(
         const deviceId = await automationDeviceId(automationId)
         return automationApiForDevice(deviceId).listAutomationRuns(automationId)
       }
-      const deviceIds = [
-        LOCAL_DEVICE_ID,
-        ...rememberedCloudDevices
-          .filter(device => isUsableDevice(device))
-          .map(device => device.device_id),
-      ]
-      const responses = await Promise.all(
-        deviceIds.map(deviceId => automationApiForDevice(deviceId).listAutomationRuns())
-      )
-      return { items: responses.flatMap(response => response.items) }
+      return localServices.automationApi!.listAutomationRuns()
     },
   }
 
@@ -1148,6 +1160,10 @@ export function createHybridWorkbenchServices(
       local: localServices.deliveryApi,
       cloud: cloudProjectSpaceApi,
       defaultLocation: 'cloud',
+    },
+    projectSpaceDetailServices: {
+      local: localServices.projectSpaceDetailServices?.local,
+      cloud: cloudServices.projectSpaceDetailServices?.cloud,
     },
     teamApi: {
       // Wegent Teams are backend CRDs. The local service only exposes the

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -3175,42 +3175,44 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
   })
   const aitableApi = createLocalAITableApi(request)
   const dwsApi = createDwsApi(request)
+  const teamApi = {
+    listTeams: async () => [LOCAL_WORKBENCH_TEAM],
+    getDefaultWorkbenchTeam: async () => LOCAL_WORKBENCH_TEAM,
+  }
+  const modelApi = {
+    listModels: async () => {
+      let codexOfficialModels: CodexOfficialModel[]
+      let codexOfficialError: string | null
+      let codexAuthConfigured: boolean
+      try {
+        await ensureStatus()
+        const [codexOfficialResult, nextCodexAuthConfigured] = await Promise.all([
+          requestLocalCodexOfficialModels(request).then(
+            value => ({ value, error: null }),
+            error => ({
+              value: null,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          ),
+          loadLocalCodexAuthConfigured(request),
+        ])
+        codexOfficialModels = codexOfficialResult.value?.models ?? []
+        codexOfficialError = codexOfficialResult.error
+        codexAuthConfigured = nextCodexAuthConfigured
+      } catch (error) {
+        codexOfficialModels = []
+        codexOfficialError = error instanceof Error ? error.message : String(error)
+        codexAuthConfigured = false
+      }
+      return {
+        data: localRuntimeModels(codexOfficialModels, codexOfficialError, codexAuthConfigured),
+      }
+    },
+  }
 
   return {
-    teamApi: {
-      listTeams: async () => [LOCAL_WORKBENCH_TEAM],
-      getDefaultWorkbenchTeam: async () => LOCAL_WORKBENCH_TEAM,
-    },
-    modelApi: {
-      listModels: async () => {
-        let codexOfficialModels: CodexOfficialModel[]
-        let codexOfficialError: string | null
-        let codexAuthConfigured: boolean
-        try {
-          await ensureStatus()
-          const [codexOfficialResult, nextCodexAuthConfigured] = await Promise.all([
-            requestLocalCodexOfficialModels(request).then(
-              value => ({ value, error: null }),
-              error => ({
-                value: null,
-                error: error instanceof Error ? error.message : String(error),
-              })
-            ),
-            loadLocalCodexAuthConfigured(request),
-          ])
-          codexOfficialModels = codexOfficialResult.value?.models ?? []
-          codexOfficialError = codexOfficialResult.error
-          codexAuthConfigured = nextCodexAuthConfigured
-        } catch (error) {
-          codexOfficialModels = []
-          codexOfficialError = error instanceof Error ? error.message : String(error)
-          codexAuthConfigured = false
-        }
-        return {
-          data: localRuntimeModels(codexOfficialModels, codexOfficialError, codexAuthConfigured),
-        }
-      },
-    },
+    teamApi,
+    modelApi,
     skillApi: {
       listSkills: async () => [],
       getTeamSkills: async () => ({ skills: [], preload_skills: [] }),
@@ -3254,6 +3256,17 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
     projectSpaceApis: {
       local: deliveryApi,
       defaultLocation: 'local',
+    },
+    projectSpaceDetailServices: {
+      local: {
+        deliveryApi,
+        projectChatClient: localProjectChatClient,
+        projectChatAgentApi: localProjectChatAgentApi,
+        loopItemExecutionApi: localLoopItemExecutionApi,
+        deviceApi,
+        modelApi,
+        teamApi,
+      },
     },
     runtimeWorkApi,
     automationApi,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/features/auth/useAuth'
 import type {
   IMPrivateSession,
   ProjectWithTasks,
+  RuntimeProjectSpaceRef,
   RuntimeTaskAddress,
   RuntimeIMNotificationSettingsResponse,
 } from '@/types/api'
@@ -88,6 +89,13 @@ function boardRouteParam(contentRoute: string, name: string): string | null {
   const searchIndex = contentRoute.indexOf('?')
   if (searchIndex < 0) return null
   return new URLSearchParams(contentRoute.slice(searchIndex + 1)).get(name)
+}
+
+function boardRouteProjectRef(contentRoute: string): RuntimeProjectSpaceRef | null {
+  const projectId = boardRouteParam(contentRoute, 'projectId')
+  const projectStore = boardRouteParam(contentRoute, 'projectStore')
+  if (!projectId || (projectStore !== 'local' && projectStore !== 'backend')) return null
+  return { projectId, projectStore }
 }
 
 interface DesktopWorkbenchLayoutProps {
@@ -923,9 +931,9 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
                 runtimeWork={state.runtimeWork}
                 services={services}
                 onOpenRuntimeTask={openProjectSpaceRuntimeTask}
-                activeProjectId={
+                activeProjectRef={
                   workspaceTabs?.activeTab.kind === 'board'
-                    ? boardRouteParam(workspaceTabs.activeTab.contentRoute, 'projectId')
+                    ? boardRouteProjectRef(workspaceTabs.activeTab.contentRoute)
                     : undefined
                 }
                 focusedItemId={
@@ -935,12 +943,12 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
                 }
                 onFocusedItemHandled={() => {
                   if (!workspaceTabs || workspaceTabs.activeTab.kind !== 'board') return
-                  const projectId = boardRouteParam(
-                    workspaceTabs.activeTab.contentRoute,
-                    'projectId'
-                  )
+                  const projectRef = boardRouteProjectRef(workspaceTabs.activeTab.contentRoute)
                   const params = new URLSearchParams()
-                  if (projectId) params.set('projectId', projectId)
+                  if (projectRef) {
+                    params.set('projectStore', projectRef.projectStore)
+                    params.set('projectId', projectRef.projectId)
+                  }
                   workspaceTabs.updateActiveTab({
                     contentRoute: `/todo${params.size ? `?${params.toString()}` : ''}`,
                   })
@@ -955,6 +963,7 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
                     return
                   }
                   const params = new URLSearchParams()
+                  params.set('projectStore', project.project_store)
                   params.set('projectId', project.id)
                   workspaceTabs.updateActiveTab({
                     title: project.name,

--- a/wework/src/features/todo/CloudProjectsHome.tsx
+++ b/wework/src/features/todo/CloudProjectsHome.tsx
@@ -7,13 +7,22 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { cn } from '@/lib/utils'
 import { CloudTodoModal as Modal } from './CloudTodoModal'
+import { projectSpaceKey } from './projectSpaceSelection'
 import { memberAvatarClasses, memberNameById } from './todoShared'
 
 export interface ProjectsHomeProject {
   id: string
   name: string
   location: 'local' | 'cloud'
+  project_store: 'local' | 'backend'
   updated_at: string
+}
+
+function projectKey(project: ProjectsHomeProject): string {
+  return projectSpaceKey({
+    projectStore: project.project_store,
+    projectId: project.id,
+  })
 }
 
 interface CloudProjectsHomeProps {
@@ -24,8 +33,8 @@ interface CloudProjectsHomeProps {
   myWork: CloudMyWorkItem[]
   searchQuery: string
   onCreateProject: () => void
-  onSelectProject: (projectId: string) => void
-  onManageProject: (projectId: string) => void
+  onSelectProject: (project: ProjectsHomeProject) => void
+  onManageProject: (project: ProjectsHomeProject) => void
   onSelectItem: (item: CloudMyWorkItem) => void
   onOpenMyWork: () => void
 }
@@ -200,7 +209,14 @@ export function CloudProjectsHome({
     [projects, query]
   )
 
-  const allItems = useMemo(() => Object.values(projectItems).flat(), [projectItems])
+  const allItemEntries = useMemo(
+    () =>
+      Object.entries(projectItems).flatMap(([spaceKey, items]) =>
+        items.map(item => ({ item, spaceKey }))
+      ),
+    [projectItems]
+  )
+  const allItems = useMemo(() => allItemEntries.map(entry => entry.item), [allItemEntries])
   const completedCount = useMemo(
     () => allItems.filter(item => item.status === 'completed').length,
     [allItems]
@@ -223,10 +239,10 @@ export function CloudProjectsHome({
 
   const recentActivity = useMemo(
     () =>
-      [...allItems]
-        .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+      [...allItemEntries]
+        .sort((a, b) => b.item.updated_at.localeCompare(a.item.updated_at))
         .slice(0, MAX_RECENT_ACTIVITY),
-    [allItems]
+    [allItemEntries]
   )
   const myTodos = useMemo(
     () => myWork.filter(item => item.status !== 'completed').slice(0, MAX_MY_TODOS),
@@ -261,8 +277,8 @@ export function CloudProjectsHome({
     completed: t('todo.status_completed', '已完成'),
   }
 
-  const projectNameById = useMemo(
-    () => new Map(projects.map(project => [String(project.id), project.name])),
+  const projectByKey = useMemo(
+    () => new Map(projects.map(project => [projectKey(project), project])),
     [projects]
   )
 
@@ -313,12 +329,12 @@ export function CloudProjectsHome({
                 {t('todo.home_no_activity', '暂无动态')}
               </p>
             ) : (
-              recentActivity.map((item, itemIndex) => {
-                const projectId = String(item.cloud_project_id)
+              recentActivity.map(({ item, spaceKey }, itemIndex) => {
+                const project = projectByKey.get(spaceKey)
                 const actorName =
-                  memberNameById(projectMembers[projectId] ?? [], item.assignee_user_id) ??
+                  memberNameById(projectMembers[spaceKey] ?? [], item.assignee_user_id) ??
                   item.created_by_user_name ??
-                  memberNameById(projectMembers[projectId] ?? [], item.created_by_user_id) ??
+                  memberNameById(projectMembers[spaceKey] ?? [], item.created_by_user_id) ??
                   t('todo.home_activity_someone', '有人')
                 const actionLabel =
                   item.status === 'completed'
@@ -326,9 +342,11 @@ export function CloudProjectsHome({
                     : t('todo.home_activity_updated', '更新了任务')
                 return (
                   <button
-                    key={item.id}
+                    key={`${spaceKey}:${item.id}`}
                     type="button"
-                    onClick={() => onSelectProject(projectId)}
+                    onClick={() => {
+                      if (project) onSelectProject(project)
+                    }}
                     className="flex w-full items-start gap-2.5 rounded-lg px-2 py-2.5 text-left transition hover:bg-muted/60"
                   >
                     <span
@@ -346,7 +364,7 @@ export function CloudProjectsHome({
                         </span>
                       </span>
                       <span className="mt-0.5 block truncate text-xs text-text-muted">
-                        {projectNameById.get(projectId) ?? ''} · {statusLabels[item.status]}
+                        {project?.name ?? ''} · {statusLabels[item.status]}
                       </span>
                     </span>
                     <span className="mt-0.5 shrink-0 text-xs text-text-muted">
@@ -421,19 +439,19 @@ export function CloudProjectsHome({
           >
             {sortedProjects.map(project => (
               <ProjectSpaceRow
-                key={project.id}
+                key={projectKey(project)}
                 project={project}
-                members={projectMembers[project.id] ?? []}
+                members={projectMembers[projectKey(project)] ?? []}
                 openLabel={t('todo.home_open', '打开')}
                 manageLabel={t('todo.home_manage', '管理')}
                 localLabel={t('todo.location_local', '本地')}
                 taskCountLabel={t('todo.home_task_count', '{{count}} 任务', {
-                  count: projectCounts[project.id] ?? 0,
+                  count: projectCounts[projectKey(project)] ?? 0,
                 })}
                 memberCountLabel={t('todo.home_member_count', '{{count}} 人', {
-                  count: (projectMembers[project.id] ?? []).length,
+                  count: (projectMembers[projectKey(project)] ?? []).length,
                 })}
-                onOpen={() => onSelectProject(project.id)}
+                onOpen={() => onSelectProject(project)}
               />
             ))}
           </div>
@@ -473,25 +491,25 @@ export function CloudProjectsHome({
               ) : (
                 manageProjects.map(project => (
                   <ProjectSpaceRow
-                    key={project.id}
+                    key={projectKey(project)}
                     project={project}
-                    members={projectMembers[project.id] ?? []}
+                    members={projectMembers[projectKey(project)] ?? []}
                     openLabel={t('todo.home_open', '打开')}
                     manageLabel={t('todo.home_manage', '管理')}
                     localLabel={t('todo.location_local', '本地')}
                     taskCountLabel={t('todo.home_task_count', '{{count}} 任务', {
-                      count: projectCounts[project.id] ?? 0,
+                      count: projectCounts[projectKey(project)] ?? 0,
                     })}
                     memberCountLabel={t('todo.home_member_count', '{{count}} 人', {
-                      count: (projectMembers[project.id] ?? []).length,
+                      count: (projectMembers[projectKey(project)] ?? []).length,
                     })}
                     onOpen={() => {
                       setManageOpen(false)
-                      onSelectProject(project.id)
+                      onSelectProject(project)
                     }}
                     onManage={() => {
                       setManageOpen(false)
-                      onManageProject(project.id)
+                      onManageProject(project)
                     }}
                   />
                 ))

--- a/wework/src/features/todo/CloudProjectsHome.tsx
+++ b/wework/src/features/todo/CloudProjectsHome.tsx
@@ -7,34 +7,19 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { cn } from '@/lib/utils'
 import { CloudTodoModal as Modal } from './CloudTodoModal'
-import { projectSpaceKey } from './projectSpaceSelection'
+import { projectKey, type LocatedProjectSpace } from './projectSpaceSelection'
 import { memberAvatarClasses, memberNameById } from './todoShared'
 
-export interface ProjectsHomeProject {
-  id: string
-  name: string
-  location: 'local' | 'cloud'
-  project_store: 'local' | 'backend'
-  updated_at: string
-}
-
-function projectKey(project: ProjectsHomeProject): string {
-  return projectSpaceKey({
-    projectStore: project.project_store,
-    projectId: project.id,
-  })
-}
-
 interface CloudProjectsHomeProps {
-  projects: ProjectsHomeProject[]
+  projects: LocatedProjectSpace[]
   projectCounts: Record<string, number>
   projectMembers: Record<string, CloudProjectMember[]>
   projectItems: Record<string, CloudLoopItem[]>
   myWork: CloudMyWorkItem[]
   searchQuery: string
   onCreateProject: () => void
-  onSelectProject: (project: ProjectsHomeProject) => void
-  onManageProject: (project: ProjectsHomeProject) => void
+  onSelectProject: (project: LocatedProjectSpace) => void
+  onManageProject: (project: LocatedProjectSpace) => void
   onSelectItem: (item: CloudMyWorkItem) => void
   onOpenMyWork: () => void
 }
@@ -52,13 +37,13 @@ function isWithinLastWeek(timestamp: string | null | undefined, nowMs: number): 
   return !Number.isNaN(valueMs) && valueMs >= nowMs - WEEK_MS
 }
 
-function matchesQuery(project: ProjectsHomeProject, query: string): boolean {
+function matchesQuery(project: LocatedProjectSpace, query: string): boolean {
   if (!query) return true
   return project.name.toLowerCase().includes(query)
 }
 
 interface ProjectSpaceRowProps {
-  project: ProjectsHomeProject
+  project: LocatedProjectSpace
   members: CloudProjectMember[]
   openLabel: string
   manageLabel: string

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -83,8 +83,8 @@ const item = {
   completed_at: null,
 }
 
-function services(): WorkbenchServices {
-  const workbenchServices = {
+function services(overrides: Partial<WorkbenchServices> = {}): WorkbenchServices {
+  const baseServices = {
     deliveryApi: {
       listCloudProjects: vi.fn(async () => ({ items: [project] })),
       createCloudProject: vi.fn(async values => ({
@@ -227,6 +227,7 @@ function services(): WorkbenchServices {
       })),
     },
   } as unknown as WorkbenchServices
+  const workbenchServices = { ...baseServices, ...overrides } as WorkbenchServices
   workbenchServices.projectSpaceDetailServices = {
     local: {
       get deliveryApi() {
@@ -322,15 +323,17 @@ describe('CloudTodoWorkspace', () => {
     localApi.listCloudProjects = vi.fn(async () => ({ items: [localProject] }))
     const cloudApi = services().deliveryApi!
     cloudApi.listCloudProjects = vi.fn(() => new Promise(() => undefined))
-    const workbenchServices = {
-      ...localServices,
+    const workbenchServices = services({
       deliveryApi: cloudApi,
       projectSpaceApis: {
         local: localApi,
         cloud: cloudApi,
         defaultLocation: 'local' as const,
       },
-    } as WorkbenchServices
+      deviceApi: localServices.deviceApi,
+      modelApi: localServices.modelApi,
+      teamApi: localServices.teamApi,
+    })
 
     render(
       <CloudTodoWorkspace
@@ -344,6 +347,36 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.queryByText('正在加载项目空间…')).not.toBeInTheDocument()
     expect(localApi.listLoopItems).not.toHaveBeenCalled()
     expect(localApi.listCloudProjectMembers).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a local project-list failure instead of rendering an empty state', async () => {
+    const localServices = services()
+    const localApi = localServices.deliveryApi!
+    localApi.listCloudProjects = vi.fn(async () => {
+      throw new Error('local executor unavailable')
+    })
+    const cloudApi = services().deliveryApi!
+    cloudApi.listCloudProjects = vi.fn(() => new Promise(() => undefined))
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        services={services({
+          deliveryApi: cloudApi,
+          projectSpaceApis: {
+            local: localApi,
+            cloud: cloudApi,
+            defaultLocation: 'local',
+          },
+        })}
+      />
+    )
+
+    expect(await screen.findByTestId('local-project-spaces-error')).toHaveTextContent(
+      'local executor unavailable'
+    )
+    expect(screen.queryByText('创建第一个项目空间')).not.toBeInTheDocument()
   })
 
   it('keeps local project details inside local services while cloud is unavailable', async () => {
@@ -399,8 +432,8 @@ describe('CloudTodoWorkspace', () => {
     expect(cloudApi.listLoopItems).not.toHaveBeenCalled()
     expect(cloudApi.listCloudProjectMembers).not.toHaveBeenCalled()
     expect(cloudApi.listCloudFiles).not.toHaveBeenCalled()
-    expect(cloudServices.modelApi.listModels).not.toHaveBeenCalled()
-    expect(cloudServices.deviceApi.listDevices).not.toHaveBeenCalled()
+    expect(localServices.modelApi.listModels).toHaveBeenCalled()
+    expect(localServices.deviceApi.listDevices).toHaveBeenCalled()
   })
 
   it('resets project-specific view state when a controlled project changes externally', async () => {
@@ -2241,6 +2274,67 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.getByTestId('cloud-todo-detail-title')).toHaveValue('Implement cloud MCP')
     expect(screen.getByTestId('my-work-group-action-WEG-1')).toBeVisible()
     expect(screen.queryByTestId('cloud-todo-board-breadcrumb')).toBeNull()
+  })
+
+  it('routes my-work actions by project store when local and cloud IDs collide', async () => {
+    const sharedProjectId = 'same-project-id'
+    const localProject = {
+      ...project,
+      id: sharedProjectId,
+      name: 'Local project',
+      project_store: 'local' as const,
+    }
+    const cloudProject = {
+      ...project,
+      id: sharedProjectId,
+      name: 'Cloud project',
+      project_store: 'backend' as const,
+    }
+    const approvalItem = {
+      ...item,
+      id: 'LOCAL-APPROVAL',
+      cloud_project_id: sharedProjectId,
+      project_key: 'LOCAL',
+      project_name: 'Local project',
+      has_active_task: false,
+      execution_state: 'pending_approval',
+      can_approve: true,
+    }
+    const localApi = services().deliveryApi!
+    localApi.listCloudProjects = vi.fn(async () => ({ items: [localProject] }))
+    localApi.listMyWork = vi.fn(async () => ({ items: [approvalItem] }))
+    localApi.approveLoopItemRun = vi.fn(async () => approvalItem)
+    const cloudApi = services().deliveryApi!
+    cloudApi.listCloudProjects = vi.fn(async () => ({ items: [cloudProject] }))
+    cloudApi.listMyWork = vi.fn(async () => ({ items: [] }))
+    cloudApi.approveLoopItemRun = vi.fn(async () => approvalItem)
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        services={services({
+          deliveryApi: cloudApi,
+          projectSpaceApis: {
+            local: localApi,
+            cloud: cloudApi,
+            defaultLocation: 'local',
+          },
+        })}
+      />
+    )
+
+    await userEvent.click(await screen.findByTestId('cloud-my-work'))
+    await userEvent.click(await screen.findByTestId('my-work-approve-LOCAL-APPROVAL'))
+
+    await waitFor(() =>
+      expect(localApi.approveLoopItemRun).toHaveBeenCalledWith(
+        sharedProjectId,
+        'LOCAL-APPROVAL',
+        item.version
+      )
+    )
+    expect(cloudApi.approveLoopItemRun).not.toHaveBeenCalled()
   })
 
   it('uses pointer dragging for TODO cards without starting a native system drag', async () => {

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -84,7 +84,7 @@ const item = {
 }
 
 function services(): WorkbenchServices {
-  return {
+  const workbenchServices = {
     deliveryApi: {
       listCloudProjects: vi.fn(async () => ({ items: [project] })),
       createCloudProject: vi.fn(async values => ({
@@ -227,6 +227,55 @@ function services(): WorkbenchServices {
       })),
     },
   } as unknown as WorkbenchServices
+  workbenchServices.projectSpaceDetailServices = {
+    local: {
+      get deliveryApi() {
+        return workbenchServices.projectSpaceApis?.local ?? workbenchServices.deliveryApi!
+      },
+      get projectChatClient() {
+        return workbenchServices.localProjectChatClient
+      },
+      get projectChatAgentApi() {
+        return workbenchServices.localProjectChatAgentApi
+      },
+      get loopItemExecutionApi() {
+        return workbenchServices.localLoopItemExecutionApi
+      },
+      get deviceApi() {
+        return workbenchServices.deviceApi
+      },
+      get modelApi() {
+        return workbenchServices.modelApi
+      },
+      get teamApi() {
+        return workbenchServices.teamApi
+      },
+    },
+    cloud: {
+      get deliveryApi() {
+        return workbenchServices.projectSpaceApis?.cloud ?? workbenchServices.deliveryApi!
+      },
+      get projectChatClient() {
+        return workbenchServices.projectChatClient
+      },
+      get projectChatAgentApi() {
+        return workbenchServices.projectChatAgentApi
+      },
+      get projectAutomationApi() {
+        return workbenchServices.projectAutomationApi
+      },
+      get deviceApi() {
+        return workbenchServices.deviceApi
+      },
+      get modelApi() {
+        return workbenchServices.modelApi
+      },
+      get teamApi() {
+        return workbenchServices.teamApi
+      },
+    },
+  }
+  return workbenchServices
 }
 
 describe('CloudTodoWorkspace', () => {
@@ -247,7 +296,7 @@ describe('CloudTodoWorkspace', () => {
         user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
         localProjects={[]}
         services={services()}
-        activeProjectId={null}
+        activeProjectRef={null}
         onActiveProjectChange={onActiveProjectChange}
       />
     )
@@ -259,6 +308,99 @@ describe('CloudTodoWorkspace', () => {
 
     await userEvent.click(screen.getByRole('button', { name: '项目空间' }))
     expect(onActiveProjectChange).toHaveBeenLastCalledWith(null)
+  })
+
+  it('renders local projects without waiting for the cloud project list', async () => {
+    const localProject = {
+      ...project,
+      id: 21,
+      name: 'Local Board',
+      project_store: 'local' as const,
+    }
+    const localServices = services()
+    const localApi = localServices.deliveryApi!
+    localApi.listCloudProjects = vi.fn(async () => ({ items: [localProject] }))
+    const cloudApi = services().deliveryApi!
+    cloudApi.listCloudProjects = vi.fn(() => new Promise(() => undefined))
+    const workbenchServices = {
+      ...localServices,
+      deliveryApi: cloudApi,
+      projectSpaceApis: {
+        local: localApi,
+        cloud: cloudApi,
+        defaultLocation: 'local' as const,
+      },
+    } as WorkbenchServices
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        services={workbenchServices}
+      />
+    )
+
+    expect(await screen.findByTestId('cloud-sidebar-project-21')).toHaveTextContent('Local Board')
+    expect(screen.queryByText('正在加载项目空间…')).not.toBeInTheDocument()
+    expect(localApi.listLoopItems).not.toHaveBeenCalled()
+    expect(localApi.listCloudProjectMembers).not.toHaveBeenCalled()
+  })
+
+  it('keeps local project details inside local services while cloud is unavailable', async () => {
+    const localProject = {
+      ...project,
+      id: 22,
+      name: 'Offline Local',
+      project_store: 'local' as const,
+    }
+    const localItem = { ...item, id: 'LOCAL-1', cloud_project_id: 22 }
+    const localServices = services()
+    const localApi = localServices.deliveryApi!
+    localApi.listCloudProjects = vi.fn(async () => ({ items: [localProject] }))
+    localApi.listLoopItems = vi.fn(async () => ({ items: [localItem] }))
+    const cloudServices = services()
+    const cloudApi = cloudServices.deliveryApi!
+    cloudApi.listCloudProjects = vi.fn(() => new Promise(() => undefined))
+    const workbenchServices = {
+      ...localServices,
+      deliveryApi: cloudApi,
+      projectSpaceApis: {
+        local: localApi,
+        cloud: cloudApi,
+        defaultLocation: 'local' as const,
+      },
+      projectSpaceDetailServices: {
+        local: {
+          deliveryApi: localApi,
+          deviceApi: localServices.deviceApi,
+          modelApi: localServices.modelApi,
+          teamApi: localServices.teamApi,
+        },
+      },
+    } as WorkbenchServices
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        services={workbenchServices}
+      />
+    )
+
+    await userEvent.click(await screen.findByTestId('cloud-sidebar-project-22'))
+    expect(await screen.findByTestId('cloud-todo-card-LOCAL-1')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('cloud-project-files-view'))
+    expect(await screen.findByTestId('cloud-files-upload')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('cloud-project-manage-view'))
+    expect(await screen.findByTestId('cloud-project-members-toggle')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('cloud-project-automation-view'))
+    expect(await screen.findByTestId('project-automation-view')).toBeInTheDocument()
+
+    expect(cloudApi.listLoopItems).not.toHaveBeenCalled()
+    expect(cloudApi.listCloudProjectMembers).not.toHaveBeenCalled()
+    expect(cloudApi.listCloudFiles).not.toHaveBeenCalled()
+    expect(cloudServices.modelApi.listModels).not.toHaveBeenCalled()
+    expect(cloudServices.deviceApi.listDevices).not.toHaveBeenCalled()
   })
 
   it('resets project-specific view state when a controlled project changes externally', async () => {
@@ -273,7 +415,7 @@ describe('CloudTodoWorkspace', () => {
         user={user}
         localProjects={[]}
         services={workbenchServices}
-        activeProjectId={controlledProject.id}
+        activeProjectRef={{ projectStore: 'backend', projectId: controlledProject.id }}
       />
     )
 
@@ -285,7 +427,7 @@ describe('CloudTodoWorkspace', () => {
         user={user}
         localProjects={[]}
         services={workbenchServices}
-        activeProjectId={null}
+        activeProjectRef={null}
       />
     )
 
@@ -738,14 +880,14 @@ describe('CloudTodoWorkspace', () => {
     }))
     const selectedProjectIds = new Set<number>()
     workbenchServices.deliveryApi!.listLoopItems = vi.fn(async (projectId: number) => {
-      // The bootstrap preloads counts for every project; only the board fetch
-      // for the selected project stays pending so the skeleton can be asserted.
-      if (selectedProjectIds.has(projectId)) {
+      // Project lists no longer preload board details. Keep each project's first
+      // explicit detail fetch pending so the switching skeleton can be asserted.
+      if (!selectedProjectIds.has(projectId)) {
+        selectedProjectIds.add(projectId)
         await new Promise<void>(resolve => {
           resolveBoardFetch = () => resolve()
         })
       }
-      selectedProjectIds.add(projectId)
       return { items: projectId === 12 ? [otherItem] : [item] }
     })
     render(
@@ -1112,7 +1254,7 @@ describe('CloudTodoWorkspace', () => {
         user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
         localProjects={[]}
         services={workbenchServices}
-        activeProjectId={null}
+        activeProjectRef={null}
         onActiveProjectChange={onActiveProjectChange}
       />
     )

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -352,9 +352,16 @@ describe('CloudTodoWorkspace', () => {
   it('surfaces a local project-list failure instead of rendering an empty state', async () => {
     const localServices = services()
     const localApi = localServices.deliveryApi!
-    localApi.listCloudProjects = vi.fn(async () => {
-      throw new Error('local executor unavailable')
-    })
+    const recoveredProject = {
+      ...project,
+      id: 23,
+      name: 'Recovered Local',
+      project_store: 'local' as const,
+    }
+    localApi.listCloudProjects = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('local executor unavailable'))
+      .mockResolvedValue({ items: [recoveredProject] })
     const cloudApi = services().deliveryApi!
     cloudApi.listCloudProjects = vi.fn(() => new Promise(() => undefined))
 
@@ -377,6 +384,12 @@ describe('CloudTodoWorkspace', () => {
       'local executor unavailable'
     )
     expect(screen.queryByText('创建第一个项目空间')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('local-project-spaces-retry'))
+    expect(await screen.findByTestId('cloud-sidebar-project-23')).toHaveTextContent(
+      'Recovered Local'
+    )
+    expect(screen.queryByTestId('local-project-spaces-error')).not.toBeInTheDocument()
   })
 
   it('keeps local project details inside local services while cloud is unavailable', async () => {

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -71,6 +71,7 @@ import { CloudProjectManageView } from './CloudProjectManageView'
 import { waitForDwsAuthentication } from './dwsAuth'
 import { ProjectAutomationView } from './ProjectAutomationView'
 import {
+  type LocatedProjectSpace,
   projectSpaceKey,
   projectSpaceRef,
   projectSupportsRobotAutomation,
@@ -213,8 +214,12 @@ function AITableGroupFieldPicker({
   )
 }
 
-interface LocatedCloudProject extends CloudProject {
-  location: ProjectSpaceLocation
+type LocatedCloudProject = LocatedProjectSpace
+type LocatedLoopItem = CloudLoopItem & {
+  project_store?: RuntimeProjectSpaceRef['projectStore']
+}
+type LocatedMyWorkItem = CloudMyWorkItem & {
+  project_store: RuntimeProjectSpaceRef['projectStore']
 }
 
 interface AvailableProjectSpaceApi {
@@ -767,22 +772,22 @@ export function CloudTodoWorkspace({
   const selectedProjectRef =
     activeProjectRef === undefined ? internalSelectedProjectRef : activeProjectRef
   const selectedProjectId = selectedProjectRef?.projectId ?? null
-  const [items, setItems] = useState<CloudLoopItem[]>([])
+  const [items, setItems] = useState<LocatedLoopItem[]>([])
   // Which project's items are currently in `items`. Anything else rendered on
   // the board would be stale, so the board shows the skeleton instead.
   const [itemsProjectKey, setItemsProjectKey] = useState<string | null>(null)
-  const [localMyWork, setLocalMyWork] = useState<CloudMyWorkItem[]>([])
-  const [cloudMyWork, setCloudMyWork] = useState<CloudMyWorkItem[]>([])
+  const [localMyWork, setLocalMyWork] = useState<LocatedMyWorkItem[]>([])
+  const [cloudMyWork, setCloudMyWork] = useState<LocatedMyWorkItem[]>([])
   const myWork = useMemo(() => [...localMyWork, ...cloudMyWork], [cloudMyWork, localMyWork])
   const [rootView, setRootView] = useState<RootView>('projects')
   const [projectView, setProjectView] = useState<ProjectView>('board')
-  const [selectedItem, setSelectedItem] = useState<CloudLoopItem | null>(null)
+  const [selectedItem, setSelectedItem] = useState<LocatedLoopItem | null>(null)
   // Items of the detail drawer's project when it differs from the board project,
   // so the drawer can stay open without switching the board view.
-  const [detailItems, setDetailItems] = useState<CloudLoopItem[]>([])
+  const [detailItems, setDetailItems] = useState<LocatedLoopItem[]>([])
   const [createProjectOpen, setCreateProjectOpen] = useState(false)
   const [createTodoOpen, setCreateTodoOpen] = useState(false)
-  const [createTodoParent, setCreateTodoParent] = useState<CloudLoopItem | null>(null)
+  const [createTodoParent, setCreateTodoParent] = useState<LocatedLoopItem | null>(null)
   const [createTodoStatus, setCreateTodoStatus] = useState<CloudLoopItem['status']>('inbox')
   const [boardParentId, setBoardParentId] = useState<string | null>(null)
   const [projectAssistantOpen, setProjectAssistantOpen] = useState(false)
@@ -901,6 +906,7 @@ export function CloudTodoWorkspace({
 
   const [localProjectsLoading, setLocalProjectsLoading] = useState(Boolean(projectSpaceApis.local))
   const [cloudProjectsLoading, setCloudProjectsLoading] = useState(Boolean(projectSpaceApis.cloud))
+  const [localProjectsError, setLocalProjectsError] = useState<string | null>(null)
   const [boardError, setBoardError] = useState<string | null>(null)
   const [dingtalkAuthPrompt, setDingtalkAuthPrompt] = useState(false)
   const [dingtalkAuthBusy, setDingtalkAuthBusy] = useState(false)
@@ -977,24 +983,41 @@ export function CloudTodoWorkspace({
   const selectedProjectKey = selectedProject
     ? projectSpaceKey(projectSpaceRef(selectedProject))
     : null
-  const projectForId = useCallback(
-    (projectId: string) => {
-      if (selectedProject?.id === projectId) return selectedProject
-      const matches = projects.filter(project => project.id === projectId)
+  const projectForItem = useCallback(
+    (item: Pick<LocatedLoopItem, 'cloud_project_id' | 'project_store'>) => {
+      if (item.project_store) {
+        return projects.find(project =>
+          sameProjectSpace(projectSpaceRef(project), {
+            projectStore: item.project_store!,
+            projectId: item.cloud_project_id,
+          })
+        )
+      }
+      if (selectedProject?.id === item.cloud_project_id) return selectedProject
+      const matches = projects.filter(project => project.id === item.cloud_project_id)
       return matches.length === 1 ? matches[0] : undefined
     },
     [projects, selectedProject]
   )
+  const locateItems = useCallback(
+    <T extends CloudLoopItem>(
+      sourceItems: T[],
+      projectStore: RuntimeProjectSpaceRef['projectStore']
+    ): Array<T & { project_store: RuntimeProjectSpaceRef['projectStore'] }> =>
+      sourceItems.map(item => ({ ...item, project_store: projectStore })),
+    []
+  )
   const updateMyWorkItem = useCallback(
     (updated: CloudLoopItem) => {
-      const project = projectForId(updated.cloud_project_id)
+      const current = myWork.find(entry => entry.id === updated.id)
+      const project = projectForItem(current ?? updated)
       if (!project) return
       const setSourceMyWork = project.location === 'local' ? setLocalMyWork : setCloudMyWork
       setSourceMyWork(current =>
         current.map(entry => (entry.id === updated.id ? { ...entry, ...updated } : entry))
       )
     },
-    [projectForId]
+    [myWork, projectForItem]
   )
   const selectedProjectAutomationSupported = selectedProject
     ? projectSupportsRobotAutomation(selectedProject)
@@ -1275,19 +1298,17 @@ export function CloudTodoWorkspace({
   // `boardError` distinguishes a failed fetch (skeleton stays) from a
   // successfully loaded but empty project (renders the empty columns).
   const boardItemsLoading = selectedProject !== null && itemsProjectKey !== selectedProjectKey
-  const selectedItemApi = selectedItem
-    ? apiForProject(projectForId(selectedItem.cloud_project_id))
-    : undefined
+  const selectedItemProject = selectedItem ? projectForItem(selectedItem) : undefined
+  const selectedItemApi = apiForProject(selectedItemProject)
   // Source for the detail drawer / creation dialog when the selected todo lives
   // in a project other than the one shown on the board.
   const detailAllItems =
-    selectedItem && selectedItem.cloud_project_id !== selectedProjectId ? detailItems : items
+    selectedItemProject &&
+    !sameProjectSpace(projectSpaceRef(selectedItemProject), selectedProjectRef)
+      ? detailItems
+      : items
   const createTodoProject = createTodoParent
-    ? (projects.find(
-        project =>
-          project.id === createTodoParent.cloud_project_id &&
-          project.project_store === selectedProject?.project_store
-      ) ?? null)
+    ? (projectForItem(createTodoParent) ?? null)
     : selectedProject
   const createTodoApi = apiForProject(createTodoProject)
   const boardParent = items.find(item => item.id === boardParentId) ?? null
@@ -1364,7 +1385,7 @@ export function CloudTodoWorkspace({
 
   async function confirmArchiveItem() {
     if (!archiveItem || archiveBusy) return
-    const api = apiForProject(projectForId(archiveItem.cloud_project_id))
+    const api = apiForProject(projectForItem(archiveItem))
     if (!api) return
     setArchiveBusy(true)
     setArchiveError(null)
@@ -1442,6 +1463,7 @@ export function CloudTodoWorkspace({
       .listCloudProjects()
       .then(response => {
         if (!active) return
+        setLocalProjectsError(null)
         setLocalProjectSpaces(
           response.items.map(project => ({
             ...project,
@@ -1452,7 +1474,9 @@ export function CloudTodoWorkspace({
       })
       .catch(error => {
         console.error('[Wework project spaces] local list failed', error)
-        if (active) setLocalProjectSpaces([])
+        if (active) {
+          setLocalProjectsError(error instanceof Error ? error.message : '本地项目空间加载失败')
+        }
       })
       .finally(() => {
         if (active) setLocalProjectsLoading(false)
@@ -1490,7 +1514,7 @@ export function CloudTodoWorkspace({
     }
   }, [projectSpaceApis.cloud])
   useEffect(() => {
-    if (!selectedProjectId || !selectedProjectKey || !selectedProjectApi) return
+    if (!selectedProject || !selectedProjectId || !selectedProjectKey || !selectedProjectApi) return
     let active = true
     const refreshItems = () => {
       const prepare =
@@ -1505,9 +1529,10 @@ export function CloudTodoWorkspace({
           const signature = boardSnapshotKey(response.items, null)
           if (boardSnapshotSignatureRef.current === signature) return
           boardSnapshotSignatureRef.current = signature
-          applyBoardItems(selectedProjectKey, response.items, null)
+          const locatedItems = locateItems(response.items, selectedProject.project_store)
+          applyBoardItems(selectedProjectKey, locatedItems, null)
           // Keep the projects-home cache in sync with the board fetch.
-          setProjectItems(current => ({ ...current, [selectedProjectKey]: response.items }))
+          setProjectItems(current => ({ ...current, [selectedProjectKey]: locatedItems }))
           setProjectCounts(current => ({
             ...current,
             [selectedProjectKey]: response.items.length,
@@ -1563,6 +1588,7 @@ export function CloudTodoWorkspace({
     selectedProjectApi,
     selectedProjectId,
     selectedProjectKey,
+    locateItems,
     services.aitableApi,
     services.dwsApi,
   ])
@@ -1623,7 +1649,7 @@ export function CloudTodoWorkspace({
     void api
       .listMyWork()
       .then(response => {
-        if (active) setLocalMyWork(response.items)
+        if (active) setLocalMyWork(locateItems(response.items, 'local'))
       })
       .catch(error => {
         console.error('[Wework project spaces] local my work failed', error)
@@ -1632,7 +1658,7 @@ export function CloudTodoWorkspace({
     return () => {
       active = false
     }
-  }, [projectSpaceApis.local, rootView, selectedProjectId])
+  }, [locateItems, projectSpaceApis.local, rootView, selectedProjectId])
 
   useEffect(() => {
     if (rootView !== 'my-work' && !(rootView === 'projects' && !selectedProjectId)) return
@@ -1642,7 +1668,7 @@ export function CloudTodoWorkspace({
     void api
       .listMyWork()
       .then(response => {
-        if (active) setCloudMyWork(response.items)
+        if (active) setCloudMyWork(locateItems(response.items, 'backend'))
       })
       .catch(error => {
         console.warn('[Wework project spaces] cloud my work failed', error)
@@ -1651,7 +1677,7 @@ export function CloudTodoWorkspace({
     return () => {
       active = false
     }
-  }, [projectSpaceApis.cloud, rootView, selectedProjectId])
+  }, [locateItems, projectSpaceApis.cloud, rootView, selectedProjectId])
   useEffect(() => {
     if (!globalSearchOpen) return
     let active = true
@@ -1681,17 +1707,25 @@ export function CloudTodoWorkspace({
   // Load the drawer project's items when the drawer shows a todo from a project
   // other than the one on the board, so subtasks and parent options stay correct.
   useEffect(() => {
-    if (!selectedItem || selectedItem.cloud_project_id === selectedProjectId) return
-    const detailApi = apiForProject(projectForId(selectedItem.cloud_project_id))
+    if (
+      !selectedItem ||
+      (selectedItemProject &&
+        sameProjectSpace(projectSpaceRef(selectedItemProject), selectedProjectRef))
+    ) {
+      return
+    }
+    const detailApi = apiForProject(selectedItemProject)
     if (!detailApi) return
     let active = true
     void detailApi.listLoopItems(selectedItem.cloud_project_id).then(response => {
-      if (active) setDetailItems(response.items)
+      if (active && selectedItemProject) {
+        setDetailItems(locateItems(response.items, selectedItemProject.project_store))
+      }
     })
     return () => {
       active = false
     }
-  }, [apiForProject, projectForId, selectedItem, selectedProjectId])
+  }, [apiForProject, locateItems, selectedItem, selectedItemProject, selectedProjectRef])
 
   async function moveItem(itemId: string, columnKey: string, beforeItemId: string | null = null) {
     const item = items.find(candidate => candidate.id === itemId)
@@ -1730,7 +1764,7 @@ export function CloudTodoWorkspace({
     }
     setBoardError(null)
     try {
-      const itemApi = apiForProject(projectForId(item.cloud_project_id))
+      const itemApi = apiForProject(projectForItem(item))
       if (!itemApi) throw new Error('项目空间当前不可用')
       const update =
         nativeGroupBy === 'status'
@@ -1749,10 +1783,11 @@ export function CloudTodoWorkspace({
                   }
               : { tags: column.groupValue ? [column.groupValue] : [] }
       const updated = await itemApi.updateLoopItem(item.id, { version: item.version, ...update })
+      const locatedUpdated = { ...updated, project_store: item.project_store }
       setItems(current =>
-        current.map(candidate => (candidate.id === updated.id ? updated : candidate))
+        current.map(candidate => (candidate.id === updated.id ? locatedUpdated : candidate))
       )
-      setSelectedItem(current => (current?.id === updated.id ? updated : current))
+      setSelectedItem(current => (current?.id === updated.id ? locatedUpdated : current))
       if (reordered) {
         await itemApi.reorderLoopItems(item.cloud_project_id, {
           parent_id: item.parent_id,
@@ -1763,8 +1798,7 @@ export function CloudTodoWorkspace({
       track('board_item_moved', {
         group_by: nativeGroupBy,
         reordered: beforeItemId !== null,
-        source:
-          projects.find(project => project.id === item.cloud_project_id)?.location ?? 'unknown',
+        source: projectForItem(item)?.location ?? 'unknown',
       })
     } catch (cause) {
       setItems(previousItems)
@@ -1835,10 +1869,7 @@ export function CloudTodoWorkspace({
     }
   }
 
-  const aiChatProject =
-    selectedItem !== null
-      ? projects.find(project => project.id === selectedItem.cloud_project_id)
-      : undefined
+  const aiChatProject = selectedItemProject
 
   return (
     <div
@@ -2063,6 +2094,14 @@ export function CloudTodoWorkspace({
               />
             </div>
           )}
+          {!selectedProject && projects.length > 0 && localProjectsError ? (
+            <div
+              data-testid="local-project-spaces-error"
+              className="shrink-0 border-b border-border bg-destructive/5 px-4 py-2 text-sm text-destructive"
+            >
+              本地项目空间加载失败：{localProjectsError}
+            </div>
+          ) : null}
           {rootView === 'my-work' ? (
             <CloudMyWorkView
               items={myWork}
@@ -2071,7 +2110,7 @@ export function CloudTodoWorkspace({
                 if (item.can_view_detail !== false) setSelectedItem(item)
               }}
               onApproveItem={async item => {
-                const api = apiForProject(projectForId(item.cloud_project_id))
+                const api = apiForProject(projectForItem(item))
                 if (!api) return
                 try {
                   const updated = await api.approveLoopItemRun(
@@ -2085,6 +2124,13 @@ export function CloudTodoWorkspace({
                 }
               }}
             />
+          ) : !selectedProject && projects.length === 0 && localProjectsError ? (
+            <div
+              data-testid="local-project-spaces-error"
+              className="flex flex-1 items-center justify-center px-6 text-sm text-destructive"
+            >
+              本地项目空间加载失败：{localProjectsError}
+            </div>
           ) : (projectSpaceApis.local ? localProjectsLoading : cloudProjectsLoading) ? (
             <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
               正在加载项目空间…
@@ -2113,9 +2159,9 @@ export function CloudTodoWorkspace({
               myWork={myWork}
               searchQuery=""
               onCreateProject={() => setCreateProjectOpen(true)}
-              onSelectProject={project => selectProject(project as LocatedCloudProject)}
+              onSelectProject={selectProject}
               onManageProject={project => {
-                selectProject(project as LocatedCloudProject)
+                selectProject(project)
                 setProjectView('manage')
               }}
               onSelectItem={item => {
@@ -2743,7 +2789,7 @@ export function CloudTodoWorkspace({
           onQueryChange={setGlobalSearchQuery}
           onClose={() => setGlobalSearchOpen(false)}
           onSelectProject={project => {
-            selectProject(project as LocatedCloudProject)
+            selectProject(project)
             setRootView('projects')
             setProjectView('board')
             setSelectedItem(null)
@@ -2751,10 +2797,10 @@ export function CloudTodoWorkspace({
           }}
           onSelectItem={(project, item) => {
             if (item.can_view_detail === false) return
-            selectProject(project as LocatedCloudProject)
+            selectProject(project)
             setRootView('projects')
             setProjectView('board')
-            setSelectedItem(item)
+            setSelectedItem({ ...item, project_store: project.project_store })
             setGlobalSearchOpen(false)
           }}
         />
@@ -2770,13 +2816,12 @@ export function CloudTodoWorkspace({
           currentUserId={user.id}
           localProjects={localProjects}
           aitableApi={
-            projects.find(project => project.id === selectedItem.cloud_project_id)
-              ?.task_provider === 'dingtalk_aitable'
+            selectedItemProject?.task_provider === 'dingtalk_aitable'
               ? services.aitableApi
               : undefined
           }
           item={selectedItem}
-          project={projects.find(project => project.id === selectedItem.cloud_project_id)}
+          project={selectedItemProject}
           allItems={detailAllItems}
           onClose={() => {
             setSelectedItem(null)
@@ -2788,12 +2833,18 @@ export function CloudTodoWorkspace({
           }}
           onAddChild={() => openTodoCreation(selectedItem)}
           onUpdated={updated => {
-            setItems(current => current.map(item => (item.id === updated.id ? updated : item)))
-            setDetailItems(current =>
-              current.map(item => (item.id === updated.id ? updated : item))
+            const locatedUpdated = {
+              ...updated,
+              project_store: selectedItem.project_store,
+            }
+            setItems(current =>
+              current.map(item => (item.id === updated.id ? locatedUpdated : item))
             )
-            updateMyWorkItem(updated)
-            setSelectedItem(updated)
+            setDetailItems(current =>
+              current.map(item => (item.id === updated.id ? locatedUpdated : item))
+            )
+            updateMyWorkItem(locatedUpdated)
+            setSelectedItem(locatedUpdated)
             track('feature_action_completed', { domain: 'board_item', action: 'update' })
           }}
         />
@@ -2814,7 +2865,11 @@ export function CloudTodoWorkspace({
           defaultLocation={projectSpaceApis.defaultLocation}
           onClose={() => setCreateProjectOpen(false)}
           onCreated={(project, location) => {
-            const locatedProject = { ...project, location }
+            const locatedProject: LocatedCloudProject = {
+              ...project,
+              project_store: location === 'local' ? 'local' : 'backend',
+              location,
+            }
             const spaceKey = projectSpaceKey(projectSpaceRef(locatedProject))
             const projectApi = projectSpaceApis[location]
             prependProject(locatedProject)
@@ -2845,10 +2900,17 @@ export function CloudTodoWorkspace({
             setCreateTodoParent(null)
           }}
           onCreated={item => {
-            if (item.cloud_project_id === selectedProjectId) {
-              setItems(current => [...current, item])
+            const locatedItem = {
+              ...item,
+              project_store: createTodoProject.project_store,
+            }
+            if (
+              selectedProject &&
+              sameProjectSpace(projectSpaceRef(createTodoProject), projectSpaceRef(selectedProject))
+            ) {
+              setItems(current => [...current, locatedItem])
             } else {
-              setDetailItems(current => [...current, item])
+              setDetailItems(current => [...current, locatedItem])
             }
             const targetProjectKey = projectSpaceKey(projectSpaceRef(createTodoProject))
             setProjectCounts(current => ({
@@ -2857,7 +2919,7 @@ export function CloudTodoWorkspace({
             }))
             setCreateTodoOpen(false)
             setCreateTodoParent(null)
-            if (item.assignee_agent_id) setSelectedItem(item)
+            if (item.assignee_agent_id) setSelectedItem(locatedItem)
             track('board_item_created', {
               has_parent: item.parent_id !== null,
               source: createTodoProject.location,

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -55,6 +55,7 @@ import { track } from '@/telemetry/client'
 import { AITableView } from '@/features/todo/AITableView'
 import type {
   ProjectWithTasks,
+  RuntimeProjectSpaceRef,
   RuntimeTaskAddress,
   RuntimeWorkListResponse,
   User as UserProfile,
@@ -69,7 +70,12 @@ import {
 import { CloudProjectManageView } from './CloudProjectManageView'
 import { waitForDwsAuthentication } from './dwsAuth'
 import { ProjectAutomationView } from './ProjectAutomationView'
-import { projectSupportsRobotAutomation } from './projectSpaceSelection'
+import {
+  projectSpaceKey,
+  projectSpaceRef,
+  projectSupportsRobotAutomation,
+  sameProjectSpace,
+} from './projectSpaceSelection'
 import { CloudProjectsHome } from './CloudProjectsHome'
 import { CloudFilesView } from './CloudFilesView'
 import { ProjectSpaceChatSidebar } from './ProjectSpaceChatSidebar'
@@ -221,7 +227,7 @@ interface CloudTodoWorkspaceProps {
   localProjects: ProjectWithTasks[]
   runtimeWork?: RuntimeWorkListResponse | null
   services: WorkbenchServices
-  activeProjectId?: string | null
+  activeProjectRef?: RuntimeProjectSpaceRef | null
   focusedItemId?: string | null
   onFocusedItemHandled?: () => void
   onActiveProjectChange?: (project: LocatedCloudProject | null) => void
@@ -693,7 +699,7 @@ export function CloudTodoWorkspace({
   localProjects,
   runtimeWork,
   services,
-  activeProjectId,
+  activeProjectRef,
   focusedItemId,
   onFocusedItemHandled,
   onActiveProjectChange,
@@ -714,23 +720,60 @@ export function CloudTodoWorkspace({
       }),
     [projectSpaceApis]
   )
-  const [projects, setProjects] = useState<LocatedCloudProject[]>([])
+  const [localProjectSpaces, setLocalProjectSpaces] = useState<LocatedCloudProject[]>([])
+  const [cloudProjectSpaces, setCloudProjectSpaces] = useState<LocatedCloudProject[]>([])
+  const projects = useMemo(
+    () => [...localProjectSpaces, ...cloudProjectSpaces],
+    [cloudProjectSpaces, localProjectSpaces]
+  )
+  const replaceProject = useCallback(
+    (currentProject: LocatedCloudProject, updated: CloudProject) => {
+      const setProjectSpaces =
+        currentProject.location === 'local' ? setLocalProjectSpaces : setCloudProjectSpaces
+      setProjectSpaces(current =>
+        current.map(project =>
+          projectSpaceKey(projectSpaceRef(project)) ===
+          projectSpaceKey(projectSpaceRef(currentProject))
+            ? { ...updated, location: currentProject.location }
+            : project
+        )
+      )
+    },
+    []
+  )
+  const removeProjectFromList = useCallback((projectToRemove: LocatedCloudProject) => {
+    const setProjectSpaces =
+      projectToRemove.location === 'local' ? setLocalProjectSpaces : setCloudProjectSpaces
+    const key = projectSpaceKey(projectSpaceRef(projectToRemove))
+    setProjectSpaces(current =>
+      current.filter(project => projectSpaceKey(projectSpaceRef(project)) !== key)
+    )
+  }, [])
+  const prependProject = useCallback((project: LocatedCloudProject) => {
+    const setProjectSpaces =
+      project.location === 'local' ? setLocalProjectSpaces : setCloudProjectSpaces
+    setProjectSpaces(current => [project, ...current])
+  }, [])
   const [projectCounts, setProjectCounts] = useState<Record<string, number>>({})
   const [projectMembers, setProjectMembers] = useState<Record<string, CloudProjectMember[]>>({})
   // Active robots of the selected project, used to resolve the assignee name
   // of robot-assigned tasks (local loop items only carry the agent id).
   const [projectAgents, setProjectAgents] = useState<Record<string, ProjectChatAgent[]>>({})
   // Every project's loop items, cached for the projects-home overview
-  // (stats, recent activity). Keyed by project id.
+  // (stats, recent activity). Keyed by project store and project id.
   const [projectItems, setProjectItems] = useState<Record<string, CloudLoopItem[]>>({})
-  const [internalSelectedProjectId, setSelectedProjectId] = useState<string | null>(null)
-  const selectedProjectId =
-    activeProjectId === undefined ? internalSelectedProjectId : activeProjectId
+  const [internalSelectedProjectRef, setSelectedProjectRef] =
+    useState<RuntimeProjectSpaceRef | null>(null)
+  const selectedProjectRef =
+    activeProjectRef === undefined ? internalSelectedProjectRef : activeProjectRef
+  const selectedProjectId = selectedProjectRef?.projectId ?? null
   const [items, setItems] = useState<CloudLoopItem[]>([])
   // Which project's items are currently in `items`. Anything else rendered on
   // the board would be stale, so the board shows the skeleton instead.
-  const [itemsProjectId, setItemsProjectId] = useState<string | null>(null)
-  const [myWork, setMyWork] = useState<CloudMyWorkItem[]>([])
+  const [itemsProjectKey, setItemsProjectKey] = useState<string | null>(null)
+  const [localMyWork, setLocalMyWork] = useState<CloudMyWorkItem[]>([])
+  const [cloudMyWork, setCloudMyWork] = useState<CloudMyWorkItem[]>([])
+  const myWork = useMemo(() => [...localMyWork, ...cloudMyWork], [cloudMyWork, localMyWork])
   const [rootView, setRootView] = useState<RootView>('projects')
   const [projectView, setProjectView] = useState<ProjectView>('board')
   const [selectedItem, setSelectedItem] = useState<CloudLoopItem | null>(null)
@@ -763,7 +806,7 @@ export function CloudTodoWorkspace({
   const [projectSearchQuery, setProjectSearchQuery] = useState('')
   const [projectSearchFilters, setProjectSearchFilters] =
     useState<TaskSearchFilters>(emptyTaskSearchFilters)
-  const locallyRequestedProjectIdRef = useRef<string | null | undefined>(undefined)
+  const locallyRequestedProjectRef = useRef<RuntimeProjectSpaceRef | null | undefined>(undefined)
   const focusedItemRequestRef = useRef<string | null>(null)
   const projectHeaderRef = useRef<HTMLElement>(null)
   const projectHeaderContentRef = useRef<HTMLDivElement>(null)
@@ -793,13 +836,13 @@ export function CloudTodoWorkspace({
   }, [])
 
   useEffect(() => {
-    if (activeProjectId === undefined) return
-    if (locallyRequestedProjectIdRef.current === activeProjectId) {
-      locallyRequestedProjectIdRef.current = undefined
+    if (activeProjectRef === undefined) return
+    if (sameProjectSpace(locallyRequestedProjectRef.current, activeProjectRef)) {
+      locallyRequestedProjectRef.current = undefined
       return
     }
     resetProjectViewState()
-  }, [activeProjectId, resetProjectViewState])
+  }, [activeProjectRef, resetProjectViewState])
 
   useLayoutEffect(() => {
     const header = projectHeaderRef.current
@@ -856,7 +899,8 @@ export function CloudTodoWorkspace({
     return () => observer.disconnect()
   }, [items, projectAssistantOpen, projectHeaderLevel, projectView, selectedProjectId])
 
-  const [loading, setLoading] = useState(true)
+  const [localProjectsLoading, setLocalProjectsLoading] = useState(Boolean(projectSpaceApis.local))
+  const [cloudProjectsLoading, setCloudProjectsLoading] = useState(Boolean(projectSpaceApis.cloud))
   const [boardError, setBoardError] = useState<string | null>(null)
   const [dingtalkAuthPrompt, setDingtalkAuthPrompt] = useState(false)
   const [dingtalkAuthBusy, setDingtalkAuthBusy] = useState(false)
@@ -898,14 +942,14 @@ export function CloudTodoWorkspace({
   // loaded-but-empty project (renders empty columns) from a failed fetch
   // (renders the skeleton plus the error banner instead of an empty board).
   const applyBoardItems = useCallback(
-    (projectId: string, fetchedItems: CloudLoopItem[], error: string | null) => {
+    (spaceKey: string, fetchedItems: CloudLoopItem[], error: string | null) => {
       console.info('[Wework project board] snapshot applied', {
-        projectId,
+        projectSpace: spaceKey,
         itemCount: fetchedItems.length,
         outcome: error ? 'failed' : 'loaded',
       })
       setItems(fetchedItems)
-      setItemsProjectId(projectId)
+      setItemsProjectKey(spaceKey)
       setBoardError(error)
     },
     []
@@ -924,33 +968,56 @@ export function CloudTodoWorkspace({
       setDingtalkAuthBusy(false)
     }
   }
-  const selectedProject = projects.find(project => project.id === selectedProjectId) ?? null
+  const selectedProject =
+    projects.find(
+      project =>
+        project.id === selectedProjectRef?.projectId &&
+        project.project_store === selectedProjectRef.projectStore
+    ) ?? null
+  const selectedProjectKey = selectedProject
+    ? projectSpaceKey(projectSpaceRef(selectedProject))
+    : null
+  const projectForId = useCallback(
+    (projectId: string) => {
+      if (selectedProject?.id === projectId) return selectedProject
+      const matches = projects.filter(project => project.id === projectId)
+      return matches.length === 1 ? matches[0] : undefined
+    },
+    [projects, selectedProject]
+  )
+  const updateMyWorkItem = useCallback(
+    (updated: CloudLoopItem) => {
+      const project = projectForId(updated.cloud_project_id)
+      if (!project) return
+      const setSourceMyWork = project.location === 'local' ? setLocalMyWork : setCloudMyWork
+      setSourceMyWork(current =>
+        current.map(entry => (entry.id === updated.id ? { ...entry, ...updated } : entry))
+      )
+    },
+    [projectForId]
+  )
   const selectedProjectAutomationSupported = selectedProject
     ? projectSupportsRobotAutomation(selectedProject)
     : false
-  const apiForProjectId = useCallback(
-    (projectId: string) => {
-      const project = projects.find(candidate => candidate.id === projectId)
-      if (project?.task_provider === 'dingtalk_aitable' && projectSpaceApis.local) {
+  const apiForProject = useCallback(
+    (project: LocatedCloudProject | null | undefined) => {
+      if (!project) return undefined
+      if (project.task_provider === 'dingtalk_aitable' && projectSpaceApis.local) {
         return projectSpaceApis.local
       }
-      return (
-        (project ? projectSpaceApis[project.location] : undefined) ??
-        services.deliveryApi ??
-        availableProjectSpaceApis[0]?.api
-      )
+      return projectSpaceApis[project.location]
     },
-    [availableProjectSpaceApis, projectSpaceApis, projects, services.deliveryApi]
+    [projectSpaceApis]
   )
-  const selectedProjectApi = selectedProject ? apiForProjectId(selectedProject.id) : undefined
-  const selectedProjectAgentApi =
-    selectedProject?.location === 'local'
-      ? services.localProjectChatAgentApi
-      : services.projectChatAgentApi
-  const selectedProjectChatClient =
-    selectedProject?.location === 'local'
-      ? services.localProjectChatClient
-      : services.projectChatClient
+  const selectedProjectServices = selectedProject
+    ? services.projectSpaceDetailServices?.[selectedProject.location]
+    : undefined
+  const selectedProjectApi =
+    selectedProject?.task_provider === 'dingtalk_aitable'
+      ? apiForProject(selectedProject)
+      : selectedProjectServices?.deliveryApi
+  const selectedProjectAgentApi = selectedProjectServices?.projectChatAgentApi
+  const selectedProjectChatClient = selectedProjectServices?.projectChatClient
   const selectedProjectSelfManagedExecution = selectedProject?.location === 'local'
   const selectedProjectLocation = selectedProject?.location
   const isAITableProject = selectedProject?.task_provider === 'dingtalk_aitable'
@@ -959,13 +1026,8 @@ export function CloudTodoWorkspace({
   // render, so unrelated workspace re-renders do not restart the queue load
   // (which flashed the loading state).
   const automationExecutionApi = useMemo(() => {
-    const stop = services.deliveryApi?.stopExecution
-      ? (projectId: string, executionId: number) =>
-          services.deliveryApi!.stopExecution(projectId, executionId)
-      : undefined
-    if (selectedProject?.location === 'local') {
-      const local = services.localLoopItemExecutionApi
-      return local ? { ...local, stop } : undefined
+    if (selectedProject?.location === 'local' && selectedProjectServices?.loopItemExecutionApi) {
+      return selectedProjectServices.loopItemExecutionApi
     }
     if (!selectedProjectApi) return undefined
     return {
@@ -973,20 +1035,13 @@ export function CloudTodoWorkspace({
         selectedProjectApi
           .listLoopItemExecutions(projectId, options)
           .then(response => response.items),
-      stop:
-        stop ??
-        ((projectId: string, executionId: number) =>
-          selectedProjectApi.stopExecution(projectId, executionId)),
+      stop: (projectId: string, executionId: number) =>
+        selectedProjectApi.stopExecution(projectId, executionId),
     }
-  }, [
-    selectedProject?.location,
-    selectedProjectApi,
-    services.deliveryApi,
-    services.localLoopItemExecutionApi,
-  ])
+  }, [selectedProject?.location, selectedProjectApi, selectedProjectServices?.loopItemExecutionApi])
   const selectedProjectAgents = useMemo(
-    () => (selectedProjectId ? (projectAgents[selectedProjectId] ?? []) : []),
-    [projectAgents, selectedProjectId]
+    () => (selectedProjectKey ? (projectAgents[selectedProjectKey] ?? []) : []),
+    [projectAgents, selectedProjectKey]
   )
   const agentNameById = useMemo(() => {
     const names: Record<string, string> = {}
@@ -1004,7 +1059,7 @@ export function CloudTodoWorkspace({
     : null
 
   useEffect(() => {
-    if (!selectedProjectId || !selectedProjectAgentApi) return
+    if (!selectedProjectId || !selectedProjectKey || !selectedProjectAgentApi) return
     let cancelled = false
     void selectedProjectAgentApi
       .list(selectedProjectId)
@@ -1012,18 +1067,18 @@ export function CloudTodoWorkspace({
         if (cancelled) return
         setProjectAgents(current => ({
           ...current,
-          [selectedProjectId]: agents.filter(agent => agent.status === 'active'),
+          [selectedProjectKey]: agents.filter(agent => agent.status === 'active'),
         }))
       })
       .catch(() => {
         if (!cancelled) {
-          setProjectAgents(current => ({ ...current, [selectedProjectId]: [] }))
+          setProjectAgents(current => ({ ...current, [selectedProjectKey]: [] }))
         }
       })
     return () => {
       cancelled = true
     }
-  }, [selectedProjectAgentApi, selectedProjectId])
+  }, [selectedProjectAgentApi, selectedProjectId, selectedProjectKey])
 
   useEffect(() => {
     if (!selectedProjectId || !selectedProjectLocation) return
@@ -1096,7 +1151,7 @@ export function CloudTodoWorkspace({
             ...Array.from(
               new Map(
                 [
-                  ...(selectedProject ? (projectMembers[selectedProject.id] ?? []) : []),
+                  ...(selectedProjectKey ? (projectMembers[selectedProjectKey] ?? []) : []),
                   ...items.flatMap(item =>
                     item.assignee_user_id && item.assignee_name
                       ? [{ user_id: item.assignee_user_id, user_name: item.assignee_name }]
@@ -1219,16 +1274,22 @@ export function CloudTodoWorkspace({
   // switch this flips to the skeleton in the same render, before the fetch.
   // `boardError` distinguishes a failed fetch (skeleton stays) from a
   // successfully loaded but empty project (renders the empty columns).
-  const boardItemsLoading = selectedProject !== null && itemsProjectId !== selectedProjectId
-  const selectedItemApi = selectedItem ? apiForProjectId(selectedItem.cloud_project_id) : undefined
+  const boardItemsLoading = selectedProject !== null && itemsProjectKey !== selectedProjectKey
+  const selectedItemApi = selectedItem
+    ? apiForProject(projectForId(selectedItem.cloud_project_id))
+    : undefined
   // Source for the detail drawer / creation dialog when the selected todo lives
   // in a project other than the one shown on the board.
   const detailAllItems =
     selectedItem && selectedItem.cloud_project_id !== selectedProjectId ? detailItems : items
   const createTodoProject = createTodoParent
-    ? (projects.find(project => project.id === createTodoParent.cloud_project_id) ?? null)
+    ? (projects.find(
+        project =>
+          project.id === createTodoParent.cloud_project_id &&
+          project.project_store === selectedProject?.project_store
+      ) ?? null)
     : selectedProject
-  const createTodoApi = createTodoProject ? apiForProjectId(createTodoProject.id) : undefined
+  const createTodoApi = apiForProject(createTodoProject)
   const boardParent = items.find(item => item.id === boardParentId) ?? null
   const boardLayerCount = items.filter(item => item.parent_id === boardParentId).length
   const boardBreadcrumb: CloudLoopItem[] = []
@@ -1240,22 +1301,21 @@ export function CloudTodoWorkspace({
     breadcrumbItem = items.find(candidate => candidate.id === breadcrumbItem?.parent_id) ?? null
   }
 
-  function applyProjectSelection(projectId: string | null) {
-    locallyRequestedProjectIdRef.current = projectId
-    setSelectedProjectId(projectId)
+  function applyProjectSelection(project: LocatedCloudProject | null) {
+    const ref = project ? projectSpaceRef(project) : null
+    locallyRequestedProjectRef.current = ref
+    setSelectedProjectRef(ref)
     resetProjectViewState()
   }
 
-  function selectProject(projectId: string | null) {
-    applyProjectSelection(projectId)
-    onActiveProjectChange?.(
-      projectId === null ? null : (projects.find(project => project.id === projectId) ?? null)
-    )
+  function selectProject(project: LocatedCloudProject | null) {
+    applyProjectSelection(project)
+    onActiveProjectChange?.(project)
   }
 
   async function renameSelectedProject() {
     if (!renameProject) return
-    const api = apiForProjectId(renameProject.id)
+    const api = apiForProject(renameProject)
     if (!api) throw new Error('项目空间接口当前不可用')
     setRenameBusy(true)
     setRenameError(null)
@@ -1264,11 +1324,7 @@ export function CloudTodoWorkspace({
         name: renameProjectName.trim(),
         version: renameProject.version,
       })
-      setProjects(current =>
-        current.map(project =>
-          project.id === updated.id ? { ...updated, location: project.location } : project
-        )
-      )
+      replaceProject(renameProject, updated)
       track('feature_action_completed', { domain: 'project_space', action: 'rename' })
       setRenameProject(null)
     } catch (cause) {
@@ -1281,19 +1337,21 @@ export function CloudTodoWorkspace({
 
   async function confirmArchiveProject() {
     if (!archiveProject || archiveBusy) return
-    const api = apiForProjectId(archiveProject.id)
+    const api = apiForProject(archiveProject)
     if (!api) return
     setArchiveBusy(true)
     setArchiveError(null)
     try {
       await api.archiveCloudProject(archiveProject.id, archiveProject.version)
-      setProjects(current => current.filter(project => project.id !== archiveProject.id))
+      removeProjectFromList(archiveProject)
       setProjectCounts(current => {
         const next = { ...current }
-        delete next[archiveProject.id]
+        delete next[projectSpaceKey(projectSpaceRef(archiveProject))]
         return next
       })
-      if (selectedProjectId === archiveProject.id) selectProject(null)
+      if (sameProjectSpace(selectedProjectRef, projectSpaceRef(archiveProject))) {
+        selectProject(null)
+      }
       track('feature_action_completed', { domain: 'project_space', action: 'delete' })
       setArchiveProject(null)
     } catch (cause) {
@@ -1306,7 +1364,7 @@ export function CloudTodoWorkspace({
 
   async function confirmArchiveItem() {
     if (!archiveItem || archiveBusy) return
-    const api = apiForProjectId(archiveItem.cloud_project_id)
+    const api = apiForProject(projectForId(archiveItem.cloud_project_id))
     if (!api) return
     setArchiveBusy(true)
     setArchiveError(null)
@@ -1328,19 +1386,19 @@ export function CloudTodoWorkspace({
         }
       }
       setItems(current => current.filter(item => !archivedIds.has(item.id)))
-      setProjectItems(current => ({
-        ...current,
-        [archiveItem.cloud_project_id]: (current[archiveItem.cloud_project_id] ?? []).filter(
-          item => !archivedIds.has(item.id)
-        ),
-      }))
-      setProjectCounts(current => ({
-        ...current,
-        [archiveItem.cloud_project_id]: Math.max(
-          0,
-          (current[archiveItem.cloud_project_id] ?? 0) - archivedIds.size
-        ),
-      }))
+      const archiveProjectKey = selectedProjectKey
+      if (archiveProjectKey) {
+        setProjectItems(current => ({
+          ...current,
+          [archiveProjectKey]: (current[archiveProjectKey] ?? []).filter(
+            item => !archivedIds.has(item.id)
+          ),
+        }))
+        setProjectCounts(current => ({
+          ...current,
+          [archiveProjectKey]: Math.max(0, (current[archiveProjectKey] ?? 0) - archivedIds.size),
+        }))
+      }
       if (boardParentId && archivedIds.has(boardParentId)) setBoardParentId(null)
       if (selectedItem && archivedIds.has(selectedItem.id)) setSelectedItem(null)
       track('feature_action_completed', { domain: 'board_item', action: 'delete' })
@@ -1377,51 +1435,62 @@ export function CloudTodoWorkspace({
   }
 
   useEffect(() => {
+    const api = projectSpaceApis.local
+    if (!api) return
     let active = true
-    void Promise.all(
-      availableProjectSpaceApis.map(async ({ api, location }) => {
-        let response
-        try {
-          response = await api.listCloudProjects()
-        } catch {
-          return { details: [], projects: [] }
-        }
-        const projects = response.items.map(project => ({ ...project, location }))
-        const details = await Promise.all(
-          projects.map(async project => {
-            // DingTalk AI Table projects are only fetched when their board is
-            // opened: an unauthenticated dws must not error-spam on app open.
-            const skipBoardFetch = project.task_provider === 'dingtalk_aitable'
-            const [loopItemsResult, membersResult] = await Promise.allSettled([
-              skipBoardFetch ? Promise.resolve({ items: [] }) : api.listLoopItems(project.id),
-              api.listCloudProjectMembers(project.id),
-            ])
-            const loopItems =
-              loopItemsResult.status === 'fulfilled' ? loopItemsResult.value.items : []
-            const members = membersResult.status === 'fulfilled' ? membersResult.value : []
-            return [project.id, loopItems.length, members, loopItems] as const
-          })
-        )
-        return { details, projects }
-      })
-    )
-      .then(results => {
+    void api
+      .listCloudProjects()
+      .then(response => {
         if (!active) return
-        const details = results.flatMap(result => result.details)
-        setProjects(results.flatMap(result => result.projects))
-        setProjectCounts(Object.fromEntries(details.map(([id, count]) => [id, count])))
-        setProjectMembers(Object.fromEntries(details.map(([id, , members]) => [id, members])))
-        setProjectItems(Object.fromEntries(details.map(([id, , , loopItems]) => [id, loopItems])))
+        setLocalProjectSpaces(
+          response.items.map(project => ({
+            ...project,
+            project_store: 'local',
+            location: 'local',
+          }))
+        )
+      })
+      .catch(error => {
+        console.error('[Wework project spaces] local list failed', error)
+        if (active) setLocalProjectSpaces([])
       })
       .finally(() => {
-        if (active) setLoading(false)
+        if (active) setLocalProjectsLoading(false)
       })
     return () => {
       active = false
     }
-  }, [availableProjectSpaceApis])
+  }, [projectSpaceApis.local])
+
   useEffect(() => {
-    if (!selectedProjectId || !selectedProjectApi) return
+    const api = projectSpaceApis.cloud
+    if (!api) return
+    let active = true
+    void api
+      .listCloudProjects()
+      .then(response => {
+        if (!active) return
+        setCloudProjectSpaces(
+          response.items.map(project => ({
+            ...project,
+            project_store: 'backend',
+            location: 'cloud',
+          }))
+        )
+      })
+      .catch(error => {
+        console.warn('[Wework project spaces] cloud list failed', error)
+        if (active) setCloudProjectSpaces([])
+      })
+      .finally(() => {
+        if (active) setCloudProjectsLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [projectSpaceApis.cloud])
+  useEffect(() => {
+    if (!selectedProjectId || !selectedProjectKey || !selectedProjectApi) return
     let active = true
     const refreshItems = () => {
       const prepare =
@@ -1436,9 +1505,13 @@ export function CloudTodoWorkspace({
           const signature = boardSnapshotKey(response.items, null)
           if (boardSnapshotSignatureRef.current === signature) return
           boardSnapshotSignatureRef.current = signature
-          applyBoardItems(selectedProjectId, response.items, null)
+          applyBoardItems(selectedProjectKey, response.items, null)
           // Keep the projects-home cache in sync with the board fetch.
-          setProjectItems(current => ({ ...current, [selectedProjectId]: response.items }))
+          setProjectItems(current => ({ ...current, [selectedProjectKey]: response.items }))
+          setProjectCounts(current => ({
+            ...current,
+            [selectedProjectKey]: response.items.length,
+          }))
           // Only sync the open drawer when it belongs to this project; a drawer
           // opened from another view (e.g. my work) must not be closed here.
           setSelectedItem(current =>
@@ -1459,7 +1532,7 @@ export function CloudTodoWorkspace({
               if (!status.authenticated || status.token_valid === false) {
                 if (!active) return
                 setDingtalkAuthPrompt(true)
-                applyBoardItems(selectedProjectId, [], null)
+                applyBoardItems(selectedProjectKey, [], null)
                 return
               }
             } catch {
@@ -1472,7 +1545,7 @@ export function CloudTodoWorkspace({
           const signature = boardSnapshotKey([], message)
           if (boardSnapshotSignatureRef.current === signature) return
           boardSnapshotSignatureRef.current = signature
-          applyBoardItems(selectedProjectId, [], message)
+          applyBoardItems(selectedProjectKey, [], message)
         })
     }
     refreshItems()
@@ -1489,16 +1562,35 @@ export function CloudTodoWorkspace({
     selectedProject,
     selectedProjectApi,
     selectedProjectId,
+    selectedProjectKey,
     services.aitableApi,
     services.dwsApi,
   ])
+  useEffect(() => {
+    if (!selectedProjectId || !selectedProjectKey || !selectedProjectApi) return
+    let active = true
+    void selectedProjectApi
+      .listCloudProjectMembers(selectedProjectId)
+      .then(members => {
+        if (active) setProjectMembers(current => ({ ...current, [selectedProjectKey]: members }))
+      })
+      .catch(error => {
+        console.warn('[Wework project board] member refresh failed', {
+          projectId: selectedProjectId,
+          error,
+        })
+      })
+    return () => {
+      active = false
+    }
+  }, [selectedProjectApi, selectedProjectId, selectedProjectKey])
   useEffect(() => {
     if (!focusedItemId) {
       focusedItemRequestRef.current = null
       return
     }
-    if (!selectedProjectId || itemsProjectId !== selectedProjectId) return
-    const requestKey = `${selectedProjectId}:${focusedItemId}`
+    if (!selectedProjectId || !selectedProjectKey || itemsProjectKey !== selectedProjectKey) return
+    const requestKey = `${selectedProjectKey}:${focusedItemId}`
     if (focusedItemRequestRef.current === requestKey) return
     const focusedItem = items.find(item => item.id === focusedItemId)
     if (!focusedItem || focusedItem.can_view_detail === false) return
@@ -1515,18 +1607,82 @@ export function CloudTodoWorkspace({
     return () => {
       active = false
     }
-  }, [focusedItemId, items, itemsProjectId, onFocusedItemHandled, selectedProjectId])
+  }, [
+    focusedItemId,
+    items,
+    itemsProjectKey,
+    onFocusedItemHandled,
+    selectedProjectId,
+    selectedProjectKey,
+  ])
   useEffect(() => {
     if (rootView !== 'my-work' && !(rootView === 'projects' && !selectedProjectId)) return
-    void Promise.all(availableProjectSpaceApis.map(({ api }) => api.listMyWork())).then(responses =>
-      setMyWork(responses.flatMap(response => response.items))
-    )
-  }, [availableProjectSpaceApis, rootView, selectedProjectId])
+    const api = projectSpaceApis.local
+    if (!api) return
+    let active = true
+    void api
+      .listMyWork()
+      .then(response => {
+        if (active) setLocalMyWork(response.items)
+      })
+      .catch(error => {
+        console.error('[Wework project spaces] local my work failed', error)
+        if (active) setLocalMyWork([])
+      })
+    return () => {
+      active = false
+    }
+  }, [projectSpaceApis.local, rootView, selectedProjectId])
+
+  useEffect(() => {
+    if (rootView !== 'my-work' && !(rootView === 'projects' && !selectedProjectId)) return
+    const api = projectSpaceApis.cloud
+    if (!api) return
+    let active = true
+    void api
+      .listMyWork()
+      .then(response => {
+        if (active) setCloudMyWork(response.items)
+      })
+      .catch(error => {
+        console.warn('[Wework project spaces] cloud my work failed', error)
+        if (active) setCloudMyWork([])
+      })
+    return () => {
+      active = false
+    }
+  }, [projectSpaceApis.cloud, rootView, selectedProjectId])
+  useEffect(() => {
+    if (!globalSearchOpen) return
+    let active = true
+    void Promise.allSettled(
+      projects.map(async project => {
+        const api = apiForProject(project)
+        if (!api) return null
+        const response = await api.listLoopItems(project.id)
+        return { project, items: response.items }
+      })
+    ).then(results => {
+      if (!active) return
+      setProjectItems(current => {
+        const next = { ...current }
+        results.forEach(result => {
+          if (result.status === 'fulfilled' && result.value) {
+            next[projectSpaceKey(projectSpaceRef(result.value.project))] = result.value.items
+          }
+        })
+        return next
+      })
+    })
+    return () => {
+      active = false
+    }
+  }, [apiForProject, globalSearchOpen, projects])
   // Load the drawer project's items when the drawer shows a todo from a project
   // other than the one on the board, so subtasks and parent options stay correct.
   useEffect(() => {
     if (!selectedItem || selectedItem.cloud_project_id === selectedProjectId) return
-    const detailApi = apiForProjectId(selectedItem.cloud_project_id)
+    const detailApi = apiForProject(projectForId(selectedItem.cloud_project_id))
     if (!detailApi) return
     let active = true
     void detailApi.listLoopItems(selectedItem.cloud_project_id).then(response => {
@@ -1535,7 +1691,7 @@ export function CloudTodoWorkspace({
     return () => {
       active = false
     }
-  }, [apiForProjectId, selectedItem, selectedProjectId])
+  }, [apiForProject, projectForId, selectedItem, selectedProjectId])
 
   async function moveItem(itemId: string, columnKey: string, beforeItemId: string | null = null) {
     const item = items.find(candidate => candidate.id === itemId)
@@ -1574,7 +1730,7 @@ export function CloudTodoWorkspace({
     }
     setBoardError(null)
     try {
-      const itemApi = apiForProjectId(item.cloud_project_id)
+      const itemApi = apiForProject(projectForId(item.cloud_project_id))
       if (!itemApi) throw new Error('项目空间当前不可用')
       const update =
         nativeGroupBy === 'status'
@@ -1669,11 +1825,7 @@ export function CloudTodoWorkspace({
         },
       })
       if (personalGroupKey) localStorage.removeItem(personalGroupKey)
-      setProjects(current =>
-        current.map(project =>
-          project.id === updated.id ? { ...updated, location: project.location } : project
-        )
-      )
+      replaceProject(selectedProject, updated)
       track('feature_action_completed', { domain: 'project_space', action: 'save_grouping' })
     } catch (cause) {
       track('operation_failed', { operation: 'project_space_action' })
@@ -1769,13 +1921,15 @@ export function CloudTodoWorkspace({
             <div className="mt-2 min-h-0 flex-1 overflow-y-auto">
               {projects.map(project => {
                 const ProjectLocationIcon = project.location === 'local' ? HardDrive : Cloud
+                const spaceKey = projectSpaceKey(projectSpaceRef(project))
                 return (
                   <div
-                    key={project.id}
+                    key={spaceKey}
                     data-cloud-project-menu-root
                     className={cn(
                       'group relative flex h-[30px] w-full items-center rounded-[10px] px-0 text-base leading-5',
-                      rootView === 'projects' && selectedProjectId === project.id
+                      rootView === 'projects' &&
+                        sameProjectSpace(selectedProjectRef, projectSpaceRef(project))
                         ? 'bg-[rgb(var(--color-sidebar-active))] text-text-primary'
                         : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'
                     )}
@@ -1784,7 +1938,7 @@ export function CloudTodoWorkspace({
                       type="button"
                       data-testid={`cloud-sidebar-project-${project.id}`}
                       onClick={() => {
-                        selectProject(project.id)
+                        selectProject(project)
                         setRootView('projects')
                         setProjectView('board')
                         setSelectedItem(null)
@@ -1794,9 +1948,9 @@ export function CloudTodoWorkspace({
                       <ProjectLocationIcon className="h-4 w-4 shrink-0 text-[rgb(var(--color-sidebar-text-muted))]" />
                       <span className="min-w-0 flex-1 truncate text-left">{project.name}</span>
                     </button>
-                    {projectCounts[project.id] ? (
+                    {projectCounts[spaceKey] ? (
                       <span className="flex h-7 w-7 shrink-0 items-center justify-center text-xs text-[rgb(var(--color-sidebar-text-muted))] group-hover:hidden">
-                        {projectCounts[project.id]}
+                        {projectCounts[spaceKey]}
                       </span>
                     ) : null}
                     <Tooltip
@@ -1917,7 +2071,7 @@ export function CloudTodoWorkspace({
                 if (item.can_view_detail !== false) setSelectedItem(item)
               }}
               onApproveItem={async item => {
-                const api = apiForProjectId(item.cloud_project_id)
+                const api = apiForProject(projectForId(item.cloud_project_id))
                 if (!api) return
                 try {
                   const updated = await api.approveLoopItemRun(
@@ -1925,17 +2079,13 @@ export function CloudTodoWorkspace({
                     item.id,
                     item.version
                   )
-                  setMyWork(current =>
-                    current.map(entry =>
-                      entry.id === updated.id ? { ...entry, ...updated } : entry
-                    )
-                  )
+                  updateMyWorkItem(updated)
                 } catch (error) {
                   console.error('[Wework] Failed to approve task from my work', error)
                 }
               }}
             />
-          ) : loading ? (
+          ) : (projectSpaceApis.local ? localProjectsLoading : cloudProjectsLoading) ? (
             <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
               正在加载项目空间…
             </div>
@@ -1963,9 +2113,9 @@ export function CloudTodoWorkspace({
               myWork={myWork}
               searchQuery=""
               onCreateProject={() => setCreateProjectOpen(true)}
-              onSelectProject={projectId => selectProject(projectId)}
-              onManageProject={projectId => {
-                selectProject(projectId)
+              onSelectProject={project => selectProject(project as LocatedCloudProject)}
+              onManageProject={project => {
+                selectProject(project as LocatedCloudProject)
                 setProjectView('manage')
               }}
               onSelectItem={item => {
@@ -2036,6 +2186,7 @@ export function CloudTodoWorkspace({
                     {selectedProject.access_role !== 'RestrictedAnalyst' && (
                       <button
                         type="button"
+                        data-testid="cloud-project-files-view"
                         onClick={() => setProjectView('files')}
                         className={cn(
                           'rounded-md px-3.5 py-1 text-sm',
@@ -2144,7 +2295,9 @@ export function CloudTodoWorkspace({
                     {projectSearchOpen && (
                       <TaskSearchPanel
                         items={items}
-                        members={projectMembers[selectedProject.id] ?? []}
+                        members={
+                          selectedProjectKey ? (projectMembers[selectedProjectKey] ?? []) : []
+                        }
                         query={projectSearchQuery}
                         filters={projectSearchFilters}
                         tags={availableTags}
@@ -2185,13 +2338,13 @@ export function CloudTodoWorkspace({
                 selectedProjectAutomationSupported &&
                 selectedProjectApi ? (
                 <ProjectAutomationView
-                  api={projectSpaceApis[selectedProject.location] ?? selectedProjectApi}
+                  api={selectedProjectApi}
                   projectChatAgentApi={selectedProjectAgentApi}
-                  projectAutomationApi={services.projectAutomationApi}
+                  projectAutomationApi={selectedProjectServices?.projectAutomationApi}
                   executionApi={automationExecutionApi}
-                  deviceApi={services.deviceApi}
-                  modelApi={services.modelApi}
-                  teamApi={services.teamApi}
+                  deviceApi={selectedProjectServices?.deviceApi}
+                  modelApi={selectedProjectServices?.modelApi}
+                  teamApi={selectedProjectServices?.teamApi}
                   localProjects={localProjects}
                   runtimeWork={runtimeWork}
                   project={selectedProject}
@@ -2210,20 +2363,12 @@ export function CloudTodoWorkspace({
                 />
               ) : projectView === 'manage' && selectedProjectApi ? (
                 <CloudProjectManageView
-                  api={projectSpaceApis[selectedProject.location] ?? selectedProjectApi}
+                  api={selectedProjectApi}
                   aitableApi={aitableApi}
                   dwsApi={services.dwsApi}
                   project={selectedProject}
                   boardCardDisplay={boardCardDisplay}
-                  onProjectUpdated={updated =>
-                    setProjects(current =>
-                      current.map(project =>
-                        project.id === updated.id
-                          ? { ...updated, location: project.location }
-                          : project
-                      )
-                    )
-                  }
+                  onProjectUpdated={updated => replaceProject(selectedProject, updated)}
                 />
               ) : (
                 <div className="flex min-h-0 flex-1 flex-col pb-6 pt-4">
@@ -2597,16 +2742,16 @@ export function CloudTodoWorkspace({
           query={globalSearchQuery}
           onQueryChange={setGlobalSearchQuery}
           onClose={() => setGlobalSearchOpen(false)}
-          onSelectProject={projectId => {
-            selectProject(projectId)
+          onSelectProject={project => {
+            selectProject(project as LocatedCloudProject)
             setRootView('projects')
             setProjectView('board')
             setSelectedItem(null)
             setGlobalSearchOpen(false)
           }}
-          onSelectItem={(projectId, item) => {
+          onSelectItem={(project, item) => {
             if (item.can_view_detail === false) return
-            selectProject(projectId)
+            selectProject(project as LocatedCloudProject)
             setRootView('projects')
             setProjectView('board')
             setSelectedItem(item)
@@ -2647,9 +2792,7 @@ export function CloudTodoWorkspace({
             setDetailItems(current =>
               current.map(item => (item.id === updated.id ? updated : item))
             )
-            setMyWork(current =>
-              current.map(entry => (entry.id === updated.id ? { ...entry, ...updated } : entry))
-            )
+            updateMyWorkItem(updated)
             setSelectedItem(updated)
             track('feature_action_completed', { domain: 'board_item', action: 'update' })
           }}
@@ -2672,16 +2815,17 @@ export function CloudTodoWorkspace({
           onClose={() => setCreateProjectOpen(false)}
           onCreated={(project, location) => {
             const locatedProject = { ...project, location }
+            const spaceKey = projectSpaceKey(projectSpaceRef(locatedProject))
             const projectApi = projectSpaceApis[location]
-            setProjects(current => [locatedProject, ...current])
+            prependProject(locatedProject)
             if (projectApi) {
               void projectApi
                 .listCloudProjectMembers(project.id)
                 .then(members =>
-                  setProjectMembers(current => ({ ...current, [project.id]: members }))
+                  setProjectMembers(current => ({ ...current, [spaceKey]: members }))
                 )
             }
-            applyProjectSelection(project.id)
+            applyProjectSelection(locatedProject)
             onActiveProjectChange?.(locatedProject)
             setCreateProjectOpen(false)
           }}
@@ -2706,9 +2850,10 @@ export function CloudTodoWorkspace({
             } else {
               setDetailItems(current => [...current, item])
             }
+            const targetProjectKey = projectSpaceKey(projectSpaceRef(createTodoProject))
             setProjectCounts(current => ({
               ...current,
-              [item.cloud_project_id]: (current[item.cloud_project_id] ?? 0) + 1,
+              [targetProjectKey]: (current[targetProjectKey] ?? 0) + 1,
             }))
             setCreateTodoOpen(false)
             setCreateTodoParent(null)

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -907,6 +907,7 @@ export function CloudTodoWorkspace({
   const [localProjectsLoading, setLocalProjectsLoading] = useState(Boolean(projectSpaceApis.local))
   const [cloudProjectsLoading, setCloudProjectsLoading] = useState(Boolean(projectSpaceApis.cloud))
   const [localProjectsError, setLocalProjectsError] = useState<string | null>(null)
+  const [localProjectsRefreshNonce, setLocalProjectsRefreshNonce] = useState(0)
   const [boardError, setBoardError] = useState<string | null>(null)
   const [dingtalkAuthPrompt, setDingtalkAuthPrompt] = useState(false)
   const [dingtalkAuthBusy, setDingtalkAuthBusy] = useState(false)
@@ -1455,6 +1456,12 @@ export function CloudTodoWorkspace({
     setCreateTodoOpen(true)
   }
 
+  function retryLocalProjects() {
+    setLocalProjectsError(null)
+    setLocalProjectsLoading(true)
+    setLocalProjectsRefreshNonce(current => current + 1)
+  }
+
   useEffect(() => {
     const api = projectSpaceApis.local
     if (!api) return
@@ -1484,7 +1491,7 @@ export function CloudTodoWorkspace({
     return () => {
       active = false
     }
-  }, [projectSpaceApis.local])
+  }, [localProjectsRefreshNonce, projectSpaceApis.local])
 
   useEffect(() => {
     const api = projectSpaceApis.cloud
@@ -1540,8 +1547,15 @@ export function CloudTodoWorkspace({
           // Only sync the open drawer when it belongs to this project; a drawer
           // opened from another view (e.g. my work) must not be closed here.
           setSelectedItem(current =>
-            current && current.cloud_project_id === selectedProjectId
-              ? (response.items.find(item => item.id === current.id) ?? null)
+            current &&
+            sameProjectSpace(
+              {
+                projectStore: current.project_store ?? selectedProject.project_store,
+                projectId: current.cloud_project_id,
+              },
+              projectSpaceRef(selectedProject)
+            )
+              ? (locatedItems.find(item => item.id === current.id) ?? null)
               : current
           )
         })
@@ -2097,9 +2111,17 @@ export function CloudTodoWorkspace({
           {!selectedProject && projects.length > 0 && localProjectsError ? (
             <div
               data-testid="local-project-spaces-error"
-              className="shrink-0 border-b border-border bg-destructive/5 px-4 py-2 text-sm text-destructive"
+              className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-destructive/5 px-4 py-2 text-sm text-destructive"
             >
-              本地项目空间加载失败：{localProjectsError}
+              <span>本地项目空间加载失败：{localProjectsError}</span>
+              <button
+                type="button"
+                data-testid="local-project-spaces-retry"
+                onClick={retryLocalProjects}
+                className="h-7 shrink-0 rounded-md border border-destructive/30 px-2 text-xs font-medium hover:bg-destructive/10"
+              >
+                {t('common.retry', '重试')}
+              </button>
             </div>
           ) : null}
           {rootView === 'my-work' ? (
@@ -2127,9 +2149,17 @@ export function CloudTodoWorkspace({
           ) : !selectedProject && projects.length === 0 && localProjectsError ? (
             <div
               data-testid="local-project-spaces-error"
-              className="flex flex-1 items-center justify-center px-6 text-sm text-destructive"
+              className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-sm text-destructive"
             >
-              本地项目空间加载失败：{localProjectsError}
+              <span>本地项目空间加载失败：{localProjectsError}</span>
+              <button
+                type="button"
+                data-testid="local-project-spaces-retry"
+                onClick={retryLocalProjects}
+                className="h-8 rounded-lg border border-destructive/30 px-3 text-sm font-medium hover:bg-destructive/10"
+              >
+                {t('common.retry', '重试')}
+              </button>
             </div>
           ) : (projectSpaceApis.local ? localProjectsLoading : cloudProjectsLoading) ? (
             <div className="flex flex-1 items-center justify-center text-sm text-text-muted">

--- a/wework/src/features/todo/GlobalTodoSearch.tsx
+++ b/wework/src/features/todo/GlobalTodoSearch.tsx
@@ -2,33 +2,18 @@ import { Cloud, Search, X } from 'lucide-react'
 import type { CloudLoopItem, CloudProjectMember } from '@/api/deliveries'
 import { useTranslation } from '@/hooks/useTranslation'
 import { columns } from './todoShared'
-import { projectSpaceKey } from './projectSpaceSelection'
+import { projectKey, type LocatedProjectSpace } from './projectSpaceSelection'
 import { emptyTaskSearchFilters, searchTasks } from './taskSearch'
 
-interface SearchProject {
-  id: string
-  name: string
-  project_key: string
-  description: string
-  project_store: 'local' | 'backend'
-}
-
 interface GlobalTodoSearchProps {
-  projects: SearchProject[]
+  projects: LocatedProjectSpace[]
   projectItems: Record<string, CloudLoopItem[]>
   projectMembers: Record<string, CloudProjectMember[]>
   query: string
   onQueryChange: (query: string) => void
   onClose: () => void
-  onSelectProject: (project: SearchProject) => void
-  onSelectItem: (project: SearchProject, item: CloudLoopItem) => void
-}
-
-function projectKey(project: SearchProject): string {
-  return projectSpaceKey({
-    projectStore: project.project_store,
-    projectId: project.id,
-  })
+  onSelectProject: (project: LocatedProjectSpace) => void
+  onSelectItem: (project: LocatedProjectSpace, item: CloudLoopItem) => void
 }
 
 export function GlobalTodoSearch({
@@ -129,7 +114,7 @@ export function GlobalTodoSearch({
                   </h3>
                   {taskResults.slice(0, 50).map(({ item, parentPath, project }) => (
                     <button
-                      key={`${project.id}:${item.id}`}
+                      key={`${projectKey(project)}:${item.id}`}
                       type="button"
                       data-testid={`cloud-global-search-result-${item.id}`}
                       disabled={item.can_view_detail === false}

--- a/wework/src/features/todo/GlobalTodoSearch.tsx
+++ b/wework/src/features/todo/GlobalTodoSearch.tsx
@@ -2,6 +2,7 @@ import { Cloud, Search, X } from 'lucide-react'
 import type { CloudLoopItem, CloudProjectMember } from '@/api/deliveries'
 import { useTranslation } from '@/hooks/useTranslation'
 import { columns } from './todoShared'
+import { projectSpaceKey } from './projectSpaceSelection'
 import { emptyTaskSearchFilters, searchTasks } from './taskSearch'
 
 interface SearchProject {
@@ -9,6 +10,7 @@ interface SearchProject {
   name: string
   project_key: string
   description: string
+  project_store: 'local' | 'backend'
 }
 
 interface GlobalTodoSearchProps {
@@ -18,8 +20,15 @@ interface GlobalTodoSearchProps {
   query: string
   onQueryChange: (query: string) => void
   onClose: () => void
-  onSelectProject: (projectId: string) => void
-  onSelectItem: (projectId: string, item: CloudLoopItem) => void
+  onSelectProject: (project: SearchProject) => void
+  onSelectItem: (project: SearchProject, item: CloudLoopItem) => void
+}
+
+function projectKey(project: SearchProject): string {
+  return projectSpaceKey({
+    projectStore: project.project_store,
+    projectId: project.id,
+  })
 }
 
 export function GlobalTodoSearch({
@@ -44,10 +53,10 @@ export function GlobalTodoSearch({
   const taskResults = normalizedQuery
     ? projects.flatMap(project =>
         searchTasks(
-          projectItems[project.id] ?? [],
+          projectItems[projectKey(project)] ?? [],
           normalizedQuery,
           emptyTaskSearchFilters,
-          projectMembers[project.id] ?? []
+          projectMembers[projectKey(project)] ?? []
         )
           .slice(0, 20)
           .map(result => ({ ...result, project }))
@@ -99,9 +108,9 @@ export function GlobalTodoSearch({
                   </h3>
                   {matchingProjects.map(project => (
                     <button
-                      key={project.id}
+                      key={projectKey(project)}
                       type="button"
-                      onClick={() => onSelectProject(project.id)}
+                      onClick={() => onSelectProject(project)}
                       className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-muted/60"
                     >
                       <Cloud className="h-4 w-4 shrink-0 text-text-muted" />
@@ -124,7 +133,7 @@ export function GlobalTodoSearch({
                       type="button"
                       data-testid={`cloud-global-search-result-${item.id}`}
                       disabled={item.can_view_detail === false}
-                      onClick={() => onSelectItem(project.id, item)}
+                      onClick={() => onSelectItem(project, item)}
                       className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-muted/60 disabled:cursor-default disabled:opacity-60"
                     >
                       <span className="w-40 shrink-0 truncate font-mono text-xs leading-5 text-text-muted">

--- a/wework/src/features/todo/TaskSearchPermissions.test.tsx
+++ b/wework/src/features/todo/TaskSearchPermissions.test.tsx
@@ -62,9 +62,10 @@ describe('task search permissions', () => {
             name: 'Public project',
             project_key: 'PUBLIC',
             description: '',
+            project_store: 'backend',
           },
         ]}
-        projectItems={{ 'project-1': [restrictedItem] }}
+        projectItems={{ 'backend:project-1': [restrictedItem] }}
         projectMembers={{}}
         query="other"
         onQueryChange={() => undefined}

--- a/wework/src/features/todo/projectSpaceSelection.ts
+++ b/wework/src/features/todo/projectSpaceSelection.ts
@@ -3,6 +3,9 @@ import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
 import type { RuntimeProjectSpaceRef, RuntimeTaskAddress } from '@/types/api'
 
 export type ProjectSpaceApi = NonNullable<WorkbenchServices['deliveryApi']>
+export type LocatedProjectSpace = CloudProject & {
+  location: 'local' | 'cloud'
+}
 
 export interface ProjectSpaceOption {
   key: string
@@ -16,12 +19,6 @@ export function projectStoreLocation(
   return projectStore === 'local' ? 'local' : 'cloud'
 }
 
-export function projectLocationStore(
-  location: 'local' | 'cloud'
-): RuntimeProjectSpaceRef['projectStore'] {
-  return location === 'local' ? 'local' : 'backend'
-}
-
 export function projectSpaceRef(project: CloudProject): RuntimeProjectSpaceRef {
   return {
     projectStore: project.project_store,
@@ -31,6 +28,13 @@ export function projectSpaceRef(project: CloudProject): RuntimeProjectSpaceRef {
 
 export function projectSpaceKey(ref: RuntimeProjectSpaceRef): string {
   return `${ref.projectStore}:${ref.projectId}`
+}
+
+export function projectKey(project: Pick<CloudProject, 'id' | 'project_store'>): string {
+  return projectSpaceKey({
+    projectStore: project.project_store,
+    projectId: project.id,
+  })
 }
 
 export function sameProjectSpace(

--- a/wework/src/features/todo/projectSpaceSelection.ts
+++ b/wework/src/features/todo/projectSpaceSelection.ts
@@ -10,6 +10,18 @@ export interface ProjectSpaceOption {
   api: ProjectSpaceApi
 }
 
+export function projectStoreLocation(
+  projectStore: RuntimeProjectSpaceRef['projectStore']
+): 'local' | 'cloud' {
+  return projectStore === 'local' ? 'local' : 'cloud'
+}
+
+export function projectLocationStore(
+  location: 'local' | 'cloud'
+): RuntimeProjectSpaceRef['projectStore'] {
+  return location === 'local' ? 'local' : 'backend'
+}
+
 export function projectSpaceRef(project: CloudProject): RuntimeProjectSpaceRef {
   return {
     projectStore: project.project_store,
@@ -19,6 +31,14 @@ export function projectSpaceRef(project: CloudProject): RuntimeProjectSpaceRef {
 
 export function projectSpaceKey(ref: RuntimeProjectSpaceRef): string {
   return `${ref.projectStore}:${ref.projectId}`
+}
+
+export function sameProjectSpace(
+  left: RuntimeProjectSpaceRef | null | undefined,
+  right: RuntimeProjectSpaceRef | null | undefined
+): boolean {
+  if (!left || !right) return left === right
+  return left.projectStore === right.projectStore && left.projectId === right.projectId
 }
 
 export function runtimeCloudProjectId(project: CloudProject | null): string | undefined {

--- a/wework/src/features/workbench/workbenchCloudDataEvents.ts
+++ b/wework/src/features/workbench/workbenchCloudDataEvents.ts
@@ -3,6 +3,7 @@ import type { RuntimeWorkSearchRequest, RuntimeWorkSearchResponse } from '@/type
 export const WORKBENCH_CLOUD_SEARCH_RESULTS_EVENT = 'wework:cloud-search-results'
 export const WORKBENCH_CLOUD_ARCHIVES_CHANGED_EVENT = 'wework:cloud-archives-changed'
 export const WORKBENCH_MODELS_CHANGED_EVENT = 'wework:workbench-models-changed'
+export const WORKBENCH_AUTOMATIONS_CHANGED_EVENT = 'wework:workbench-automations-changed'
 
 export interface WorkbenchCloudSearchResultsDetail {
   request: RuntimeWorkSearchRequest
@@ -26,4 +27,9 @@ export function notifyWorkbenchCloudArchivesChanged(): void {
 export function notifyWorkbenchModelsChanged(): void {
   if (typeof window === 'undefined') return
   window.dispatchEvent(new Event(WORKBENCH_MODELS_CHANGED_EVENT))
+}
+
+export function notifyWorkbenchAutomationsChanged(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(WORKBENCH_AUTOMATIONS_CHANGED_EVENT))
 }

--- a/wework/src/features/workbench/workbenchServices.ts
+++ b/wework/src/features/workbench/workbenchServices.ts
@@ -69,6 +69,22 @@ export interface ProjectSpaceApis {
   defaultLocation: ProjectSpaceLocation
 }
 
+export interface ProjectSpaceDetailServices {
+  deliveryApi: DeliveryApi
+  projectChatClient?: ProjectChatClient
+  projectChatAgentApi?: ReturnType<typeof createProjectChatAgentApi>
+  projectAutomationApi?: ReturnType<typeof createProjectAutomationApi>
+  loopItemExecutionApi?: ReturnType<typeof createLocalLoopItemExecutionApi>
+  deviceApi: WorkbenchServices['deviceApi']
+  modelApi: WorkbenchServices['modelApi']
+  teamApi: WorkbenchServices['teamApi']
+}
+
+export interface ProjectSpaceDetailServiceMap {
+  local?: ProjectSpaceDetailServices
+  cloud?: ProjectSpaceDetailServices
+}
+
 export interface AutomationApi {
   listAutomations: () => Promise<AutomationListResponse>
   getAutomation: (automationId: string) => Promise<{ automation: Automation }>
@@ -120,6 +136,7 @@ export interface WorkbenchServices {
   dwsApi?: DwsApi
   externalIssueApi?: ExternalIssueApi
   projectSpaceApis?: ProjectSpaceApis
+  projectSpaceDetailServices?: ProjectSpaceDetailServiceMap
   imSessionApi?: ReturnType<typeof createImSessionApi>
   runtimeWorkApi?: ReturnType<typeof createRuntimeWorkApi>
   automationApi?: AutomationApi
@@ -229,6 +246,10 @@ export function createDefaultWorkbenchServices(
       local: localServices.deliveryApi,
       cloud: cloudProjectSpaceApi,
       defaultLocation: 'cloud',
+    },
+    projectSpaceDetailServices: {
+      local: localServices.projectSpaceDetailServices?.local,
+      cloud: cloudServices.projectSpaceDetailServices?.cloud,
     },
   }
 }

--- a/wework/src/features/workspace-tabs/WorkspaceTabsContext.test.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabsContext.test.tsx
@@ -121,7 +121,7 @@ describe('WorkspaceTabsProvider routing', () => {
 
   test('recreates the preferred startup tab when the persisted list no longer contains it', () => {
     localStorage.setItem(
-      'wework.workspaceTabs.v2:context-test',
+      'wework.workspaceTabs.v3:context-test',
       JSON.stringify({
         activeTabId: 'task-1',
         tabs: [

--- a/wework/src/features/workspace-tabs/workspaceTabs.ts
+++ b/wework/src/features/workspace-tabs/workspaceTabs.ts
@@ -22,7 +22,7 @@ export interface WorkspaceTabLabels {
 
 const WORKSPACE_TAB_PARAM = 'workspaceTab'
 const WORKSPACE_TAB_TITLE_PARAM = 'workspaceTabTitle'
-const WORKSPACE_TABS_STORAGE_PREFIX = 'wework.workspaceTabs.v2:'
+const WORKSPACE_TABS_STORAGE_PREFIX = 'wework.workspaceTabs.v3:'
 
 function newTabId(kind: WorkspaceTabKind): string {
   return `${kind}-${crypto.randomUUID()}`

--- a/wework/src/features/workspace-tabs/workspaceWindow.test.ts
+++ b/wework/src/features/workspace-tabs/workspaceWindow.test.ts
@@ -79,7 +79,7 @@ describe('openWorkspaceTabWindow', () => {
     expect(setFocus).toHaveBeenCalledOnce()
     expect(destroy).not.toHaveBeenCalled()
     const [label] = WebviewWindow.mock.calls[0]
-    expect(JSON.parse(localStorage.getItem(`wework.workspaceTabs.v2:${label}`) ?? 'null')).toEqual({
+    expect(JSON.parse(localStorage.getItem(`wework.workspaceTabs.v3:${label}`) ?? 'null')).toEqual({
       activeTabId: tab.id,
       tabs: [tab],
     })
@@ -100,7 +100,7 @@ describe('openWorkspaceTabWindow', () => {
     expect(destroy).toHaveBeenCalledOnce()
     expect(show).not.toHaveBeenCalled()
     const [label] = WebviewWindow.mock.calls[0]
-    expect(localStorage.getItem(`wework.workspaceTabs.v2:${label}`)).toBeNull()
+    expect(localStorage.getItem(`wework.workspaceTabs.v3:${label}`)).toBeNull()
   })
 
   test('destroys a created Tauri window when revealing it fails', async () => {
@@ -113,7 +113,7 @@ describe('openWorkspaceTabWindow', () => {
     expect(destroy).toHaveBeenCalledOnce()
     expect(setFocus).not.toHaveBeenCalled()
     const [label] = WebviewWindow.mock.calls[0]
-    expect(localStorage.getItem(`wework.workspaceTabs.v2:${label}`)).toBeNull()
+    expect(localStorage.getItem(`wework.workspaceTabs.v3:${label}`)).toBeNull()
   })
 
   test('destroys a hidden Tauri window when creation times out', async () => {
@@ -130,7 +130,7 @@ describe('openWorkspaceTabWindow', () => {
     expect(destroy).toHaveBeenCalledOnce()
     expect(show).not.toHaveBeenCalled()
     const [label] = WebviewWindow.mock.calls[0]
-    expect(localStorage.getItem(`wework.workspaceTabs.v2:${label}`)).toBeNull()
+    expect(localStorage.getItem(`wework.workspaceTabs.v3:${label}`)).toBeNull()
     vi.useRealTimers()
   })
 })

--- a/wework/src/pages/AutomationsPage.tsx
+++ b/wework/src/pages/AutomationsPage.tsx
@@ -47,6 +47,7 @@ import type {
   AutomationSchedule,
   AutomationSource,
 } from '@/types/automation'
+import { WORKBENCH_AUTOMATIONS_CHANGED_EVENT } from '@/features/workbench/workbenchCloudDataEvents'
 
 type StatusFilter = 'all' | 'active' | 'paused'
 
@@ -179,9 +180,12 @@ export function AutomationsPage() {
   useEffect(() => {
     const initialLoad = window.setTimeout(() => void loadAutomations(), 0)
     const timer = window.setInterval(() => void loadAutomations(), 30_000)
+    const handleAutomationsChanged = () => void loadAutomations()
+    window.addEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, handleAutomationsChanged)
     return () => {
       window.clearTimeout(initialLoad)
       window.clearInterval(timer)
+      window.removeEventListener(WORKBENCH_AUTOMATIONS_CHANGED_EVENT, handleAutomationsChanged)
     }
   }, [loadAutomations])
 


### PR DESCRIPTION
## Summary

- decouple local and cloud project-space list loading so local spaces render and remain interactive without waiting for cloud
- route project detail operations through source-bound services keyed by `projectStore + projectId`, removing cross-source API fallbacks
- isolate local project automation and the standalone automation list from unavailable cloud runtimes
- migrate persisted workspace tabs to v3 so legacy project routes without a source return to the project-space home
- add the implementation plan and CI-registered desktop E2E coverage

## Root cause

Project identity was represented by a bare `projectId`, while project lists, detail caches, routes, and hybrid services inferred the storage source at request time. The shared workspace lifecycle also preloaded local and cloud data together and exposed complete hybrid services to local project details. As a result, cloud latency or failure could block the local list and leak cloud requests into local board, files, management, automation, and execution flows.

## Key changes

- split local/cloud project list and “my work” request lifecycles
- index project state with `projectStore:projectId`
- encode `projectStore` in board routes and invalidate legacy v2 workspace-tab persistence
- add local/cloud `ProjectSpaceDetailServices` bundles and require detail views to use the selected source bundle
- remove project-detail delivery API fallbacks and eager per-project task/member preloading
- make hybrid automation listing return local results immediately and refresh cloud automation results asynchronously
- preserve exact source routing for project files, members, tasks, executions, chat agents, and automation dependencies

## Verification

- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- focused Vitest suite: 8 files, 303 tests passed
- pre-push full Wework suite: 386 files, 3,872 tests passed
- desktop E2E checkpoint:
  - `pnpm --filter wework e2e:desktop -- --segment offline-local-project-space`
  - cloud project list returns 503
  - local project and task creation/update succeed
  - local board, files, management, project automation, and standalone automation open successfully
  - zero cloud project-detail HTTP requests
- isolated real-Tauri `ai:verify`:
  - created a local project
  - verified board, files, management, and automation views
  - verified the route contains `projectStore=local`
  - the initial dev Executor compilation exceeded the first frontend wait window and produced one transient isolated SQLite lock; after the Executor became ready, reload recovered and the complete verification passed

## Documentation

- `docs/plans/2026-08-15-wework-local-cloud-project-space-decoupling.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local and cloud projects now remain separate across selection, details, tasks, members, and automations.
  * Local project data remains available when cloud services are unavailable, with retry support for local loading errors.
  * Automation lists refresh automatically after changes and load local results without waiting for cloud responses.
  * Search and recent activity distinguish projects sharing the same ID across spaces.
  * Workspace navigation preserves the selected project source.

* **Bug Fixes**
  * Prevented local actions from incorrectly calling cloud services.
  * Updated workspace tab persistence for improved isolation.

* **Tests**
  * Added desktop coverage for offline local workflows and cross-space isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->