### PR TITLE
fix(chat): 修复 MCP 工具名称误分类

### DIFF
--- a/backend/app/services/execution/emitters/websocket.py
+++ b/backend/app/services/execution/emitters/websocket.py
@@ -310,6 +310,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
             tool_name=event.tool_name or "",
             tool_input=event.tool_input or {},
             display_name=display_name,
+            tool_protocol=(event.data.get("tool_protocol") if event.data else None),
         )
         if event.data and event.data.get("argument_status") == "streaming":
             block["status"] = "generating_arguments"

--- a/backend/app/services/execution/emitters/websocket.py
+++ b/backend/app/services/execution/emitters/websocket.py
@@ -311,6 +311,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
             tool_input=event.tool_input or {},
             display_name=display_name,
             tool_protocol=(event.data.get("tool_protocol") if event.data else None),
+            server_label=(event.data.get("server_label") if event.data else None),
         )
         if event.data and event.data.get("argument_status") == "streaming":
             block["status"] = "generating_arguments"

--- a/backend/tests/services/execution/test_emitters.py
+++ b/backend/tests/services/execution/test_emitters.py
@@ -167,8 +167,8 @@ class TestWebSocketResultEmitter:
             }
 
     @pytest.mark.asyncio
-    async def test_tool_start_preserves_mcp_protocol_in_created_block(self):
-        """MCP tool starts should retain their protocol in the live block."""
+    async def test_tool_start_preserves_mcp_metadata_in_created_block(self):
+        """MCP tool starts should retain their metadata in the live block."""
         from app.services.execution.emitters import WebSocketResultEmitter
 
         with patch(
@@ -184,7 +184,10 @@ class TestWebSocketResultEmitter:
                 subtask_id=2,
                 tool_name="list_resources",
                 tool_use_id="tool-list-resources",
-                data={"tool_protocol": "mcp_call"},
+                data={
+                    "tool_protocol": "mcp_call",
+                    "server_label": "wegent-knowledge",
+                },
             )
 
             await emitter.emit(event)
@@ -192,6 +195,7 @@ class TestWebSocketResultEmitter:
             block = mock_ws.emit_block_created.await_args.kwargs["block"]
             assert block["tool_name"] == "list_resources"
             assert block["tool_protocol"] == "mcp_call"
+            assert block["server_label"] == "wegent-knowledge"
 
     @pytest.mark.asyncio
     async def test_tool_result_emits_interactive_form_render_payload(self):

--- a/backend/tests/services/execution/test_emitters.py
+++ b/backend/tests/services/execution/test_emitters.py
@@ -167,6 +167,33 @@ class TestWebSocketResultEmitter:
             }
 
     @pytest.mark.asyncio
+    async def test_tool_start_preserves_mcp_protocol_in_created_block(self):
+        """MCP tool starts should retain their protocol in the live block."""
+        from app.services.execution.emitters import WebSocketResultEmitter
+
+        with patch(
+            "app.services.chat.webpage_ws_chat_emitter.get_webpage_ws_emitter"
+        ) as mock_get:
+            mock_ws = AsyncMock()
+            mock_get.return_value = mock_ws
+
+            emitter = WebSocketResultEmitter(task_id=1, subtask_id=2)
+            event = ExecutionEvent.create(
+                EventType.TOOL_START,
+                task_id=1,
+                subtask_id=2,
+                tool_name="list_resources",
+                tool_use_id="tool-list-resources",
+                data={"tool_protocol": "mcp_call"},
+            )
+
+            await emitter.emit(event)
+
+            block = mock_ws.emit_block_created.await_args.kwargs["block"]
+            assert block["tool_name"] == "list_resources"
+            assert block["tool_protocol"] == "mcp_call"
+
+    @pytest.mark.asyncio
     async def test_tool_result_emits_interactive_form_render_payload(self):
         """Interactive form tool results should update the real tool block with render payload."""
         from app.services.execution.emitters import WebSocketResultEmitter

