### PR TITLE
fix(frontend): improve responsive knowledge picker

### DIFF
--- a/frontend/e2e/pages/tasks/provider-native-knowledge.page.ts
+++ b/frontend/e2e/pages/tasks/provider-native-knowledge.page.ts
@@ -5,7 +5,7 @@ export class ProviderNativeKnowledgePage {
 
   async openPicker(): Promise<void> {
     const contextButton = this.page.getByTestId('knowledge-context-button')
-    if (!(await contextButton.isVisible().catch(() => false))) {
+    if (!(await contextButton.isVisible())) {
       await this.page.getByTestId('mobile-input-more-actions-button').click()
       await expect(this.page.getByTestId('mobile-input-more-actions-menu')).toBeVisible()
     }

--- a/frontend/e2e/pages/tasks/provider-native-knowledge.page.ts
+++ b/frontend/e2e/pages/tasks/provider-native-knowledge.page.ts
@@ -1,12 +1,18 @@
 import { expect, Page } from '@playwright/test'
 
+const MOBILE_VIEWPORT_MAX_WIDTH = 767
+
 export class ProviderNativeKnowledgePage {
   constructor(private readonly page: Page) {}
 
   async openPicker(): Promise<void> {
     const contextButton = this.page.getByTestId('knowledge-context-button')
-    if (!(await contextButton.isVisible())) {
-      await this.page.getByTestId('mobile-input-more-actions-button').click()
+    const viewportWidth =
+      this.page.viewportSize()?.width ?? (await this.page.evaluate(() => window.innerWidth))
+    if (viewportWidth <= MOBILE_VIEWPORT_MAX_WIDTH) {
+      const moreActionsButton = this.page.getByTestId('mobile-input-more-actions-button')
+      await expect(moreActionsButton).toBeVisible()
+      await moreActionsButton.click()
       await expect(this.page.getByTestId('mobile-input-more-actions-menu')).toBeVisible()
     }
     await expect(contextButton).toBeVisible()
@@ -138,7 +144,7 @@ export class ProviderNativeKnowledgePage {
     knowledgeBaseName: string
   ): Promise<void> {
     const knowledgeBase = this.page.getByTestId(`knowledge-picker-kb-${knowledgeBaseId}`)
-    if (await knowledgeBase.isVisible().catch(() => false)) return
+    if (await knowledgeBase.isVisible()) return
 
     const search = this.page.getByTestId('context-selector-knowledge-search-input')
     await search.fill(knowledgeBaseName)

--- a/frontend/e2e/pages/tasks/provider-native-knowledge.page.ts
+++ b/frontend/e2e/pages/tasks/provider-native-knowledge.page.ts
@@ -4,7 +4,13 @@ export class ProviderNativeKnowledgePage {
   constructor(private readonly page: Page) {}
 
   async openPicker(): Promise<void> {
-    await this.page.getByTestId('knowledge-context-button').click()
+    const contextButton = this.page.getByTestId('knowledge-context-button')
+    if (!(await contextButton.isVisible().catch(() => false))) {
+      await this.page.getByTestId('mobile-input-more-actions-button').click()
+      await expect(this.page.getByTestId('mobile-input-more-actions-menu')).toBeVisible()
+    }
+    await expect(contextButton).toBeVisible()
+    await contextButton.click()
     await expect(this.page.getByTestId('knowledge-source-picker')).toBeVisible()
     const personalSource = this.page.getByTestId('knowledge-picker-source-personal')
     const personalSourceIsActive = await personalSource.evaluate(element =>
@@ -139,9 +145,10 @@ export class ProviderNativeKnowledgePage {
     await expect(knowledgeBase).toBeVisible()
   }
 
-  private async closePicker(): Promise<void> {
+  async closePicker(): Promise<void> {
     await this.page.keyboard.press('Escape')
     await expect(this.page.getByTestId('context-selector-popover')).toBeHidden()
+    await expect(this.page.getByTestId('context-selector-drawer')).toBeHidden()
   }
 
   private async expectIncludeSubfoldersControlHidden(): Promise<void> {

--- a/frontend/e2e/tests/tasks/provider-native-dingtalk.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-dingtalk.spec.ts
@@ -72,7 +72,9 @@ test.describe('Provider-native DingTalk and multi-provider access', () => {
     for (const viewport of viewports) {
       await page.setViewportSize({ width: viewport.width, height: viewport.height })
       await knowledge.openPicker()
-      await expect(page.getByTestId(viewport.container)).toBeVisible()
+      const container = page.getByTestId(viewport.container)
+      await expect(container).toBeVisible()
+      await expect(container).toHaveAttribute('data-state', 'open')
 
       await page.getByTestId('knowledge-picker-dingtalk-parent').click()
       const compactDingTalkOption = page.getByTestId(

--- a/frontend/e2e/tests/tasks/provider-native-dingtalk.spec.ts
+++ b/frontend/e2e/tests/tasks/provider-native-dingtalk.spec.ts
@@ -59,6 +59,38 @@ test.describe('Provider-native DingTalk and multi-provider access', () => {
     await deleteProviderNativeResources(request, resources)
   })
 
+  test('knowledge picker uses mobile, tablet, and desktop navigation at its responsive breakpoints', async ({
+    page,
+  }) => {
+    const knowledge = new ProviderNativeKnowledgePage(page)
+    const viewports = [
+      { width: 375, height: 812, container: 'context-selector-drawer', compact: true },
+      { width: 768, height: 1024, container: 'context-selector-popover', compact: true },
+      { width: 1024, height: 768, container: 'context-selector-popover', compact: false },
+    ] as const
+
+    for (const viewport of viewports) {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await knowledge.openPicker()
+      await expect(page.getByTestId(viewport.container)).toBeVisible()
+
+      await page.getByTestId('knowledge-picker-dingtalk-parent').click()
+      const compactDingTalkOption = page.getByTestId(
+        'knowledge-picker-responsive-dingtalk-wikispace'
+      )
+      const desktopDingTalkOption = page.getByTestId('knowledge-picker-dingtalk-wikispace')
+      if (viewport.compact) {
+        await expect(compactDingTalkOption).toBeVisible()
+        await expect(desktopDingTalkOption).toBeHidden()
+      } else {
+        await expect(compactDingTalkOption).toBeHidden()
+        await expect(desktopDingTalkOption).toBeVisible()
+      }
+
+      await knowledge.closePicker()
+    }
+  })
+
   test('E2E-A2-005 reads one exact DingTalk document', async ({ page, request }) => {
     const prompt = makePrompt('005', '输出唯一断言标记。')
     await scenario(request, prompt, [

--- a/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
@@ -273,16 +273,11 @@ describe('external knowledge source registry — ContextSelector (conversation)'
     )
   })
 
-  it('pages through all external nodes when opening a knowledge base', async () => {
-    mockListFakeNodes.mockImplementation((_knowledgeBaseId: string, params?: { offset?: number }) =>
-      Promise.resolve({
-        items:
-          params?.offset === 0
-            ? Array.from({ length: 500 }, (_, index) => makeFakeDocument(index))
-            : [makeFakeDocument(500)],
-        has_more: params?.offset === 0,
-      })
-    )
+  it('renders external nodes when opening a knowledge base', async () => {
+    mockListFakeNodes.mockResolvedValue({
+      items: [makeFakeDocument(1)],
+      has_more: false,
+    })
 
     render(
       <ContextSelector
@@ -311,20 +306,14 @@ describe('external knowledge source registry — ContextSelector (conversation)'
 
     await waitFor(() =>
       expect(
-        screen.getByTestId('knowledge-picker-external-node-document:doc-500')
+        screen.getByTestId('knowledge-picker-external-node-document:doc-1')
       ).toBeInTheDocument()
     )
-    expect(mockListFakeNodes).toHaveBeenNthCalledWith(
-      1,
+    expect(mockListFakeNodes).toHaveBeenCalledWith(
       'lib-1',
       expect.objectContaining({ recursive: true, limit: 500, offset: 0 })
     )
-    expect(mockListFakeNodes).toHaveBeenNthCalledWith(
-      2,
-      'lib-1',
-      expect.objectContaining({ recursive: true, limit: 500, offset: 500 })
-    )
-  }, 15000)
+  })
 
   it('writes a full ExternalKnowledgeRef (incl. mode/scope) onto the selectedContexts channel', async () => {
     const onSelect = jest.fn()

--- a/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
@@ -26,6 +26,21 @@ const mockListFakeNodes = jest.fn()
 
 const mockT = (key: string, fallback?: string | Record<string, unknown>) =>
   typeof fallback === 'string' ? fallback : key
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})
+
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({ t: mockT }),
 }))

--- a/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
@@ -324,7 +324,7 @@ describe('external knowledge source registry — ContextSelector (conversation)'
       'lib-1',
       expect.objectContaining({ recursive: true, limit: 500, offset: 500 })
     )
-  })
+  }, 15000)
 
   it('writes a full ExternalKnowledgeRef (incl. mode/scope) onto the selectedContexts channel', async () => {
     const onSelect = jest.fn()

--- a/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/external-knowledge-source-registry.test.tsx
@@ -523,6 +523,79 @@ describe('external knowledge source registry — ContextSelector (conversation)'
     await waitFor(() => expect(onChange).toHaveBeenLastCalledWith([]))
   })
 
+  it('opens and selects whole-KB-only external sources without a document loader', async () => {
+    const onReplaceContexts = jest.fn()
+    registerExternalKnowledgeSource(FAKE_PROVIDER, {
+      providerId: FAKE_PROVIDER,
+      label: 'Fake Provider',
+      capabilities: {
+        supportsKnowledgeBaseSelection: true,
+        supportsDocumentSelection: false,
+        supportsDocumentTree: false,
+        supportsScopedRetrieval: false,
+      },
+      scopes: [
+        {
+          key: 'organization',
+          label: 'Organization',
+          icon: 'organization',
+        },
+      ],
+      listKnowledgeBases: mockListFakeKnowledgeBases,
+      toRef: kb => ({
+        provider: FAKE_PROVIDER,
+        mode: 'explicit',
+        id: kb.knowledge_base_id,
+        name: kb.knowledge_base_name,
+        scope: kb.scope ?? undefined,
+      }),
+    })
+
+    render(
+      <ContextSelector
+        open={true}
+        onOpenChange={jest.fn()}
+        selectedContexts={[]}
+        onSelect={jest.fn()}
+        onDeselect={jest.fn()}
+        onReplaceContexts={onReplaceContexts}
+      >
+        <button>trigger</button>
+      </ContextSelector>
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(`knowledge-picker-source-external:${FAKE_PROVIDER}`)
+      ).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByTestId(`knowledge-picker-source-external:${FAKE_PROVIDER}`))
+    fireEvent.click(screen.getByTestId('knowledge-picker-external-scope-organization'))
+    fireEvent.click(await screen.findByTestId('knowledge-picker-external-kb-lib-1'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-picker-document-column')).toHaveTextContent('Fake Lib')
+      expect(screen.getByTestId('knowledge-picker-document-column')).toHaveTextContent(
+        'picker.emptyDocuments'
+      )
+    })
+    expect(mockListFakeNodes).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId('knowledge-picker-external-kb-select-lib-1'))
+    expect(onReplaceContexts).toHaveBeenCalledWith(
+      [],
+      [
+        expect.objectContaining({
+          type: 'external_knowledge',
+          ref: expect.objectContaining({
+            provider: FAKE_PROVIDER,
+            id: 'lib-1',
+          }),
+        }),
+      ]
+    )
+  })
+
   it('opens external knowledge bases without selecting them when whole-KB selection is unsupported', async () => {
     const onSelect = jest.fn()
     registerExternalKnowledgeSource(FAKE_PROVIDER, {

--- a/frontend/src/__tests__/features/tasks/components/chat/ChatContextInput.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/ChatContextInput.test.tsx
@@ -14,7 +14,11 @@ jest.mock('@/lib/runtime-config', () => ({
 }))
 
 jest.mock('@/features/tasks/components/chat/AddContextButton', () => {
-  const MockAddContextButton = () => <button data-testid="add-context-button">add</button>
+  const MockAddContextButton = ({ onClick }: { onClick: () => void }) => (
+    <button data-testid="add-context-button" onClick={onClick}>
+      add
+    </button>
+  )
   MockAddContextButton.displayName = 'MockAddContextButton'
   return MockAddContextButton
 })
@@ -43,10 +47,12 @@ jest.mock('@/features/tasks/components/chat/ContextSelector', () => {
     children,
     onSelect,
     onReplaceContexts,
+    onOpenChange,
   }: {
     children: React.ReactNode
     onSelect: (context: ContextItem) => void
     onReplaceContexts?: (idsToRemove: (number | string)[], contextsToAdd: ContextItem[]) => void
+    onOpenChange: (open: boolean) => void
   }) => (
     <div>
       {children}
@@ -58,6 +64,9 @@ jest.mock('@/features/tasks/components/chat/ContextSelector', () => {
         onClick={() => onReplaceContexts?.([], [externalContext])}
       >
         select external
+      </button>
+      <button data-testid="close-selector" onClick={() => onOpenChange(false)}>
+        close selector
       </button>
     </div>
   )
@@ -78,6 +87,23 @@ function ChatContextInputHarness() {
 }
 
 describe('ChatContextInput', () => {
+  it('notifies its parent when the selector opens and closes', () => {
+    const onSelectorOpenChange = jest.fn()
+    render(
+      <ChatContextInput
+        selectedContexts={[]}
+        onContextsChange={jest.fn()}
+        onSelectorOpenChange={onSelectorOpenChange}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('add-context-button'))
+    expect(onSelectorOpenChange).toHaveBeenLastCalledWith(true)
+
+    fireEvent.click(screen.getByTestId('close-selector'))
+    expect(onSelectorOpenChange).toHaveBeenLastCalledWith(false)
+  })
+
   it('preserves internal and external selections made in the same render turn', () => {
     render(<ChatContextInputHarness />)
 

--- a/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
@@ -37,7 +37,8 @@ const mockGetDingTalkWikispaceNodes = jest.fn()
 const mockGetDingTalkWikispaceSyncStatus = jest.fn()
 let mockIsMobile = false
 
-const mockT = (key: string) => key
+const mockT = (key: string, options?: { count?: number }) =>
+  key === 'knowledge:picker.selectedCount' ? `${key}:${options?.count ?? 0}` : key
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
     t: mockT,
@@ -297,7 +298,17 @@ describe('ContextSelector organization grouping', () => {
       <ContextSelector
         open={true}
         onOpenChange={onOpenChange}
-        selectedContexts={[]}
+        selectedContexts={[
+          {
+            id: 'docs:file-1',
+            name: 'DingTalk document',
+            type: 'dingtalk_doc',
+            doc_url: 'https://alidocs.dingtalk.com/i/nodes/file-1',
+            node_type: 'file',
+            dingtalk_node_id: 'file-1',
+            source: 'docs',
+          },
+        ]}
         onSelect={jest.fn()}
         onDeselect={jest.fn()}
       >
@@ -310,7 +321,9 @@ describe('ContextSelector organization grouping', () => {
     })
     expect(screen.getByTestId('context-selector-knowledge-tab')).toBeInTheDocument()
     expect(screen.getByTestId('context-selector-table-tab')).toBeInTheDocument()
-    expect(screen.getByTestId('context-selector-selected-count')).toBeInTheDocument()
+    expect(screen.getByTestId('context-selector-selected-count')).toHaveTextContent(
+      'knowledge:picker.selectedCount:1'
+    )
 
     fireEvent.click(screen.getByTestId('context-selector-done-button'))
     expect(onOpenChange).toHaveBeenCalledWith(false)
@@ -359,6 +372,7 @@ describe('ContextSelector organization grouping', () => {
   })
 
   it('uses a drill-down document view on narrow screens', async () => {
+    mockIsMobile = true
     render(
       <ContextSelector
         open={true}

--- a/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
@@ -35,12 +35,17 @@ const mockGetDingTalkDocs = jest.fn()
 const mockGetDingTalkSyncStatus = jest.fn()
 const mockGetDingTalkWikispaceNodes = jest.fn()
 const mockGetDingTalkWikispaceSyncStatus = jest.fn()
+let mockIsMobile = false
 
 const mockT = (key: string) => key
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
     t: mockT,
   }),
+}))
+
+jest.mock('@/features/layout/hooks/useMediaQuery', () => ({
+  useIsMobile: () => mockIsMobile,
 }))
 
 jest.mock('next/link', () => {
@@ -95,6 +100,15 @@ jest.mock('@/components/ui/popover', () => ({
   ),
 }))
 
+jest.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="context-selector-drawer">{children}</div>
+  ),
+  DrawerTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
 jest.mock('@/components/ui/command', () => ({
   Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -121,7 +135,13 @@ jest.mock('@/components/ui/command', () => ({
 jest.mock('@/components/ui/tabs', () => ({
   Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  TabsTrigger: ({
+    children,
+    value: _value,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { value: string }) => (
+    <button {...props}>{children}</button>
+  ),
   TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
@@ -190,6 +210,7 @@ function createAllGroupedResponse({
 
 describe('ContextSelector organization grouping', () => {
   beforeEach(() => {
+    mockIsMobile = false
     mockListKnowledgeBases.mockResolvedValue({ items: [] })
     mockGetBoundKnowledgeBases.mockResolvedValue({ items: [] })
     mockGetAllGroupedKnowledgeBases.mockResolvedValue(
@@ -268,6 +289,33 @@ describe('ContextSelector organization grouping', () => {
     expect(screen.getByTestId('context-selector-popover')).toHaveAttribute('data-side', 'top')
   })
 
+  it('uses a bottom drawer on mobile while preserving knowledge and table access', async () => {
+    mockIsMobile = true
+    const onOpenChange = jest.fn()
+
+    render(
+      <ContextSelector
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedContexts={[]}
+        onSelect={jest.fn()}
+        onDeselect={jest.fn()}
+      >
+        <button>trigger</button>
+      </ContextSelector>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-selector-drawer')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('context-selector-knowledge-tab')).toBeInTheDocument()
+    expect(screen.getByTestId('context-selector-table-tab')).toBeInTheDocument()
+    expect(screen.getByTestId('context-selector-selected-count')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('context-selector-done-button'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
   it('opens an internal knowledge base without selecting it and uses a separate scope control', async () => {
     const onSelect = jest.fn()
 
@@ -310,6 +358,48 @@ describe('ContextSelector organization grouping', () => {
     })
   })
 
+  it('uses a drill-down document view on narrow screens', async () => {
+    render(
+      <ContextSelector
+        open={true}
+        onOpenChange={jest.fn()}
+        selectedContexts={[]}
+        onSelect={jest.fn()}
+        onDeselect={jest.fn()}
+      >
+        <button>trigger</button>
+      </ContextSelector>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-picker-source-organization')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('knowledge-picker-source-column')).not.toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-knowledge-base-column')).not.toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-document-column')).toHaveClass('hidden')
+    expect(screen.queryByTestId('knowledge-picker-mobile-back')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('knowledge-picker-source-organization'))
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-picker-kb-1')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('knowledge-picker-kb-1'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-picker-source-column')).toHaveClass('hidden')
+    })
+    expect(screen.getByTestId('knowledge-picker-knowledge-base-column')).toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-document-column')).not.toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-mobile-back')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('knowledge-picker-mobile-back'))
+
+    expect(screen.getByTestId('knowledge-picker-source-column')).not.toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-knowledge-base-column')).not.toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-document-column')).toHaveClass('hidden')
+  })
+
   it('expands group knowledge into first-level group rows before showing knowledge bases', async () => {
     mockGetAllGroupedKnowledgeBases.mockResolvedValue(
       createAllGroupedResponse({
@@ -349,15 +439,26 @@ describe('ContextSelector organization grouping', () => {
 
     fireEvent.click(screen.getByTestId('knowledge-picker-source-group'))
     await waitFor(() => {
-      expect(screen.getByTestId('knowledge-picker-group-dev-group')).toBeInTheDocument()
+      expect(screen.getByTestId('knowledge-picker-responsive-group-options')).toBeInTheDocument()
     })
-    expect(screen.getByText('Dev Experience')).toBeInTheDocument()
+    expect(screen.getByTestId('knowledge-picker-group-dev-group')).toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-group-dev-group')).toHaveClass('lg:flex')
+    expect(screen.getByTestId('knowledge-picker-responsive-group-dev-group')).toHaveTextContent(
+      'Dev Experience'
+    )
     expect(screen.queryByTestId('knowledge-picker-kb-2')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByTestId('knowledge-picker-group-dev-group'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-group-dev-group'))
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-kb-2')).toBeInTheDocument()
     })
+    expect(screen.getByTestId('knowledge-picker-responsive-group-back')).toHaveTextContent(
+      'Dev Experience'
+    )
+
+    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-group-back'))
+    expect(screen.getByTestId('knowledge-picker-responsive-group-dev-group')).toBeInTheDocument()
+    expect(screen.queryByTestId('knowledge-picker-kb-2')).not.toBeInTheDocument()
   })
 
   it('keeps empty groups visible in the group knowledge section', async () => {
@@ -405,13 +506,17 @@ describe('ContextSelector organization grouping', () => {
     })
     fireEvent.click(screen.getByTestId('knowledge-picker-source-group'))
     await waitFor(() => {
-      expect(screen.getByTestId('knowledge-picker-group-empty-group')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('knowledge-picker-responsive-group-empty-group')
+      ).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Empty Group')).toBeInTheDocument()
+    expect(screen.getByTestId('knowledge-picker-responsive-group-empty-group')).toHaveTextContent(
+      'Empty Group'
+    )
     expect(screen.getByTestId('knowledge-picker-group-empty-group')).toHaveTextContent('0')
 
-    fireEvent.click(screen.getByTestId('knowledge-picker-group-empty-group'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-group-empty-group'))
     await waitFor(() => {
       expect(screen.getByText('picker.emptyKnowledgeBases')).toBeInTheDocument()
     })
@@ -514,7 +619,9 @@ describe('ContextSelector organization grouping', () => {
 
     fireEvent.click(screen.getByTestId('knowledge-picker-source-group'))
     await waitFor(() => {
-      expect(screen.getByText('fallback-group')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('knowledge-picker-responsive-group-fallback-group')
+      ).toHaveTextContent('fallback-group')
     })
   })
 
@@ -1244,9 +1351,11 @@ describe('ContextSelector organization grouping', () => {
 
     fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
     await waitFor(() => {
-      expect(screen.getByTestId('knowledge-picker-dingtalk-docs')).toBeInTheDocument()
+      expect(screen.getByTestId('knowledge-picker-responsive-dingtalk-options')).toBeInTheDocument()
     })
-    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-docs'))
+    expect(screen.getByTestId('knowledge-picker-dingtalk-docs')).toHaveClass('hidden')
+    expect(screen.getByTestId('knowledge-picker-dingtalk-docs')).toHaveClass('lg:flex')
+    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-dingtalk-docs'))
 
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-all-docs')).toBeInTheDocument()
@@ -1327,7 +1436,7 @@ describe('ContextSelector organization grouping', () => {
     })
 
     fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
-    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-wikispace'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-dingtalk-wikispace'))
 
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-space-space-1')).toBeInTheDocument()
@@ -1405,7 +1514,7 @@ describe('ContextSelector organization grouping', () => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-parent')).toBeInTheDocument()
     })
     fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
-    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-wikispace'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-dingtalk-wikispace'))
 
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-space-space-1')).toBeInTheDocument()

--- a/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/context-selector.test.tsx
@@ -414,7 +414,8 @@ describe('ContextSelector organization grouping', () => {
     expect(screen.getByTestId('knowledge-picker-document-column')).toHaveClass('hidden')
   })
 
-  it('expands group knowledge into first-level group rows before showing knowledge bases', async () => {
+  it('drills into group knowledge before showing knowledge bases on narrow screens', async () => {
+    mockIsMobile = true
     mockGetAllGroupedKnowledgeBases.mockResolvedValue(
       createAllGroupedResponse({
         groups: [
@@ -455,14 +456,15 @@ describe('ContextSelector organization grouping', () => {
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-responsive-group-options')).toBeInTheDocument()
     })
-    expect(screen.getByTestId('knowledge-picker-group-dev-group')).toHaveClass('hidden')
-    expect(screen.getByTestId('knowledge-picker-group-dev-group')).toHaveClass('lg:flex')
     expect(screen.getByTestId('knowledge-picker-responsive-group-dev-group')).toHaveTextContent(
       'Dev Experience'
     )
     expect(screen.queryByTestId('knowledge-picker-kb-2')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-group-dev-group'))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('knowledge-picker-responsive-group-dev-group'))
+      await Promise.resolve()
+    })
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-kb-2')).toBeInTheDocument()
     })
@@ -520,17 +522,15 @@ describe('ContextSelector organization grouping', () => {
     })
     fireEvent.click(screen.getByTestId('knowledge-picker-source-group'))
     await waitFor(() => {
-      expect(
-        screen.getByTestId('knowledge-picker-responsive-group-empty-group')
-      ).toBeInTheDocument()
+      expect(screen.getByTestId('knowledge-picker-group-empty-group')).toBeInTheDocument()
     })
 
-    expect(screen.getByTestId('knowledge-picker-responsive-group-empty-group')).toHaveTextContent(
+    expect(screen.getByTestId('knowledge-picker-group-empty-group')).toHaveTextContent(
       'Empty Group'
     )
     expect(screen.getByTestId('knowledge-picker-group-empty-group')).toHaveTextContent('0')
 
-    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-group-empty-group'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-group-empty-group'))
     await waitFor(() => {
       expect(screen.getByText('picker.emptyKnowledgeBases')).toBeInTheDocument()
     })
@@ -633,9 +633,9 @@ describe('ContextSelector organization grouping', () => {
 
     fireEvent.click(screen.getByTestId('knowledge-picker-source-group'))
     await waitFor(() => {
-      expect(
-        screen.getByTestId('knowledge-picker-responsive-group-fallback-group')
-      ).toHaveTextContent('fallback-group')
+      expect(screen.getByTestId('knowledge-picker-group-fallback-group')).toHaveTextContent(
+        'fallback-group'
+      )
     })
   })
 
@@ -1365,11 +1365,9 @@ describe('ContextSelector organization grouping', () => {
 
     fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
     await waitFor(() => {
-      expect(screen.getByTestId('knowledge-picker-responsive-dingtalk-options')).toBeInTheDocument()
+      expect(screen.getByTestId('knowledge-picker-dingtalk-docs')).toBeInTheDocument()
     })
-    expect(screen.getByTestId('knowledge-picker-dingtalk-docs')).toHaveClass('hidden')
-    expect(screen.getByTestId('knowledge-picker-dingtalk-docs')).toHaveClass('lg:flex')
-    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-dingtalk-docs'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-docs'))
 
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-all-docs')).toBeInTheDocument()
@@ -1450,7 +1448,7 @@ describe('ContextSelector organization grouping', () => {
     })
 
     fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
-    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-dingtalk-wikispace'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-wikispace'))
 
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-space-space-1')).toBeInTheDocument()
@@ -1528,7 +1526,7 @@ describe('ContextSelector organization grouping', () => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-parent')).toBeInTheDocument()
     })
     fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-parent'))
-    fireEvent.click(screen.getByTestId('knowledge-picker-responsive-dingtalk-wikispace'))
+    fireEvent.click(screen.getByTestId('knowledge-picker-dingtalk-wikispace'))
 
     await waitFor(() => {
       expect(screen.getByTestId('knowledge-picker-dingtalk-space-space-1')).toBeInTheDocument()

--- a/frontend/src/__tests__/features/tasks/components/input/ChatInput.focus.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/ChatInput.focus.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 
 import ChatInput from '@/features/tasks/components/input/ChatInput'
 
@@ -40,6 +40,57 @@ jest.mock('@/features/tasks/components/chat/SkillFlyAnimation', () => ({
 }))
 
 describe('ChatInput external focus', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('auto focuses when no other control has focus', () => {
+    jest.useFakeTimers()
+    render(
+      <ChatInput
+        message=""
+        setMessage={jest.fn()}
+        handleSendMessage={jest.fn()}
+        isLoading={false}
+        autoFocus
+      />
+    )
+
+    const input = screen.getByTestId('message-input')
+    expect(input).not.toHaveFocus()
+
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(input).toHaveFocus()
+  })
+
+  test('does not steal focus from another control after delayed auto focus was scheduled', () => {
+    jest.useFakeTimers()
+    render(
+      <>
+        <button type="button" data-testid="external-control">
+          External control
+        </button>
+        <ChatInput
+          message=""
+          setMessage={jest.fn()}
+          handleSendMessage={jest.fn()}
+          isLoading={false}
+          autoFocus
+        />
+      </>
+    )
+
+    const externalControl = screen.getByTestId('external-control')
+    const input = screen.getByTestId('message-input')
+    externalControl.focus()
+
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(externalControl).toHaveFocus()
+    expect(input).not.toHaveFocus()
+  })
+
   test('moves the cursor to the end when focusAtEndSignal changes', async () => {
     const props = {
       setMessage: jest.fn(),

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -70,19 +70,44 @@ jest.mock('@/features/tasks/components/MobileCorrectionModeToggle', () => ({
 
 jest.mock('@/features/tasks/components/chat/ChatContextInput', () => ({
   __esModule: true,
-  default: () => (
-    <>
-      <button type="button" aria-controls="context-selector-popover">
-        Context
-      </button>
-      {createPortal(
-        <div id="context-selector-popover" role="dialog" data-testid="owned-context-popover">
-          Context selector
-        </div>,
-        document.body
-      )}
-    </>
-  ),
+  default: function MockChatContextInput({
+    onSelectorOpenChange,
+  }: {
+    onSelectorOpenChange?: (open: boolean) => void
+  }) {
+    const [open, setOpen] = React.useState(false)
+    return (
+      <>
+        <button
+          type="button"
+          aria-controls="context-selector-popover"
+          onClick={() => {
+            setOpen(true)
+            onSelectorOpenChange?.(true)
+          }}
+        >
+          Context
+        </button>
+        {open
+          ? createPortal(
+              <div id="context-selector-popover" role="dialog" data-testid="owned-context-popover">
+                Context selector
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false)
+                    onSelectorOpenChange?.(false)
+                  }}
+                >
+                  Close context
+                </button>
+              </div>,
+              document.body
+            )
+          : null}
+      </>
+    )
+  },
 }))
 
 jest.mock('@/features/tasks/components/AttachmentButton', () => ({
@@ -313,15 +338,22 @@ describe('MobileChatInputControls layout', () => {
     expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
   })
 
-  it('keeps the menu open while interacting with a popover opened by the menu', () => {
+  it('hides the more actions menu while keeping its context selector mounted', () => {
     render(<MobileChatInputControls {...buildProps()} />)
 
     fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
-    const ownedPopover = screen.getByTestId('owned-context-popover')
-    fireEvent.pointerDown(ownedPopover)
-    fireEvent.keyDown(ownedPopover, { key: 'Escape' })
+    fireEvent.click(screen.getByRole('button', { name: 'Context' }))
 
-    expect(screen.getByTestId('mobile-input-more-actions-menu')).toBeInTheDocument()
+    const menu = screen.getByTestId('mobile-input-more-actions-menu')
+    expect(menu).toHaveClass('invisible')
+    expect(menu).toHaveClass('pointer-events-none')
+    expect(screen.getByTestId('owned-context-popover')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close context' }))
+
+    expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('owned-context-popover')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mobile-input-more-actions-button')).toHaveFocus()
   })
 
   it('closes the menu when interacting with an unrelated dialog', () => {

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -33,23 +33,36 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
 
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & { showHandle?: boolean }
->(({ className, children, showHandle = true, ...props }, ref) => (
-  <DrawerPortal>
-    <DrawerOverlay />
-    <DrawerPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-base',
-        className
-      )}
-      {...props}
-    >
-      {showHandle && <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />}
-      {children}
-    </DrawerPrimitive.Content>
-  </DrawerPortal>
-))
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & {
+    showHandle?: boolean
+    handleClassName?: string
+    overlayClassName?: string
+  }
+>(
+  (
+    { className, children, showHandle = true, handleClassName, overlayClassName, ...props },
+    ref
+  ) => (
+    <DrawerPortal>
+      <DrawerOverlay className={overlayClassName} />
+      <DrawerPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-base',
+          className
+        )}
+        {...props}
+      >
+        {showHandle && (
+          <div
+            className={cn('mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted', handleClassName)}
+          />
+        )}
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+)
 DrawerContent.displayName = 'DrawerContent'
 
 const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/frontend/src/features/tasks/components/chat/AddContextButton.tsx
+++ b/frontend/src/features/tasks/components/chat/AddContextButton.tsx
@@ -36,6 +36,7 @@ export default function AddContextButton({
         type="button"
         onClick={onClick}
         className="w-full flex items-center justify-between px-3 py-2.5 text-left transition-colors hover:bg-hover active:bg-hover"
+        data-testid="knowledge-context-button"
       >
         <span className="flex items-center gap-3">
           <BookOpenText className="h-4 w-4 text-text-muted" />

--- a/frontend/src/features/tasks/components/chat/ChatContextInput.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatContextInput.tsx
@@ -19,6 +19,8 @@ interface ChatContextInputProps {
   triggerVariant?: 'button' | 'menu-item'
   /** Render compact icon-only desktop trigger */
   iconOnly?: boolean
+  /** Notify a parent menu so it can hide while the selector is open. */
+  onSelectorOpenChange?: (open: boolean) => void
 }
 
 /**
@@ -35,8 +37,17 @@ export default function ChatContextInput({
   excludeKnowledgeBaseId,
   triggerVariant = 'button',
   iconOnly = false,
+  onSelectorOpenChange,
 }: ChatContextInputProps) {
   const [selectorOpen, setSelectorOpen] = useState(false)
+
+  const handleSelectorOpenChange = useCallback(
+    (open: boolean) => {
+      setSelectorOpen(open)
+      onSelectorOpenChange?.(open)
+    },
+    [onSelectorOpenChange]
+  )
 
   const handleSelect = useCallback(
     (context: ContextItem) => {
@@ -99,7 +110,7 @@ export default function ChatContextInput({
   return (
     <ContextSelector
       open={selectorOpen}
-      onOpenChange={setSelectorOpen}
+      onOpenChange={handleSelectorOpenChange}
       selectedContexts={selectedContexts}
       onSelect={handleSelect}
       onDeselect={handleDeselect}
@@ -110,7 +121,7 @@ export default function ChatContextInput({
     >
       <div>
         <AddContextButton
-          onClick={() => setSelectorOpen(true)}
+          onClick={() => handleSelectorOpenChange(true)}
           selectedCount={selectedContexts.length}
           triggerVariant={triggerVariant}
           iconOnly={iconOnly}

--- a/frontend/src/features/tasks/components/chat/ContextSelector.tsx
+++ b/frontend/src/features/tasks/components/chat/ContextSelector.tsx
@@ -5,8 +5,10 @@
 'use client'
 
 import React, { useEffect, useState, useMemo, useCallback } from 'react'
-import { Check, Database, Table2 } from 'lucide-react'
+import { Check, Database, Table2, X } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
   Command,
@@ -26,6 +28,7 @@ import type { BoundKnowledgeBaseDetail } from '@/types/task-knowledge-base'
 import type { ContextItem, TableContext } from '@/types/context'
 import { useExternalKnowledgeSources } from '@/features/knowledge/externalKnowledgeSourceRegistry'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { cn } from '@/lib/utils'
 import { KnowledgeSourcePicker, type GroupedKnowledgeBases } from './KnowledgeSourcePicker'
 
@@ -113,6 +116,7 @@ export default function ContextSelector({
   const [searchValue, setSearchValue] = useState('')
   const [activeTab, setActiveTab] = useState('knowledge')
   const knowledgeBaseError = error
+  const isMobile = useIsMobile()
 
   const fetchKnowledgeBases = useCallback(async () => {
     setLoading(true)
@@ -273,14 +277,224 @@ export default function ContextSelector({
     }
   }, [open])
 
+  const selectedContextCount = selectedContexts.filter(context =>
+    ['knowledge_base', 'table', 'external_knowledge'].includes(context.type)
+  ).length
+
+  const selectorContent = (
+    <Tabs
+      value={activeTab}
+      onValueChange={handleTabChange}
+      className="flex min-h-0 flex-1 flex-col"
+    >
+      <div className="flex min-h-11 shrink-0 items-center justify-between border-b border-border px-4 lg:hidden">
+        <h2 className="text-base font-semibold text-text-primary">
+          {t('knowledge:picker.selectContent')}
+        </h2>
+        <button
+          type="button"
+          aria-label={t('common:actions.close')}
+          className="flex h-11 w-11 items-center justify-center rounded-md text-text-muted hover:bg-surface hover:text-text-primary"
+          onClick={() => onOpenChange(false)}
+          data-testid="context-selector-close-button"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <TabsList className="h-11 w-full shrink-0 rounded-none border-b border-border bg-transparent p-0 lg:h-9">
+        <TabsTrigger
+          value="knowledge"
+          className={cn(
+            'h-full flex-1 rounded-none border-b-2 border-transparent text-sm font-medium',
+            'data-[state=active]:border-primary data-[state=active]:text-primary',
+            'data-[state=inactive]:text-text-muted hover:text-text-primary'
+          )}
+          data-testid="context-selector-knowledge-tab"
+        >
+          <Database className="mr-1.5 h-3.5 w-3.5" />
+          {t('knowledge:title')}
+        </TabsTrigger>
+        <TabsTrigger
+          value="table"
+          className={cn(
+            'h-full flex-1 rounded-none border-b-2 border-transparent text-sm font-medium',
+            'data-[state=active]:border-blue-500 data-[state=active]:text-blue-600',
+            'data-[state=inactive]:text-text-muted hover:text-text-primary'
+          )}
+          data-testid="context-selector-table-tab"
+        >
+          <Table2 className="mr-1.5 h-3.5 w-3.5" />
+          {t('knowledge:table.title')}
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="knowledge" className="m-0 min-h-0 flex-1 overflow-hidden">
+        <div className="flex h-full min-h-0 flex-1 flex-col">
+          <Input
+            placeholder={t('knowledge:search_placeholder')}
+            value={searchValue}
+            onChange={event => setSearchValue(event.target.value)}
+            className={cn(
+              'h-11 shrink-0 rounded-none border-b border-border text-sm lg:h-9',
+              'placeholder:text-text-muted'
+            )}
+            data-testid="context-selector-knowledge-search-input"
+          />
+          <KnowledgeSourcePicker
+            groupedKnowledgeBases={groupedKnowledgeBases}
+            boundKnowledgeBases={boundKnowledgeBases}
+            externalSources={externalSources}
+            selectedContexts={selectedContexts}
+            searchValue={searchValue}
+            loading={loading}
+            error={knowledgeBaseError}
+            onRetry={handleKnowledgeBaseRetry}
+            onSelect={onSelect}
+            onDeselect={onDeselect}
+            onSelectMultiple={onSelectMultiple}
+            onDeselectMultiple={onDeselectMultiple}
+            onReplaceContexts={onReplaceContexts}
+          />
+        </div>
+      </TabsContent>
+
+      <TabsContent value="table" className="m-0 min-h-0 flex-1 overflow-hidden">
+        <Command className="flex min-h-0 flex-1 flex-col border-0">
+          <CommandInput
+            placeholder={t('knowledge:search_placeholder')}
+            value={searchValue}
+            onValueChange={setSearchValue}
+            className={cn(
+              'h-11 shrink-0 rounded-none border-b border-border text-sm lg:h-9',
+              'placeholder:text-text-muted'
+            )}
+          />
+          <CommandList className="min-h-0 max-h-none flex-1 overflow-y-auto lg:max-h-[calc(var(--radix-popover-content-available-height)-72px)]">
+            {tableLoading ? (
+              <div className="px-3 py-4 text-center text-sm text-text-muted">
+                {t('common:actions.loading')}
+              </div>
+            ) : tableError ? (
+              <div className="px-3 py-4 text-center">
+                <p className="mb-2 text-sm text-red-500">{tableError}</p>
+                <button onClick={fetchTables} className="text-xs text-primary hover:underline">
+                  {t('common:actions.retry')}
+                </button>
+              </div>
+            ) : tables.length === 0 ? (
+              <div className="px-4 py-6 text-center">
+                <p className="mb-2 text-sm text-text-muted">{t('knowledge:table.empty')}</p>
+                <p className="text-xs text-text-muted">{t('knowledge:table.emptyHint')}</p>
+              </div>
+            ) : (
+              <>
+                <CommandEmpty className="py-4 text-center text-sm text-text-muted">
+                  {t('common:branches.no_match')}
+                </CommandEmpty>
+
+                <CommandGroup>
+                  {tables.map(doc => {
+                    const tableContextId = `table-${doc.id}`
+                    const selected = isSelected(tableContextId)
+
+                    return (
+                      <CommandItem
+                        key={`table-${doc.id}`}
+                        value={`${doc.name} ${doc.id}`}
+                        onSelect={() => handleTableSelect(doc)}
+                        className={cn(
+                          'group mx-1 my-[2px] cursor-pointer select-none rounded-md',
+                          'max-lg:min-h-11 px-3 py-2 text-sm text-text-primary',
+                          'data-[selected=true]:bg-blue-500/10 data-[selected=true]:text-blue-600',
+                          'aria-selected:bg-hover',
+                          '!flex !flex-row !items-start !justify-between !gap-2'
+                        )}
+                      >
+                        <div className="flex min-w-0 flex-1 items-start gap-2">
+                          <Table2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-500" />
+                          <div className="flex min-w-0 flex-1 flex-col">
+                            <span
+                              className="truncate text-sm font-medium text-text-primary"
+                              title={doc.name}
+                            >
+                              {doc.name}
+                            </span>
+                            {doc.source_config?.url && (
+                              <span
+                                className="truncate text-xs text-text-muted"
+                                title={doc.source_config.url}
+                              >
+                                {(() => {
+                                  try {
+                                    const url = new URL(doc.source_config.url)
+                                    return url.hostname
+                                  } catch {
+                                    return doc.source_config.url
+                                  }
+                                })()}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <Check
+                          className={cn(
+                            'mt-0.5 h-3.5 w-3.5 shrink-0',
+                            selected ? 'text-blue-500 opacity-100' : 'opacity-0'
+                          )}
+                        />
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </TabsContent>
+
+      <div className="flex min-h-16 shrink-0 items-center justify-between border-t border-border px-4 lg:hidden">
+        <span className="text-sm text-text-primary" data-testid="context-selector-selected-count">
+          {t('knowledge:picker.selectedCount', { count: selectedContextCount })}
+        </span>
+        <Button
+          type="button"
+          variant="primary"
+          className="min-h-11 min-w-24"
+          onClick={() => onOpenChange(false)}
+          data-testid="context-selector-done-button"
+        >
+          {t('common:actions.done')}
+        </Button>
+      </div>
+    </Tabs>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange} shouldScaleBackground={false}>
+        <DrawerTrigger asChild>{children}</DrawerTrigger>
+        <DrawerContent
+          className="h-[82dvh] max-h-[680px] overflow-hidden rounded-t-2xl border-border bg-base p-0"
+          handleClassName="mt-2 h-1 w-9 bg-text-muted/30"
+          overlayClassName="bg-black/45"
+          data-testid="context-selector-drawer"
+        >
+          <DrawerTitle className="sr-only">{t('knowledge:picker.selectContent')}</DrawerTitle>
+          {selectorContent}
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         className={cn(
-          'p-0 w-[760px] max-w-[calc(100vw-24px)] border border-border bg-base',
-          'max-h-[var(--radix-popover-content-available-height)] shadow-xl rounded-xl overflow-hidden',
-          'flex flex-col'
+          'flex w-[760px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-xl border border-border bg-base p-0 shadow-xl',
+          'max-h-[var(--radix-popover-content-available-height)]',
+          'md:h-[min(680px,var(--radix-popover-content-available-height))] lg:h-auto'
         )}
         align="start"
         side="top"
@@ -290,164 +504,7 @@ export default function ContextSelector({
         sticky="partial"
         data-testid="context-selector-popover"
       >
-        <Tabs
-          value={activeTab}
-          onValueChange={handleTabChange}
-          className="flex flex-col flex-1 min-h-0"
-        >
-          {/* Tab list: Knowledge | Table — fixed height, no flex tricks needed */}
-          <TabsList className="w-full rounded-none border-b border-border bg-transparent h-9 p-0 flex-shrink-0">
-            <TabsTrigger
-              value="knowledge"
-              className={cn(
-                'flex-1 rounded-none border-b-2 border-transparent h-full text-sm font-medium',
-                'data-[state=active]:border-primary data-[state=active]:text-primary',
-                'data-[state=inactive]:text-text-muted hover:text-text-primary'
-              )}
-            >
-              <Database className="w-3.5 h-3.5 mr-1.5" />
-              {t('knowledge:title')}
-            </TabsTrigger>
-            <TabsTrigger
-              value="table"
-              className={cn(
-                'flex-1 rounded-none border-b-2 border-transparent h-full text-sm font-medium',
-                'data-[state=active]:border-blue-500 data-[state=active]:text-blue-600',
-                'data-[state=inactive]:text-text-muted hover:text-text-primary'
-              )}
-            >
-              <Table2 className="w-3.5 h-3.5 mr-1.5" />
-              {t('knowledge:table.title')}
-            </TabsTrigger>
-          </TabsList>
-
-          {/* Knowledge Base Tab */}
-          <TabsContent value="knowledge" className="m-0 min-h-0 flex-1 overflow-hidden">
-            <div className="flex min-h-0 flex-1 flex-col">
-              <Input
-                placeholder={t('knowledge:search_placeholder')}
-                value={searchValue}
-                onChange={event => setSearchValue(event.target.value)}
-                className={cn(
-                  'h-9 rounded-none border-b border-border flex-shrink-0',
-                  'placeholder:text-text-muted text-sm'
-                )}
-                data-testid="context-selector-knowledge-search-input"
-              />
-              <KnowledgeSourcePicker
-                groupedKnowledgeBases={groupedKnowledgeBases}
-                boundKnowledgeBases={boundKnowledgeBases}
-                externalSources={externalSources}
-                selectedContexts={selectedContexts}
-                searchValue={searchValue}
-                loading={loading}
-                error={knowledgeBaseError}
-                onRetry={handleKnowledgeBaseRetry}
-                onSelect={onSelect}
-                onDeselect={onDeselect}
-                onSelectMultiple={onSelectMultiple}
-                onDeselectMultiple={onDeselectMultiple}
-                onReplaceContexts={onReplaceContexts}
-              />
-            </div>
-          </TabsContent>
-
-          {/* Table Tab */}
-          <TabsContent value="table" className="m-0 min-h-0 flex-1 overflow-hidden">
-            <Command className="border-0 flex min-h-0 flex-1 flex-col">
-              <CommandInput
-                placeholder={t('knowledge:search_placeholder')}
-                value={searchValue}
-                onValueChange={setSearchValue}
-                className={cn(
-                  'h-9 rounded-none border-b border-border flex-shrink-0',
-                  'placeholder:text-text-muted text-sm'
-                )}
-              />
-              <CommandList className="min-h-0 max-h-[calc(var(--radix-popover-content-available-height)-72px)] flex-1 overflow-y-auto">
-                {tableLoading ? (
-                  <div className="py-4 px-3 text-center text-sm text-text-muted">
-                    {t('common:actions.loading')}
-                  </div>
-                ) : tableError ? (
-                  <div className="py-4 px-3 text-center">
-                    <p className="text-sm text-red-500 mb-2">{tableError}</p>
-                    <button onClick={fetchTables} className="text-xs text-primary hover:underline">
-                      {t('common:actions.retry')}
-                    </button>
-                  </div>
-                ) : tables.length === 0 ? (
-                  <div className="py-6 px-4 text-center">
-                    <p className="text-sm text-text-muted mb-2">{t('knowledge:table.empty')}</p>
-                    <p className="text-xs text-text-muted">{t('knowledge:table.emptyHint')}</p>
-                  </div>
-                ) : (
-                  <>
-                    <CommandEmpty className="py-4 text-center text-sm text-text-muted">
-                      {t('common:branches.no_match')}
-                    </CommandEmpty>
-
-                    <CommandGroup>
-                      {tables.map(doc => {
-                        const tableContextId = `table-${doc.id}`
-                        const selected = isSelected(tableContextId)
-
-                        return (
-                          <CommandItem
-                            key={`table-${doc.id}`}
-                            value={`${doc.name} ${doc.id}`}
-                            onSelect={() => handleTableSelect(doc)}
-                            className={cn(
-                              'group cursor-pointer select-none',
-                              'px-3 py-2 text-sm text-text-primary',
-                              'rounded-md mx-1 my-[2px]',
-                              'data-[selected=true]:bg-blue-500/10 data-[selected=true]:text-blue-600',
-                              'aria-selected:bg-hover',
-                              '!flex !flex-row !items-start !justify-between !gap-2'
-                            )}
-                          >
-                            <div className="flex items-start gap-2 min-w-0 flex-1">
-                              <Table2 className="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
-                              <div className="flex flex-col min-w-0 flex-1">
-                                <span
-                                  className="font-medium text-sm text-text-primary truncate"
-                                  title={doc.name}
-                                >
-                                  {doc.name}
-                                </span>
-                                {doc.source_config?.url && (
-                                  <span
-                                    className="text-xs text-text-muted truncate"
-                                    title={doc.source_config.url}
-                                  >
-                                    {(() => {
-                                      try {
-                                        const url = new URL(doc.source_config.url)
-                                        return url.hostname
-                                      } catch {
-                                        return doc.source_config.url
-                                      }
-                                    })()}
-                                  </span>
-                                )}
-                              </div>
-                            </div>
-                            <Check
-                              className={cn(
-                                'h-3.5 w-3.5 shrink-0 mt-0.5',
-                                selected ? 'opacity-100 text-blue-500' : 'opacity-0'
-                              )}
-                            />
-                          </CommandItem>
-                        )
-                      })}
-                    </CommandGroup>
-                  </>
-                )}
-              </CommandList>
-            </Command>
-          </TabsContent>
-        </Tabs>
+        {selectorContent}
       </PopoverContent>
     </Popover>
   )

--- a/frontend/src/features/tasks/components/chat/ContextSelector.tsx
+++ b/frontend/src/features/tasks/components/chat/ContextSelector.tsx
@@ -278,7 +278,7 @@ export default function ContextSelector({
   }, [open])
 
   const selectedContextCount = selectedContexts.filter(context =>
-    ['knowledge_base', 'table', 'external_knowledge'].includes(context.type)
+    ['knowledge_base', 'table', 'dingtalk_doc', 'external_knowledge'].includes(context.type)
   ).length
 
   const selectorContent = (

--- a/frontend/src/features/tasks/components/chat/KnowledgeSelectionControl.tsx
+++ b/frontend/src/features/tasks/components/chat/KnowledgeSelectionControl.tsx
@@ -35,7 +35,7 @@ export function KnowledgeSelectionControl({
       aria-label={label}
       disabled={disabled}
       title={title}
-      className="group flex h-11 w-11 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-primary/5 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base disabled:cursor-not-allowed disabled:opacity-60 md:h-9 md:w-9"
+      className="group flex h-11 w-11 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-primary/5 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base disabled:cursor-not-allowed disabled:opacity-60 lg:h-9 lg:w-9"
       onClick={event => {
         event.stopPropagation()
         onToggle()

--- a/frontend/src/features/tasks/components/chat/KnowledgeSourcePicker.tsx
+++ b/frontend/src/features/tasks/components/chat/KnowledgeSourcePicker.tsx
@@ -7,6 +7,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Building2,
+  ChevronLeft,
   ChevronRight,
   Cloud,
   Database,
@@ -1203,6 +1204,108 @@ export function KnowledgeSourcePicker({
     }
   }
 
+  const selectGroup = (name: string) => {
+    setActiveSource('group')
+    setActiveGroup(name)
+    setExternalScope(null)
+    setActiveKnowledgeBase(null)
+    setActiveDingTalkSpace(null)
+  }
+
+  const selectExternalScope = (source: ExternalKnowledgeSource, scope: ExternalKnowledgeScope) => {
+    setActiveSource(`external:${source.providerId}`)
+    setActiveGroup(null)
+    setExternalScope(scope)
+    setActiveKnowledgeBase(null)
+    setActiveDingTalkSpace(null)
+    void loadExternalKnowledgeBases(source, scope, searchValue)
+  }
+
+  const selectDingTalkSection = (source: 'dingtalk:docs' | 'dingtalk:wikispace') => {
+    setActiveSource(source)
+    setActiveGroup(null)
+    setExternalScope(null)
+    setActiveKnowledgeBase(null)
+    setActiveDingTalkSpace(null)
+  }
+
+  const filteredGroupEntries = groupEntries.filter(([, group]) =>
+    groupMatchesSearch([group.name, group.displayName].join(' '), searchValue)
+  )
+
+  const dingtalkSections = [
+    {
+      key: 'dingtalk:docs' as const,
+      label: tChat('dingtalkDocs.myDocsTab'),
+      count: dingtalkTrees.totalCount,
+      icon: FileText,
+    },
+    {
+      key: 'dingtalk:wikispace' as const,
+      label: tChat('dingtalkDocs.wikispaceTab'),
+      count: dingtalkTrees.wikispaceTotalCount,
+      icon: Database,
+    },
+  ]
+
+  const renderResponsiveGroupOptions = () => {
+    if (filteredGroupEntries.length === 0) {
+      return (
+        <div className="lg:hidden">
+          <PickerEmpty label={t('picker.emptyGroups')} />
+        </div>
+      )
+    }
+
+    return (
+      <ResponsiveSecondaryOptions title={t('picker.selectGroup')} testId="group">
+        {filteredGroupEntries.map(([name, group]) => (
+          <ResponsiveSecondaryOption
+            key={name}
+            icon={Users}
+            label={group.displayName}
+            count={group.items.length}
+            onClick={() => selectGroup(name)}
+            testId={`knowledge-picker-responsive-group-${name}`}
+          />
+        ))}
+      </ResponsiveSecondaryOptions>
+    )
+  }
+
+  const renderResponsiveDingTalkOptions = () => (
+    <ResponsiveSecondaryOptions title={t('picker.selectCategory')} testId="dingtalk">
+      {dingtalkSections.map(section => (
+        <ResponsiveSecondaryOption
+          key={section.key}
+          icon={section.icon}
+          label={section.label}
+          count={section.count}
+          onClick={() => selectDingTalkSection(section.key)}
+          testId={
+            section.key === 'dingtalk:docs'
+              ? 'knowledge-picker-responsive-dingtalk-docs'
+              : 'knowledge-picker-responsive-dingtalk-wikispace'
+          }
+        />
+      ))}
+    </ResponsiveSecondaryOptions>
+  )
+
+  const renderResponsiveExternalScopeOptions = (source: ExternalKnowledgeSource) => (
+    <ResponsiveSecondaryOptions title={t('picker.selectScope')} testId="external">
+      {getExternalKnowledgeScopes(source).map(scope => (
+        <ResponsiveSecondaryOption
+          key={scope.key}
+          icon={getExternalScopeIcon(scope)}
+          label={getExternalScopeLabel(scope, t)}
+          onClick={() => selectExternalScope(source, scope.key)}
+          testId={`knowledge-picker-responsive-external-scope-${scope.key}`}
+        />
+      ))}
+    </ResponsiveSecondaryOptions>
+  )
+
   const renderMiddleColumn = () => {
     const isInternalSource =
       activeSource === 'personal' || activeSource === 'group' || activeSource === 'organization'
@@ -1226,6 +1329,11 @@ export function KnowledgeSourcePicker({
                 items={boundKnowledgeBaseItems}
                 query={searchValue}
                 selectedContexts={selectedContexts}
+                activeId={
+                  activeKnowledgeBase?.source === 'internal'
+                    ? activeKnowledgeBase.knowledgeBase.id
+                    : undefined
+                }
                 onOpen={selectInternalKb}
                 onToggle={toggleInternalKnowledgeBase}
               />
@@ -1235,6 +1343,11 @@ export function KnowledgeSourcePicker({
             items={groupedKnowledgeBases.personal}
             query={searchValue}
             selectedContexts={selectedContexts}
+            activeId={
+              activeKnowledgeBase?.source === 'internal'
+                ? activeKnowledgeBase.knowledgeBase.id
+                : undefined
+            }
             onOpen={selectInternalKb}
             onToggle={toggleInternalKnowledgeBase}
           />
@@ -1247,6 +1360,11 @@ export function KnowledgeSourcePicker({
           items={groupedKnowledgeBases.organization}
           query={searchValue}
           selectedContexts={selectedContexts}
+          activeId={
+            activeKnowledgeBase?.source === 'internal'
+              ? activeKnowledgeBase.knowledgeBase.id
+              : undefined
+          }
           onOpen={selectInternalKb}
           onToggle={toggleInternalKnowledgeBase}
         />
@@ -1254,15 +1372,35 @@ export function KnowledgeSourcePicker({
     }
     if (activeSource === 'group') {
       if (!activeGroup) {
-        return <PickerEmpty label={t('picker.selectKnowledgeBase')} />
+        return (
+          <>
+            {renderResponsiveGroupOptions()}
+            <div className="hidden h-full lg:block">
+              <PickerEmpty label={t('picker.selectKnowledgeBase')} />
+            </div>
+          </>
+        )
       }
       const group = groupedKnowledgeBases.group.get(activeGroup)
       return (
         <div className="flex h-full min-h-0 flex-col">
+          <ResponsiveDrilldownHeader
+            label={group?.displayName ?? activeGroup}
+            onBack={() => {
+              setActiveGroup(null)
+              setActiveKnowledgeBase(null)
+            }}
+            testId="knowledge-picker-responsive-group-back"
+          />
           <KnowledgeBaseRows
             items={group?.items ?? []}
             query={searchValue}
             selectedContexts={selectedContexts}
+            activeId={
+              activeKnowledgeBase?.source === 'internal'
+                ? activeKnowledgeBase.knowledgeBase.id
+                : undefined
+            }
             onOpen={selectInternalKb}
             onToggle={toggleInternalKnowledgeBase}
           />
@@ -1271,7 +1409,14 @@ export function KnowledgeSourcePicker({
     }
 
     if (activeSource === 'dingtalk') {
-      return <PickerEmpty label={t('picker.selectKnowledgeBase')} />
+      return (
+        <>
+          {renderResponsiveDingTalkOptions()}
+          <div className="hidden h-full lg:block">
+            <PickerEmpty label={t('picker.selectKnowledgeBase')} />
+          </div>
+        </>
+      )
     }
 
     if (activeSource === 'dingtalk:docs') {
@@ -1314,13 +1459,35 @@ export function KnowledgeSourcePicker({
 
     if (activeExternalSource) {
       if (!externalScope) {
-        return <PickerEmpty label={t('picker.selectKnowledgeBase')} />
+        return (
+          <>
+            {renderResponsiveExternalScopeOptions(activeExternalSource)}
+            <div className="hidden h-full lg:block">
+              <PickerEmpty label={t('picker.selectKnowledgeBase')} />
+            </div>
+          </>
+        )
       }
 
       const cacheKey = `${activeExternalSource.providerId}:${externalScope}`
       const state = externalKbByScope.get(cacheKey)
+      const activeScope = getExternalKnowledgeScopes(activeExternalSource).find(
+        scope => scope.key === externalScope
+      )
       return (
         <div className="flex min-h-0 flex-col">
+          <ResponsiveDrilldownHeader
+            label={
+              activeScope
+                ? getExternalScopeLabel(activeScope, t)
+                : (activeExternalSource.label ?? activeExternalSource.providerId)
+            }
+            onBack={() => {
+              setExternalScope(null)
+              setActiveKnowledgeBase(null)
+            }}
+            testId="knowledge-picker-responsive-external-scope-back"
+          />
           {state?.loading ? (
             <PickerLoading label={t('picker.loading')} />
           ) : state?.error ? (
@@ -1335,6 +1502,11 @@ export function KnowledgeSourcePicker({
               source={activeExternalSource}
               items={state?.items ?? []}
               selectedContexts={selectedContexts}
+              activeId={
+                activeKnowledgeBase?.source === 'external'
+                  ? activeKnowledgeBase.knowledgeBase.knowledge_base_id
+                  : undefined
+              }
               onOpen={kb => selectExternalKb(activeExternalSource, kb)}
               onToggle={kb => toggleExternalKnowledgeBase(activeExternalSource, kb)}
             />
@@ -1347,7 +1519,7 @@ export function KnowledgeSourcePicker({
   }
 
   const renderSourceColumn = () => (
-    <div className="space-y-1 p-2">
+    <div className="flex gap-2 overflow-x-auto p-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden lg:block lg:space-y-1 lg:overflow-x-visible">
       {sourceRows.map(row => {
         const Icon = row.icon
         const active =
@@ -1364,7 +1536,9 @@ export function KnowledgeSourcePicker({
             <button
               type="button"
               className={cn(
-                'flex min-h-11 w-full items-center justify-between rounded-md px-3 py-2 text-left',
+                'flex min-h-11 items-center py-2 text-left',
+                'max-lg:w-auto max-lg:shrink-0 max-lg:justify-start max-lg:gap-2 max-lg:rounded-lg max-lg:border max-lg:border-border max-lg:px-3',
+                'lg:w-full lg:justify-between lg:rounded-md lg:px-3',
                 active ? 'bg-primary/10 text-primary' : 'hover:bg-surface text-text-primary'
               )}
               onClick={() => {
@@ -1390,45 +1564,36 @@ export function KnowledgeSourcePicker({
             </button>
 
             {isGroupSource && active
-              ? groupEntries
-                  .filter(([, group]) =>
-                    groupMatchesSearch([group.name, group.displayName].join(' '), searchValue)
+              ? filteredGroupEntries.map(([name, group]) => {
+                  const groupActive = activeGroup === name
+                  return (
+                    <button
+                      key={name}
+                      type="button"
+                      className={cn(
+                        'hidden min-h-11 items-center py-2 text-left lg:flex',
+                        'lg:w-full lg:justify-between lg:rounded-md lg:pl-8 lg:pr-3',
+                        groupActive
+                          ? 'bg-primary/10 text-primary'
+                          : 'hover:bg-surface text-text-primary'
+                      )}
+                      onClick={() => selectGroup(name)}
+                      data-testid={`knowledge-picker-group-${name}`}
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        <Users className="h-4 w-4 shrink-0 text-text-muted" />
+                        <TruncatedText
+                          text={group.displayName}
+                          focusable={false}
+                          className="text-sm font-medium"
+                        />
+                      </span>
+                      <Badge variant="secondary" size="sm">
+                        {group.items.length}
+                      </Badge>
+                    </button>
                   )
-                  .map(([name, group]) => {
-                    const groupActive = activeGroup === name
-                    return (
-                      <button
-                        key={name}
-                        type="button"
-                        className={cn(
-                          'flex min-h-11 w-full items-center justify-between rounded-md py-2 pl-8 pr-3 text-left',
-                          groupActive
-                            ? 'bg-primary/10 text-primary'
-                            : 'hover:bg-surface text-text-primary'
-                        )}
-                        onClick={() => {
-                          setActiveSource('group')
-                          setActiveGroup(name)
-                          setExternalScope(null)
-                          setActiveKnowledgeBase(null)
-                          setActiveDingTalkSpace(null)
-                        }}
-                        data-testid={`knowledge-picker-group-${name}`}
-                      >
-                        <span className="flex min-w-0 items-center gap-2">
-                          <Users className="h-4 w-4 shrink-0 text-text-muted" />
-                          <TruncatedText
-                            text={group.displayName}
-                            focusable={false}
-                            className="text-sm font-medium"
-                          />
-                        </span>
-                        <Badge variant="secondary" size="sm">
-                          {group.items.length}
-                        </Badge>
-                      </button>
-                    )
-                  })
+                })
               : null}
 
             {externalSource
@@ -1440,19 +1605,13 @@ export function KnowledgeSourcePicker({
                       key={scope.key}
                       type="button"
                       className={cn(
-                        'flex min-h-11 w-full items-center justify-between rounded-md py-2 pl-8 pr-3 text-left',
+                        'hidden min-h-11 items-center py-2 text-left lg:flex',
+                        'lg:w-full lg:justify-between lg:rounded-md lg:pl-8 lg:pr-3',
                         scopeActive
                           ? 'bg-primary/10 text-primary'
                           : 'hover:bg-surface text-text-primary'
                       )}
-                      onClick={() => {
-                        setActiveSource(`external:${externalSource.providerId}`)
-                        setActiveGroup(null)
-                        setExternalScope(scope.key)
-                        setActiveKnowledgeBase(null)
-                        setActiveDingTalkSpace(null)
-                        void loadExternalKnowledgeBases(externalSource, scope.key, searchValue)
-                      }}
+                      onClick={() => selectExternalScope(externalSource, scope.key)}
                       data-testid={`knowledge-picker-external-scope-${scope.key}`}
                     >
                       <span className="flex min-w-0 items-center gap-2">
@@ -1470,22 +1629,7 @@ export function KnowledgeSourcePicker({
               : null}
 
             {row.key === 'dingtalk' && activeSource.startsWith('dingtalk')
-              ? (
-                  [
-                    {
-                      key: 'dingtalk:docs' as SourceKey,
-                      label: tChat('dingtalkDocs.myDocsTab'),
-                      count: dingtalkTrees.totalCount,
-                      icon: FileText,
-                    },
-                    {
-                      key: 'dingtalk:wikispace' as SourceKey,
-                      label: tChat('dingtalkDocs.wikispaceTab'),
-                      count: dingtalkTrees.wikispaceTotalCount,
-                      icon: Database,
-                    },
-                  ] as const
-                ).map(section => {
+              ? dingtalkSections.map(section => {
                   const SectionIcon = section.icon
                   const sectionActive = activeSource === section.key
                   return (
@@ -1493,18 +1637,13 @@ export function KnowledgeSourcePicker({
                       key={section.key}
                       type="button"
                       className={cn(
-                        'flex min-h-11 w-full items-center justify-between rounded-md py-2 pl-8 pr-3 text-left',
+                        'hidden min-h-11 items-center py-2 text-left lg:flex',
+                        'lg:w-full lg:justify-between lg:rounded-md lg:pl-8 lg:pr-3',
                         sectionActive
                           ? 'bg-primary/10 text-primary'
                           : 'hover:bg-surface text-text-primary'
                       )}
-                      onClick={() => {
-                        setActiveSource(section.key)
-                        setActiveGroup(null)
-                        setExternalScope(null)
-                        setActiveKnowledgeBase(null)
-                        setActiveDingTalkSpace(null)
-                      }}
+                      onClick={() => selectDingTalkSection(section.key)}
                       data-testid={
                         section.key === 'dingtalk:docs'
                           ? 'knowledge-picker-dingtalk-docs'
@@ -1711,23 +1850,69 @@ export function KnowledgeSourcePicker({
     )
   }
 
+  const hasResponsiveDocumentView =
+    activeKnowledgeBase !== null ||
+    activeSource === 'dingtalk:docs' ||
+    (activeSource === 'dingtalk:wikispace' && activeDingTalkSpace !== null)
+
+  const closeResponsiveDocumentView = () => {
+    setActiveKnowledgeBase(null)
+    setActiveDingTalkSpace(null)
+    if (activeSource === 'dingtalk:docs') {
+      setActiveSource('dingtalk')
+    }
+  }
+
   return (
     <div
-      className="grid min-h-0 grid-cols-1 grid-rows-[minmax(0,4fr)_minmax(0,5fr)_minmax(0,7fr)] overflow-hidden md:grid-cols-[180px_220px_minmax(0,1fr)] md:grid-rows-1"
-      style={{
-        height: 'min(520px, calc(var(--radix-popover-content-available-height) - 72px))',
-      }}
+      className={cn(
+        'grid h-full min-h-0 grid-cols-1 overflow-hidden',
+        'md:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.1fr)] md:grid-rows-[auto_minmax(0,1fr)]',
+        'lg:h-[min(520px,calc(var(--radix-popover-content-available-height,592px)-72px))] lg:grid-cols-[180px_220px_minmax(0,1fr)] lg:grid-rows-1',
+        hasResponsiveDocumentView ? 'grid-rows-1' : 'grid-rows-[auto_minmax(0,1fr)]'
+      )}
       data-testid="knowledge-source-picker"
     >
-      <div className="min-h-0 border-b border-border md:border-b-0 md:border-r">
+      <div
+        className={cn(
+          'min-h-0 border-b border-border md:col-start-1 md:row-start-1 md:block md:border-r lg:col-auto lg:row-auto lg:border-b-0',
+          hasResponsiveDocumentView && 'hidden md:block'
+        )}
+        data-testid="knowledge-picker-source-column"
+      >
         <div className="h-full min-h-0 overflow-y-auto">{renderSourceColumn()}</div>
       </div>
 
-      <div className="min-h-0 border-b border-border md:border-b-0 md:border-r">
+      <div
+        className={cn(
+          'min-h-0 border-b border-border md:col-start-1 md:row-start-2 md:block md:border-b-0 md:border-r lg:col-auto lg:row-auto',
+          hasResponsiveDocumentView && 'hidden md:block'
+        )}
+        data-testid="knowledge-picker-knowledge-base-column"
+      >
         <div className="h-full min-h-0 overflow-y-auto">{renderMiddleColumn()}</div>
       </div>
 
-      <div className="min-h-0 overflow-hidden">{renderDocumentColumn()}</div>
+      <div
+        className={cn(
+          'min-h-0 overflow-hidden md:col-start-2 md:row-span-2 md:row-start-1 md:flex md:flex-col lg:col-auto lg:row-auto lg:row-span-1',
+          hasResponsiveDocumentView ? 'flex flex-col' : 'hidden'
+        )}
+        data-testid="knowledge-picker-document-column"
+      >
+        {hasResponsiveDocumentView ? (
+          <button
+            type="button"
+            className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3 text-sm font-medium text-text-primary md:hidden"
+            onClick={closeResponsiveDocumentView}
+            data-testid="knowledge-picker-mobile-back"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            {t('document.backToList')}
+          </button>
+        ) : null}
+        <div className="min-h-0 flex-1 overflow-hidden">{renderDocumentColumn()}</div>
+      </div>
     </div>
   )
 }
@@ -1736,12 +1921,14 @@ function KnowledgeBaseRows({
   items,
   query,
   selectedContexts,
+  activeId,
   onOpen,
   onToggle,
 }: {
   items: KnowledgeBase[]
   query: string
   selectedContexts: ContextItem[]
+  activeId?: number
   onOpen: (kb: KnowledgeBase) => void
   onToggle: (kb: KnowledgeBase) => void
 }) {
@@ -1765,7 +1952,10 @@ function KnowledgeBaseRows({
         return (
           <div
             key={item.id}
-            className="flex min-h-11 w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left hover:bg-surface"
+            className={cn(
+              'flex min-h-11 w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left hover:bg-surface',
+              activeId === item.id && 'bg-primary/10 lg:bg-transparent'
+            )}
           >
             <button
               type="button"
@@ -1784,6 +1974,7 @@ function KnowledgeBaseRows({
                   {t('picker.count.documents', { count: item.document_count ?? 0 })}
                 </span>
               </span>
+              <ChevronRight className="ml-auto h-4 w-4 shrink-0 text-text-muted lg:hidden" />
             </button>
             <KnowledgeSelectionControl
               state={selectionState}
@@ -1802,12 +1993,14 @@ function ExternalKnowledgeBaseRows({
   source,
   items,
   selectedContexts,
+  activeId,
   onOpen,
   onToggle,
 }: {
   source: ExternalKnowledgeSource
   items: ExternalKnowledgeBase[]
   selectedContexts: ContextItem[]
+  activeId?: string
   onOpen: (kb: ExternalKnowledgeBase) => void
   onToggle: (kb: ExternalKnowledgeBase) => void
 }) {
@@ -1829,7 +2022,10 @@ function ExternalKnowledgeBaseRows({
         return (
           <div
             key={item.knowledge_base_id}
-            className="flex min-h-11 w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left hover:bg-surface"
+            className={cn(
+              'flex min-h-11 w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left hover:bg-surface',
+              activeId === item.knowledge_base_id && 'bg-primary/10 lg:bg-transparent'
+            )}
           >
             <button
               type="button"
@@ -1848,6 +2044,7 @@ function ExternalKnowledgeBaseRows({
                   {t('picker.count.documents', { count: item.document_count ?? 0 })}
                 </span>
               </span>
+              <ChevronRight className="ml-auto h-4 w-4 shrink-0 text-text-muted lg:hidden" />
             </button>
             {canSelectKnowledgeBase ? (
               <KnowledgeSelectionControl
@@ -2307,6 +2504,87 @@ function ExternalDocumentNode({
           ))
         : null}
     </div>
+  )
+}
+
+function ResponsiveSecondaryOptions({
+  title,
+  testId,
+  children,
+}: {
+  title: string
+  testId: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="space-y-1 p-2 lg:hidden"
+      data-testid={`knowledge-picker-responsive-${testId}-options`}
+    >
+      <div className="px-3 pb-2 pt-1 text-xs font-medium text-text-muted">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+function ResponsiveSecondaryOption({
+  icon: Icon,
+  label,
+  count,
+  onClick,
+  testId,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  count?: number
+  onClick: () => void
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      className="flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2 text-left text-text-primary hover:bg-surface"
+      onClick={onClick}
+      data-testid={testId}
+    >
+      <Icon className="h-4 w-4 shrink-0 text-text-muted" />
+      <TruncatedText
+        text={label}
+        focusable={false}
+        className="min-w-0 flex-1 text-sm font-medium"
+      />
+      {count !== undefined ? (
+        <Badge variant="secondary" size="sm">
+          {count}
+        </Badge>
+      ) : null}
+      <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
+    </button>
+  )
+}
+
+function ResponsiveDrilldownHeader({
+  label,
+  onBack,
+  testId,
+}: {
+  label: string
+  onBack: () => void
+  testId: string
+}) {
+  const { t } = useTranslation('knowledge')
+
+  return (
+    <button
+      type="button"
+      className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3 text-left text-sm font-medium text-text-primary hover:bg-surface lg:hidden"
+      onClick={onBack}
+      aria-label={t('picker.changeSelection', { name: label })}
+      data-testid={testId}
+    >
+      <ChevronLeft className="h-4 w-4 shrink-0" />
+      <TruncatedText text={label} focusable={false} className="min-w-0 flex-1" />
+    </button>
   )
 }
 

--- a/frontend/src/features/tasks/components/chat/KnowledgeSourcePicker.tsx
+++ b/frontend/src/features/tasks/components/chat/KnowledgeSourcePicker.tsx
@@ -7,7 +7,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Building2,
-  ChevronLeft,
   ChevronRight,
   Cloud,
   Database,
@@ -27,7 +26,6 @@ import { TruncatedText } from '@/components/common/long-text'
 import { SelectionIndicator } from '@/components/ui/selection-indicator'
 import { getFolderTree, listDocuments } from '@/apis/knowledge'
 import type { BoundKnowledgeBaseDetail } from '@/types/task-knowledge-base'
-import type { DingtalkDocNode } from '@/types/dingtalk-doc'
 import type { KnowledgeBase, KnowledgeDocument, KnowledgeFolder } from '@/types/knowledge'
 import type {
   ContextItem,
@@ -62,6 +60,16 @@ import {
   useDingTalkKnowledgeSelection,
 } from './DingTalkKnowledgePicker'
 import { KnowledgeSelectionControl } from './KnowledgeSelectionControl'
+import {
+  KnowledgeSourcePickerLayout,
+  ResponsiveDrilldownHeader,
+  ResponsiveSecondaryOption,
+  ResponsiveSecondaryOptions,
+} from './KnowledgeSourcePickerResponsive'
+import {
+  type KnowledgeSourceKey,
+  useKnowledgePickerNavigation,
+} from './useKnowledgePickerNavigation'
 
 export interface GroupedKnowledgeBases {
   personal: KnowledgeBase[]
@@ -74,15 +82,6 @@ export interface GroupedKnowledgeBaseGroup {
   displayName: string
   items: KnowledgeBase[]
 }
-
-type SourceKey =
-  | 'personal'
-  | 'group'
-  | 'organization'
-  | 'dingtalk'
-  | 'dingtalk:docs'
-  | 'dingtalk:wikispace'
-  | `external:${string}`
 
 const INTERNAL_DOCUMENT_PAGE_SIZE = 200
 const DEFAULT_EXTERNAL_SCOPE_ICON = 'cloud'
@@ -102,19 +101,6 @@ interface KnowledgeSourcePickerProps {
   onDeselectMultiple?: (ids: (number | string)[]) => void
   onReplaceContexts: (idsToRemove: (number | string)[], contextsToAdd: ContextItem[]) => void
 }
-
-interface ActiveInternalKnowledgeBase {
-  source: 'internal'
-  knowledgeBase: KnowledgeBase
-}
-
-interface ActiveExternalKnowledgeBase {
-  source: 'external'
-  provider: ExternalKnowledgeSource
-  knowledgeBase: ExternalKnowledgeBase
-}
-
-type ActiveKnowledgeBase = ActiveInternalKnowledgeBase | ActiveExternalKnowledgeBase
 
 interface InternalTreeNode {
   id: string
@@ -595,11 +581,21 @@ export function KnowledgeSourcePicker({
     () => externalSources.filter(source => source.listKnowledgeBases),
     [externalSources]
   )
-  const [activeSource, setActiveSource] = useState<SourceKey>('personal')
-  const [activeGroup, setActiveGroup] = useState<string | null>(null)
-  const [externalScope, setExternalScope] = useState<ExternalKnowledgeScope | null>(null)
-  const [activeKnowledgeBase, setActiveKnowledgeBase] = useState<ActiveKnowledgeBase | null>(null)
-  const [activeDingTalkSpace, setActiveDingTalkSpace] = useState<DingtalkDocNode | null>(null)
+  const {
+    activeSource,
+    activeGroup,
+    externalScope,
+    activeKnowledgeBase,
+    activeDingTalkSpace,
+    selectSource,
+    selectGroup,
+    selectExternalScope: navigateToExternalScope,
+    selectDingTalkSection,
+    openInternalKnowledgeBase,
+    openExternalKnowledgeBase,
+    openDingTalkSpace,
+    back: navigateBack,
+  } = useKnowledgePickerNavigation()
   const dingtalkTrees = useDingTalkDocTrees({ enabled: activeSource.startsWith('dingtalk') })
   const {
     selectedIds: selectedDingTalkIds,
@@ -661,16 +657,15 @@ export function KnowledgeSourcePicker({
   }, [browseableExternalSources])
 
   useEffect(() => {
+    if (!externalScope) return
     if (!activeExternalSource) {
-      setExternalScope(null)
+      selectSource(activeSource)
       return
     }
     const scopes = getExternalKnowledgeScopes(activeExternalSource)
-    setExternalScope(prev => {
-      if (prev && scopes.some(scope => scope.key === prev)) return prev
-      return null
-    })
-  }, [activeExternalSource])
+    if (scopes.some(scope => scope.key === externalScope)) return
+    selectSource(activeSource)
+  }, [activeExternalSource, activeSource, externalScope, selectSource])
 
   const groupEntries = useMemo(
     () => Array.from(groupedKnowledgeBases.group.entries()),
@@ -699,31 +694,31 @@ export function KnowledgeSourcePicker({
   const sourceRows = useMemo(
     () => [
       {
-        key: 'personal' as SourceKey,
+        key: 'personal' as KnowledgeSourceKey,
         label: t('picker.sources.personal'),
         count: groupedKnowledgeBases.personal.length,
         icon: User,
       },
       {
-        key: 'group' as SourceKey,
+        key: 'group' as KnowledgeSourceKey,
         label: t('picker.sources.group'),
         count: groupedKnowledgeBases.group.size,
         icon: Users,
       },
       {
-        key: 'organization' as SourceKey,
+        key: 'organization' as KnowledgeSourceKey,
         label: t('picker.sources.organization'),
         count: groupedKnowledgeBases.organization.length,
         icon: Building2,
       },
       {
-        key: 'dingtalk' as SourceKey,
+        key: 'dingtalk' as KnowledgeSourceKey,
         label: tChat('dingtalkDocs.tabTitle'),
         count: 2,
         icon: MessageSquareText,
       },
       ...browseableExternalSources.map(source => ({
-        key: `external:${source.providerId}` as SourceKey,
+        key: `external:${source.providerId}` as KnowledgeSourceKey,
         label: source.label ?? source.providerId,
         count: externalKnowledgeBaseCounts.get(source.providerId) ?? 0,
         icon: Cloud,
@@ -1190,43 +1185,23 @@ export function KnowledgeSourcePicker({
   )
 
   const selectInternalKb = (kb: KnowledgeBase) => {
-    setActiveKnowledgeBase({ source: 'internal', knowledgeBase: kb })
+    openInternalKnowledgeBase(kb)
     if (!internalTreeByKb.has(kb.id)) {
       void loadInternalTree(kb)
     }
   }
 
   const selectExternalKb = (source: ExternalKnowledgeSource, kb: ExternalKnowledgeBase) => {
-    setActiveKnowledgeBase({ source: 'external', provider: source, knowledgeBase: kb })
+    openExternalKnowledgeBase(source, kb)
     const cacheKey = `${source.providerId}:${kb.knowledge_base_id}`
     if (!externalNodesByKb.has(cacheKey)) {
       void loadExternalNodes(source, kb)
     }
   }
 
-  const selectGroup = (name: string) => {
-    setActiveSource('group')
-    setActiveGroup(name)
-    setExternalScope(null)
-    setActiveKnowledgeBase(null)
-    setActiveDingTalkSpace(null)
-  }
-
   const selectExternalScope = (source: ExternalKnowledgeSource, scope: ExternalKnowledgeScope) => {
-    setActiveSource(`external:${source.providerId}`)
-    setActiveGroup(null)
-    setExternalScope(scope)
-    setActiveKnowledgeBase(null)
-    setActiveDingTalkSpace(null)
+    navigateToExternalScope(source.providerId, scope)
     void loadExternalKnowledgeBases(source, scope, searchValue)
-  }
-
-  const selectDingTalkSection = (source: 'dingtalk:docs' | 'dingtalk:wikispace') => {
-    setActiveSource(source)
-    setActiveGroup(null)
-    setExternalScope(null)
-    setActiveKnowledgeBase(null)
-    setActiveDingTalkSpace(null)
   }
 
   const filteredGroupEntries = groupEntries.filter(([, group]) =>
@@ -1386,10 +1361,7 @@ export function KnowledgeSourcePicker({
         <div className="flex h-full min-h-0 flex-col">
           <ResponsiveDrilldownHeader
             label={group?.displayName ?? activeGroup}
-            onBack={() => {
-              setActiveGroup(null)
-              setActiveKnowledgeBase(null)
-            }}
+            onBack={navigateBack}
             testId="knowledge-picker-responsive-group-back"
           />
           <KnowledgeBaseRows
@@ -1451,7 +1423,7 @@ export function KnowledgeSourcePicker({
           lastSyncedAt={dingtalkTrees.wikispaceLastSyncedAt}
           onRetry={dingtalkTrees.fetchWikispace}
           onSync={dingtalkTrees.syncWikispace}
-          onOpen={setActiveDingTalkSpace}
+          onOpen={openDingTalkSpace}
           onToggle={node => toggleDingTalkNode(node, node)}
         />
       )
@@ -1482,10 +1454,7 @@ export function KnowledgeSourcePicker({
                 ? getExternalScopeLabel(activeScope, t)
                 : (activeExternalSource.label ?? activeExternalSource.providerId)
             }
-            onBack={() => {
-              setExternalScope(null)
-              setActiveKnowledgeBase(null)
-            }}
+            onBack={navigateBack}
             testId="knowledge-picker-responsive-external-scope-back"
           />
           {state?.loading ? (
@@ -1541,13 +1510,7 @@ export function KnowledgeSourcePicker({
                 'lg:w-full lg:justify-between lg:rounded-md lg:px-3',
                 active ? 'bg-primary/10 text-primary' : 'hover:bg-surface text-text-primary'
               )}
-              onClick={() => {
-                setActiveSource(row.key)
-                setActiveGroup(null)
-                setExternalScope(null)
-                setActiveKnowledgeBase(null)
-                setActiveDingTalkSpace(null)
-              }}
+              onClick={() => selectSource(row.key)}
               data-testid={
                 row.key === 'dingtalk'
                   ? 'knowledge-picker-dingtalk-parent'
@@ -1855,65 +1818,14 @@ export function KnowledgeSourcePicker({
     activeSource === 'dingtalk:docs' ||
     (activeSource === 'dingtalk:wikispace' && activeDingTalkSpace !== null)
 
-  const closeResponsiveDocumentView = () => {
-    setActiveKnowledgeBase(null)
-    setActiveDingTalkSpace(null)
-    if (activeSource === 'dingtalk:docs') {
-      setActiveSource('dingtalk')
-    }
-  }
-
   return (
-    <div
-      className={cn(
-        'grid h-full min-h-0 grid-cols-1 overflow-hidden',
-        'md:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.1fr)] md:grid-rows-[auto_minmax(0,1fr)]',
-        'lg:h-[min(520px,calc(var(--radix-popover-content-available-height,592px)-72px))] lg:grid-cols-[180px_220px_minmax(0,1fr)] lg:grid-rows-1',
-        hasResponsiveDocumentView ? 'grid-rows-1' : 'grid-rows-[auto_minmax(0,1fr)]'
-      )}
-      data-testid="knowledge-source-picker"
-    >
-      <div
-        className={cn(
-          'min-h-0 border-b border-border md:col-start-1 md:row-start-1 md:block md:border-r lg:col-auto lg:row-auto lg:border-b-0',
-          hasResponsiveDocumentView && 'hidden md:block'
-        )}
-        data-testid="knowledge-picker-source-column"
-      >
-        <div className="h-full min-h-0 overflow-y-auto">{renderSourceColumn()}</div>
-      </div>
-
-      <div
-        className={cn(
-          'min-h-0 border-b border-border md:col-start-1 md:row-start-2 md:block md:border-b-0 md:border-r lg:col-auto lg:row-auto',
-          hasResponsiveDocumentView && 'hidden md:block'
-        )}
-        data-testid="knowledge-picker-knowledge-base-column"
-      >
-        <div className="h-full min-h-0 overflow-y-auto">{renderMiddleColumn()}</div>
-      </div>
-
-      <div
-        className={cn(
-          'min-h-0 overflow-hidden md:col-start-2 md:row-span-2 md:row-start-1 md:flex md:flex-col lg:col-auto lg:row-auto lg:row-span-1',
-          hasResponsiveDocumentView ? 'flex flex-col' : 'hidden'
-        )}
-        data-testid="knowledge-picker-document-column"
-      >
-        {hasResponsiveDocumentView ? (
-          <button
-            type="button"
-            className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3 text-sm font-medium text-text-primary md:hidden"
-            onClick={closeResponsiveDocumentView}
-            data-testid="knowledge-picker-mobile-back"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            {t('document.backToList')}
-          </button>
-        ) : null}
-        <div className="min-h-0 flex-1 overflow-hidden">{renderDocumentColumn()}</div>
-      </div>
-    </div>
+    <KnowledgeSourcePickerLayout
+      hasDocumentView={hasResponsiveDocumentView}
+      sourceColumn={renderSourceColumn()}
+      knowledgeBaseColumn={renderMiddleColumn()}
+      documentColumn={renderDocumentColumn()}
+      onBack={navigateBack}
+    />
   )
 }
 
@@ -2504,87 +2416,6 @@ function ExternalDocumentNode({
           ))
         : null}
     </div>
-  )
-}
-
-function ResponsiveSecondaryOptions({
-  title,
-  testId,
-  children,
-}: {
-  title: string
-  testId: string
-  children: React.ReactNode
-}) {
-  return (
-    <div
-      className="space-y-1 p-2 lg:hidden"
-      data-testid={`knowledge-picker-responsive-${testId}-options`}
-    >
-      <div className="px-3 pb-2 pt-1 text-xs font-medium text-text-muted">{title}</div>
-      {children}
-    </div>
-  )
-}
-
-function ResponsiveSecondaryOption({
-  icon: Icon,
-  label,
-  count,
-  onClick,
-  testId,
-}: {
-  icon: React.ComponentType<{ className?: string }>
-  label: string
-  count?: number
-  onClick: () => void
-  testId: string
-}) {
-  return (
-    <button
-      type="button"
-      className="flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2 text-left text-text-primary hover:bg-surface"
-      onClick={onClick}
-      data-testid={testId}
-    >
-      <Icon className="h-4 w-4 shrink-0 text-text-muted" />
-      <TruncatedText
-        text={label}
-        focusable={false}
-        className="min-w-0 flex-1 text-sm font-medium"
-      />
-      {count !== undefined ? (
-        <Badge variant="secondary" size="sm">
-          {count}
-        </Badge>
-      ) : null}
-      <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
-    </button>
-  )
-}
-
-function ResponsiveDrilldownHeader({
-  label,
-  onBack,
-  testId,
-}: {
-  label: string
-  onBack: () => void
-  testId: string
-}) {
-  const { t } = useTranslation('knowledge')
-
-  return (
-    <button
-      type="button"
-      className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3 text-left text-sm font-medium text-text-primary hover:bg-surface lg:hidden"
-      onClick={onBack}
-      aria-label={t('picker.changeSelection', { name: label })}
-      data-testid={testId}
-    >
-      <ChevronLeft className="h-4 w-4 shrink-0" />
-      <TruncatedText text={label} focusable={false} className="min-w-0 flex-1" />
-    </button>
   )
 }
 

--- a/frontend/src/features/tasks/components/chat/KnowledgeSourcePickerResponsive.tsx
+++ b/frontend/src/features/tasks/components/chat/KnowledgeSourcePickerResponsive.tsx
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { TruncatedText } from '@/components/common/long-text'
+import { useTranslation } from '@/hooks/useTranslation'
+import { cn } from '@/lib/utils'
+
+interface KnowledgeSourcePickerLayoutProps {
+  hasDocumentView: boolean
+  sourceColumn: React.ReactNode
+  knowledgeBaseColumn: React.ReactNode
+  documentColumn: React.ReactNode
+  onBack: () => void
+}
+
+export function KnowledgeSourcePickerLayout({
+  hasDocumentView,
+  sourceColumn,
+  knowledgeBaseColumn,
+  documentColumn,
+  onBack,
+}: KnowledgeSourcePickerLayoutProps) {
+  const { t } = useTranslation('knowledge')
+
+  return (
+    <div
+      className={cn(
+        'grid h-full min-h-0 grid-cols-1 overflow-hidden',
+        'md:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.1fr)] md:grid-rows-[auto_minmax(0,1fr)]',
+        'lg:h-[min(520px,calc(var(--radix-popover-content-available-height,592px)-72px))] lg:grid-cols-[180px_220px_minmax(0,1fr)] lg:grid-rows-1',
+        hasDocumentView ? 'grid-rows-1' : 'grid-rows-[auto_minmax(0,1fr)]'
+      )}
+      data-testid="knowledge-source-picker"
+    >
+      <div
+        className={cn(
+          'min-h-0 border-b border-border md:col-start-1 md:row-start-1 md:block md:border-r lg:col-auto lg:row-auto lg:border-b-0',
+          hasDocumentView && 'hidden md:block'
+        )}
+        data-testid="knowledge-picker-source-column"
+      >
+        <div className="h-full min-h-0 overflow-y-auto">{sourceColumn}</div>
+      </div>
+
+      <div
+        className={cn(
+          'min-h-0 border-b border-border md:col-start-1 md:row-start-2 md:block md:border-b-0 md:border-r lg:col-auto lg:row-auto',
+          hasDocumentView && 'hidden md:block'
+        )}
+        data-testid="knowledge-picker-knowledge-base-column"
+      >
+        <div className="h-full min-h-0 overflow-y-auto">{knowledgeBaseColumn}</div>
+      </div>
+
+      <div
+        className={cn(
+          'min-h-0 overflow-hidden md:col-start-2 md:row-span-2 md:row-start-1 md:flex md:flex-col lg:col-auto lg:row-auto lg:row-span-1',
+          hasDocumentView ? 'flex flex-col' : 'hidden'
+        )}
+        data-testid="knowledge-picker-document-column"
+      >
+        {hasDocumentView ? (
+          <button
+            type="button"
+            className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3 text-sm font-medium text-text-primary md:hidden"
+            onClick={onBack}
+            data-testid="knowledge-picker-mobile-back"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            {t('document.backToList')}
+          </button>
+        ) : null}
+        <div className="min-h-0 flex-1 overflow-hidden">{documentColumn}</div>
+      </div>
+    </div>
+  )
+}
+
+export function ResponsiveSecondaryOptions({
+  title,
+  testId,
+  children,
+}: {
+  title: string
+  testId: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="space-y-1 p-2 lg:hidden"
+      data-testid={`knowledge-picker-responsive-${testId}-options`}
+    >
+      <div className="px-3 pb-2 pt-1 text-xs font-medium text-text-muted">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+export function ResponsiveSecondaryOption({
+  icon: Icon,
+  label,
+  count,
+  onClick,
+  testId,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  count?: number
+  onClick: () => void
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      className="flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2 text-left text-text-primary hover:bg-surface"
+      onClick={onClick}
+      data-testid={testId}
+    >
+      <Icon className="h-4 w-4 shrink-0 text-text-muted" />
+      <TruncatedText
+        text={label}
+        focusable={false}
+        className="min-w-0 flex-1 text-sm font-medium"
+      />
+      {count !== undefined ? (
+        <Badge variant="secondary" size="sm">
+          {count}
+        </Badge>
+      ) : null}
+      <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
+    </button>
+  )
+}
+
+export function ResponsiveDrilldownHeader({
+  label,
+  onBack,
+  testId,
+}: {
+  label: string
+  onBack: () => void
+  testId: string
+}) {
+  const { t } = useTranslation('knowledge')
+
+  return (
+    <button
+      type="button"
+      className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3 text-left text-sm font-medium text-text-primary hover:bg-surface lg:hidden"
+      onClick={onBack}
+      aria-label={t('picker.changeSelection', { name: label })}
+      data-testid={testId}
+    >
+      <ChevronLeft className="h-4 w-4 shrink-0" />
+      <TruncatedText text={label} focusable={false} className="min-w-0 flex-1" />
+    </button>
+  )
+}

--- a/frontend/src/features/tasks/components/chat/useKnowledgePickerNavigation.ts
+++ b/frontend/src/features/tasks/components/chat/useKnowledgePickerNavigation.ts
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useCallback, useReducer } from 'react'
+
+import type { DingtalkDocNode } from '@/types/dingtalk-doc'
+import type { KnowledgeBase } from '@/types/knowledge'
+import type { ExternalKnowledgeSource } from '@/features/knowledge/externalKnowledgeSourceRegistry'
+import type { ExternalKnowledgeBase, ExternalKnowledgeScope } from '@/types/external-knowledge'
+
+export type KnowledgeSourceKey =
+  | 'personal'
+  | 'group'
+  | 'organization'
+  | 'dingtalk'
+  | 'dingtalk:docs'
+  | 'dingtalk:wikispace'
+  | `external:${string}`
+
+export interface ActiveInternalKnowledgeBase {
+  source: 'internal'
+  knowledgeBase: KnowledgeBase
+}
+
+export interface ActiveExternalKnowledgeBase {
+  source: 'external'
+  provider: ExternalKnowledgeSource
+  knowledgeBase: ExternalKnowledgeBase
+}
+
+export type ActiveKnowledgeBase = ActiveInternalKnowledgeBase | ActiveExternalKnowledgeBase
+
+type ExternalSourceKey = `external:${string}`
+type DingTalkSectionKey = 'dingtalk:docs' | 'dingtalk:wikispace'
+
+type KnowledgeBaseParent =
+  | { source: 'personal' | 'organization' }
+  | { source: 'group'; group: string }
+  | { source: ExternalSourceKey; scope: ExternalKnowledgeScope }
+
+type ExternalKnowledgeBaseParent = Extract<KnowledgeBaseParent, { source: ExternalSourceKey }>
+
+type NavigationState =
+  | { view: 'source'; source: KnowledgeSourceKey }
+  | { view: 'group'; source: 'group'; group: string }
+  | { view: 'external-scope'; source: ExternalSourceKey; scope: ExternalKnowledgeScope }
+  | { view: 'dingtalk-section'; source: DingTalkSectionKey }
+  | { view: 'knowledge-base'; parent: KnowledgeBaseParent; knowledgeBase: ActiveKnowledgeBase }
+  | { view: 'dingtalk-space'; source: 'dingtalk:wikispace'; space: DingtalkDocNode }
+
+type NavigationAction =
+  | { type: 'select-source'; source: KnowledgeSourceKey }
+  | { type: 'select-group'; group: string }
+  | { type: 'select-external-scope'; providerId: string; scope: ExternalKnowledgeScope }
+  | { type: 'select-dingtalk-section'; source: DingTalkSectionKey }
+  | { type: 'open-internal-knowledge-base'; knowledgeBase: KnowledgeBase }
+  | {
+      type: 'open-external-knowledge-base'
+      provider: ExternalKnowledgeSource
+      knowledgeBase: ExternalKnowledgeBase
+    }
+  | { type: 'open-dingtalk-space'; space: DingtalkDocNode }
+  | { type: 'back' }
+
+const INITIAL_NAVIGATION_STATE: NavigationState = {
+  view: 'source',
+  source: 'personal',
+}
+
+function isExternalKnowledgeBaseParent(
+  parent: KnowledgeBaseParent
+): parent is ExternalKnowledgeBaseParent {
+  return parent.source.startsWith('external:')
+}
+
+function getActiveSource(state: NavigationState): KnowledgeSourceKey {
+  return state.view === 'knowledge-base' ? state.parent.source : state.source
+}
+
+function getInternalKnowledgeBaseParent(state: NavigationState): KnowledgeBaseParent {
+  if (state.view === 'group') {
+    return { source: 'group', group: state.group }
+  }
+  if (state.view === 'knowledge-base' && state.parent.source === 'group') {
+    return state.parent
+  }
+
+  const source = getActiveSource(state)
+  return source === 'organization' ? { source } : { source: 'personal' }
+}
+
+function getExternalKnowledgeBaseParent(
+  state: NavigationState,
+  provider: ExternalKnowledgeSource,
+  knowledgeBase: ExternalKnowledgeBase
+): KnowledgeBaseParent {
+  if (state.view === 'external-scope') {
+    return { source: state.source, scope: state.scope }
+  }
+  if (state.view === 'knowledge-base' && isExternalKnowledgeBaseParent(state.parent)) {
+    return state.parent
+  }
+
+  return {
+    source: `external:${provider.providerId}`,
+    scope: knowledgeBase.scope ?? 'all',
+  }
+}
+
+function navigateBack(state: NavigationState): NavigationState {
+  if (state.view === 'knowledge-base') {
+    if (state.parent.source === 'group') {
+      return { view: 'group', source: 'group', group: state.parent.group }
+    }
+    if (isExternalKnowledgeBaseParent(state.parent)) {
+      return {
+        view: 'external-scope',
+        source: state.parent.source,
+        scope: state.parent.scope,
+      }
+    }
+    return { view: 'source', source: state.parent.source }
+  }
+  if (state.view === 'dingtalk-space') {
+    return { view: 'dingtalk-section', source: 'dingtalk:wikispace' }
+  }
+  if (state.view === 'dingtalk-section') {
+    return { view: 'source', source: 'dingtalk' }
+  }
+  if (state.view === 'group') {
+    return { view: 'source', source: 'group' }
+  }
+  if (state.view === 'external-scope') {
+    return { view: 'source', source: state.source }
+  }
+  return state
+}
+
+function navigationReducer(state: NavigationState, action: NavigationAction): NavigationState {
+  switch (action.type) {
+    case 'select-source':
+      return { view: 'source', source: action.source }
+    case 'select-group':
+      return { view: 'group', source: 'group', group: action.group }
+    case 'select-external-scope':
+      return {
+        view: 'external-scope',
+        source: `external:${action.providerId}`,
+        scope: action.scope,
+      }
+    case 'select-dingtalk-section':
+      return { view: 'dingtalk-section', source: action.source }
+    case 'open-internal-knowledge-base':
+      return {
+        view: 'knowledge-base',
+        parent: getInternalKnowledgeBaseParent(state),
+        knowledgeBase: { source: 'internal', knowledgeBase: action.knowledgeBase },
+      }
+    case 'open-external-knowledge-base':
+      return {
+        view: 'knowledge-base',
+        parent: getExternalKnowledgeBaseParent(state, action.provider, action.knowledgeBase),
+        knowledgeBase: {
+          source: 'external',
+          provider: action.provider,
+          knowledgeBase: action.knowledgeBase,
+        },
+      }
+    case 'open-dingtalk-space':
+      return { view: 'dingtalk-space', source: 'dingtalk:wikispace', space: action.space }
+    case 'back':
+      return navigateBack(state)
+  }
+}
+
+export function useKnowledgePickerNavigation() {
+  const [state, dispatch] = useReducer(navigationReducer, INITIAL_NAVIGATION_STATE)
+
+  const selectSource = useCallback((source: KnowledgeSourceKey) => {
+    dispatch({ type: 'select-source', source })
+  }, [])
+  const selectGroup = useCallback((group: string) => {
+    dispatch({ type: 'select-group', group })
+  }, [])
+  const selectExternalScope = useCallback((providerId: string, scope: ExternalKnowledgeScope) => {
+    dispatch({ type: 'select-external-scope', providerId, scope })
+  }, [])
+  const selectDingTalkSection = useCallback((source: DingTalkSectionKey) => {
+    dispatch({ type: 'select-dingtalk-section', source })
+  }, [])
+  const openInternalKnowledgeBase = useCallback((knowledgeBase: KnowledgeBase) => {
+    dispatch({ type: 'open-internal-knowledge-base', knowledgeBase })
+  }, [])
+  const openExternalKnowledgeBase = useCallback(
+    (provider: ExternalKnowledgeSource, knowledgeBase: ExternalKnowledgeBase) => {
+      dispatch({ type: 'open-external-knowledge-base', provider, knowledgeBase })
+    },
+    []
+  )
+  const openDingTalkSpace = useCallback((space: DingtalkDocNode) => {
+    dispatch({ type: 'open-dingtalk-space', space })
+  }, [])
+  const back = useCallback(() => {
+    dispatch({ type: 'back' })
+  }, [])
+
+  return {
+    activeSource: getActiveSource(state),
+    activeGroup:
+      state.view === 'group'
+        ? state.group
+        : state.view === 'knowledge-base' && state.parent.source === 'group'
+          ? state.parent.group
+          : null,
+    externalScope:
+      state.view === 'external-scope'
+        ? state.scope
+        : state.view === 'knowledge-base' && isExternalKnowledgeBaseParent(state.parent)
+          ? state.parent.scope
+          : null,
+    activeKnowledgeBase: state.view === 'knowledge-base' ? state.knowledgeBase : null,
+    activeDingTalkSpace: state.view === 'dingtalk-space' ? state.space : null,
+    selectSource,
+    selectGroup,
+    selectExternalScope,
+    selectDingTalkSection,
+    openInternalKnowledgeBase,
+    openExternalKnowledgeBase,
+    openDingTalkSpace,
+    back,
+  }
+}

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -297,7 +297,16 @@ export default function ChatInput({
     if (autoFocus && !isInputDisabled && editableRef.current) {
       // Use setTimeout to ensure the DOM is fully rendered
       const timer = setTimeout(() => {
-        editableRef.current?.focus()
+        const activeElement = document.activeElement
+        const canTakeFocus =
+          !activeElement ||
+          activeElement === document.body ||
+          activeElement === document.documentElement
+
+        // Do not steal focus after the user or an overlay has focused another control.
+        if (canTakeFocus) {
+          editableRef.current?.focus()
+        }
       }, 100)
       return () => clearTimeout(timer)
     }

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -236,6 +236,7 @@ export function MobileChatInputControls({
 }: MobileChatInputControlsProps) {
   const { t } = useTranslation('chat')
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
+  const [contextSelectorOpen, setContextSelectorOpen] = useState(false)
   const moreMenuButtonRef = useRef<HTMLButtonElement>(null)
   const moreMenuRef = useRef<HTMLDivElement>(null)
   const [moreMenuStyle, setMoreMenuStyle] = useState<React.CSSProperties>({})
@@ -274,12 +275,27 @@ export function MobileChatInputControls({
   )
   const hasSecondaryActions =
     showAttachmentAction || showChatContexts || showSkillAction || showVideoSettings
+  const closeMoreMenu = useCallback(() => {
+    setMoreMenuOpen(false)
+    setContextSelectorOpen(false)
+  }, [])
   const handleAttachmentFileSelect = useCallback(
     (files: File | File[]) => {
-      setMoreMenuOpen(false)
+      closeMoreMenu()
       onFileSelect(files)
     },
-    [onFileSelect]
+    [closeMoreMenu, onFileSelect]
+  )
+  const handleContextSelectorOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setContextSelectorOpen(true)
+        return
+      }
+      closeMoreMenu()
+      moreMenuButtonRef.current?.focus()
+    },
+    [closeMoreMenu]
   )
 
   const updateMoreMenuPosition = useCallback(() => {
@@ -346,12 +362,12 @@ export function MobileChatInputControls({
         return
       }
       if (isOwnedPopoverTarget(target)) return
-      setMoreMenuOpen(false)
+      closeMoreMenu()
     }
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape' || event.defaultPrevented || isOwnedPopoverTarget(event.target))
         return
-      setMoreMenuOpen(false)
+      closeMoreMenu()
     }
 
     document.addEventListener('pointerdown', handlePointerDown)
@@ -360,7 +376,7 @@ export function MobileChatInputControls({
       document.removeEventListener('pointerdown', handlePointerDown)
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [moreMenuOpen])
+  }, [closeMoreMenu, moreMenuOpen])
 
   // Render send button based on state
   const renderSendButton = () => {
@@ -477,7 +493,13 @@ export function MobileChatInputControls({
           aria-label="More actions"
           data-testid="mobile-input-more-actions-button"
           title="More actions"
-          onClick={() => setMoreMenuOpen(open => !open)}
+          onClick={() => {
+            if (moreMenuOpen) {
+              closeMoreMenu()
+              return
+            }
+            setMoreMenuOpen(true)
+          }}
           className="h-8 w-8 p-0 rounded-full border border-border bg-base text-text-muted hover:text-text-primary hover:bg-hover"
         >
           <Plus className="h-4 w-4" />
@@ -487,7 +509,7 @@ export function MobileChatInputControls({
           <div
             ref={moreMenuRef}
             data-testid="mobile-input-more-actions-menu"
-            className="fixed z-50 w-56 overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+            className={`fixed z-50 w-56 overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md ${contextSelectorOpen ? 'invisible pointer-events-none' : ''}`}
             style={moreMenuStyle}
           >
             {hasSecondaryActions && (
@@ -524,6 +546,7 @@ export function MobileChatInputControls({
                     onContextsChange={setSelectedContexts}
                     excludeKnowledgeBaseId={knowledgeBaseId}
                     triggerVariant="menu-item"
+                    onSelectorOpenChange={handleContextSelectorOpenChange}
                   />
                 )}
                 {showSkillAction && onToggleSkill && (

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -10,6 +10,8 @@
   "document_count": "{{count}} document",
   "documents_count": "{{count}} documents",
   "picker": {
+    "selectContent": "Select content",
+    "selectedCount": "{{count}} selected",
     "columns": {
       "sources": "Primary Group",
       "knowledgeBases": "Secondary Group"
@@ -35,6 +37,10 @@
     "loading": "Loading knowledge bases...",
     "loadingDocuments": "Loading documents...",
     "retry": "Retry",
+    "selectGroup": "Select a group",
+    "selectCategory": "Select a content type",
+    "selectScope": "Select a scope",
+    "changeSelection": "Change {{name}}",
     "empty": "No content",
     "emptyGroups": "No groups",
     "emptyKnowledgeBases": "No knowledge bases",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -10,6 +10,8 @@
   "document_count": "{{count}} 篇文档",
   "documents_count": "{{count}} 篇文档",
   "picker": {
+    "selectContent": "选择内容",
+    "selectedCount": "已选择 {{count}} 项",
     "columns": {
       "sources": "一级分组",
       "knowledgeBases": "二级分组"
@@ -35,6 +37,10 @@
     "loading": "加载知识库中...",
     "loadingDocuments": "加载文档中...",
     "retry": "重试",
+    "selectGroup": "选择群组",
+    "selectCategory": "选择内容类型",
+    "selectScope": "选择范围",
+    "changeSelection": "更换{{name}}",
     "empty": "暂无内容",
     "emptyGroups": "暂无群组",
     "emptyKnowledgeBases": "暂无知识库",


### PR DESCRIPTION
## Summary

- adapt the chat context selector and knowledge source picker for mobile and tablet layouts
- move nested group and external-source browsing into a clearer drill-down flow while preserving all existing selection capabilities
- keep the desktop three-column experience unchanged and improve mobile touch targets, scrolling, and drawer sizing
- cover responsive layout, selection behavior, scrolling, and external-provider rendering with focused tests

## Verification

- pre-push ESLint: passed
- pre-push TypeScript: passed
- chat-core unit tests: 130 passed
- frontend unit tests: 1976 total (1975 passed, 1 existing todo)
- focused responsive and knowledge-picker tests: 39 passed
- translation consistency check: passed

## Scope

UI/UX and test changes only; no backend, API, data-model, or feature removal changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive knowledge and context selection experiences for mobile and desktop layouts.
  * Added mobile drill-down navigation for groups, categories, scopes, knowledge bases, and documents.
  * Added clearer selection counts, navigation controls, and completion actions.
  * Added customizable drawer handles and overlays.
* **Bug Fixes**
  * Improved mobile chat controls when switching between menus and context selection.
  * Adjusted responsive sizing for knowledge selection controls.
  * Improved handling of knowledge bases without individual document listings.
* **Localization**
  * Added English and Simplified Chinese translations for picker actions and selection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->