### PR TITLE
fix(wework): keep board PR popover visible

### DIFF
--- a/docs/en/wework/developer-guide/wework-ai-verification.md
+++ b/docs/en/wework/developer-guide/wework-ai-verification.md
@@ -35,6 +35,12 @@ Supported operations are `snapshot`, `text`, `click`, `fill`, `press`, `wait-for
 
 The controller listens only on `127.0.0.1` and creates a single-use Bearer token per session. The Vite environment enables the channel only for the development instance started by `ai:verify start`; normal development and production builds do not expose it. The session file contains the token, so treat it as short-lived local credential and never commit or share it.
 
+## Control protocol
+
+After startup, the WebView calls `/ready` and then short-polls `/commands`. The controller immediately returns `204` when the queue is empty; the WebView briefly throttles through `/control-tick` before polling again. After receiving a command, the WebView calls `/started` and `/results` in order to acknowledge execution and submit the final result.
+
+`ai:verify` and desktop E2E share this protocol, so endpoint and polling semantics must remain aligned when either side changes. Do not convert `/commands` to long polling: it conflicts with the WebView control loop, leaves later commands queued, and surfaces as repeated timeouts. The controller must also remove a timed-out command from the queue so a later poll cannot execute stale work.
+
 ## AI workflow
 
 An AI should start with `snapshot` to confirm the route and available `data-testid` values, make the smallest required interaction, and use `wait-for` plus `snapshot` or `text` to verify the result. Always call `stop` when finished. On failure, keep the session directory and inspect `app.log`.

--- a/docs/zh/wework/developer-guide/wework-ai-verification.md
+++ b/docs/zh/wework/developer-guide/wework-ai-verification.md
@@ -35,6 +35,12 @@ pnpm --filter wework ai:verify stop --session /path/to/session.json
 
 控制器只监听 `127.0.0.1`，并为每个会话生成一次性 Bearer token。该通道只有在 `ai:verify start` 启动的开发实例中通过 Vite 环境变量启用；普通开发与生产构建不会暴露控制接口。session 文件包含 token，应视为短期本地凭据，不应提交或共享。
 
+## 控制协议
+
+WebView 启动后先调用 `/ready`，随后用短轮询请求 `/commands`。控制器在队列为空时立即返回 `204`；WebView 通过 `/control-tick` 做短暂节流，再发起下一次轮询。收到命令后，WebView 依次调用 `/started` 和 `/results`，分别确认命令已开始执行并提交最终结果。
+
+`ai:verify` 和桌面端 E2E 共用这套协议，修改任一端时必须保持端点和轮询语义一致。不要把 `/commands` 改成长轮询：这会与 WebView 的控制循环冲突，使后续命令留在队列中并表现为连续超时。控制器还必须在命令超时后将其从队列移除，避免过期命令在下一次轮询中被执行。
+
 ## AI 验证流程
 
 AI 应先执行 `snapshot` 确认路由和可用的 `data-testid`，再进行最小必要操作，并以 `wait-for` 加 `snapshot` 或 `text` 验证结果。结束时必须执行 `stop`；若失败，保留该会话目录中的 `app.log` 以便诊断。

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -119,14 +119,11 @@ function authorized(request, token) {
   return request.headers.authorization === `Bearer ${token}`
 }
 
-export function takeWritableCommandPoll(commandPolls) {
-  let poll = commandPolls.shift()
-  while (poll) {
-    clearTimeout(poll.timer)
-    if (!poll.closed && !poll.response.destroyed && !poll.response.writableEnded) return poll
-    poll = commandPolls.shift()
+export function acknowledgeStartedCommand(pending, started) {
+  if (!pending.has(started.id)) {
+    return { status: 404, value: { error: `Unknown command ${started.id}` } }
   }
-  return undefined
+  return { status: 200, value: { ok: true } }
 }
 
 async function stopOwnedSessionProcesses(session) {
@@ -220,7 +217,6 @@ export function monitorAppProcess(app, pending, onExit) {
 async function runServer(sessionPath, token) {
   const session = JSON.parse(await readFile(sessionPath, 'utf8'))
   const queue = []
-  const commandPolls = []
   const pending = new Map()
   let ready = null
   let app = null
@@ -243,27 +239,19 @@ async function runServer(sessionPath, token) {
       if (request.method === 'GET' && url.pathname === '/commands') {
         const command = queue.shift()
         if (command) return json(response, 200, command)
-
-        const poll = { response, timer: undefined, closed: false }
-        poll.timer = setTimeout(() => {
-          const index = commandPolls.indexOf(poll)
-          if (index >= 0) commandPolls.splice(index, 1)
-          response.writeHead(204, corsHeaders)
-          response.end()
-        }, defaultTimeoutMs)
-        commandPolls.push(poll)
-        response.once('close', () => {
-          poll.closed = true
-          const index = commandPolls.indexOf(poll)
-          if (index < 0) return
-          commandPolls.splice(index, 1)
-          clearTimeout(poll.timer)
-        })
-        return
-      }
-      if (request.method === 'GET' && url.pathname === '/control-tick') {
         response.writeHead(204, corsHeaders)
         return response.end()
+      }
+      if (request.method === 'GET' && url.pathname === '/control-tick') {
+        return setTimeout(() => {
+          response.writeHead(204, corsHeaders)
+          response.end()
+        }, 50)
+      }
+      if (request.method === 'POST' && url.pathname === '/started') {
+        const started = await readBody(request)
+        const acknowledgement = acknowledgeStartedCommand(pending, started)
+        return json(response, acknowledgement.status, acknowledgement.value)
       }
       if (request.method === 'POST' && url.pathname === '/results') {
         const result = await readBody(request)
@@ -285,7 +273,6 @@ async function runServer(sessionPath, token) {
           appExitSignal: appExit?.signal ?? null,
           appExitError: appExit?.error ?? null,
           queuedCommands: queue.length,
-          commandPolls: commandPolls.length,
           pendingCommands: pending.size,
         })
       }
@@ -299,12 +286,7 @@ async function runServer(sessionPath, token) {
           pending.set(id, { resolve: resolvePromise, reject })
         )
         const nextCommand = { id, ...command }
-        const poll = takeWritableCommandPoll(commandPolls)
-        if (poll) {
-          json(poll.response, 200, nextCommand)
-        } else {
-          queue.push(nextCommand)
-        }
+        queue.push(nextCommand)
         try {
           return json(response, 200, {
             ok: true,
@@ -316,6 +298,8 @@ async function runServer(sessionPath, token) {
           })
         } catch (error) {
           pending.delete(id)
+          const queuedIndex = queue.findIndex(item => item.id === id)
+          if (queuedIndex >= 0) queue.splice(queuedIndex, 1)
           return json(response, 500, { ok: false, error: String(error.message ?? error) })
         }
       }

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -4,46 +4,35 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test, vi } from 'vitest'
 import {
+  acknowledgeStartedCommand,
   appExitMessage,
   monitorAppProcess,
   readSessionForCleanup,
   resolveCommandTimeout,
   resolveStartupTimeout,
   startupFailureMessage,
-  takeWritableCommandPoll,
 } from './ai-verify.mjs'
 
-function commandPoll(response) {
-  return {
-    response,
-    timer: setTimeout(() => {}, 60_000),
-    closed: false,
-  }
-}
-
-describe('takeWritableCommandPoll', () => {
-  test('skips disconnected responses and returns the next writable poll', () => {
-    const disconnected = commandPoll({ destroyed: true, writableEnded: false })
-    const closed = commandPoll({ destroyed: false, writableEnded: false })
-    closed.closed = true
-    const ended = commandPoll({ destroyed: false, writableEnded: true })
-    const writable = commandPoll({ destroyed: false, writableEnded: false })
-    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
-
-    expect(takeWritableCommandPoll([disconnected, closed, ended, writable])).toBe(writable)
-    expect(clearTimeoutSpy).toHaveBeenCalledTimes(4)
-
-    clearTimeoutSpy.mockRestore()
+describe('acknowledgeStartedCommand', () => {
+  test('accepts the start acknowledgement for a pending command', () => {
+    expect(
+      acknowledgeStartedCommand(new Map([['command-1', {}]]), {
+        id: 'command-1',
+        clientId: 'client-1',
+      })
+    ).toEqual({ status: 200, value: { ok: true } })
   })
 
-  test('returns undefined when every pending response is stale', () => {
-    const stalePolls = [
-      commandPoll({ destroyed: true, writableEnded: false }),
-      commandPoll({ destroyed: false, writableEnded: true }),
-    ]
-
-    expect(takeWritableCommandPoll(stalePolls)).toBeUndefined()
-    expect(stalePolls).toHaveLength(0)
+  test('rejects acknowledgements for commands that are no longer pending', () => {
+    expect(
+      acknowledgeStartedCommand(new Map(), {
+        id: 'missing-command',
+        clientId: 'client-1',
+      })
+    ).toEqual({
+      status: 404,
+      value: { error: 'Unknown command missing-command' },
+    })
   })
 })
 

--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import '@/i18n'
+import type { TaskChangeRequestSnapshot } from '@/api/changeRequests'
+import type { CloudLoopItem } from '@/api/deliveries'
+import { CloudTodoBoardCard } from './CloudTodoBoardCard'
+
+const changeRequestMonitorMocks = vi.hoisted(() => ({
+  useTaskChangeRequest: vi.fn(),
+}))
+
+vi.mock('@/features/workbench/changeRequestMonitor', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/features/workbench/changeRequestMonitor')>()
+  return {
+    ...actual,
+    useTaskChangeRequest: changeRequestMonitorMocks.useTaskChangeRequest,
+  }
+})
+
+const item = {
+  id: 'WEG-85',
+  title: 'Keep the pull request popup visible',
+  description: null,
+  status: 'in_review',
+  priority: 'none',
+  can_edit: true,
+  can_view_detail: true,
+  updated_at: '2026-08-21T00:00:00Z',
+} as CloudLoopItem
+
+const snapshot: TaskChangeRequestSnapshot = {
+  target: {
+    deviceId: 'local',
+    taskId: 'task-85',
+    workspacePath: '/workspace',
+    remoteUrl: 'https://github.com/wecode-ai/Wegent.git',
+    branch: 'fix/board-pr-popup',
+  },
+  changeRequest: {
+    provider: 'github',
+    number: 85,
+    url: 'https://github.com/wecode-ai/Wegent/pull/85',
+    title: 'Keep the pull request popup visible',
+    state: 'open',
+    draft: false,
+    checks: 'pending',
+    mergeability: 'unknown',
+    mergeQueue: 'not_queued',
+  },
+  fetchedAt: '2026-08-21T00:00:00Z',
+  stale: false,
+  error: null,
+}
+
+describe('CloudTodoBoardCard', () => {
+  it('opens the pull request popup toward the card content', async () => {
+    changeRequestMonitorMocks.useTaskChangeRequest.mockReturnValue(snapshot)
+
+    render(
+      <CloudTodoBoardCard
+        item={item}
+        taskBindings={[
+          {
+            id: 85,
+            device_id: 'local',
+            task_id: 'task-85',
+            task_title: 'Fix the board popup',
+            running: false,
+            changeRequestTarget: snapshot.target,
+            finalResponseLoaded: true,
+          },
+        ]}
+        onClick={vi.fn()}
+        onArchive={vi.fn()}
+        display={{
+          showAssignee: false,
+          showPriority: false,
+          showTags: false,
+          showDate: false,
+        }}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('cloud-todo-card-change-request-WEG-85-85'))
+
+    expect(screen.getByTestId('cloud-todo-card-change-request-WEG-85-85-popover')).toHaveClass(
+      'left-0'
+    )
+  })
+})

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -347,6 +347,7 @@ export function CloudTodoBoardCard({
               <ChangeRequestStatusIcon
                 snapshot={changeRequestSnapshot}
                 testId={`cloud-todo-card-change-request-${item.id}-${currentTaskBinding.id}`}
+                popoverAlign="left"
                 repairing={repairingChangeRequest}
                 onContinueRepair={
                   autoRepairStatus(changeRequestSnapshot.changeRequest) &&


### PR DESCRIPTION
## Summary

- align the board PR status popover toward the card content so it stays inside the visible board area
- restore the AI verification WebView control protocol by handling `/started`, using short polling, and removing timed-out queued commands
- document the shared `ai:verify` and desktop E2E control protocol in Chinese and English

## Root cause

The board card used the status icon default alignment, which could place the popup outside the clipped board viewport. Separately, the `ai:verify` controller had drifted from the WebView protocol: it did not accept `/started` and used long polling while the client expected short polling through `/control-tick`, causing commands after startup to remain queued and time out.

## Verification

- board component tests: 3 passed
- `ai-verify` tests: 19 passed
- ESLint, TypeScript, Prettier, and `git diff --check` passed
- real isolated Tauri session completed three snapshots plus `active-element` in 4.27 seconds with zero queued or pending commands
- full pre-push suite reached 4,638 passing tests; 3 unrelated temporary-chat tests failed only in the original dirty worktree containing uncommitted user changes, so the committed branch was pushed from a clean isolated worktree

Closes WORK-85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved change-request pop-up alignment on cloud todo board cards for clearer viewing.
  - Improved AI verification command handling, including reliable acknowledgements, queue cleanup after timeouts, and clearer empty-queue responses.

- **Documentation**
  - Added English and Chinese guidance for the AI verification control protocol, including WebView readiness, command processing, acknowledgements, result submission, timeouts, and compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->