### PR TITLE
fix(wework): prevent pinyin duplication during IME input

### DIFF
--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -136,6 +136,7 @@ export interface ChatInputProps {
   value: string
   onChange: (value: string) => void
   onBlur?: () => void
+  onCompositionStart?: () => void
   onCompositionEnd?: () => void
   onSubmit: (
     valueOverride?: string,
@@ -543,6 +544,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     value,
     onChange,
     onBlur,
+    onCompositionStart,
     onCompositionEnd,
     onSubmit,
     disabled,
@@ -774,6 +776,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     value,
     onChange,
     onBlur,
+    onCompositionStart,
     onCompositionEnd,
     onSubmit: handleSubmit,
     disabled,

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -61,6 +61,7 @@ interface CompactChatComposerProps {
   value: string
   onChange: (value: string) => void
   onBlur?: () => void
+  onCompositionStart?: () => void
   onCompositionEnd?: () => void
   onSubmit: (submittedValue?: string, options?: ComposerSubmitOptions) => void
   disabled: boolean
@@ -110,6 +111,7 @@ export const CompactChatComposer = forwardRef<ComposerTextareaHandle, CompactCha
       value,
       onChange,
       onBlur,
+      onCompositionStart,
       onCompositionEnd,
       onSubmit,
       disabled,
@@ -375,6 +377,7 @@ export const CompactChatComposer = forwardRef<ComposerTextareaHandle, CompactCha
               value={value}
               onChange={handleComposerChange}
               onBlur={onBlur}
+              onCompositionStart={onCompositionStart}
               onCompositionEnd={onCompositionEnd}
               onSubmit={onSubmit}
               canSend={canSend}
@@ -591,6 +594,7 @@ export const CompactChatComposer = forwardRef<ComposerTextareaHandle, CompactCha
                 value={value}
                 onChange={handleComposerChange}
                 onBlur={onBlur}
+                onCompositionStart={onCompositionStart}
                 onCompositionEnd={onCompositionEnd}
                 onSubmit={onSubmit}
                 canSend={canSend}

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -106,6 +106,7 @@ export const ComposerTextarea = forwardRef<ComposerTextareaHandle, ComposerTexta
       value,
       onChange,
       onBlur,
+      onCompositionStart,
       onCompositionEnd,
       onSubmit,
       canSend,
@@ -1236,11 +1237,12 @@ export const ComposerTextarea = forwardRef<ComposerTextareaHandle, ComposerTexta
 
     const handleCompositionStart = useCallback(() => {
       setIsComposing(true)
+      onCompositionStart?.()
       debugComposerEvent('composition-start', {
         propValue: textMetrics(valueRef.current),
         suppressEnterUntilKeyUp: suppressEnterUntilKeyUpRef.current,
       })
-    }, [])
+    }, [onCompositionStart])
 
     const handleCompositionEnd = useCallback(() => {
       setIsComposing(false)

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -51,6 +51,7 @@ interface ProjectChatComposerProps {
   value: string
   onChange: (value: string) => void
   onBlur?: () => void
+  onCompositionStart?: () => void
   onCompositionEnd?: () => void
   onSubmit: (submittedValue?: string, options?: ComposerSubmitOptions) => void
   disabled: boolean
@@ -125,6 +126,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
       value,
       onChange,
       onBlur,
+      onCompositionStart,
       onCompositionEnd,
       onSubmit,
       disabled,
@@ -429,6 +431,7 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
             value={value}
             onChange={handleComposerChange}
             onBlur={onBlur}
+            onCompositionStart={onCompositionStart}
             onCompositionEnd={onCompositionEnd}
             onSubmit={onSubmit}
             canSend={canSend}

--- a/wework/src/components/chat/composer/composerTextareaTypes.ts
+++ b/wework/src/components/chat/composer/composerTextareaTypes.ts
@@ -26,6 +26,7 @@ export interface ComposerTextareaProps {
   value: string
   onChange: (value: string) => void
   onBlur?: () => void
+  onCompositionStart?: () => void
   onCompositionEnd?: () => void
   onSubmit: (submittedValue?: string, options?: ComposerSubmitOptions) => void
   canSend: boolean

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -304,6 +304,47 @@ describe('BufferedChatInput', () => {
     await waitFor(() => expect(onChange).toHaveBeenLastCalledWith('nihao'))
   })
 
+  test('cancels a queued frame flush when composition starts', async () => {
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame'] })
+    const onChange = vi.fn()
+    render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
+
+    const input = screen.getByTestId('chat-message-input')
+    await userEvent.type(input, 'draft')
+    fireEvent.blur(input)
+    fireEvent.compositionStart(input)
+    vi.advanceTimersByTime(20)
+
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.compositionEnd(input)
+    vi.advanceTimersByTime(20)
+
+    expect(onChange).toHaveBeenLastCalledWith('draft')
+  })
+
+  test('preserves caller composition callbacks', () => {
+    const onCompositionStart = vi.fn()
+    const onCompositionEnd = vi.fn()
+    render(
+      <BufferedChatInput
+        value=""
+        onChange={vi.fn()}
+        onCompositionStart={onCompositionStart}
+        onCompositionEnd={onCompositionEnd}
+        onSubmit={vi.fn()}
+        disabled={false}
+      />
+    )
+
+    const input = screen.getByTestId('chat-message-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+
+    expect(onCompositionStart).toHaveBeenCalledOnce()
+    expect(onCompositionEnd).toHaveBeenCalledOnce()
+  })
+
   test('restores a buffered draft after switching chat scopes', async () => {
     const drafts = new Map<string, string>()
     const onBlankChange = vi.fn((value: string) => drafts.set('blank', value))

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -289,6 +289,21 @@ describe('BufferedChatInput', () => {
     expect(onChange).toHaveBeenLastCalledWith('draft')
   })
 
+  test('does not flush transient composition text after the debounce window', async () => {
+    const onChange = vi.fn()
+    render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
+
+    const input = screen.getByTestId('chat-message-input')
+    fireEvent.compositionStart(input)
+    await userEvent.type(input, 'nihao')
+    await new Promise(resolve => window.setTimeout(resolve, 350))
+
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.compositionEnd(input)
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith('nihao'))
+  })
+
   test('restores a buffered draft after switching chat scopes', async () => {
     const drafts = new Map<string, string>()
     const onBlankChange = vi.fn((value: string) => drafts.set('blank', value))

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -25,6 +25,8 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   onSubmit,
   insertion,
   onDraftEdit,
+  onCompositionStart: onParentCompositionStart,
+  onCompositionEnd: onParentCompositionEnd,
   ...props
 }: BufferedChatInputProps) {
   const scopeKey = props.projectChat?.scopeKey
@@ -38,6 +40,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const draftRef = useRef(draft)
   const appliedInsertionIdRef = useRef<number | null>(null)
   const flushTimeoutRef = useRef<number | null>(null)
+  const flushFrameRef = useRef<number | null>(null)
   const composerRef = useRef<ChatInputHandle>(null)
   const committedValueRef = useRef(value)
   const pendingChangeRef = useRef(onChange)
@@ -59,6 +62,13 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     if (flushTimeoutRef.current !== null) {
       window.clearTimeout(flushTimeoutRef.current)
       flushTimeoutRef.current = null
+    }
+  }, [])
+
+  const cancelPendingFlushFrame = useCallback(() => {
+    if (flushFrameRef.current !== null) {
+      window.cancelAnimationFrame(flushFrameRef.current)
+      flushFrameRef.current = null
     }
   }, [])
 
@@ -110,13 +120,14 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   // Flush a pending draft whenever it would be discarded (scope switch or unmount).
   useEffect(() => {
     return () => {
+      cancelPendingFlush()
+      cancelPendingFlushFrame()
       const pendingDraft = draftRef.current
       if (pendingDraft !== committedValueRef.current) {
-        cancelPendingFlush()
         pendingChangeRef.current(pendingDraft)
       }
     }
-  }, [cancelPendingFlush, scopeKey])
+  }, [cancelPendingFlush, cancelPendingFlushFrame, scopeKey])
 
   useEffect(() => {
     if (!insertion || appliedInsertionIdRef.current === insertion.id) return
@@ -149,23 +160,31 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   // Flush after the next frame so the editor state settles first.
   const flushDraftNextFrame = useCallback(
     (reason: string) => {
+      cancelPendingFlushFrame()
       recordComposerDiagnostic('draft-flush-request', {
         reason,
         draftLength: draftRef.current.length,
       })
-      window.requestAnimationFrame(() => flushDraft(draftRef.current, reason))
+      flushFrameRef.current = window.requestAnimationFrame(() => {
+        flushFrameRef.current = null
+        if (isComposingRef.current) return
+        flushDraft(draftRef.current, reason)
+      })
     },
-    [flushDraft]
+    [cancelPendingFlushFrame, flushDraft]
   )
   const handleBlur = useCallback(() => flushDraftNextFrame('blur'), [flushDraftNextFrame])
   const handleCompositionStart = useCallback(() => {
     isComposingRef.current = true
+    cancelPendingFlushFrame()
     cancelPendingFlush()
-  }, [cancelPendingFlush])
+    onParentCompositionStart?.()
+  }, [cancelPendingFlush, cancelPendingFlushFrame, onParentCompositionStart])
   const handleCompositionEnd = useCallback(() => {
     isComposingRef.current = false
     flushDraftNextFrame('composition-end')
-  }, [flushDraftNextFrame])
+    onParentCompositionEnd?.()
+  }, [flushDraftNextFrame, onParentCompositionEnd])
 
   const handleSubmit = useCallback(
     (valueOverride?: string, options?: ChatSubmitOptions) => {

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -43,6 +43,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const pendingChangeRef = useRef(onChange)
   const programmaticUpdateDepthRef = useRef(0)
   const draftEditVersionRef = useRef(0)
+  const isComposingRef = useRef(false)
   const scopeKeyRef = useRef(scopeKey)
   scopeKeyRef.current = scopeKey
 
@@ -136,9 +137,13 @@ export const BufferedChatInput = memo(function BufferedChatInput({
         draftEditVersionRef.current += 1
         onDraftEdit?.()
       }
+      if (isComposingRef.current) {
+        cancelPendingFlush()
+        return
+      }
       scheduleDraftFlush(nextDraft)
     },
-    [onDraftEdit, scheduleDraftFlush]
+    [cancelPendingFlush, onDraftEdit, scheduleDraftFlush]
   )
 
   // Flush after the next frame so the editor state settles first.
@@ -153,10 +158,14 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     [flushDraft]
   )
   const handleBlur = useCallback(() => flushDraftNextFrame('blur'), [flushDraftNextFrame])
-  const handleCompositionEnd = useCallback(
-    () => flushDraftNextFrame('composition-end'),
-    [flushDraftNextFrame]
-  )
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true
+    cancelPendingFlush()
+  }, [cancelPendingFlush])
+  const handleCompositionEnd = useCallback(() => {
+    isComposingRef.current = false
+    flushDraftNextFrame('composition-end')
+  }, [flushDraftNextFrame])
 
   const handleSubmit = useCallback(
     (valueOverride?: string, options?: ChatSubmitOptions) => {
@@ -198,6 +207,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
       value={draft}
       onChange={setDraft}
       onBlur={handleBlur}
+      onCompositionStart={handleCompositionStart}
       onCompositionEnd={handleCompositionEnd}
       onSubmit={handleSubmit}
     />


### PR DESCRIPTION
## Summary

- stop the buffered composer from flushing transient IME composition text
- propagate `onCompositionStart` through compact, fullscreen, and project composers
- add a regression test for composition sessions that exceed the 300 ms draft debounce

## Root cause

The buffered composer continued its 300 ms parent-state debounce while macOS IME composition was active. A debounced value containing transient pinyin could reach the parent after WebKit removed the composition text, then be reapplied to ProseMirror immediately before the committed Chinese characters were inserted. The result was duplicated `pinyin + 汉字` text.

## User impact

Chinese input now keeps pre-edit text local to the active editor and only persists the final committed text after `compositionend`. The existing draft debounce remains active for ordinary typing, preserving the CPU and render-performance optimization.

## Validation

- `pnpm --filter wework test src/components/layout/BufferedChatInput.test.tsx src/components/chat/composer/ComposerTextarea.test.tsx src/components/chat/composer/ComposerProseMirrorEditor.test.tsx` — 85 passed
- `pnpm --filter wework exec tsc --noEmit`
- Wework pre-push ESLint, TypeScript, and unit tests
- isolated real-Tauri verification with Chinese draft text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input behavior for IME users by preventing draft updates while text composition is in progress.
  * Pending draft updates are canceled when composition begins and resume after composition ends, reducing premature or incomplete message handling.
  * Preserved composition behavior across compact, fullscreen, and project chat input modes.

* **Tests**
  * Added coverage for composition timing, queued update cancellation, and callback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->