### PR TITLE
fix(ci): wait for async executor RPC responses

### DIFF
--- a/backend/tests/docker/test_executor_home_acceptance_scripts.py
+++ b/backend/tests/docker/test_executor_home_acceptance_scripts.py
@@ -4,8 +4,10 @@
 
 """Executable contracts for target-environment persistence acceptance."""
 
+import json
 import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -13,6 +15,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 PROBE = ROOT / "scripts" / "acceptance" / "executor-home-persistence-probe.sh"
+RPC_PROBE = ROOT / "scripts" / "acceptance" / "executor-rpc-probe.py"
 REMOTE_DOCKER_ACCEPTANCE = (
     ROOT / "scripts" / "acceptance" / "remote-device-worktree-persistence.sh"
 )
@@ -351,6 +354,65 @@ def test_remote_docker_acceptance_fails_explicitly_without_docker():
 
     assert result.returncode != 0
     assert "Docker CLI not found" in result.stderr
+
+
+def _write_delayed_fake_executor(path: Path) -> None:
+    path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import sys
+            import threading
+            import time
+
+            request = json.loads(sys.stdin.readline())
+
+            def respond():
+                time.sleep(0.2)
+                print(
+                    json.dumps(
+                        {
+                            "type": "response",
+                            "id": request["id"],
+                            "ok": True,
+                            "result": {"async": True},
+                        }
+                    ),
+                    flush=True,
+                )
+
+            threading.Thread(target=respond, daemon=True).start()
+            for _line in sys.stdin:
+                pass
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def test_rpc_probe_keeps_stdin_open_until_async_response(tmp_path: Path):
+    executor = tmp_path / "delayed-executor.py"
+    _write_delayed_fake_executor(executor)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RPC_PROBE),
+            str(executor),
+            "device-stable-1",
+            "runtime.worktrees.prepare",
+            "{}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"async": True}
 
 
 def test_acceptance_scripts_are_valid_shell_and_cover_required_lifecycle():

--- a/scripts/acceptance/executor-rpc-probe.py
+++ b/scripts/acceptance/executor-rpc-probe.py
@@ -3,9 +3,12 @@
 
 import json
 import os
+import queue
 import subprocess
 import sys
-from typing import Any
+import threading
+import time
+from typing import Any, TextIO
 
 
 def parse_response(stdout: str, request_id: str) -> dict[str, Any] | None:
@@ -17,6 +20,26 @@ def parse_response(stdout: str, request_id: str) -> dict[str, Any] | None:
         if message.get("type") == "response" and message.get("id") == request_id:
             return message
     return None
+
+
+def enqueue_lines(stream: TextIO, lines: queue.Queue[str | None]) -> None:
+    for line in stream:
+        lines.put(line)
+    lines.put(None)
+
+
+def collect_lines(stream: TextIO, lines: list[str]) -> None:
+    lines.extend(stream)
+
+
+def stop_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
 
 
 def main() -> int:
@@ -47,21 +70,58 @@ def main() -> int:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        bufsize=1,
         env=env,
     )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    stdout_lines: queue.Queue[str | None] = queue.Queue()
+    stderr_lines: list[str] = []
+    stdout_reader = threading.Thread(
+        target=enqueue_lines,
+        args=(process.stdout, stdout_lines),
+        daemon=True,
+    )
+    stderr_reader = threading.Thread(
+        target=collect_lines,
+        args=(process.stderr, stderr_lines),
+        daemon=True,
+    )
+    stdout_reader.start()
+    stderr_reader.start()
+
+    process.stdin.write(json.dumps(request, separators=(",", ":")) + "\n")
+    process.stdin.flush()
+
+    deadline = time.monotonic() + 20
+    response = None
+    timed_out = False
     try:
-        stdout, stderr = process.communicate(
-            json.dumps(request, separators=(",", ":")) + "\n",
-            timeout=20,
-        )
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.communicate(timeout=5)
+        while response is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            try:
+                line = stdout_lines.get(timeout=remaining)
+            except queue.Empty:
+                timed_out = True
+                break
+            if line is None:
+                break
+            response = parse_response(line, request_id)
+    finally:
+        stop_process(process)
+        stdout_reader.join(timeout=1)
+        stderr_reader.join(timeout=1)
+
+    if timed_out:
         raise SystemExit(f"Executor RPC {method} timed out")
 
-    response = parse_response(stdout, request_id)
     if response is None:
-        detail = stderr.strip()
+        detail = "".join(stderr_lines).strip()
         raise SystemExit(
             f"Executor RPC {method} produced no response"
             + (f": {detail}" if detail else "")


### PR DESCRIPTION
## Summary

- keep Executor app IPC stdin open while waiting for the matching RPC response
- read stdout and stderr concurrently without losing the existing hard timeout
- add a delayed-response regression test that reproduces the release acceptance failure

## Root cause

The RPC probe used communicate with input, which closed stdin immediately after sending the request. The Executor treats stdin EOF as app IPC shutdown, so the asynchronous runtime.worktrees.prepare handler was terminated after logging request started but before it could emit a response.

## Verification

- cd backend && uv run pytest tests/docker (35 passed)
- focused delayed RPC response regression test passed
- Black and isort checks passed
- Python syntax and git diff checks passed
- repository pre-push quality gate passed

## Context

Follow-up to #2951 and release run https://github.com/wecode-ai/Wegent/actions/runs/32688451996.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the acceptance probe’s handling of delayed responses.
  * The probe now keeps its input stream open while waiting for asynchronous results.
  * Added more reliable output processing and cleanup to prevent premature timeouts and incomplete response reporting.
* **Tests**
  * Added coverage verifying correct behavior when responses arrive asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->