### PR TITLE
fix(wework): default applications to smart apps

### DIFF
--- a/docs/en/architecture/deepseek-harness-apps.md
+++ b/docs/en/architecture/deepseek-harness-apps.md
@@ -9,12 +9,14 @@ Scope: Wework imports a DeepSeek Harness package as a Smart app, binds it to one
 ```mermaid
 flowchart LR
     EXPERIMENT[Experimental features toggle] --> PLUS[Top tab bar +]
+    EXPERIMENT --> SIDEBAR[Sidebar Applications entry]
     EXPERIMENT --> APPS[Applications workspace]
     EXPERIMENT --> ROUTES[Smart app view and resident restoration]
     PLUS --> APPS
+    SIDEBAR --> APPS
     APPS --> SITES[Sites]
     APPS --> MINIAPP[Mini Programs]
-    APPS --> MARKET[Smart apps]
+    APPS -->|Default /sites| MARKET[Smart apps]
     ROUTES --> MARKET
     MARKET --> DEFAULTS[Register bundled marketplace and idempotently install defaults]
     DEFAULTS --> BUILDER[Smart App Builder plugin]
@@ -68,9 +70,14 @@ sequenceDiagram
     participant D as DeepSeek Harness
     participant W as Native WebView
 
-    U->>C: + → Smart apps
-    C->>A: Open the Applications workspace
-    A->>M: Select Smart apps beside Sites and Mini Programs
+    alt Open from the top tab bar
+        U->>C: + → Smart apps
+        C->>A: Open /sites?app_type=smart_app
+    else Open from the sidebar
+        U->>A: Applications
+        A->>A: Open the default /sites path
+    end
+    A->>M: Select Smart apps by default beside Sites and Mini Programs
     alt Create a Smart app
         U->>M: Create Smart app
         M->>M: Register wework-personal and confirm smart-app-builder is installed
@@ -138,7 +145,7 @@ sequenceDiagram
 | Resident app startup restoration                                                       | `wework/src/features/harness-apps/ResidentSmartAppsManager.tsx`                                                                                            |
 | Starting / failed state, workspace tabs, and native WebViews                           | `wework/src/App.tsx`, `wework/src/features/harness-apps/`, `wework/src/features/workspace-tabs/workspaceTabs.ts`                                           |
 
-Application-type navigation order invariant: when experimental Smart apps are enabled, Smart apps appear before Sites and Mini Programs.
+Application-type navigation order and default-route invariant: when experimental Smart apps are enabled, Smart apps appear before Sites and Mini Programs; the sidebar Applications entry continues to open the default `/sites` path, that path selects Smart apps automatically without adding an `app_type` query parameter to represent the default, and an explicit application-type query parameter continues to override the default selection.
 
 Invariants: all user-facing names use “Smart apps,” while DeepSeek Harness appears only as a runtime implementation detail; Smart apps belong to the Applications workspace and must appear as a peer application type beside Sites and Mini Programs, while the plugin marketplace and plugin management page do not host Smart app management UI; `smart-app-builder` may exist as a development-tool plugin, but its product entry belongs to the experimental Smart app marketplace, its workflow keeps DSH source read-only, composes external plugin packages, verifies them in the Wework built-in browser, and ends installation through native preview, version validation, and model confirmation instead of editing the local installation registry; the entire Smart apps feature is experimental, so when the toggle is off the top “+” and Applications workspace expose no Smart apps entry, direct visits to `/sites?app_type=smart_app` and stale app tabs leave the feature, and resident apps are not restored; when enabled, `/sites?app_type=smart_app` owns the Smart app marketplace and installed management views, while running apps use independent tabs, with no mixing of the Applications workspace, management view, and runtime tab responsibilities; top tab bar “+ → Smart apps” opens the Smart apps type inside Applications, while the workspace tab title remains “Applications”; DeepSeek Harness source remains read-only; application installers contain only a small runtime descriptor and never the DSH runtime archive or recursively registered `node_modules`; runtime release assets use the exact `harness-runtime-<platform>-<content-fingerprint>.tar.gz` naming convention, while the descriptor pins an HTTPS download URL, SHA-256, and byte length; first use downloads to a temporary file, validates it completely, atomically activates an archive-hash cache entry, and then extracts by content fingerprint under app data; failed, truncated, or mismatched downloads never activate or pollute the cache, and concurrent app launches share one download and extraction critical section; production macOS builds sign every Mach-O file in staging with a Developer ID, secure timestamp, and hardened runtime before creating the release asset, and signing mode and identity are part of the content fingerprint so unsigned or differently signed assets are never reused; the archived Node then receives the V8 JIT and executable-memory entitlements after generic Mach-O pre-signing and passes a real V8 Isolate startup check instead of only `node --version`; packages are validated before being written to immutable `name/version` directories; the package DSH version range must contain the actual runtime version; every Smart app instance owns an isolated `DSH_HOME`, port, and process group; the bound model is persisted and can only be changed while the app is stopped, while credentials exist only in the runtime proxy and child environment; Resident means that the main window automatically starts the app and opens its tab once per Wework launch; a normal Open action creates and selects the app's single tab immediately, shows real “prepare runtime, load app, start app” stages tied to the current app name with continuous motion, reuses that same tab for the native WebView after HTTP readiness, and shows failure plus retry in the same tab without allowing tab-strip motion or backend startup time to block tab creation; switching to another workspace tab only hides the running Smart app host and suspends interaction, without disconnecting React effects or closing or recreating the native WebView, and switching back restores the same page and in-memory state; starting, stopping, or failing one instance cannot affect another; stop, uninstall, disabling experimental features, and Wework exit reclaim the complete process group.
 Plugins marked `INSTALLED_BY_DEFAULT` in the `wework-personal` catalog are installed idempotently after bundled marketplace registration. The Smart app creation entry confirms `smart-app-builder` is installed before writing the plugin-referenced fresh-chat draft and navigating; installation failure stays on the marketplace page instead of opening an empty chat. Default-plugin reconciliation reads existing plugin configuration through the Executor-explicitly-allowed Codex `config/read` method and treats a present but user-disabled plugin as configured, so default synchronization must never re-enable it.

--- a/docs/zh/architecture/deepseek-harness-apps.md
+++ b/docs/zh/architecture/deepseek-harness-apps.md
@@ -9,12 +9,14 @@ sidebar_position: 25
 ```mermaid
 flowchart LR
     EXPERIMENT[实验性功能开关] --> PLUS[顶部标签栏 +]
