### PR TITLE
fix(backend): relay non-zero device command exits instead of failing RPC

### DIFF
--- a/backend/app/api/ws/wework_runtime_namespace.py
+++ b/backend/app/api/ws/wework_runtime_namespace.py
@@ -173,7 +173,13 @@ class WeworkRuntimeNamespace(socketio.AsyncNamespace):
         except (RuntimeRpcError, DeviceCommandError) as exc:
             return ipc_error(data, "runtime_rpc_failed", str(exc), request_id)
 
-        if result.get("success") is False:
+        # ``device.execute_command`` is a pass-through executor command whose
+        # ``success`` field reports the command exit code, not RPC transport
+        # health. A non-zero exit (e.g. ``git_is_worktree`` exiting 1 on a
+        # non-git directory) is a valid result the client must interpret, so
+        # relay it verbatim to match the local Tauri IPC path. Other runtime
+        # methods use ``success: False`` to signal an RPC-level failure.
+        if method != "device.execute_command" and result.get("success") is False:
             return ipc_error(
                 data,
                 "runtime_rpc_failed",

--- a/backend/tests/api/ws/test_wework_runtime_namespace.py
+++ b/backend/tests/api/ws/test_wework_runtime_namespace.py
@@ -195,6 +195,43 @@ async def test_runtime_request_rejects_executor_failure_envelope(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_runtime_request_relays_device_command_nonzero_exit(monkeypatch):
+    """A device command that runs but exits non-zero is a valid result.
+
+    ``device.execute_command`` is a pass-through executor command: a
+    ``success: False`` envelope means the command exited non-zero (e.g.
+    ``git_is_worktree`` intentionally exits 1 on a non-git directory), not
+    that the RPC transport failed. It must be relayed verbatim so the client
+    can interpret the exit code, matching the local Tauri IPC path.
+    """
+
+    namespace = WeworkRuntimeNamespace()
+    command_result = {"success": False, "stdout": "false", "stderr": ""}
+    monkeypatch.setattr(
+        wework_runtime_namespace,
+        "relay_ipc_request",
+        AsyncMock(return_value=command_result),
+    )
+    monkeypatch.setattr(
+        namespace,
+        "get_session",
+        AsyncMock(return_value={"user_id": 7}),
+    )
+
+    response = await namespace.on_runtime_request(
+        "browser-sid",
+        {
+            "id": "req-1",
+            "device_id": "cloud-device",
+            "method": "device.execute_command",
+            "params": {"command_key": "git_is_worktree", "args": ["/home/ubuntu"]},
+        },
+    )
+
+    assert response == {"id": "req-1", "ok": True, "result": command_result}
+
+
+@pytest.mark.asyncio
 async def test_runtime_request_requires_device_id(monkeypatch):
     namespace = WeworkRuntimeNamespace()
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Cloud (`device.execute_command`) delivery on a **non-git** project surfaced `runtime_rpc_failed: Runtime RPC 'device.execute_command' failed`, while the same non-git project on a **local** device worked fine.

Root cause: the backend relay `on_runtime_request` treated any executor response with `success: false` as an RPC-level failure and converted it to `runtime_rpc_failed`. But `device.execute_command` is a pass-through command whose `success` field reports the command **exit code**, not RPC transport health. `git_is_worktree` (used by the frontend to detect a git repo) intentionally `exit 1` on a non-git directory:

```sh
... else printf 'false\n'; exit 1; fi
```

- **Local path** (Tauri IPC): returns `{success:false, stdout:"false"}` verbatim → `probeGitRepository` returns `false` → git section hidden, delivery works.
- **Cloud path** (socket relay): `success:false` was collapsed into a thrown `runtime_rpc_failed`, so `probeGitRepository` couldn't distinguish "not a git repo" from "RPC failed" → env panel shows a spurious git section + the raw RPC error.

Fix: skip the `success:false → runtime_rpc_failed` conversion for `device.execute_command` so the client interprets the exit code itself, matching the local Tauri IPC path. Other runtime methods (e.g. `runtime.codex.app_server.restart`) keep using `success:false` to signal RPC failure.

## Test plan

- [x] `test_runtime_request_relays_device_command_nonzero_exit` (new) — asserts `device.execute_command` with `success:false` is relayed verbatim (`ok:true, result`). Verified it fails without the guard and passes with it.
- [x] `test_runtime_request_rejects_executor_failure_envelope` (existing) still passes — other methods keep the conversion.
- [x] `uv run pytest tests/api/ws/test_wework_runtime_namespace.py tests/services/test_local_device_command_service.py` → 89 passed.
- [ ] Manual: verify a cloud non-git project (e.g. `~/桌面`) hides the git section and allows delivery, matching local non-git behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device command execution results marked as unsuccessful are now returned correctly instead of being treated as transport errors.
  * Preserved the original command result details for more accurate status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->