### PR TITLE
fix(wework): submit cloud connection with enter

### DIFF
--- a/wework/src/features/cloud-connection/CloudConnectionDialog.test.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionDialog.test.tsx
@@ -54,6 +54,29 @@ describe('CloudConnectionDialog', () => {
     expect(screen.getByTestId('cloud-backend-url-input')).toHaveValue('https://saved.example.com')
   })
 
+  it('starts cloud authorization when pressing Enter in the Backend URL input', async () => {
+    const connectWithAuthorization = vi.fn().mockResolvedValue(undefined)
+    const onClose = vi.fn()
+
+    renderDialog(
+      {
+        ...cloudConnection('https://saved.example.com'),
+        connectWithAuthorization,
+      },
+      onClose
+    )
+
+    await userEvent.click(screen.getByTestId('cloud-backend-url-input'))
+    await userEvent.keyboard('{Enter}')
+
+    expect(connectWithAuthorization).toHaveBeenCalledWith(
+      'https://saved.example.com',
+      expect.any(Function),
+      ''
+    )
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps the optional Socket URL in collapsed advanced settings', async () => {
     const connection = {
       ...cloudConnection('https://saved.example.com'),

--- a/wework/src/features/cloud-connection/CloudConnectionDialog.tsx
+++ b/wework/src/features/cloud-connection/CloudConnectionDialog.tsx
@@ -186,7 +186,11 @@ export function CloudConnectionDialog({
             </div>
           </div>
         ) : (
-          <div className="mt-5 space-y-5">
+          <form
+            data-testid="cloud-authorization-form"
+            onSubmit={handleAuthorizationSubmit}
+            className="mt-5 space-y-5"
+          >
             <div>
               <label
                 htmlFor="cloud-backend-url-input"
@@ -277,11 +281,7 @@ export function CloudConnectionDialog({
                   {t('workbench.cloud_connection_disconnect', '断开连接')}
                 </button>
               )}
-              <form
-                data-testid="cloud-authorization-form"
-                onSubmit={handleAuthorizationSubmit}
-                className={canDisconnect ? 'flex-1' : 'w-full'}
-              >
+              <div className={canDisconnect ? 'flex-1' : 'w-full'}>
                 <button
                   type="submit"
                   data-testid="cloud-authorization-submit-button"
@@ -303,9 +303,9 @@ export function CloudConnectionDialog({
                     </>
                   )}
                 </button>
-              </form>
+              </div>
             </div>
-          </div>
+          </form>
         )}
       </div>
     </div>,


### PR DESCRIPTION
## Summary

- Submit the cloud authorization form when Enter is pressed in the Backend URL input.
- Keep keyboard and button submissions on the same authorization path.
- Add a dialog regression test for Enter submission.

## Verification

- `pnpm --filter wework test src/features/cloud-connection/CloudConnectionDialog.test.tsx`
- `pnpm --filter wework exec prettier --check src/features/cloud-connection/CloudConnectionDialog.tsx src/features/cloud-connection/CloudConnectionDialog.test.tsx`
- `pnpm --filter wework exec eslint src/features/cloud-connection/CloudConnectionDialog.tsx src/features/cloud-connection/CloudConnectionDialog.test.tsx`
- Attempted isolated real-Tauri verification; the app remained at local-runtime startup and did not reach the dialog. Session was stopped after log inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cloud connection dialog’s form behavior so pressing Enter in the Backend URL field starts authorization and closes the dialog as expected.

* **Tests**
  * Added coverage for submitting the cloud connection flow with the saved backend URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->