### PR TITLE
fix(wework): defer Mermaid rendering until fence closes

### DIFF
--- a/wework/src/components/chat/AssistantMarkdown.diagram.test.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.diagram.test.tsx
@@ -32,6 +32,9 @@ test('keeps an unfinished Mermaid fence as source while the model is streaming',
     expect(container.querySelector('[data-testid="markdown-code-block"]')).toHaveTextContent(
       'A[Start]'
     )
+    expect(
+      container.querySelector('[data-testid="markdown-code-block-language"]')
+    ).toHaveTextContent('mermaid')
   })
 
   rerender(
@@ -45,6 +48,55 @@ test('keeps an unfinished Mermaid fence as source while the model is streaming',
     const preview = container.querySelector('[data-testid="diagram-preview"]')
     expect(preview).toHaveAttribute('data-language', 'mermaid')
     expect(preview).toHaveAttribute('data-code', 'graph LR\n  A[Start] --> B[Streaming]')
+  })
+})
+
+test('distinguishes identical completed and unfinished Mermaid blocks while streaming', async () => {
+  const diagram = 'graph LR\n  A[Start] --> B[Done]'
+  const { container } = render(
+    <AssistantMarkdown
+      content={`\`\`\`mermaid\n${diagram}\n\`\`\`\n\n\`\`\`mermaid\n${diagram}`}
+      isStreaming
+    />
+  )
+
+  await waitFor(() => {
+    expect(container.querySelectorAll('[data-testid="diagram-preview"]')).toHaveLength(1)
+    expect(container.querySelectorAll('[data-testid="markdown-code-block"]')).toHaveLength(1)
+  })
+  expect(container.querySelector('[data-testid="diagram-preview"]')).toHaveAttribute(
+    'data-code',
+    diagram
+  )
+  expect(
+    container.querySelector('[data-testid="markdown-code-scroll-container"]')
+  ).toHaveTextContent('A[Start] --> B[Done]')
+})
+
+test('preserves rendered paragraph identity across ordinary streaming updates', async () => {
+  const { container, rerender } = render(
+    <AssistantMarkdown content={'First paragraph.\n\nStable viewport anchor.'} isStreaming />
+  )
+
+  const anchor = await waitFor(() => {
+    const element = Array.from(container.querySelectorAll('[data-scroll-anchor]')).find(node =>
+      node.textContent?.includes('Stable viewport anchor.')
+    )
+    expect(element).toBeDefined()
+    return element as HTMLElement
+  })
+  anchor.setAttribute('data-e2e-anchor-id', 'stable-streaming-anchor')
+
+  rerender(
+    <AssistantMarkdown
+      content={'First paragraph.\n\nStable viewport anchor.\n\nLater streamed paragraph.'}
+      isStreaming
+    />
+  )
+
+  await waitFor(() => {
+    expect(container.querySelector('[data-e2e-anchor-id="stable-streaming-anchor"]')).toBe(anchor)
+    expect(container).toHaveTextContent('Later streamed paragraph.')
   })
 })
 

--- a/wework/src/components/chat/AssistantMarkdown.diagram.test.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.diagram.test.tsx
@@ -22,20 +22,23 @@ test('routes Mermaid fenced code to the diagram preview', async () => {
   expect(container.querySelector('[data-testid="markdown-code-block"]')).not.toBeInTheDocument()
 })
 
