### PR TITLE
fix(wework): move PR status to task leading area

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -1,48 +1,80 @@
-**Comparison Target**
+# Design QA
 
-- Source visual truth: `/Users/hongyu9/.wework/workspace/attachments/draft/1787208914557/image.png`
-- IME defect evidence: `/Users/hongyu9/.wework/workspace/attachments/draft/1787209843976/image.png`
-- Implementation screenshot: `/Volumes/OuterHD/OuterIdeaProjects/Wegent/wework/test-results/ai-verify/issue-composer-rich-editor.png`
-- Rich-content screenshot: `/Volumes/OuterHD/OuterIdeaProjects/Wegent/wework/test-results/ai-verify/issue-composer-rich-editor-content.png`
-- Combined comparison: `/Volumes/OuterHD/OuterIdeaProjects/Wegent/wework/test-results/ai-verify/issue-composer-comparison.png`
-- State: Wework real Tauri app, light theme, local “我的任务” project, fullscreen new-Issue editor.
-- Viewport and density: implementation capture `2560 × 1440` physical pixels, approximately `1280 × 720` CSS pixels at `2×`; source capture `3840 × 1996` physical pixels. Both were proportionally fitted to `1280 × 720` canvases before the side-by-side comparison.
+- Source visual truth:
+  `/Users/axb-mac/.wework/workspace/attachments/draft/1787287286894/image.png`
+- Implementation screenshot:
+  `wework/test-results/ai-verify/2026-08-21T04-44-50-868Z-22271/pr-status-left.png`
+- Focused comparison:
+  `wework/test-results/ai-verify/2026-08-21T04-44-50-868Z-22271/pr-status-comparison.png`
+- Popover screenshot:
+  `wework/test-results/ai-verify/2026-08-21T04-44-50-868Z-22271/pr-status-popover.png`
+- Viewport: 1600 × 900 CSS px in the isolated Tauri WebView.
+- Pixel dimensions: source 544 × 400 px; implementation 2560 × 1440 px.
+- Density normalization: the implementation capture uses the desktop display density;
+  the focused comparison crops the implementation and places both references on
+  600 × 430 px canvases. The source and implementation have different themes and
+  content, so the comparison evaluates the requested task-row placement rather
+  than whole-screen pixel parity.
+- State: expanded project with a selected task linked to GitHub PR #2886; PR checks
+  are pending.
 
-**Full-view Comparison**
+## Full-view comparison evidence
 
-- The title, property controls, divider, editor column, footer, radii, neutral colors, and panel elevation remain consistent with the supplied screen.
-- The description region now fills the available vertical space. The Markdown/file hint is anchored at the bottom of that region instead of appearing near the middle of the page.
-- The plain textarea has been replaced by the existing BlockNote editor, preserving the product’s Notion-like block controls, Markdown shortcuts, slash commands, nested lists, and semantic headings.
+The real Tauri capture shows the PR status trigger at the leading edge of the task
+row, inside the indentation area before the title. The task title starts immediately
+after the 24 px trigger and remains aligned with the task content. Trailing task
+metadata and runtime state remain at the right edge.
 
-**Focused Region Comparison**
+Measured CSS boxes:
 
-- The supplied red-box region was inspected against the lower editor region in the implementation screenshot. The misplaced helper text is resolved and no longer indicates a prematurely ended input area.
-- The editor content region was inspected in the real Tauri rich-content screenshot. Typography, spacing, foreground/background balance, and copy use existing Wework tokens; no new raster or decorative assets are involved.
+- Task row: x 6–234, height 30 px.
+- PR status trigger: x 14–38, size 24 × 24 px.
+- Task title: x 42–174, height 20 px.
+- Open status popover: x 14–270, size 256 × 103 px.
 
-**Required Fidelity Surfaces**
+## Focused region comparison evidence
 
-- Fonts and typography: existing Wework semantic typography is preserved; title, metadata, body, hint, and footer retain the expected hierarchy.
-- Spacing and layout rhythm: the editor is a flex-filling region with a stable minimum height; the footer remains fixed and visible.
-- Colors and visual tokens: unchanged neutral Wework tokens; no new literal application-chrome colors.
-- Image quality and assets: no visual assets were added or replaced.
-- Copy and content: existing localized title, placeholder, Markdown/file hint, draft status, and submit copy are preserved.
+The side-by-side focused comparison confirms the requested structural change:
+the source marks a blank leading column, and the implementation now uses that
+column for the PR/MR status while preserving the title and trailing metadata
+regions. The status popover opens from the left-aligned trigger toward the content
+area instead of extending off the outer edge.
 
-**Comparison History**
+## Required fidelity surfaces
 
