### PR TITLE
fix(wework): debounce IME draft flushes

### DIFF
--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -359,6 +359,26 @@ describe('BufferedChatInput', () => {
     expect(onChange).toHaveBeenLastCalledWith('draft')
   })
 
+  test('cancels a blur frame queued during composition before scheduling the debounce', () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
+
+    const input = screen.getByTestId('chat-message-input') as HTMLElement & { value: string }
+    fireEvent.compositionStart(input)
+    act(() => {
+      input.value = 'draft'
+    })
+    fireEvent.blur(input)
+    fireEvent.compositionEnd(input)
+
+    act(() => vi.advanceTimersByTime(299))
+    expect(onChange).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(onChange).toHaveBeenLastCalledWith('draft')
+  })
+
   test('preserves caller composition callbacks', () => {
     const onCompositionStart = vi.fn()
     const onCompositionEnd = vi.fn()

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -282,33 +282,43 @@ describe('BufferedChatInput', () => {
   })
 
   test('debounces onChange during the 300ms window', async () => {
+    vi.useFakeTimers()
     const onChange = vi.fn()
     render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
 
-    await userEvent.type(screen.getByTestId('chat-message-input'), 'draft')
+    const input = screen.getByTestId('chat-message-input') as HTMLElement & { value: string }
+    act(() => {
+      input.value = 'draft'
+    })
     // onChange must not fire synchronously with typing; it is deferred by the debounce.
     expect(onChange).not.toHaveBeenCalled()
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith('draft')
+    act(() => vi.advanceTimersByTime(299))
+    expect(onChange).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
     })
+    expect(onChange).toHaveBeenCalledWith('draft')
   })
 
-  test('flushes the draft on composition end before the debounce window elapses', async () => {
+  test('debounces the committed draft after composition ends', async () => {
+    vi.useFakeTimers()
     const onChange = vi.fn()
     render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
 
-    const input = screen.getByTestId('chat-message-input')
-    await userEvent.type(input, 'draft')
+    const input = screen.getByTestId('chat-message-input') as HTMLElement & { value: string }
+    fireEvent.compositionStart(input)
+    act(() => {
+      input.value = 'nihao'
+    })
+    fireEvent.compositionEnd(input)
+
+    act(() => vi.advanceTimersByTime(299))
     expect(onChange).not.toHaveBeenCalled()
 
-    // Composition end flushes on the next animation frame, well inside the
-    // 300ms debounce window, so onChange must fire without the debounce timer.
-    vi.useFakeTimers({ toFake: ['requestAnimationFrame'] })
-    fireEvent.compositionEnd(input)
-    vi.advanceTimersByTime(20)
-
-    expect(onChange).toHaveBeenLastCalledWith('draft')
+    act(() => vi.advanceTimersByTime(1))
+    expect(onChange).toHaveBeenLastCalledWith('nihao')
   })
 
   test('does not flush transient composition text after the debounce window', async () => {
@@ -327,21 +337,25 @@ describe('BufferedChatInput', () => {
   })
 
   test('cancels a queued frame flush when composition starts', async () => {
-    vi.useFakeTimers({ toFake: ['requestAnimationFrame'] })
+    vi.useFakeTimers()
     const onChange = vi.fn()
     render(<BufferedChatInput value="" onChange={onChange} onSubmit={vi.fn()} disabled={false} />)
 
-    const input = screen.getByTestId('chat-message-input')
-    await userEvent.type(input, 'draft')
+    const input = screen.getByTestId('chat-message-input') as HTMLElement & { value: string }
+    act(() => {
+      input.value = 'draft'
+    })
     fireEvent.blur(input)
     fireEvent.compositionStart(input)
-    vi.advanceTimersByTime(20)
+    act(() => vi.advanceTimersByTime(20))
 
     expect(onChange).not.toHaveBeenCalled()
 
     fireEvent.compositionEnd(input)
-    vi.advanceTimersByTime(20)
+    act(() => vi.advanceTimersByTime(299))
 
+    expect(onChange).not.toHaveBeenCalled()
+    act(() => vi.advanceTimersByTime(1))
     expect(onChange).toHaveBeenLastCalledWith('draft')
   })
 

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -110,13 +110,13 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   )
 
   const scheduleDraftFlush = useCallback(
-    (nextDraft: string) => {
+    (nextDraft: string, reason = 'debounce') => {
       cancelPendingFlush()
       pendingChangeRef.current = onChange
       flushTimeoutRef.current = window.setTimeout(() => {
         flushTimeoutRef.current = null
         recordComposerDiagnostic('draft-flush', {
-          reason: 'debounce',
+          reason,
           draftLength: nextDraft.length,
         })
         onChange(nextDraft)
@@ -206,9 +206,9 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   }, [cancelPendingFlush, cancelPendingFlushFrame, onParentCompositionStart])
   const handleCompositionEnd = useCallback(() => {
     isComposingRef.current = false
-    flushDraftNextFrame('composition-end')
+    scheduleDraftFlush(draftRef.current, 'composition-end-debounce')
     onParentCompositionEnd?.()
-  }, [flushDraftNextFrame, onParentCompositionEnd])
+  }, [onParentCompositionEnd, scheduleDraftFlush])
 
   const handleSubmit = useCallback(
     (valueOverride?: string, options?: ChatSubmitOptions) => {

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -206,9 +206,10 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   }, [cancelPendingFlush, cancelPendingFlushFrame, onParentCompositionStart])
   const handleCompositionEnd = useCallback(() => {
     isComposingRef.current = false
+    cancelPendingFlushFrame()
     scheduleDraftFlush(draftRef.current, 'composition-end-debounce')
     onParentCompositionEnd?.()
-  }, [onParentCompositionEnd, scheduleDraftFlush])
+  }, [cancelPendingFlushFrame, onParentCompositionEnd, scheduleDraftFlush])
 
   const handleSubmit = useCallback(
     (valueOverride?: string, options?: ChatSubmitOptions) => {


### PR DESCRIPTION
## Summary

- debounce committed IME draft synchronization instead of flushing on the next animation frame
- cancel pending blur frames before starting the composition-end debounce
- avoid re-rendering the workbench provider tree after every Chinese composition commit
- keep composition buffering and caller composition callbacks intact

## Root cause

Feedback WF-1A01FAED728 showed input frames as high as 632 ms. Each `compositionend` immediately propagated the draft to `WorkbenchProvider`, causing a broad synchronous re-render while the user was typing Chinese.

## Verification

- `pnpm --filter wework test src/components/layout/BufferedChatInput.test.tsx src/components/chat/composer/ComposerProseMirrorEditor.test.tsx src/components/chat/composer/ComposerTextarea.test.tsx` — 98 passed
- `pnpm --filter wework exec prettier --check src/components/layout/BufferedChatInput.tsx src/components/layout/BufferedChatInput.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/BufferedChatInput.tsx src/components/layout/BufferedChatInput.test.tsx`
- repository pre-push gate — ESLint, TypeScript and Wework unit tests passed
- isolated real Tauri session — mixed Chinese/English input remained intact after the debounced parent draft synchronization

## Documentation

No documentation changes: this only adjusts internal composer synchronization timing and does not change user-facing behavior or APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat draft handling during typing and composition input.
  * Draft updates now consistently wait for the debounce interval before being committed, including after composition ends.
  * Improved cancellation of pending draft updates to prevent premature commits.
  * Prevented blur-related updates from being committed while composition is still in progress.
  * Improved consistency when rapidly changing, composing, or leaving a chat input field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->