### PR TITLE
fix(wework): support standard DSH release bundles

### DIFF
--- a/docs/en/wework/plugins-and-skills.md
+++ b/docs/en/wework/plugins-and-skills.md
@@ -24,6 +24,8 @@ For an existing package, choose **Import local package** from the marketplace, o
 
 The current Wework build bundles DeepSeek Harness Runtime `0.1.0-rc.8`. A Smart app package must declare a compatible `requirements.dsh` value in `plugin-manifest.json`; use `"dsh": "0.1.0-rc.8"` when the package should require the exact bundled runtime.
 
+Wework supports the standard DSH release ZIP format. Its `plugin-manifest.json` declares each npm package's `name`, `role`, and destination `path` in `packages`, while the ZIP root contains the matching `.tgz` files. The single `profile-bundle` path must match `entry.installPackage`. The `entry` object only needs `installPackage` and `profile`; it does not declare `webUrl`. At launch, Wework assigns the local URL, installs every declared package, and binds the selected Wework model to the profile.
+
 Choose a Wework model before installation. The model is bound only to that Smart app, so other Smart apps can use different models. After installation, each app shows its version, bound model, and **Installed**, **Running**, or **Failed to start** state; you can change the bound model while the app is stopped. Choose **Open** to start an isolated Harness instance, animate it into the top tab strip, and open it in its own workspace tab. Choose **Stop** to close that tab and reclaim the instance. Enable **Resident** to start the app and open its tab automatically whenever the Wework main window starts.
 
 ## Delete a personal plugin

--- a/docs/zh/wework/plugins-and-skills.md
+++ b/docs/zh/wework/plugins-and-skills.md
@@ -28,6 +28,8 @@ Skill 为 AI 提供特定任务的操作说明和资源；插件可以组合 Ski
 
 当前 Wework 捆绑 DeepSeek Harness Runtime `0.1.0-rc.8`。智能工作台安装包的 `plugin-manifest.json` 必须声明兼容该版本的 `requirements.dsh`；需要精确绑定当前 Runtime 时，使用 `"dsh": "0.1.0-rc.8"`。
 
+Wework 支持标准 DSH Release ZIP：`plugin-manifest.json` 通过 `packages` 声明各 npm 包的 `name`、`role` 和目标 `path`，ZIP 根目录包含对应的 `.tgz` 文件，其中唯一的 `profile-bundle` 路径必须与 `entry.installPackage` 一致。`entry` 只需要 `installPackage` 和 `profile`，不需要声明 `webUrl`；Wework 会在启动时分配本地地址、安装清单中的全部包，并把用户选择的 Wework 模型绑定到 profile。
+
 安装前需要选择一个 Wework 模型。这个模型只绑定到当前智能工作台，其他智能工作台可以分别选择不同模型。安装完成后，工作台会显示版本、绑定模型和 **已安装 / 运行中 / 启动失败** 状态；工作台停止时可以直接修改绑定模型。点击 **打开** 后，Wework 启动隔离的 Harness 实例，并播放工作台进入顶部标签栏的动效，再把智能工作台作为独立工作区标签页打开；点击 **停止** 会关闭对应标签页并回收实例。打开 **常驻** 后，Wework 每次启动主窗口时都会自动启动该工作台并打开它的标签页。
 
 ### 删除个人插件

