### PR TITLE
fix(wework): stop delayed chat scroll jumps

### DIFF
--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -478,6 +478,22 @@ async function waitForBottom(control, description, timeoutMs) {
   throw new Error(`${description} remained ${distanceFromBottom(metrics)}px from the bottom`)
 }
 
+async function assertScrollPositionRemainsStable(control, initialMetrics, description, timeoutMs) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const metrics = await getSingleElementMetrics(control, SCROLLER_SELECTOR, description)
+    assert.ok(
+      distanceFromBottom(metrics) > 8,
+      `${description} returned to the bottom after the user scrolled upward`
+    )
+    assert.ok(
+      Math.abs(metrics.scrollTop - initialMetrics.scrollTop) <= 8,
+      `${description} jumped from ${initialMetrics.scrollTop}px to ${metrics.scrollTop}px`
+    )
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+}
+
 async function waitForRenderedAppend(control, previousContentLength, timeoutMs) {
   const startedAt = Date.now()
   let processText = ''
@@ -1610,13 +1626,36 @@ export function createDesktopScenario({
       await control.command(
         'waitFor',
         `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="send-message-button"]`,
-        { stableMs: 750, timeoutMs: uiTimeoutMs }
+        { timeoutMs: uiTimeoutMs }
       )
       await control.command('waitFor', ASSISTANT_CONTENT_SELECTOR, {
         text: MARKER,
-        stableMs: 750,
         timeoutMs: uiTimeoutMs,
       })
+
+      await control.command('scrollFromBottomAsUser', SCROLLER_SELECTOR, { value: '160' })
+      const completedUserScrollPosition = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The completed conversation immediately after the user scrolled upward'
+      )
+      assert.ok(
+        distanceFromBottom(completedUserScrollPosition) > 8,
+        'The user scroll did not move the completed conversation away from the bottom'
+      )
+      await assertScrollPositionRemainsStable(
+        control,
+        completedUserScrollPosition,
+        'The completed conversation while delayed bottom-follow work could still run',
+        uiTimeoutMs
+      )
+      await capture(control, 'streaming-text-18-completed-user-scroll-stable.png')
+      await control.command('scrollToBottomAsUser', SCROLLER_SELECTOR)
+      await waitForBottom(
+        control,
+        'The completed conversation after restoring the downstream test precondition',
+        uiTimeoutMs
+      )
       const completedSnapshot = JSON.parse(
         await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
       )
@@ -1637,36 +1676,6 @@ export function createDesktopScenario({
         'The pause button remained after completion'
       )
       await capture(control, 'streaming-text-17-response-completed.png')
-
-      await control.command('scrollFromBottomAsUser', SCROLLER_SELECTOR, { value: '160' })
-      const completedUserScrollPosition = await getSingleElementMetrics(
-        control,
-        SCROLLER_SELECTOR,
-        'The completed conversation immediately after the user scrolled upward'
-      )
-      assert.ok(
-        distanceFromBottom(completedUserScrollPosition) > 8,
-        'The user scroll did not move the completed conversation away from the bottom'
-      )
-      await new Promise(resolve => setTimeout(resolve, 1_250))
-      const stableCompletedUserScrollPosition = await getSingleElementMetrics(
-        control,
-        SCROLLER_SELECTOR,
-        'The completed conversation after delayed bottom-follow work had time to run'
-      )
-      assert.ok(
-        Math.abs(
-          stableCompletedUserScrollPosition.scrollTop - completedUserScrollPosition.scrollTop
-        ) <= 8,
-        `The completed conversation jumped from ${completedUserScrollPosition.scrollTop}px to ${stableCompletedUserScrollPosition.scrollTop}px after the user scrolled upward`
-      )
-      await capture(control, 'streaming-text-18-completed-user-scroll-stable.png')
-      await control.command('scrollToBottomAsUser', SCROLLER_SELECTOR)
-      await waitForBottom(
-        control,
-        'The completed conversation after restoring the downstream test precondition',
-        uiTimeoutMs
-      )
 
       await verifyStoppedTurnOrder(control)
       active = false

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -19,6 +19,7 @@ const PHASE_FLIP_TEXT = 'WEWORK_DESKTOP_E2E_FALLBACK_FINAL_FROM_PROCESS'
 const TIMER_PROMPT = 'WEWORK_DESKTOP_E2E_RUNNING_TIMER_PERSISTS'
 const TIMER_COMPLETION = 'WEWORK_DESKTOP_E2E_RUNNING_TIMER_COMPLETE'
 const ORDER_STOP_PROMPT = 'WEWORK_DESKTOP_E2E_ORDER_STOPPED_TURN'
+const ORDER_STOP_PARTIAL = 'WEWORK_DESKTOP_E2E_ORDER_STOP_PARTIAL'
 const ORDER_FOLLOW_UP_PREFIX = 'WEWORK_DESKTOP_E2E_ORDER_FOLLOW_UP'
 const ORDER_COMPLETION_PREFIX = 'WEWORK_DESKTOP_E2E_ORDER_COMPLETION'
 const ORDER_FOLLOW_UP_COUNT = 26
@@ -658,6 +659,11 @@ export function createDesktopScenario({
     await control.command('waitFor', '[data-testid="pause-response-button"]', {
       timeoutMs: uiTimeoutMs,
     })
+    await control.command('waitFor', PROCESS_TEXT_SELECTOR, {
+      text: ORDER_STOP_PARTIAL,
+      stableMs: 500,
+      timeoutMs: uiTimeoutMs,
+    })
     await control.command('click', '[data-testid="pause-response-button"]')
     await control.command('waitFor', '[data-testid="assistant-stopped-notice"]', {
       timeoutMs: uiTimeoutMs,
@@ -725,7 +731,7 @@ export function createDesktopScenario({
           'Content-Type': 'text/event-stream; charset=utf-8',
         })
         response.flushHeaders()
-        response.write(sse([responseCreated(responseId)]))
+        response.write(sse([responseCreated(responseId), assistantMessage(ORDER_STOP_PARTIAL)]))
         return true
       }
       if (timerStage === 'awaiting-tool-output' && requestContainsToolOutput(body)) {

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -1631,6 +1631,37 @@ export function createDesktopScenario({
         'The pause button remained after completion'
       )
       await capture(control, 'streaming-text-17-response-completed.png')
+
+      await control.command('scrollFromBottomAsUser', SCROLLER_SELECTOR, { value: '160' })
+      const completedUserScrollPosition = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The completed conversation immediately after the user scrolled upward'
+      )
+      assert.ok(
+        distanceFromBottom(completedUserScrollPosition) > 8,
+        'The user scroll did not move the completed conversation away from the bottom'
+      )
+      await new Promise(resolve => setTimeout(resolve, 1_250))
+      const stableCompletedUserScrollPosition = await getSingleElementMetrics(
+        control,
+        SCROLLER_SELECTOR,
+        'The completed conversation after delayed bottom-follow work had time to run'
+      )
+      assert.ok(
+        Math.abs(
+          stableCompletedUserScrollPosition.scrollTop - completedUserScrollPosition.scrollTop
+        ) <= 8,
+        `The completed conversation jumped from ${completedUserScrollPosition.scrollTop}px to ${stableCompletedUserScrollPosition.scrollTop}px after the user scrolled upward`
+      )
+      await capture(control, 'streaming-text-18-completed-user-scroll-stable.png')
+      await control.command('scrollToBottomAsUser', SCROLLER_SELECTOR)
+      await waitForBottom(
+        control,
+        'The completed conversation after restoring the downstream test precondition',
+        uiTimeoutMs
+      )
+
       await verifyStoppedTurnOrder(control)
       active = false
     },

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -3441,6 +3441,47 @@ describe('ScrollableMessageArea', () => {
     expect(scroller.scrollTo).not.toHaveBeenCalled()
   })
 
+  test('cancels delayed bottom following as soon as the user scrolls upward', () => {
+    render(
+      <ScrollableMessageArea
+        conversationKey="delayed-bottom-follow"
+        messages={[
+          {
+            id: 'delayed-bottom-follow-assistant',
+            role: 'assistant',
+            content: '回复已完成',
+            status: 'done',
+            createdAt: '2026-08-18T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 600,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn()
+
+    fireEvent.wheel(scroller, { deltaY: -80 })
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled()
+  })
+
   test('scrolls to a newly applied guidance message inserted before the assistant continuation', () => {
     const streamingMessage = {
       id: 'guidance-stream',

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -3442,12 +3442,94 @@ describe('ScrollableMessageArea', () => {
   })
 
   test('cancels delayed bottom following as soon as the user scrolls upward', () => {
+    const resizeCallbacks: ResizeObserverCallback[] = []
+    vi.stubGlobal(
+      'ResizeObserver',
+      class ResizeObserverMock {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallbacks.push(callback)
+        }
+        observe() {}
+        disconnect() {}
+      }
+    )
+
     render(
       <ScrollableMessageArea
         conversationKey="delayed-bottom-follow"
         messages={[
           {
             id: 'delayed-bottom-follow-assistant',
+            role: 'assistant',
+            content: '回复已完成',
+            status: 'done',
+            createdAt: '2026-08-18T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    const anchor = screen.getByText('回复已完成').closest('[data-scroll-anchor]')!
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 600,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+    mockRect(scroller, 100, 300)
+    let anchorTopAtScrollZero = 500
+    anchor.getBoundingClientRect = vi.fn(() => {
+      const top = anchorTopAtScrollZero - scroller.scrollTop
+      return {
+        top,
+        bottom: top + 800,
+        left: 0,
+        right: 320,
+        width: 320,
+        height: 800,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect
+    })
+
+    fireEvent.wheel(scroller, { deltaY: -80 })
+    scroller.scrollTop = 440
+    fireEvent.scroll(scroller)
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled()
+
+    anchorTopAtScrollZero += 120
+    act(() => {
+      resizeCallbacks.forEach(callback => callback([], {} as ResizeObserver))
+    })
+
+    expect(scroller.scrollTop).toBe(560)
+    expect(anchor.getBoundingClientRect().top).toBe(60)
+  })
+
+  test('keeps delayed bottom following for pointer input without scrolling', () => {
+    render(
+      <ScrollableMessageArea
+        conversationKey="pointer-without-scroll"
+        messages={[
+          {
+            id: 'pointer-without-scroll-assistant',
             role: 'assistant',
             content: '回复已完成',
             status: 'done',
@@ -3473,13 +3555,13 @@ describe('ScrollableMessageArea', () => {
     })
     scroller.scrollTo = vi.fn()
 
-    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.pointerDown(scroller)
 
     act(() => {
       vi.runOnlyPendingTimers()
     })
 
-    expect(scroller.scrollTo).not.toHaveBeenCalled()
+    expect(scroller.scrollTo).toHaveBeenCalled()
   })
 
   test('scrolls to a newly applied guidance message inserted before the assistant continuation', () => {

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -925,17 +925,17 @@ function ScrollableMessagePaneContent({
       return
     }
 
+    if (userScrollPausedAutoFollowRef.current) {
+      restoreUserViewportAnchor()
+      return
+    }
+
     const shouldFollowBottom =
       followingBottomKeyRef.current === currentScrollKey ||
       (currentScrollKey !== null &&
         getConversationScrollSnapshot(currentScrollKey)?.pinnedToBottom === true)
     if (shouldFollowBottom) {
       setScrollToBottom('auto', { saveSnapshot: false })
-      return
-    }
-
-    if (userScrollPausedAutoFollowRef.current) {
-      restoreUserViewportAnchor()
       return
     }
 
@@ -986,10 +986,19 @@ function ScrollableMessagePaneContent({
     scrollToBottom('smooth', { saveSnapshot: true })
   }
 
-  const markUserScrollIntent = useCallback(() => {
-    userScrollIntentRef.current = true
-    captureUserViewportAnchor()
-  }, [captureUserViewportAnchor])
+  const markUserScrollIntent = useCallback(
+    (event?: Event | { nativeEvent?: Event }) => {
+      userScrollIntentRef.current = true
+      clearScheduledScrolls()
+      captureUserViewportAnchor()
+
+      const nativeEvent = event && 'nativeEvent' in event ? event.nativeEvent : event
+      if (nativeEvent && 'deltaY' in nativeEvent && Number(nativeEvent.deltaY) < 0) {
+        userScrollPausedAutoFollowRef.current = true
+      }
+    },
+    [captureUserViewportAnchor, clearScheduledScrolls]
+  )
 
   const handleScroll = useCallback(() => {
     if (autoScrollSuspended || isTurnNavigationAutoScrollSuspended()) {

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -989,13 +989,13 @@ function ScrollableMessagePaneContent({
   const markUserScrollIntent = useCallback(
     (event?: Event | { nativeEvent?: Event }) => {
       userScrollIntentRef.current = true
-      clearScheduledScrolls()
-      captureUserViewportAnchor()
 
       const nativeEvent = event && 'nativeEvent' in event ? event.nativeEvent : event
-      if (nativeEvent && 'deltaY' in nativeEvent && Number(nativeEvent.deltaY) < 0) {
-        userScrollPausedAutoFollowRef.current = true
-      }
+      if (!nativeEvent || !('deltaY' in nativeEvent) || Number(nativeEvent.deltaY) >= 0) return
+
+      clearScheduledScrolls()
+      captureUserViewportAnchor()
+      userScrollPausedAutoFollowRef.current = true
     },
     [captureUserViewportAnchor, clearScheduledScrolls]
   )


### PR DESCRIPTION
## Summary

- cancel delayed bottom-follow work as soon as the user starts scrolling
- prioritize the user's viewport anchor over stale bottom-pinned state
- add unit and desktop E2E coverage for completed-response scroll stability

## Root cause

AI response rendering schedules repeated bottom alignment while layout measurements settle. User scroll intent did not take ownership until the later `scroll` event, leaving a race where a pending timer could move the viewport after the gesture began.

## User impact

Completed and streaming conversations no longer jump back to another position when the user scrolls upward.

## Validation

- `pnpm --filter wework test src/components/chat/ScrollableMessageArea.test.tsx src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework exec prettier --check wework/src/components/chat/ScrollableMessageArea.tsx wework/src/components/chat/ScrollableMessageArea.test.tsx wework/e2e/desktop/scenarios/streaming-text.scenario.mjs`
- `pnpm --filter wework exec eslint wework/src/components/chat/ScrollableMessageArea.tsx wework/src/components/chat/ScrollableMessageArea.test.tsx`
- `RUSTC_WRAPPER= pnpm --filter wework e2e:desktop --segment rendering-extensions`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling when users scroll upward during or after streaming responses.
  * Preserved the user’s viewport position and cancelled automatic bottom-following when manual scrolling begins.
  * Prevented pointer interactions without scrolling from unnecessarily interrupting automatic bottom-following.
  * Added verification that partial responses appear before a paused stream and that scrolling remains stable after streaming completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->