### PR TITLE
fix(wework): mark synced model catalogs ready

### DIFF
--- a/docs/en/architecture/README.md
+++ b/docs/en/architecture/README.md
@@ -6,10 +6,11 @@ sidebar_position: 1
 
 Before changing a flow below, update its connection graph, sequence diagram, code ownership, and essential invariants, confirm that the path is complete, and only then change code. Keep one independently maintained file per topic; add one file and one catalog row for a new governed flow.
 
-| Logic                                        | Architecture file                                        | Change scope                                                                                     |
-| -------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Board automation and Wegent execution        | [board-automation.md](board-automation.md)               | Assignment, execution truth, runtime activation, continuation, cancellation, terminal projection |
-| Embedded-browser navigation and tabs         | [embedded-browser.md](embedded-browser.md)               | Bridge routing, pending open, WebView lifecycle, navigation completion, multi-tab E2E            |
-| Project execution state and Runtime capacity | [project-execution-state.md](project-execution-state.md) | Claim, event ordering, cancellation, retry, lease, concurrency capacity, UI projection           |
+| Logic                                        | Architecture file                                              | Change scope                                                                                     |
+| -------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Board automation and Wegent execution        | [board-automation.md](board-automation.md)                     | Assignment, execution truth, runtime activation, continuation, cancellation, terminal projection |
+| Embedded-browser navigation and tabs         | [embedded-browser.md](embedded-browser.md)                     | Bridge routing, pending open, WebView lifecycle, navigation completion, multi-tab E2E            |
+| Project execution state and Runtime capacity | [project-execution-state.md](project-execution-state.md)       | Claim, event ordering, cancellation, retry, lease, concurrency capacity, UI projection           |
+| Runtime model catalog synchronization        | [runtime-model-catalog-sync.md](runtime-model-catalog-sync.md) | Catalog write, Codex restart, model verification, ready state, task creation                     |
 
 Detailed product prose remains in the existing developer guides. This directory contains only reviewable architecture truth.

--- a/docs/en/architecture/runtime-model-catalog-sync.md
+++ b/docs/en/architecture/runtime-model-catalog-sync.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 40
+---
+
+# Runtime model catalog synchronization
+
+Scope: Wework synchronizes locally configured models into the target device's Codex catalog and immediately creates a Runtime task after synchronization.
+
+```mermaid
+flowchart LR
+    SEND[Workbench send] --> PREPARE[prepareRuntimeModel]
+    PREPARE --> CONFIG[(local model configuration)]
+    PREPARE --> CONFIRM[user confirmation]
+    CONFIRM --> WRITE[runtime.codex.catalog.custom.write]
+    WRITE --> RESTART[runtime.codex.app_server.restart]
+    RESTART --> LIST[runtime.codex.models.list]
+    LIST --> VERIFY[verify target model]
+    VERIFY --> READY[markLocalModelCatalogReady]
+    READY --> CREATE[build payload and create Runtime task]
+```
+
+```mermaid
+sequenceDiagram
+    participant W as Workbench
+    participant L as Local runtime API
+    participant D as Target device Executor
+    participant C as Codex App Server
+    participant S as Local model configuration
+
+    W->>L: prepareRuntimeModel(deviceId, modelId)
+    L->>W: request synchronization confirmation
+    W->>L: confirm + sync
+    L->>D: catalog.custom.write(full catalog)
+    L->>D: app_server.restart(ifIdle)
+    D->>C: restart and load catalog
+    L->>D: models.list(includeHidden)
+    D-->>L: loaded models
+    L->>L: verify target model exists
+    L->>S: mark the written snapshot ready
+    L-->>W: prepared = true
+    W->>L: createRuntimeTask
+    L->>S: read ready model configuration
+    L->>D: runtime.tasks.create
+```
+
+| Edge                                         | Code owner                                                      |
+| -------------------------------------------- | --------------------------------------------------------------- |
+| Model preparation before Workbench send      | `wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts` |
+| Catalog write, restart, verification, create | `wework/src/api/local/localServices.ts`                         |
+| Model configuration versions and ready state | `wework/src/features/model-settings/localModelSettings.ts`      |
+| Cloud-device Runtime RPC forwarding          | `backend/app/services/device/runtime_rpc_service.py`            |
+| Real-desktop protocol-matrix regression      | `wework/e2e/desktop/modules/desktop-build-flows.mjs`            |
+
+Invariants: catalog synchronization is serialized per device and deduplicated by catalog version; the written snapshot becomes ready only after the catalog write succeeds, Codex restarts successfully, and the target model is queryable; ready updates use `id + updatedAt` and must not overwrite configuration created during synchronization; task payloads may use only ready local models; synchronization failure or cancellation must not create a Runtime task.

