### PR TITLE
fix(wework): default composer to two lines

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -539,6 +539,8 @@ recipe closely:
   shadow;
 - do not add a dark visible border in the normal state; forced-color mode may
   add an explicit outline;
+- the default desktop input starts at two text lines; compact composers start
+  at one line and grow only when content requires it;
 - multiline input horizontal inset is `12px`;
 - attachment inset is `8px`, with the nested radius derived from the outer
   composer radius rather than chosen independently;

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -193,8 +193,8 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('project-chat-composer')).toHaveClass(
       'shadow-[0_0_0_0.5px_rgba(13,13,13,0.12),0_3px_7.5px_rgba(0,0,0,0.04),0_0_20px_rgba(0,0,0,0.05)]'
     )
-    expect(input).toHaveAttribute('rows', '1')
-    expect(input).toHaveClass('min-h-8', 'max-h-[112px]', 'pt-1', 'placeholder:text-text-muted/55')
+    expect(input).toHaveAttribute('rows', '2')
+    expect(input).toHaveClass('min-h-12', 'max-h-[112px]', 'pt-1', 'placeholder:text-text-muted/55')
     fireEvent.click(input)
     expect(form).toHaveAttribute('data-short-expanded', 'true')
     fireEvent.pointerDown(document.body)
@@ -1082,6 +1082,7 @@ describe('ChatInput', () => {
       'rounded-[26px]'
     )
     expect(screen.getByTestId('compact-input-pill')).toHaveClass('min-h-[52px]')
+    expect(screen.getByTestId('chat-message-input')).toHaveAttribute('rows', '1')
     expect(screen.getByTestId('chat-message-input')).toHaveClass(
       'py-[14px]',
       'scrollbar-none',

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -434,7 +434,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
             canSend={canSend}
             disabled={disabled}
             placeholder={placeholder}
-            rows={1}
+            rows={2}
             onPasteFiles={onFileSelect}
             onOpenSkillFile={onOpenSkillFile}
             workspaceTarget={workspaceTarget}
@@ -464,7 +464,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
               return true
             }}
             className={cn(
-              'max-h-[112px] min-h-8 w-full resize-none overflow-y-auto bg-transparent px-0 pb-0 pt-1 text-chat text-text-primary outline-none placeholder:text-text-muted/55',
+              'max-h-[112px] min-h-12 w-full resize-none overflow-y-auto bg-transparent px-0 pb-0 pt-1 text-chat text-text-primary outline-none placeholder:text-text-muted/55',
               styles.input
             )}
             skillMenuClassName="left-[-1rem] right-[-0.5rem]"


### PR DESCRIPTION
## Summary

- make the default desktop composer start at two text lines
- keep the compact composer at one line
- document the composer height contract and add regression assertions

## Root cause

The desktop project composer explicitly used one row and a 32px minimum height, so it rendered with the same initial density as compact mode.

## Validation

- `pnpm --filter wework test src/components/chat/ChatInput.test.tsx` (109 passed)
- focused Prettier and ESLint checks
- pre-push Wework ESLint, TypeScript, and unit tests
- isolated real Tauri verification: desktop composer reports `rows=2` and 48px height

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Desktop chat composers now open with two lines of space for easier message composition.
  * The desktop editor has a taller minimum height, while compact mobile composers continue to start with one line and expand as needed.
* **Tests**
  * Updated coverage to reflect the new desktop and mobile composer sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->