### PR TITLE
feat(channels): show compact DingTalk progress

### DIFF
--- a/backend/app/services/channels/dingtalk/emitter.py
+++ b/backend/app/services/channels/dingtalk/emitter.py
@@ -2,25 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Response Emitters for DingTalk Stream.
-
-This module provides ResultEmitter implementations for DingTalk:
-- SyncResponseEmitter: Re-exported from generic emitter module
-- StreamingResponseEmitter: DingTalk-specific streaming via AI Card
-"""
+"""DingTalk response emitters backed by a single AI Card."""
 
 import asyncio
 import logging
+import re
 import time
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from app.core.cache import cache_manager
-
-# Re-export SyncResponseEmitter from generic module for backward compatibility
 from app.services.channels.emitter import SyncResponseEmitter
 from app.services.execution.emitters import ResultEmitter
-from shared.models import ExecutionEvent
+from shared.models import EventType, ExecutionEvent
+from shared.utils.sensitive_data_masker import mask_string
 
 if TYPE_CHECKING:
     from dingtalk_stream import ChatbotMessage
@@ -28,25 +23,222 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Export both for backward compatibility
 __all__ = ["SyncResponseEmitter", "StreamingResponseEmitter"]
+
+_MARKDOWN_TOKEN_RE = re.compile(r"[`*_>#]+")
+_CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x1f\x7f]+")
+
+
+def _compact_text(value: Any, limit: int) -> str:
+    """Return one safe, bounded line for the compact IM projection."""
+    if not isinstance(value, str):
+        return ""
+    text = mask_string(value)
+    text = _CONTROL_CHARACTER_RE.sub(" ", text)
+    text = _MARKDOWN_TOKEN_RE.sub("", text)
+    text = " ".join(text.split()).strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 1].rstrip()}…"
+
+
+@dataclass
+class _CompactProgressState:
+    """Serializable, bounded DingTalk progress projection."""
+
+    mode: str = "progress"
+    current: str = "正在理解需求…"
+    recent: list[str] = field(default_factory=list)
+    blocks: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    MAX_RECENT = 2
+    MAX_BLOCKS = 20
+    MAX_STEP_LENGTH = 80
+    MAX_CARD_LENGTH = 320
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "_CompactProgressState":
+        if not isinstance(value, dict):
+            return cls()
+        mode = (
+            value.get("mode")
+            if value.get("mode") in {"progress", "answer"}
+            else "progress"
+        )
+        current = _compact_text(value.get("current"), cls.MAX_STEP_LENGTH)
+        recent = value.get("recent") if isinstance(value.get("recent"), list) else []
+        recent = [
+            text
+            for item in recent[-cls.MAX_RECENT :]
+            if (text := _compact_text(item, cls.MAX_STEP_LENGTH))
+        ]
+        blocks = value.get("blocks") if isinstance(value.get("blocks"), dict) else {}
+        safe_blocks = {
+            str(block_id): _safe_block(block)
+            for block_id, block in list(blocks.items())[-cls.MAX_BLOCKS :]
+            if isinstance(block, dict)
+        }
+        return cls(
+            mode=mode,
+            current=current or "正在处理…",
+            recent=recent,
+            blocks=safe_blocks,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "current": self.current,
+            "recent": self.recent[-self.MAX_RECENT :],
+            "blocks": self.blocks,
+        }
+
+    def set_current(self, value: str) -> None:
+        text = _compact_text(value, self.MAX_STEP_LENGTH)
+        if text:
+            self.current = text
+
+    def complete(self, value: str) -> None:
+        text = _compact_text(value, self.MAX_STEP_LENGTH)
+        if text and (not self.recent or self.recent[-1] != text):
+            self.recent.append(text)
+            self.recent = self.recent[-self.MAX_RECENT :]
+        self.current = "继续处理…"
+
+    def remember_block(self, block: dict[str, Any]) -> None:
+        block_id = str(block.get("id") or "").strip()
+        if not block_id:
+            return
+        if block_id not in self.blocks and len(self.blocks) >= self.MAX_BLOCKS:
+            self.blocks.pop(next(iter(self.blocks)))
+        self.blocks[block_id] = block
+
+    def render(self) -> str:
+        lines = ["**执行进度**"]
+        lines.extend(f"✅ {item}" for item in self.recent[-self.MAX_RECENT :])
+        lines.append(f"⏳ {self.current or '正在处理…'}")
+        return "\n".join(lines)[: self.MAX_CARD_LENGTH]
+
+
+def _safe_block(block: Any) -> dict[str, Any]:
+    """Keep only fields needed to project a block safely."""
+    if not isinstance(block, dict):
+        return {}
+    block_type = _compact_text(block.get("type"), 24).lower()
+    safe = {
+        "id": str(block.get("id") or "").strip(),
+        "type": block_type,
+        "status": _compact_text(block.get("status"), 24).lower(),
+        "process_kind": _compact_text(block.get("process_kind"), 32).lower(),
+        "tool_name": _compact_text(block.get("tool_name"), 40),
+        "display_name": _compact_text(block.get("display_name"), 40),
+        "title": _compact_text(block.get("title"), 80),
+        "agent_type": _compact_text(block.get("agent_type"), 40),
+    }
+    if block_type in {"text", "plan"}:
+        safe["content"] = _compact_text(block.get("content"), 80)
+    render_payload = block.get("render_payload")
+    safe["needs_input"] = bool(
+        block.get("needs_input")
+        or (
+            isinstance(render_payload, dict)
+            and render_payload.get("kind") == "request_user_input"
+        )
+        or safe["tool_name"] == "request_user_input"
+    )
+    return safe
+
+
+def _merge_safe_block(
+    existing: dict[str, Any], updates: Any, block_id: str
+) -> dict[str, Any]:
+    if not isinstance(updates, dict):
+        return existing
+    merged = {**existing, "id": block_id}
+    for key in (
+        "type",
+        "status",
+        "process_kind",
+        "tool_name",
+        "display_name",
+        "title",
+        "agent_type",
+        "content",
+        "render_payload",
+    ):
+        if key in updates:
+            merged[key] = updates[key]
+    return _safe_block(merged)
+
+
+def _tool_label(value: dict[str, Any]) -> str:
+    return value.get("display_name") or value.get("tool_name") or "工具"
+
+
+def _project_block(state: _CompactProgressState, block: dict[str, Any]) -> None:
+    if not block:
+        return
+    status = block.get("status") or "pending"
+    block_type = block.get("type")
+    if block.get("needs_input"):
+        state.set_current("等待你在 Wework 中确认…")
+    elif block_type == "thinking":
+        state.set_current("正在分析…")
+    elif block_type == "tool":
+        _project_tool_block(state, block, status)
+    elif block_type == "subagent":
+        _project_subagent_block(state, block, status)
+    elif block_type in {"text", "plan"}:
+        _project_text_block(state, block, status)
+    else:
+        state.set_current("正在处理新步骤…")
+
+
+def _project_tool_block(
+    state: _CompactProgressState, block: dict[str, Any], status: str
+) -> None:
+    label = _tool_label(block)
+    if status in {"error", "failed"}:
+        state.set_current(f"工具执行失败：{label}")
+    elif status in {"done", "completed", "success"}:
+        state.complete(f"工具完成：{label}")
+    else:
+        state.set_current(f"正在使用工具：{label}")
+
+
+def _project_subagent_block(
+    state: _CompactProgressState, block: dict[str, Any], status: str
+) -> None:
+    label = block.get("title") or block.get("display_name") or block.get("agent_type")
+    label = label or "协作任务"
+    if status in {"error", "failed"}:
+        state.set_current(f"协作任务失败：{label}")
+    elif status in {"done", "completed", "success"}:
+        state.complete(f"协作任务完成：{label}")
+    else:
+        state.set_current(f"正在协同处理：{label}")
+
+
+def _project_text_block(
+    state: _CompactProgressState, block: dict[str, Any], status: str
+) -> None:
+    content = block.get("content")
+    if not content:
+        state.set_current("正在整理过程…")
+    elif status in {"done", "completed", "success"}:
+        state.complete(content)
+    else:
+        state.set_current(content)
 
 
 class StreamingResponseEmitter(ResultEmitter):
-    """Streaming response emitter for DingTalk using AI Card.
+    """Render compact progress and the final answer into one DingTalk AI Card."""
 
