### PR TITLE
fix(wework): render linked tasks without remote wait

### DIFF
--- a/docs/en/architecture/issue-runtime-delivery-projection.md
+++ b/docs/en/architecture/issue-runtime-delivery-projection.md
@@ -29,6 +29,9 @@ flowchart LR
     ISSUE --> DETAIL
     BINDING --> DETAIL
     DELIVERY --> DETAIL
+    DETAIL -->|independent request / arrival| BINDING_VIEW[Linked-task section]
+    DETAIL -->|independent request / arrival| DELIVERY_VIEW[Delivery section]
+    DETAIL -->|independent request / arrival| DIRECTORY_VIEW[Member / agent / team section]
     DETAIL --> VIEW[Task terminal state / stage state / delivery N/M]
 
     DELIVERY --> FILE_INDEX[Project delivery-file index + Issue/task ancestry]
@@ -57,8 +60,17 @@ sequenceDiagram
         D-->>E: publish Issue changed
     end
     E-->>U: invalidate the current Issue projection
-    U->>O: reload Issue, TaskBinding, and Delivery data
-    O-->>U: return a consistent stage state and delivery coverage
+    par Independently refresh detail sections in one invalidation cycle
+        U->>O: Read TaskBinding data
+        O-->>U: Render linked tasks immediately
+    and
+        U->>O: Read Delivery and attachment data
+        O-->>U: Render deliveries and attachments independently
+    and
+        U->>O: Read member, agent, and team directories
+        O-->>U: Render assignment sources independently
+    end
+    Note over O,U: Fast local TaskBinding data does not wait for slower remote directories
 
     alt Status persistence fails
         O-->>W: explicit observable failure with bounded retry
