### PR TITLE
fix(wework): improve board task progress preview

### DIFF
--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -621,7 +621,6 @@ async function verifyWorkspaceIssueCreation(control) {
   await captureVerificationScreenshot(control, 'workspace-issue-03-new-task-sidebar.png')
   await control.command('click', `${taskPanelBackdrop} [data-testid="ai-chat-modal-close"]`)
 
-  await control.command('click', `${boardContentSelector} [data-testid="cloud-todo-detail-close"]`)
   await control.command('click', boardTabSelector)
   await control.command('waitFor', `${boardContentSelector} [data-testid="cloud-todo-workspace"]`, {
     visible: true,
@@ -792,13 +791,6 @@ async function verifyExplicitlyTrackedTask(control, taskTabTestId) {
     activeBoardContentSelector
   )
   await control.command('click', '[data-testid="ai-chat-modal-close"]', {
-    visible: true,
-  })
-  await control.command('waitFor', '[data-testid="cloud-todo-detail"]', {
-    visible: true,
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
-  await control.command('click', '[data-testid="cloud-todo-detail-close"]', {
     visible: true,
   })
   await control.command(

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -833,6 +833,17 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     assert.ok(workflowBinding)
     const workflowTaskRow = `[data-testid="cloud-todo-open-workflow-task-stage-1-${workflowBinding.id}"]`
     await control.command('click', '[data-testid="ai-chat-modal-close"]')
+    const workflowIssueCard = `${activeBoard} [data-testid="cloud-todo-card-${workflowIssue.id}"]`
+    await control.command('waitFor', workflowIssueCard, {
+      text: workflowIssue.title,
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('click', workflowIssueCard, { visible: true })
+    await control.command('waitFor', `${activeBoard} [data-testid="cloud-todo-detail-title"]`, {
+      text: workflowIssue.title,
+      timeoutMs: uiTimeoutMs,
+    })
     await control.command('waitFor', workflowTaskRow, {
       timeoutMs: uiTimeoutMs,
     })
@@ -859,7 +870,6 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     await control.command('click', `${activeBoard} [data-testid="cloud-project-board-view"]`, {
       visible: true,
     })
-    const workflowIssueCard = `${activeBoard} [data-testid="cloud-todo-card-${workflowIssue.id}"]`
     await control.command('waitFor', workflowIssueCard, {
       text: workflowIssue.title,
       timeoutMs: uiTimeoutMs,

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1955,7 +1955,7 @@ function getWebSearchToolBlocks(blocks: ProcessingBlock[]) {
   )
 }
 
-function AssistantMessage({
+export function AssistantMessage({
   message,
   conversationKey,
   devices,

--- a/wework/src/components/layout/SidebarHoverCard.tsx
+++ b/wework/src/components/layout/SidebarHoverCard.tsx
@@ -1,11 +1,6 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
-import { createPortal } from 'react-dom'
+import type { ReactNode } from 'react'
+import { HoverCard } from '@/components/ui/hover-card'
 import { cn } from '@/lib/utils'
-
-const HOVER_OPEN_DELAY_MS = 450
-const HOVER_CLOSE_DELAY_MS = 120
-const HOVER_CARD_GAP = 10
-const VIEWPORT_PADDING = 8
 
 interface SidebarHoverCardProps {
   children: ReactNode
@@ -15,11 +10,6 @@ interface SidebarHoverCardProps {
   cardClassName?: string
 }
 
-interface HoverCardPosition {
-  left: number
-  top: number
-}
-
 export function SidebarHoverCard({
   children,
   content,
@@ -27,124 +17,15 @@ export function SidebarHoverCard({
   interactive = false,
   cardClassName,
 }: SidebarHoverCardProps) {
-  const anchorRef = useRef<HTMLDivElement>(null)
-  const cardRef = useRef<HTMLDivElement>(null)
-  const openTimerRef = useRef<number | null>(null)
-  const closeTimerRef = useRef<number | null>(null)
-  const [position, setPosition] = useState<HoverCardPosition | null>(null)
-
-  const clearTimers = useCallback(() => {
-    if (openTimerRef.current !== null) {
-      window.clearTimeout(openTimerRef.current)
-      openTimerRef.current = null
-    }
-    if (closeTimerRef.current !== null) {
-      window.clearTimeout(closeTimerRef.current)
-      closeTimerRef.current = null
-    }
-  }, [])
-
-  const close = useCallback(() => {
-    clearTimers()
-    setPosition(null)
-  }, [clearTimers])
-
-  const scheduleOpen = useCallback(() => {
-    clearTimers()
-    openTimerRef.current = window.setTimeout(() => {
-      openTimerRef.current = null
-      const rect = anchorRef.current?.getBoundingClientRect()
-      if (!rect) return
-      setPosition({
-        left: Math.min(rect.right + HOVER_CARD_GAP, window.innerWidth - 328),
-        top: Math.max(VIEWPORT_PADDING, Math.min(rect.top, window.innerHeight - 220)),
-      })
-    }, HOVER_OPEN_DELAY_MS)
-  }, [clearTimers])
-
-  const scheduleClose = useCallback(() => {
-    if (!interactive) {
-      close()
-      return
-    }
-    if (openTimerRef.current !== null) {
-      window.clearTimeout(openTimerRef.current)
-      openTimerRef.current = null
-    }
-    if (closeTimerRef.current === null) {
-      closeTimerRef.current = window.setTimeout(close, HOVER_CLOSE_DELAY_MS)
-    }
-  }, [close, interactive])
-
-  const keepOpen = useCallback(() => {
-    if (closeTimerRef.current !== null) {
-      window.clearTimeout(closeTimerRef.current)
-      closeTimerRef.current = null
-    }
-  }, [])
-
-  useEffect(
-    () => () => {
-      if (openTimerRef.current !== null) window.clearTimeout(openTimerRef.current)
-      if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current)
-    },
-    []
-  )
-
-  useEffect(() => {
-    if (!position) return
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const path = event.composedPath()
-      if (path.includes(anchorRef.current as EventTarget)) {
-        keepOpen()
-        return
-      }
-      if (interactive && path.includes(cardRef.current as EventTarget)) {
-        keepOpen()
-        return
-      }
-      scheduleClose()
-    }
-
-    document.addEventListener('pointermove', handlePointerMove, true)
-    window.addEventListener('blur', close)
-    window.addEventListener('scroll', close, true)
-    return () => {
-      document.removeEventListener('pointermove', handlePointerMove, true)
-      window.removeEventListener('blur', close)
-      window.removeEventListener('scroll', close, true)
-    }
-  }, [close, interactive, keepOpen, position, scheduleClose])
-
   return (
-    <div
-      ref={anchorRef}
-      onMouseEnter={scheduleOpen}
-      onMouseLeave={scheduleClose}
-      onPointerDownCapture={close}
-      onContextMenuCapture={close}
+    <HoverCard
+      testId={testId}
+      interactive={interactive}
+      content={content}
+      cardClassName={cn('w-[310px]', cardClassName)}
+      estimatedWidth={cardClassName?.includes('w-[320px]') ? 320 : 310}
     >
       {children}
-      {position &&
-        createPortal(
-          <div
-            ref={cardRef}
-            data-testid={testId}
-            role={interactive ? 'dialog' : 'tooltip'}
-            style={position}
-            onMouseEnter={interactive ? keepOpen : undefined}
-            onMouseLeave={interactive ? scheduleClose : undefined}
-            className={cn(
-              'fixed z-[78] w-[310px] rounded-xl border border-border bg-background p-3 text-xs text-text-primary shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
-              interactive ? 'pointer-events-auto' : 'pointer-events-none',
-              cardClassName
-            )}
-          >
-            {content}
-          </div>,
-          document.body
-        )}
-    </div>
+    </HoverCard>
   )
 }

--- a/wework/src/components/ui/hover-card.test.tsx
+++ b/wework/src/components/ui/hover-card.test.tsx
@@ -1,0 +1,129 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { HoverCard } from './hover-card'
+
+describe('HoverCard', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('opens after the hover delay and stays open while the pointer is over the card', async () => {
+    vi.useFakeTimers()
+    render(
+      <HoverCard
+        testId="hover-card"
+        interactive
+        content={<div data-testid="hover-card-scroll-area">Progress details</div>}
+      >
+        <button type="button">Current task</button>
+      </HoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Current task'))
+    await act(async () => vi.advanceTimersByTime(449))
+    expect(screen.queryByTestId('hover-card')).not.toBeInTheDocument()
+
+    await act(async () => vi.advanceTimersByTime(1))
+    const card = screen.getByTestId('hover-card')
+    expect(card).toHaveTextContent('Progress details')
+
+    fireEvent.mouseLeave(screen.getByText('Current task'))
+    fireEvent.mouseEnter(card)
+    fireEvent.scroll(screen.getByTestId('hover-card-scroll-area'))
+    await act(async () => vi.advanceTimersByTime(120))
+    expect(card).toBeInTheDocument()
+  })
+
+  test('opens on focus and closes on Escape', () => {
+    render(
+      <HoverCard
+        testId="focus-hover-card"
+        openOnFocus
+        content={<div>Keyboard progress details</div>}
+      >
+        <button type="button">Current task</button>
+      </HoverCard>
+    )
+
+    fireEvent.focus(screen.getByText('Current task'))
+    expect(screen.getByTestId('focus-hover-card')).toHaveTextContent('Keyboard progress details')
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByTestId('focus-hover-card')).not.toBeInTheDocument()
+  })
+
+  test('positions the card to the left when the right side has less space', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      const isCard = this.dataset.testid === 'positioned-hover-card'
+      return {
+        x: isCard ? 530 : 900,
+        y: 100,
+        width: isCard ? 360 : 100,
+        height: isCard ? 220 : 40,
+        top: 100,
+        right: isCard ? 890 : 1000,
+        bottom: isCard ? 320 : 140,
+        left: isCard ? 530 : 900,
+        toJSON: () => undefined,
+      }
+    })
+    vi.stubGlobal('innerWidth', 1024)
+    vi.stubGlobal('innerHeight', 768)
+
+    render(
+      <HoverCard
+        testId="positioned-hover-card"
+        estimatedWidth={360}
+        content={<div>Progress details</div>}
+      >
+        <div>Current task</div>
+      </HoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Current task'))
+    await act(async () => vi.advanceTimersByTime(450))
+
+    expect(screen.getByTestId('positioned-hover-card')).toHaveStyle({ left: '530px', top: '100px' })
+  })
+
+  test('measures the rendered card and moves it above the bottom viewport edge', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      const isCard = this.dataset.testid === 'bottom-hover-card'
+      return {
+        x: isCard ? 530 : 900,
+        y: isCard ? 700 : 680,
+        width: isCard ? 360 : 100,
+        height: isCard ? 340 : 40,
+        top: isCard ? 700 : 680,
+        right: isCard ? 890 : 1000,
+        bottom: isCard ? 1040 : 720,
+        left: isCard ? 530 : 900,
+        toJSON: () => undefined,
+      }
+    })
+    vi.stubGlobal('innerWidth', 1024)
+    vi.stubGlobal('innerHeight', 768)
+
+    render(
+      <HoverCard
+        testId="bottom-hover-card"
+        estimatedWidth={360}
+        estimatedHeight={220}
+        content={<div>Progress details</div>}
+      >
+        <div>Current task</div>
+      </HoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Current task'))
+    await act(async () => vi.advanceTimersByTime(450))
+
+    expect(screen.getByTestId('bottom-hover-card')).toHaveStyle({
+      left: '530px',
+      top: '380px',
+    })
+  })
+})

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+const DEFAULT_OPEN_DELAY_MS = 450
+const CLOSE_DELAY_MS = 120
+const CARD_GAP = 10
+const VIEWPORT_PADDING = 8
+
+interface HoverCardProps {
+  children: ReactNode
+  content: ReactNode
+  testId: string
+  interactive?: boolean
+  openOnFocus?: boolean
+  cardClassName?: string
+  estimatedWidth?: number
+  estimatedHeight?: number
+}
+
+interface HoverCardPosition {
+  left: number
+  top: number
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum)
+}
+
+function hoverCardPosition(
+  anchor: DOMRect,
+  estimatedWidth: number,
+  estimatedHeight: number
+): HoverCardPosition {
+  const availableRight = window.innerWidth - anchor.right - CARD_GAP
+  const availableLeft = anchor.left - CARD_GAP
+  const displayRight = availableRight >= estimatedWidth || availableRight >= availableLeft
+  const desiredLeft = displayRight
+    ? anchor.right + CARD_GAP
+    : anchor.left - CARD_GAP - estimatedWidth
+  const desiredTop =
+    anchor.top + estimatedHeight + VIEWPORT_PADDING <= window.innerHeight
+      ? anchor.top
+      : anchor.bottom - estimatedHeight
+  const maximumLeft = Math.max(
+    VIEWPORT_PADDING,
+    window.innerWidth - estimatedWidth - VIEWPORT_PADDING
+  )
+  const maximumTop = Math.max(
+    VIEWPORT_PADDING,
+    window.innerHeight - estimatedHeight - VIEWPORT_PADDING
+  )
+
+  return {
+    left: clamp(desiredLeft, VIEWPORT_PADDING, maximumLeft),
+    top: clamp(desiredTop, VIEWPORT_PADDING, maximumTop),
+  }
+}
+
+export function HoverCard({
+  children,
+  content,
+  testId,
+  interactive = false,
+  openOnFocus = false,
+  cardClassName,
+  estimatedWidth = 310,
+  estimatedHeight = 220,
+}: HoverCardProps) {
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const openTimerRef = useRef<number | null>(null)
+  const closeTimerRef = useRef<number | null>(null)
+  const [position, setPosition] = useState<HoverCardPosition | null>(null)
+
+  const clearTimers = useCallback(() => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current)
+      openTimerRef.current = null
+    }
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  const close = useCallback(() => {
+    clearTimers()
+    setPosition(null)
+  }, [clearTimers])
+
+  const open = useCallback(() => {
+    clearTimers()
+    const rect = anchorRef.current?.getBoundingClientRect()
+    if (!rect) return
+    setPosition(hoverCardPosition(rect, estimatedWidth, estimatedHeight))
+  }, [clearTimers, estimatedHeight, estimatedWidth])
+
+  const scheduleOpen = useCallback(() => {
+    clearTimers()
+    openTimerRef.current = window.setTimeout(() => {
+      openTimerRef.current = null
+      open()
+    }, DEFAULT_OPEN_DELAY_MS)
+  }, [clearTimers, open])
+
+  const scheduleClose = useCallback(() => {
+    if (!interactive) {
+      close()
+      return
+    }
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current)
+      openTimerRef.current = null
+    }
+    if (closeTimerRef.current === null) {
+      closeTimerRef.current = window.setTimeout(close, CLOSE_DELAY_MS)
+    }
+  }, [close, interactive])
+
+  const keepOpen = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (openTimerRef.current !== null) window.clearTimeout(openTimerRef.current)
+      if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current)
+    },
+    []
+  )
+
+  useLayoutEffect(() => {
+    if (!position) return
+    const anchorRect = anchorRef.current?.getBoundingClientRect()
+    const cardRect = cardRef.current?.getBoundingClientRect()
+    if (!anchorRect || !cardRect) return
+
+    const nextPosition = hoverCardPosition(
+      anchorRect,
+      cardRect.width || estimatedWidth,
+      cardRect.height || estimatedHeight
+    )
+    if (nextPosition.left === position.left && nextPosition.top === position.top) return
+    setPosition(nextPosition)
+  }, [estimatedHeight, estimatedWidth, position])
+
+  useEffect(() => {
+    if (!position) return
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const path = event.composedPath()
+      if (path.includes(anchorRef.current as EventTarget)) {
+        keepOpen()
+        return
+      }
+      if (interactive && path.includes(cardRef.current as EventTarget)) {
+        keepOpen()
+        return
+      }
+      scheduleClose()
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close()
+    }
+    const handleScroll = (event: Event) => {
+      if (event.target instanceof Node && cardRef.current?.contains(event.target)) return
+      close()
+    }
+
+    document.addEventListener('pointermove', handlePointerMove, true)
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('blur', close)
+    window.addEventListener('scroll', handleScroll, true)
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove, true)
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('blur', close)
+      window.removeEventListener('scroll', handleScroll, true)
+    }
+  }, [close, interactive, keepOpen, position, scheduleClose])
+
+  return (
+    <div
+      ref={anchorRef}
+      onMouseEnter={scheduleOpen}
+      onMouseLeave={scheduleClose}
+      onFocusCapture={openOnFocus ? open : undefined}
+      onBlurCapture={openOnFocus ? scheduleClose : undefined}
+      onPointerDownCapture={close}
+      onContextMenuCapture={close}
+    >
+      {children}
+      {position &&
+        createPortal(
+          <div
+            ref={cardRef}
+            data-testid={testId}
+            role={interactive ? 'dialog' : 'tooltip'}
+            style={position}
+            onMouseEnter={interactive ? keepOpen : undefined}
+            onMouseLeave={interactive ? scheduleClose : undefined}
+            onFocusCapture={interactive ? keepOpen : undefined}
+            onBlurCapture={interactive ? scheduleClose : undefined}
+            className={cn(
+              'fixed z-[78] max-h-[calc(100vh-1rem)] overflow-y-auto rounded-xl border border-border bg-background p-3 text-xs text-text-primary shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+              interactive ? 'pointer-events-auto' : 'pointer-events-none',
+              cardClassName
+            )}
+          >
+            {content}
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}

--- a/wework/src/features/todo/AiChatModal.test.tsx
+++ b/wework/src/features/todo/AiChatModal.test.tsx
@@ -515,4 +515,29 @@ describe('AiChatModal', () => {
     await userEvent.click(screen.getByTestId('ai-chat-open-runtime-task'))
     expect(onOpenRuntimeTask).toHaveBeenCalledWith(address)
   })
+
+  it('separates returning to the Issue from closing the unified sidebar', async () => {
+    const onBack = vi.fn()
+    const onClose = vi.fn()
+
+    render(
+      <AiChatModal
+        project={project}
+        localProjects={localProjects}
+        task={task}
+        initialAddress={{ deviceId: 'local-device', taskId: 'runtime-1' }}
+        embedded
+        open
+        onBack={onBack}
+        onClose={onClose}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('ai-chat-modal-back'))
+    expect(onBack).toHaveBeenCalledOnce()
+    expect(onClose).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByTestId('ai-chat-modal-close'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
 })

--- a/wework/src/features/todo/AiChatModal.tsx
+++ b/wework/src/features/todo/AiChatModal.tsx
@@ -30,6 +30,7 @@ interface AiChatModalProps {
    * even while the temporary task is still executing. */
   open: boolean
   onClose: () => void
+  onBack?: () => void
   initialAddress?: RuntimeTaskAddress | null
   initialLocalProjectId?: number | null
   inheritFromTask?: RuntimeTaskAddress | null
@@ -69,6 +70,7 @@ export function AiChatModal({
   task,
   open,
   onClose,
+  onBack,
   initialAddress = null,
   initialLocalProjectId = null,
   inheritFromTask = null,
@@ -295,8 +297,8 @@ export function AiChatModal({
             <header className="flex h-12 shrink-0 items-center gap-2 px-3">
               <button
                 type="button"
-                data-testid="ai-chat-modal-close"
-                onClick={onClose}
+                data-testid="ai-chat-modal-back"
+                onClick={onBack ?? onClose}
                 aria-label={t('workbench.back_to_work_item', '返回 Issue')}
                 className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-secondary transition hover:bg-muted hover:text-text-primary"
               >
@@ -318,6 +320,15 @@ export function AiChatModal({
                   <ArrowUpRight className="h-3.5 w-3.5" />
                 </button>
               ) : null}
+              <button
+                type="button"
+                data-testid="ai-chat-modal-close"
+                onClick={onClose}
+                aria-label={t('common.close', '关闭')}
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-secondary transition hover:bg-muted hover:text-text-primary"
+              >
+                <X className="h-4 w-4" />
+              </button>
             </header>
             <TemporaryChatPanel
               currentProject={selectedLocalProject}

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -12,7 +12,9 @@ import {
 import type { CloudLoopItem } from '@/api/deliveries'
 import type { TaskChangeRequestSnapshot, TaskChangeRequestTarget } from '@/api/changeRequests'
 import { ChangeRequestStatusIcon } from '@/components/common/ChangeRequestStatusIcon'
+import { AssistantMessage } from '@/components/chat/MessageList'
 import { AssistantThinkingIndicator } from '@/components/chat/AssistantThinkingIndicator'
+import { ToolBlocksDisplay } from '@/components/chat/blocks/ToolBlocksDisplay'
 import {
   getToolActivityFilePaths,
   getToolActivityKind,
@@ -20,6 +22,7 @@ import {
 } from '@/components/chat/blocks/toolBlockActivity'
 import { getInputField } from '@/components/chat/blocks/toolBlockKinds'
 import { Tooltip } from '@/components/ui/tooltip'
+import { HoverCard } from '@/components/ui/hover-card'
 import {
   getRuntimeConversationLiveActivitySnapshot,
   getRuntimeConversationMessages,
@@ -33,6 +36,7 @@ import {
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { RuntimeTaskAddress } from '@/types/api'
+import type { ProcessingBlock, WorkbenchMessage } from '@/types/workbench'
 import type { ChangeRequestMonitor } from '@/features/workbench/changeRequestMonitor'
 import { useTaskChangeRequest } from '@/features/workbench/changeRequestMonitor'
 import {
@@ -40,7 +44,11 @@ import {
   stoppedTaskNeedsAttention,
 } from '@/features/workbench/changeRequestStatus'
 import { isLoopItemExecutionActive } from './cloudMyWorkModel'
-import { finalAssistantMessagesPreview } from './runtimeTaskResponsePreview'
+import {
+  finalAssistantMessagesText,
+  latestResponseLine,
+  latestAssistantMessage,
+} from './runtimeTaskResponsePreview'
 import { priorityBadgeClasses } from './todoShared'
 
 export interface BoardCardDisplaySettings {
@@ -166,6 +174,7 @@ export interface CloudTodoBoardTaskBinding {
   running: boolean
   changeRequestTarget?: TaskChangeRequestTarget | null
   finalResponsePreview?: string | null
+  finalResponseMessage?: WorkbenchMessage | null
   finalResponseLoaded?: boolean
 }
 
@@ -237,13 +246,16 @@ export function CloudTodoBoardCard({
     [currentTaskBinding, hasActiveTask]
   )
   const currentActivity = useRuntimeTaskActivity(currentActivityAddress)
+  const currentTaskMessage = useRuntimeTaskLatestAssistantMessage(currentTaskAddress)
   const cachedFinalResponsePreview = useRuntimeTaskFinalResponse(
     item.status === 'in_review' ? currentTaskAddress : null
   )
-  const finalResponsePreview =
-    currentTaskBinding?.finalResponsePreview || cachedFinalResponsePreview
+  const finalResponseText = currentTaskBinding?.finalResponsePreview || cachedFinalResponsePreview
+  const finalResponsePreview = finalResponseText ? latestResponseLine(finalResponseText) : null
   const finalResponseLoaded =
     currentTaskBinding?.finalResponseLoaded || cachedFinalResponsePreview !== null
+  const showFinalResponsePreview =
+    item.status === 'in_review' && finalResponseLoaded && Boolean(finalResponsePreview)
   const {
     attributes,
     listeners,
@@ -322,72 +334,95 @@ export function CloudTodoBoardCard({
       </button>
 
       {currentTaskBinding && showCurrentTask ? (
-        <div
-          role={onOpenActivity ? 'button' : undefined}
-          tabIndex={onOpenActivity ? 0 : undefined}
-          aria-label={
-            onOpenActivity ? currentTaskBinding.task_title || currentTaskBinding.task_id : undefined
+        <HoverCard
+          testId={`cloud-todo-card-progress-popup-${item.id}`}
+          interactive
+          openOnFocus
+          estimatedWidth={360}
+          estimatedHeight={240}
+          cardClassName="w-[360px] max-w-[calc(100vw-1rem)]"
+          content={
+            <RuntimeTaskProgressPopup
+              item={item}
+              binding={currentTaskBinding}
+              activity={currentActivity}
+              message={
+                currentActivity.active
+                  ? currentTaskMessage
+                  : (currentTaskBinding.finalResponseMessage ?? currentTaskMessage)
+              }
+              finalResponseText={finalResponseText}
+            />
           }
-          data-testid={`cloud-todo-card-tasks-${item.id}`}
-          onClick={onOpenActivity}
-          onKeyDown={event => {
-            if (!onOpenActivity || (event.key !== 'Enter' && event.key !== ' ')) return
-            event.preventDefault()
-            onOpenActivity()
-          }}
-          className={cn(
-            'w-full border-t border-border/60 px-3.5 py-2 text-left transition',
-            onOpenActivity
-              ? 'cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus/30'
-              : 'cursor-default'
-          )}
         >
-          <div className="flex min-w-0 items-center gap-2 text-xs text-text-secondary">
-            {changeRequestSnapshot?.changeRequest ? (
-              <ChangeRequestStatusIcon
-                snapshot={changeRequestSnapshot}
-                testId={`cloud-todo-card-change-request-${item.id}-${currentTaskBinding.id}`}
-                popoverAlign="left"
-                repairing={repairingChangeRequest}
-                onContinueRepair={
-                  autoRepairStatus(changeRequestSnapshot.changeRequest) &&
-                  onContinueChangeRequestRepair
-                    ? async () => {
-                        setRepairingChangeRequest(true)
-                        try {
-                          await onContinueChangeRequestRepair(
-                            currentTaskBinding,
-                            changeRequestSnapshot
-                          )
-                        } finally {
-                          setRepairingChangeRequest(false)
-                        }
-                      }
-                    : undefined
-                }
-              />
-            ) : (
-              <ListTodo className="h-3.5 w-3.5" />
+          <div
+            role={onOpenActivity ? 'button' : undefined}
+            tabIndex={onOpenActivity ? 0 : undefined}
+            aria-label={
+              onOpenActivity
+                ? currentTaskBinding.task_title || currentTaskBinding.task_id
+                : undefined
+            }
+            data-testid={`cloud-todo-card-tasks-${item.id}`}
+            onClick={onOpenActivity}
+            onKeyDown={event => {
+              if (!onOpenActivity || (event.key !== 'Enter' && event.key !== ' ')) return
+              event.preventDefault()
+              onOpenActivity()
+            }}
+            className={cn(
+              'w-full border-t border-border/60 px-3.5 py-2 text-left transition',
+              onOpenActivity
+                ? 'cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus/30'
+                : 'cursor-default'
             )}
-            <span
-              data-testid={`cloud-todo-card-task-${item.id}-${currentTaskBinding.id}`}
-              className="min-w-0 truncate"
-            >
-              {currentTaskBinding.task_title || currentTaskBinding.task_id}
-            </span>
+          >
+            <div className="flex min-w-0 items-center gap-2 text-xs text-text-secondary">
+              {changeRequestSnapshot?.changeRequest ? (
+                <ChangeRequestStatusIcon
+                  snapshot={changeRequestSnapshot}
+                  testId={`cloud-todo-card-change-request-${item.id}-${currentTaskBinding.id}`}
+                  popoverAlign="left"
+                  repairing={repairingChangeRequest}
+                  onContinueRepair={
+                    autoRepairStatus(changeRequestSnapshot.changeRequest) &&
+                    onContinueChangeRequestRepair
+                      ? async () => {
+                          setRepairingChangeRequest(true)
+                          try {
+                            await onContinueChangeRequestRepair(
+                              currentTaskBinding,
+                              changeRequestSnapshot
+                            )
+                          } finally {
+                            setRepairingChangeRequest(false)
+                          }
+                        }
+                      : undefined
+                  }
+                />
+              ) : (
+                <ListTodo className="h-3.5 w-3.5" />
+              )}
+              <span
+                data-testid={`cloud-todo-card-task-${item.id}-${currentTaskBinding.id}`}
+                className="min-w-0 flex-1 truncate"
+                title={currentTaskBinding.task_title || currentTaskBinding.task_id}
+              >
+                {showFinalResponsePreview ? (
+                  <span data-testid={`cloud-todo-card-final-response-${item.id}`}>
+                    {finalResponsePreview}
+                  </span>
+                ) : (
+                  currentTaskBinding.task_title || currentTaskBinding.task_id
+                )}
+              </span>
+            </div>
+            {currentActivity.active ? (
+              <RuntimeTaskLiveActivity itemId={item.id} activity={currentActivity} />
+            ) : null}
           </div>
-          {currentActivity.active ? (
-            <RuntimeTaskLiveActivity itemId={item.id} activity={currentActivity} />
-          ) : null}
-          {item.status === 'in_review' && finalResponseLoaded ? (
-            <p
-              data-testid={`cloud-todo-card-final-response-${item.id}`}
-              className="ml-5 mt-1.5 line-clamp-3 whitespace-pre-line border-l border-border/70 pl-2 text-xs leading-5 text-text-secondary"
-            >
-              {finalResponsePreview || t('todo.no_final_task_response', '暂无最终回复')}
-            </p>
-          ) : null}
-        </div>
+        </HoverCard>
       ) : null}
     </article>
   )
@@ -396,9 +431,11 @@ export function CloudTodoBoardCard({
 function RuntimeTaskLiveActivity({
   itemId,
   activity,
+  expanded = false,
 }: {
   itemId: string
   activity: RuntimeLiveActivity
+  expanded?: boolean
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const lastTool = activity.tools.at(-1)
@@ -407,6 +444,15 @@ function RuntimeTaskLiveActivity({
   )
   const activeTools = activity.tools.filter(
     block => block.status !== 'done' && block.status !== 'error'
+  )
+  const processingBlocks = useMemo<ProcessingBlock[]>(
+    () =>
+      activity.tools.map(block => ({
+        ...block,
+        type: 'tool',
+        subtaskId: `board:${itemId}`,
+      })),
+    [activity.tools, itemId]
   )
 
   useLayoutEffect(() => {
@@ -417,24 +463,128 @@ function RuntimeTaskLiveActivity({
   return (
     <div
       ref={scrollRef}
-      data-testid={`cloud-todo-card-activity-${itemId}`}
-      className="scrollbar-none ml-5 mt-1.5 h-5 min-w-0 overflow-y-auto border-l border-border/70 pl-2 text-xs leading-5 text-text-muted"
+      data-testid={
+        expanded ? `cloud-todo-card-popup-activity-${itemId}` : `cloud-todo-card-activity-${itemId}`
+      }
+      className={cn(
+        'scrollbar-none min-w-0 overflow-y-auto',
+        expanded
+          ? 'max-h-44 text-chat text-text-primary'
+          : 'ml-5 mt-1.5 h-5 border-l border-border/70 pl-2 text-xs leading-5 text-text-muted'
+      )}
     >
-      {completedTools.map(block => (
-        <RuntimeTaskToolActivity key={block.id} itemId={itemId} block={block} />
-      ))}
-      {activity.thinking ? (
-        <div className="flex h-5 min-w-0 items-center">
+      {expanded ? (
+        processingBlocks.length > 0 ? (
+          <ToolBlocksDisplay
+            blocks={processingBlocks}
+            isStreaming={activity.active}
+            processingPhase="live"
+            showInterToolThinking
+            thinkingContent={activity.thinking}
+            stateKey={`cloud-todo-card:${itemId}:progress-popup`}
+          />
+        ) : activity.thinking ? (
           <AssistantThinkingIndicator
             content={activity.thinking}
-            testId={`cloud-todo-card-thinking-${itemId}`}
-            className="text-xs leading-5"
+            testId={`cloud-todo-card-popup-thinking-${itemId}`}
           />
+        ) : null
+      ) : (
+        <>
+          {completedTools.map(block => (
+            <RuntimeTaskToolActivity key={block.id} itemId={itemId} block={block} />
+          ))}
+          {activity.thinking ? (
+            <div className="flex h-5 min-w-0 items-center">
+              <AssistantThinkingIndicator
+                content={activity.thinking}
+                testId={`cloud-todo-card-thinking-${itemId}`}
+                className="text-xs leading-5"
+              />
+            </div>
+          ) : null}
+          {activeTools.map(block => (
+            <RuntimeTaskToolActivity key={block.id} itemId={itemId} block={block} />
+          ))}
+        </>
+      )}
+    </div>
+  )
+}
+
+function RuntimeTaskProgressPopup({
+  item,
+  binding,
+  activity,
+  message,
+  finalResponseText,
+}: {
+  item: CloudLoopItem
+  binding: CloudTodoBoardTaskBinding
+  activity: RuntimeLiveActivity
+  message: WorkbenchMessage | null
+  finalResponseText: string | null
+}) {
+  const { t } = useTranslation('common')
+  const taskTitle = binding.task_title || binding.task_id
+
+  return (
+    <div
+      data-testid={`cloud-todo-card-progress-popup-content-${item.id}`}
+      className="min-w-0 space-y-2"
+    >
+      <div className="min-w-0 border-b border-border/60 pb-2">
+        <div className="text-sm font-medium leading-5 text-text-primary">
+          {t('todo.task_progress_details', '当前任务进展')}
         </div>
-      ) : null}
-      {activeTools.map(block => (
-        <RuntimeTaskToolActivity key={block.id} itemId={itemId} block={block} />
-      ))}
+        <div className="mt-0.5 line-clamp-2 text-xs leading-5 text-text-secondary">{taskTitle}</div>
+      </div>
+      {message ? (
+        <RuntimeTaskMessage itemId={item.id} message={message} />
+      ) : activity.active ? (
+        <RuntimeTaskLiveActivity itemId={item.id} activity={activity} expanded />
+      ) : finalResponseText ? (
+        <RuntimeTaskMessage
+          itemId={item.id}
+          message={{
+            id: `board-progress-${item.id}`,
+            role: 'assistant',
+            content: finalResponseText,
+            status: 'done',
+            createdAt: '',
+          }}
+        />
+      ) : (
+        <p
+          data-testid={`cloud-todo-card-progress-empty-${item.id}`}
+          className="text-xs leading-5 text-text-muted"
+        >
+          {t('todo.task_progress_empty', '暂无任务进展详情')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function RuntimeTaskMessage({ itemId, message }: { itemId: string; message: WorkbenchMessage }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const scrollArea = scrollRef.current
+    if (scrollArea) scrollArea.scrollTop = scrollArea.scrollHeight
+  }, [message])
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid={`cloud-todo-card-progress-response-${itemId}`}
+      className="max-h-56 min-w-0 overscroll-contain overflow-y-auto"
+    >
+      <AssistantMessage
+        message={message}
+        conversationKey={`cloud-todo-card:${itemId}:progress-popup`}
+        devices={[]}
+      />
     </div>
   )
 }
@@ -483,10 +633,33 @@ function useRuntimeTaskFinalResponse(address: RuntimeTaskAddress | null): string
     [address]
   )
   const getSnapshot = useCallback(
-    () => (address ? finalAssistantMessagesPreview(getRuntimeConversationMessages(address)) : null),
+    () => (address ? finalAssistantMessagesText(getRuntimeConversationMessages(address)) : null),
     [address]
   )
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+function useRuntimeTaskLatestAssistantMessage(
+  address: RuntimeTaskAddress | null
+): WorkbenchMessage | null {
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      address ? subscribeRuntimeConversation(address, listener) : () => undefined,
+    [address]
+  )
+  const getSnapshot = useCallback(
+    () =>
+      address
+        ? JSON.stringify(latestAssistantMessage(getRuntimeConversationMessages(address)))
+        : '',
+    [address]
+  )
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  return useMemo(
+    () => (snapshot ? (JSON.parse(snapshot) as WorkbenchMessage | null) : null),
+    [snapshot]
+  )
 }
 
 function runtimeToolActivityText(

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -1284,6 +1284,11 @@ describe('CloudTodoWorkspace', () => {
 
     expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-open', 'no')
     expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('cloud-todo-card-WEG-1'))
+
+    expect(await screen.findByTestId('cloud-todo-detail')).toBeInTheDocument()
+    expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
   })
 
   it('dismisses the unified Issue and conversation panel in one action', async () => {

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -44,6 +44,7 @@ vi.mock('./AiChatModal', () => ({
     task,
     open,
     onClose,
+    onBack,
     initialAddress,
     onOpenRuntimeTask,
     onAddressChange,
@@ -54,6 +55,7 @@ vi.mock('./AiChatModal', () => ({
     task?: { id: string }
     open: boolean
     onClose: () => void
+    onBack?: () => void
     initialAddress?: { deviceId: string; taskId: string } | null
     onOpenRuntimeTask?: (address: { deviceId: string; taskId: string }) => void
     onAddressChange?: (address: { deviceId: string; taskId: string }) => void
@@ -91,6 +93,11 @@ vi.mock('./AiChatModal', () => ({
       >
         打开完整任务
       </button>
+      {onBack ? (
+        <button type="button" data-testid="ai-chat-modal-back" onClick={onBack}>
+          返回 Issue
+        </button>
+      ) : null}
       <button type="button" data-testid="ai-chat-modal-close" onClick={onClose}>
         关闭
       </button>
@@ -691,6 +698,10 @@ describe('CloudTodoWorkspace', () => {
       'text-xs',
       'border-l'
     )
+    expect(screen.getByTestId('cloud-todo-card-activity-WEG-1')).not.toHaveClass(
+      'group-hover:h-20',
+      'group-focus-within:h-20'
+    )
 
     act(() => {
       applyRuntimeConversationAction(address, {
@@ -731,6 +742,13 @@ describe('CloudTodoWorkspace', () => {
       'overflow-y-auto'
     )
     expect(screen.getByTestId('cloud-todo-card-thinking-WEG-1')).toHaveClass('text-xs', 'leading-5')
+
+    fireEvent.mouseEnter(screen.getByTestId('cloud-todo-card-tasks-WEG-1'))
+    const progressPopup = await screen.findByTestId('cloud-todo-card-progress-popup-WEG-1')
+    expect(progressPopup).toHaveTextContent('当前任务进展')
+    expect(progressPopup).toHaveTextContent('验证完整工作流')
+    expect(progressPopup).toHaveTextContent('调用 1 个工具')
+    expect(progressPopup).toHaveTextContent('pnpm test')
 
     await userEvent.click(screen.getByTestId('cloud-todo-card-tasks-WEG-1'))
     expect(await screen.findByTestId('cloud-todo-detail')).toBeInTheDocument()
@@ -785,11 +803,20 @@ describe('CloudTodoWorkspace', () => {
 
     await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
     expect(await screen.findByTestId('cloud-todo-card-final-response-WEG-1')).toHaveTextContent(
-      '第一行 第二行 第三行'
-    )
-    expect(screen.getByTestId('cloud-todo-card-final-response-WEG-1')).not.toHaveTextContent(
       '第四行'
     )
+    expect(screen.getByTestId('cloud-todo-card-final-response-WEG-1')).not.toHaveTextContent(
+      '第一行'
+    )
+
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(240)
+    fireEvent.mouseEnter(screen.getByTestId('cloud-todo-card-tasks-WEG-1'))
+    const progressPopup = await screen.findByTestId('cloud-todo-card-progress-popup-WEG-1')
+    const progressResponse = screen.getByTestId('cloud-todo-card-progress-response-WEG-1')
+    expect(progressPopup).toHaveTextContent('当前任务进展')
+    expect(progressResponse).toHaveTextContent('第一行 第二行 第三行 第四行')
+    await waitFor(() => expect(progressResponse.scrollTop).toBe(240))
+    expect(progressResponse.querySelector('.assistant-markdown')).toBeInTheDocument()
   })
 
   it('reports the concrete project name for the active document tab', async () => {
@@ -1156,6 +1183,12 @@ describe('CloudTodoWorkspace', () => {
       'true'
     )
     expect(screen.getByTestId('cloud-todo-panel-stack')).toHaveClass('has-conversation')
+    const issueResources = screen.getByTestId('cloud-todo-compact-issue')
+    expect(issueResources).toHaveTextContent('文件附件')
+    expect(issueResources).toHaveTextContent('任务会话')
+    expect(issueResources).toHaveTextContent('Implement cloud delivery')
+    expect(issueResources).toHaveTextContent('子 Issue')
+    expect(issueResources).not.toHaveTextContent('Implement cloud MCP')
     expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-task-id', 'WEG-1')
     expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute(
       'data-runtime-task-id',
@@ -1167,9 +1200,13 @@ describe('CloudTodoWorkspace', () => {
       deviceId: 'local-device',
       taskId: 'runtime-248868498',
     })
-    await userEvent.click(screen.getByTestId('ai-chat-modal-close'))
+    await userEvent.click(screen.getByTestId('ai-chat-modal-back'))
     expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
     expect(screen.getByTestId('cloud-todo-detail')).toBeInTheDocument()
+    await userEvent.click(await screen.findByTestId('cloud-todo-open-task-conversation-1'))
+    await userEvent.click(screen.getByTestId('ai-chat-modal-close'))
+    expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
   })
 
   it('aggregates every bound task and creates another current-user task in the issue detail', async () => {
@@ -1249,7 +1286,7 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
   })
 
-  it('dismisses the floating panel stack one level at a time from the backdrop', async () => {
+  it('dismisses the unified Issue and conversation panel in one action', async () => {
     render(
       <CloudTodoWorkspace
         user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
@@ -1274,20 +1311,6 @@ describe('CloudTodoWorkspace', () => {
     await userEvent.keyboard('{Escape}')
 
     expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
-    expect(screen.getByTestId('cloud-todo-detail')).toBeInTheDocument()
-
-    await userEvent.click(await screen.findByTestId('cloud-todo-open-task-conversation-1'))
-    await userEvent.click(screen.getByTestId('cloud-todo-detail-dismiss-layer'))
-
-    expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
-    expect(screen.getByTestId('cloud-todo-detail')).toBeInTheDocument()
-    expect(screen.getByTestId('cloud-todo-panel-stack')).toHaveAttribute(
-      'data-conversation-open',
-      'false'
-    )
-
-    await userEvent.click(screen.getByTestId('cloud-todo-detail-dismiss-layer'))
-
     expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
     expect(screen.queryByTestId('cloud-todo-detail-dismiss-layer')).not.toBeInTheDocument()
   })
@@ -3726,18 +3749,21 @@ describe('CloudTodoWorkspace', () => {
     expect(await screen.findByTestId('cloud-todo-column-in_review')).toHaveTextContent(
       'Stopped task Issue'
     )
-    expect(await screen.findByTestId('cloud-todo-card-tasks-WEG-1')).toHaveTextContent(
+    expect(await screen.findByTestId('cloud-todo-card-tasks-WEG-1')).toHaveAttribute(
+      'aria-label',
       'Stopped task'
     )
-    expect(screen.getByTestId('cloud-todo-card-tasks-WEG-1')).not.toHaveTextContent('Task')
+    expect(screen.getByTestId('cloud-todo-card-tasks-WEG-1')).not.toHaveTextContent('Stopped task')
     expect(await screen.findByTestId('cloud-todo-card-final-response-WEG-1')).toHaveTextContent(
-      '第一行：已经完成修复 第二行：测试全部通过 第三行：可以开始验收'
-    )
-    expect(screen.getByTestId('cloud-todo-card-final-response-WEG-1')).not.toHaveTextContent(
       '第四行：不应展示'
     )
-    expect(await screen.findByTestId('cloud-todo-card-final-response-WEG-4')).toHaveTextContent(
-      '暂无最终回复'
+    expect(screen.getByTestId('cloud-todo-card-final-response-WEG-1')).not.toHaveTextContent(
+      '第一行：已经完成修复'
+    )
+    expect(screen.queryByTestId('cloud-todo-card-final-response-WEG-4')).not.toBeInTheDocument()
+    fireEvent.mouseEnter(screen.getByTestId('cloud-todo-card-tasks-WEG-4'))
+    expect(await screen.findByTestId('cloud-todo-card-progress-empty-WEG-4')).toHaveTextContent(
+      '暂无任务进展详情'
     )
     expect(getRuntimeTranscript).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -4166,6 +4166,8 @@ export function CloudTodoWorkspace({
                                       onClick={() => {
                                         if (item.can_view_detail !== false) {
                                           setBackgroundTaskItemId(null)
+                                          setSelectedTaskBinding(null)
+                                          setTaskComposerRequest(null)
                                           setSelectedItem(item)
                                         }
                                       }}

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from 'react'
 import {
   DndContext,
@@ -20,6 +21,7 @@ import {
 } from '@dnd-kit/core'
 import {
   Archive,
+  ArrowLeft,
   Bot,
   Check,
   ChevronDown,
@@ -28,17 +30,21 @@ import {
   Cloud,
   Copy,
   Ellipsis,
+  File,
   GitBranch,
   Grid3X3,
   HardDrive,
   ListTodo,
   LockKeyhole,
+  MessageSquare,
   Plus,
   Search,
   Settings,
+  X,
 } from 'lucide-react'
 import type {
   CloudLoopItem,
+  CloudLoopItemAttachment,
   CloudMyWorkItem,
   CloudProject,
   CloudProjectMember,
@@ -91,6 +97,7 @@ import {
   completeChangeRequestAutoRepair,
 } from '@/features/workbench/changeRequestStatus'
 import { isRuntimeTaskExecutionRunning } from '@/features/workbench/runtimeTaskLifecycle/projection'
+import { runtimeMessagesToWorkbenchMessages } from '@/features/workbench/runtimePaneMessages'
 import type { RuntimeTaskLifecycleStoreSnapshot } from '@/features/workbench/runtimeTaskLifecycle'
 import { hydrateRuntimeTaskAddress } from '@/features/workbench/workbenchRuntimeHelpers'
 import { AITableView } from '@/features/todo/AITableView'
@@ -102,6 +109,7 @@ import type {
   RuntimeWorkListResponse,
   User as UserProfile,
 } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
 import { CloudTodoModal as Modal } from './CloudTodoModal'
 import { CloudMyWorkView } from './CloudMyWorkView'
 import { stopLocalRobotQueueExecution } from './localRobotQueueDispatcher'
@@ -131,7 +139,10 @@ import { GlobalTodoSearch } from './GlobalTodoSearch'
 import { BoardQuickCreate } from './BoardQuickCreate'
 import { parseDingTalkAITableLink, repositoryProviderConfig } from './projectProviderConfig'
 import { isRuntimeMyWorkItem, runtimeMyWorkItems } from './runtimeMyWork'
-import { finalAssistantTranscriptPreview } from './runtimeTaskResponsePreview'
+import {
+  finalAssistantTranscriptMessage,
+  finalAssistantTranscriptText,
+} from './runtimeTaskResponsePreview'
 import { TaskSearchPanel } from './TaskSearchPanel'
 import { TodoEditor } from './TodoEditor'
 import { IssueComposer } from './IssueComposer'
@@ -153,6 +164,41 @@ import type { WorkflowDeliverableDraft } from './WorkflowStageCompletionDialog'
 type ProjectView = 'board' | 'table' | 'files' | 'automation' | 'manage'
 type RootView = 'projects' | 'my-work' | 'settings'
 type ProjectTaskProvider = 'local' | 'github' | 'gitlab' | 'dingtalk_aitable'
+
+function IssueResourceSection({
+  icon,
+  title,
+  count,
+  empty,
+  children,
+}: {
+  icon: ReactNode
+  title: string
+  count: number
+  empty: string
+  children: ReactNode
+}) {
+  return (
+    <section className="task-conversation-resource-section">
+      <header className="task-conversation-resource-heading">
+        <span className="text-text-muted">{icon}</span>
+        <span className="min-w-0 flex-1 truncate">{title}</span>
+        <span className="task-conversation-resource-count">{count}</span>
+      </header>
+      {count > 0 ? (
+        <div className="space-y-0.5 px-2 pb-2">{children}</div>
+      ) : (
+        <p className="px-4 pb-3 text-xs text-text-muted">{empty}</p>
+      )}
+    </section>
+  )
+}
+
+function formatCompactFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
 type NativeBoardGroupBy = 'status' | 'priority' | 'assignee' | 'tag'
 
 const nativeBoardGroupFields: AITableField[] = [
@@ -1225,7 +1271,14 @@ export function CloudTodoWorkspace({
     LocatedLoopItem[] | null
   >(null)
   const [runtimeFinalResponsePreviews, setRuntimeFinalResponsePreviews] = useState<
-    Record<string, { signature: string; text: string | null }>
+    Record<
+      string,
+      {
+        signature: string
+        text: string | null
+        message: WorkbenchMessage | null
+      }
+    >
   >({})
   const runtimeFinalResponseRequestsRef = useRef(new Set<string>())
   const runtimeFinalResponseLatestSignatureRef = useRef(new Map<string, string>())
@@ -1444,6 +1497,13 @@ export function CloudTodoWorkspace({
                   taskId: binding.task_id,
                 })
               ]?.text ?? null,
+            finalResponseMessage:
+              runtimeFinalResponsePreviews[
+                runtimeConversationKey({
+                  deviceId: binding.device_id,
+                  taskId: binding.task_id,
+                })
+              ]?.message ?? null,
             finalResponseLoaded:
               runtimeConversationKey({
                 deviceId: binding.device_id,
@@ -2457,10 +2517,13 @@ export function CloudTodoWorkspace({
             if (runtimeFinalResponseLatestSignatureRef.current.get(addressKey) !== signature) {
               return
             }
-            const text = finalAssistantTranscriptPreview(transcript)
+            const text = finalAssistantTranscriptText(transcript)
+            const message = finalAssistantTranscriptMessage({
+              messages: runtimeMessagesToWorkbenchMessages(transcript.messages ?? []),
+            })
             setRuntimeFinalResponsePreviews(current => ({
               ...current,
-              [addressKey]: { signature, text },
+              [addressKey]: { signature, text, message },
             }))
           })
           .catch(error => {
@@ -2471,6 +2534,13 @@ export function CloudTodoWorkspace({
               },
               error,
             })
+            if (runtimeFinalResponseLatestSignatureRef.current.get(addressKey) !== signature) {
+              return
+            }
+            setRuntimeFinalResponsePreviews(current => ({
+              ...current,
+              [addressKey]: { signature, text: null, message: null },
+            }))
           })
           .finally(() => {
             runtimeFinalResponseRequestsRef.current.delete(requestKey)
@@ -2939,6 +3009,38 @@ export function CloudTodoWorkspace({
     (selectedTaskBinding?.work_item_id === selectedItem.id ||
       taskComposerRequest?.workItemId === selectedItem.id)
   )
+  const [issueResourceAttachmentState, setIssueResourceAttachmentState] = useState<{
+    itemId: string | null
+    attachments: CloudLoopItemAttachment[]
+  }>({ itemId: null, attachments: [] })
+  const issueResourceAttachments =
+    issueResourceAttachmentState.itemId === selectedItem?.id
+      ? issueResourceAttachmentState.attachments
+      : []
+  const issueResourceAttachmentsLoading = Boolean(
+    taskPanelOpen &&
+    selectedItem &&
+    selectedItemApi &&
+    issueResourceAttachmentState.itemId !== selectedItem.id
+  )
+
+  useEffect(() => {
+    if (!taskPanelOpen || !selectedItem || !selectedItemApi) return
+    let active = true
+    void selectedItemApi.listLoopItemAttachments(selectedItem.id).then(
+      attachments => {
+        if (!active) return
+        setIssueResourceAttachmentState({ itemId: selectedItem.id, attachments })
+      },
+      () => {
+        if (!active) return
+        setIssueResourceAttachmentState({ itemId: selectedItem.id, attachments: [] })
+      }
+    )
+    return () => {
+      active = false
+    }
+  }, [selectedItem, selectedItemApi, taskPanelOpen])
 
   function closeTaskPanel() {
     setSelectedTaskBinding(null)
@@ -2952,10 +3054,6 @@ export function CloudTodoWorkspace({
   }
 
   function closeTopPanel() {
-    if (taskPanelOpen) {
-      closeTaskPanel()
-      return
-    }
     closeIssuePanelStack()
   }
 
@@ -2965,16 +3063,14 @@ export function CloudTodoWorkspace({
       if (event.key !== 'Escape') return
       event.preventDefault()
       event.stopPropagation()
-      if (taskPanelOpen) {
-        setSelectedTaskBinding(null)
-        setTaskComposerRequest(null)
-        return
-      }
+      setBackgroundTaskItemId(null)
       setSelectedItem(null)
+      setSelectedTaskBinding(null)
+      setTaskComposerRequest(null)
     }
     window.addEventListener('keydown', handleEscape, true)
     return () => window.removeEventListener('keydown', handleEscape, true)
-  }, [backgroundTaskItemId, selectedItem, taskPanelOpen])
+  }, [backgroundTaskItemId, selectedItem])
 
   return (
     <div
@@ -4201,6 +4297,141 @@ export function CloudTodoWorkspace({
             data-conversation-open={taskPanelOpen ? 'true' : 'false'}
             className={cn('todo-panel-stack', taskPanelOpen && 'has-conversation')}
           >
+            {taskPanelOpen && backgroundTaskItemId !== selectedItem.id ? (
+              <aside
+                data-testid="cloud-todo-compact-issue"
+                className="task-conversation-issue-context flex min-h-0 flex-col bg-background"
+              >
+                <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+                  <button
+                    type="button"
+                    data-testid="cloud-todo-compact-issue-back"
+                    onClick={closeTaskPanel}
+                    aria-label="返回 Issue 详情"
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-secondary transition hover:bg-muted hover:text-text-primary"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                  </button>
+                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-text-secondary">
+                    {selectedItem.id} · Issue 附件
+                  </span>
+                  <button
+                    type="button"
+                    data-testid="cloud-todo-panel-close"
+                    onClick={closeIssuePanelStack}
+                    aria-label="关闭"
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-secondary transition hover:bg-muted hover:text-text-primary"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </header>
+                <div className="min-h-0 flex-1 overflow-y-auto py-2">
+                  <IssueResourceSection
+                    icon={<File className="h-3.5 w-3.5" />}
+                    title="文件附件"
+                    count={issueResourceAttachments.length}
+                    empty={issueResourceAttachmentsLoading ? '正在加载…' : '暂无文件附件'}
+                  >
+                    {issueResourceAttachments.map(attachment => (
+                      <button
+                        key={attachment.id}
+                        type="button"
+                        data-testid={`cloud-todo-resource-attachment-${attachment.id}`}
+                        onClick={() =>
+                          void selectedItemApi?.downloadLoopItemAttachment(
+                            attachment.id,
+                            attachment.display_name
+                          )
+                        }
+                        className="task-conversation-resource-row"
+                      >
+                        <File className="h-4 w-4 shrink-0 text-text-muted" />
+                        <span className="min-w-0 flex-1 truncate">{attachment.display_name}</span>
+                        <span className="shrink-0 text-xs text-text-muted">
+                          {formatCompactFileSize(attachment.size_bytes)}
+                        </span>
+                      </button>
+                    ))}
+                  </IssueResourceSection>
+
+                  <IssueResourceSection
+                    icon={<MessageSquare className="h-3.5 w-3.5" />}
+                    title="任务会话"
+                    count={(itemTaskBindings[selectedItem.id] ?? []).length}
+                    empty="暂无任务会话"
+                  >
+                    {(itemTaskBindings[selectedItem.id] ?? []).map(binding => {
+                      const selected = selectedTaskBinding?.id === binding.id
+                      return (
+                        <button
+                          key={binding.id}
+                          type="button"
+                          data-testid={`cloud-todo-resource-conversation-${binding.id}`}
+                          data-selected={selected ? 'true' : 'false'}
+                          onClick={() => {
+                            setTaskComposerRequest(null)
+                            setSelectedTaskBinding({
+                              ...binding,
+                              work_item_id: selectedItem.id,
+                            })
+                          }}
+                          className={cn(
+                            'task-conversation-resource-row',
+                            selected && 'is-selected'
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              'h-2 w-2 shrink-0 rounded-full',
+                              selected ? 'bg-primary' : 'bg-text-muted/50'
+                            )}
+                          />
+                          <span className="min-w-0 flex-1 truncate">
+                            {binding.task_title || binding.task_id}
+                          </span>
+                          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+                        </button>
+                      )
+                    })}
+                  </IssueResourceSection>
+
+                  <IssueResourceSection
+                    icon={<ListTodo className="h-3.5 w-3.5" />}
+                    title="子 Issue"
+                    count={
+                      detailAllItems.filter(candidate => candidate.parent_id === selectedItem.id)
+                        .length
+                    }
+                    empty="暂无子 Issue"
+                  >
+                    {detailAllItems
+                      .filter(candidate => candidate.parent_id === selectedItem.id)
+                      .map(child => (
+                        <button
+                          key={child.id}
+                          type="button"
+                          data-testid={`cloud-todo-resource-child-${child.id}`}
+                          onClick={() => {
+                            setSelectedTaskBinding(null)
+                            setTaskComposerRequest(null)
+                            setSelectedItem(child)
+                          }}
+                          className="task-conversation-resource-row"
+                        >
+                          <span
+                            className={cn(
+                              'h-2 w-2 shrink-0 rounded-full',
+                              columnDotClasses[child.status]
+                            )}
+                          />
+                          <span className="min-w-0 flex-1 truncate">{child.title}</span>
+                          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+                        </button>
+                      ))}
+                  </IssueResourceSection>
+                </div>
+              </aside>
+            ) : null}
             {backgroundTaskItemId !== selectedItem.id &&
             selectedItem.can_view_detail !== false &&
             selectedItemApi ? (
@@ -4456,7 +4687,8 @@ export function CloudTodoWorkspace({
                     ? taskComposerRequest.workflowNodeId
                     : undefined
                 }
-                onClose={closeTaskPanel}
+                onClose={closeIssuePanelStack}
+                onBack={closeTaskPanel}
                 onAddressChange={address => {
                   if (
                     taskComposerRequest?.workItemId === selectedItem.id &&

--- a/wework/src/features/todo/runtimeTaskResponsePreview.test.ts
+++ b/wework/src/features/todo/runtimeTaskResponsePreview.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  finalAssistantMessagesText,
   finalAssistantMessagesPreview,
+  finalAssistantTranscriptText,
   finalAssistantTranscriptPreview,
 } from './runtimeTaskResponsePreview'
 
@@ -17,7 +19,33 @@ describe('runtimeTaskResponsePreview', () => {
           content: '',
         },
       ])
-    ).toBe('第一行\n第二行\n第三行')
+    ).toBe('第四行')
+  })
+
+  test('keeps the full final assistant response for expanded progress details', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: '第一行\n第二行\n第三行\n第四行',
+      },
+    ]
+
+    expect(finalAssistantMessagesText(messages)).toBe('第一行\n第二行\n第三行\n第四行')
+    expect(
+      finalAssistantTranscriptText({
+        messages: [],
+        turns: [
+          {
+            items: [
+              {
+                type: 'assistant_text',
+                content: '第一行\n第二行\n第三行\n第四行',
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe('第一行\n第二行\n第三行\n第四行')
   })
 
   it('falls back to canonical assistant turn items', () => {
@@ -35,6 +63,6 @@ describe('runtimeTaskResponsePreview', () => {
           },
         ],
       })
-    ).toBe('完成修复\n测试通过')
+    ).toBe('测试通过')
   })
 })

--- a/wework/src/features/todo/runtimeTaskResponsePreview.ts
+++ b/wework/src/features/todo/runtimeTaskResponsePreview.ts
@@ -16,32 +16,62 @@ interface RuntimeResponseTurn {
   }[]
 }
 
-export function firstThreeResponseLines(value: string): string | null {
+export function latestResponseLine(value: string): string | null {
   const lines = value
     .split(/\r?\n/)
     .map(line => line.trim())
     .filter(Boolean)
-    .slice(0, 3)
-  return lines.length > 0 ? lines.join('\n') : null
+  return lines.at(-1) ?? null
 }
 
 export function finalAssistantMessagesPreview(
   messages: readonly RuntimeResponseMessage[]
 ): string | null {
+  const response = finalAssistantMessagesText(messages)
+  return response ? latestResponseLine(response) : null
+}
+
+export function finalAssistantMessagesText(
+  messages: readonly RuntimeResponseMessage[]
+): string | null {
   for (const message of [...messages].reverse()) {
     if (!message.role?.toLowerCase().startsWith('assistant')) continue
-    const preview = firstThreeResponseLines(messageText(message))
-    if (preview) return preview
+    const content = messageText(message)
+    if (content) return content
   }
   return null
+}
+
+export function latestAssistantMessage<T extends RuntimeResponseMessage>(
+  messages: readonly T[]
+): T | null {
+  for (const message of [...messages].reverse()) {
+    if (!message.role?.toLowerCase().startsWith('assistant')) continue
+    if (messageText(message) || message.blocks?.length) return message
+  }
+  return null
+}
+
+export function finalAssistantTranscriptMessage<T extends RuntimeResponseMessage>(transcript: {
+  messages: readonly T[]
+}): T | null {
+  return latestAssistantMessage(transcript.messages)
 }
 
 export function finalAssistantTranscriptPreview(transcript: {
   messages: readonly RuntimeResponseMessage[]
   turns: readonly RuntimeResponseTurn[]
 }): string | null {
-  const messagePreview = finalAssistantMessagesPreview(transcript.messages)
-  if (messagePreview) return messagePreview
+  const response = finalAssistantTranscriptText(transcript)
+  return response ? latestResponseLine(response) : null
+}
+
+export function finalAssistantTranscriptText(transcript: {
+  messages: readonly RuntimeResponseMessage[]
+  turns: readonly RuntimeResponseTurn[]
+}): string | null {
+  const messageResponse = finalAssistantMessagesText(transcript.messages)
+  if (messageResponse) return messageResponse
 
   for (const turn of [...transcript.turns].reverse()) {
     const content = turn.items
@@ -49,8 +79,8 @@ export function finalAssistantTranscriptPreview(transcript: {
         item.type === 'assistant_text' && typeof item.content === 'string' ? [item.content] : []
       )
       .join('\n')
-    const turnPreview = firstThreeResponseLines(content)
-    if (turnPreview) return turnPreview
+      .trim()
+    if (content) return content
   }
   return null
 }

--- a/wework/src/features/todo/task-detail-layout.css
+++ b/wework/src/features/todo/task-detail-layout.css
@@ -26,19 +26,83 @@
 }
 
 .todo-panel-stack.has-conversation {
-  left: 12px;
+  width: min(860px, calc(100% - 24px));
+  max-width: calc(100% - 24px);
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 16px;
+  background: rgb(var(--color-bg-base));
+  box-shadow:
+    0 12px 28px -8px rgb(0 0 0 / 18%),
+    0 0 24px rgb(0 0 0 / 5%);
 }
 
 .todo-panel-stack.has-conversation .task-detail-workspace-panel-shell {
-  flex: 1 1 460px;
-  min-width: 0;
-  max-width: 460px;
+  display: none;
 }
 
 .todo-panel-stack.has-conversation .task-conversation-workspace-panel {
-  flex: 1 1 480px;
+  flex: 1 1 auto;
+  width: auto;
   min-width: 0;
-  max-width: 480px;
+  max-width: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.task-conversation-issue-context {
+  width: 300px;
+  min-width: 300px;
+  border-right: 1px solid rgb(var(--color-border));
+}
+
+.task-conversation-resource-section + .task-conversation-resource-section {
+  border-top: 1px solid rgb(var(--color-border));
+}
+
+.task-conversation-resource-heading {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  color: rgb(var(--color-text-secondary));
+  font-size: var(--text-xs);
+  font-weight: 500;
+}
+
+.task-conversation-resource-count {
+  min-width: 20px;
+  border-radius: 999px;
+  background: rgb(var(--color-bg-muted));
+  padding: 1px 6px;
+  color: rgb(var(--color-text-muted));
+  font-size: var(--text-xs);
+  text-align: center;
+}
+
+.task-conversation-resource-row {
+  display: flex;
+  width: 100%;
+  min-height: 34px;
+  align-items: center;
+  gap: 8px;
+  border-radius: 8px;
+  padding: 6px 8px;
+  color: rgb(var(--color-text-secondary));
+  font-size: var(--text-xs);
+  text-align: left;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.task-conversation-resource-row:hover,
+.task-conversation-resource-row.is-selected {
+  background: rgb(var(--color-bg-muted));
+  color: rgb(var(--color-text-primary));
 }
 
 @keyframes todo-panel-backdrop-enter {
@@ -156,8 +220,9 @@
     max-width: none;
   }
 
-  .todo-panel-stack.has-conversation .task-detail-workspace-panel-shell {
-    display: none;
+  .todo-panel-stack.has-conversation {
+    left: auto;
+    width: calc(100% - 24px);
   }
 
   .task-detail-workspace-panel-shell,
@@ -166,6 +231,11 @@
     width: 100%;
     min-width: 0;
     max-width: none;
+  }
+
+  .task-conversation-issue-context {
+    width: 260px;
+    min-width: 260px;
   }
 
   @keyframes task-conversation-workspace-panel-enter {
@@ -178,6 +248,12 @@
       opacity: 1;
       transform: translateX(0);
     }
+  }
+}
+
+@media (max-width: 700px) {
+  .task-conversation-issue-context {
+    display: none;
   }
 }
 

--- a/wework/src/features/workbench/runtimeThinking.ts
+++ b/wework/src/features/workbench/runtimeThinking.ts
@@ -1,6 +1,9 @@
 import type { ProcessingBlock, ToolBlock, WorkbenchMessage } from '@/types/workbench'
 
-export type RuntimeLiveToolActivity = Pick<ToolBlock, 'id' | 'status' | 'toolName' | 'toolInput'>
+export type RuntimeLiveToolActivity = Pick<
+  ToolBlock,
+  'id' | 'status' | 'toolName' | 'toolInput' | 'createdAt' | 'completedAt' | 'durationMs'
+>
 
 export interface RuntimeLiveActivity {
   active: boolean
@@ -36,6 +39,9 @@ export function getLatestRuntimeLiveActivity(messages: WorkbenchMessage[]): Runt
             status: block.status,
             toolName: block.toolName,
             toolInput: block.toolInput,
+            createdAt: block.createdAt,
+            completedAt: block.completedAt,
+            durationMs: block.durationMs,
           })) ?? [],
     }
   }

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -3432,6 +3432,8 @@
     "my_work_month": "Month",
     "my_work_no_due_date": "No due date",
     "no_final_task_response": "No final response",
+    "task_progress_details": "Current task progress",
+    "task_progress_empty": "No task progress details",
     "my_work_pending_approval": "Pending my approval",
     "my_work_approve": "Approve",
     "my_work_running": "In progress",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -3429,6 +3429,8 @@
     "my_work_month": "月",
     "my_work_no_due_date": "无截止日期",
     "no_final_task_response": "暂无最终回复",
+    "task_progress_details": "当前任务进展",
+    "task_progress_empty": "暂无任务进展详情",
     "my_work_pending_approval": "待我批准",
     "my_work_approve": "批准",
     "my_work_running": "正在执行",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - View live task progress, tool activity, and complete assistant responses in an interactive hover card.
  - Browse Issue attachments, task sessions, and child Issues from the conversation panel, including downloadable files.
  - Navigate back from conversations to the related Issue without closing the modal.
  - Hover cards now support keyboard interaction and adjust their placement to remain visible on screen.

- **Improvements**
  - Task previews now display the latest response line, while expanded views retain the full response.
  - Unified Issue and conversation panels close consistently with Escape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->