### PR TITLE
fix(wework): keep PR icons inside sidebar rows

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -407,6 +407,10 @@ may reveal on hover/focus but must remain keyboard accessible.
   screenshot-matched review artifacts must use that width.
 - Sidebar rows are `30px` high with a `10px` radius, `8px–10px` horizontal
   padding, `14px` text, and an ordinary `16px` icon.
+- Leading status icons may occupy reserved indentation only when their negative
+  offset is fully contained by the row's left padding. Keep icons in the normal
+  flex flow for shallow pinned and top-level task rows so the glyph and its hit
+  target remain inside the sidebar viewport.
 - Priority task entries are selectable two-line data rows rather than compact
   navigation rows. They use a `48px` minimum height so the title and `12px–14px`
   source metadata remain readable.

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -31,6 +31,8 @@ import {
   cacheRuntimeConversationQueuePaused,
   clearRuntimeConversationCacheForTests,
 } from '@/features/workbench/runtimeConversationCache'
+import type { TaskChangeRequestSnapshot } from '@/api/changeRequests'
+import * as changeRequestMonitor from '@/features/workbench/changeRequestMonitor'
 
 const experimentalFeatures = vi.hoisted(() => ({ enabled: true }))
 
@@ -3981,6 +3983,107 @@ describe('DesktopSidebar', () => {
     expect(screen.getByTestId('sidebar-pinned-section')).toContainElement(
       screen.getByTestId('runtime-local-task-row-old-task')
     )
+  })
+
+  test('keeps change request icons inside shallow pinned and task rows', async () => {
+    const snapshot: TaskChangeRequestSnapshot = {
+      target: {
+        deviceId: 'local-device',
+        taskId: 'task-with-pr',
+        workspacePath: '/repo/Wegent',
+        remoteUrl: 'https://github.com/wecode-ai/Wegent.git',
+        branch: 'fix/sidebar-pr-icon',
+      },
+      changeRequest: {
+        provider: 'github',
+        number: 2875,
+        url: 'https://github.com/wecode-ai/Wegent/pull/2875',
+        title: 'Keep PR icons inside the sidebar',
+        state: 'open',
+        draft: false,
+        checks: 'success',
+        mergeability: 'mergeable',
+        mergeQueue: 'not_queued',
+      },
+      fetchedAt: '2026-08-21T00:00:00Z',
+      stale: false,
+      error: null,
+    }
+    const changeRequestSpy = vi
+      .spyOn(changeRequestMonitor, 'useTaskChangeRequest')
+      .mockReturnValue(snapshot)
+
+    try {
+      renderSidebar({
+        runtimeWork: {
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              totalTasks: 2,
+              deviceWorkspaces: [
+                {
+                  id: 91,
+                  deviceId: 'local-device',
+                  deviceName: 'Local Mac',
+                  deviceStatus: 'online',
+                  available: true,
+                  workspacePath: '/repo/Wegent',
+                  tasks: [
+                    {
+                      taskId: 'pinned-task',
+                      threadId: 'pinned-thread',
+                      pinned: true,
+                      workspacePath: '/repo/Wegent',
+                      title: 'Pinned task',
+                      runtime: 'codex',
+                    },
+                    {
+                      taskId: 'project-task',
+                      workspacePath: '/repo/Wegent',
+                      title: 'Project task',
+                      runtime: 'codex',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          chats: [
+            {
+              deviceId: 'local-device',
+              available: true,
+              workspacePath: '/workspace/chats/task-with-pr',
+              workspaceKind: 'chat',
+              tasks: [
+                {
+                  taskId: 'chat-task',
+                  workspacePath: '/workspace/chats/task-with-pr',
+                  workspaceKind: 'chat',
+                  title: 'Chat task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+          totalTasks: 3,
+        },
+      })
+
+      const pinnedIcon = screen.getByTestId('runtime-local-task-change-request-pinned-task')
+      const chatIcon = screen.getByTestId('runtime-local-task-change-request-chat-task')
+      expect(pinnedIcon.parentElement?.parentElement).toHaveClass('mr-1')
+      expect(pinnedIcon.parentElement?.parentElement).not.toHaveClass('-ml-7')
+      expect(chatIcon.parentElement?.parentElement).toHaveClass('mr-1')
+      expect(chatIcon.parentElement?.parentElement).not.toHaveClass('-ml-7')
+
+      await userEvent.click(screen.getByTestId('project-item-button'))
+      expect(
+        screen.getByTestId('runtime-local-task-change-request-project-task').parentElement
+          ?.parentElement
+      ).toHaveClass('-ml-7', 'mr-1')
+    } finally {
+      changeRequestSpy.mockRestore()
+    }
   })
 
   test('excludes pinned runtime tasks from the collapsed project task count', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1410,6 +1410,7 @@ function RuntimeTaskRow({
   onToggleRuntimeTaskNotification,
   priorityReason,
   priorityLayout = false,
+  changeRequestInIndent = false,
   splitGroup,
 }: {
   workspace: RuntimeDeviceWorkspace
@@ -1436,6 +1437,7 @@ function RuntimeTaskRow({
   ) => Promise<void> | void
   priorityReason?: RuntimeTaskPriorityReason
   priorityLayout?: boolean
+  changeRequestInIndent?: boolean
   splitGroup?: WorkbenchSplitGroupMembership
 }) {
   const { t } = useTranslation('common')
@@ -1739,7 +1741,7 @@ function RuntimeTaskRow({
                 ? continueChangeRequestRepair
                 : undefined
             }
-            className={priorityLayout ? 'mr-1' : '-ml-7 mr-1'}
+            className={changeRequestInIndent && !priorityLayout ? '-ml-7 mr-1' : 'mr-1'}
             popoverAlign="left"
           />
           {priorityLayout ? (
@@ -2874,6 +2876,7 @@ function ProjectItem({
                       unread={unreadTaskKeys.has(getRuntimeTaskReminderItemKey(workspace, task))}
                       marked={task.pinned}
                       indentClassName="pl-9"
+                      changeRequestInIndent
                       imNotificationSettings={imNotificationSettings}
                       showDeviceMarker={showDeviceMarker}
                       onOpenRuntimeTask={onOpenRuntimeTask}


### PR DESCRIPTION
## Summary

- keep pull request status icons inside shallow pinned and top-level task rows
- preserve the existing inset alignment for deeply indented project task rows
- add regression coverage and document the sidebar inset constraint

## Testing

- `pnpm --filter wework test src/components/layout/DesktopSidebar.test.tsx` (109 passed)
- `pnpm --filter wework exec prettier --check src/components/layout/DesktopSidebar.tsx src/components/layout/DesktopSidebar.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopSidebar.tsx src/components/layout/DesktopSidebar.test.tsx`
- pre-push checks: ESLint, TypeScript, and unit tests passed

## Desktop verification

- isolated Tauri application and local executor started successfully
- the desktop automation control client failed during startup, so `ai:verify snapshot` timed out; logs contained no runtime error associated with this sidebar change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-request status icon placement in the desktop sidebar.
  * Icons now remain fully visible and clickable across pinned chats, standalone tasks, and expanded project task rows.
  * Preserved appropriate indentation for nested project tasks while preventing icons from extending outside the sidebar.

* **Documentation**
  * Added guidance clarifying status icon positioning and sidebar boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->