### PR TITLE
test(frontend): harden navigation readiness in E2E

### DIFF
--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -162,6 +162,17 @@ test('login test', async ({ page }) => {
 5. **Wait Strategies**: Use proper wait strategies instead of fixed timeouts
 6. **Coverage**: Enable coverage for integration and critical path tests
 
+When a test only requires the document to be interactive, pass the readiness
+contract directly to navigation:
+
+```typescript
+await page.goto('/chat', { waitUntil: 'domcontentloaded' })
+```
+
+Do not call `page.goto()` with its default `load` wait and then call
+`waitForLoadState('domcontentloaded')`. The second wait cannot run if a
+non-critical resource keeps the `load` event pending.
+
 ## Debugging
 
 ### Visual Debugging

--- a/frontend/e2e/tests/tasks/team-selection.spec.ts
+++ b/frontend/e2e/tests/tasks/team-selection.spec.ts
@@ -334,18 +334,16 @@ test.describe('Team Selection', () => {
 
     test('should restore from localStorage when navigating to new chat', async ({ page }) => {
       // Set preferred team
-      await page.goto('/chat')
+      await page.goto('/chat', { waitUntil: 'domcontentloaded' })
       await page.evaluate(() => {
         localStorage.setItem('wegent_last_team_id_chat', '1')
       })
 
       // Navigate to a task
-      await page.goto('/chat?taskId=999')
-      await page.waitForLoadState('domcontentloaded')
+      await page.goto('/chat?taskId=999', { waitUntil: 'domcontentloaded' })
 
       // Navigate back to new chat
-      await page.goto('/chat')
-      await page.waitForLoadState('domcontentloaded')
+      await page.goto('/chat', { waitUntil: 'domcontentloaded' })
 
       // Team should be restored from localStorage
       // Verify by checking localStorage was read (hard to verify UI without mock)


### PR DESCRIPTION
## Summary
- analyze all merge queue failures from August 23, 2026 (Asia/Shanghai)
- use `domcontentloaded` as the direct navigation readiness contract in the failing team-selection regression
- document the Playwright navigation rule so future tests do not wait for `load` before requesting an earlier state

## Root cause evidence
- Wework E2E model-readiness failures occurred before the local executor stdio deadlock fix `39f4ef445`; merge queue runs after that fix passed
- frontend trace for run `32620993772` shows the access-denied page fully rendered while `page.goto` still waited for the `load` event
- the following `waitForLoadState('domcontentloaded')` could never execute because `page.goto` had not returned

## Verification
- `pnpm --dir frontend exec prettier --check e2e/README.md e2e/tests/tasks/team-selection.spec.ts`
- `pnpm --dir frontend exec eslint e2e/tests/tasks/team-selection.spec.ts`
- Playwright collection lists the focused team-selection suite successfully with explicit local-only credentials
- pre-push frontend ESLint, TypeScript, and unit tests passed

## CI soak
- merge only after five consecutive complete GitHub CI rounds pass for this commit