### PR TITLE
fix(wework): auto-continue single IM session

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -2300,16 +2300,6 @@ last_updated = "2026-07-30T00:00:00Z"`
       })
       phase = 'private-im-model-binding'
       await control.command('click', '[data-testid="continue-in-im-button"]')
-      await control.command(
-        'waitFor',
-        '[data-testid="continue-im-session-desktop-e2e-im-session"]',
-        {
-          timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-        }
-      )
-      await control.command('clickWhenEnabled', '[data-testid="continue-im-submit-button"]', {
-        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-      })
       await withTimeout(
         (async () => {
           while (control.runtimeImBindingRequests.length === 0) {
@@ -2318,6 +2308,19 @@ last_updated = "2026-07-30T00:00:00Z"`
         })(),
         DEFAULT_STEP_TIMEOUT_MS,
         'The runtime task was not bound to the private IM session'
+      )
+      await withTimeout(
+        (async () => {
+          while (
+            Number(
+              await control.command('getElementCount', '[data-testid="continue-im-dialog-overlay"]')
+            ) !== 0
+          ) {
+            await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
+          }
+        })(),
+        DEFAULT_STEP_TIMEOUT_MS,
+        'The single private IM session dialog did not close after automatic binding'
       )
       const runtimeImBinding = control.runtimeImBindingRequests.at(-1)
       assert.equal(

--- a/wework/src/components/chat/ContinueInImDialog.test.tsx
+++ b/wework/src/components/chat/ContinueInImDialog.test.tsx
@@ -55,6 +55,7 @@ describe('ContinueInImDialog', () => {
         loading={false}
         submitting={false}
         sessions={[createSession(1, 'Alice'), createSession(2, 'Bob')]}
+        autoSubmitSingle
         onClose={vi.fn()}
         onSubmit={onSubmit}
       />
@@ -68,10 +69,57 @@ describe('ContinueInImDialog', () => {
       'aria-pressed',
       'false'
     )
+    expect(onSubmit).not.toHaveBeenCalled()
 
     await userEvent.click(screen.getByTestId('continue-im-submit-button'))
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(['session-1']))
+  })
+
+  test('auto-submits the only private IM session once after loading', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { rerender } = render(
+      <ContinueInImDialog
+        open
+        loading
+        submitting={false}
+        sessions={[createSession(1, 'Alice')]}
+        autoSubmitSingle
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    rerender(
+      <ContinueInImDialog
+        open
+        loading={false}
+        submitting={false}
+        sessions={[createSession(1, 'Alice')]}
+        autoSubmitSingle
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(['session-1']))
+    expect(localStorage.getItem('wework.continueInIm.lastSessionKeys')).toBe('["session-1"]')
+
+    rerender(
+      <ContinueInImDialog
+        open
+        loading={false}
+        submitting={false}
+        sessions={[createSession(1, 'Alice')]}
+        autoSubmitSingle
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
   test('submits selected session keys', async () => {

--- a/wework/src/components/chat/ContinueInImDialog.tsx
+++ b/wework/src/components/chat/ContinueInImDialog.tsx
@@ -17,6 +17,7 @@ interface ContinueInImDialogProps {
   submitLabel?: string
   allowMultiple?: boolean
   rememberSelection?: boolean
+  autoSubmitSingle?: boolean
   defaultSelectedSessionKeys?: string[]
   onClose: () => void
   onSubmit: (sessionKeys: string[]) => Promise<void>
@@ -32,6 +33,7 @@ export function ContinueInImDialog({
   submitLabel,
   allowMultiple,
   rememberSelection,
+  autoSubmitSingle,
   defaultSelectedSessionKeys,
   onClose,
   onSubmit,
@@ -50,6 +52,7 @@ export function ContinueInImDialog({
       submitLabel={submitLabel}
       allowMultiple={allowMultiple}
       rememberSelection={rememberSelection}
+      autoSubmitSingle={autoSubmitSingle}
       defaultSelectedSessionKeys={defaultSelectedSessionKeys}
       onClose={onClose}
       onSubmit={onSubmit}
@@ -126,6 +129,7 @@ function ContinueInImDialogContent({
   submitLabel,
   allowMultiple = true,
   rememberSelection = true,
+  autoSubmitSingle = false,
   defaultSelectedSessionKeys: providedDefaultSelectedSessionKeys = [],
   onClose,
   onSubmit,
@@ -133,6 +137,7 @@ function ContinueInImDialogContent({
   const { t } = useTranslation('common')
   const dialogRef = useRef<HTMLElement | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+  const autoSubmitAttemptedRef = useRef(false)
   const [rememberedSessionKeys] = useState(readRememberedSessionKeys)
   const [manualSelectedSessionKeys, setManualSelectedSessionKeys] = useState<Set<string> | null>(
     null
@@ -170,6 +175,25 @@ function ContinueInImDialogContent({
   useEffect(() => {
     closeButtonRef.current?.focus()
   }, [])
+
+  useEffect(() => {
+    if (
+      !autoSubmitSingle ||
+      loading ||
+      submitting ||
+      sessions.length !== 1 ||
+      autoSubmitAttemptedRef.current
+    ) {
+      return
+    }
+
+    const sessionKey = sessions[0].session_key
+    autoSubmitAttemptedRef.current = true
+    if (rememberSelection) {
+      writeRememberedSessionKeys([sessionKey])
+    }
+    void onSubmit([sessionKey])
+  }, [autoSubmitSingle, loading, onSubmit, rememberSelection, sessions, submitting])
 
   const toggleSession = (sessionKey: string) => {
     setManualSelectedSessionKeys(current => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2064,7 +2064,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
-  test('opens continue-in-im dialog from the active runtime task topbar button', async () => {
+  test('automatically continues to the only private IM session from the topbar', async () => {
     const onListImPrivateSessions = vi.fn().mockResolvedValue({
       total: 1,
       items: [
@@ -2083,6 +2083,7 @@ describe('DesktopWorkbenchLayout', () => {
         },
       ],
     })
+    const onBindRuntimeTaskToImSessions = vi.fn().mockResolvedValue(undefined)
 
     render(
       <DesktopWorkbenchLayout
@@ -2105,14 +2106,25 @@ describe('DesktopWorkbenchLayout', () => {
           },
         ]}
         onListImPrivateSessions={onListImPrivateSessions}
+        onBindRuntimeTaskToImSessions={onBindRuntimeTaskToImSessions}
       />
     )
 
     await userEvent.click(screen.getByTestId('continue-in-im-button'))
 
     expect(onListImPrivateSessions).toHaveBeenCalledTimes(1)
-    expect(await screen.findByRole('dialog')).toBeInTheDocument()
-    expect(await screen.findByTestId('continue-im-session-session-1')).toHaveTextContent('Alice')
+    await waitFor(() =>
+      expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledWith(
+        {
+          deviceId: 'device-1',
+          workspacePath: '/workspace/project-alpha',
+          taskId: 'runtime-1',
+        },
+        ['session-1']
+      )
+    )
+    expect(await screen.findByTestId('transient-notice')).toHaveTextContent('已发送到私聊')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   test('hides task fork and IM actions while experimental features are disabled', () => {
@@ -2586,6 +2598,7 @@ describe('DesktopWorkbenchLayout', () => {
       .fn()
       .mockReturnValueOnce(firstRequest.promise)
       .mockReturnValueOnce(secondRequest.promise)
+    const onBindRuntimeTaskToImSessions = vi.fn().mockResolvedValue(undefined)
 
     render(
       <DesktopWorkbenchLayout
@@ -2608,6 +2621,7 @@ describe('DesktopWorkbenchLayout', () => {
           },
         ]}
         onListImPrivateSessions={onListImPrivateSessions}
+        onBindRuntimeTaskToImSessions={onBindRuntimeTaskToImSessions}
       />
     )
 
@@ -2634,34 +2648,49 @@ describe('DesktopWorkbenchLayout', () => {
       ],
     })
 
-    expect(await screen.findByTestId('continue-im-session-session-2')).toHaveTextContent(
-      'Fresh session'
-    )
-
-    firstRequest.resolve({
-      total: 1,
-      items: [
+    await waitFor(() =>
+      expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledWith(
         {
-          session_key: 'session-1',
-          channel_type: 'wecom',
-          channel_label: 'WeCom',
-          channel_id: 101,
-          conversation_id: 'conversation-1',
-          sender_id: 'sender-1',
-          display_name: 'Stale session',
-          mode: 'chat',
-          state: 'idle',
-          active_task_id: null,
-          last_seen_at: '2026-06-20T00:00:00.000Z',
+          deviceId: 'device-1',
+          workspacePath: '/workspace/project-alpha',
+          taskId: 'runtime-1',
         },
-      ],
+        ['session-2']
+      )
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await act(async () => {
+      firstRequest.resolve({
+        total: 1,
+        items: [
+          {
+            session_key: 'session-1',
+            channel_type: 'wecom',
+            channel_label: 'WeCom',
+            channel_id: 101,
+            conversation_id: 'conversation-1',
+            sender_id: 'sender-1',
+            display_name: 'Stale session',
+            mode: 'chat',
+            state: 'idle',
+            active_task_id: null,
+            last_seen_at: '2026-06-20T00:00:00.000Z',
+          },
+        ],
+      })
+      await firstRequest.promise
     })
 
-    await waitFor(() => expect(screen.queryByText('Stale session')).not.toBeInTheDocument())
-    expect(screen.getByText('Fresh session')).toBeInTheDocument()
+    expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledTimes(1)
+    expect(onBindRuntimeTaskToImSessions).not.toHaveBeenCalledWith(expect.anything(), ['session-1'])
   })
 
-  test('shows a failure notice when bind handler is missing', async () => {
+  test('keeps the dialog open for manual retry when automatic binding fails', async () => {
+    const onBindRuntimeTaskToImSessions = vi
+      .fn()
+      .mockRejectedValue(new Error('Missing bind handler'))
+
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
@@ -2700,18 +2729,21 @@ describe('DesktopWorkbenchLayout', () => {
             },
           ],
         })}
+        onBindRuntimeTaskToImSessions={onBindRuntimeTaskToImSessions}
       />
     )
 
     await userEvent.click(screen.getByTestId('continue-in-im-button'))
-    expect(await screen.findByTestId('continue-im-session-session-1')).toHaveAttribute(
+    expect(await screen.findByTestId('transient-notice')).toHaveTextContent('继续到私聊失败')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('continue-im-session-session-1')).toHaveAttribute(
       'aria-pressed',
       'true'
     )
-    await userEvent.click(screen.getByTestId('continue-im-submit-button'))
+    expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledTimes(1)
 
-    expect(await screen.findByTestId('transient-notice')).toHaveTextContent('继续到私聊失败')
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('continue-im-submit-button'))
+    await waitFor(() => expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledTimes(2))
   })
 
   test('positions the scroll-to-bottom button above the sticky composer footer', async () => {

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useMemo, useState, type ReactNode } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -1203,7 +1203,7 @@ describe('MobileWorkbenchLayout', () => {
     expect(screen.getByTestId('model-selector-button')).toHaveTextContent('kimi-for-coding')
   })
 
-  test('opens continue-in-im dialog from the active runtime task header button', async () => {
+  test('automatically continues to the only private IM session from the mobile header', async () => {
     const onListImPrivateSessions = vi.fn().mockResolvedValue({
       total: 1,
       items: [
@@ -1222,6 +1222,7 @@ describe('MobileWorkbenchLayout', () => {
         },
       ],
     })
+    const onBindRuntimeTaskToImSessions = vi.fn().mockResolvedValue(undefined)
 
     renderAtMobileWidth(
       <MobileWorkbenchLayout
@@ -1246,6 +1247,7 @@ describe('MobileWorkbenchLayout', () => {
         onInputChange={vi.fn()}
         onSend={vi.fn()}
         onListImPrivateSessions={onListImPrivateSessions}
+        onBindRuntimeTaskToImSessions={onBindRuntimeTaskToImSessions}
       />
     )
 
@@ -1253,8 +1255,18 @@ describe('MobileWorkbenchLayout', () => {
 
     expect(screen.getByTestId('mobile-continue-in-im-button')).toHaveClass('h-11', 'min-w-[44px]')
     expect(onListImPrivateSessions).toHaveBeenCalledTimes(1)
-    expect(await screen.findByRole('dialog')).toBeInTheDocument()
-    expect(await screen.findByTestId('continue-im-session-session-1')).toHaveTextContent('Alice')
+    await waitFor(() =>
+      expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledWith(
+        {
+          deviceId: 'device-1',
+          workspacePath: '/workspace/project-alpha',
+          taskId: 'runtime-1',
+        },
+        ['session-1']
+      )
+    )
+    expect(await screen.findByTestId('transient-notice')).toHaveTextContent('已发送到私聊')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   test('hides continue-in-im action without a mobile runtime task', () => {
@@ -1307,6 +1319,7 @@ describe('MobileWorkbenchLayout', () => {
       .fn()
       .mockReturnValueOnce(firstRequest.promise)
       .mockReturnValueOnce(secondRequest.promise)
+    const onBindRuntimeTaskToImSessions = vi.fn().mockResolvedValue(undefined)
 
     renderAtMobileWidth(
       <MobileWorkbenchLayout
@@ -1331,6 +1344,7 @@ describe('MobileWorkbenchLayout', () => {
         onInputChange={vi.fn()}
         onSend={vi.fn()}
         onListImPrivateSessions={onListImPrivateSessions}
+        onBindRuntimeTaskToImSessions={onBindRuntimeTaskToImSessions}
       />
     )
 
@@ -1357,34 +1371,49 @@ describe('MobileWorkbenchLayout', () => {
       ],
     })
 
-    expect(await screen.findByTestId('continue-im-session-session-2')).toHaveTextContent(
-      'Fresh session'
-    )
-
-    firstRequest.resolve({
-      total: 1,
-      items: [
+    await waitFor(() =>
+      expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledWith(
         {
-          session_key: 'session-1',
-          channel_type: 'wecom',
-          channel_label: 'WeCom',
-          channel_id: 101,
-          conversation_id: 'conversation-1',
-          sender_id: 'sender-1',
-          display_name: 'Stale session',
-          mode: 'chat',
-          state: 'idle',
-          active_task_id: null,
-          last_seen_at: '2026-06-20T00:00:00.000Z',
+          deviceId: 'device-1',
+          workspacePath: '/workspace/project-alpha',
+          taskId: 'runtime-1',
         },
-      ],
+        ['session-2']
+      )
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await act(async () => {
+      firstRequest.resolve({
+        total: 1,
+        items: [
+          {
+            session_key: 'session-1',
+            channel_type: 'wecom',
+            channel_label: 'WeCom',
+            channel_id: 101,
+            conversation_id: 'conversation-1',
+            sender_id: 'sender-1',
+            display_name: 'Stale session',
+            mode: 'chat',
+            state: 'idle',
+            active_task_id: null,
+            last_seen_at: '2026-06-20T00:00:00.000Z',
+          },
+        ],
+      })
+      await firstRequest.promise
     })
 
-    await waitFor(() => expect(screen.queryByText('Stale session')).not.toBeInTheDocument())
-    expect(screen.getByText('Fresh session')).toBeInTheDocument()
+    expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledTimes(1)
+    expect(onBindRuntimeTaskToImSessions).not.toHaveBeenCalledWith(expect.anything(), ['session-1'])
   })
 
-  test('shows a failure notice when mobile bind handler is missing', async () => {
+  test('keeps the mobile dialog open for manual retry when automatic binding fails', async () => {
+    const onBindRuntimeTaskToImSessions = vi
+      .fn()
+      .mockRejectedValue(new Error('Missing bind handler'))
+
     renderAtMobileWidth(
       <MobileWorkbenchLayout
         state={{
@@ -1425,18 +1454,21 @@ describe('MobileWorkbenchLayout', () => {
             },
           ],
         })}
+        onBindRuntimeTaskToImSessions={onBindRuntimeTaskToImSessions}
       />
     )
 
     await userEvent.click(screen.getByTestId('mobile-continue-in-im-button'))
-    expect(await screen.findByTestId('continue-im-session-session-1')).toHaveAttribute(
+    expect(await screen.findByTestId('transient-notice')).toHaveTextContent('继续到私聊失败')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('continue-im-session-session-1')).toHaveAttribute(
       'aria-pressed',
       'true'
     )
-    await userEvent.click(screen.getByTestId('continue-im-submit-button'))
+    expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledTimes(1)
 
-    expect(await screen.findByTestId('transient-notice')).toHaveTextContent('继续到私聊失败')
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('continue-im-submit-button'))
+    await waitFor(() => expect(onBindRuntimeTaskToImSessions).toHaveBeenCalledTimes(2))
   })
 
   test('opens project creation as a mobile bottom sheet from the drawer', async () => {

--- a/wework/src/components/layout/useRuntimeTaskContinueInIm.ts
+++ b/wework/src/components/layout/useRuntimeTaskContinueInIm.ts
@@ -73,6 +73,7 @@ export function useRuntimeTaskContinueInIm(currentRuntimeTask: RuntimeTaskAddres
       loading,
       submitting,
       sessions,
+      autoSubmitSingle: true,
       onClose: closeDialog,
       onSubmit: submit,
     },


### PR DESCRIPTION
## Summary

- automatically continue a runtime task when the private IM session list has exactly one choice
- preserve the existing selector for multiple sessions and keep the dialog open for manual retry after an automatic bind failure
- cover desktop, mobile, dialog behavior, stale responses, and the real Tauri task flow

## Testing

- `pnpm --filter wework typecheck`
- targeted ESLint and Prettier checks for the six changed files
- `VITEST_MAX_WORKERS=1 pnpm --filter wework test ContinueInImDialog.test.tsx DesktopWorkbenchLayout.test.tsx MobileWorkbenchLayout.test.tsx` (235 tests)
- real Tauri `core-task-flow` checkpoint
- pre-push Wework ESLint, TypeScript, and unit-test gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically binds a runtime task to the only available private IM session.
  * Saves the selected session and prevents duplicate submissions.
  * Keeps the session dialog open when automatic binding fails, allowing manual retry.
  * Displays success feedback and closes the dialog after successful binding.

* **Bug Fixes**
  * Prevents stale responses from affecting reopened session dialogs.
  * Verifies automatic binding behavior across desktop and mobile workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->