### PR TITLE
test(wework): wait for experimental toggle readiness

### DIFF
--- a/wework/e2e/desktop/modules/preferences-automation-flows.mjs
+++ b/wework/e2e/desktop/modules/preferences-automation-flows.mjs
@@ -195,7 +195,9 @@ async function ensureExperimentalFeaturesEnabled(control) {
   if (
     (await control.command('getAttribute', toggleSelector, { value: 'aria-checked' })) !== 'true'
   ) {
-    await control.command('click', toggleSelector)
+    await control.command('clickWhenEnabled', toggleSelector, {
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
     await waitForAttribute(
       control,
       toggleSelector,

--- a/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
@@ -177,7 +177,11 @@ async function configureClaude(control, executablePath, version, timeoutMs) {
   await control.command('click', '[data-testid="settings-menu-button"]')
   const snapshot = JSON.parse(await control.command('snapshot', 'body'))
   if (!snapshot.testIds.includes('settings-nav-harnesses')) {
-    await control.command('click', '[data-testid="general-experimental-features-toggle"]')
+    await control.command(
+      'clickWhenEnabled',
+      '[data-testid="general-experimental-features-toggle"]',
+      { timeoutMs }
+    )
     await control.command('waitFor', '[data-testid="settings-nav-harnesses"]', { timeoutMs })
   }
   await control.command('click', '[data-testid="settings-nav-harnesses"]')

--- a/wework/e2e/desktop/scenarios/local-terminal.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/local-terminal.scenario.mjs
@@ -258,7 +258,11 @@ async function configureHarnesses(control, executables, timeoutMs, capturePage) 
   await control.command('click', '[data-testid="settings-menu-button"]')
   const settingsSnapshot = JSON.parse(await control.command('snapshot', 'body'))
   if (!settingsSnapshot.testIds.includes('settings-nav-harnesses')) {
-    await control.command('click', '[data-testid="general-experimental-features-toggle"]')
+    await control.command(
+      'clickWhenEnabled',
+      '[data-testid="general-experimental-features-toggle"]',
+      { timeoutMs }
+    )
     await control.command('waitFor', '[data-testid="settings-nav-harnesses"]', { timeoutMs })
   }
   await control.command('click', '[data-testid="settings-nav-harnesses"]')


### PR DESCRIPTION
## What changed

- wait for the experimental-features toggle to become enabled before clicking it
- apply the same readiness synchronization to the shared preferences flow, Claude runtime scenario, and local harness scenario

## Root cause

The General settings page renders the toggle before `getAppPreferences()` and runtime settings finish loading. During that interval the product correctly disables preference controls, but the desktop E2E scenarios used an immediate `click` command. GitHub Actions reached that interval and failed with:

`Selector "[data-testid="general-experimental-features-toggle"]" is disabled`

The scenarios now use the existing `clickWhenEnabled` control command and retain the normal checkpoint timeout.

## Impact

This changes E2E synchronization only. Product behavior, selectors, and assertions are unchanged.

## Verification

- `pnpm --filter wework e2e:desktop -- --segment claude-runtime` — passed
- Wework pre-push ESLint — passed
- Wework pre-push TypeScript — passed
- Wework pre-push unit tests — passed
- Prettier and `node --check` for all changed files — passed

The `local-harness` verification progressed beyond the changed toggle step, then hit a separate missing Kimi model-option failure. That checkpoint passed in the referenced GitHub Actions baseline and the later failure is outside this PR's scope.

Fixes the failure observed in GitHub Actions run 32026038482, Core shard 2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated setup for experimental features by waiting until the toggle is ready before activating it.
  * Increased reliability of desktop scenarios covering Claude runtime and local terminal workflows.
  * Reduced potential test failures caused by attempting to interact with controls before they are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->