### PR TITLE
fix: remove board origin markers from runtime task rows

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -2021,6 +2021,13 @@ describe('DesktopSidebar', () => {
                 workspaceKind: 'chat',
                 title: 'hi',
                 runtime: 'codex',
+                runtimeHandle: {
+                  origin: {
+                    type: 'board_comment',
+                    cloudProjectId: 'project-1',
+                    loopItemId: 'item-1',
+                  },
+                },
               },
             ],
           },
@@ -2052,6 +2059,7 @@ describe('DesktopSidebar', () => {
     )
     expect(screen.queryByTestId(`runtime-workspace-row-${chatPath}`)).not.toBeInTheDocument()
     expect(screen.getByTestId('runtime-local-task-row-chat-1')).toHaveTextContent('hi')
+    expect(screen.queryByTestId('runtime-local-task-board-comment-chat-1')).not.toBeInTheDocument()
     expect(screen.queryByTestId('runtime-local-task-device-marker-chat-1')).not.toBeInTheDocument()
     expect(screen.queryByTestId('runtime-local-task-device-icon-chat-1')).not.toBeInTheDocument()
     expect(screen.queryByTestId('runtime-workspace-row-/tmp/spike')).not.toBeInTheDocument()
@@ -2068,6 +2076,13 @@ describe('DesktopSidebar', () => {
       deviceId: 'local-device',
       workspacePath: chatPath,
       taskId: 'chat-1',
+      runtimeHandle: {
+        origin: {
+          type: 'board_comment',
+          cloudProjectId: 'project-1',
+          loopItemId: 'item-1',
+        },
+      },
     })
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -68,7 +68,6 @@ import {
   autoRepairStatus,
   buildChangeRequestRepairPrompt,
 } from '@/features/workbench/changeRequestStatus'
-import { runtimeTaskBoardOrigin } from '@/features/workbench/runtimeTaskOrigin'
 import {
   getRuntimeConversationQueuePaused,
   subscribeRuntimeConversation,
@@ -1465,11 +1464,6 @@ function RuntimeTaskRow({
   const repositoryLabel = getRuntimeTaskRepositoryLabel(workspace, task)
   const branchLabel = getRuntimeTaskBranch(task)
   const taskWorkspacePath = task.workspacePath || workspace.workspacePath
-  const boardOrigin = runtimeTaskBoardOrigin(task)
-  const boardOriginLabel =
-    boardOrigin === 'board_comment'
-      ? t('workbench.runtime_task_origin_board_comment', '看板评论')
-      : t('workbench.runtime_task_origin_board_task', '看板任务')
   const hostLabel =
     workspace.remoteHostId ||
     (workspace.workspaceSource === 'remote' ? workspace.deviceName || workspace.deviceId : null)
@@ -1765,13 +1759,6 @@ function RuntimeTaskRow({
                     data-testid={`runtime-local-task-title-shimmer-${task.taskId}`}
                   />
                 ) : null}
-                {boardOrigin ? (
-                  <MessageCircle
-                    data-testid={`runtime-local-task-board-comment-${task.taskId}`}
-                    className="h-3 w-3 shrink-0 text-[rgb(var(--color-sidebar-text-muted))]"
-                    aria-label={boardOriginLabel}
-                  />
-                ) : null}
                 <span data-testid={`runtime-local-task-drag-activator-${task.taskId}`}>
                   {task.title}
                 </span>
@@ -1804,13 +1791,6 @@ function RuntimeTaskRow({
                   aria-hidden="true"
                   className="runtime-task-title-shimmer"
                   data-testid={`runtime-local-task-title-shimmer-${task.taskId}`}
-                />
-              ) : null}
-              {boardOrigin ? (
-                <MessageCircle
-                  data-testid={`runtime-local-task-board-comment-${task.taskId}`}
-                  className="mr-1 inline h-3 w-3 shrink-0 text-[rgb(var(--color-sidebar-text-muted))]"
-                  aria-label={boardOriginLabel}
                 />
               ) : null}
               <span data-testid={`runtime-local-task-drag-activator-${task.taskId}`}>

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -8,7 +8,6 @@ import {
   FolderPlus,
   GitCompareArrows,
   Loader2,
-  MessageCircle,
   Monitor,
   RotateCw,
   Search,
@@ -23,7 +22,6 @@ import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { isImeEnterEvent } from '@/lib/ime'
 import { cn } from '@/lib/utils'
 import { getRuntimeTaskReminderItemKey } from '@/features/workbench/runtimeTaskReminders'
-import { runtimeTaskBoardOrigin } from '@/features/workbench/runtimeTaskOrigin'
 import {
   getRuntimeTaskLifecycleKey,
   useRuntimeTaskLifecycleStoreSnapshot,
@@ -476,11 +474,6 @@ export function MobileDrawer({
                       const workspaceTitle = getRuntimeTaskWorkspaceTitle(workspace)
                       const queued = isRuntimeTaskQueued(task)
                       const taskAddress = getRuntimeTaskAddress(workspace, task)
-                      const boardOrigin = runtimeTaskBoardOrigin(task)
-                      const boardOriginLabel =
-                        boardOrigin === 'board_comment'
-                          ? t('workbench.runtime_task_origin_board_comment', '看板评论')
-                          : t('workbench.runtime_task_origin_board_task', '看板任务')
                       return (
                         <div
                           key={`${workspace.deviceId}:${task.workspacePath}:${task.taskId}`}
@@ -502,12 +495,6 @@ export function MobileDrawer({
                                 : 'text-text-primary hover:bg-muted',
                             ].join(' ')}
                           >
-                            {boardOrigin ? (
-                              <MessageCircle
-                                className="mr-2 h-4 w-4 shrink-0 text-text-tertiary"
-                                aria-label={boardOriginLabel}
-                              />
-                            ) : null}
                             <span className="min-w-0 flex-1 truncate">{task.title}</span>
                             {queued ? (
                               <span
@@ -685,11 +672,6 @@ export function MobileDrawer({
                                 const workspaceTitle = getRuntimeTaskWorkspaceTitle(workspace)
                                 const queued = isRuntimeTaskQueued(task)
                                 const taskAddress = getRuntimeTaskAddress(workspace, task)
-                                const boardOrigin = runtimeTaskBoardOrigin(task)
-                                const boardOriginLabel =
-                                  boardOrigin === 'board_comment'
-                                    ? t('workbench.runtime_task_origin_board_comment', '看板评论')
-                                    : t('workbench.runtime_task_origin_board_task', '看板任务')
                                 return (
                                   <div
                                     key={`${workspace.deviceId}:${task.workspacePath}:${task.taskId}`}
@@ -711,12 +693,6 @@ export function MobileDrawer({
                                           : 'text-text-primary hover:bg-muted',
                                       ].join(' ')}
                                     >
-                                      {boardOrigin ? (
-                                        <MessageCircle
-                                          className="mr-2 h-4 w-4 shrink-0 text-text-tertiary"
-                                          aria-label={boardOriginLabel}
-                                        />
-                                      ) : null}
                                       <span className="min-w-0 flex-1 truncate">{task.title}</span>
                                       {queued ? (
                                         <span

--- a/wework/src/features/workbench/runtimeTaskOrigin.test.ts
+++ b/wework/src/features/workbench/runtimeTaskOrigin.test.ts
@@ -1,31 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { isProjectAutomationManagerRuntimeTask, runtimeTaskBoardOrigin } from './runtimeTaskOrigin'
+import { isProjectAutomationManagerRuntimeTask } from './runtimeTaskOrigin'
 
-describe('runtimeTaskBoardOrigin', () => {
-  it('recognizes persisted board comment origin metadata', () => {
-    expect(
-      runtimeTaskBoardOrigin({
-        runtimeHandle: {
-          origin: {
-            type: 'board_comment',
-            cloudProjectId: 'project-1',
-            loopItemId: 'item-1',
-          },
-        },
-      })
-    ).toBe('board_comment')
-  })
-
-  it('recognizes board task automation origin metadata', () => {
-    expect(runtimeTaskBoardOrigin({ runtimeHandle: { origin: { type: 'board_task' } } })).toBe(
-      'board_task'
-    )
-  })
-
-  it('does not classify ordinary runtime tasks as board work', () => {
-    expect(runtimeTaskBoardOrigin({ runtimeHandle: { threadId: 'thread-1' } })).toBeNull()
-  })
-
+describe('isProjectAutomationManagerRuntimeTask', () => {
   it('recognizes project automation manager sessions', () => {
     expect(
       isProjectAutomationManagerRuntimeTask({

--- a/wework/src/features/workbench/runtimeTaskOrigin.ts
+++ b/wework/src/features/workbench/runtimeTaskOrigin.ts
@@ -5,13 +5,6 @@ function runtimeTaskOrigin(task: Pick<RuntimeTaskSummary, 'runtimeHandle'>) {
   return origin && typeof origin === 'object' ? (origin as Record<string, unknown>) : null
 }
 
-export function runtimeTaskBoardOrigin(
-  task: Pick<RuntimeTaskSummary, 'runtimeHandle'>
-): 'board_comment' | 'board_task' | null {
-  const type = runtimeTaskOrigin(task)?.type
-  return type === 'board_comment' || type === 'board_task' ? type : null
-}
-
 export function isProjectAutomationManagerRuntimeTask(
   task: Pick<RuntimeTaskSummary, 'runtimeHandle'>
 ): boolean {

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -112,8 +112,6 @@
     "project_chat_agent_unavailable": "This robot is no longer in this project",
     "project_chat_agent_start_failed": "The robot task could not be started",
     "task_activity_title": "Activity",
-    "runtime_task_origin_board_comment": "Board activity",
-    "runtime_task_origin_board_task": "Board task",
     "task_activity_count": "{{count}} total",
     "task_activity_empty": "No activity yet",
     "task_activity_empty_with_ai": "{{name}} is queued and will start automatically, then submit the result for your review.",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -113,8 +113,6 @@
     "project_chat_agent_unavailable": "该机器人已不在此项目中",
     "project_chat_agent_start_failed": "机器人任务未能启动",
     "task_activity_title": "动态",
-    "runtime_task_origin_board_comment": "看板动态",
-    "runtime_task_origin_board_task": "看板任务",
     "task_activity_count": "共 {{count}} 条",
     "task_activity_empty": "暂无动态",
     "task_activity_empty_with_ai": "{{name}} 已进入执行队列，将自动处理并提交结果供你验收。",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed board-origin icons and labels from runtime task entries in desktop sidebars and mobile drawers.
  * Runtime tasks now display their titles and existing status information without board-specific indicators.

* **Tests**
  * Updated coverage for chat runtime tasks containing board-comment metadata.
  * Removed tests and translations for deprecated board-origin labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->