### PR TITLE
chore(wework): add runtime create diagnostics

### DIFF
--- a/docs/en/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/wework/developer-guide/wework-performance-diagnostics.md
@@ -20,6 +20,22 @@ The desktop startup screen waits only for the local executor to report ready thr
 
 When the startup screen remains visible, align `Frontend logging initialized` in the frontend log with `app IPC stdio ready` in the executor log. The interval primarily measures local executor cold startup. Later entries such as `runtime work list finished` identify workbench data-loading time. Do not mistake a background cloud synchronization timeout for the local startup gate.
 
+## Diagnosing Runtime Task Creation
+
+The frontend writes key task-creation stages to the persisted log with the `[Wework] Runtime task create diagnostic` prefix. This does not require Performance Diagnostics to be enabled. Records contain only the stage, task/device identifiers, model identifiers, elapsed time, and result; they do not contain message content, credentials, or model connection configuration.
+
+When an optimistic task is visible but the executor never receives `runtime.tasks.create`, find the last stage logged in this sequence:
+
+1. `workbench-model-prepare-*`: the workbench starts and completes its initial model preparation.
+2. `workbench-runtime-create-dispatched`: the workbench begins calling the runtime creation API.
+3. `hybrid-local-device-discovery-*` and `hybrid-route-resolved`: the hybrid service completes device discovery and selects the local or cloud route.
+4. `hybrid-create-forwarded`: the creation request is forwarded to the selected runtime API.
+5. `local-device-resolved`, `local-primary-model-prepared`, `local-supervisor-model-prepared`, and `local-payload-built`: the local/remote Executor IPC client completes device resolution, model preparation, and payload construction.
+6. `local-rpc-dispatched` and `local-rpc-resolved`: `runtime.tasks.create` is sent and returns.
+7. `hybrid-create-resolved` or `hybrid-create-failed`: the hybrid service observes the final result.
+
+A missing next stage usually means the call stalled between the two records. Correlate the same `taskId` across the frontend log, cloud WebSocket RPC log, and executor log to identify whether model synchronization, device discovery, payload construction, IPC dispatch, or the executor response is blocked.
+
 ## Enabling Diagnostics
 
 Press the hidden shortcut in the Wework window:

--- a/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
@@ -20,6 +20,22 @@ Wework 内置一个默认关闭的前端性能诊断开关，用于定位 releas
 
 排查启动页长时间不消失时，对齐前端日志的 `Frontend logging initialized` 与 executor 日志的 `app IPC stdio ready`。两者之间的时间主要反映本地 executor 冷启动；`runtime work list finished` 等后续记录用于判断工作台数据加载耗时。不要把后台云端同步的超时误判为本地启动门控。
 
