### PR TITLE
fix(ci): stabilize Wework merge queue checks

### DIFF
--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -59,7 +59,7 @@ cloud_segments=(
   plugin-auto-update
 )
 # Group checkpoints by observed Cloud CI duration and order each shard from
-# longest to shortest so the five runners keep both local workers busy.
+# longest to shortest so the five serial runners finish at similar times.
 # shellcheck disable=SC2054 # Each element is one comma-joined shard.
 cloud_shards=(
   goal-lifecycle,window-lifecycle,cloud-worktree-tools,telemetry-consent
@@ -69,8 +69,8 @@ cloud_shards=(
   core-task-flow,conversation-state,supervisor-lifecycle,automation-lifecycle,browser-multi-tabs
 )
 # Keep the number of core desktop runners fixed as checkpoints grow. Group
-# checkpoints by observed Core CI duration and order each shard so both local
-# workers stay balanced while reusing the same prebuilt application.
+# checkpoints by observed Core CI duration and order each shard so the serial
+# runners stay balanced while reusing the same prebuilt application.
 # shellcheck disable=SC2054 # Each element is one comma-joined shard.
 core_shards=(
   rendering-extensions,resilience,runtime-task-queue

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -8,6 +8,7 @@ classifier="$script_dir/classify-ci-changes.sh"
 desktop_classifier="$script_dir/classify-wework-desktop-e2e.sh"
 cloud_checkpoint_flows="$repo_root/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs"
 desktop_build_flows="$repo_root/wework/e2e/desktop/modules/desktop-build-flows.mjs"
+desktop_checkpoint_runner="$repo_root/wework/e2e/desktop/run-checkpoints.mjs"
 
 assert_invalid_desktop_shards_rejected() {
   local temp_dir
@@ -807,13 +808,13 @@ wework_desktop_cloud_job="$(
 if [[ "$wework_desktop_cloud_job" != *"needs.changes.outputs.wework_desktop_cloud_e2e == 'true'"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"fromJSON(needs.changes.outputs.wework_desktop_cloud_e2e_matrix)"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"--parallel-segments"* ]] ||
-  [[ "$wework_desktop_cloud_job" != *'WEWORK_E2E_PARALLEL_CHECKPOINTS: "2"'* ]] ||
+  [[ "$wework_desktop_cloud_job" != *'WEWORK_E2E_PARALLEL_CHECKPOINTS: "1"'* ]] ||
   [[ "$wework_desktop_cloud_job" != *'WEWORK_E2E_ISOLATED_XVFB: "true"'* ]] ||
   [[ "$wework_desktop_cloud_job" != *"compression-level: 0"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"name: Download shared Wework desktop E2E build"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"WEWORK_E2E_APP_BIN:"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"WEWORK_E2E_EXECUTOR_BIN:"* ]]; then
-  printf 'Wework Cloud desktop E2E must use five prebuilt shards with local parallelism\n' >&2
+  printf 'Wework Cloud desktop E2E must use five prebuilt serial shards\n' >&2
   exit 1
 fi
 
@@ -822,9 +823,14 @@ wework_desktop_core_job="$(
     "$wework_workflow"
 )"
 if [[ "$wework_desktop_core_job" != *"needs.changes.outputs.wework_desktop_core_e2e == 'true'"* ]] ||
-  [[ "$wework_desktop_core_job" != *'WEWORK_E2E_PARALLEL_CHECKPOINTS: "2"'* ]] ||
+  [[ "$wework_desktop_core_job" != *'WEWORK_E2E_PARALLEL_CHECKPOINTS: "1"'* ]] ||
   [[ "$wework_desktop_core_job" != *"compression-level: 0"* ]]; then
   printf 'Wework Core desktop E2E must use its segment classification\n' >&2
+  exit 1
+fi
+
+if ! grep -Fq 'const DEFAULT_PARALLEL_CHECKPOINTS = 1' "$desktop_checkpoint_runner"; then
+  printf 'Wework desktop E2E must default to one checkpoint per runner\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -353,7 +353,7 @@ jobs:
           WEWORK_E2E_EXECUTOR_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/wegent-executor
           WEWORK_E2E_CODEX_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex
           WEWORK_E2E_ISOLATED_XVFB: "true"
-          WEWORK_E2E_PARALLEL_CHECKPOINTS: "2"
+          WEWORK_E2E_PARALLEL_CHECKPOINTS: "1"
           WEWORK_E2E_PARALLEL_SCOPE: core
           WEWORK_E2E_SEGMENTS: ${{ matrix.segments }}
         run: |
@@ -424,7 +424,7 @@ jobs:
           WEWORK_E2E_CODEX_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/codex/x86_64-unknown-linux-gnu/vendor/x86_64-unknown-linux-musl/bin/codex
           WEWORK_E2E_EXECUTOR_BIN: ${{ github.workspace }}/.ci-artifacts/wework-core-e2e-build/wegent-executor
           WEWORK_E2E_ISOLATED_XVFB: "true"
-          WEWORK_E2E_PARALLEL_CHECKPOINTS: "2"
+          WEWORK_E2E_PARALLEL_CHECKPOINTS: "1"
           WEWORK_E2E_PARALLEL_SCOPE: cloud
           WEWORK_E2E_SEGMENTS: ${{ matrix.segments }}
         run: |

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -130,11 +130,13 @@ its own minimal fixtures instead of depending on tasks or UI state created only
 by the complete flow. PR CI builds the smallest segment matrix for the changed
 feature paths. Shared desktop infrastructure, merge queue, scheduled runs, and
 `ci:all` still run the complete desktop suites. The complete Core and Cloud
-suites each use five fixed GitHub Actions matrix jobs. Every job runs two
-checkpoints concurrently with isolated Xvfb displays, ports, application data,
-and Executor Homes. Shards are balanced from observed CI durations; a new or
-materially slower checkpoint requires rebalancing instead of adding runners,
-removing coverage, or rerunning failures. CI first builds one Core Tauri
+suites each use five fixed GitHub Actions matrix jobs. Every job runs its
+checkpoints serially so multiple real Tauri, WebView, and Executor stacks do not
+contend for CPU and memory on the same GitHub runner and push normal asynchronous
+state beyond the shared 10-second step timeout. The ten matrix jobs still provide
+suite-level parallelism across runners. Shards are balanced from observed CI
+durations; a new or materially slower checkpoint requires rebalancing instead of
+adding runners, removing coverage, or rerunning failures. CI first builds one Core Tauri
 application, Executor, and Codex artifact. In `--build-only` mode, the
 independent Tauri and Executor builds run concurrently on the same runner. Every
 Core and Cloud shard downloads and reuses that artifact instead of rebuilding

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -128,9 +128,11 @@ checkpoint。跳过上游时，每个 checkpoint 会自行建立最小前置 fix
 完整流程才创建的任务或 UI 状态。PR CI 会根据改动的功能路径组合最小 segment
 矩阵；共享桌面基础设施、merge queue、定时任务和 `ci:all` 仍运行完整桌面套件。
 完整 Core 和 Cloud 套件各固定使用 5 个 GitHub Actions matrix job；每个 job
-通过隔离的 Xvfb、端口、应用数据和 Executor Home 同时运行 2 个 checkpoint。
-分片按 CI 实测耗时平衡，新增或明显变慢的 checkpoint 必须重新校准分片，不能靠
-增加 runner、删覆盖或重跑失败用例来缩短关键路径。CI 会先构建一次 Core Tauri
+串行运行其 checkpoint，避免多个真实 Tauri、WebView 和 Executor 栈在同一
+GitHub runner 上争用 CPU 和内存，导致正常异步状态越过统一的 10 秒门槛。
+跨 runner 的 10 个 matrix job 仍提供套件级并行。分片按 CI 实测耗时平衡，
+新增或明显变慢的 checkpoint 必须重新校准分片，不能靠增加 runner、删覆盖或
+重跑失败用例来缩短关键路径。CI 会先构建一次 Core Tauri
 应用、Executor 和 Codex artifact，其中 `--build-only` 会在同一 runner 内并行
 编译相互独立的 Tauri 应用和 Executor；各 Core/Cloud 分片下载并复用该 artifact，
 不再重复执行 Vite、Tauri 和 Executor 构建。Rust 构建同时复用由 `main`

--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url'
 import { DESKTOP_CHECKPOINTS } from './checkpoints.mjs'
 
 const HEARTBEAT_INTERVAL_MS = 30_000
-const DEFAULT_PARALLEL_CHECKPOINTS = 3
+const DEFAULT_PARALLEL_CHECKPOINTS = 1
 const CHECKPOINT_SCENARIO_MODULES = {
   'conversation-state': './scenarios/conversation-mention.scenario.mjs',
   'temporary-chat': './scenarios/temporary-chat.scenario.mjs',


### PR DESCRIPTION
## Summary

- run Wework Core and Cloud desktop checkpoints serially inside each GitHub Actions matrix job
- keep the existing five Core and five Cloud jobs for cross-runner parallelism and full coverage
- make serial execution the desktop checkpoint runner default and enforce it in the CI contract tests
- document the resource-isolation invariant in both Chinese and English guides

## Root cause

In the 12-hour window ending August 20, 2026, four merge queue runs failed, all in Wework Desktop E2E after per-runner checkpoint concurrency was increased from one to two in #2821:

- `workspace-attachments`: the document attachment selector timed out
- `model-routing`: the switch-model retry action timed out
- `local-harness`: the Kimi Code version text timed out
- `window-lifecycle`: the virtualized conversation did not reach the top within 3 seconds

The failures span unrelated product flows but share the same new execution topology: two real Tauri/WebView/Executor stacks competing on one GitHub-hosted runner. For the three selector timeouts, the uploaded failure snapshots already contain the expected target state, showing that the product state arrived just after the shared 10-second wait expired. The surrounding Lint, Tests, browser E2E, and other desktop shards passed.

The ten existing Core/Cloud matrix jobs already provide suite-level parallelism. Serializing checkpoints within each runner removes the resource contention without weakening assertions, increasing timeouts, retrying failures, or changing E2E scenarios.

## Validation

- `.github/scripts/test-classify-ci-changes.sh`
- `.github/scripts/test-ci-cache-policy.sh`
- `bash -n` for changed shell scripts
- `node --check wework/e2e/desktop/run-checkpoints.mjs`
- Prettier for the workflow, runner, and synchronized docs
- full pre-push Wework ESLint, TypeScript, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI & Testing**
  * Updated desktop Core and Cloud end-to-end testing to use five runners per suite, with checkpoints executed serially on each runner.
  * Maintained parallel execution across ten total runners for faster suite completion.
  * Updated validation checks and default checkpoint settings to reflect the new execution model.

* **Documentation**
  * Updated English and Chinese guides to describe the revised desktop E2E sharding and runner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->