### PR TITLE
fix(wework): restore titlebar actions after smart apps

### DIFF
--- a/wework/e2e/desktop/modules/shared.mjs
+++ b/wework/e2e/desktop/modules/shared.mjs
@@ -1190,9 +1190,13 @@ async function sendPromptUntilScenarioRequest(control, selector, prompt, scenari
   )
 }
 
-async function visibleModelOptionId(control, targetOptionIds) {
+function modelProviderSelector(providerId) {
+  return providerId ? `[data-model-provider-id="${providerId}"]` : ''
+}
+
+async function visibleModelOptionId(control, targetOptionIds, providerId) {
   for (const targetOptionId of targetOptionIds) {
-    const targetSelector = `[data-testid="model-selector-submenu"] [data-testid="${targetOptionId}"]`
+    const targetSelector = `[data-testid="model-selector-submenu"] [data-testid="${targetOptionId}"]${modelProviderSelector(providerId)}`
     await control.command('scrollIntoView', targetSelector).catch(() => undefined)
     const metrics = await control
       .command('getElementMetrics', targetSelector)
@@ -1215,9 +1219,9 @@ async function visibleModelOptionId(control, targetOptionIds) {
   return null
 }
 
-async function revealGroupedModelOption(control, targetOptionIds) {
+async function revealGroupedModelOption(control, targetOptionIds, providerId) {
   const menu = JSON.parse(await control.command('snapshot', 'body'))
-  if (await visibleModelOptionId(control, targetOptionIds)) return true
+  if (await visibleModelOptionId(control, targetOptionIds, providerId)) return true
   const familyTestIds = menu.testIds.filter(testId => testId.startsWith('model-family-'))
 
   for (const familyTestId of familyTestIds) {
@@ -1225,7 +1229,7 @@ async function revealGroupedModelOption(control, targetOptionIds) {
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     })
     await new Promise(resolvePromise => setTimeout(resolvePromise, 150))
-    if (await visibleModelOptionId(control, targetOptionIds)) return true
+    if (await visibleModelOptionId(control, targetOptionIds, providerId)) return true
   }
 
   return false
@@ -1235,6 +1239,13 @@ function modelOptionIdCandidates(modelIds) {
   return (Array.isArray(modelIds) ? modelIds : [modelIds]).map(modelId =>
     modelId.startsWith('model-option-') ? modelId : `model-option-${modelId}`
   )
+}
+
+function expectedModelProviderId(modelIds) {
+  const targetOptionIds = modelOptionIdCandidates(modelIds)
+  return targetOptionIds.includes(`model-option-${DEFAULT_MODEL_ID}`)
+    ? MODEL_PROVIDER_ID
+    : undefined
 }
 
 function hasModelOption(menu, targetOptionIds) {
@@ -1343,6 +1354,7 @@ async function selectE2EModel(
   composerSelector = ''
 ) {
   const labels = Array.isArray(modelLabels) ? modelLabels : [modelLabels]
+  const expectedProviderId = expectedModelProviderId(modelIds)
   const modelSelectorButton = `${composerSelector} [data-testid="model-selector-button"]`.trim()
   await control.command('waitFor', modelSelectorButton, {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
@@ -1351,11 +1363,19 @@ async function selectE2EModel(
   const selectedModelLabel = await control.command('getText', modelSelectorButton, {
     visible: true,
   })
-  if (labels.some(label => selectedModelLabel.includes(label))) return
+  const selectedProviderId = await control.command('getAttribute', modelSelectorButton, {
+    value: 'data-model-provider-id',
+  })
+  if (
+    labels.some(label => selectedModelLabel.includes(label)) &&
+    (!expectedProviderId || selectedProviderId === expectedProviderId)
+  ) {
+    return
+  }
 
   await ensureModelOptionVisible(control, modelIds, modelSelectorButton)
   const targetOptionIds = modelOptionIdCandidates(modelIds)
-  let targetOptionId = await visibleModelOptionId(control, targetOptionIds)
+  let targetOptionId = await visibleModelOptionId(control, targetOptionIds, expectedProviderId)
   if (!targetOptionId) {
     const menu = JSON.parse(await control.command('snapshot', 'body'))
     if (!menu.testIds.includes('model-selector-menu')) {
@@ -1365,11 +1385,11 @@ async function selectE2EModel(
         visible: true,
       })
     }
-    await revealGroupedModelOption(control, targetOptionIds)
-    targetOptionId = await visibleModelOptionId(control, targetOptionIds)
+    await revealGroupedModelOption(control, targetOptionIds, expectedProviderId)
+    targetOptionId = await visibleModelOptionId(control, targetOptionIds, expectedProviderId)
   }
   assert.ok(targetOptionId, `No visible model option matched ${modelOptionIdCandidates(modelIds)}`)
-  const targetSelector = `[data-testid="model-selector-submenu"] [data-testid="${targetOptionId}"]`
+  const targetSelector = `[data-testid="model-selector-submenu"] [data-testid="${targetOptionId}"]${modelProviderSelector(expectedProviderId)}`
   await control.command('waitFor', targetSelector, {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
@@ -1385,6 +1405,15 @@ async function selectE2EModel(
     )
   }
   await waitForE2EModelLabel(control, labels, modelSelectorButton)
+  if (expectedProviderId) {
+    assert.equal(
+      await control.command('getAttribute', modelSelectorButton, {
+        value: 'data-model-provider-id',
+      }),
+      expectedProviderId,
+      'The model selector did not retain the expected provider'
+    )
+  }
   await control.command('press', 'body', { key: 'Escape' })
   await waitForSnapshot(
     control,

--- a/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
@@ -305,6 +305,30 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         harnessStateValue,
         'Switching away from and back to a Harness app reset its in-memory page state'
       )
+      const taskTabSelector = '[role="tab"][data-tab-kind="task"]'
+      await control.command('click', taskTabSelector)
+      await control.command(
+        'waitFor',
+        '[data-testid="workbench-main-header"] [data-testid="titlebar-main-actions"]',
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await control.command(
+        'waitFor',
+        '[data-testid="workbench-main-header"] [data-testid="toggle-right-workspace-panel-button"]',
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await control.command('click', `[data-testid="workspace-tab-select-${appTabId}"]`)
+      await control.command(
+        'waitFor',
+        `[data-testid="workspace-tab-content-${appTabId}"][aria-hidden="false"]`,
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
       await control.command('click', `[data-testid="workspace-tab-select-${managementTabId}"]`)
       await control.command(
         'waitFor',

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -274,6 +274,15 @@ export function WorkspaceTabSurface({
   // disconnects their effects. Keep the current iframe route connected while
   // inactive; AppIframe hides the native WebView through its active prop.
   const keepIframeActive = Boolean(iframe)
+
+  useLayoutEffect(() => {
+    if (!active) return
+    // React Activity may reveal a retained workspace after AppRoutes has already
+    // committed its active-tab effect. Re-sync at the surface boundary so titlebar
+    // portals mounted during that reveal cannot keep the previous tab's visibility.
+    setActiveWorkspaceTabPortalOwner(tab.id)
+  }, [active, tab.id])
+
   return (
     <WorkspaceTabPortalOwner ownerId={tab.id}>
       <Activity mode={active || keepTaskRuntimeActive || keepIframeActive ? 'visible' : 'hidden'}>

--- a/wework/src/WorkspaceTabSurface.test.tsx
+++ b/wework/src/WorkspaceTabSurface.test.tsx
@@ -11,6 +11,9 @@ import { getWorkbenchPluginRuntime } from '@/plugin-runtime/bootstrap'
 const appIframeMocks = vi.hoisted(() => ({
   cleanup: vi.fn(),
 }))
+const portalOwnershipMocks = vi.hoisted(() => ({
+  setActiveOwner: vi.fn(),
+}))
 
 vi.mock('@/components/topnav/AppIframe', () => ({
   AppIframe: ({ active }: { active?: boolean }) => {
@@ -23,9 +26,14 @@ vi.mock('@/components/topnav/TitlebarActionsPortal', () => ({
   WorkspaceTabPortalOwner: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
+vi.mock('@/components/topnav/workspaceTabPortalOwnership', () => ({
+  setActiveWorkspaceTabPortalOwner: portalOwnershipMocks.setActiveOwner,
+}))
+
 describe('WorkspaceTabSurface', () => {
   afterEach(() => {
     appIframeMocks.cleanup.mockClear()
+    portalOwnershipMocks.setActiveOwner.mockClear()
   })
 
   test('keeps an inactive iframe app connected so its page state survives tab switches', () => {
@@ -70,6 +78,44 @@ describe('WorkspaceTabSurface', () => {
 
     unmount()
     expect(appIframeMocks.cleanup).toHaveBeenCalledTimes(1)
+    dispose()
+  })
+
+  test('re-syncs titlebar portal ownership when a retained workspace becomes active again', () => {
+    const dispose = getWorkbenchPluginRuntime().apps.register({
+      key: 'harness-titlebar',
+      mode: 'iframe',
+      url: 'http://localhost:3000',
+      hidden: true,
+      labelKey: 'harness-titlebar.label',
+      label: 'Titlebar Harness',
+      descriptionKey: 'harness-titlebar.description',
+      description: 'Titlebar Harness',
+    })
+    const props = {
+      cloudWebUrl: null,
+      lifecycleStore: {} as never,
+      services: {} as never,
+      tab: {
+        id: 'smart-app-tab-1',
+        kind: 'auxiliary' as const,
+        title: 'Titlebar Harness',
+        contentRoute: '/app/harness-titlebar',
+      },
+      user: {
+        id: 1,
+        user_name: 'tester',
+        email: 'tester@example.com',
+      },
+    }
+
+    const { rerender, unmount } = render(<WorkspaceTabSurface {...props} active={false} />)
+    expect(portalOwnershipMocks.setActiveOwner).not.toHaveBeenCalled()
+
+    rerender(<WorkspaceTabSurface {...props} active />)
+
+    expect(portalOwnershipMocks.setActiveOwner).toHaveBeenLastCalledWith('smart-app-tab-1')
+    unmount()
     dispose()
   })
 

--- a/wework/src/components/chat/composer/ModelSelector.test.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.test.tsx
@@ -77,6 +77,7 @@ const SAMPLE_MODEL: UnifiedModel = {
   type: 'runtime',
   provider: 'local',
   config: {
+    codexProviderId: 'openai',
     weworkModelKind: 'codex-official',
     ui: { family: 'codex-official', controls: ['speed'] },
   },
@@ -137,6 +138,10 @@ describe('ModelSelector desktop layout', () => {
     )
 
     expect(screen.getByTestId('model-selector-button')).toHaveClass('text-sm', 'font-normal')
+    expect(screen.getByTestId('model-selector-button')).toHaveAttribute(
+      'data-model-provider-id',
+      'openai'
+    )
     expect(screen.getByTestId('model-selector-width-measure')).toHaveClass(
       'left-0',
       'top-0',
@@ -187,7 +192,10 @@ describe('ModelSelector desktop layout', () => {
     fireEvent.click(screen.getByTestId('model-selector-button'))
     fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
 
-    expect(await screen.findByTestId(`model-option-${SAMPLE_MODEL.name}`)).toBeInTheDocument()
+    expect(await screen.findByTestId(`model-option-${SAMPLE_MODEL.name}`)).toHaveAttribute(
+      'data-model-provider-id',
+      'openai'
+    )
     expect(screen.queryByTestId('model-selector-family-submenu')).not.toBeInTheDocument()
     expect(screen.queryByTestId('model-family-codex-official')).not.toBeInTheDocument()
   })

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -74,6 +74,11 @@ function isCloudModel(model: UnifiedModel): boolean {
   return model.provider !== 'local'
 }
 
+function codexProviderId(model: UnifiedModel | null): string | undefined {
+  const providerId = model?.config?.codexProviderId
+  return typeof providerId === 'string' ? providerId : undefined
+}
+
 export function ModelSelector({
   models,
   selectedModel,
@@ -582,6 +587,7 @@ export function ModelSelector({
           key={`${model.type}:${model.name}`}
           type="button"
           data-testid={`model-option-${model.name}`}
+          data-model-provider-id={codexProviderId(model)}
           aria-disabled={modelDisabled}
           title={disabledMessage}
           onClick={() => {
@@ -770,6 +776,7 @@ export function ModelSelector({
                         key={`${model.type}:${model.name}`}
                         type="button"
                         data-testid={`model-option-${model.name}`}
+                        data-model-provider-id={codexProviderId(model)}
                         aria-disabled={modelDisabled}
                         title={disabledMessage}
                         onClick={() => {
@@ -1078,6 +1085,7 @@ export function ModelSelector({
             : t('workbench.model_selector')
         }
         tooltipLabel={t('workbench.model_picker_title', '选择模型')}
+        modelProviderId={codexProviderId(selectedModel)}
         buttonClassName={buttonClassName}
         maxClosedWidth={maxClosedWidth}
         onToggle={() => {

--- a/wework/src/components/chat/composer/ModelSelectorTrigger.tsx
+++ b/wework/src/components/chat/composer/ModelSelectorTrigger.tsx
@@ -26,6 +26,7 @@ interface ModelSelectorTriggerProps {
   shortcut?: string | null
   ariaLabel: string
   tooltipLabel: string
+  modelProviderId?: string
   buttonClassName?: string
   maxClosedWidth?: number
   onToggle: () => void
@@ -55,6 +56,7 @@ export function ModelSelectorTrigger({
   shortcut,
   ariaLabel,
   tooltipLabel,
+  modelProviderId,
   buttonClassName,
   maxClosedWidth = CLOSED_MAX_WIDTH,
   onToggle,
@@ -112,6 +114,7 @@ export function ModelSelectorTrigger({
         ref={buttonRef}
         type="button"
         data-testid="model-selector-button"
+        data-model-provider-id={modelProviderId}
         onClick={onToggle}
         onPointerEnter={() => {
           if (!open && tooltipSuppressed) setTooltipSuppressed(false)

--- a/wework/src/features/todo/IssueComposer.test.tsx
+++ b/wework/src/features/todo/IssueComposer.test.tsx
@@ -74,6 +74,7 @@ async function replaceIssueDescription(value: string) {
   const editor = screen.getByTestId('workspace-issue-description')
   await user.click(editor)
   await user.keyboard('{Control>}a{/Control}{Backspace}')
+  await waitFor(() => expect(editor).toHaveTextContent(''))
   if (value) {
     fireEvent.paste(editor, {
       clipboardData: {

--- a/wework/src/features/todo/TaskDescriptionEditor.tsx
+++ b/wework/src/features/todo/TaskDescriptionEditor.tsx
@@ -356,7 +356,6 @@ export function TaskDescriptionEditor({
       className={cn('task-description-editor', className)}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
-      onBlurCapture={emitEditorChange}
       onPasteCapture={handlePasteCapture}
       onCompositionStartCapture={handleCompositionStartCapture}
       onCompositionEndCapture={handleCompositionEndCapture}

--- a/wework/src/features/todo/TaskDescriptionEditor.tsx
+++ b/wework/src/features/todo/TaskDescriptionEditor.tsx
@@ -356,6 +356,7 @@ export function TaskDescriptionEditor({
       className={cn('task-description-editor', className)}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
+      onBlurCapture={emitEditorChange}
       onPasteCapture={handlePasteCapture}
       onCompositionStartCapture={handleCompositionStartCapture}
       onCompositionEndCapture={handleCompositionEndCapture}


### PR DESCRIPTION
## Summary

- re-sync workspace-tab portal ownership when a retained Smart app or task surface becomes active
- cover switching from a Smart app back to a task in the desktop Harness E2E scenario
- flush the Issue Markdown editor on blur to fix the full-suite failure exposed by pre-push checks

## Verification

- `pnpm --filter wework test src/WorkspaceTabSurface.test.tsx src/components/topnav/TitlebarActionsPortal.test.tsx src/components/topnav/ChromeTitlebar.test.tsx`
- `pnpm --filter wework test src/features/todo/IssueComposer.test.tsx src/features/todo/TaskDescriptionEditor.test.tsx`
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- pre-push: ESLint, TypeScript, and all 4542 Wework unit tests passed

## Desktop verification

An isolated Tauri session reached the WebView, but the isolated local runtime remained on the slow-startup screen. The desktop Harness E2E now asserts that task titlebar actions are restored after switching away from a Smart app.