--- a/wework/src-tauri/src/harness_apps.rs
+++ b/wework/src-tauri/src/harness_apps.rs
@@ -3,7 +3,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -34,7 +34,13 @@ const MAX_ENTRIES: usize = 8_000;
 pub struct HarnessAppEntry {
     install_package: String,
     profile: String,
-    web_url: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct HarnessAppPackage {
+    name: String,
+    role: String,
+    path: String,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -52,6 +58,8 @@ pub struct HarnessAppManifest {
     #[serde(rename = "type")]
     package_type: String,
     description: String,
+    #[serde(default)]
+    packages: Vec<HarnessAppPackage>,
     entry: HarnessAppEntry,
     requirements: HarnessAppRequirements,
     #[serde(default)]
@@ -285,6 +293,43 @@ fn validate_manifest(manifest: &HarnessAppManifest) -> Result<(), String> {
     }
     if !safe_relative(Path::new(&manifest.entry.install_package)) {
         return Err("Harness app installPackage must stay inside the package".to_string());
+    }
+    if !manifest.packages.is_empty() {
+        let mut names = HashSet::new();
+        let mut paths = HashSet::new();
+        let mut profile_bundle_paths = Vec::new();
+        for package in &manifest.packages {
+            if package.name.trim().is_empty()
+                || package.role.trim().is_empty()
+                || package.path.trim().is_empty()
+            {
+                return Err("Harness app package declaration is incomplete".to_string());
+            }
+            if !safe_relative(Path::new(&package.path)) {
+                return Err("Harness app package path must stay inside the package".to_string());
+            }
+            if !names.insert(package.name.as_str()) {
+                return Err(format!(
+                    "Harness app package name is duplicated: {}",
+                    package.name
+                ));
+            }
+            if !paths.insert(package.path.as_str()) {
+                return Err(format!(
+                    "Harness app package path is duplicated: {}",
+                    package.path
+                ));
+            }
+            if package.role == "profile-bundle" {
+                profile_bundle_paths.push(package.path.as_str());
+            }
+        }
+        if profile_bundle_paths.as_slice() != [manifest.entry.install_package.as_str()] {
+            return Err(
+                "Harness app must declare its installPackage as the only profile-bundle"
+                    .to_string(),
+            );
+        }
     }
     Ok(())
 }
@@ -945,16 +990,149 @@ fn copy_directory(source: &Path, destination: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn npm_archive_name(path: &Path) -> Result<String, String> {
+    let file = fs::File::open(path)
+        .map_err(|error| format!("Failed to open Harness npm package: {error}"))?;
+    let mut archive = Archive::new(GzDecoder::new(file));
+    for entry in archive
+        .entries()
+        .map_err(|error| format!("Harness npm package is invalid: {error}"))?
+    {
+        let mut entry =
+            entry.map_err(|error| format!("Failed to inspect Harness npm package: {error}"))?;
+        if entry
+            .path()
+            .map_err(|error| format!("Harness npm package path is invalid: {error}"))?
+            == Path::new("package/package.json")
+        {
+            let mut content = String::new();
+            entry
+                .read_to_string(&mut content)
+                .map_err(|error| format!("Failed to read Harness npm package metadata: {error}"))?;
+            let package: Value = serde_json::from_str(&content)
+                .map_err(|error| format!("Harness npm package metadata is invalid: {error}"))?;
+            return package["name"]
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| "Harness npm package has no name".to_string());
+        }
+    }
+    Err("Harness npm package has no package.json".to_string())
+}
+
+fn extract_npm_archive(archive_path: &Path, destination: &Path) -> Result<(), String> {
+    fs::create_dir_all(destination)
+        .map_err(|error| format!("Failed to create Harness npm package directory: {error}"))?;
+    let file = fs::File::open(archive_path)
+        .map_err(|error| format!("Failed to open Harness npm package: {error}"))?;
+    let mut archive = Archive::new(GzDecoder::new(file));
+    let mut written = 0_u64;
+    for (index, entry) in archive
+        .entries()
+        .map_err(|error| format!("Harness npm package is invalid: {error}"))?
+        .enumerate()
+    {
+        if index >= MAX_ENTRIES {
+            return Err("Harness npm package contains too many entries".to_string());
+        }
+        let mut entry =
+            entry.map_err(|error| format!("Failed to inspect Harness npm package: {error}"))?;
+        let path = entry
+            .path()
+            .map_err(|error| format!("Harness npm package path is invalid: {error}"))?;
+        let relative = path
+            .strip_prefix("package")
+            .map_err(|_| "Harness npm package root is invalid".to_string())?;
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        if !safe_relative(relative) {
+            return Err("Harness npm package contains an unsafe path".to_string());
+        }
+        let kind = entry.header().entry_type();
+        if !(kind.is_file() || kind.is_dir()) {
+            return Err("Harness npm package contains an unsupported entry type".to_string());
+        }
+        let output = destination.join(relative);
+        if kind.is_dir() {
+            fs::create_dir_all(&output)
+                .map_err(|error| format!("Failed to create Harness npm directory: {error}"))?;
+        } else {
+            if let Some(parent) = output.parent() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    format!("Failed to create Harness npm package parent: {error}")
+                })?;
+            }
+            let mut file = fs::File::create(&output)
+                .map_err(|error| format!("Failed to create Harness npm package file: {error}"))?;
+            let remaining = MAX_EXTRACTED_BYTES.saturating_sub(written);
+            let copied = std::io::copy(&mut entry.by_ref().take(remaining + 1), &mut file)
+                .map_err(|error| format!("Failed to extract Harness npm package file: {error}"))?;
+            if copied > remaining {
+                return Err("Harness npm package expands beyond 250 MB".to_string());
+            }
+            written += copied;
+        }
+    }
+    Ok(())
+}
+
+fn materialize_manifest_packages(
+    manifest: &HarnessAppManifest,
+    package_root: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    let install_package = package_root.join(&manifest.entry.install_package);
+    if install_package.is_dir() {
+        return Ok(vec![install_package]);
+    }
+    let mut archives = HashMap::new();
+    for entry in fs::read_dir(package_root)
+        .map_err(|error| format!("Failed to inspect Harness release package: {error}"))?
+    {
+        let entry =
+            entry.map_err(|error| format!("Failed to inspect Harness release entry: {error}"))?;
+        let path = entry.path();
+        if path.extension().is_some_and(|extension| extension == "tgz") {
+            let name = npm_archive_name(&path)?;
+            if archives.insert(name.clone(), path).is_some() {
+                return Err(format!("Harness npm package is duplicated: {name}"));
+            }
+        }
+    }
+    if manifest.packages.is_empty() {
+        return Err(format!(
+            "Harness app installPackage is missing: {}",
+            manifest.entry.install_package
+        ));
+    }
+    let mut packages = manifest.packages.iter().collect::<Vec<_>>();
+    packages.sort_by_key(|package| package.role == "profile-bundle");
+    let mut paths = Vec::with_capacity(packages.len());
+    for package in packages {
+        let archive = archives
+            .get(&package.name)
+            .ok_or_else(|| format!("Harness npm package is missing: {}", package.name))?;
+        let destination = package_root.join(&package.path);
+        extract_npm_archive(archive, &destination)?;
+        paths.push(destination);
+    }
+    if !install_package.is_dir() {
+        return Err("Harness app profile bundle was not materialized".to_string());
+    }
+    Ok(paths)
+}
+
 fn prepare_instance_bundle(
     installation: &HarnessAppInstallation,
     home: &Path,
     use_wework_model: bool,
-) -> Result<PathBuf, String> {
+) -> Result<Vec<PathBuf>, String> {
     let source = Path::new(&installation.package_path);
     let destination = home.join("wework-package");
     let _ = fs::remove_dir_all(home.join("wework-bundle"));
     let _ = fs::remove_dir_all(&destination);
     copy_directory(source, &destination)?;
+    let packages = materialize_manifest_packages(&installation.manifest, &destination)?;
     let install_package = destination.join(&installation.manifest.entry.install_package);
     if use_wework_model {
         let patch_path = install_package.join("cordis.patch.yml");
@@ -1001,7 +1179,7 @@ fn prepare_instance_bundle(
         fs::write(&patch_path, model_patch)
             .map_err(|error| format!("Failed to write instance model patch: {error}"))?;
     }
-    Ok(install_package)
+    Ok(packages)
 }
 
 fn write_wework_model_settings(home: &Path, base_url: &str) -> Result<(), String> {
@@ -1056,14 +1234,28 @@ fn install_harness_plugin(
     package: &Path,
     label: &str,
 ) -> Result<(), String> {
-    let args = vec![
+    install_harness_plugins(runtime, home, profile, &[package.to_path_buf()], label)
+}
+
+fn install_harness_plugins(
+    runtime: &DshRuntime,
+    home: &Path,
+    profile: &str,
+    packages: &[PathBuf],
+    label: &str,
+) -> Result<(), String> {
+    let mut args = vec![
         "plugin".to_string(),
         "--profile".to_string(),
         profile.to_string(),
         "add".to_string(),
         "--ignore-scripts".to_string(),
-        format!("file:{}", package.display()),
     ];
+    args.extend(
+        packages
+            .iter()
+            .map(|package| format!("file:{}", package.display())),
+    );
     let output = dsh_command(runtime, &args, home)
         .output()
         .map_err(|error| format!("Failed to install {label}: {error}"))?;
@@ -1186,7 +1378,7 @@ pub async fn start_harness_app(
         (None, None) => None,
         _ => return Err("Smart app context registration is incomplete".to_string()),
     };
-    let install_package = prepare_instance_bundle(&installation, &home, use_wework_model)?;
+    let install_packages = prepare_instance_bundle(&installation, &home, use_wework_model)?;
     prepare_web_profile(&home, &installation.manifest.entry.profile)?;
     if let Some(base_url) = model_base_url.as_deref() {
         write_wework_model_settings(&home, base_url)?;
@@ -1207,12 +1399,12 @@ pub async fn start_harness_app(
             "Wework model context plugin",
         )?;
     }
-    install_harness_plugin(
+    install_harness_plugins(
         &runtime,
         &home,
         &installation.manifest.entry.profile,
-        &install_package,
-        "Harness app bundle",
+        &install_packages,
+        "Harness app packages",
     )?;
     emit_progress("startingApp");
     let port = free_port()?;

--- a/wework/src-tauri/src/harness_apps/tests.rs
+++ b/wework/src-tauri/src/harness_apps/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use flate2::{write::GzEncoder, Compression};
 use std::io::Write;
+use tar::Builder;
 use tempfile::tempdir;
 use zip::write::SimpleFileOptions;
 
@@ -16,8 +18,7 @@ fn manifest(dsh: &str) -> String {
           "description":"Test",
           "entry":{{
             "installPackage":"packages/bundle/test",
-            "profile":"test",
-            "webUrl":"http://127.0.0.1:3080/"
+            "profile":"test"
           }},
           "requirements":{{"dsh":"{dsh}","node":">=22"}}
         }}"#
@@ -38,6 +39,25 @@ fn write_archive(path: &Path, manifest: &str) {
     archive
         .write_all(b"plugins:\n  test:\n    provider: deepseek\n    model: default\n")
         .unwrap();
+    archive.finish().unwrap();
+}
+
+fn write_npm_archive(path: &Path, name: &str, files: &[(&str, &str)]) {
+    let file = fs::File::create(path).unwrap();
+    let encoder = GzEncoder::new(file, Compression::fast());
+    let mut archive = Builder::new(encoder);
+    let package = serde_json::json!({ "name": name, "version": "0.1.0" }).to_string();
+    let mut entries = vec![("package/package.json", package.as_str())];
+    entries.extend_from_slice(files);
+    for (path, content) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, path, content.as_bytes())
+            .unwrap();
+    }
     archive.finish().unwrap();
 }
 
@@ -121,7 +141,10 @@ fn instance_patch_binds_provider_and_model() {
         error: None,
     };
 
-    let output = prepare_instance_bundle(&installation, directory.path(), true).unwrap();
+    let output = prepare_instance_bundle(&installation, directory.path(), true)
+        .unwrap()
+        .pop()
+        .unwrap();
     let patch = fs::read_to_string(output.join("cordis.patch.yml")).unwrap();
 
     assert!(patch.contains("provider: wework-local"));
@@ -134,6 +157,72 @@ fn instance_patch_binds_provider_and_model() {
         .path()
         .join("wework-package/packages/ops/sibling/package.json")
         .is_file());
+}
+
+#[test]
+fn standard_dsh_release_materializes_and_installs_all_declared_packages() {
+    let directory = tempdir().unwrap();
+    let package = directory.path().join("package");
+    fs::create_dir_all(&package).unwrap();
+    write_npm_archive(
+        &package.join("dashboard.tgz"),
+        "@example/dashboard",
+        &[("package/lib/index.js", "export default {}\n")],
+    );
+    write_npm_archive(
+        &package.join("dashboard-app.tgz"),
+        "@example/dashboard-app",
+        &[(
+            "package/cordis.patch.yml",
+            "- insert:\n    - id: dashboard\n      name: '@example/dashboard'\n",
+        )],
+    );
+    let manifest: HarnessAppManifest = serde_json::from_value(serde_json::json!({
+        "name": "dashboard",
+        "displayName": "Dashboard",
+        "version": "0.1.0",
+        "type": "deepseek-harness-plugin-bundle",
+        "description": "Dashboard",
+        "packages": [
+            {
+                "name": "@example/dashboard-app",
+                "role": "profile-bundle",
+                "path": "packages/bundle/dashboard-app"
+            },
+            {
+                "name": "@example/dashboard",
+                "role": "host-and-web-plugin",
+                "path": "packages/ops/dashboard"
+            }
+        ],
+        "entry": {
+            "installPackage": "packages/bundle/dashboard-app",
+            "profile": "web"
+        },
+        "requirements": {"dsh": "0.1.0-rc.8", "node": ">=22"}
+    }))
+    .unwrap();
+    let installation = HarnessAppInstallation {
+        id: "dashboard".to_string(),
+        manifest,
+        package_path: package.display().to_string(),
+        sha256: "hash".to_string(),
+        model_key: Some("model".to_string()),
+        resident: false,
+        runtime_version: None,
+        state: "installed".to_string(),
+        web_url: None,
+        error: None,
+    };
+
+    let packages = prepare_instance_bundle(&installation, directory.path(), true).unwrap();
+
+    assert_eq!(packages.len(), 2);
+    assert!(packages[0].ends_with("packages/ops/dashboard"));
+    assert!(packages[1].ends_with("packages/bundle/dashboard-app"));
+    let patch = fs::read_to_string(packages[1].join("cordis.patch.yml")).unwrap();
+    assert!(patch.contains("- id: agent-default-model"));
+    assert!(patch.contains("provider: wework-local"));
 }
 
 #[test]
@@ -160,7 +249,10 @@ fn instance_patch_adds_agent_default_model_when_the_bundle_has_no_model_fields()
         error: None,
     };
 
