### PR TITLE
fix(wework): restore markdown preview heading hierarchy

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -145,6 +145,11 @@ the static CSS bundle:
 | Heading large  |       `24px` |              `29px` | `500`     | rare prominent heading                |
 | Display        |       `28px` |         `32px–34px` | `500`     | exceptional home/onboarding use only  |
 
+Document-style Markdown previews use the heading ramp for clear content
+hierarchy: H1 uses Heading large, H2 uses Heading medium, and H3 uses Heading
+small. Lower heading levels continue through the semantic UI sizes. Compact
+chat and process Markdown keep their denser heading scale.
+
 The default UI font size is `14px`; the default code font size is `12px`.
 Appearance settings may change UI size from `11px` through `16px` and code size
 from `8px` through `24px`, in whole-pixel steps. Changing UI size scales every

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -43,9 +43,45 @@ const DIAGRAM_LANGUAGES = new Set(['mermaid', 'mmd', 'plantuml', 'puml'])
 interface AssistantMarkdownProps {
   content: string
   isStreaming?: boolean
-  variant?: 'default' | 'process'
+  variant?: 'default' | 'document' | 'process'
   onOpenFile?: (path: string, options?: WorkspaceFileOpenOptions) => void
   fileChanges?: TurnFileChangesSummary
+}
+
+const MARKDOWN_HEADING_CLASSES = {
+  default: {
+    h1: 'mb-4 mt-6 text-lg font-semibold text-text-primary',
+    h2: 'mb-3 mt-5 text-base font-semibold text-text-primary',
+    h3: 'mb-2 mt-4 text-sm font-semibold text-text-primary',
+  },
+  document: {
+    h1: 'mb-5 mt-8 text-heading-lg font-semibold tracking-[-0.02em] text-text-primary',
+    h2: 'mb-4 mt-7 text-heading-md font-semibold tracking-[-0.01em] text-text-primary',
+    h3: 'mb-3 mt-6 text-heading-sm font-semibold text-text-primary',
+  },
+  process: {
+    h1: 'mb-2 mt-3 text-base font-semibold text-text-primary',
+    h2: 'mb-1.5 mt-3 text-sm font-semibold text-text-primary',
+    h3: 'mb-1 mt-2 text-sm font-semibold text-text-primary',
+  },
+} as const
+
+const DOCUMENT_MARKDOWN_HEADING_COMPONENTS = {
+  h4: ({ children }: { children?: ReactNode }) => (
+    <h4 data-scroll-anchor className="mb-2 mt-5 text-lg font-semibold text-text-primary">
+      {children}
+    </h4>
+  ),
+  h5: ({ children }: { children?: ReactNode }) => (
+    <h5 data-scroll-anchor className="mb-2 mt-4 text-base font-semibold text-text-primary">
+      {children}
+    </h5>
+  ),
+  h6: ({ children }: { children?: ReactNode }) => (
+    <h6 data-scroll-anchor className="mb-2 mt-4 text-sm font-semibold text-text-secondary">
+      {children}
+    </h6>
+  ),
 }
 
 type AssistantMarkdownPart =
@@ -83,44 +119,25 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
     }
     openFileRef.current?.(path)
   }, [])
