### PR TITLE
fix(wework): restore embedded browser Inspect Element in release builds

### DIFF
--- a/wework/src-tauri/src/embedded_browser.rs
+++ b/wework/src-tauri/src/embedded_browser.rs
@@ -1131,10 +1131,6 @@ fn bootstrap_is_stable_at_build(post_build_navigation: bool) -> bool {
     !post_build_navigation
 }
 
-fn embedded_browser_devtools_enabled(release_build: bool, debug_assertions: bool) -> bool {
-    !release_build && debug_assertions
-}
-
 fn entry_readiness(
     state: &EmbeddedBrowserState,
     label: &str,
@@ -2086,10 +2082,10 @@ pub async fn embedded_browser_open(
         .data_directory(data_directory)
         .data_store_identifier(EMBEDDED_BROWSER_DATA_STORE_ID)
         .initialization_script(EMBEDDED_BROWSER_DIAGNOSTICS_SCRIPT)
-        .devtools(embedded_browser_devtools_enabled(
-            cfg!(wework_release_build),
-            cfg!(debug_assertions),
-        ))
+        // Match the main webview: keep the native right-click "Inspect
+        // Element" entry in debug builds and in release builds compiled with
+        // the release-devtools feature (the default release packaging).
+        .devtools(cfg!(any(debug_assertions, feature = "release-devtools")))
         .accept_first_mouse(true)
         .on_navigation({
             let state = state.inner().clone();

--- a/wework/src-tauri/src/embedded_browser/tests.rs
+++ b/wework/src-tauri/src/embedded_browser/tests.rs
@@ -14,7 +14,7 @@ use super::{
     bridge_request_authorized, browser_file_url_from_path, browser_host_is_ready,
     browser_open_action, browser_webview_url, consume_approved_agent_risk,
     directory_entry_modified_unix_seconds, directory_listing_html, download_event_owner,
-    embedded_browser_devtools_enabled, file_url_path, format_directory_entry_modified,
+    file_url_path, format_directory_entry_modified,
     format_file_size, is_history_recordable_url, loaded_browser_url, local_file_browser_title,
     logical_owner_for_native_label, merge_request_option, native_webview_label, read_http_request,
     ready_logical_entry, register_agent_approval, register_preview_source, relabel_logical_entry,
@@ -86,14 +86,6 @@ fn browser_ready_requires_both_bootstrap_and_host_readiness() {
 fn atomic_builder_navigation_is_stable_without_a_load_event() {
     assert!(bootstrap_is_stable_at_build(false));
     assert!(!bootstrap_is_stable_at_build(true));
-}
-
-#[test]
-fn embedded_browser_devtools_are_debug_only() {
-    assert!(embedded_browser_devtools_enabled(false, true));
-    assert!(!embedded_browser_devtools_enabled(false, false));
-    assert!(!embedded_browser_devtools_enabled(true, false));
-    assert!(!embedded_browser_devtools_enabled(true, true));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Right-clicking inside the Wework embedded browser no longer shows the native **Inspect Element** menu item in release builds.

## Root cause

#2789 ("detach embedded browser inspector on macOS") changed the embedded browser webview from `.devtools(true)` to a debug-only gate (`!wework_release_build && debug_assertions`). That disabled `WKWebView.isInspectable` in release builds, so WebKit no longer renders the Inspect Element context-menu item. The PR's actual intent was only to detach the Inspector in debug builds to fix E2E snapshot issues — the release-build regression was a side effect.

This also contradicts the behavior established in #2151, which compiles Tauri devtools into release builds by default (`WEWORK_RELEASE_DEVTOOLS=1` → `--features release-devtools`) and explicitly documents that the embedded browser keeps right-click Inspect Element.

## Fix

Gate the embedded browser devtools flag the same way as the main webview: `cfg!(any(debug_assertions, feature = "release-devtools"))`. Debug builds and default release packaging keep Inspect Element; only distributions built with `WEWORK_RELEASE_DEVTOOLS=0` omit it, as documented.

The obsolete `embedded_browser_devtools_enabled` helper and its debug-only unit test are removed.

## Verification

- `cargo check` (default features) ✅
- `cargo check --features release-devtools` ✅
- `cargo test embedded_browser` — 68 passed ✅
- Pre-commit hooks ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds can now include the native “Inspect Element” option when developer tools are enabled.
* **Bug Fixes**
  * Debug builds continue to provide developer tools as expected.
  * Developer tools availability is now handled consistently across supported build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->