### PR TITLE
fix(wework): show live task activity on board cards

### DIFF
--- a/docs/en/architecture/issue-task-workflow.md
+++ b/docs/en/architecture/issue-task-workflow.md
@@ -41,6 +41,9 @@ flowchart LR
     TASK_COMPOSER -->|first message| BINDING
     BINDING -->|open existing task| SIDEBAR[Task conversation sidebar]
     BINDING --> TASK[(Wework Runtime Task)]
+    TASK --> CONVERSATION_CACHE[Shared Runtime conversation cache]
+    BINDING --> BOARD_ACTIVITY[Single-row board-card live activity]
+    CONVERSATION_CACHE --> BOARD_ACTIVITY
     TASK_COMPOSER --> CONTEXT[Structured Issue origin<br/>space_id + item_id]
     SIDEBAR --> CONTEXT
     CONTEXT --> TASK
@@ -78,6 +81,8 @@ sequenceDiagram
     participant B as Task binding
     participant E as Execution service
     participant R as Runtime scheduler
+    participant Q as Runtime conversation cache
+    participant K as Board card
     participant M as project-space capability
     participant V as Delivery service
     participant H as Human review service
@@ -128,6 +133,8 @@ sequenceDiagram
     B->>R: Carry structured space_id and item_id on every turn
     R->>M: Enable the stable capability with a ContextGrant
     M-->>R: Return the Issue description, attachments, and other current context
+    R-->>Q: Store streaming thinking by device_id:task_id
+    Q-->>K: Scroll tools and latest thinking while the bound task is running
     R-->>D: Stream progress, terminal result, and delivered assets
     B-->>O: Runtime Task status changes
     E-->>O: Execution status changes
@@ -145,24 +152,25 @@ sequenceDiagram
     O->>I: Aggregate all required stages and free tasks
 ```
 
-| Edge                                                      | Code ownership                                                                            |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| Issue Composer to Issue, draft, and attachments           | Wework `IssueComposer` and ProjectSpace API; compact and fullscreen views share one draft |
-| Stage DAG editing and adjacent insertion                  | Wework `ProjectWorkflowEditor`                                                            |
-| Explicit orchestration save and re-entry restoration      | Wework `ProjectAutomationView`, `ProjectWorkflowEditor`, and ProjectSpace API             |
-| Project orchestration definition and Issue snapshot       | Backend workflow schemas/services; Wework Automation DAG UI                               |
-| Dependency edge to successor context                      | Workflow node dependency context; Composer / automation instruction                       |
-| User/AI coordination to concrete tasks                    | Standard Wework Composer, AI manager, `LoopItemTaskBinding`                               |
-| Issue new/existing task to right-side conversation        | `CloudTodoWorkspace`, `TodoEditor`, `AiChatModal`                                         |
-| Runtime Task binding to stage-status synchronization      | `projectSpaceSelection`, `WorkbenchProvider`, and ProjectSpace API                        |
-| Stage task status history and latest-terminal aggregation | Wework `issueWorkflow`, `IssueWorkflowDag`, and the Issue workflow snapshot               |
-| Node deliverables to human review and advancement         | Delivery API, workflow decision service, and `IssueWorkflowDag`                           |
-| Issue board entry to manual task or orchestration         | `CloudTodoWorkspace`, `workItemTaskInput`, and the Issue workflow snapshot                |
-| Issue conversation to current project-space context       | Runtime metadata, ContextGrant, bundled `wework-space` Plugin, and Local Gateway          |
-| Stage to automated execution                              | `project_automation_execution.py`, `loop_item_executions/service.py`                      |
-| Workspace and successor-task inheritance                  | Runtime Task summary and Wework project work controls                                     |
-| DAG readiness, stage, and Issue aggregation               | Backend workflow service; local ProjectSpace service; live Wework projection              |
-| Execution truth to Issue activity                         | Project chat stream, task activity cards, delivery/attachment projection                  |
+| Edge                                                                | Code ownership                                                                            |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Issue Composer to Issue, draft, and attachments                     | Wework `IssueComposer` and ProjectSpace API; compact and fullscreen views share one draft |
+| Stage DAG editing and adjacent insertion                            | Wework `ProjectWorkflowEditor`                                                            |
+| Explicit orchestration save and re-entry restoration                | Wework `ProjectAutomationView`, `ProjectWorkflowEditor`, and ProjectSpace API             |
+| Project orchestration definition and Issue snapshot                 | Backend workflow schemas/services; Wework Automation DAG UI                               |
+| Dependency edge to successor context                                | Workflow node dependency context; Composer / automation instruction                       |
+| User/AI coordination to concrete tasks                              | Standard Wework Composer, AI manager, `LoopItemTaskBinding`                               |
+| Issue new/existing task to right-side conversation                  | `CloudTodoWorkspace`, `TodoEditor`, `AiChatModal`                                         |
+| Runtime Task binding to stage-status synchronization                | `projectSpaceSelection`, `WorkbenchProvider`, and ProjectSpace API                        |
+| Runtime Task binding plus conversation cache to board live activity | `CloudTodoWorkspace`, `CloudTodoBoardCard`, and `runtimeConversationCache`                |
+| Stage task status history and latest-terminal aggregation           | Wework `issueWorkflow`, `IssueWorkflowDag`, and the Issue workflow snapshot               |
+| Node deliverables to human review and advancement                   | Delivery API, workflow decision service, and `IssueWorkflowDag`                           |
+| Issue board entry to manual task or orchestration                   | `CloudTodoWorkspace`, `workItemTaskInput`, and the Issue workflow snapshot                |
+| Issue conversation to current project-space context                 | Runtime metadata, ContextGrant, bundled `wework-space` Plugin, and Local Gateway          |
+| Stage to automated execution                                        | `project_automation_execution.py`, `loop_item_executions/service.py`                      |
+| Workspace and successor-task inheritance                            | Runtime Task summary and Wework project work controls                                     |
+| DAG readiness, stage, and Issue aggregation                         | Backend workflow service; local ProjectSpace service; live Wework projection              |
+| Execution truth to Issue activity                                   | Project chat stream, task activity cards, delivery/attachment projection                  |
 
 Invariants:
 
@@ -187,6 +195,9 @@ Invariants:
 - A node may declare zero or more required deliverables with stable IDs and value types. The task Composer and Issue detail must show those requirements and their fulfillment methods. A submitted Delivery must resolve through its source TaskBinding to exactly one `workflow_node_id` and bind every value to a `requirement_id`. Approval is forbidden while required deliverables are missing, while an authorized user may force advancement with a non-empty reason. See [Workflow stage deliverables and dependency context](workflow-stage-deliverables.md) for the complete lifecycle.
 - An Agent bound to an Issue stage uses the shared `wework-space` MCP for the same Delivery creation, asset upload/download, read, finalize, and draft-discard capabilities available to a user. Write operations resolve the source TaskBinding from the ContextGrant Runtime address and never accept model-selected stage ownership.
 - Each stage task's Runtime state is persisted in `task_statuses` under stable `device_id:task_id`, and Issue detail displays that state per task instead of exposing only the stage aggregate.
+- A board card may subscribe to the shared Runtime conversation cache only through a `LoopItemTaskBinding`'s stable `device_id:task_id`. Loading a transcript in the task-conversation sidebar must merge it into that same cache, and an empty cache notification or snapshot must not erase activity already visible in the sidebar. Binding selection prefers a task that Runtime reports as running; when the Issue execution is already active but the work-list projection is still catching up, the card still subscribes to the current binding and renders activity only while the cache contains a streaming assistant. Tool activity and thinking share one fixed-height row with consistent typography. An indented guide visually associates that row with the task; the viewport hides its scrollbar while retaining scrolling and follows the newest status instead of growing the card with activity history. While a tool is running, that tool must be the latest visible item instead of being obscured by stale thinking; thinking becomes visible again after the tool settles and later reasoning arrives. Clicking the task activity region must open the bound task rather than only the Issue, and the outside-dismiss layer must not cover the board's native scrollbar. This content is an ephemeral read-only projection: it is never copied into `LoopItem`, `LoopItemExecution`, or stage state and never drives a state transition.
+- When a board status change starts a task automatically, the conversation panel may remain mounted invisibly to create the task and retain its stream subscription, but it must not open the Issue detail or task sidebar. The bound task is revealed only after the user explicitly clicks its activity region.
+- Moving an Issue from Inbox to Pending first opens the task-send composer so the user can confirm its content; the status change is deferred until that confirmation. After the user sends the task, the conversation continues creating and running in the background and the task-conversation sidebar closes.
 - A stage is `running` while any bound task is running. Otherwise, the trusted terminal state of the most recently bound task determines the current stage result. A later success supersedes an older failure for stage aggregation, while the old task remains visibly failed in task history. Issue detail rendering and human-decision validation must recompute the stage from task truth instead of trusting a potentially stale stage snapshot. Human-stage success enters `awaiting_approval`; it never completes automatically.
 - Only approval or force advancement unlocks successors. Rejection preserves tasks, deliverables, and prior decisions instead of rolling them back or overwriting audit history.
 - Every node decision records action, actor user id, reason, and timestamp. Force advancement requires a non-empty reason; approval may include a note; rejection requires a reason.

--- a/docs/zh/architecture/issue-task-workflow.md
+++ b/docs/zh/architecture/issue-task-workflow.md
@@ -41,6 +41,9 @@ flowchart LR
     TASK_COMPOSER -->|首条消息| BINDING
     BINDING -->|打开已有任务| SIDEBAR[右侧任务会话]
     BINDING --> TASK[(Wework Runtime Task)]
+    TASK --> CONVERSATION_CACHE[共享 Runtime 会话缓存]
+    BINDING --> BOARD_ACTIVITY[看板卡片单行实时活动]
+    CONVERSATION_CACHE --> BOARD_ACTIVITY
     TASK_COMPOSER --> CONTEXT[结构化 Issue 来源<br/>space_id + item_id]
     SIDEBAR --> CONTEXT
     CONTEXT --> TASK
@@ -78,6 +81,8 @@ sequenceDiagram
     participant B as Task Binding
     participant E as Execution 服务
     participant R as Runtime scheduler
+    participant Q as Runtime 会话缓存
+    participant K as 看板卡片
     participant M as project-space capability
     participant V as Delivery 服务
     participant H as 人工验收服务
@@ -128,6 +133,8 @@ sequenceDiagram
     B->>R: 每轮携带结构化 space_id 与 item_id
     R->>M: 以 ContextGrant 启用稳定 capability
     M-->>R: 返回 Issue 描述、附件与其他当前上下文
+    R-->>Q: 按 device_id:task_id 写入流式 thinking
+    Q-->>K: 绑定任务运行中时滚动投影工具与最新 thinking
     R-->>D: 流式进度、终态与交付附件
     B-->>O: Runtime Task 状态变化
     E-->>O: execution 状态变化
@@ -145,24 +152,25 @@ sequenceDiagram
     O->>I: 聚合全部必要阶段与自由任务状态
 ```
 
