### PR TITLE
fix(wework): show paused follow-up queues in sidebar

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -27,6 +27,10 @@ import {
   dispatchWorkbenchSidebarPaneDragCancel,
   dispatchWorkbenchSidebarPaneDragStart,
 } from './workbenchPaneDrag'
+import {
+  cacheRuntimeConversationQueuePaused,
+  clearRuntimeConversationCacheForTests,
+} from '@/features/workbench/runtimeConversationCache'
 
 const experimentalFeatures = vi.hoisted(() => ({ enabled: true }))
 
@@ -201,9 +205,11 @@ describe('DesktopSidebar', () => {
     setActiveKeybindings([])
     Element.prototype.scrollIntoView = vi.fn()
     vi.mocked(openLocalWorkspace).mockReset()
+    clearRuntimeConversationCacheForTests()
   })
 
   afterEach(() => {
+    clearRuntimeConversationCacheForTests()
     vi.useRealTimers()
     vi.unstubAllEnvs()
   })
@@ -2815,6 +2821,79 @@ describe('DesktopSidebar', () => {
     expect(runningStatus).not.toHaveTextContent('运行中')
     expect(runningStatus.querySelector('svg')).not.toBeNull()
     expect(screen.queryByTestId('runtime-local-task-running-codex-idle')).not.toBeInTheDocument()
+  })
+
+  test('shows a paused status when a running task has a paused follow-up queue', async () => {
+    renderSidebar({
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Wegent' },
+            totalTasks: 1,
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'local-device',
+                deviceName: 'Local Mac',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/repo/Wegent',
+                tasks: [
+                  {
+                    taskId: 'paused-follow-up',
+                    workspacePath: '/repo/Wegent',
+                    title: 'Paused follow-up',
+                    runtime: 'codex',
+                    running: true,
+                    updatedAt: '2026-08-19T03:00:00Z',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+    })
+
+    await userEvent.click(screen.getByTestId('project-item-button'))
+    expect(screen.getByTestId('runtime-local-task-running-paused-follow-up')).toBeInTheDocument()
+
+    act(() => {
+      cacheRuntimeConversationQueuePaused(
+        {
+          deviceId: 'local-device',
+          taskId: 'paused-follow-up',
+          workspacePath: '/repo/Wegent',
+        },
+        true
+      )
+    })
+
+    expect(screen.getByTestId('runtime-local-task-queue-paused-paused-follow-up')).toHaveAttribute(
+      'aria-label',
+      '追问队列已暂停'
+    )
+    expect(
+      screen.queryByTestId('runtime-local-task-running-paused-follow-up')
+    ).not.toBeInTheDocument()
+
+    act(() => {
+      cacheRuntimeConversationQueuePaused(
+        {
+          deviceId: 'local-device',
+          taskId: 'paused-follow-up',
+          workspacePath: '/repo/Wegent',
+        },
+        false
+      )
+    })
+
+    expect(screen.getByTestId('runtime-local-task-running-paused-follow-up')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('runtime-local-task-queue-paused-paused-follow-up')
+    ).not.toBeInTheDocument()
   })
 
   test('shows queued positions and runs queue actions through the workbench', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -19,6 +19,7 @@ import {
   MessageCircle,
   MessageCircleOff,
   MessageSquarePlus,
+  Pause,
   Pin,
   Plus,
   RotateCw,
@@ -28,7 +29,15 @@ import {
   UserRound,
   X,
 } from 'lucide-react'
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import type {
   KeyboardEvent,
   MouseEvent as ReactMouseEvent,
@@ -49,6 +58,10 @@ import { SHOW_PLUGINS_NAVIGATION } from '@/features/plugins/visibility'
 import { getRuntimeTaskReminderItemKey } from '@/features/workbench/runtimeTaskReminders'
 import { WorkbenchContext } from '@/features/workbench/workbenchContexts'
 import { runtimeTaskBoardOrigin } from '@/features/workbench/runtimeTaskOrigin'
+import {
+  getRuntimeConversationQueuePaused,
+  subscribeRuntimeConversation,
+} from '@/features/workbench/runtimeConversationCache'
 import {
   getRuntimeTaskLifecycleKey,
   useRuntimeTaskLifecycle,
@@ -1561,6 +1574,7 @@ function RuntimeTaskRow({
     !workspace.available || !onArchiveRuntimeTask || archiving || archivePending
   const taskAddress = getRuntimeTaskAddress(workspace, task)
   const taskLifecycle = useRuntimeTaskLifecycle(taskAddress)
+  const queuePaused = useRuntimeTaskQueuePaused(taskAddress)
   const queued = isRuntimeTaskQueued(task)
   const queuePosition =
     queued && Number.isInteger(task.queuePosition) && Number(task.queuePosition) > 0
@@ -1933,6 +1947,19 @@ function RuntimeTaskRow({
                       </span>
                     ) : null}
                   </span>
+                ) : queuePaused ? (
+                  <span
+                    data-testid={`runtime-local-task-queue-paused-${task.taskId}`}
+                    role="status"
+                    title={t('workbench.runtime_task_queue_paused')}
+                    aria-label={t('workbench.runtime_task_queue_paused')}
+                    className="flex h-[30px] w-[30px] items-center justify-center"
+                  >
+                    <Pause
+                      className="h-3.5 w-3.5 text-[rgb(var(--color-sidebar-text-muted))]"
+                      aria-hidden="true"
+                    />
+                  </span>
                 ) : taskLifecycle?.derived.shouldShowSidebarRunning ? (
                   <span
                     data-testid={`runtime-local-task-running-${task.taskId}`}
@@ -2242,6 +2269,26 @@ function RuntimeTaskRow({
       />
     </>
   )
+}
+
+function useRuntimeTaskQueuePaused(address: RuntimeTaskAddress): boolean {
+  const stableAddress = useMemo<RuntimeTaskAddress>(
+    () => ({
+      deviceId: address.deviceId,
+      taskId: address.taskId,
+    }),
+    [address.deviceId, address.taskId]
+  )
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeRuntimeConversation(stableAddress, listener),
+    [stableAddress]
+  )
+  const getSnapshot = useCallback(
+    () => getRuntimeConversationQueuePaused(stableAddress),
+    [stableAddress]
+  )
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 }
 
 function LocalHarnessSessionRow({

--- a/wework/src/features/workbench/runtimeConversationCache.test.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.test.ts
@@ -22,6 +22,7 @@ import {
   removeOptimisticRuntimeConversationGuidance,
   markRuntimeConversationAssistantStarted,
   runtimeConversationSnapshotSettlesLatestTurn,
+  subscribeRuntimeConversation,
   settleRuntimeConversationAcceptedMessage,
   settleRuntimeConversationGuidance,
   settleRuntimeConversationSubagents,
@@ -54,6 +55,20 @@ describe('runtimeConversationCache', () => {
     })
 
     expect(getRuntimeConversationMessages(address)).toHaveLength(1)
+  })
+
+  test('notifies conversation subscribers when the follow-up queue pause changes', () => {
+    let notifications = 0
+    const unsubscribe = subscribeRuntimeConversation(address, () => {
+      notifications += 1
+    })
+
+    cacheRuntimeConversationQueuePaused(address, true)
+    cacheRuntimeConversationQueuePaused(address, true)
+    cacheRuntimeConversationQueuePaused(address, false)
+
+    expect(notifications).toBe(2)
+    unsubscribe()
   })
 
   test('settles an accepted queued message when its runtime turn starts', () => {

--- a/wework/src/features/workbench/runtimeConversationCache.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.ts
@@ -793,11 +793,14 @@ export function cacheRuntimeConversationQueuePaused(address: RuntimeTaskAddress,
 }
 
 export function cacheRuntimeConversationQueuePausedByKey(key: string, paused: boolean) {
+  const previous = queuedMessagesPausedByConversation.get(key) ?? false
+  if (previous === paused) return
   if (!paused) {
     queuedMessagesPausedByConversation.delete(key)
-    return
+  } else {
+    cacheBoundedEntry(queuedMessagesPausedByConversation, key, true)
   }
-  cacheBoundedEntry(queuedMessagesPausedByConversation, key, true)
+  notifyRuntimeConversation(key)
 }
 
 export function runtimeConversationKey(address: RuntimeTaskAddress): string {

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -480,6 +480,7 @@
     "archive_runtime_task_remove_failed": "Task archived, but failed to remove the worktree",
     "archive_runtime_task_remove_failed_detail": "Task archived, but failed to remove the worktree: {{message}}",
     "runtime_task_running": "Running",
+    "runtime_task_queue_paused": "Follow-up queue paused",
     "task_plan_progress": "Step {{current}} / {{total}}",
     "task_plan_completed": "Task steps completed",
     "subagents_status": "Subagent status",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -479,6 +479,7 @@
     "archive_runtime_task_remove_failed": "任务已归档，但删除工作树失败",
     "archive_runtime_task_remove_failed_detail": "任务已归档，但删除工作树失败：{{message}}",
     "runtime_task_running": "运行中",
+    "runtime_task_queue_paused": "追问队列已暂停",
     "task_plan_progress": "第 {{current}} / {{total}} 步",
     "task_plan_completed": "任务步骤已完成",
     "subagents_status": "子智能体状态",


### PR DESCRIPTION
## Summary
- publish follow-up queue pause changes through the existing runtime conversation subscription
- show a dedicated paused indicator in desktop sidebar task rows, ahead of the running spinner
- add Chinese and English accessible labels plus regression coverage for pause and resume transitions

## Verification
- `pnpm --filter wework test src/features/workbench/runtimeConversationCache.test.ts src/components/layout/DesktopSidebar.test.tsx` (122 passed)
- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework exec tsc -b`
- pre-push full Wework ESLint, TypeScript, and unit tests passed

## Real Tauri verification
- attempted twice with `pnpm --filter wework ai:verify start`; both isolated launches timed out before the WebView started because `scripts/dev-mac-app.sh` stalled in shell heredoc setup under the current host process load. No application/runtime error from this change was emitted. Will retry while CI runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paused status indicator for runtime task follow-up queues in the desktop sidebar.
  * The status updates automatically when a queue is paused or resumed.
  * Added localized paused-queue text in English and Simplified Chinese.

* **Bug Fixes**
  * Prevented redundant queue-status updates when the state has not changed.

* **Tests**
  * Added coverage for paused, resumed, subscription, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->