### PR TITLE
fix(wework): stabilize long code block rendering

### DIFF
--- a/executor/src/runtime_work/handler/sidebar.rs
+++ b/executor/src/runtime_work/handler/sidebar.rs
@@ -115,11 +115,14 @@ impl RuntimeWorkRpcHandler {
         let project_key = string_field(&payload, "projectKey")
             .or_else(|| string_field(&payload, "project_key"))
             .ok_or_else(|| AppIpcError::new("bad_request", "projectKey is required"))?;
-        let thread_id = string_field(&payload, "threadId")
-            .or_else(|| string_field(&payload, "thread_id"))
-            .ok_or_else(|| AppIpcError::new("bad_request", "threadId is required"))?;
+        let thread_id = self.resolve_sidebar_thread_id(
+            string_field(&payload, "threadId")
+                .or_else(|| string_field(&payload, "thread_id"))
+                .ok_or_else(|| AppIpcError::new("bad_request", "threadId is required"))?,
+        );
         let before_thread_id = string_field(&payload, "beforeThreadId")
-            .or_else(|| string_field(&payload, "before_thread_id"));
+            .or_else(|| string_field(&payload, "before_thread_id"))
+            .map(|thread_id| self.resolve_sidebar_thread_id(thread_id));
         let insert_at_end = bool_field(&payload, "insertAtEnd")
             .or_else(|| bool_field(&payload, "insert_at_end"))
             .unwrap_or(false);
@@ -134,15 +137,26 @@ impl RuntimeWorkRpcHandler {
     }
 
     pub(super) async fn pin_sidebar_task(&self, payload: Value) -> Result<Value, AppIpcError> {
-        let thread_id = string_field(&payload, "threadId")
-            .or_else(|| string_field(&payload, "thread_id"))
-            .ok_or_else(|| AppIpcError::new("bad_request", "threadId is required"))?;
+        let thread_id = self.resolve_sidebar_thread_id(
+            string_field(&payload, "threadId")
+                .or_else(|| string_field(&payload, "thread_id"))
+                .ok_or_else(|| AppIpcError::new("bad_request", "threadId is required"))?,
+        );
         let pinned = bool_field(&payload, "pinned")
             .ok_or_else(|| AppIpcError::new("bad_request", "pinned is required"))?;
         let before_thread_id = string_field(&payload, "beforeThreadId")
-            .or_else(|| string_field(&payload, "before_thread_id"));
+            .or_else(|| string_field(&payload, "before_thread_id"))
+            .map(|thread_id| self.resolve_sidebar_thread_id(thread_id));
         set_codex_global_thread_pinned(&thread_id, pinned, before_thread_id.as_deref())
             .map_err(|error| AppIpcError::new("codex_global_state_error", error))?;
         Ok(sidebar_mutation_response(&self.device_id))
+    }
+
+    pub(super) fn resolve_sidebar_thread_id(&self, thread_id: String) -> String {
+        self.store
+            .get_task(&thread_id)
+            .and_then(|task| task.thread_id)
+            .filter(|provider_thread_id| !provider_thread_id.trim().is_empty())
+            .unwrap_or(thread_id)
     }
 }

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -1578,6 +1578,31 @@ fn recording_provider_thread_removes_cached_messages_but_keeps_presentations() {
 }
 
 #[test]
