### PR TITLE
feat(frontend): promote resource library navigation

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
@@ -268,6 +268,14 @@ describe('TaskSidebar scroll structure', () => {
     expect(within(fixedSection).getByText('common:navigation.flow')).toBeInTheDocument()
     expect(within(fixedSection).getByText('common:navigation.code')).toBeInTheDocument()
     expect(within(fixedSection).getByText('common:navigation.wiki')).toBeInTheDocument()
+    expect(within(fixedSection).getByTestId('resource-library-sidebar-button')).toBeInTheDocument()
+    expect(
+      within(fixedSection).getByTestId('resource-library-sidebar-button-summary')
+    ).toHaveTextContent('resource-library:summary')
+    expect(within(fixedSection).getByTestId('resource-library-sidebar-button-summary')).toHaveClass(
+      'text-text-muted',
+      'truncate'
+    )
     expect(within(fixedSection).getByText('common:navigation.more')).toBeInTheDocument()
     expect(within(fixedSection).getByTestId('task-sidebar-more-summary')).toHaveTextContent(
       'common:navigation.more_summary'
@@ -277,12 +285,13 @@ describe('TaskSidebar scroll structure', () => {
       'truncate'
     )
     expect(within(fixedSection).getByLabelText('More navigation')).toHaveClass('lucide-layout-grid')
-    expect(
-      within(fixedSection).queryByTestId('resource-library-sidebar-button')
-    ).not.toBeInTheDocument()
     expect(within(fixedSection).queryByText('devices:my_devices')).not.toBeInTheDocument()
     expect(within(fixedSection).queryByText('common:navigation.inbox')).not.toBeInTheDocument()
-    expect(within(fixedSection).queryByText('resource-library:title')).not.toBeInTheDocument()
+    expect(
+      within(fixedSection)
+        .getByTestId('resource-library-sidebar-button')
+        .compareDocumentPosition(within(fixedSection).getByTestId('task-sidebar-more-button'))
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
 
     expect(within(scrollableSection).queryByText('common:navigation.wiki')).not.toBeInTheDocument()
     expect(within(scrollableSection).queryByText('devices:my_devices')).not.toBeInTheDocument()
@@ -378,7 +387,7 @@ describe('TaskSidebar scroll structure', () => {
     fireEvent.mouseEnter(within(fixedSection).getByTestId('task-sidebar-more-button'))
 
     const flyout = screen.getByTestId('task-sidebar-more-flyout')
-    expect(within(flyout).getByText('resource-library:title')).toBeInTheDocument()
+    expect(within(flyout).queryByText('resource-library:title')).not.toBeInTheDocument()
     expect(within(flyout).getByText('devices:my_devices')).toBeInTheDocument()
     expect(within(flyout).getByText('common:navigation.inbox')).toBeInTheDocument()
   })
@@ -394,11 +403,11 @@ describe('TaskSidebar scroll structure', () => {
     const scrollableSection = screen.getAllByTestId('task-sidebar-scroll-content')[0]
 
     expect(within(fixedSection).getByText('common:navigation.wiki')).toBeInTheDocument()
-    expect(within(fixedSection).queryByText('resource-library:title')).not.toBeInTheDocument()
+    expect(within(fixedSection).getByText('resource-library:title')).toBeInTheDocument()
     expect(within(fixedSection).queryByText('devices:my_devices')).not.toBeInTheDocument()
     expect(within(fixedSection).queryByText('common:navigation.inbox')).not.toBeInTheDocument()
 
-    expect(within(scrollableSection).getByText('resource-library:title')).toBeInTheDocument()
+    expect(within(scrollableSection).queryByText('resource-library:title')).not.toBeInTheDocument()
     expect(within(scrollableSection).getByText('devices:my_devices')).toBeInTheDocument()
     expect(within(scrollableSection).getByText('common:navigation.inbox')).toBeInTheDocument()
   })

--- a/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
@@ -176,6 +176,7 @@ export default function TaskSidebar({
     | 'wework'
   interface NavigationButton {
     label: string
+    summary?: string
     icon: typeof Workflow
     path: string
     isActive: boolean
@@ -223,6 +224,7 @@ export default function TaskSidebar({
     },
     {
       label: t('resource-library:title'),
+      summary: t('resource-library:summary'),
       icon: Library,
       path: resourceLibraryPath,
       isActive: pageType === 'resource-library' || currentPath === resourceLibraryPath,
@@ -330,14 +332,16 @@ export default function TaskSidebar({
       btn.buttonPageType === 'flow' ||
       btn.buttonPageType === 'code' ||
       btn.buttonPageType === 'wework' ||
-      btn.buttonPageType === 'knowledge'
+      btn.buttonPageType === 'knowledge' ||
+      btn.buttonPageType === 'resource-library'
   )
   const moreNavigationButtons = navigationButtons.filter(
     btn =>
       btn.buttonPageType !== 'flow' &&
       btn.buttonPageType !== 'code' &&
       btn.buttonPageType !== 'wework' &&
-      btn.buttonPageType !== 'knowledge'
+      btn.buttonPageType !== 'knowledge' &&
+      btn.buttonPageType !== 'resource-library'
   )
   const fixedSecondaryNavigationButtons = SIDEBAR_NAV_CONFIG.keepSecondaryNavFixed
     ? moreNavigationButtons
@@ -369,12 +373,20 @@ export default function TaskSidebar({
                   className={`h-4 w-4 flex-shrink-0 ${btn.isActive ? 'text-primary' : ''}`}
                 />
                 <span
-                  className={`min-w-0 truncate text-[14px] leading-5 font-medium ${
+                  className={`${btn.summary ? 'shrink-0' : 'min-w-0 truncate'} text-[14px] leading-5 font-medium ${
                     btn.isActive ? 'text-primary' : 'text-text-primary'
                   }`}
                 >
                   {btn.label}
                 </span>
+                {btn.summary && (
+                  <span
+                    data-testid={`${btn.testId ?? `task-sidebar-nav-${btn.buttonPageType}-button`}-summary`}
+                    className="min-w-0 truncate text-[11px] font-normal text-text-muted"
+                  >
+                    {btn.summary}
+                  </span>
+                )}
               </span>
               {btn.unreadCount !== undefined && btn.unreadCount > 0 && (
                 <span className="ml-auto flex items-center justify-center min-w-[18px] h-[18px] px-1.5 text-[11px] font-medium bg-red-500 text-white rounded-full">

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -121,7 +121,7 @@
     "flow": "Automation",
     "inbox": "Inbox",
     "more": "More",
-    "more_summary": "Library · Devices · Inbox",
+    "more_summary": "Devices · Inbox",
     "settings": "Settings",
     "docs": "Docs",
     "feedback": "Feedback",

--- a/frontend/src/i18n/locales/en/resource-library.json
+++ b/frontend/src/i18n/locales/en/resource-library.json
@@ -1,5 +1,6 @@
 {
   "title": "Resource Library",
+  "summary": "Agents · Skills · MCP",
   "description": "Discover Agents and Skills published by teams and the community, then add and use them right away",
   "mine": {
     "title": "My Capabilities",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -121,7 +121,7 @@
     "flow": "自动化",
     "inbox": "待办",
     "more": "更多",
-    "more_summary": "资源库 · 设备 · 待办",
+    "more_summary": "设备 · 待办",
     "settings": "设置",
     "docs": "文档",
     "feedback": "问题反馈",

--- a/frontend/src/i18n/locales/zh-CN/resource-library.json
+++ b/frontend/src/i18n/locales/zh-CN/resource-library.json
@@ -1,5 +1,6 @@
 {
   "title": "资源库",
+  "summary": "智能体 · 技能 · MCP",
   "description": "发现团队与社区发布的智能体和技能，添加后直接使用",
   "mine": {
     "title": "我的能力",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource Library is now a primary navigation item with a summary highlighting Agents, Skills, and MCP.
  * Navigation items can display supporting summaries alongside their labels.
* **Improvements**
  * Resource Library no longer appears in the More menu.
  * Updated English and Chinese navigation translations to reflect the revised menu structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->