### PR TITLE
fix(wework): bind target URL directly for user browser opens

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -9842,7 +9842,7 @@ describe('DesktopWorkbenchLayout', () => {
         'embedded_browser_open',
         expect.objectContaining({
           label: 'workspace-browser-runtime-a',
-          url: 'about:blank',
+          url: 'https://example.com/',
         }),
         undefined
       )
@@ -9858,7 +9858,7 @@ describe('DesktopWorkbenchLayout', () => {
         'embedded_browser_open',
         expect.objectContaining({
           label: 'workspace-browser-runtime-b',
-          url: 'about:blank',
+          url: 'https://example.org/',
         }),
         undefined
       )

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -1430,6 +1430,42 @@ describe('WorkspaceBrowserPanel', () => {
     })
   })
 
+  test('binds the target URL directly for user open requests', async () => {
+    mockBrowserHostRect()
+    embeddedBrowserMocks.openEmbeddedBrowser.mockResolvedValueOnce({
+      nativeLabel: 'workspace-browser-native-1',
+      title: null,
+      url: 'https://example.test/',
+    })
+    render(
+      <WorkspaceBrowserPanel
+        active
+        openRequest={{
+          id: 'test-user-1',
+          baseLabel: 'workspace-browser',
+          source: 'user',
+          disposition: 'new-tab',
+          label: 'workspace-browser',
+          url: 'https://example.test/',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalledWith(
+        'https://example.test/',
+        {
+          x: 500,
+          y: 120,
+          width: 400,
+          height: 300,
+        },
+        'workspace-browser'
+      )
+    })
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://example.test/')
+  })
+
   test('opens an external request in a hidden browser while the panel is inactive', async () => {
     mockBrowserHostRect()
     const openRequest = {

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -1857,7 +1857,10 @@ export function WorkspaceBrowserTabPanel({
     }
     if (handledOpenRequestIdRef.current === openRequest.id) return
     handledOpenRequestIdRef.current = openRequest.id
-    activeOpenRequestIdRef.current = openRequest.id
+    // Only agent (bridge) opens defer the initial navigation to the bridge and
+    // therefore create the host with about:blank. User, popup, and restore
+    // requests bind the target URL directly during host creation.
+    activeOpenRequestIdRef.current = openRequest.source === 'agent' ? openRequest.id : null
     logBrowserOpenDiagnostic('request_consumed', {
       active,
       label,
@@ -1866,7 +1869,15 @@ export function WorkspaceBrowserTabPanel({
       url: openRequest.url,
     })
     openBrowserUrl(openRequest.url)
-  }, [active, label, openBrowserUrl, openRequest?.id, openRequest?.label, openRequest?.url])
+  }, [
+    active,
+    label,
+    openBrowserUrl,
+    openRequest?.id,
+    openRequest?.label,
+    openRequest?.source,
+    openRequest?.url,
+  ])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()


### PR DESCRIPTION
## Problem

Clicking an `http(s)` or `file` link inside a Wework chat opens the embedded browser, but the page never loads and stays on `about:blank`.

## Root Cause

`9c594aa8f` introduced the bridge-owned initial navigation flow: the native host is created with `about:blank` and the Rust bridge navigates to the target URL after the bootstrap load finishes. The gating condition was "the open request carries an id", but **every** open request has an id — including user link clicks from chat (`source: 'user'`, id from `crypto.randomUUID()`) and HTML file links (`requestEmbeddedBrowserOpen`). The bridge only performs the deferred navigation for agent-sourced requests, so user/popup/restore opens were left on `about:blank` forever.

## Fix

Gate the deferred-navigation path on `openRequest.source === 'agent'` in `WorkspaceBrowserPanel`. User, popup, and restore requests bind the target URL directly during host creation again, matching the documented scope of the `about:blank` bootstrap flow (`docs/*/architecture/embedded-browser.md`).

## Tests

- Added a regression test: user-sourced open requests create the host with the target URL directly.
- Updated `DesktopWorkbenchLayout` test whose assertion (added by the same commit) encoded the buggy `about:blank` expectation for user opens.
- Full wework suite passes: 4097 tests, ESLint and TypeScript clean (pre-push checks).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser pages opened from runtime tasks now navigate to the requested URL instead of initially displaying a blank page.
  * New tabs opened by users now load the requested address immediately.
  * The browser address bar now correctly reflects the URL when opening new tabs or restoring browser pages.
  * Added regression coverage to help prevent incorrect blank-page navigation in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->