### PR TITLE
fix(frontend): show public skill update time

### DIFF
--- a/frontend/src/__tests__/features/admin/PublicSkillList.test.tsx
+++ b/frontend/src/__tests__/features/admin/PublicSkillList.test.tsx
@@ -69,6 +69,7 @@ describe('PublicSkillList', () => {
         is_active: true,
         is_public: true,
         user_id: 1,
+        updated_at: '2026-08-17T08:00:00Z',
       },
     ])
   })
@@ -88,6 +89,13 @@ describe('PublicSkillList', () => {
 
     expect(await screen.findByText('技术开发')).toBeInTheDocument()
     expect(screen.queryByText('python')).not.toBeInTheDocument()
+  })
+
+  it('shows the skill update time', async () => {
+    render(<PublicSkillList />)
+
+    expect(await screen.findByText(/admin:public_skills\.columns\.updated_at:/)).toBeInTheDocument()
+    expect(screen.queryByText(/admin:public_skills\.columns\.created_at:/)).not.toBeInTheDocument()
   })
 
   it('falls back to skill keywords when marketplace tags are missing', async () => {

--- a/frontend/src/__tests__/features/admin/PublicSkillList.test.tsx
+++ b/frontend/src/__tests__/features/admin/PublicSkillList.test.tsx
@@ -94,7 +94,8 @@ describe('PublicSkillList', () => {
   it('shows the skill update time', async () => {
     render(<PublicSkillList />)
 
-    expect(await screen.findByText(/admin:public_skills\.columns\.updated_at:/)).toBeInTheDocument()
+    const updatedAt = await screen.findByText(/admin:public_skills\.columns\.updated_at:/)
+    expect(updatedAt).toHaveTextContent('2026')
     expect(screen.queryByText(/admin:public_skills\.columns\.created_at:/)).not.toBeInTheDocument()
   })
 

--- a/frontend/src/features/admin/components/PublicSkillList.tsx
+++ b/frontend/src/features/admin/components/PublicSkillList.tsx
@@ -439,8 +439,8 @@ const PublicSkillList: React.FC = () => {
                             </>
                           )}
                           <span>
-                            {t('admin:public_skills.columns.created_at')}:{' '}
-                            {formatDate(skill.created_at)}
+                            {t('admin:public_skills.columns.updated_at')}:{' '}
+                            {formatDate(skill.updated_at)}
                           </span>
                         </div>
                       </div>

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -232,7 +232,7 @@
       "version": "Version",
       "author": "Author",
       "tags": "Skill Keywords",
-      "created_at": "Created At",
+      "updated_at": "Updated At",
       "actions": "Actions"
     },
     "confirm": {

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -232,7 +232,7 @@
       "version": "版本",
       "author": "作者",
       "tags": "技能关键词",
-      "created_at": "创建时间",
+      "updated_at": "更新时间",
       "actions": "操作"
     },
     "confirm": {


### PR DESCRIPTION
## What changed

- Show the last update date in the public skill management list.
- Replace the lower-value creation date with the update date to avoid adding visual clutter.
- Add Chinese and English translations and focused component coverage.

## Why

Administrators need to know whether a public skill is current. The creation date does not reflect later ZIP or metadata updates, while the existing `updated_at` API field does.

## Impact

The public skill management cards now display `Updated At` / `更新时间`. No backend or API changes are required.

## Validation

- `pnpm --dir frontend test -- --runInBand src/__tests__/features/admin/PublicSkillList.test.tsx`
- Pre-push frontend ESLint, TypeScript, and unit tests
- Pre-push Wework ESLint, TypeScript, and unit tests
- Pre-push executor cargo fmt, test, and clippy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - The public skills list now shows each skill’s last updated date instead of its creation date.
  - Updated English and Chinese labels to reflect the new date information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->