+    EXPERIMENT --> SIDEBAR[侧边栏应用入口]
     EXPERIMENT --> APPS[应用工作区]
     EXPERIMENT --> ROUTES[智能应用视图与常驻恢复]
     PLUS --> APPS
+    SIDEBAR --> APPS
     APPS --> SITES[站点]
     APPS --> MINIAPP[小程序]
-    APPS --> MARKET[智能应用]
+    APPS -->|默认 /sites| MARKET[智能应用]
     ROUTES --> MARKET
     MARKET --> DEFAULTS[注册内置市场并幂等安装默认插件]
     DEFAULTS --> BUILDER[智能应用开发助手插件]
@@ -68,9 +70,14 @@ sequenceDiagram
     participant D as DeepSeek Harness
     participant W as 原生 WebView
 
-    U->>C: + → 智能应用
-    C->>A: 打开应用工作区
-    A->>M: 选择与站点、小程序并列的智能应用
+    alt 从顶部标签栏打开
+        U->>C: + → 智能应用
+        C->>A: 打开 /sites?app_type=smart_app
+    else 从侧边栏打开
+        U->>A: 应用
+        A->>A: 打开默认路径 /sites
+    end
+    A->>M: 默认选择与站点、小程序并列的智能应用
     alt 创建智能应用
         U->>M: 创建智能应用
         M->>M: 注册 wework-personal 并确认 smart-app-builder 已安装
@@ -138,7 +145,7 @@ sequenceDiagram
 | 常驻应用的启动恢复                                                 | `wework/src/features/harness-apps/ResidentSmartAppsManager.tsx`                                                                                            |
 | 启动中 / 失败状态、工作区标签与原生 WebView                        | `wework/src/App.tsx`、`wework/src/features/harness-apps/`、`wework/src/features/workspace-tabs/workspaceTabs.ts`                                           |
 
