### PR TITLE
fix(ci): harden Playwright system dependency install against apt hangs

### DIFF
--- a/.github/scripts/install-playwright-system-deps.sh
+++ b/.github/scripts/install-playwright-system-deps.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly max_attempts="${PLAYWRIGHT_INSTALL_MAX_ATTEMPTS:-3}"
+readonly timeout_seconds="${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-600}"
+readonly apt_conf_path="${APT_CONFIG_PATH:-/etc/apt/apt.conf.d/99wegent-playwright}"
+
+write_apt_config() {
+  if [[ -n "${APT_CONFIG:-}" ]]; then
+    return
+  fi
+
+  printf '%s\n' \
+    'Acquire::http::Timeout "15";' \
+    'Acquire::https::Timeout "15";' \
+    'Acquire::Retries "3";' \
+    | sudo tee "$apt_conf_path" >/dev/null
+}
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  echo "Installing Playwright system dependencies (attempt $attempt/$max_attempts)"
+
+  write_apt_config
+
+  if timeout \
+    --signal=TERM \
+    --kill-after=15s \
+    "${timeout_seconds}s" \
+    pnpm exec playwright install-deps chromium; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -eq "$max_attempts" ]]; then
+    echo "Playwright system dependency installation failed after $max_attempts attempts" >&2
+    exit 1
+  fi
+
+  sleep $((attempt * 5))
+done

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Install Playwright system dependencies
         working-directory: ./frontend
-        run: pnpm exec playwright install-deps chromium
+        run: ../.github/scripts/install-playwright-system-deps.sh
 
       - name: Run database migrations
         working-directory: ./backend
@@ -577,7 +577,7 @@ jobs:
 
       - name: Install Playwright system dependencies
         working-directory: ./frontend
-        run: pnpm exec playwright install-deps chromium
+        run: ../.github/scripts/install-playwright-system-deps.sh
 
       - name: Download executor E2E runtime
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093


### PR DESCRIPTION
## Problem

`pnpm exec playwright install-deps chromium` can hang for the full 35-minute job timeout when GitHub's `azure.archive.ubuntu.com` apt mirror stalls. This was observed in merge queue runs where E2E shard logs stopped at `apt-get update` until the job was cancelled.

## Change

Add `.github/scripts/install-playwright-system-deps.sh` and use it from both E2E workflow jobs. The script:

- writes apt HTTP/HTTPS timeout and retry settings
- runs the install under `timeout`
- retries up to 3 times with backoff

This keeps the primary flow intact and avoids both indefinite apt hangs and duplicated workflow snippets.

## Verification

- `bash -n .github/scripts/install-playwright-system-deps.sh`
- local pre-push quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test environment setup by adding configurable timeouts and retries when installing Chromium system dependencies.
  * Updated automated browser tests to use the more resilient dependency installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->