@@ -73,15 +85,16 @@ sequenceDiagram
     U-->>U: Project read-only folders without copying or moving assets
 ```
 
-| Edge                                              | Code ownership                                                                                   |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Runtime lifecycle → Issue status synchronization  | Wework `deliveries` API and the Backend `project_workflow_projection` atomic task-status command |
-| TaskBinding + task status → stage state           | Wework `issueWorkflow`, Backend workflow projection                                              |
-| Delivery finalize → fulfillment and node binding  | Backend Delivery service, `wework-space` MCP                                                     |
-| fulfillment → N/M coverage and approval gate      | Backend deliverable projection, workflow decision service                                        |
-| Issue changed → detail refresh                    | Backend `loop_item_events`, Wework `projectChatSocket`, and `CloudTodoWorkspace`                 |
-| Issue, TaskBinding, Delivery → UI                 | Wework `TodoEditor`, `IssueWorkflowDag`                                                          |
-| Delivery asset + LoopItem ancestry → file manager | Backend `cloud_files` service and cloud-project API, Wework `CloudFilesView`                     |
+| Edge                                                    | Code ownership                                                                                   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Runtime lifecycle → Issue status synchronization        | Wework `deliveries` API and the Backend `project_workflow_projection` atomic task-status command |
+| TaskBinding + task status → stage state                 | Wework `issueWorkflow`, Backend workflow projection                                              |
+| Delivery finalize → fulfillment and node binding        | Backend Delivery service, `wework-space` MCP                                                     |
+| fulfillment → N/M coverage and approval gate            | Backend deliverable projection, workflow decision service                                        |
+| Issue changed → detail refresh                          | Backend `loop_item_events`, Wework `projectChatSocket`, and `CloudTodoWorkspace`                 |
+| Issue, TaskBinding, Delivery → UI                       | Wework `TodoEditor`, `IssueWorkflowDag`                                                          |
+| Independent detail loading and stale-response isolation | Wework `TodoEditor`                                                                              |
+| Delivery asset + LoopItem ancestry → file manager       | Backend `cloud_files` service and cloud-project API, Wework `CloudFilesView`                     |
 
 Essential invariants:
 
@@ -89,7 +102,7 @@ Essential invariants:
 - A human task may display queued only when Runtime explicitly reports queued. An unknown newly bound task state must preserve the backend stage state or display synchronizing; it must not infer queued.
 - Stage state is derived from TaskBinding order and persisted terminal truth: any running task wins, otherwise the latest bound trusted terminal state wins; a successful human stage enters `awaiting_approval`.
 - Delivery finalize atomically freezes the Delivery, typed fulfillments, and node `delivery_id`. Only persisted `fulfillments[].requirement_id` values count toward N/M.
-- Runtime-state updates and Delivery finalize both invalidate the Issue-detail projection. A refresh must read Issue, TaskBinding, and Delivery together instead of mixing cache versions.
+- Runtime-state updates and Delivery finalize both invalidate the Issue-detail projection. The same invalidation cycle must request fresh Issue, TaskBinding, and Delivery data while isolating stale responses; each detail section renders as soon as its own data arrives, and fast local TaskBinding data must not wait for independent remote member, agent, or team directories.
 - Status-persistence failures return structured errors and use bounded retry. They must not create an unbounded PATCH loop or change UI semantics.
 - Human approval uses a server-side live recomputation of stage state and delivery coverage, never a client cache or a possibly stale node snapshot.
 - The project delivery-file index returns the complete persisted parent chain from the root Issue to the task owning the Delivery. The frontend must not infer task hierarchy from titles, identifiers, or file paths.

--- a/docs/zh/architecture/issue-runtime-delivery-projection.md
+++ b/docs/zh/architecture/issue-runtime-delivery-projection.md
@@ -29,6 +29,9 @@ flowchart LR
     ISSUE --> DETAIL
     BINDING --> DETAIL
     DELIVERY --> DETAIL
+    DETAIL -->|独立请求 / 独立到达| BINDING_VIEW[关联任务区]
+    DETAIL -->|独立请求 / 独立到达| DELIVERY_VIEW[交付区]
+    DETAIL -->|独立请求 / 独立到达| DIRECTORY_VIEW[成员 / 机器人 / 团队区]
     DETAIL --> VIEW[任务终态 / 阶段状态 / 交付 N/M]
 
     DELIVERY --> FILE_INDEX[项目交付文件索引 + Issue/任务祖先链]
@@ -57,8 +60,17 @@ sequenceDiagram
         D-->>E: 发布 Issue changed
     end
     E-->>U: 失效当前 Issue 投影
-    U->>O: 重新读取 Issue、TaskBinding 和 Delivery
-    O-->>U: 返回一致的阶段状态和交付覆盖
+    par 同一失效周期内独立刷新详情分区
+        U->>O: 读取 TaskBinding
+        O-->>U: 立即渲染关联任务
+    and
+        U->>O: 读取 Delivery 与附件
+        O-->>U: 独立渲染交付与附件
+    and
+        U->>O: 读取成员、机器人与团队目录
+        O-->>U: 独立渲染指派来源
+    end
+    Note over O,U: 快速本地 TaskBinding 不等待较慢的远端目录请求
 
     alt 状态写入失败
         O-->>W: 明确失败，可观测且有界重试
@@ -81,6 +93,7 @@ sequenceDiagram
 | fulfillment → N/M 覆盖与审批门禁              | Backend deliverable projection、workflow decision service                       |
 | Issue changed → 详情刷新                      | Backend `loop_item_events`、Wework `projectChatSocket` 与 `CloudTodoWorkspace`  |
 | Issue、TaskBinding、Delivery → UI             | Wework `TodoEditor`、`IssueWorkflowDag`                                         |
+| 详情分区独立加载与过期响应隔离                | Wework `TodoEditor`                                                             |
 | Delivery asset + LoopItem 父子链 → 文件管理器 | Backend `cloud_files` service 与 cloud-project API、Wework `CloudFilesView`     |
 
 必要不变量：
@@ -89,7 +102,7 @@ sequenceDiagram
 - 人工任务只有 Runtime 明确报告 queued 时才能显示排队中。新绑定任务状态未知时必须保留后端阶段状态或显示“同步中”，不得推导 queued。
 - 阶段状态由 TaskBinding 顺序和持久化终态确定：任一 running 优先，否则使用最近绑定任务的可信终态；人工阶段成功后进入 `awaiting_approval`。
 - Delivery finalize 必须在同一事务内固化 Delivery、typed fulfillments 和节点 `delivery_id`；只有 `fulfillments[].requirement_id` 计入 N/M。
-- Runtime 状态更新和 Delivery finalize 都必须使 Issue 详情投影失效。刷新后必须同时读取 Issue、TaskBinding 和 Delivery，禁止混合不同版本的缓存。
+- Runtime 状态更新和 Delivery finalize 都必须使 Issue 详情投影失效。同一失效周期必须重新请求 Issue、TaskBinding 和 Delivery，并隔离已经过期的响应；各详情分区必须在自己的数据到达后立即渲染，不得让本地 TaskBinding 等快速来源等待成员、机器人、团队等独立远端目录请求。
 - 状态写入失败必须返回结构化错误并执行有界重试，不得形成无上限 PATCH 循环；失败不得改变 UI 语义。
 - 人工审批必须使用服务端实时重算的阶段状态和交付覆盖，不得信任客户端缓存或可能滞后的节点快照。
 - 项目交付文件索引必须返回从根 Issue 到交付所属任务的完整、持久化父子链；前端不得通过标题、编号或文件路径猜测任务层级。

--- a/wework/src/components/layout/workspace-panels/WorkspaceTextFileEditor.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceTextFileEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { WorkspaceTextFileEditor } from './WorkspaceTextFileEditor'
@@ -20,10 +20,9 @@ describe('WorkspaceTextFileEditor', () => {
     expect(content).toBeInstanceOf(HTMLElement)
 
     await user.click(content as HTMLElement)
-    await user.keyboard('{Control>}a{/Control}export const authenticated = true')
-    await waitFor(() =>
-      expect(onChange).toHaveBeenLastCalledWith('export const authenticated = true')
-    )
+    await user.keyboard('{Control>}a{/Control}')
+    await user.paste('export const authenticated = true')
+    expect(onChange).toHaveBeenLastCalledWith('export const authenticated = true')
 
     rerender(
       <WorkspaceTextFileEditor
@@ -39,9 +38,7 @@ describe('WorkspaceTextFileEditor', () => {
     expect(content).toHaveTextContent('export const authenticated = true')
 
     await user.keyboard('{Control>}z{/Control}')
-    await waitFor(() =>
-      expect(onChange).toHaveBeenLastCalledWith('export const authenticated = false')
-    )
+    expect(onChange).toHaveBeenLastCalledWith('export const authenticated = false')
     expect(content).toHaveTextContent('export const authenticated = false')
   })
 })

--- a/wework/src/features/todo/TodoEditor.test.tsx
+++ b/wework/src/features/todo/TodoEditor.test.tsx
@@ -112,6 +112,56 @@ describe('TodoEditor external item sync', () => {
     )
   })
 
+  it('keeps same-item data during refresh and clears it when switching items', async () => {
+    const never = new Promise<never>(() => undefined)
+    const switchingApi = {
+      listDeliveries: vi.fn(async () => ({ items: [] })),
+      listTaskBindings: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            id: 8,
+            device_id: 'local-device',
+            task_id: 'first-task',
+            task_title: '第一个 Issue 的任务',
+          },
+        ])
+        .mockImplementation(() => never),
+      listLoopItemAttachments: vi.fn(async () => []),
+      listLoopItemCollaborators: vi.fn(async () => []),
+      listCloudProjectMembers: vi.fn(async () => []),
+    } as never
+    const secondItem = {
+      ...baseItem,
+      id: 'WEG-2',
+      title: 'Second issue',
+    } as unknown as CloudLoopItem
+    const renderEditor = (item: CloudLoopItem, taskRefreshKey: number) => (
+      <TodoEditor
+        mode="edit"
+        presentation="workspace-panel"
+        item={item}
+        project={project}
+        allItems={[baseItem, secondItem]}
+        onUpdated={vi.fn()}
+        onAddChild={vi.fn()}
+        onClose={vi.fn()}
+        api={switchingApi}
+        taskRefreshKey={taskRefreshKey}
+        currentUserId={1}
+      />
+    )
+    const view = render(renderEditor(baseItem, 0))
+
+    expect(await screen.findByText('第一个 Issue 的任务')).toBeInTheDocument()
+
+    view.rerender(renderEditor(baseItem, 1))
+    expect(screen.getByText('第一个 Issue 的任务')).toBeInTheDocument()
+
+    view.rerender(renderEditor(secondItem, 1))
+    expect(screen.queryByText('第一个 Issue 的任务')).not.toBeInTheDocument()
+  })
+
   it('shows the automation provenance on a generated task', () => {
     render(
       editorElement({

--- a/wework/src/features/todo/TodoEditor.test.tsx
+++ b/wework/src/features/todo/TodoEditor.test.tsx
@@ -67,6 +67,51 @@ function editorElement(item: CloudLoopItem) {
 }
 
 describe('TodoEditor external item sync', () => {
+  it('renders local task bindings without waiting for independent remote directories', async () => {
+    const never = new Promise<never>(() => undefined)
+    const fastBindingsApi = {
+      listDeliveries: vi.fn(() => never),
+      listTaskBindings: vi.fn(async () => [
+        {
+          id: 7,
+          device_id: 'local-device',
+          task_id: 'local-task',
+          task_title: '立即显示的本地任务',
+        },
+      ]),
+      listLoopItemAttachments: vi.fn(() => never),
+      listLoopItemCollaborators: vi.fn(() => never),
+      listCloudProjectMembers: vi.fn(() => never),
+    } as never
+    const projectChatAgentApi = {
+      list: vi.fn(() => never),
+    } as never
+    const teamApi = {
+      listTeams: vi.fn(() => never),
+    } as never
+
+    render(
+      <TodoEditor
+        mode="edit"
+        presentation="workspace-panel"
+        item={baseItem}
+        project={project}
+        allItems={[baseItem]}
+        onUpdated={vi.fn()}
+        onAddChild={vi.fn()}
+        onClose={vi.fn()}
+        api={fastBindingsApi}
+        projectChatAgentApi={projectChatAgentApi}
+        teamApi={teamApi}
+        currentUserId={1}
+      />
+    )
+
+    expect(await screen.findByTestId('cloud-todo-open-task-conversation-7')).toHaveTextContent(
+      '立即显示的本地任务'
+    )
+  })
+
   it('shows the automation provenance on a generated task', () => {
     render(
       editorElement({

--- a/wework/src/features/todo/TodoEditor.tsx
+++ b/wework/src/features/todo/TodoEditor.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -676,6 +677,7 @@ export function TodoEditor(props: TodoEditorProps) {
   const editItemId = item?.id ?? null
   const editProjectId = item?.cloud_project_id ?? null
   const createProjectId = createProps?.project.id ?? null
+  const loadedEditItemIdRef = useRef(editItemId)
   const visibleAttachments = useMemo(() => {
     const merged = new Map<string, AttachmentRow>()
     markdownAttachmentRows(description).forEach(attachment => merged.set(attachment.id, attachment))
@@ -692,6 +694,16 @@ export function TodoEditor(props: TodoEditorProps) {
     if (!node) return
     node.scrollTop = 0
   }, [editItemId, isCreate])
+
+  useLayoutEffect(() => {
+    if (loadedEditItemIdRef.current === editItemId) return
+    loadedEditItemIdRef.current = editItemId
+    setDeliveries([])
+    setSelectedDelivery(null)
+    setTasks([])
+    setAttachments([])
+    setCollaborators([])
+  }, [editItemId])
 
   // Edit mode loads everything tied to the item id.
   useEffect(() => {

--- a/wework/src/features/todo/TodoEditor.tsx
+++ b/wework/src/features/todo/TodoEditor.tsx
@@ -696,37 +696,32 @@ export function TodoEditor(props: TodoEditorProps) {
   // Edit mode loads everything tied to the item id.
   useEffect(() => {
     if (editItemId == null || editProjectId == null) return
-    void Promise.allSettled([
-      api.listDeliveries(editItemId),
-      api.listTaskBindings(editItemId),
-      api.listLoopItemAttachments(editItemId),
-      api.listLoopItemCollaborators(editItemId),
-      api.listCloudProjectMembers(editProjectId),
+    let active = true
+    const applyResult = <T,>(request: Promise<T>, apply: (value: T) => void) => {
+      void request.then(
+        value => {
+          if (active) apply(value)
+        },
+        () => undefined
+      )
+    }
+
+    applyResult(api.listDeliveries(editItemId), response => setDeliveries(response.items))
+    applyResult(api.listTaskBindings(editItemId), setTasks)
+    applyResult(api.listLoopItemAttachments(editItemId), setAttachments)
+    applyResult(api.listLoopItemCollaborators(editItemId), setCollaborators)
+    applyResult(api.listCloudProjectMembers(editProjectId), setProjectMembers)
+    applyResult(
       props.projectChatAgentApi?.list(String(editProjectId)) ?? Promise.resolve([]),
-      props.teamApi?.listTeams() ?? Promise.resolve([]),
-    ]).then(
-      ([
-        deliveryResult,
-        taskResult,
-        attachmentResult,
-        collaboratorResult,
-        memberResult,
-        agentResult,
-        teamResult,
-      ]) => {
-        if (deliveryResult.status === 'fulfilled') setDeliveries(deliveryResult.value.items)
-        if (taskResult.status === 'fulfilled') setTasks(taskResult.value)
-        if (attachmentResult.status === 'fulfilled') setAttachments(attachmentResult.value)
-        if (collaboratorResult.status === 'fulfilled') setCollaborators(collaboratorResult.value)
-        if (memberResult.status === 'fulfilled') setProjectMembers(memberResult.value)
-        if (agentResult.status === 'fulfilled') {
-          setProjectAgents(agentResult.value.filter(agent => agent.status === 'active'))
-        }
-        if (teamResult.status === 'fulfilled') {
-          setWegentTeams(teamResult.value.filter(team => team.is_active !== false))
-        }
-      }
+      agents => setProjectAgents(agents.filter(agent => agent.status === 'active'))
     )
+    applyResult(props.teamApi?.listTeams() ?? Promise.resolve([]), teams =>
+      setWegentTeams(teams.filter(team => team.is_active !== false))
+    )
+
+    return () => {
+      active = false
+    }
   }, [
     api,
     editItemId,


### PR DESCRIPTION
## Summary

- remove the shared loading barrier between local task bindings and independent Issue detail data
- render each detail section as soon as its own request resolves while ignoring stale responses
- clear item-scoped detail state before paint when switching Issues while preserving same-Issue refresh data
- document the independent hydration invariant in the Chinese and English architecture guides
- stabilize the CodeMirror theme-switch unit test by replacing slow character-by-character replay with an equivalent paste action

## Verification

- `pnpm --filter wework test src/features/todo/TodoEditor.test.tsx` (22 passed)
- `pnpm --filter wework test src/components/layout/workspace-panels/WorkspaceTextFileEditor.test.tsx src/features/todo/TodoEditor.test.tsx` (23 passed)
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks for changed Wework files
- `pnpm --filter wework test` (418 files, 4271 tests passed)
- pre-push quality checks: ESLint, TypeScript, and unit tests passed
- isolated real-Tauri verification: opened local `default-work-items`, created and opened an Issue, and confirmed the detail view rendered while cloud team services were unavailable

## Regression coverage

- keeps delivery, attachment, collaborator, member, agent, and team requests pending forever and verifies that the resolved local task binding still renders immediately
- preserves visible task data during a same-Issue refresh and clears it before paint when switching to another Issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Issue details now load linked tasks, deliveries, attachments, collaborators, members, agents, and teams independently.
  - Locally available task bindings appear immediately without waiting for other detail sections.
  - Delayed or failed requests no longer block other sections from displaying.
  - Outdated responses cannot overwrite newer information.
  - Switching between items clears stale editing details while preserving valid data during refreshes.

- **Documentation**
  - Updated architecture guidance for independent detail loading and reliable refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->