-    This emitter uses DingTalk's AIMarkdownCardInstance to send streaming
-    updates to the user, providing a typewriter-like experience.
-
-    Usage:
-        emitter = StreamingResponseEmitter(dingtalk_client, incoming_message)
-        # ... trigger AI response with this emitter ...
-        # The emitter will automatically send streaming updates to DingTalk
-    """
-
-    # Minimum interval between streaming updates (in seconds)
-    # DingTalk has rate limits, so we throttle updates
     MIN_UPDATE_INTERVAL = 0.8
+    MAX_FINAL_CONTENT_LENGTH = 4000
+    FINAL_TRUNCATION_SUFFIX = "\n\n…（内容已截断，请在 Wework 查看完整结果）"
+    PROGRESS_STATE_SUFFIX = ":progress"
+    DISPLAY_LOCK_SUFFIX = ":display-lock"
 
     def __init__(
         self,
@@ -54,81 +246,88 @@ class StreamingResponseEmitter(ResultEmitter):
         incoming_message: "ChatbotMessage",
         existing_card_instance_id: Optional[str] = None,
     ):
-        """Initialize StreamingResponseEmitter.
-
-        Args:
-            dingtalk_client: DingTalk stream client instance
-            incoming_message: The incoming message to reply to
-            existing_card_instance_id: Existing card instance ID to reconnect to
-                (used when reconstructing emitter in a different worker)
-        """
         from dingtalk_stream import AIMarkdownCardInstance
 
         self._dingtalk_client = dingtalk_client
         self._incoming_message = incoming_message
-        # Use official AIMarkdownCardInstance for streaming
         self._card = AIMarkdownCardInstance(dingtalk_client, incoming_message)
-        # Simplify the card layout - only show content, remove unused fields
         self._card.set_order(["msgContent"])
         self._full_content = ""
-        self._last_update_time = 0.0
         self._pending_content = ""
+        self._last_update_time = 0.0
         self._finished = False
         self._shared_content_key: Optional[str] = None
+        self._progress = _CompactProgressState()
+        self._update_lock = asyncio.Lock()
+        self._reconnected = bool(existing_card_instance_id)
 
         if existing_card_instance_id:
-            # Reconnect to an existing AI Card (cross-worker scenario)
             self._card.card_instance_id = existing_card_instance_id
             self._started = True
         else:
             self._started = False
 
-    async def _ensure_card_started(self) -> bool:
-        """Ensure the AI card is created and started.
-
-        Returns:
-            True if card is ready, False if creation failed
-        """
-        if self._started:
-            return True
-
-        try:
-            # Use the official SDK method to start the card
-            logger.info("[StreamingEmitter] Starting AI card...")
-            self._card.ai_start()
-
-            if not self._card.card_instance_id:
-                logger.error(
-                    "[StreamingEmitter] Failed to create AI card - no instance ID returned"
-                )
-                return False
-
-            self._started = True
-            logger.info(
-                f"[StreamingEmitter] AI card started successfully, "
-                f"instance_id={self._card.card_instance_id}"
-            )
-            return True
-
-        except Exception as e:
-            logger.exception(f"[StreamingEmitter] Failed to start AI card: {e}")
-            return False
-
     @property
     def card_instance_id(self) -> Optional[str]:
-        """Get the card instance ID if the card has been started."""
         return self._card.card_instance_id if self._card else None
 
-    def set_shared_content_key(self, key: str) -> None:
-        """Enable Redis-backed shared content accumulation for multi-pod streaming.
+    @property
+    def _progress_state_key(self) -> Optional[str]:
+        if not self._shared_content_key:
+            return None
+        return f"{self._shared_content_key}{self.PROGRESS_STATE_SUFFIX}"
 
