### PR TITLE
fix(wework): render absolute visualize references

### DIFF
--- a/docs/en/wegent/user-guide/coding/managing-code-tasks.md
+++ b/docs/en/wegent/user-guide/coding/managing-code-tasks.md
@@ -251,10 +251,10 @@ Export task conversation history and code changes:
 
 When Codex creates an HTML visualization in the task workspace and references it in its response, Wework displays the chart or interactive page directly in that response. You do not need to copy a file path or open a separate browser.
 
-- Wework supports the latest visualize content reference, such as `visualize{"path":"/absolute/path/visualizations/chart.html"}`. The absolute path does not need to appear in the current response's file changes, but it must point to an HTML file inside a `visualizations` directory.
+- Wework supports the latest visualize content reference, such as `visualize{"path":"/absolute/path/output/chart.html"}`. The absolute path does not need to appear in the current response's file changes, and the containing directory is unrestricted, so HTML generated in workspace output folders or Wework attachment drafts can be displayed directly.
 - The legacy `::codex-inline-vis{file="chart.html"}` directive remains supported. Legacy directives resolve relative paths or unique file names only from files created or modified in the current response, including fragments organized by date and thread under `.codex/visualizations/`.
 - The visualization runs in a script-isolated iframe and cannot access the Wework page.
-- Only `.html`, `.htm`, or `.xhtml` files are accepted. Malformed references, paths containing parent traversal, and directives inside code fences remain normal text.
+- Wework's desktop backend reads the HTML before passing it to the isolated iframe. Only regular UTF-8 `.html`, `.htm`, or `.xhtml` files up to 5 MB are accepted; symbolic links, malformed references, paths containing parent traversal, and directives inside code fences remain normal text or are not loaded.
 - Wework wraps HTML fragments in a UTF-8 visualization host, supplies the Codex visualization theme variables, and automatically sizes the iframe to the fragment content.
 
 ### Mermaid and PlantUML Diagrams

--- a/docs/zh/wegent/user-guide/coding/managing-code-tasks.md
+++ b/docs/zh/wegent/user-guide/coding/managing-code-tasks.md
@@ -251,10 +251,10 @@ graph LR
 
 当 Codex 在任务工作区中生成 HTML 可视化文件并在回复中引用它时，Wework 会在该回复内直接显示图表或交互页面，无需复制文件路径或另开浏览器。
 
-- Wework 支持最新的 visualize 内容引用，例如 `visualize{"path":"/绝对路径/visualizations/chart.html"}`。该绝对路径无需出现在当前回复的文件变更摘要中，但必须指向 `visualizations` 目录内的 HTML 文件。
+- Wework 支持最新的 visualize 内容引用，例如 `visualize{"path":"/绝对路径/output/chart.html"}`。该绝对路径无需出现在当前回复的文件变更摘要中，也不限定文件所在目录，因此工作区输出和 Wework 附件草稿中的 HTML 都可以直接显示。
 - 旧版 `::codex-inline-vis{file="chart.html"}` 指令仍然可用。旧版指令只会从当前回复创建或修改的文件中解析相对路径或唯一同名文件，包括 `.codex/visualizations/` 下按日期和会话组织的片段。
 - 可视化在脚本隔离的 iframe 中运行，无法访问 Wework 页面。
-- 只接受 `.html`、`.htm` 或 `.xhtml` 文件。格式错误、包含父目录跳转的路径，以及位于代码块内的指令按普通文本显示。
+- HTML 由 Wework 桌面后端读取，再交给隔离的 iframe 渲染。只接受不超过 5 MB 的 UTF-8 `.html`、`.htm` 或 `.xhtml` 普通文件；符号链接、格式错误、包含父目录跳转的路径，以及位于代码块内的指令按普通文本显示或不会加载。
 - Wework 使用 UTF-8 的可视化宿主包装 HTML 片段，提供 Codex 可视化主题变量，并根据片段内容自动调整 iframe 高度。
 
 ### Mermaid 和 PlantUML 图表

