### PR TITLE
fix(wework): order runtime tasks by latest activity

### DIFF
--- a/executor/src/runtime_work/codex_global_state.rs
+++ b/executor/src/runtime_work/codex_global_state.rs
@@ -257,6 +257,10 @@ impl CodexGlobalProjectIndex {
             .position(|value| value == thread_id)
     }
 
+    pub fn has_manual_thread_order(&self, project_key: &str) -> bool {
+        self.project_thread_orders.contains_key(project_key)
+    }
+
     pub fn thread_sort_order(&self, project_key: &str, thread_id: &str, fallback: usize) -> usize {
         let Some(order) = self.project_thread_orders.get(project_key) else {
             return fallback;

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -206,16 +206,15 @@ impl RuntimeWorkRpcHandler {
                     link.pinned = project_index.is_pinned_thread(thread_id);
                     link.pinned_order = project_index.pinned_thread_order(thread_id);
                     let project_key = runtime_task_sidebar_project_key(&link, project_index);
-                    link.list_order =
-                        project_index
-                            .has_manual_thread_order(&project_key)
-                            .then(|| {
-                                project_index.thread_sort_order(
-                                    &project_key,
-                                    thread_id,
-                                    link.list_order.unwrap_or(usize::MAX / 2),
-                                )
-                            });
+                    if project_index.has_manual_thread_order(&project_key) {
+                        let order = project_index.thread_sort_order(
+                            &project_key,
+                            thread_id,
+                            link.list_order.unwrap_or(usize::MAX / 2),
+                        );
+                        link.list_order = Some(order);
+                        link.sidebar_order = Some(order);
+                    }
                 }
                 link
             })
@@ -375,15 +374,15 @@ impl RuntimeWorkRpcHandler {
             link.group_workspace_path = Some(project_workspace_path.clone());
             link.group_project_key = Some(project_key.clone());
             if let Some(thread_id) = link.thread_id.as_deref() {
-                link.list_order = project_index
-                    .has_manual_thread_order(&project_key)
-                    .then(|| {
-                        project_index.thread_sort_order(
-                            &project_key,
-                            thread_id,
-                            link.list_order.unwrap_or(usize::MAX / 2),
-                        )
-                    });
+                if project_index.has_manual_thread_order(&project_key) {
+                    let order = project_index.thread_sort_order(
+                        &project_key,
+                        thread_id,
+                        link.list_order.unwrap_or(usize::MAX / 2),
+                    );
+                    link.list_order = Some(order);
+                    link.sidebar_order = Some(order);
+                }
             }
             kept_project += 1;
             log_runtime_project_filter_item(

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -206,11 +206,16 @@ impl RuntimeWorkRpcHandler {
                     link.pinned = project_index.is_pinned_thread(thread_id);
                     link.pinned_order = project_index.pinned_thread_order(thread_id);
                     let project_key = runtime_task_sidebar_project_key(&link, project_index);
-                    link.list_order = Some(project_index.thread_sort_order(
-                        &project_key,
-                        thread_id,
-                        link.list_order.unwrap_or(usize::MAX / 2),
-                    ));
+                    link.list_order =
+                        project_index
+                            .has_manual_thread_order(&project_key)
+                            .then(|| {
+                                project_index.thread_sort_order(
+                                    &project_key,
+                                    thread_id,
+                                    link.list_order.unwrap_or(usize::MAX / 2),
+                                )
+                            });
                 }
                 link
             })
