### PR TITLE
fix(executor-manager): persist hourly logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,6 +241,8 @@ services:
       - "${EXECUTOR_MANAGER_PORT:-8001}:8001"
     environment:
       - TZ=${TZ:-Asia/Shanghai}
+      - WEGENT_LOG_FILE_PATH=/app/logs/info.log
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - TASK_API_DOMAIN=${TASK_API_DOMAIN:-http://backend:8000}
       - EXECUTOR_MANAGER_EXTERNAL_URL=${EXECUTOR_MANAGER_EXTERNAL_URL:-http://executor_manager:8001}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
@@ -280,6 +282,7 @@ services:
       # - OTEL_TRACES_SAMPLER_ARG=1.0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./logs/executor_manager:/app/logs
     depends_on:
       - backend
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,7 +242,6 @@ services:
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - WEGENT_LOG_FILE_PATH=/app/logs/info.log
-      - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - TASK_API_DOMAIN=${TASK_API_DOMAIN:-http://backend:8000}
       - EXECUTOR_MANAGER_EXTERNAL_URL=${EXECUTOR_MANAGER_EXTERNAL_URL:-http://executor_manager:8001}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}

--- a/executor_manager/main.py
+++ b/executor_manager/main.py
@@ -17,12 +17,11 @@ import os
 from contextlib import asynccontextmanager
 
 import uvicorn
-
 from executor_manager.services.sandbox import get_sandbox_manager
 from routers.routers import app  # Import the FastAPI app defined in routes.py
 
 # Import the shared logger
-from shared.logger import setup_logger
+from shared.logger import configure_file_logging, setup_logger
 from shared.telemetry.config import get_otel_config
 
 # Setup logger
@@ -35,6 +34,10 @@ async def lifespan(app):
     FastAPI application lifecycle manager.
     Starts the task queue consumers when the application starts, and performs cleanup operations when the application shuts down.
     """
+    log_file = os.environ.get("WEGENT_LOG_FILE_PATH", "").strip()
+    if log_file:
+        configure_file_logging(log_file)
+
     # Initialize OpenTelemetry if enabled (configuration from shared/telemetry/config.py)
     otel_config = get_otel_config("wegent-executor-manager")
     if otel_config.enabled:

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -164,7 +164,7 @@ def _file_log_handler(
             encoding="utf-8",
             utc=False,
         )
-        handler.suffix = "%Y%m%d-%H"
+        handler.suffix = "%Y%m%d-%H%z"
         handler.setFormatter(logging.Formatter(format, datefmt))
         if include_request_id:
             handler.addFilter(RequestIdFilter())

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -14,10 +14,12 @@ Supports automatic request_id injection into log messages via ContextVar.
 
 import atexit
 import logging
+import math
 import multiprocessing
 import os
 import sys
-from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
+import time
+from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from typing import Optional
 
 
@@ -73,18 +75,56 @@ class NonBlockingStreamHandler(logging.StreamHandler):
             pass
 
 
-_FILE_HANDLER: Optional[RotatingFileHandler] = None
+class HourlyRotatingFileHandler(TimedRotatingFileHandler):
+    """Rotate on natural hour boundaries with multi-process locking."""
+
+    def computeRollover(self, currentTime: float) -> float:
+        if self.utc:
+            offset = 0
+        else:
+            offset = -time.timezone
+            if time.daylight and time.localtime(currentTime).tm_isdst:
+                offset = -time.altzone
+        local_time = currentTime + offset
+        next_hour = (math.floor(local_time / 3600) + 1) * 3600
+        return next_hour - offset
+
+    def doRollover(self) -> None:
+        import fcntl
+
+        lock_path = self.baseFilename + ".lock"
+        with open(lock_path, "a") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                self._do_rollover_locked()
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+    def _do_rollover_locked(self) -> None:
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        rollover_time = self.rolloverAt - self.interval
+        time_tuple = (
+            time.gmtime(rollover_time) if self.utc else time.localtime(rollover_time)
+        )
+        destination = self.rotation_filename(
+            self.baseFilename + "." + time.strftime(self.suffix, time_tuple)
+        )
+        if not os.path.exists(destination):
+            self.rotate(self.baseFilename, destination)
+
+        self.stream = self._open()
+        now = int(time.time())
+        new_rollover = self.computeRollover(now)
+        while new_rollover <= now:
+            new_rollover += self.interval
+        self.rolloverAt = new_rollover
+
+
+_FILE_HANDLER: Optional[HourlyRotatingFileHandler] = None
 _FILE_HANDLER_PATH: Optional[str] = None
-
-
-def _get_int_env(name: str, default: int) -> int:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except ValueError:
-        return default
 
 
 def _logger_has_handler(logger: logging.Logger, handler: logging.Handler) -> bool:
@@ -97,8 +137,8 @@ def _file_log_handler(
     format: str,
     datefmt: str,
     include_request_id: bool,
-) -> Optional[RotatingFileHandler]:
-    """Return the shared rotating file handler when file logging is configured."""
+) -> Optional[HourlyRotatingFileHandler]:
+    """Return the shared hourly file handler when file logging is configured."""
     global _FILE_HANDLER, _FILE_HANDLER_PATH
 
     log_file = os.environ.get("WEGENT_LOG_FILE_PATH", "").strip()
@@ -113,15 +153,18 @@ def _file_log_handler(
             _FILE_HANDLER_PATH = None
 
     if _FILE_HANDLER is None:
-        os.makedirs(os.path.dirname(log_file), exist_ok=True)
-        max_bytes = _get_int_env("WEGENT_LOG_FILE_MAX_BYTES", 10 * 1024 * 1024)
-        backup_count = _get_int_env("WEGENT_LOG_FILE_BACKUP_COUNT", 5)
-        handler = RotatingFileHandler(
-            log_file,
-            maxBytes=max_bytes,
-            backupCount=backup_count,
+        log_dir = os.path.dirname(log_file)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+        handler = HourlyRotatingFileHandler(
+            filename=log_file,
+            when="h",
+            interval=1,
+            backupCount=0,
             encoding="utf-8",
+            utc=False,
         )
+        handler.suffix = "%Y%m%d-%H"
         handler.setFormatter(logging.Formatter(format, datefmt))
         if include_request_id:
             handler.addFilter(RequestIdFilter())
@@ -135,14 +178,10 @@ def _file_log_handler(
 def configure_file_logging(
     log_file: str,
     *,
-    max_bytes: int = 10 * 1024 * 1024,
-    backup_count: int = 5,
     level: int = logging.INFO,
 ) -> None:
-    """Enable shared rotating file logging for existing and future loggers."""
+    """Enable shared hourly file logging for existing and future loggers."""
     os.environ["WEGENT_LOG_FILE_PATH"] = log_file
-    os.environ["WEGENT_LOG_FILE_MAX_BYTES"] = str(max_bytes)
-    os.environ["WEGENT_LOG_FILE_BACKUP_COUNT"] = str(backup_count)
 
     handler = _file_log_handler(
         level=level,

--- a/shared/tests/test_logger.py
+++ b/shared/tests/test_logger.py
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import time
+from datetime import datetime
+from pathlib import Path
+from typing import Generator
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -35,7 +40,7 @@ class FakeQueueListener(QueueListenerThatRaisesOnSecondStop):
 
 
 @pytest.fixture
-def reset_file_handler(monkeypatch):
+def reset_file_handler(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     monkeypatch.delenv("WEGENT_LOG_FILE_PATH", raising=False)
     yield
     if logger_module._FILE_HANDLER is not None:
@@ -80,7 +85,7 @@ def test_queue_listener_shutdown_callback_is_idempotent(mocker):
         logging.Logger.manager.loggerDict.pop(logger.name, None)
 
 
-def test_hourly_file_handler_rolls_over_on_next_natural_hour(tmp_path):
+def test_hourly_file_handler_rolls_over_on_next_natural_hour(tmp_path: Path) -> None:
     handler = HourlyRotatingFileHandler(
         tmp_path / "info.log",
         when="h",
@@ -99,7 +104,53 @@ def test_hourly_file_handler_rolls_over_on_next_natural_hour(tmp_path):
         handler.close()
 
 
-def test_setup_logger_writes_to_hourly_file(tmp_path, monkeypatch, reset_file_handler):
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="tzset is unavailable")
+def test_hourly_archive_names_are_unique_across_dst_fall_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_tz = os.environ.get("TZ")
+    monkeypatch.setenv("TZ", "America/New_York")
+    time.tzset()
+    handler = HourlyRotatingFileHandler(
+        tmp_path / "info.log",
+        when="h",
+        interval=1,
+        backupCount=0,
+        encoding="utf-8",
+    )
+    handler.suffix = "%Y%m%d-%H%z"
+
+    try:
+        timezone = ZoneInfo("America/New_York")
+        first_hour = datetime(2026, 11, 1, 1, 30, tzinfo=timezone, fold=0)
+        second_hour = datetime(2026, 11, 1, 1, 30, tzinfo=timezone, fold=1)
+
+        first_suffix = time.strftime(
+            handler.suffix,
+            time.localtime(first_hour.timestamp()),
+        )
+        second_suffix = time.strftime(
+            handler.suffix,
+            time.localtime(second_hour.timestamp()),
+        )
+
+        assert first_suffix == "20261101-01-0400"
+        assert second_suffix == "20261101-01-0500"
+    finally:
+        handler.close()
+        if original_tz is None:
+            monkeypatch.delenv("TZ")
+        else:
+            monkeypatch.setenv("TZ", original_tz)
+        time.tzset()
+
+
+def test_setup_logger_writes_to_hourly_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reset_file_handler: None,
+) -> None:
     log_file = tmp_path / "executor_manager" / "info.log"
     monkeypatch.setenv("WEGENT_LOG_FILE_PATH", str(log_file))
     logger = setup_logger(
@@ -113,7 +164,7 @@ def test_setup_logger_writes_to_hourly_file(tmp_path, monkeypatch, reset_file_ha
             "INFO - executor manager file logging\n"
         )
         assert isinstance(logger_module._FILE_HANDLER, HourlyRotatingFileHandler)
-        assert logger_module._FILE_HANDLER.suffix == "%Y%m%d-%H"
+        assert logger_module._FILE_HANDLER.suffix == "%Y%m%d-%H%z"
         assert logger_module._FILE_HANDLER.backupCount == 0
     finally:
         for handler in list(logger.handlers):

--- a/shared/tests/test_logger.py
+++ b/shared/tests/test_logger.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import time
+
+import pytest
 
 from shared import logger as logger_module
-from shared.logger import setup_logger
+from shared.logger import HourlyRotatingFileHandler, setup_logger
 
 
 class QueueListenerThatRaisesOnSecondStop:
@@ -29,6 +32,16 @@ class FakeQueueListener(QueueListenerThatRaisesOnSecondStop):
 
     def start(self):
         self._thread = object()
+
+
+@pytest.fixture
+def reset_file_handler(monkeypatch):
+    monkeypatch.delenv("WEGENT_LOG_FILE_PATH", raising=False)
+    yield
+    if logger_module._FILE_HANDLER is not None:
+        logger_module._FILE_HANDLER.close()
+    logger_module._FILE_HANDLER = None
+    logger_module._FILE_HANDLER_PATH = None
 
 
 def test_stop_queue_listener_safely_ignores_duplicate_stop():
@@ -64,4 +77,47 @@ def test_queue_listener_shutdown_callback_is_idempotent(mocker):
         for handler in list(logger.handlers):
             logger.removeHandler(handler)
             handler.close()
+        logging.Logger.manager.loggerDict.pop(logger.name, None)
+
+
+def test_hourly_file_handler_rolls_over_on_next_natural_hour(tmp_path):
+    handler = HourlyRotatingFileHandler(
+        tmp_path / "info.log",
+        when="h",
+        interval=1,
+        backupCount=0,
+        encoding="utf-8",
+    )
+
+    try:
+        current_time = time.mktime((2026, 8, 20, 10, 23, 45, 0, 0, -1))
+
+        rollover = time.localtime(handler.computeRollover(current_time))
+
+        assert (rollover.tm_hour, rollover.tm_min, rollover.tm_sec) == (11, 0, 0)
+    finally:
+        handler.close()
+
+
+def test_setup_logger_writes_to_hourly_file(tmp_path, monkeypatch, reset_file_handler):
+    log_file = tmp_path / "executor_manager" / "info.log"
+    monkeypatch.setenv("WEGENT_LOG_FILE_PATH", str(log_file))
+    logger = setup_logger(
+        "test-hourly-file-logging",
+        use_multiprocessing_safe=False,
+    )
+
+    try:
+        logger.info("executor manager file logging")
+        assert log_file.read_text(encoding="utf-8").endswith(
+            "INFO - executor manager file logging\n"
+        )
+        assert isinstance(logger_module._FILE_HANDLER, HourlyRotatingFileHandler)
+        assert logger_module._FILE_HANDLER.suffix == "%Y%m%d-%H"
+        assert logger_module._FILE_HANDLER.backupCount == 0
+    finally:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            if handler is not logger_module._FILE_HANDLER:
+                handler.close()
         logging.Logger.manager.loggerDict.pop(logger.name, None)


### PR DESCRIPTION
## Summary
- persist executor-manager logs to a host-mounted directory in Docker Compose
- rotate file logs on natural hour boundaries with multi-process locking
- keep console output while attaching file logging to root and existing loggers
- retain hourly archives without automatic deletion

## Tests
- `cd executor_manager && PYTHONPATH=.. uv run --python 3.11 pytest tests/ --cov=executors --cov-report=xml --cov-report=term-missing -q -s` (267 passed)
- `cd shared && COVERAGE_CORE=sysmon PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 uv run --python 3.10 pytest tests/ --cov=utils --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing -q -p no:cacheprovider` (281 passed)
- `INTERNAL_SERVICE_TOKEN=test docker compose config --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable file logging for the executor service.
  * Logs can now be written to a mounted directory with adjustable log levels.
  * Log files rotate automatically at the start of each hour.

* **Bug Fixes**
  * Improved multi-process coordination during log rotation to help prevent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->