### PR TITLE
fix(wework): start board tasks without overlays

### DIFF
--- a/wework/src/features/todo/AiChatModal.test.tsx
+++ b/wework/src/features/todo/AiChatModal.test.tsx
@@ -231,27 +231,6 @@ describe('AiChatModal', () => {
     expect(screen.getByTestId('mock-chat-panel')).toHaveAttribute('data-auto-submit', 'no')
   })
 
-  it('submits the original title immediately when a work item moves to in progress', () => {
-    render(
-      <AiChatModal
-        project={project}
-        localProjects={localProjects}
-        task={task}
-        initialTaskInput="Implement cloud MCP"
-        autoSubmitInitialTaskInput
-        embedded
-        open
-        onClose={vi.fn()}
-      />
-    )
-
-    expect(screen.getByTestId('mock-chat-panel')).toHaveAttribute(
-      'data-initial-input',
-      'Implement cloud MCP'
-    )
-    expect(screen.getByTestId('mock-chat-panel')).toHaveAttribute('data-auto-submit', 'yes')
-  })
-
   it('always creates private AI conversations with the Codex runtime', async () => {
     render(
       <AiChatModal

--- a/wework/src/features/todo/AiChatModal.tsx
+++ b/wework/src/features/todo/AiChatModal.tsx
@@ -15,11 +15,11 @@ import { WorkbenchHarnessSelector } from '@/components/layout/WorkbenchHarnessSe
 import { TemporaryChatPanel } from '@/components/layout/workspace-panels/TemporaryChatPanel'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
-import type { ProjectWithTasks, RuntimeSendRequest, RuntimeTaskAddress } from '@/types/api'
+import type { ProjectWithTasks, RuntimeTaskAddress } from '@/types/api'
 import { ConnectedIssueProjectWork } from './ConnectedIssueProjectWork'
-import { projectSpaceChatRuntimeContext } from './projectProviderConfig'
 import { useProjectRuntimeTaskComposer } from './useProjectRuntimeTaskComposer'
 import { WorkItemComposerGuide } from './WorkItemComposerGuide'
+import { buildWorkItemRuntimeContext } from './workItemRuntimeContext'
 
 interface AiChatModalProps {
   project: CloudProject
@@ -36,7 +36,6 @@ interface AiChatModalProps {
   inheritFromTask?: RuntimeTaskAddress | null
   taskTitle?: string | null
   initialTaskInput?: string
-  autoSubmitInitialTaskInput?: boolean
   workflowNodeId?: string
   onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void> | void
   onAddressChange?: (address: RuntimeTaskAddress) => void
@@ -76,7 +75,6 @@ export function AiChatModal({
   inheritFromTask = null,
   taskTitle,
   initialTaskInput = '',
-  autoSubmitInitialTaskInput = false,
   workflowNodeId,
   onOpenRuntimeTask,
   onAddressChange,
@@ -116,72 +114,8 @@ export function AiChatModal({
     },
     []
   )
-  const runtimeContext = useMemo<
-    Pick<RuntimeSendRequest, 'cloudProjectId' | 'origin' | 'additionalContext'>
-  >(
-    () => ({
-      cloudProjectId: String(project.id),
-      ...(task
-        ? {
-            origin: {
-              type: 'board_task' as const,
-              cloudProjectId: String(project.id),
-              loopItemId: String(task.id),
-            },
-          }
-        : {}),
-      additionalContext: {
-        ...projectSpaceChatRuntimeContext(project, task),
-        ...(task
-          ? {
-              issueEnvironment: {
-                kind: 'application' as const,
-                value: [
-                  '<issue_environment>',
-                  JSON.stringify({
-                    project: {
-                      id: String(project.id),
-                      name: project.name,
-                      description: project.description ?? '',
-                    },
-                    issue: {
-                      id: String(task.id),
-                      title: task.title,
-                      description: task.description ?? '',
-                      status: task.status,
-                      priority: task.priority,
-                      tags: task.tags ?? [],
-                      assigneeUserId: task.assignee_user_id ?? null,
-                      assigneeAgentId: task.assignee_agent_id || null,
-                      dueDate: task.due_at ?? null,
-                    },
-                    orchestration: task.workflow
-                      ? {
-                          advancementPolicy: task.workflow.advancement_policy ?? 'manual',
-                          stageMode:
-                            task.workflow.stage_mode ??
-                            (task.workflow.nodes.length ? 'dag' : 'none'),
-                          currentStageId: workflowNodeId ?? null,
-                          stages: task.workflow.nodes.map(node => ({
-                            id: node.id,
-                            name: node.name,
-                            prompt: node.prompt ?? '',
-                            status: node.status,
-                            dependsOn: node.depends_on,
-                            dependencyContext: node.dependency_context ?? {},
-                            required: node.required,
-                          })),
-                        }
-                      : null,
-                  }),
-                  '</issue_environment>',
-                  'Treat this Issue as immutable execution context. The user message is the concrete task instruction.',
-                ].join('\n'),
-              },
-            }
-          : {}),
-      },
-    }),
+  const runtimeContext = useMemo(
+    () => buildWorkItemRuntimeContext(project, task, workflowNodeId),
     [project, task, workflowNodeId]
   )
 
@@ -236,7 +170,6 @@ export function AiChatModal({
         instanceId={instanceId}
         testId={testId}
         initialInput={initialTaskInput}
-        autoSubmitInitialInput={autoSubmitInitialTaskInput}
         initialAddress={options.startFresh ? null : currentAddress}
         createTask={createConversation}
         onAddressChange={rememberAddress}

--- a/wework/src/features/todo/BackgroundTaskStarter.test.tsx
+++ b/wework/src/features/todo/BackgroundTaskStarter.test.tsx
@@ -1,0 +1,77 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RuntimeTaskAddress } from '@/types/api'
+import { BackgroundTaskStarter } from './BackgroundTaskStarter'
+
+const mocks = vi.hoisted(() => ({
+  createConversation: vi.fn(),
+}))
+
+vi.mock('./useProjectRuntimeTaskComposer', () => ({
+  useProjectRuntimeTaskComposer: () => mocks.createConversation,
+}))
+
+describe('BackgroundTaskStarter', () => {
+  it('starts the runtime task without rendering a UI surface', async () => {
+    const address: RuntimeTaskAddress = {
+      deviceId: 'local-device',
+      taskId: 'runtime-created',
+    }
+    const onAddressChange = vi.fn()
+    mocks.createConversation.mockImplementation(async (_input, options) => {
+      options.onRuntimeTaskOptimisticOpen(address)
+      return address
+    })
+
+    const { container } = render(
+      <BackgroundTaskStarter
+        project={{
+          id: 11,
+          name: 'Wegent V4',
+          description: '',
+        }}
+        localProjects={[{ id: 91, name: '运营工作区', tasks: [] }]}
+        task={{
+          id: 'WEG-1',
+          cloud_project_id: 11,
+          sequence_number: 1,
+          parent_id: null,
+          created_by_user_id: 1,
+          assignee_user_id: null,
+          title: 'Implement cloud MCP',
+          description: 'Use the shared workspace',
+          status: 'pending',
+          priority: 'high',
+          due_at: null,
+          sort_order: 0,
+          current_delivery_id: null,
+          version: 1,
+          created_at: '2026-07-22T00:00:00Z',
+          updated_at: '2026-07-22T00:00:00Z',
+          completed_at: null,
+        }}
+        input="Implement cloud MCP"
+        initialLocalProjectId={91}
+        onAddressChange={onAddressChange}
+        onError={vi.fn()}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    await waitFor(() => expect(mocks.createConversation).toHaveBeenCalledOnce())
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      'Implement cloud MCP',
+      expect.objectContaining({
+        attachments: [],
+        executionModel: {},
+        optimisticUserMessage: expect.objectContaining({
+          role: 'user',
+          content: 'Implement cloud MCP',
+        }),
+      })
+    )
+    expect(onAddressChange).toHaveBeenCalledOnce()
+    expect(onAddressChange).toHaveBeenCalledWith(address)
+  })
+})

--- a/wework/src/features/todo/BackgroundTaskStarter.tsx
+++ b/wework/src/features/todo/BackgroundTaskStarter.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+import type { CloudLoopItem, CloudProject } from '@/api/deliveries'
+import { createRuntimeUserMessage } from '@/features/workbench/runtimeUserMessage'
+import type { ProjectWithTasks, RuntimeTaskAddress } from '@/types/api'
+import { useProjectRuntimeTaskComposer } from './useProjectRuntimeTaskComposer'
+import { buildWorkItemRuntimeContext } from './workItemRuntimeContext'
+
+interface BackgroundTaskStarterProps {
+  project: CloudProject
+  localProjects: ProjectWithTasks[]
+  task: CloudLoopItem
+  input: string
+  initialLocalProjectId?: number | null
+  inheritFromTask?: RuntimeTaskAddress | null
+  workflowNodeId?: string
+  prepareTask?: (
+    address: RuntimeTaskAddress,
+    localProject: ProjectWithTasks | null
+  ) => void | (() => void | Promise<void>) | Promise<void | (() => void | Promise<void>)>
+  onTaskCreated?: (
+    address: RuntimeTaskAddress,
+    localProject: ProjectWithTasks | null
+  ) => Promise<void> | void
+  onAddressChange: (address: RuntimeTaskAddress) => void
+  onError: (message: string) => void
+}
+
+export function BackgroundTaskStarter({
+  project,
+  localProjects,
+  task,
+  input,
+  initialLocalProjectId = null,
+  inheritFromTask = null,
+  workflowNodeId,
+  prepareTask,
+  onTaskCreated,
+  onAddressChange,
+  onError,
+}: BackgroundTaskStarterProps) {
+  const startedRef = useRef(false)
+  const addressReportedRef = useRef(false)
+  const selectedLocalProject = useMemo(
+    () =>
+      localProjects.find(candidate => candidate.id === initialLocalProjectId) ??
+      localProjects.find(candidate => String(candidate.id) === String(project.id)) ??
+      localProjects[0] ??
+      null,
+    [initialLocalProjectId, localProjects, project.id]
+  )
+  const runtimeContext = useMemo(
+    () => buildWorkItemRuntimeContext(project, task, workflowNodeId),
+    [project, task, workflowNodeId]
+  )
+  const createConversation = useProjectRuntimeTaskComposer({
+    project: selectedLocalProject,
+    workspaceSource: inheritFromTask,
+    runtimeContext,
+    prepareTask,
+    onTaskCreated,
+  })
+
+  useEffect(() => {
+    if (startedRef.current) return
+    startedRef.current = true
+    const reportAddress = (address: RuntimeTaskAddress) => {
+      if (addressReportedRef.current) return
+      addressReportedRef.current = true
+      onAddressChange(address)
+    }
+    void createConversation(input, {
+      attachments: [],
+      executionModel: {},
+      optimisticUserMessage: createRuntimeUserMessage(input, []),
+      onError,
+      onRuntimeTaskOptimisticOpen: reportAddress,
+    }).then(address => {
+      if (address) reportAddress(address)
+    })
+  }, [createConversation, input, onAddressChange, onError])
+
+  return null
+}

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -105,6 +105,39 @@ vi.mock('./AiChatModal', () => ({
   ),
 }))
 
+vi.mock('./BackgroundTaskStarter', () => ({
+  BackgroundTaskStarter: ({
+    onAddressChange,
+    onTaskCreated,
+    prepareTask,
+  }: {
+    onAddressChange: (address: { deviceId: string; taskId: string }) => void
+    onTaskCreated?: (
+      address: { deviceId: string; taskId: string },
+      localProject: { id: number; name: string; tasks: [] } | null
+    ) => void | Promise<void>
+    prepareTask?: (
+      address: { deviceId: string; taskId: string },
+      localProject: { id: number; name: string; tasks: [] } | null
+    ) => void | Promise<void | (() => void | Promise<void>)>
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-start-background-task"
+      onClick={() => {
+        const address = { deviceId: 'local-device', taskId: 'runtime-created' }
+        const localProject = { id: 91, name: '运营工作区', tasks: [] as [] }
+        void Promise.resolve(prepareTask?.(address, localProject)).then(() => {
+          onAddressChange(address)
+          return onTaskCreated?.(address, localProject)
+        })
+      }}
+    >
+      后台创建 Runtime 任务
+    </button>
+  ),
+}))
+
 const project = {
   id: 11,
   public_id: 'cloud-public-id',
@@ -1261,7 +1294,7 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-open', 'yes')
   })
 
-  it('continues a task in the background after sending it from pending', async () => {
+  it('starts a pending task in the background without mounting any panel', async () => {
     const workbenchServices = services()
     workbenchServices.deliveryApi!.listLoopItems = vi.fn(async () => ({
       items: [{ ...item, status: 'pending' as const }],
@@ -1278,12 +1311,18 @@ describe('CloudTodoWorkspace', () => {
     await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
     await userEvent.click(await screen.findByTestId('cloud-todo-card-WEG-1'))
     await userEvent.click(screen.getByTestId('cloud-todo-create-task'))
-    expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-open', 'yes')
 
-    await userEvent.click(screen.getByTestId('mock-create-runtime-task'))
-
-    expect(screen.getByTestId('ai-chat-modal')).toHaveAttribute('data-open', 'no')
+    expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
     expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-panel-stack')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-detail-dismiss-layer')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('mock-start-background-task'))
+
+    expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-panel-stack')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-detail-dismiss-layer')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('cloud-todo-card-WEG-1'))
 
@@ -3065,7 +3104,7 @@ describe('CloudTodoWorkspace', () => {
     })
   })
 
-  it('creates a queued task and opens its task composer', async () => {
+  it('creates a queued task and starts it without opening a task composer', async () => {
     const workbenchServices = services()
     workbenchServices.deliveryApi!.listLoopItems = vi.fn(async () => ({ items: [item] }))
     workbenchServices.deliveryApi!.createLoopItem = vi.fn(async (_projectId, values) => ({
@@ -3099,7 +3138,10 @@ describe('CloudTodoWorkspace', () => {
         parent_id: null,
       })
     )
-    expect(screen.getByTestId('ai-chat-modal')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-start-background-task')).toBeInTheDocument()
+    expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-panel-stack')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cloud-todo-detail-dismiss-layer')).not.toBeInTheDocument()
   })
 
   it('binds a human workflow task without inventing an automation queue state', async () => {

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -152,6 +152,7 @@ import { associateLoopItemTags, loopItemLocalProject } from '@/api/localProjectA
 import { emptyTaskSearchFilters, type TaskSearchFilters } from './taskSearch'
 import { boardStatusColorClasses, columnDotClasses, columns, reorderLaneItems } from './todoShared'
 import { AiChatModal } from './AiChatModal'
+import { BackgroundTaskStarter } from './BackgroundTaskStarter'
 import {
   shouldDeferWorkItemMoveUntilTaskCreated,
   shouldPrepareWorkItemTask,
@@ -463,7 +464,6 @@ type SelectedTaskBinding = Pick<
 type TaskComposerRequest = {
   workItemId: string
   initialInput: string
-  autoSubmit: boolean
   backgroundAfterSend: boolean
   workflowNodeId?: string
   inheritFromTask?: RuntimeTaskAddress | null
@@ -2680,7 +2680,6 @@ export function CloudTodoWorkspace({
       setTaskComposerRequest({
         workItemId: item.id,
         initialInput: workItemTaskInput(item),
-        autoSubmit: false,
         backgroundAfterSend: true,
       })
       return
@@ -2777,7 +2776,6 @@ export function CloudTodoWorkspace({
         setTaskComposerRequest({
           workItemId: locatedUpdated.id,
           initialInput: workItemTaskInput(locatedUpdated),
-          autoSubmit: column.status === 'in_progress',
           backgroundAfterSend: column.status === 'in_progress',
         })
       } else if (
@@ -2983,10 +2981,10 @@ export function CloudTodoWorkspace({
         setSelectedItem(locatedItem)
       }
       if (input.createTask) {
+        setBackgroundTaskItemId(locatedItem.id)
         setTaskComposerRequest({
           workItemId: locatedItem.id,
           initialInput: workItemTaskInput(locatedItem),
-          autoSubmit: true,
           backgroundAfterSend: true,
         })
       }
@@ -3006,9 +3004,11 @@ export function CloudTodoWorkspace({
   const taskPanelOpen = Boolean(
     selectedItem &&
     aiChatProject &&
+    backgroundTaskItemId !== selectedItem.id &&
     (selectedTaskBinding?.work_item_id === selectedItem.id ||
       taskComposerRequest?.workItemId === selectedItem.id)
   )
+  const taskStartingInBackground = backgroundTaskItemId === selectedItem?.id
   const [issueResourceAttachmentState, setIssueResourceAttachmentState] = useState<{
     itemId: string | null
     attachments: CloudLoopItemAttachment[]
@@ -3055,6 +3055,73 @@ export function CloudTodoWorkspace({
 
   function closeTopPanel() {
     closeIssuePanelStack()
+  }
+
+  async function prepareSelectedItemTask(address: RuntimeTaskAddress) {
+    if (!selectedItem) return
+    const itemApi = apiForProject(selectedItemProject)
+    if (!itemApi) return
+    try {
+      const latest = await itemApi.getLoopItem(selectedItem.id)
+      const workflowNodeId =
+        taskComposerRequest?.workItemId === selectedItem.id
+          ? taskComposerRequest.workflowNodeId
+          : undefined
+      await itemApi.bindTask(latest.id, address, latest.title, workflowNodeId)
+      publishProjectSpaceTaskBindingChanged(address)
+      setBoardRefreshNonce(value => value + 1)
+      return async () => {
+        await itemApi.unbindTask(latest.id, address)
+        publishProjectSpaceTaskBindingChanged(address)
+        setBoardRefreshNonce(value => value + 1)
+      }
+    } catch (cause) {
+      setBoardError(cause instanceof Error ? cause.message : '关联任务与 Issue 失败，请重试')
+      setBoardRefreshNonce(value => value + 1)
+      throw cause
+    }
+  }
+
+  async function handleSelectedItemTaskCreated(
+    _address: RuntimeTaskAddress,
+    localProject: ProjectWithTasks | null
+  ) {
+    if (!selectedItem) return
+    const itemApi = apiForProject(selectedItemProject)
+    if (!itemApi) return
+    try {
+      const latest = await itemApi.getLoopItem(selectedItem.id)
+      const associatedTags =
+        isMyTasksBoard && localProject ? associateLoopItemTags(latest, localProject) : latest.tags
+      const associationChanged =
+        associatedTags.length !== latest.tags.length ||
+        associatedTags.some((tag, index) => tag !== latest.tags[index])
+      const updated =
+        latest.status === 'inbox' || associationChanged
+          ? await itemApi.updateLoopItem(latest.id, {
+              version: latest.version,
+              ...(latest.status === 'inbox' ? { status: 'pending' } : {}),
+              ...(associationChanged ? { tags: associatedTags } : {}),
+            })
+          : latest
+      const locatedUpdated = {
+        ...updated,
+        project_store: selectedItem.project_store,
+      }
+      setItems(current =>
+        current.map(item =>
+          item.id === locatedUpdated.id ? preferNewestLoopItemSnapshot(item, locatedUpdated) : item
+        )
+      )
+      setSelectedItem(current =>
+        current?.id === locatedUpdated.id
+          ? preferNewestLoopItemSnapshot(current, locatedUpdated)
+          : current
+      )
+    } catch (cause) {
+      setBoardError(cause instanceof Error ? cause.message : '关联任务与 Issue 失败，请重试')
+      setBoardRefreshNonce(value => value + 1)
+    }
   }
 
   useEffect(() => {
@@ -4293,7 +4360,7 @@ export function CloudTodoWorkspace({
             className="todo-panel-backdrop"
           />
         ) : null}
-        {selectedItem ? (
+        {selectedItem && !taskStartingInBackground ? (
           <div
             data-testid="cloud-todo-panel-stack"
             data-conversation-open={taskPanelOpen ? 'true' : 'false'}
@@ -4497,11 +4564,12 @@ export function CloudTodoWorkspace({
                       })
                     }
                   }
+                  const backgroundAfterSend = selectedItem.status === 'pending' && !workflowNodeId
+                  setBackgroundTaskItemId(backgroundAfterSend ? selectedItem.id : null)
                   setTaskComposerRequest({
                     workItemId: selectedItem.id,
                     initialInput: workflowNode ? workflowStageTaskInput(workflowNode) : '',
-                    autoSubmit: false,
-                    backgroundAfterSend: selectedItem.status === 'pending' && !workflowNodeId,
+                    backgroundAfterSend,
                     workflowNodeId,
                     inheritFromTask,
                   })
@@ -4679,11 +4747,6 @@ export function CloudTodoWorkspace({
                     ? taskComposerRequest.initialInput
                     : ''
                 }
-                autoSubmitInitialTaskInput={
-                  taskComposerRequest?.workItemId === selectedItem.id
-                    ? taskComposerRequest.autoSubmit
-                    : false
-                }
                 workflowNodeId={
                   taskComposerRequest?.workItemId === selectedItem.id
                     ? taskComposerRequest.workflowNodeId
@@ -4692,94 +4755,58 @@ export function CloudTodoWorkspace({
                 onClose={closeIssuePanelStack}
                 onBack={closeTaskPanel}
                 onAddressChange={address => {
-                  if (
+                  const backgroundAfterSend =
                     taskComposerRequest?.workItemId === selectedItem.id &&
                     taskComposerRequest.backgroundAfterSend
-                  ) {
-                    setBackgroundTaskItemId(selectedItem.id)
+                  if (backgroundAfterSend) {
+                    setBackgroundTaskItemId(null)
+                    setSelectedItem(null)
+                    setSelectedTaskBinding(null)
+                  } else {
+                    setSelectedTaskBinding({
+                      id: -Date.now(),
+                      device_id: address.deviceId,
+                      task_id: address.taskId,
+                      task_title: null,
+                      work_item_id: selectedItem.id,
+                    })
                   }
-                  setSelectedTaskBinding({
-                    id: -Date.now(),
-                    device_id: address.deviceId,
-                    task_id: address.taskId,
-                    task_title: null,
-                    work_item_id: selectedItem.id,
-                  })
                   setTaskComposerRequest(null)
                   setBoardRefreshNonce(value => value + 1)
                 }}
-                prepareTask={async address => {
-                  const itemApi = apiForProject(selectedItemProject)
-                  if (!itemApi) return
-                  try {
-                    const latest = await itemApi.getLoopItem(selectedItem.id)
-                    const workflowNodeId =
-                      taskComposerRequest?.workItemId === selectedItem.id
-                        ? taskComposerRequest.workflowNodeId
-                        : undefined
-                    await itemApi.bindTask(latest.id, address, latest.title, workflowNodeId)
-                    publishProjectSpaceTaskBindingChanged(address)
-                    setBoardRefreshNonce(value => value + 1)
-                    return async () => {
-                      await itemApi.unbindTask(latest.id, address)
-                      publishProjectSpaceTaskBindingChanged(address)
-                      setBoardRefreshNonce(value => value + 1)
-                    }
-                  } catch (cause) {
-                    setBoardError(
-                      cause instanceof Error ? cause.message : '关联任务与 Issue 失败，请重试'
-                    )
-                    setBoardRefreshNonce(value => value + 1)
-                    throw cause
-                  }
-                }}
-                onTaskCreated={async (_address, localProject) => {
-                  const itemApi = apiForProject(selectedItemProject)
-                  if (!itemApi) return
-                  try {
-                    const latest = await itemApi.getLoopItem(selectedItem.id)
-                    const associatedTags =
-                      isMyTasksBoard && localProject
-                        ? associateLoopItemTags(latest, localProject)
-                        : latest.tags
-                    const associationChanged =
-                      associatedTags.length !== latest.tags.length ||
-                      associatedTags.some((tag, index) => tag !== latest.tags[index])
-                    const updated =
-                      latest.status === 'inbox' || associationChanged
-                        ? await itemApi.updateLoopItem(latest.id, {
-                            version: latest.version,
-                            ...(latest.status === 'inbox' ? { status: 'pending' } : {}),
-                            ...(associationChanged ? { tags: associatedTags } : {}),
-                          })
-                        : latest
-                    const locatedUpdated = {
-                      ...updated,
-                      project_store: selectedItem.project_store,
-                    }
-                    setItems(current =>
-                      current.map(item =>
-                        item.id === locatedUpdated.id
-                          ? preferNewestLoopItemSnapshot(item, locatedUpdated)
-                          : item
-                      )
-                    )
-                    setSelectedItem(current =>
-                      current?.id === locatedUpdated.id
-                        ? preferNewestLoopItemSnapshot(current, locatedUpdated)
-                        : current
-                    )
-                  } catch (cause) {
-                    setBoardError(
-                      cause instanceof Error ? cause.message : '关联任务与 Issue 失败，请重试'
-                    )
-                    setBoardRefreshNonce(value => value + 1)
-                  }
-                }}
+                prepareTask={prepareSelectedItemTask}
+                onTaskCreated={handleSelectedItemTaskCreated}
                 onOpenRuntimeTask={onOpenRuntimeTask}
               />
             ) : null}
           </div>
+        ) : null}
+        {selectedItem &&
+        aiChatProject &&
+        taskStartingInBackground &&
+        taskComposerRequest?.workItemId === selectedItem.id ? (
+          <BackgroundTaskStarter
+            project={aiChatProject}
+            localProjects={localProjects}
+            task={selectedItem}
+            input={taskComposerRequest.initialInput}
+            initialLocalProjectId={
+              localProjectIdForItem(selectedItem) ??
+              (isMyTasksBoard ? selectedLocalProject?.id : null)
+            }
+            inheritFromTask={taskComposerRequest.inheritFromTask}
+            workflowNodeId={taskComposerRequest.workflowNodeId}
+            onAddressChange={() => {
+              setBackgroundTaskItemId(null)
+              setSelectedItem(null)
+              setSelectedTaskBinding(null)
+              setTaskComposerRequest(null)
+              setBoardRefreshNonce(value => value + 1)
+            }}
+            prepareTask={prepareSelectedItemTask}
+            onTaskCreated={handleSelectedItemTaskCreated}
+            onError={setBoardError}
+          />
         ) : null}
         {selectedProject && projectAssistantOpen && !selectedItem ? (
           <ProjectSpaceChatSidebar

--- a/wework/src/features/todo/workItemRuntimeContext.ts
+++ b/wework/src/features/todo/workItemRuntimeContext.ts
@@ -1,0 +1,72 @@
+import type { CloudLoopItem, CloudProject } from '@/api/deliveries'
+import type { RuntimeSendRequest } from '@/types/api'
+import { projectSpaceChatRuntimeContext } from './projectProviderConfig'
+
+export function buildWorkItemRuntimeContext(
+  project: CloudProject,
+  task?: CloudLoopItem,
+  workflowNodeId?: string
+): Pick<RuntimeSendRequest, 'cloudProjectId' | 'origin' | 'additionalContext'> {
+  return {
+    cloudProjectId: String(project.id),
+    ...(task
+      ? {
+          origin: {
+            type: 'board_task' as const,
+            cloudProjectId: String(project.id),
+            loopItemId: String(task.id),
+          },
+        }
+      : {}),
+    additionalContext: {
+      ...projectSpaceChatRuntimeContext(project, task),
+      ...(task
+        ? {
+            issueEnvironment: {
+              kind: 'application' as const,
+              value: [
+                '<issue_environment>',
+                JSON.stringify({
+                  project: {
+                    id: String(project.id),
+                    name: project.name,
+                    description: project.description ?? '',
+                  },
+                  issue: {
+                    id: String(task.id),
+                    title: task.title,
+                    description: task.description ?? '',
+                    status: task.status,
+                    priority: task.priority,
+                    tags: task.tags ?? [],
+                    assigneeUserId: task.assignee_user_id ?? null,
+                    assigneeAgentId: task.assignee_agent_id || null,
+                    dueDate: task.due_at ?? null,
+                  },
+                  orchestration: task.workflow
+                    ? {
+                        advancementPolicy: task.workflow.advancement_policy ?? 'manual',
+                        stageMode:
+                          task.workflow.stage_mode ?? (task.workflow.nodes.length ? 'dag' : 'none'),
+                        currentStageId: workflowNodeId ?? null,
+                        stages: task.workflow.nodes.map(node => ({
+                          id: node.id,
+                          name: node.name,
+                          prompt: node.prompt ?? '',
+                          status: node.status,
+                          dependsOn: node.depends_on,
+                          dependencyContext: node.dependency_context ?? {},
+                          required: node.required,
+                        })),
+                      }
+                    : null,
+                }),
+                '</issue_environment>',
+                'Treat this Issue as immutable execution context. The user message is the concrete task instruction.',
+              ].join('\n'),
+            },
+          }
+        : {}),
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- decouple background board-task creation from `AiChatModal` and all floating panel surfaces
- start pending and newly queued tasks through a headless runtime starter that renders no DOM
- share work-item runtime context and task binding/update callbacks between interactive chat and background execution
- add regressions proving no modal, panel stack, or backdrop is mounted during background start

## Verification

- `pnpm --filter wework test src/features/todo/BackgroundTaskStarter.test.tsx src/features/todo/AiChatModal.test.tsx src/features/todo/CloudTodoWorkspace.test.tsx` (99 passed)
- Prettier checks passed
- ESLint passed
- pre-push Wework ESLint, TypeScript, and full unit-test gate passed
- isolated real-Tauri verification was attempted twice; the controlled session did not reach an operable board before `ai:verify` timed out during workbench startup

Closes WORK-124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now start in the background without keeping the conversation panel open.
  * Added background task creation with progress callbacks and immediate task address updates.
  * Runtime context now includes relevant project, task, issue, and workflow details.

* **Bug Fixes**
  * Improved task panel behavior during background creation, including automatic closing after successful creation.

* **Tests**
  * Added coverage for background task creation and updated pending and queued task scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->