### PR TITLE
fix(wework): show environment status without remote delay

### DIFF
--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -285,6 +285,112 @@ describe('loadProjectEnvironment', () => {
     })
   })
 
+  test('publishes a GitHub pull request before its merge queue lookup finishes', async () => {
+    let resolveMergeQueue: (value: {
+      success: boolean
+      stdout: Record<string, unknown>
+      stderr: string
+    }) => void = () => {}
+    const mergeQueueResult = new Promise<{
+      success: boolean
+      stdout: Record<string, unknown>
+      stderr: string
+    }>(resolve => {
+      resolveMergeQueue = resolve
+    })
+    const executeCommand = vi.fn((_: string, data: { command_key: string }) => {
+      if (data.command_key === 'git_branch') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'fix/fast-pr-status\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_remote_url') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'https://github.com/wecode-ai/Wegent.git\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_github_pull_requests') {
+        return Promise.resolve({
+          success: true,
+          stdout: [
+            {
+              number: 2875,
+              url: 'https://github.com/wecode-ai/Wegent/pull/2875',
+              title: 'fix(executor): converge cancelled runtime turns',
+              state: 'OPEN',
+              isDraft: false,
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
+              statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+            },
+          ],
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_github_pull_request_merge_queue') {
+        return mergeQueueResult
+      }
+      return Promise.resolve({
+        success: true,
+        stdout: '',
+        stderr: '',
+      })
+    })
+    const onPartialInfo = vi.fn()
+    const load = loadProjectEnvironment(
+      { executeCommand },
+      null,
+      {
+        deviceId: 'local-device',
+        path: '/workspace/fast-pr-status',
+      },
+      { force: true, onPartialInfo }
+    )
+
+    await vi.waitFor(() => {
+      expect(onPartialInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          changeRequest: {
+            provider: 'github',
+            state: 'found',
+            changeRequest: expect.objectContaining({
+              number: 2875,
+              mergeQueue: 'unknown',
+            }),
+          },
+        })
+      )
+    })
+
+    let settled = false
+    void load.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    resolveMergeQueue({
+      success: true,
+      stdout: { data: { resource: { mergeQueueEntry: null } } },
+      stderr: '',
+    })
+
+    await expect(load).resolves.toMatchObject({
+      changeRequest: {
+        provider: 'github',
+        state: 'found',
+        changeRequest: expect.objectContaining({
+          number: 2875,
+          mergeQueue: 'not_queued',
+        }),
+      },
+    })
+  })
+
   test('keeps a GitHub pull request pending while it is in the merge queue', async () => {
     const executeCommand = vi
       .fn()
@@ -1124,6 +1230,117 @@ describe('loadProjectEnvironment', () => {
     expect(executeCommand).toHaveBeenCalledTimes(10)
   })
 
+  test('publishes stale environment info immediately while revalidating an expired cache', async () => {
+    const initialNow = Date.now()
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(initialNow)
+    let pullRequestLookupCount = 0
+    let resolveRefreshedPullRequests: (value: {
+      success: boolean
+      stdout: unknown[]
+      stderr: string
+    }) => void = () => {}
+    const refreshedPullRequests = new Promise<{
+      success: boolean
+      stdout: unknown[]
+      stderr: string
+    }>(resolve => {
+      resolveRefreshedPullRequests = resolve
+    })
+    const executeCommand = vi.fn((_: string, data: { command_key: string }) => {
+      if (data.command_key === 'git_branch') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'fix/cached-pr-status\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_remote_url') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'https://github.com/wecode-ai/Wegent.git\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_github_pull_requests') {
+        pullRequestLookupCount += 1
+        if (pullRequestLookupCount === 1) {
+          return Promise.resolve({
+            success: true,
+            stdout: [
+              {
+                number: 2875,
+                url: 'https://github.com/wecode-ai/Wegent/pull/2875',
+                title: 'Cached pull request',
+                state: 'CLOSED',
+                isDraft: false,
+                statusCheckRollup: [],
+              },
+            ],
+            stderr: '',
+          })
+        }
+        return refreshedPullRequests
+      }
+      return Promise.resolve({
+        success: true,
+        stdout: '',
+        stderr: '',
+      })
+    })
+    const api = { executeCommand }
+    const target = {
+      deviceId: 'local-device',
+      path: '/workspace/cached-pr-status',
+    }
+
+    const initialInfo = await loadProjectEnvironment(api, null, target)
+    expect(initialInfo.changeRequest?.changeRequest?.number).toBe(2875)
+
+    dateNow.mockReturnValue(initialNow + 2000)
+    const onPartialInfo = vi.fn()
+    const refresh = loadProjectEnvironment(api, null, target, { onPartialInfo })
+
+    expect(onPartialInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branchName: 'fix/cached-pr-status',
+        changeRequest: expect.objectContaining({
+          state: 'found',
+          changeRequest: expect.objectContaining({ number: 2875 }),
+        }),
+      })
+    )
+
+    let settled = false
+    void refresh.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    resolveRefreshedPullRequests({
+      success: true,
+      stdout: [
+        {
+          number: 2876,
+          url: 'https://github.com/wecode-ai/Wegent/pull/2876',
+          title: 'Refreshed pull request',
+          state: 'CLOSED',
+          isDraft: false,
+          statusCheckRollup: [],
+        },
+      ],
+      stderr: '',
+    })
+
+    await expect(refresh).resolves.toMatchObject({
+      changeRequest: {
+        state: 'found',
+        changeRequest: expect.objectContaining({ number: 2876 }),
+      },
+    })
+    dateNow.mockRestore()
+  })
+
   test('deduplicates a forced refresh while the current environment load is still pending', async () => {
     let resolveBranch: (value: {
       success: boolean
@@ -1311,6 +1528,93 @@ describe('loadProjectEnvironment', () => {
       additions: '+3',
       deletions: '-1',
       changeRequest: expect.objectContaining({ state: 'found' }),
+    })
+  })
+
+  test('publishes the branch before a slow pull request lookup finishes', async () => {
+    let resolvePullRequests: (value: {
+      success: boolean
+      stdout: unknown[]
+      stderr: string
+    }) => void = () => {}
+    const pullRequestsResult = new Promise<{
+      success: boolean
+      stdout: unknown[]
+      stderr: string
+    }>(resolve => {
+      resolvePullRequests = resolve
+    })
+    const executeCommand = vi.fn((_: string, data: { command_key: string }) => {
+      if (data.command_key === 'git_branch') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'fix/fast-branch-status\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_remote_url') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'https://github.com/wecode-ai/Wegent.git\n',
+          stderr: '',
+        })
+      }
+      if (data.command_key === 'git_github_pull_requests') {
+        return pullRequestsResult
+      }
+      return Promise.resolve({
+        success: true,
+        stdout: '',
+        stderr: '',
+      })
+    })
+    const onPartialInfo = vi.fn()
+    const load = loadProjectEnvironment(
+      { executeCommand },
+      {
+        id: 1004,
+        name: 'Wegent',
+        config: {
+          mode: 'workspace' as const,
+          execution: {
+            targetType: 'local' as const,
+            deviceId: 'device-123',
+          },
+          workspace: {
+            source: 'local_path' as const,
+            localPath: '/workspace/Wegent',
+          },
+        },
+      },
+      undefined,
+      { onPartialInfo }
+    )
+
+    await vi.waitFor(() => {
+      expect(onPartialInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchName: 'fix/fast-branch-status',
+        })
+      )
+    })
+    expect(onPartialInfo.mock.calls[0]?.[0]).not.toHaveProperty('changeRequest')
+
+    let settled = false
+    void load.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    resolvePullRequests({
+      success: true,
+      stdout: [],
+      stderr: '',
+    })
+
+    await expect(load).resolves.toMatchObject({
+      branchName: 'fix/fast-branch-status',
+      changeRequest: expect.objectContaining({ state: 'not_found' }),
     })
   })
 

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -37,6 +37,12 @@ const EMPTY_ENVIRONMENT_INFO: EnvironmentInfo = {
 }
 const INVALID_BRANCH_CHARACTERS = new Set([' ', '~', '^', ':', '?', '*', '[', '\\', ']'])
 const ENVIRONMENT_INFO_CACHE_TTL_MS = 1500