@@ -370,11 +375,15 @@ impl RuntimeWorkRpcHandler {
             link.group_workspace_path = Some(project_workspace_path.clone());
             link.group_project_key = Some(project_key.clone());
             if let Some(thread_id) = link.thread_id.as_deref() {
-                link.list_order = Some(project_index.thread_sort_order(
-                    &project_key,
-                    thread_id,
-                    link.list_order.unwrap_or(usize::MAX / 2),
-                ));
+                link.list_order = project_index
+                    .has_manual_thread_order(&project_key)
+                    .then(|| {
+                        project_index.thread_sort_order(
+                            &project_key,
+                            thread_id,
+                            link.list_order.unwrap_or(usize::MAX / 2),
+                        )
+                    });
             }
             kept_project += 1;
             log_runtime_project_filter_item(

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -79,6 +79,8 @@ pub(crate) struct RuntimeTaskLink {
     #[serde(skip)]
     pub list_order: Option<usize>,
     #[serde(skip)]
+    pub sidebar_order: Option<usize>,
+    #[serde(skip)]
     pub group_workspace_path: Option<String>,
     #[serde(skip)]
     pub group_project_key: Option<String>,
@@ -123,6 +125,7 @@ impl RuntimeTaskLink {
             runtime_project_key: None,
             runtime_workspace_roots: Vec::new(),
             list_order: None,
+            sidebar_order: None,
             group_workspace_path: None,
             group_project_key: None,
             pinned: false,
@@ -161,6 +164,7 @@ impl RuntimeTaskLink {
             runtime_project_key: None,
             runtime_workspace_roots: Vec::new(),
             list_order: None,
+            sidebar_order: None,
             group_workspace_path: None,
             group_project_key: None,
             pinned: false,
@@ -258,6 +262,7 @@ impl RuntimeTaskLink {
                 .map(|link| link.runtime_workspace_roots.clone())
                 .unwrap_or_default(),
             list_order: None,
+            sidebar_order: None,
             group_workspace_path: None,
             group_project_key: None,
             pinned: false,
@@ -289,6 +294,7 @@ impl RuntimeTaskLink {
             runtime_project_key: self.runtime_project_key.clone(),
             runtime_workspace_roots: self.runtime_workspace_roots.clone(),
             list_order: self.list_order,
+            sidebar_order: self.sidebar_order,
             group_workspace_path: self.group_workspace_path.clone(),
             group_project_key: self.group_project_key.clone(),
             pinned: self.pinned,
@@ -343,6 +349,7 @@ impl Default for RuntimeTaskLink {
             runtime_project_key: None,
             runtime_workspace_roots: Vec::new(),
             list_order: None,
+            sidebar_order: None,
             group_workspace_path: None,
             group_project_key: None,
             pinned: false,
@@ -668,7 +675,7 @@ fn local_task_json(link: RuntimeTaskLink) -> Value {
     if let Some(thread_id) = link.thread_id.clone() {
         task.insert("threadId".to_owned(), Value::String(thread_id));
     }
-    if let Some(order) = link.list_order {
+    if let Some(order) = link.sidebar_order {
         task.insert("sidebarOrder".to_owned(), json!(order));
     }
     if let Some(git_info) = link.git_info {

--- a/executor/src/runtime_work/worktrees.rs
+++ b/executor/src/runtime_work/worktrees.rs
@@ -1448,6 +1448,7 @@ mod tests {
             runtime_project_key: None,
             runtime_workspace_roots: Vec::new(),
             list_order: None,
+            sidebar_order: None,
             group_workspace_path: None,
             group_project_key: None,
             pinned: false,

--- a/executor/tests/app_runtime_work_workspace_contract.rs
+++ b/executor/tests/app_runtime_work_workspace_contract.rs
@@ -1212,6 +1212,100 @@ async fn runtime_task_list_uses_thread_root_hints_and_skips_projectless_threads(
 }
 
 #[tokio::test]
+async fn runtime_task_list_preserves_unlisted_thread_order_for_hinted_manual_project() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-hinted-order-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let codex_home = temp_path("runtime-hinted-order-codex-home", "dir");
+    let _codex_home = EnvGuard::set("CODEX_HOME", &codex_home.display().to_string());
+    write_codex_global_state(
+        &codex_home,
+        json!({
+            "electron-saved-workspace-roots": ["/repo/Wegent"],
+            "project-order": ["/repo/Wegent"],
+            "thread-workspace-root-hints": {
+                "thread-unlisted-first": "/repo/Wegent",
+                "thread-unlisted-second": "/repo/Wegent",
+                "thread-listed": "/repo/Wegent"
+            },
+            "sidebar-project-thread-orders": {
+                "/repo/Wegent": {
+                    "threadIds": ["thread-listed"],
+                    "sortKey": "manual"
+                }
+            }
+        }),
+    );
+    let threads = json!([
+        {
+            "id": "thread-unlisted-first",
+            "cwd": "/tmp/outside-a",
+            "name": "Unlisted first",
+            "createdAt": 1780000000000_i64,
+            "updatedAt": 1780000010000_i64,
+            "status": "idle",
+            "turns": []
+        },
+        {
+            "id": "thread-unlisted-second",
+            "cwd": "/tmp/outside-b",
+            "name": "Unlisted second",
+            "createdAt": 1780000000000_i64,
+            "updatedAt": 1780000030000_i64,
+            "status": "idle",
+            "turns": []
+        },
+        {
+            "id": "thread-listed",
+            "cwd": "/tmp/outside-c",
+            "name": "Listed",
+            "createdAt": 1780000000000_i64,
+            "updatedAt": 1780000020000_i64,
+            "status": "idle",
+            "turns": []
+        }
+    ])
+    .to_string();
+    let fake_codex =
+        write_fake_codex_with_threads(&temp_path("runtime-hinted-order-log", "jsonl"), &threads);
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let listed = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.list",
+            "payload": {}
+        }))
+        .await
+        .expect("task list should succeed");
+
+    let tasks = listed["workspaces"][0]["tasks"]
+        .as_array()
+        .expect("workspace tasks");
+    assert_eq!(
+        tasks
+            .iter()
+            .map(|task| task["taskId"].as_str().expect("task id"))
+            .collect::<Vec<_>>(),
+        vec![
+            "thread-listed",
+            "thread-unlisted-first",
+            "thread-unlisted-second"
+        ]
+    );
+    assert_eq!(
+        tasks
+            .iter()
+            .map(|task| task["sidebarOrder"].as_u64().expect("sidebar order"))
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2]
+    );
+}
+
+#[tokio::test]
 async fn runtime_archives_project_and_all_conversations() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-archive-project-home", "dir");

--- a/executor/tests/app_runtime_work_workspace_contract.rs
+++ b/executor/tests/app_runtime_work_workspace_contract.rs
@@ -468,6 +468,7 @@ async fn runtime_task_list_groups_threads_under_open_workspace_roots() {
     assert_eq!(workspace["updatedAt"], 1780000060000_i64);
     assert_eq!(workspace["tasks"][0]["createdAt"], 1780000000000_i64);
     assert_eq!(workspace["tasks"][0]["updatedAt"], 1780000060000_i64);
+    assert!(workspace["tasks"][0]["sidebarOrder"].is_null());
 }
 
 #[tokio::test]

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
@@ -43,6 +43,40 @@ describe('runtimeTaskSidebarHelpers', () => {
     ])
   })
 
+  test('sorts tasks without manual order by latest activity', () => {
+    const workspace: RuntimeDeviceWorkspace = {
+      deviceId: 'device-1',
+      workspacePath: '/workspace/chats',
+      workspaceKind: 'chat',
+      available: true,
+      tasks: [
+        {
+          taskId: 'recently-reactivated',
+          workspacePath: '/workspace/chats/recently-reactivated',
+          workspaceKind: 'chat',
+          title: 'Recently reactivated',
+          runtime: 'codex',
+          createdAt: '2026-08-01T02:00:00.000Z',
+          updatedAt: '2026-08-17T02:00:00.000Z',
+        },
+        {
+          taskId: 'previously-first',
+          workspacePath: '/workspace/chats/previously-first',
+          workspaceKind: 'chat',
+          title: 'Previously first',
+          runtime: 'codex',
+          createdAt: '2026-08-16T02:00:00.000Z',
+          updatedAt: '2026-08-16T02:00:00.000Z',
+        },
+      ],
+    }
+
+    expect(getRuntimeChatSidebarTaskItems([workspace]).map(item => item.task.taskId)).toEqual([
+      'recently-reactivated',
+      'previously-first',
+    ])
+  })
+
   test('keeps the current task visible beyond the collapsed ordered task list', () => {
     const workspace: RuntimeDeviceWorkspace = {
       deviceId: 'device-1',
@@ -308,7 +342,7 @@ describe('runtimeTaskSidebarHelpers', () => {
     ])
   })
 
-  test('keeps a resumed task in place while its latest turn is streaming', () => {
+  test('moves a resumed task to the top while its latest turn is streaming', () => {
     const workspace: RuntimeDeviceWorkspace = {
       deviceId: 'device-1',
       workspacePath: '/workspace/repo',
@@ -338,12 +372,12 @@ describe('runtimeTaskSidebarHelpers', () => {
     }
 
     expect(getRuntimeSidebarTaskItems([workspace]).map(item => item.task.taskId)).toEqual([
-      'completed',
       'running',
+      'completed',
     ])
   })
 
-  test('moves a streaming task only after its latest turn completes', () => {
+  test('keeps a recently updated task first after its latest turn completes', () => {
     const workspace: RuntimeDeviceWorkspace = {
       deviceId: 'device-1',
       workspacePath: '/workspace/repo',
@@ -373,8 +407,8 @@ describe('runtimeTaskSidebarHelpers', () => {
     }
 
     expect(getRuntimeSidebarTaskItems([workspace]).map(item => item.task.taskId)).toEqual([
-      'idle',
       'streaming',
+      'idle',
     ])
 
     workspace.tasks[0] = {

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -19,7 +19,7 @@ export function isRuntimeTaskQueued(task: RuntimeTaskSummary): boolean {
 }
 
 function getRuntimeTaskSortTime(task: RuntimeTaskSummary) {
-  const value = task.completedAt ?? task.createdAt ?? task.updatedAt
+  const value = task.updatedAt ?? task.createdAt ?? task.completedAt
   if (value == null) return 0
   const timestamp = new Date(value).getTime()
   return Number.isNaN(timestamp) ? 0 : timestamp


### PR DESCRIPTION
## What changed

- Preserve `sidebarOrder` only when a project has an explicit manual thread order.
- Sort unordered runtime tasks by their latest `updatedAt` activity.
- Add executor contract and Wework helper regression coverage.

## Why

Runtime task collection assigned a fallback sidebar order to every task, so resumed tasks stayed in their previous position instead of moving according to recent activity.

## Impact

Recently active tasks move to the top unless the user has manually reordered the project.

## Validation

- `cargo fmt --check`
- `cargo test --test app_runtime_work_workspace_contract runtime_task_list_groups_threads_under_open_workspace_roots`
- `pnpm --filter wework test src/components/layout/runtimeTaskSidebarHelpers.test.ts`
- Wework Prettier and ESLint checks
- Full pre-push Wework ESLint, TypeScript, and unit tests
- Full pre-push executor library tests and Clippy

## Verification note

Isolated Tauri verification was attempted. The first cold build exceeded the WebView connection timeout; logs show the application completed compilation and started immediately afterward. The isolated process was stopped cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task sidebar ordering when no manual order is configured.
  * Active or recently updated tasks now appear first, including resumed and streaming tasks.
  * Preserved manually configured ordering while retaining source order for unlisted tasks.
  * Unordered tasks now correctly report no sidebar position.
* **Tests**
  * Added coverage for automatic ordering, manual ordering, and sidebar position behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->