### PR TITLE
fix(wework): cascade robot execution device selection

### DIFF
--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -2052,6 +2052,11 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         ),
         'unselected'
       )
+      await control.command('waitFor', '[data-testid="cloud-project-chat-agent-device"]', {
+        text: 'local-device',
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
       assert.equal(
         await control.command(
           'getAttribute',
@@ -2060,11 +2065,6 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         ),
         'selected'
       )
-      await control.command('waitFor', '[data-testid="cloud-project-chat-agent-device"]', {
-        text: 'local-device',
-        timeoutMs: uiTimeoutMs,
-        visible: true,
-      })
       assert.equal(
         await control.command(
           'getAttribute',

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -2058,8 +2058,13 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
           '[data-testid="cloud-project-chat-agent-device"] [data-selection-state]',
           { value: 'data-selection-state', visible: true }
         ),
-        'unselected'
+        'selected'
       )
+      await control.command('waitFor', '[data-testid="cloud-project-chat-agent-device"]', {
+        text: 'local-device',
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
       assert.equal(
         await control.command(
           'getAttribute',
@@ -2083,19 +2088,6 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         value: '回归巡检机器人',
         visible: true,
       })
-      await control.command('click', '[data-testid="cloud-project-chat-agent-device"]', {
-        visible: true,
-      })
-      await control.command('waitFor', '[data-testid="cloud-project-chat-agent-device-menu"]', {
-        text: 'local-device',
-        timeoutMs: uiTimeoutMs,
-        visible: true,
-      })
-      await control.command(
-        'click',
-        '[data-testid="cloud-project-chat-agent-device-option-local-device"]',
-        { visible: true }
-      )
       const saveWithoutModel = await control.command(
         'getAttribute',
         '[data-testid="cloud-project-chat-agent-save"]',

--- a/wework/src/features/todo/ProjectChatAgentsSection.test.tsx
+++ b/wework/src/features/todo/ProjectChatAgentsSection.test.tsx
@@ -380,12 +380,10 @@ describe('ProjectChatAgentsSection', () => {
         executionDeviceId: 'stale-cloud-device',
       }),
     ])
-    mock.deviceApi = {
-      listDevices: vi.fn(async () => [
-        { device_id: 'local-device', device_type: 'local', status: 'online' },
-        { device_id: 'stale-cloud-device', device_type: 'cloud', status: 'online' },
-      ]),
-    }
+    mock.deviceApi.listDevices = vi.fn(async () => [
+      { device_id: 'local-device', device_type: 'local', status: 'online' },
+      { device_id: 'stale-cloud-device', device_type: 'cloud', status: 'online' },
+    ])
     render(
       <ProjectChatAgentsSection
         project={{ ...project, project_store: 'local' }}
@@ -440,12 +438,10 @@ describe('ProjectChatAgentsSection', () => {
 
   it('lists only projects with a workspace on the selected cloud device', async () => {
     const mock = services()
-    mock.deviceApi = {
-      listDevices: vi.fn(async () => [
-        { device_id: 'local-device', device_type: 'local', status: 'online' },
-        { device_id: 'cloud-device', device_type: 'cloud', status: 'online' },
-      ]),
-    }
+    mock.deviceApi.listDevices = vi.fn(async () => [
+      { device_id: 'local-device', device_type: 'local', status: 'online' },
+      { device_id: 'cloud-device', device_type: 'cloud', status: 'online' },
+    ])
     const runtimeWork = {
       projects: [
         {
@@ -509,34 +505,33 @@ describe('ProjectChatAgentsSection', () => {
 
   it('auto-selects the preferred device when an environment has multiple devices', async () => {
     const mock = services()
-    mock.deviceApi = {
-      listDevices: vi.fn(async () => [
-        {
-          device_id: 'offline-default-device',
-          device_type: 'local',
-          status: 'offline',
-          is_default: true,
-        },
-        { device_id: 'online-device', device_type: 'app', status: 'online' },
-        {
-          device_id: 'online-default-device',
-          device_type: 'local',
-          status: 'online',
-          is_default: true,
-        },
-      ]),
-    }
+    mock.deviceApi.listDevices = vi.fn(async () => [
+      {
+        device_id: 'offline-default-device',
+        device_type: 'local',
+        status: 'offline',
+        is_default: true,
+      },
+      { device_id: 'online-device', device_type: 'app', status: 'online' },
+      {
+        device_id: 'online-default-device',
+        device_type: 'local',
+        status: 'online',
+        is_default: true,
+      },
+    ])
     renderSection(mock)
 
     await userEvent.click(await screen.findByTestId('cloud-project-chat-agent-add'))
 
-    expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent(
-      'online-default-device'
-    )
-    expect(screen.getByTestId('cloud-project-chat-agent-device').firstElementChild).toHaveAttribute(
-      'data-selection-state',
-      'selected'
-    )
+    await waitFor(() => {
+      expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent(
+        'online-default-device'
+      )
+      expect(
+        screen.getByTestId('cloud-project-chat-agent-device').firstElementChild
+      ).toHaveAttribute('data-selection-state', 'selected')
+    })
   })
 
   it('auto-selects a sole device when devices load after the editor opens', async () => {
@@ -544,14 +539,12 @@ describe('ProjectChatAgentsSection', () => {
     let resolveDevices:
       | ((devices: Array<{ device_id: string; device_type: string; status: string }>) => void)
       | undefined
-    mock.deviceApi = {
-      listDevices: vi.fn(
-        () =>
-          new Promise(resolve => {
-            resolveDevices = resolve
-          })
-      ),
-    }
+    mock.deviceApi.listDevices = vi.fn(
+      () =>
+        new Promise(resolve => {
+          resolveDevices = resolve
+        })
+    )
     renderSection(mock)
 
     await userEvent.click(await screen.findByTestId('cloud-project-chat-agent-add'))

--- a/wework/src/features/todo/ProjectChatAgentsSection.test.tsx
+++ b/wework/src/features/todo/ProjectChatAgentsSection.test.tsx
@@ -372,6 +372,38 @@ describe('ProjectChatAgentsSection', () => {
     expect(screen.queryByText('旧的保存错误')).not.toBeInTheDocument()
   })
 
+  it('selects a local device when editing a local-project robot with a stale cloud device', async () => {
+    const mock = services([
+      agent({
+        model: MODEL_NAME,
+        executionEnvironment: 'cloud',
+        executionDeviceId: 'stale-cloud-device',
+      }),
+    ])
+    mock.deviceApi = {
+      listDevices: vi.fn(async () => [
+        { device_id: 'local-device', device_type: 'local', status: 'online' },
+        { device_id: 'stale-cloud-device', device_type: 'cloud', status: 'online' },
+      ]),
+    }
+    render(
+      <ProjectChatAgentsSection
+        project={{ ...project, project_store: 'local' }}
+        projectChatAgentApi={mock.projectChatAgentApi}
+        deviceApi={mock.deviceApi}
+        modelApi={mock.modelApi}
+        teamApi={mock.teamApi}
+        localProjects={[]}
+        canManage
+      />
+    )
+
+    await userEvent.click(await screen.findByTestId('cloud-project-chat-agent-agent-1'))
+
+    expect(screen.getByTestId('cloud-project-chat-agent-environment')).toHaveTextContent('我的本地')
+    expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent('local-device')
+  })
+
   it('hides local runtime models when the robot runs in the cloud', async () => {
     const mock = services()
     mock.modelApi = {

--- a/wework/src/features/todo/ProjectChatAgentsSection.test.tsx
+++ b/wework/src/features/todo/ProjectChatAgentsSection.test.tsx
@@ -1,6 +1,6 @@
 import '@/i18n'
 
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import type { CloudProject } from '@/api/deliveries'
@@ -244,8 +244,9 @@ describe('ProjectChatAgentsSection', () => {
     expect(selectionState('cloud-project-chat-agent-model')).toHaveClass('text-text-muted')
     expect(selectionState('cloud-project-chat-agent-device')).toHaveAttribute(
       'data-selection-state',
-      'unselected'
+      'selected'
     )
+    expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent('local-device')
     expect(selectionState('cloud-project-chat-agent-execution-project')).toHaveAttribute(
       'data-selection-state',
       'unselected'
@@ -257,10 +258,7 @@ describe('ProjectChatAgentsSection', () => {
 
     await userEvent.click(screen.getByTestId('cloud-project-chat-agent-save'))
     expect(selectionState('cloud-project-chat-agent-model')).toHaveAttribute('data-invalid', 'true')
-    expect(selectionState('cloud-project-chat-agent-device')).toHaveAttribute(
-      'data-invalid',
-      'true'
-    )
+    expect(selectionState('cloud-project-chat-agent-device')).not.toHaveAttribute('data-invalid')
     expect(mock.create).not.toHaveBeenCalled()
 
     await userEvent.click(screen.getByTestId('cloud-project-chat-agent-model'))
@@ -355,6 +353,25 @@ describe('ProjectChatAgentsSection', () => {
     )
   })
 
+  it('clears a previous save error when the corrected robot saves successfully', async () => {
+    const mock = services([agent({ model: MODEL_NAME })])
+    mock.update.mockRejectedValueOnce(new Error('旧的保存错误'))
+    renderSection(mock)
+
+    await userEvent.click(await screen.findByTestId('cloud-project-chat-agent-agent-1'))
+    await userEvent.click(screen.getByTestId('cloud-project-chat-agent-save'))
+    expect(await screen.findByTestId('cloud-project-chat-agent-error')).toHaveTextContent(
+      '旧的保存错误'
+    )
+
+    await userEvent.type(screen.getByTestId('cloud-project-chat-agent-capability'), '已修正配置')
+    await userEvent.click(screen.getByTestId('cloud-project-chat-agent-save'))
+
+    await waitFor(() => expect(mock.update).toHaveBeenCalledTimes(2))
+    expect(screen.queryByTestId('cloud-project-chat-agent-editor')).not.toBeInTheDocument()
+    expect(screen.queryByText('旧的保存错误')).not.toBeInTheDocument()
+  })
+
   it('hides local runtime models when the robot runs in the cloud', async () => {
     const mock = services()
     mock.modelApi = {
@@ -440,9 +457,10 @@ describe('ProjectChatAgentsSection', () => {
     await userEvent.click(
       await screen.findByTestId('cloud-project-chat-agent-environment-option-cloud')
     )
-    await userEvent.click(screen.getByTestId('cloud-project-chat-agent-device'))
-    await userEvent.click(
-      await screen.findByTestId('cloud-project-chat-agent-device-option-cloud-device')
+    await waitFor(() =>
+      expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent(
+        'cloud-device'
+      )
     )
     await userEvent.click(screen.getByTestId('cloud-project-chat-agent-execution-project'))
 
@@ -455,6 +473,65 @@ describe('ProjectChatAgentsSection', () => {
     expect(
       screen.queryByTestId('cloud-project-chat-agent-execution-project-option-7')
     ).not.toBeInTheDocument()
+  })
+
+  it('auto-selects the preferred device when an environment has multiple devices', async () => {
+    const mock = services()
+    mock.deviceApi = {
+      listDevices: vi.fn(async () => [
+        {
+          device_id: 'offline-default-device',
+          device_type: 'local',
+          status: 'offline',
+          is_default: true,
+        },
+        { device_id: 'online-device', device_type: 'app', status: 'online' },
+        {
+          device_id: 'online-default-device',
+          device_type: 'local',
+          status: 'online',
+          is_default: true,
+        },
+      ]),
+    }
+    renderSection(mock)
+
+    await userEvent.click(await screen.findByTestId('cloud-project-chat-agent-add'))
+
+    expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent(
+      'online-default-device'
+    )
+    expect(screen.getByTestId('cloud-project-chat-agent-device').firstElementChild).toHaveAttribute(
+      'data-selection-state',
+      'selected'
+    )
+  })
+
+  it('auto-selects a sole device when devices load after the editor opens', async () => {
+    const mock = services()
+    let resolveDevices:
+      | ((devices: Array<{ device_id: string; device_type: string; status: string }>) => void)
+      | undefined
+    mock.deviceApi = {
+      listDevices: vi.fn(
+        () =>
+          new Promise(resolve => {
+            resolveDevices = resolve
+          })
+      ),
+    }
+    renderSection(mock)
+
+    await userEvent.click(await screen.findByTestId('cloud-project-chat-agent-add'))
+    expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent('选择执行设备')
+
+    await act(async () => {
+      resolveDevices?.([{ device_id: 'late-local-device', device_type: 'local', status: 'online' }])
+    })
+
+    expect(screen.getByTestId('cloud-project-chat-agent-device')).toHaveTextContent(
+      'late-local-device'
+    )
   })
 
   it('verifies a bound Git workspace before enabling robot concurrency above one', async () => {

--- a/wework/src/features/todo/ProjectChatAgentsSection.tsx
+++ b/wework/src/features/todo/ProjectChatAgentsSection.tsx
@@ -18,6 +18,37 @@ interface ProjectChatAgentTemplate {
   systemPrompt: string
 }
 
+function deviceMatchesEnvironment(
+  device: { device_type?: string },
+  environment: ProjectChatAgent['executionEnvironment']
+) {
+  return environment === 'local'
+    ? device.device_type === 'local' || device.device_type === 'app'
+    : device.device_type === 'cloud' || device.device_type === 'remote'
+}
+
+function resolveExecutionDevice(
+  current: string,
+  devices: Array<{
+    device_id: string
+    device_type?: string
+    status?: string
+    is_default?: boolean
+  }>,
+  environment: ProjectChatAgent['executionEnvironment']
+) {
+  const matchingDevices = devices.filter(device => deviceMatchesEnvironment(device, environment))
+  if (matchingDevices.some(device => device.device_id === current)) return current
+  const preferredDevice =
+    matchingDevices.find(device => device.status === 'online' && device.is_default) ??
+    matchingDevices.find(device => device.status === 'online') ??
+    matchingDevices.find(device => device.status === 'busy' && device.is_default) ??
+    matchingDevices.find(device => device.status === 'busy') ??
+    matchingDevices.find(device => device.is_default) ??
+    matchingDevices[0]
+  return preferredDevice?.device_id ?? ''
+}
+
 const templateButtonClass =
   'flex min-h-20 items-center gap-3.5 rounded-xl border border-border bg-background p-4 text-left transition hover:border-text-tertiary hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30'
 
@@ -79,6 +110,7 @@ export function ProjectChatAgentsSection({
   const sectionRef = useRef<HTMLElement>(null)
   const handledCreateRequestKey = useRef(0)
   const collectionRevision = useRef(0)
+  const agentExecutionEnvironmentRef = useRef(agentExecutionEnvironment)
 
   useEffect(() => {
     if (!projectChatAgentApi) return
@@ -109,7 +141,11 @@ export function ProjectChatAgentsSection({
     deviceApi
       .listDevices()
       .then(devices => {
-        if (active) setAvailableDevices(devices)
+        if (!active) return
+        setAvailableDevices(devices)
+        setAgentExecutionDeviceId(current =>
+          resolveExecutionDevice(current, devices, agentExecutionEnvironmentRef.current)
+        )
       })
       .catch(() => {
         if (active) setAvailableDevices([])
@@ -157,6 +193,9 @@ export function ProjectChatAgentsSection({
     agentExecutionEnvironment === 'cloud'
       ? availableModels.filter(model => model.type !== 'runtime')
       : availableModels
+  const executionDevices = availableDevices.filter(device =>
+    deviceMatchesEnvironment(device, agentExecutionEnvironment)
+  )
   // A cloud robot can only bind a code project that already has an available
   // workspace on the selected cloud device. The runtime work registry is the
   // same source the device management page uses.
@@ -205,14 +244,15 @@ export function ProjectChatAgentsSection({
       setAgentCapabilityDescription(template?.capabilityDescription ?? '')
       setAgentVisibility('creator_admin')
       setAgentExecutionEnvironment('local')
+      agentExecutionEnvironmentRef.current = 'local'
       setAgentRuntime('codex')
       setAgentWegentTeamId('')
       setAgentExecutionMode('auto')
       setAgentMaxConcurrentExecutions(1)
-      setAgentExecutionDeviceId('')
+      setAgentExecutionDeviceId(resolveExecutionDevice('', availableDevices, 'local'))
       setAgentLocalProjectId('')
     },
-    [t]
+    [availableDevices, t]
   )
 
   useEffect(() => {
@@ -253,7 +293,9 @@ export function ProjectChatAgentsSection({
     setAgentSystemPrompt(agent.systemPrompt)
     setAgentCapabilityDescription(agent.capabilityDescription ?? '')
     setAgentVisibility(agent.visibility)
-    setAgentExecutionEnvironment(localProjectOnly ? 'local' : agent.executionEnvironment)
+    const executionEnvironment = localProjectOnly ? 'local' : agent.executionEnvironment
+    setAgentExecutionEnvironment(executionEnvironment)
+    agentExecutionEnvironmentRef.current = executionEnvironment
     setAgentRuntime(agent.runtime)
     setAgentWegentTeamId(agent.wegentTeamId ?? '')
     setAgentExecutionMode(agent.executionMode)
@@ -279,6 +321,7 @@ export function ProjectChatAgentsSection({
     )
       return
     setAgentSaveAttempted(true)
+    setError(null)
     if (
       (agentRuntime === 'codex' && (!agentModel.trim() || !agentExecutionDeviceId)) ||
       (agentRuntime === 'wegent' && agentWegentTeamId === '')
@@ -665,6 +708,7 @@ export function ProjectChatAgentsSection({
                         setAgentRuntime('codex')
                         setAgentWegentTeamId('')
                         if (localProjectOnly && next !== 'local') return
+                        agentExecutionEnvironmentRef.current = next
                         setAgentExecutionEnvironment(next)
                         // A project binding is resolved against the selected
                         // device, so changing environments clears the old one.
@@ -678,19 +722,9 @@ export function ProjectChatAgentsSection({
                           )
                           return model?.type === 'runtime' ? '' : current
                         })
-                        setAgentExecutionDeviceId(current => {
-                          const currentDevice = availableDevices.find(
-                            device => device.device_id === current
-                          )
-                          if (!currentDevice) return ''
-                          const matches =
-                            next === 'local'
-                              ? currentDevice.device_type === 'local' ||
-                                currentDevice.device_type === 'app'
-                              : currentDevice.device_type === 'cloud' ||
-                                currentDevice.device_type === 'remote'
-                          return matches ? current : ''
-                        })
+                        setAgentExecutionDeviceId(current =>
+                          resolveExecutionDevice(current, availableDevices, next)
+                        )
                       }}
                       options={[
                         { value: 'local', label: t('workbench.project_chat_agent_env_local') },
@@ -764,16 +798,10 @@ export function ProjectChatAgentsSection({
                               return stillAvailable ? current : ''
                             })
                           }}
-                          options={availableDevices
-                            .filter(device =>
-                              agentExecutionEnvironment === 'local'
-                                ? device.device_type === 'local' || device.device_type === 'app'
-                                : device.device_type === 'cloud' || device.device_type === 'remote'
-                            )
-                            .map(device => ({
-                              value: device.device_id,
-                              label: `${device.device_id}${device.status ? `（${device.status}）` : ''}`,
-                            }))}
+                          options={executionDevices.map(device => ({
+                            value: device.device_id,
+                            label: `${device.device_id}${device.status ? `（${device.status}）` : ''}`,
+                          }))}
                         />
                       </SettingsRow>
                       <SettingsRow

--- a/wework/src/features/todo/ProjectChatAgentsSection.tsx
+++ b/wework/src/features/todo/ProjectChatAgentsSection.tsx
@@ -302,13 +302,8 @@ export function ProjectChatAgentsSection({
     setAgentMaxConcurrentExecutions(agent.maxConcurrentExecutions)
     setAgentLocalProjectId(agent.localProjectId ?? '')
     const boundDevice = agent.executionDeviceId ?? ''
-    const deviceIsLocalCapable = availableDevices.some(
-      device =>
-        device.device_id === boundDevice &&
-        (device.device_type === 'local' || device.device_type === 'app')
-    )
     setAgentExecutionDeviceId(
-      localProjectOnly && boundDevice && !deviceIsLocalCapable ? '' : boundDevice
+      resolveExecutionDevice(boundDevice, availableDevices, executionEnvironment)
     )
   }
 


### PR DESCRIPTION
## What changed

- Cascade execution-device selection from the selected robot execution environment.
- Automatically choose the preferred matching device, prioritizing online default devices.
- Reconcile device selection when the device list loads after the editor opens.
- Clear stale save errors before retrying so successful saves do not leave an old error visible.
- Update unit and desktop E2E regression coverage for the automatic selection behavior.

## Why

The robot editor filtered devices by environment but left the required device field empty. Users had to make a redundant selection even when a clear preferred device existed. Save errors also remained visible after a corrected configuration saved successfully.

## User impact

Creating or editing an automation robot now selects a suitable execution device automatically after the environment is chosen, while still allowing manual changes.

## Validation

- `pnpm --filter wework test src/features/todo/ProjectChatAgentsSection.test.tsx`
- `pnpm --filter wework typecheck`
- Focused ESLint and Prettier checks
- Repository pre-push checks: Wework ESLint, TypeScript and unit tests; Backend Black, isort and syntax; Settings configuration; Executor fmt, tests and clippy; Alembic multi-head check

The focused desktop automation checkpoint was attempted locally, but an existing project-chat completion assertion timed out before reaching the robot editor assertions. The mocked local model request and response were recorded successfully; no failure involved the changed robot configuration flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Devices are now automatically selected based on the current execution environment.
  * The preferred available device is retained when possible, with sensible fallbacks when availability changes.
  * Device selection updates automatically as devices load or the execution environment changes.

* **Bug Fixes**
  * Saving after correcting an error now clears the previous save error.
  * Device validation is no longer required when saving without a model if a suitable local device is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->