-- Earlier P1: the fixed-height textarea ended around the upper half of the fullscreen panel, leaving the helper text visually stranded. Fix: made the document column and description region consume the remaining height and gave the block editor a full-height container. Post-fix evidence: `issue-composer-comparison.png`.
-- Earlier P1: the fullscreen description was a raw textarea rather than a Typora/Notion-style editing surface. Fix: reused the existing BlockNote Markdown editor and retained file paste/drop behavior. Post-fix evidence: `issue-composer-rich-editor.png` and `issue-composer-rich-editor-content.png`.
-- Earlier P1: confirming Chinese Pinyin with Space inside a nested list could leave intermediate pinyin and committed Chinese as separate content. Fix: editor changes are buffered during native composition and published only after WebKit finalizes `compositionend`; Space and ordinary Enter remain untouched. Post-fix evidence: focused IME regression tests.
+- Fonts and typography: unchanged existing Wework typography is preserved. The
+  title keeps its existing size, weight, line height, and truncation.
+- Spacing and layout rhythm: passed. The 24 px status trigger plus 4 px gap consumes
+  the previous 28 px leading indentation without shifting the normal task title.
+- Colors and visual tokens: passed. Existing semantic status colors and sidebar
+  tokens are unchanged.
+- Image quality and asset fidelity: not applicable; the change reuses the existing
+  Lucide status icons and does not add raster or custom-drawn assets.
+- Copy and content: unchanged. Existing PR/MR labels, task titles, tooltips, and
+  actions remain intact.
 
-**Interaction Verification**
+## Findings
 
-- Opened the new-Issue composer and expanded it in an isolated real Tauri session.
-- Verified the description is `contenteditable`, occupies the fullscreen document region, accepts content, and keeps the footer visible.
-- Verified title and editor updates, draft autosave state, fullscreen layout, and rich editor rendering.
-- Unit coverage verifies Markdown loading/emission, file paste/drop, draft persistence, creation, continuous creation, IME Space confirmation buffering, and first-press Enter after composition.
-- Real-Tauri debug logs were checked; no browser console error was recorded for the changed flow.
+No actionable P0, P1, or P2 visual mismatches remain within the requested scope.
 
-**Residual Test Gap**
+## Interaction verification
 
-- Automated desktop control cannot drive the macOS Chinese candidate window itself. The composition/Space state boundary and first-press Enter behavior are covered directly in regression tests, while the same editor is verified in real Tauri.
+- Clicking the leading PR status trigger opens its details popover.
+- The popover remains visible and opens toward the task content area.
+- The trigger retains its existing accessible label and test ID.
+- The selected task row and its title remain clickable outside the trigger.
+- No app errors were observed during the primary interaction.
+
+## Comparison history
+
+Initial implementation placed the PR/MR status after the title and split-group
+metadata. The implementation moved it before the title with a negative leading
+margin that exactly offsets its width and gap, then changed the task-list popover
+alignment to open from the trigger's left edge. The post-fix real-Tauri screenshots
+and element metrics above confirm the final placement.
+
+## Follow-up polish
+
+No P3 follow-up is required for this focused change.
 
 final result: passed

--- a/wework/src/components/common/ChangeRequestStatusIcon.test.tsx
+++ b/wework/src/components/common/ChangeRequestStatusIcon.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import type { TaskChangeRequestSnapshot } from '@/api/changeRequests'
 import { ChangeRequestStatusIcon } from './ChangeRequestStatusIcon'
@@ -34,5 +35,48 @@ describe('ChangeRequestStatusIcon', () => {
     expect(screen.getByTestId('merged-change-request').querySelector('svg')).toHaveClass(
       'text-violet-500'
     )
+  })
+
+  it('supports positioning the trigger and opening the popover toward the content area', async () => {
+    const snapshot: TaskChangeRequestSnapshot = {
+      target: {
+        deviceId: 'local',
+        taskId: 'task-48',
+        workspacePath: '/workspace',
+        remoteUrl: 'https://github.com/wecode-ai/Wegent.git',
+        branch: 'feature/pr-status',
+      },
+      changeRequest: {
+        provider: 'github',
+        number: 48,
+        url: 'https://github.com/wecode-ai/Wegent/pull/48',
+        title: 'Show PR status',
+        state: 'open',
+        draft: false,
+        checks: 'pending',
+        mergeability: 'unknown',
+        mergeQueue: 'not_queued',
+      },
+      fetchedAt: '2026-08-21T00:00:00Z',
+      stale: false,
+      error: null,
+    }
+
+    render(
+      <ChangeRequestStatusIcon
+        snapshot={snapshot}
+        testId="positioned-change-request"
+        className="-ml-7 mr-1"
+        popoverAlign="left"
+      />
+    )
+
+    const trigger = screen.getByTestId('positioned-change-request')
+    expect(trigger.parentElement?.parentElement).toHaveClass('-ml-7', 'mr-1')
+
+    await userEvent.click(trigger)
+
+    expect(screen.getByTestId('positioned-change-request-popover')).toHaveClass('left-0')
+    expect(screen.getByTestId('positioned-change-request-popover')).not.toHaveClass('right-0')
   })
 })

