### PR TITLE
fix(resource-library): label team-shared skills

### DIFF
--- a/backend/app/api/endpoints/kind/skills.py
+++ b/backend/app/api/endpoints/kind/skills.py
@@ -1238,15 +1238,16 @@ def list_unified_skills(
     user_default_skill_ids = skill_binding_service.list_user_default_skill_ids(
         db, current_user.id
     )
-    user_groups = get_user_groups(db, current_user.id)
-    group_namespaces = [group for group in user_groups if group != "default"]
-    group_shared_skill_ids = (
-        skill_binding_service.list_group_skill_ids_for_authorized_namespaces(
-            db, group_namespaces
+    group_namespaces: list[str] = []
+    group_shared_skill_ids: set[int] = set()
+    if scope != "group" or not group_name:
+        user_groups = get_user_groups(db, current_user.id)
+        group_namespaces = [group for group in user_groups if group != "default"]
+        group_shared_skill_ids = (
+            skill_binding_service.list_group_skill_ids_for_authorized_namespaces(
+                db, group_namespaces
+            )
         )
-        if scope in {"personal", "all"} or (scope == "group" and not group_name)
-        else set()
-    )
     bound_skill_ids = (
         set(user_default_skill_ids) if scope in {"personal", "all"} else set()
     )

--- a/backend/app/api/endpoints/kind/skills.py
+++ b/backend/app/api/endpoints/kind/skills.py
@@ -339,6 +339,7 @@ class UnifiedSkillResponse(BaseModel):
     is_active: bool
     is_public: bool
     user_id: int  # ID of the user who uploaded this skill
+    is_group_shared: bool = False
     publication_status: Optional[str] = None
     availability: SkillAvailability = Field(default_factory=SkillAvailability)
     source: Optional[SkillSourceResponse] = (
@@ -1237,6 +1238,15 @@ def list_unified_skills(
     user_default_skill_ids = skill_binding_service.list_user_default_skill_ids(
         db, current_user.id
     )
+    user_groups = get_user_groups(db, current_user.id)
+    group_namespaces = [group for group in user_groups if group != "default"]
+    group_shared_skill_ids = (
+        skill_binding_service.list_group_skill_ids_for_authorized_namespaces(
+            db, group_namespaces
+        )
+        if scope in {"personal", "all"} or (scope == "group" and not group_name)
+        else set()
+    )
     bound_skill_ids = (
         set(user_default_skill_ids) if scope in {"personal", "all"} else set()
     )
@@ -1277,17 +1287,14 @@ def list_unified_skills(
                 .order_by(Kind.created_at.desc())
                 .all()
             )
-            bound_skill_ids.update(
-                skill_binding_service.list_group_skill_ids(
-                    db,
-                    group_name,
-                    current_user.id,
+            group_shared_skill_ids = (
+                skill_binding_service.list_group_skill_ids_for_authorized_namespaces(
+                    db, [group_name]
                 )
             )
+            bound_skill_ids.update(group_shared_skill_ids)
         else:
             # Query all user's groups (excluding default)
-            user_groups = get_user_groups(db, current_user.id)
-            group_namespaces = [g for g in user_groups if g != "default"]
             if group_namespaces:
                 skill_kinds = (
                     db.query(Kind)
@@ -1301,19 +1308,9 @@ def list_unified_skills(
                 )
             else:
                 skill_kinds = []
-            for group_namespace in group_namespaces:
-                bound_skill_ids.update(
-                    skill_binding_service.list_group_skill_ids(
-                        db,
-                        group_namespace,
-                        current_user.id,
-                    )
-                )
+            bound_skill_ids.update(group_shared_skill_ids)
     else:  # scope == "all"
         # Query personal + all user's groups in a single query
-        user_groups = get_user_groups(db, current_user.id)
-        group_namespaces = [g for g in user_groups if g != "default"]
-
         # Build OR conditions for optimized single query
         conditions = [
             # Personal skills in default namespace
@@ -1334,14 +1331,7 @@ def list_unified_skills(
             .order_by(Kind.created_at.desc())
             .all()
         )
-        for group_namespace in group_namespaces:
-            bound_skill_ids.update(
-                skill_binding_service.list_group_skill_ids(
-                    db,
-                    group_namespace,
-                    current_user.id,
-                )
-            )
+        bound_skill_ids.update(group_shared_skill_ids)
 
     direct_skill_ids = {skill.id for skill in skill_kinds}
     missing_bound_skill_ids = bound_skill_ids - direct_skill_ids
@@ -1393,6 +1383,7 @@ def list_unified_skills(
                     "is_active": True,
                     "is_public": False,
                     "user_id": kind.user_id,
+                    "is_group_shared": kind.id in group_shared_skill_ids,
                     "publication_status": capability.get("publishStatus"),
                     "availability": {
                         "in_my_default": kind.id in user_default_skill_ids,
@@ -1437,6 +1428,7 @@ def list_unified_skills(
                     "is_active": True,
                     "is_public": True,
                     "user_id": kind.user_id,
+                    "is_group_shared": kind.id in group_shared_skill_ids,
                     "publication_status": capability.get("publishStatus"),
                     "availability": {
                         "in_my_default": kind.id in user_default_skill_ids,

--- a/backend/app/services/skill_binding_service.py
+++ b/backend/app/services/skill_binding_service.py
@@ -240,7 +240,7 @@ class SkillBindingService:
             .filter(
                 Kind.kind == SKILL_BINDING_KIND,
                 Kind.namespace.in_(group_namespaces),
-                Kind.is_active == True,
+                Kind.is_active,
             )
             .all()
         )
@@ -259,7 +259,7 @@ class SkillBindingService:
             .filter(
                 Kind.id.in_(skill_ids),
                 Kind.kind == "Skill",
-                Kind.is_active == True,
+                Kind.is_active,
             )
             .all()
         }

--- a/backend/app/services/skill_binding_service.py
+++ b/backend/app/services/skill_binding_service.py
@@ -219,13 +219,50 @@ class SkillBindingService:
         self, db: Session, group_namespace: str, user_id: int
     ) -> set[int]:
         """Return active Skill ids installed in a group."""
-        skill_ids: set[int] = set()
-        for binding in self.list_group_bindings(db, group_namespace, user_id):
-            skill_id = self._extract_skill_id(binding)
-            if skill_id is None or not self._get_active_skill(db, skill_id):
-                continue
-            skill_ids.add(skill_id)
-        return skill_ids
+        role = get_effective_role_in_group(db, user_id, group_namespace)
+        if not role or not has_permission(role, GroupRole.Reporter):
+            return set()
+        return self.list_group_skill_ids_for_authorized_namespaces(
+            db, [group_namespace]
+        )
+
+    def list_group_skill_ids_for_authorized_namespaces(
+        self,
+        db: Session,
+        group_namespaces: list[str],
+    ) -> set[int]:
+        """Return active Skill ids bound to already-authorized groups."""
+        if not group_namespaces:
+            return set()
+
+        bindings = (
+            db.query(Kind)
+            .filter(
+                Kind.kind == SKILL_BINDING_KIND,
+                Kind.namespace.in_(group_namespaces),
+                Kind.is_active == True,
+            )
+            .all()
+        )
+        skill_ids = {
+            skill_id
+            for binding in bindings
+            if self._is_group_binding(binding, binding.namespace)
+            if (skill_id := self._extract_skill_id(binding)) is not None
+        }
+        if not skill_ids:
+            return set()
+
+        return {
+            skill_id
+            for (skill_id,) in db.query(Kind.id)
+            .filter(
+                Kind.id.in_(skill_ids),
+                Kind.kind == "Skill",
+                Kind.is_active == True,
+            )
+            .all()
+        }
 
     def is_skill_available_to_group(
         self,

--- a/backend/tests/api/test_skills_api.py
+++ b/backend/tests/api/test_skills_api.py
@@ -1538,6 +1538,7 @@ tags: ["public", "api", "test"]
             assert len(matching) == 1
             assert matching[0]["id"] == skill.id
             assert matching[0]["namespace"] == skill.namespace
+            assert matching[0]["is_group_shared"] is True
             assert matching[0]["publication_status"] == "published"
 
         remove_response = test_client.delete(
@@ -1559,6 +1560,15 @@ tags: ["public", "api", "test"]
         )
         assert all(item["id"] != skill.id for item in removed_group_response.json())
         assert any(item["id"] == skill.id for item in retained_group_response.json())
+
+        all_response = test_client.get(
+            "/api/v1/kinds/skills/unified",
+            params={"scope": "all"},
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+        all_matching = [item for item in all_response.json() if item["id"] == skill.id]
+        assert len(all_matching) == 1
+        assert all_matching[0]["is_group_shared"] is True
 
     def test_unified_skills_keep_personal_and_group_skills_with_same_name(
         self,

--- a/frontend/e2e/tests/tasks/provider-native-chat.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-chat.spec.ts
@@ -508,7 +508,7 @@ test.describe('Provider-native Wegent knowledge access', () => {
   ): Promise<number> {
     await knowledgePage.sendMessage(prompt)
     const taskId = await knowledgePage.waitForTaskId()
-    await waitForTaskTerminal(request, token, taskId)
+    await waitForTaskTerminal(token, taskId)
     await expect(page.getByTestId('send-button')).toBeVisible({ timeout: 30000 })
     return taskId
   }

--- a/frontend/e2e/tests/tasks/provider-native-chat.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-chat.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../../fixtures/provider-native-knowledge'
 import { ProviderNativeKnowledgePage } from '../../pages/tasks/provider-native-knowledge.page'
 import { ApiClient, createApiClient } from '../../utils/api-client'
+import { waitForTaskTerminal } from '../../utils/provider-native-test-support'
 
 const API_BASE_URL = process.env.E2E_API_URL || 'http://localhost:8000'
 const MOCK_MODEL_SERVER_URL = process.env.MOCK_MODEL_SERVER_URL || 'http://localhost:9999'
@@ -20,10 +21,6 @@ const LIST_DOCUMENTS_TOOL = 'wegent_kb_list_documents'
 const READ_DOCUMENT_TOOL = 'wegent_kb_read_document_content'
 const SEARCH_KNOWLEDGE_BASE_TOOL = 'wegent_kb_search_knowledge_base'
 const WEGENT_SKILL_HEADING = '# Wegent Knowledge Base Skill'
-
-interface RuntimeCheckResponse {
-  task_status: string
-}
 
 interface RecordedToolCall {
   id: string
@@ -511,29 +508,9 @@ test.describe('Provider-native Wegent knowledge access', () => {
   ): Promise<number> {
     await knowledgePage.sendMessage(prompt)
     const taskId = await knowledgePage.waitForTaskId()
-    await waitForBackendTerminal(request, taskId)
+    await waitForTaskTerminal(request, token, taskId)
     await expect(page.getByTestId('send-button')).toBeVisible({ timeout: 30000 })
     return taskId
-  }
-
-  async function waitForBackendTerminal(request: APIRequestContext, taskId: number): Promise<void> {
-    const deadline = Date.now() + 60000
-    let status = 'UNKNOWN'
-    while (Date.now() < deadline) {
-      const response = await request.get(`${API_BASE_URL}/api/tasks/${taskId}/runtime-check`, {
-        headers: authHeaders(),
-      })
-      status =
-        response.status() === 200
-          ? ((await response.json()) as RuntimeCheckResponse).task_status.toUpperCase()
-          : `HTTP_${response.status()}`
-      if (status.startsWith('COMPLETED')) return
-      if (status.startsWith('FAILED') || status.startsWith('CANCELLED')) {
-        throw new Error(`Task ${taskId} reached terminal status ${status}`)
-      }
-      await new Promise(resolve => setTimeout(resolve, 500))
-    }
-    expect(status, `Task ${taskId} should complete`).toMatch(/^COMPLETED/)
   }
 
   async function collectEvidence(request: APIRequestContext, taskId: number, prompt: string) {

--- a/frontend/e2e/tests/tasks/provider-native-claudecode.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-claudecode.spec.ts
@@ -96,7 +96,7 @@ test.describe('Provider-native ClaudeCode access', () => {
     const taskId = await knowledge.waitForTaskId()
     const dispatchedTask = await getTask(request, resources.token, taskId)
     expect((dispatchedTask as { model_id?: string }).model_id).toBe(CLAUDE_MODEL_NAME)
-    await waitForTaskTerminal(request, resources.token, taskId)
+    await waitForTaskTerminal(resources.token, taskId)
     const task = await getTask(request, resources.token, taskId)
     const bodies = await getScenarioModelBodies(request, prompt)
     const requestText = modelRequestText(bodies)
@@ -143,7 +143,7 @@ test.describe('Provider-native ClaudeCode access', () => {
     await knowledge.selectDingTalkDocuments(['doc-d1'])
     await knowledge.sendMessage(prompt)
     const taskId = await knowledge.waitForTaskId()
-    await waitForTaskTerminal(request, resources.token, taskId)
+    await waitForTaskTerminal(resources.token, taskId)
     const task = await getTask(request, resources.token, taskId)
     const requestText = modelRequestText(await getScenarioModelBodies(request, prompt))
 

--- a/frontend/e2e/tests/tasks/provider-native-dingtalk.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-dingtalk.spec.ts
@@ -522,7 +522,7 @@ test.describe('Provider-native DingTalk and multi-provider access', () => {
     await select(knowledge)
     await knowledge.sendMessage(prompt)
     const taskId = await knowledge.waitForTaskId()
-    await waitForTaskTerminal(request, resources.token, taskId)
+    await waitForTaskTerminal(resources.token, taskId)
     await expect(page.getByTestId('send-button')).toBeVisible({ timeout: 30_000 })
     return getTask(request, resources.token, taskId)
   }

--- a/frontend/e2e/tests/tasks/provider-native-state-and-contract.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-state-and-contract.spec.ts
@@ -154,7 +154,7 @@ test.describe('Provider-native binding state and contracts', () => {
     await knowledge.selectDingTalkDocuments(['doc-d1'])
     await knowledge.sendMessage(firstPrompt)
     const taskId = await knowledge.waitForTaskId()
-    await waitForTaskTerminal(request, resources.token, taskId)
+    await waitForTaskTerminal(resources.token, taskId)
 
     const beforeResponse = await request.get(
       `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/external-knowledge-refs`,
@@ -207,7 +207,7 @@ test.describe('Provider-native binding state and contracts', () => {
     )
     await knowledge.sendMessage(firstPrompt)
     const taskId = await knowledge.waitForTaskId()
-    await waitForTaskTerminal(request, resources.token, taskId)
+    await waitForTaskTerminal(resources.token, taskId)
 
     const secondPrompt = makePrompt('016-second', '所选文档的核心设计第 5 点是什么？')
     await scenario(request, secondPrompt, [
@@ -445,7 +445,7 @@ test.describe('Provider-native binding state and contracts', () => {
     await knowledge.sendMessage(prompt)
     const taskId = await knowledge.waitForTaskId()
     if (expectedTaskId) expect(taskId).toBe(expectedTaskId)
-    await waitForTaskTerminal(request, resources.token, taskId)
+    await waitForTaskTerminal(resources.token, taskId)
     return getTask(request, resources.token, taskId)
   }
 })

--- a/frontend/e2e/utils/provider-native-test-support.ts
+++ b/frontend/e2e/utils/provider-native-test-support.ts
@@ -278,14 +278,18 @@ export async function waitForTaskTerminal(
   await expect
     .poll(
       async () => {
-        const response = await request.get(
-          `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/runtime-check`,
-          { headers: authHeaders(token) }
-        )
-        if (response.status() !== 200) return `HTTP_${response.status()}`
-        const body = (await response.json()) as { task_status: string }
-        finalStatus = body.task_status.toUpperCase()
-        return finalStatus
+        try {
+          const response = await request.get(
+            `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/runtime-check`,
+            { headers: authHeaders(token) }
+          )
+          if (response.status() !== 200) return `HTTP_${response.status()}`
+          const body = (await response.json()) as { task_status: string }
+          finalStatus = body.task_status.toUpperCase()
+          return finalStatus
+        } catch (error) {
+          return `NETWORK_ERROR_${error instanceof Error ? error.message : String(error)}`
+        }
       },
       { timeout: 60_000, message: `Task ${taskId} should reach ${expected}` }
     )

--- a/frontend/e2e/utils/provider-native-test-support.ts
+++ b/frontend/e2e/utils/provider-native-test-support.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, expect, Page } from '@playwright/test'
+import { APIRequestContext, expect, Page, request as playwrightRequest } from '@playwright/test'
 import { ADMIN_USER } from '../config/test-users'
 import {
   createProviderNativeKnowledgeFixture,
@@ -269,32 +269,33 @@ export async function getMcpCalls(request: APIRequestContext): Promise<RecordedP
 }
 
 export async function waitForTaskTerminal(
-  request: APIRequestContext,
   token: string,
   taskId: number,
   expected: RegExp = /^COMPLETED/
 ): Promise<string> {
+  const runtimeRequest = await playwrightRequest.newContext({
+    extraHTTPHeaders: authHeaders(token),
+  })
   let finalStatus = ''
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await request.get(
-            `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/runtime-check`,
-            { headers: authHeaders(token) }
+  try {
+    await expect
+      .poll(
+        async () => {
+          const response = await runtimeRequest.get(
+            `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/runtime-check`
           )
           if (response.status() !== 200) return `HTTP_${response.status()}`
           const body = (await response.json()) as { task_status: string }
           finalStatus = body.task_status.toUpperCase()
           return finalStatus
-        } catch (error) {
-          return `NETWORK_ERROR_${error instanceof Error ? error.message : String(error)}`
-        }
-      },
-      { timeout: 60_000, message: `Task ${taskId} should reach ${expected}` }
-    )
-    .toMatch(expected)
-  return finalStatus
+        },
+        { timeout: 60_000, message: `Task ${taskId} should reach ${expected}` }
+      )
+      .toMatch(expected)
+    return finalStatus
+  } finally {
+    await runtimeRequest.dispose()
+  }
 }
 
 export async function getTask(request: APIRequestContext, token: string, taskId: number) {

--- a/frontend/src/__tests__/features/settings/components/SkillListWithScope.default-enabled.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/SkillListWithScope.default-enabled.test.tsx
@@ -223,6 +223,7 @@ function buildSkill(overrides: Partial<UnifiedSkill>): UnifiedSkill {
     is_active: overrides.is_active ?? true,
     is_public: overrides.is_public ?? false,
     user_id: overrides.user_id ?? 1,
+    is_group_shared: overrides.is_group_shared,
     publication_status: overrides.publication_status,
     availability: overrides.availability,
     source: overrides.source,
@@ -424,6 +425,24 @@ describe('SkillListWithScope default enabled skills', () => {
     )
     const privateCard = screen.getByTestId('skill-library-item-8')
     expect(within(privateCard).queryByTestId('published-skill-8-indicator')).toBeNull()
+  })
+
+  it('labels a personal source Skill shared by binding as a team Skill', async () => {
+    mockedFetchUnifiedSkillsList.mockResolvedValue([
+      buildSkill({
+        id: 9,
+        name: 'team-shared-skill',
+        displayName: 'Team Shared Skill',
+        namespace: 'default',
+        is_group_shared: true,
+      }),
+    ])
+
+    render(<SkillListWithScope scope="all" compact />)
+
+    const card = await screen.findByTestId('skill-library-item-9')
+    expect(within(card).getByText('团队技能')).toBeInTheDocument()
+    expect(within(card).queryByText('我的技能')).toBeNull()
   })
 
   it('notifies the resource library when an external skill creation is cancelled', async () => {

--- a/frontend/src/__tests__/features/settings/components/SkillListWithScope.default-enabled.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/SkillListWithScope.default-enabled.test.tsx
@@ -438,11 +438,15 @@ describe('SkillListWithScope default enabled skills', () => {
       }),
     ])
 
-    render(<SkillListWithScope scope="all" compact />)
+    const { rerender } = render(<SkillListWithScope scope="all" sourceFilter="group" compact />)
 
     const card = await screen.findByTestId('skill-library-item-9')
     expect(within(card).getByText('团队技能')).toBeInTheDocument()
     expect(within(card).queryByText('我的技能')).toBeNull()
+
+    rerender(<SkillListWithScope scope="all" sourceFilter="personal" compact />)
+
+    expect(screen.queryByTestId('skill-library-item-9')).not.toBeInTheDocument()
   })
 
   it('notifies the resource library when an external skill creation is cancelled', async () => {

--- a/frontend/src/apis/skills.ts
+++ b/frontend/src/apis/skills.ts
@@ -325,6 +325,7 @@ export interface UnifiedSkill {
   is_active: boolean
   is_public: boolean
   user_id: number // ID of the user who uploaded this skill
+  is_group_shared?: boolean
   publication_status?: 'published' | 'archived'
   availability?: SkillAvailability
   /** Source information for git-imported skills */

--- a/frontend/src/features/settings/components/SkillListWithScope.tsx
+++ b/frontend/src/features/settings/components/SkillListWithScope.tsx
@@ -317,23 +317,24 @@ export function SkillListWithScope({
     return scope === 'group' && !!currentGroup?.my_role && canDelete(currentGroup.my_role)
   }
 
+  const isGroupSkill = useCallback(
+    (skill: UnifiedSkill) =>
+      !isSystemSkill(skill) &&
+      (Boolean(skill.namespace && skill.namespace !== 'default') || Boolean(skill.is_group_shared)),
+    []
+  )
+
   const getSkillSourceLabel = (skill: UnifiedSkill): string => {
     if (isSystemSkill(skill)) return tSettings('skills.source.system')
-    if (skill.namespace && skill.namespace !== 'default') return tSettings('skills.source.group')
+    if (isGroupSkill(skill)) return tSettings('skills.source.group')
     if (user && skill.user_id === user.id) return tSettings('skills.source.personal')
     return tSettings('skills.source.library')
   }
 
-  const isGroupSkill = useCallback(
-    (skill: UnifiedSkill) =>
-      !isSystemSkill(skill) && Boolean(skill.namespace && skill.namespace !== 'default'),
-    []
-  )
-
   const matchesSourceFilter = useCallback(
     (skill: UnifiedSkill): boolean => {
       if (sourceFilter === 'personal') {
-        return !isSystemSkill(skill) && skill.namespace === 'default'
+        return !isSystemSkill(skill) && !isGroupSkill(skill)
       }
       if (sourceFilter === 'group') {
         return isGroupSkill(skill)


### PR DESCRIPTION
## What changed

- expose whether a skill is shared to an accessible team through a group binding
- reuse the existing “Team Skill” source label and source filter for team-shared personal skills
- batch-load group skill bindings to avoid per-team and per-skill N+1 queries
- add backend and frontend regression coverage

## Why

Skills created in the personal namespace and shared to teams remained labeled as personal skills because the UI only checked the namespace. The sharing relation is stored as a SkillBinding, so the unified skills response now exposes that effective team scope.

## User impact

A skill shared to any team is consistently shown and filtered as a Team Skill, regardless of whether the underlying source remains in the personal namespace.

## Validation

- `uv run pytest tests/services/test_skill_binding_service.py tests/api/test_skills_api.py -k "skill_binding or unified_group_skills_include_installed_skill_bindings"`
- `pnpm test -- --runInBand src/__tests__/features/settings/components/SkillListWithScope.default-enabled.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- repository pre-push quality checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill listings now indicate whether a skill is shared with a team.
  * Shared skills are labeled “团队技能,” including personal skills shared through team spaces.
  * Skill filtering and source labels consistently recognize team-shared skills across scopes.

* **Bug Fixes**
  * Improved visibility of shared skills across authorized team spaces.
  * Prevented unauthorized access to group-shared skill information.
  * Improved reliability when checking task status during native provider tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->