### PR TITLE
build(wework): add one-command release packaging

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -154,17 +154,11 @@ jobs:
       - name: Install Wework Electron dependencies
         run: pnpm --dir wework/electron install --frozen-lockfile
 
-      - name: Prepare bundled sidecars
-        working-directory: wework
-        run: |
-          pnpm run prepare:codex --materialize
-          pnpm run prepare:dws
-
       - name: Build Electron application
         env:
           VITE_WEGENT_BACKEND_URL: https://api.wecode.ai
           VITE_WEWORK_RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.channel }}
-        run: pnpm --filter wework ai:verify:electron:build
+        run: pnpm --filter wework build:release
 
       - name: Resolve packaged application
         id: package

--- a/wework/README.md
+++ b/wework/README.md
@@ -39,10 +39,7 @@ Prepare the bundled resources and build the Electron application for the
 current platform:
 
 ```bash
-pnpm --filter wework run prepare:codex --materialize
-pnpm --filter wework run prepare:dws
-pnpm --filter wework run prepare:harness-runtime --materialize
-pnpm --filter wework build:desktop
+pnpm --filter wework build:release
 ```
 
 GitHub releases are built by `.github/workflows/wework-app.yml`.

--- a/wework/package.json
+++ b/wework/package.json
@@ -16,6 +16,7 @@
     "build:dsh-app": "WEWORK_DSH_APP_OUT_DIR=$PWD/dsh/app-wework/web vite build",
     "build": "tsc -b && vite build",
     "build:desktop": "pnpm run ai:verify:electron:build",
+    "build:release": "pnpm run prepare:codex --materialize && pnpm run prepare:dws && pnpm run build:desktop",
     "build:mac": "pnpm run build:desktop",
     "build:windows": "pnpm run build:desktop",
     "build:mac:devtools": "WEWORK_RELEASE_DEVTOOLS=1 pnpm run build:desktop",

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -140,13 +140,13 @@ describe('bundled plugin resources', () => {
     expect(script).toContain("'--exclude=test-results'")
   })
 
-  test('uses the Electron packager in GitHub desktop releases', () => {
+  test('uses the shared release build command in GitHub desktop releases', () => {
     const workflow = readFileSync(
       resolve(process.cwd(), '../.github/workflows/wework-app.yml'),
       'utf8'
     )
 
-    expect(workflow).toContain('ai:verify:electron:build')
+    expect(workflow).toContain('pnpm --filter wework build:release')
   })
 
   test('publishes packaged Electron artifacts for all desktop platforms', () => {


### PR DESCRIPTION
## Summary

- add `pnpm --filter wework build:release` as the complete release packaging entry point
- prepare Codex and DWS sidecars before the existing desktop packaging flow
- make the GitHub release workflow reuse the same command
- simplify the Wework README to document the single command

## Verification

- `pnpm --filter wework exec prettier --check package.json README.md ../.github/workflows/wework-app.yml`
- `git diff --check`
- package script value checked with Node
- full release packaging not run locally because it is expensive and push/CI owns broader verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consolidated release-build command that prepares required resources and builds the desktop application in one step.

* **Documentation**
  * Updated desktop build instructions to use the new release-build command.

* **Chores**
  * Simplified the automated release workflow by using the consolidated build process.

* **Tests**
  * Updated release-build validation to reflect the streamlined workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->