### PR TITLE
fix(wework): distinguish merged pull request status

### DIFF
--- a/wework/src/components/layout/EnvironmentInfoPopover.test.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.test.tsx
@@ -303,6 +303,8 @@ describe('EnvironmentInfoPopover', () => {
     expect(
       screen.getByTestId('change-request-button').querySelector('[aria-hidden="true"]')
     ).toHaveClass('text-green-500')
+    expect(screen.getByTestId('change-request-pull-request-icon')).toBeInTheDocument()
+    expect(screen.queryByTestId('change-request-merged-icon')).not.toBeInTheDocument()
   })
 
   test('shows merge conflicts on the pull request icon without adding a second row', () => {
@@ -386,6 +388,48 @@ describe('EnvironmentInfoPopover', () => {
     expect(button).toHaveAccessibleName(/合并队列中/)
     expect(button).not.toHaveAccessibleName(/检查通过/)
     expect(button.querySelector('[aria-hidden="true"]')).not.toHaveClass('text-green-500')
+  })
+
+  test('shows a purple icon for a merged pull request', () => {
+    const popoverContainer = document.createElement('div')
+    document.body.appendChild(popoverContainer)
+    portalContainers.push(popoverContainer)
+
+    render(
+      <EnvironmentInfoPopover
+        info={{
+          additions: '+0',
+          deletions: '-0',
+          executionTarget: 'local',
+          branchName: 'feature/merged-change-request',
+          changeRequest: {
+            provider: 'github',
+            state: 'found',
+            changeRequest: {
+              provider: 'github',
+              number: 2780,
+              url: 'https://github.com/wecode-ai/Wegent/pull/2780',
+              title: 'feat(wework): merged change request',
+              state: 'merged',
+              draft: false,
+              checks: 'success',
+              mergeability: 'unknown',
+              mergeQueue: 'not_queued',
+            },
+          },
+        }}
+        popoverContainer={popoverContainer}
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    const icon = screen.getByTestId('change-request-button').querySelector('[aria-hidden="true"]')
+    expect(screen.getByTestId('change-request-state')).toHaveTextContent('已合并')
+    expect(icon).toHaveClass('text-violet-500')
+    expect(icon).not.toHaveClass('text-green-500')
+    expect(screen.getByTestId('change-request-merged-icon')).toBeInTheDocument()
+    expect(screen.queryByTestId('change-request-pull-request-icon')).not.toBeInTheDocument()
   })
 
   test('opens Git hosting settings from a GitLab CLI recovery hint', async () => {

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -9,6 +9,7 @@ import {
   FolderOpen,
   GitCommit,
   GitBranch,
+  GitMerge,
   GitPullRequest,
   Info,
   Link2,
@@ -544,13 +545,23 @@ export function EnvironmentInfoPopover({
                                 !changeRequest.draft &&
                                 changeRequest.mergeQueue !== 'queued' &&
                                 'text-green-500',
-                              changeRequest.state === 'merged' && 'text-green-500',
+                              changeRequest.state === 'merged' && 'text-violet-500',
                               changeRequest.state === 'closed' && 'text-red-500',
                               changeRequest.mergeability === 'conflicting' && 'text-red-500'
                             )}
                             aria-hidden="true"
                           >
-                            <GitPullRequest className="h-[18px] w-[18px]" />
+                            {changeRequest.state === 'merged' ? (
+                              <GitMerge
+                                data-testid="change-request-merged-icon"
+                                className="h-[18px] w-[18px]"
+                              />
+                            ) : (
+                              <GitPullRequest
+                                data-testid="change-request-pull-request-icon"
+                                className="h-[18px] w-[18px]"
+                              />
+                            )}
                             {changeRequest.mergeability === 'conflicting' ? (
                               <span className="absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background text-red-500">
                                 <TriangleAlert className="h-3 w-3 fill-background" />


### PR DESCRIPTION
## Summary

- render merged pull requests with the dedicated merge icon
- use violet for merged state while keeping mergeable pull requests green
- add focused component coverage for icon and color semantics

## Verification

- `pnpm --filter wework test src/components/layout/EnvironmentInfoPopover.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/EnvironmentInfoPopover.tsx src/components/layout/EnvironmentInfoPopover.test.tsx`
- Wework pre-push ESLint, TypeScript, and unit tests
- real Tauri desktop change-request status scenario