### PR TITLE
fix(wework): queue replies for running task sessions

### DIFF
--- a/docs/en/architecture/automation-manager-continuation.md
+++ b/docs/en/architecture/automation-manager-continuation.md
@@ -9,7 +9,8 @@ flowchart LR
     EXEC[(automation_manager execution)] --> BIND[Persist execution_id + executor_type + manager_type]
     BIND --> ROOT[Manager activity comment]
     EXEC --> SESSION[Bound Runtime session]
-    USER[User reply] --> ROUTE[Resolve execution from replied comment]
+    USER[User reply] --> QUEUE[Queue by manager-comment session]
+    QUEUE --> ROUTE[Resolve execution from replied comment]
     ROOT --> ROUTE
     ROUTE --> REPLY[Create new manager-authored reply]
     ROUTE --> SESSION
@@ -30,6 +31,8 @@ sequenceDiagram
     C->>C: Persist execution_id, executor_type, and manager_type on activity
     C-->>W: Publish manager comment with complete identity
     U->>W: Reply to a custom AI manager comment
+    W->>W: retain it in that comment-session queue while running
+    W->>W: take the next reply in creation order after the prior turn settles
     W->>C: manager:continue(user comment, manager comment)
     C->>X: Validate execution ID, task, project, and Runtime binding
     C->>C: Create a new streaming reply with manager identity
@@ -39,12 +42,12 @@ sequenceDiagram
     C->>C: Update only comment state, not task AI execution state
 ```
 
-| Boundary | Code ownership |
-| --- | --- |
-| Execution-to-comment identity binding | `backend/app/services/project_automation_execution.py` |
-| Comment detection and routing | `wework/src/features/todo/TaskActivityView.tsx` |
-| Socket contract | `wework/src/api/backend/projectChatSocket.ts`, `backend/app/api/ws/wework_runtime_namespace.py` |
-| Execution and comment validation | `backend/app/services/project_chat/service.py` |
-| Runtime-session continuation | `wework/src/features/workbench/` |
+| Boundary                              | Code ownership                                                                                  |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Execution-to-comment identity binding | `backend/app/services/project_automation_execution.py`                                          |
+| Comment detection and routing         | `wework/src/features/todo/TaskActivityView.tsx`                                                 |
+| Socket contract                       | `wework/src/api/backend/projectChatSocket.ts`, `backend/app/api/ws/wework_runtime_namespace.py` |
+| Execution and comment validation      | `backend/app/services/project_chat/service.py`                                                  |
+| Runtime-session continuation          | `wework/src/features/workbench/`                                                                |
 
-Invariants: before a manager activity comment is published it must persist `execution_id`, `executor_type=automation_manager`, and the corresponding `manager_type`; neither the UI nor the continuation service may infer comment identity from the task's current assignee; continuation is selected from the replied comment's bound execution and Runtime session; only custom `automation_manager` executions may enter this path; the user reply and manager answer are separate new comments, and an existing comment's author identity is immutable; continuation reuses the original manager session; conversation replies must not overwrite the task's current robot execution state, assignee, or board status.
+Invariants: before a manager activity comment is published it must persist `execution_id`, `executor_type=automation_manager`, and the corresponding `manager_type`; neither the UI nor the continuation service may infer comment identity from the task's current assignee; continuation is selected from the replied comment's bound execution and Runtime session; only custom `automation_manager` executions may enter this path; follow-ups appended while the same manager-comment session is running must be queued and sent in creation order; the user reply and manager answer are separate new comments, and an existing comment's author identity is immutable; continuation reuses the original manager session; conversation replies must not overwrite the task's current robot execution state, assignee, or board status.

--- a/docs/en/architecture/automation-manager-continuation.md
+++ b/docs/en/architecture/automation-manager-continuation.md
@@ -31,7 +31,7 @@ sequenceDiagram
     C->>C: Persist execution_id, executor_type, and manager_type on activity
     C-->>W: Publish manager comment with complete identity
     U->>W: Reply to a custom AI manager comment
-    W->>W: retain it in that comment-session queue while running
+    W->>W: retain it in that comment-session queue while pending or streaming
     W->>W: take the next reply in creation order after the prior turn settles
     W->>C: manager:continue(user comment, manager comment)
     C->>X: Validate execution ID, task, project, and Runtime binding
@@ -50,4 +50,4 @@ sequenceDiagram
 | Execution and comment validation      | `backend/app/services/project_chat/service.py`                                                  |
 | Runtime-session continuation          | `wework/src/features/workbench/`                                                                |
 
-Invariants: before a manager activity comment is published it must persist `execution_id`, `executor_type=automation_manager`, and the corresponding `manager_type`; neither the UI nor the continuation service may infer comment identity from the task's current assignee; continuation is selected from the replied comment's bound execution and Runtime session; only custom `automation_manager` executions may enter this path; follow-ups appended while the same manager-comment session is running must be queued and sent in creation order; the user reply and manager answer are separate new comments, and an existing comment's author identity is immutable; continuation reuses the original manager session; conversation replies must not overwrite the task's current robot execution state, assignee, or board status.
+Invariants: before a manager activity comment is published it must persist `execution_id`, `executor_type=automation_manager`, and the corresponding `manager_type`; neither the UI nor the continuation service may infer comment identity from the task's current assignee; continuation is selected from the replied comment's bound execution and Runtime session; only custom `automation_manager` executions may enter this path; follow-ups appended while the same manager-comment session is `pending` or `streaming` must be retained in its queue and sent in creation order; the user reply and manager answer are separate new comments, and an existing comment's author identity is immutable; continuation reuses the original manager session; conversation replies must not overwrite the task's current robot execution state, assignee, or board status.

--- a/docs/en/architecture/board-automation.md
+++ b/docs/en/architecture/board-automation.md
@@ -54,25 +54,25 @@ sequenceDiagram
     T->>X: accepted/running
     T-->>P: completion, failure, or cancellation ACK
     P->>X: validate linked IDs and write terminal state
-    E->>Q: append to a running parent-comment session
+    E->>Q: append to a pending or streaming parent-comment session
     Q-->>E: retain as a queued message
     P->>Q: previous turn becomes terminal
     Q->>R: continue the same parent-comment session in order
     X-->>E: UI reads execution truth only
 ```
 
-| Edge                                   | Code owner                                                                        |
-| -------------------------------------- | --------------------------------------------------------------------------------- |
-| Entry → assignment                     | `backend/app/services/loop_items/`, `project_automation_execution.py`             |
-| Assignee storage → API meaning         | `backend/app/models/delivery.py`, `backend/app/schemas/delivery.py`               |
-| Assignment → execution truth           | `backend/app/services/loop_item_executions/service.py`                            |
-| Execution → immutable activity         | `loop_item_executions/service.py`, `project_automation_execution.py`              |
-| Execution → runtime activation         | `board_team_execution.py`, `robot_queue_tasks.py`, Wework puller                  |
-| Wegent request → board MCP             | `execution/request_builder.py`, `mcp_server/tools/wework_space.py`                |
-| Runtime event → terminal state         | `board_team_completion.py`, Executor status updates                               |
-| Comment → exact continuation           | `board_team_continuation.py`, `project_automation_tasks.py`                       |
-| Running comment → ordered continuation | `wework/src/features/todo/TaskActivityView.tsx`, conversation message queue cache |
+| Edge                                             | Code owner                                                                        |
+| ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Entry → assignment                               | `backend/app/services/loop_items/`, `project_automation_execution.py`             |
+| Assignee storage → API meaning                   | `backend/app/models/delivery.py`, `backend/app/schemas/delivery.py`               |
+| Assignment → execution truth                     | `backend/app/services/loop_item_executions/service.py`                            |
+| Execution → immutable activity                   | `loop_item_executions/service.py`, `project_automation_execution.py`              |
+| Execution → runtime activation                   | `board_team_execution.py`, `robot_queue_tasks.py`, Wework puller                  |
+| Wegent request → board MCP                       | `execution/request_builder.py`, `mcp_server/tools/wework_space.py`                |
+| Runtime event → terminal state                   | `board_team_completion.py`, Executor status updates                               |
+| Comment → exact continuation                     | `board_team_continuation.py`, `project_automation_tasks.py`                       |
+| Pending/streaming comment → ordered continuation | `wework/src/features/todo/TaskActivityView.tsx`, conversation message queue cache |
 
