### PR TITLE
fix(wework): preserve ordered list start values

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -27,6 +27,7 @@ Before changing a Wework flow, identify the affected product area and trace its 
 - Follow the Codex-derived, neutral-first visual system in `DESIGN.md`: grayscale surfaces, `14px` default desktop UI text, sparse hairlines and shadows, inverse-neutral primary actions, and blue only for focus, links, or narrow selection accents. Green and teal are restricted to semantic success/addition states and must never define product chrome or default actions.
 - Use the Codex component density documented in `DESIGN.md`: `30px` sidebar rows, `28px` app-shell tabs and composer actions, `16px` standard desktop icons, and `4px–8px` action-group gaps. Reuse the shared component's established size instead of inventing a local height.
 - Use the shared typography scale and semantic `heading-*`, `text-chat`, and `text-code` roles. Never add arbitrary `text-[Npx]`, literal CSS `font-size`, or literal inline `fontSize` values; `pnpm lint` enforces this rule.
+- Custom Markdown renderers must preserve semantic attributes supplied by the parser, such as an ordered list's `start` value.
 - Preserve platform text-navigation semantics in the ProseMirror chat composer. Register only composer-specific key bindings instead of the document-level `baseKeymap`, and scope mention caret workarounds to unmodified arrow keys.
 
 ## i18n

--- a/wework/src/components/chat/AssistantMarkdown.ordered-list.test.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.ordered-list.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import { AssistantMarkdown } from './AssistantMarkdown'
+
+test('preserves ordered-list starts when prose separates numbered items', () => {
+  const { container } = render(
+    <AssistantMarkdown
+      content={[
+        '1. First issue',
+        '',
+        'First explanation.',
+        '',
+        '2. Second issue',
+        '',
+        'Second explanation.',
+        '',
+        '3. Third issue',
+      ].join('\n')}
+    />
+  )
+
+  expect(
+    Array.from(container.querySelectorAll('ol')).map(list => list.getAttribute('start'))
+  ).toEqual([null, '2', '3'])
+})

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { HTMLAttributes, ReactNode } from 'react'
+import type { HTMLAttributes, OlHTMLAttributes, ReactNode } from 'react'
 import type { Element as HastElement } from 'hast'
 import { FileText, Folder, Link2 } from 'lucide-react'
 import { Streamdown } from 'streamdown'
@@ -153,8 +153,9 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
           {children}
         </ul>
       ),
-      ol: ({ children }: { children?: ReactNode }) => (
+      ol: ({ children, start }: OlHTMLAttributes<HTMLOListElement>) => (
         <ol
+          start={start}
           className={`${variant === 'process' ? 'mb-1.5 space-y-0.5 pl-5' : 'mb-3 space-y-1.5 pl-8'} list-decimal`}
         >
           {children}


### PR DESCRIPTION
## Summary

- preserve the Markdown parser's `start` value when rendering ordered lists
- add regression coverage for numbered items separated by explanatory paragraphs
- document the semantic-attribute requirement for custom Markdown renderers

## Verification

- `pnpm --filter wework test src/components/chat/AssistantMarkdown.ordered-list.test.tsx src/components/chat/AssistantMarkdown.typography.test.tsx src/components/chat/AssistantMarkdown.diagram.test.tsx src/components/chat/AssistantMarkdown.windowing.test.ts`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework exec eslint src/components/chat/AssistantMarkdown.tsx src/components/chat/AssistantMarkdown.ordered-list.test.tsx`
- pre-push Wework ESLint, TypeScript, and full unit-test checks
- isolated real-Tauri verification: generated three prose-separated ordered-list segments and confirmed visible numbering `1`, `2`, `3` plus DOM `start` values default, `2`, `3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved ordered-list numbering in rendered Markdown, including lists that continue after intervening prose.
  - Maintained correct numbering for lists that begin with a non-default value.

- **Tests**
  - Added coverage verifying ordered-list start values and numbering are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->