-应用类型导航顺序不变量：启用实验性智能应用后，“智能应用”必须排在“站点”和“小程序”之前。
+应用类型导航顺序与默认路由不变量：启用实验性智能应用后，“智能应用”必须排在“站点”和“小程序”之前；侧边栏“应用”必须保持打开默认路径 `/sites`，该路径必须自动选择智能应用且不得为了表达默认选择而追加 `app_type` 查询参数；显式应用类型查询参数仍优先于默认选择。
 
 不变量：所有用户可见名称统一为“智能应用”，DeepSeek Harness 只作为运行时技术说明出现；智能应用属于“应用”工作区，必须与“站点”“小程序”作为同级应用类型展示，插件市场和插件管理页不得承载智能应用管理界面；`smart-app-builder` 可以作为开发工具插件存在，但其产品入口必须位于实验性智能应用市场，创建流程必须保持 DSH 源码只读，复用外部插件包，通过 Wework 内置浏览器验证，并以原生预览、版本检查和模型确认结束安装，不得直接改写本机安装注册表；智能应用整体属于实验性功能，关闭开关时顶部“+”和应用工作区不得显示智能应用入口，直接访问 `/sites?app_type=smart_app` 或遗留应用标签必须退出该功能，常驻应用不得自动恢复；开启开关后，`/sites?app_type=smart_app` 必须承载智能应用市场和已安装管理，运行中的应用必须使用独立标签，应用工作区、管理视图和运行标签三层职责不得混合；顶部标签栏“+ → 智能应用”必须直接打开应用工作区的智能应用类型，工作区标签标题仍为“应用”；DeepSeek Harness 源码保持只读；应用安装包只能携带小型 Runtime 描述文件，不得内置 DSH Runtime 归档或递归登记其 `node_modules`；Runtime 发布资产必须统一使用 `harness-runtime-<platform>-<content-fingerprint>.tar.gz` 命名，描述文件必须固定其 HTTPS 下载地址、SHA-256 和字节数，首次使用时下载到临时文件，完整校验后原子写入按归档哈希组织的缓存，再按内容指纹解包到应用数据目录；下载失败、截断或校验不一致不得激活或污染缓存，多个应用并发启动必须复用同一个下载和解包临界区；macOS 正式构建必须在创建发布资产前使用 Developer ID、secure timestamp 和 hardened runtime 签署暂存目录中的每个 Mach-O 文件，签名模式和身份必须进入内容指纹，禁止复用未签名或由其他身份签名的资产；归档中的 Node 必须在通用 Mach-O 预签名之后最后签入 V8 所需的 JIT 与可执行内存权限，并通过实际创建 V8 Isolate 校验，不能只检查 `node --version`；安装包必须先校验再写入不可变的 `name/version` 目录；插件声明的 DSH 版本范围必须包含实际 Runtime 版本；每个智能应用实例拥有独立 `DSH_HOME`、端口和进程组；绑定模型必须持久化且只能在应用停止时修改，模型凭据只存在于运行期代理和子进程环境中；“常驻”必须表示主窗口每次启动时自动启动并打开应用标签，且每个启动周期只执行一次；普通打开必须立即创建并选中唯一的应用标签，在该标签内展示与当前应用名称关联的“准备运行环境、加载应用、启动应用”真实阶段和连续动画，HTTP 就绪后必须复用同一标签加载原生 WebView，失败时也必须在同一标签展示错误与重试，不得用标签栏动效或后端启动耗时阻塞标签创建；切换到其他工作区标签时，运行中的智能应用只能隐藏其宿主并暂停交互，不得断开 React effect、关闭或重建原生 WebView，切回后必须恢复同一页面及其内存状态；一个实例的启动、停止或失败不得影响其他实例；停止、卸载、关闭实验性功能和 Wework 退出都必须回收完整进程组。
 `wework-personal` 清单中标记为 `INSTALLED_BY_DEFAULT` 的插件必须在内置市场注册后幂等安装。智能应用创建入口必须确认 `smart-app-builder` 已安装后才写入带插件引用的新会话草稿并跳转，安装失败必须留在市场页，不得打开空白会话。默认插件协调必须通过 Executor 明确允许的 Codex `config/read` 读取已有插件配置，并将已存在但被用户禁用的插件视为已配置，不得借默认同步重新启用它。

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -1095,7 +1095,7 @@ describe('App plugins route', () => {
       }
       throw new Error(`Unexpected request: ${url}`)
     })