--- a/wework/src-tauri/src/inline_visualization.rs
+++ b/wework/src-tauri/src/inline_visualization.rs
@@ -1,0 +1,134 @@
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+const MAX_INLINE_VISUALIZATION_BYTES: usize = 5_000_000;
+
+#[tauri::command]
+pub async fn read_inline_visualization_html(path: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || read_inline_visualization_html_impl(&path))
+        .await
+        .map_err(|error| format!("Failed to join visualization read task: {error}"))?
+}
+
+fn read_inline_visualization_html_impl(path: &str) -> Result<String, String> {
+    let path = validate_visualization_path(path)?;
+    let metadata = std::fs::symlink_metadata(&path)
+        .map_err(|error| format!("Failed to inspect visualization file: {error}"))?;
+    if metadata.file_type().is_symlink() {
+        return Err("Visualization file may not be a symbolic link".to_string());
+    }
+    if !metadata.is_file() {
+        return Err("Visualization path is not a regular file".to_string());
+    }
+    if metadata.len() > MAX_INLINE_VISUALIZATION_BYTES as u64 {
+        return Err("Visualization file exceeds the 5 MB limit".to_string());
+    }
+
+    let file = std::fs::File::open(&path)
+        .map_err(|error| format!("Failed to open visualization file: {error}"))?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take((MAX_INLINE_VISUALIZATION_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("Failed to read visualization file: {error}"))?;
+    if bytes.len() > MAX_INLINE_VISUALIZATION_BYTES {
+        return Err("Visualization file exceeds the 5 MB limit".to_string());
+    }
+
+    String::from_utf8(bytes).map_err(|_| "Visualization file is not valid UTF-8".to_string())
+}
+
+fn validate_visualization_path(path: &str) -> Result<PathBuf, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Visualization path is empty".to_string());
+    }
+
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err("Visualization path must be absolute".to_string());
+    }
+    if path
+        .components()
+        .any(|component| component == Component::ParentDir)
+    {
+        return Err("Visualization path may not contain parent traversal".to_string());
+    }
+    if !is_html_path(&path) {
+        return Err("Visualization file must be HTML".to_string());
+    }
+    Ok(path)
+}
+
+fn is_html_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("html")
+                || extension.eq_ignore_ascii_case("htm")
+                || extension.eq_ignore_ascii_case("xhtml")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_inline_visualization_html_impl, MAX_INLINE_VISUALIZATION_BYTES};
+    use std::io::Write;
+
+    #[test]
+    fn reads_absolute_utf8_html_file() {
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let path = directory.path().join("visualization.html");
+        std::fs::write(&path, "<main>可视化</main>").expect("visualization should be written");
+
+        assert_eq!(
+            read_inline_visualization_html_impl(path.to_str().expect("path should be UTF-8"))
+                .expect("visualization should be read"),
+            "<main>可视化</main>"
+        );
+    }
+
+    #[test]
+    fn rejects_relative_non_html_and_oversized_files() {
+        assert_eq!(
+            read_inline_visualization_html_impl("visualization.html").unwrap_err(),
+            "Visualization path must be absolute"
+        );
+
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let text_path = directory.path().join("visualization.txt");
+        std::fs::write(&text_path, "not html").expect("text file should be written");
+        assert_eq!(
+            read_inline_visualization_html_impl(text_path.to_str().expect("path should be UTF-8"))
+                .unwrap_err(),
+            "Visualization file must be HTML"
+        );
+
+        let large_path = directory.path().join("large.html");
+        let mut file = std::fs::File::create(&large_path).expect("large file should be created");
+        file.write_all(&vec![b'x'; MAX_INLINE_VISUALIZATION_BYTES + 1])
+            .expect("large file should be written");
+        assert_eq!(
+            read_inline_visualization_html_impl(large_path.to_str().expect("path should be UTF-8"))
+                .unwrap_err(),
+            "Visualization file exceeds the 5 MB limit"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let target = directory.path().join("target.html");
+        let link = directory.path().join("link.html");
+        std::fs::write(&target, "<main>target</main>").expect("target should be written");
+        symlink(&target, &link).expect("symbolic link should be created");
+
+        assert_eq!(
+            read_inline_visualization_html_impl(link.to_str().expect("path should be UTF-8"))
+                .unwrap_err(),
+            "Visualization file may not be a symbolic link"
+        );
+    }
+}

