### PR TITLE
feat(macos): enable acceptFirstMouse for window configuration

### DIFF
--- a/wework/src-tauri/tauri.conf.json
+++ b/wework/src-tauri/tauri.conf.json
@@ -21,6 +21,7 @@
         "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "acceptFirstMouse": true,
         "decorations": true,
         "transparent": false,
         "dragDropEnabled": false,
@@ -38,9 +39,7 @@
         "enable": true,
         "scope": {
           "requireLiteralLeadingDot": false,
-          "allow": [
-            "**/*"
-          ]
+          "allow": ["**/*"]
         }
       }
     }
@@ -56,10 +55,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": [
-      "binaries/wegent-executor",
-      "binaries/dws"
-    ],
+    "externalBin": ["binaries/wegent-executor", "binaries/dws"],
     "resources": [
       "binaries/codex/**/*",
       "bundled-execution-runtimes/*",

--- a/wework/src/test/macos-window-chrome.test.ts
+++ b/wework/src/test/macos-window-chrome.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest'
 interface TauriWindowConfig {
   titleBarStyle?: string
   hiddenTitle?: boolean
+  acceptFirstMouse?: boolean
   decorations?: boolean
   transparent?: boolean
   windowEffects?: unknown
@@ -38,6 +39,7 @@ describe('macOS window chrome', () => {
 
     expect(mainWindow.titleBarStyle).toBe('Overlay')
     expect(mainWindow.hiddenTitle).toBe(true)
+    expect(mainWindow.acceptFirstMouse).toBe(true)
     expect(mainWindow.decorations).toBe(true)
     expect(mainWindow.transparent).toBe(false)
     expect(mainWindow).not.toHaveProperty('windowEffects')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS window interaction by allowing clicks to activate the app immediately.

* **Tests**
  * Added coverage to verify the enhanced macOS window behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->