+## Runtime 任务创建诊断
+
+前端会将任务创建关键阶段以 `[Wework] Runtime task create diagnostic` 前缀写入持久化日志，无需开启性能诊断。记录只包含阶段、任务/设备标识、模型标识、耗时和结果，不包含消息正文、凭据或模型连接配置。
+
+排查“乐观任务已显示，但 executor 没有收到 `runtime.tasks.create`”时，按以下顺序查找最后出现的阶段：
+
+1. `workbench-model-prepare-*`：工作台发起并完成首次模型准备。
+2. `workbench-runtime-create-dispatched`：工作台开始调用 runtime 创建接口。
+3. `hybrid-local-device-discovery-*` 和 `hybrid-route-resolved`：混合服务完成设备发现并选定本地或云端路由。
+4. `hybrid-create-forwarded`：创建请求已转发到选定的 runtime API。
+5. `local-device-resolved`、`local-primary-model-prepared`、`local-supervisor-model-prepared` 和 `local-payload-built`：本地/远程 Executor IPC 客户端完成设备解析、模型准备和 payload 构建。
+6. `local-rpc-dispatched` 与 `local-rpc-resolved`：`runtime.tasks.create` 已发出并返回。
+7. `hybrid-create-resolved` 或 `hybrid-create-failed`：混合服务观察到最终结果。
+
+缺少下一个阶段通常表示调用停在两条记录之间。结合相同 `taskId` 对齐前端日志、云端 WebSocket RPC 日志和 executor 日志，确认是模型同步、设备发现、payload 构建、IPC 发送还是 executor 响应卡住。
+
 ## 开启方式
 
 在 Wework 窗口中按隐藏快捷键：

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -21,6 +21,7 @@ import {
 import { requestCloudModelCatalogSync } from '@/features/model-settings/cloudModelCatalogSyncRequest'
 import { isAppDeviceRegistration, isCurrentAppDeviceId } from '@/lib/app-device-registration'
 import { isCloudDevice, isRemoteDevice, isUsableDevice } from '@/lib/device-capabilities'
+import { logRuntimeTaskCreateStage } from '@/lib/runtime-create-diagnostics'
 import {
   EMPTY_RUNTIME_WORK,
   mergeDeviceLists,
@@ -407,15 +408,43 @@ export function createHybridWorkbenchServices(
     Boolean(deviceId && (deviceId === 'local-device' || localDeviceIds.has(deviceId)))
   const isKnownCloudDeviceId = (deviceId?: string | null) =>
     Boolean(deviceId && rememberedCloudDevices.some(device => device.device_id === deviceId))
-  const runtimeApiForCreate = async (deviceId?: string | null) => {
-    if (isLocalDeviceId(deviceId)) return localServices.runtimeWorkApi!
+  const runtimeApiForCreate = async (
+    deviceId: string | null | undefined,
+    taskId: string | undefined
+  ) => {
+    if (isLocalDeviceId(deviceId)) {
+      logRuntimeTaskCreateStage('hybrid-route-resolved', {
+        taskId: taskId ?? null,
+        deviceId: deviceId ?? null,
+        route: 'local',
+        discoveryRequired: false,
+      })
+      return localServices.runtimeWorkApi!
+    }
 
     // Device discovery and task creation race during bootstrap. An unknown route must
     // not default to cloud because that makes a local task wait on an unavailable
     // cloud connection. Refresh the authoritative local device identities first.
-    if (!isKnownCloudDeviceId(deviceId)) {
+    const discoveryRequired = !isKnownCloudDeviceId(deviceId)
+    if (discoveryRequired) {
+      logRuntimeTaskCreateStage('hybrid-local-device-discovery-started', {
+        taskId: taskId ?? null,
+        deviceId: deviceId ?? null,
+      })
       await listLocalDevices()
+      logRuntimeTaskCreateStage('hybrid-local-device-discovery-resolved', {
+        taskId: taskId ?? null,
+        deviceId: deviceId ?? null,
+        resolvedAsLocal: isLocalDeviceId(deviceId),
+      })
     }
+    const route = isLocalDeviceId(deviceId) ? 'local' : 'cloud'
+    logRuntimeTaskCreateStage('hybrid-route-resolved', {
+      taskId: taskId ?? null,
+      deviceId: deviceId ?? null,
+      route,
+      discoveryRequired,
+    })
     return runtimeApi(deviceId)
   }
   const invalidateCloudArchiveCache = () => {
@@ -1002,7 +1031,36 @@ export function createHybridWorkbenchServices(
       return routeByAddress(data).reorderQueuedRuntimeTask(data)
     },
     async createRuntimeTask(data: RuntimeTaskCreateRequest) {
-      return (await runtimeApiForCreate(data.deviceId)).createRuntimeTask(data)
+      const startedAt = Date.now()
+      logRuntimeTaskCreateStage('hybrid-create-started', {
+        taskId: data.taskId ?? null,
+        deviceId: data.deviceId ?? null,
+        runtime: data.runtime,
+      })
+      try {
+        const api = await runtimeApiForCreate(data.deviceId, data.taskId)
+        logRuntimeTaskCreateStage('hybrid-create-forwarded', {
+          taskId: data.taskId ?? null,
+          deviceId: data.deviceId ?? null,
+          elapsedMs: Date.now() - startedAt,
+        })
+        const response = await api.createRuntimeTask(data)
+        logRuntimeTaskCreateStage('hybrid-create-resolved', {
+          taskId: response.taskId || data.taskId || null,
+          deviceId: response.deviceId || data.deviceId || null,
+          elapsedMs: Date.now() - startedAt,
+          accepted: response.accepted,
+        })
+        return response
+      } catch (error) {
+        logRuntimeTaskCreateStage('hybrid-create-failed', {
+          taskId: data.taskId ?? null,
+          deviceId: data.deviceId ?? null,
+          elapsedMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.name : typeof error,
+        })
+        throw error
+      }
     },
     forkRuntimeTask(data: RuntimeTaskForkRequest) {
       return runtimeApi(data.target.deviceId).forkRuntimeTask(data)

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -111,6 +111,7 @@ import {
 } from '@/tauri/localWorkspaceFiles'
 import { WEWORK_MIN_EXECUTOR_VERSION } from '@/lib/device-capabilities'
 import { normalizeModelOptionAliases, normalizeModelOptionValue } from '@/lib/model-ui'
+import { logRuntimeTaskCreateStage } from '@/lib/runtime-create-diagnostics'
 import {
   runtimePermissionMode,
   runtimePermissionProfile,
@@ -2719,14 +2720,27 @@ export function createRuntimeWorkApiFromIpc(
       return requestWithLocalDevice('runtime.tasks.cancel', data)
     },
     async createRuntimeTask(data: RuntimeTaskCreateRequest): Promise<RuntimeTaskCreateResponse> {
+      const startedAt = Date.now()
+      logRuntimeTaskCreateStage('local-create-started', {
+        taskId: data.taskId ?? null,
+        deviceId: data.deviceId ?? null,
+        runtime: data.runtime,
+      })
       const localDeviceId = await resolveDeviceId(data as unknown as Record<string, unknown>)
+      logRuntimeTaskCreateStage('local-device-resolved', {
+        taskId: data.taskId ?? null,
+        requestedDeviceId: data.deviceId ?? null,
+        deviceId: localDeviceId,
+        elapsedMs: Date.now() - startedAt,
+      })
       if (!(await prepareRuntimeModel({ deviceId: localDeviceId, modelId: data.modelId }))) {
         throw modelCatalogSyncCancelled()
       }
-      console.info('[Wework] Runtime task primary model preparation completed', {
+      logRuntimeTaskCreateStage('local-primary-model-prepared', {
+        taskId: data.taskId ?? null,
         deviceId: localDeviceId,
-        taskId: data.taskId,
         modelId: data.modelId ?? null,
+        elapsedMs: Date.now() - startedAt,
       })
       const supervisorModelId = data.initialSupervisor?.modelSelection?.modelName
       if (
@@ -2735,11 +2749,11 @@ export function createRuntimeWorkApiFromIpc(
       ) {
         throw modelCatalogSyncCancelled()
       }
-      console.info('[Wework] Runtime task model preparation completed', {
+      logRuntimeTaskCreateStage('local-supervisor-model-prepared', {
+        taskId: data.taskId ?? null,
         deviceId: localDeviceId,
-        taskId: data.taskId,
-        modelId: data.modelId ?? null,
         supervisorModelId: supervisorModelId ?? null,
+        elapsedMs: Date.now() - startedAt,
       })
       const payload = await createLocalRuntimeTaskPayload(
         data,
@@ -2748,6 +2762,11 @@ export function createRuntimeWorkApiFromIpc(
         options.cloudModelGateway,
         user
       )
+      logRuntimeTaskCreateStage('local-payload-built', {
+        taskId: data.taskId ?? null,
+        deviceId: localDeviceId,
+        elapsedMs: Date.now() - startedAt,
+      })
       debugLocalRuntimeCreatePayload(data, payload)
       const executionRequest = recordValue(payload.executionRequest)
       console.info('[Wework] Friendly task title request', {
@@ -2761,11 +2780,23 @@ export function createRuntimeWorkApiFromIpc(
         userId: executionRequest.user_id ?? null,
         userName: stringValue(executionRequest.user_name),
       })
+      logRuntimeTaskCreateStage('local-rpc-dispatched', {
+        taskId: data.taskId ?? null,
+        deviceId: localDeviceId,
+        method: 'runtime.tasks.create',
+        elapsedMs: Date.now() - startedAt,
+      })
       const response = await request<Partial<RuntimeTaskCreateResponse>>(
         'runtime.tasks.create',
         payload,
         localDeviceId
       )
+      logRuntimeTaskCreateStage('local-rpc-resolved', {
+        taskId: data.taskId ?? null,
+        deviceId: localDeviceId,
+        elapsedMs: Date.now() - startedAt,
+        accepted: response.accepted ?? true,
+      })
       const responseRecord = recordValue(response)
       const workspacePath =
         stringValue(responseRecord.workspacePath) ??

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -14,6 +14,7 @@ import {
 import { supportsGitWorktreeExecution } from '@/lib/projectClassification'
 import { localRuntimeAttachments, remoteAttachmentIds } from '@/lib/runtime-attachments'
 import { normalizeRuntimeWorkspacePath, runtimeProjectUiId } from '@/lib/runtime-project'
+import { logRuntimeTaskCreateStage } from '@/lib/runtime-create-diagnostics'
 import { notifyMainRuntimeWorkChanged } from '@/tauri/runtimeWorkSync'
 import type { AppPreferences } from '@/tauri/appPreferences'
 import { useAppPreferencesState } from '@/features/app-preferences/useAppPreferencesState'
@@ -950,6 +951,11 @@ export function useWorkbenchRuntimeMessaging({
         }
       }
 
+      logRuntimeTaskCreateStage('workbench-model-prepare-started', {
+        taskId,
+        deviceId: optimisticDeviceId,
+        modelId: executionModel.modelId ?? null,
+      })
       try {
         const prepared = await executorClient.runtime.prepareRuntimeModel({
           deviceId: optimisticDeviceId,
@@ -970,7 +976,18 @@ export function useWorkbenchRuntimeMessaging({
             return false
           }
         }
+        logRuntimeTaskCreateStage('workbench-model-prepare-resolved', {
+          taskId,
+          deviceId: optimisticDeviceId,
+          modelId: executionModel.modelId ?? null,
+          supervisorModelId: supervisorModelId ?? null,
+        })
       } catch (error) {
+        logRuntimeTaskCreateStage('workbench-model-prepare-failed', {
+          taskId,
+          deviceId: optimisticDeviceId,
+          error: runtimeLaunchErrorName(error),
+        })
         reportError(runtimeSendError(error, '发送失败'), options)
         return false
       }
@@ -1128,6 +1145,11 @@ export function useWorkbenchRuntimeMessaging({
         ) {
           await new Promise(resolve => window.setTimeout(resolve, worktreeCreationDelayMs))
         }
+        logRuntimeTaskCreateStage('workbench-runtime-create-dispatched', {
+          taskId,
+          deviceId: optimisticAddress.deviceId,
+          runtime,
+        })
         return executorClient.runtime.createRuntimeTask(createRequest)
       })()
       void createResponsePromise.catch(() => undefined)

--- a/wework/src/lib/runtime-create-diagnostics.test.ts
+++ b/wework/src/lib/runtime-create-diagnostics.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { logRuntimeTaskCreateStage } from './runtime-create-diagnostics'
+
+const mocks = vi.hoisted(() => ({
+  writeInfoLog: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  info: mocks.writeInfoLog,
+}))
+
+describe('logRuntimeTaskCreateStage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.writeInfoLog.mockResolvedValue(undefined)
+  })
+
+  it('writes structured diagnostics to the persisted frontend log', () => {
+    logRuntimeTaskCreateStage('hybrid-create-started', {
+      taskId: 'runtime-123',
+      deviceId: 'cloud-device',
+    })
+
+    expect(mocks.writeInfoLog).toHaveBeenCalledWith(
+      '[Wework] Runtime task create diagnostic ' +
+        '{"stage":"hybrid-create-started","taskId":"runtime-123","deviceId":"cloud-device"}'
+    )
+  })
+
+  it('does not reject the runtime flow when persisted logging fails', async () => {
+    mocks.writeInfoLog.mockRejectedValue(new Error('log unavailable'))
+
+    expect(() =>
+      logRuntimeTaskCreateStage('local-rpc-dispatched', {
+        taskId: 'runtime-123',
+      })
+    ).not.toThrow()
+    await Promise.resolve()
+  })
+
+  it('falls back to the stage when details cannot be serialized', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    logRuntimeTaskCreateStage('local-payload-built', circular)
+
+    expect(mocks.writeInfoLog).toHaveBeenCalledWith(
+      '[Wework] Runtime task create diagnostic ' +
+        '{"stage":"local-payload-built","serializationFailed":true}'
+    )
+  })
+})

--- a/wework/src/lib/runtime-create-diagnostics.ts
+++ b/wework/src/lib/runtime-create-diagnostics.ts
@@ -1,0 +1,27 @@
+import { info as writeInfoLog } from '@tauri-apps/plugin-log'
+
+const LOG_PREFIX = '[Wework] Runtime task create diagnostic'
+
+function serializeDiagnostic(entry: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(entry)
+  } catch {
+    return JSON.stringify({
+      stage: entry.stage,
+      serializationFailed: true,
+    })
+  }
+}
+
+export function logRuntimeTaskCreateStage(stage: string, details: Record<string, unknown>): void {
+  const entry = {
+    stage,
+    ...details,
+  }
+  console.info(LOG_PREFIX, entry)
+  try {
+    void writeInfoLog(`${LOG_PREFIX} ${serializeDiagnostic(entry)}`).catch(() => undefined)
+  } catch {
+    // Diagnostics must never interrupt runtime task creation.
+  }
+}


### PR DESCRIPTION
## Summary

- persist structured runtime task creation stages from the workbench through hybrid routing and local/cloud Executor IPC
- include task/device correlation identifiers and elapsed time without logging prompts, credentials, or model connection configuration
- document how to identify the stalled boundary from exported Wework diagnostics

## CI evidence

GitHub Actions run `31944175187`, job `95158248771`, intermittently timed out in `cloud-local-responses` after the optimistic task appeared.

- the failed artifact contained no model inference request
- the cloud Executor received model catalog preparation RPCs but never received `runtime.tasks.create`
- a successful comparison run followed the same preparation sequence and then immediately sent `runtime.tasks.create`

The available evidence places the stall before the remote task-create RPC, but does not distinguish workbench model preparation, hybrid device discovery/routing, local payload construction, or IPC dispatch. This PR adds durable stage boundaries only; it does not change task creation or E2E behavior.

## Verification

- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework test src/lib/runtime-create-diagnostics.test.ts src/api/hybrid/hybridServices.test.ts src/api/local/localServices.test.ts`
- `pnpm --filter wework test src/features/workbench/WorkbenchProvider.test.tsx`
- full pre-push Wework ESLint, TypeScript, and unit-test checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed runtime task-creation diagnostics across local and cloud workflows.
  * Diagnostic logs now capture task-creation stages, timing, routing, model preparation, and RPC results.
  * Added guidance for correlating diagnostic entries across frontend, cloud, and executor logs.

* **Bug Fixes**
  * Diagnostic logging failures no longer interrupt runtime task creation.
  * Added fallback handling when diagnostic details cannot be serialized.

* **Tests**
  * Added coverage for structured logging, error handling, and serialization fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->