-    window.history.pushState({}, '', '/sites')
+    window.history.pushState({}, '', '/sites?app_type=web')
 
     renderApp()
     await updateAppPreferences({ experimentalFeaturesEnabled: true })

--- a/wework/src/components/sites/SitesWorkspace.test.tsx
+++ b/wework/src/components/sites/SitesWorkspace.test.tsx
@@ -316,6 +316,7 @@ describe('SitesWorkspace', () => {
   })
 
   test('shows experimental Smart apps beside Sites and Mini Programs', async () => {
+    window.history.replaceState({}, '', '/sites?app_type=web')
     const api = createApi()
 
     render(
@@ -347,6 +348,28 @@ describe('SitesWorkspace', () => {
     expect(screen.queryByTestId('sites-search-input')).not.toBeInTheDocument()
     expect(screen.queryByTestId('sites-create-button')).not.toBeInTheDocument()
     expect(window.location.search).toBe('?app_type=smart_app')
+  })
+
+  test('selects Smart apps for the default Applications path without changing the path', async () => {
+    const api = createApi()
+
+    render(
+      <SitesWorkspace
+        api={api}
+        onCreate={vi.fn()}
+        smartAppsEnabled
+        smartAppsContent={<div data-testid="smart-apps-content">智能应用市场</div>}
+      />
+    )
+
+    expect(await screen.findByTestId('smart-apps-content')).toBeInTheDocument()
+    expect(screen.getByTestId('applications-tab-smart-app')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(window.location.pathname).toBe('/sites')
+    expect(window.location.search).toBe('')
+    expect(api.listSites).not.toHaveBeenCalled()
   })
 
   test('opens a requested Smart apps view without loading the Sites collection', async () => {

--- a/wework/src/components/sites/SitesWorkspace.tsx
+++ b/wework/src/components/sites/SitesWorkspace.tsx
@@ -63,7 +63,7 @@ function isSecurityCheckingError(error: unknown): boolean {
 function getInitialAppType(smartAppsEnabled: boolean): ApplicationWorkspaceType {
   if (typeof window === 'undefined') return DEFAULT_APPLICATION_TYPE
   const requestedType = new URLSearchParams(window.location.search).get('app_type')
-  if (smartAppsEnabled && requestedType === 'smart_app') return 'smart_app'
+  if (smartAppsEnabled && (!requestedType || requestedType === 'smart_app')) return 'smart_app'
   return getApplicationTypeDefinition(requestedType ?? '')?.appType ?? DEFAULT_APPLICATION_TYPE
 }
 
@@ -248,6 +248,7 @@ export function SitesWorkspace({
 
   useEffect(() => {
     const handlePopState = () => setActiveAppType(getInitialAppType(smartAppsEnabled))
+    handlePopState()
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
   }, [smartAppsEnabled])


### PR DESCRIPTION
## Summary

- keep the Applications sidebar entry on the default `/sites` path
- select Smart apps automatically for `/sites` when experimental features are enabled
- preserve explicit application-type query parameters and update the governed Smart apps architecture docs
- update the Sites plugin test to request the explicit web application type

## Verification

- `pnpm --filter wework test src/components/sites/SitesWorkspace.test.tsx`
- `pnpm --filter wework test src/App.plugins.test.tsx -t 'opens Smart apps beside Sites and Mini Programs in Applications'`
- `pnpm --filter wework test src/App.plugins.test.tsx -t 'ensures the cloud Sites plugin and opens it in a new chat'`
- full pre-push Wework ESLint, TypeScript, and 4483 unit tests
- pre-push Executor cargo fmt, cargo test --all-features --lib, and cargo clippy after rebasing latest main
- isolated real Tauri verification: clicking Applications kept the location at `/sites`, selected the Smart apps tab, and rendered the marketplace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart Apps are now selected by default when opening `/sites`, when enabled.
  * Explicit application type parameters continue to override the default selection.
  * Sidebar and top-bar navigation now provide distinct entry points for applications.
* **Bug Fixes**
  * Application selection now stays synchronized with the URL on initial load and browser navigation.
* **Documentation**
  * Updated English and Chinese architecture documentation to describe the revised navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->