### PR TITLE
fix(wework): resolve hidden vision sidecar models

### DIFF
--- a/backend/app/services/model_aggregation_service.py
+++ b/backend/app/services/model_aggregation_service.py
@@ -46,6 +46,11 @@ from shared.codex_model_catalog import codex_catalog_model_id_from_config
 
 logger = logging.getLogger(__name__)
 
+VISION_SIDECAR_API_FORMATS = frozenset(
+    {"openai-responses", "openai-chat-completions", "anthropic-messages"}
+)
+VisionSidecarIdentity = tuple[str, str, str, int, str]
+
 
 def _normalize_runtime_family_part(value: Any) -> Optional[str]:
     if not isinstance(value, str):
@@ -66,6 +71,51 @@ def build_model_runtime_family(
         return provider_key
 
     return f"{provider_key}.{protocol_key}"
+
+
+def _vision_sidecar_reference_identity(value: Any) -> Optional[VisionSidecarIdentity]:
+    if not isinstance(value, dict):
+        return None
+    model_name = value.get("modelName")
+    model_type = value.get("modelType")
+    namespace = value.get("namespace")
+    resource_user_id = value.get("resourceUserId")
+    api_format = value.get("apiFormat")
+    if (
+        not isinstance(model_name, str)
+        or not model_name.strip()
+        or model_type not in {"public", "user", "group"}
+        or not isinstance(namespace, str)
+        or not namespace.strip()
+        or isinstance(resource_user_id, bool)
+        or not isinstance(resource_user_id, int)
+        or resource_user_id < 0
+        or api_format not in VISION_SIDECAR_API_FORMATS
+    ):
+        return None
+    return (
+        model_name.strip(),
+        model_type,
+        namespace.strip(),
+        resource_user_id,
+        api_format,
+    )
+
+
+def _vision_sidecar_api_format(config: Dict[str, Any]) -> Optional[str]:
+    protocol = _normalize_runtime_family_part(config.get("protocol"))
+    api_format = _normalize_runtime_family_part(
+        config.get("apiFormat") or config.get("api_format") or config.get("wire_api")
+    )
+    if protocol == "openai-responses" or api_format == "responses":
+        return "openai-responses"
+    if protocol in {"anthropic-messages", "claude"}:
+        return "anthropic-messages"
+    if protocol in {"openai-chat-completions", "openai"} or api_format == (
+        "chat/completions"
+    ):
+        return "openai-chat-completions"
+    return None
 
 
 class ModelType(str, Enum):
@@ -121,6 +171,7 @@ class UnifiedModel:
         created_at: Optional[Any] = None,
         updated_at: Optional[Any] = None,
         is_reference: bool = False,
+        is_vision_sidecar_reference: bool = False,
     ):
         self.name = name
         self.type = model_type
@@ -145,6 +196,7 @@ class UnifiedModel:
         self.created_at = created_at
         self.updated_at = updated_at
         self.is_reference = is_reference
+        self.is_vision_sidecar_reference = is_vision_sidecar_reference
         self.runtime_family = runtime_family or build_model_runtime_family(
             provider, self.config
         )
@@ -194,7 +246,21 @@ class UnifiedModel:
         }
         if self.resource_user_id is not None:
             result["resourceUserId"] = self.resource_user_id
+        if self.is_vision_sidecar_reference:
+            result["isVisionSidecarReference"] = True
         return result
+
+    def vision_sidecar_identity(self) -> Optional[VisionSidecarIdentity]:
+        api_format = _vision_sidecar_api_format(self.config)
+        if api_format is None or self.resource_user_id is None:
+            return None
+        return (
+            self.name,
+            self.type.value,
+            self.namespace,
+            self.resource_user_id,
+            api_format,
+        )
 
     def to_full_dict(self) -> Dict[str, Any]:
         """Convert to full dictionary without exposing sensitive env values."""
@@ -491,6 +557,39 @@ class ModelAggregationService:
             model_sub_group=CODEX_RUNTIME_MODEL_SUB_GROUP,
         )
 
+    @staticmethod
+    def _append_wework_vision_sidecar_references(
+        models: List[UnifiedModel], candidates: List[UnifiedModel]
+    ) -> None:
+        referenced_identities = {
+            identity
+            for model in models
+            if (
+                identity := _vision_sidecar_reference_identity(
+                    model.config.get("visionSidecarModel")
+                )
+            )
+            is not None
+        }
+        existing_identities = {
+            identity
+            for model in models
+            if (identity := model.vision_sidecar_identity()) is not None
+        }
+        for candidate in candidates:
+            identity = candidate.vision_sidecar_identity()
+            if (
+                identity is None
+                or identity not in referenced_identities
+                or identity in existing_identities
+                or not candidate.is_active
+                or (candidate.model_capabilities or {}).get("supportsImage") is not True
+            ):
+                continue
+            candidate.is_vision_sidecar_reference = True
+            models.append(candidate)
+            existing_identities.add(identity)
+
     def list_available_models(
         self,
         db: Session,
@@ -547,6 +646,7 @@ class ModelAggregationService:
             )
 
         result: List[UnifiedModel] = []
