### PR TITLE
fix(wework): accelerate Electron startup

### DIFF
--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -598,6 +598,7 @@ async function createWindow(): Promise<void> {
     primaryDshSecurityInstalled = false
     mainWindow = null
   })
+  await mainWindow.loadFile(resolve(packageRoot, 'dist/shell/index.html'))
 }
 
 async function setDockVisible(visible: boolean): Promise<void> {
@@ -939,6 +940,10 @@ function startDesktopRuntime(): Promise<void> {
       runtimePhase = 'failed'
       runtimeError = error instanceof Error ? error.message : String(error)
       console.error('[runtime] startup failed', error)
+      mainWindow?.show()
+      void startupSplash?.close().catch(splashError => {
+        console.error('[startup-splash] failed to close after runtime failure', splashError)
+      })
     })
     .finally(() => {
       runtimeStartPromise = null
@@ -990,8 +995,7 @@ if (hasSingleInstanceLock) {
       },
       htmlPath: resolve(packageRoot, 'dist/shell/startup-splash/index.html'),
     })
-    await startupSplash.show()
-    await createWindow()
+    await Promise.all([startupSplash.show(), createWindow()])
     void startDesktopRuntime()
   })
 }

--- a/wework/electron/src/runtime/bundled-runtime-materializer.ts
+++ b/wework/electron/src/runtime/bundled-runtime-materializer.ts
@@ -1,7 +1,7 @@
+import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-import * as tar from 'tar'
 
 interface RuntimeDescriptor {
   dshVersion: string
@@ -77,7 +77,7 @@ async function materializeRuntime(
   await rm(temporary, { recursive: true, force: true })
   await mkdir(temporary, { recursive: true, mode: 0o700 })
   try {
-    await tar.x({ file: archive, cwd: temporary })
+    await extractArchive(archive, temporary)
     if (!(await runtimeMatches(temporary, runtime))) {
       throw new Error(`Bundled DSH runtime identity is invalid: ${runtime.assetName}`)
     }
@@ -86,6 +86,27 @@ async function materializeRuntime(
   } finally {
     await rm(temporary, { recursive: true, force: true })
   }
+}
+
+function extractArchive(archive: string, destination: string): Promise<void> {
+  return new Promise((resolveExtraction, rejectExtraction) => {
+    const child = spawn('tar', ['-xzf', archive, '-C', destination], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+    const stderr: Buffer[] = []
+    child.stderr.on('data', chunk => stderr.push(Buffer.from(chunk)))
+    child.once('error', rejectExtraction)
+    child.once('close', code => {
+      if (code === 0) {
+        resolveExtraction()
+        return
+      }
+      const detail = Buffer.concat(stderr).toString('utf8').trim()
+      rejectExtraction(
+        new Error(`Bundled DSH runtime extraction failed (${code ?? 'signal'}): ${detail}`)
+      )
+    })
+  })
 }
 
 async function runtimeMatches(root: string, runtime: RuntimeDescriptor): Promise<boolean> {

--- a/wework/scripts/prepare-harness-runtime.mjs
+++ b/wework/scripts/prepare-harness-runtime.mjs
@@ -1,6 +1,16 @@
 import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
-import { access, cp, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  access,
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
 import path from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -2459,7 +2459,9 @@ export function useWorkbenchPaneSession({
       setError('当前对话还没有可压缩的 Codex 线程')
       return false
     }
-    if (paneStatus.isBusy) {
+    const currentTaskIsBusy =
+      lifecycleStore.getTask(currentRuntimeTask)?.derived.isBusy ?? paneStatus.isBusy
+    if (currentTaskIsBusy) {
       setError('当前回复进行中，完成后再压缩上下文')
       return false
     }
@@ -2467,7 +2469,14 @@ export function useWorkbenchPaneSession({
       return send('/compact')
     }
     return compactRuntimePaneTask(currentRuntimeTask, { onError: setError })
-  }, [compactRuntimePaneTask, currentRuntimeTask, paneStatus.isBusy, send, setError])
+  }, [
+    compactRuntimePaneTask,
+    currentRuntimeTask,
+    lifecycleStore,
+    paneStatus.isBusy,
+    send,
+    setError,
+  ])
 
   const setCurrentGoal = useCallback(async () => {
     projectChat.setSelectedModelOption('collaborationMode', 'default')

--- a/wework/src/components/topnav/AppIframe.test.tsx
+++ b/wework/src/components/topnav/AppIframe.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { AppIframe } from './AppIframe'
 
@@ -364,5 +364,48 @@ describe('AppIframe', () => {
       )
     )
     boundsSpy.mockRestore()
+  })
+
+  test('does not reveal a reduced-motion native webview after cleanup', async () => {
+    runtimeMocks.isDesktopRuntime.mockReturnValue(true)
+    const frames: FrameRequestCallback[] = []
+    const frameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => frames.push(callback))
+    const mediaSpy = vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+    } as MediaQueryList)
+    const boundsSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 620,
+      height: 600,
+      left: 10,
+      right: 810,
+      top: 20,
+      width: 800,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    const { unmount } = render(
+      <AppIframe
+        appKey="wegent"
+        src="http://localhost:3000"
+        title="Wegent"
+        workspaceTabId="agent-reduced-motion"
+      />
+    )
+    await waitFor(() => expect(frames).toHaveLength(1))
+
+    act(() => frames.shift()?.(performance.now()))
+    expect(frames).toHaveLength(1)
+    const callsBeforeCleanup = embeddedBrowserMocks.setEmbeddedBrowserBounds.mock.calls.length
+
+    unmount()
+    act(() => frames.shift()?.(performance.now()))
+
+    expect(embeddedBrowserMocks.setEmbeddedBrowserBounds).toHaveBeenCalledTimes(callsBeforeCleanup)
+    boundsSpy.mockRestore()
+    mediaSpy.mockRestore()
+    frameSpy.mockRestore()
   })
 })

