### PR TITLE
fix(wework): preserve project tab when opening full task

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -13,7 +13,7 @@ import type {
   RuntimeIMNotificationSettingsResponse,
 } from '@/types/api'
 import { stripAppBasePath } from '@/config/runtime'
-import { buildRuntimeTaskRoute, isSettingsRoute, navigateTo } from '@/lib/navigation'
+import { isSettingsRoute, navigateTo } from '@/lib/navigation'
 import { shouldUseNativeProjectDirectoryPicker } from '@/e2e/automation'
 import { cn } from '@/lib/utils'
 import { DesktopSidebar } from './DesktopSidebar'
@@ -63,6 +63,7 @@ import {
   getWorkbenchPaneKey,
   type WorkbenchPaneIdentity,
 } from './workbenchPaneIdentity'
+import { openProjectSpaceRuntimeTaskInTab } from './projectSpaceRuntimeTaskNavigation'
 import { useWorkbenchSplitGroups, workbenchSplitStorageKeys } from './useWorkbenchSplitGroups'
 
 type ImNotificationDialogMode = { type: 'global' } | { type: 'task'; address: RuntimeTaskAddress }
@@ -527,15 +528,7 @@ export function DesktopWorkbenchLayout({ routeActive = true }: DesktopWorkbenchL
   )
   const openProjectSpaceRuntimeTask = useCallback(
     async (address: RuntimeTaskAddress) => {
-      await openRuntimeTaskOutsideHarness(address)
-      if (!workspaceTabs) return
-      const contentRoute = buildRuntimeTaskRoute(address)
-      const taskTab = workspaceTabs.tabs.find(tab => tab.kind === 'task')
-      if (taskTab) {
-        workspaceTabs.selectTab(taskTab.id, { contentRoute })
-        return
-      }
-      workspaceTabs.openTab('task', { contentRoute })
+      await openProjectSpaceRuntimeTaskInTab(address, workspaceTabs, openRuntimeTaskOutsideHarness)
     },
     [openRuntimeTaskOutsideHarness, workspaceTabs]
   )

--- a/wework/src/components/layout/projectSpaceRuntimeTaskNavigation.test.ts
+++ b/wework/src/components/layout/projectSpaceRuntimeTaskNavigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { WorkspaceTabsContextValue } from '@/features/workspace-tabs/workspaceTabsContextValue'
+import { openProjectSpaceRuntimeTaskInTab } from './projectSpaceRuntimeTaskNavigation'
+
+describe('openProjectSpaceRuntimeTaskInTab', () => {
+  test('selects the task tab before opening a full task from a project space', async () => {
+    const address = {
+      deviceId: 'local-device',
+      taskId: 'runtime-1',
+    }
+    const taskTab = {
+      id: 'task-existing',
+      kind: 'task' as const,
+      title: '任务',
+      contentRoute: '/',
+      fixed: true,
+    }
+    const boardTab = {
+      id: 'board-existing',
+      kind: 'board' as const,
+      title: '工作空间',
+      contentRoute: '/todo?projectStore=local&projectId=default-work-items',
+      fixed: true,
+    }
+    const callOrder: string[] = []
+    const selectTab = vi.fn(() => callOrder.push('select-task-tab'))
+    const openRuntimeTask = vi.fn(async () => {
+      callOrder.push('open-runtime-task')
+    })
+    const workspaceTabs = {
+      tabs: [taskTab, boardTab],
+      activeTabId: boardTab.id,
+      activeTab: boardTab,
+      openTab: vi.fn(),
+      selectTab,
+      closeTab: vi.fn(),
+      closeOtherTabs: vi.fn(),
+      restoreClosedTab: vi.fn(),
+      moveTab: vi.fn(),
+      updateActiveTab: vi.fn(),
+    } as WorkspaceTabsContextValue
+
+    await openProjectSpaceRuntimeTaskInTab(address, workspaceTabs, openRuntimeTask)
+
+    expect(callOrder).toEqual(['select-task-tab', 'open-runtime-task'])
+    expect(selectTab).toHaveBeenCalledWith(taskTab.id, {
+      contentRoute: '/runtime-tasks?deviceId=local-device&taskId=runtime-1',
+    })
+    expect(workspaceTabs.tabs).toEqual([taskTab, boardTab])
+  })
+})

--- a/wework/src/components/layout/projectSpaceRuntimeTaskNavigation.ts
+++ b/wework/src/components/layout/projectSpaceRuntimeTaskNavigation.ts
@@ -1,0 +1,20 @@
+import type { WorkspaceTabsContextValue } from '@/features/workspace-tabs/workspaceTabsContextValue'
+import { buildRuntimeTaskRoute } from '@/lib/navigation'
+import type { RuntimeTaskAddress } from '@/types/api'
+
+export async function openProjectSpaceRuntimeTaskInTab(
+  address: RuntimeTaskAddress,
+  workspaceTabs: WorkspaceTabsContextValue | null,
+  openRuntimeTask: (address: RuntimeTaskAddress) => Promise<void>
+) {
+  if (workspaceTabs) {
+    const contentRoute = buildRuntimeTaskRoute(address)
+    const taskTab = workspaceTabs.tabs.find(tab => tab.kind === 'task')
+    if (taskTab) {
+      workspaceTabs.selectTab(taskTab.id, { contentRoute })
+    } else {
+      workspaceTabs.openTab('task', { contentRoute })
+    }
+  }
+  await openRuntimeTask(address)
+}


### PR DESCRIPTION
## Summary

- select or create the runtime task tab before navigating from a project-space task card to the full task
- preserve the existing project workspace tab instead of allowing route synchronization to overwrite it
- add focused regression coverage for the navigation order and retained tab state

## Root cause

The full-task handler navigated to the runtime-task route before activating the task tab. The workspace-tab route listener therefore handled the route change while the board tab was still active and rewrote that tab as a task tab, making the project workspace tab disappear.

## Verification

- `pnpm --filter wework test src/components/layout/projectSpaceRuntimeTaskNavigation.test.ts src/components/layout/DesktopWorkbenchLayout.test.tsx src/features/todo/CloudTodoWorkspace.test.tsx --run` (291 passed)
- Prettier passed
- ESLint passed
- TypeScript passed in pre-push
- Full Wework unit-test suite passed in pre-push

## Notes

- No existing E2E scenario was modified.
- Isolated Tauri verification exposed an unrelated desktop-control result-post timeout after first-run Codex initialization; that infrastructure issue is intentionally not included in this fix.

Closes WORK-86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation when opening runtime tasks from project spaces.
  * Existing task tabs are now selected when available, while new task tabs open with the correct destination.
  * Prevented unnecessary changes to the workspace tab list during navigation.

* **Tests**
  * Added coverage for selecting existing tabs and opening runtime-task routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->