### PR TITLE
fix(wework): restore board composer keyboard focus

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -29,6 +29,7 @@ Before changing a Wework flow, identify the affected product area and trace its 
 - Use the shared typography scale and semantic `heading-*`, `text-chat`, and `text-code` roles. Never add arbitrary `text-[Npx]`, literal CSS `font-size`, or literal inline `fontSize` values; `pnpm lint` enforces this rule.
 - Custom Markdown renderers must preserve semantic attributes supplied by the parser, such as an ordered list's `start` value.
 - Preserve platform text-navigation semantics in the ProseMirror chat composer. Register only composer-specific key bindings instead of the document-level `baseKeymap`, and scope mention caret workarounds to unmodified arrow keys.
+- Focus popup composers through their exact editor target; a mixed `querySelector` returns the first matching element in DOM order, not the first selector in the list. In WKWebView, keep a completely empty contenteditable position native instead of replacing it with a decoration widget so programmatic focus can start the platform text input session.
 
 ## i18n
 

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -500,10 +500,11 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     await control.command('waitFor', `${activeBoard} [data-testid="workspace-issue-input"]`, {
       timeoutMs: uiTimeoutMs,
     })
-    assert.equal(
-      await control.command('getActiveElementTestId', 'body'),
-      'workspace-issue-input',
-      'Opening the board task composer did not focus its editor'
+    await waitForValue(
+      () => control.command('getActiveElementTestId', 'body'),
+      testId => testId === 'workspace-issue-input',
+      'Opening the board task composer did not focus its editor',
+      uiTimeoutMs
     )
     assert.equal(
       await control.command(

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -500,12 +500,6 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     await control.command('waitFor', `${activeBoard} [data-testid="workspace-issue-input"]`, {
       timeoutMs: uiTimeoutMs,
     })
-    await waitForValue(
-      () => control.command('getActiveElementTestId', 'body'),
-      testId => testId === 'workspace-issue-input',
-      'Opening the board task composer did not focus its editor',
-      uiTimeoutMs
-    )
     assert.equal(
       await control.command(
         'getElementCount',

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -501,9 +501,11 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
       timeoutMs: uiTimeoutMs,
     })
     assert.equal(
-      await control.command(
-        'getElementCount',
-        `${activeBoard} [data-testid="workspace-issue-input"] .composer-empty-caret`
+      Number(
+        await control.command(
+          'getElementCount',
+          `${activeBoard} [data-testid="workspace-issue-input"] .composer-empty-caret`
+        )
       ),
       0,
       'The empty board task composer replaced its native caret with a widget'

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -500,6 +500,19 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     await control.command('waitFor', `${activeBoard} [data-testid="workspace-issue-input"]`, {
       timeoutMs: uiTimeoutMs,
     })
+    assert.equal(
+      await control.command('getActiveElementTestId', 'body'),
+      'workspace-issue-input',
+      'Opening the board task composer did not focus its editor'
+    )
+    assert.equal(
+      await control.command(
+        'getElementCount',
+        `${activeBoard} [data-testid="workspace-issue-input"] .composer-empty-caret`
+      ),
+      0,
+      'The empty board task composer replaced its native caret with a widget'
+    )
     await control.command('fill', `${activeBoard} [data-testid="workspace-issue-input"]`, {
       value: '真实后端智能体看板任务',
     })

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
@@ -351,6 +351,12 @@ describe('ComposerProseMirrorEditor', () => {
     expect(editor.querySelector('.composer-empty-caret')).toHaveAttribute('aria-hidden', 'true')
   })
 
+  test('uses the native caret when the composer is completely empty', () => {
+    renderEditor('')
+
+    expect(screen.getByTestId('composer-editor').querySelector('.composer-empty-caret')).toBeNull()
+  })
+
   test('keeps the caret outside the skill while repeatedly moving left', () => {
     const { editorRef, onChange } = renderEditor()
     const editor = screen.getByTestId('composer-editor')

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
@@ -160,7 +160,10 @@ export const ComposerProseMirrorEditor = forwardRef<
                 if (
                   !state.selection.empty ||
                   !state.selection.$head.parent.isTextblock ||
-                  state.selection.$head.parent.content.size > 0
+                  state.selection.$head.parent.content.size > 0 ||
+                  // WKWebView needs the only empty text position to remain native
+                  // so programmatic focus can start a text input session.
+                  (state.doc.childCount === 1 && state.doc.firstChild?.content.size === 0)
                 ) {
                   return null
                 }

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -3358,8 +3358,9 @@ describe('CloudTodoWorkspace', () => {
 
     await user.click((await screen.findAllByText('Wegent V4'))[0])
     await user.click(screen.getByTestId('cloud-todo-column-add-pending'))
-    await user.click(screen.getByTestId('workspace-issue-input'))
-    await user.paste('Pending Issue')
+    const input = screen.getByTestId('workspace-issue-input')
+    await waitFor(() => expect(input).toHaveFocus())
+    await user.keyboard('Pending Issue')
     await user.click(screen.getByTestId('workspace-issue-submit'))
 
     await waitFor(() =>

--- a/wework/src/features/todo/IssueComposer.test.tsx
+++ b/wework/src/features/todo/IssueComposer.test.tsx
@@ -655,4 +655,24 @@ describe('IssueComposer', () => {
     fireEvent.click(screen.getByTestId('workspace-issue-composer'))
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
+
+  it('accepts typing immediately after opening a task composer popup', async () => {
+    const user = userEvent.setup()
+    render(
+      <IssueComposer
+        projects={[workItemProject]}
+        initialBoardKey="backend:1"
+        initialStartExecution
+        presentation="popup"
+        onCancel={vi.fn()}
+        onCreate={vi.fn()}
+      />
+    )
+
+    const input = screen.getByTestId('workspace-issue-input')
+    await waitFor(() => expect(input).toHaveFocus())
+    await user.keyboard('无需再次点击')
+
+    expect(input).toHaveTextContent('无需再次点击')
+  })
 })

--- a/wework/src/features/todo/IssueComposer.tsx
+++ b/wework/src/features/todo/IssueComposer.tsx
@@ -314,7 +314,7 @@ export function IssueComposer({
     const previousFocus = document.activeElement as HTMLElement | null
     const frame = window.requestAnimationFrame(() => {
       const focusTarget = panelRef.current?.querySelector<HTMLElement>(
-        '[data-testid="workspace-issue-input"], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        '[data-testid="workspace-issue-input"]'
       )
       focusTarget?.focus()
     })


### PR DESCRIPTION
## Summary
- focus the board task composer editor explicitly when its popup opens
- keep the fully empty ProseMirror document on the native WKWebView caret/input path
- add unit and desktop E2E regression coverage for immediate typing without an extra click
- document the popup composer focus and native-caret constraints

## Verification
- real Wework dev app: programmatic focus now produces WKWebView beforeinput composition events without clicking the editor
- pnpm --filter wework test src/components/chat/composer/ComposerProseMirrorEditor.test.tsx src/features/todo/IssueComposer.test.tsx src/features/todo/CloudTodoWorkspace.test.tsx (151 passed)
- pnpm --filter wework typecheck
- focused Prettier and ESLint checks
- pre-push Wework ESLint, TypeScript, and unit tests

Fixes WORK-87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task composer popups so the workspace issue input is focused automatically when opened.
  - Users can begin typing immediately without clicking the input first.
  - Preserved the native caret in empty message composers for more reliable text entry and programmatic focus.
  - Prevented empty-caret decorations from appearing in empty composers.

- **Tests**
  - Added coverage for automatic focus, immediate typing, keyboard input, and empty-composer caret behavior across desktop and task creation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->