-    let output = prepare_instance_bundle(&installation, directory.path(), true).unwrap();
+    let output = prepare_instance_bundle(&installation, directory.path(), true)
+        .unwrap()
+        .pop()
+        .unwrap();
     let patch = fs::read_to_string(output.join("cordis.patch.yml")).unwrap();
 
     assert!(patch.contains("- id: scanner"));

--- a/wework/src/api/local/harnessApps.ts
+++ b/wework/src/api/local/harnessApps.ts
@@ -19,7 +19,6 @@ export interface HarnessAppManifest {
   entry: {
     installPackage: string
     profile: string
-    webUrl: string
   }
   requirements: {
     dsh: string


### PR DESCRIPTION
## Summary

- accept standard DSH manifests without `entry.webUrl`
- materialize every manifest-declared npm `.tgz` package and install host packages with the profile bundle in one DSH command
- keep Wework model binding mandatory by patching the selected model into the profile bundle
- validate package declarations and safely bound npm archive extraction
- document the supported standard DSH release layout in Chinese and English

## Verification

- `cargo test --manifest-path wework/src-tauri/Cargo.toml harness_apps::tests -- --nocapture` (13 passed)
- `pnpm --filter wework exec tsc --noEmit`
- full pre-push ESLint, TypeScript, and Wework unit tests passed with `VITEST_MAX_WORKERS=4`
- imported and installed `/Users/axb-mac/Downloads/dsh-xlsx2dashboard-0.1.0.zip` in an isolated real Wework Tauri session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Smart app release packages containing multiple named npm packages.
  - Packages can now be assigned roles and installation paths, including profile bundles.
  - Package archives are validated, safely extracted, and installed automatically.
  - Runtime setup now supports automatic local URL assignment and model binding.

- **Documentation**
  - Documented the standard DSH Release ZIP structure and package configuration requirements in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->