-        When set, content is accumulated in Redis using APPEND so all pods
-        sharing the same card write to a single content buffer.
-        """
+    @property
+    def _display_lock_key(self) -> Optional[str]:
+        if not self._shared_content_key:
+            return None
+        return f"{self._shared_content_key}{self.DISPLAY_LOCK_SUFFIX}"
+
+    def set_shared_content_key(self, key: str) -> None:
+        """Enable Redis-backed answer and progress state sharing."""
         self._shared_content_key = key
 
-    async def _redis_append(self, content: str) -> None:
-        """Append content to shared Redis key without reading back."""
+    async def _ensure_card_started(self) -> bool:
+        if self._started:
+            return True
+        try:
+            logger.info("[StreamingEmitter] Starting AI card...")
+            self._card.ai_start()
+            if not self._card.card_instance_id:
+                logger.error("[StreamingEmitter] AI card has no instance ID")
+                return False
+            self._started = True
+            logger.info(
+                "[StreamingEmitter] AI card started: instance_id=%s",
+                self._card.card_instance_id,
+            )
+            return True
+        except Exception:
+            logger.exception("[StreamingEmitter] Failed to start AI card")
+            return False
+
+    async def _load_progress_state(self) -> None:
+        key = self._progress_state_key
+        if key:
+            cached = await cache_manager.get(key)
+            if cached is not None:
+                self._progress = _CompactProgressState.from_dict(cached)
+
+    async def _save_progress_state(self) -> None:
+        key = self._progress_state_key
+        if not key:
+            return
+        from app.services.channels.callback import CHANNEL_TASK_CALLBACK_TTL
+
+        saved = await cache_manager.set(
+            key,
+            self._progress.to_dict(),
+            expire=CHANNEL_TASK_CALLBACK_TTL,
+        )
+        if not saved:
+            logger.warning("[StreamingEmitter] Failed to persist compact progress")
+
+    async def _redis_append_answer(self, content: str) -> None:
         from app.services.channels.callback import CHANNEL_TASK_CALLBACK_TTL
 
         redis_client = await cache_manager._get_client()
@@ -140,23 +339,7 @@ class StreamingResponseEmitter(ResultEmitter):
         finally:
             await redis_client.aclose()
 
-    async def _redis_append_and_get(self, content: str) -> str:
-        """Append content to shared Redis key and return full accumulated content."""
-        from app.services.channels.callback import CHANNEL_TASK_CALLBACK_TTL
-
-        redis_client = await cache_manager._get_client()
-        try:
-            await redis_client.append(self._shared_content_key, content.encode("utf-8"))
-            await redis_client.expire(
-                self._shared_content_key, CHANNEL_TASK_CALLBACK_TTL
-            )
-            raw = await redis_client.get(self._shared_content_key)
-            return raw.decode("utf-8") if raw else ""
-        finally:
-            await redis_client.aclose()
-
-    async def _redis_get_full_content(self) -> str:
-        """Get full accumulated content from Redis."""
+    async def _redis_get_answer(self) -> str:
         redis_client = await cache_manager._get_client()
         try:
             raw = await redis_client.get(self._shared_content_key)
@@ -165,280 +348,344 @@ class StreamingResponseEmitter(ResultEmitter):
             await redis_client.aclose()
 
     async def _redis_cleanup(self) -> None:
-        """Delete the shared content key from Redis."""
-        try:
-            await cache_manager.delete(self._shared_content_key)
-        except Exception as e:
-            logger.warning(
-                f"[StreamingEmitter] Failed to cleanup Redis key "
-                f"{self._shared_content_key}: {e}"
-            )
-
-    async def _send_streaming_update(self, content: str, force: bool = False) -> None:
-        """Send a streaming update to the AI card.
-
-        Args:
-            content: The content to send (will be accumulated)
-            force: If True, send immediately regardless of throttling
-        """
-        if self._finished or not self._card.card_instance_id:
+        if not self._shared_content_key:
             return
-
-        current_time = time.time()
-        time_since_last = current_time - self._last_update_time
-
-        if self._shared_content_key:
-            # Multi-pod mode: persist to Redis IMMEDIATELY to preserve ordering
-            # (the /callback endpoint returns 200 only after this completes,
-            # so the executor won't send the next chunk until this APPEND is done)
-            await self._redis_append(content)
-
-            # Throttle only the display (ai_streaming call)
-            if not force and time_since_last < self.MIN_UPDATE_INTERVAL:
-                return
-
+        keys = [self._shared_content_key]
+        keys.extend(
+            key for key in (self._progress_state_key, self._display_lock_key) if key
+        )
+        try:
+            redis_client = await cache_manager._get_client()
             try:
-                full_content = await self._redis_get_full_content()
-                self._full_content = full_content
+                await redis_client.delete(*keys)
+            finally:
+                await redis_client.aclose()
+        except Exception:
+            logger.exception("[StreamingEmitter] Failed to clean shared card state")
 
-                logger.debug(
-                    f"[StreamingEmitter] Sending streaming update, "
-                    f"content_len={len(self._full_content)}"
+    async def _may_update_display(self, force: bool) -> bool:
+        if force:
+            return True
+        if self._display_lock_key:
+            redis_client = await cache_manager._get_client()
+            try:
+                allowed = await redis_client.set(
+                    self._display_lock_key,
+                    b"1",
+                    nx=True,
+                    px=int(self.MIN_UPDATE_INTERVAL * 1000),
                 )
+                return bool(allowed)
+            finally:
+                await redis_client.aclose()
+        return time.time() - self._last_update_time >= self.MIN_UPDATE_INTERVAL
 
-                self._card.ai_streaming(self._full_content, append=False)
-                self._last_update_time = current_time
-            except Exception as e:
-                logger.exception(
-                    f"[StreamingEmitter] Failed to send streaming update: {e}"
-                )
-        else:
-            # Single-pod mode: accumulate locally with throttling
-            self._pending_content += content
+    async def _write_card(self, content: str, *, force: bool = False) -> bool:
+        if self._finished or not self._card.card_instance_id or not content:
+            return False
+        if not await self._may_update_display(force):
+            return False
+        try:
+            self._card.ai_streaming(content, append=False)
+            self._last_update_time = time.time()
+            return True
+        except Exception:
+            logger.exception("[StreamingEmitter] Failed to update AI card")
+            return False
 
-            if not force and time_since_last < self.MIN_UPDATE_INTERVAL:
+    async def _render_current_mode(self, *, force: bool = False) -> None:
+        if self._progress.mode == "answer":
+            answer = await self._current_answer()
+            await self._write_card(self._truncate_final(answer), force=force)
+            return
+        await self._write_card(self._progress.render(), force=force)
+
+    async def _update_progress(
+        self, updater: Callable[[_CompactProgressState], None]
+    ) -> None:
+        async with self._update_lock:
+            if self._finished or not await self._ensure_card_started():
                 return
+            await self._load_progress_state()
+            if self._progress.mode != "progress":
+                return
+            updater(self._progress)
+            await self._save_progress_state()
+            await self._render_current_mode()
 
-            if self._pending_content:
-                try:
-                    self._full_content += self._pending_content
+    async def _current_answer(self) -> str:
+        if self._shared_content_key:
+            return await self._redis_get_answer()
+        return f"{self._full_content}{self._pending_content}"
 
-                    logger.debug(
-                        f"[StreamingEmitter] Sending streaming update, "
-                        f"content_len={len(self._full_content)}"
-                    )
+    async def _send_answer_update(self, content: str) -> None:
+        if self._shared_content_key:
+            await self._redis_append_answer(content)
+            if not await self._may_update_display(False):
+                return
+            self._full_content = await self._redis_get_answer()
+        else:
+            self._pending_content += content
+            if not await self._may_update_display(False):
+                return
+            self._full_content += self._pending_content
+            self._pending_content = ""
+        await self._write_card_without_throttle(
+            self._truncate_final(self._full_content)
+        )
 
-                    self._card.ai_streaming(self._full_content, append=False)
+    async def _write_card_without_throttle(self, content: str) -> None:
+        if not content:
+            return
+        try:
+            self._card.ai_streaming(content, append=False)
+            self._last_update_time = time.time()
+        except Exception:
+            logger.exception("[StreamingEmitter] Failed to stream answer")
 
-                    self._pending_content = ""
-                    self._last_update_time = current_time
-                except Exception as e:
-                    logger.exception(
-                        f"[StreamingEmitter] Failed to send streaming update: {e}"
-                    )
+    def _truncate_final(self, content: str) -> str:
+        suffix = self.FINAL_TRUNCATION_SUFFIX
+        if len(content) <= self.MAX_FINAL_CONTENT_LENGTH:
+            return content
+        return f"{content[: self.MAX_FINAL_CONTENT_LENGTH - len(suffix)]}{suffix}"
 
     async def emit(self, event: ExecutionEvent) -> None:
-        """Emit a single event.
-
-        Args:
-            event: Execution event to emit
-        """
-        from shared.models import EventType
-
-        if event.type == EventType.START:
-            await self.emit_start(
-                task_id=event.task_id,
-                subtask_id=event.subtask_id,
-                message_id=event.message_id,
-            )
-        elif event.type == EventType.CHUNK:
+        event_type = (
+            event.type.value if isinstance(event.type, EventType) else event.type
+        )
+        if event_type == EventType.START.value:
+            await self.emit_start(event.task_id, event.subtask_id, event.message_id)
+        elif event_type == EventType.CHUNK.value:
             await self.emit_chunk(
-                task_id=event.task_id,
-                subtask_id=event.subtask_id,
-                content=event.content or "",
-                offset=event.offset,
+                event.task_id, event.subtask_id, event.content or "", event.offset
             )
-        elif event.type == EventType.DONE:
-            await self.emit_done(
-                task_id=event.task_id,
-                subtask_id=event.subtask_id,
-                result=event.result,
-            )
-        elif event.type == EventType.ERROR:
+        elif event_type == EventType.THINKING.value:
+            await self.emit_thinking(event.task_id, event.subtask_id)
+        elif event_type == EventType.TOOL_START.value:
+            await self.emit_tool_start(event)
+        elif event_type == EventType.TOOL_RESULT.value:
+            await self.emit_tool_result(event)
+        elif event_type == EventType.BLOCK_CREATED.value:
+            await self.emit_block_created(event)
+        elif event_type == EventType.BLOCK_UPDATED.value:
+            await self.emit_block_updated(event)
+        elif event_type == EventType.STATUS_UPDATED.value:
+            await self.emit_status_updated(event)
+        elif event_type == EventType.PROGRESS.value:
+            await self.emit_progress(event)
+        elif event_type == EventType.DONE.value:
+            await self.emit_done(event.task_id, event.subtask_id, event.result)
+        elif event_type == EventType.ERROR.value:
             await self.emit_error(
-                task_id=event.task_id,
-                subtask_id=event.subtask_id,
-                error=event.error or "Unknown error",
+                event.task_id, event.subtask_id, event.error or "Unknown error"
             )
+        elif event_type in {EventType.CANCEL.value, EventType.CANCELLED.value}:
+            await self.emit_cancelled(event.task_id, event.subtask_id)
 
     async def emit_start(
         self,
-        task_id: int,
+        task_id: Any,
         subtask_id: int,
         message_id: Optional[int] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
-        """Emit start event - create and start the AI card."""
-        logger.info(f"[StreamingEmitter] start task={task_id} subtask={subtask_id}")
-        await self._ensure_card_started()
+        logger.info("[StreamingEmitter] start task=%s subtask=%s", task_id, subtask_id)
+        async with self._update_lock:
+            if not await self._ensure_card_started():
+                return
+            await self._load_progress_state()
+            await self._save_progress_state()
+            await self._render_current_mode(force=not self._reconnected)
+
+    async def emit_thinking(self, task_id: Any, subtask_id: int) -> None:
+        await self._update_progress(lambda state: state.set_current("正在分析…"))
+
+    async def emit_status_prefix(
+        self,
+        task_id: Any,
+        subtask_id: int,
+        content: str,
+        **kwargs: Any,
+    ) -> None:
+        """Show dispatch acknowledgement as progress, not answer content."""
+        await self._update_progress(lambda state: state.set_current(content))
+
+    async def emit_tool_start(self, event: ExecutionEvent) -> None:
+        label = _compact_text(
+            (event.data or {}).get("display_name") or event.tool_name, 40
+        )
+        await self._update_progress(
+            lambda state: state.set_current(f"正在使用工具：{label or '工具'}")
+        )
+
+    async def emit_tool_result(self, event: ExecutionEvent) -> None:
+        label = _compact_text(
+            (event.data or {}).get("display_name") or event.tool_name, 40
+        )
+        status = str((event.data or {}).get("status") or "").lower()
+        failed = status in {"error", "failed"} or bool((event.data or {}).get("error"))
+
+        def update(state: _CompactProgressState) -> None:
+            if failed:
+                state.set_current(f"工具执行失败：{label or '工具'}")
+            else:
+                state.complete(f"工具完成：{label or '工具'}")
+
+        await self._update_progress(update)
+
+    async def emit_block_created(self, event: ExecutionEvent) -> None:
+        block = _safe_block((event.data or {}).get("block"))
+
+        def update(state: _CompactProgressState) -> None:
+            state.remember_block(block)
+            _project_block(state, block)
+
+        await self._update_progress(update)
+
+    async def emit_block_updated(self, event: ExecutionEvent) -> None:
+        block_id = str((event.data or {}).get("block_id") or "").strip()
+        updates = (event.data or {}).get("updates")
+        if not block_id or not isinstance(updates, dict):
+            return
+
+        def update(state: _CompactProgressState) -> None:
+            existing = state.blocks.get(block_id, {"id": block_id})
+            block = _merge_safe_block(existing, updates, block_id)
+            state.remember_block(block)
+            _project_block(state, block)
+
+        await self._update_progress(update)
+
+    async def emit_status_updated(self, event: ExecutionEvent) -> None:
+        data = event.data or {}
+        phase = str(data.get("phase") or "").lower()
+        if data.get("context_compaction") or phase == "summary_compact":
+            await self._update_progress(
+                lambda state: state.set_current("正在整理上下文…")
+            )
+
+    async def emit_progress(self, event: ExecutionEvent) -> None:
+        progress = max(0, min(int(event.progress or 0), 100))
+        status = _compact_text(event.status, 50)
+        if not progress and not status:
+            return
+        text = f"任务进度 {progress}%" if progress else "正在处理"
+        if status:
+            text = f"{text}：{status}"
+        await self._update_progress(lambda state: state.set_current(text))
 
     async def emit_chunk(
         self,
-        task_id: int,
+        task_id: Any,
         subtask_id: int,
         content: str,
         offset: int,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
-        """Emit chunk event - send streaming update to DingTalk."""
         if not content:
             return
+        async with self._update_lock:
+            if self._finished or not await self._ensure_card_started():
+                return
+            await self._load_progress_state()
+            self._progress.mode = "answer"
+            await self._save_progress_state()
+            await self._send_answer_update(content)
 
-        # Ensure card is started
-        if not await self._ensure_card_started():
-            return
-
-        # Use throttling to reduce API calls
-        await self._send_streaming_update(content)
+    async def _final_content(self, result: Optional[dict]) -> str:
+        content = await self._current_answer()
+        if isinstance(result, dict):
+            for field_name in ("value", "output"):
+                result_value = result.get(field_name)
+                if isinstance(result_value, str) and result_value:
+                    content = result_value
+                    break
+        return self._truncate_final(content)
 
     async def emit_done(
         self,
-        task_id: int,
+        task_id: Any,
         subtask_id: int,
         result: Optional[dict] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
-        """Emit done event - finalize the AI card."""
-        if self._finished:
-            logger.warning("[StreamingEmitter] emit_done called but already finished")
-            return
-
-        # Get full content - from Redis if in shared mode
-        if self._shared_content_key:
-            final_content = await self._redis_get_full_content()
-        else:
-            final_content = self._full_content
-
-        # Use result content if provided and longer than accumulated content.
-        # This is critical for device mode where executor events arrive via
-        # device WebSocket rather than /callback, so the emitter's internal
-        # _full_content only contains the initial acknowledgment message.
-        if result and isinstance(result, dict):
-            result_value = result.get("value", "")
-            if result_value and len(result_value) > len(final_content):
-                final_content = result_value
-                logger.info(
-                    f"[StreamingEmitter] Using result.value ({len(result_value)} chars) "
-                    f"instead of accumulated content ({len(self._full_content)} chars)"
-                )
-
-        logger.info(
-            f"[StreamingEmitter] done task={task_id} subtask={subtask_id} "
-            f"final_content_len={len(final_content)}, pending_len={len(self._pending_content)}"
-        )
-
-        try:
-            # Ensure card is started
-            if not await self._ensure_card_started():
-                logger.error("[StreamingEmitter] Cannot finish - card not started")
+        async with self._update_lock:
+            if self._finished:
+                logger.warning("[StreamingEmitter] emit_done called after finish")
                 return
-
-            # Send any remaining pending content
-            if self._pending_content:
-                final_content += self._pending_content
+            try:
+                if not await self._ensure_card_started():
+                    return
+                await self._load_progress_state()
+                self._progress.mode = "answer"
+                await self._save_progress_state()
+                final_content = await self._final_content(result)
                 self._pending_content = ""
-
-            # IMPORTANT: Send the final complete content via ai_streaming before ai_finish
-            # DingTalk AI Card requires the last streaming update to contain the full content
-            # before calling ai_finish, otherwise the card may show truncated content
-            self._card.ai_streaming(final_content, append=False)
-
-            # Small delay to ensure streaming update is processed before finish
-            await asyncio.sleep(0.1)
-
-            # Finalize the card using official SDK
-            self._card.ai_finish(final_content)
-            self._finished = True
-            logger.info("[StreamingEmitter] AI card finished successfully")
-
-        except Exception as e:
-            logger.exception(f"[StreamingEmitter] Failed to finish AI card: {e}")
-        finally:
-            if self._shared_content_key:
+                self._full_content = final_content
+                logger.info(
+                    "[StreamingEmitter] done task=%s subtask=%s content_len=%s",
+                    task_id,
+                    subtask_id,
+                    len(final_content),
+                )
+                self._card.ai_streaming(final_content, append=False)
+                await asyncio.sleep(0.1)
+                self._card.ai_finish(final_content)
+                self._finished = True
+            except Exception:
+                logger.exception("[StreamingEmitter] Failed to finish AI card")
+            finally:
                 await self._redis_cleanup()
 
     async def emit_error(
         self,
-        task_id: int,
+        task_id: Any,
         subtask_id: int,
         error: str,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
-        """Emit error event - mark the AI card as failed."""
-        if self._finished:
-            return
-
-        logger.warning(
-            f"[StreamingEmitter] error task={task_id} subtask={subtask_id} "
-            f"error={error}"
-        )
-
-        try:
-            # Ensure card is started
-            if not await self._ensure_card_started():
+        async with self._update_lock:
+            if self._finished:
                 return
-
-            # Mark card as failed using official SDK
-            self._card.ai_fail()
-            self._finished = True
-
-        except Exception as e:
-            logger.exception(
-                f"[StreamingEmitter] Failed to mark AI card as failed: {e}"
+            logger.warning(
+                "[StreamingEmitter] error task=%s subtask=%s error=%s",
+                task_id,
+                subtask_id,
+                mask_string(error),
             )
-        finally:
-            if self._shared_content_key:
+            try:
+                if await self._ensure_card_started():
+                    self._card.ai_fail()
+                    self._finished = True
+            except Exception:
+                logger.exception("[StreamingEmitter] Failed to mark AI card failed")
+            finally:
                 await self._redis_cleanup()
 
     async def emit_cancelled(
         self,
-        task_id: int,
+        task_id: Any,
         subtask_id: int,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
-        """Emit cancelled event - mark the AI card as cancelled."""
-        if self._finished:
-            return
-
-        logger.info(f"[StreamingEmitter] cancelled task={task_id} subtask={subtask_id}")
-
-        try:
-            # Ensure card is started
-            if not await self._ensure_card_started():
+        async with self._update_lock:
+            if self._finished:
                 return
-
-            # Get full content from Redis if in shared mode
-            if self._shared_content_key:
-                self._full_content = await self._redis_get_full_content()
-
-            # Add cancellation note to content
-            self._full_content += "\n\n⚠️ 任务已取消"
-
-            # Send final content and finish the card
-            self._card.ai_streaming(self._full_content, append=False)
-            await asyncio.sleep(0.1)
-            self._card.ai_finish(self._full_content)
-            self._finished = True
-
-        except Exception as e:
-            logger.exception(
-                f"[StreamingEmitter] Failed to mark AI card as cancelled: {e}"
-            )
-        finally:
-            if self._shared_content_key:
+            try:
+                if not await self._ensure_card_started():
+                    return
+                answer = (await self._current_answer()).rstrip()
+                content = f"{answer}\n\n⚠️ 任务已取消" if answer else "⚠️ 任务已取消"
+                content = self._truncate_final(content)
+                self._card.ai_streaming(content, append=False)
+                await asyncio.sleep(0.1)
+                self._card.ai_finish(content)
+                self._finished = True
+            except Exception:
+                logger.exception("[StreamingEmitter] Failed to cancel AI card")
+            finally:
                 await self._redis_cleanup()
 
     async def close(self) -> None:
-        """Close the emitter and release resources."""
         if self._shared_content_key and not self._finished:
             await self._redis_cleanup()

--- a/backend/app/services/channels/handler.py
+++ b/backend/app/services/channels/handler.py
@@ -1209,8 +1209,8 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         if not streaming_emitter:
             return None
 
-        await streaming_emitter.emit_start(task_id=callback_key, subtask_id=0)
         self._prepare_streaming_emitter(callback_key, streaming_emitter)
+        await streaming_emitter.emit_start(task_id=callback_key, subtask_id=0)
         return streaming_emitter
 
     async def _emit_private_im_runtime_stream_error(
@@ -1407,6 +1407,7 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         streaming_emitter = await self.create_streaming_emitter(message_context)
         if streaming_emitter:
             response_emitter = streaming_emitter
+            self._prepare_streaming_emitter(task_id, streaming_emitter)
             await streaming_emitter.emit_start(
                 task_id=task_id,
                 subtask_id=assistant_subtask.id,
@@ -1417,7 +1418,6 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
                 subtask_id=assistant_subtask.id,
                 content=initial_stream_content,
             )
-            self._prepare_streaming_emitter(task_id, streaming_emitter)
         else:
             response_emitter = SyncResponseEmitter()
             if initial_stream_content:
@@ -2774,6 +2774,7 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
 
         if streaming_emitter:
             response_emitter = streaming_emitter
+            self._prepare_streaming_emitter(task_id, streaming_emitter)
             # Start the card immediately to get card_instance_id before registration,
             # matching Device/Cloud mode behavior. This ensures the card_instance_id
             # is available in Redis for cross-pod emitter reconstruction.
@@ -2781,8 +2782,6 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
                 task_id=task_id,
                 subtask_id=trigger_data["assistant_subtask"].id,
             )
-            # Enable Redis-backed content sharing for multi-pod consistency
-            self._prepare_streaming_emitter(task_id, streaming_emitter)
         else:
             response_emitter = SyncResponseEmitter()
 
@@ -2998,12 +2997,14 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         # streaming events from the executor can update the same card.
         streaming_emitter = await self.create_streaming_emitter(message_context)
         if streaming_emitter:
+            self._prepare_streaming_emitter(result.task.id, streaming_emitter)
             await streaming_emitter.emit_start(
                 task_id=result.task.id,
                 subtask_id=result.assistant_subtask.id,
                 shell_type="ClaudeCode",
             )
-            await streaming_emitter.emit_chunk(
+            await self._emit_initial_stream_content(
+                streaming_emitter,
                 task_id=result.task.id,
                 subtask_id=result.assistant_subtask.id,
                 content=(
@@ -3012,10 +3013,7 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
                     "状态: 正在执行\n\n"
                     "任务完成后将自动发送结果。"
                 ),
-                offset=0,
             )
-            # Enable Redis-backed content sharing for multi-pod consistency
-            self._prepare_streaming_emitter(result.task.id, streaming_emitter)
 
         # Build message for device: vision content if images present
         if message_context.images:
@@ -3153,12 +3151,14 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         # open so that streaming events from the executor can update it.
         streaming_emitter = await self.create_streaming_emitter(message_context)
         if streaming_emitter:
+            self._prepare_streaming_emitter(result.task.id, streaming_emitter)
             await streaming_emitter.emit_start(
                 task_id=result.task.id,
                 subtask_id=result.assistant_subtask.id,
                 shell_type="ClaudeCode",
             )
-            await streaming_emitter.emit_chunk(
+            await self._emit_initial_stream_content(
+                streaming_emitter,
                 task_id=result.task.id,
                 subtask_id=result.assistant_subtask.id,
                 content=(
@@ -3167,10 +3167,7 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
                     "状态: 等待执行\n\n"
                     "任务完成后将收到通知。"
                 ),
-                offset=0,
             )
-            # Enable Redis-backed content sharing for multi-pod consistency
-            self._prepare_streaming_emitter(result.task.id, streaming_emitter)
             # Register emitter so callback events reuse the same AI Card
             await self._register_streaming_emitter(
                 task_id=result.task.id,

--- a/backend/tests/api/ws/test_wework_runtime_namespace.py
+++ b/backend/tests/api/ws/test_wework_runtime_namespace.py
@@ -77,6 +77,62 @@ async def test_runtime_event_forwards_im_chunk_to_channel_callbacks(monkeypatch)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "event_data", "expected_type"),
+    [
+        (
+            "response.reasoning_summary_text.delta",
+            {"delta": "Inspecting the workspace"},
+            "thinking",
+        ),
+        (
+            "response.block.created",
+            {
+                "block": {
+                    "id": "tool-1",
+                    "type": "tool",
+                    "tool_name": "Read",
+                    "status": "pending",
+                }
+            },
+            "block_created",
+        ),
+    ],
+)
+async def test_runtime_event_forwards_im_progress_events_to_channel_callbacks(
+    monkeypatch,
+    event_type,
+    event_data,
+    expected_type,
+):
+    namespace = DeviceNamespace()
+    forward = AsyncMock()
+    monkeypatch.setattr(
+        local_task_responses, "forward_event_to_channel_callbacks", forward
+    )
+
+    result = await _relay_runtime_event(
+        namespace,
+        monkeypatch,
+        {
+            "event_type": event_type,
+            "taskId": "runtime-375023196",
+            "subtaskId": "runtime-375023196",
+            "data": event_data,
+            "source": _im_source(),
+        },
+    )
+
+    assert result == {"success": True}
+    event = forward.await_args.kwargs["event"]
+    assert event.type == expected_type
+    if expected_type == "thinking":
+        assert event.content == "Inspecting the workspace"
+    else:
+        assert event.data["block"]["tool_name"] == "Read"
+
+
+@pytest.mark.asyncio
 async def test_runtime_event_completes_im_channel_callback_on_terminal_event(
     monkeypatch,
 ):

--- a/backend/tests/services/channels/dingtalk/test_emitter.py
+++ b/backend/tests/services/channels/dingtalk/test_emitter.py
@@ -1,0 +1,447 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for compact DingTalk AI Card progress."""
+
+from unittest.mock import AsyncMock
+
+import dingtalk_stream
+import pytest
+
+from app.services.channels.dingtalk import emitter as emitter_module
+from app.services.channels.dingtalk.emitter import StreamingResponseEmitter
+from shared.models import EventType, ExecutionEvent
+
+
+class FakeCard:
+    def __init__(self, _client, _message):
+        self.card_instance_id = None
+        self.order = []
+        self.updates: list[str] = []
+        self.finished: list[str] = []
+        self.failed = False
+
+    def set_order(self, order):
+        self.order = order
+
+    def ai_start(self):
+        self.card_instance_id = "card-1"
+
+    def ai_streaming(self, content, append=False):
+        assert append is False
+        self.updates.append(content)
+
+    def ai_finish(self, content):
+        self.finished.append(content)
+
+    def ai_fail(self):
+        self.failed = True
+
+
+class FakeRedis:
+    def __init__(self, cache):
+        self.cache = cache
+
+    async def append(self, key, value):
+        self.cache.raw[key] = self.cache.raw.get(key, b"") + value
+
+    async def expire(self, _key, _ttl):
+        return True
+
+    async def get(self, key):
+        return self.cache.raw.get(key)
+
+    async def set(self, key, value, nx=False, px=None):
+        if nx and key in self.cache.raw:
+            return None
+        self.cache.raw[key] = value
+        return True
+
+    async def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            deleted += int(key in self.cache.raw or key in self.cache.structured)
+            self.cache.raw.pop(key, None)
+            self.cache.structured.pop(key, None)
+        return deleted
+
+    async def aclose(self):
+        return None
+
+
+class FakeCache:
+    def __init__(self):
+        self.raw: dict[str, bytes] = {}
+        self.structured: dict[str, object] = {}
+
+    async def _get_client(self):
+        return FakeRedis(self)
+
+    async def get(self, key):
+        return self.structured.get(key)
+
+    async def set(self, key, value, expire=None):
+        self.structured[key] = value
+        return True
+
+    async def delete(self, key):
+        self.raw.pop(key, None)
+        return self.structured.pop(key, None) is not None
+
+
+@pytest.fixture
+def card_factory(monkeypatch: pytest.MonkeyPatch):
+    cards: list[FakeCard] = []
+
+    def create_card(client, message):
+        card = FakeCard(client, message)
+        cards.append(card)
+        return card
+
+    monkeypatch.setattr(dingtalk_stream, "AIMarkdownCardInstance", create_card)
+    return cards
+
+
+@pytest.fixture
+def emitter(card_factory):
+    result = StreamingResponseEmitter(object(), object())
+    result.MIN_UPDATE_INTERVAL = 0
+    return result
+
+
+@pytest.mark.asyncio
+async def test_start_and_thinking_render_safe_compact_status(emitter, card_factory):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.THINKING,
+            task_id=1,
+            subtask_id=2,
+            content="private chain of thought that must not leave Wework",
+        )
+    )
+
+    card = card_factory[0]
+    assert "正在理解需求" in card.updates[0]
+    assert "正在分析" in card.updates[-1]
+    assert "private chain of thought" not in "".join(card.updates)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_status_stays_in_progress_mode(emitter, card_factory):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit_status_prefix(
+        task_id=1,
+        subtask_id=2,
+        content="任务已发送到设备 device-1\n\n状态: 正在执行",
+    )
+    await emitter.emit_thinking(task_id=1, subtask_id=2)
+
+    card = card_factory[0]
+    assert "任务已发送到设备 device-1 状态: 正在执行" in card.updates[-2]
+    assert "正在分析" in card.updates[-1]
+    assert emitter._progress.mode == "progress"
+
+
+@pytest.mark.asyncio
+async def test_progress_window_is_bounded_and_omits_tool_payloads(
+    emitter, card_factory
+):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.TOOL_START,
+            task_id=1,
+            subtask_id=2,
+            tool_name="Read",
+            tool_input={"path": "/secret/input"},
+        )
+    )
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.TOOL_RESULT,
+            task_id=1,
+            subtask_id=2,
+            tool_name="Read",
+            tool_output="secret tool output",
+            data={"status": "completed"},
+        )
+    )
+    for index in range(3):
+        await emitter.emit(
+            ExecutionEvent.create(
+                EventType.BLOCK_CREATED,
+                task_id=1,
+                subtask_id=2,
+                data={
+                    "block": {
+                        "id": f"commentary-{index}",
+                        "type": "text",
+                        "process_kind": "assistant_message",
+                        "content": f"已完成过程步骤 {index}",
+                        "status": "done",
+                    }
+                },
+            )
+        )
+
+    rendered = card_factory[0].updates[-1]
+    assert rendered.splitlines() == [
+        "**执行进度**",
+        "✅ 已完成过程步骤 1",
+        "✅ 已完成过程步骤 2",
+        "⏳ 继续处理…",
+    ]
+    assert len(rendered) <= 320
+    all_updates = "".join(card_factory[0].updates)
+    assert "/secret/input" not in all_updates
+    assert "secret tool output" not in all_updates
+
+
+@pytest.mark.asyncio
+async def test_reasoning_block_is_generic_and_process_text_masks_secrets(
+    emitter, card_factory
+):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.BLOCK_CREATED,
+            task_id=1,
+            subtask_id=2,
+            data={
+                "block": {
+                    "id": "reasoning-1",
+                    "type": "thinking",
+                    "content": "raw private reasoning",
+                    "status": "streaming",
+                }
+            },
+        )
+    )
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.BLOCK_CREATED,
+            task_id=1,
+            subtask_id=2,
+            data={
+                "block": {
+                    "id": "commentary-1",
+                    "type": "text",
+                    "content": "**检查配置**\n token=supersecretvalue",
+                    "status": "streaming",
+                }
+            },
+        )
+    )
+
+    all_updates = "".join(card_factory[0].updates)
+    assert "raw private reasoning" not in all_updates
+    assert "supersecretvalue" not in all_updates
+    assert "检查配置" in card_factory[0].updates[-1]
+    assert "raw private reasoning" not in str(emitter._progress.to_dict())
+
+
+@pytest.mark.asyncio
+async def test_block_update_reuses_tool_name_without_exposing_output(
+    emitter, card_factory
+):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.BLOCK_CREATED,
+            task_id=1,
+            subtask_id=2,
+            data={
+                "block": {
+                    "id": "tool-1",
+                    "type": "tool",
+                    "tool_name": "Bash",
+                    "status": "pending",
+                }
+            },
+        )
+    )
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.BLOCK_UPDATED,
+            task_id=1,
+            subtask_id=2,
+            data={
+                "block_id": "tool-1",
+                "updates": {
+                    "status": "done",
+                    "tool_output": "do not show this output",
+                },
+            },
+        )
+    )
+
+    rendered = card_factory[0].updates[-1]
+    assert "工具完成：Bash" in rendered
+    assert "do not show this output" not in "".join(card_factory[0].updates)
+
+
+@pytest.mark.asyncio
+async def test_interactive_block_points_user_back_to_wework(emitter, card_factory):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.BLOCK_CREATED,
+            task_id=1,
+            subtask_id=2,
+            data={
+                "block": {
+                    "id": "input-1",
+                    "type": "tool",
+                    "tool_name": "request_user_input",
+                    "tool_input": {"question": "secret question"},
+                    "status": "pending",
+                    "render_payload": {"kind": "request_user_input"},
+                }
+            },
+        )
+    )
+
+    rendered = card_factory[0].updates[-1]
+    assert "等待你在 Wework 中确认" in rendered
+    assert "secret question" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_answer_stream_and_terminal_result_replace_progress(
+    emitter, card_factory
+):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit_thinking(task_id=1, subtask_id=2)
+    await emitter.emit_chunk(task_id=1, subtask_id=2, content="部分回答", offset=4)
+
+    card = card_factory[0]
+    assert card.updates[-1] == "部分回答"
+    assert "执行进度" not in card.updates[-1]
+
+    await emitter.emit_done(
+        task_id=1,
+        subtask_id=2,
+        result={"value": "最终回答"},
+    )
+
+    assert card.finished == ["最终回答"]
+    assert card.updates[-1] == "最终回答"
+    assert "正在分析" not in card.finished[-1]
+
+
+@pytest.mark.asyncio
+async def test_terminal_result_uses_consistent_length_limit(emitter, card_factory):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit_done(
+        task_id=1,
+        subtask_id=2,
+        result={"value": "答" * 5000},
+    )
+
+    final = card_factory[0].finished[-1]
+    assert len(final) == emitter.MAX_FINAL_CONTENT_LENGTH
+    assert "内容已截断" in final
+
+
+@pytest.mark.asyncio
+async def test_structured_terminal_output_does_not_replace_streamed_answer(
+    emitter, card_factory
+):
+    await emitter.emit_start(task_id=1, subtask_id=2)
+    await emitter.emit_chunk(task_id=1, subtask_id=2, content="最终回答", offset=4)
+    await emitter.emit_done(
+        task_id=1,
+        subtask_id=2,
+        result={"output": [{"type": "internal", "content": "do not render"}]},
+    )
+
+    final = card_factory[0].finished[-1]
+    assert final == "最终回答"
+    assert "do not render" not in final
+
+
+@pytest.mark.asyncio
+async def test_shared_progress_survives_worker_reconstruction_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+
+    first = StreamingResponseEmitter(object(), object())
+    first.set_shared_content_key("channel:streaming_content:task-1")
+    first._may_update_display = AsyncMock(return_value=True)
+    await first.emit_start(task_id="task-1", subtask_id=2)
+    await first.emit(
+        ExecutionEvent.create(
+            EventType.TOOL_RESULT,
+            task_id=1,
+            subtask_id=2,
+            tool_name="Read",
+            data={"status": "completed"},
+        )
+    )
+
+    second = StreamingResponseEmitter(
+        object(),
+        object(),
+        existing_card_instance_id="card-1",
+    )
+    second.set_shared_content_key("channel:streaming_content:task-1")
+    second._may_update_display = AsyncMock(return_value=True)
+    await second.emit_start(task_id="task-1", subtask_id=2)
+    await second.emit(
+        ExecutionEvent.create(
+            EventType.BLOCK_CREATED,
+            task_id=1,
+            subtask_id=2,
+            data={
+                "block": {
+                    "id": "commentary-1",
+                    "type": "text",
+                    "content": "检查完成",
+                    "status": "done",
+                }
+            },
+        )
+    )
+
+    state_key = "channel:streaming_content:task-1:progress"
+    assert cache.structured[state_key]["recent"] == [
+        "工具完成：Read",
+        "检查完成",
+    ]
+
+    await second.emit_done(
+        task_id="task-1",
+        subtask_id=2,
+        result={"value": "完成"},
+    )
+    assert state_key not in cache.structured
+    assert "channel:streaming_content:task-1" not in cache.raw
+
+
+@pytest.mark.asyncio
+async def test_display_throttle_does_not_drop_shared_progress(
+    monkeypatch: pytest.MonkeyPatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object())
+    emitter.set_shared_content_key("channel:streaming_content:task-2")
+    await emitter.emit_start(task_id="task-2", subtask_id=2)
+    emitter._may_update_display = AsyncMock(return_value=False)
+
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.TOOL_RESULT,
+            task_id=1,
+            subtask_id=2,
+            tool_name="Read",
+            data={"status": "completed"},
+        )
+    )
+
+    state = cache.structured["channel:streaming_content:task-2:progress"]
+    assert state["recent"] == ["工具完成：Read"]