+        vision_reference_candidates: List[UnifiedModel] = []
         seen_names: Dict[str, ModelType] = {}  # Track names to handle duplicates
 
         # Determine which namespaces to query based on scope
@@ -631,17 +731,6 @@ class ModelAggregationService:
                 ):
                     continue
 
-                # Filter out models not enabled for wework
-                if (
-                    client_origin == CLIENT_ORIGIN_WEWORK
-                    and not self._is_model_available_in_wework(model_data)
-                ):
-                    continue
-
-                # Deduplicate by name
-                if resource.name in seen_names:
-                    continue
-
                 unified = UnifiedModel(
                     name=resource.name,
                     model_type=resource_type,  # Use determined type (USER or GROUP)
@@ -665,6 +754,16 @@ class ModelAggregationService:
                     updated_at=resource.updated_at,
                     is_reference=resource.id in referenced_ids,
                 )
+                vision_reference_candidates.append(unified)
+                # Exact sidecar identities still need to remain resolvable when
+                # a selectable model with the same name won catalog precedence.
+                if resource.name in seen_names:
+                    continue
+                if (
+                    client_origin == CLIENT_ORIGIN_WEWORK
+                    and not self._is_model_available_in_wework(model_data)
+                ):
+                    continue
                 result.append(unified)
                 seen_names[resource.name] = resource_type
 
@@ -699,12 +798,6 @@ class ModelAggregationService:
             ):
                 continue
 
-            # Filter out public models not enabled for wework
-            if client_origin == CLIENT_ORIGIN_WEWORK and not model_dict.get(
-                "is_wework_available", False
-            ):
-                continue
-
             unified = UnifiedModel(
                 name=model_dict.get("name", ""),
                 model_type=ModelType.PUBLIC,  # Mark as public model
@@ -730,6 +823,11 @@ class ModelAggregationService:
                 created_at=model_dict.get("created_at"),
                 updated_at=model_dict.get("updated_at"),
             )
+            vision_reference_candidates.append(unified)
+            if client_origin == CLIENT_ORIGIN_WEWORK and not model_dict.get(
+                "is_wework_available", False
+            ):
+                continue
 
             # If name already exists as user model, we still add public model
             # The type field will differentiate them
@@ -742,6 +840,11 @@ class ModelAggregationService:
             result.append(unified)
             if model_name not in seen_names:
                 seen_names[model_name] = ModelType.PUBLIC
+
+        if client_origin == CLIENT_ORIGIN_WEWORK:
+            self._append_wework_vision_sidecar_references(
+                result, vision_reference_candidates
+            )
 
         # Sort by name
         result.sort(key=lambda x: x.name)

