### PR TITLE
fix(wework): align My Work with runtime lifecycle

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -186,6 +186,13 @@ current chat pane. It does not archive or delete the previous task, which must
 remain under its project and be reopenable. The environment popover must list
 and copy every project root, not only the primary root.
 
+The local task inventory in My Work comes from `runtimeWork`, but its running
+and queued groups must read the same `RuntimeTaskLifecycleStore` snapshot as the
+sidebar. The sidebar spinner, composer, and My Work must not independently
+infer lifecycle state from `RuntimeTaskSummary.running`, transcript data, or
+messages; an asynchronous task-list snapshot could otherwise project a task
+that is still running into a completed or action-required group.
+
 These rules apply only to local Codex projects. Remote and cloud tasks retain
 their existing single-workspace selection semantics; local multi-root support
 must not implicitly broaden a remote execution scope.

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -146,6 +146,11 @@ Claude Code 的 `/compact` 是普通原生命令；Codex 仍使用其 app-server
 只清空当前聊天 pane，不归档或删除原任务；原任务继续显示在项目下，并可重新打开。
 环境弹层必须展示和复制项目的全部根目录，而不是只显示主根。
 
+“我的工作”中的本地任务清单来自 `runtimeWork`，但任务所处的运行中或排队分组必须
+读取同一个 `RuntimeTaskLifecycleStore` 快照。侧栏 spinner、composer 和“我的工作”
+不能各自从 `RuntimeTaskSummary.running`、transcript 或消息状态重新推断生命周期；
+否则异步任务列表快照会把仍在运行的任务错误投影到已完成或待处理分组。
+
 这些规则只改变本地 Codex 项目。远程和云端任务仍遵循其原有的单 workspace 选择
 语义，不能因为本地多目录支持而隐式扩大远程执行范围。
 

--- a/wework/e2e/desktop/modules/task-state-flows.mjs
+++ b/wework/e2e/desktop/modules/task-state-flows.mjs
@@ -587,6 +587,67 @@ async function verifyBackgroundCompletionRestore({
       `Reloading duplicated "${text}"`
     )
   }
