### PR TITLE
perf(wework): speed up pre-push unit tests

### DIFF
--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -384,7 +384,7 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
         echo -e "   ${YELLOW}   Run 'pnpm install' from the repository root to install dependencies${NC}"
         WARNINGS+=("Wework: node_modules not found, checks skipped")
     else
-        echo -e "   Running ESLint, TypeScript, and unit tests in parallel..."
+        echo -e "   Running ESLint and TypeScript in parallel..."
 
         pnpm --filter wework lint > "$TEMP_DIR/wework_eslint.log" 2>&1 &
         ESLINT_PID=$!
@@ -392,16 +392,19 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
         pnpm --filter wework typecheck > "$TEMP_DIR/wework_tsc.log" 2>&1 &
         TSC_PID=$!
 
-        pnpm --filter wework test > "$TEMP_DIR/wework_test.log" 2>&1 &
-        TEST_PID=$!
-
         wait "$ESLINT_PID"
         ESLINT_EXIT=$?
 
         wait "$TSC_PID"
         TSC_EXIT=$?
 
-        wait "$TEST_PID"
+        # Vitest's jsdom workers are CPU and memory intensive. Let the suite use
+        # the machine after the static checks finish instead of making all three
+        # processes contend for the same resources.
+        WEWORK_TEST_WORKERS="${WEWORK_PRE_PUSH_TEST_WORKERS:-4}"
+        echo -e "   Running unit tests with $WEWORK_TEST_WORKERS workers..."
+        VITEST_MAX_WORKERS="$WEWORK_TEST_WORKERS" \
+            pnpm --filter wework test > "$TEMP_DIR/wework_test.log" 2>&1
         TEST_EXIT=$?
 
         if [ $ESLINT_EXIT -eq 0 ]; then

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -179,6 +179,21 @@ if ! grep -qE '^pnpm --filter wework test$' "$CALL_LOG"; then
     exit 1
 fi
 
+if ! grep -qE 'Running unit tests with 4 workers' "$WEWORK_TEST_OUT"; then
+    echo "Expected Wework pre-push tests to use four workers by default."
+    cat "$WEWORK_TEST_OUT"
+    exit 1
+fi
+
+STATIC_CHECK_LINE=$(grep -n 'Running ESLint and TypeScript in parallel' "$WEWORK_TEST_OUT" | cut -d: -f1)
+UNIT_TEST_LINE=$(grep -n 'Running unit tests with 4 workers' "$WEWORK_TEST_OUT" | cut -d: -f1)
+if [ -z "$STATIC_CHECK_LINE" ] || [ -z "$UNIT_TEST_LINE" ] ||
+    [ "$STATIC_CHECK_LINE" -ge "$UNIT_TEST_LINE" ]; then
+    echo "Expected Wework static checks to be reported before unit tests."
+    cat "$WEWORK_TEST_OUT"
+    exit 1
+fi
+
 : > "$CALL_LOG"
 
 # This range moved a Next.js route and verifies stale generated route types are


### PR DESCRIPTION
## Summary

- run Wework ESLint and TypeScript checks in parallel before starting Vitest
- let Vitest run without contention from the static checks
- use four Vitest workers in pre-push while keeping the repository default and CI configuration unchanged
- cover the new pre-push sequencing and worker count in the hook regression test

## Performance

- 2 workers: 236.32s for 458 files / 4635 tests
- 4 workers without static-check contention: 127.12s for the same suite
- ESLint and TypeScript in parallel: about 54s

## Verification

- `bash -n scripts/hooks/ai-push-gate.sh scripts/hooks/test-ai-push-gate.sh`
- `bash scripts/hooks/test-ai-push-gate.sh`
- `pnpm --filter wework test -- --maxWorkers=4` (458 files, 4635 tests passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Linting and TypeScript checks now run in parallel before unit tests, reducing validation time.
  * Unit tests support a configurable worker limit, defaulting to four workers.

* **Bug Fixes**
  * Improved push-gate validation ordering and preserved unit test result reporting.

* **Tests**
  * Added regression coverage for test worker defaults and static check ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->