-| 边                                   | 代码归属                                                                  |
-| ------------------------------------ | ------------------------------------------------------------------------- |
-| Issue Composer → Issue、草稿与附件   | Wework `IssueComposer`、ProjectSpace API；同一草稿在紧凑与全屏视图间共享  |
-| 阶段 DAG 编辑与前后插入              | Wework `ProjectWorkflowEditor`                                            |
-| 编排显式保存与重新进入回填           | Wework `ProjectAutomationView`、`ProjectWorkflowEditor`、ProjectSpace API |
-| 项目编排定义与 Issue 快照            | Backend workflow schema/service；Wework 自动化页 DAG UI                   |
-| 依赖边 → 后继阶段上下文              | Workflow node dependency context；Composer / automation instruction       |
-| 用户管理 / AI 调度 → 具体任务        | 标准 Wework Composer、AI manager、`LoopItemTaskBinding`                   |
-| Issue 新建任务 / 已有任务 → 右侧会话 | `CloudTodoWorkspace`、`TodoEditor`、`AiChatModal`                         |
-| Runtime Task 绑定 → 阶段状态同步     | `projectSpaceSelection`、`WorkbenchProvider`、ProjectSpace API            |
-| 阶段任务状态历史与最近终态聚合       | Wework `issueWorkflow`、`IssueWorkflowDag`、Issue workflow snapshot       |
-| 节点交付物 → 人工验收与推进          | Delivery API、workflow decision service、`IssueWorkflowDag`               |
-| Issue 看板入口 → 手动任务或编排      | `CloudTodoWorkspace`、`workItemTaskInput`、Issue workflow snapshot        |
-| Issue 会话 → 项目空间当前上下文      | Runtime metadata、ContextGrant、内置 `wework-space` Plugin、Local Gateway |
-| 阶段 → 自动化执行                    | `project_automation_execution.py`、`loop_item_executions/service.py`      |
-| 工作空间与后继任务继承               | Runtime Task summary、Wework project work controls                        |
-| DAG 就绪判断、阶段与 Issue 状态聚合  | Backend workflow service；本地 ProjectSpace 服务；Wework 实时投影         |
-| 执行真值 → Issue 动态                | Project chat stream、Task activity cards、Delivery/attachment projection  |
+| 边                                          | 代码归属                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------- |
+| Issue Composer → Issue、草稿与附件          | Wework `IssueComposer`、ProjectSpace API；同一草稿在紧凑与全屏视图间共享  |
+| 阶段 DAG 编辑与前后插入                     | Wework `ProjectWorkflowEditor`                                            |
+| 编排显式保存与重新进入回填                  | Wework `ProjectAutomationView`、`ProjectWorkflowEditor`、ProjectSpace API |
+| 项目编排定义与 Issue 快照                   | Backend workflow schema/service；Wework 自动化页 DAG UI                   |
+| 依赖边 → 后继阶段上下文                     | Workflow node dependency context；Composer / automation instruction       |
+| 用户管理 / AI 调度 → 具体任务               | 标准 Wework Composer、AI manager、`LoopItemTaskBinding`                   |
+| Issue 新建任务 / 已有任务 → 右侧会话        | `CloudTodoWorkspace`、`TodoEditor`、`AiChatModal`                         |
+| Runtime Task 绑定 → 阶段状态同步            | `projectSpaceSelection`、`WorkbenchProvider`、ProjectSpace API            |
+| Runtime Task 绑定 + 会话缓存 → 看板实时活动 | `CloudTodoWorkspace`、`CloudTodoBoardCard`、`runtimeConversationCache`    |
+| 阶段任务状态历史与最近终态聚合              | Wework `issueWorkflow`、`IssueWorkflowDag`、Issue workflow snapshot       |
+| 节点交付物 → 人工验收与推进                 | Delivery API、workflow decision service、`IssueWorkflowDag`               |
+| Issue 看板入口 → 手动任务或编排             | `CloudTodoWorkspace`、`workItemTaskInput`、Issue workflow snapshot        |
+| Issue 会话 → 项目空间当前上下文             | Runtime metadata、ContextGrant、内置 `wework-space` Plugin、Local Gateway |
+| 阶段 → 自动化执行                           | `project_automation_execution.py`、`loop_item_executions/service.py`      |
+| 工作空间与后继任务继承                      | Runtime Task summary、Wework project work controls                        |
+| DAG 就绪判断、阶段与 Issue 状态聚合         | Backend workflow service；本地 ProjectSpace 服务；Wework 实时投影         |
+| 执行真值 → Issue 动态                       | Project chat stream、Task activity cards、Delivery/attachment projection  |
 
 不变量：
 
@@ -187,6 +195,9 @@ sequenceDiagram
 - 节点可声明零个或多个带稳定 ID 和值类型的必要交付物。任务 Composer 和 Issue 详情必须明示这些要求及履约方法；提交的 Delivery 必须通过来源 TaskBinding 归属到唯一 `workflow_node_id`，并逐项绑定 `requirement_id`。未满足必要交付物时不得批准，但允许具有权限的用户填写原因后强制推进；完整生命周期见 [工作流阶段交付与依赖上下文](workflow-stage-deliverables.md)。
 - 绑定 Issue 阶段的 Agent 必须能通过统一 `wework-space` MCP 完成与用户相同的 Delivery 创建、附件上传与下载、读取、提交和草稿丢弃；写操作必须从 ContextGrant 的 Runtime 地址解析来源 TaskBinding，不得接受模型指定的阶段归属。
 - 每个阶段任务的 Runtime 状态必须按稳定的 `device_id:task_id` 写入 `task_statuses`，Issue 详情必须逐条展示，不得只展示阶段汇总状态。
+- 看板卡片只能用 `LoopItemTaskBinding` 的稳定 `device_id:task_id` 订阅共享 Runtime 会话缓存。任务会话侧栏加载 transcript 时必须合并回同一缓存，空缓存通知或空快照不得清除侧栏已经展示的活动。选择绑定时优先采用 Runtime 已报告运行的任务；当 Issue 执行状态已生效但运行列表尚未同步时，仍须订阅当前绑定，并仅在缓存中确有流式 assistant 时展示实时活动。工具调用和 thinking 共用固定一行、统一字号的状态窗口；窗口通过缩进引导线归属于任务行，隐藏滚动条但保留滚动能力，并在更新时跟随最新状态，不能让卡片随历史活动增高。工具执行期间当前工具必须成为最新可见项，不能被旧 thinking 固定遮住；工具结束并产生后续 thinking 后再展示 thinking。任务活动区域必须打开对应绑定任务，不能退化成只打开 Issue；侧栏外部关闭层不得覆盖看板原生滚动条。该内容是瞬态只读投影，不得复制进 `LoopItem`、`LoopItemExecution` 或阶段状态，也不得反向驱动任何状态迁移。
+- 看板状态变更自动启动任务时，会话面板可以在隐藏状态下维持创建与流式订阅，但不得自动打开 Issue 详情或任务侧边栏；只有用户主动点击任务活动区域时才展示对应任务。
+- 从收集箱移动到待开始时，先打开“发送任务”界面让用户确认任务内容，确认前不提交状态变更。用户发送后，会话转入后台继续创建和执行，任务会话侧边栏自动收起。
 - 阶段存在任一运行中任务时状态为 `running`；否则由最近绑定任务的可信终态决定当前阶段结果。后续成功必须覆盖旧失败对阶段汇总状态的影响，但旧任务失败状态仍保留在任务历史中。Issue 详情展示和人工决策校验必须从任务真值重算阶段，不得信任可能滞后的阶段快照。人工阶段成功后只能进入 `awaiting_approval`，不能自动完成。
 - 只有用户批准或带原因强制推进后，后继节点才可解锁；驳回必须保留任务、交付物和历史决定，不得回滚或覆盖审计记录。
 - 节点决定必须记录 action、actor user id、reason 和 timestamp。强制推进必须填写非空原因；普通批准可选备注；驳回必须填写原因。

--- a/wework/src/components/chat/AssistantThinkingIndicator.tsx
+++ b/wework/src/components/chat/AssistantThinkingIndicator.tsx
@@ -1,20 +1,26 @@
 import { useTranslation } from '@/hooks/useTranslation'
+import { cn } from '@/lib/utils'
 
 const THINKING_PREVIEW_MAX_LENGTH = 96
 
 export function AssistantThinkingIndicator({
   content = '',
   testId = 'thinking-indicator',
+  className,
 }: {
   content?: string
   testId?: string
+  className?: string
 }) {
   const { t } = useTranslation('chat')
   const preview = buildThinkingPreview(content)
   const text = preview ? `${t('thinking.running')} · ${preview}` : t('thinking.running')
 
   return (
-    <div className="inline-flex min-w-0 max-w-full items-center text-chat" data-testid={testId}>
+    <div
+      className={cn('inline-flex min-w-0 max-w-full items-center text-chat', className)}
+      data-testid={testId}
+    >
       <span className="waiting-thinking-text min-w-0 truncate">{text}</span>
     </div>
   )

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -85,6 +85,7 @@ import {
   cacheConversationVirtualMeasurements,
   getConversationVirtualMeasurements,
 } from '@/features/workbench/runtimeConversationCache'
+import { getRuntimeMessageActiveThinking } from '@/features/workbench/runtimeThinking'
 
 interface MessageListProps {
   messages: WorkbenchMessage[]
@@ -1947,24 +1948,6 @@ function getDisplayProcessingBlocks(
     })
 }
 