--- a/docs/en/architecture/README.md
+++ b/docs/en/architecture/README.md
@@ -21,7 +21,7 @@ Before changing a flow below, update its connection graph, sequence diagram, cod
 | Text-model vision delegation                       | [model-vision-delegation.md](model-vision-delegation.md)                     | Explicit model reference, catalog capability, sidecar configuration, image replacement, failure isolation     |
 | Wework host plugin runtime                         | [workbench-plugin-runtime.md](workbench-plugin-runtime.md)                   | Profile composition, services and UI slots, dynamic modules, sidecars, teardown, and recovery                 |
 | Smart apps (DeepSeek Harness runtime)              | [deepseek-harness-apps.md](deepseek-harness-apps.md)                         | Application-type navigation, package validation, version binding, model proxying, instances, tabs, and cleanup |
-| IM private-chat runtime streaming                  | [im-runtime-streaming.md](im-runtime-streaming.md)                           | Callback key, `runtime:event` envelope, relay and IM forwarding, terminal event, failure isolation            |
+| IM private-chat runtime streaming                  | [im-runtime-streaming.md](im-runtime-streaming.md)                           | Callback key, `runtime:event` envelope, compact progress projection, terminal event, failure isolation         |
 | Codex notification isolation                       | [codex-notification-routing.md](codex-notification-routing.md)               | Shared app-server, thread routing, burst isolation, process exit, terminal projection                         |
 
 Detailed product prose remains in the existing developer guides. This directory contains only reviewable architecture truth.

