### PR TITLE
fix(wework): launch pnpm through cmd on Windows

### DIFF
--- a/wework/scripts/child-process-command.mjs
+++ b/wework/scripts/child-process-command.mjs
@@ -1,0 +1,17 @@
+export function wrapWindowsScriptCommand(
+  command,
+  args,
+  { platform = process.platform, commandInterpreter = process.env.ComSpec || 'cmd.exe' } = {}
+) {
+  if (
+    platform !== 'win32' ||
+    (!command.toLowerCase().endsWith('.cmd') && !command.toLowerCase().endsWith('.bat'))
+  ) {
+    return { command, args }
+  }
+
+  return {
+    command: commandInterpreter,
+    args: ['/c', command, ...args],
+  }
+}

--- a/wework/scripts/child-process-command.test.mjs
+++ b/wework/scripts/child-process-command.test.mjs
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { wrapWindowsScriptCommand } from './child-process-command.mjs'
+
+describe('wrapWindowsScriptCommand', () => {
+  it('leaves native commands unchanged', () => {
+    expect(
+      wrapWindowsScriptCommand('tar', ['--version'], {
+        platform: 'win32',
+        commandInterpreter: 'cmd.exe',
+      })
+    ).toEqual({
+      command: 'tar',
+      args: ['--version'],
+    })
+  })
+
+  it('leaves commands unchanged outside Windows', () => {
+    expect(
+      wrapWindowsScriptCommand('pnpm.cmd', ['install'], {
+        platform: 'darwin',
+        commandInterpreter: 'cmd.exe',
+      })
+    ).toEqual({
+      command: 'pnpm.cmd',
+      args: ['install'],
+    })
+  })
+
+  it('runs Windows command scripts through the command interpreter', () => {
+    expect(
+      wrapWindowsScriptCommand('pnpm.CMD', ['install', '--prod'], {
+        platform: 'win32',
+        commandInterpreter: 'C:\\Windows\\System32\\cmd.exe',
+      })
+    ).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/c', 'pnpm.CMD', 'install', '--prod'],
+    })
+  })
+})

--- a/wework/scripts/dev-windows-app.mjs
+++ b/wework/scripts/dev-windows-app.mjs
@@ -20,6 +20,8 @@ import { delimiter, dirname, join, resolve, basename, isAbsolute } from 'node:pa
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
+import { wrapWindowsScriptCommand } from './child-process-command.mjs'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
@@ -433,16 +435,9 @@ function resolveCommand(command) {
 
 function run(command, args, options = {}) {
   return new Promise((resolvePromise, rejectPromise) => {
-    let finalCommand = resolveCommand(command)
-    let finalArgs = args
-
-    if (
-      process.platform === 'win32' &&
-      (finalCommand.endsWith('.cmd') || finalCommand.endsWith('.bat'))
-    ) {
-      finalArgs = ['/c', finalCommand, ...args]
-      finalCommand = 'cmd.exe'
-    }
+    const resolved = wrapWindowsScriptCommand(resolveCommand(command), args)
+    const finalCommand = resolved.command
+    const finalArgs = resolved.args
 
     const child = spawn(finalCommand, finalArgs, {
       stdio: 'inherit',

--- a/wework/scripts/prepare-deepseek-harness-runtime.mjs
+++ b/wework/scripts/prepare-deepseek-harness-runtime.mjs
@@ -7,6 +7,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
 
+import { wrapWindowsScriptCommand } from './child-process-command.mjs'
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const source = path.join(root, 'harness-runtime')
 const targetDirectory = path.join(root, 'src-tauri', 'bundled-deepseek-harness')
@@ -23,7 +25,8 @@ const archiveFormatVersion = 'tar-gzip-fast-v1'
 
 function run(command, args, cwd, environment = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const resolved = wrapWindowsScriptCommand(command, args)
+    const child = spawn(resolved.command, resolved.args, {
       cwd,
       env: { ...process.env, ...environment },
       stdio: 'inherit',
@@ -56,6 +59,7 @@ const sourceFingerprint = createHash('sha256')
   .update(sourceContents.map(content => content.toString('base64')).join('\0'))
   .digest('hex')
 const nodeName = process.platform === 'win32' ? 'node.exe' : 'node'
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 
 try {
   const currentMetadata = JSON.parse(await readFile(metadata, 'utf8'))
@@ -75,7 +79,7 @@ try {
   await rm(temporaryMetadata, { force: true })
   await mkdir(staging, { recursive: true })
   await Promise.all(sourceFiles.map(file => cp(path.join(source, file), path.join(staging, file))))
-  await run('pnpm', ['install', '--prod', '--frozen-lockfile'], staging)
+  await run(pnpmCommand, ['install', '--prod', '--frozen-lockfile'], staging)
 
   const nodeDirectory = path.join(staging, 'node', 'bin')
   await mkdir(nodeDirectory, { recursive: true })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility when running `.cmd` and `.bat` scripts.
  * Ensured development and setup processes consistently use the appropriate Windows command interpreter.
  * Added platform-specific handling for package manager commands.

* **Tests**
  * Added coverage for Windows script execution and unchanged behavior on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->