### PR TITLE
fix(wework): handle Home and End in the chat composer

### DIFF
--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
@@ -236,6 +236,71 @@ describe('ComposerProseMirrorEditor', () => {
     })
   })
 
+  test.each([
+    ['Home', 0],
+    ['End', 'before after'.length],
+  ])('moves the caret with %s without inserting a control character', (key, selectionOffset) => {
+    const { editorRef, onChange } = renderEditor('before after')
+    const editor = screen.getByTestId('composer-editor')
+
+    act(() => {
+      editorRef.current?.setValue('before after', 'before '.length)
+      editorRef.current?.focus()
+    })
+
+    expect(fireEvent.keyDown(editor, { key, code: key })).toBe(false)
+    expect(editorRef.current?.getSnapshot()).toMatchObject({
+      value: 'before after',
+      selectionOffset,
+      selectionStart: selectionOffset,
+      selectionEnd: selectionOffset,
+    })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    ['Home', 0, 'before '.length],
+    ['End', 'before '.length, 'before after'.length],
+  ])('extends the selection with Shift+%s', (key, selectionStart, selectionEnd) => {
+    const { editorRef } = renderEditor('before after')
+    const editor = screen.getByTestId('composer-editor')
+
+    act(() => {
+      editorRef.current?.setValue('before after', 'before '.length)
+      editorRef.current?.focus()
+    })
+
+    expect(fireEvent.keyDown(editor, { key, code: key, shiftKey: true })).toBe(false)
+    expect(editorRef.current?.getSnapshot()).toMatchObject({
+      value: 'before after',
+      selectionStart,
+      selectionEnd,
+    })
+  })
+
+  test.each([
+    ['Home', 0],
+    ['End', 'first line\nsecond line'.length],
+  ])('moves to the document boundary with Cmd/Ctrl+%s', (key, selectionOffset) => {
+    const { editorRef } = renderEditor('first line\nsecond line')
+    const editor = screen.getByTestId('composer-editor')
+
+    act(() => {
+      editorRef.current?.setValue('first line\nsecond line', 'first line'.length)
+      editorRef.current?.focus()
+    })
+
+    expect(
+      fireEvent.keyDown(editor, {
+        key,
+        code: key,
+        metaKey: key === 'Home',
+        ctrlKey: key === 'End',
+      })
+    ).toBe(false)
+    expect(editorRef.current?.getSnapshot().selectionOffset).toBe(selectionOffset)
+  })
+
   test('keeps line breaks when pasting rich text', () => {
     const { editorRef, onChange } = renderEditor('')
     const editor = screen.getByTestId('composer-editor')

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
@@ -329,6 +329,11 @@ export const ComposerProseMirrorEditor = forwardRef<
         event.stopImmediatePropagation()
         return
       }
+      if (moveComposerCaretToBoundary(view, event)) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        return
+      }
       const handledByComposer = callbacksRef.current.onKeyDown(
         event,
         readComposerSnapshot(view.state)
@@ -573,6 +578,28 @@ function setComposerSelection(view: EditorView, event: KeyboardEvent, position: 
   event.preventDefault()
   event.stopPropagation()
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, position)))
+  view.focus()
+  return true
+}
+
+function moveComposerCaretToBoundary(view: EditorView, event: KeyboardEvent): boolean {
+  if (event.key !== 'Home' && event.key !== 'End') return false
+
+  const { selection } = view.state
+  const { $head } = selection
+  const target =
+    event.metaKey || event.ctrlKey
+      ? event.key === 'Home'
+        ? TextSelection.atStart(view.state.doc).from
+        : TextSelection.atEnd(view.state.doc).to
+      : event.key === 'Home'
+        ? $head.start()
+        : $head.end()
+
+  const nextSelection = event.shiftKey
+    ? TextSelection.create(view.state.doc, selection.anchor, target)
+    : TextSelection.create(view.state.doc, target)
+  view.dispatch(view.state.tr.setSelection(nextSelection))
   view.focus()
   return true
 }


### PR DESCRIPTION
# fix(wework): handle Home and End in the chat composer

## Summary

Fixes an issue where pressing Home or End in the Wework chat composer could
insert control characters into the message:

- Home inserted `\x01` (`Ctrl-A`)
- End inserted `\x04` (`Ctrl-D`)

Home and End now move the composer selection without modifying the message
content.

## Root cause

The ProseMirror composer did not handle Home and End during its capture-phase
keyboard processing. On macOS Tauri/WKWebView, the unhandled key events could
continue through the native input pipeline and be converted into control
characters.

## Changes

- Handle Home and End directly in `ComposerProseMirrorEditor`.
- Preserve Shift+Home and Shift+End selection expansion.
- Support Cmd/Ctrl+Home and Cmd/Ctrl+End for document boundaries.
- Prevent the handled events from reaching the browser text-input pipeline.
- Do not filter `\x01` or `\x04` globally, so real Ctrl-A and Ctrl-D behavior is
  not affected.
- Add regression tests for navigation, selection expansion, document
  boundaries, unchanged content, and prevented input events.

## Behavior

| Key | Result |
| --- | --- |
| Home | Move to the current paragraph start |
| End | Move to the current paragraph end |
| Shift+Home | Extend the selection to the current paragraph start |
| Shift+End | Extend the selection to the current paragraph end |
| Cmd/Ctrl+Home | Move to the document start |
| Cmd/Ctrl+End | Move to the document end |

## Testing

- Focused Vitest: `ComposerProseMirrorEditor.test.tsx` — 44 tests passed.
- ESLint passed for the changed files.
- Prettier passed for the changed files.
- `git diff --check` passed.
- Wework production build passed with `pnpm --filter wework build`.

## Manual verification

In the Wework chat composer:

1. Type text across one or more lines.
2. Press Home and End.
3. Confirm the caret moves and no visible square/control character appears.
4. Confirm the message value is unchanged.
5. Verify Shift+Home and Shift+End select text.
6. Verify Cmd/Ctrl+Home and Cmd/Ctrl+End move to document boundaries.
7. Verify normal Ctrl-A behavior is unchanged.

## Compatibility

- No backend, database, or protocol changes.
- No changes to terminal input handling.
- The fix is scoped to the ProseMirror chat composer.

## Screenshot

before: 
<img width="853" height="720" alt="before" src="https://github.com/user-attachments/assets/56292446-5948-4685-a652-62f6e7c9fcdd" />

after:
<img width="851" height="200" alt="after" src="https://github.com/user-attachments/assets/1bf10042-c9a8-4db9-8c3f-fe6e07a179ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Home and End keyboard shortcuts in the message composer to move the caret to the start or end of the current text block.
  * Added Ctrl/Cmd+Home and Ctrl/Cmd+End support for navigating to document boundaries.
  * Holding Shift while using these shortcuts now extends the text selection.

* **Bug Fixes**
  * Prevented keyboard shortcuts from inserting unwanted control characters or triggering unintended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->