### PR TITLE
fix(wework): expand sidebar drag activators

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -414,10 +414,10 @@ may reveal on hover/focus but must remain keyboard accessible.
 - Keep the sidebar base surface stable when the application window gains or
   loses focus. Window focus must not darken the task or work-items sidebar.
 - Sortable sidebar rows must keep the sortable container separate from the
-  pointer activator. Only the primary icon-and-label or label region may start
-  pointer sorting, after at least `6px` of movement; trailing actions, metadata,
-  and unused row space must remain click-only. Preserve keyboard sorting on the
-  sortable container.
+  pointer activator. The primary non-action area, including unused space beside
+  a short label, may start pointer sorting after at least `6px` of movement.
+  Trailing actions and metadata must remain outside the activator. Preserve
+  keyboard sorting on the sortable container.
 - Section spacing may be larger than row spacing; avoid divider-heavy grouping.
 - On macOS light theme, use the captured warm translucent/off-white sidebar
   material and keep the main canvas pure white. Preserve the traffic-light safe

--- a/wework/scripts/dev-executor-reload.test.mjs
+++ b/wework/scripts/dev-executor-reload.test.mjs
@@ -38,7 +38,7 @@ function waitForOutput(stream, pattern, timeoutMs = 10_000) {
   })
 }
 
