### PR TITLE
fix(wework): preserve completed task activity state

### DIFF
--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -257,14 +257,17 @@ impl RuntimeTaskLink {
             supervisor,
             git_info,
             created_at: timestamp_ms_field(thread, "createdAt").unwrap_or_else(now_ms),
-            updated_at: timestamp_ms_field(thread, "updatedAt").unwrap_or_else(now_ms),
-            completed_at: if running {
-                local_link.as_ref().and_then(|link| link.completed_at)
-            } else if local_settled_status.is_some() {
-                local_link.as_ref().and_then(|link| link.completed_at)
+            updated_at: if running {
+                timestamp_ms_field(thread, "updatedAt").unwrap_or_else(now_ms)
             } else {
-                timestamp_ms_field(thread, "updatedAt")
-                    .or_else(|| local_link.as_ref().and_then(|link| link.completed_at))
+                local_completed_at
+                    .or_else(|| timestamp_ms_field(thread, "updatedAt"))
+                    .unwrap_or_else(now_ms)
+            },
+            completed_at: if running || local_settled_status.is_some() {
+                local_completed_at
+            } else {
+                local_completed_at.or_else(|| timestamp_ms_field(thread, "updatedAt"))
             },
             runtime_handle: local_link
                 .as_ref()
@@ -1170,6 +1173,32 @@ mod tests {
             false,
         );
 
+        assert_eq!(link.completed_at, Some(1_780_000_100_000));
+    }
+
+    #[test]
+    fn completed_wework_task_keeps_its_persisted_activity_time() {
+        let local_link = RuntimeTaskLink {
+            local_task_id: "task-1".to_owned(),
+            thread_id: Some("thread-1".to_owned()),
+            workspace_path: "/workspace/project".to_owned(),
+            status: "done".to_owned(),
+            completed_at: Some(1_780_000_100_000),
+            ..RuntimeTaskLink::default()
+        };
+        let link = RuntimeTaskLink::from_thread_metadata(
+            &json!({
+                "id": "thread-1",
+                "status": "idle",
+                "createdAt": 1_780_000_000,
+                "updatedAt": 1_780_086_400,
+            }),
+            Some(local_link),
+            "/workspace/project".to_owned(),
+            false,
+        );
+
+        assert_eq!(link.updated_at, 1_780_000_100_000);
         assert_eq!(link.completed_at, Some(1_780_000_100_000));
     }
 

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -2055,6 +2055,12 @@ describe('ScrollableMessageArea', () => {
     mockScrollRelativeRect(firstMessageAnchor, scroller, 180, 60)
     act(() => vi.advanceTimersByTime(80))
     expect(scroller.scrollTop).toBe(84)
+    act(() => vi.runOnlyPendingTimers())
+    expect(scroller.scrollTop).toBe(84)
+    expect(getConversationScrollSnapshot('navigation-settle')).toEqual({
+      distanceFromBottomPx: 1216,
+      pinnedToBottom: false,
+    })
     expect(content).toBeInTheDocument()
     vi.stubGlobal('ResizeObserver', originalResizeObserver)
   })

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -378,9 +378,18 @@ function ScrollableMessagePaneContent({
   const handleTurnNavigationScrollTargetChange = useCallback(
     (messageId: string | null) => {
       const scrolling = messageId !== null
+      const wasScrolling = turnNavigationScrollingRef.current
       turnNavigationScrollingRef.current = scrolling
       setTurnNavigationTargetMessageId(messageId)
       const element = activeScrollRefRef.current.current
+      if (wasScrolling && !scrolling && element && currentScrollKey !== null) {
+        const snapshot = createScrollSnapshot(element)
+        setConversationScrollSnapshot(currentScrollKey, snapshot)
+        followingBottomKeyRef.current = null
+        lastScrollTopRef.current = element.scrollTop
+        isAtBottomRef.current = snapshot.pinnedToBottom
+        userScrollPausedAutoFollowRef.current = !snapshot.pinnedToBottom
+      }
       console.warn('[Wework] Message turn navigation scroll ownership', {
         scrolling,
         messageId,

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
@@ -892,7 +892,7 @@ describe('RuntimeTaskLifecycleStore', () => {
     )
 
     expect(restoredStore.getTask(address)?.derived.shouldShowUnread).toBe(true)
-    expect(localStorage.getItem('wework.runtimeTaskLifecycle.test.running')).toBe('[]')
+    expect(localStorage.getItem('wework.runtimeTaskLifecycle.test.running.v2')).toBe('[]')
   })
 
   test('marks background non-Goal completion unread and clears it when opened', () => {
@@ -967,7 +967,7 @@ describe('RuntimeTaskLifecycleStore', () => {
     const setItem = vi
       .spyOn(Storage.prototype, 'setItem')
       .mockImplementation(function (key, value) {
-        if (key === 'wework.runtimeTaskLifecycle.test.unread') {
+        if (key === 'wework.runtimeTaskLifecycle.test.unread.v2') {
           throw new Error('storage unavailable')
         }
         return originalSetItem.call(this, key, value)
@@ -991,9 +991,29 @@ describe('RuntimeTaskLifecycleStore', () => {
     store.goalStatusReceived(address, 'paused')
 
     expect(
-      setItem.mock.calls.filter(([key]) => key === 'wework.runtimeTaskLifecycle.test.unread')
+      setItem.mock.calls.filter(([key]) => key === 'wework.runtimeTaskLifecycle.test.unread.v2')
     ).toHaveLength(1)
     setItem.mockRestore()
+  })
+
+  test('ignores unread and running state persisted by the broken v1 schema', () => {
+    const key = getRuntimeTaskLifecycleKey(address)
+    localStorage.setItem('wework.runtimeTaskLifecycle.test.unread', JSON.stringify([key]))
+    localStorage.setItem('wework.runtimeTaskLifecycle.test.running', JSON.stringify([key]))
+
+    const store = new RuntimeTaskLifecycleStore('test')
+    store.syncRuntimeWork(
+      runtimeWork(
+        task({
+          running: false,
+          status: 'done',
+          completedAt: 1_786_692_066_192,
+        })
+      )
+    )
+
+    expect(store.getTask(address)?.derived.shouldShowUnread).toBe(false)
+    expect(store.getSnapshot().runningTaskKeys).toEqual(new Set())
   })
 
   test('gates every lifecycle mutation through one provider ownership boundary', () => {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
@@ -51,8 +51,8 @@ export class RuntimeTaskLifecycleStore {
 
   constructor(userId: number | string | null | undefined) {
     const storageScope = `wework.runtimeTaskLifecycle.${userId ?? 'anonymous'}`
-    this.unreadStorageKey = `${storageScope}.unread`
-    this.runningStorageKey = `${storageScope}.running`
+    this.unreadStorageKey = `${storageScope}.unread.v2`
+    this.runningStorageKey = `${storageScope}.running.v2`
     this.previousRunningTaskKeys = readStoredTaskKeys(this.runningStorageKey)
     this.persistedRunningSerialized = serializeTaskKeys(this.previousRunningTaskKeys)
   }


### PR DESCRIPTION
## Summary

- keep completed Wework tasks anchored to their persisted completion time instead of provider thread refresh timestamps
- prevent historical completed tasks from appearing recently updated and being reconciled as newly completed
- invalidate unread/running lifecycle state written by the broken v1 persistence schema

## Root cause

For idle Wework threads, runtime task projection preferred the provider thread's `updatedAt` over the locally persisted `completed_at`. Refreshing thread metadata therefore changed historical task activity time and made transcript completion timestamps differ from the task summary, which could mark old conversations unread after upgrade.

## Verification

- `pnpm --filter wework test` — 418 files, 4268 tests passed
- `cargo test --manifest-path executor/Cargo.toml --lib` — 912 passed, 1 ignored
- `cargo clippy --manifest-path executor/Cargo.toml --all-features --all-targets -- -D warnings`
- pre-push ESLint, TypeScript, Wework unit tests, Cargo fmt/test/clippy
- isolated real Tauri verification: local executor online, bootstrap completed, 0 running tasks, 0 lifecycle unread tasks, 0 visible unread tasks

## Documentation

No documentation update is needed: this corrects internal timestamp projection and invalidates broken local persistence without changing product contracts or an architecture-cataloged flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed local tasks now retain their recorded completion time accurately.
  * Running tasks continue to display the latest provider update time.
  * Improved lifecycle state persistence to prevent outdated saved data from being reused.
  * Unread task state is no longer rewritten unnecessarily during unrelated lifecycle events.
  * Chat navigation now correctly preserves scroll position and pauses automatic scrolling when the conversation is no longer pinned to the bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->