### PR TITLE
fix(wework): default scheme-less browser URLs to HTTP

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -776,6 +776,64 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         timeoutMs: 5_000,
       })
       assert.equal(readyWait.ok, true, `Bridge fixture wait failed: ${JSON.stringify(readyWait)}`)
+
+      const fixtureServerUrl = new URL(control.url)
+      const schemeLessLocalhostUrl = `localhost:${fixtureServerUrl.port}${FIXTURE_PATH}`
+      const normalizedLocalhostUrl = `http://${schemeLessLocalhostUrl}`
+      assert.equal(
+        await control.command('getAttribute', BROWSER_INPUT_SELECTOR, {
+          value: 'autocapitalize',
+        }),
+        'none',
+        'The browser address bar did not disable automatic capitalization'
+      )
+      assert.equal(
+        await control.command('getAttribute', BROWSER_INPUT_SELECTOR, {
+          value: 'autocomplete',
+        }),
+        'off',
+        'The browser address bar did not disable autocomplete'
+      )
+      assert.equal(
+        await control.command('getAttribute', BROWSER_INPUT_SELECTOR, {
+          value: 'autocorrect',
+        }),
+        'off',
+        'The browser address bar did not disable automatic correction'
+      )
+      assert.equal(
+        await control.command('getAttribute', BROWSER_INPUT_SELECTOR, {
+          value: 'spellcheck',
+        }),
+        'false',
+        'The browser address bar did not disable spell checking'
+      )
+      await control.command('fill', BROWSER_INPUT_SELECTOR, {
+        value: schemeLessLocalhostUrl,
+      })
+      assert.equal(
+        await control.command('getValue', BROWSER_INPUT_SELECTOR),
+        schemeLessLocalhostUrl,
+        'The browser address bar changed lowercase localhost before submission'
+      )
+      await control.command('submit', BROWSER_INPUT_SELECTOR)
+      await waitForControlValue(
+        control,
+        BROWSER_INPUT_SELECTOR,
+        normalizedLocalhostUrl,
+        uiTimeoutMs,
+        'The browser address bar did not default a scheme-less localhost URL to HTTP'
+      )
+      const localhostWait = await bridgeCall({
+        action: 'waitFor',
+        options: { condition: { textVisible: READY_TEXT } },
+        timeoutMs: 5_000,
+      })
+      assert.equal(
+        localhostWait.ok,
+        true,
+        `The HTTP localhost fixture did not load: ${JSON.stringify(localhostWait)}`
+      )
       await new Promise(resolve => setTimeout(resolve, 300))
 
       const pendingAgentWait = bridgeCall({

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -834,6 +834,21 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         true,
         `The HTTP localhost fixture did not load: ${JSON.stringify(localhostWait)}`
       )
+      const localhostLocation = await bridgeCall({
+        action: 'evaluate',
+        expression: 'location.href',
+        timeoutMs: 5_000,
+      })
+      assert.equal(
+        localhostLocation.ok,
+        true,
+        `HTTP localhost location evaluation failed: ${JSON.stringify(localhostLocation)}`
+      )
+      assert.equal(
+        localhostLocation.value,
+        normalizedLocalhostUrl,
+        'The embedded browser did not navigate to the normalized HTTP URL'
+      )
       await new Promise(resolve => setTimeout(resolve, 300))
 
       const pendingAgentWait = bridgeCall({

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5648,7 +5648,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(browserTab).toHaveTextContent(/^example.com$/)
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://example.com/'
+      'http://example.com/'
     )
     expect(screen.getByTestId('workspace-browser-frame')).toHaveClass('bg-background')
   })
@@ -5710,10 +5710,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(rightPanelShell).toHaveStyle({ width: '0px' })
     expect(screen.getByTestId('right-workspace-panel')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-browser-panel')).toHaveClass('hidden')
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://weibo.com/'
+      'http://weibo.com/'
     )
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
@@ -5724,10 +5724,10 @@ describe('DesktopWorkbenchLayout', () => {
       'true'
     )
     expect(screen.getByTestId('workspace-browser-panel')).not.toHaveClass('hidden')
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://weibo.com/'
+      'http://weibo.com/'
     )
   })
 
@@ -5765,7 +5765,7 @@ describe('DesktopWorkbenchLayout', () => {
       expect(rightPanelShell).toHaveStyle({ width: '0px' })
       expect(screen.queryByTestId('right-workspace-resize-handle')).not.toBeInTheDocument()
     })
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
 
@@ -5773,7 +5773,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(content).toHaveStyle({ width: '420px' })
     expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
   })
 
   test('does not leave the browser loading when submitting the current URL again', async () => {
@@ -5786,7 +5786,7 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.type(urlInput, 'weibo.com{Enter}')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://weibo.com/'
+      'http://weibo.com/'
     )
 
     await userEvent.type(urlInput, '{Enter}')
@@ -5794,7 +5794,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() =>
       expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
         'src',
-        'https://weibo.com/'
+        'http://weibo.com/'
       )
     )
     expect(screen.queryByTestId('workspace-browser-loading')).not.toBeInTheDocument()