--- a/wework/src-tauri/src/inline_visualization.rs
+++ b/wework/src-tauri/src/inline_visualization.rs
@@ -2,7 +2,9 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 const MAX_INLINE_VISUALIZATION_BYTES: usize = 5_000_000;
+const SYMBOLIC_LINK_ERROR: &str = "Visualization file may not be a symbolic link";
 
+/// Reads a validated local HTML visualization for sandboxed frontend rendering.
 #[tauri::command]
 pub async fn read_inline_visualization_html(path: String) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || read_inline_visualization_html_impl(&path))
@@ -12,10 +14,12 @@ pub async fn read_inline_visualization_html(path: String) -> Result<String, Stri
 
 fn read_inline_visualization_html_impl(path: &str) -> Result<String, String> {
     let path = validate_visualization_path(path)?;
-    let metadata = std::fs::symlink_metadata(&path)
+    let file = open_visualization_file(&path)?;
+    let metadata = file
+        .metadata()
         .map_err(|error| format!("Failed to inspect visualization file: {error}"))?;
-    if metadata.file_type().is_symlink() {
-        return Err("Visualization file may not be a symbolic link".to_string());
+    if is_reparse_point(&metadata) {
+        return Err(SYMBOLIC_LINK_ERROR.to_string());
     }
     if !metadata.is_file() {
         return Err("Visualization path is not a regular file".to_string());
@@ -24,8 +28,6 @@ fn read_inline_visualization_html_impl(path: &str) -> Result<String, String> {
         return Err("Visualization file exceeds the 5 MB limit".to_string());
     }
 
-    let file = std::fs::File::open(&path)
-        .map_err(|error| format!("Failed to open visualization file: {error}"))?;
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
     file.take((MAX_INLINE_VISUALIZATION_BYTES + 1) as u64)
         .read_to_end(&mut bytes)
@@ -35,6 +37,51 @@ fn read_inline_visualization_html_impl(path: &str) -> Result<String, String> {
     }
 
     String::from_utf8(bytes).map_err(|_| "Visualization file is not valid UTF-8".to_string())
+}
+
+fn open_visualization_file(path: &Path) -> Result<std::fs::File, String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+
+    options.open(path).map_err(map_visualization_open_error)
+}
+
+fn map_visualization_open_error(error: std::io::Error) -> String {
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(libc::ELOOP) {
+        return SYMBOLIC_LINK_ERROR.to_string();
+    }
+
+    format!("Failed to open visualization file: {error}")
+}
+
+fn is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        return metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0;
+    }
+
+    #[cfg(not(windows))]
+    false
 }
 
 fn validate_visualization_path(path: &str) -> Result<PathBuf, String> {
@@ -71,8 +118,11 @@ fn is_html_path(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_inline_visualization_html_impl, MAX_INLINE_VISUALIZATION_BYTES};
-    use std::io::Write;
+    use super::{
+        open_visualization_file, read_inline_visualization_html_impl,
+        MAX_INLINE_VISUALIZATION_BYTES,
+    };
+    use std::io::{Read, Write};
 
     #[test]
     fn reads_absolute_utf8_html_file() {
@@ -130,5 +180,29 @@ mod tests {
                 .unwrap_err(),
             "Visualization file may not be a symbolic link"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reads_from_the_validated_handle_after_path_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let path = directory.path().join("visualization.html");
+        let moved_path = directory.path().join("moved.html");
+        let replacement_path = directory.path().join("replacement.html");
+        std::fs::write(&path, "<main>approved</main>").expect("visualization should be written");
+        std::fs::write(&replacement_path, "<main>replacement</main>")
+            .expect("replacement should be written");
+
+        let file = open_visualization_file(&path).expect("visualization should be opened");
+        std::fs::rename(&path, &moved_path).expect("visualization should be moved");
+        symlink(&replacement_path, &path).expect("replacement symlink should be created");
+
+        let mut contents = String::new();
+        file.take((MAX_INLINE_VISUALIZATION_BYTES + 1) as u64)
+            .read_to_string(&mut contents)
+            .expect("opened visualization should be readable");
+        assert_eq!(contents, "<main>approved</main>");
     }
 }

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod embedded_browser;
 mod embedded_browser_tls;
 #[cfg(desktop)]
 mod feedback;
+mod inline_visualization;
 mod local_executor;
 mod local_terminal;
 mod local_workspace_files;
@@ -5104,6 +5105,7 @@ pub fn run() {
             read_clipboard_workspace_paths,
             read_dropped_workspace_paths,
             inspect_workspace_paths,
+            inline_visualization::read_inline_visualization_html,
             diagram_image::copy_diagram_png,
             diagram_image::save_diagram_png,
             get_local_executor_device_id,

--- a/wework/src/components/chat/CodexInlineVisualizationHost.test.tsx
+++ b/wework/src/components/chat/CodexInlineVisualizationHost.test.tsx
@@ -1,10 +1,17 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { CodexInlineVisualizationHost } from './CodexInlineVisualizationHost'
+
+const invokeMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@tauri-apps/api/core', () => ({
   convertFileSrc: (path: string) => `asset://localhost/${path.replace(/^\/+/, '')}`,
+  invoke: invokeMock,
 }))