-Invariants: all entries share assignment and activation; changing the assignee to a robot must create its queued execution in the same business transaction, and automatic execution remains owned by the existing queue-consumption path; activation occurs only after commit; `loop_item_executions` is the sole board-execution truth; a task contains multiple comments and each comment's author identity is immutable after creation; when a person creates a root comment and the assignee is a robot, the robot answers with a new reply; when a person replies to a robot-created root comment, the assigned robot answers with another new reply; a follow-up appended while the same parent-comment session is running must enter that session's pending-message queue and be sent in creation order, never discarded because the Runtime is busy or dispatched as a parallel continuation; comments are connected only through `reply_to_message_id` and `thread_root_message_id`, never by rewriting an existing comment's author; an AI-manager activity and its selected project-robot activity are always distinct; Wegent binding uses exact execution/task/subtask/team IDs; MySQL `loop_items.assignee_team_id=0` means unassigned only, and services plus APIs must normalize it to `null` instead of treating `0` as a Team ID; optional Team/Task IDs in `loop_item_executions` use a separate but consistent `0 ↔ null` boundary; cancellation writes intent first and only a Runtime ACK writes terminal state; messages and UI never overwrite execution state.
+Invariants: all entries share assignment and activation; changing the assignee to a robot must create its queued execution in the same business transaction, and automatic execution remains owned by the existing queue-consumption path; activation occurs only after commit; `loop_item_executions` is the sole board-execution truth; a task contains multiple comments and each comment's author identity is immutable after creation; when a person creates a root comment and the assignee is a robot, the robot answers with a new reply; when a person replies to a robot-created root comment, the assigned robot answers with another new reply; a follow-up appended while the same parent-comment session is `pending` or `streaming` must be retained in that session's pending-message queue and sent in creation order, never discarded because the Runtime is busy or dispatched as a parallel continuation; comments are connected only through `reply_to_message_id` and `thread_root_message_id`, never by rewriting an existing comment's author; an AI-manager activity and its selected project-robot activity are always distinct; Wegent binding uses exact execution/task/subtask/team IDs; MySQL `loop_items.assignee_team_id=0` means unassigned only, and services plus APIs must normalize it to `null` instead of treating `0` as a Team ID; optional Team/Task IDs in `loop_item_executions` use a separate but consistent `0 ↔ null` boundary; cancellation writes intent first and only a Runtime ACK writes terminal state; messages and UI never overwrite execution state.
 
 See the [cloud-project collaboration guide](../wegent/developer-guide/cloud-project-collaboration.md) for domain, API, and delivery details.

--- a/docs/en/architecture/board-automation.md
+++ b/docs/en/architecture/board-automation.md
@@ -23,7 +23,10 @@ flowchart LR
     TEAM --> EVENT
     EVENT --> PROJECT[shared terminal projector]
     PROJECT --> EXEC
+    USER_REPLY[User follow-up] --> CONT_QUEUE[queue by parent-comment session]
+    CONT_QUEUE -->|previous turn terminal| ACTIVATE
     ACTIVITY --> VIEW[queue / card / activity]
+    CONT_QUEUE --> VIEW
     EXEC --> VIEW
 ```
 
@@ -37,6 +40,7 @@ sequenceDiagram
     participant R as runtime activator
     participant T as Runtime / Team
     participant P as terminal projector
+    participant Q as comment continuation queue
 
     E->>A: assign(agent, item)
     A->>I: write assignee; MySQL stores unassigned Team as sentinel 0
@@ -50,20 +54,25 @@ sequenceDiagram
     T->>X: accepted/running
     T-->>P: completion, failure, or cancellation ACK
     P->>X: validate linked IDs and write terminal state
+    E->>Q: append to a running parent-comment session
+    Q-->>E: retain as a queued message
+    P->>Q: previous turn becomes terminal
+    Q->>R: continue the same parent-comment session in order
     X-->>E: UI reads execution truth only
 ```
 
-| Edge                           | Code owner                                                            |
-| ------------------------------ | --------------------------------------------------------------------- |
-| Entry → assignment             | `backend/app/services/loop_items/`, `project_automation_execution.py` |
-| Assignee storage → API meaning | `backend/app/models/delivery.py`, `backend/app/schemas/delivery.py`   |
-| Assignment → execution truth   | `backend/app/services/loop_item_executions/service.py`                |
-| Execution → immutable activity | `loop_item_executions/service.py`, `project_automation_execution.py`  |
-| Execution → runtime activation | `board_team_execution.py`, `robot_queue_tasks.py`, Wework puller      |
-| Wegent request → board MCP     | `execution/request_builder.py`, `mcp_server/tools/wework_space.py`    |
-| Runtime event → terminal state | `board_team_completion.py`, Executor status updates                   |
-| Comment → exact continuation   | `board_team_continuation.py`, `project_automation_tasks.py`           |
+| Edge                                   | Code owner                                                                        |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| Entry → assignment                     | `backend/app/services/loop_items/`, `project_automation_execution.py`             |
+| Assignee storage → API meaning         | `backend/app/models/delivery.py`, `backend/app/schemas/delivery.py`               |
+| Assignment → execution truth           | `backend/app/services/loop_item_executions/service.py`                            |
+| Execution → immutable activity         | `loop_item_executions/service.py`, `project_automation_execution.py`              |
+| Execution → runtime activation         | `board_team_execution.py`, `robot_queue_tasks.py`, Wework puller                  |
+| Wegent request → board MCP             | `execution/request_builder.py`, `mcp_server/tools/wework_space.py`                |
+| Runtime event → terminal state         | `board_team_completion.py`, Executor status updates                               |
+| Comment → exact continuation           | `board_team_continuation.py`, `project_automation_tasks.py`                       |
+| Running comment → ordered continuation | `wework/src/features/todo/TaskActivityView.tsx`, conversation message queue cache |
 