+fn sidebar_thread_id_resolves_local_task_alias() {
+    let index_path = temp_runtime_work_index_path("sidebar-thread-alias");
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(index_path.clone());
+    let mut link = RuntimeTaskLink::new_pending(
+        "task-1".to_owned(),
+        "/tmp/project".to_owned(),
+        "Task".to_owned(),
+    );
+    link.thread_id = Some("thread-1".to_owned());
+    handler.upsert_local_task(link);
+
+    assert_eq!(
+        handler.resolve_sidebar_thread_id("task-1".to_owned()),
+        "thread-1"
+    );
+    assert_eq!(
+        handler.resolve_sidebar_thread_id("thread-1".to_owned()),
+        "thread-1"
+    );
+
+    let _ = fs::remove_file(index_path);
+}
+
+#[test]
 fn linked_failed_codex_turn_does_not_create_cached_transcript() {
     let index_path = temp_runtime_work_index_path("linked-failure-provider-source");
     let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -11,6 +11,23 @@ const TOOL_COMPLETION = '本地分支落后于 main，CI 跑的提交是 719f996
 const LEGACY_CONVERSATION_PROMPT = 'WEWORK_DESKTOP_E2E_LEGACY_CONVERSATION_INITIAL'
 const LEGACY_CONVERSATION_COMPLETION = 'WEWORK_DESKTOP_E2E_LEGACY_CONVERSATION_COMPLETE'
 const LEGACY_TRANSCRIPT_ITEM_ID = 'wework-desktop-e2e-legacy-assistant-text'
+const LONG_CODE_PROMPT = 'WEWORK_DESKTOP_E2E_LONG_CODE_TERMINAL_BURST'
+const LONG_CODE_MARKER = 'WEWORK_DESKTOP_E2E_LONG_CODE_LINE_110'
+const LONG_CODE_COMPLETION = [
+  'The completed response contains one long SQL block.',
+  '',
+  '```sql',
+  ...Array.from(
+    { length: 110 },
+    (_, index) =>
+      `SELECT ${index + 1} AS value_${index + 1}${index === 109 ? `, '${LONG_CODE_MARKER}' AS marker` : ''};`
+  ),
+  '```',
+].join('\n')
+const LONG_CODE_REASONING = Array.from(
+  { length: 180 },
+  (_, index) => `Completed reasoning line ${index + 1} for the terminal rendering burst.`
+).join('\n')
 const VISUALIZATION_PROMPT = 'WEWORK_DESKTOP_E2E_ABSOLUTE_VISUALIZATION'
 const VISUALIZATION_TITLE = 'Absolute visualization E2E'
 const VISUALIZATION_MARKER = 'WEWORK_DESKTOP_E2E_VISUALIZATION_VISIBLE'
@@ -46,6 +63,7 @@ const USER_MESSAGE_E2E_ID = 'streaming-text-latest-user-message'
 const USER_MESSAGE_SELECTOR_MARKED = `${ACTIVE_WORKBENCH_SELECTOR} [data-e2e-anchor-id="${USER_MESSAGE_E2E_ID}"]`
 const PROCESSING_SUMMARY_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="processing-summary-header"]`
 const PROCESS_TEXT_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="process-text-block"]`
