### PR TITLE
fix(wework): open browser with contextual shortcuts

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
@@ -6,9 +6,6 @@ const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
 const RIGHT_PANEL_TOGGLE_SELECTOR =
   '[data-workspace-tab-portal-owner]:not([hidden]) [data-testid="toggle-right-workspace-panel-button"]'
-const RIGHT_BROWSER_OPTION_SELECTOR = '[data-testid="right-workspace-browser-option"]'
-const RIGHT_NEW_TAB_BROWSER_OPTION_SELECTOR =
-  '[data-testid="right-workspace-new-tab-menu"] [data-testid="right-workspace-browser-option"]'
 const RIGHT_NEW_TAB_CHAT_OPTION_SELECTOR =
   '[data-testid="right-workspace-new-tab-menu"] [data-testid="right-workspace-chat-option"]'
 const RIGHT_NEW_TAB_TERMINAL_OPTION_SELECTOR =
@@ -29,6 +26,9 @@ const FIXTURE_A_TEXT = 'Embedded Browser Multi Tab A'
 const FIXTURE_B_TEXT = 'Embedded Browser Multi Tab B'
 const BRIDGE_RUNTIME_FILE = 'embedded-browser-bridge.json'
 const BROWSER_LABEL = 'workspace-browser'
+const OPEN_BROWSER_WHILE_CLOSED_KEY =
+  process.platform === 'win32' ? 'Control+Shift+B' : 'Meta+Shift+B'
+const OPEN_BROWSER_WHILE_OPEN_KEY = process.platform === 'win32' ? 'Control+T' : 'Meta+T'
 
 function fixtureHtml(title, text) {
   return [
@@ -138,8 +138,14 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
       const fixtureBUrl = control.url + FIXTURE_B_PATH
 
       await control.command('waitFor', RIGHT_PANEL_TOGGLE_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await control.command('click', RIGHT_PANEL_TOGGLE_SELECTOR)
-      await control.command('click', RIGHT_BROWSER_OPTION_SELECTOR)
+      assert.equal(
+        await control.command('getAttribute', '[data-testid="right-workspace-panel-shell"]', {
+          value: 'aria-hidden',
+        }),
+        'true',
+        'The browser shortcut checkpoint did not start with the right panel closed'
+      )
+      await control.command('press', 'body', { key: OPEN_BROWSER_WHILE_CLOSED_KEY })
       await control.command('waitFor', BROWSER_INPUT_SELECTOR, { timeoutMs: uiTimeoutMs })
 
       await callBridge(bridgeIdentity, { action: 'open', url: fixtureAUrl, timeoutMs: 8000 })
@@ -152,12 +158,13 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
       )
       const firstBrowserLabel = (await callBridge(bridgeIdentity, { action: 'status' })).label
       const secondBrowserLabel = firstBrowserLabel + '-2'
+      await control.command('press', 'body', { key: OPEN_BROWSER_WHILE_CLOSED_KEY })
       await waitForSnapshot(
         control,
         snapshot =>
           snapshot.testIds.includes('right-workspace-browser-tab-1') &&
           !snapshot.testIds.includes('right-workspace-browser-tab-2'),
-        'The right workspace did not start with one browser tab',
+        'The closed-panel browser shortcut fired again while the right panel was open',
         uiTimeoutMs,
         'body'
       )
@@ -166,8 +173,7 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
       await control.command('click', RIGHT_NEW_TAB_CHAT_OPTION_SELECTOR)
       await control.command('click', RIGHT_WORKSPACE_NEW_TAB_SELECTOR)
       await control.command('click', RIGHT_NEW_TAB_TERMINAL_OPTION_SELECTOR)
-      await control.command('click', RIGHT_WORKSPACE_NEW_TAB_SELECTOR)
-      await control.command('click', RIGHT_NEW_TAB_BROWSER_OPTION_SELECTOR)
+      await control.command('press', 'body', { key: OPEN_BROWSER_WHILE_OPEN_KEY })
       const mixedTabsSnapshot = await waitForSnapshot(
         control,
         snapshot =>

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5536,6 +5536,35 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('workspace-browser-frame')).toHaveClass('bg-background')
   })
 