-Invariants: all entries share assignment and activation; changing the assignee to a robot must create its queued execution in the same business transaction, and automatic execution remains owned by the existing queue-consumption path; activation occurs only after commit; `loop_item_executions` is the sole board-execution truth; a task contains multiple comments and each comment's author identity is immutable after creation; when a person creates a root comment and the assignee is a robot, the robot answers with a new reply; when a person replies to a robot-created root comment, the assigned robot answers with another new reply; comments are connected only through `reply_to_message_id` and `thread_root_message_id`, never by rewriting an existing comment's author; an AI-manager activity and its selected project-robot activity are always distinct; Wegent binding uses exact execution/task/subtask/team IDs; MySQL `loop_items.assignee_team_id=0` means unassigned only, and services plus APIs must normalize it to `null` instead of treating `0` as a Team ID; optional Team/Task IDs in `loop_item_executions` use a separate but consistent `0 ↔ null` boundary; cancellation writes intent first and only a Runtime ACK writes terminal state; messages and UI never overwrite execution state.
+Invariants: all entries share assignment and activation; changing the assignee to a robot must create its queued execution in the same business transaction, and automatic execution remains owned by the existing queue-consumption path; activation occurs only after commit; `loop_item_executions` is the sole board-execution truth; a task contains multiple comments and each comment's author identity is immutable after creation; when a person creates a root comment and the assignee is a robot, the robot answers with a new reply; when a person replies to a robot-created root comment, the assigned robot answers with another new reply; a follow-up appended while the same parent-comment session is running must enter that session's pending-message queue and be sent in creation order, never discarded because the Runtime is busy or dispatched as a parallel continuation; comments are connected only through `reply_to_message_id` and `thread_root_message_id`, never by rewriting an existing comment's author; an AI-manager activity and its selected project-robot activity are always distinct; Wegent binding uses exact execution/task/subtask/team IDs; MySQL `loop_items.assignee_team_id=0` means unassigned only, and services plus APIs must normalize it to `null` instead of treating `0` as a Team ID; optional Team/Task IDs in `loop_item_executions` use a separate but consistent `0 ↔ null` boundary; cancellation writes intent first and only a Runtime ACK writes terminal state; messages and UI never overwrite execution state.
 
 See the [cloud-project collaboration guide](../wegent/developer-guide/cloud-project-collaboration.md) for domain, API, and delivery details.

--- a/docs/en/architecture/board-automation.md
+++ b/docs/en/architecture/board-automation.md
@@ -56,7 +56,7 @@ sequenceDiagram
     P->>X: validate linked IDs and write terminal state
     E->>Q: append to a pending or streaming parent-comment session
     Q-->>E: retain as a queued message
-    P->>Q: previous turn becomes terminal
+    T-->>Q: parent-comment Runtime session becomes terminal
     Q->>R: continue the same parent-comment session in order
     X-->>E: UI reads execution truth only
 ```

--- a/docs/zh/architecture/automation-manager-continuation.md
+++ b/docs/zh/architecture/automation-manager-continuation.md
@@ -31,7 +31,7 @@ sequenceDiagram
     C->>C: 将 execution_id、executor_type、manager_type 写入活动评论
     C-->>W: 发布身份完整的调度员评论
     U->>W: 回复自定义 AI 调度员评论
-    W->>W: 运行中则保存到该评论会话队列
+    W->>W: 会话为 pending 或 streaming 时保存到该评论会话队列
     W->>W: 前一轮终态后按创建顺序取下一条
     W->>C: manager:continue(用户评论, 调度员评论)
     C->>X: 校验 execution_id、任务、项目和 Runtime 绑定
@@ -50,4 +50,4 @@ sequenceDiagram
 | execution 与评论校验     | `backend/app/services/project_chat/service.py`                                                  |
 | Runtime 会话继续         | `wework/src/features/workbench/`                                                                |
 
-不变量：调度员活动评论发布前必须持久化 `execution_id`、`executor_type=automation_manager` 和对应的 `manager_type`，UI 与续聊服务不得从任务当前负责人反推评论身份；续聊目标由被回复评论绑定的 execution 和 Runtime 会话决定；仅自定义 `automation_manager` execution 可以进入此路径；同一调度员评论会话运行时的追加回复必须排队并按创建顺序发送；用户回复和调度员回答必须是两条新评论，既有评论作者身份不可修改；续聊复用原调度员会话；对话回复不得覆盖任务当前机器人的执行状态、负责人或看板状态。
+不变量：调度员活动评论发布前必须持久化 `execution_id`、`executor_type=automation_manager` 和对应的 `manager_type`，UI 与续聊服务不得从任务当前负责人反推评论身份；续聊目标由被回复评论绑定的 execution 和 Runtime 会话决定；仅自定义 `automation_manager` execution 可以进入此路径；同一调度员评论会话处于 `pending` 或 `streaming` 状态时，追加回复必须保留在该会话队列中并按创建顺序发送；用户回复和调度员回答必须是两条新评论，既有评论作者身份不可修改；续聊复用原调度员会话；对话回复不得覆盖任务当前机器人的执行状态、负责人或看板状态。

--- a/docs/zh/architecture/automation-manager-continuation.md
+++ b/docs/zh/architecture/automation-manager-continuation.md
@@ -9,7 +9,8 @@ flowchart LR
     EXEC[(automation_manager execution)] --> BIND[持久化 execution_id + executor_type + manager_type]
     BIND --> ROOT[调度员活动评论]
     EXEC --> SESSION[绑定 Runtime 会话]
-    USER[用户回复] --> ROUTE[按被回复评论解析执行身份]
+    USER[用户回复] --> QUEUE[按调度员评论会话排队]
+    QUEUE --> ROUTE[按被回复评论解析执行身份]
     ROOT --> ROUTE
     ROUTE --> REPLY[新建调度员身份回复]
     ROUTE --> SESSION
@@ -30,6 +31,8 @@ sequenceDiagram
     C->>C: 将 execution_id、executor_type、manager_type 写入活动评论
     C-->>W: 发布身份完整的调度员评论
     U->>W: 回复自定义 AI 调度员评论
+    W->>W: 运行中则保存到该评论会话队列
+    W->>W: 前一轮终态后按创建顺序取下一条
     W->>C: manager:continue(用户评论, 调度员评论)
     C->>X: 校验 execution_id、任务、项目和 Runtime 绑定
     C->>C: 创建新的调度员身份 streaming 回复
@@ -39,12 +42,12 @@ sequenceDiagram
     C->>C: 仅更新评论状态，不改任务 AI 执行状态
 ```
 
-| 边界 | 代码归属 |
-| --- | --- |
-| execution → 评论身份绑定 | `backend/app/services/project_automation_execution.py` |
-| 评论识别与路由 | `wework/src/features/todo/TaskActivityView.tsx` |
-| Socket 合约 | `wework/src/api/backend/projectChatSocket.ts`、`backend/app/api/ws/wework_runtime_namespace.py` |
-| execution 与评论校验 | `backend/app/services/project_chat/service.py` |
-| Runtime 会话继续 | `wework/src/features/workbench/` |
+| 边界                     | 代码归属                                                                                        |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| execution → 评论身份绑定 | `backend/app/services/project_automation_execution.py`                                          |
+| 评论识别与路由           | `wework/src/features/todo/TaskActivityView.tsx`                                                 |
+| Socket 合约              | `wework/src/api/backend/projectChatSocket.ts`、`backend/app/api/ws/wework_runtime_namespace.py` |
+| execution 与评论校验     | `backend/app/services/project_chat/service.py`                                                  |
+| Runtime 会话继续         | `wework/src/features/workbench/`                                                                |
 
-不变量：调度员活动评论发布前必须持久化 `execution_id`、`executor_type=automation_manager` 和对应的 `manager_type`，UI 与续聊服务不得从任务当前负责人反推评论身份；续聊目标由被回复评论绑定的 execution 和 Runtime 会话决定；仅自定义 `automation_manager` execution 可以进入此路径；用户回复和调度员回答必须是两条新评论，既有评论作者身份不可修改；续聊复用原调度员会话；对话回复不得覆盖任务当前机器人的执行状态、负责人或看板状态。
+不变量：调度员活动评论发布前必须持久化 `execution_id`、`executor_type=automation_manager` 和对应的 `manager_type`，UI 与续聊服务不得从任务当前负责人反推评论身份；续聊目标由被回复评论绑定的 execution 和 Runtime 会话决定；仅自定义 `automation_manager` execution 可以进入此路径；同一调度员评论会话运行时的追加回复必须排队并按创建顺序发送；用户回复和调度员回答必须是两条新评论，既有评论作者身份不可修改；续聊复用原调度员会话；对话回复不得覆盖任务当前机器人的执行状态、负责人或看板状态。

