### PR TITLE
fix(ci): stabilize merge queue runtime flows

### DIFF
--- a/docs/en/architecture/git-worktree-execution.md
+++ b/docs/en/architecture/git-worktree-execution.md
@@ -53,6 +53,7 @@ sequenceDiagram
     U->>B: runtime.tasks.create(taskId, sourcePath, git_worktree)
     B->>E: relay unchanged
     E->>E: compute stable plannedPath and persist intent
+    E->>E: recognize an uncreated plannedPath by the managed path convention
     E-->>U: accepted/queued + plannedPath
     U->>U: hydrate the current task address and list projection with plannedPath
     alt no slot available
@@ -120,7 +121,7 @@ Essential invariants:
 18. Deferred creation persists the source-repository fingerprint captured while planning and compares it with a freshly computed fingerprint after acquiring a slot. Replacing the source directory with another repository fails as `worktree_source_changed`.
 19. A stop timeout has an unknown outcome. It never clears Runtime cancellation control or treats the task as stopped; an archive/delete retry still requires a stop acknowledgement from the same Runtime.
 20. `preserveSnapshot=false` is terminal cleanup: the Executor deletes any existing snapshot reference and removes the record from `worktrees.json`; later `runtime.worktrees.list` calls never return a tombstone for the cleaned Worktree.
-21. Workspace-kind detection prefers real Git metadata. The `worktrees/<id>/<project>` path convention is only a fallback when no Git repository or Worktree metadata can be resolved. A normal repository is never projected as a Worktree solely because an ancestor directory is named `worktrees`.
+21. Workspace-kind detection for an existing workspace prefers Git metadata on the candidate root itself. An uncreated managed planned path is recognized first by the `worktrees/<id>/<project>` convention and is not rejected because a higher Executor source checkout has a `.git` directory. An existing candidate root with normal repository metadata remains a workspace and is never projected as a Worktree solely because an ancestor directory is named `worktrees`.
 22. After Runtime accepts task creation, a work-list refresh failure only defers reconciliation; it never removes the accepted task from local visibility or reports the send as failed.
 23. Optimistic Worktree navigation may carry only task identity before the planned path returns. Once the create response or task list first provides the planned or final path, Wework hydrates that path into the current task address. The current task, list projection, and later Terminal, IDE, and file operations never retain a pathless optimistic address indefinitely.
 

--- a/docs/en/architecture/project-execution-state.md
+++ b/docs/en/architecture/project-execution-state.md
@@ -12,6 +12,8 @@ flowchart LR
     CLAIM --> ACTIVE[(active attempt + lease)]
     ACTIVE --> PROCESS[real process]
     PROCESS --> EVENT[attempt/sequence event]
+    CANCEL_FENCE[Runtime cancellation output fence] --> EVENT
+    PROCESS --> CANCEL_FENCE
     EVENT --> FENCE[identity and ordering fence]
     FENCE --> TRUTH[(execution-state truth)]
     TRUTH --> NORMALIZE[execution ID sentinel normalization]
@@ -47,6 +49,8 @@ sequenceDiagram
     else cancellation
         U->>S: cancellation intent
         S->>R: cancel command
+        R->>R: close this attempt's event output first
+        R->>P: abort
         R-->>S: stopped ACK
         S->>S: write cancelled and release slot
     else lease expiry
@@ -60,10 +64,10 @@ sequenceDiagram
 | ------------------------------------- | --------------------------------------------------------------- |
 | Claim, attempt, and state transitions | `backend/app/services/loop_item_executions/service.py`          |
 | Execution ID storage and normalization | `backend/app/models/loop_item_execution.py`, execution API/schema |
-| Scheduler, slots, and real process    | `executor/src/runner/`, `executor/src/runtime_work/`            |
+| Scheduler, slots, real process, and cancellation event fence | `executor/src/runner/`, `executor/src/runtime_work/`, `executor/src/local/backend/tasks.rs` |
 | Local IPC and Runtime RPC             | `executor/src/local/app_ipc.rs`, Backend device runtime service |
 | UI projection                         | Wework workbench stores and board queries                       |
 
