### PR TITLE
fix(wework): focus composer after opening conversation

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -5,8 +5,8 @@
 from contextlib import asynccontextmanager, contextmanager
 from typing import AsyncGenerator, Generator, Optional
 
-from sqlalchemy import create_engine
-from sqlalchemy.engine import make_url
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
@@ -16,6 +16,21 @@ from app.db.timezone import MYSQL_SESSION_TIMEZONE_OFFSET
 
 # Database connection URL (using sync driver)
 SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL
+
+
+def _configure_sqlite_engine(sqlite_engine: Engine) -> Engine:
+    """Enable SQLite settings required by concurrent API and worker access."""
+
+    @event.listens_for(sqlite_engine, "connect")
+    def set_sqlite_pragmas(dbapi_connection, _connection_record) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA busy_timeout=30000")
+        finally:
+            cursor.close()
+
+    return sqlite_engine
 
 
 def _create_engine():
@@ -28,10 +43,12 @@ def _create_engine():
         # SQLite configuration
         # - check_same_thread=False: Required for SQLite to work with multiple threads
         # - SQLite doesn't support connection pooling parameters like pool_size
-        return create_engine(
-            SQLALCHEMY_DATABASE_URL,
-            connect_args={"check_same_thread": False},
-            pool_pre_ping=True,
+        return _configure_sqlite_engine(
+            create_engine(
+                SQLALCHEMY_DATABASE_URL,
+                connect_args={"check_same_thread": False, "timeout": 30},
+                pool_pre_ping=True,
+            )
         )
     else:
         # MySQL configuration
@@ -88,7 +105,13 @@ def _create_async_engine() -> AsyncEngine:
     """Create async database engine."""
     async_url = _get_async_database_url()
     if async_url.startswith("sqlite"):
-        return create_async_engine(async_url, pool_pre_ping=True)
+        async_engine = create_async_engine(
+            async_url,
+            connect_args={"timeout": 30},
+            pool_pre_ping=True,
+        )
+        _configure_sqlite_engine(async_engine.sync_engine)
+        return async_engine
     async_engine = create_async_engine(
         async_url,
         pool_pre_ping=True,

--- a/backend/tests/db/test_session.py
+++ b/backend/tests/db/test_session.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from app.db import session
+
+
+def test_sqlite_engine_enables_concurrent_access_pragmas(
+    monkeypatch,
+    tmp_path,
+):
+    database_path = tmp_path / "concurrent.sqlite3"
+    monkeypatch.setattr(
+        session,
+        "SQLALCHEMY_DATABASE_URL",
+        f"sqlite:///{database_path}",
+    )
+
+    engine = session._create_engine()
+
+    try:
+        with engine.connect() as connection:
+            journal_mode = connection.exec_driver_sql("PRAGMA journal_mode").scalar()
+            busy_timeout = connection.exec_driver_sql("PRAGMA busy_timeout").scalar()
+
+        assert journal_mode == "wal"
+        assert busy_timeout == 30000
+    finally:
+        engine.dispose()

--- a/scripts/hooks/check-alembic-heads.sh
+++ b/scripts/hooks/check-alembic-heads.sh
@@ -175,12 +175,12 @@ echo ""
 
 # Find all heads (revisions not referenced by any down_revision)
 HEADS=""
-while IFS= read -r rev; do
+for rev in $ALL_REVISIONS; do
     [ -z "$rev" ] && continue
     if ! key_exists "$IS_REFERENCED" "$rev"; then
         HEADS="${HEADS}${rev}"$'\n'
     fi
-done <<< "$ALL_REVISIONS"
+done
 
 # Count heads (remove empty lines)
 HEAD_COUNT=$(echo "$HEADS" | grep -c .)
@@ -196,7 +196,7 @@ if [ "$NON_STANDARD_COUNT" -gt 0 ]; then
     while IFS= read -r id; do
         [ -z "$id" ] && continue
         echo -e "   ${YELLOW}• $id${NC}"
-    done <<< "$NON_STANDARD_IDS"
+    done < <(printf '%s' "$NON_STANDARD_IDS")
     echo ""
     echo -e "${YELLOW}   Recommendation: Use 'alembic revision --autogenerate' to generate${NC}"
     echo -e "${YELLOW}   standard 12-character hexadecimal revision IDs.${NC}"
@@ -223,7 +223,7 @@ else
         [ -z "$head" ] && continue
         head_file=$(get_value "$REVISIONS" "$head")
         echo -e "   ${RED}• ${head}${NC} (${head_file})"
-    done <<< "$HEADS"
+    done < <(printf '%s' "$HEADS")
     echo ""
 
     # Provide fix instructions

--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -76,6 +76,7 @@ Any Wework UI, Tauri command, local-runtime, IPC, or desktop integration behavio
 pnpm --filter wework ai:verify start
 pnpm --filter wework ai:verify snapshot --session <session-path>
 pnpm --filter wework ai:verify debug --session <session-path>
+pnpm --filter wework ai:verify active-element --session <session-path>
 pnpm --filter wework ai:verify click --session <session-path> --selector '[data-testid="..."]'
 pnpm --filter wework ai:verify click-at --session <session-path> --value '{"x":640,"y":360}'
 pnpm --filter wework ai:verify click-then-macrotask --session <session-path> --selector '[data-testid="..."]' --target '[data-testid="..."]'

--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -847,6 +847,12 @@ async function reopenCurrentTurnNavigationTask(
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     }
   )
+  const activeElementTestId = await control.command('getActiveElementTestId', 'body')
+  assert.equal(
+    activeElementTestId,
+    'chat-message-input',
+    'Opening a conversation from the sidebar did not transfer keyboard focus to the composer'
+  )
   if (expectedTurnCount > E2E_TRANSCRIPT_PAGE_SIZE) {
     await control.command('waitFor', '[data-testid="load-older-runtime-transcript-button"]', {
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -27,7 +27,7 @@ const corsHeaders = {
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
-  pnpm --filter wework ai:verify <capture|capture-popout|capture-workspace|snapshot|debug|click|click-at|click-then-macrotask|context-menu|seed-local-project|terminal-snapshot|reload|close-to-tray|request-close|dismiss-popout|drag|drop-file|drop-paths|fill|get-attribute|hover|metrics|navigate|paste-paths|pointer-move|press|scroll-into-view|select-text|show-popout|system-drag-drop|wait-for|window-focus-snapshot|text|status|stop> --session PATH [options]
+  pnpm --filter wework ai:verify <capture|capture-popout|capture-workspace|snapshot|debug|active-element|click|click-at|click-then-macrotask|context-menu|seed-local-project|terminal-snapshot|reload|close-to-tray|request-close|dismiss-popout|drag|drop-file|drop-paths|fill|get-attribute|hover|metrics|navigate|paste-paths|pointer-move|press|scroll-into-view|select-text|show-popout|system-drag-drop|wait-for|window-focus-snapshot|text|status|stop> --session PATH [options]
 
 Options:
   --codex-home-initialization true
@@ -404,6 +404,7 @@ async function main() {
     'capture-workspace': 'captureWorkspaceWindow',
     snapshot: 'snapshot',
     debug: 'getWorkbenchDebugSnapshot',
+    'active-element': 'getActiveElementTestId',
     click: 'click',
     'click-at': 'clickAt',
     'click-then-macrotask': 'clickThenMacrotask',
@@ -445,6 +446,7 @@ async function main() {
     command === 'capture-workspace' ||
     command === 'snapshot' ||
     command === 'debug' ||
+    command === 'active-element' ||
     command === 'click-at' ||
     command === 'seed-local-project' ||
     command === 'terminal-snapshot' ||

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -171,28 +171,21 @@ if ! [[ "$WEWORK_PORT" =~ ^[0-9]+$ ]] || [ "$WEWORK_PORT" -lt 1 ] || [ "$WEWORK_
 fi
 
 is_port_available() {
-  node - "$1" <<'NODE'
-const net = require('node:net')
-const port = Number(process.argv[2])
-
-const canListen = host =>
-  new Promise(resolve => {
-    const server = net.createServer()
-
-    server.once('error', () => resolve(false))
-    server.listen(port, host, () => {
-      server.close(() => resolve(true))
-    })
-  })
-
-;(async () => {
-  for (const host of ['127.0.0.1', '0.0.0.0']) {
-    if (!(await canListen(host))) {
-      process.exit(1)
-    }
-  }
-})()
-NODE
+  node -e '
+    const net = require("node:net")
+    const port = Number(process.argv[1])
+    const canListen = host =>
+      new Promise(resolve => {
+        const server = net.createServer()
+        server.once("error", () => resolve(false))
+        server.listen(port, host, () => server.close(() => resolve(true)))
+      })
+    ;(async () => {
+      for (const host of ["127.0.0.1", "0.0.0.0"]) {
+        if (!(await canListen(host))) process.exit(1)
+      }
+    })()
+  ' "$1"
 }
 
 find_available_wework_port() {
@@ -200,7 +193,7 @@ find_available_wework_port() {
 
   while [ "$port" -le 65535 ]; do
     if is_port_available "$port"; then
-      echo "$port"
+      AVAILABLE_WEWORK_PORT="$port"
       return 0
     fi
     port="$((port + 1))"
@@ -240,7 +233,8 @@ build_wework_dev_title() {
   echo "$worktree_name"
 }
 
-AVAILABLE_WEWORK_PORT="$(find_available_wework_port "$WEWORK_PORT")"
+AVAILABLE_WEWORK_PORT=""
+find_available_wework_port "$WEWORK_PORT"
 if [ "$AVAILABLE_WEWORK_PORT" != "$WEWORK_PORT" ]; then
   echo "WEWORK_PORT $WEWORK_PORT is already in use; using $AVAILABLE_WEWORK_PORT instead."
 fi
@@ -320,13 +314,13 @@ WEWORK_APP_IDENTIFIER_VALUE="${WEWORK_APP_IDENTIFIER:-}" \
 WEWORK_DISABLE_BACKGROUND_THROTTLING_VALUE="${WEWORK_DISABLE_BACKGROUND_THROTTLING:-0}" \
 WEWORK_DIR_VALUE="$WEWORK_DIR" \
 TAURI_DEV_CONFIG_VALUE="$TAURI_DEV_CONFIG" \
-python3 - <<'PY'
+python3 -c '
 import json
 import os
 
 config = {
     "build": {
-        "devUrl": f"http://localhost:{os.environ['WEWORK_PORT_VALUE']}",
+        "devUrl": "http://localhost:{}".format(os.environ["WEWORK_PORT_VALUE"]),
         "beforeDevCommand": os.environ["BEFORE_DEV_COMMAND_VALUE"],
     },
 }
@@ -357,7 +351,7 @@ if os.environ["WEWORK_RELEASE_UI_VALUE"] != "true":
 with open(os.environ["TAURI_DEV_CONFIG_VALUE"], "w", encoding="utf-8") as handle:
     json.dump(config, handle, indent=2)
     handle.write("\n")
-PY
+'
 
 echo "Starting WeWork mac app"
 echo "  RELEASE_UI=$WEWORK_RELEASE_UI"

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -2,7 +2,29 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { requestWorkbenchComposerFocus } from '@/lib/workbenchComposerFocus'
 import { BufferedChatInput } from './BufferedChatInput'
+
+function createProjectChat(scopeKey: string) {
+  return {
+    models: [],
+    skills: [],
+    selectedModel: null,
+    selectedModelOptions: {},
+    selectedSkills: [],
+    attachments: [],
+    uploadingFiles: new Map(),
+    errors: new Map(),
+    isOptionsLocked: false,
+    setSelectedModel: vi.fn(),
+    setSelectedModelOption: vi.fn(),
+    toggleSkill: vi.fn(),
+    handleFileSelect: vi.fn(),
+    removeAttachment: vi.fn(),
+    listLocalSkills: vi.fn(),
+    scopeKey,
+  }
+}
 
 describe('BufferedChatInput', () => {
   afterEach(() => {
@@ -403,5 +425,65 @@ describe('BufferedChatInput', () => {
     await waitFor(() => {
       expect(screen.getByTestId('chat-message-input')).toHaveValue('unfinished draft')
     })
+  })
+
+  test('focuses the matching composer when a conversation is selected', async () => {
+    render(
+      <>
+        <button type="button">Conversation</button>
+        <BufferedChatInput
+          value=""
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          disabled={false}
+          projectChat={createProjectChat('runtime:device-1:task-1')}
+        />
+      </>
+    )
+    const conversation = screen.getByRole('button', { name: 'Conversation' })
+    conversation.focus()
+
+    requestWorkbenchComposerFocus('runtime:device-1:task-1')
+
+    await waitFor(() => expect(screen.getByTestId('chat-message-input')).toHaveFocus())
+  })
+
+  test('does not focus a disabled or non-matching composer', async () => {
+    const projectChat = createProjectChat('runtime:device-1:task-1')
+    const { rerender } = render(
+      <>
+        <button type="button">Conversation</button>
+        <BufferedChatInput
+          value=""
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          disabled={false}
+          projectChat={projectChat}
+        />
+      </>
+    )
+    const conversation = screen.getByRole('button', { name: 'Conversation' })
+    conversation.focus()
+
+    requestWorkbenchComposerFocus('runtime:device-1:task-2')
+    await new Promise(resolve => window.requestAnimationFrame(resolve))
+    expect(conversation).toHaveFocus()
+
+    rerender(
+      <>
+        <button type="button">Conversation</button>
+        <BufferedChatInput
+          value=""
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          disabled
+          projectChat={projectChat}
+        />
+      </>
+    )
+    screen.getByRole('button', { name: 'Conversation' }).focus()
+    requestWorkbenchComposerFocus('runtime:device-1:task-1')
+    await new Promise(resolve => window.requestAnimationFrame(resolve))
+    expect(screen.getByRole('button', { name: 'Conversation' })).toHaveFocus()
   })
 })

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   ChatInput,
   type ChatInputHandle,
@@ -54,7 +54,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const scopeKeyRef = useRef(scopeKey)
   scopeKeyRef.current = scopeKey
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const focusRequestedComposer = (event: Event) => {
       const detail = (event as CustomEvent<WorkbenchComposerFocusDetail>).detail
       if (props.disabled || !scopeKey || detail?.scopeKey !== scopeKey) return

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -6,6 +6,10 @@ import {
   type ChatSubmitOptions,
 } from '@/components/chat/ChatInput'
 import { recordComposerDiagnostic } from '@/components/chat/composer/composerDiagnostics'
+import {
+  WORKBENCH_COMPOSER_FOCUS_EVENT,
+  type WorkbenchComposerFocusDetail,
+} from '@/lib/workbenchComposerFocus'
 
 export interface BufferedChatInputInsertion {
   id: number
@@ -49,6 +53,18 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const isComposingRef = useRef(false)
   const scopeKeyRef = useRef(scopeKey)
   scopeKeyRef.current = scopeKey
+
+  useEffect(() => {
+    const focusRequestedComposer = (event: Event) => {
+      const detail = (event as CustomEvent<WorkbenchComposerFocusDetail>).detail
+      if (props.disabled || !scopeKey || detail?.scopeKey !== scopeKey) return
+      composerRef.current?.focus()
+    }
+    window.addEventListener(WORKBENCH_COMPOSER_FOCUS_EVENT, focusRequestedComposer)
+    return () => {
+      window.removeEventListener(WORKBENCH_COMPOSER_FOCUS_EVENT, focusRequestedComposer)
+    }
+  }, [props.disabled, scopeKey])
 
   const setComposerValue = useCallback((nextValue: string, cursor: number) => {
     programmaticUpdateDepthRef.current += 1

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -40,6 +40,8 @@ import { projectSpaceApis } from '@/features/todo/projectSpaceSelection'
 import { WorkbenchBackground } from '@/features/appearance'
 import { useResizableSidebar } from './useResizableSidebar'
 import { useOptionalWorkspaceTabs } from '@/features/workspace-tabs/workspaceTabsContextValue'
+import { getRuntimeTaskChatScopeKey } from '@/features/workbench/workbenchProviderHelpers'
+import { requestWorkbenchComposerFocus } from '@/lib/workbenchComposerFocus'
 import {
   archiveLocalHarnessSession,
   closeLocalTerminal,
@@ -273,8 +275,10 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
           currentProject: null,
         })
       )
-      if (currentPath === '/' && isSameRuntimeTask(state.currentRuntimeTask, address)) return
-      await onOpenRuntimeTask(address)
+      if (!(currentPath === '/' && isSameRuntimeTask(state.currentRuntimeTask, address))) {
+        await onOpenRuntimeTask(address)
+      }
+      requestWorkbenchComposerFocus(getRuntimeTaskChatScopeKey(address))
     },
     [activateSplitPane, currentPath, onOpenRuntimeTask, state.currentRuntimeTask]
   )

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1560,6 +1560,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
     }
     case 'getWorkbenchDebugSnapshot':
       return JSON.stringify(getWorkbenchDebugSnapshot())
+    case 'getActiveElementTestId':
+      return document.activeElement?.getAttribute('data-testid') ?? ''
     case 'getLocalExecutorStatus':
       return JSON.stringify(await invoke(LOCAL_EXECUTOR_COMMANDS.status))
     case 'getLocalExecutorLog':

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -2461,6 +2461,7 @@ describe('CloudTodoWorkspace', () => {
   })
 
   it('defaults new issues to the inbox', async () => {
+    const user = userEvent.setup()
     const workbenchServices = services()
     workbenchServices.deliveryApi!.createLoopItem = vi.fn(async (_projectId, values) => ({
       ...item,
@@ -2479,9 +2480,10 @@ describe('CloudTodoWorkspace', () => {
     )
 
     await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
-    await userEvent.click(screen.getByTestId('cloud-todo-add'))
-    await userEvent.type(screen.getByTestId('workspace-issue-input'), 'Inbox Issue')
-    await userEvent.click(screen.getByTestId('workspace-issue-submit'))
+    await user.click(screen.getByTestId('cloud-todo-add'))
+    await user.click(screen.getByTestId('workspace-issue-input'))
+    await user.paste('Inbox Issue')
+    await user.click(screen.getByTestId('workspace-issue-submit'))
 
     await waitFor(() =>
       expect(workbenchServices.deliveryApi?.createLoopItem).toHaveBeenCalledWith(11, {
@@ -2494,6 +2496,7 @@ describe('CloudTodoWorkspace', () => {
   })
 
   it('creates a new issue with the status of the board column entry point', async () => {
+    const user = userEvent.setup()
     const workbenchServices = services()
     workbenchServices.deliveryApi!.createLoopItem = vi.fn(async (_projectId, values) => ({
       ...item,
@@ -2512,9 +2515,10 @@ describe('CloudTodoWorkspace', () => {
     )
 
     await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
-    await userEvent.click(screen.getByTestId('cloud-todo-column-add-in_progress'))
-    await userEvent.type(screen.getByTestId('workspace-issue-input'), 'Active Issue')
-    await userEvent.click(screen.getByTestId('workspace-issue-submit'))
+    await user.click(screen.getByTestId('cloud-todo-column-add-in_progress'))
+    await user.click(screen.getByTestId('workspace-issue-input'))
+    await user.paste('Active Issue')
+    await user.click(screen.getByTestId('workspace-issue-submit'))
 
     await waitFor(() =>
       expect(workbenchServices.deliveryApi?.createLoopItem).toHaveBeenCalledWith(11, {

--- a/wework/src/lib/workbenchComposerFocus.ts
+++ b/wework/src/lib/workbenchComposerFocus.ts
@@ -1,4 +1,9 @@
 export const WORKBENCH_NEW_CHAT_FOCUS_EVENT = 'wework:focus-new-chat-composer'
+export const WORKBENCH_COMPOSER_FOCUS_EVENT = 'wework:focus-composer'
+
+export interface WorkbenchComposerFocusDetail {
+  scopeKey: string
+}
 
 export function focusComposerAtEnd(element: HTMLElement | null | undefined) {
   if (!element) return
@@ -20,5 +25,15 @@ export function focusComposerAtEnd(element: HTMLElement | null | undefined) {
 export function requestNewChatComposerFocus() {
   window.requestAnimationFrame(() => {
     window.dispatchEvent(new Event(WORKBENCH_NEW_CHAT_FOCUS_EVENT))
+  })
+}
+
+export function requestWorkbenchComposerFocus(scopeKey: string) {
+  window.requestAnimationFrame(() => {
+    window.dispatchEvent(
+      new CustomEvent<WorkbenchComposerFocusDetail>(WORKBENCH_COMPOSER_FOCUS_EVENT, {
+        detail: { scopeKey },
+      })
+    )
   })
 }


### PR DESCRIPTION
## Summary
- transfer keyboard focus from the sidebar conversation row to the matching active composer after opening a conversation
- add unit and desktop E2E regression coverage for the real active element
- remove detached `ai:verify` startup deadlocks caused by heredoc/command-substitution pipes and document the new focus inspection command
- stabilize project-space issue creation tests by using the existing paste interaction path instead of per-character ProseMirror updates

## Verification
- `pnpm --filter wework test` (405 files, 4126 tests passed before syncing latest main)
- pre-push Wework checks after syncing latest main: ESLint, TypeScript, and all unit tests passed
- `pnpm --filter wework test src/components/layout/BufferedChatInput.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx` (214 tests passed)
- `pnpm --filter wework test src/features/todo/CloudTodoWorkspace.test.tsx` (70 tests passed)
- real isolated Tauri QA via `ai:verify`: created a local project and task, opened New Task, clicked the existing sidebar conversation once, and verified `active-element` returned `chat-message-input` without a second composer click
- `bash -n wework/scripts/dev-mac-app.sh`
- `node --check wework/scripts/ai-verify.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reopening or activating a conversation now places keyboard focus in the appropriate chat composer.
  * Focus remains in its current location when the composer is disabled or belongs to another conversation.
  * Improved reliability for database operations during concurrent activity.
* **Testing**
  * Added automated coverage for composer focus behavior and active-element verification.
* **Developer Tools**
  * Added a desktop verification command for inspecting the currently focused interface element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->