--- a/docs/en/architecture/im-runtime-streaming.md
+++ b/docs/en/architecture/im-runtime-streaming.md
@@ -4,7 +4,7 @@ sidebar_position: 50
 
 # IM private-chat continuation streaming from the native runtime
 
-Scope: how model output returns to the IM card after an IM private-chat message continues a native runtime task. It excludes IM binding, `/switch` task selection, and cloud Shell execution.
+Scope: how model output and compact execution progress return to the same IM card after an IM private-chat message continues a native runtime task. It excludes IM binding, `/switch` task selection, and cloud Shell execution.
 
 ```mermaid
 flowchart LR
@@ -18,7 +18,8 @@ flowchart LR
     DEV --> WEWORK[Wework runtime namespace]
     DEV --> BRIDGE[LocalTaskResponsesHandler bridge]
     BRIDGE --> REG
-    REG --> CARD[IM card streaming and terminal update]
+    REG --> PROJECT[Channel progress projection]
+    PROJECT --> CARD[Same-card redraw and terminal update]
 ```
 
 ```mermaid
@@ -36,19 +37,21 @@ sequenceDiagram
     E-->>D: runtime:event(event_type, taskId, data, source)
     D->>W: Relay runtime:event
     D->>C: Forward parsed event when source.source == im
-    C-->>U: Stream deltas into the IM card
+    C-->>U: Project reasoning, tools, and process blocks into bounded progress
+    C-->>U: Replace progress when answer streaming begins
     E-->>D: runtime:event(response.completed, source)
     D->>W: Relay terminal event
     D->>C: handle_task_completed(COMPLETED)
-    C-->>U: Write final answer and release the emitter
+    C-->>U: Keep only the final answer and release the emitter
 ```
 
 | Boundary                         | Code ownership                                                        |
 | -------------------------------- | --------------------------------------------------------------------- |
 | IM continuation and registration | `backend/app/services/channels/handler.py`                            |
 | Callback key and forwarding      | `backend/app/services/channels/callback.py`                           |
