### PR TITLE
Feat/harness app screenshot bridge

### DIFF
--- a/wework/README.md
+++ b/wework/README.md
@@ -10,6 +10,10 @@ Wework is the Wegent desktop workbench for local-first AI coding and workplace w
 - Connect to a Wegent Backend when cloud models, cloud devices, remote runtime work, or encrypted Codex auth sync are needed.
 - Package macOS builds as DMG releases with bundled Codex binaries and Tauri updater metadata.
 - Build iOS simulator, device, and App Store Connect packages from the same Tauri app.
+- Let smart app (harness plugin) pages capture their own webview through a
+  native screenshot bridge (`plugin:wegent-capture|capture_webview_snapshot`),
+  so in-browser features such as monitor-card screenshots work inside the
+  embedded browser without the standard `getDisplayMedia` API.
 
 ## Development
 

--- a/wework/src-tauri/build.rs
+++ b/wework/src-tauri/build.rs
@@ -16,7 +16,11 @@ fn main() {
     prepare_dws_sidecar();
     verify_bundled_codex_binary();
     ensure_codex_resource_glob_exists();
-    tauri_build::build()
+    tauri_build::try_build(tauri_build::Attributes::new().plugin(
+        "wegent-capture",
+        tauri_build::InlinedPlugin::new().commands(&["capture_webview_snapshot"]),
+    ))
+    .expect("tauri-build should succeed");
 }
 
 fn configure_build_profile() {

--- a/wework/src-tauri/capabilities/harness-apps.json
+++ b/wework/src-tauri/capabilities/harness-apps.json
@@ -1,0 +1,10 @@
+{
+  "identifier": "harness-apps",
+  "description": "Allows harness app (smart app / plugin) pages served on the local loopback to capture their own webview through the native screenshot bridge.",
+  "local": false,
+  "webviews": ["*"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*"]
+  },
+  "permissions": ["wegent-capture:allow-capture-webview-snapshot"]
+}

--- a/wework/src-tauri/src/embedded_browser.rs
+++ b/wework/src-tauri/src/embedded_browser.rs
@@ -819,7 +819,28 @@ fn relabel_tab_routes(
 }
 
 fn should_disable_web_security(label: &str) -> bool {
+    is_harness_app_browser_label(label)
+}
+
+pub(crate) fn is_harness_app_browser_label(label: &str) -> bool {
     label.starts_with(HARNESS_APP_BROWSER_LABEL_PREFIX)
+}
+
+/// Map a Tauri webview label (e.g. `embedded-browser-native-1`) back to the
+/// logical embedded browser label (e.g. `app-harness-...` / `workspace-browser`).
+#[cfg(target_os = "macos")]
+pub(crate) fn logical_label_for_native_label(
+    state: &EmbeddedBrowserState,
+    native_label: &str,
+) -> Result<Option<String>, String> {
+    Ok(state
+        .webviews
+        .lock()
+        .map_err(|_| "Embedded browser state lock poisoned".to_string())?
+        .iter()
+        .find_map(|(logical_label, entry)| {
+            (entry.native_label == native_label).then(|| logical_label.clone())
+        }))
 }
 
 fn browser_data_directory(

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod system_drag;
 mod system_lock;
 mod system_sleep;
 mod todo_store;
+mod wegent_capture;
 mod workbench_background;
 #[cfg(desktop)]
 mod workbench_plugins;
@@ -5088,7 +5089,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_shell::init());
+        .plugin(tauri_plugin_shell::init())
+        .plugin(wegent_capture::plugin());
 
     #[cfg(desktop)]
     let builder = builder.plugin(

--- a/wework/src-tauri/src/wegent_capture.rs
+++ b/wework/src-tauri/src/wegent_capture.rs
@@ -1,0 +1,154 @@
+//! Native screenshot bridge for harness app pages.
+//!
+//! Harness app (smart app / plugin) pages run inside the Wework embedded
+//! browser as remote content (`http://127.0.0.1:<random-port>`), so the
+//! standard `getDisplayMedia` API is not available and Tauri rejects
+//! remote-origin IPC unless a capability explicitly grants it.
+//!
+//! This inlined plugin exposes a single command that captures the calling
+//! webview natively. `capabilities/harness-apps.json` grants it only to
+//! local-loopback remote pages; the command additionally verifies the caller
+//! is a harness app webview so ordinary embedded browser tabs stay out.
+
+use tauri::{State, Webview, Wry};
+
+use crate::embedded_browser::EmbeddedBrowserState;
+#[cfg(target_os = "macos")]
+use crate::embedded_browser::{
+    embedded_browser_capture_snapshot, is_harness_app_browser_label, logical_label_for_native_label,
+};
+
+pub fn plugin() -> tauri::plugin::TauriPlugin<Wry> {
+    tauri::plugin::Builder::new("wegent-capture")
+        .invoke_handler(tauri::generate_handler![capture_webview_snapshot])
+        .build()
+}
+
+/// Capture the current webview as a PNG data URL.
+///
+/// The command resolves the calling webview itself, so harness pages do not
+/// need to know their webview label. Only webviews whose logical embedded
+/// browser label is a harness app (`app-harness-*`) are accepted.
+#[tauri::command]
+pub async fn capture_webview_snapshot(
+    state: State<'_, EmbeddedBrowserState>,
+    webview: Webview<Wry>,
+) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let native_label = webview.label().to_string();
+        let logical_label = logical_label_for_native_label(state.inner(), &native_label)?
+            .ok_or_else(|| {
+                format!("Current webview {native_label} is not an embedded browser webview")
+            })?;
+        if !is_harness_app_browser_label(&logical_label) {
+            return Err(format!(
+                "Screenshot bridge is only available to harness app webviews, got {logical_label}"
+            ));
+        }
+        embedded_browser_capture_snapshot(state, Some(logical_label)).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (state, webview);
+        Err("Embedded browser screenshots are currently supported on macOS only".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tauri::utils::acl::{
+        capability::{Capability, CapabilityFile},
+        manifest::{Manifest, PermissionFile},
+        resolved::Resolved,
+        Commands, ExecutionContext, Permission,
+    };
+    use tauri::{utils::platform::Target, Url};
+
+    use super::is_harness_app_browser_label;
+
+    fn wegent_capture_manifest() -> Manifest {
+        Manifest::new(
+            vec![PermissionFile {
+                default: None,
+                set: vec![],
+                permission: vec![Permission {
+                    version: None,
+                    identifier: "allow-capture-webview-snapshot".into(),
+                    description: None,
+                    commands: Commands {
+                        allow: vec!["capture_webview_snapshot".into()],
+                        deny: vec![],
+                    },
+                    scope: Default::default(),
+                    platforms: None,
+                }],
+            }],
+            None,
+        )
+    }
+
+    fn load_harness_apps_capability() -> Capability {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/capabilities/harness-apps.json"
+        );
+        match CapabilityFile::load(path).expect("harness-apps.json should load") {
+            CapabilityFile::Capability(capability) => capability,
+            _ => panic!("harness-apps.json must contain a single capability"),
+        }
+    }
+
+    #[test]
+    fn harness_capability_grants_capture_only_to_loopback_pages() {
+        let mut acl = BTreeMap::new();
+        acl.insert("wegent-capture".to_string(), wegent_capture_manifest());
+        let mut capabilities = BTreeMap::new();
+        let capability = load_harness_apps_capability();
+        capabilities.insert(capability.identifier.clone(), capability);
+
+        let resolved = Resolved::resolve(&acl, capabilities, Target::current())
+            .expect("capability resolution should succeed");
+        let command = "plugin:wegent-capture|capture_webview_snapshot";
+        let resolved_commands = resolved
+            .allowed_commands
+            .get(command)
+            .expect("capture command should be allowed by the harness capability");
+
+        let loopback_url = Url::parse("http://127.0.0.1:3080/").unwrap();
+        let harness_webview = "embedded-browser-native-42";
+        let allowed_on_harness_webview = resolved_commands.iter().any(|cmd| {
+            cmd.webviews
+                .iter()
+                .any(|pattern| pattern.matches(harness_webview))
+                && matches!(&cmd.context, ExecutionContext::Remote { url } if url.test(&loopback_url))
+        });
+        assert!(
+            allowed_on_harness_webview,
+            "loopback harness webview should be allowed to capture"
+        );
+
+        let remote_url = Url::parse("https://example.com/").unwrap();
+        let allowed_on_remote_origin = resolved_commands.iter().any(|cmd| {
+            cmd.webviews
+                .iter()
+                .any(|pattern| pattern.matches(harness_webview))
+                && matches!(&cmd.context, ExecutionContext::Remote { url } if url.test(&remote_url))
+        });
+        assert!(
+            !allowed_on_remote_origin,
+            "non-loopback origins must not be able to capture"
+        );
+    }
+
+    #[test]
+    fn capture_is_limited_to_harness_app_webviews() {
+        assert!(is_harness_app_browser_label(
+            "app-harness-dsh-opsduty-workbench-auxiliary-workspace-tab"
+        ));
+        assert!(!is_harness_app_browser_label("workspace-browser"));
+        assert!(!is_harness_app_browser_label("embedded-browser-native-1"));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native screenshot capture for embedded smart-app webviews.
  * Smart apps can capture their own webview snapshots without browser screen-sharing prompts.
  * Capture access is restricted to approved local harness pages.
* **Documentation**
  * Documented the new smart-app webview screenshot capability.
* **Bug Fixes**
  * Improved embedded-browser identification to ensure capture requests target the correct webview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->