### PR TITLE
fix(wework): preserve active board during task start

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -30,6 +30,10 @@ import { useRuntimeTaskRouteRestoration } from './useRuntimeTaskRouteRestoration
 import { modelSelectionFromRuntimeHandle } from './runtimeContextUsage'
 import { writeCachedRemoteRuntimeWork } from './remoteRuntimeWorkCache'
 import {
+  WorkspaceTabsContext,
+  type WorkspaceTabsContextValue,
+} from '@/features/workspace-tabs/workspaceTabsContextValue'
+import {
   RuntimeTaskLifecycleStore,
   useRuntimeTaskLifecycle,
   useRuntimeTaskLifecycleStore,
@@ -5645,7 +5649,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent('none')
   })
 
-  test('does not reopen a newly created task after the user switches tasks', async () => {
+  test('does not navigate away from the board when a background task starts', async () => {
     const createResponse = deferred<RuntimeTaskCreateResponse>()
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(
@@ -5661,19 +5665,12 @@ describe('WorkbenchProvider runtime tasks', () => {
                   workspacePath: '/workspace/project-alpha',
                   mapped: true,
                   available: true,
-                  tasks: [
-                    {
-                      taskId: 'runtime-b',
-                      workspacePath: '/workspace/project-alpha',
-                      title: 'Runtime B',
-                      runtime: 'codex',
-                    },
-                  ],
+                  tasks: [],
                 },
               ],
             },
           ],
-          totalTasks: 1,
+          totalTasks: 0,
         })
       ),
       createRuntimeTask: vi.fn(() => createResponse.promise),
@@ -5682,7 +5679,45 @@ describe('WorkbenchProvider runtime tasks', () => {
       runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
     })
 
-    renderWorkbench(<ProjectSendProbe />, services)
+    const taskTab = {
+      id: 'task-tab',
+      kind: 'task' as const,
+      title: '任务',
+      contentRoute: '/',
+      fixed: false,
+    }
+    const boardTab = {
+      id: 'board-tab',
+      kind: 'board' as const,
+      title: '项目空间',
+      contentRoute: '/todo',
+      fixed: false,
+    }
+    let workspaceTabs: WorkspaceTabsContextValue = {
+      tabs: [taskTab, boardTab],
+      activeTabId: taskTab.id,
+      activeTab: taskTab,
+      openTab: vi.fn(),
+      selectTab: vi.fn(),
+      closeTab: vi.fn(),
+      closeOtherTabs: vi.fn(),
+      restoreClosedTab: vi.fn(),
+      moveTab: vi.fn(),
+      updateActiveTab: vi.fn(),
+    }
+    const view = render(
+      <WorkspaceTabsContext.Provider value={workspaceTabs}>
+        <WorkbenchProvider
+          user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+          services={services}
+          workspaceTabId={taskTab.id}
+        >
+          <WorkbenchProbeSessionProvider>
+            <ProjectSendProbe />
+          </WorkbenchProbeSessionProvider>
+        </WorkbenchProvider>
+      </WorkspaceTabsContext.Provider>
+    )
 
     await userEvent.click(await screen.findByText('select project'))
     await userEvent.click(screen.getByText('set input'))
@@ -5690,18 +5725,32 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
     const optimisticRequest = runtimeWorkApi.createRuntimeTask.mock.calls[0][0]
 