@@ -5823,9 +5823,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('browser-tab-add')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('right-workspace-browser-tab-1'))
-    expect(screen.getAllByTestId('workspace-browser-url-input')[0]).toHaveValue(
-      'https://weibo.com/'
-    )
+    expect(screen.getAllByTestId('workspace-browser-url-input')[0]).toHaveValue('http://weibo.com/')
   })
 
   test('mixes browser pages with chat and terminal tabs in the right workspace tab bar', async () => {
@@ -5885,10 +5883,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('right-workspace-new-tab-menu')).not.toBeInTheDocument()
     expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
     expect(await screen.findByTestId('workspace-file-tree')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://weibo.com/'
+      'http://weibo.com/'
     )
 
     await userEvent.click(screen.getByTestId('right-workspace-browser-tab-1'))
@@ -5897,10 +5895,10 @@ describe('DesktopWorkbenchLayout', () => {
       'aria-selected',
       'true'
     )
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://weibo.com/'
+      'http://weibo.com/'
     )
   })
 
@@ -9762,7 +9760,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     expect(activePane().getByTestId('workspace-browser-url-input')).toHaveValue(
-      'https://example.com/'
+      'http://example.com/'
     )
 
     rerender(<DesktopWorkbenchLayout {...propsForTask(taskB)} />)
@@ -9783,11 +9781,11 @@ describe('DesktopWorkbenchLayout', () => {
       'true'
     )
     expect(activePane().getByTestId('workspace-browser-url-input')).toHaveValue(
-      'https://example.com/'
+      'http://example.com/'
     )
     expect(activePane().getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'https://example.com/'
+      'http://example.com/'
     )
   })
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5701,7 +5701,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
-    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'weibo.com{Enter}')
+    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'example.com{Enter}')
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
@@ -5710,10 +5710,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(rightPanelShell).toHaveStyle({ width: '0px' })
     expect(screen.getByTestId('right-workspace-panel')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-browser-panel')).toHaveClass('hidden')
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'http://weibo.com/'
+      'http://example.com/'
     )
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
@@ -5724,10 +5724,10 @@ describe('DesktopWorkbenchLayout', () => {
       'true'
     )
     expect(screen.getByTestId('workspace-browser-panel')).not.toHaveClass('hidden')
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'http://weibo.com/'
+      'http://example.com/'
     )
   })
 
@@ -5736,7 +5736,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
-    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'weibo.com{Enter}')
+    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'example.com{Enter}')
 
     vi.spyOn(getDesktopWorkbenchMainElement(), 'getBoundingClientRect').mockReturnValue(
       createRect({ left: 0, top: 0, width: 1000, height: 720 })
@@ -5765,7 +5765,7 @@ describe('DesktopWorkbenchLayout', () => {
       expect(rightPanelShell).toHaveStyle({ width: '0px' })
       expect(screen.queryByTestId('right-workspace-resize-handle')).not.toBeInTheDocument()
     })
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
 
@@ -5773,7 +5773,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(content).toHaveStyle({ width: '420px' })
     expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
   })
 
   test('does not leave the browser loading when submitting the current URL again', async () => {
@@ -5783,10 +5783,10 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
 
     const urlInput = screen.getByTestId('workspace-browser-url-input')
-    await userEvent.type(urlInput, 'weibo.com{Enter}')
+    await userEvent.type(urlInput, 'example.com{Enter}')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'http://weibo.com/'
+      'http://example.com/'
     )
 
     await userEvent.type(urlInput, '{Enter}')
@@ -5794,7 +5794,7 @@ describe('DesktopWorkbenchLayout', () => {
     await waitFor(() =>
       expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
         'src',
-        'http://weibo.com/'
+        'http://example.com/'
       )
     )
     expect(screen.queryByTestId('workspace-browser-loading')).not.toBeInTheDocument()
@@ -5805,7 +5805,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
-    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'weibo.com{Enter}')
+    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'example.com{Enter}')
 
     await userEvent.click(screen.getByTestId('right-workspace-new-tab-button'))
     const menu = screen.getByTestId('right-workspace-new-tab-menu')
@@ -5823,7 +5823,9 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('browser-tab-add')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('right-workspace-browser-tab-1'))
-    expect(screen.getAllByTestId('workspace-browser-url-input')[0]).toHaveValue('http://weibo.com/')
+    expect(screen.getAllByTestId('workspace-browser-url-input')[0]).toHaveValue(
+      'http://example.com/'
+    )
   })
 
   test('mixes browser pages with chat and terminal tabs in the right workspace tab bar', async () => {
@@ -5869,7 +5871,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
-    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'weibo.com{Enter}')
+    await userEvent.type(screen.getByTestId('workspace-browser-url-input'), 'example.com{Enter}')
 
     await userEvent.click(screen.getByTestId('right-workspace-new-tab-button'))
 
@@ -5883,10 +5885,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('right-workspace-new-tab-menu')).not.toBeInTheDocument()
     expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
     expect(await screen.findByTestId('workspace-file-tree')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'http://weibo.com/'
+      'http://example.com/'
     )
 
     await userEvent.click(screen.getByTestId('right-workspace-browser-tab-1'))