--- a/docs/zh/architecture/board-automation.md
+++ b/docs/zh/architecture/board-automation.md
@@ -56,7 +56,7 @@ sequenceDiagram
     P->>X: 校验关联 ID 后写终态
     E->>Q: 向 pending 或 streaming 的父评论会话追加消息
     Q-->>E: 保存为待发送消息
-    P->>Q: 前一轮进入终态
+    T-->>Q: 父评论 Runtime 会话进入终态
     Q->>R: 按顺序继续同一父评论会话
     X-->>E: UI 只读取 execution 真值
 ```

--- a/docs/zh/architecture/board-automation.md
+++ b/docs/zh/architecture/board-automation.md
@@ -23,7 +23,10 @@ flowchart LR
     TEAM --> EVENT
     EVENT --> PROJECT[统一终态投影器]
     PROJECT --> EXEC
+    USER_REPLY[用户追加评论] --> CONT_QUEUE[按父评论会话排队]
+    CONT_QUEUE -->|前一轮终态| ACTIVATE
     ACTIVITY --> VIEW[队列 / 卡片 / 活动流]
+    CONT_QUEUE --> VIEW
     EXEC --> VIEW
 ```
 
@@ -37,6 +40,7 @@ sequenceDiagram
     participant R as runtime 激活器
     participant T as Runtime / Team
     participant P as 终态投影器
+    participant Q as 评论续聊队列
 
     E->>A: assign(agent, item)
     A->>I: 写负责人；MySQL 未分配 Team 写 0 哨兵
@@ -50,6 +54,10 @@ sequenceDiagram
     T->>X: accepted/running
     T-->>P: 完成、失败或取消 ACK
     P->>X: 校验关联 ID 后写终态
+    E->>Q: 向运行中的父评论会话追加消息
+    Q-->>E: 保存为待发送消息
+    P->>Q: 前一轮进入终态
+    Q->>R: 按顺序继续同一父评论会话
     X-->>E: UI 只读取 execution 真值
 ```
 
@@ -63,7 +71,8 @@ sequenceDiagram
 | Wegent 请求 → 看板 MCP   | `execution/request_builder.py`、`mcp_server/tools/wework_space.py`    |
 | Runtime 事件 → 终态      | `board_team_completion.py`、Executor 状态更新                         |
 | 评论 → 精确续聊          | `board_team_continuation.py`、`project_automation_tasks.py`           |
+| 运行中评论 → 顺序续聊    | `wework/src/features/todo/TaskActivityView.tsx`、会话消息队列缓存     |
 
-不变量：所有入口共用指派与激活器；机器人负责人变更必须在同一业务事务中创建对应的 queued execution，自动执行由该 execution 的既有队列消费链负责；激活只能发生在提交后；`loop_item_executions` 是看板执行唯一真值；任务包含多个评论，每条评论的作者身份创建后不可修改；人创建父评论且负责人是机器人时，机器人以新评论回复该父评论；机器人创建父评论后，人回复该评论时，负责人机器人以另一条新评论继续回复；评论之间只通过 `reply_to_message_id` 和 `thread_root_message_id` 建立线程关系，不得通过改写旧评论作者表达交接；AI 调度员评论与其选中的项目机器人评论必须始终分离；Wegent 绑定使用精确 execution/task/subtask/team ID；MySQL `loop_items.assignee_team_id=0` 只表示未分配，服务和 API 必须将其归一化为 `null`，不得把 `0` 当作 Team ID；`loop_item_executions` 的可选 Team/Task ID 使用独立但一致的 `0 ↔ null` 边界；取消先写意图，只有 Runtime ACK 写终态；消息和 UI 不能反向覆盖执行状态。
+不变量：所有入口共用指派与激活器；机器人负责人变更必须在同一业务事务中创建对应的 queued execution，自动执行由该 execution 的既有队列消费链负责；激活只能发生在提交后；`loop_item_executions` 是看板执行唯一真值；任务包含多个评论，每条评论的作者身份创建后不可修改；人创建父评论且负责人是机器人时，机器人以新评论回复该父评论；机器人创建父评论后，人回复该评论时，负责人机器人以另一条新评论继续回复；同一父评论会话运行时的追加消息必须进入该会话的待发送队列，按创建顺序逐条发送，不能因 Runtime 忙碌而丢弃或创建并行续聊；评论之间只通过 `reply_to_message_id` 和 `thread_root_message_id` 建立线程关系，不得通过改写旧评论作者表达交接；AI 调度员评论与其选中的项目机器人评论必须始终分离；Wegent 绑定使用精确 execution/task/subtask/team ID；MySQL `loop_items.assignee_team_id=0` 只表示未分配，服务和 API 必须将其归一化为 `null`，不得把 `0` 当作 Team ID；`loop_item_executions` 的可选 Team/Task ID 使用独立但一致的 `0 ↔ null` 边界；取消先写意图，只有 Runtime ACK 写终态；消息和 UI 不能反向覆盖执行状态。
 
 详细领域、API 与交付说明见 [云项目协作开发指南](../wegent/developer-guide/cloud-project-collaboration.md)。

--- a/docs/zh/architecture/board-automation.md
+++ b/docs/zh/architecture/board-automation.md
@@ -54,25 +54,25 @@ sequenceDiagram
     T->>X: accepted/running
     T-->>P: 完成、失败或取消 ACK
     P->>X: 校验关联 ID 后写终态
-    E->>Q: 向运行中的父评论会话追加消息
+    E->>Q: 向 pending 或 streaming 的父评论会话追加消息
     Q-->>E: 保存为待发送消息
     P->>Q: 前一轮进入终态
     Q->>R: 按顺序继续同一父评论会话
     X-->>E: UI 只读取 execution 真值
 ```
 
-| 边                       | 代码归属                                                              |
-| ------------------------ | --------------------------------------------------------------------- |
-| 入口 → 指派              | `backend/app/services/loop_items/`、`project_automation_execution.py` |
-| 负责人存储 → API 语义    | `backend/app/models/delivery.py`、`backend/app/schemas/delivery.py`   |
-| 指派 → execution 真值    | `backend/app/services/loop_item_executions/service.py`                |
-| execution → 独立评论     | `loop_item_executions/service.py`、`project_automation_execution.py`  |
-| execution → runtime 激活 | `board_team_execution.py`、`robot_queue_tasks.py`、Wework puller      |
-| Wegent 请求 → 看板 MCP   | `execution/request_builder.py`、`mcp_server/tools/wework_space.py`    |
-| Runtime 事件 → 终态      | `board_team_completion.py`、Executor 状态更新                         |
-| 评论 → 精确续聊          | `board_team_continuation.py`、`project_automation_tasks.py`           |
-| 运行中评论 → 顺序续聊    | `wework/src/features/todo/TaskActivityView.tsx`、会话消息队列缓存     |
+| 边                                | 代码归属                                                              |
+| --------------------------------- | --------------------------------------------------------------------- |
+| 入口 → 指派                       | `backend/app/services/loop_items/`、`project_automation_execution.py` |
+| 负责人存储 → API 语义             | `backend/app/models/delivery.py`、`backend/app/schemas/delivery.py`   |
+| 指派 → execution 真值             | `backend/app/services/loop_item_executions/service.py`                |
+| execution → 独立评论              | `loop_item_executions/service.py`、`project_automation_execution.py`  |
+| execution → runtime 激活          | `board_team_execution.py`、`robot_queue_tasks.py`、Wework puller      |
+| Wegent 请求 → 看板 MCP            | `execution/request_builder.py`、`mcp_server/tools/wework_space.py`    |
+| Runtime 事件 → 终态               | `board_team_completion.py`、Executor 状态更新                         |
+| 评论 → 精确续聊                   | `board_team_continuation.py`、`project_automation_tasks.py`           |
+| pending/streaming 评论 → 顺序续聊 | `wework/src/features/todo/TaskActivityView.tsx`、会话消息队列缓存     |
 