-Invariants: attempt identity and event sequence must match; late events cannot overwrite a newer attempt; terminal state and slot release are atomic; sending cancellation is not cancellation success, and Runtime scope exit must guarantee the stopped acknowledgement; `loop_item_executions.team_id/backend_task_id=0` means unbound only, existence checks must use positive-ID semantics, and APIs/UI must normalize the sentinel to `null`; capacity belongs to each device Runtime scheduler and aggregate capacity is not execution truth; persisted queue state and queued task IDs come from one scheduler snapshot; Run now may temporarily push a selected queued execution beyond `slot_max`, in which case `slot_used` is projected exactly from active task IDs and no other queued execution starts automatically until active usage drops below the limit; UI never derives or writes runtime state.
+Invariants: attempt identity and event sequence must match; late events cannot overwrite a newer attempt; terminal state and slot release are atomic; sending cancellation is not cancellation success. Runtime atomically closes that attempt's event output before aborting the task and emits exactly one cancellation terminal event; detached streaming callbacks cannot project more content after cancellation begins, and Runtime scope exit still guarantees the stopped acknowledgement. `loop_item_executions.team_id/backend_task_id=0` means unbound only, existence checks must use positive-ID semantics, and APIs/UI must normalize the sentinel to `null`; capacity belongs to each device Runtime scheduler and aggregate capacity is not execution truth; persisted queue state and queued task IDs come from one scheduler snapshot; Run now may temporarily push a selected queued execution beyond `slot_max`, in which case `slot_used` is projected exactly from active task IDs and no other queued execution starts automatically until active usage drops below the limit; UI never derives or writes runtime state.
 
 See [project execution state-of-truth refactoring](../wework/developer-guide/wework-project-execution-state-truth-refactoring.md) for the detailed state matrix and acceptance coverage.

--- a/docs/zh/architecture/git-worktree-execution.md
+++ b/docs/zh/architecture/git-worktree-execution.md
@@ -53,6 +53,7 @@ sequenceDiagram
     U->>B: runtime.tasks.create(taskId, sourcePath, git_worktree)
     B->>E: 原样转发
     E->>E: 计算稳定 plannedPath 并持久化任务意图
+    E->>E: 按托管路径约定识别尚未创建的 plannedPath
     E-->>U: accepted/queued + plannedPath
     U->>U: 用 plannedPath 水合当前任务地址和列表投影
     alt 无可用 slot
@@ -120,7 +121,7 @@ sequenceDiagram
 18. 延迟创建必须持久化计划阶段的源仓库 fingerprint，并在获得 slot 后与创建前重新计算的 fingerprint 比较；源目录被替换为另一个仓库时必须以 `worktree_source_changed` 失败。
 19. 停止超时是未知结果，不得清除 Runtime 取消控制或把任务当作已停止；重试归档/删除前仍必须获得同一 Runtime 的停止 ACK。
 20. `preserveSnapshot=false` 表示终态清理：Executor 必须删除已有快照引用并从 `worktrees.json` 移除记录；后续 `runtime.worktrees.list` 不得返回已清理的墓碑条目。
-21. 工作区类型判定优先使用真实 Git 元数据；只有路径中没有可解析的 Git 仓库或 Worktree 元数据时，才允许使用 `worktrees/<id>/<project>` 路径约定兜底。普通仓库不得仅因任一父目录名为 `worktrees` 被投影成 Worktree。
+21. 已存在工作区的类型判定优先使用自身真实 Git 元数据；尚未创建的托管计划路径必须先按 `worktrees/<id>/<project>` 约定识别，不能被更高层 Executor 源码仓库的 `.git` 否定。已有候选根自身包含普通仓库 `.git` 时仍判定为普通工作区，不能仅因任一父目录名为 `worktrees` 被投影成 Worktree。
 22. Runtime 接受任务后，列表刷新失败只能降级为稍后对账，不能撤销已接受任务的本地可见状态或报告发送失败。
 23. Worktree 乐观导航可以在计划路径返回前只携带任务身份；创建响应或任务列表首次提供计划/最终路径后，Wework 必须将该路径回填到当前任务地址。当前任务、列表投影和后续 Terminal、IDE、文件操作不得长期保留无路径的乐观地址。
 

--- a/docs/zh/architecture/project-execution-state.md
+++ b/docs/zh/architecture/project-execution-state.md
@@ -12,6 +12,8 @@ flowchart LR
     CLAIM --> ACTIVE[(活动 attempt + lease)]
     ACTIVE --> PROCESS[真实进程]
     PROCESS --> EVENT[带 attempt/sequence 的事件]
+    CANCEL_FENCE[Runtime 取消出口栅栏] --> EVENT
+    PROCESS --> CANCEL_FENCE
     EVENT --> FENCE[身份与顺序栅栏]
     FENCE --> TRUTH[(执行状态真值)]
     TRUTH --> NORMALIZE[执行 ID 哨兵归一化]