--- a/wework/src/components/common/ChangeRequestStatusIcon.tsx
+++ b/wework/src/components/common/ChangeRequestStatusIcon.tsx
@@ -44,11 +44,15 @@ export function ChangeRequestStatusIcon({
   testId,
   repairing = false,
   onContinueRepair,
+  className,
+  popoverAlign = 'right',
 }: {
   snapshot: TaskChangeRequestSnapshot | null
   testId: string
   repairing?: boolean
   onContinueRepair?: () => Promise<void> | void
+  className?: string
+  popoverAlign?: 'left' | 'right'
 }) {
   const { t } = useTranslation('common')
   const [open, setOpen] = useState(false)
@@ -61,7 +65,10 @@ export function ChangeRequestStatusIcon({
   const prefix = changeRequest.provider === 'gitlab' ? '!' : '#'
 
   return (
-    <span className="relative inline-flex shrink-0" onClick={event => event.stopPropagation()}>
+    <span
+      className={cn('relative inline-flex shrink-0', className)}
+      onClick={event => event.stopPropagation()}
+    >
       <Tooltip label={`${prefix}${changeRequest.number} · ${label}`}>
         <button
           type="button"
@@ -77,7 +84,10 @@ export function ChangeRequestStatusIcon({
       {open ? (
         <span
           data-testid={`${testId}-popover`}
-          className="absolute right-0 top-7 z-50 w-64 rounded-xl border border-border bg-popover p-3 text-left shadow-lg"
+          className={cn(
+            'absolute top-7 z-50 w-64 rounded-xl border border-border bg-popover p-3 text-left shadow-lg',
+            popoverAlign === 'left' ? 'left-0' : 'right-0'
+          )}
         >
           <span className="block truncate text-sm font-medium text-text-primary">
             {prefix}

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1735,6 +1735,19 @@ function RuntimeTaskRow({
             (archivePending || archiving) && 'hidden'
           )}
         >
+          <ChangeRequestStatusIcon
+            snapshot={changeRequestSnapshot}
+            testId={`runtime-local-task-change-request-${task.taskId}`}
+            repairing={repairingChangeRequest}
+            onContinueRepair={
+              changeRequestSnapshot?.changeRequest &&
+              autoRepairStatus(changeRequestSnapshot.changeRequest)
+                ? continueChangeRequestRepair
+                : undefined
+            }
+            className={priorityLayout ? 'mr-1' : '-ml-7 mr-1'}
+            popoverAlign="left"
+          />
           {priorityLayout ? (
             <span className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
               <span
@@ -1818,17 +1831,6 @@ function RuntimeTaskRow({
               <span>{splitGroup.displayNumber}</span>
             </span>
           ) : null}
-          <ChangeRequestStatusIcon
-            snapshot={changeRequestSnapshot}
-            testId={`runtime-local-task-change-request-${task.taskId}`}
-            repairing={repairingChangeRequest}
-            onContinueRepair={
-              changeRequestSnapshot?.changeRequest &&
-              autoRepairStatus(changeRequestSnapshot.changeRequest)
-                ? continueChangeRequestRepair
-                : undefined
-            }
-          />
           <span
             data-testid={`runtime-local-task-trailing-${task.taskId}`}
             className={cn(


### PR DESCRIPTION
## Summary

- move the task PR/MR status trigger into the unused leading indentation area
- preserve the task title and trailing metadata positions
- align the PR/MR details popover toward the sidebar content area
- add component coverage and refresh the real-Tauri design QA evidence

## Verification

- `pnpm --filter wework test src/components/common/ChangeRequestStatusIcon.test.tsx src/components/layout/DesktopSidebar.test.tsx` (110 tests)
- `pnpm --filter wework exec prettier --check src/components/common/ChangeRequestStatusIcon.tsx src/components/common/ChangeRequestStatusIcon.test.tsx src/components/layout/DesktopSidebar.tsx`
- `pnpm --filter wework exec eslint src/components/common/ChangeRequestStatusIcon.tsx src/components/common/ChangeRequestStatusIcon.test.tsx src/components/layout/DesktopSidebar.tsx`
- pre-push Wework ESLint, TypeScript, and unit tests
- isolated real-Tauri verification with GitHub PR #2886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added flexible positioning and popover alignment for change request status controls.
  - Improved task-row status controls with left-aligned popovers for better visibility in priority layouts.

- **Bug Fixes**
  - Updated status control placement to prevent overlap and improve access within task rows.

- **Tests**
  - Added coverage verifying custom positioning and popover alignment behavior.

- **Documentation**
  - Updated QA reporting to reflect task-row status controls and current verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->