+let environmentLoadSequence = 0
+
+interface EnvironmentLoadDiagnostics {
+  loadId: number
+  startedAt: number
+}
 
 export type EnvironmentDiffMode = 'branch' | 'unstaged' | 'staged' | 'commit'
 
@@ -58,6 +64,7 @@ type EnvironmentInfoCacheEntry = {
   expiresAt: number
   promise: Promise<EnvironmentInfo>
   settled: boolean
+  value?: EnvironmentInfo
   partialState: {
     info?: EnvironmentInfo
     listeners: Set<(info: EnvironmentInfo) => void>
@@ -68,6 +75,45 @@ const environmentInfoCaches = new WeakMap<
   DeviceCommandApi,
   Map<string, EnvironmentInfoCacheEntry>
 >()
+
+function environmentNow(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+function logEnvironmentLoad(
+  diagnostics: EnvironmentLoadDiagnostics,
+  stage: string,
+  details: Record<string, unknown> = {}
+): void {
+  console.info('[Wework] Environment load', {
+    loadId: diagnostics.loadId,
+    stage,
+    elapsedMs: Math.round(environmentNow() - diagnostics.startedAt),
+    ...details,
+  })
+}
+
+async function traceEnvironmentOperation<T>(
+  diagnostics: EnvironmentLoadDiagnostics,
+  stage: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const startedAt = environmentNow()
+  logEnvironmentLoad(diagnostics, `${stage}:started`)
+  try {
+    const result = await operation()
+    logEnvironmentLoad(diagnostics, `${stage}:completed`, {
+      durationMs: Math.round(environmentNow() - startedAt),
+    })
+    return result
+  } catch (error) {
+    logEnvironmentLoad(diagnostics, `${stage}:failed`, {
+      durationMs: Math.round(environmentNow() - startedAt),
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
+}
 
 function outputAsString(output: DeviceCommandResponse['stdout']): string {
   if (typeof output === 'string') {
@@ -325,7 +371,9 @@ async function loadChangeRequest(
   deviceId: string,
   path: string,
   remoteUrl: string,
-  branchName: string
+  branchName: string,
+  diagnostics: EnvironmentLoadDiagnostics,
+  onInitialLookup?: (lookup: ChangeRequestLookup) => void
 ): Promise<ChangeRequestLookup | undefined> {
   const remote = parseGitRemote(remoteUrl)
   const branch = branchName.trim()
@@ -340,13 +388,16 @@ async function loadChangeRequest(
 
   let response: DeviceCommandResponse
   try {
-    response = await api.executeCommand(deviceId, {
-      command_key: provider === 'github' ? 'git_github_pull_requests' : 'git_gitlab_merge_requests',
-      path,
-      args: [branch],
-      timeout_seconds: 20,
-      max_output_bytes: 256 * 1024,
-    })
+    response = await traceEnvironmentOperation(diagnostics, 'change_request', () =>
+      api.executeCommand(deviceId, {
+        command_key:
+          provider === 'github' ? 'git_github_pull_requests' : 'git_gitlab_merge_requests',
+        path,
+        args: [branch],
+        timeout_seconds: 20,
+        max_output_bytes: 256 * 1024,
+      })
+    )
   } catch {
     return { provider, state: 'error' }
   }
@@ -367,15 +418,23 @@ async function loadChangeRequest(
     return { provider, state: 'not_found' }
   }
 
+  onInitialLookup?.({
+    provider,
+    state: 'found',
+    changeRequest: { ...changeRequest },
+  })
+
   if (provider === 'github' && changeRequest.state === 'open') {
     try {
-      const queueResponse = await api.executeCommand(deviceId, {
-        command_key: 'git_github_pull_request_merge_queue',
-        path,
-        args: ['-F', `url=${changeRequest.url}`],
-        timeout_seconds: 20,
-        max_output_bytes: 64 * 1024,
-      })
+      const queueResponse = await traceEnvironmentOperation(diagnostics, 'merge_queue', () =>
+        api.executeCommand(deviceId, {
+          command_key: 'git_github_pull_request_merge_queue',
+          path,
+          args: ['-F', `url=${changeRequest.url}`],
+          timeout_seconds: 20,
+          max_output_bytes: 64 * 1024,
+        })
+      )
       if (queueResponse.success) {
         changeRequest.mergeQueue = githubMergeQueueState(outputAsRecord(queueResponse.stdout))
       }
@@ -712,7 +771,11 @@ async function loadProjectEnvironmentUncached(
   api: DeviceCommandApi,
   project: ProjectWithTasks | null,
   target?: EnvironmentWorkspaceTarget | null,
-  onPartialInfo?: (info: EnvironmentInfo) => void
+  onPartialInfo?: (info: EnvironmentInfo) => void,
+  diagnostics: EnvironmentLoadDiagnostics = {
+    loadId: ++environmentLoadSequence,
+    startedAt: environmentNow(),
+  }
 ): Promise<EnvironmentInfo> {
   if (!project && !target) {
     return EMPTY_ENVIRONMENT_INFO
@@ -733,9 +796,12 @@ async function loadProjectEnvironmentUncached(
   let deviceId: string
   let path: string
   try {
-    const context = await commandContext(api, project, target)
+    const context = await traceEnvironmentOperation(diagnostics, 'workspace_context', () =>
+      commandContext(api, project, target)
+    )
     deviceId = context.deviceId
     path = context.path
+    logEnvironmentLoad(diagnostics, 'workspace_ready', { deviceId, path })
   } catch (error) {
     return {
       ...baseInfo,
@@ -750,39 +816,71 @@ async function loadProjectEnvironmentUncached(
   }
 
   try {
-    const branchNamePromise = runGitCommand(api, deviceId, 'git_branch', path)
-    const shortStatPromise = loadBranchDiffShortStat(api, deviceId, path)
-    const porcelainPromise = runGitCommand(api, deviceId, 'git_status_porcelain', path).catch(
-      () => ''
+    const branchNamePromise = traceEnvironmentOperation(diagnostics, 'git_branch', () =>
+      runGitCommand(api, deviceId, 'git_branch', path)
     )
-    const remoteUrlPromise = runGitCommand(api, deviceId, 'git_remote_url', path).catch(() => '')
-    const changeRequestEnabledPromise = getAppPreferences().then(
-      preferences => preferences.changeRequestStatusEnabled
+    const shortStatPromise = traceEnvironmentOperation(diagnostics, 'git_diff', () =>
+      loadBranchDiffShortStat(api, deviceId, path)
     )
-    const changeRequestPromise = Promise.all([
-      branchNamePromise,
-      remoteUrlPromise,
-      changeRequestEnabledPromise,
-    ]).then(async ([branchName, remoteUrl, changeRequestStatusEnabled]) => {
-      const changeRequest = changeRequestStatusEnabled
-        ? await loadChangeRequest(api, deviceId, path, remoteUrl, branchName)
-        : undefined
-      onPartialInfo?.({
-        ...environmentWorkspaceInfo,
-        additions: '',
-        deletions: '',
-        isGitRepository: true,
-        branchName,
-        createPullRequestUrl: buildPullRequestUrl(remoteUrl, branchName),
-        ...(changeRequest ? { changeRequest } : {}),
-      })
-      return changeRequest
-    })
-    const [branchName, shortStat, porcelain, remoteUrl, changeRequest] = await Promise.all([
-      branchNamePromise,
+    const porcelainPromise = traceEnvironmentOperation(diagnostics, 'git_status', () =>
+      runGitCommand(api, deviceId, 'git_status_porcelain', path)
+    ).catch(() => '')
+    const remoteUrlPromise = traceEnvironmentOperation(diagnostics, 'git_remote', () =>
+      runGitCommand(api, deviceId, 'git_remote_url', path)
+    ).catch(() => '')
+    const changeRequestEnabledPromise = traceEnvironmentOperation(
+      diagnostics,
+      'change_request_preference',
+      () => getAppPreferences().then(preferences => preferences.changeRequestStatusEnabled)
+    )
+    const branchInfoPromise = Promise.all([branchNamePromise, remoteUrlPromise]).then(
+      ([branchName, remoteUrl]) => {
+        const branchInfo: EnvironmentInfo = {
+          ...environmentWorkspaceInfo,
+          additions: '',
+          deletions: '',
+          isGitRepository: true,
+          branchName,
+          createPullRequestUrl: buildPullRequestUrl(remoteUrl, branchName),
+        }
+        logEnvironmentLoad(diagnostics, 'branch_published', { branchName })
+        onPartialInfo?.(branchInfo)
+        return { branchInfo, branchName, remoteUrl }
+      }
+    )
+    const changeRequestPromise = Promise.all([branchInfoPromise, changeRequestEnabledPromise]).then(
+      async ([{ branchInfo, branchName, remoteUrl }, changeRequestStatusEnabled]) => {
+        const changeRequest = changeRequestStatusEnabled
+          ? await loadChangeRequest(
+              api,
+              deviceId,
+              path,
+              remoteUrl,
+              branchName,
+              diagnostics,
+              initialLookup => {
+                logEnvironmentLoad(diagnostics, 'change_request_published', {
+                  state: initialLookup.state,
+                  number: initialLookup.changeRequest?.number,
+                })
+                onPartialInfo?.({ ...branchInfo, changeRequest: initialLookup })
+              }
+            )
+          : undefined
+        if (changeRequest) {
+          logEnvironmentLoad(diagnostics, 'change_request_final_published', {
+            state: changeRequest.state,
+            number: changeRequest.changeRequest?.number,
+          })
+          onPartialInfo?.({ ...branchInfo, changeRequest })
+        }
+        return changeRequest
+      }
+    )
+    const [{ branchName, remoteUrl }, shortStat, porcelain, changeRequest] = await Promise.all([
+      branchInfoPromise,
       shortStatPromise,
       porcelainPromise,
-      remoteUrlPromise,
       changeRequestPromise,
     ])
     const diff = parseGitShortStat(shortStat)
@@ -805,7 +903,7 @@ async function loadProjectEnvironmentUncached(
       diff.additions = `+${porcelainLines.length}`
     }
 
-    return {
+    const result = {
       ...environmentWorkspaceInfo,
       ...diff,
       isGitRepository: true,
@@ -813,6 +911,12 @@ async function loadProjectEnvironmentUncached(
       createPullRequestUrl: buildPullRequestUrl(remoteUrl, branchName),
       ...(changeRequest ? { changeRequest } : {}),
     }
+    logEnvironmentLoad(diagnostics, 'completed', {
+      branchName,
+      changeRequestState: changeRequest?.state,
+      changeRequestNumber: changeRequest?.changeRequest?.number,
+    })
+    return result
   } catch (error) {
     const isGitRepository = await probeGitRepository(api, deviceId, path).catch(() => undefined)
     if (isGitRepository === false) {
@@ -835,13 +939,18 @@ export async function loadProjectEnvironment(
   target?: EnvironmentWorkspaceTarget | null,
   options: EnvironmentInfoLoadOptions = {}
 ): Promise<EnvironmentInfo> {
+  const diagnostics: EnvironmentLoadDiagnostics = {
+    loadId: ++environmentLoadSequence,
+    startedAt: environmentNow(),
+  }
   if (!project && !target) {
     return cloneEnvironmentInfo(EMPTY_ENVIRONMENT_INFO)
   }
 
   const cacheKey = environmentInfoCacheKey(project, target)
   if (!cacheKey) {
-    return loadProjectEnvironmentUncached(api, project, target, options.onPartialInfo)
+    logEnvironmentLoad(diagnostics, 'cache_bypassed')
+    return loadProjectEnvironmentUncached(api, project, target, options.onPartialInfo, diagnostics)
   }
 
   const now = Date.now()
@@ -850,6 +959,10 @@ export async function loadProjectEnvironment(
   // Forced polling must still share an in-flight load. Replacing a slow request
   // on every poll prevents any result from settling the environment loading state.
   if (cached && (!cached.settled || (!options.force && cached.expiresAt > now))) {
+    logEnvironmentLoad(diagnostics, cached.settled ? 'cache_hit' : 'cache_joined', {
+      force: Boolean(options.force),
+      expiresInMs: cached.expiresAt - now,
+    })
     if (options.onPartialInfo) {
       cached.partialState.listeners.add(options.onPartialInfo)
       if (cached.partialState.info) {
@@ -857,20 +970,56 @@ export async function loadProjectEnvironment(
       }
     }
     try {
-      return cloneEnvironmentInfo(await cached.promise)
+      const info = cloneEnvironmentInfo(await cached.promise)
+      logEnvironmentLoad(diagnostics, 'cache_result_returned')
+      return info
     } finally {
       if (options.onPartialInfo) {
         cached.partialState.listeners.delete(options.onPartialInfo)
       }
     }
   }
+  const staleInfo =
+    !options.force && cached?.settled && cached.value
+      ? cloneEnvironmentInfo(cached.value)
+      : undefined
+  if (staleInfo && options.onPartialInfo) {
+    logEnvironmentLoad(diagnostics, 'stale_cache_published', {
+      branchName: staleInfo.branchName,
+      changeRequestNumber: staleInfo.changeRequest?.changeRequest?.number,
+    })
+    options.onPartialInfo(cloneEnvironmentInfo(staleInfo))
+  }
 
   const partialState: EnvironmentInfoCacheEntry['partialState'] = {
+    info: staleInfo,
     listeners: new Set(options.onPartialInfo ? [options.onPartialInfo] : []),
   }
-  const promise = loadProjectEnvironmentUncached(api, project, target, partialInfo => {
-    partialState.info = cloneEnvironmentInfo(partialInfo)
-    partialState.listeners.forEach(listener => listener(cloneEnvironmentInfo(partialInfo)))
+  const promise = loadProjectEnvironmentUncached(
+    api,
+    project,
+    target,
+    partialInfo => {
+      const previousInfo = partialState.info
+      partialState.info =
+        previousInfo &&
+        previousInfo.workspacePath === partialInfo.workspacePath &&
+        previousInfo.deviceId === partialInfo.deviceId &&
+        !partialInfo.changeRequest
+          ? {
+              ...partialInfo,
+              ...(previousInfo.changeRequest ? { changeRequest: previousInfo.changeRequest } : {}),
+            }
+          : cloneEnvironmentInfo(partialInfo)
+      partialState.listeners.forEach(listener =>
+        listener(cloneEnvironmentInfo(partialState.info ?? partialInfo))
+      )
+    },
+    diagnostics
+  )
+  logEnvironmentLoad(diagnostics, 'cache_miss', {
+    force: Boolean(options.force),
+    revalidatingStale: Boolean(staleInfo),
   })
   const entry: EnvironmentInfoCacheEntry = {
     expiresAt: now + ENVIRONMENT_INFO_CACHE_TTL_MS,
@@ -880,7 +1029,8 @@ export async function loadProjectEnvironment(
   }
   environmentInfoCache.set(cacheKey, entry)
   void promise.then(
-    () => {
+    info => {
+      entry.value = cloneEnvironmentInfo(info)
       entry.settled = true
     },
     () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -42,6 +42,7 @@ import {
 import { configuredWorkspacePath, executionDeviceId } from '@/lib/project-workspace'
 import { setActiveKeybindings } from '@/lib/keybindings'
 import type { ProjectWithTasks, RuntimeTaskAddress, RuntimeWorkListResponse } from '@/types/api'
+import type { EnvironmentInfo } from '@/types/environment'
 import type { RuntimeSubagentStatus, WorkbenchMessage } from '@/types/workbench'
 import '@/i18n'
 import {
@@ -9444,6 +9445,80 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('environment-branch-row')).toHaveTextContent('暂无分支')
     expect(screen.queryByTestId('environment-commit-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('create-pull-request-button')).not.toBeInTheDocument()
+  })
+
+  test('shows a partial branch result before environment loading finishes', async () => {
+    mockDesktopWorkbenchMainWidth(1024)
+    let publishPartialInfo: ((info: EnvironmentInfo) => void) | undefined
+    const onLoadEnvironmentInfo = vi.fn(
+      (
+        _project: unknown,
+        _target: unknown,
+        options?: { onPartialInfo?: (info: EnvironmentInfo) => void }
+      ) => {
+        publishPartialInfo = options?.onPartialInfo
+        return new Promise<EnvironmentInfo>(() => {})
+      }
+    )
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{ ...activeProjectState, currentRuntimeTask: activeProjectRuntimeTask }}
+        onLoadEnvironmentInfo={onLoadEnvironmentInfo}
+      />
+    )
+
+    await waitFor(() => expect(publishPartialInfo).toBeTypeOf('function'))
+    expect(screen.getByTestId('environment-branch-row')).toHaveTextContent('加载中')
+
+    const cachedPullRequest: EnvironmentInfo = {
+      additions: '+0',
+      deletions: '-0',
+      executionTarget: 'local',
+      deviceId: 'device-1',
+      workspacePath: '/workspace/github_wegent',
+      branchName: 'fix/fast-branch-status',
+      changeRequest: {
+        provider: 'github',
+        state: 'found',
+        changeRequest: {
+          provider: 'github',
+          number: 2875,
+          url: 'https://github.com/wecode-ai/Wegent/pull/2875',
+          title: 'Cached pull request',
+          state: 'open',
+          draft: false,
+          checks: 'success',
+          mergeability: 'mergeable',
+          mergeQueue: 'not_queued',
+        },
+      },
+    }
+    act(() => {
+      publishPartialInfo?.(cachedPullRequest)
+    })
+
+    expect(screen.getByTestId('change-request-button')).toHaveAccessibleName(
+      expect.stringContaining('#2875')
+    )
+
+    act(() => {
+      publishPartialInfo?.({
+        additions: '',
+        deletions: '',
+        executionTarget: 'local',
+        deviceId: 'device-1',
+        workspacePath: '/workspace/github_wegent',
+        branchName: 'fix/fast-branch-status',
+      })
+    })
+
+    expect(screen.getByTestId('environment-branch-row')).toHaveTextContent('fix/fast-branch-status')
+    expect(screen.getByTestId('environment-branch-row')).not.toHaveTextContent('加载中')
+    expect(screen.getByTestId('change-request-button')).toHaveAccessibleName(
+      expect.stringContaining('#2875')
+    )
   })
 
   test('closes the branch menu when Escape is pressed', async () => {

--- a/wework/src/components/layout/EnvironmentInfoPopover.test.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.test.tsx
@@ -257,6 +257,33 @@ describe('EnvironmentInfoPopover', () => {
     expect(screen.queryByText('-0')).not.toBeInTheDocument()
   })
 
+  test('shows a resolved branch while the rest of the environment is still loading', () => {
+    const popoverContainer = document.createElement('div')
+    document.body.appendChild(popoverContainer)
+    portalContainers.push(popoverContainer)
+
+    render(
+      <EnvironmentInfoPopover
+        info={{
+          additions: '',
+          deletions: '',
+          executionTarget: 'local',
+          branchName: 'fix/fast-branch-status',
+          loading: true,
+          branchLoading: false,
+        }}
+        popoverContainer={popoverContainer}
+        open
+        onOpenChange={vi.fn()}
+        onListBranches={vi.fn().mockResolvedValue([])}
+        onCheckoutBranch={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    expect(screen.getByTestId('environment-branch-row')).toHaveTextContent('fix/fast-branch-status')
+    expect(screen.getByTestId('environment-branch-row')).not.toHaveTextContent('加载中')
+  })
+
   test('renders the pull request associated with the current branch', async () => {
     const popoverContainer = document.createElement('div')
     document.body.appendChild(popoverContainer)

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -472,7 +472,7 @@ export function EnvironmentInfoPopover({
                     <BranchSelector
                       variant="environment"
                       currentBranch={info.branchName}
-                      loading={info.loading}
+                      loading={info.branchLoading ?? info.loading}
                       onRefresh={onRefresh}
                       onListBranches={onListBranches}
                       onCheckoutBranch={onCheckoutBranch}

--- a/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
+++ b/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
@@ -353,11 +353,29 @@ export function useWorkbenchPaneEnvironment({
     async ({ force, showLoading }: { force: boolean; showLoading: boolean }) => {
       const requestId = environmentInfoRequestSequence.current + 1
       environmentInfoRequestSequence.current = requestId
+      const startedAt = performance.now()
+      const logLoad = (stage: string, details: Record<string, unknown> = {}) => {
+        console.info('[Wework] Environment UI', {
+          requestId,
+          stage,
+          elapsedMs: Math.round(performance.now() - startedAt),
+          workspacePath: activeWorkspaceTarget?.path,
+          deviceId: activeWorkspaceTarget?.deviceId,
+          force,
+          showLoading,
+          ...details,
+        })
+      }
+      logLoad('requested', {
+        workspaceTargetResolving,
+        environmentWorkspaceReady,
+      })
 
       if (workspaceTargetResolving) {
         if (showLoading) {
-          setEnvironmentInfo(info => ({ ...info, loading: true }))
+          setEnvironmentInfo(info => ({ ...info, loading: true, branchLoading: true }))
         }
+        logLoad('waiting_for_workspace_target')
         return
       }
 
@@ -365,8 +383,10 @@ export function useWorkbenchPaneEnvironment({
         setEnvironmentInfo(info => ({
           ...info,
           loading: false,
+          branchLoading: false,
           error: workspaceTargetError ?? 'Workspace is not ready',
         }))
+        logLoad('workspace_not_ready', { error: workspaceTargetError })
         return
       }
 
@@ -374,7 +394,11 @@ export function useWorkbenchPaneEnvironment({
         setEnvironmentInfo(info =>
           info.workspacePath === activeWorkspaceTarget?.path &&
           info.deviceId === activeWorkspaceTarget?.deviceId
-            ? { ...info, loading: true }
+            ? {
+                ...info,
+                loading: true,
+                branchLoading: !info.branchName && info.branchLoading !== false,
+              }
             : {
                 additions: '',
                 deletions: '',
@@ -383,6 +407,7 @@ export function useWorkbenchPaneEnvironment({
                 workspacePath: activeWorkspaceTarget?.path,
                 workspaceRoots,
                 loading: true,
+                branchLoading: true,
               }
         )
       }
@@ -392,22 +417,43 @@ export function useWorkbenchPaneEnvironment({
           activeWorkspaceTarget: latestActiveWorkspaceTarget,
         } = environmentContextRef.current
         const applyEnvironmentInfo = (info: EnvironmentInfo, loading: boolean) => {
-          if (environmentInfoRequestSequence.current !== requestId) return
+          if (environmentInfoRequestSequence.current !== requestId) {
+            logLoad('discarded_stale_result', {
+              activeRequestId: environmentInfoRequestSequence.current,
+            })
+            return
+          }
           const actualDevice = findWorkbenchDevice(
             devicesRef.current,
             latestActiveWorkspaceTarget?.deviceId ?? info.deviceId
           )
-          setEnvironmentInfo({
-            ...info,
-            workspaceRoots,
-            executionTarget: actualDevice
-              ? isCloudDevice(actualDevice)
-                ? 'cloud'
-                : isRemoteDevice(actualDevice)
-                  ? 'remote'
-                  : 'local'
-              : info.executionTarget,
-            loading,
+          logLoad(loading ? 'partial_published' : 'completed', {
+            branchName: info.branchName,
+            changeRequestState: info.changeRequest?.state,
+            changeRequestNumber: info.changeRequest?.changeRequest?.number,
+          })
+          setEnvironmentInfo(current => {
+            const preserveCurrentChangeRequest =
+              loading &&
+              !info.changeRequest &&
+              current.workspacePath === info.workspacePath &&
+              current.deviceId === info.deviceId
+            return {
+              ...info,
+              ...(preserveCurrentChangeRequest && current.changeRequest
+                ? { changeRequest: current.changeRequest }
+                : {}),
+              workspaceRoots,
+              executionTarget: actualDevice
+                ? isCloudDevice(actualDevice)
+                  ? 'cloud'
+                  : isRemoteDevice(actualDevice)
+                    ? 'remote'
+                    : 'local'
+                : info.executionTarget,
+              loading,
+              branchLoading: false,
+            }
           })
         }
         const info = await loadEnvironmentInfo(
@@ -421,9 +467,13 @@ export function useWorkbenchPaneEnvironment({
         applyEnvironmentInfo(info, false)
       } catch (error) {
         if (environmentInfoRequestSequence.current === requestId) {
+          logLoad('failed', {
+            error: error instanceof Error ? error.message : String(error),
+          })
           setEnvironmentInfo(info => ({
             ...info,
             loading: false,
+            branchLoading: false,
             error: error instanceof Error ? error.message : 'Failed to load environment info',
           }))
         }
@@ -571,7 +621,7 @@ export function useWorkbenchPaneEnvironment({
       worktreeAvailability,
       isGitProject,
       branchName: environmentInfo.branchName,
-      branchLoading: environmentInfo.loading,
+      branchLoading: environmentInfo.branchLoading ?? environmentInfo.loading,
       onRefreshBranch: undefined,
       onListBranches:
         activeWorkspaceTarget && gitActionsAvailable ? listPaneEnvironmentBranches : undefined,

--- a/wework/src/types/environment.ts
+++ b/wework/src/types/environment.ts
@@ -41,4 +41,5 @@ export interface EnvironmentInfo {
   changeRequest?: ChangeRequestLookup
   error?: string
   loading?: boolean
+  branchLoading?: boolean
 }


### PR DESCRIPTION
## Summary

- publish the current branch and pull request before slower remote enrichment finishes
- reuse stale environment data immediately when switching back to a workspace, then revalidate in the background
- keep cached PR state visible during partial refreshes and separate branch loading from full environment loading
- add request/load timing logs for workspace, Git, PR, merge queue, cache, and UI publication stages

## Verification

- pre-push ESLint passed
- pre-push TypeScript passed
- pre-push Wework unit tests passed
- focused environment and popover tests: 60 passed
- focused desktop workbench integration test passed
- isolated real-Tauri session launched and local Git fixture was seeded; the automation reload command timed out during final control verification

## Issue

- WORK-43