### PR TITLE
fix(backend): allow cloud runtime auth commands

### DIFF
--- a/backend/app/services/device/command_service.py
+++ b/backend/app/services/device/command_service.py
@@ -35,6 +35,9 @@ DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024
 MAX_OUTPUT_BYTES = 5 * 1024 * 1024
 SOCKET_ACK_GRACE_SECONDS = 5
 REMOTE_DEVICE_COMMAND_KEYS = frozenset({"pwd", "home_dir", "ls_dirs", "mkdir_p"})
+CLOUD_DEVICE_COMMAND_KEYS = REMOTE_DEVICE_COMMAND_KEYS | frozenset(
+    {"read_runtime_auth_file", "sync_runtime_auth_file"}
+)
 LOCAL_COMMAND_DEVICE_TYPES = frozenset({DeviceType.LOCAL, DeviceType.APP})
 
 
@@ -102,7 +105,12 @@ async def _resolve_dispatch_device_id(
             f"Device command RPC is not supported for {device_type.value} devices"
         )
 
-    if command_key not in REMOTE_DEVICE_COMMAND_KEYS:
+    supported_command_keys = (
+        CLOUD_DEVICE_COMMAND_KEYS
+        if device_type == DeviceType.CLOUD
+        else REMOTE_DEVICE_COMMAND_KEYS
+    )
+    if command_key not in supported_command_keys:
         raise DeviceCommandError(
             f"Device command key '{command_key}' is not supported for "
             f"{device_type.value} devices"

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -2387,6 +2387,141 @@ async def test_execute_configured_device_command_allows_remote_directory_creatio
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command_key", "stdout", "env"),
+    [
+        (
+            "read_runtime_auth_file",
+            '{"status":"read","path":"~/.codex/auth.json","content":"{}"}',
+            {
+                "WEGENT_RUNTIME_CONFIG_RUNTIME": "codex",
+                "WEGENT_RUNTIME_CONFIG_TARGET_PATH": "~/.codex/auth.json",
+            },
+        ),
+        (
+            "sync_runtime_auth_file",
+            '{"status":"written","path":"~/.codex/auth.json"}',
+            {
+                "WEGENT_RUNTIME_CONFIG_RUNTIME": "codex",
+                "WEGENT_RUNTIME_CONFIG_TARGET_PATH": "~/.codex/auth.json",
+                "WEGENT_RUNTIME_CONFIG_CONTENT": "{}",
+            },
+        ),
+    ],
+)
+async def test_execute_configured_device_command_allows_cloud_runtime_auth_commands(
+    monkeypatch,
+    command_key,
+    stdout,
+    env,
+):
+    """Cloud devices should support the constrained runtime auth commands."""
+    from app.schemas.device import DeviceType
+    from app.services.device import command_service
+    from app.services.device.command_registry import resolve_local_device_command
+
+    execute_mock = AsyncMock(
+        return_value={
+            "success": True,
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "duration": 0.02,
+            "timed_out": False,
+        }
+    )
+    online_mock = AsyncMock(return_value={"socket_id": "socket-cloud"})
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: SimpleNamespace(
+            name="cloud-crd",
+            json={
+                "spec": {
+                    "deviceType": "cloud",
+                    "cloudConfig": {"deviceId": "runtime-cloud"},
+                }
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_online_info_by_type",
+        online_mock,
+    )
+    monkeypatch.setattr(
+        command_service.local_device_command_service,
+        "execute_command",
+        execute_mock,
+    )
+
+    result = await command_service.execute_configured_device_command(
+        db=object(),
+        user_id=7,
+        device_id="cloud-crd",
+        command_key=command_key,
+        env=env,
+    )
+
+    command_definition = resolve_local_device_command(command_key)
+    assert command_definition is not None
+    assert result["success"] is True
+    assert isinstance(result["stdout"], dict)
+    online_mock.assert_awaited_once_with(7, "runtime-cloud", DeviceType.CLOUD)
+    execute_mock.assert_awaited_once_with(
+        user_id=7,
+        device_id="runtime-cloud",
+        command=command_definition.command,
+        path=None,
+        args=[],
+        env=env,
+        timeout_seconds=60,
+        max_output_bytes=1024 * 1024,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_configured_device_command_rejects_remote_runtime_auth_command(
+    monkeypatch,
+):
+    """Remote devices should not gain access to runtime auth commands."""
+    from app.services.device import command_service
+
+    execute_mock = AsyncMock()
+    online_mock = AsyncMock(return_value={"socket_id": "socket-remote"})
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: SimpleNamespace(
+            name="remote-device",
+            json={"spec": {"deviceType": "remote"}},
+        ),
+    )
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_online_info_by_type",
+        online_mock,
+    )
+    monkeypatch.setattr(
+        command_service.local_device_command_service,
+        "execute_command",
+        execute_mock,
+    )
+
+    with pytest.raises(command_service.DeviceCommandError) as exc_info:
+        await command_service.execute_configured_device_command(
+            db=object(),
+            user_id=7,
+            device_id="remote-device",
+            command_key="read_runtime_auth_file",
+        )
+
+    assert "not supported for remote devices" in str(exc_info.value)
+    online_mock.assert_not_awaited()
+    execute_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_execute_configured_device_command_rejects_cloud_unsupported_command_key(
     monkeypatch,
 ):

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -2410,11 +2410,11 @@ async def test_execute_configured_device_command_allows_remote_directory_creatio
     ],
 )
 async def test_execute_configured_device_command_allows_cloud_runtime_auth_commands(
-    monkeypatch,
-    command_key,
-    stdout,
-    env,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    command_key: str,
+    stdout: str,
+    env: dict[str, str],
+) -> None:
     """Cloud devices should support the constrained runtime auth commands."""
     from app.schemas.device import DeviceType
     from app.services.device import command_service
@@ -2482,8 +2482,8 @@ async def test_execute_configured_device_command_allows_cloud_runtime_auth_comma
 
 @pytest.mark.asyncio
 async def test_execute_configured_device_command_rejects_remote_runtime_auth_command(
-    monkeypatch,
-):
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Remote devices should not gain access to runtime auth commands."""
     from app.services.device import command_service
 


### PR DESCRIPTION
## What changed

- allow cloud devices to run the constrained `read_runtime_auth_file` and `sync_runtime_auth_file` commands
- keep ordinary remote devices restricted to the existing directory command allowlist
- add regression coverage for cloud auth import/sync and remote-device rejection

## Why

Remote workspace routing introduced a shared cloud/remote command allowlist that only included directory operations. The Codex auth UI still offered online cloud devices, so importing or syncing `auth.json` failed with `Device command key ... is not supported for cloud devices`.

## Impact

Cloud devices can again import and receive Codex `auth.json` through the existing validated command implementations. No additional commands are exposed to ordinary remote devices.

## Validation

- `uv run black --check app/services/device/command_service.py tests/services/test_local_device_command_service.py`
- `uv run pytest tests/services/test_local_device_command_service.py tests/services/test_user_runtime_config_service.py` (93 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud devices can now run supported runtime authentication file commands.
  * Command results are processed and routed correctly, with required environment details and execution limits applied.

* **Bug Fixes**
  * Prevented remote devices from running cloud-only authentication commands.
  * Invalid commands are rejected before device lookup or dispatch, improving validation and avoiding unnecessary device operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->