### PR TITLE
fix(executor): preserve goal completion turn routing

### DIFF
--- a/docs/en/architecture/codex-notification-routing.md
+++ b/docs/en/architecture/codex-notification-routing.md
@@ -35,8 +35,10 @@ sequenceDiagram
     H->>B: Deliver only to thread B
     H->>H: Also deliver to global stream
     Note over A: Thread A queue is unaffected
+    C->>H: Thread A thread/goal/updated
+    H->>A: Correct provisional turn/start result with first trusted protocol turnId
     C->>H: Thread A item/started(userMessage)
-    H->>A: Correct stale turn/start result with protocol turnId
+    H->>A: Confirm the same active turn
     C->>H: Thread A turn/completed
     H->>A: Deliver completion
     A->>A: Produce one terminal outcome
@@ -57,6 +59,7 @@ sequenceDiagram
 - Notifications with a `threadId` enter only the matching turn stream; the global stream still receives every notification.
 - Process-exit notifications without a `threadId` reach every active thread.
 - A thread subscription exists before any request that may start its turn.
-- A root user message's `item/started` protocol `turnId` corrects a stale ID returned by `turn/start`, so later Goal and completion notifications from that turn are not discarded as stale.
+- A turn ID returned by `turn/start` is provisional until the first trusted protocol event confirms it; `turn/started`, a root user message's `item/started`, and an earlier `thread/goal/updated` or `thread/goal/cleared` during that provisional turn correct the active turn with their protocol `turnId`.
+- Goal state notifications enter the same turn state machine even when they precede the root user message, and later notifications from that turn are not discarded as stale.
 - Assistant and other non-root-user item notifications cannot replace the active turn.
 - Lag in the global background router must not fail unrelated active turns.

--- a/docs/zh/architecture/codex-notification-routing.md
+++ b/docs/zh/architecture/codex-notification-routing.md
@@ -35,8 +35,10 @@ sequenceDiagram
     H->>B: 仅投递到线程 B
     H->>H: 同时投递到全局流
     Note over A: 线程 A 队列不受影响
+    C->>H: 线程 A thread/goal/updated
+    H->>A: 用首个可信协议 turnId 校正 provisional turn/start 返回值
     C->>H: 线程 A item/started(userMessage)
-    H->>A: 用协议 turnId 校正 turn/start 返回值
+    H->>A: 确认同一活跃 turn
     C->>H: 线程 A turn/completed
     H->>A: 投递完成通知
     A->>A: 生成唯一终态
@@ -57,6 +59,7 @@ sequenceDiagram
 - 带 `threadId` 的通知只能进入匹配线程的 turn 流；全局流仍接收全部通知。
 - 无 `threadId` 的进程退出通知必须到达所有活跃线程。
 - 线程订阅必须在可能启动该线程 turn 的请求之前建立。
-- 根用户消息的 `item/started` 所携带的协议 `turnId` 必须校正 `turn/start` 返回的过期 turn ID，后续同一 turn 的 Goal 与完成通知不得被误判为 stale。
+- `turn/start` 返回的 turn ID 在首个可信协议事件确认前只是 provisional；`turn/started`、根用户消息的 `item/started`，以及 provisional turn 期间先到达的 `thread/goal/updated` 或 `thread/goal/cleared` 必须用其协议 `turnId` 校正活跃 turn。
+- Goal 状态通知即使先于根用户消息到达，也必须进入同一 turn 状态机；同一 turn 后续通知不得被误判为 stale。
 - 助手消息等非根用户消息不得替换当前活跃 turn。
 - 全局后台路由掉队不得把无关活跃 turn 标记为失败。

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2504,7 +2504,9 @@ fn observed_active_turn_id(
                 .and_then(|item| item.get("type"))
                 .and_then(Value::as_str)
                 == Some("userMessage"));
-    if !starts_root_turn {
+    let confirms_provisional_turn = active_turn_id.is_some()
+        && matches!(method, Some("thread/goal/updated" | "thread/goal/cleared"));
+    if !starts_root_turn && !confirms_provisional_turn {
         return None;
     }
     root_turn_notification_id(message, state)

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -1836,6 +1836,27 @@ fn started_user_item_corrects_a_mismatched_turn_start_response() {
 }
 
 #[test]
+fn goal_update_corrects_a_provisional_turn_before_the_user_item_starts() {
+    let state = CodexRunState::default();
+    let notification = json!({
+        "method": "thread/goal/updated",
+        "params": {
+            "threadId": "thread-1",
+            "turnId": "turn-2",
+            "goal": {
+                "status": "complete"
+            }
+        }
+    });
+
+    assert_eq!(
+        observed_active_turn_id(Some("turn-1"), &notification, &state),
+        Some("turn-2".to_owned())
+    );
+    assert_eq!(observed_active_turn_id(None, &notification, &state), None);
+}
+
+#[test]
 fn codex_run_state_uses_commentary_channel_delta_as_fallback_final_content() {
     let mut state = CodexRunState::default();
 


### PR DESCRIPTION
## Summary

- treat `turn/start` IDs as provisional until a trusted protocol event confirms the active turn
- allow early Goal status notifications to correct the active turn before the root user item starts
- document the notification-routing invariant in Chinese and English

## Root cause

The Goal restart E2E exposed an ordering race where `thread/goal/updated` arrived before `item/started(userMessage)`. The Goal event carried the real protocol turn ID, while `turn/start` had returned a different provisional ID, so the event was discarded as stale. The executor kept the Goal active and the task running indefinitely after completion.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib agents::codex::tests::` (122 passed)
- pre-push `cargo test --all-features --lib`
- pre-push `cargo clippy`
- `pnpm --filter wework exec node e2e/desktop/task-flow.e2e.mjs --goal-restart-only`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turn tracking when goal updates arrive before the root user message.
  * Goal notifications now correctly confirm or correct a provisional active turn.
  * Subsequent notifications for the same turn are retained instead of being incorrectly treated as stale.

* **Documentation**
  * Updated architecture documentation to describe the revised notification sequence and turn-identification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->