### PR TITLE
fix(executor): converge cancelled runtime turns

### DIFF
--- a/executor/src/runtime_work/handler/claude_turns.rs
+++ b/executor/src/runtime_work/handler/claude_turns.rs
@@ -321,7 +321,7 @@ impl RuntimeWorkRpcHandler {
                         "cancelled",
                         Some(message),
                     );
-                    handler.finish_local_task(&local_task_id, execution_id, None, "cancelled");
+                    handler.settle_cancelled_local_task_execution(&local_task_id, execution_id);
                     handler.emit_claude_runtime_event(
                         &local_task_id,
                         &request,

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -786,6 +786,37 @@ impl RuntimeWorkRpcHandler {
         true
     }
 
+    pub(super) fn settle_cancelled_local_task_execution(
+        &self,
+        local_task_id: &str,
+        execution_id: u64,
+    ) {
+        {
+            let mut active = self
+                .active_turn_cancellations
+                .lock()
+                .expect("active turn cancellation map lock should not be poisoned");
+            let Some(control) = active.get_mut(local_task_id) else {
+                return;
+            };
+            if control.execution_id != execution_id || !control.stop_requested {
+                return;
+            }
+            control.stop_acknowledged = true;
+            if !self.clear_worktree_execution_lease(local_task_id, control) {
+                return;
+            }
+            active.remove(local_task_id);
+        }
+        self.store.update_task(local_task_id, |link| {
+            link.updated_at = now_ms();
+            link.completed_at = Some(link.updated_at);
+            link.status = "cancelled".to_owned();
+            apply_local_execution_state(link, false, None);
+        });
+        self.schedule_worktree_prune();
+    }
+
     fn clear_worktree_execution_lease(
         &self,
         local_task_id: &str,

--- a/executor/src/runtime_work/handler/tasks.rs
+++ b/executor/src/runtime_work/handler/tasks.rs
@@ -660,15 +660,10 @@ impl RuntimeWorkRpcHandler {
             .ok_or_else(|| AppIpcError::new("bad_request", "taskId is required"))?;
         let gate = self.task_send_gate(&local_task_id);
         let _guard = gate.lock().await;
-        self.send_message_with_active_turn_check(payload, true)
-            .await
+        self.send_message_after_local_checks(payload).await
     }
 
-    async fn send_message_with_active_turn_check(
-        &self,
-        payload: Value,
-        verify_no_active_turn: bool,
-    ) -> Result<Value, AppIpcError> {
+    async fn send_message_after_local_checks(&self, payload: Value) -> Result<Value, AppIpcError> {
         let local_task_id = runtime_task_id(&payload)
             .ok_or_else(|| AppIpcError::new("bad_request", "taskId is required"))?;
         let existing_link = self.local_task_link(&local_task_id);
@@ -826,19 +821,6 @@ impl RuntimeWorkRpcHandler {
         };
         let link_for_send = existing_link.as_ref().or(recovered_link.as_ref());
         let ephemeral = request.ephemeral || link_for_send.is_some_and(|link| link.ephemeral);
-        if verify_no_active_turn && !ephemeral {
-            let thread = self
-                .read_codex_recent_turns(&thread_id)
-                .await
-                .map_err(|error| AppIpcError::new("codex_error", error))?;
-            if codex_thread_has_in_progress_turn(&thread) {
-                return Ok(json!({
-                    "success": false,
-                    "error": "runtime task is already running",
-                    "code": "bad_request",
-                }));
-            }
-        }
 
         let mut fields = task_fields(&request.task_id, &request.subtask_id);
         fields.push(("local_task_id", local_task_id.clone()));
@@ -938,8 +920,7 @@ impl RuntimeWorkRpcHandler {
                 }
             }
         }
-        self.send_message_with_active_turn_check(payload, false)
-            .await
+        self.send_message_after_local_checks(payload).await
     }
 
     async fn interrupt_provider_active_turn(&self, thread_id: &str) -> bool {

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -417,6 +417,81 @@ async fn stopped_turn_guard_acknowledges_scope_exit() {
 }
 
 #[tokio::test]
+async fn runtime_terminal_cancellation_settles_execution_after_stop_request_times_out() {
+    let root =
+        temp_runtime_work_index_path("stopped-turn-final-consistency").with_extension("directory");
+    let source = root.join("source");
+    let managed_root = root.join("workspace/worktrees");
+    initialize_test_repository(&source);
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(root.join("runtime-work/index.json"));
+    handler.worktrees = WorktreeManager::new(root.join("runtime-work/worktrees.json"));
+    handler
+        .worktrees
+        .update_settings(WorktreeSettingsPatch {
+            worktree_root: Some(managed_root.display().to_string()),
+            ..WorktreeSettingsPatch::default()
+        })
+        .unwrap();
+    let worktree = handler
+        .worktrees
+        .prepare(&source, "task-1", None, false)
+        .unwrap();
+    handler.upsert_local_task(RuntimeTaskLink::new_pending(
+        "task-1".to_owned(),
+        worktree.path.clone(),
+        "Task".to_owned(),
+    ));
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    let (stopped_tx, stopped_rx) = oneshot::channel();
+    let execution_id = handler
+        .start_local_task_execution(
+            "task-1".to_owned(),
+            Some(&worktree.path),
+            cancel_tx,
+            stopped_rx,
+        )
+        .expect("local execution should start");
+    let _stopped_sender = stopped_tx;
+
+    assert!(
+        !handler
+            .abort_active_turn_with_timeout("task-1", Duration::from_millis(20))
+            .await,
+        "the stop request should time out while the turn scope remains active"
+    );
+    tokio::time::timeout(Duration::from_secs(1), cancel_rx)
+        .await
+        .expect("the stop attempt should send cancellation")
+        .expect("the runtime cancellation receiver should remain available");
+    assert!(handler.is_active_local_task("task-1"));
+
+    handler.settle_cancelled_local_task_execution("task-1", execution_id);
+
+    assert!(
+        !handler.is_active_local_task("task-1"),
+        "the runtime terminal result must settle stale active state without another stop request"
+    );
+    let task = handler
+        .store
+        .get_task("task-1")
+        .expect("the stopped task should remain persisted");
+    assert_eq!(task.status, "cancelled");
+    assert!(!task.running);
+    assert!(task.completed_at.is_some());
+    let restarted = WorktreeManager::new(root.join("runtime-work/worktrees.json"));
+    assert!(
+        restarted
+            .reconcile()
+            .expect("restart reconciliation should succeed")
+            .iter()
+            .all(|outcome| !outcome.interrupted_execution),
+        "the runtime terminal result must clear durable execution evidence"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
 async fn unarchive_restores_managed_worktree_before_reactivating_task() {
     let root =
         temp_runtime_work_index_path("unarchive-worktree-restore").with_extension("directory");

--- a/executor/src/runtime_work/handler/turns.rs
+++ b/executor/src/runtime_work/handler/turns.rs
@@ -803,7 +803,7 @@ impl RuntimeWorkRpcHandler {
                 );
                 let _ = mapper_handle.await;
                 handler.clear_active_codex_transcript(&turn_local_task_id);
-                handler.finish_local_task(&turn_local_task_id, execution_id, None, "cancelled");
+                handler.settle_cancelled_local_task_execution(&turn_local_task_id, execution_id);
                 handler.clear_active_codex_turn(&turn_local_task_id, execution_id);
                 handler.mark_thread_event_routes_idle_for_local_task(&turn_local_task_id);
                 handler.clear_active_request_user_input(&turn_local_task_id, execution_id);

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -2280,7 +2280,7 @@ async fn runtime_tasks_send_rejects_running_local_task_until_cancelled() {
 }
 
 #[tokio::test]
-async fn runtime_tasks_send_rejects_provider_active_turn_after_local_execution_settles() {
+async fn runtime_tasks_send_delegates_provider_turn_admission_to_codex() {
     let _lock = env_lock().await;
     let executor_home = temp_path("runtime-send-provider-active-home", "dir");
     let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
@@ -2295,19 +2295,7 @@ async fn runtime_tasks_send_rejects_provider_active_turn_after_local_execution_s
     let fake_codex = write_fake_codex_hanging_turn(&log_path);
     let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
 
-    let transcript = handler
-        .handle_runtime_rpc(json!({
-            "method": "runtime.tasks.transcript",
-            "payload": {
-                "workspacePath": "/tmp/project",
-                "taskId": "local-task-1"
-            }
-        }))
-        .await
-        .expect("provider-active transcript should load");
-    assert_eq!(transcript["running"], true);
-
-    let rejected = handler
+    let sent = handler
         .handle_runtime_rpc(json!({
             "method": "runtime.tasks.send",
             "payload": {
@@ -2322,22 +2310,44 @@ async fn runtime_tasks_send_rejects_provider_active_turn_after_local_execution_s
             }
         }))
         .await
-        .expect("provider-active send should return a contract response");
+        .expect("provider-active send should be delegated to Codex");
 
     assert_eq!(
-        rejected,
+        sent,
         json!({
-            "success": false,
-            "error": "runtime task is already running",
-            "code": "bad_request"
+            "success": true,
+            "accepted": true,
+            "deviceId": "device-1",
+            "taskId": "local-task-1",
+            "runtime": "codex",
+            "status": "running",
+            "queuePosition": null
         })
     );
+    wait_for_codex_call(&log_path, "turn/start").await;
     let calls = read_json_lines(&log_path);
-    assert!(calls.iter().any(|call| call["method"] == "thread/read"));
     assert!(
-        calls.iter().all(|call| call["method"] != "turn/start"),
-        "send must not create an overlapping Codex turn: {calls:?}"
+        calls
+            .iter()
+            .all(|call| call["method"] != "thread/read" && call["method"] != "thread/turns/list"),
+        "Executor must not use a provider state snapshot to decide turn admission: {calls:?}"
     );
+    assert!(
+        calls.iter().any(|call| call["method"] == "turn/start"),
+        "Codex must atomically decide whether the turn is started or steered: {calls:?}"
+    );
+
+    let cancelled = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.cancel",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "taskId": "local-task-1"
+            }
+        }))
+        .await
+        .expect("delegated turn should remain cancellable");
+    assert_eq!(cancelled["accepted"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- delegate provider turn admission to Codex `turn/start` instead of deciding from an Executor-side state snapshot
- settle local cancellation state when the authoritative runtime terminal result arrives, even if the stop request previously timed out
- clear durable worktree execution evidence so restart reconciliation does not revive a cancelled task

## Validation

- `cargo fmt --manifest-path executor/Cargo.toml -- --check`
- `cargo test --manifest-path executor/Cargo.toml --lib runtime_work::handler::tests:: -- --nocapture` (105 passed before rebase)
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_send_contract -- --nocapture` (39 passed before rebase)
- focused cancellation and turn-admission tests passed again after rebasing onto latest `origin/main`
- pre-push `cargo test --all-features --lib` and `cargo clippy` passed
- real Tauri `ai:verify` session reached the usable Wework shell

## Desktop E2E note

The registered `resilience` segment was attempted once. It failed in the shared project fixture while delivering `clickWhenEnabled` during delete-and-recreate project setup, before the runtime turn/cancel scenario was reached. The first project creation and `runtime.workspaces.remove` succeeded; no existing E2E was changed based on this unrelated control-delivery failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling when stopping an execution times out.
  * Cancelled tasks now consistently settle as inactive with accurate completion details.
  * Improved cleanup of execution state and temporary work areas after cancellation.
  * Sending a new message during an active turn is now delegated correctly, preserving cancellation support.

* **Tests**
  * Added regression coverage for terminal cancellation and active-turn message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->