+
+  const completedTaskDebugSnapshot = JSON.parse(
+    await control.command('getWorkbenchDebugSnapshot', 'body')
+  )
+  const completedTaskAddress = completedTaskDebugSnapshot.workbench?.currentRuntimeTask
+  assert.equal(
+    completedTaskAddress?.taskId,
+    taskId,
+    'The completed task address was unavailable before My Work lifecycle verification'
+  )
+  await control.command('dispatchRuntimeLifecycleEvent', 'body', {
+    value: JSON.stringify({
+      address: completedTaskAddress,
+      type: 'transcript_received',
+      transcript: {
+        taskId,
+        messages: [],
+        running: true,
+        turns: [{ id: 'my-work-stale-snapshot-turn', items: [], status: 'streaming' }],
+      },
+    }),
+  })
+  await control.command('waitFor', `[data-testid="${runningTaskTestId}"]`, {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+
+  await control.command('navigate', 'body', { value: '/todo' })
+  await control.command('waitFor', '[data-testid="cloud-my-work"]', {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await control.command('click', '[data-testid="cloud-my-work"]')
+  await control.command('waitFor', `[data-testid="my-work-group-running-${taskId}"]`, {
+    text: 'WEWORK_DESKTOP_E2E_BACKGROUND_COMPLETION_RESTORE',
+    visible: true,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  const myWorkSnapshot = JSON.parse(
+    await control.command('snapshot', '[data-testid="cloud-my-work-view"]')
+  )
+  assert.equal(
+    myWorkSnapshot.testIds.includes(`my-work-group-done-${taskId}`),
+    false,
+    'My Work used the stale completed Runtime snapshot instead of the shared running lifecycle'
+  )
+
+  await control.command('dispatchRuntimeLifecycleEvent', 'body', {
+    value: JSON.stringify({
+      address: completedTaskAddress,
+      type: 'transcript_received',
+      transcript: {
+        taskId,
+        messages: [],
+        running: false,
+        turns: [],
+      },
+    }),
+  })
+  await control.command('navigate', 'body', { value: '/' })
+  await control.command('waitFor', `[data-testid="${taskRowTestId}"]`, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
 }
 
 async function waitForTaskRowByText(control, expectedText) {

--- a/wework/e2e/desktop/modules/task-state-flows.mjs
+++ b/wework/e2e/desktop/modules/task-state-flows.mjs
@@ -644,6 +644,15 @@ async function verifyBackgroundCompletionRestore({
       },
     }),
   })
+  await waitForSnapshot(
+    control,
+    snapshot =>
+      snapshot.testIds.includes(`my-work-group-done-${taskId}`) &&
+      !snapshot.testIds.includes(`my-work-group-running-${taskId}`),
+    'My Work did not move the settled local task from running to done',
+    DEFAULT_STEP_TIMEOUT_MS,
+    '[data-testid="cloud-my-work-view"]'
+  )
   await control.command('navigate', 'body', { value: '/' })
   await control.command('waitFor', `[data-testid="${taskRowTestId}"]`, {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -37,6 +37,7 @@ import { ConnectionsSettingsPage } from '@/components/settings/ConnectionsSettin
 import { useTranslation } from '@/hooks/useTranslation'
 import { useWorkbenchShellEventHandlers } from './workbenchShellEvents'
 import { EMPTY_RUNTIME_TASK_REMINDERS } from '@/features/workbench/runtimeTaskReminders'
+import { useRuntimeTaskLifecycleStoreSnapshot } from '@/features/workbench/runtimeTaskLifecycle'
 import { CloudTodoWorkspace } from '@/features/todo/CloudTodoWorkspace'
 import { resolveLocalTodoProjects } from '@/features/todo/localTodoProjects'
 import { projectSpaceApis } from '@/features/todo/projectSpaceSelection'
@@ -110,6 +111,7 @@ interface DesktopWorkbenchLayoutProps {
 export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchLayoutProps) {
   const { t } = useTranslation('common')
   const { logout: onLogout } = useAuth()
+  const runtimeTaskLifecycle = useRuntimeTaskLifecycleStoreSnapshot()
   const {
     state,
     cloudWorkStatus,
@@ -1062,6 +1064,7 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
                 user={state.user}
                 localProjects={localTodoProjects}
                 runtimeWork={state.runtimeWork}
+                runtimeTaskLifecycle={runtimeTaskLifecycle}
                 services={services}
                 onOpenRuntimeTask={openProjectSpaceRuntimeTask}
                 onOpenSettings={options => openSettings(options, '/todo')}

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -62,6 +62,7 @@ import { cn } from '@/lib/utils'
 import { track } from '@/telemetry/client'
 import { runtimeConversationKey } from '@/features/workbench/runtimeConversationCache'
 import { isRuntimeTaskExecutionRunning } from '@/features/workbench/runtimeTaskLifecycle/projection'
+import type { RuntimeTaskLifecycleStoreSnapshot } from '@/features/workbench/runtimeTaskLifecycle'
 import { hydrateRuntimeTaskAddress } from '@/features/workbench/workbenchRuntimeHelpers'
 import { AITableView } from '@/features/todo/AITableView'
 import type {
@@ -371,6 +372,7 @@ interface CloudTodoWorkspaceProps {
   user: UserProfile
   localProjects: ProjectWithTasks[]
   runtimeWork?: RuntimeWorkListResponse | null
+  runtimeTaskLifecycle?: RuntimeTaskLifecycleStoreSnapshot
   services: WorkbenchServices
   embedded?: boolean
   activeProjectRef?: RuntimeProjectSpaceRef | null
@@ -866,6 +868,7 @@ export function CloudTodoWorkspace({
   user,
   localProjects,
   runtimeWork,
+  runtimeTaskLifecycle,
   services,
   embedded = false,
   activeProjectRef,
@@ -953,7 +956,10 @@ export function CloudTodoWorkspace({
   // Which project's items are currently in `items`. Anything else rendered on
   // the board would be stale, so the board shows the skeleton instead.
   const [itemsProjectKey, setItemsProjectKey] = useState<string | null>(null)
-  const myWork = useMemo(() => runtimeMyWorkItems(runtimeWork), [runtimeWork])
+  const myWork = useMemo(
+    () => runtimeMyWorkItems(runtimeWork, runtimeTaskLifecycle),
+    [runtimeTaskLifecycle, runtimeWork]
+  )
   const [rootView, setRootView] = useState<RootView>('projects')
   const [projectView, setProjectView] = useState<ProjectView>('board')
   const [selectedItem, setSelectedItem] = useState<LocatedLoopItem | null>(null)

--- a/wework/src/features/todo/runtimeMyWork.test.ts
+++ b/wework/src/features/todo/runtimeMyWork.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { RuntimeTaskSummary, RuntimeWorkListResponse } from '@/types/api'
+import { RuntimeTaskLifecycleStore } from '@/features/workbench/runtimeTaskLifecycle'
 import { runtimeMyWorkItems } from './runtimeMyWork'
 
 function task(overrides: Partial<RuntimeTaskSummary> = {}): RuntimeTaskSummary {
@@ -89,5 +90,27 @@ describe('runtimeMyWorkItems', () => {
       ['failed', 'pending', false],
       ['done', 'completed', false],
     ])
+  })
+
+  it('uses the shared lifecycle state that drives the sidebar running indicator', () => {
+    const work = runtimeWork([task({ running: false, status: 'done' })])
+    const address = {
+      deviceId: 'device-1',
+      taskId: 'task-1',
+      runtime: 'codex' as const,
+      workspacePath: '/tmp/project',
+    }
+    const lifecycleStore = new RuntimeTaskLifecycleStore('my-work-test')
+    lifecycleStore.syncRuntimeWork(work)
+    lifecycleStore.executorStarted(address)
+
+    const [item] = runtimeMyWorkItems(work, lifecycleStore.getSnapshot())
+
+    expect(item).toMatchObject({
+      id: 'task-1',
+      status: 'in_progress',
+      has_active_task: true,
+      execution_state: 'running',
+    })
   })
 })

--- a/wework/src/features/todo/runtimeMyWork.ts
+++ b/wework/src/features/todo/runtimeMyWork.ts
@@ -5,17 +5,32 @@ import type {
   RuntimeTaskSummary,
   RuntimeWorkListResponse,
 } from '@/types/api'
+import {
+  getRuntimeTaskLifecycleKey,
+  type RuntimeTaskLifecycleStoreSnapshot,
+} from '@/features/workbench/runtimeTaskLifecycle'
 import { runtimeTaskBoardState } from '@/features/workbench/runtimeTaskLifecycle/projection'
 
 export interface RuntimeMyWorkItem extends CloudMyWorkItem {
   runtime_address: RuntimeTaskAddress
 }
 
-function taskBoardStatus(task: RuntimeTaskSummary): {
+function taskBoardStatus(
+  task: RuntimeTaskSummary,
+  address: RuntimeTaskAddress,
+  lifecycleSnapshot?: RuntimeTaskLifecycleStoreSnapshot
+): {
   status: CloudMyWorkItem['status']
   hasActiveTask: boolean
 } {
-  const state = runtimeTaskBoardState(task)
+  const lifecycle = lifecycleSnapshot?.tasks.get(getRuntimeTaskLifecycleKey(address))
+  if (lifecycle?.derived.isRunning) {
+    return { status: 'in_progress', hasActiveTask: true }
+  }
+  if (lifecycle?.derived.isQueued) {
+    return { status: 'pending', hasActiveTask: false }
+  }
+  const state = runtimeTaskBoardState(lifecycle?.task ?? task)
   if (state === 'active') return { status: 'in_progress', hasActiveTask: true }
   if (state === 'completed') return { status: 'completed', hasActiveTask: false }
   return { status: 'pending', hasActiveTask: false }
@@ -37,10 +52,19 @@ function runtimeCloudProjectId(task: RuntimeTaskSummary): string | null {
 
 function workspaceItems(
   workspace: RuntimeDeviceWorkspace,
-  project: { key: string; name: string }
+  project: { key: string; name: string },
+  lifecycleSnapshot?: RuntimeTaskLifecycleStoreSnapshot
 ): RuntimeMyWorkItem[] {
   return workspace.tasks.map(task => {
-    const lifecycle = taskBoardStatus(task)
+    const runtimeAddress: RuntimeTaskAddress = {
+      deviceId: workspace.deviceId,
+      taskId: task.taskId,
+      runtime: task.runtime,
+      threadId: task.threadId,
+      workspacePath: task.workspacePath || workspace.workspacePath,
+      runtimeHandle: task.runtimeHandle,
+    }
+    const lifecycle = taskBoardStatus(task, runtimeAddress, lifecycleSnapshot)
     const projectId = runtimeCloudProjectId(task) ?? `runtime:${project.key}`
     return {
       id: task.taskId,
@@ -70,34 +94,38 @@ function workspaceItems(
       project_key: project.key,
       project_name: project.name,
       has_active_task: lifecycle.hasActiveTask,
-      runtime_address: {
-        deviceId: workspace.deviceId,
-        taskId: task.taskId,
-        runtime: task.runtime,
-        threadId: task.threadId,
-        workspacePath: task.workspacePath || workspace.workspacePath,
-        runtimeHandle: task.runtimeHandle,
-      },
+      runtime_address: runtimeAddress,
     }
   })
 }
 
-export function runtimeMyWorkItems(runtimeWork: RuntimeWorkListResponse | null | undefined) {
+export function runtimeMyWorkItems(
+  runtimeWork: RuntimeWorkListResponse | null | undefined,
+  lifecycleSnapshot?: RuntimeTaskLifecycleStoreSnapshot
+) {
   if (!runtimeWork) return []
   const items = [
     ...runtimeWork.projects.flatMap(projectWork =>
       projectWork.deviceWorkspaces.flatMap(workspace =>
-        workspaceItems(workspace, {
-          key: projectWork.project.key,
-          name: projectWork.project.name,
-        })
+        workspaceItems(
+          workspace,
+          {
+            key: projectWork.project.key,
+            name: projectWork.project.name,
+          },
+          lifecycleSnapshot
+        )
       )
     ),
     ...runtimeWork.chats.flatMap(workspace =>
-      workspaceItems(workspace, {
-        key: 'LOCAL',
-        name: workspace.label || '本地任务',
-      })
+      workspaceItems(
+        workspace,
+        {
+          key: 'LOCAL',
+          name: workspace.label || '本地任务',
+        },
+        lifecycleSnapshot
+      )
     ),
   ]
   const unique = new Map<string, RuntimeMyWorkItem>()


### PR DESCRIPTION
## Summary

- make My Work derive running and queued groups from the shared runtime lifecycle snapshot used by the local-task sidebar
- keep runtimeWork as the task inventory while preventing stale completed summaries from hiding actively running local tasks
- add a real desktop E2E regression to the CI-covered conversation-state checkpoint
- document the shared lifecycle source in Chinese and English developer guides

## Verification

- `pnpm --filter wework test src/features/todo/runtimeMyWork.test.ts`
- `pnpm --filter wework test src/features/todo/CloudTodoWorkspace.test.tsx -t "shows runtime tasks"`
- `pnpm --filter wework typecheck`
- `pnpm --filter wework lint:task-lifecycle`
- `pnpm --filter wework e2e:desktop --segment conversation-state`

Desktop E2E evidence: `wework/test-results/desktop-e2e/2026-08-20T16-29-48-269Z-34730`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task status accuracy in My Work by synchronizing running and queued states with shared runtime lifecycle information.
  * Prevented stale transcript updates from incorrectly marking completed tasks as finished.

* **Documentation**
  * Added guidance explaining consistent lifecycle-state handling across the sidebar, composer, and My Work.

* **Tests**
  * Added coverage for task restoration, running-state synchronization, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->