--- a/backend/tests/services/test_model_aggregation_service.py
+++ b/backend/tests/services/test_model_aggregation_service.py
@@ -8,6 +8,8 @@ Tests for ModelAggregationService.
 Focuses on testing model compatibility filtering for custom shells.
 """
 
+from typing import Any, Optional
+
 import pytest
 from sqlalchemy.orm import Session
 
@@ -1101,6 +1103,87 @@ class TestModelAggregationService:
         assert "user-wework-model" in names
         assert "public-no-wework" not in names
         assert "user-no-wework" not in names
+
+    def test_wework_includes_hidden_explicit_vision_sidecar_reference(
+        self, test_db: Session, test_user: User, monkeypatch
+    ):
+        """A valid sidecar target stays resolvable without becoming selectable."""
+        reference = {
+            "modelName": "hidden-vision-sidecar",
+            "modelType": "public",
+            "namespace": "default",
+            "resourceUserId": 0,
+            "apiFormat": "openai-chat-completions",
+        }
+
+        def public_model(
+            name: str,
+            *,
+            is_wework_available: bool = False,
+            supports_image: bool = False,
+            vision_sidecar: Optional[dict[str, Any]] = None,
+        ) -> Kind:
+            is_sidecar = name == "hidden-vision-sidecar"
+            spec: dict[str, Any] = {
+                "protocol": "openai" if is_sidecar else "openai-responses",
+                **({"apiFormat": "chat/completions"} if is_sidecar else {}),
+                "modelConfig": {
+                    "env": {"model": "openai", "model_id": name},
+                    **(
+                        {"visionSidecarModel": vision_sidecar} if vision_sidecar else {}
+                    ),
+                },
+                "modelCapabilities": {"supportsImage": supports_image},
+            }
+            if is_wework_available:
+                spec["isWeworkAvailable"] = True
+            return Kind(
+                user_id=0,
+                kind="Model",
+                name=name,
+                namespace="default",
+                json={
+                    "apiVersion": "agent.wecode.io/v1",
+                    "kind": "Model",
+                    "metadata": {"name": name, "namespace": "default"},
+                    "spec": spec,
+                    "status": {"state": "Available"},
+                },
+                is_active=True,
+            )
+
+        primary = public_model(
+            "visible-text-primary",
+            is_wework_available=True,
+            vision_sidecar=reference,
+        )
+        sidecar = public_model("hidden-vision-sidecar", supports_image=True)
+        unrelated = public_model("unreferenced-hidden-vision", supports_image=True)
+        test_db.add_all([primary, sidecar, unrelated])
+        test_db.commit()
+        monkeypatch.setattr(
+            "app.services.model_aggregation_service.kind_service.list_resources",
+            lambda user_id, kind, namespace: [],
+        )
+
+        models = model_aggregation_service.list_available_models(
+            db=test_db,
+            current_user=test_user,
+            scope="all",
+            model_category_type="llm",
+            client_origin="wework",
+            include_config=True,
+        )
+        models_by_name = {model["name"]: model for model in models}
+
+        assert (
+            models_by_name["visible-text-primary"]["config"]["visionSidecarModel"]
+            == reference
+        )
+        assert (
+            models_by_name["hidden-vision-sidecar"]["isVisionSidecarReference"] is True
+        )
+        assert "unreferenced-hidden-vision" not in models_by_name
 
     def test_frontend_lists_models_regardless_of_wework_flag(
         self, test_db: Session, test_user: User, monkeypatch

--- a/wework/e2e/desktop/modules/cloud-environment.mjs
+++ b/wework/e2e/desktop/modules/cloud-environment.mjs
@@ -665,7 +665,6 @@ class RealCloudEnvironment {
         protocol: 'openai',
         apiFormat: 'chat/completions',
         modelType: 'llm',
-        isWeworkAvailable: true,
         modelCapabilities: {
           supportsImage: true,
         },
@@ -673,7 +672,7 @@ class RealCloudEnvironment {
     })
 
     const unifiedModels = await fetchJson(
-      `${this.backendUrl}/api/models/unified?include_config=true&scope=all&model_category_type=llm&client_origin=wework`,
+      `${this.backendUrl}/api/models/unified?include_config=true&scope=all&model_category_type=llm&client_origin=frontend`,
       { headers }
     )
     const sidecar = unifiedModels.data?.find(
@@ -716,6 +715,19 @@ class RealCloudEnvironment {
         isWeworkAvailable: true,
       },
     })
+
+    const weworkModels = await fetchJson(
+      `${this.backendUrl}/api/models/unified?include_config=true&scope=all&model_category_type=llm&client_origin=wework`,
+      { headers }
+    )
+    const hiddenSidecar = weworkModels.data?.find(
+      model => model.name === sidecar.name && model.type === sidecar.type
+    )
+    assert.equal(
+      hiddenSidecar?.isVisionSidecarReference,
+      true,
+      'The non-selectable cloud vision sidecar was not returned as a hidden reference'
+    )
 
     await createModel({
       apiVersion: 'agent.wecode.io/v1',

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -688,7 +688,7 @@ describe('createHybridWorkbenchServices', () => {
     expect(response.data[1]).toEqual(responsesModel)
   })
 
-  it('keeps only explicit cloud vision references that resolve to an available image model', async () => {
+  it('resolves hidden cloud vision references without exposing them as primary models', async () => {
     const visionModel = {
       name: 'cloud-vision',
       type: 'public',
@@ -699,6 +699,7 @@ describe('createHybridWorkbenchServices', () => {
       config: { protocol: 'openai-responses' },
       runtime: { family: 'openai.openai-responses' },
       isActive: true,
+      isVisionSidecarReference: true,
     }
     const reference = {
       modelName: visionModel.name,
@@ -737,10 +738,11 @@ describe('createHybridWorkbenchServices', () => {
     await services.modelApi.listModels()
     await vi.waitFor(async () => {
       const refreshed = await services.modelApi.listModels()
-      expect(refreshed.data).toHaveLength(3)
+      expect(refreshed.data).toHaveLength(2)
     })
     const response = await services.modelApi.listModels()
 
+    expect(response.data.map(model => model.name)).not.toContain(visionModel.name)
     expect(
       response.data.find(model => model.name === configuredDeepSeek.name)?.config
     ).toMatchObject({ visionSidecarModel: reference })

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -146,20 +146,22 @@ function annotateLocalModels(models: UnifiedModel[]): UnifiedModel[] {
 
 function annotateCloudModels(models: UnifiedModel[]): UnifiedModel[] {
   const compatibleModels = models.filter(supportsCloudExecution)
-  return compatibleModels.map(model => {
-    const config = recordValue(model.config)
-    if (!Object.hasOwn(config, 'visionSidecarModel')) return model
-    const visionSidecarModel = resolveCloudVisionSidecarReference(
-      config.visionSidecarModel,
-      compatibleModels
-    )
-    if (visionSidecarModel) {
-      return { ...model, config: { ...config, visionSidecarModel } }
-    }
-    const sanitizedConfig = { ...config }
-    delete sanitizedConfig.visionSidecarModel
-    return { ...model, config: sanitizedConfig }
-  })
+  return compatibleModels
+    .filter(model => model.isVisionSidecarReference !== true)
+    .map(model => {
+      const config = recordValue(model.config)
+      if (!Object.hasOwn(config, 'visionSidecarModel')) return model
+      const visionSidecarModel = resolveCloudVisionSidecarReference(
+        config.visionSidecarModel,
+        compatibleModels
+      )
+      if (visionSidecarModel) {
+        return { ...model, config: { ...config, visionSidecarModel } }
+      }
+      const sanitizedConfig = { ...config }
+      delete sanitizedConfig.visionSidecarModel
+      return { ...model, config: sanitizedConfig }
+    })
 }
 
 function normalizedModelId(model: UnifiedModel): string {

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -2667,6 +2667,7 @@ export interface UnifiedModel {
   config?: Record<string, unknown>
   runtime?: ModelRuntime | null
   isActive?: boolean
+  isVisionSidecarReference?: boolean
   compatibilityDisabled?: boolean
   compatibilityDisabledReason?: ModelCompatibilityDisabledReason
 }


### PR DESCRIPTION
## Summary

- return exact vision Sidecar targets to Wework as hidden reference-only model entries, even when those models are intentionally unavailable as primary Wework selections
- preserve fail-closed Sidecar validation by requiring an accessible, active, image-capable target with an exact name/type/namespace/resource-owner/API-format identity
- remove reference-only entries from Wework's selectable primary-model list after using them to validate configured Sidecars
- extend unit and real desktop E2E coverage for a text-only primary model backed by a non-selectable vision Sidecar

## Root cause

The validation introduced in #2780 resolves each explicit `visionSidecarModel` against Wework's unified model response. That fail-closed behavior is correct, but the backend filtered out every model without `isWeworkAvailable`, including models that were deliberately configured only as vision Sidecars. Wework therefore could not resolve the exact referenced identity, removed `visionSidecarModel`, and launched the text-only primary model without a vision caller. The observed OCR/computer-tool behavior was the resulting text-only catalog behavior, not a Sidecar request failure.

A read-only production check confirmed the affected DeepSeek text primaries explicitly reference an active, image-capable Qwen target that is not marked Wework-selectable. Read-only model telemetry also showed earlier Wework Sidecar requests reaching that target, followed by later DeepSeek Wework traffic without the corresponding Sidecar calls. The later vision-preprocessor change in #2839 does not remove the reference and is not the cause.

## Safety invariants

- hidden models are returned only when an already-visible Wework primary explicitly references their full identity
- the target must be accessible in the current aggregation scope, active, image-capable, and use a supported API format
- reference-only targets carry `isVisionSidecarReference: true` and never appear as selectable primary models
- invalid or unresolved references remain removed by the existing client-side validation

## Verification

- `cd backend && uv run pytest tests/services/test_model_aggregation_service.py -q` — 32 passed
- `pnpm --filter wework test src/api/hybrid/hybridServices.test.ts src/features/workbench/runtimeModelSelection.test.ts src/features/cloud-connection/modelExecution.test.ts src/api/local/localServices.test.ts` — 142 passed
- `pnpm --filter wework typecheck` — passed
- Prettier and ESLint on all changed Wework files — passed
- Black, isort, syntax, settings, and Alembic multi-head checks — passed
- repository pre-push Wework ESLint, TypeScript, and complete unit suite — passed
- `pnpm --filter wework e2e:desktop:cloud-vision` with the CI Python 3.12 runtime — passed against a real Tauri app, real backend, bundled Codex 0.147.0, and observable main/Sidecar model requests