+  test('uses separate browser shortcuts for the closed and open right panel', async () => {
+    renderWorkspacePanelLayout()
+
+    expect(screen.getByTestId('right-workspace-panel-shell')).toHaveAttribute('aria-hidden', 'true')
+
+    fireEvent.keyDown(window, { key: 'b', metaKey: true, shiftKey: true })
+
+    expect(await screen.findByTestId('right-workspace-browser-tab-1')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(screen.getByTestId('right-workspace-panel-shell')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    )
+    expect(screen.getByTestId('workspace-browser-url-input')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 't', metaKey: true })
+
+    expect(await screen.findByTestId('right-workspace-browser-tab-2')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    fireEvent.keyDown(window, { key: 'b', metaKey: true, shiftKey: true })
+
+    expect(screen.queryByTestId('right-workspace-browser-tab-3')).not.toBeInTheDocument()
+  })
+
   test('deactivates the right workspace browser while settings are open', async () => {
     renderWorkspacePanelLayout()
 

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -185,7 +185,7 @@ import {
   TaskSupervisorControl,
   type TaskSupervisorConfig,
 } from './TaskSupervisorControl'
-import { WEWORK_OPEN_TERMINAL_EVENT } from '@/lib/keybindings'
+import { isEditableShortcutTarget, WEWORK_OPEN_TERMINAL_EVENT } from '@/lib/keybindings'
 import type {
   ModelSelectionConfig,
   RuntimeName,
@@ -3039,6 +3039,24 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const selectBrowserView = useCallback(() => {
     openBrowserTab()
   }, [openBrowserTab])
+  useEffect(() => {
+    if (!paneActive || !paneVisible || rightPanelOpen) return
+
+    const handleOpenBrowser = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || isEditableShortcutTarget(event.target)) return
+      const primaryPressed =
+        getPlatform() === 'win'
+          ? event.ctrlKey && event.shiftKey && !event.metaKey
+          : event.metaKey && event.shiftKey && !event.ctrlKey
+      if (!primaryPressed || event.altKey || event.key.toLowerCase() !== 'b') return
+
+      event.preventDefault()
+      selectBrowserView()
+    }
+
+    window.addEventListener('keydown', handleOpenBrowser)
+    return () => window.removeEventListener('keydown', handleOpenBrowser)
+  }, [paneActive, paneVisible, rightPanelOpen, selectBrowserView])
   const selectTerminalView = useCallback(() => {
     openRightPanelTab(allocateTerminalTab())
   }, [allocateTerminalTab, openRightPanelTab])


### PR DESCRIPTION
## What
- open the Wework built-in browser with `Command+Shift+B` on macOS or `Ctrl+Shift+B` on Windows when the right sidebar is closed
- preserve `Command+T` / `Ctrl+T` for creating a browser tab while the sidebar is open
- cover both shortcut contexts in component and desktop E2E tests

## Why
The browser shortcut previously required the right sidebar to be open, so users could not launch the built-in browser directly from the workbench.

## Impact
Desktop Wework shortcut handling only. The closed-sidebar shortcut is ignored while the sidebar is already open, avoiding overlap with the existing new-tab shortcut.

## Checks
- `pnpm --dir wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx -t "opens the browser with context-specific keyboard shortcuts"`
- `pnpm --dir wework exec prettier --check src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs`
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework test`
- `pnpm --dir wework run test:e2e:desktop -- --checkpoint browser-multi-tabs`
- isolated real-Tauri `ai:verify`: closed `Command+Shift+B` created tab 1, repeated `Command+Shift+B` created no duplicate, and open-panel `Command+T` created tab 2