-test('renders and updates an unfinished Mermaid fence while the model is streaming', async () => {
+test('keeps an unfinished Mermaid fence as source while the model is streaming', async () => {
   const { container, rerender } = render(
     <AssistantMarkdown content={'```mermaid\ngraph LR\n  A[Start]'} isStreaming />
   )
 
   await waitFor(() => {
-    expect(container.querySelector('[data-testid="diagram-preview"]')).toHaveAttribute(
-      'data-language',
-      'mermaid'
+    expect(container.querySelector('[data-testid="diagram-preview"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-testid="markdown-code-block"]')).toHaveTextContent(
+      'A[Start]'
     )
   })
 
   rerender(
-    <AssistantMarkdown content={'```mermaid\ngraph LR\n  A[Start] --> B[Streaming]'} isStreaming />
+    <AssistantMarkdown
+      content={'```mermaid\ngraph LR\n  A[Start] --> B[Streaming]\n```'}
+      isStreaming
+    />
   )
 
   await waitFor(() => {
@@ -45,15 +48,15 @@ test('renders and updates an unfinished Mermaid fence while the model is streami
   })
 })
 
-test('renders an unfinished PlantUML fence while the model is streaming', async () => {
+test('keeps an unfinished PlantUML fence as source while the model is streaming', async () => {
   const { container } = render(
     <AssistantMarkdown content={'```plantuml\n@startuml\nAlice -> Bob: Streaming'} isStreaming />
   )
 
   await waitFor(() => {
-    expect(container.querySelector('[data-testid="diagram-preview"]')).toHaveAttribute(
-      'data-language',
-      'plantuml'
+    expect(container.querySelector('[data-testid="diagram-preview"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-testid="markdown-code-block"]')).toHaveTextContent(
+      'Alice -> Bob: Streaming'
     )
   })
 })

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -103,6 +103,10 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
     () => stripUnsupportedContentReferenceCitations(bufferedContent),
     [bufferedContent]
   )
+  const unclosedDiagramCodes = useMemo(
+    () => findUnclosedDiagramCodes(displayContent),
+    [displayContent]
+  )
   const windowMarkdown = isTauriRuntime() && variant === 'default'
   const contentParts = useMemo(() => {
     const parts = splitCodexInlineVisualizations(displayContent)
@@ -180,7 +184,12 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <strong className="font-semibold">{children}</strong>
       ),
       code: (props: MarkdownCodeProps) => (
-        <MarkdownCode {...props} compact={variant === 'process'} isStreaming={isStreaming} />
+        <MarkdownCode
+          {...props}
+          compact={variant === 'process'}
+          isStreaming={isStreaming}
+          unclosedDiagramCodes={unclosedDiagramCodes}
+        />
       ),
       inlineCode: ({ children }: { children?: ReactNode }) => (
         <MarkdownInlineCode compact={variant === 'process'}>{children}</MarkdownInlineCode>
@@ -225,7 +234,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <AssistantMarkdownImage src={src} alt={alt} />
       ),
     }),
-    [headingClasses, isStreaming, openFile, variant]
+    [headingClasses, isStreaming, openFile, unclosedDiagramCodes, variant]
   )
 
   return (
@@ -338,6 +347,7 @@ type MarkdownCodeProps = {
   node?: HastElement
   compact?: boolean
   isStreaming?: boolean
+  unclosedDiagramCodes?: ReadonlySet<string>
 } & HTMLAttributes<HTMLElement>
 
 function MarkdownCode({
@@ -346,6 +356,7 @@ function MarkdownCode({
   node,
   compact = false,
   isStreaming = false,
+  unclosedDiagramCodes = new Set<string>(),
   ...props
 }: MarkdownCodeProps) {
   const match = /language-(\w*)/.exec(className || '')
@@ -358,6 +369,13 @@ function MarkdownCode({
   if (isBlock) {
     const lang = match ? match[1] || '' : ''
     if (DIAGRAM_LANGUAGES.has(lang.toLowerCase())) {
+      if (isStreaming && unclosedDiagramCodes.has(text.trimEnd())) {
+        return (
+          <MarkdownCodeBlock lang={lang} compact={compact} isStreaming>
+            {text || children}
+          </MarkdownCodeBlock>
+        )
+      }
       return <MarkdownDiagramPreview code={text.trimEnd()} language={lang} />
     }
     return (
@@ -399,6 +417,48 @@ function areAssistantMarkdownPropsEqual(
 
 function prepareAssistantMarkdownContent(content: string): string {
   return encodeLocalMarkdownLinks(content.replace(CODEX_PLAN_TAG_PATTERN, ''))
+}
+
+function findUnclosedDiagramCodes(content: string): ReadonlySet<string> {
+  const unclosedCodes = new Set<string>()
+  const lines = content.split('\n')
+  let openingFence: {
+    character: '`' | '~'
+    length: number
+    language: string
+    code: string[]
+  } | null = null
+
+  for (const line of lines) {
+    if (!openingFence) {
+      const match = /^(?<fence>`{3,}|~{3,})\s*(?<language>[\w+-]*)[^\n]*$/.exec(line)
+      if (!match?.groups) continue
+
+      const fence = match.groups.fence
+      const language = match.groups.language.toLowerCase()
+      if (!DIAGRAM_LANGUAGES.has(language)) continue
+
+      openingFence = {
+        character: fence[0] as '`' | '~',
+        length: fence.length,
+        language,
+        code: [],
+      }
+      continue
+    }
+
+    const closingFence = new RegExp(`^${openingFence.character}{${openingFence.length},}\\s*$`)
+    if (closingFence.test(line)) {
+      openingFence = null
+      continue
+    }
+    openingFence.code.push(line)
+  }
+
+  if (openingFence) {
+    unclosedCodes.add(openingFence.code.join('\n').trimEnd())
+  }
+  return unclosedCodes
 }
 
 function stripUnsupportedContentReferenceCitations(content: string): string {

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -43,6 +43,12 @@ const WEWORK_MARKDOWN_FILE_LINK_PREFIX = `https://${WEWORK_MARKDOWN_FILE_LINK_HO
 const MARKDOWN_LINK_PATTERN = /(!?)\[([^\]\n]+)\]\(([^)\n]+)\)/g
 const MARKDOWN_WINDOW_ROOT_MARGIN = '800px 0px'
 const DIAGRAM_LANGUAGES = new Set(['mermaid', 'mmd', 'plantuml', 'puml'])
+const STREAMING_DIAGRAM_LANGUAGES = new Map([
+  ['weworkstreamingmermaid', 'mermaid'],
+  ['weworkstreamingmmd', 'mmd'],
+  ['weworkstreamingplantuml', 'plantuml'],
+  ['weworkstreamingpuml', 'puml'],
+])
 interface AssistantMarkdownProps {
   content: string
   isStreaming?: boolean
@@ -102,10 +108,6 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
   const displayContent = useMemo(
     () => stripUnsupportedContentReferenceCitations(bufferedContent),
     [bufferedContent]
-  )
-  const unclosedDiagramCodes = useMemo(
-    () => findUnclosedDiagramCodes(displayContent),
-    [displayContent]
   )
   const windowMarkdown = isTauriRuntime() && variant === 'default'
   const contentParts = useMemo(() => {
@@ -184,12 +186,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <strong className="font-semibold">{children}</strong>
       ),
       code: (props: MarkdownCodeProps) => (
-        <MarkdownCode
-          {...props}
-          compact={variant === 'process'}
-          isStreaming={isStreaming}
-          unclosedDiagramCodes={unclosedDiagramCodes}
-        />
+        <MarkdownCode {...props} compact={variant === 'process'} isStreaming={isStreaming} />
       ),
       inlineCode: ({ children }: { children?: ReactNode }) => (
         <MarkdownInlineCode compact={variant === 'process'}>{children}</MarkdownInlineCode>
@@ -234,7 +231,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
         <AssistantMarkdownImage src={src} alt={alt} />
       ),
     }),
-    [headingClasses, isStreaming, openFile, unclosedDiagramCodes, variant]
+    [headingClasses, isStreaming, openFile, variant]
   )
 
   return (
@@ -265,7 +262,10 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
               urlTransform={url => url}
               components={components}
             >
-              {prepareAssistantMarkdownContent(part.content)}
+              {prepareAssistantMarkdownContent(
+                part.content,
+                isStreaming && index === contentParts.length - 1
+              )}
             </Streamdown>
           </WindowedMarkdownChunk>
         ) : (
@@ -279,7 +279,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
             urlTransform={url => url}
             components={components}
           >
-            {prepareAssistantMarkdownContent(part.content)}
+            {prepareAssistantMarkdownContent(part.content, isStreaming)}
           </Streamdown>
         )
       )}
@@ -347,7 +347,6 @@ type MarkdownCodeProps = {
   node?: HastElement
   compact?: boolean
   isStreaming?: boolean
-  unclosedDiagramCodes?: ReadonlySet<string>
 } & HTMLAttributes<HTMLElement>
 
 function MarkdownCode({
@@ -356,7 +355,6 @@ function MarkdownCode({
   node,
   compact = false,
   isStreaming = false,
-  unclosedDiagramCodes = new Set<string>(),
   ...props
 }: MarkdownCodeProps) {
   const match = /language-(\w*)/.exec(className || '')
@@ -368,14 +366,15 @@ function MarkdownCode({
     text.includes('\n')
   if (isBlock) {
     const lang = match ? match[1] || '' : ''
+    const streamingDiagramLanguage = STREAMING_DIAGRAM_LANGUAGES.get(lang.toLowerCase())
+    if (streamingDiagramLanguage) {
+      return (
+        <MarkdownCodeBlock lang={streamingDiagramLanguage} compact={compact} isStreaming>
+          {text || children}
+        </MarkdownCodeBlock>
+      )
+    }
     if (DIAGRAM_LANGUAGES.has(lang.toLowerCase())) {
-      if (isStreaming && unclosedDiagramCodes.has(text.trimEnd())) {
-        return (
-          <MarkdownCodeBlock lang={lang} compact={compact} isStreaming>
-            {text || children}
-          </MarkdownCodeBlock>
-        )
-      }
       return <MarkdownDiagramPreview code={text.trimEnd()} language={lang} />
     }
     return (
@@ -415,50 +414,59 @@ function areAssistantMarkdownPropsEqual(
   )
 }
 
-function prepareAssistantMarkdownContent(content: string): string {
-  return encodeLocalMarkdownLinks(content.replace(CODEX_PLAN_TAG_PATTERN, ''))
+function prepareAssistantMarkdownContent(content: string, isStreaming = false): string {
+  const normalizedContent = content.replace(CODEX_PLAN_TAG_PATTERN, '')
+  return encodeLocalMarkdownLinks(
+    isStreaming ? markUnclosedDiagramFence(normalizedContent) : normalizedContent
+  )
 }
 
-function findUnclosedDiagramCodes(content: string): ReadonlySet<string> {
-  const unclosedCodes = new Set<string>()
+function markUnclosedDiagramFence(content: string): string {
   const lines = content.split('\n')
   let openingFence: {
     character: '`' | '~'
     length: number
     language: string
-    code: string[]
+    lineIndex: number
+    match: RegExpExecArray
   } | null = null
 
-  for (const line of lines) {
+  for (const [lineIndex, line] of lines.entries()) {
     if (!openingFence) {
-      const match = /^(?<fence>`{3,}|~{3,})\s*(?<language>[\w+-]*)[^\n]*$/.exec(line)
+      const match =
+        /^(?<indent> {0,3})(?<fence>`{3,}|~{3,})(?<spacing>[ \t]*)(?<language>[\w+-]*)(?<remainder>[^\n]*)$/.exec(
+          line
+        )
       if (!match?.groups) continue
 
       const fence = match.groups.fence
       const language = match.groups.language.toLowerCase()
-      if (!DIAGRAM_LANGUAGES.has(language)) continue
-
       openingFence = {
         character: fence[0] as '`' | '~',
         length: fence.length,
         language,
-        code: [],
+        lineIndex,
+        match,
       }
       continue
     }
 
-    const closingFence = new RegExp(`^${openingFence.character}{${openingFence.length},}\\s*$`)
+    const closingFence = new RegExp(
+      `^ {0,3}${openingFence.character}{${openingFence.length},}[ \\t]*$`
+    )
     if (closingFence.test(line)) {
       openingFence = null
-      continue
     }
-    openingFence.code.push(line)
   }
 
-  if (openingFence) {
-    unclosedCodes.add(openingFence.code.join('\n').trimEnd())
-  }
-  return unclosedCodes
+  if (!openingFence || !DIAGRAM_LANGUAGES.has(openingFence.language)) return content
+
+  const { groups } = openingFence.match
+  if (!groups) return content
+  lines[openingFence.lineIndex] =
+    `${groups.indent}${groups.fence}${groups.spacing}` +
+    `weworkstreaming${openingFence.language}${groups.remainder}`
+  return lines.join('\n')
 }
 
 function stripUnsupportedContentReferenceCitations(content: string): string {


### PR DESCRIPTION
## Summary
- keep incomplete Mermaid and PlantUML fences in the streaming code-block renderer
- render diagram previews immediately after their closing fence arrives
- prevent normal streaming intermediate syntax from surfacing Mermaid parser errors

## Verification
- `pnpm --filter wework test src/components/chat/AssistantMarkdown.diagram.test.tsx src/components/chat/MarkdownDiagramPreview.test.tsx src/components/chat/MarkdownDiagramRenderer.integration.test.tsx`
- `pnpm --filter wework typecheck`
- pre-push: ESLint, TypeScript, and unit tests

## Notes
- rebased on `origin/main` at `36a615239` before opening this PR
- no documentation update is needed: this is an internal streaming rendering fix with no documented interface changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming diagram rendering by showing unfinished Mermaid and PlantUML diagrams as code until their closing fences arrive.
  * Completed diagram blocks continue to render as visual previews once streaming finishes.
  * Preserved streamed paragraph content consistently as additional text arrives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->