### PR TITLE
fix(wework): cache reused runtime descriptors

### DIFF
--- a/wework/scripts/prepare-harness-runtime.mjs
+++ b/wework/scripts/prepare-harness-runtime.mjs
@@ -211,6 +211,10 @@ async function reusePublishedRuntime(runtime) {
   }
   const descriptor = validateDescriptor(await response.json(), runtime)
   await ensurePublishedAsset(descriptor, runtime)
+  await writeFile(
+    path.join(assetDirectory, runtime.descriptorName),
+    `${JSON.stringify(descriptor, null, 2)}\n`
+  )
   console.log(`Reused published Harness runtime: ${runtime.assetName}`)
   return descriptor
 }


### PR DESCRIPTION
## Root cause

The versioned Harness runtime remote-reuse path downloaded the archive but did not persist its descriptor into `wework/node_modules/.cache/harness-runtime-assets`. The release workflow requires both files when collecting runtime publication assets, so the Windows, macOS arm64, and macOS x64 release jobs failed with `ENOENT`.

## Fix

Persist the validated descriptor beside the reused archive, matching the rebuild path invariant.

## Verification

- `pnpm --filter wework run prepare:harness-runtime`
- Verified every generated runtime catalog entry has both archive and descriptor in the runtime asset cache
- Pre-push Wework ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime reuse by securely caching validated published runtime assets locally after verification.
  * Helps ensure required runtime assets remain available for subsequent use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->