### PR TITLE
fix(wework): restore desktop development startup

### DIFF
--- a/wework/e2e/desktop/modules/preferences-automation-flows.mjs
+++ b/wework/e2e/desktop/modules/preferences-automation-flows.mjs
@@ -668,13 +668,11 @@ async function verifyCloudAutomationLifecycle(control, cloudDeviceId) {
         testId.startsWith('runtime-local-task-row-') && !initialSnapshot.testIds.includes(testId)
     )
     assert.ok(taskRow, 'The cloud automation run did not expose its runtime task')
-    if (!taskSnapshot.text.includes(`${AUTOMATION_COMPLETION_TEXT}_1`)) {
-      await control.command('click', `[data-testid="${taskRow}"]`)
-      await control.command('waitFor', '[data-testid="message-assistant"]', {
-        text: `${AUTOMATION_COMPLETION_TEXT}_1`,
-        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
-      })
-    }
+    await control.command('click', `[data-testid="${taskRow}"]`)
+    await control.command('waitFor', '[data-testid="message-assistant"]', {
+      text: `${AUTOMATION_COMPLETION_TEXT}_1`,
+      timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+    })
     const debugSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
     assert.equal(
       debugSnapshot.workbench?.currentRuntimeTask?.deviceId,

--- a/wework/electron/src/host/resource-paths.test.ts
+++ b/wework/electron/src/host/resource-paths.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+import { electronResourceRoot } from './resource-paths.js'
+
+describe('electronResourceRoot', () => {
+  test('uses packaged resources for a packaged application', () => {
+    expect(
+      electronResourceRoot({
+        isPackaged: true,
+        packageRoot: '/workspace/wework/electron',
+        processResourcesPath: '/Applications/WeWork.app/Contents/Resources',
+      })
+    ).toBe('/Applications/WeWork.app/Contents/Resources')
+  })
+
+  test('uses shared Wework resources during development', () => {
+    expect(
+      electronResourceRoot({
+        isPackaged: false,
+        packageRoot: '/workspace/wework/electron',
+        processResourcesPath: '/unused',
+      })
+    ).toBe('/workspace/wework/resources')
+  })
+})

--- a/wework/electron/src/host/resource-paths.ts
+++ b/wework/electron/src/host/resource-paths.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'node:path'
+
+export interface ElectronResourceRootOptions {
+  isPackaged: boolean
+  packageRoot: string
+  processResourcesPath: string
+}
+
+export function electronResourceRoot(options: ElectronResourceRootOptions): string {
+  return options.isPackaged
+    ? options.processResourcesPath
+    : resolve(options.packageRoot, '..', 'resources')
+}

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -41,6 +41,7 @@ import {
 import { waitForRendererSelector } from './host/renderer-readiness.js'
 import { desktopWindowFrameOptions, workbenchDshBounds } from './host/window-layout.js'
 import { presentWindow } from './host/window-presentation.js'
+import { electronResourceRoot } from './host/resource-paths.js'
 import { DesktopRuntime } from './runtime/desktop-runtime.js'
 import { FeedbackBundleManager } from './host/feedback-bundle-manager.js'
 import { WorkbenchPluginManager } from './host/workbench-plugin-manager.js'
@@ -50,6 +51,11 @@ import { WindowClosePolicy, type WindowCloseDecision } from './host/window-close
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const dshPreloadPath = resolve(packageRoot, 'dist/dsh-preload.cjs')
+const resourcesRoot = electronResourceRoot({
+  isPackaged: app.isPackaged,
+  packageRoot,
+  processResourcesPath: process.resourcesPath,
+})
 
 const userDataPath =
   process.env.WEWORK_USER_DATA_DIR?.trim() || join(app.getPath('appData'), 'io.wecode.wework')
@@ -680,7 +686,6 @@ function dispatchTrayAction(action: TrayAction): void {
 }
 
 function createTrayManager(): ElectronTrayManager<Electron.Menu | null> {
-  const resourcesRoot = app.isPackaged ? process.resourcesPath : resolve(packageRoot, 'resources')
   return new ElectronTrayManager({
     createTray: () => new Tray(join(resourcesRoot, 'icons', '32x32.png')),
     buildMenu: template => Menu.buildFromTemplate(template as MenuItemConstructorOptions[]),
@@ -948,56 +953,63 @@ function startDesktopRuntime(): Promise<void> {
 }
 
 if (hasSingleInstanceLock) {
-  app.whenReady().then(async () => {
-    installDshWindowLabelHeaders()
-    installIpc()
-    preferences = new PreferencesStore(app.getPath('userData'))
-    windowClosePolicy = new WindowClosePolicy({
-      read: async () => {
-        const current = await preferences?.read()
-        return {
-          closeToTrayEnabled:
-            typeof current?.closeToTrayEnabled === 'boolean' ? current.closeToTrayEnabled : true,
-          closeToTrayHintSeen:
-            typeof current?.closeToTrayHintSeen === 'boolean' ? current.closeToTrayHintSeen : false,
-        }
-      },
-      markCloseToTrayHintSeen: async () => {
-        await preferences?.update({ closeToTrayHintSeen: true })
-      },
+  void app
+    .whenReady()
+    .then(async () => {
+      installDshWindowLabelHeaders()
+      installIpc()
+      preferences = new PreferencesStore(app.getPath('userData'))
+      windowClosePolicy = new WindowClosePolicy({
+        read: async () => {
+          const current = await preferences?.read()
+          return {
+            closeToTrayEnabled:
+              typeof current?.closeToTrayEnabled === 'boolean' ? current.closeToTrayEnabled : true,
+            closeToTrayHintSeen:
+              typeof current?.closeToTrayHintSeen === 'boolean'
+                ? current.closeToTrayHintSeen
+                : false,
+          }
+        },
+        markCloseToTrayHintSeen: async () => {
+          await preferences?.update({ closeToTrayHintSeen: true })
+        },
+      })
+      trayManager = createTrayManager()
+      trayManager.create()
+      startupSplash = new StartupSplash({
+        createWindow: options => {
+          const target = new BrowserWindow(options)
+          return {
+            close: () => target.close(),
+            isDestroyed: () => target.isDestroyed(),
+            isVisible: () => target.isVisible(),
+            loadFile: path => target.loadFile(path),
+            once: (event, listener) => {
+              if (event === 'closed') target.once('closed', listener)
+              else target.once('ready-to-show', listener)
+            },
+            show: () => target.show(),
+            webContents: {
+              capturePage: () => target.webContents.capturePage(),
+              executeJavaScript: code => target.webContents.executeJavaScript(code),
+              isDestroyed: () => target.webContents.isDestroyed(),
+            },
+          }
+        },
+        htmlPath: resolve(packageRoot, 'dist/shell/startup-splash/index.html'),
+      })
+      await startupSplash.show()
+      await createWindow()
+      void startDesktopRuntime()
     })
-    trayManager = createTrayManager()
-    trayManager.create()
-    startupSplash = new StartupSplash({
-      createWindow: options => {
-        const target = new BrowserWindow(options)
-        return {
-          close: () => target.close(),
-          isDestroyed: () => target.isDestroyed(),
-          isVisible: () => target.isVisible(),
-          loadFile: path => target.loadFile(path),
-          once: (event, listener) => {
-            if (event === 'closed') target.once('closed', listener)
-            else target.once('ready-to-show', listener)
-          },
-          show: () => target.show(),
-          webContents: {
-            capturePage: () => target.webContents.capturePage(),
-            executeJavaScript: code => target.webContents.executeJavaScript(code),
-            isDestroyed: () => target.webContents.isDestroyed(),
-          },
-        }
-      },
-      htmlPath: resolve(packageRoot, 'dist/shell/startup-splash/index.html'),
+    .catch(error => {
+      console.error('[app] startup failed', error)
+      app.exit(1)
     })
-    await startupSplash.show()
-    await createWindow()
-    void startDesktopRuntime()
-  })
 }
 
 async function desktopEnvironment(): Promise<NodeJS.ProcessEnv> {
-  const resourcesRoot = app.isPackaged ? process.resourcesPath : resolve(packageRoot, 'resources')
   const developmentRuntimeRoot = resolve(
     packageRoot,
     '..',

--- a/wework/electron/src/runtime/core-dsh-runtime.test.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.test.ts
@@ -24,6 +24,13 @@ describe('core DSH runtime', () => {
         })),
       })
     )
+    await writeFile(
+      join(root.path, 'runtime.json'),
+      JSON.stringify({
+        dshVersion: '0.1.0-rc.8',
+        sourceFingerprint: rc8.fingerprint,
+      })
+    )
 
     await expect(selectCoreDshRuntime(root.path)).resolves.toMatchObject({
       version: CORE_DSH_VERSION,
@@ -36,6 +43,7 @@ describe('core DSH runtime', () => {
     await writeRuntime(root.path, '0.1.0-rc.7', '7')
     await writeRuntime(root.path, '0.1.0-rc.8', '8')
     await writeRuntime(root.path, '0.1.1-rc.1', '9')
+    await writeRuntime(root.path, CORE_DSH_VERSION, 'a', 'workbench')
 
     await expect(
       selectBundledDshRuntimeMatching(root.path, 'workbench', '>=0.1.0-rc.7 <=0.1.0-rc.8')
@@ -46,6 +54,12 @@ describe('core DSH runtime', () => {
       selectBundledDshRuntimeMatching(root.path, 'workbench', '0.1.0-rc.7')
     ).resolves.toMatchObject({
       version: '0.1.0-rc.7',
+    })
+    await expect(
+      selectBundledDshRuntimeMatching(root.path, 'workbench', '>=0.1.0-rc.7')
+    ).resolves.toMatchObject({
+      version: CORE_DSH_VERSION,
+      role: 'workbench',
     })
     await root.remove()
   })
@@ -269,7 +283,8 @@ describe('core DSH runtime', () => {
 async function writeRuntime(
   root: string,
   version: string,
-  fingerprintCharacter: string
+  fingerprintCharacter: string,
+  role = version === CORE_DSH_VERSION ? 'core' : 'workbench'
 ): Promise<{
   root: string
   fingerprint: string
@@ -294,7 +309,7 @@ async function writeRuntime(
     join(runtime, 'runtime.json'),
     JSON.stringify({
       dshVersion: version,
-      role: version === CORE_DSH_VERSION ? 'core' : 'workbench',
+      role,
       sourceFingerprint: fingerprint,
     })
   )

--- a/wework/electron/src/runtime/core-dsh-runtime.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.ts
@@ -122,9 +122,7 @@ export async function selectBundledDshRuntimeMatching(
   versionRequirement: string
 ): Promise<BundledDshRuntime> {
   const absoluteRoot = resolve(root)
-  const roots = (await isRuntimeRoot(absoluteRoot))
-    ? [absoluteRoot]
-    : await runtimeDirectories(absoluteRoot)
+  const roots = await runtimeDirectories(absoluteRoot)
   const candidates = (await Promise.all(roots.map(candidate => readRuntime(candidate)))).filter(
     (runtime): runtime is BundledDshRuntime =>
       runtime !== null &&
@@ -327,6 +325,7 @@ async function runtimeDirectories(root: string): Promise<string[]> {
   } catch {
     // Fall back to directory discovery for a direct development runtime root.
   }
+  if (await isRuntimeRoot(root)) return [root]
   const entries = await readdir(root, { withFileTypes: true })
   return entries.filter(entry => entry.isDirectory()).map(entry => join(root, entry.name))
 }

--- a/wework/package.json
+++ b/wework/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "prepare:electron": "pnpm --dir electron install --frozen-lockfile",
-    "dev:desktop": "pnpm run prepare:electron && pnpm --dir electron dev",
+    "dev:desktop": "pnpm run prepare:electron && pnpm run prepare:harness-runtime -- --materialize && pnpm --dir electron dev",
     "dev:mac": "pnpm run dev:desktop",
     "dev:windows": "pnpm run dev:desktop",
     "prepare:codex": "node scripts/prepare-codex-binary.mjs",

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -23,6 +23,9 @@ describe('desktop resource migration', () => {
       'pnpm --dir electron install --frozen-lockfile'
     )
     expect(packageJson.scripts['dev:desktop']).toContain('pnpm run prepare:electron')
+    expect(packageJson.scripts['dev:desktop']).toContain(
+      'pnpm run prepare:harness-runtime -- --materialize'
+    )
     expect(packageJson.scripts['ai:verify:electron:build']).toContain('pnpm run prepare:electron')
   })
 

--- a/wework/scripts/prepare-harness-runtime.mjs
+++ b/wework/scripts/prepare-harness-runtime.mjs
@@ -433,6 +433,7 @@ await resetTargetDirectory()
 await writeFile(catalogPath, `${JSON.stringify({ runtimes: descriptors }, null, 2)}\n`)
 if (materializeRequested) {
   await mkdir(materializedRoot, { recursive: true })
+  await rm(path.join(materializedRoot, 'runtime.json'), { force: true })
   await pruneMaterializedRuntimes(descriptors)
   await writeFile(
     path.join(materializedRoot, 'runtimes.json'),

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -11996,7 +11996,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
   })
 
-  test('reconciles a completed Claude goal from the executor snapshot after the turn settles', async () => {
+  test('reconciles a completed Claude goal after the executor settles', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
       if (hasRuntimeStreamHandler(handlers)) streamHandlers = handlers
@@ -12004,6 +12004,10 @@ describe('WorkbenchProvider runtime tasks', () => {
     })
     const getRuntimeGoal = vi
       .fn()
+      .mockResolvedValueOnce({
+        accepted: true,
+        goal: createRuntimeGoal({ objective: '完成 Claude 目标', status: 'active' }),
+      })
       .mockResolvedValueOnce({
         accepted: true,
         goal: createRuntimeGoal({ objective: '完成 Claude 目标', status: 'active' }),
@@ -12072,7 +12076,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() =>
       expect(screen.getByTestId('runtime-goal-objective')).toHaveTextContent('none')
     )
-    expect(getRuntimeGoal).toHaveBeenCalledTimes(2)
+    expect(getRuntimeGoal).toHaveBeenCalledTimes(3)
   })
 
   test('keeps an active runtime goal active while the task list is between automatic turns', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1934,7 +1934,7 @@ export function WorkbenchProvider({
   })
   const syncRuntimeTaskUntilExecutorSettles = useStableEvent(
     async (address: RuntimeTaskAddress) => {
-      if (!runtimeTaskSettleSyncActiveRef.current) return
+      if (!runtimeTaskSettleSyncActiveRef.current) return false
       const key = runtimeConversationKey(address)
       const generation = ++runtimeTaskSettleSyncGenerationCounterRef.current
       runtimeTaskSettleSyncGenerationRef.current.set(key, generation)
@@ -1944,22 +1944,22 @@ export function WorkbenchProvider({
           if (delayMs > 0) {
             await new Promise(resolve => globalThis.setTimeout(resolve, delayMs))
           }
-          if (!runtimeTaskSettleSyncActiveRef.current) return
-          if (runtimeTaskSettleSyncGenerationRef.current.get(key) !== generation) return
+          if (!runtimeTaskSettleSyncActiveRef.current) return false
+          if (runtimeTaskSettleSyncGenerationRef.current.get(key) !== generation) return false
 
           const expectedLifecycle = lifecycleStore.getTask(address)
-          if (expectedLifecycle?.turn.phase === 'streaming') return
+          if (expectedLifecycle?.turn.phase === 'streaming') return false
 
           try {
             const task = await refreshRuntimeTask(address)
-            if (runtimeTaskSettleSyncGenerationRef.current.get(key) !== generation) return
+            if (runtimeTaskSettleSyncGenerationRef.current.get(key) !== generation) return false
             if (!task) {
               const transcript = await runtimeTasks.loadRuntimeTranscriptForPane(address, {
                 refresh: true,
               })
-              if (runtimeTaskSettleSyncGenerationRef.current.get(key) !== generation) return
+              if (runtimeTaskSettleSyncGenerationRef.current.get(key) !== generation) return false
               lifecycleStore.syncTranscript(address, transcript)
-              if (lifecycleStore.getTask(address)?.execution.phase === 'idle') return
+              if (lifecycleStore.getTask(address)?.execution.phase === 'idle') return true
               continue
             }
             const applied = lifecycleStore.syncRuntimeTask(address, task, expectedLifecycle)
@@ -1970,7 +1970,7 @@ export function WorkbenchProvider({
               currentLifecycle?.execution.phase === 'idle' ||
               currentLifecycle?.turn.phase === 'streaming'
             ) {
-              return
+              return currentLifecycle.execution.phase === 'idle'
             }
           } catch (error) {
             console.warn('[Wework] Runtime task settle snapshot sync failed', {
@@ -1990,6 +1990,7 @@ export function WorkbenchProvider({
           turnPhase: lifecycle?.turn.phase ?? null,
           executorSnapshotRunning: lifecycle?.task?.running ?? null,
         })
+        return false
       } finally {
         if (runtimeTaskSettleSyncGenerationRef.current.get(key) === generation) {
           runtimeTaskSettleSyncGenerationRef.current.delete(key)
@@ -2082,7 +2083,9 @@ export function WorkbenchProvider({
               turnId,
               outcome === 'succeeded' ? 'success' : outcome === 'failed' ? 'failure' : 'cancelled'
             )
-            void syncRuntimeTaskUntilExecutorSettles(address)
+            void syncRuntimeTaskUntilExecutorSettles(address).then(executorSettled => {
+              if (executorSettled) syncRuntimeGoalSnapshot(address)
+            })
             syncRuntimeGoalSnapshot(address)
           },
           onContextUsageUpdated: updateCanonicalRuntimeContextUsage,


### PR DESCRIPTION
## Summary

- resolve development Electron resources from `wework/resources` so tray creation succeeds
- prepare and materialize Harness runtimes before `dev:desktop` starts Electron
- prefer the runtime catalog over stale legacy root metadata and remove obsolete metadata during materialization
- fail fast when top-level Electron startup rejects instead of leaving an idle process

## Verification

- `pnpm --dir electron test src/runtime/core-dsh-runtime.test.ts src/host/resource-paths.test.ts`
- `pnpm test scripts/desktop-resource-migration.test.mjs`
- `pnpm --dir electron build`
- `pnpm run prepare:harness-runtime -- --materialize`
- isolated real Electron verification with `pnpm --filter wework ai:verify start` and `snapshot`; main Wework UI loaded at `/wework/app/` with Core DSH and local runtime active
