### PR TITLE
fix(wework): settle overlapping PR status refreshes

### DIFF
--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -1124,6 +1124,80 @@ describe('loadProjectEnvironment', () => {
     expect(executeCommand).toHaveBeenCalledTimes(10)
   })
 
+  test('deduplicates a forced refresh while the current environment load is still pending', async () => {
+    let resolveBranch: (value: {
+      success: boolean
+      stdout: string
+      stderr: string
+    }) => void = () => {}
+    const branchResult = new Promise<{
+      success: boolean
+      stdout: string
+      stderr: string
+    }>(resolve => {
+      resolveBranch = resolve
+    })
+    const executeCommand = vi.fn((_: string, data: { command_key: string }) => {
+      if (data.command_key === 'git_branch') {
+        return branchResult
+      }
+      if (data.command_key === 'git_remote_url') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'https://github.com/wecode-ai/Wegent.git\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_github_pull_requests') {
+        return Promise.resolve({
+          success: true,
+          stdout: [],
+          stderr: '',
+        })
+      }
+      return Promise.resolve({
+        success: true,
+        stdout: '',
+        stderr: '',
+      })
+    })
+    const api = { executeCommand }
+    const project = {
+      id: 1002,
+      name: 'Wegent',
+      config: {
+        mode: 'workspace' as const,
+        execution: {
+          targetType: 'local' as const,
+          deviceId: 'device-123',
+        },
+        workspace: {
+          source: 'local_path' as const,
+          localPath: '/workspace/Wegent',
+        },
+      },
+    }
+
+    const initialLoad = loadProjectEnvironment(api, project)
+    const forcedRefresh = loadProjectEnvironment(api, project, undefined, { force: true })
+
+    await vi.waitFor(() => {
+      expect(executeCommand).toHaveBeenCalledTimes(3)
+    })
+
+    resolveBranch({
+      success: true,
+      stdout: 'fix/environment-refresh\n',
+      stderr: '',
+    })
+
+    const [initialInfo, refreshedInfo] = await Promise.all([initialLoad, forcedRefresh])
+
+    expect(initialInfo).toEqual(refreshedInfo)
+    expect(initialInfo.branchName).toBe('fix/environment-refresh')
+    expect(executeCommand).toHaveBeenCalledTimes(5)
+  })
+
   test('uses git diff against HEAD for tracked uncommitted changes', async () => {
     const executeCommand = vi.fn((_: string, data: { command_key: string; args?: string[] }) => {
       if (data.command_key === 'git_branch') {

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -56,6 +56,7 @@ const NO_CHANGES_TO_COMMIT_MESSAGE = 'No changes to commit'
 type EnvironmentInfoCacheEntry = {
   expiresAt: number
   promise: Promise<EnvironmentInfo>
+  settled: boolean
 }
 
 const environmentInfoCaches = new WeakMap<
@@ -815,15 +816,27 @@ export async function loadProjectEnvironment(
   const now = Date.now()
   const environmentInfoCache = getEnvironmentInfoCache(api)
   const cached = environmentInfoCache.get(cacheKey)
-  if (!options.force && cached && cached.expiresAt > now) {
+  // Forced polling must still share an in-flight load. Replacing a slow request
+  // on every poll prevents any result from settling the environment loading state.
+  if (cached && (!cached.settled || (!options.force && cached.expiresAt > now))) {
     return cloneEnvironmentInfo(await cached.promise)
   }
 
   const promise = loadProjectEnvironmentUncached(api, project, target)
-  environmentInfoCache.set(cacheKey, {
+  const entry: EnvironmentInfoCacheEntry = {
     expiresAt: now + ENVIRONMENT_INFO_CACHE_TTL_MS,
     promise,
-  })
+    settled: false,
+  }
+  environmentInfoCache.set(cacheKey, entry)
+  void promise.then(
+    () => {
+      entry.settled = true
+    },
+    () => {
+      entry.settled = true
+    }
+  )
 
   try {
     return cloneEnvironmentInfo(await promise)


### PR DESCRIPTION
## Summary

- Reuse an in-flight environment info request even when periodic polling requests a forced refresh.
- Allow a completed forced refresh to bypass the TTL without replacing a still-pending request.
- Add regression coverage for overlapping forced environment refreshes.

## Root cause

Task polling runs every five seconds, while the environment command can take longer than ten seconds. Each forced poll replaced the in-flight cache entry, so earlier results were discarded by request sequencing and the PR/environment status never settled beyond loading.

## Verification

- Focused environment and executor reload tests: 45 passed.
- Wework TypeScript check passed.
- Wework lint passed.
- Full Wework unit suite passed via the pre-push hook.
- An isolated Tauri ai:verify session confirmed the branch and environment state settle without overlapping five-second command batches.