+| DingTalk progress projection and card redraw | `backend/app/services/channels/dingtalk/emitter.py`       |
 | `runtime:event` envelope         | `executor/src/runtime_work/events.rs`, `executor/src/local/backend.rs` |
 | Relay and IM bridge              | `backend/app/api/ws/device_namespace.py`                              |
 | Envelope normalization, terminal dialect | `backend/app/api/ws/local_task_responses.py`      |
 
-Invariants: the native runtime returns streaming output only through `runtime:event` envelopes, so the flat `response.*` device events do not cover this flow and the relay path must forward IM callbacks itself; the callback key is always `runtime:<device_id>:<local_task_id>`, where `device_id` comes from the device session identity and must equal the `address.device_id` used at IM registration; envelopes use camelCase (`taskId`, `subtaskId`) and must be normalized before the event parser; the native terminal dialect differs from the Responses API — the final answer lives in `data.value` and failures in `data.error.message`, while the shared parser reads `data.response.output[].content[].text` and does not recognize `response.failed`, so terminal events must be translated into an `ExecutionEvent` in the bridge or the card finishes empty or hangs forever; envelopes without `source` or with `source.source != "im"` must not enter IM forwarding; the Wework relay runs before IM forwarding, and IM channel failures stay isolated per channel and must never block the relay or persistence; terminal events must go through `handle_task_completed` so the final content is written and the emitter is released, never deltas alone.
+Invariants: the native runtime returns streaming output only through `runtime:event` envelopes, so the flat `response.*` device events do not cover this flow and the relay path must forward IM callbacks itself; the callback key is always `runtime:<device_id>:<local_task_id>`, where `device_id` comes from the device session identity and must equal the `address.device_id` used at IM registration; envelopes use camelCase (`taskId`, `subtaskId`) and must be normalized before the event parser; the native terminal dialect differs from the Responses API — the final answer lives in `data.value` and failures in `data.error.message`, while the shared parser reads `data.response.output[].content[].text` and does not recognize `response.failed`, so terminal events must be translated into an `ExecutionEvent` in the bridge or the card finishes empty or hangs forever; envelopes without `source` or with `source.source != "im"` must not enter IM forwarding; the Wework relay runs before IM forwarding, and IM channel failures stay isolated per channel and must never block the relay or persistence; DingTalk projects only user-readable process text, tool names, and statuses, never raw private reasoning, tool arguments, or tool output; progress uses a fixed-size window persisted across workers, and display throttling must not lose state; answer streaming switches the card from progress mode to answer mode, and the terminal card keeps only the final answer; terminal events must go through `handle_task_completed` so the final content is written, progress state is cleaned up, and the emitter is released, never deltas alone.