--- a/docs/zh/architecture/README.md
+++ b/docs/zh/architecture/README.md
@@ -6,10 +6,11 @@ sidebar_position: 1
 
 修改下表逻辑前，先更新对应连线图、时序图、代码归属和必要不变量，确认逻辑闭环后再改代码。每个主题独立维护；新增受约束逻辑时增加一个文件和一行索引。
 
-| 逻辑                        | 架构文件                                                 | 修改范围                                                          |
-| --------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------- |
-| 看板自动化与 Wegent 执行    | [board-automation.md](board-automation.md)               | 指派、执行真值、runtime 激活、续聊、取消、终态投影                |
-| 内置浏览器导航与多标签      | [embedded-browser.md](embedded-browser.md)               | bridge 路由、pending open、WebView 生命周期、导航完成、多标签 E2E |
-| 项目执行状态与 Runtime 容量 | [project-execution-state.md](project-execution-state.md) | claim、事件顺序、取消、重试、lease、并发容量、UI 投影             |
+| 逻辑                        | 架构文件                                                       | 修改范围                                                          |
+| --------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| 看板自动化与 Wegent 执行    | [board-automation.md](board-automation.md)                     | 指派、执行真值、runtime 激活、续聊、取消、终态投影                |
+| 内置浏览器导航与多标签      | [embedded-browser.md](embedded-browser.md)                     | bridge 路由、pending open、WebView 生命周期、导航完成、多标签 E2E |
+| 项目执行状态与 Runtime 容量 | [project-execution-state.md](project-execution-state.md)       | claim、事件顺序、取消、重试、lease、并发容量、UI 投影             |
+| Runtime 模型目录同步        | [runtime-model-catalog-sync.md](runtime-model-catalog-sync.md) | 目录写入、Codex 重启、模型验证、ready 状态、任务创建              |
 
 详细产品说明继续放在原开发指南；本目录只保存可评审的架构真值。

--- a/docs/zh/architecture/runtime-model-catalog-sync.md
+++ b/docs/zh/architecture/runtime-model-catalog-sync.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 40
+---
+
+# Runtime 模型目录同步
+
+范围：Wework 将本地配置的模型同步到目标设备的 Codex 目录，并在同步完成后立即创建 Runtime 任务。
+
+```mermaid
+flowchart LR
+    SEND[Workbench 发送] --> PREPARE[prepareRuntimeModel]
+    PREPARE --> CONFIG[(本地模型配置)]
+    PREPARE --> CONFIRM[用户确认]
+    CONFIRM --> WRITE[runtime.codex.catalog.custom.write]
+    WRITE --> RESTART[runtime.codex.app_server.restart]
+    RESTART --> LIST[runtime.codex.models.list]
+    LIST --> VERIFY[验证目标模型]
+    VERIFY --> READY[markLocalModelCatalogReady]
+    READY --> CREATE[构建 payload 并创建 Runtime 任务]
+```
+
+```mermaid
+sequenceDiagram
+    participant W as Workbench
+    participant L as Local runtime API
+    participant D as 目标设备 Executor
+    participant C as Codex App Server
+    participant S as 本地模型配置
+
+    W->>L: prepareRuntimeModel(deviceId, modelId)
+    L->>W: 请求同步确认
+    W->>L: confirm + sync
+    L->>D: catalog.custom.write(完整目录)
+    L->>D: app_server.restart(ifIdle)
+    D->>C: 重启并加载目录
+    L->>D: models.list(includeHidden)
+    D-->>L: 已加载模型
+    L->>L: 验证目标模型存在
+    L->>S: 标记本次写入快照 ready
+    L-->>W: prepared = true
+    W->>L: createRuntimeTask
+    L->>S: 读取 ready 模型配置
+    L->>D: runtime.tasks.create
+```
+
+| 边                             | 代码归属                                                        |
+| ------------------------------ | --------------------------------------------------------------- |
+| Workbench 发送前模型准备       | `wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts` |
+| 目录写入、重启、验证和任务创建 | `wework/src/api/local/localServices.ts`                         |
+| 模型配置版本与 ready 状态      | `wework/src/features/model-settings/localModelSettings.ts`      |
+| 云设备 Runtime RPC 转发        | `backend/app/services/device/runtime_rpc_service.py`            |
+| 真实桌面协议矩阵回归           | `wework/e2e/desktop/modules/desktop-build-flows.mjs`            |
+
+不变量：模型目录按设备串行同步并按目录版本去重；只有目录写入成功、Codex 重启成功且目标模型可查询后，当前写入快照才能标记为 ready；ready 更新必须使用 `id + updatedAt`，不得覆盖同步期间产生的新配置；任务 payload 只能读取已 ready 的本地模型；同步失败或取消时不得创建 Runtime 任务。

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -3,6 +3,7 @@ import { getLocalUser, LOCAL_USER } from './localSession'
 import { createLocalAppServices, createRuntimeWorkApiFromIpc } from './localServices'
 import {
   clearLocalModelConfigs,
+  listLocalModelConfigs,
   saveLocalModelConfig,
 } from '@/features/model-settings/localModelSettings'
 import { saveLocalProxyUrl } from '@/features/model-settings/localProxySettings'
