### PR TITLE
perf(ci): increase Wework E2E shards to eight

### DIFF
--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -62,25 +62,31 @@ cloud_segments=(
   plugin-auto-update
 )
 # Group checkpoints by observed Cloud CI duration and order each shard from
-# longest to shortest so the five serial runners finish at similar times.
+# longest to shortest so the eight serial runners finish at similar times.
 # shellcheck disable=SC2054 # Each element is one comma-joined shard.
 cloud_shards=(
-  goal-lifecycle,window-lifecycle,cloud-worktree-tools,telemetry-consent
-  model-routing,project-automation,workspace-attachments,plugin-auto-update
-  embedded-browser,cloud-worktree-create,workspace-tabs,cloud-worktree-archive-restore,cloud-worktree-device-restart
-  resilience,rendering-extensions,cloud-worktree-queued-cancel,priority-filter,cloud-worktree-capability
-  core-task-flow,conversation-state,supervisor-lifecycle,automation-lifecycle,browser-multi-tabs,cloud-project-creation
+  goal-lifecycle,telemetry-consent,cloud-worktree-capability
+  model-routing,plugin-auto-update,priority-filter
+  embedded-browser,cloud-worktree-device-restart,cloud-project-creation
+  resilience,cloud-worktree-queued-cancel,browser-multi-tabs
+  core-task-flow,supervisor-lifecycle,automation-lifecycle
+  window-lifecycle,cloud-worktree-tools,cloud-worktree-archive-restore
+  project-automation,workspace-attachments,cloud-worktree-create
+  conversation-state,rendering-extensions,workspace-tabs
 )
-# Keep the number of core desktop runners fixed as checkpoints grow. Group
-# checkpoints by observed Core CI duration and order each shard so the serial
-# runners stay balanced while reusing the same prebuilt application.
+# Group checkpoints by observed Core CI duration and order each shard so the
+# eight serial runners stay balanced while reusing the same prebuilt
+# application.
 # shellcheck disable=SC2054 # Each element is one comma-joined shard.
 core_shards=(
-  rendering-extensions,resilience,runtime-task-queue
-  project-ai-settings,model-routing,window-lifecycle
-  core-task-flow,embedded-browser,browser-toolbar-actions,automation-lifecycle,priority-filter,temporary-chat
-  claude-runtime,workspace-attachments,local-harness,supervisor-lifecycle,codex-notification-isolation,local-file-preview
-  conversation-state,goal-lifecycle,workspace-tabs,project-automation,permission-modes
+  rendering-extensions,runtime-task-queue,local-file-preview
+  project-ai-settings,window-lifecycle,permission-modes
+  core-task-flow,temporary-chat,codex-notification-isolation
+  claude-runtime,workspace-attachments,local-harness
+  conversation-state,goal-lifecycle,workspace-tabs
+  resilience,supervisor-lifecycle
+  model-routing,project-automation,automation-lifecycle
+  embedded-browser,browser-toolbar-actions,priority-filter
 )
 
 validate_core_shards() {

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -350,7 +350,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "turn lifecycle changes select supervisor and resilience coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-1","name":"Core / shard 1","segments":"resilience"},{"id":"core-4","name":"Core / shard 4","segments":"supervisor-lifecycle"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-6","name":"Core / shard 6","segments":"resilience,supervisor-lifecycle"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/workbench/runtimeTaskLifecycle/reducer.ts"
@@ -358,7 +358,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "runtime pane events select supervisor and conversation coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-4","name":"Core / shard 4","segments":"supervisor-lifecycle"},{"id":"core-5","name":"Core / shard 5","segments":"conversation-state"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-5","name":"Core / shard 5","segments":"conversation-state"},{"id":"core-6","name":"Core / shard 6","segments":"supervisor-lifecycle"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/workbench/runtimePaneMessages.ts"
@@ -373,9 +373,9 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 
 full_desktop_expected='wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-1","name":"Core / shard 1","segments":"rendering-extensions,resilience,runtime-task-queue"},{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings,model-routing,window-lifecycle"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow,embedded-browser,browser-toolbar-actions,automation-lifecycle,priority-filter,temporary-chat"},{"id":"core-4","name":"Core / shard 4","segments":"claude-runtime,workspace-attachments,local-harness,supervisor-lifecycle,codex-notification-isolation,local-file-preview"},{"id":"core-5","name":"Core / shard 5","segments":"conversation-state,goal-lifecycle,workspace-tabs,project-automation,permission-modes"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-1","name":"Core / shard 1","segments":"rendering-extensions,runtime-task-queue,local-file-preview"},{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings,window-lifecycle,permission-modes"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow,temporary-chat,codex-notification-isolation"},{"id":"core-4","name":"Core / shard 4","segments":"claude-runtime,workspace-attachments,local-harness"},{"id":"core-5","name":"Core / shard 5","segments":"conversation-state,goal-lifecycle,workspace-tabs"},{"id":"core-6","name":"Core / shard 6","segments":"resilience,supervisor-lifecycle"},{"id":"core-7","name":"Core / shard 7","segments":"model-routing,project-automation,automation-lifecycle"},{"id":"core-8","name":"Core / shard 8","segments":"embedded-browser,browser-toolbar-actions,priority-filter"}]}
 wework_desktop_cloud_e2e=true
-wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"goal-lifecycle,window-lifecycle,cloud-worktree-tools,telemetry-consent"},{"id":"cloud-2","name":"Cloud / shard 2","segments":"model-routing,project-automation,workspace-attachments,plugin-auto-update"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"embedded-browser,cloud-worktree-create,workspace-tabs,cloud-worktree-archive-restore,cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"resilience,rendering-extensions,cloud-worktree-queued-cancel,priority-filter,cloud-worktree-capability"},{"id":"cloud-5","name":"Cloud / shard 5","segments":"core-task-flow,conversation-state,supervisor-lifecycle,automation-lifecycle,browser-multi-tabs,cloud-project-creation"}]}
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"goal-lifecycle,telemetry-consent,cloud-worktree-capability"},{"id":"cloud-2","name":"Cloud / shard 2","segments":"model-routing,plugin-auto-update,priority-filter"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"embedded-browser,cloud-worktree-device-restart,cloud-project-creation"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"resilience,cloud-worktree-queued-cancel,browser-multi-tabs"},{"id":"cloud-5","name":"Cloud / shard 5","segments":"core-task-flow,supervisor-lifecycle,automation-lifecycle"},{"id":"cloud-6","name":"Cloud / shard 6","segments":"window-lifecycle,cloud-worktree-tools,cloud-worktree-archive-restore"},{"id":"cloud-7","name":"Cloud / shard 7","segments":"project-automation,workspace-attachments,cloud-worktree-create"},{"id":"cloud-8","name":"Cloud / shard 8","segments":"conversation-state,rendering-extensions,workspace-tabs"}]}
 wework_desktop_other_e2e=true
 wework_desktop_other_e2e_matrix={"include":[{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""}]}
 wework_desktop_macos_inspector_e2e=true'