@@ -47,6 +49,8 @@ sequenceDiagram
     else 取消
         U->>S: cancel intent
         S->>R: cancel command
+        R->>R: 先关闭该 attempt 的事件出口
+        R->>P: abort
         R-->>S: stopped ACK
         S->>S: 写 cancelled 并释放 slot
     else lease 过期
@@ -60,10 +64,10 @@ sequenceDiagram
 | -------------------------- | --------------------------------------------------------------- |
 | claim、attempt 与状态转换  | `backend/app/services/loop_item_executions/service.py`          |
 | 执行 ID 存储与归一化       | `backend/app/models/loop_item_execution.py`、execution API/schema |
-| scheduler、slot 与真实进程 | `executor/src/runner/`、`executor/src/runtime_work/`            |
+| scheduler、slot、真实进程与取消事件栅栏 | `executor/src/runner/`、`executor/src/runtime_work/`、`executor/src/local/backend/tasks.rs` |
 | 本地 IPC 和 Runtime RPC    | `executor/src/local/app_ipc.rs`、Backend device runtime service |
 | UI 投影                    | Wework workbench stores 与 board queries                        |
 
-不变量：attempt 身份和事件序列必须匹配；迟到事件不能覆盖新 attempt；终态与 slot 释放原子发生；取消发送不等于取消成功，Runtime 作用域退出必须保证停止 ACK；`loop_item_executions.team_id/backend_task_id=0` 只表示未绑定，存在性判断必须使用正 ID 语义，API/UI 必须归一化为 `null`；容量属于各设备 Runtime scheduler，聚合容量不是执行真值；队列持久化和排队任务 ID 必须来自同一个 scheduler 快照；“立即执行”允许指定排队任务临时突破 `slot_max`，此时 `slot_used` 必须由活动任务 ID 精确投影，且在活动数重新低于上限前不得自动启动其他排队任务；UI 不推导或回写运行状态。
+不变量：attempt 身份和事件序列必须匹配；迟到事件不能覆盖新 attempt；终态与 slot 释放原子发生；取消发送不等于取消成功，Runtime 必须先原子关闭该 attempt 的事件出口，再中止任务并发送唯一取消终态，已分离的流式回调不得在取消开始后继续投影内容，作用域退出必须保证停止 ACK；`loop_item_executions.team_id/backend_task_id=0` 只表示未绑定，存在性判断必须使用正 ID 语义，API/UI 必须归一化为 `null`；容量属于各设备 Runtime scheduler，聚合容量不是执行真值；队列持久化和排队任务 ID 必须来自同一个 scheduler 快照；“立即执行”允许指定排队任务临时突破 `slot_max`，此时 `slot_used` 必须由活动任务 ID 精确投影，且在活动数重新低于上限前不得自动启动其他排队任务；UI 不推导或回写运行状态。
 
 详细状态矩阵与验收见 [项目执行状态真实性重构](../wework/developer-guide/wework-project-execution-state-truth-refactoring.md)。

--- a/executor/src/local/backend/tasks.rs
+++ b/executor/src/local/backend/tasks.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use tokio::task::JoinHandle;
 
 use crate::{
-    emitter::ResponsesEventBuilder,
+    emitter::{EventEnvelope, ResponsesEventBuilder},
     protocol::{ExecutionRequest, TaskStatus},
     runner::{AgentEngine, EventSink, ExecutionOutcome},
     server::{RunnerResult, TaskRunner},
@@ -86,8 +86,51 @@ where
 }
 
 struct ManagedTaskHandle {
+    identity: Arc<()>,
     builder: ResponsesEventBuilder,
+    cancellation: Arc<CancellationState>,
     handle: JoinHandle<()>,
+}
+
+struct CancellationState {
+    cancelled: tokio::sync::RwLock<bool>,
+}
+
+impl CancellationState {
+    fn new() -> Self {
+        Self {
+            cancelled: tokio::sync::RwLock::new(false),
+        }
+    }
+
+    async fn cancel(&self) {
+        *self.cancelled.write().await = true;
+    }
+}
+
+#[derive(Clone)]
+struct CancellationAwareEventSink<S> {
+    inner: S,
+    cancellation: Arc<CancellationState>,
+}
+
+impl<S> EventSink for CancellationAwareEventSink<S>
+where
+    S: EventSink,
+{
+    type SendFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send>>;
+
+    fn send(&self, event: EventEnvelope) -> Self::SendFuture {
+        let inner = self.inner.clone();
+        let cancellation = Arc::clone(&self.cancellation);
+        Box::pin(async move {
+            let cancelled = cancellation.cancelled.read().await;
+            if *cancelled {
+                return Ok(());
+            }
+            inner.send(event).await
+        })
+    }
 }
 
 impl<E, S> ManagedLocalTaskRunner<E, S>