@@ -1569,7 +1570,7 @@ describe('createLocalAppServices', () => {
       modelId: 'qwen3-coder',
       baseUrl: 'http://localhost:11434/v1',
       apiKey: 'cloud-device-key',
-      catalogReady: true,
+      catalogReady: false,
     })
     const request = vi.fn().mockImplementation(async (method: string) => {
       if (method === 'runtime.codex.app_server.restart') return { restarted: true }
@@ -1654,6 +1655,7 @@ describe('createLocalAppServices', () => {
     expect(request).toHaveBeenCalledWith('runtime.tasks.create', expect.any(Object), 'cloud-device')
     expect(request).toHaveBeenCalledWith('runtime.tasks.send', expect.any(Object), 'cloud-device')
     expect(requestModelCatalogSync).toHaveBeenCalledTimes(1)
+    expect(listLocalModelConfigs()[0].catalogReady).toBe(true)
   })
 
   test('synchronizes the same configured catalog independently for each cloud device', async () => {

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -2238,6 +2238,7 @@ export function createRuntimeWorkApiFromIpc(
           if (!expectedModelAvailable) {
             throw new Error(i18n.t('workbench.cloud_model_catalog_sync_verify_failed'))
           }
+          markLocalModelCatalogReady(currentCatalogModels)
           appliedCatalogKey = currentCatalogKey
           syncedModelCatalogKeys.add(currentDeviceCatalogKey)
         })


### PR DESCRIPTION
## What

- Mark the exact local model catalog snapshot ready after catalog write, Codex restart, and model verification succeed.
- Extend the local runtime regression test to start from `catalogReady: false` and assert immediate task create/send succeeds.
- Document the runtime model catalog synchronization flow and invariants in Chinese and English architecture docs.

## Why

The cloud desktop E2E could successfully write and verify a custom model catalog, but the local configuration still remained not ready. Immediate runtime task payload construction then failed with the restart-required guard before any task thread was created, leaving the E2E waiting until timeout.

## Verification

- `pnpm --filter wework test src/api/local/localServices.test.ts` — 55 passed
- Wework pre-push ESLint, TypeScript, and unit tests — passed
- Prettier and `git diff --check` — passed
- `pnpm --filter wework e2e:desktop:cloud -- --segment model-routing` — all 9 cloud model-routing protocol cases passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local model catalogs are now marked ready after successful cloud model synchronization and verification.
* **Documentation**
  * Added architecture documentation describing Runtime model catalog synchronization, including preparation, confirmation, verification, restart, and task creation.
  * Documented synchronization safeguards such as serialization, version deduplication, ready-state handling, and failure behavior in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->