@@ -5895,10 +5897,10 @@ describe('DesktopWorkbenchLayout', () => {
       'aria-selected',
       'true'
     )
-    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://weibo.com/')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
     expect(screen.getByTestId('workspace-browser-frame')).toHaveAttribute(
       'src',
-      'http://weibo.com/'
+      'http://example.com/'
     )
   })
 

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -180,6 +180,18 @@ describe('WorkspaceBrowserPanel', () => {
     embeddedBrowserMocks.setEmbeddedBrowserBounds.mockResolvedValue(undefined)
   })
 
+  test('disables text correction in the browser address bar', () => {
+    render(<WorkspaceBrowserPanel active />)
+
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveAttribute(
+      'autocapitalize',
+      'none'
+    )
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveAttribute('autocomplete', 'off')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveAttribute('autocorrect', 'off')
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveAttribute('spellcheck', 'false')
+  })
+
   test('clears cookies from the browser actions submenu and reports completion', async () => {
     render(<WorkspaceBrowserPanel active />)
 
@@ -252,7 +264,7 @@ describe('WorkspaceBrowserPanel', () => {
 
     await waitFor(() => {
       expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledWith(
-        'https://example.com/',
+        'http://example.com/',
         {
           x: 500,
           y: 120,

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -2103,6 +2103,10 @@ export function WorkspaceBrowserTabPanel({
               name="url"
               data-testid="workspace-browser-url-input"
               value={address}
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
               onChange={event => setAddress(event.target.value)}
               onFocus={() => {
                 addressEditingRef.current = true

--- a/wework/src/lib/browser-url.test.ts
+++ b/wework/src/lib/browser-url.test.ts
@@ -3,7 +3,12 @@ import { normalizeBrowserUrl } from './browser-url'
 
 describe('browser URL helpers', () => {
   test('normalizes supported browser URLs', () => {
-    expect(normalizeBrowserUrl('example.test')).toBe('https://example.test/')
+    expect(normalizeBrowserUrl('example.test')).toBe('http://example.test/')
+    expect(normalizeBrowserUrl('localhost:3000')).toBe('http://localhost:3000/')
+    expect(normalizeBrowserUrl('localhost:3000/path?mode=dev')).toBe(
+      'http://localhost:3000/path?mode=dev'
+    )
+    expect(normalizeBrowserUrl('http://example.test')).toBe('http://example.test/')
     expect(normalizeBrowserUrl('https://example.test/mygroups?gid=1')).toBe(
       'https://example.test/mygroups?gid=1'
     )

--- a/wework/src/lib/browser-url.ts
+++ b/wework/src/lib/browser-url.ts
@@ -55,7 +55,7 @@ export function normalizeBrowserUrl(value: string, appUrl?: string): string | nu
 
   const withProtocol =
     localPathToFileUrl(trimmed) ??
-    (/^[a-z][a-z\d+\-.]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`)
+    (/^[a-z][a-z\d+\-.]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`)
 
   try {
     const url = new URL(withProtocol)


### PR DESCRIPTION
## What changed

- Default scheme-less addresses in the Wework built-in browser to `http://`.
- Disable address-bar capitalization, autocorrect, autocomplete, and spell checking.
- Add unit and desktop E2E coverage for lowercase `localhost` input and successful HTTP navigation.
- Update existing workbench assertions to match the new default protocol.

## Why

The Wework built-in browser previously converted addresses such as `localhost:3000` to HTTPS. Local development servers commonly expose HTTP only, so navigation failed or produced TLS errors. Browser text correction could also display or submit an altered `Localhost` value.

## Impact

Users can enter `localhost`, hostnames, and other scheme-less addresses and navigate over HTTP by default. Explicit `http://` and `https://` addresses remain unchanged.

## Validation

- `pnpm --dir wework exec vitest run src/lib/browser-url.test.ts src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx`
- `pnpm --dir wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --dir wework typecheck`
- Targeted ESLint and Prettier checks
- `pnpm --dir wework e2e:desktop -- --segment embedded-browser`
- Repository pre-push checks, including all Wework unit tests, ESLint, TypeScript, executor tests, clippy, and configuration checks

Related: WEWORKBU0CEBB1-35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser address-bar input now preserves typed URL casing and disables autocomplete, autocorrect, capitalization, and spell checking.
  * Localhost URLs support paths and query strings while loading correctly in the embedded browser.

* **Bug Fixes**
  * URLs entered without a protocol now default to `http://`, including local and standard domain addresses.
  * Existing explicit `http://` and `https://` URLs continue to behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->