--- a/wework/src/components/topnav/AppIframe.tsx
+++ b/wework/src/components/topnav/AppIframe.tsx
@@ -123,6 +123,7 @@ export function AppIframe({
       window.requestAnimationFrame(() => {
         const bounds = hostRef.current ? elementBounds(hostRef.current) : null
         if (!bounds || !activeRef.current) return
+        if (revealGenerationRef.current !== generation) return
         if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
           void setEmbeddedBrowserBounds(bounds, true, label).catch(error => {
             console.error('Failed to reveal app webview:', error)

--- a/wework/src/components/topnav/AppIframe.tsx
+++ b/wework/src/components/topnav/AppIframe.tsx
@@ -291,6 +291,7 @@ export function AppIframe({
     lifecycleGenerationRef.current = generation
 
     return () => {
+      revealGenerationRef.current += 1
       window.setTimeout(() => {
         if (lifecycleGenerationRef.current !== generation) return
 

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -1271,6 +1271,52 @@ describe('runtimeConversationTurns', () => {
     ])
   })
 
+  test('matches duplicate completed assistant text one-to-one', () => {
+    const content = 'Repeated completion'
+    const local: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [
+          {
+            id: 'live-message-1',
+            type: 'assistant_text',
+            content,
+            createdAt: '2026-08-01T00:00:00.000Z',
+          },
+          {
+            id: 'live-message-2',
+            type: 'assistant_text',
+            content,
+            createdAt: '2026-08-01T00:00:01.000Z',
+          },
+        ],
+        status: 'done',
+      },
+    ]
+    const snapshot: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [
+          {
+            id: 'snapshot-message-1',
+            type: 'assistant_text',
+            content,
+            createdAt: '2026-08-01T00:00:00.000Z',
+          },
+        ],
+        status: 'done',
+      },
+    ]
+
+    const merged = mergeRuntimeConversationTurns(local, snapshot)
+
+    expect(merged[0].items).toHaveLength(2)
+    expect(merged[0].items.map(item => item.id)).toEqual(['live-message-2', 'snapshot-message-1'])
+    expect(projectRuntimeConversationTurns(merged).map(message => message.content)).toEqual([
+      `${content}\n\n${content}`,
+    ])
+  })
+
   test('keeps realtime tail items temporarily missing from a full Codex snapshot', () => {
     const local: RuntimeConversationTurn[] = [
       {

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -1667,6 +1667,49 @@ describe('runtimeConversationTurns', () => {
     expect(merged[0].status).toBe('done')
   })
 
+  test('keeps a transcript assistant item when a completed text block races the snapshot', () => {
+    const content = 'Initial goal turn complete'
+    const assistantItem = {
+      id: 'message-1',
+      type: 'assistant_text' as const,
+      content,
+      createdAt: '2026-08-25T07:49:01.000Z',
+    }
+    let turns: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [assistantItem],
+        status: 'streaming',
+      },
+    ]
+
+    turns = reduceRuntimeConversationTurns(turns, {
+      type: 'block_created',
+      subtaskId: 'turn-1',
+      block: {
+        id: assistantItem.id,
+        subtaskId: 'turn-1',
+        type: 'text',
+        processKind: 'assistant_message',
+        content,
+        status: 'done',
+        createdAt: Date.parse(assistantItem.createdAt),
+      },
+    })
+    turns = mergeRuntimeConversationTurns(turns, [
+      {
+        id: 'turn-1',
+        items: [assistantItem],
+        status: 'streaming',
+      },
+    ])
+
+    expect(turns[0].items).toEqual([assistantItem])
+    expect(projectRuntimeConversationTurns(turns).map(message => message.content)).toEqual([
+      content,
+    ])
+  })
+
   test('preserves the live tool start when a snapshot falls back to the turn start', () => {
     const localBlock: ProcessingBlock = {
       id: 'tool-1',

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -913,7 +913,10 @@ function upsertRuntimeBlock(
 
   const existingIndex = items.findIndex(item => item.id === block.id)
   if (existingIndex >= 0) {
-    if (items[existingIndex]?.type === 'assistant_text' && turnStatus === 'done') {
+    if (
+      items[existingIndex]?.type === 'assistant_text' &&
+      (turnStatus === 'done' || block.type === 'text')
+    ) {
       return items
     }
     return upsertBlocks(items, [block])


### PR DESCRIPTION
## Summary

- package DSH runtimes with self-contained pnpm links so packaged Electron builds can start outside the developer machine
- use native tar extraction for the first-run runtime materialization path
- create the splash and main window in parallel and show the startup shell when runtime startup fails
- reject external symbolic links while preparing bundled runtimes

## Root cause

The Electron migration archived pnpm node_modules containing links to the developer machine global virtual store. Those links were broken after installation, so the Core DSH runtime was rejected and the startup splash remained indefinitely. A self-contained archive fixed correctness, but JavaScript tar extraction of the 378 MB expanded runtime took about 58 seconds. Native tar reduces that step to about 13 seconds.

## Verification

- Electron unit tests: 35 files / 121 tests passed
- Wework script tests: 16 tests passed
- Electron typecheck, ESLint, Prettier, and git diff check passed
- native-window-startup desktop E2E passed with startup splash lifecycle evidence
- isolated cold start: previously timed out after 120 seconds; now ready in 15.5 seconds
- cached runtime materialization: 0.05 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop startup reliability and recovery when runtime startup fails.
  - Prevented stale webview animations after a view is closed or refreshed.
  - Improved workbench activity indicators during runtime tasks.
  - Prevented duplicate or missing assistant messages when conversation history updates.
  - Strengthened bundled runtime extraction and packaging reliability.

- **Tests**
  - Added coverage for conversation reconciliation, reduced-motion webviews, and cloud automation completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->