### PR TITLE
fix(ci): repair release image builds

### DIFF
--- a/backend/tests/docker/test_executor_home_acceptance_scripts.py
+++ b/backend/tests/docker/test_executor_home_acceptance_scripts.py
@@ -368,6 +368,9 @@ def test_acceptance_scripts_are_valid_shell_and_cover_required_lifecycle():
         "initialize_runtime_identity",
         "Docker volume identity changed",
         "WEGENT_WORKTREE_PERSISTENT_STORAGE_VERIFIED=true",
+        "executor-rpc-probe.py",
+        "executor-persistence-json.py",
+        '--mount "type=bind,src=$SCRIPT_DIR,dst=$PROBE_TARGET_DIR,readonly"',
     ):
         assert required_contract in docker_script
 

--- a/backend/tests/docker/test_workspace_patch_dockerfiles.py
+++ b/backend/tests/docker/test_workspace_patch_dockerfiles.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for workspace dependency patches in Node image builds."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+DOCKERFILES = (
+    ROOT / "docker" / "frontend" / "Dockerfile",
+    ROOT / "docker" / "standalone" / "Dockerfile",
+)
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES, ids=lambda path: path.parent.name)
+def test_pnpm_install_stages_copy_workspace_patches(dockerfile: Path):
+    content = dockerfile.read_text(encoding="utf-8")
+    install_stages = [
+        stage
+        for stage in re.split(r"(?m)^FROM ", content)[1:]
+        if "pnpm install --frozen-lockfile" in stage
+    ]
+
+    assert install_stages, f"no pnpm install stage found in {dockerfile}"
+    for stage in install_stages:
+        copy_index = stage.find("COPY patches ./patches")
+        install_index = stage.find("pnpm install --frozen-lockfile")
+        assert 0 <= copy_index < install_index

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # Copy dependency files and postinstall scripts
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 COPY packages/chat-core/package.json ./packages/chat-core/package.json
 COPY frontend/package.json ./frontend/package.json
 COPY frontend/scripts ./frontend/scripts

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 
 # Copy dependency files and postinstall scripts
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 COPY packages/chat-core/package.json ./packages/chat-core/package.json
 COPY frontend/package.json ./frontend/package.json
 COPY frontend/scripts ./frontend/scripts
@@ -59,6 +60,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 COPY packages/chat-core/package.json ./packages/chat-core/package.json
 COPY wework/package.json ./wework/package.json
 

--- a/scripts/acceptance/remote-device-worktree-persistence.sh
+++ b/scripts/acceptance/remote-device-worktree-persistence.sh
@@ -17,7 +17,8 @@ VOLUME_NAME="${WEGENT_ACCEPTANCE_VOLUME_NAME:-$CONTAINER_PREFIX-home}"
 KEEP_ARTIFACTS="${WEGENT_ACCEPTANCE_KEEP_ARTIFACTS:-0}"
 ALLOW_EXISTING_VOLUME="${WEGENT_ACCEPTANCE_ALLOW_EXISTING_VOLUME:-0}"
 EXECUTOR_HOME="/home/wegent/.wecode/wegent-executor"
-PROBE_TARGET="/opt/wegent-acceptance/executor-home-persistence-probe.sh"
+PROBE_TARGET_DIR="/opt/wegent-acceptance"
+PROBE_TARGET="$PROBE_TARGET_DIR/executor-home-persistence-probe.sh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROBE_SCRIPT="$SCRIPT_DIR/executor-home-persistence-probe.sh"
 
@@ -30,6 +31,9 @@ done
     fail "logical device ID contains unsupported characters: $DEVICE_ID"
 }
 [ -x "$PROBE_SCRIPT" ] || fail "persistence probe is not executable: $PROBE_SCRIPT"
+for helper in executor-rpc-probe.py executor-persistence-json.py; do
+    [ -f "$SCRIPT_DIR/$helper" ] || fail "persistence probe helper is missing: $helper"
+done
 command -v "$DOCKER_BIN" >/dev/null 2>&1 || {
     fail "Docker CLI not found: $DOCKER_BIN"
 }
@@ -95,7 +99,7 @@ start_container() {
         -e WEGENT_ACCEPTANCE_VOLUME_ID="$VOLUME_ID" \
         -e WEGENT_ACCEPTANCE_PROBE_ID="$PROBE_ID" \
         --mount "type=volume,src=$VOLUME_NAME,dst=$EXECUTOR_HOME" \
-        --mount "type=bind,src=$PROBE_SCRIPT,dst=$PROBE_TARGET,readonly" \
+        --mount "type=bind,src=$SCRIPT_DIR,dst=$PROBE_TARGET_DIR,readonly" \
         "$image" \
         >/dev/null
 }


### PR DESCRIPTION
## Summary

- copy workspace patches into every frontend and standalone pnpm dependency stage
- mount the complete remote-device acceptance directory so RPC and JSON helpers are available in the container
- add regression contracts for workspace patches and acceptance helper mounting

## Verification

- cd backend && uv run pytest tests/docker (34 passed)
- uv run black --check on the changed Python tests
- uv run isort --check-only on the changed Python tests
- bash -n on the acceptance scripts
- git diff --check
- repository pre-push quality gate passed

## Verification limit

The local Docker daemon was unavailable, so real image builds and the container acceptance flow are left to GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker dependency installation so workspace patches are available during builds.
  * Enhanced remote acceptance checks to reliably access and validate required persistence and diagnostic scripts.

* **Tests**
  * Added coverage for Docker build stages to ensure patches are copied before dependency installation.
  * Expanded acceptance checks to verify required scripts and read-only script-directory access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->