+  const headingClasses = MARKDOWN_HEADING_CLASSES[variant]
   const components = useMemo(
     () => ({
       h1: ({ children }: { children?: ReactNode }) => (
-        <h1
-          data-scroll-anchor
-          className={
-            variant === 'process'
-              ? 'mb-2 mt-3 text-base font-semibold text-text-primary'
-              : 'mb-4 mt-6 text-lg font-semibold text-text-primary'
-          }
-        >
+        <h1 data-scroll-anchor className={headingClasses.h1}>
           {children}
         </h1>
       ),
       h2: ({ children }: { children?: ReactNode }) => (
-        <h2
-          data-scroll-anchor
-          className={
-            variant === 'process'
-              ? 'mb-1.5 mt-3 text-sm font-semibold text-text-primary'
-              : 'mb-3 mt-5 text-base font-semibold text-text-primary'
-          }
-        >
+        <h2 data-scroll-anchor className={headingClasses.h2}>
           {children}
         </h2>
       ),
       h3: ({ children }: { children?: ReactNode }) => (
-        <h3
-          data-scroll-anchor
-          className={
-            variant === 'process'
-              ? 'mb-1 mt-2 text-sm font-semibold text-text-primary'
-              : 'mb-2 mt-4 text-sm font-semibold text-text-primary'
-          }
-        >
+        <h3 data-scroll-anchor className={headingClasses.h3}>
           {children}
         </h3>
       ),
+      ...(variant === 'document' ? DOCUMENT_MARKDOWN_HEADING_COMPONENTS : {}),
       p: ({ children }: { children?: ReactNode }) => (
         <p
           data-scroll-anchor
@@ -200,7 +217,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <AssistantMarkdownImage src={src} alt={alt} />
       ),
     }),
-    [openFile, variant]
+    [headingClasses, openFile, variant]
   )
 
   return (

--- a/wework/src/components/chat/AssistantMarkdown.typography.test.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.typography.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import { AssistantMarkdown } from './AssistantMarkdown'
+
+test('uses document typography for every Markdown heading level', () => {
+  render(
+    <AssistantMarkdown
+      content={[
+        '# Heading 1',
+        '## Heading 2',
+        '### Heading 3',
+        '#### Heading 4',
+        '##### Heading 5',
+        '###### Heading 6',
+      ].join('\n\n')}
+      variant="document"
+    />
+  )
+
+  expect(screen.getByRole('heading', { level: 1 })).toHaveClass('text-heading-lg')
+  expect(screen.getByRole('heading', { level: 2 })).toHaveClass('text-heading-md')
+  expect(screen.getByRole('heading', { level: 3 })).toHaveClass('text-heading-sm')
+  expect(screen.getByRole('heading', { level: 4 })).toHaveClass('text-lg')
+  expect(screen.getByRole('heading', { level: 5 })).toHaveClass('text-base')
+  expect(screen.getByRole('heading', { level: 6 })).toHaveClass('text-sm')
+})

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
@@ -14,8 +14,10 @@ const appearanceMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/components/chat/AssistantMarkdown', () => ({
-  AssistantMarkdown: ({ content }: { content: string }) => (
-    <div data-testid="assistant-markdown">{content}</div>
+  AssistantMarkdown: ({ content, variant }: { content: string; variant?: string }) => (
+    <div data-testid="assistant-markdown" data-variant={variant}>
+      {content}
+    </div>
   ),
 }))
 
@@ -93,6 +95,7 @@ test('renders Markdown files as a scrollable preview by default', () => {
     'scrollbar-soft'
   )
   expect(screen.getByTestId('assistant-markdown')).toHaveTextContent('# Project')
+  expect(screen.getByTestId('assistant-markdown')).toHaveAttribute('data-variant', 'document')
   expect(codeViewMocks.render).not.toHaveBeenCalled()
 })
 

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
@@ -260,7 +260,7 @@ function WorkspaceMarkdownPreview({ file }: { file: WorkspaceTextFileResponse })
       className="scrollbar-soft min-w-0 flex-1 overflow-y-scroll bg-background"
     >
       <div className="mx-auto max-w-4xl px-8 py-6 text-base leading-7 text-text-primary">
-        <AssistantMarkdown content={file.content} />
+        <AssistantMarkdown content={file.content} variant="document" />
       </div>
       {file.truncated && (
         <div className="sticky bottom-0 border-t border-border bg-background/95 px-4 py-2 text-xs text-amber-700 backdrop-blur-sm">


### PR DESCRIPTION
## What changed

- add a document typography variant to the shared Markdown renderer
- use the document variant in workspace Markdown file previews
- style H1-H6 with a clear semantic heading hierarchy
- keep compact chat and process Markdown typography unchanged
- document the Markdown preview heading hierarchy in the Wework design guide
- add regression coverage for document headings and preview integration

## Root cause

The workspace file preview reused the compact chat Markdown typography. In that
variant, H2 used the same base size as ordinary body content, so Markdown
headings did not present a clear visual hierarchy.

## Impact

Markdown files previewed in Wework now show distinct heading levels while chat
messages retain their existing compact layout.

## Validation

- `pnpm --filter wework test src/components/chat/AssistantMarkdown.typography.test.tsx src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx`
- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint:typography`
- full Wework pre-push ESLint, TypeScript, and unit-test checks
- isolated real Tauri verification opening `README.md` in the workspace file preview


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Markdown file previews with document-style typography.
  - Added distinct heading sizing for all Markdown heading levels.
  - Preserved compact heading styles for chat and process content.

- **Bug Fixes**
  - Improved consistency and readability of headings in rendered Markdown previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->