+
+beforeEach(() => {
+  invokeMock.mockReset()
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -12,7 +19,7 @@ afterEach(() => {
 
 describe('CodexInlineVisualizationHost', () => {
   test('loads an absolute ChatGPT visualize path without file change metadata', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<div>可视化内容</div>'))
+    invokeMock.mockResolvedValue('<div>可视化内容</div>')
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:absolute-visualization')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
 
@@ -29,15 +36,13 @@ describe('CodexInlineVisualizationHost', () => {
     expect(host).toHaveAttribute('data-visualization-mode', 'wide')
     expect(frame).toHaveAttribute('title', 'Latency')
     await waitFor(() => expect(frame).toHaveAttribute('src', 'blob:absolute-visualization'))
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      'asset://localhost/tmp/codex/visualizations/latency.html'
-    )
+    expect(invokeMock).toHaveBeenCalledWith('read_inline_visualization_html', {
+      path: '/tmp/codex/visualizations/latency.html',
+    })
   })
 
   test('loads the unique nested fragment as a UTF-8 sandbox document and resizes safely', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('<h2>月度趋势</h2><svg style="stroke:var(--viz-series-1)"></svg>')
-    )
+    invokeMock.mockResolvedValue('<h2>月度趋势</h2><svg style="stroke:var(--viz-series-1)"></svg>')
     let documentBlob: Blob | undefined
     vi.spyOn(URL, 'createObjectURL').mockImplementation(blob => {
       documentBlob = blob

--- a/wework/src/components/chat/CodexInlineVisualizationHost.tsx
+++ b/wework/src/components/chat/CodexInlineVisualizationHost.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { localHtmlBrowserUrl } from './assistantMarkdownLinks'
 import { joinDevicePath } from '@/lib/device-workspace-path'
+import { readInlineVisualizationHtml } from '@/tauri/inlineVisualization'
 import type { TurnFileChangesSummary } from '@/types/api'
 
 const MIN_FRAME_HEIGHT = 120
@@ -76,15 +77,11 @@ export function CodexInlineVisualizationHost({
   useFrameResizeMessages(frameRef, resizeToken, setFrameHeight)
 
   useEffect(() => {
-    if (!sourceUrl || typeof URL.createObjectURL !== 'function') return
+    if (!sourcePath || !sourceUrl || typeof URL.createObjectURL !== 'function') return
 
     let active = true
     let objectUrl: string | undefined
-    void fetch(sourceUrl)
-      .then(response => {
-        if (!response.ok) throw new Error(`Failed to load visualization: ${response.status}`)
-        return response.text()
-      })
+    void readInlineVisualizationHtml(sourcePath)
       .then(fragment => {
         if (!active) return
         objectUrl = URL.createObjectURL(
@@ -100,10 +97,10 @@ export function CodexInlineVisualizationHost({
       active = false
       if (objectUrl) URL.revokeObjectURL(objectUrl)
     }
-  }, [resizeToken, sourceUrl])
+  }, [resizeToken, sourcePath, sourceUrl])
 
   if (!sourceUrl) return null
-  const frameUrl = documentUrl?.source === sourceUrl ? documentUrl.url : sourceUrl
+  const frameUrl = documentUrl?.source === sourceUrl ? documentUrl.url : 'about:blank'
 
   return (
     <div

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -24,7 +24,11 @@ vi.mock('@/lib/embedded-browser', () => ({
 }))
 
 describe('MessageList', () => {
-  test('renders a generated Codex inline visualization from the changed workspace file', () => {
+  test('renders a generated Codex inline visualization from the changed workspace file', async () => {
+    tauriCoreMock.invoke.mockResolvedValueOnce('<div>折线图</div>')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:workspace-visualization')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
     render(
       <MessageList
         messages={[
@@ -64,14 +68,19 @@ describe('MessageList', () => {
 
     expect(screen.getByText('已生成折线图。')).toBeInTheDocument()
     expect(screen.queryByText('::codex-inline-vis')).not.toBeInTheDocument()
-    expect(screen.getByTestId('codex-inline-visualization-frame')).toHaveAttribute(
-      'src',
-      'asset://localhost/Users/dev/workspace/.codex/visualizations/2026/07/23/thread-1/weekly-values-line-chart.html'
+    await waitFor(() =>
+      expect(screen.getByTestId('codex-inline-visualization-frame')).toHaveAttribute(
+        'src',
+        'blob:workspace-visualization'
+      )
     )
+    expect(tauriCoreMock.invoke).toHaveBeenCalledWith('read_inline_visualization_html', {
+      path: '/Users/dev/workspace/.codex/visualizations/2026/07/23/thread-1/weekly-values-line-chart.html',
+    })
   })
 
   test('renders a ChatGPT visualize content reference from its absolute path', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<div>可视化内容</div>'))
+    tauriCoreMock.invoke.mockResolvedValueOnce('<div>可视化内容</div>')
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:chatgpt-visualization')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
 
@@ -99,6 +108,43 @@ describe('MessageList', () => {
       expect(screen.getByTestId('codex-inline-visualization-frame')).toHaveAttribute(
         'src',
         'blob:chatgpt-visualization'
+      )
+    )
+  })
+
+  test('renders a ChatGPT visualize content reference from the Wework attachment draft', async () => {
+    tauriCoreMock.invoke.mockResolvedValueOnce('<div>看板内容</div>')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:wework-attachment-visualization')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-attachment-visualization',
+            role: 'assistant',
+            content:
+              'visualize{"path":"/Users/me/.wework/workspace/attachments/draft/task-board.html","mode":"wide","title":"任务池调度多看板 Demo"}',
+            status: 'done',
+            createdAt: '2026-08-16T10:00:00Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByText('visualize')).not.toBeInTheDocument()
+    expect(screen.getByTestId('codex-inline-visualization')).toHaveAttribute(
+      'data-visualization-mode',
+      'wide'
+    )
+    expect(screen.getByTestId('codex-inline-visualization-frame')).toHaveAttribute(
+      'title',
+      '任务池调度多看板 Demo'
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('codex-inline-visualization-frame')).toHaveAttribute(
+        'src',
+        'blob:wework-attachment-visualization'
       )
     )
   })

--- a/wework/src/lib/codex-directives.test.ts
+++ b/wework/src/lib/codex-directives.test.ts
@@ -82,11 +82,31 @@ describe('stripCodexUiDirectives', () => {
     ])
   })
 
+  test('parses visualize references from any absolute HTML path', () => {
+    const content = [
+      'visualize{"path":"/Users/me/project/output/task-board.html","mode":"wide","title":"Task board"}',
+      'visualize{"path":"/tmp/private.html"}',
+    ].join('\n')
+
+    expect(splitCodexInlineVisualizations(content)).toEqual([
+      {
+        kind: 'visualization',
+        file: '/Users/me/project/output/task-board.html',
+        mode: 'wide',
+        title: 'Task board',
+      },
+      {
+        kind: 'visualization',
+        file: '/tmp/private.html',
+      },
+    ])
+  })
+
   test('preserves malformed, unsafe, and code-fenced visualization directives as markdown', () => {
     const content = [
       '::codex-inline-vis{file="../private.html"}',
-      'visualize{"path":"/tmp/private.html"}',
       'visualize{"path":"relative/visualizations/trend.html"}',
+      'visualize{"path":"/Users/me/project/../private.html"}',
       '```text',
       '::codex-inline-vis{file="trend.html"}',
       'visualize{"path":"/tmp/visualizations/trend.html"}',

--- a/wework/src/lib/codex-directives.ts
+++ b/wework/src/lib/codex-directives.ts
@@ -138,10 +138,10 @@ function isSafeLegacyVisualizationFile(file: string): boolean {
 
 function isSafeAbsoluteVisualizationFile(file: string): boolean {
   const normalized = file.replace(/\\/g, '/')
+  const segments = normalized.split('/')
   return (
     (normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized)) &&
-    normalized.split('/').includes('visualizations') &&
-    !normalized.split('/').some(segment => segment === '..') &&
+    !segments.some(segment => segment === '..') &&
     /\.(?:html?|xhtml)$/i.test(normalized)
   )
 }

--- a/wework/src/tauri/inlineVisualization.ts
+++ b/wework/src/tauri/inlineVisualization.ts
@@ -1,0 +1,5 @@
+import { invoke } from '@tauri-apps/api/core'
+
+export async function readInlineVisualizationHtml(path: string): Promise<string> {
+  return invoke<string>('read_inline_visualization_html', { path })
+}


### PR DESCRIPTION
## What changed

- accept `visualize...` references to HTML files at any absolute local path instead of requiring a `visualizations` directory
- read visualization HTML through a bounded Tauri command before rendering it in the sandboxed iframe
- keep relative visualization assets working through the document base URL
- document the supported paths and file-level safety boundaries in Chinese and English

## Why

Wework displayed visualize directives as raw text when generated HTML lived in attachment drafts or other output directories. The parser incorrectly treated a directory-name convention as a security boundary.

## Impact

HTML visualizations generated in workspaces and Wework attachment drafts now render inline. The desktop backend still enforces absolute paths, HTML extensions, UTF-8 content, regular non-symlink files, no parent traversal, and a 5 MB size limit.

## Validation

- focused Vitest suite: 154 tests passed
- ESLint, Prettier, TypeScript typecheck passed
- Rust inline visualization tests: 3 passed
- `cargo check --locked` passed
- Wework real Tauri visualization desktop E2E passed
- pre-push Wework ESLint, TypeScript, and unit-test suite passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline visualizations can reference HTML/XHTML files from workspace and attachment paths, not only dedicated visualization folders.
  * Supported files must be valid UTF-8, no larger than 5 MB, and render securely in an isolated frame.
  * Added validation for unsafe paths, symbolic links, unsupported extensions, malformed references, and parent-directory traversal.

* **Documentation**
  * Updated English and Chinese guides with supported formats, limits, and security requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->