@@ -114,6 +157,7 @@ where
             self.running_tasks.remove(&task_id);
             return false;
         };
+        state.cancellation.cancel().await;
         state.handle.abort();
         let _ = state.handle.await;
         self.running_tasks.remove(&task_id);
@@ -175,19 +219,37 @@ where
             }
 
             running_tasks.add(task_id.clone());
-            let mut guard = handles.lock().expect("managed task lock");
+            let identity = Arc::new(());
+            let cancellation = Arc::new(CancellationState::new());
+            let task_sink = CancellationAwareEventSink {
+                inner: sink,
+                cancellation: Arc::clone(&cancellation),
+            };
             let handle = tokio::spawn(run_managed_task(
                 engine,
-                sink,
+                task_sink,
                 builder.clone(),
                 request,
                 running_tasks.clone(),
                 Arc::clone(&handles),
+                Arc::clone(&identity),
             ));
-            if let Some(previous) = guard.insert(task_id, ManagedTaskHandle { builder, handle }) {
+            let previous = {
+                let mut guard = handles.lock().expect("managed task lock");
+                guard.insert(
+                    task_id,
+                    ManagedTaskHandle {
+                        identity,
+                        builder,
+                        cancellation,
+                        handle,
+                    },
+                )
+            };
+            if let Some(previous) = previous {
+                previous.cancellation.cancel().await;
                 previous.handle.abort();
             }
-            drop(guard);
 
             RunnerResult::accepted(TaskStatus::Running)
         })
@@ -201,6 +263,7 @@ async fn run_managed_task<E, S>(
     request: ExecutionRequest,
     running_tasks: LocalRunningTaskTracker,
     handles: Arc<Mutex<BTreeMap<String, ManagedTaskHandle>>>,
+    identity: Arc<()>,
 ) where
     E: AgentEngine,
     S: EventSink,