--- a/docs/zh/architecture/README.md
+++ b/docs/zh/architecture/README.md
@@ -21,7 +21,7 @@ sidebar_position: 1
 | 文本模型视觉委托                     | [model-vision-delegation.md](model-vision-delegation.md)                     | 显式模型引用、catalog 能力、sidecar 配置、图片替换、失败隔离          |
 | Wework 宿主插件运行时                | [workbench-plugin-runtime.md](workbench-plugin-runtime.md)                   | profile 装配、服务与 UI slot、动态模块、sidecar、卸载与恢复           |
 | 智能应用（DeepSeek Harness Runtime） | [deepseek-harness-apps.md](deepseek-harness-apps.md)                         | 应用类型导航、安装包校验、版本绑定、模型代理、独立实例、标签页与回收  |
-| IM 私聊续聊本地 Runtime              | [im-runtime-streaming.md](im-runtime-streaming.md)                           | callback key、`runtime:event` 信封、中继与 IM 转发、终态、失败隔离    |
+| IM 私聊续聊本地 Runtime              | [im-runtime-streaming.md](im-runtime-streaming.md)                           | callback key、`runtime:event` 信封、紧凑进度投影、终态、失败隔离      |
 | Codex 通知流隔离                     | [codex-notification-routing.md](codex-notification-routing.md)               | 共享 app-server、线程路由、突发隔离、进程退出、终态投影               |
 
 详细产品说明继续放在原开发指南；本目录只保存可评审的架构真值。

