### PR TITLE
fix(wework): stop plugin sync when socket is disconnected

### DIFF
--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { convertFileSrc, invoke, isTauri } from '@tauri-apps/api/core'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -403,6 +403,7 @@ function mockSystemSkillsFetch(
     marketplaceUpdateAvailable: boolean
     marketplaceUpdatePolicy: 'manual' | 'auto'
     autoUpdateBatchSizes: number[]
+    deviceAutoSyncGate: Promise<void>
   }> = {}
 ) {
   let marketplaceUpdateAvailable = Boolean(overrides.marketplaceUpdateAvailable)
@@ -892,10 +893,7 @@ function mockSystemSkillsFetch(
       }
       if (requestUrl.pathname === '/api/plugins/installed/sync-device') {
         syncDeviceCalls += 1
-        if (deviceAutoSyncSucceeds) {
-          marketplaceDeviceState = 'installed'
-        }
-        return Promise.resolve({
+        const response = {
           ok: true,
           status: 200,
           json: () =>
@@ -923,7 +921,16 @@ function mockSystemSkillsFetch(
                 ],
               },
             }),
-        })
+        }
+        const completeSync = () => {
+          if (deviceAutoSyncSucceeds) {
+            marketplaceDeviceState = 'installed'
+          }
+          return response
+        }
+        return overrides.deviceAutoSyncGate
+          ? overrides.deviceAutoSyncGate.then(completeSync)
+          : Promise.resolve(completeSync())
       }
       if (requestUrl.pathname === '/api/plugins/installed/auto-update-batch') {
         autoUpdateBatchCalls += 1
@@ -2215,6 +2222,71 @@ describe('PluginsWorkspace', () => {
     render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
     expect(await screen.findByTestId('plugin-marketplace-actions-101')).toBeInTheDocument()
     expect(marketplaceMock.getSyncDeviceCalls()).toBe(1)
+  })
+
+  test('waits for the live socket connection before auto-syncing account installs', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: false })
+    const marketplaceMock = mockSystemSkillsFetch({
+      marketplaceInstalled: true,
+      marketplaceDeviceState: 'pending',
+      deviceAutoSyncSucceeds: true,
+    })
+    mockCodexAppServerInvoke({ deviceId: 'current-device' })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('plugin-marketplace-install-101')).toHaveTextContent('重试安装')
+    )
+    expect(marketplaceMock.getSyncDeviceCalls()).toBe(0)
+
+    act(() => {
+      setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: true })
+    })
+
+    await waitFor(() => expect(marketplaceMock.getSyncDeviceCalls()).toBe(1))
+    await waitFor(() =>
+      expect(screen.getByTestId('plugin-marketplace-actions-101')).toBeInTheDocument()
+    )
+  })
+
+  test('stops showing syncing when the socket disconnects during auto-sync', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    vi.mocked(isTauri).mockReturnValue(true)
+    let releaseDeviceSync: (() => void) | null = null
+    const deviceAutoSyncGate = new Promise<void>(resolve => {
+      releaseDeviceSync = resolve
+    })
+    const marketplaceMock = mockSystemSkillsFetch({
+      marketplaceInstalled: true,
+      marketplaceDeviceState: 'pending',
+      deviceAutoSyncSucceeds: false,
+      deviceAutoSyncGate,
+    })
+    mockCodexAppServerInvoke({ deviceId: 'current-device' })
+
+    render(<PluginsWorkspace cloudApiBaseUrl="/api" cloudToken="cloud-token" />)
+
+    await waitFor(() => expect(marketplaceMock.getSyncDeviceCalls()).toBe(1))
+    expect(screen.getByTestId('plugin-marketplace-install-101')).toHaveTextContent('同步中')
+
+    act(() => {
+      setLocalExecutorCloudConnectionStatus({ apiBaseUrl: '/api', connected: false })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('plugin-marketplace-install-101')).toHaveTextContent('重试安装')
+    )
+
+    act(() => releaseDeviceSync?.())
   })
 
   test('does not auto-sync an account install before same-device local state resolves', async () => {

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -36,7 +36,10 @@ import { getRuntimeConfig } from '@/config/runtime'
 import { getErrorMessage } from '@/lib/error-message'
 import { navigateTo } from '@/lib/navigation'
 import { openCloudAuthorizationWindow } from '@/lib/cloud-authorization-window'
-import { refreshLocalExecutorCloudConnectionStatus } from '@/features/cloud-connection/localExecutorCloudConnectionStatus'
+import {
+  refreshLocalExecutorCloudConnectionStatus,
+  useLocalExecutorCloudConnectionStatus,
+} from '@/features/cloud-connection/localExecutorCloudConnectionStatus'
 import {
   notifyLocalPluginSkillsChanged,
   queuePluginPromptTrial,
@@ -1296,6 +1299,10 @@ export function PluginsWorkspace({
 }: PluginsWorkspaceProps) {
   const { t } = useTranslation('common')
   const appearanceMode = useOptionalAppearance()?.resolvedMode ?? 'light'
+  const localExecutorCloudConnection = useLocalExecutorCloudConnectionStatus()
+  const deviceCloudConnected =
+    localExecutorCloudConnection.apiBaseUrl === (cloudApiBaseUrl || '') &&
+    localExecutorCloudConnection.connected
   const [query, setQuery] = useState('')
   const [searchResultWindow, setSearchResultWindow] = useState({ query: '', limit: 0 })
   const [marketplaceDistributionFilter, setMarketplaceDistributionFilter] = useState<
@@ -3917,6 +3924,7 @@ export function PluginsWorkspace({
 
   useEffect(() => {
     if (!cloudMarketplaceAvailable || !cloudToken || !currentDeviceId) return
+    if (!deviceCloudConnected) return
     if (localInstalledStateReadyKey !== marketplaceCacheKeyValue) return
     if (pluginMarketplaceState.isLoading) return
     const autoUpdateCandidateReleaseKeys = pluginMarketplaceState.items.flatMap(item => {
@@ -3945,6 +3953,7 @@ export function PluginsWorkspace({
 
     const finishDeviceSync = beginPluginDeviceSync(currentDeviceId)
     if (!finishDeviceSync) return
+    setDeviceAutoSyncSettled(false)
     autoUpdateAttemptKeysRef.current.add(attemptKey)
     const deviceId = currentDeviceId
 
@@ -4010,6 +4019,7 @@ export function PluginsWorkspace({
     cloudMarketplaceAvailable,
     cloudToken,
     currentDeviceId,
+    deviceCloudConnected,
     installedPlugins,
     localInstalledStateReadyKey,
     marketplaceCacheKeyValue,
@@ -4023,12 +4033,17 @@ export function PluginsWorkspace({
     if (!cloudMarketplaceAvailable || !cloudToken || !currentDeviceId) return
     if (localInstalledStateReadyKey !== marketplaceCacheKeyValue) return
     if (pluginMarketplaceState.isLoading) return
-    if (hasAttemptedPluginDeviceAutoSync(currentDeviceId)) return
     if (!marketplaceNeedsDeviceSync(pluginMarketplaceState.items)) return
+    if (!deviceCloudConnected) {
+      setDeviceAutoSyncSettled(true)
+      return
+    }
+    if (hasAttemptedPluginDeviceAutoSync(currentDeviceId)) return
 
     const finishDeviceSync = beginPluginDeviceSync(currentDeviceId)
     if (!finishDeviceSync) return
 
+    setDeviceAutoSyncSettled(false)
     markPluginDeviceAutoSyncAttempted(currentDeviceId)
     const deviceId = currentDeviceId
 
@@ -4101,6 +4116,7 @@ export function PluginsWorkspace({
     cloudMarketplaceAvailable,
     cloudToken,
     currentDeviceId,
+    deviceCloudConnected,
     localInstalledStateReadyKey,
     marketplaceCacheKeyValue,
     pluginApi,


### PR DESCRIPTION
## Summary

- gate marketplace device auto-sync and auto-update on the live local-executor cloud socket connection
- stop showing an indefinite syncing state when the socket is disconnected
- resume the pending sync automatically after the socket reconnects
- cover initial disconnection and mid-sync disconnection with unit tests

## Root cause

The plugin workspace started device sync based on marketplace state alone. It did not observe the local executor's live cloud socket status, so a disconnected socket could leave pending installs displayed as “同步中” indefinitely even though synchronization could not complete.

## Impact

When the socket is offline, pending marketplace installs now settle to the retry action instead of remaining stuck. Once the socket reconnects, the normal auto-sync path runs without adding a fallback transport or changing the API contract.

## Validation

- `pnpm --filter wework test src/components/plugins/PluginsWorkspace.test.tsx` (80 tests passed)
- `pnpm --filter wework typecheck`
- targeted Prettier and ESLint checks
- repository pre-push checks: ESLint, TypeScript, and unit tests
- isolated Tauri verification with the backend/socket unavailable: pending plugins showed “重试安装” and no sync request was sent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic plugin updates and device synchronization now wait until the cloud connection is available.
  * Disconnected devices no longer trigger unnecessary synchronization attempts.
  * Auto-sync correctly returns to a retry state if the connection drops during synchronization.
  * Improved handling when the live connection reconnects before syncing begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->