### PR TITLE
feat(image): implement temporary download URLs for generated images

### DIFF
--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -393,6 +393,11 @@ class TaskQueryMixin:
         )
 
         refresh_extended_video_result_urls(task_dict, user_id)
+        from app.services.execution.agents.image.download_url import (
+            refresh_task_image_download_urls,
+        )
+
+        refresh_task_image_download_urls(task_dict)
         return task_dict
 
     def get_task_skills(

--- a/backend/app/services/attachment/public_link.py
+++ b/backend/app/services/attachment/public_link.py
@@ -6,6 +6,7 @@
 
 import secrets
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
 
 from jose import JWTError, jwt
 
@@ -30,6 +31,18 @@ def generate_public_attachment_token(
         "exp": now + expires_delta,
     }
     return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def build_public_attachment_download_url(
+    attachment_id: int,
+    expires_delta: timedelta,
+    base_url: str = "",
+) -> str:
+    """Create a public attachment download URL with a scoped expiring token."""
+    token = generate_public_attachment_token(attachment_id, expires_delta)
+    query = urlencode({"token": token})
+    prefix = base_url.strip().rstrip("/")
+    return f"{prefix}/api/attachments/download/shared?{query}"
 
 
 def verify_public_attachment_token(token: str) -> dict:

--- a/backend/app/services/execution/agents/image/download_url.py
+++ b/backend/app/services/execution/agents/image/download_url.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Temporary download URLs for generated images."""
+
+from datetime import timedelta
+from typing import Any
+
+from app.core.config import settings
+from app.services.attachment.public_link import (
+    build_public_attachment_download_url,
+)
+
+IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS = 3600
+
+
+def build_image_download_url(attachment_id: int) -> str:
+    """Create a one-hour public download URL for a generated image."""
+    return build_public_attachment_download_url(
+        attachment_id,
+        timedelta(seconds=IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS),
+        settings.WEGENT_BACKEND_PUBLIC_URL,
+    )
+
+
+def refresh_image_result_download_urls(result: Any) -> Any:
+    """Return an image result with fresh temporary download URLs."""
+    if not isinstance(result, dict):
+        return result
+
+    blocks = result.get("blocks")
+    if not isinstance(blocks, list):
+        return result
+
+    refreshed_blocks: list[Any] | None = None
+    for index, block in enumerate(blocks):
+        if not isinstance(block, dict) or block.get("type") != "image":
+            continue
+        attachment_ids = block.get("image_attachment_ids")
+        if not isinstance(attachment_ids, list):
+            continue
+        valid_ids = [
+            attachment_id
+            for attachment_id in attachment_ids
+            if isinstance(attachment_id, int)
+        ]
+        if not valid_ids:
+            continue
+        if refreshed_blocks is None:
+            refreshed_blocks = list(blocks)
+        refreshed_block = dict(block)
+        refreshed_block["image_download_urls"] = [
+            build_image_download_url(attachment_id) for attachment_id in valid_ids
+        ]
+        refreshed_block["image_download_url_expires_in_seconds"] = (
+            IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+        )
+        refreshed_blocks[index] = refreshed_block
+
+    if refreshed_blocks is None:
+        return result
+    refreshed = dict(result)
+    refreshed["blocks"] = refreshed_blocks
+    return refreshed
+
+
+def refresh_task_image_download_urls(task_dict: dict[str, Any]) -> None:
+    """Refresh generated-image download URLs in a task detail response."""
+    task_dict["result"] = refresh_image_result_download_urls(task_dict.get("result"))
+    subtasks = task_dict.get("subtasks")
+    if not isinstance(subtasks, list):
+        return
+    for subtask in subtasks:
+        if isinstance(subtask, dict):
+            subtask["result"] = refresh_image_result_download_urls(
+                subtask.get("result")
+            )

--- a/backend/app/services/execution/agents/image/generation_service.py
+++ b/backend/app/services/execution/agents/image/generation_service.py
@@ -22,6 +22,10 @@ from app.services.execution.agents.video.materials import (
 )
 
 from .attachment_uploader import upload_image_attachment
+from .download_url import (
+    IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS,
+    build_image_download_url,
+)
 from .providers import get_image_provider
 
 
@@ -94,13 +98,16 @@ class ImageGenerationService:
                 index=index,
             )
             persisted_url = context_service.build_attachment_url(attachment_id)
+            download_url = build_image_download_url(attachment_id)
             image_urls.append(persisted_url)
             attachment_ids.append(attachment_id)
             images.append(
                 {
-                    "url": persisted_url,
+                    "url": download_url,
+                    "attachment_url": persisted_url,
                     "size": image.size,
                     "attachment_id": attachment_id,
+                    "expires_in_seconds": IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS,
                 }
             )
 
@@ -116,6 +123,10 @@ class ImageGenerationService:
                     "status": "done",
                     "is_placeholder": False,
                     "image_urls": image_urls,
+                    "image_download_urls": [image["url"] for image in images],
+                    "image_download_url_expires_in_seconds": (
+                        IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+                    ),
                     "image_attachment_ids": attachment_ids,
                     "image_count": len(image_urls),
                     "timestamp": int(time.time() * 1000),

--- a/backend/app/services/execution/agents/image/image_agent.py
+++ b/backend/app/services/execution/agents/image/image_agent.py
@@ -25,6 +25,10 @@ from shared.prompts.constants import USER_QUESTION_MARKER, extract_user_question
 
 from ...emitters import ResultEmitter
 from ..base import PollingAgent
+from .download_url import (
+    IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS,
+    build_image_download_url,
+)
 from .intent_analyzer import ImageIntentAnalyzer, ImageIntentResult
 from .providers import get_image_provider
 
@@ -204,6 +208,7 @@ class ImageAgent(PollingAgent):
             user_id = request.user.get("id") if request.user else None
             attachment_ids: List[int] = []
             image_urls: List[str] = []
+            image_download_urls: List[str] = []
 
             for i, image in enumerate(result.images):
                 # Get image URL (either direct URL or convert from base64)
@@ -228,6 +233,7 @@ class ImageAgent(PollingAgent):
                     image_urls.append(
                         context_service.build_attachment_url(attachment_id)
                     )
+                    image_download_urls.append(build_image_download_url(attachment_id))
 
             # Emit final image block with persisted attachment URLs
             final_image_block = {
@@ -236,6 +242,10 @@ class ImageAgent(PollingAgent):
                 "status": "done",
                 "is_placeholder": False,
                 "image_urls": image_urls,
+                "image_download_urls": image_download_urls,
+                "image_download_url_expires_in_seconds": (
+                    IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+                ),
                 "image_attachment_ids": attachment_ids,
                 "image_count": len(image_urls),
                 "image_size": image_size,

--- a/backend/tests/api/endpoints/test_attachment_access.py
+++ b/backend/tests/api/endpoints/test_attachment_access.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 from app.api.endpoints.adapter import attachments
 from app.models.subtask_context import ContextType
-from app.services.attachment.public_link import generate_public_attachment_token
+from app.services.attachment.public_link import build_public_attachment_download_url
 from app.services.context import context_service
 
 
@@ -46,12 +46,12 @@ def test_signed_public_download_does_not_require_login(
         filename="reference.mp4",
         binary_data=b"video-content",
     )
-    token = generate_public_attachment_token(context.id, timedelta(minutes=1))
-
-    response = test_client.get(
-        "/api/attachments/download/shared",
-        params={"token": token},
+    download_url = build_public_attachment_download_url(
+        context.id,
+        timedelta(hours=1),
     )
+
+    response = test_client.get(download_url)
 
     assert response.status_code == 200
     assert response.content == b"video-content"

--- a/backend/tests/services/execution/agents/image/test_download_url.py
+++ b/backend/tests/services/execution/agents/image/test_download_url.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+from app.services.attachment.public_link import verify_public_attachment_token
+from app.services.execution.agents.image.download_url import (
+    IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS,
+    refresh_image_result_download_urls,
+    refresh_task_image_download_urls,
+)
+
+
+def test_refresh_task_image_download_urls_supports_stored_tasks() -> None:
+    stored_result = {
+        "blocks": [
+            {
+                "type": "image",
+                "image_attachment_ids": [96],
+                "image_urls": ["/api/attachments/96/download"],
+            }
+        ]
+    }
+    task_dict = {
+        "result": stored_result,
+        "subtasks": [{"result": stored_result}],
+    }
+
+    with patch(
+        "app.services.execution.agents.image.download_url."
+        "settings.WEGENT_BACKEND_PUBLIC_URL",
+        "https://backend.example",
+    ):
+        refresh_task_image_download_urls(task_dict)
+
+    for result in (task_dict["result"], task_dict["subtasks"][0]["result"]):
+        block = result["blocks"][0]
+        download_url = block["image_download_urls"][0]
+        parsed_url = urlparse(download_url)
+        token = parse_qs(parsed_url.query)["token"][0]
+        payload = verify_public_attachment_token(token)
+
+        assert parsed_url.scheme == "https"
+        assert parsed_url.netloc == "backend.example"
+        assert parsed_url.path == "/api/attachments/download/shared"
+        assert payload["attachment_id"] == 96
+        assert payload["exp"] - payload["iat"] == IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+        assert (
+            block["image_download_url_expires_in_seconds"]
+            == IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+        )
+
+    assert "image_download_urls" not in stored_result["blocks"][0]
+
+
+def test_refresh_image_result_download_urls_reuses_non_image_result() -> None:
+    result = {"blocks": [{"type": "text", "content": "hello"}]}
+
+    assert refresh_image_result_download_urls(result) is result

--- a/backend/tests/services/execution/agents/image/test_generation_service.py
+++ b/backend/tests/services/execution/agents/image/test_generation_service.py
@@ -2,11 +2,90 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 
+from app.services.attachment.public_link import verify_public_attachment_token
+from app.services.execution.agents.image.download_url import (
+    IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS,
+)
 from app.services.execution.agents.image.generation_service import (
     ImageGenerationService,
 )
+from app.services.execution.agents.image.providers.base import (
+    ImageGenerationResult,
+    ImageResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_generated_image_returns_one_hour_download_url() -> None:
+    token_info = SimpleNamespace(user_id=7, task_id=8, subtask_id=9)
+    provider = MagicMock()
+    provider.generate = AsyncMock(
+        return_value=ImageGenerationResult(
+            images=[ImageResult(url="https://provider.example/image.png")],
+            model="image-model",
+        )
+    )
+
+    with (
+        patch(
+            "app.services.execution.agents.image.generation_service."
+            "resolve_generation_context",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.services.execution.agents.image.generation_service."
+            "resolve_generation_model",
+            return_value={"protocol": "gpt-image", "imageConfig": {}},
+        ),
+        patch(
+            "app.services.execution.agents.image.generation_service."
+            "normalize_reference_materials",
+            return_value=[],
+        ),
+        patch(
+            "app.services.execution.agents.image.generation_service."
+            "get_image_provider",
+            return_value=provider,
+        ),
+        patch(
+            "app.services.execution.agents.image.generation_service."
+            "upload_image_attachment",
+            new=AsyncMock(return_value=42),
+        ),
+        patch(
+            "app.services.execution.agents.image.download_url."
+            "settings.WEGENT_BACKEND_PUBLIC_URL",
+            "https://files.example",
+        ),
+    ):
+        result = await ImageGenerationService().generate(
+            db=MagicMock(),
+            token_info=token_info,
+            prompt="draw a lighthouse",
+        )
+
+    image = result["images"][0]
+    parsed_url = urlparse(image["url"])
+    token = parse_qs(parsed_url.query)["token"][0]
+    payload = verify_public_attachment_token(token)
+
+    assert parsed_url.scheme == "https"
+    assert parsed_url.netloc == "files.example"
+    assert parsed_url.path == "/api/attachments/download/shared"
+    assert payload["attachment_id"] == 42
+    assert payload["exp"] - payload["iat"] == IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+    assert image["expires_in_seconds"] == IMAGE_DOWNLOAD_URL_EXPIRES_SECONDS
+    assert image["attachment_url"] == "/api/attachments/42/download"
+    assert result["result_data"]["blocks"][0]["image_urls"] == [
+        "/api/attachments/42/download"
+    ]
+    assert result["result_data"]["blocks"][0]["image_download_urls"] == [image["url"]]
 
 
 def test_reference_image_format_uses_model_capabilities() -> None:

--- a/backend/tests/services/execution/agents/image/test_image_agent.py
+++ b/backend/tests/services/execution/agents/image/test_image_agent.py
@@ -14,9 +14,11 @@ Tests the image generation agent workflow including:
 import asyncio
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from app.services.attachment.public_link import verify_public_attachment_token
 from shared.models import EventType, ExecutionRequest
 
 
@@ -393,6 +395,15 @@ class TestImageAgent:
         done_event = done_calls[0][0][0]
         image_urls = done_event.result["blocks"][0]["image_urls"]
         assert image_urls == ["/api/attachments/999/download"]
+        image_download_urls = done_event.result["blocks"][0]["image_download_urls"]
+        download_token = parse_qs(urlparse(image_download_urls[0]).query)["token"][0]
+        token_payload = verify_public_attachment_token(download_token)
+        assert token_payload["attachment_id"] == 999
+        assert token_payload["exp"] - token_payload["iat"] == 3600
+        assert (
+            done_event.result["blocks"][0]["image_download_url_expires_in_seconds"]
+            == 3600
+        )
         uploaded_url = mock_upload.await_args.kwargs["image_url"]
         assert uploaded_url.startswith("data:image/jpeg;base64,")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated images now include secure, publicly accessible download links.
  * Download links expire after one hour to help protect attachments.
  * Task and subtask image results automatically receive refreshed download links when viewed.
* **Bug Fixes**
  * Improved handling of malformed or non-image results without altering unrelated data.
* **Tests**
  * Added coverage for secure links, expiration details, nested task results, and image generation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->