--- a/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
@@ -116,15 +116,15 @@ describe('ToolBlock', () => {
 
   it('preserves other MCP list tool names', () => {
     const tool = blockToToolPair({
-      id: 'tool-list-nodes',
+      id: 'tool-list-resources',
       type: 'tool',
-      tool_use_id: 'tool-list-nodes',
-      tool_name: 'list_nodes',
+      tool_use_id: 'tool-list-resources',
+      tool_name: 'list_resources',
       tool_protocol: 'mcp',
       status: 'done',
     })
 
-    expect(tool.toolName).toBe('list_nodes')
+    expect(tool.toolName).toBe('list_resources')
   })
 
   it('continues normalizing non-MCP list tools', () => {

--- a/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
@@ -99,7 +99,6 @@ describe('ToolBlock', () => {
       tool_use_id: 'tool-list-documents',
       tool_name: 'wegent_kb_list_documents',
       tool_protocol: 'mcp_call',
-      server_label: 'wegent-knowledge',
       status: 'done',
       tool_input: { knowledge_base_id: 1 },
       tool_output: JSON.stringify({ total: 5, returned_count: 5, items: [] }),

--- a/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { ToolBlock } from '@/features/tasks/components/message/thinking/components/ToolBlock'
 import type { ToolPair } from '@/features/tasks/components/message/thinking/types'
+import { blockToToolPair } from '@/features/tasks/components/message/thinking/utils/blockToToolPair'
 
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
@@ -89,5 +90,53 @@ describe('ToolBlock', () => {
     )
 
     expect(screen.getByText('加载技能 weibo-tools')).toBeInTheDocument()
+  })
+
+  it('preserves MCP tool identity instead of rendering list tools as file glob', () => {
+    const tool = blockToToolPair({
+      id: 'tool-list-documents',
+      type: 'tool',
+      tool_use_id: 'tool-list-documents',
+      tool_name: 'wegent_kb_list_documents',
+      tool_protocol: 'mcp_call',
+      server_label: 'wegent-knowledge',
+      status: 'done',
+      tool_input: { knowledge_base_id: 1 },
+      tool_output: JSON.stringify({ total: 5, returned_count: 5, items: [] }),
+    })
+
+    expect(tool.toolName).toBe('wegent_kb_list_documents')
+
+    render(<ToolBlock tool={tool} defaultExpanded />)
+
+    expect(screen.getByText('wegent_kb_list_documents')).toBeInTheDocument()
+    expect(screen.queryByText('thinking.tools.glob')).not.toBeInTheDocument()
+    expect(screen.queryByText('Files (1)')).not.toBeInTheDocument()
+  })
+
+  it('preserves other MCP list tool names', () => {
+    const tool = blockToToolPair({
+      id: 'tool-list-nodes',
+      type: 'tool',
+      tool_use_id: 'tool-list-nodes',
+      tool_name: 'list_nodes',
+      tool_protocol: 'mcp',
+      status: 'done',
+    })
+
+    expect(tool.toolName).toBe('list_nodes')
+  })
+
+  it('continues normalizing non-MCP list tools', () => {
+    const tool = blockToToolPair({
+      id: 'tool-list-files',
+      type: 'tool',
+      tool_use_id: 'tool-list-files',
+      tool_name: 'sandbox_list_files',
+      tool_protocol: 'function_call',
+      status: 'done',
+    })
+
+    expect(tool.toolName).toBe('Glob')
   })
 })

--- a/frontend/src/features/tasks/components/message/thinking/types.ts
+++ b/frontend/src/features/tasks/components/message/thinking/types.ts
@@ -130,7 +130,6 @@ export interface ToolBlock extends BaseBlock {
   tool_use_id: string // Tool call ID
   tool_name: string // Tool name
   tool_protocol?: string // Tool call protocol, such as mcp_call or function_call
-  server_label?: string // MCP server label
   display_name?: string // Display name for tool (optional)
   tool_input?: Record<string, unknown> // Tool input parameters
   tool_output?: unknown // Tool execution result

--- a/frontend/src/features/tasks/components/message/thinking/types.ts
+++ b/frontend/src/features/tasks/components/message/thinking/types.ts
@@ -129,6 +129,8 @@ export interface ToolBlock extends BaseBlock {
   type: 'tool'
   tool_use_id: string // Tool call ID
   tool_name: string // Tool name
+  tool_protocol?: string // Tool call protocol, such as mcp_call or function_call
+  server_label?: string // MCP server label
   display_name?: string // Display name for tool (optional)
   tool_input?: Record<string, unknown> // Tool input parameters
   tool_output?: unknown // Tool execution result

--- a/frontend/src/features/tasks/components/message/thinking/utils/blockToToolPair.ts
+++ b/frontend/src/features/tasks/components/message/thinking/utils/blockToToolPair.ts
@@ -22,7 +22,11 @@ function normalizeToolStatus(status: ToolBlock['status']): ToolStatus {
 }
 
 export function blockToToolPair(block: ToolBlock): ToolPair {
-  const normalizedToolName = normalizeToolName(block.tool_name || 'unknown')
+  const rawToolName = block.tool_name || 'unknown'
+  const normalizedToolName =
+    block.tool_protocol === 'mcp' || block.tool_protocol === 'mcp_call'
+      ? rawToolName
+      : normalizeToolName(rawToolName)
   const rawToolUseStep: ThinkingStep = {
     title: `Using ${normalizedToolName}`,
     next_action: 'continue',

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -262,6 +262,8 @@ export interface ChatBlock {
   content?: string
   tool_use_id?: string
   tool_name?: string
+  tool_protocol?: string
+  server_label?: string
   tool_input?: Record<string, unknown>
   tool_output?: unknown
   parent_tool_use_id?: string

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -263,7 +263,6 @@ export interface ChatBlock {
   tool_use_id?: string
   tool_name?: string
   tool_protocol?: string
-  server_label?: string
   tool_input?: Record<string, unknown>
   tool_output?: unknown
   parent_tool_use_id?: string


### PR DESCRIPTION
## 背景

MCP 工具名中包含 `list`、`find` 等关键词时，前端会将其误识别为内置文件查询工具 `Glob`。

例如 `wegent_kb_list_documents` 被展示为“查找文件”，工具结果也被错误渲染为 `Files (1)`，无法体现真实调用的 MCP 工具。

## 修改内容

- MCP 工具调用保留 Provider 返回的原始工具名。
- 非 MCP 工具继续沿用现有工具名归一化规则。
- 前端消息类型补充 `tool_protocol` 和 `server_label` 字段。
- 增加回归测试，覆盖：
  - `wegent_kb_list_documents` 保留原始名称。
  - 其他包含 `list` 的 MCP 工具不再被识别为 `Glob`。
  - 普通 `sandbox_list_files` 仍按原有逻辑识别为 `Glob`。

## 效果

知识库 MCP 工具将展示真实工具名及通用结果，不再错误显示为“查找文件 / Files (1)”。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool display for MCP integrations by preserving original tool names.
  * Prevented MCP tools from being incorrectly identified as file-glob tools.
  * Maintained existing name normalization for non-MCP tools.

* **Enhancements**
  * Improved consistency between live tool events and rendered tool blocks.
  * Preserved relevant tool metadata during MCP activity reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->