-function getLatestActiveThinkingContent(blocks: ProcessingBlock[] | undefined): string {
-  if (!blocks?.length) return ''
-
-  for (let index = blocks.length - 1; index >= 0; index -= 1) {
-    const block = blocks[index]
-    if (
-      block?.type === 'thinking' &&
-      block.status !== 'done' &&
-      block.status !== 'error' &&
-      block.content.trim()
-    ) {
-      return block.content
-    }
-  }
-
-  return ''
-}
-
 function getWebSearchToolBlocks(blocks: ProcessingBlock[]) {
   return blocks.filter(
     (block): block is Extract<ProcessingBlock, { type: 'tool' }> =>
@@ -2042,9 +2025,7 @@ function AssistantMessage({
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = !isCancelled && message.status === 'streaming'
-  const activeThinkingContent = isStreaming
-    ? (message.streamingThinkingContent ?? getLatestActiveThinkingContent(message.blocks))
-    : ''
+  const activeThinkingContent = isStreaming ? getRuntimeMessageActiveThinking(message) : ''
   const hasRunningBlocks = hasRunningProcessingBlocks(displayBlocks)
   const isAssistantRunning = isStreaming || hasRunningBlocks
   const canShowFinalArtifacts = !isAssistantRunning

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -257,7 +257,9 @@ function getActivityStats(blocks: ToolBlock[]): ActivityStats {
   )
 }
 
-export function getToolActivityKind(block: ToolBlock): ToolActivityKind {
+export function getToolActivityKind(
+  block: Pick<ToolBlock, 'toolName' | 'toolInput'>
+): ToolActivityKind {
   const name = block.toolName.toLowerCase()
   if (isFileReadToolName(name)) return 'file'
   if (isFileCreateToolName(name)) return 'create'
@@ -271,7 +273,9 @@ export function getToolActivityKind(block: ToolBlock): ToolActivityKind {
   return 'tool'
 }
 
-export function getToolActivityFilePaths(block: ToolBlock): string[] {
+export function getToolActivityFilePaths(
+  block: Pick<ToolBlock, 'toolName' | 'toolInput'>
+): string[] {
   const name = block.toolName.toLowerCase()
   if (isFileReadToolName(name) || isFileCreateToolName(name) || isFileEditToolName(name)) {
     return getFileInputPaths(block)
@@ -283,7 +287,9 @@ export function getToolActivityFilePaths(block: ToolBlock): string[] {
   return getReadCommandFilePaths(command)
 }
 
-export function getToolActivitySearchItem(block: ToolBlock): ToolActivitySearchItem | undefined {
+export function getToolActivitySearchItem(
+  block: Pick<ToolBlock, 'id' | 'toolName' | 'toolInput'>
+): ToolActivitySearchItem | undefined {
   const name = block.toolName.toLowerCase()
   if (isWebSearchToolName(name) || getToolActivityKind(block) !== 'search') return undefined
 

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -2255,6 +2255,65 @@ describe('DesktopSidebar', () => {
     await act(async () => resolvePinRequest?.())
   })
 
+  test('moves a project task to the pinned section before the pin request finishes', async () => {
+    let resolvePinRequest: (() => void) | undefined
+    const onSetRuntimeTaskPinned = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolvePinRequest = resolve
+        })
+    )
+    renderSidebar({
+      runtimeWork: {
+        projects: [
+          {
+            project: {
+              id: 7,
+              key: 'project-7',
+              name: 'Wegent',
+              stateDeviceId: 'local-device',
+            },
+            totalTasks: 1,
+            deviceWorkspaces: [
+              {
+                deviceId: 'local-device',
+                available: true,
+                workspacePath: '/repo/Wegent',
+                tasks: [
+                  {
+                    taskId: 'optimistic-project-task',
+                    threadId: 'optimistic-project-thread',
+                    workspacePath: '/repo/Wegent',
+                    title: 'Optimistic project task',
+                    runtime: 'codex',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalTasks: 1,
+      },
+      onSetRuntimeTaskPinned,
+    })
+
+    await userEvent.click(screen.getByTestId('project-item-button'))
+    await userEvent.click(screen.getByTestId('runtime-local-task-mark-optimistic-project-task'))
+
+    await waitFor(() => {
+      const pinnedRow = screen.getByTestId('runtime-local-task-row-optimistic-project-task')
+      expect(screen.getByTestId('sidebar-pinned-section')).toContainElement(pinnedRow)
+    })
+    expect(onSetRuntimeTaskPinned).toHaveBeenCalledWith({
+      deviceId: 'local-device',
+      threadId: 'optimistic-project-thread',
+      pinned: true,
+    })
+
+    await act(async () => resolvePinRequest?.())
+  })
+
   test('returns a chat task to the task section when pinning fails', async () => {
     const onSetRuntimeTaskPinned = vi.fn().mockRejectedValue(new Error('pin failed'))
     const chatPath = '/Users/alice/Documents/Codex/2026-07-12/pin-failure'
@@ -3442,17 +3501,19 @@ describe('DesktopSidebar', () => {
 
     const taskRow = screen.getByTestId('runtime-local-task-row-codex-1')
     const markButton = screen.getByTestId('runtime-local-task-mark-codex-1')
-    const pinIcon = screen.getByTestId('runtime-local-task-pin-icon-codex-1')
 
     expect(taskRow).not.toHaveAttribute('data-marked')
     expect(taskRow.className).not.toContain('color-sidebar-marked')
 
     await user.click(markButton)
 
-    expect(taskRow).toHaveAttribute('data-marked', 'true')
-    expect(taskRow.className).not.toContain('color-sidebar-marked')
-    expect(pinIcon).toHaveClass('fill-current')
-    expect(markButton).toHaveAttribute('aria-label', '取消置顶')
+    const pinnedTaskRow = screen.getByTestId('runtime-local-task-row-codex-1')
+    const unpinButton = screen.getByTestId('runtime-local-task-mark-codex-1')
+    expect(screen.getByTestId('sidebar-pinned-section')).toContainElement(pinnedTaskRow)
+    expect(pinnedTaskRow).toHaveAttribute('data-marked', 'true')
+    expect(pinnedTaskRow.className).not.toContain('color-sidebar-marked')
+    expect(screen.getByTestId('runtime-local-task-pin-icon-codex-1')).toHaveClass('fill-current')
+    expect(unpinButton).toHaveAttribute('aria-label', '取消置顶')
     expect(onOpenRuntimeTask).not.toHaveBeenCalled()
     expect(onSetRuntimeTaskPinned).toHaveBeenLastCalledWith({
       deviceId: 'local-device',
@@ -3460,12 +3521,17 @@ describe('DesktopSidebar', () => {
       pinned: true,
     })
 
-    await user.click(markButton)
+    await user.click(unpinButton)
 
-    expect(taskRow).not.toHaveAttribute('data-marked')
-    expect(taskRow.className).not.toContain('color-sidebar-marked')
-    expect(pinIcon).not.toHaveClass('fill-current')
-    expect(markButton).toHaveAttribute('aria-label', '置顶任务')
+    const unpinnedTaskRow = screen.getByTestId('runtime-local-task-row-codex-1')
+    const pinButton = screen.getByTestId('runtime-local-task-mark-codex-1')
+    expect(screen.queryByTestId('sidebar-pinned-section')).not.toBeInTheDocument()
+    expect(unpinnedTaskRow).not.toHaveAttribute('data-marked')
+    expect(unpinnedTaskRow.className).not.toContain('color-sidebar-marked')
+    expect(screen.getByTestId('runtime-local-task-pin-icon-codex-1')).not.toHaveClass(
+      'fill-current'
+    )
+    expect(pinButton).toHaveAttribute('aria-label', '置顶任务')
     expect(onSetRuntimeTaskPinned).toHaveBeenLastCalledWith({
       deviceId: 'local-device',
       threadId: 'thread-1',
@@ -3515,7 +3581,10 @@ describe('DesktopSidebar', () => {
       threadId: 'legacy-thread-id',
       pinned: true,
     })
-    expect(pinButton).toHaveAttribute('aria-label', '取消置顶')
+    expect(screen.getByTestId('runtime-local-task-mark-legacy-thread-id')).toHaveAttribute(
+      'aria-label',
+      '取消置顶'
+    )
   })
 
   test('reserves runtime task hover actions without padding the truncated title', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -303,7 +303,6 @@ interface RuntimeTaskPinOverride {
   base: boolean
   value: boolean
   requestId: number
-  source: RuntimeWorkListResponse | null | undefined
 }
 
 function getRuntimeTaskPinOverrideKey(deviceId: string, threadId: string) {
@@ -3068,10 +3067,10 @@ export function DesktopSidebar({
   const [expandedProjectIds, setExpandedProjectIds] = useState<Set<number>>(() =>
     readStoredNumberSet(expandedProjectIdsStorageKey)
   )
-  const [chatTaskPinOverrides, setChatTaskPinOverrides] = useState<
+  const [runtimeTaskPinOverrides, setRuntimeTaskPinOverrides] = useState<
     Map<string, RuntimeTaskPinOverride>
   >(() => new Map())
-  const chatTaskPinRequestIdRef = useRef(0)
+  const runtimeTaskPinRequestIdRef = useRef(0)
   const [sidebarScrolled, setSidebarScrolled] = useState(false)
   const {
     scrollContainerRef: sidebarWorklistsScrollRef,
@@ -3091,10 +3090,35 @@ export function DesktopSidebar({
       ),
     [devices, runtimeWork, standaloneDeviceId, standaloneWorkspacePath]
   )
-  const sidebarRuntimeProjects = useMemo(() => {
+  const sidebarRuntimeProjectSource = useMemo(() => {
     const items = runtimeWork?.projects ?? []
     return standaloneProjectWork ? [standaloneProjectWork, ...items] : items
   }, [runtimeWork?.projects, standaloneProjectWork])
+  const sidebarRuntimeProjects = useMemo(
+    () =>
+      sidebarRuntimeProjectSource.map(projectWork => ({
+        ...projectWork,
+        deviceWorkspaces: projectWork.deviceWorkspaces.map(workspace => ({
+          ...workspace,
+          tasks: workspace.tasks.map(task => {
+            const threadId = getRuntimeTaskThreadId(task)
+            const persistedPinned = Boolean(task.pinned)
+            const override = threadId
+              ? runtimeTaskPinOverrides.get(
+                  getRuntimeTaskPinOverrideKey(
+                    projectWork.project.stateDeviceId ?? workspace.deviceId,
+                    threadId
+                  )
+                )
+              : undefined
+            const pinned =
+              override && override.base === persistedPinned ? override.value : persistedPinned
+            return pinned === persistedPinned ? task : { ...task, pinned }
+          }),
+        })),
+      })),
+    [runtimeTaskPinOverrides, sidebarRuntimeProjectSource]
+  )
   const sidebarProjects = useMemo(() => {
     if (runtimeWork || standaloneProjectWork) {
       return sidebarRuntimeProjects.map(runtimeProjectToProject)
@@ -3163,17 +3187,15 @@ export function DesktopSidebar({
         const threadId = getRuntimeTaskThreadId(item.task)
         const persistedPinned = Boolean(item.task.pinned)
         const override = threadId
-          ? chatTaskPinOverrides.get(
+          ? runtimeTaskPinOverrides.get(
               getRuntimeTaskPinOverrideKey(item.workspace.deviceId, threadId)
             )
           : undefined
         const pinned =
-          override && override.source === runtimeWork && override.base === persistedPinned
-            ? override.value
-            : persistedPinned
+          override && override.base === persistedPinned ? override.value : persistedPinned
         return pinned === persistedPinned ? item : { ...item, task: { ...item.task, pinned } }
       }),
-    [chatTaskItems, chatTaskPinOverrides, runtimeWork]
+    [chatTaskItems, runtimeTaskPinOverrides]
   )
   const regularChatTaskItems = useMemo(
     () => chatTaskItemsWithPinState.filter(({ task }) => !task.pinned),
@@ -3345,29 +3367,42 @@ export function DesktopSidebar({
     if (!isArchivingPriority) setPriorityForceArchiveItems(null)
   }
 
-  const setChatTaskPinned = async (data: RuntimeTaskPinRequest) => {
+  const setRuntimeTaskPinnedOptimistically = async (data: RuntimeTaskPinRequest) => {
     if (!onSetRuntimeTaskPinned) return
-    const chatTask = chatTaskItems.find(
-      ({ workspace, task }) =>
-        workspace.deviceId === data.deviceId && getRuntimeTaskThreadId(task) === data.threadId
-    )
-    if (!chatTask) {
+    const projectTask = sidebarRuntimeProjectSource
+      .flatMap(projectWork =>
+        getRuntimeSidebarTaskItems(projectWork.deviceWorkspaces).map(item => ({
+          ...item,
+          stateDeviceId: projectWork.project.stateDeviceId ?? item.workspace.deviceId,
+        }))
+      )
+      .find(
+        ({ stateDeviceId, task }) =>
+          stateDeviceId === data.deviceId && getRuntimeTaskThreadId(task) === data.threadId
+      )
+    const runtimeTask =
+      projectTask ??
+      chatTaskItems.find(
+        ({ workspace, task }) =>
+          workspace.deviceId === data.deviceId && getRuntimeTaskThreadId(task) === data.threadId
+      )
+    if (!runtimeTask) {
       await onSetRuntimeTaskPinned(data)
       return
     }
 
     const key = getRuntimeTaskPinOverrideKey(data.deviceId, data.threadId)
-    const requestId = ++chatTaskPinRequestIdRef.current
-    const base = Boolean(chatTask.task.pinned)
-    setChatTaskPinOverrides(current => {
+    const requestId = ++runtimeTaskPinRequestIdRef.current
+    const base = Boolean(runtimeTask.task.pinned)
+    setRuntimeTaskPinOverrides(current => {
       const next = new Map(current)
-      next.set(key, { base, value: data.pinned, requestId, source: runtimeWork })
+      next.set(key, { base, value: data.pinned, requestId })
       return next
     })
     try {
       await onSetRuntimeTaskPinned(data)
     } catch (error) {
-      setChatTaskPinOverrides(current => {
+      setRuntimeTaskPinOverrides(current => {
         if (current.get(key)?.requestId !== requestId) return current
         const next = new Map(current)
         next.delete(key)
@@ -3897,11 +3932,7 @@ export function DesktopSidebar({
                     onRenameRuntimeTask={onRenameRuntimeTask}
                     onArchiveRuntimeTask={onArchiveRuntimeTask}
                     onSetRuntimeTaskPinned={
-                      onSetRuntimeTaskPinned
-                        ? item.isStandaloneChat
-                          ? setChatTaskPinned
-                          : onSetRuntimeTaskPinned
-                        : undefined
+                      onSetRuntimeTaskPinned ? setRuntimeTaskPinnedOptimistically : undefined
                     }
                     onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
                   />
@@ -3986,9 +4017,9 @@ export function DesktopSidebar({
                             onOpenRuntimeTask={onOpenRuntimeTask}
                             onMarkRuntimeTaskRead={onMarkRuntimeTaskRead}
                             onSetRuntimeTaskPinned={
-                              projectWork || !onSetRuntimeTaskPinned
-                                ? onSetRuntimeTaskPinned
-                                : setChatTaskPinned
+                              onSetRuntimeTaskPinned
+                                ? setRuntimeTaskPinnedOptimistically
+                                : undefined
                             }
                             onRenameRuntimeTask={onRenameRuntimeTask}
                             onArchiveRuntimeTask={onArchiveRuntimeTask}
@@ -4052,7 +4083,11 @@ export function DesktopSidebar({
                             onSetRuntimeProjectPinned={onSetRuntimeProjectPinned}
                             onSetRuntimeProjectAppearance={onSetRuntimeProjectAppearance}
                             onReorderRuntimeProjectTasks={onReorderRuntimeProjectTasks}
-                            onSetRuntimeTaskPinned={onSetRuntimeTaskPinned}
+                            onSetRuntimeTaskPinned={
+                              onSetRuntimeTaskPinned
+                                ? setRuntimeTaskPinnedOptimistically
+                                : undefined
+                            }
                             onRenameProject={openProjectEditor}
                             onOpenRuntimeTask={onOpenRuntimeTask}
                             onMarkRuntimeTaskRead={onMarkRuntimeTaskRead}
@@ -4322,7 +4357,11 @@ export function DesktopSidebar({
                               onSetRuntimeProjectPinned={onSetRuntimeProjectPinned}
                               onSetRuntimeProjectAppearance={onSetRuntimeProjectAppearance}
                               onReorderRuntimeProjectTasks={onReorderRuntimeProjectTasks}
-                              onSetRuntimeTaskPinned={onSetRuntimeTaskPinned}
+                              onSetRuntimeTaskPinned={
+                                onSetRuntimeTaskPinned
+                                  ? setRuntimeTaskPinnedOptimistically
+                                  : undefined
+                              }
                               onRenameProject={openProjectEditor}
                               onOpenRuntimeTask={onOpenRuntimeTask}
                               onMarkRuntimeTaskRead={onMarkRuntimeTaskRead}
@@ -4463,7 +4502,9 @@ export function DesktopSidebar({
                               onRenameRuntimeTask={onRenameRuntimeTask}
                               onArchiveRuntimeTask={onArchiveRuntimeTask}
                               onSetRuntimeTaskPinned={
-                                onSetRuntimeTaskPinned ? setChatTaskPinned : undefined
+                                onSetRuntimeTaskPinned
+                                  ? setRuntimeTaskPinnedOptimistically
+                                  : undefined
                               }
                               onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
                             />

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -15,7 +15,10 @@ import {
   isRuntimeTaskBusyError,
 } from '@/features/workbench/runtimePaneStatus'
 import {
+  abortRuntimeConversationHydration,
   applyRuntimeConversationAction,
+  beginRuntimeConversationHydration,
+  completeRuntimeConversationHydration,
   getRuntimeConversationMessages,
   removeRuntimeConversationTurn,
   subscribeRuntimeConversation,
@@ -196,8 +199,10 @@ export function TemporaryChatPanel({
     if (!address) return
     const syncMessages = () => {
       const nextMessages = getRuntimeConversationMessages(address)
-      setMessages(nextMessages)
-      if (nextMessages.length > 0) setError(null)
+      if (nextMessages.length > 0) {
+        setMessages(nextMessages)
+        setError(null)
+      }
     }
     return subscribeRuntimeConversation(address, syncMessages)
   }, [address])
@@ -206,15 +211,25 @@ export function TemporaryChatPanel({
     if (!address || sendEphemeral) return
     if (createdAddressKeyRef.current === `${address.deviceId}:${address.taskId}`) return
     let cancelled = false
+    const hydrationToken = beginRuntimeConversationHydration(address)
     void loadRuntimeTranscriptForPane(address)
       .then(transcript => {
-        if (cancelled) return
+        if (cancelled) {
+          abortRuntimeConversationHydration(address, hydrationToken)
+          return
+        }
         lifecycleStore.syncTranscript(address, transcript, {
           preserveActiveTurn: lifecycleStore.getTask(address)?.derived.isRunning ?? false,
         })
-        if (transcript.messages.length > 0) setMessages(transcript.messages)
+        const nextMessages = completeRuntimeConversationHydration(
+          address,
+          hydrationToken,
+          transcript.turns
+        )
+        if (nextMessages.length > 0) setMessages(nextMessages)
       })
       .catch(caughtError => {
+        abortRuntimeConversationHydration(address, hydrationToken)
         if (!cancelled && getRuntimeConversationMessages(address).length === 0) {
           setError(caughtError instanceof Error ? caughtError.message : '加载临时聊天失败')
         }
@@ -227,6 +242,7 @@ export function TemporaryChatPanel({
   const loadFullTranscript = useCallback(async () => {
     if (!address || loadingFullTranscript) return
     setLoadingFullTranscript(true)
+    const hydrationToken = beginRuntimeConversationHydration(address)
     try {
       const transcript = await loadRuntimeTranscriptForPane(address, {
         includeFullContent: true,
@@ -235,10 +251,16 @@ export function TemporaryChatPanel({
       lifecycleStore.syncTranscript(address, transcript, {
         preserveActiveTurn: lifecycleStore.getTask(address)?.derived.isRunning ?? false,
       })
-      if (transcript.messages.length > 0) {
-        setMessages(transcript.messages)
+      const nextMessages = completeRuntimeConversationHydration(
+        address,
+        hydrationToken,
+        transcript.turns
+      )
+      if (nextMessages.length > 0) {
+        setMessages(nextMessages)
       }
     } catch (caughtError) {
+      abortRuntimeConversationHydration(address, hydrationToken)
       setError(caughtError instanceof Error ? caughtError.message : '加载完整输出失败')
     } finally {
       setLoadingFullTranscript(false)

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -236,6 +236,7 @@ export function TemporaryChatPanel({
       })
     return () => {
       cancelled = true
+      abortRuntimeConversationHydration(address, hydrationToken)
     }
   }, [address, lifecycleStore, loadRuntimeTranscriptForPane, sendEphemeral])
 

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -330,7 +330,7 @@ function RuntimeTaskLiveActivity({
   useLayoutEffect(() => {
     const scrollArea = scrollRef.current
     if (scrollArea) scrollArea.scrollTop = scrollArea.scrollHeight
-  }, [activity.thinking, activity.tools.length, lastTool?.status])
+  }, [activity.thinking, activity.tools.length, lastTool?.status, lastTool?.toolInput])
 
   return (
     <div

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -1,11 +1,35 @@
 import { useDraggable, useDroppable } from '@dnd-kit/core'
 import { CSS } from '@dnd-kit/utilities'
 import { Archive, Bot, CalendarDays, Ellipsis, Flag, ListTodo } from 'lucide-react'
-import { useState } from 'react'
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import type { CloudLoopItem } from '@/api/deliveries'
+import { AssistantThinkingIndicator } from '@/components/chat/AssistantThinkingIndicator'
+import {
+  getToolActivityFilePaths,
+  getToolActivityKind,
+  getToolActivitySearchItem,
+} from '@/components/chat/blocks/toolBlockActivity'
+import { getInputField } from '@/components/chat/blocks/toolBlockKinds'
 import { Tooltip } from '@/components/ui/tooltip'
+import {
+  getRuntimeConversationLiveActivitySnapshot,
+  subscribeRuntimeConversation,
+} from '@/features/workbench/runtimeConversationCache'
+import {
+  runtimeLiveActivityFromSnapshot,
+  type RuntimeLiveActivity,
+  type RuntimeLiveToolActivity,
+} from '@/features/workbench/runtimeThinking'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
+import type { RuntimeTaskAddress } from '@/types/api'
 import { isLoopItemExecutionActive } from './cloudMyWorkModel'
 import { priorityBadgeClasses } from './todoShared'
 
@@ -117,13 +141,17 @@ export function CloudTodoCardContent({ item, display, agentNames }: CloudTodoCar
   )
 }
 
+export interface CloudTodoBoardTaskBinding {
+  id: number
+  device_id: string
+  task_id: string
+  task_title: string | null
+  running: boolean
+}
+
 interface CloudTodoBoardCardProps {
   item: CloudLoopItem
-  taskBindings?: Array<{
-    id: number
-    task_id: string
-    task_title: string | null
-  }>
+  taskBindings?: CloudTodoBoardTaskBinding[]
   onClick: () => void
   onArchive: () => void
   onOpenActivity?: () => void
@@ -138,6 +166,7 @@ export function CloudTodoBoardCard({
   taskBindings = [],
   onClick,
   onArchive,
+  onOpenActivity,
   display,
   agentNames,
   dragDisabled = false,
@@ -146,7 +175,19 @@ export function CloudTodoBoardCard({
   const { t } = useTranslation('common')
   const [menuOpen, setMenuOpen] = useState(false)
   const hasActiveTask = isLoopItemExecutionActive(item)
-  const currentTaskBinding = hasActiveTask ? taskBindings[0] : undefined
+  const runningTaskBinding = taskBindings.find(binding => binding.running)
+  const currentTaskBinding = runningTaskBinding ?? (hasActiveTask ? taskBindings[0] : undefined)
+  const currentTaskAddress = useMemo<RuntimeTaskAddress | null>(
+    () =>
+      currentTaskBinding && (currentTaskBinding.running || hasActiveTask)
+        ? {
+            deviceId: currentTaskBinding.device_id,
+            taskId: currentTaskBinding.task_id,
+          }
+        : null,
+    [currentTaskBinding, hasActiveTask]
+  )
+  const currentActivity = useRuntimeTaskActivity(currentTaskAddress)
   const {
     attributes,
     listeners,
@@ -168,7 +209,7 @@ export function CloudTodoBoardCard({
       data-testid={`cloud-todo-card-drop-${item.id}`}
       style={{ transform: CSS.Translate.toString(transform) }}
       className={cn(
-        'group relative w-full touch-none overflow-hidden rounded-xl border border-border bg-background text-left shadow-sm transition hover:-translate-y-px hover:border-text-primary/15 hover:shadow-md',
+        'group relative h-fit w-full touch-none overflow-hidden rounded-xl border border-border bg-background text-left shadow-sm transition hover:-translate-y-px hover:border-text-primary/15 hover:shadow-md',
         isDragging && 'opacity-25 shadow-none',
         isOver && !isDragging && 'border-focus ring-1 ring-focus/50'
       )}
@@ -226,8 +267,28 @@ export function CloudTodoBoardCard({
 
       {currentTaskBinding ? (
         <div
+          role={onOpenActivity ? 'button' : undefined}
+          tabIndex={onOpenActivity ? 0 : undefined}
+          aria-label={
+            onOpenActivity
+              ? `${t('todo.current_running_task', '正在执行')} ${
+                  currentTaskBinding.task_title || currentTaskBinding.task_id
+                }`
+              : undefined
+          }
           data-testid={`cloud-todo-card-tasks-${item.id}`}
-          className="border-t border-border/60 px-3.5 py-2"
+          onClick={onOpenActivity}
+          onKeyDown={event => {
+            if (!onOpenActivity || (event.key !== 'Enter' && event.key !== ' ')) return
+            event.preventDefault()
+            onOpenActivity()
+          }}
+          className={cn(
+            'w-full border-t border-border/60 px-3.5 py-2 text-left transition',
+            onOpenActivity
+              ? 'cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus/30'
+              : 'cursor-default'
+          )}
         >
           <div className="flex min-w-0 items-center gap-2 text-xs text-text-secondary">
             <ListTodo className="h-3.5 w-3.5" />
@@ -241,8 +302,134 @@ export function CloudTodoBoardCard({
               {currentTaskBinding.task_title || currentTaskBinding.task_id}
             </span>
           </div>
+          {currentActivity.active ? (
+            <RuntimeTaskLiveActivity itemId={item.id} activity={currentActivity} />
+          ) : null}
         </div>
       ) : null}
     </article>
   )
+}
+
+function RuntimeTaskLiveActivity({
+  itemId,
+  activity,
+}: {
+  itemId: string
+  activity: RuntimeLiveActivity
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const lastTool = activity.tools.at(-1)
+  const completedTools = activity.tools.filter(
+    block => block.status === 'done' || block.status === 'error'
+  )
+  const activeTools = activity.tools.filter(
+    block => block.status !== 'done' && block.status !== 'error'
+  )
+
+  useLayoutEffect(() => {
+    const scrollArea = scrollRef.current
+    if (scrollArea) scrollArea.scrollTop = scrollArea.scrollHeight
+  }, [activity.thinking, activity.tools.length, lastTool?.status])
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid={`cloud-todo-card-activity-${itemId}`}
+      className="scrollbar-none ml-5 mt-1.5 h-5 min-w-0 overflow-y-auto border-l border-border/70 pl-2 text-xs leading-5 text-text-muted"
+    >
+      {completedTools.map(block => (
+        <RuntimeTaskToolActivity key={block.id} itemId={itemId} block={block} />
+      ))}
+      {activity.thinking ? (
+        <div className="flex h-5 min-w-0 items-center">
+          <AssistantThinkingIndicator
+            content={activity.thinking}
+            testId={`cloud-todo-card-thinking-${itemId}`}
+            className="text-xs leading-5"
+          />
+        </div>
+      ) : null}
+      {activeTools.map(block => (
+        <RuntimeTaskToolActivity key={block.id} itemId={itemId} block={block} />
+      ))}
+    </div>
+  )
+}
+
+function RuntimeTaskToolActivity({
+  itemId,
+  block,
+}: {
+  itemId: string
+  block: RuntimeLiveActivity['tools'][number]
+}) {
+  const { t } = useTranslation('chat')
+  const running = block.status !== 'done' && block.status !== 'error'
+
+  return (
+    <div
+      data-testid={`cloud-todo-card-tool-${itemId}-${block.id}`}
+      className="flex h-5 min-w-0 items-center"
+    >
+      <span className={cn('min-w-0 truncate', running && 'waiting-thinking-text')}>
+        {runtimeToolActivityText(block, t)}
+      </span>
+    </div>
+  )
+}
+
+function useRuntimeTaskActivity(address: RuntimeTaskAddress | null): RuntimeLiveActivity {
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      address ? subscribeRuntimeConversation(address, listener) : () => undefined,
+    [address]
+  )
+  const getSnapshot = useCallback(
+    () => (address ? getRuntimeConversationLiveActivitySnapshot(address) : ''),
+    [address]
+  )
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  return useMemo(() => runtimeLiveActivityFromSnapshot(snapshot), [snapshot])
+}
+
+function runtimeToolActivityText(
+  block: RuntimeLiveToolActivity,
+  t: ReturnType<typeof useTranslation>['t']
+): string {
+  const kind = getToolActivityKind(block)
+  const paths = getToolActivityFilePaths(block)
+  const path = paths[0] ? displayActivityPath(paths[0]) : ''
+  const command = getInputField(block, 'command', 'cmd', 'commandLine')?.replace(/\s+/g, ' ').trim()
+  const search = getToolActivitySearchItem(block)
+  const running = block.status !== 'done' && block.status !== 'error'
+
+  if (kind === 'command') {
+    return activityLabel(t('tool_activity.command_action'), command)
+  }
+  if (kind === 'file') {
+    return activityLabel(t('tool_activity.file_action'), path)
+  }
+  if (kind === 'search') {
+    return activityLabel(
+      t(running ? 'tool_activity.search_running' : 'tool_activity.search_done'),
+      search?.query
+    )
+  }
+  if (kind === 'edit') {
+    return activityLabel(t('tool_activity.edit_action'), path)
+  }
+  if (kind === 'create') {
+    return activityLabel(t('tool_activity.create_action'), path)
+  }
+  return activityLabel(t('tool_activity.other_action'), block.toolName)
+}
+
+function activityLabel(label: string, detail: string | undefined): string {
+  return detail ? `${label} · ${detail}` : label
+}
+
+function displayActivityPath(path: string): string {
+  return path.replaceAll('\\', '/').split('/').filter(Boolean).at(-1) ?? path
 }

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -1,15 +1,18 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@/i18n'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import {
+  applyRuntimeConversationAction,
+  clearRuntimeConversationCacheForTests,
+} from '@/features/workbench/runtimeConversationCache'
 import type { User } from '@/types/api'
 import { CloudTodoWorkspace } from './CloudTodoWorkspace'
 import {
   isSelfManagedWorkItem,
   shouldDeferWorkItemMoveUntilTaskCreated,
   shouldPrepareWorkItemTask,
-  shouldRevealWorkItemWorkflowActions,
   workItemTaskInput,
 } from './workItemTaskInput'
 
@@ -43,6 +46,7 @@ vi.mock('./AiChatModal', () => ({
     onClose,
     initialAddress,
     onOpenRuntimeTask,
+    onAddressChange,
     onTaskCreated,
     workflowNodeId,
   }: {
@@ -51,6 +55,7 @@ vi.mock('./AiChatModal', () => ({
     onClose: () => void
     initialAddress?: { deviceId: string; taskId: string } | null
     onOpenRuntimeTask?: (address: { deviceId: string; taskId: string }) => void
+    onAddressChange?: (address: { deviceId: string; taskId: string }) => void
     onTaskCreated?: (address: { deviceId: string; taskId: string }) => void | Promise<void>
     workflowNodeId?: string
   }) => (
@@ -64,9 +69,11 @@ vi.mock('./AiChatModal', () => ({
       <button
         type="button"
         data-testid="mock-create-runtime-task"
-        onClick={() =>
-          void onTaskCreated?.({ deviceId: 'local-device', taskId: 'runtime-created' })
-        }
+        onClick={() => {
+          const address = { deviceId: 'local-device', taskId: 'runtime-created' }
+          onAddressChange?.(address)
+          void onTaskCreated?.(address)
+        }}
       >
         创建 Runtime 任务
       </button>
@@ -145,7 +152,7 @@ describe('shouldPrepareWorkItemTask', () => {
     ).toBe(true)
   })
 
-  it('keeps an inbox issue in place until its pending task is actually created', () => {
+  it('keeps an inbox issue in place while the user confirms its pending task', () => {
     expect(shouldDeferWorkItemMoveUntilTaskCreated(item, 'pending', 0)).toBe(true)
     expect(shouldDeferWorkItemMoveUntilTaskCreated(item, 'in_progress', 0)).toBe(false)
     expect(shouldDeferWorkItemMoveUntilTaskCreated(item, 'pending', 1)).toBe(false)
@@ -186,63 +193,9 @@ describe('shouldPrepareWorkItemTask', () => {
     }
 
     expect(isSelfManagedWorkItem(presetWorkflowIssue)).toBe(false)
-    expect(shouldDeferWorkItemMoveUntilTaskCreated(presetWorkflowIssue, 'pending', 0)).toBe(false)
     expect(shouldPrepareWorkItemTask(presetWorkflowIssue, 'pending', 0)).toBe(false)
-    expect(shouldRevealWorkItemWorkflowActions(presetWorkflowIssue, 'pending')).toBe(true)
     expect(isSelfManagedWorkItem(aiManagedIssue)).toBe(false)
-    expect(shouldDeferWorkItemMoveUntilTaskCreated(aiManagedIssue, 'pending', 0)).toBe(false)
     expect(shouldPrepareWorkItemTask(aiManagedIssue, 'pending', 0)).toBe(false)
-    expect(shouldRevealWorkItemWorkflowActions(aiManagedIssue, 'pending')).toBe(false)
-  })
-
-  it('does not reveal workflow actions for automated, blocked, or already-moved stages', () => {
-    const automatedWorkflowIssue = {
-      ...item,
-      status: 'inbox' as const,
-      workflow: {
-        version: 1,
-        definition_version: 1,
-        stage_mode: 'dag' as const,
-        advancement_policy: 'manual' as const,
-        nodes: [
-          {
-            id: 'develop',
-            name: '开发',
-            depends_on: [],
-            required: true,
-            workspace_policy: 'composer' as const,
-            automation_rule_id: 'rule-1',
-            status: 'ready' as const,
-          },
-        ],
-      },
-    }
-
-    expect(shouldRevealWorkItemWorkflowActions(automatedWorkflowIssue, 'pending')).toBe(false)
-    expect(
-      shouldRevealWorkItemWorkflowActions(
-        {
-          ...automatedWorkflowIssue,
-          workflow: {
-            ...automatedWorkflowIssue.workflow,
-            nodes: [
-              {
-                ...automatedWorkflowIssue.workflow.nodes[0],
-                automation_rule_id: null,
-                status: 'blocked' as const,
-              },
-            ],
-          },
-        },
-        'pending'
-      )
-    ).toBe(false)
-    expect(
-      shouldRevealWorkItemWorkflowActions(
-        { ...automatedWorkflowIssue, status: 'pending' },
-        'pending'
-      )
-    ).toBe(false)
   })
 
   it('treats legacy workflows with stages as preset orchestration', () => {
@@ -480,6 +433,7 @@ function services(overrides: Partial<WorkbenchServices> = {}): WorkbenchServices
 
 describe('CloudTodoWorkspace', () => {
   beforeEach(() => {
+    clearRuntimeConversationCacheForTests()
     telemetryMocks.track.mockClear()
     vi.stubGlobal(
       'ResizeObserver',
@@ -492,6 +446,7 @@ describe('CloudTodoWorkspace', () => {
   })
 
   afterEach(() => {
+    clearRuntimeConversationCacheForTests()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
     localStorage.clear()
@@ -577,6 +532,126 @@ describe('CloudTodoWorkspace', () => {
     )
     expect(screen.queryByText('补充回归截图')).not.toBeInTheDocument()
     expect(screen.queryByTestId('cloud-todo-card-add-child-WEG-1')).not.toBeInTheDocument()
+  })
+
+  it('shows live thinking for the running runtime task on its board card', async () => {
+    const workbenchServices = services()
+    workbenchServices.deliveryApi!.listTaskBindings = vi.fn(async () => [
+      {
+        id: 2,
+        loop_item_id: item.id,
+        task_user_id: 1,
+        device_id: 'local-device',
+        task_id: 'runtime-2',
+        task_title: '验证完整工作流',
+        backend_task_id: null,
+        linked_at: '2026-08-16T00:01:00Z',
+      },
+    ])
+    const address = { deviceId: 'local-device', taskId: 'runtime-2' }
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'turn-1',
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      content: '',
+      reasoningChunk: 'Investigating board data flow',
+    })
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        runtimeWork={{
+          projects: [
+            {
+              project: { id: project.id, name: project.name },
+              deviceWorkspaces: [
+                {
+                  deviceId: address.deviceId,
+                  available: true,
+                  workspacePath: '/tmp/wegent',
+                  tasks: [
+                    {
+                      taskId: address.taskId,
+                      workspacePath: '/tmp/wegent',
+                      title: '验证完整工作流',
+                      runtime: 'codex',
+                      running: false,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          chats: [],
+          totalTasks: 1,
+        }}
+        services={workbenchServices}
+      />
+    )
+
+    await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
+    expect(await screen.findByTestId('cloud-todo-card-thinking-WEG-1')).toHaveTextContent(
+      '正在思考 · Investigating board data flow'
+    )
+    expect(screen.getByTestId('cloud-todo-card-activity-WEG-1')).toHaveClass(
+      'h-5',
+      'overflow-y-auto',
+      'scrollbar-none',
+      'text-xs',
+      'border-l'
+    )
+
+    act(() => {
+      applyRuntimeConversationAction(address, {
+        type: 'block_created',
+        subtaskId: 'turn-1',
+        block: {
+          id: 'tool-1',
+          subtaskId: 'turn-1',
+          type: 'tool',
+          toolName: 'functions.exec_command',
+          toolInput: { cmd: 'pnpm test' },
+          status: 'streaming',
+          createdAt: Date.now(),
+        },
+      })
+      applyRuntimeConversationAction(address, {
+        type: 'assistant_chunk',
+        subtaskId: 'turn-1',
+        content: '',
+        reasoningChunk: '. Rendering latest thinking',
+      })
+    })
+
+    expect(screen.getByTestId('cloud-todo-card-thinking-WEG-1')).toHaveTextContent(
+      '正在思考 · Rendering latest thinking'
+    )
+    expect(screen.getByTestId('cloud-todo-card-tool-WEG-1-tool-1')).toHaveTextContent(
+      '运行命令 · pnpm test'
+    )
+    expect(
+      screen
+        .getByTestId('cloud-todo-card-thinking-WEG-1')
+        .compareDocumentPosition(screen.getByTestId('cloud-todo-card-tool-WEG-1-tool-1')) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).not.toBe(0)
+    expect(screen.getByTestId('cloud-todo-card-activity-WEG-1')).toHaveClass(
+      'h-5',
+      'overflow-y-auto'
+    )
+    expect(screen.getByTestId('cloud-todo-card-thinking-WEG-1')).toHaveClass('text-xs', 'leading-5')
+
+    await userEvent.click(screen.getByTestId('cloud-todo-card-tasks-WEG-1'))
+    expect(await screen.findByTestId('cloud-todo-detail')).toBeInTheDocument()
+    expect(await screen.findByTestId('ai-chat-modal')).toHaveAttribute(
+      'data-runtime-task-id',
+      'runtime-2'
+    )
   })
 
   it('reports the concrete project name for the active document tab', async () => {
@@ -1005,6 +1080,31 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.getByTestId('ai-chat-modal')).not.toHaveAttribute('data-runtime-task-id')
   })
 
+  it('continues a task in the background after sending it from pending', async () => {
+    const workbenchServices = services()
+    workbenchServices.deliveryApi!.listLoopItems = vi.fn(async () => ({
+      items: [{ ...item, status: 'pending' as const }],
+    }))
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[{ id: 91, name: '运营工作区', tasks: [] }]}
+        services={workbenchServices}
+      />
+    )
+
+    await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
+    await userEvent.click(await screen.findByTestId('cloud-todo-card-WEG-1'))
+    await userEvent.click(screen.getByTestId('cloud-todo-create-task'))
+    expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-open', 'yes')
+
+    await userEvent.click(screen.getByTestId('mock-create-runtime-task'))
+
+    expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-open', 'no')
+    expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
+  })
+
   it('closes the work-item drawer when the user clicks outside it', async () => {
     render(
       <CloudTodoWorkspace
@@ -1021,6 +1121,7 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.getByTestId('cloud-todo-detail').parentElement).toHaveClass(
       'task-detail-workspace-panel-shell'
     )
+    expect(screen.getByTestId('cloud-todo-detail-dismiss-layer')).toHaveClass('bottom-3')
 
     await userEvent.click(screen.getByTestId('cloud-todo-detail-dismiss-layer'))
 

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -61,6 +61,7 @@ import { copyTextToClipboard } from '@/lib/clipboard'
 import { cn } from '@/lib/utils'
 import { track } from '@/telemetry/client'
 import { hydrateRuntimeTaskAddress } from '@/features/workbench/workbenchRuntimeHelpers'
+import { isRuntimeTaskExecutionRunning } from '@/features/workbench/runtimeTaskLifecycle/projection'
 import { AITableView } from '@/features/todo/AITableView'
 import type {
   ProjectWithTasks,
@@ -76,6 +77,7 @@ import {
   CloudTodoBoardCard,
   CloudTodoCardContent,
   type BoardCardDisplaySettings,
+  type CloudTodoBoardTaskBinding,
 } from './CloudTodoBoardCard'
 import { CloudProjectManageView } from './CloudProjectManageView'
 import { waitForDwsAuthentication } from './dwsAuth'
@@ -109,11 +111,11 @@ import { AiChatModal } from './AiChatModal'
 import {
   shouldDeferWorkItemMoveUntilTaskCreated,
   shouldPrepareWorkItemTask,
-  shouldRevealWorkItemWorkflowActions,
   workItemTaskInput,
   workflowStageTaskInput,
 } from './workItemTaskInput'
 import type { WorkflowDeliverableDraft } from './WorkflowStageCompletionDialog'
+import { runtimeConversationKey } from '@/features/workbench/runtimeConversationCache'
 
 type ProjectView = 'board' | 'table' | 'files' | 'automation' | 'manage'
 type RootView = 'projects' | 'my-work' | 'settings'
@@ -348,6 +350,7 @@ type TaskComposerRequest = {
   workItemId: string
   initialInput: string
   autoSubmit: boolean
+  backgroundAfterSend: boolean
   workflowNodeId?: string
   inheritFromTask?: RuntimeTaskAddress | null
 }
@@ -938,6 +941,7 @@ export function CloudTodoWorkspace({
   const [rootView, setRootView] = useState<RootView>('projects')
   const [projectView, setProjectView] = useState<ProjectView>('board')
   const [selectedItem, setSelectedItem] = useState<LocatedLoopItem | null>(null)
+  const [backgroundTaskItemId, setBackgroundTaskItemId] = useState<string | null>(null)
   // Items of the detail drawer's project when it differs from the board project,
   // so the drawer can stay open without switching the board view.
   const [detailItems, setDetailItems] = useState<LocatedLoopItem[]>([])
@@ -1200,6 +1204,47 @@ export function CloudTodoWorkspace({
     }
     return result
   }, [runtimeWork])
+  const runtimeTaskRunningByAddress = useMemo(() => {
+    const result = new Map<string, boolean>()
+    const workspaces = [
+      ...(runtimeWork?.projects ?? []).flatMap(projectWork => projectWork.deviceWorkspaces),
+      ...(runtimeWork?.chats ?? []),
+    ]
+    for (const workspace of workspaces) {
+      for (const task of workspace.tasks) {
+        result.set(
+          runtimeConversationKey({
+            deviceId: workspace.deviceId,
+            taskId: task.taskId,
+          }),
+          isRuntimeTaskExecutionRunning(task)
+        )
+      }
+    }
+    return result
+  }, [runtimeWork])
+  const boardTaskBindings = useMemo<Record<string, CloudTodoBoardTaskBinding[]>>(
+    () =>
+      Object.fromEntries(
+        Object.entries(itemTaskBindings).map(([itemId, bindings]) => [
+          itemId,
+          bindings.map(binding => ({
+            id: binding.id,
+            device_id: binding.device_id,
+            task_id: binding.task_id,
+            task_title: binding.task_title,
+            running:
+              runtimeTaskRunningByAddress.get(
+                runtimeConversationKey({
+                  deviceId: binding.device_id,
+                  taskId: binding.task_id,
+                })
+              ) ?? false,
+          })),
+        ])
+      ),
+    [itemTaskBindings, runtimeTaskRunningByAddress]
+  )
   const localProjectIdForItem = useCallback(
     (item: CloudLoopItem): number | null => {
       const storedAssociation = loopItemLocalProject(item)
@@ -2091,10 +2136,12 @@ export function CloudTodoWorkspace({
     ) {
       setSelectedTaskBinding(null)
       setSelectedItem(item)
+      setBackgroundTaskItemId(null)
       setTaskComposerRequest({
         workItemId: item.id,
         initialInput: workItemTaskInput(item),
         autoSubmit: false,
+        backgroundAfterSend: true,
       })
       return
     }
@@ -2186,19 +2233,13 @@ export function CloudTodoWorkspace({
       if (shouldOpenTaskComposer) {
         setSelectedTaskBinding(null)
         setSelectedItem(locatedUpdated)
+        setBackgroundTaskItemId(column.status === 'in_progress' ? locatedUpdated.id : null)
         setTaskComposerRequest({
           workItemId: locatedUpdated.id,
           initialInput: workItemTaskInput(locatedUpdated),
           autoSubmit: column.status === 'in_progress',
+          backgroundAfterSend: column.status === 'in_progress',
         })
-      } else if (
-        nativeGroupBy === 'status' &&
-        column.status === 'pending' &&
-        shouldRevealWorkItemWorkflowActions(item, column.status) &&
-        locatedUpdated.can_view_detail !== false
-      ) {
-        setSelectedTaskBinding(null)
-        setSelectedItem(locatedUpdated)
       }
       track('board_item_moved', {
         group_by: nativeGroupBy,
@@ -2397,6 +2438,7 @@ export function CloudTodoWorkspace({
           workItemId: locatedItem.id,
           initialInput: workItemTaskInput(locatedItem),
           autoSubmit: true,
+          backgroundAfterSend: true,
         })
       }
       track('board_item_created', {
@@ -2646,17 +2688,18 @@ export function CloudTodoWorkspace({
           </aside>
         ) : null}
         <main className="relative flex min-w-0 flex-1 flex-col">
-          {selectedItem ? (
+          {selectedItem && backgroundTaskItemId !== selectedItem.id ? (
             <button
               type="button"
               data-testid="cloud-todo-detail-dismiss-layer"
               aria-label="关闭 Issue 详情"
               onClick={() => {
                 setSelectedItem(null)
+                setBackgroundTaskItemId(null)
                 setSelectedTaskBinding(null)
                 setTaskComposerRequest(null)
               }}
-              className="absolute inset-0 z-30 cursor-default bg-transparent"
+              className="absolute inset-x-0 bottom-3 top-0 z-30 cursor-default bg-transparent"
             />
           ) : null}
           {!embedded && !selectedProject && (
@@ -3466,24 +3509,36 @@ export function CloudTodoWorkspace({
                                       item={item}
                                       taskBindings={
                                         itemTaskBindingsProjectKey === selectedProjectKey
-                                          ? (itemTaskBindings[item.id] ?? [])
+                                          ? (boardTaskBindings[item.id] ?? [])
                                           : []
                                       }
                                       onClick={() => {
-                                        if (item.can_view_detail !== false) setSelectedItem(item)
+                                        if (item.can_view_detail !== false) {
+                                          setBackgroundTaskItemId(null)
+                                          setSelectedItem(item)
+                                        }
                                       }}
                                       onArchive={() => {
                                         setArchiveError(null)
                                         setArchiveItem(item)
                                       }}
-                                      onOpenActivity={
-                                        selectedProject.location === 'cloud'
-                                          ? () => {
-                                              if (item.can_view_detail !== false)
-                                                setSelectedItem(item)
-                                            }
-                                          : undefined
-                                      }
+                                      onOpenActivity={() => {
+                                        if (item.can_view_detail === false) return
+                                        const binding =
+                                          boardTaskBindings[item.id]?.find(
+                                            candidate => candidate.running
+                                          ) ?? boardTaskBindings[item.id]?.[0]
+                                        if (!binding) return
+                                        setBackgroundTaskItemId(null)
+                                        setSelectedItem(item)
+                                        setSelectedTaskBinding({
+                                          id: binding.id,
+                                          device_id: binding.device_id,
+                                          task_id: binding.task_id,
+                                          task_title: binding.task_title,
+                                          work_item_id: item.id,
+                                        })
+                                      }}
                                       display={boardCardDisplay}
                                       agentNames={agentNameById}
                                       dragDisabled={isAITableProject}
@@ -3572,7 +3627,10 @@ export function CloudTodoWorkspace({
             </>
           )}
         </main>
-        {selectedItem && selectedItem.can_view_detail !== false && selectedItemApi ? (
+        {selectedItem &&
+        backgroundTaskItemId !== selectedItem.id &&
+        selectedItem.can_view_detail !== false &&
+        selectedItemApi ? (
           <TodoEditor
             key={selectedItem.id}
             mode="edit"
@@ -3624,6 +3682,7 @@ export function CloudTodoWorkspace({
                 workItemId: selectedItem.id,
                 initialInput: workflowNode ? workflowStageTaskInput(workflowNode) : '',
                 autoSubmit: false,
+                backgroundAfterSend: selectedItem.status === 'pending',
                 workflowNodeId,
                 inheritFromTask,
               })
@@ -3735,6 +3794,7 @@ export function CloudTodoWorkspace({
             }}
             onClose={() => {
               setSelectedItem(null)
+              setBackgroundTaskItemId(null)
               setSelectedTaskBinding(null)
               setTaskComposerRequest(null)
             }}
@@ -3796,7 +3856,7 @@ export function CloudTodoWorkspace({
                 ? selectedTaskBinding.task_title
                 : null
             }
-            open
+            open={backgroundTaskItemId !== selectedItem.id}
             embedded
             initialTaskInput={
               taskComposerRequest?.workItemId === selectedItem.id
@@ -3814,10 +3874,17 @@ export function CloudTodoWorkspace({
                 : undefined
             }
             onClose={() => {
+              setBackgroundTaskItemId(null)
               setSelectedTaskBinding(null)
               setTaskComposerRequest(null)
             }}
             onAddressChange={address => {
+              if (
+                taskComposerRequest?.workItemId === selectedItem.id &&
+                taskComposerRequest.backgroundAfterSend
+              ) {
+                setBackgroundTaskItemId(selectedItem.id)
+              }
               setSelectedTaskBinding({
                 id: -Date.now(),
                 device_id: address.deviceId,

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -111,6 +111,7 @@ import { AiChatModal } from './AiChatModal'
 import {
   shouldDeferWorkItemMoveUntilTaskCreated,
   shouldPrepareWorkItemTask,
+  shouldRevealWorkItemWorkflowActions,
   workItemTaskInput,
   workflowStageTaskInput,
 } from './workItemTaskInput'
@@ -2240,6 +2241,15 @@ export function CloudTodoWorkspace({
           autoSubmit: column.status === 'in_progress',
           backgroundAfterSend: column.status === 'in_progress',
         })
+      } else if (
+        nativeGroupBy === 'status' &&
+        column.status === 'pending' &&
+        shouldRevealWorkItemWorkflowActions(item, column.status) &&
+        locatedUpdated.can_view_detail !== false
+      ) {
+        setBackgroundTaskItemId(null)
+        setSelectedTaskBinding(null)
+        setSelectedItem(locatedUpdated)
       }
       track('board_item_moved', {
         group_by: nativeGroupBy,

--- a/wework/src/features/todo/workItemTaskInput.ts
+++ b/wework/src/features/todo/workItemTaskInput.ts
@@ -54,3 +54,17 @@ export function shouldDeferWorkItemMoveUntilTaskCreated(
     targetStatus === 'pending' && shouldPrepareWorkItemTask(item, targetStatus, taskBindingCount)
   )
 }
+
+export function shouldRevealWorkItemWorkflowActions(
+  item: Pick<CloudLoopItem, 'status' | 'workflow'>,
+  targetStatus: TaskEntryStatus
+): boolean {
+  return (
+    item.status === 'inbox' &&
+    targetStatus === 'pending' &&
+    !isSelfManagedWorkItem(item) &&
+    Boolean(
+      item.workflow?.nodes.some(stage => !stage.automation_rule_id && stage.status === 'ready')
+    )
+  )
+}

--- a/wework/src/features/todo/workItemTaskInput.ts
+++ b/wework/src/features/todo/workItemTaskInput.ts
@@ -54,17 +54,3 @@ export function shouldDeferWorkItemMoveUntilTaskCreated(
     targetStatus === 'pending' && shouldPrepareWorkItemTask(item, targetStatus, taskBindingCount)
   )
 }
-
-export function shouldRevealWorkItemWorkflowActions(
-  item: Pick<CloudLoopItem, 'status' | 'workflow'>,
-  targetStatus: TaskEntryStatus
-): boolean {
-  return (
-    item.status === 'inbox' &&
-    targetStatus === 'pending' &&
-    !isSelfManagedWorkItem(item) &&
-    Boolean(
-      item.workflow?.nodes.some(stage => !stage.automation_rule_id && stage.status === 'ready')
-    )
-  )
-}

--- a/wework/src/features/workbench/runtimeConversationCache.test.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import {
+  abortRuntimeConversationHydration,
   appendOptimisticRuntimeConversationGuidance,
   applyRuntimeConversationGoalContinuation,
   applyRuntimeConversationSubagentActivity,
   applyRuntimeConversationAction,
+  beginRuntimeConversationHydration,
   cacheConversationScrollSnapshot,
   cacheConversationVirtualMeasurements,
   cacheRuntimeConversationQueuedMessages,
   cacheRuntimeConversationQueuePaused,
   clearRuntimeConversationCacheForTests,
+  completeRuntimeConversationHydration,
   evictRuntimeConversation,
   getConversationScrollSnapshot,
   getConversationVirtualMeasurements,
@@ -66,6 +69,31 @@ describe('runtimeConversationCache', () => {
     })
 
     expect(getRuntimeConversationLiveActivitySnapshot(address)).toBe('')
+  })
+
+  test('keeps a replacement hydration active when the older request resolves later', () => {
+    const olderToken = beginRuntimeConversationHydration(address)
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'turn-1',
+    })
+    abortRuntimeConversationHydration(address, olderToken)
+
+    const replacementToken = beginRuntimeConversationHydration(address)
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_chunk',
+      subtaskId: 'turn-1',
+      content: '',
+      reasoningChunk: 'replacement request activity',
+    })
+
+    abortRuntimeConversationHydration(address, olderToken)
+    completeRuntimeConversationHydration(address, replacementToken, [])
+
+    expect(getRuntimeConversationLiveActivitySnapshot(address)).toContain(
+      'replacement request activity'
+    )
   })
 
   test('notifies conversation subscribers when the follow-up queue pause changes', () => {

--- a/wework/src/features/workbench/runtimeConversationCache.test.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.test.ts
@@ -13,6 +13,7 @@ import {
   getConversationScrollSnapshot,
   getConversationVirtualMeasurements,
   getRuntimeConversationCacheStats,
+  getRuntimeConversationLiveActivitySnapshot,
   getRuntimeConversationMetadata,
   getRuntimeConversationMessages,
   getRuntimeConversationQueuedMessages,
@@ -55,6 +56,16 @@ describe('runtimeConversationCache', () => {
     })
 
     expect(getRuntimeConversationMessages(address)).toHaveLength(1)
+  })
+
+  test('does not project an empty live-activity row before thinking or tools arrive', () => {
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'turn-1',
+    })
+
+    expect(getRuntimeConversationLiveActivitySnapshot(address)).toBe('')
   })
 
   test('notifies conversation subscribers when the follow-up queue pause changes', () => {

--- a/wework/src/features/workbench/runtimeConversationCache.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.ts
@@ -27,6 +27,7 @@ import {
   createOptimisticRuntimeGuidanceMessage,
 } from './runtimeGuidanceMessages'
 import { updateRuntimeGoalContinuation } from '@/lib/runtime-goal'
+import { getLatestRuntimeLiveActivity, runtimeLiveActivitySnapshot } from './runtimeThinking'
 
 const MAX_CONVERSATION_CACHE_ENTRIES = 50
 const turnsByConversation = new Map<string, RuntimeConversationTurn[]>()
@@ -156,6 +157,12 @@ export function settleRuntimeConversationSubagents(address: RuntimeTaskAddress):
 export function getRuntimeConversationMessages(address: RuntimeTaskAddress): WorkbenchMessage[] {
   const key = runtimeConversationKey(address)
   return projectRuntimeConversationTurns(touchEntry(turnsByConversation, key) ?? [])
+}
+
+export function getRuntimeConversationLiveActivitySnapshot(address: RuntimeTaskAddress): string {
+  return runtimeLiveActivitySnapshot(
+    getLatestRuntimeLiveActivity(getRuntimeConversationMessages(address))
+  )
 }
 
 export function subscribeRuntimeConversation(

--- a/wework/src/features/workbench/runtimeTaskLifecycle/projection.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/projection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import type { RuntimeTaskSummary } from '@/types/api'
 import {
+  isRuntimeTaskExecutionRunning,
   normalizeRuntimeTaskSummary,
   runtimeTaskReconciliationSnapshot,
   shouldReplaceRuntimeTaskProjection,
@@ -36,6 +37,14 @@ describe('runtimeTaskProjection', () => {
       running: true,
       turnStatus: 'inProgress',
     })
+  })
+
+  test('recognizes executor-reported running tasks before turn status catches up', () => {
+    expect(isRuntimeTaskExecutionRunning(task({ running: true }))).toBe(true)
+    expect(isRuntimeTaskExecutionRunning(task({ running: true, optimistic: true }))).toBe(false)
+    expect(
+      isRuntimeTaskExecutionRunning(task({ running: true, completedAt: 1_786_676_400_000 }))
+    ).toBe(false)
   })
 
   test('normalizes completed executor state into one terminal projection', () => {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/projection.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/projection.ts
@@ -117,6 +117,15 @@ export function isRuntimeTaskConfirmedActive(task: RuntimeTaskSummary): boolean 
   )
 }
 
+export function isRuntimeTaskExecutionRunning(task: RuntimeTaskSummary): boolean {
+  const normalizedTask = normalizeRuntimeTaskSummary(task)
+  return (
+    normalizedTask.optimistic !== true &&
+    normalizedTask.running === true &&
+    normalizedTask.completedAt == null
+  )
+}
+
 function isRuntimeTaskOptimisticallyActive(task: RuntimeTaskSummary): boolean {
   return (
     task.optimistic === true &&

--- a/wework/src/features/workbench/runtimeThinking.ts
+++ b/wework/src/features/workbench/runtimeThinking.ts
@@ -1,0 +1,70 @@
+import type { ProcessingBlock, ToolBlock, WorkbenchMessage } from '@/types/workbench'
+
+export type RuntimeLiveToolActivity = Pick<ToolBlock, 'id' | 'status' | 'toolName' | 'toolInput'>
+
+export interface RuntimeLiveActivity {
+  active: boolean
+  thinking: string
+  tools: RuntimeLiveToolActivity[]
+}
+
+export const EMPTY_RUNTIME_LIVE_ACTIVITY: RuntimeLiveActivity = {
+  active: false,
+  thinking: '',
+  tools: [],
+}
+
+export function getRuntimeMessageActiveThinking(message: WorkbenchMessage): string {
+  if (message.role !== 'assistant' || message.status !== 'streaming') return ''
+
+  return message.streamingThinkingContent?.trim() || getLatestActiveThinkingBlock(message.blocks)
+}
+
+export function getLatestRuntimeLiveActivity(messages: WorkbenchMessage[]): RuntimeLiveActivity {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.role !== 'assistant' || message.status !== 'streaming') continue
+
+    return {
+      active: true,
+      thinking: getRuntimeMessageActiveThinking(message),
+      tools:
+        message.blocks
+          ?.filter(block => block.type === 'tool')
+          .map(block => ({
+            id: block.id,
+            status: block.status,
+            toolName: block.toolName,
+            toolInput: block.toolInput,
+          })) ?? [],
+    }
+  }
+  return EMPTY_RUNTIME_LIVE_ACTIVITY
+}
+
+export function runtimeLiveActivitySnapshot(activity: RuntimeLiveActivity): string {
+  if (!activity.active || (!activity.thinking && activity.tools.length === 0)) return ''
+  return JSON.stringify(activity)
+}
+
+export function runtimeLiveActivityFromSnapshot(snapshot: string): RuntimeLiveActivity {
+  return snapshot ? (JSON.parse(snapshot) as RuntimeLiveActivity) : EMPTY_RUNTIME_LIVE_ACTIVITY
+}
+
+function getLatestActiveThinkingBlock(blocks: ProcessingBlock[] | undefined): string {
+  if (!blocks?.length) return ''
+
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index]
+    if (
+      block?.type === 'thinking' &&
+      block.status !== 'done' &&
+      block.status !== 'error' &&
+      block.content.trim()
+    ) {
+      return block.content
+    }
+  }
+
+  return ''
+}

--- a/wework/src/features/workbench/useWorkbenchProjectActions.ts
+++ b/wework/src/features/workbench/useWorkbenchProjectActions.ts
@@ -502,10 +502,17 @@ export function useWorkbenchProjectActions({
 
   const setRuntimeTaskPinned = useCallback(
     async (data: RuntimeTaskPinRequest) => {
-      await executorClient.runtime.setRuntimeTaskPinned(data)
-      await refreshWorkLists()
+      dispatch({ type: 'runtime_task_pin_changed', ...data })
+      try {
+        await executorClient.runtime.setRuntimeTaskPinned(data)
+        await refreshWorkLists()
+        dispatch({ type: 'runtime_task_pin_changed', ...data })
+      } catch (error) {
+        dispatch({ type: 'runtime_task_pin_changed', ...data, pinned: !data.pinned })
+        throw error
+      }
     },
-    [executorClient, refreshWorkLists]
+    [dispatch, executorClient, refreshWorkLists]
   )
 
   const getDeviceHomeDirectory = useCallback(

--- a/wework/src/features/workbench/workbenchReducer.test.ts
+++ b/wework/src/features/workbench/workbenchReducer.test.ts
@@ -245,6 +245,73 @@ describe('workbenchReducer', () => {
     ])
   })
 
+  test('updates pinned state across project and chat runtime task projections', () => {
+    const projectTask = {
+      taskId: 'project-thread',
+      workspacePath: '/workspace/repo',
+      title: 'Project task',
+      runtime: 'codex' as const,
+      pinned: false,
+    }
+    const chatTask = {
+      taskId: 'chat-task',
+      threadId: 'chat-thread',
+      workspacePath: '/workspace/chat',
+      title: 'Chat task',
+      runtime: 'claude_code' as const,
+      pinned: false,
+    }
+    const state = {
+      ...initialWorkbenchState,
+      runtimeWork: {
+        projects: [
+          {
+            project: {
+              id: 7,
+              name: 'Repo',
+              stateDeviceId: 'project-state-device',
+            },
+            deviceWorkspaces: [
+              {
+                deviceId: 'workspace-device',
+                workspacePath: '/workspace/repo',
+                available: true,
+                tasks: [projectTask],
+              },
+            ],
+            totalTasks: 1,
+          },
+        ],
+        chats: [
+          {
+            deviceId: 'chat-device',
+            workspacePath: '/workspace/chat',
+            workspaceKind: 'chat',
+            available: true,
+            tasks: [chatTask],
+          },
+        ],
+        totalTasks: 2,
+      },
+    }
+
+    const projectUpdated = workbenchReducer(state, {
+      type: 'runtime_task_pin_changed',
+      deviceId: 'project-state-device',
+      threadId: 'project-thread',
+      pinned: true,
+    })
+    const chatUpdated = workbenchReducer(projectUpdated, {
+      type: 'runtime_task_pin_changed',
+      deviceId: 'chat-device',
+      threadId: 'chat-thread',
+      pinned: true,
+    })
+
+    expect(chatUpdated.runtimeWork?.projects[0].deviceWorkspaces[0].tasks[0].pinned).toBe(true)
+    expect(chatUpdated.runtimeWork?.chats[0].tasks[0].pinned).toBe(true)
+  })
+
   test('updates only the matching runtime task supervisor state', () => {
     const state = {
       ...initialWorkbenchState,

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -85,6 +85,12 @@ export type WorkbenchAction =
       runtimeWork: RuntimeWorkListResponse
     }
   | {
+      type: 'runtime_task_pin_changed'
+      deviceId: string
+      threadId: string
+      pinned: boolean
+    }
+  | {
       type: 'device_status_changed'
       deviceId: string
       status: WorkbenchDeviceStatus
@@ -1031,6 +1037,36 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
           state.devices,
           runtimeWork
         ),
+      }
+    }
+    case 'runtime_task_pin_changed': {
+      if (!state.runtimeWork) return state
+      const updateWorkspace = (
+        workspace: RuntimeDeviceWorkspace,
+        deviceId = workspace.deviceId
+      ) => {
+        if (deviceId !== action.deviceId) return workspace
+        let changed = false
+        const tasks = workspace.tasks.map(task => {
+          const threadId = task.threadId || (task.runtime === 'codex' ? task.taskId : null)
+          if (threadId !== action.threadId || Boolean(task.pinned) === action.pinned) return task
+          changed = true
+          return { ...task, pinned: action.pinned }
+        })
+        return changed ? { ...workspace, tasks } : workspace
+      }
+      return {
+        ...state,
+        runtimeWork: {
+          ...state.runtimeWork,
+          projects: state.runtimeWork.projects.map(project => ({
+            ...project,
+            deviceWorkspaces: project.deviceWorkspaces.map(workspace =>
+              updateWorkspace(workspace, project.project.stateDeviceId ?? workspace.deviceId)
+            ),
+          })),
+          chats: state.runtimeWork.chats.map(workspace => updateWorkspace(workspace)),
+        },
       }
     }
     case 'device_status_changed': {


### PR DESCRIPTION
## Summary

- show the current local runtime tool/thinking activity in a fixed single-row board-card viewport
- keep task execution in the background without automatically opening sidebars, while preserving explicit task navigation
- open the task composer when moving Inbox issues to Pending and collapse it after send
- hydrate task transcripts into the shared conversation cache and preserve visible conversations across empty snapshots
- keep the board scrollbar interactive while detail/task sidebars are open

## Verification

- `pnpm --filter wework test src/features/todo/CloudTodoWorkspace.test.tsx src/components/chat/MessageList.test.tsx src/features/workbench/runtimeConversationCache.test.ts src/features/workbench/runtimeTaskLifecycle/projection.test.ts` (253 passed)
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint:typography`
- `pnpm --filter wework lint:task-lifecycle`
- pre-push ESLint, TypeScript, and unit-test suite
- real Tauri verification with active long-running tool calls: activity viewport stayed at 20px, card height stayed bounded, task navigation remained stable, and the board scrollbar remained outside the dismiss layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Board cards now show live task activity, including thinking, tool usage, and completion updates.
  - Tasks can continue running in the background after being started from board actions or workflows.
  - Users can open active task details directly from board cards.
  - Runtime conversations now preserve and synchronize streaming activity across views.
  - Task pinning updates immediately in the sidebar and safely reverts if unsuccessful.

- **Bug Fixes**
  - Improved task selection and display for running activities.
  - Prevented empty conversation synchronization from clearing existing messages.
  - Improved handling of delayed conversation hydration and task state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->