+const LONG_CODE_SCROLL_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="markdown-code-scroll-container"]`
 const VIEWPORT_ANCHOR_TEXT = `${VIEWPORT_MARKER}: this paragraph must remain fixed after the user scrolls upward.`
 const VIEWPORT_ANCHOR_E2E_ID = 'streaming-text-viewport-anchor'
 const VIEWPORT_ANCHOR_SCOPE_SELECTOR = `${PROCESS_TEXT_SELECTOR} [data-scroll-anchor]`
@@ -656,6 +674,32 @@ export function createDesktopScenario({
     releaseToolFinalCompletion = resolve
   })
 
+  const verifyLongCodeTerminalBurst = async control => {
+    await control.command('click', '[data-testid="new-chat-button"]')
+    await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+    await control.command('fill', COMPOSER_SELECTOR, { value: LONG_CODE_PROMPT })
+    await control.command('press', COMPOSER_SELECTOR, { key: 'Enter' })
+    await control.command('waitFor', ASSISTANT_CONTENT_SELECTOR, {
+      text: LONG_CODE_MARKER,
+      stableMs: 750,
+      timeoutMs: uiTimeoutMs,
+    })
+    assert.equal(
+      await control.command('getAttribute', LONG_CODE_SCROLL_SELECTOR, {
+        value: 'data-syntax-highlighted',
+      }),
+      'false',
+      'The long completed code block enabled expensive syntax highlighting'
+    )
+    assert.equal(
+      Number(await control.command('getElementCount', `${LONG_CODE_SCROLL_SELECTOR} .token`)),
+      0,
+      'The long completed code block rendered syntax token nodes'
+    )
+    await waitForBottom(control, 'The terminal-burst long-code conversation', uiTimeoutMs)
+    await capture(control, 'streaming-text-00-long-code-terminal-burst.png')
+  }
+
   const verifyStoppedTurnOrder = async control => {
     await control.command('click', '[data-testid="new-chat-button"]')
     await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
@@ -729,6 +773,18 @@ export function createDesktopScenario({
       const responseId = `wework-streaming-text-${Date.now()}`
       const latestInput = latestModelInputText(body)
       const followUpNumber = orderFollowUpNumber(body)
+      if (latestInput.includes(LONG_CODE_PROMPT)) {
+        response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
+        response.end(
+          sse([
+            responseCreated(responseId),
+            ...reasoningEvents('wework-long-code-reasoning', LONG_CODE_REASONING),
+            assistantMessage(LONG_CODE_COMPLETION),
+            responseCompleted(responseId),
+          ])
+        )
+        return true
+      }
       if (followUpNumber !== null) {
         response.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' })
         response.end(
@@ -929,6 +985,11 @@ export function createDesktopScenario({
         active = false
         return
       }
+      if (process.env.WEWORK_E2E_LONG_CODE_ONLY === 'true') {
+        await verifyLongCodeTerminalBurst(control)
+        active = false
+        return
+      }
       const visualizationDirectory = join(workspacePath, 'visualizations')
       const visualizationPath = join(visualizationDirectory, 'absolute-reference.html')
       await mkdir(visualizationDirectory, { recursive: true })
@@ -972,6 +1033,8 @@ export function createDesktopScenario({
         active = false
         return
       }
+
+      await verifyLongCodeTerminalBurst(control)
 
       await control.command('click', '[data-testid="new-chat-button"]')
       await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })

--- a/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/streaming-text.scenario.mjs
@@ -675,6 +675,7 @@ export function createDesktopScenario({
   })
 
   const verifyLongCodeTerminalBurst = async control => {
+    await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR)
     await control.command('click', '[data-testid="new-chat-button"]')
     await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
     await control.command('fill', COMPOSER_SELECTOR, { value: LONG_CODE_PROMPT })

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -180,7 +180,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <strong className="font-semibold">{children}</strong>
       ),
       code: (props: MarkdownCodeProps) => (
-        <MarkdownCode {...props} compact={variant === 'process'} />
+        <MarkdownCode {...props} compact={variant === 'process'} isStreaming={isStreaming} />
       ),
       inlineCode: ({ children }: { children?: ReactNode }) => (
         <MarkdownInlineCode compact={variant === 'process'}>{children}</MarkdownInlineCode>
@@ -225,7 +225,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <AssistantMarkdownImage src={src} alt={alt} />
       ),
     }),
-    [headingClasses, openFile, variant]
+    [headingClasses, isStreaming, openFile, variant]
   )
 
   return (
@@ -337,9 +337,17 @@ function estimateMarkdownChunkHeight(content: string): number {
 type MarkdownCodeProps = {
   node?: HastElement
   compact?: boolean
+  isStreaming?: boolean
 } & HTMLAttributes<HTMLElement>
 
-function MarkdownCode({ className, children, node, compact = false, ...props }: MarkdownCodeProps) {
+function MarkdownCode({
+  className,
+  children,
+  node,
+  compact = false,
+  isStreaming = false,
+  ...props
+}: MarkdownCodeProps) {
   const match = /language-(\w*)/.exec(className || '')
   const text = reactNodeToText(children)
   const isBlock =
@@ -353,7 +361,7 @@ function MarkdownCode({ className, children, node, compact = false, ...props }: 
       return <MarkdownDiagramPreview code={text.trimEnd()} language={lang} />
     }
     return (
-      <MarkdownCodeBlock lang={lang} compact={compact}>
+      <MarkdownCodeBlock lang={lang} compact={compact} isStreaming={isStreaming}>
         {text || children}
       </MarkdownCodeBlock>
     )

--- a/wework/src/components/chat/MarkdownCodeBlock.test.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.test.tsx
@@ -63,11 +63,8 @@ describe('MarkdownCodeBlock', () => {
     expect(scrollContainer.querySelector('.token')).toBeInTheDocument()
   })
 
-  test('keeps long completed code as stable plain text', () => {
-    const code = Array.from(
-      { length: 110 },
-      (_, index) => `SELECT ${index + 1} AS value_${index + 1};`
-    ).join('\n')
+  test('keeps completed code over the line limit as stable plain text', () => {
+    const code = Array.from({ length: 81 }, (_, index) => `-- ${index + 1}`).join('\n')
 
     render(<MarkdownCodeBlock lang="sql">{code}</MarkdownCodeBlock>)
 
@@ -75,7 +72,20 @@ describe('MarkdownCodeBlock', () => {
     expect(scrollContainer).toHaveAttribute('data-syntax-highlighted', 'false')
     expect(scrollContainer.querySelector('.token')).not.toBeInTheDocument()
     const plainCode = scrollContainer.querySelector('code')
-    expect(plainCode).toHaveTextContent('SELECT 110 AS value_110;')
+    expect(plainCode).toHaveTextContent('-- 81')
+    expect(plainCode?.parentElement).toHaveStyle({ color: '#abb2bf' })
+  })
+
+  test('keeps completed code over the character limit as stable plain text', () => {
+    const code = `-- ${'x'.repeat(2_000)}`
+
+    render(<MarkdownCodeBlock lang="sql">{code}</MarkdownCodeBlock>)
+
+    const scrollContainer = screen.getByTestId('markdown-code-scroll-container')
+    expect(scrollContainer).toHaveAttribute('data-syntax-highlighted', 'false')
+    expect(scrollContainer.querySelector('.token')).not.toBeInTheDocument()
+    const plainCode = scrollContainer.querySelector('code')
+    expect(plainCode).toHaveTextContent(code)
     expect(plainCode?.parentElement).toHaveStyle({ color: '#abb2bf' })
   })
 })

--- a/wework/src/components/chat/MarkdownCodeBlock.test.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.test.tsx
@@ -45,4 +45,37 @@ describe('MarkdownCodeBlock', () => {
       expect(token).toHaveStyle({ display: 'inline' })
     })
   })
+
+  test('renders streaming code without syntax highlighting', () => {
+    const { rerender } = render(
+      <MarkdownCodeBlock lang="sql" isStreaming>
+        SELECT 1
+      </MarkdownCodeBlock>
+    )
+
+    const scrollContainer = screen.getByTestId('markdown-code-scroll-container')
+    expect(scrollContainer).toHaveAttribute('data-syntax-highlighted', 'false')
+    expect(scrollContainer.querySelector('.token')).not.toBeInTheDocument()
+
+    rerender(<MarkdownCodeBlock lang="sql">SELECT 1</MarkdownCodeBlock>)
+
+    expect(scrollContainer).toHaveAttribute('data-syntax-highlighted', 'true')
+    expect(scrollContainer.querySelector('.token')).toBeInTheDocument()
+  })
+
+  test('keeps long completed code as stable plain text', () => {
+    const code = Array.from(
+      { length: 110 },
+      (_, index) => `SELECT ${index + 1} AS value_${index + 1};`
+    ).join('\n')
+
+    render(<MarkdownCodeBlock lang="sql">{code}</MarkdownCodeBlock>)
+
+    const scrollContainer = screen.getByTestId('markdown-code-scroll-container')
+    expect(scrollContainer).toHaveAttribute('data-syntax-highlighted', 'false')
+    expect(scrollContainer.querySelector('.token')).not.toBeInTheDocument()
+    const plainCode = scrollContainer.querySelector('code')
+    expect(plainCode).toHaveTextContent('SELECT 110 AS value_110;')
+    expect(plainCode?.parentElement).toHaveStyle({ color: '#abb2bf' })
+  })
 })

--- a/wework/src/components/chat/MarkdownCodeBlock.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.tsx
@@ -69,11 +69,14 @@ const CODE_ACTION_BUTTON_CLASS =
 
 const CODE_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+const MAX_HIGHLIGHTED_CODE_CHARS = 2_000
+const MAX_HIGHLIGHTED_CODE_LINES = 80
 
 const codeCustomStyle: CSSProperties = {
   margin: 0,
   padding: '0.75rem 1rem',
   background: 'transparent',
+  color: '#abb2bf',
   fontSize: 'var(--text-code)',
   lineHeight: '1.8',
 }
@@ -84,12 +87,14 @@ interface MarkdownCodeBlockProps {
   lang?: string
   children: ReactNode
   compact?: boolean
+  isStreaming?: boolean
 }
 
 export function MarkdownCodeBlock({
   lang = '',
   children,
   compact = false,
+  isStreaming = false,
 }: MarkdownCodeBlockProps) {
   const [copied, setCopied] = useState(false)
   const text = String(children).replace(/\n$/, '')
@@ -108,6 +113,7 @@ export function MarkdownCodeBlock({
   const codeStyle = getCodeCustomStyle(effectiveWrapLines)
   const codeProps = getCodeTagProps(effectiveWrapLines)
   const lineProps = getLineProps(effectiveWrapLines)
+  const shouldHighlight = shouldHighlightCode(text, isStreaming)
 
   const handleCopy = async () => {
     await copyCodeText(text)
@@ -179,28 +185,40 @@ export function MarkdownCodeBlock({
       <div
         data-testid="markdown-code-scroll-container"
         data-wrap={effectiveWrapLines ? 'true' : 'false'}
+        data-syntax-highlighted={shouldHighlight ? 'true' : 'false'}
         className={
           effectiveWrapLines
             ? 'max-w-full select-none overflow-x-hidden'
             : 'max-w-full select-none overflow-x-auto'
         }
       >
-        <SyntaxHighlighter
-          language={language || 'text'}
-          style={oneDark}
-          customStyle={codeStyle}
-          codeTagProps={codeProps}
-          lineProps={lineProps}
-          PreTag="div"
-          showLineNumbers={false}
-          wrapLines={effectiveWrapLines}
-          wrapLongLines={effectiveWrapLines}
-        >
-          {text}
-        </SyntaxHighlighter>
+        {shouldHighlight ? (
+          <SyntaxHighlighter
+            language={language || 'text'}
+            style={oneDark}
+            customStyle={codeStyle}
+            codeTagProps={codeProps}
+            lineProps={lineProps}
+            PreTag="div"
+            showLineNumbers={false}
+            wrapLines={effectiveWrapLines}
+            wrapLongLines={effectiveWrapLines}
+          >
+            {text}
+          </SyntaxHighlighter>
+        ) : (
+          <pre style={codeStyle}>
+            <code {...codeProps}>{text}</code>
+          </pre>
+        )}
       </div>
     </div>
   )
+}
+
+function shouldHighlightCode(text: string, isStreaming: boolean): boolean {
+  if (isStreaming || text.length > MAX_HIGHLIGHTED_CODE_CHARS) return false
+  return text.split('\n', MAX_HIGHLIGHTED_CODE_LINES + 1).length <= MAX_HIGHLIGHTED_CODE_LINES
 }
 
 function normalizeLanguage(lang: string): string {

--- a/wework/src/features/workbench/workbenchReducer.test.ts
+++ b/wework/src/features/workbench/workbenchReducer.test.ts
@@ -1676,6 +1676,86 @@ describe('workbenchReducer', () => {
     ])
   })
 
+  test('refreshes sidebar metadata without replacing a newer lifecycle projection', () => {
+    const state = workbenchReducer(initialWorkbenchState, {
+      type: 'runtime_work_refreshed',
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo',
+                available: true,
+                tasks: [
+                  {
+                    taskId: 'completed-task',
+                    workspacePath: '/workspace/repo',
+                    title: 'Completed task',
+                    runtime: 'codex',
+                    running: false,
+                    status: 'done',
+                    completedAt: 200,
+                    updatedAt: 200,
+                    pinned: false,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+    })
+
+    const refreshed = workbenchReducer(state, {
+      type: 'runtime_work_refreshed',
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo',
+                available: true,
+                tasks: [
+                  {
+                    taskId: 'completed-task',
+                    threadId: 'provider-thread',
+                    workspacePath: '/workspace/repo',
+                    title: 'Completed task',
+                    runtime: 'codex',
+                    running: false,
+                    status: 'active',
+                    updatedAt: 100,
+                    pinned: true,
+                    pinnedOrder: 0,
+                    sidebarOrder: 3,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+    })
+
+    expect(refreshed.runtimeWork?.projects[0].deviceWorkspaces[0].tasks[0]).toMatchObject({
+      taskId: 'completed-task',
+      threadId: 'provider-thread',
+      status: 'done',
+      completedAt: 200,
+      pinned: true,
+      pinnedOrder: 0,
+      sidebarOrder: 3,
+    })
+  })
+
   test('keeps chat and project workspace task ordering separate when paths overlap', () => {
     const state = workbenchReducer(initialWorkbenchState, {
       type: 'lists_refreshed',

--- a/wework/src/features/workbench/workbenchReducer.test.ts
+++ b/wework/src/features/workbench/workbenchReducer.test.ts
@@ -1756,6 +1756,120 @@ describe('workbenchReducer', () => {
     })
   })
 
+  test('keeps omitted sidebar metadata and applies explicit removals', () => {
+    const state = workbenchReducer(initialWorkbenchState, {
+      type: 'runtime_work_refreshed',
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo',
+                available: true,
+                tasks: [
+                  {
+                    taskId: 'completed-task',
+                    workspacePath: '/workspace/repo',
+                    title: 'Completed task',
+                    runtime: 'codex',
+                    running: false,
+                    status: 'done',
+                    completedAt: 200,
+                    updatedAt: 200,
+                    pinned: true,
+                    pinnedOrder: 0,
+                    sidebarOrder: 3,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+    })
+
+    const omitted = workbenchReducer(state, {
+      type: 'runtime_work_refreshed',
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo',
+                available: true,
+                tasks: [
+                  {
+                    taskId: 'completed-task',
+                    workspacePath: '/workspace/repo',
+                    title: 'Completed task',
+                    runtime: 'codex',
+                    running: false,
+                    status: 'active',
+                    updatedAt: 100,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+    })
+
+    expect(omitted.runtimeWork?.projects[0].deviceWorkspaces[0].tasks[0]).toMatchObject({
+      pinned: true,
+      pinnedOrder: 0,
+      sidebarOrder: 3,
+    })
+
+    const removed = workbenchReducer(omitted, {
+      type: 'runtime_work_refreshed',
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo',
+                available: true,
+                tasks: [
+                  {
+                    taskId: 'completed-task',
+                    workspacePath: '/workspace/repo',
+                    title: 'Completed task',
+                    runtime: 'codex',
+                    running: false,
+                    status: 'active',
+                    updatedAt: 100,
+                    pinned: false,
+                    pinnedOrder: null,
+                    sidebarOrder: null,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+    })
+
+    expect(removed.runtimeWork?.projects[0].deviceWorkspaces[0].tasks[0]).toMatchObject({
+      pinned: false,
+      pinnedOrder: null,
+      sidebarOrder: null,
+    })
+  })
+
   test('keeps chat and project workspace task ordering separate when paths overlap', () => {
     const state = workbenchReducer(initialWorkbenchState, {
       type: 'lists_refreshed',

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -394,9 +394,9 @@ function mergeRuntimeTaskListState(
   return {
     ...current,
     ...(next.threadId ? { threadId: next.threadId } : {}),
-    pinned: next.pinned,
-    pinnedOrder: next.pinnedOrder,
-    sidebarOrder: next.sidebarOrder,
+    ...(next.pinned === undefined ? {} : { pinned: next.pinned }),
+    ...(next.pinnedOrder === undefined ? {} : { pinnedOrder: next.pinnedOrder }),
+    ...(next.sidebarOrder === undefined ? {} : { sidebarOrder: next.sidebarOrder }),
   }
 }
 

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -364,7 +364,11 @@ function mergeRuntimeTasks(
   const merged = currentTasks
     .map(task => {
       const nextTask = nextById.get(task.taskId)
-      if (nextTask) return shouldReplaceRuntimeTaskProjection(task, nextTask) ? nextTask : task
+      if (nextTask) {
+        return shouldReplaceRuntimeTaskProjection(task, nextTask)
+          ? nextTask
+          : mergeRuntimeTaskListState(task, nextTask)
+      }
       if (
         isFreshOptimisticRuntimeTask(task) &&
         !resolvedTaskKeys.has(runtimeTaskKey(deviceId, task))
@@ -381,6 +385,19 @@ function mergeRuntimeTasks(
     }
   })
   return merged
+}
+
+function mergeRuntimeTaskListState(
+  current: RuntimeTaskSummary,
+  next: RuntimeTaskSummary
+): RuntimeTaskSummary {
+  return {
+    ...current,
+    ...(next.threadId ? { threadId: next.threadId } : {}),
+    pinned: next.pinned,
+    pinnedOrder: next.pinnedOrder,
+    sidebarOrder: next.sidebarOrder,
+  }
 }
 
 function isOptimisticRuntimeTask(task: RuntimeTaskSummary): boolean {


### PR DESCRIPTION
## Summary

- render streaming code blocks as stable plain monospaced text instead of repeatedly rebuilding syntax-highlighted token trees
- keep completed code blocks over 2,000 characters or 80 lines in the stable renderer while preserving highlighting for shorter completed blocks
- add unit coverage and a real desktop terminal-burst regression with a 110-line SQL block
- harden runtime-task pin refreshes exposed by the desktop CI scenario, preserving sidebar metadata independently from newer lifecycle state

## Verification

- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework test src/components/chat/MarkdownCodeBlock.test.tsx src/components/chat/AssistantMarkdown.diagram.test.tsx src/components/chat/MessageList.test.tsx`
- `WEWORK_E2E_LONG_CODE_ONLY=true pnpm --filter wework e2e:desktop --segment rendering-extensions`
- `pnpm --dir wework test --run src/features/workbench/workbenchReducer.test.ts`
- `cargo test --manifest-path executor/Cargo.toml sidebar_thread_id_resolves_local_task_alias`
- `pnpm --filter wework e2e:desktop --segment automation-lifecycle`
- pre-push Wework ESLint, TypeScript, and unit tests
- pre-push Backend format/syntax, settings, Knowledge Engine syntax, Executor fmt/test/clippy, and Alembic checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved code block rendering while responses are streaming.
  - Long code blocks now display as plain text when syntax highlighting may affect performance.
  - Added visual state information indicating whether syntax highlighting is active.

- **Bug Fixes**
  - Syntax highlighting is restored automatically after streaming completes.
  - Preserved readable formatting and styling for lengthy code content.
  - Improved sidebar thread reordering and pinning reliability.
  - Preserved task metadata during runtime refreshes.

- **Tests**
  - Added coverage for streaming, long-code rendering, highlighting restoration, and sidebar synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->