-不变量：所有入口共用指派与激活器；机器人负责人变更必须在同一业务事务中创建对应的 queued execution，自动执行由该 execution 的既有队列消费链负责；激活只能发生在提交后；`loop_item_executions` 是看板执行唯一真值；任务包含多个评论，每条评论的作者身份创建后不可修改；人创建父评论且负责人是机器人时，机器人以新评论回复该父评论；机器人创建父评论后，人回复该评论时，负责人机器人以另一条新评论继续回复；同一父评论会话运行时的追加消息必须进入该会话的待发送队列，按创建顺序逐条发送，不能因 Runtime 忙碌而丢弃或创建并行续聊；评论之间只通过 `reply_to_message_id` 和 `thread_root_message_id` 建立线程关系，不得通过改写旧评论作者表达交接；AI 调度员评论与其选中的项目机器人评论必须始终分离；Wegent 绑定使用精确 execution/task/subtask/team ID；MySQL `loop_items.assignee_team_id=0` 只表示未分配，服务和 API 必须将其归一化为 `null`，不得把 `0` 当作 Team ID；`loop_item_executions` 的可选 Team/Task ID 使用独立但一致的 `0 ↔ null` 边界；取消先写意图，只有 Runtime ACK 写终态；消息和 UI 不能反向覆盖执行状态。
+不变量：所有入口共用指派与激活器；机器人负责人变更必须在同一业务事务中创建对应的 queued execution，自动执行由该 execution 的既有队列消费链负责；激活只能发生在提交后；`loop_item_executions` 是看板执行唯一真值；任务包含多个评论，每条评论的作者身份创建后不可修改；人创建父评论且负责人是机器人时，机器人以新评论回复该父评论；机器人创建父评论后，人回复该评论时，负责人机器人以另一条新评论继续回复；同一父评论会话处于 `pending` 或 `streaming` 状态时，追加消息必须保留在该会话的待发送队列中，按创建顺序逐条发送，不能因 Runtime 忙碌而丢弃或创建并行续聊；评论之间只通过 `reply_to_message_id` 和 `thread_root_message_id` 建立线程关系，不得通过改写旧评论作者表达交接；AI 调度员评论与其选中的项目机器人评论必须始终分离；Wegent 绑定使用精确 execution/task/subtask/team ID；MySQL `loop_items.assignee_team_id=0` 只表示未分配，服务和 API 必须将其归一化为 `null`，不得把 `0` 当作 Team ID；`loop_item_executions` 的可选 Team/Task ID 使用独立但一致的 `0 ↔ null` 边界；取消先写意图，只有 Runtime ACK 写终态；消息和 UI 不能反向覆盖执行状态。
 
 详细领域、API 与交付说明见 [云项目协作开发指南](../wegent/developer-guide/cloud-project-collaboration.md)。

--- a/wework/e2e/desktop/modules/window-attachment-flows.mjs
+++ b/wework/e2e/desktop/modules/window-attachment-flows.mjs
@@ -495,12 +495,16 @@ async function verifyBackgroundTaskWindowLifecycle({
     })
   }
 