@@ -387,7 +387,7 @@ assert_desktop_case "runner-only changes retain full coverage" \
 assert_desktop_case "embedded browser files select browser coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"embedded-browser,browser-toolbar-actions"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-8","name":"Core / shard 8","segments":"embedded-browser,browser-toolbar-actions"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}
 wework_desktop_macos_inspector_e2e=true' \
@@ -396,7 +396,7 @@ wework_desktop_macos_inspector_e2e=true' \
 assert_desktop_case "browser toolbar scenario is invoked by Core and macOS CI" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"embedded-browser,browser-toolbar-actions"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-8","name":"Core / shard 8","segments":"embedded-browser,browser-toolbar-actions"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}
 wework_desktop_macos_inspector_e2e=true' \
@@ -415,7 +415,7 @@ assert_desktop_case "Claude runtime messaging selects task and Claude coverage" 
 wework_desktop_core_e2e=true
 wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"},{"id":"core-4","name":"Core / shard 4","segments":"claude-runtime"}]}
 wework_desktop_cloud_e2e=true
-wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"cloud-worktree-tools"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"cloud-worktree-create,cloud-worktree-archive-restore,cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"cloud-worktree-queued-cancel,cloud-worktree-capability"}]}
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"cloud-worktree-capability"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"cloud-worktree-queued-cancel"},{"id":"cloud-6","name":"Cloud / shard 6","segments":"cloud-worktree-tools,cloud-worktree-archive-restore"},{"id":"cloud-7","name":"Cloud / shard 7","segments":"cloud-worktree-create"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts"
@@ -423,7 +423,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "local file preview files select the shared preview checkpoint" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-4","name":"Core / shard 4","segments":"local-file-preview"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-1","name":"Core / shard 1","segments":"local-file-preview"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx"
@@ -443,7 +443,7 @@ wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-skill-mention-renderi
 assert_desktop_case "model settings select task launch and model routing coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings,model-routing"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"},{"id":"core-7","name":"Core / shard 7","segments":"model-routing"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/model-settings/localModelSettings.ts"
@@ -451,7 +451,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "composer plugin files select project plugin coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings,model-routing"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"},{"id":"core-7","name":"Core / shard 7","segments":"model-routing"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/components/chat/composer/PluginPickerMenu.tsx"
@@ -459,7 +459,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "automation files select only automation lifecycle coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"automation-lifecycle"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-7","name":"Core / shard 7","segments":"automation-lifecycle"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/automations/AutomationDetailWorkspace.tsx"
@@ -467,7 +467,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "project automation files select lifecycle and project coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"automation-lifecycle"},{"id":"core-5","name":"Core / shard 5","segments":"project-automation"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-7","name":"Core / shard 7","segments":"project-automation,automation-lifecycle"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/todo/ProjectAutomationRulesSection.tsx"
@@ -475,9 +475,9 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "project automation E2E changes select core and cloud coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"automation-lifecycle"},{"id":"core-5","name":"Core / shard 5","segments":"project-automation"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-7","name":"Core / shard 7","segments":"project-automation,automation-lifecycle"}]}
 wework_desktop_cloud_e2e=true
-wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"goal-lifecycle,window-lifecycle,cloud-worktree-tools,telemetry-consent"},{"id":"cloud-2","name":"Cloud / shard 2","segments":"model-routing,project-automation,workspace-attachments,plugin-auto-update"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"embedded-browser,cloud-worktree-create,workspace-tabs,cloud-worktree-archive-restore,cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"resilience,rendering-extensions,cloud-worktree-queued-cancel,priority-filter,cloud-worktree-capability"},{"id":"cloud-5","name":"Cloud / shard 5","segments":"core-task-flow,conversation-state,supervisor-lifecycle,automation-lifecycle,browser-multi-tabs,cloud-project-creation"}]}
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"goal-lifecycle,telemetry-consent,cloud-worktree-capability"},{"id":"cloud-2","name":"Cloud / shard 2","segments":"model-routing,plugin-auto-update,priority-filter"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"embedded-browser,cloud-worktree-device-restart,cloud-project-creation"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"resilience,cloud-worktree-queued-cancel,browser-multi-tabs"},{"id":"cloud-5","name":"Cloud / shard 5","segments":"core-task-flow,supervisor-lifecycle,automation-lifecycle"},{"id":"cloud-6","name":"Cloud / shard 6","segments":"window-lifecycle,cloud-worktree-tools,cloud-worktree-archive-restore"},{"id":"cloud-7","name":"Cloud / shard 7","segments":"project-automation,workspace-attachments,cloud-worktree-create"},{"id":"cloud-8","name":"Cloud / shard 8","segments":"conversation-state,rendering-extensions,workspace-tabs"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/e2e/desktop/scenarios/project-automation.scenario.mjs"
@@ -495,7 +495,7 @@ assert_desktop_case "cloud files select only the cloud suite" \
 wework_desktop_core_e2e=false
 wework_desktop_core_e2e_matrix={"include":[]}
 wework_desktop_cloud_e2e=true
-wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"goal-lifecycle,window-lifecycle,cloud-worktree-tools,telemetry-consent"},{"id":"cloud-2","name":"Cloud / shard 2","segments":"model-routing,project-automation,workspace-attachments,plugin-auto-update"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"embedded-browser,cloud-worktree-create,workspace-tabs,cloud-worktree-archive-restore,cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"resilience,rendering-extensions,cloud-worktree-queued-cancel,priority-filter,cloud-worktree-capability"},{"id":"cloud-5","name":"Cloud / shard 5","segments":"core-task-flow,conversation-state,supervisor-lifecycle,automation-lifecycle,browser-multi-tabs,cloud-project-creation"}]}
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"goal-lifecycle,telemetry-consent,cloud-worktree-capability"},{"id":"cloud-2","name":"Cloud / shard 2","segments":"model-routing,plugin-auto-update,priority-filter"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"embedded-browser,cloud-worktree-device-restart,cloud-project-creation"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"resilience,cloud-worktree-queued-cancel,browser-multi-tabs"},{"id":"cloud-5","name":"Cloud / shard 5","segments":"core-task-flow,supervisor-lifecycle,automation-lifecycle"},{"id":"cloud-6","name":"Cloud / shard 6","segments":"window-lifecycle,cloud-worktree-tools,cloud-worktree-archive-restore"},{"id":"cloud-7","name":"Cloud / shard 7","segments":"project-automation,workspace-attachments,cloud-worktree-create"},{"id":"cloud-8","name":"Cloud / shard 8","segments":"conversation-state,rendering-extensions,workspace-tabs"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/features/cloud-connection/CloudConnectionProvider.tsx"
@@ -505,7 +505,7 @@ assert_desktop_case "worktree UI changes select local launch and cloud lifecycle
 wework_desktop_core_e2e=true
 wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"},{"id":"core-4","name":"Core / shard 4","segments":"workspace-attachments"}]}
 wework_desktop_cloud_e2e=true
-wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"cloud-worktree-tools"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"cloud-worktree-create,cloud-worktree-archive-restore,cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"cloud-worktree-queued-cancel,cloud-worktree-capability"}]}
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"cloud-worktree-capability"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"cloud-worktree-queued-cancel"},{"id":"cloud-6","name":"Cloud / shard 6","segments":"cloud-worktree-tools,cloud-worktree-archive-restore"},{"id":"cloud-7","name":"Cloud / shard 7","segments":"cloud-worktree-create"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/lib/worktree-availability.ts"
@@ -515,7 +515,7 @@ assert_desktop_case "backend runtime Worktree changes select the cloud lifecycle
 wework_desktop_core_e2e=false
 wework_desktop_core_e2e_matrix={"include":[]}
 wework_desktop_cloud_e2e=true
-wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"cloud-worktree-tools"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"cloud-worktree-create,cloud-worktree-archive-restore,cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"cloud-worktree-queued-cancel,cloud-worktree-capability"}]}
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shard 1","segments":"cloud-worktree-capability"},{"id":"cloud-3","name":"Cloud / shard 3","segments":"cloud-worktree-device-restart"},{"id":"cloud-4","name":"Cloud / shard 4","segments":"cloud-worktree-queued-cancel"},{"id":"cloud-6","name":"Cloud / shard 6","segments":"cloud-worktree-tools,cloud-worktree-archive-restore"},{"id":"cloud-7","name":"Cloud / shard 7","segments":"cloud-worktree-create"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "backend/app/services/device/runtime_route.py"
@@ -533,7 +533,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "Codex notification isolation scenario is invoked by the core CI shard" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-4","name":"Core / shard 4","segments":"codex-notification-isolation"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"codex-notification-isolation"}]}
 wework_desktop_cloud_e2e=false
 wework_desktop_cloud_e2e_matrix={"include":[]}
 wework_desktop_other_e2e=false
@@ -551,7 +551,7 @@ wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-plugin-lifecycle","na
 assert_desktop_case "desktop sidebar selects all owned checkpoints" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow,priority-filter"},{"id":"core-4","name":"Core / shard 4","segments":"workspace-attachments"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-2","name":"Core / shard 2","segments":"project-ai-settings"},{"id":"core-3","name":"Core / shard 3","segments":"core-task-flow"},{"id":"core-4","name":"Core / shard 4","segments":"workspace-attachments"},{"id":"core-8","name":"Core / shard 8","segments":"priority-filter"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/components/layout/DesktopSidebar.tsx"
@@ -559,7 +559,7 @@ wework_desktop_other_e2e_matrix={"include":[]}' \
 assert_desktop_case "priority section selects only its dedicated checkpoint" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
-wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"priority-filter"}]}
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-8","name":"Core / shard 8","segments":"priority-filter"}]}
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/components/layout/DesktopSidebarPrioritySection.tsx"

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -313,7 +313,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.changes.outputs.wework_desktop_core_e2e_matrix) }}
 
     steps:
@@ -393,7 +393,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.changes.outputs.wework_desktop_cloud_e2e_matrix) }}
 
     steps:


### PR DESCRIPTION
## Summary

- increase Wework desktop Core E2E from 5 to 8 shards
- increase Wework desktop Cloud E2E from 5 to 8 shards
- rebalance checkpoint assignments and raise both workflow parallelism limits to 8
- update classifier expectations for the new shard layout

## Verification

- `.github/scripts/test-classify-ci-changes.sh`
- `bash -n .github/scripts/classify-wework-desktop-e2e.sh .github/scripts/test-classify-ci-changes.sh`
- `shellcheck .github/scripts/classify-wework-desktop-e2e.sh .github/scripts/test-classify-ci-changes.sh`
- generated full matrices contain 8 Core shards / 23 segments and 8 Cloud shards / 24 segments
- `git diff --check`

Task: WEWORKC2FA61-345