### PR TITLE
fix(frontend): dismiss mobile input actions menu

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -43,7 +43,7 @@ jest.mock('@/features/tasks/components/chat/ChatContextInput', () => ({
   __esModule: true,
   default: () => (
     <>
-      <button type="button" aria-controls="context-selector-popover">
+      <button type="button" aria-controls="context-selector-popover" data-testid="context-button">
         Context
       </button>
       {createPortal(

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -4,6 +4,7 @@
 
 import '@testing-library/jest-dom'
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { MobileChatInputControlsProps } from '@/features/tasks/components/input/MobileChatInputControls'
 import { MobileChatInputControls } from '@/features/tasks/components/input/MobileChatInputControls'
@@ -40,7 +41,19 @@ jest.mock('@/features/tasks/components/MobileCorrectionModeToggle', () => ({
 
 jest.mock('@/features/tasks/components/chat/ChatContextInput', () => ({
   __esModule: true,
-  default: () => <button type="button">Context</button>,
+  default: () => (
+    <>
+      <button type="button" aria-controls="context-selector-popover">
+        Context
+      </button>
+      {createPortal(
+        <div id="context-selector-popover" role="dialog" data-testid="owned-context-popover">
+          Context selector
+        </div>,
+        document.body
+      )}
+    </>
+  ),
 }))
 
 jest.mock('@/features/tasks/components/AttachmentButton', () => ({
@@ -223,6 +236,31 @@ describe('MobileChatInputControls layout', () => {
 
     fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
     fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
+  })
+
+  it('keeps the menu open while interacting with a popover opened by the menu', () => {
+    render(<MobileChatInputControls {...buildProps()} />)
+
+    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    const ownedPopover = screen.getByTestId('owned-context-popover')
+    fireEvent.pointerDown(ownedPopover)
+    fireEvent.keyDown(ownedPopover, { key: 'Escape' })
+
+    expect(screen.getByTestId('mobile-input-more-actions-menu')).toBeInTheDocument()
+  })
+
+  it('closes the menu when interacting with an unrelated dialog', () => {
+    render(
+      <>
+        <MobileChatInputControls {...buildProps()} />
+        <div role="dialog" data-testid="unrelated-dialog" />
+      </>
+    )
+
+    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    fireEvent.pointerDown(screen.getByTestId('unrelated-dialog'))
 
     expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
   })

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -45,7 +45,11 @@ jest.mock('@/features/tasks/components/chat/ChatContextInput', () => ({
 
 jest.mock('@/features/tasks/components/AttachmentButton', () => ({
   __esModule: true,
-  default: () => <button type="button">Attach</button>,
+  default: ({ onFileSelect }: { onFileSelect: (files: File[]) => void }) => (
+    <button type="button" onClick={() => onFileSelect([new File(['content'], 'test.txt')])}>
+      Attach
+    </button>
+  ),
 }))
 
 jest.mock('@/features/tasks/components/input/SendButton', () => ({
@@ -192,5 +196,34 @@ describe('MobileChatInputControls layout', () => {
     expect(menu).toHaveClass('fixed')
     expect(menu).toHaveClass('overflow-y-auto')
     expect(menu).toHaveClass('overscroll-contain')
+  })
+
+  it('closes the more actions menu after selecting an attachment', () => {
+    const props = buildProps()
+    render(<MobileChatInputControls {...props} />)
+
+    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }))
+
+    expect(props.onFileSelect).toHaveBeenCalledWith([expect.any(File)])
+    expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the more actions menu when tapping outside', () => {
+    render(<MobileChatInputControls {...buildProps()} />)
+
+    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    fireEvent.pointerDown(document.body)
+
+    expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the more actions menu when pressing Escape', () => {
+    render(<MobileChatInputControls {...buildProps()} />)
+
+    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -145,6 +145,22 @@ function mockDeferredModelsLoad(models: Model[]) {
   }
 }
 
+function mockDeferredModelFailure(error: Error) {
+  let rejectModels!: (error: Error) => void
+  const promise = new Promise<{ data: Model[] }>((_, reject) => {
+    rejectModels = reject
+  })
+  ;(modelApis.getUnifiedModels as jest.Mock).mockReturnValue(promise)
+  return {
+    async reject() {
+      await act(async () => {
+        rejectModels(error)
+        await promise.catch(() => undefined)
+      })
+    },
+  }
+}
+
 describe('useModelSelection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -176,7 +192,7 @@ describe('useModelSelection', () => {
   })
 
   it('does not retry non-network model loading failures', async () => {
-    ;(modelApis.getUnifiedModels as jest.Mock).mockRejectedValue(new Error('Server rejected'))
+    const modelLoad = mockDeferredModelFailure(new Error('Server rejected'))
 
     const { result } = renderHook(() =>
       useModelSelection({
@@ -186,9 +202,10 @@ describe('useModelSelection', () => {
       })
     )
 
-    await waitFor(() => {
-      expect(result.current.error).toBe('common:models.errors.load_models_failed')
-    })
+    await modelLoad.reject()
+
+    expect(result.current.error).toBe('common:models.errors.load_models_failed')
+    expect(result.current.isLoading).toBe(false)
     expect(modelApis.getUnifiedModels).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -150,7 +150,8 @@ function mockDeferredModelFailure(error: Error) {
   const promise = new Promise<{ data: Model[] }>((_, reject) => {
     rejectModels = reject
   })
-  ;(modelApis.getUnifiedModels as jest.Mock).mockReturnValue(promise)
+  const getUnifiedModelsMock = modelApis.getUnifiedModels as jest.Mock
+  getUnifiedModelsMock.mockReturnValue(promise)
   return {
     async reject() {
       await act(async () => {

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -210,6 +210,7 @@ export function MobileChatInputControls({
   const { t } = useTranslation('chat')
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
   const moreMenuButtonRef = useRef<HTMLButtonElement>(null)
+  const moreMenuRef = useRef<HTMLDivElement>(null)
   const [moreMenuStyle, setMoreMenuStyle] = useState<React.CSSProperties>({})
   const showChatContexts = canUseChatContexts(taskType, selectedTeam)
   const isGenerationMode = taskType === 'image' || taskType === 'video'
@@ -241,6 +242,13 @@ export function MobileChatInputControls({
     effectiveRequiresWorkspace !== false
   const showBranchAction = showRepositoryAction && Boolean(selectedRepo)
   const hasSecondaryActions = showAttachmentAction || showChatContexts || showSkillAction
+  const handleAttachmentFileSelect = useCallback(
+    (files: File | File[]) => {
+      setMoreMenuOpen(false)
+      onFileSelect(files)
+    },
+    [onFileSelect]
+  )
 
   const updateMoreMenuPosition = useCallback(() => {
     const button = moreMenuButtonRef.current
@@ -286,6 +294,37 @@ export function MobileChatInputControls({
       viewport?.removeEventListener('scroll', updateMoreMenuPosition)
     }
   }, [moreMenuOpen, updateMoreMenuPosition])
+
+  useEffect(() => {
+    if (!moreMenuOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (moreMenuButtonRef.current?.contains(target) || moreMenuRef.current?.contains(target)) {
+        return
+      }
+      if (
+        target instanceof Element &&
+        target.closest('[role="dialog"], [role="listbox"], [role="menu"]')
+      ) {
+        return
+      }
+      setMoreMenuOpen(false)
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMoreMenuOpen(false)
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [moreMenuOpen])
 
   // Render send button based on state
   const renderSendButton = () => {
@@ -410,6 +449,7 @@ export function MobileChatInputControls({
 
         {moreMenuOpen && (
           <div
+            ref={moreMenuRef}
             data-testid="mobile-input-more-actions-menu"
             className="fixed z-50 w-56 overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
             style={moreMenuStyle}
@@ -418,7 +458,7 @@ export function MobileChatInputControls({
               <div className="flex flex-col">
                 {showAttachmentAction && (
                   <AttachmentButton
-                    onFileSelect={onFileSelect}
+                    onFileSelect={handleAttachmentFileSelect}
                     disabled={isStreaming}
                     accept={attachmentAccept}
                     triggerVariant="menu-item"

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -298,24 +298,28 @@ export function MobileChatInputControls({
   useEffect(() => {
     if (!moreMenuOpen) return
 
+    const isOwnedPopoverTarget = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) return false
+      const popoverId = target.closest('[role="dialog"]')?.id
+      if (!popoverId) return false
+
+      return Array.from(moreMenuRef.current?.querySelectorAll('[aria-controls]') ?? []).some(
+        trigger => trigger.getAttribute('aria-controls') === popoverId
+      )
+    }
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target
       if (!(target instanceof Node)) return
       if (moreMenuButtonRef.current?.contains(target) || moreMenuRef.current?.contains(target)) {
         return
       }
-      if (
-        target instanceof Element &&
-        target.closest('[role="dialog"], [role="listbox"], [role="menu"]')
-      ) {
-        return
-      }
+      if (isOwnedPopoverTarget(target)) return
       setMoreMenuOpen(false)
     }
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMoreMenuOpen(false)
-      }
+      if (event.key !== 'Escape' || event.defaultPrevented || isOwnedPopoverTarget(event.target))
+        return
+      setMoreMenuOpen(false)
     }
 
     document.addEventListener('pointerdown', handlePointerDown)


### PR DESCRIPTION
## Summary

- close the mobile input actions menu after selecting attachments
- dismiss the menu when tapping outside or pressing Escape
- scope nested-popover handling to selectors opened by this menu
- add regression coverage for attachment selection, outside dismissal, Escape, nested popovers, and unrelated dialogs
- make the existing model-load failure test deterministic after the full pre-push suite exposed a timing race

## Root cause

The mobile attachment action was moved into a custom menu controlled by `moreMenuOpen`, but selecting a file only invoked the upload callback. The custom menu also had no outside-click or keyboard dismissal handling.

The initial outside-click implementation exempted overlays by generic ARIA roles. It now recognizes only Radix popovers whose `aria-controls` trigger belongs to this menu, so unrelated overlays still dismiss it and nested Escape handling stays scoped.

## Validation

- focused Jest suites: 19 tests passed
- frontend ESLint passed
- frontend TypeScript passed
- frontend full unit suite passed in pre-push checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile chat actions menu so it closes after attachment selection, outside interaction, or pressing Escape.
  * Preserved interactions with supported popovers and dialogs while the menu is open.
  * Ensured attachment selection is processed correctly before continuing the upload flow.
  * Improved model-loading failure handling with clearer error messaging and reliable completion states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->