### PR TITLE
fix(wework): stabilize AI verification control startup

### DIFF
--- a/scripts/test-wework-dev-mac-port.sh
+++ b/scripts/test-wework-dev-mac-port.sh
@@ -89,11 +89,14 @@ assert_contains() {
 requested_port="$(find_free_port_pair)"
 expected_port="$((requested_port + 1))"
 ready_file="$(mktemp -t wework-port-listener.XXXXXX)"
+port_lock_root="$(mktemp -d -t wework-port-locks.XXXXXX)"
 rm -f "$ready_file"
 listener_pid=""
 
 cleanup() {
   rm -f "$ready_file"
+  find "$port_lock_root" -type f -name pid -delete 2>/dev/null || true
+  find "$port_lock_root" -depth -type d -exec rmdir {} \; 2>/dev/null || true
   if [ -n "$listener_pid" ] && kill -0 "$listener_pid" 2>/dev/null; then
     kill "$listener_pid"
     wait "$listener_pid" 2>/dev/null || true
@@ -109,6 +112,7 @@ output="$(
   WEGENT_DISABLE_SHARED_CARGO_TARGET=1 \
     WEWORK_DRY_RUN=1 \
     WEWORK_PORT="$requested_port" \
+    WEWORK_PORT_LOCK_ROOT="$port_lock_root" \
     VITE_WEGENT_BACKEND_URL="https://backend.example.com/api" \
     VITE_WEGENT_SOCKET_URL="wss://socket.example.com" \
     bash "$DEV_SCRIPT"
@@ -119,5 +123,25 @@ assert_contains "$output" "\"devUrl\": \"http://localhost:$expected_port\"" "Tau
 assert_contains "$output" "pnpm exec vite --host 0.0.0.0 --port $expected_port --strictPort" "beforeDevCommand"
 assert_contains "$output" "VITE_WEGENT_BACKEND_URL=https://backend.example.com/api" "backend URL"
 assert_contains "$output" "VITE_WEGENT_SOCKET_URL=wss://socket.example.com" "socket URL"
+
+kill "$listener_pid"
+wait "$listener_pid" 2>/dev/null || true
+listener_pid=""
+mkdir "$port_lock_root/$requested_port"
+echo "$$" >"$port_lock_root/$requested_port/pid"
+locked_output="$(
+  WEGENT_DISABLE_SHARED_CARGO_TARGET=1 \
+    WEWORK_DRY_RUN=1 \
+    WEWORK_PORT="$requested_port" \
+    WEWORK_PORT_LOCK_ROOT="$port_lock_root" \
+    VITE_WEGENT_BACKEND_URL="https://backend.example.com/api" \
+    VITE_WEGENT_SOCKET_URL="wss://socket.example.com" \
+    bash "$DEV_SCRIPT"
+)"
+assert_contains "$locked_output" "WEWORK_PORT=$expected_port" "locked-port dry-run output"
+if [ -d "$port_lock_root/$expected_port" ]; then
+  echo "Expected selected port lock to be released after dry run." >&2
+  exit 1
+fi
 
 echo "WeWork macOS dev port selection regression test passed"

--- a/wework/e2e/desktop/modules/cloud-environment.mjs
+++ b/wework/e2e/desktop/modules/cloud-environment.mjs
@@ -752,6 +752,7 @@ class RealCloudEnvironment {
       '',
       codexUpstreamApiFormat(protocol)
     )
+    await this.restartCloudExecutor()
   }
 
   async waitForDevice(deviceId, logPath) {

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -16,7 +16,7 @@ import { buildAiVerifyEnvironment } from './ai-verify-environment.mjs'
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const weworkDir = resolve(scriptDir, '..')
 const defaultTimeoutMs = 30_000
-const startupTimeoutMs = 60_000
+const startupTimeoutMs = 120_000
 const commandResultGraceMs = 5_000
 const corsHeaders = {
   'access-control-allow-headers': 'authorization, content-type',
@@ -134,12 +134,49 @@ async function stopOwnedSessionProcesses(session) {
 }
 
 function signalProcessGroup(processGroupId, signal) {
+  if (!Number.isInteger(processGroupId)) return Promise.resolve()
   return new Promise(resolvePromise => {
     execFile('/bin/kill', [`-${signal}`, `-${processGroupId}`], () => {
       // The process group may already have exited.
       resolvePromise()
     })
   })
+}
+
+async function removeSessionAuthLink(session) {
+  if (!session?.directory) return
+  await rm(join(session.directory, 'executor-home', 'codex', 'auth.json'), { force: true })
+}
+
+async function cleanupFailedStart(sessionPath, controllerPid) {
+  await signalProcessGroup(controllerPid, 'TERM')
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
+  let session
+  try {
+    session = JSON.parse(await readFile(sessionPath, 'utf8'))
+  } catch {
+    // The controller may have exited before completing the session file.
+  }
+  await stopOwnedSessionProcesses(session ?? {})
+  await signalProcessGroup(controllerPid, 'KILL')
+  await removeSessionAuthLink(session)
+}
+
+export function startupFailureMessage(status, timeoutMs) {
+  if (status?.appExited) {
+    if (status.appExitError) {
+      return `Wework failed to start before its WebView connected to AI verification: ${status.appExitError}`
+    }
+    const cause =
+      status.appExitSignal !== null
+        ? `signal ${status.appExitSignal}`
+        : `code ${status.appExitCode ?? 'unknown'}`
+    return `Wework exited with ${cause} before its WebView connected to AI verification`
+  }
+  const phase = status?.pid
+    ? 'the Tauri launcher was still waiting for its WebView'
+    : 'the Tauri launcher had not started'
+  return `Timed out after ${timeoutMs}ms while ${phase}`
 }
 
 async function runServer(sessionPath, token) {
@@ -149,6 +186,8 @@ async function runServer(sessionPath, token) {
   const pending = new Map()
   let ready = null
   let app = null
+  let appExit = null
+  let shutdownPromise = null
   const server = createServer((request, response) => {
     void (async () => {
       const url = new URL(request.url ?? '/', 'http://127.0.0.1')
@@ -203,6 +242,10 @@ async function runServer(sessionPath, token) {
           ready: Boolean(ready),
           readyInfo: ready,
           pid: app?.pid ?? null,
+          appExited: appExit !== null,
+          appExitCode: appExit?.code ?? null,
+          appExitSignal: appExit?.signal ?? null,
+          appExitError: appExit?.error ?? null,
           queuedCommands: queue.length,
           commandPolls: commandPolls.length,
           pendingCommands: pending.size,
@@ -239,7 +282,7 @@ async function runServer(sessionPath, token) {
       }
       if (request.method === 'POST' && url.pathname === '/shutdown') {
         response.once('finish', () => {
-          void stopOwnedSessionProcesses(updated).finally(() => server.close(() => process.exit(0)))
+          void shutdown(0)
         })
         json(response, 200, { ok: true })
         return
@@ -257,6 +300,16 @@ async function runServer(sessionPath, token) {
     controlUrl,
     status: 'starting',
   }
+  const shutdown = exitCode => {
+    if (shutdownPromise) return shutdownPromise
+    shutdownPromise = stopOwnedSessionProcesses({ launcherPid: app?.pid }).finally(() => {
+      server.close(() => process.exit(exitCode))
+      server.closeAllConnections()
+    })
+    return shutdownPromise
+  }
+  process.once('SIGINT', () => void shutdown(130))
+  process.once('SIGTERM', () => void shutdown(143))
   await writeFile(sessionPath, `${JSON.stringify(updated, null, 2)}\n`)
   const log = join(session.directory, 'app.log')
   const executorHome = join(session.directory, 'executor-home')
@@ -292,9 +345,16 @@ async function runServer(sessionPath, token) {
       'data',
       chunk => void import('node:fs/promises').then(({ appendFile }) => appendFile(log, chunk))
     )
-  app.once('exit', code => {
+  app.once('exit', (code, signal) => {
+    appExit = { code, signal }
     for (const waiter of pending.values())
       waiter.reject(new Error(`Wework exited with code ${code ?? 'unknown'}`))
+    pending.clear()
+  })
+  app.once('error', error => {
+    appExit = { code: null, signal: null, error: String(error.message ?? error) }
+    for (const waiter of pending.values())
+      waiter.reject(new Error(`Wework failed to start: ${error.message ?? error}`))
     pending.clear()
   })
 }
@@ -359,39 +419,70 @@ async function main() {
       { detached: true, stdio: 'ignore' }
     )
     child.unref()
-    const startupDeadline = Date.now() + resolveStartupTimeout(options.timeout)
-    while (Date.now() < startupDeadline) {
-      let session
-      try {
-        session = JSON.parse(await readFile(sessionPath, 'utf8'))
-      } catch (error) {
-        if (!(error instanceof SyntaxError)) throw error
-        await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
-        continue
-      }
-      if (session.controlUrl) {
-        try {
-          const status = await request(session, token, '/status')
-          if (status.ready) {
-            console.log(
-              JSON.stringify({ session: sessionPath, controlUrl: session.controlUrl }, null, 2)
-            )
-            return
-          }
-        } catch {
-          // The controller can be briefly unavailable while its process starts.
+    let controllerExit = null
+    let controllerError = null
+    child.once('exit', (code, signal) => {
+      controllerExit = { code, signal }
+    })
+    child.once('error', error => {
+      controllerError = error
+    })
+    const startupTimeout = resolveStartupTimeout(options.timeout)
+    const startupDeadline = Date.now() + startupTimeout
+    let lastStatus = null
+    try {
+      while (Date.now() < startupDeadline) {
+        if (controllerError) {
+          throw new Error(`AI verification controller failed to start: ${controllerError.message}`)
         }
+        if (controllerExit) {
+          throw new Error(
+            `AI verification controller exited with ${
+              controllerExit.signal !== null
+                ? `signal ${controllerExit.signal}`
+                : `code ${controllerExit.code ?? 'unknown'}`
+            } during startup`
+          )
+        }
+        let session
+        try {
+          session = JSON.parse(await readFile(sessionPath, 'utf8'))
+        } catch (error) {
+          if (!(error instanceof SyntaxError)) throw error
+          await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+          continue
+        }
+        if (session.controlUrl) {
+          try {
+            lastStatus = await request(session, token, '/status')
+            if (lastStatus.ready) {
+              console.log(
+                JSON.stringify({ session: sessionPath, controlUrl: session.controlUrl }, null, 2)
+              )
+              return
+            }
+            if (lastStatus.appExited) {
+              throw new Error(startupFailureMessage(lastStatus, startupTimeout))
+            }
+          } catch (error) {
+            if (lastStatus?.appExited) throw error
+            // The controller can be briefly unavailable while its process starts.
+          }
+        }
+        await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
       }
-      await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+      throw new Error(startupFailureMessage(lastStatus, startupTimeout))
+    } catch (error) {
+      await cleanupFailedStart(sessionPath, child.pid)
+      throw error
     }
-    throw new Error('Timed out waiting for the Wework WebView to connect to AI verification')
   }
   if (!options.session) throw new Error('--session is required')
   const session = JSON.parse(await readFile(options.session, 'utf8'))
   if (command === 'stop') {
     await request(session, session.token, '/shutdown', 'POST')
     await stopOwnedSessionProcesses(session)
-    await rm(join(session.directory, 'executor-home', 'codex', 'auth.json'), { force: true })
+    await removeSessionAuthLink(session)
     return
   }
   if (command === 'status') {

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -18,6 +18,8 @@ const weworkDir = resolve(scriptDir, '..')
 const defaultTimeoutMs = 30_000
 const startupTimeoutMs = 120_000
 const commandResultGraceMs = 5_000
+const failedStartCleanupGraceMs = 1_000
+const cleanupSessionPollMs = 50
 const corsHeaders = {
   'access-control-allow-headers': 'authorization, content-type',
   'access-control-allow-methods': 'GET, POST, OPTIONS',
@@ -43,7 +45,8 @@ Options:
   --text TEXT               Expected text for wait-for
   --visible true            Require a visible element for wait-for
   --stable MS               Require the wait-for condition to remain stable
-  --timeout MS              Command timeout (default: ${defaultTimeoutMs})`)
+  --timeout MS              Startup timeout for start (default: ${startupTimeoutMs});
+                            command timeout otherwise (default: ${defaultTimeoutMs})`)
 }
 
 function parseArgs(argv) {
@@ -148,35 +151,70 @@ async function removeSessionAuthLink(session) {
   await rm(join(session.directory, 'executor-home', 'codex', 'auth.json'), { force: true })
 }
 
+export async function readSessionForCleanup(sessionPath, timeoutMs = failedStartCleanupGraceMs) {
+  const deadline = Date.now() + timeoutMs
+  let session
+  while (Date.now() <= deadline) {
+    try {
+      session = JSON.parse(await readFile(sessionPath, 'utf8'))
+      if (Number.isInteger(session.launcherPid)) break
+    } catch {
+      // The controller may still be replacing the session file.
+    }
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
+    await new Promise(resolvePromise =>
+      setTimeout(resolvePromise, Math.min(cleanupSessionPollMs, remainingMs))
+    )
+  }
+  return { directory: dirname(sessionPath), ...(session ?? {}) }
+}
+
 async function cleanupFailedStart(sessionPath, controllerPid) {
   await signalProcessGroup(controllerPid, 'TERM')
-  await new Promise(resolvePromise => setTimeout(resolvePromise, 250))
-  let session
-  try {
-    session = JSON.parse(await readFile(sessionPath, 'utf8'))
-  } catch {
-    // The controller may have exited before completing the session file.
-  }
-  await stopOwnedSessionProcesses(session ?? {})
+  const session = await readSessionForCleanup(sessionPath)
+  await stopOwnedSessionProcesses(session)
   await signalProcessGroup(controllerPid, 'KILL')
   await removeSessionAuthLink(session)
 }
 
+export function appExitMessage(appExit) {
+  if (appExit?.error) return `Wework failed to start: ${appExit.error}`
+  if (appExit?.signal !== null && appExit?.signal !== undefined) {
+    return `Wework exited with signal ${appExit.signal}`
+  }
+  return `Wework exited with code ${appExit?.code ?? 'unknown'}`
+}
+
 export function startupFailureMessage(status, timeoutMs) {
   if (status?.appExited) {
-    if (status.appExitError) {
-      return `Wework failed to start before its WebView connected to AI verification: ${status.appExitError}`
-    }
-    const cause =
-      status.appExitSignal !== null
-        ? `signal ${status.appExitSignal}`
-        : `code ${status.appExitCode ?? 'unknown'}`
-    return `Wework exited with ${cause} before its WebView connected to AI verification`
+    return `${appExitMessage({
+      code: status.appExitCode,
+      signal: status.appExitSignal,
+      error: status.appExitError,
+    })} before its WebView connected to AI verification`
   }
   const phase = status?.pid
     ? 'the Tauri launcher was still waiting for its WebView'
     : 'the Tauri launcher had not started'
   return `Timed out after ${timeoutMs}ms while ${phase}`
+}
+
+export function monitorAppProcess(app, pending, onExit) {
+  const rejectPending = message => {
+    for (const waiter of pending.values()) waiter.reject(new Error(message))
+    pending.clear()
+  }
+  app.once('exit', (code, signal) => {
+    const appExit = { code, signal, error: null }
+    onExit(appExit)
+    rejectPending(appExitMessage(appExit))
+  })
+  app.once('error', error => {
+    const appExit = { code: null, signal: null, error: String(error.message ?? error) }
+    onExit(appExit)
+    rejectPending(appExitMessage(appExit))
+  })
 }
 
 async function runServer(sessionPath, token) {
@@ -252,6 +290,7 @@ async function runServer(sessionPath, token) {
         })
       }
       if (request.method === 'POST' && url.pathname === '/command') {
+        if (appExit) return json(response, 410, { error: appExitMessage(appExit) })
         if (!ready) return json(response, 409, { error: 'Wework WebView is not ready' })
         const command = await readBody(request)
         const id = randomUUID()
@@ -339,24 +378,15 @@ async function runServer(sessionPath, token) {
     }),
     stdio: ['ignore', 'pipe', 'pipe'],
   })
-  await writeFile(sessionPath, `${JSON.stringify({ ...updated, launcherPid: app.pid }, null, 2)}\n`)
+  monitorAppProcess(app, pending, exit => {
+    appExit = exit
+  })
   for (const stream of [app.stdout, app.stderr])
     stream?.on(
       'data',
       chunk => void import('node:fs/promises').then(({ appendFile }) => appendFile(log, chunk))
     )
-  app.once('exit', (code, signal) => {
-    appExit = { code, signal }
-    for (const waiter of pending.values())
-      waiter.reject(new Error(`Wework exited with code ${code ?? 'unknown'}`))
-    pending.clear()
-  })
-  app.once('error', error => {
-    appExit = { code: null, signal: null, error: String(error.message ?? error) }
-    for (const waiter of pending.values())
-      waiter.reject(new Error(`Wework failed to start: ${error.message ?? error}`))
-    pending.clear()
-  })
+  await writeFile(sessionPath, `${JSON.stringify({ ...updated, launcherPid: app.pid }, null, 2)}\n`)
 }
 
 async function request(session, token, path, method = 'GET', body) {

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -341,10 +341,12 @@ async function runServer(sessionPath, token) {
   }
   const shutdown = exitCode => {
     if (shutdownPromise) return shutdownPromise
-    shutdownPromise = stopOwnedSessionProcesses({ launcherPid: app?.pid }).finally(() => {
-      server.close(() => process.exit(exitCode))
-      server.closeAllConnections()
-    })
+    shutdownPromise = stopOwnedSessionProcesses({ launcherPid: app?.pid })
+      .then(() => removeSessionAuthLink(session))
+      .finally(() => {
+        server.close(() => process.exit(exitCode))
+        server.closeAllConnections()
+      })
     return shutdownPromise
   }
   process.once('SIGINT', () => void shutdown(130))
@@ -484,6 +486,7 @@ async function main() {
         }
         if (session.controlUrl) {
           try {
+            lastStatus = null
             lastStatus = await request(session, token, '/status')
             if (lastStatus.ready) {
               console.log(

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -1,5 +1,12 @@
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, test, vi } from 'vitest'
 import {
+  appExitMessage,
+  monitorAppProcess,
+  readSessionForCleanup,
   resolveCommandTimeout,
   resolveStartupTimeout,
   startupFailureMessage,
@@ -77,7 +84,7 @@ describe('startupFailureMessage', () => {
         120000
       )
     ).toBe(
-      'Wework failed to start before its WebView connected to AI verification: spawn bash ENOENT'
+      'Wework failed to start: spawn bash ENOENT before its WebView connected to AI verification'
     )
   })
 
@@ -88,6 +95,64 @@ describe('startupFailureMessage', () => {
     expect(startupFailureMessage({ pid: 42 }, 120000)).toContain(
       'the Tauri launcher was still waiting for its WebView'
     )
+  })
+})
+
+describe('readSessionForCleanup', () => {
+  test('waits for the controller to publish its launcher pid', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-ai-verify-cleanup-'))
+    const sessionPath = join(directory, 'session.json')
+    await writeFile(sessionPath, '{')
+    const update = setTimeout(
+      () =>
+        void writeFile(
+          sessionPath,
+          JSON.stringify({ directory: '/isolated/session', launcherPid: 42 })
+        ),
+      10
+    )
+
+    try {
+      await expect(readSessionForCleanup(sessionPath, 200)).resolves.toEqual({
+        directory: '/isolated/session',
+        launcherPid: 42,
+      })
+    } finally {
+      clearTimeout(update)
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('derives the session directory when parsing never succeeds', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-ai-verify-cleanup-'))
+    const sessionPath = join(directory, 'session.json')
+    try {
+      await expect(readSessionForCleanup(sessionPath, 1)).resolves.toEqual({ directory })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('monitorAppProcess', () => {
+  test('captures a fast spawn error and rejects pending commands', async () => {
+    const app = new EventEmitter()
+    let appExit
+    let rejectPending
+    const pendingResult = new Promise((_, reject) => {
+      rejectPending = reject
+    })
+    const pendingExpectation = expect(pendingResult).rejects.toThrow(
+      'Wework failed to start: spawn bash ENOENT'
+    )
+
+    monitorAppProcess(app, new Map([['command', { reject: rejectPending }]]), exit => {
+      appExit = exit
+    })
+    app.emit('error', new Error('spawn bash ENOENT'))
+
+    await pendingExpectation
+    expect(appExitMessage(appExit)).toBe('Wework failed to start: spawn bash ENOENT')
   })
 })
 

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 import {
   resolveCommandTimeout,
   resolveStartupTimeout,
+  startupFailureMessage,
   takeWritableCommandPoll,
 } from './ai-verify.mjs'
 
@@ -42,12 +43,50 @@ describe('takeWritableCommandPoll', () => {
 describe('resolveStartupTimeout', () => {
   test('accepts finite positive timeout values', () => {
     expect(resolveStartupTimeout('120000')).toBe(120000)
-    expect(resolveStartupTimeout(undefined)).toBe(60000)
+    expect(resolveStartupTimeout(undefined)).toBe(120000)
   })
 
   test.each(['0', '-1', 'Infinity', 'not-a-number'])('rejects invalid timeout %s', timeout => {
     expect(() => resolveStartupTimeout(timeout)).toThrow(
       '--timeout must be a finite positive number'
+    )
+  })
+})
+
+describe('startupFailureMessage', () => {
+  test('reports an exited launcher without waiting for the timeout', () => {
+    expect(
+      startupFailureMessage(
+        {
+          appExited: true,
+          appExitCode: 1,
+          appExitSignal: null,
+        },
+        120000
+      )
+    ).toBe('Wework exited with code 1 before its WebView connected to AI verification')
+  })
+
+  test('reports launcher spawn errors', () => {
+    expect(
+      startupFailureMessage(
+        {
+          appExited: true,
+          appExitError: 'spawn bash ENOENT',
+        },
+        120000
+      )
+    ).toBe(
+      'Wework failed to start before its WebView connected to AI verification: spawn bash ENOENT'
+    )
+  })
+
+  test('distinguishes launcher preparation from WebView connection', () => {
+    expect(startupFailureMessage({ pid: null }, 120000)).toContain(
+      'the Tauri launcher had not started'
+    )
+    expect(startupFailureMessage({ pid: 42 }, 120000)).toContain(
+      'the Tauri launcher was still waiting for its WebView'
     )
   })
 })

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -164,6 +164,8 @@ fi
 BACKEND_BASE_URL="$(wework_resolve_backend_base_url)"
 BACKEND_PORT="${BACKEND_PORT:-9100}"
 WEWORK_PORT="${REQUESTED_WEWORK_PORT:-${WEWORK_PORT:-1420}}"
+WEWORK_PORT_LOCK_ROOT="${WEWORK_PORT_LOCK_ROOT:-${TMPDIR:-/tmp}/wework-dev-port-locks}"
+WEWORK_PORT_LOCK_DIR=""
 
 if ! [[ "$WEWORK_PORT" =~ ^[0-9]+$ ]] || [ "$WEWORK_PORT" -lt 1 ] || [ "$WEWORK_PORT" -gt 65535 ]; then
   echo "Error: WEWORK_PORT must be a number between 1 and 65535. Got: $WEWORK_PORT" >&2
@@ -188,11 +190,45 @@ is_port_available() {
   ' "$1"
 }
 
+release_wework_port_lock() {
+  if [ -z "$WEWORK_PORT_LOCK_DIR" ]; then
+    return
+  fi
+  rm -f "$WEWORK_PORT_LOCK_DIR/pid"
+  rmdir "$WEWORK_PORT_LOCK_DIR" 2>/dev/null || true
+  WEWORK_PORT_LOCK_DIR=""
+}
+
+try_acquire_wework_port_lock() {
+  local port="$1"
+  local lock_dir="$WEWORK_PORT_LOCK_ROOT/$port"
+  local owner_pid=""
+
+  mkdir -p "$WEWORK_PORT_LOCK_ROOT"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+    if ! [[ "$owner_pid" =~ ^[0-9]+$ ]] || kill -0 "$owner_pid" 2>/dev/null; then
+      return 1
+    fi
+    rm -f "$lock_dir/pid"
+    rmdir "$lock_dir" 2>/dev/null || return 1
+    mkdir "$lock_dir" 2>/dev/null || return 1
+  fi
+
+  echo "$$" >"$lock_dir/pid"
+  WEWORK_PORT_LOCK_DIR="$lock_dir"
+}
+
 find_available_wework_port() {
   local port="$1"
 
   while [ "$port" -le 65535 ]; do
-    if is_port_available "$port"; then
+    if try_acquire_wework_port_lock "$port"; then
+      if ! is_port_available "$port"; then
+        release_wework_port_lock
+        port="$((port + 1))"
+        continue
+      fi
       AVAILABLE_WEWORK_PORT="$port"
       return 0
     fi
@@ -235,6 +271,7 @@ build_wework_dev_title() {
 
 AVAILABLE_WEWORK_PORT=""
 find_available_wework_port "$WEWORK_PORT"
+trap release_wework_port_lock EXIT
 if [ "$AVAILABLE_WEWORK_PORT" != "$WEWORK_PORT" ]; then
   echo "WEWORK_PORT $WEWORK_PORT is already in use; using $AVAILABLE_WEWORK_PORT instead."
 fi
@@ -305,7 +342,7 @@ else
 fi
 
 TAURI_DEV_CONFIG="$(mktemp -t wework-tauri-dev.XXXXXX.json)"
-trap 'rm -f "$TAURI_DEV_CONFIG"' EXIT
+trap 'rm -f "$TAURI_DEV_CONFIG"; release_wework_port_lock' EXIT
 
 WEWORK_PORT_VALUE="$WEWORK_PORT" \
 BEFORE_DEV_COMMAND_VALUE="$BEFORE_DEV_COMMAND" \
@@ -395,7 +432,13 @@ cleanup_dev_processes() {
   TAURI_PROCESS_GROUP=""
 }
 
-trap cleanup_dev_processes EXIT
+cleanup_dev_resources() {
+  cleanup_dev_processes
+  rm -f "$TAURI_DEV_CONFIG"
+  release_wework_port_lock
+}
+
+trap cleanup_dev_resources EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -296,11 +296,15 @@ if [ -z "${WEWORK_EXECUTOR_SIDECAR:-}" ]; then
 fi
 export WEWORK_EXECUTOR_SIDECAR
 
-if [ "$WEWORK_RELEASE_UI" = "true" ]; then
-  BEFORE_DEV_COMMAND="pnpm run build && pnpm exec vite preview --host 0.0.0.0 --port $WEWORK_PORT --strictPort"
-else
-  BEFORE_DEV_COMMAND="pnpm exec vite --host 0.0.0.0 --port $WEWORK_PORT --strictPort"
-fi
+configure_before_dev_command() {
+  if [ "$WEWORK_RELEASE_UI" = "true" ]; then
+    BEFORE_DEV_COMMAND="pnpm run build && pnpm exec vite preview --host 0.0.0.0 --port $WEWORK_PORT --strictPort"
+  else
+    BEFORE_DEV_COMMAND="pnpm exec vite --host 0.0.0.0 --port $WEWORK_PORT --strictPort"
+  fi
+}
+
+configure_before_dev_command
 install_wegent_sccache_with_homebrew
 configure_wegent_cargo_target_dir "$PROJECT_DIR" "wework-src-tauri"
 
@@ -344,30 +348,34 @@ fi
 TAURI_DEV_CONFIG="$(mktemp -t wework-tauri-dev.XXXXXX.json)"
 trap 'rm -f "$TAURI_DEV_CONFIG"; release_wework_port_lock' EXIT
 
-WEWORK_PORT_VALUE="$WEWORK_PORT" \
-BEFORE_DEV_COMMAND_VALUE="$BEFORE_DEV_COMMAND" \
-WEWORK_RELEASE_UI_VALUE="$WEWORK_RELEASE_UI" \
-WEWORK_APP_IDENTIFIER_VALUE="${WEWORK_APP_IDENTIFIER:-}" \
-WEWORK_DISABLE_BACKGROUND_THROTTLING_VALUE="${WEWORK_DISABLE_BACKGROUND_THROTTLING:-0}" \
-WEWORK_DIR_VALUE="$WEWORK_DIR" \
-TAURI_DEV_CONFIG_VALUE="$TAURI_DEV_CONFIG" \
-python3 "$SCRIPT_DIR/create-tauri-dev-config.py"
+write_tauri_dev_config() {
+  WEWORK_PORT_VALUE="$WEWORK_PORT" \
+  BEFORE_DEV_COMMAND_VALUE="$BEFORE_DEV_COMMAND" \
+  WEWORK_RELEASE_UI_VALUE="$WEWORK_RELEASE_UI" \
+  WEWORK_APP_IDENTIFIER_VALUE="${WEWORK_APP_IDENTIFIER:-}" \
+  WEWORK_DISABLE_BACKGROUND_THROTTLING_VALUE="${WEWORK_DISABLE_BACKGROUND_THROTTLING:-0}" \
+  WEWORK_DIR_VALUE="$WEWORK_DIR" \
+  TAURI_DEV_CONFIG_VALUE="$TAURI_DEV_CONFIG" \
+  python3 "$SCRIPT_DIR/create-tauri-dev-config.py"
+}
 
-echo "Starting WeWork mac app"
-echo "  RELEASE_UI=$WEWORK_RELEASE_UI"
-echo "  WEWORK_PORT=$WEWORK_PORT"
-echo "  WEWORK_DEV_TITLE=$WEWORK_DEV_TITLE"
-echo "  WEWORK_DEV_WORKTREE=$WEWORK_DEV_WORKTREE"
-echo "  WEWORK_DEV_BRANCH=${WEWORK_DEV_BRANCH:-<detached>}"
-echo "  WEWORK_APP_IDENTIFIER=${WEWORK_APP_IDENTIFIER:-io.wecode.wework}"
-echo "  MACOS_BUILD_TARGET=${MACOS_BUILD_TARGET:-<native>}"
-echo "  VITE_WEGENT_BACKEND_URL=$VITE_WEGENT_BACKEND_URL"
-echo "  VITE_WEGENT_SOCKET_URL=${VITE_WEGENT_SOCKET_URL:-<backend URL>}"
-echo "  WEWORK_EXECUTOR_SIDECAR=${WEWORK_EXECUTOR_SIDECAR:-<bundled sidecar>}"
-echo "  WEWORK_SHARED_EXECUTOR_HOME=${WEWORK_SHARED_EXECUTOR_HOME:-0}"
-echo "  EXECUTOR_ISOLATION=${EXECUTOR_ISOLATION_OVERRIDE:-auto}"
-echo "  CODEX_BINARY_PATH=${CODEX_BINARY_PATH:-${CODEX_BIN:-codex}}"
-echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-<cargo default>}"
+print_startup_configuration() {
+  echo "Starting WeWork mac app"
+  echo "  RELEASE_UI=$WEWORK_RELEASE_UI"
+  echo "  WEWORK_PORT=$WEWORK_PORT"
+  echo "  WEWORK_DEV_TITLE=$WEWORK_DEV_TITLE"
+  echo "  WEWORK_DEV_WORKTREE=$WEWORK_DEV_WORKTREE"
+  echo "  WEWORK_DEV_BRANCH=${WEWORK_DEV_BRANCH:-<detached>}"
+  echo "  WEWORK_APP_IDENTIFIER=${WEWORK_APP_IDENTIFIER:-io.wecode.wework}"
+  echo "  MACOS_BUILD_TARGET=${MACOS_BUILD_TARGET:-<native>}"
+  echo "  VITE_WEGENT_BACKEND_URL=$VITE_WEGENT_BACKEND_URL"
+  echo "  VITE_WEGENT_SOCKET_URL=${VITE_WEGENT_SOCKET_URL:-<backend URL>}"
+  echo "  WEWORK_EXECUTOR_SIDECAR=${WEWORK_EXECUTOR_SIDECAR:-<bundled sidecar>}"
+  echo "  WEWORK_SHARED_EXECUTOR_HOME=${WEWORK_SHARED_EXECUTOR_HOME:-0}"
+  echo "  EXECUTOR_ISOLATION=${EXECUTOR_ISOLATION_OVERRIDE:-auto}"
+  echo "  CODEX_BINARY_PATH=${CODEX_BINARY_PATH:-${CODEX_BIN:-codex}}"
+  echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-<cargo default>}"
+}
 
 if [ "${WEWORK_MALLOC_STACK_LOGGING:-}" = "1" ]; then
   export MallocStackLogging=1
@@ -376,7 +384,9 @@ if [ "${WEWORK_MALLOC_STACK_LOGGING:-}" = "1" ]; then
   echo "  MallocStackLoggingNoCompact=1"
 fi
 
+write_tauri_dev_config
 if [ "${WEWORK_DRY_RUN:-}" = "1" ]; then
+  print_startup_configuration
   echo "  TAURI_DEV_CONFIG=$TAURI_DEV_CONFIG"
   cat "$TAURI_DEV_CONFIG"
   exit 0
@@ -405,6 +415,21 @@ if [ -z "${WEWORK_NODE_RUNTIME_ROOT:-}" ]; then
   export WEWORK_NODE_RUNTIME_ROOT="$WEWORK_DIR/node_modules/.cache/execution-runtime-node-dev"
 fi
 echo "Using Node runtime root: $WEWORK_NODE_RUNTIME_ROOT"
+
+if ! is_port_available "$WEWORK_PORT"; then
+  occupied_port="$WEWORK_PORT"
+  release_wework_port_lock
+  AVAILABLE_WEWORK_PORT=""
+  find_available_wework_port "$((occupied_port + 1))"
+  WEWORK_PORT="$AVAILABLE_WEWORK_PORT"
+  export WEWORK_DEV_PORT="$WEWORK_PORT"
+  export VITE_WEWORK_DEV_PORT="$WEWORK_PORT"
+  configure_before_dev_command
+  write_tauri_dev_config
+  echo "WEWORK_PORT $occupied_port became unavailable during preparation; using $WEWORK_PORT instead."
+fi
+
+print_startup_configuration
 TAURI_ARGS=(dev --config "$TAURI_DEV_CONFIG")
 if [ "$WEWORK_RELEASE_UI" = "true" ]; then
   TAURI_ARGS+=(--release)

--- a/wework/src/main.tsx
+++ b/wework/src/main.tsx
@@ -75,17 +75,15 @@ function renderStartupFailure(error: unknown): void {
 let shouldRenderApp = true
 if (!isSystemDragPanel) {
   try {
+    await installWeworkAutomationBridge()
+  } catch (error) {
+    console.error('[Wework] Failed to install the automation bridge:', error)
+  }
+  try {
     await initializeWorkbenchPluginRuntime()
   } catch (error) {
     renderStartupFailure(error)
     shouldRenderApp = false
-  }
-  if (shouldRenderApp) {
-    try {
-      await installWeworkAutomationBridge()
-    } catch (error) {
-      console.error('[Wework] Failed to install the automation bridge:', error)
-    }
   }
 }
 if (shouldRenderApp) renderApp()

--- a/wework/src/pages/AutomationsPage.test.tsx
+++ b/wework/src/pages/AutomationsPage.test.tsx
@@ -23,6 +23,7 @@ const automation: Automation = {
 const automationApi = {
   listAutomations: vi.fn().mockResolvedValue({ items: [automation] }),
   listAutomationRuns: vi.fn().mockResolvedValue({ items: [] }),
+  updateAutomation: vi.fn(),
 }
 
 const workbenchMock = {
@@ -79,10 +80,13 @@ vi.mock('@/components/layout/WorkbenchSearchDialog', () => ({
 }))
 
 vi.mock('@/features/automations/AutomationDetailWorkspace', () => ({
-  AutomationDetailWorkspace: ({ onClose }: { onClose: () => void }) => (
+  AutomationDetailWorkspace: ({ onClose, onSave }: { onClose: () => void; onSave: () => void }) => (
     <section data-testid="automation-detail-panel">
       <button type="button" data-testid="automation-detail-close" onClick={onClose}>
         Close
+      </button>
+      <button type="button" data-testid="automation-detail-save" onClick={onSave}>
+        Save
       </button>
     </section>
   ),
@@ -93,6 +97,7 @@ describe('AutomationsPage', () => {
     vi.clearAllMocks()
     automationApi.listAutomations.mockResolvedValue({ items: [automation] })
     automationApi.listAutomationRuns.mockResolvedValue({ items: [] })
+    workbenchMock.state.defaultTeam = null
   })
 
   test('keeps the detail panel closed after the user dismisses it', async () => {
@@ -114,6 +119,61 @@ describe('AutomationsPage', () => {
 
       expect(automationApi.listAutomations).toHaveBeenCalledTimes(2)
       expect(screen.queryByTestId('automation-detail-panel')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('preserves the selected cloud model for scheduled thread continuations', async () => {
+    vi.useFakeTimers()
+    const continuationAutomation: Automation = {
+      ...automation,
+      conversationMode: 'continue_thread',
+      taskPayload: {
+        deviceId: 'local-device',
+        modelId: 'public:desktop-e2e-public-upstream-model',
+        modelType: 'public',
+        modelOptions: {
+          reasoningEffort: 'medium',
+          weworkCloudModelNamespace: 'default',
+          weworkCloudModelResourceUserId: '0',
+        },
+      },
+      continuationPayload: {
+        address: {
+          deviceId: 'local-device',
+          taskId: 'automation-task',
+          workspacePath: '/workspace',
+        },
+        message: automation.prompt,
+      },
+    }
+    try {
+      workbenchMock.state.defaultTeam = { id: 1 }
+      automationApi.listAutomations.mockResolvedValue({ items: [continuationAutomation] })
+      automationApi.updateAutomation.mockResolvedValue({
+        automation: continuationAutomation,
+      })
+
+      render(<AutomationsPage />)
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      fireEvent.click(screen.getByTestId('automation-detail-save'))
+      await act(() => vi.advanceTimersByTimeAsync(0))
+
+      expect(automationApi.updateAutomation).toHaveBeenCalledWith(
+        continuationAutomation.id,
+        expect.objectContaining({
+          continuationPayload: expect.objectContaining({
+            modelId: 'public:desktop-e2e-public-upstream-model',
+            modelType: 'public',
+            modelOptions: {
+              reasoningEffort: 'medium',
+              weworkCloudModelNamespace: 'default',
+              weworkCloudModelResourceUserId: '0',
+            },
+          }),
+        })
+      )
     } finally {
       vi.useRealTimers()
     }

--- a/wework/src/pages/AutomationsPage.tsx
+++ b/wework/src/pages/AutomationsPage.tsx
@@ -39,7 +39,7 @@ import { buildRuntimeTaskRoute, navigateTo } from '@/lib/navigation'
 import { runtimeProjectUiId } from '@/lib/runtime-project'
 import { cn } from '@/lib/utils'
 import { track } from '@/telemetry/client'
-import type { RuntimeTaskAddress, RuntimeTaskCreateRequest } from '@/types/api'
+import type { RuntimeSendRequest, RuntimeTaskAddress, RuntimeTaskCreateRequest } from '@/types/api'
 import type {
   Automation,
   AutomationMutation,
@@ -339,6 +339,13 @@ export function AutomationsPage() {
             address: draft.continuationAddress,
             message: draft.prompt.trim(),
             ...(initialGoal ? { initialGoal } : {}),
+            ...(draft.modelId
+              ? {
+                  modelId: draft.modelId,
+                  modelType: draft.modelType as RuntimeSendRequest['modelType'],
+                  modelOptions: draft.modelOptions,
+                }
+              : {}),
           }
         : null
     return {


### PR DESCRIPTION
## Summary

- register the isolated desktop control bridge before plugin-profile initialization
- extend cold-start allowance and surface launcher exit/spawn diagnostics
- reclaim controller, Tauri process groups, and isolated auth links after failed or stopped sessions

## Verification

- `pnpm --filter wework test scripts/ai-verify.test.mjs`
- `pnpm --filter wework typecheck`
- focused Prettier and ESLint checks
- pre-push Wework ESLint, TypeScript, and unit tests
- isolated real-Tauri cold start: control channel became ready after the former 60-second limit
- verified `status`, `snapshot`, and `stop`; controller, launcher, and auth link were removed
- verified forced `--timeout 1` cleanup leaves no controller, launcher, or auth link

Task: WEWORKC2FA61-306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup failure detection with clearer status reporting and timeout explanations.
  * Extended the startup timeout to 120 seconds.
  * Added cleanup for failed processes, authentication files, and active connections.
  * Improved application exits, launch errors, and shutdown handling.
  * Prevented startup failures from blocking runtime initialization.
  * Reduced port conflicts between concurrent development instances.
  * Ensured cloud executor settings take effect after configuration changes.
  * Preserved selected model settings when saving continuing automations.
* **Tests**
  * Expanded coverage for startup failures, cleanup, launch errors, port locking, and automation model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->