-    await userEvent.click(screen.getByText('open runtime b'))
-    await waitFor(() =>
-      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
-        'device-1:runtime-b'
-      )
+    workspaceTabs = {
+      ...workspaceTabs,
+      activeTabId: boardTab.id,
+      activeTab: boardTab,
+    }
+    window.history.pushState({}, '', '/todo')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    view.rerender(
+      <WorkspaceTabsContext.Provider value={workspaceTabs}>
+        <WorkbenchProvider
+          user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+          services={services}
+          workspaceTabId={taskTab.id}
+        >
+          <WorkbenchProbeSessionProvider>
+            <ProjectSendProbe />
+          </WorkbenchProbeSessionProvider>
+        </WorkbenchProvider>
+      </WorkspaceTabsContext.Provider>
     )
 
     await act(async () => {
       createResponse.resolve({
         accepted: true,
         deviceId: 'device-1',
-        taskId: optimisticRequest.taskId,
+        taskId: 'runtime-started',
         workspacePath: '/workspace/project-alpha',
         runtime: 'codex',
       })
@@ -5709,12 +5758,10 @@ describe('WorkbenchProvider runtime tasks', () => {
     })
 
     expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
-      'device-1:runtime-b'
+      'device-1:runtime-started'
     )
-    expect(parseRuntimeTaskRoute(window.location.pathname, window.location.search)).toEqual({
-      deviceId: 'device-1',
-      taskId: 'runtime-b',
-    })
+    expect(optimisticRequest.taskId).not.toBe('runtime-started')
+    expect(window.location.pathname).toBe('/todo')
   })
 
   test('keeps a newly created task running across a stale accepted-task refresh', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -162,6 +162,7 @@ import {
   consumeWorkspaceTabTransfer,
   publishWorkspaceTabTransferState,
 } from '@/features/workspace-tabs/workspaceTabTransfer'
+import { useOptionalWorkspaceTabs } from '@/features/workspace-tabs/workspaceTabsContextValue'
 import { useWorkbenchTelemetry } from './useWorkbenchTelemetry'
 import { useAiGenerationTelemetry } from './useAiGenerationTelemetry'
 import { normalizeAiModelId } from '@/telemetry/modelCatalog'
@@ -219,6 +220,10 @@ export function WorkbenchProvider({
 }: WorkbenchProviderProps) {
   const { t } = useTranslation('common')
   const cloudConnection = useOptionalCloudConnection()
+  const workspaceTabs = useOptionalWorkspaceTabs()
+  const canNavigateWorkspaceTab = useStableEvent(
+    () => !workspaceTabId || !workspaceTabs || workspaceTabs.activeTabId === workspaceTabId
+  )
   // Preferences can change while a turn is running. Runtime transports only
   // need the account identity, so keep their service graph stable across those
   // updates and avoid an event-subscription gap during terminal delivery.
@@ -1659,6 +1664,7 @@ export function WorkbenchProvider({
     lifecycleStore,
     markRuntimeTasksArchived,
     refreshWorkLists,
+    canNavigate: canNavigateWorkspaceTab,
   })
 
   const listImPrivateSessions = useCallback(

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -57,6 +57,7 @@ interface UseWorkbenchRuntimeTasksOptions {
   lifecycleStore: RuntimeTaskLifecycleStore
   markRuntimeTasksArchived: (addresses: RuntimeTaskAddress[]) => void
   refreshWorkLists: RefreshWorkLists
+  canNavigate?: () => boolean
 }
 
 const runtimeTranscriptRequests = new Map<string, Promise<RuntimePaneTranscript>>()
@@ -70,6 +71,7 @@ export function useWorkbenchRuntimeTasks({
   lifecycleStore,
   markRuntimeTasksArchived,
   refreshWorkLists,
+  canNavigate = () => true,
 }: UseWorkbenchRuntimeTasksOptions) {
   const { t } = useTranslation('common')
   const openedRuntimeTaskKeysRef = useRef<Set<string>>(new Set())
@@ -100,11 +102,11 @@ export function useWorkbenchRuntimeTasks({
         reopeningCurrentTask,
         navigate: options?.navigate === true,
       })
-      if (options?.navigate) {
+      if (options?.navigate && canNavigate()) {
         navigateTo(buildRuntimeTaskRoute(address))
       }
     },
-    [dispatch]
+    [canNavigate, dispatch]
   )
 
   const isCurrentRuntimeTask = useCallback(


### PR DESCRIPTION
## Summary
- prevent inactive task workspace tabs from changing the global task route
- keep background task lifecycle state synchronized without stealing the active board tab
- add a regression test for switching to the board before an async task start resolves

## Verification
- `pnpm --filter wework test src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --filter wework exec prettier --check src/features/workbench/useWorkbenchRuntimeTasks.ts src/features/workbench/WorkbenchProvider.tsx src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --filter wework exec eslint src/features/workbench/useWorkbenchRuntimeTasks.ts src/features/workbench/WorkbenchProvider.tsx src/features/workbench/WorkbenchProvider.test.tsx`
- pre-push checks: ESLint, TypeScript, and unit tests passed

## Desktop verification
- attempted isolated `ai:verify`; the Vite frontend started, but the Tauri WebView did not become ready because Cargo was blocked waiting for a concurrent build-directory lock. No other build process was terminated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background task creation now keeps you on the currently active board tab instead of navigating away.
  * Newly created tasks are automatically selected after creation completes.
* **Bug Fixes**
  * Prevented background task activity from unexpectedly changing the active workspace tab.
  * Improved handling of task identifiers during optimistic creation and server synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->