--- a/docs/zh/architecture/im-runtime-streaming.md
+++ b/docs/zh/architecture/im-runtime-streaming.md
@@ -4,7 +4,7 @@ sidebar_position: 50
 
 # IM 私聊续聊本地 Runtime 的流式回传
 
-范围：IM 私聊消息进入本地 Runtime 任务后，模型输出如何回到 IM 卡片。不含 IM 绑定、`/switch` 选任务和云端 Shell 执行链路。
+范围：IM 私聊消息进入本地 Runtime 任务后，模型输出和紧凑执行进度如何回到同一张 IM 卡片。不含 IM 绑定、`/switch` 选任务和云端 Shell 执行链路。
 
 ```mermaid
 flowchart LR
@@ -18,7 +18,8 @@ flowchart LR
     DEV --> WEWORK[Wework Runtime 命名空间]
     DEV --> BRIDGE[LocalTaskResponsesHandler 桥接]
     BRIDGE --> REG
-    REG --> CARD[IM 卡片流式更新与终态]
+    REG --> PROJECT[通道进度投影]
+    PROJECT --> CARD[同一张 IM 卡片重绘与终态]
 ```
 
 ```mermaid
@@ -36,19 +37,21 @@ sequenceDiagram
     E-->>D: runtime:event(event_type, taskId, data, source)
     D->>W: 中继 runtime:event
     D->>C: source.source == im 时转发已解析事件
-    C-->>U: 流式增量写入 IM 卡片
+    C-->>U: 将思考、工具、过程块投影为有界进度
+    C-->>U: 回答开始后用回答替换进度
     E-->>D: runtime:event(response.completed, source)
     D->>W: 中继终态
     D->>C: handle_task_completed(COMPLETED)
-    C-->>U: 写入最终回答并释放 emitter
+    C-->>U: 只保留最终回答并释放 emitter
 ```
 
 | 边界                    | 代码归属                                                                     |
 | ----------------------- | ---------------------------------------------------------------------------- |
 | IM 续聊与 emitter 注册  | `backend/app/services/channels/handler.py`                                   |
 | callback key 与转发     | `backend/app/services/channels/callback.py`                                  |
+| 钉钉进度投影与卡片重绘   | `backend/app/services/channels/dingtalk/emitter.py`                          |
 | `runtime:event` 信封    | `executor/src/runtime_work/events.rs`、`executor/src/local/backend.rs`        |
 | 中继与 IM 桥接          | `backend/app/api/ws/device_namespace.py`                                     |
 | 信封归一化与终态方言翻译 | `backend/app/api/ws/local_task_responses.py`                                 |
 
-不变量：本地 Runtime 只通过 `runtime:event` 信封回传流式输出，扁平 `response.*` 设备事件不覆盖该场景，因此中继路径必须自行转发 IM callback；callback key 恒为 `runtime:<device_id>:<local_task_id>`，`device_id` 取设备会话身份，必须与 IM 侧注册时使用的 `address.device_id` 相同；信封使用 camelCase（`taskId`、`subtaskId`），桥接前必须归一化再交给事件解析器；本地 Runtime 的终态方言与 Responses API 不同——最终答案在 `data.value`，失败原因在 `data.error.message`，共享解析器读的是 `data.response.output[].content[].text` 且不识别 `response.failed`，因此终态必须先在桥接层翻译成 `ExecutionEvent`，否则卡片只会拿到空内容或永远停在处理中；缺少 `source` 或 `source.source != "im"` 的信封不得进入 IM 转发；Wework 中继先于 IM 转发执行，IM 通道失败只能按通道隔离，不得阻断中继或持久化；终态事件必须走 `handle_task_completed` 以写入最终内容并释放 emitter，不得只发增量。
+不变量：本地 Runtime 只通过 `runtime:event` 信封回传流式输出，扁平 `response.*` 设备事件不覆盖该场景，因此中继路径必须自行转发 IM callback；callback key 恒为 `runtime:<device_id>:<local_task_id>`，`device_id` 取设备会话身份，必须与 IM 侧注册时使用的 `address.device_id` 相同；信封使用 camelCase（`taskId`、`subtaskId`），桥接前必须归一化再交给事件解析器；本地 Runtime 的终态方言与 Responses API 不同——最终答案在 `data.value`，失败原因在 `data.error.message`，共享解析器读的是 `data.response.output[].content[].text` 且不识别 `response.failed`，因此终态必须先在桥接层翻译成 `ExecutionEvent`，否则卡片只会拿到空内容或永远停在处理中；缺少 `source` 或 `source.source != "im"` 的信封不得进入 IM 转发；Wework 中继先于 IM 转发执行，IM 通道失败只能按通道隔离，不得阻断中继或持久化；钉钉只投影用户可读过程文本、工具名称和状态，不得展示模型内部推理原文、工具参数或工具输出；进度使用固定大小窗口并跨 Worker 持久化，卡片更新限流不得丢失状态；回答开始后必须从进度模式切换到回答模式，终态只保留最终回答；终态事件必须走 `handle_task_completed` 以写入最终内容、清理进度状态并释放 emitter，不得只发增量。


### PR DESCRIPTION
## Summary

- render bounded, user-readable reasoning, tool, and process progress in the existing DingTalk AI Card without exposing private reasoning, tool arguments, or tool output
- persist the latest two completed steps plus the current step across workers, while throttling card redraws without dropping progress state
- keep dispatch acknowledgements in progress mode, replace progress when answer streaming starts, and finish with only the bounded final answer
- document the compact IM projection in the synchronized Chinese and English architecture flow

## Verification

- `cd backend && PYTHONWARNINGS=ignore uv run pytest tests/services/channels tests/api/ws/test_wework_runtime_namespace.py -q --disable-warnings` — 237 passed
- Black check passed for changed Python files
- isort check passed for changed Python files
- focused Flake8 check passed with the repository's Black-compatible ignores

## Validation note

- Live DingTalk AI Card validation remains for a configured deployment environment; this PR is intentionally opened as Draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact, real-time progress updates for DingTalk cards, including thinking, tool, status, and interactive confirmation states.
  * Progress updates now persist across workers and transition smoothly into streamed and final answers.
  * Sensitive reasoning, tool details, and secrets are masked or excluded from displayed content.
  * Final responses are safely length-limited and displayed without stale progress information.

* **Bug Fixes**
  * Improved event forwarding and consistent initial content handling across messaging channels.

* **Documentation**
  * Updated runtime streaming architecture documentation to describe compact progress projections and card transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->