@@ -210,7 +273,15 @@ async fn run_managed_task<E, S>(
         .run_with_events(request, sink.clone(), builder.clone())
         .await;
     running_tasks.remove(&task_id);
-    handles.lock().expect("managed task lock").remove(&task_id);
+    {
+        let mut guard = handles.lock().expect("managed task lock");
+        if guard
+            .get(&task_id)
+            .is_some_and(|state| Arc::ptr_eq(&state.identity, &identity))
+        {
+            guard.remove(&task_id);
+        }
+    }
 
     let event = match outcome {
         ExecutionOutcome::Completed { content } => builder.response_completed(&content),
@@ -241,4 +312,87 @@ fn local_event_builder(request: &ExecutionRequest) -> ResponsesEventBuilder {
             request.executor_namespace.as_deref(),
         )
         .with_validation_id(validation_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::Notify;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct DetachedLateEventEngine {
+        release_late_event: Arc<Notify>,
+    }
+
+    impl AgentEngine for DetachedLateEventEngine {
+        type RunFuture = std::future::Pending<ExecutionOutcome>;
+
+        fn run(&self, _request: ExecutionRequest) -> Self::RunFuture {
+            std::future::pending()
+        }
+
+        fn run_with_events<T>(
+            &self,
+            _request: ExecutionRequest,
+            sink: T,
+            builder: ResponsesEventBuilder,
+        ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send>>
+        where
+            T: EventSink,
+        {
+            let release_late_event = Arc::clone(&self.release_late_event);
+            tokio::spawn(async move {
+                release_late_event.notified().await;
+                let _ = sink
+                    .send(builder.response_text_delta("late output", 0))
+                    .await;
+            });
+            Box::pin(std::future::pending())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingSink {
+        events: Arc<Mutex<Vec<EventEnvelope>>>,
+    }
+
+    impl EventSink for RecordingSink {
+        type SendFuture = std::future::Ready<Result<(), String>>;
+
+        fn send(&self, event: EventEnvelope) -> Self::SendFuture {
+            self.events.lock().expect("event sink lock").push(event);
+            std::future::ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_blocks_events_from_detached_streaming_callbacks() {
+        let release_late_event = Arc::new(Notify::new());
+        let sink = RecordingSink::default();
+        let runner = ManagedLocalTaskRunner::new(
+            DetachedLateEventEngine {
+                release_late_event: Arc::clone(&release_late_event),
+            },
+            sink.clone(),
+            LocalRunningTaskTracker::default(),
+        );
+        let request = ExecutionRequest {
+            task_id: "282".to_owned(),
+            subtask_id: "536".to_owned(),
+            ..ExecutionRequest::default()
+        };
+
+        let accepted = runner.submit(request).await;
+        assert_eq!(accepted.status, TaskStatus::Running);
+        assert!(runner.cancel_task("282".to_owned(), None).await);
+        release_late_event.notify_one();
+        tokio::task::yield_now().await;
+
+        let events = sink.events.lock().expect("event sink lock");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "response.created");
+        assert_eq!(events[1].event_type, "response.incomplete");
+        assert_eq!(events[1].data["response"]["status"], "cancelled");
+    }
 }

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -653,6 +653,11 @@ fn resolved_worktree_root_and_id(path: &str) -> Option<(String, String)> {
     if let Some(worktree) = git_worktree_root_and_id(path) {
         return Some(worktree);
     }
+    if let Some((worktree_root, worktree_id)) = path_worktree_root_and_id(path) {
+        if !Path::new(&worktree_root).join(".git").is_dir() {
+            return Some((worktree_root, worktree_id));
+        }
+    }
     if git_common_workspace_root(path).is_some() {
         return None;
     }
@@ -910,6 +915,31 @@ mod tests {
         assert_eq!(
             infer_worktree_id(&planned_path).as_deref(),
             Some("runtime-1")
+        );
+    }
+
+    #[test]
+    fn planned_worktree_path_under_repository_checkout_is_a_worktree() {
+        let checkout = tempdir().expect("temporary directory");
+        std::fs::create_dir_all(checkout.path().join(".git")).expect("checkout git metadata");
+        let planned = checkout
+            .path()
+            .join("executor-home")
+            .join("workspace")
+            .join("worktrees")
+            .join("runtime-132780333")
+            .join("workspace");
+        std::fs::create_dir_all(&planned).expect("planned worktree directory");
+        let planned_path = planned.display().to_string();
+
+        assert_eq!(infer_workspace_kind(&planned_path), "worktree");
+        assert_eq!(
+            infer_worktree_id(&planned_path),
+            Some("runtime-132780333".to_owned())
+        );
+        assert_eq!(
+            workspace_task_path(&planned_path, &checkout.path().display().to_string()),
+            planned_path
         );
     }
 }

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -4458,7 +4458,7 @@ async fn wait_for_method_count(log_path: &Path, method: &str, expected: usize) {
 }
 
 async fn wait_for_logged_pid(log_path: &Path, prefix: &str) -> u32 {
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let content = fs::read_to_string(log_path).unwrap_or_default();
         if let Some(pid) = content.lines().find_map(|line| {

--- a/executor/tests/local_backend_contract.rs
+++ b/executor/tests/local_backend_contract.rs
@@ -714,7 +714,7 @@ impl RecordingTransport {
     }
 
     async fn wait_for_emits(&self, count: usize) -> Vec<RecordedCall> {
-        timeout(Duration::from_secs(3), async {
+        timeout(Duration::from_secs(10), async {
             loop {
                 let emits = self.emits();
                 if emits.len() >= count {
@@ -728,7 +728,7 @@ impl RecordingTransport {
     }
 
     async fn wait_for_emit_event(&self, event: &str) -> Vec<RecordedCall> {
-        timeout(Duration::from_secs(3), async {
+        timeout(Duration::from_secs(10), async {
             loop {
                 let emits = self.emits();
                 if emits.iter().any(|emit| emit.event == event) {

--- a/frontend/e2e/utils/provider-native-test-support.ts
+++ b/frontend/e2e/utils/provider-native-test-support.ts
@@ -281,9 +281,16 @@ export async function waitForTaskTerminal(
     await expect
       .poll(
         async () => {
-          const response = await runtimeRequest.get(
-            `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/runtime-check`
-          )
+          let response
+          try {
+            response = await runtimeRequest.get(
+              `${PROVIDER_NATIVE_API_URL}/api/tasks/${taskId}/runtime-check`
+            )
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            if (!/socket hang up|ECONNRESET/i.test(message)) throw error
+            return `TRANSPORT_ERROR_${message}`
+          }
           if (response.status() !== 200) return `HTTP_${response.status()}`
           const body = (await response.json()) as { task_status: string }
           finalStatus = body.task_status.toUpperCase()

--- a/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
@@ -1363,6 +1363,55 @@ describe('ContextSelector organization grouping', () => {
     })
   })
 
+  it('keeps DingTalk wikispace usable when internal knowledge bases fail to load', async () => {
+    mockGetAllGroupedKnowledgeBases.mockRejectedValueOnce(
+      new Error('internal knowledge bases unavailable')
+    )
+    mockGetDingTalkWikispaceNodes.mockResolvedValue({
+      total_count: 1,
+      nodes: [
+        {
+          id: 10,
+          dingtalk_node_id: 'space-1',
+          name: '研发空间',
+          doc_url: 'https://alidocs.dingtalk.com/i/spaces/space-1/overview',
+          parent_node_id: '',
+          node_type: 'folder',
+          workspace_id: 'space-1',
+          content_type: '',
+          source: 'wikispace',
+          is_active: true,
+          last_synced_at: '',
+          created_at: '',
+          updated_at: '',
+          children: [],
+        },
+      ],
+    })
+
+    render(
+      <ContextSelector
+        open={true}
+        onOpenChange={jest.fn()}
+        selectedContexts={[]}
+        onSelect={jest.fn()}
+        onDeselect={jest.fn()}
+      >
+        <button>trigger</button>
+      </ContextSelector>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-picker-dingtalk-parent')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-wikispace'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-picker-dingtalk-space-space-1')).toBeInTheDocument()
+    })
+  })
+
   it('auto-expands the folder path for selected internal documents', async () => {
     mockGetFolderTree.mockResolvedValue([
       {

--- a/frontend/src/features/tasks/components/chat/KnowledgeSourcePicker.tsx
+++ b/frontend/src/features/tasks/components/chat/KnowledgeSourcePicker.tsx
@@ -1212,10 +1212,13 @@ export function KnowledgeSourcePicker({
   }
 
   const renderMiddleColumn = () => {
-    if (loading) {
+    const isInternalSource =
+      activeSource === 'personal' || activeSource === 'group' || activeSource === 'organization'
+
+    if (isInternalSource && loading) {
       return <PickerLoading label={t('picker.loading')} />
     }
-    if (error) {
+    if (isInternalSource && error) {
       return <PickerError message={error} onRetry={onRetry} />
     }
 


### PR DESCRIPTION
## Summary

- classify planned managed worktree paths before ancestor repository discovery so queued cloud task cancellation can resolve its workspace
- fence local task callbacks during cancellation so detached streaming callbacks cannot emit after the cancellation terminal event
- keep provider-native DingTalk knowledge sources usable when the unrelated internal knowledge-base request fails
- align integration-test observation windows with existing bounded startup/event deadlines under full-suite load
- synchronize the governed worktree and execution-state architecture invariants in Chinese and English

## Root-cause evidence

- merge-queue cloud worktree logs showed cancellation failing because a not-yet-created planned worktree inherited the CI checkout's ancestor `.git`
- Wework cancellation logs showed streaming/compaction callbacks arriving after `runtime.tasks.cancel` began and before `response.incomplete`
- provider-native E2E logs showed DingTalk APIs succeeding while `/api/knowledge-bases/all-grouped` failed and the picker rendered the unrelated internal error globally
- two platform E2E shards never reached a test because runtime `playwright install-deps` blocked on the Ubuntu mirror; the branch was rebased onto #2808, which removes this runtime install path and runs platform E2E in the immutable dependency image
- CI-exact `cargo test --all-features` exposed hard 2s/3s observation deadlines expiring while the expected process/event was starting or emitted at the boundary

## Verification

- `cargo test --manifest-path executor/Cargo.toml --all-features`
- cancellation startup scenario: 20 consecutive focused passes
- local backend parallel contract suite: 10 consecutive full-file passes
- `cargo clippy --manifest-path executor/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path executor/Cargo.toml --all -- --check`
- `pnpm --dir frontend test` (315 suites, 1944 passed, 1 todo)
- `pnpm --dir frontend lint`
- pre-push frontend lint/typecheck/unit tests and executor fmt/lib tests/clippy
- final commit `ebc653eab36000464d4f3c66f53256ab563c160f`: five consecutive successful full-CI attempts for Lint, Tests, E2E Tests, Wework E2E, and Repository Policy
- verified GitHub Actions runs: `32246604385`, `32246604388`, `32246604476`, `32246604457`, and `32246603184` (all at `run_attempt=5`, completed successfully)

The five consecutive full-CI runs completed successfully before handoff.