-  await control.command('waitFor', '[data-testid="message-turn-navigation-marker"]', {
+  const firstTurnMarkerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-turn-navigation-marker"][data-turn-index="0"]`
+  await control.command('waitFor', firstTurnMarkerSelector, {
     stableMs: COMPOSER_READY_STABILITY_MS,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
-  await control.command('click', '[data-testid="message-turn-navigation-marker"]')
-  await new Promise(resolvePromise => setTimeout(resolvePromise, 2_000))
+  await control.command('click', firstTurnMarkerSelector)
+  await control.command('waitFor', `${firstTurnMarkerSelector}[data-active="true"]`, {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
   const navigationTopMetrics = await waitForTopMetrics(
     control,
     '[data-testid="desktop-workbench-content"]',

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -515,12 +515,12 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
       uiTimeoutMs,
       'The first native Wegent continuation did not reach the model service'
     )
-    await control.command(
-      'waitFor',
-      '[data-testid^="cloud-task-activity-execution-badge-"][data-status="running"]',
-      { timeoutMs: uiTimeoutMs }
-    )
     try {
+      await control.command(
+        'waitFor',
+        '[data-testid^="cloud-task-activity-execution-badge-"][data-status="running"]',
+        { timeoutMs: uiTimeoutMs }
+      )
       await control.command('fill', replyComposer, { value: QUEUED_CONTINUATION_PROMPT })
       await control.command('press', replyComposer, { key: 'Enter' })
       await control.command(

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -500,18 +500,33 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
     const replyComposer = `[data-testid="cloud-task-activity-card-composer-${rootMessageId}"]`
     await control.command('fill', replyComposer, { value: '确认继续执行' })
     await control.command('press', replyComposer, { key: 'Enter' })
+    await control.command('fill', replyComposer, { value: '补充检查排队消息' })
+    await control.command('press', replyComposer, { key: 'Enter' })
+    await control.command(
+      'waitFor',
+      `[data-testid="cloud-task-activity-card-queue-${rootMessageId}"]`,
+      {
+        text: '补充检查排队消息',
+        timeoutMs: uiTimeoutMs,
+      }
+    )
     const continuedTask = await waitForValue(
       () => cloudRequest(`/api/tasks/${teamExecution.backendTaskId}`),
-      task => (task.subtasks ?? []).some(subtask => subtask.prompt === '确认继续执行'),
-      'The board reply did not append a user turn to the native Wegent Task',
+      task => {
+        const prompts = (task.subtasks ?? []).map(subtask => subtask.prompt)
+        const firstReplyIndex = prompts.indexOf('确认继续执行')
+        const queuedReplyIndex = prompts.indexOf('补充检查排队消息')
+        return firstReplyIndex >= 0 && queuedReplyIndex > firstReplyIndex
+      },
+      'Queued board replies were not appended to the native Wegent Task in order',
       uiTimeoutMs * 3
     )
     assert.equal(continuedTask.id, teamExecution.backendTaskId)
     const agentExecutionBadgeSelector = '[data-testid^="cloud-task-activity-execution-badge-"]'
     await waitForValue(
       () => control.command('getElementCount', agentExecutionBadgeSelector),
-      count => Number(count) === 2,
-      'The native Wegent continuation was not projected as a second agent comment',
+      count => Number(count) === 3,
+      'Queued native Wegent continuations were not projected as distinct agent comments',
       uiTimeoutMs * 3
     )
     const unchangedExecution = await waitForCompletedExecution(

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -33,6 +33,8 @@ const CLOUD_MODEL_NAME = 'desktop-e2e-public-model'
 const PROJECT_CHAT_REMOTE_MODEL_NAME = 'desktop-e2e-project-chat-remote'
 const PROJECT_CHAT_REMOTE_MODEL_LABEL = 'Project Chat Remote Codex'
 const TEAM_ID = 88001
+const FIRST_CONTINUATION_PROMPT = '确认继续执行'
+const QUEUED_CONTINUATION_PROMPT = '补充检查排队消息'
 
 const PROJECT = {
   id: PROJECT_ID,
@@ -292,6 +294,14 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
   let cloudTeam = null
   let personalApiKey = null
   let managerToolCalls = 0
+  let resolveFirstContinuationStarted
+  let releaseFirstContinuation
+  const firstContinuationStarted = new Promise(resolve => {
+    resolveFirstContinuationStarted = resolve
+  })
+  const firstContinuationRelease = new Promise(resolve => {
+    releaseFirstContinuation = resolve
+  })
 
   const cloudRequest = (pathname, options) => {
     assert.ok(cloudApi, 'Real cloud API was not prepared')
@@ -498,24 +508,39 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
       { text: wegentAgent.name, timeoutMs: uiTimeoutMs }
     )
     const replyComposer = `[data-testid="cloud-task-activity-card-composer-${rootMessageId}"]`
-    await control.command('fill', replyComposer, { value: '确认继续执行' })
+    await control.command('fill', replyComposer, { value: FIRST_CONTINUATION_PROMPT })
     await control.command('press', replyComposer, { key: 'Enter' })
-    await control.command('fill', replyComposer, { value: '补充检查排队消息' })
-    await control.command('press', replyComposer, { key: 'Enter' })
+    await withTimeout(
+      firstContinuationStarted,
+      uiTimeoutMs,
+      'The first native Wegent continuation did not reach the model service'
+    )
     await control.command(
       'waitFor',
-      `[data-testid="cloud-task-activity-card-queue-${rootMessageId}"]`,
-      {
-        text: '补充检查排队消息',
-        timeoutMs: uiTimeoutMs,
-      }
+      '[data-testid^="cloud-task-activity-execution-badge-"][data-status="running"]',
+      { timeoutMs: uiTimeoutMs }
     )
+    try {
+      await control.command('fill', replyComposer, { value: QUEUED_CONTINUATION_PROMPT })
+      await control.command('press', replyComposer, { key: 'Enter' })
+      await control.command(
+        'waitFor',
+        `[data-testid="cloud-task-activity-card-queue-${rootMessageId}"]`,
+        {
+          text: QUEUED_CONTINUATION_PROMPT,
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await captureScreenshot(control, 'project-automation-board-team-queued-continuation.png')
+    } finally {
+      releaseFirstContinuation()
+    }
     const continuedTask = await waitForValue(
       () => cloudRequest(`/api/tasks/${teamExecution.backendTaskId}`),
       task => {
         const prompts = (task.subtasks ?? []).map(subtask => subtask.prompt)
-        const firstReplyIndex = prompts.indexOf('确认继续执行')
-        const queuedReplyIndex = prompts.indexOf('补充检查排队消息')
+        const firstReplyIndex = prompts.indexOf(FIRST_CONTINUATION_PROMPT)
+        const queuedReplyIndex = prompts.indexOf(QUEUED_CONTINUATION_PROMPT)
         return firstReplyIndex >= 0 && queuedReplyIndex > firstReplyIndex
       },
       'Queued board replies were not appended to the native Wegent Task in order',
@@ -1011,6 +1036,24 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
         }
         if (serialized.includes('"request_kind":"prewarm"')) {
           writeEvents([responseCreated(responseId), responseCompleted(responseId)])
+          return true
+        }
+        if (
+          serialized.includes(FIRST_CONTINUATION_PROMPT) &&
+          !serialized.includes(QUEUED_CONTINUATION_PROMPT)
+        ) {
+          response.writeHead(200, {
+            'content-type': 'text/event-stream; charset=utf-8',
+            'cache-control': 'no-cache',
+            connection: 'keep-alive',
+          })
+          response.flushHeaders()
+          response.write(createSse([responseCreated(responseId)]))
+          resolveFirstContinuationStarted()
+          await firstContinuationRelease
+          response.end(
+            createSse([assistantMessage('首条追加执行已完成。'), responseCompleted(responseId)])
+          )
           return true
         }
         const isManagerRequest = serialized.includes(

--- a/wework/src/features/todo/TaskActivityView.test.tsx
+++ b/wework/src/features/todo/TaskActivityView.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@/i18n'
 import type { ProjectChatClient, ProjectChatMessage } from '@/api/backend/projectChatSocket'
+import { clearRuntimeConversationCacheForTests } from '@/features/workbench/runtimeConversationCache'
 import { TaskActivityView } from './TaskActivityView'
 import type { Attachment } from '@/types/api'
 
@@ -155,6 +156,7 @@ const agentMessage: ProjectChatMessage = {
 
 describe('TaskActivityView', () => {
   beforeEach(() => {
+    clearRuntimeConversationCacheForTests()
     agentsMock.value = [
       {
         id: '12',
@@ -2281,8 +2283,9 @@ describe('TaskActivityView', () => {
     )
   })
 
-  it('blocks sending from the card composer while the card session is still running', async () => {
+  it('queues a card reply while its session is running and sends it after completion', async () => {
     const user = userEvent.setup()
+    let emitMessage: ((message: ProjectChatMessage) => void) | null = null
     const rootMessage: ProjectChatMessage = {
       ...userMessage,
       rootMessageId: null,
@@ -2296,14 +2299,17 @@ describe('TaskActivityView', () => {
       replyToMessageId: userMessage.messageId,
     }
     const client = {
-      subscribe: vi.fn(async () => ({
-        snapshot: {
-          messages: [rootMessage, runningAgentMessage],
-          latestSequence: 2,
-          currentUserId: '1',
-        },
-        unsubscribe: vi.fn(),
-      })),
+      subscribe: vi.fn(async (_projectId, _taskId, _afterSequence, onMessage) => {
+        emitMessage = onMessage
+        return {
+          snapshot: {
+            messages: [rootMessage, runningAgentMessage],
+            latestSequence: 2,
+            currentUserId: '1',
+          },
+          unsubscribe: vi.fn(),
+        }
+      }),
       send: vi.fn(async () => userMessage),
       startAgentResponse: vi.fn(async () => agentMessage),
       failAgentResponse: vi.fn(async () => ({ ...agentMessage, status: 'failed' as const })),
@@ -2352,8 +2358,28 @@ describe('TaskActivityView', () => {
 
     expect(client.send).not.toHaveBeenCalled()
     expect(
-      screen.getByTestId(`cloud-task-activity-card-error-${rootMessage.messageId}`)
-    ).toHaveTextContent('当前回复仍在进行中，请稍后再发送')
+      within(
+        screen.getByTestId(`cloud-task-activity-card-queue-${rootMessage.messageId}`)
+      ).getByText('继续处理')
+    ).toBeInTheDocument()
+
+    emitMessage?.({ ...runningAgentMessage, status: 'completed' })
+
+    await waitFor(() => expect(client.send).toHaveBeenCalledOnce())
+    expect(sendRuntimePaneMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: { deviceId: 'device-1', taskId: 'parent-session-1' },
+        message: '继续处理',
+      }),
+      expect.any(Object)
+    )
+    await waitFor(() =>
+      expect(
+        within(
+          screen.getByTestId(`cloud-task-activity-card-queue-${rootMessage.messageId}`)
+        ).queryByText('继续处理')
+      ).not.toBeInTheDocument()
+    )
   })
 
   it('allows a plain new comment while another parent session is still running', async () => {

--- a/wework/src/features/todo/TaskActivityView.tsx
+++ b/wework/src/features/todo/TaskActivityView.tsx
@@ -27,6 +27,7 @@ import {
   type ProjectChatControls,
   type ProjectWorkControls,
 } from '@/components/chat/ChatInput'
+import { ConversationQueuePanel } from '@/components/chat/ConversationQueuePanel'
 import { AssistantMarkdown } from '@/components/chat/AssistantMarkdown'
 import { Tooltip } from '@/components/ui/tooltip'
 import { DESKTOP_MESSAGE_LIST_CLASS } from '@/components/layout/desktopChatLayout'
@@ -34,9 +35,15 @@ import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
 import { useWorkbenchModels } from '@/features/workbench/useWorkbenchModels'
 import { useWorkbenchAttachments } from '@/features/workbench/useWorkbenchAttachments'
 import { findRuntimeTask } from '@/features/workbench/workbenchRuntimeHelpers'
+import {
+  cacheRuntimeConversationQueuedMessagesByKey,
+  getRuntimeConversationQueuedMessagesByKey,
+} from '@/features/workbench/runtimeConversationCache'
+import { persistAttachmentReferences } from '@/lib/attachments'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { isHttpUrl, openExternalUrl } from '@/lib/external-links'
 import { localRuntimeAttachments, remoteAttachmentIds } from '@/lib/runtime-attachments'
+import type { RuntimePaneQueuedMessage } from '@/types/workbench'
 import {
   buildRobotRoleDescription,
   mergeProjectChatMessages,
@@ -62,6 +69,14 @@ interface TaskActivityViewProps {
   // message list and a composer pinned to the bottom
   rail?: boolean
   linear?: boolean
+}
+
+interface TaskCardQueuedReply extends RuntimePaneQueuedMessage {
+  selectedModelName?: string
+}
+
+interface TaskCardDispatchResult extends CardCommentSendResult {
+  persisted: boolean
 }
 
 export function TaskActivityView({
@@ -184,9 +199,13 @@ export function TaskActivityView({
   const [sending, setSending] = useState(false)
   const [cancellingMessageId, setCancellingMessageId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [cardQueuedReplies, setCardQueuedReplies] = useState<Record<string, TaskCardQueuedReply[]>>(
+    {}
+  )
   const listRef = useRef<HTMLDivElement>(null)
   const followCardRef = useRef<string | null>(null)
   const refreshedRunIds = useRef(new Set<string>())
+  const queuedCardReplyInFlightRef = useRef<string | null>(null)
   const compact = rail || linear
 
   const taskAiStatus = task.ai_state?.status
@@ -491,6 +510,39 @@ export function TaskActivityView({
     return ordered.sort((left, right) => right.root.sequenceNumber - left.root.sequenceNumber)
   }, [threadMessages])
 
+  const cardQueueScopeKey = useCallback(
+    (rootId: string) =>
+      `task-activity:${projectLocation ?? 'cloud'}:${project.id}:${task.id}:${rootId}`,
+    [project.id, projectLocation, task.id]
+  )
+
+  const updateCardQueuedReplies = useCallback(
+    (rootId: string, update: (current: TaskCardQueuedReply[]) => TaskCardQueuedReply[]) => {
+      const scopeKey = cardQueueScopeKey(rootId)
+      const current = getRuntimeConversationQueuedMessagesByKey(scopeKey) as TaskCardQueuedReply[]
+      const next = update(current)
+      cacheRuntimeConversationQueuedMessagesByKey(scopeKey, next)
+      setCardQueuedReplies(queues => ({ ...queues, [rootId]: next }))
+    },
+    [cardQueueScopeKey]
+  )
+
+  useEffect(() => {
+    setCardQueuedReplies(current => {
+      let changed = false
+      const next = { ...current }
+      for (const card of commentCards) {
+        const rootId = card.root.messageId
+        if (Object.prototype.hasOwnProperty.call(next, rootId)) continue
+        next[rootId] = getRuntimeConversationQueuedMessagesByKey(
+          cardQueueScopeKey(rootId)
+        ) as TaskCardQueuedReply[]
+        changed = true
+      }
+      return changed ? next : current
+    })
+  }, [cardQueueScopeKey, commentCards])
+
   function cardSessionAddress(card: {
     root: ProjectChatMessage
     replies: ProjectChatMessage[]
@@ -518,7 +570,9 @@ export function TaskActivityView({
 
   function cardSessionActive(card: { root: ProjectChatMessage; replies: ProjectChatMessage[] }) {
     return [card.root, ...card.replies].some(
-      message => message.sender.type === 'agent' && message.status === 'streaming'
+      message =>
+        message.sender.type === 'agent' &&
+        (message.status === 'pending' || message.status === 'streaming')
     )
   }
 
@@ -699,26 +753,30 @@ export function TaskActivityView({
     }
   }
 
-  async function sendCardReply(
+  async function dispatchCardReply(
     card: {
       root: ProjectChatMessage
       replies: ProjectChatMessage[]
     },
-    text: string,
-    attachments: Attachment[]
-  ): Promise<CardCommentSendResult> {
+    queuedReply: TaskCardQueuedReply
+  ): Promise<TaskCardDispatchResult> {
     const rootId = card.root.messageId
-    if (!client || !text) return { ok: false, error: t('workbench.project_chat_send_failed') }
-    if (cardSessionActive(card)) {
-      return { ok: false, error: t('workbench.runtime_task_running_message') }
+    const text = queuedReply.content
+    const attachments = queuedReply.attachments ?? []
+    if (!client || !text) {
+      return { ok: false, persisted: false, error: t('workbench.project_chat_send_failed') }
     }
     const customManager = isCustomAutomationManager(card.root)
     const customManagerAddress = customManager ? cardSessionAddress(card) : null
     if (customManager && (!client.continueAutomationManager || !customManagerAddress)) {
-      return { ok: false, error: t('workbench.project_chat_agent_start_failed') }
+      return {
+        ok: false,
+        persisted: false,
+        error: t('workbench.project_chat_agent_start_failed'),
+      }
     }
-    setSending(true)
     setError(null)
+    let persisted = false
     try {
       const activeMentions =
         assignedAgent && !customManager
@@ -733,8 +791,9 @@ export function TaskActivityView({
         // Card composer replies are always one-level replies under the parent
         // comment.
         replyToMessageId: rootId,
-        model: selectedModel?.name ?? null,
+        model: queuedReply.selectedModelName ?? null,
       })
+      persisted = true
       // Card replies must never trigger the list-bottom follow: switch to
       // following this card synchronously so the message-change effect cannot
       // scroll the whole comment list to its end during the AI start.
@@ -742,47 +801,43 @@ export function TaskActivityView({
       setMessages(current => mergeProjectChatMessages(current, [message]))
       setCardAiErrors(current => ({ ...current, [rootId]: '' }))
       void persistConversationAttachments(attachments)
-      void persistConversationAttachments(attachments)
       if (customManager && customManagerAddress) {
-        void continueCustomAutomationManager(card.root, message, customManagerAddress, attachments)
+        await continueCustomAutomationManager(card.root, message, customManagerAddress, attachments)
         revealCardBottom(rootId)
-        return { ok: true }
+        return { ok: true, persisted: true }
       }
       if (assignedAgent && !selfManagedExecution) {
         if (assignedAgent.runtime === 'wegent') {
           if (!client.continueWegentTask) {
-            setCardAiErrors(current => ({
-              ...current,
-              [rootId]: t('workbench.project_chat_agent_start_failed'),
-            }))
+            const message = t('workbench.project_chat_agent_start_failed')
+            setCardAiErrors(current => ({ ...current, [rootId]: message }))
+            return { ok: false, persisted: true, error: message }
           } else {
-            void client
-              .continueWegentTask({
+            try {
+              const incoming = await client.continueWegentTask({
                 projectId: project.id,
                 taskId: task.id,
                 triggerMessageId: message.messageId,
                 agentId: assignedAgent.id,
                 attachmentIds: attachments.map(attachment => attachment.id),
               })
-              .then(incoming => {
-                setMessages(current => mergeProjectChatMessages(current, [incoming]))
-              })
-              .catch(cause => {
-                setCardAiErrors(current => ({
-                  ...current,
-                  [rootId]:
-                    cause instanceof Error
-                      ? cause.message
-                      : t('workbench.project_chat_agent_start_failed'),
-                }))
-              })
+              setMessages(current => mergeProjectChatMessages(current, [incoming]))
+            } catch (cause) {
+              const message =
+                cause instanceof Error
+                  ? cause.message
+                  : t('workbench.project_chat_agent_start_failed')
+              setCardAiErrors(current => ({ ...current, [rootId]: message }))
+              return { ok: false, persisted: true, error: message }
+            }
           }
           revealCardBottom(rootId)
-          return { ok: true }
+          return { ok: true, persisted: true }
         }
-        // The comment is already posted; keep the input cleared and let the
-        // AI start settle in the background, surfacing failures in the card.
-        void startTaskAiRun({
+        const queuedModel = queuedReply.selectedModelName
+          ? (availableModels.find(model => model.name === queuedReply.selectedModelName) ?? null)
+          : null
+        const started = await startTaskAiRun({
           client,
           services,
           runtime: { createProjectRuntimeTask, sendRuntimePaneMessage },
@@ -797,26 +852,108 @@ export function TaskActivityView({
           threadRootId: rootId,
           attachments,
           models: availableModels,
-          selectedModel,
-          selectedModelOptions,
+          selectedModel: queuedModel,
+          selectedModelOptions: queuedReply.modelOptions ?? {},
           onError: message => setCardAiErrors(current => ({ ...current, [rootId]: message })),
           onMessages: incoming =>
             setMessages(current => mergeProjectChatMessages(current, incoming)),
           onTaskUpdated,
           startFailedText: t('workbench.project_chat_agent_start_failed'),
         })
+        if (!started) {
+          return {
+            ok: false,
+            persisted: true,
+            error: t('workbench.project_chat_agent_start_failed'),
+          }
+        }
       }
       revealCardBottom(rootId)
-      return { ok: true }
+      return { ok: true, persisted: true }
     } catch (cause) {
       return {
         ok: false,
+        persisted,
         error: cause instanceof Error ? cause.message : t('workbench.project_chat_send_failed'),
       }
-    } finally {
-      setSending(false)
     }
   }
+
+  async function sendCardReply(
+    card: {
+      root: ProjectChatMessage
+      replies: ProjectChatMessage[]
+    },
+    text: string,
+    attachments: Attachment[]
+  ): Promise<CardCommentSendResult> {
+    const rootId = card.root.messageId
+    if (!client || !text) return { ok: false, error: t('workbench.project_chat_send_failed') }
+    const customManager = isCustomAutomationManager(card.root)
+    if (customManager && (!client.continueAutomationManager || !cardSessionAddress(card))) {
+      return { ok: false, error: t('workbench.project_chat_agent_start_failed') }
+    }
+    const queuedReply: TaskCardQueuedReply = {
+      id: `queued-task-card-${crypto.randomUUID()}`,
+      content: text,
+      status: 'queued',
+      createdAt: new Date().toISOString(),
+      attachments: persistAttachmentReferences(attachments),
+      selectedModelName: selectedModel?.name,
+      modelOptions: selectedModelOptions,
+    }
+    updateCardQueuedReplies(rootId, current => [...current, queuedReply])
+    return { ok: true }
+  }
+
+  useEffect(() => {
+    if (sending || queuedCardReplyInFlightRef.current) return
+    const candidate = commentCards
+      .flatMap(card => {
+        if (cardSessionActive(card)) return []
+        const queuedReply = (cardQueuedReplies[card.root.messageId] ?? []).find(
+          message => message.status === 'queued'
+        )
+        return queuedReply ? [{ card, queuedReply }] : []
+      })
+      .sort((left, right) =>
+        left.queuedReply.createdAt.localeCompare(right.queuedReply.createdAt)
+      )[0]
+    if (!candidate) return
+
+    const rootId = candidate.card.root.messageId
+    queuedCardReplyInFlightRef.current = candidate.queuedReply.id
+    setSending(true)
+    updateCardQueuedReplies(rootId, current =>
+      current.map(message =>
+        message.id === candidate.queuedReply.id
+          ? { ...message, status: 'sending', error: undefined }
+          : message
+      )
+    )
+    void dispatchCardReply(candidate.card, candidate.queuedReply)
+      .then(result => {
+        updateCardQueuedReplies(rootId, current =>
+          result.ok || result.persisted
+            ? current.filter(message => message.id !== candidate.queuedReply.id)
+            : current.map(message =>
+                message.id === candidate.queuedReply.id
+                  ? {
+                      ...message,
+                      status: 'failed',
+                      error: result.error ?? t('workbench.project_chat_send_failed'),
+                    }
+                  : message
+              )
+        )
+      })
+      .finally(() => {
+        queuedCardReplyInFlightRef.current = null
+        setSending(false)
+      })
+    // The dispatcher intentionally uses the latest card/session snapshot selected above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardQueuedReplies, commentCards, sending, t, updateCardQueuedReplies])
 
   async function sendNewComment(): Promise<boolean> {
     const text = newCommentDraft.trim()
@@ -1160,6 +1297,17 @@ export function TaskActivityView({
                         })}
                       </div>
                     ) : null}
+                    <div data-testid={`cloud-task-activity-card-queue-${rootId}`}>
+                      <ConversationQueuePanel
+                        queuedMessages={cardQueuedReplies[rootId] ?? []}
+                        guidanceMessages={[]}
+                        onCancelQueuedMessage={id =>
+                          updateCardQueuedReplies(rootId, current =>
+                            current.filter(message => message.id !== id)
+                          )
+                        }
+                      />
+                    </div>
                     <CardCommentComposer
                       rootId={rootId}
                       projectId={project.id}


### PR DESCRIPTION
## Summary

- Queue task-card follow-up replies while that card's agent session is pending or streaming.
- Dispatch queued replies in creation order after the current session finishes.
- Preserve queued attachments, model selection, and model options, and allow unsent items to be cancelled.
- Keep the English and Chinese architecture contracts synchronized.

## Root cause

Initial task runs already respected the global concurrency queue, but task-card follow-ups used a separate path that rejected input whenever the card session was active. The UI therefore exposed two conflicting concurrency behaviors.

## User impact

Users can continue adding context while an agent is replying. The follow-up remains visible in the existing queue panel and is sent automatically against the same parent-comment session when it becomes available.

## Verification

- `pnpm --filter wework test src/features/todo/TaskActivityView.test.tsx`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint`
- `pnpm e2e:desktop -- --segment project-automation`
- Isolated rerun of all five tests that timed out during a resource-contended pre-push run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replies added during an active or pending task session are queued instead of blocked or lost.
  * Queued replies are processed in creation order after the current task turn completes.
  * A queue panel displays pending replies and allows cancellation.
  * Queued replies retain their selected model and attachments.

* **Documentation**
  * Updated architecture documentation to describe comment follow-up queuing, ordering, and session behavior.

* **Bug Fixes**
  * Improved reliability when continuing conversations during active task execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->