### PR TITLE
fix(wework): install Electron dependencies before desktop commands

### DIFF
--- a/wework/package.json
+++ b/wework/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:desktop": "pnpm --dir electron dev",
+    "prepare:electron": "pnpm --dir electron install --frozen-lockfile",
+    "dev:desktop": "pnpm run prepare:electron && pnpm --dir electron dev",
     "dev:mac": "pnpm run dev:desktop",
     "dev:windows": "pnpm run dev:desktop",
     "prepare:codex": "node scripts/prepare-codex-binary.mjs",
@@ -38,7 +39,7 @@
     "e2e:desktop:local-terminal": "WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/local-terminal.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "e2e:desktop:streaming-text": "WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/streaming-text.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "ai:verify": "node scripts/ai-verify.mjs",
-    "ai:verify:electron:build": "VITE_WEWORK_E2E=true VITE_WEWORK_RELEASE_CHANNEL=stable VITE_WEWORK_RUNTIME_MODE=local-first pnpm run build:dsh-app && VITE_WEWORK_E2E=true VITE_WEWORK_RELEASE_CHANNEL=stable VITE_WEWORK_RUNTIME_MODE=local-first pnpm --dir electron build:package",
+    "ai:verify:electron:build": "pnpm run prepare:electron && VITE_WEWORK_E2E=true VITE_WEWORK_RELEASE_CHANNEL=stable VITE_WEWORK_RUNTIME_MODE=local-first pnpm run build:dsh-app && VITE_WEWORK_E2E=true VITE_WEWORK_RELEASE_CHANNEL=stable VITE_WEWORK_RUNTIME_MODE=local-first pnpm --dir electron build:package",
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -16,6 +16,16 @@ const scripts = [
 ]
 
 describe('desktop resource migration', () => {
+  test('desktop entrypoints install the isolated Electron workspace', async () => {
+    const packageJson = JSON.parse(await readFile(join(weworkRoot, 'package.json'), 'utf8'))
+
+    expect(packageJson.scripts['prepare:electron']).toBe(
+      'pnpm --dir electron install --frozen-lockfile'
+    )
+    expect(packageJson.scripts['dev:desktop']).toContain('pnpm run prepare:electron')
+    expect(packageJson.scripts['ai:verify:electron:build']).toContain('pnpm run prepare:electron')
+  })
+
   test.each(scripts)('%s depends only on neutral desktop resources', async relativePath => {
     const source = await readFile(join(weworkRoot, relativePath), 'utf8')
 


### PR DESCRIPTION
## Summary

- install the isolated `wework/electron` workspace before desktop development starts
- apply the same preparation to packaged Electron verification builds
- add regression coverage for the desktop entrypoint contract

## Verification

- `pnpm --filter wework test scripts/desktop-resource-migration.test.mjs`
- `pnpm --filter wework exec prettier --check package.json scripts/desktop-resource-migration.test.mjs`
- `pnpm --dir wework/electron build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Desktop development and packaging workflows now reliably install the required Electron components before running, improving setup consistency and reducing verification failures.

- **Tests**
  - Added automated coverage to confirm desktop development and build verification use the correct dependency setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->