### PR TITLE
fix(wework): handle failed optimistic task errors

### DIFF
--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -252,8 +252,29 @@ export function useWorkbenchPaneSession({
     [inputScopeKey, setInputForScope]
   )
   const [localError, setLocalError] = useState<string | null>(null)
-  const error = projectChat.setComposerError ? (projectChat.composerError ?? null) : localError
-  const setError = projectChat.setComposerError ?? setLocalError
+  const error = projectChat.composerErrorByScope
+    ? (projectChat.composerErrorByScope[inputScopeKey] ?? null)
+    : projectChat.setComposerError
+      ? (projectChat.composerError ?? null)
+      : localError
+  const setErrorForScope = useCallback(
+    (scopeKey: string, nextError: string | null) => {
+      if (projectChat.setComposerErrorForScope) {
+        projectChat.setComposerErrorForScope(scopeKey, nextError)
+        return
+      }
+      if (projectChat.setComposerError) {
+        projectChat.setComposerError(nextError)
+        return
+      }
+      setLocalError(nextError)
+    },
+    [projectChat]
+  )
+  const setError = useCallback(
+    (nextError: string | null) => setErrorForScope(inputScopeKey, nextError),
+    [inputScopeKey, setErrorForScope]
+  )
   const clearError = useCallback(() => setError(null), [setError])
   const setInput = useCallback(
     (value: string) => {
@@ -1764,6 +1785,7 @@ export function useWorkbenchPaneSession({
             runtimeGoalRequest: true,
           })
           let seededGoalAddress: RuntimeTaskAddress | null = null
+          let errorScopeKey = inputScopeKey
           const sent = await sendCurrentInput(submittedInput, {
             clientUserMessageId: optimisticMessage.id,
             initialGoal,
@@ -1780,8 +1802,9 @@ export function useWorkbenchPaneSession({
             ...(Object.prototype.hasOwnProperty.call(options, 'modelSelection')
               ? { modelSelection: options.modelSelection }
               : {}),
-            onError: setError,
+            onError: nextError => setErrorForScope(errorScopeKey, nextError),
             onRuntimeTaskOptimisticOpen: (address, context) => {
+              errorScopeKey = getRuntimeTaskChatScopeKey(address)
               options.onRuntimeTaskCreated?.(address)
               setPendingGoalState(current =>
                 current
@@ -1905,6 +1928,7 @@ export function useWorkbenchPaneSession({
           (hasCodeComments ? i18n.t('workbench.code_comment_fallback') : '')
         if (!currentRuntimeTask) {
           setInput('')
+          let errorScopeKey = inputScopeKey
           const optimisticMessage = createLocalUserMessage(
             visibleSubmittedInput,
             currentAttachments,
@@ -1930,8 +1954,9 @@ export function useWorkbenchPaneSession({
             ...(Object.prototype.hasOwnProperty.call(options, 'modelSelection')
               ? { modelSelection: options.modelSelection }
               : {}),
-            onError: setError,
+            onError: nextError => setErrorForScope(errorScopeKey, nextError),
             onRuntimeTaskOptimisticOpen: (address, context) => {
+              errorScopeKey = getRuntimeTaskChatScopeKey(address)
               options.onRuntimeTaskCreated?.(address)
               if (pendingInitialGoal) {
                 setPendingGoalState(current =>
@@ -2105,6 +2130,7 @@ export function useWorkbenchPaneSession({
         goalDraftActive,
         getRuntimeModelFields,
         input,
+        inputScopeKey,
         interruptAndSendQueuedMessage,
         lifecycleStore,
         loadRuntimeTranscriptForPane,
@@ -2116,6 +2142,7 @@ export function useWorkbenchPaneSession({
         sendCurrentInput,
         sendQueuedMessageAsGuidance,
         sendRuntimeMessage,
+        setErrorForScope,
         setError,
         setInput,
         setQueuedMessages,

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -930,6 +930,14 @@ function ProjectSendProbe({
       <button type="button" onClick={() => workbench.startNewChat()}>
         start new chat
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (currentRuntimeTask) void workbench.archiveRuntimeTask(currentRuntimeTask)
+        }}
+      >
+        archive current runtime task
+      </button>
       <button type="button" onClick={() => workbench.startNewProjectChat(7)}>
         start new project chat
       </button>
@@ -5546,6 +5554,70 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('runtime-task-errors')).toHaveTextContent(
       'executor-not-found:device-1'
     )
+    expect(screen.getByTestId('pane-session-error')).toHaveTextContent(
+      'executor-not-found:device-1'
+    )
+
+    await userEvent.click(screen.getByText('start new chat'))
+
+    expect(screen.getByTestId('pane-session-error')).toHaveTextContent('')
+  })
+
+  test('archives a failed optimistic runtime task locally and keeps it hidden after refresh', async () => {
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [],
+                },
+              ],
+            },
+          ],
+          totalTasks: 0,
+        })
+      ),
+      createRuntimeTask: vi.fn(async request => ({
+        accepted: false,
+        deviceId: request.deviceId,
+        taskId: request.taskId,
+        workspacePath: request.workspacePath,
+        runtime: 'claude_code',
+        error: 'executor-not-found:device-1',
+      })),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(await screen.findByText('select project'))
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-task-statuses')).toHaveTextContent('failed')
+    )
+
+    await userEvent.click(screen.getByText('archive current runtime task'))
+
+    await waitFor(() => expect(screen.getByTestId('runtime-task-titles')).toBeEmptyDOMElement())
+    expect(runtimeWorkApi.archiveConversation).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByText('refresh work lists'))
+
+    await waitFor(() => expect(screen.getByTestId('runtime-task-titles')).toBeEmptyDOMElement())
   })
 
   test('keeps new runtime task model selection for context usage window resolution', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -514,20 +514,21 @@ export function WorkbenchProvider({
     },
     [projectChatScopeKey, setDraftInputForScope]
   )
+  const setComposerErrorForScope = useCallback((scopeKey: string, error: string | null) => {
+    setComposerErrorByScope(current => {
+      if (error) {
+        if (current[scopeKey] === error) return current
+        return { ...current, [scopeKey]: error }
+      }
+      if (!current[scopeKey]) return current
+      const next = { ...current }
+      delete next[scopeKey]
+      return next
+    })
+  }, [])
   const setComposerError = useCallback(
-    (error: string | null) => {
-      setComposerErrorByScope(current => {
-        if (error) {
-          if (current[projectChatScopeKey] === error) return current
-          return { ...current, [projectChatScopeKey]: error }
-        }
-        if (!current[projectChatScopeKey]) return current
-        const next = { ...current }
-        delete next[projectChatScopeKey]
-        return next
-      })
-    },
-    [projectChatScopeKey]
+    (error: string | null) => setComposerErrorForScope(projectChatScopeKey, error),
+    [projectChatScopeKey, setComposerErrorForScope]
   )
   const dismissTrialGuideForScope = useCallback(() => {
     if (trialPluginName.trim()) {
@@ -2370,6 +2371,7 @@ export function WorkbenchProvider({
       isModelSelectionReady: modelSelection.isSelectionReady,
       input: draftInput,
       composerError,
+      composerErrorByScope,
       trialTemplates,
       trialPluginName,
       trialPluginApp,
@@ -2393,6 +2395,7 @@ export function WorkbenchProvider({
       setInput: setDraftInput,
       setInputForScope: setDraftInputForScope,
       setComposerError,
+      setComposerErrorForScope,
       setSelectedSkills: skillSelection.setSelectedSkills,
       toggleSkill: skillSelection.toggleSkill,
       handleFileSelect: attachmentSelection.handleFileSelect,
@@ -2424,6 +2427,7 @@ export function WorkbenchProvider({
       draftInput,
       draftInputByScope,
       composerError,
+      composerErrorByScope,
       trialTemplates,
       trialPluginName,
       trialPluginApp,
@@ -2448,6 +2452,7 @@ export function WorkbenchProvider({
       setDraftInput,
       setDraftInputForScope,
       setComposerError,
+      setComposerErrorForScope,
       skillSelection.selectedSkills,
       skillSelection.setSelectedSkills,
       skillSelection.skills,
@@ -2466,6 +2471,7 @@ export function WorkbenchProvider({
       isModelSelectionReady: modelSelection.isSelectionReady,
       input: draftInput,
       composerError,
+      composerErrorByScope,
       trialTemplates,
       trialPluginName,
       trialPluginApp,
@@ -2489,6 +2495,7 @@ export function WorkbenchProvider({
       setInput: setDraftInput,
       setInputForScope: setDraftInputForScope,
       setComposerError,
+      setComposerErrorForScope,
       setSelectedSkills: skillSelection.setSelectedSkills,
       toggleSkill: skillSelection.toggleSkill,
       handleFileSelect: attachmentSelection.handleFileSelect,
@@ -2520,6 +2527,7 @@ export function WorkbenchProvider({
       draftInput,
       draftInputByScope,
       composerError,
+      composerErrorByScope,
       trialTemplates,
       trialPluginName,
       trialPluginApp,
@@ -2543,6 +2551,7 @@ export function WorkbenchProvider({
       setDraftInput,
       setDraftInputForScope,
       setComposerError,
+      setComposerErrorForScope,
       skillSelection.selectedSkills,
       skillSelection.setSelectedSkills,
       skillSelection.skills,

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -31,6 +31,7 @@ import {
 } from './runtimePaneMessages'
 import type { WorkbenchAction } from './workbenchReducer'
 import {
+  findRuntimeTask,
   getRuntimeTaskRouteKey,
   getRuntimeTaskWorkspacePath,
   isSameRuntimeTaskAddress,
@@ -287,8 +288,16 @@ export function useWorkbenchRuntimeTasks({
     ): Promise<ArchiveRuntimeConversationsResult> => {
       const archiveTargets = uniqueRuntimeTaskAddresses(addresses)
       if (archiveTargets.length === 0) return { status: 'archived' }
+      const localFailedTargets = archiveTargets.filter(address => {
+        const task = findRuntimeTask(state.runtimeWork, address)
+        return task?.status === 'failed' && task.optimistic === true
+      })
+      const persistedTargets = archiveTargets.filter(
+        address =>
+          !localFailedTargets.some(localAddress => isSameRuntimeTaskAddress(localAddress, address))
+      )
       const results = await Promise.all(
-        archiveTargets.map(async address => {
+        persistedTargets.map(async address => {
           try {
             return { address, response: await executorClient.runtime.archiveConversation(address) }
           } catch (error) {
@@ -296,9 +305,10 @@ export function useWorkbenchRuntimeTasks({
           }
         })
       )
-      const archivedAddresses = results.flatMap(result =>
-        result.response?.accepted ? [result.address] : []
-      )
+      const archivedAddresses = [
+        ...localFailedTargets,
+        ...results.flatMap(result => (result.response?.accepted ? [result.address] : [])),
+      ]
       let worktreeCleanupSucceeded = true
       if (archivedAddresses.length > 0) {
         await completeArchivedBoardTasks(archivedAddresses)

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -191,6 +191,7 @@ export interface WorkbenchContextValue {
     isModelSelectionReady: boolean
     input: string
     composerError?: string | null
+    composerErrorByScope?: Readonly<Record<string, string>>
     trialTemplates: PluginPathComponent[]
     trialPluginName?: string
     trialPluginApp?: LocalDeviceApp
@@ -214,6 +215,7 @@ export interface WorkbenchContextValue {
     setInput: (value: string) => void
     setInputForScope: (scopeKey: string, value: string) => void
     setComposerError?: (error: string | null) => void
+    setComposerErrorForScope?: (scopeKey: string, error: string | null) => void
     setSelectedSkills: (skills: SkillRef[]) => void
     toggleSkill: (skill: SkillRef) => void
     handleFileSelect: (files: File | File[]) => Promise<void>


### PR DESCRIPTION
## Summary
- keep task creation errors scoped to the failed optimistic task instead of leaking to a new chat
- archive failed optimistic placeholders locally so refresh does not restore them
- preserve the existing delayed archive and undo flow for normal runtime tasks

## Verification
- `pnpm --dir wework test -- src/features/workbench/WorkbenchProvider.test.tsx` (189 passed)
- `pnpm --dir wework test -- src/components/layout/DesktopSidebar.test.tsx -t "optimistically archives project runtime tasks with an undo notice"`
- `pnpm --dir wework typecheck`
- pre-push Wework ESLint, TypeScript, and unit-test checks