-describe('dev executor reload', () => {
+describe('dev executor reload', { timeout: 20_000 }, () => {
   test('builds once initially and rebuilds after a source change', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'wework-executor-reload-'))
     temporaryDirectories.push(directory)

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -373,8 +373,8 @@ describe('DesktopSidebar', () => {
 
     expect(remoteSortable).toHaveAttribute('tabindex', '0')
     expect(remoteSortable).toHaveAttribute('role', 'button')
-    expect(remoteActivator).toHaveAttribute('data-sidebar-drag-activator')
-    expect(remoteButton).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(remoteActivator).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(remoteButton).toHaveAttribute('data-sidebar-drag-activator')
 
     fireEvent.pointerDown(remoteButton, {
       button: 0,
@@ -391,39 +391,21 @@ describe('DesktopSidebar', () => {
       isPrimary: true,
       pointerId: 1,
     })
-    expect(remoteSortable).not.toHaveAttribute('data-dragging')
-    fireEvent.pointerUp(document, { button: 0, clientX: 220, clientY: 10, pointerId: 1 })
-
-    fireEvent.pointerDown(remoteActivator, {
-      button: 0,
-      buttons: 1,
-      clientX: 20,
-      clientY: 45,
-      isPrimary: true,
-      pointerId: 2,
-    })
-    fireEvent.pointerMove(document, {
-      buttons: 1,
-      clientX: 20,
-      clientY: 10,
-      isPrimary: true,
-      pointerId: 2,
-    })
     expect(remoteSortable).toHaveAttribute('data-dragging', 'true')
     fireEvent.pointerMove(document, {
       buttons: 1,
-      clientX: 20,
+      clientX: 220,
       clientY: 5,
       isPrimary: true,
-      pointerId: 2,
+      pointerId: 1,
     })
     fireEvent.pointerUp(document, {
       button: 0,
       buttons: 0,
-      clientX: 20,
+      clientX: 220,
       clientY: 5,
       isPrimary: true,
-      pointerId: 2,
+      pointerId: 1,
     })
 
     await waitFor(() => expect(onReorderRuntimeProjects).toHaveBeenCalledTimes(1))
@@ -2224,7 +2206,7 @@ describe('DesktopSidebar', () => {
     })
   })
 
-  test('starts task pointer sorting only from its content-sized activator', async () => {
+  test('starts task pointer sorting from the full title area', async () => {
     const onReorderRuntimeProjectTasks = vi.fn().mockResolvedValue(undefined)
     const onOpenRuntimeTask = vi.fn()
     const chatPath = '/Users/alice/Documents/Codex/2026-07-12/manual'
@@ -2283,8 +2265,8 @@ describe('DesktopSidebar', () => {
 
     expect(firstSortable).toContainElement(firstActivator)
     expect(firstActivator).not.toContainElement(firstActions)
-    expect(firstActivator).toHaveAttribute('data-sidebar-drag-activator')
-    expect(firstTitleSpace).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(firstActivator).not.toHaveAttribute('data-sidebar-drag-activator')
+    expect(firstTitleSpace).toHaveAttribute('data-sidebar-drag-activator')
     expect(firstTrailing).not.toHaveAttribute('data-sidebar-drag-activator')
     expect(firstActions).not.toHaveAttribute('data-sidebar-drag-activator')
     expect(screen.getByTestId('runtime-local-task-row-chat-1')).not.toHaveAttribute(
@@ -2303,7 +2285,7 @@ describe('DesktopSidebar', () => {
     fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' })
     await waitFor(() => expect(firstSortable).not.toHaveAttribute('data-dragging'))
 
-    for (const [pointerId, target] of [firstTitleSpace, firstTrailing, firstActions].entries()) {
+    for (const [pointerId, target] of [firstTrailing, firstActions].entries()) {
       fireEvent.pointerDown(target, {
         button: 0,
         buttons: 1,

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -376,7 +376,15 @@ describe('DesktopSidebar', () => {
     expect(remoteSortable).toHaveAttribute('role', 'button')
     expect(remoteActivator).not.toHaveAttribute('data-sidebar-drag-activator')
     expect(remoteButton).toHaveAttribute('data-sidebar-drag-activator')
-    expect(remoteMetadata).toHaveClass('pointer-events-auto')
+    expect(remoteMetadata).toHaveClass(
+      'pointer-events-auto',
+      'group-hover/project:opacity-0',
+      'group-focus-within/project:opacity-0'
+    )
+    expect(remoteMetadata).not.toHaveClass(
+      'group-hover/project:invisible',
+      'group-focus-within/project:invisible'
+    )
 
     fireEvent.pointerDown(remoteMetadata, {
       button: 0,

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -367,6 +367,7 @@ describe('DesktopSidebar', () => {
     ) as HTMLElement
     const remoteActivator = screen.getByTestId('project-drag-activator-8')
     const remoteButton = remoteActivator.closest('button') as HTMLButtonElement
+    const remoteMetadata = screen.getByTestId('project-device-status-8')
 
     mockSidebarSortableRect(localSortable, 0)
     mockSidebarSortableRect(remoteSortable, 30)
@@ -375,8 +376,9 @@ describe('DesktopSidebar', () => {
     expect(remoteSortable).toHaveAttribute('role', 'button')
     expect(remoteActivator).not.toHaveAttribute('data-sidebar-drag-activator')
     expect(remoteButton).toHaveAttribute('data-sidebar-drag-activator')
+    expect(remoteMetadata).toHaveClass('pointer-events-auto')
 
-    fireEvent.pointerDown(remoteButton, {
+    fireEvent.pointerDown(remoteMetadata, {
       button: 0,
       buttons: 1,
       clientX: 220,
@@ -391,13 +393,38 @@ describe('DesktopSidebar', () => {
       isPrimary: true,
       pointerId: 1,
     })
+    expect(remoteSortable).not.toHaveAttribute('data-dragging')
+    fireEvent.pointerUp(document, {
+      button: 0,
+      buttons: 0,
+      clientX: 220,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+    })
+
+    fireEvent.pointerDown(remoteButton, {
+      button: 0,
+      buttons: 1,
+      clientX: 220,
+      clientY: 45,
+      isPrimary: true,
+      pointerId: 2,
+    })
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 220,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 2,
+    })
     expect(remoteSortable).toHaveAttribute('data-dragging', 'true')
     fireEvent.pointerMove(document, {
       buttons: 1,
       clientX: 220,
       clientY: 5,
       isPrimary: true,
-      pointerId: 1,
+      pointerId: 2,
     })
     fireEvent.pointerUp(document, {
       button: 0,
@@ -405,7 +432,7 @@ describe('DesktopSidebar', () => {
       clientX: 220,
       clientY: 5,
       isPrimary: true,
-      pointerId: 1,
+      pointerId: 2,
     })
 
     await waitFor(() => expect(onReorderRuntimeProjects).toHaveBeenCalledTimes(1))

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -2702,7 +2702,7 @@ function ProjectItem({
             <ProjectDeviceInlineStatus
               deviceState={projectDeviceState}
               testId={`project-device-status-${project.id}`}
-              className="pointer-events-none absolute right-2 top-1/2 max-w-[124px] -translate-y-1/2 justify-end text-right group-hover/project:invisible group-focus-within/project:invisible"
+              className="pointer-events-auto absolute right-2 top-1/2 max-w-[124px] -translate-y-1/2 justify-end text-right group-hover/project:invisible group-focus-within/project:invisible"
             />
           )}
           <div className="pointer-events-none absolute right-1 top-1/2 z-[70] flex w-[58px] shrink-0 -translate-y-1/2 items-center justify-end opacity-0 transition-opacity group-hover/project:pointer-events-auto group-hover/project:opacity-100 hover:pointer-events-auto hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1790,6 +1790,7 @@ function RuntimeTaskRow({
           {priorityLayout ? (
             <span className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
               <span
+                data-sidebar-drag-activator
                 data-testid={`runtime-local-task-title-${task.taskId}`}
                 className={cn(
                   'runtime-task-title relative flex min-w-0 items-center gap-1 truncate',
@@ -1810,10 +1811,7 @@ function RuntimeTaskRow({
                     aria-label={boardOriginLabel}
                   />
                 ) : null}
-                <span
-                  data-sidebar-drag-activator
-                  data-testid={`runtime-local-task-drag-activator-${task.taskId}`}
-                >
+                <span data-testid={`runtime-local-task-drag-activator-${task.taskId}`}>
                   {task.title}
                 </span>
               </span>
@@ -1833,6 +1831,7 @@ function RuntimeTaskRow({
             </span>
           ) : (
             <span
+              data-sidebar-drag-activator
               data-testid={`runtime-local-task-title-${task.taskId}`}
               className={cn(
                 'runtime-task-title relative min-w-0 flex-1 truncate',
@@ -1853,10 +1852,7 @@ function RuntimeTaskRow({
                   aria-label={boardOriginLabel}
                 />
               ) : null}
-              <span
-                data-sidebar-drag-activator
-                data-testid={`runtime-local-task-drag-activator-${task.taskId}`}
-              >
+              <span data-testid={`runtime-local-task-drag-activator-${task.taskId}`}>
                 {task.title}
               </span>
             </span>
@@ -2648,6 +2644,7 @@ function ProjectItem({
           <button
             type="button"
             data-testid="project-item-button"
+            data-sidebar-drag-activator
             onClick={() => {
               onToggleProject(project.id)
             }}
@@ -2658,7 +2655,6 @@ function ProjectItem({
             )}
           >
             <span
-              data-sidebar-drag-activator
               data-testid={`project-drag-activator-${project.id}`}
               className="flex min-w-0 max-w-full items-center gap-2.5"
             >

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -2702,7 +2702,7 @@ function ProjectItem({
             <ProjectDeviceInlineStatus
               deviceState={projectDeviceState}
               testId={`project-device-status-${project.id}`}
-              className="pointer-events-auto absolute right-2 top-1/2 max-w-[124px] -translate-y-1/2 justify-end text-right group-hover/project:invisible group-focus-within/project:invisible"
+              className="pointer-events-auto absolute right-2 top-1/2 max-w-[124px] -translate-y-1/2 justify-end text-right transition-opacity group-hover/project:opacity-0 group-focus-within/project:opacity-0"
             />
           )}
           <div className="pointer-events-none absolute right-1 top-1/2 z-[70] flex w-[58px] shrink-0 -translate-y-1/2 items-center justify-end opacity-0 transition-opacity group-hover/project:pointer-events-auto group-hover/project:opacity-100 hover:pointer-events-auto hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">


### PR DESCRIPTION
## Summary

- expand sortable task drag activation from the title text to the full non-action title area
- expand sortable project drag activation to the full primary project button while keeping trailing actions and device metadata outside the activator
- keep device metadata hit-testable while visually hidden on hover/focus so pointer input cannot fall through to the drag activator
- update the Wework sidebar interaction rule so short labels retain a usable drag target
- align the dev-executor reload process test timeout with its intentional debounce and restart lifecycle after the full suite exposed the default 5-second timeout as intermittent

## Verification

- `pnpm --filter wework test src/components/layout/DesktopSidebar.test.tsx` (100 passed)
- `pnpm --filter wework test scripts/dev-executor-reload.test.mjs` (1 passed)
- `pnpm --filter wework typecheck`
- focused Prettier and ESLint checks for all changed files
- final pre-push Wework checks: ESLint, TypeScript, and all 404 unit-test files passed
- isolated real Tauri verification: created one-character projects `A` and `B`, dragged `B` from center whitespace to reorder `B, A` into `A, B`, then opened the trailing project action menu successfully
- regression coverage verifies project device metadata remains outside pointer sorting, including during hover/focus hiding
