### PR TITLE
fix(wework): copy user messages through desktop clipboard

### DIFF
--- a/executor/src/runtime_work/events.rs
+++ b/executor/src/runtime_work/events.rs
@@ -259,7 +259,10 @@ struct ProcessTextStream {
     process_kind: String,
     item_id: Option<String>,
     content: String,
+    emitted_content_len: usize,
 }
+
+const PROCESS_TEXT_UPDATE_MIN_CHARS: usize = 16;
 
 impl CodexNotificationEventMapper {
     pub(crate) fn map(
@@ -740,6 +743,16 @@ impl CodexNotificationEventMapper {
             process_text.accepts(block_type, process_kind, item_id.as_deref())
         }) {
             process_text.content.push_str(&delta);
+            if delta.len() == 1
+                && process_text
+                    .content
+                    .len()
+                    .saturating_sub(process_text.emitted_content_len)
+                    < PROCESS_TEXT_UPDATE_MIN_CHARS
+            {
+                return;
+            }
+            process_text.emitted_content_len = process_text.content.len();
             emit_response_event(
                 emit_context.event_tx,
                 emit_context.device_id,
@@ -772,6 +785,7 @@ impl CodexNotificationEventMapper {
             process_kind: process_kind.to_owned(),
             item_id: item_id.clone(),
             content: delta.clone(),
+            emitted_content_len: delta.len(),
         });
         emit_response_event(
             emit_context.event_tx,
@@ -2769,6 +2783,87 @@ mod tests {
         );
         assert_eq!(completed["payload"]["data"]["updates"]["status"], "done");
         assert!(event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn coalesces_dense_process_text_deltas_before_the_terminal_update() {
+        let (event_tx, mut event_rx) = broadcast::channel(256);
+        let request = ExecutionRequest {
+            task_id: "7".to_owned(),
+            subtask_id: "8".to_owned(),
+            ..ExecutionRequest::default()
+        };
+        let mut mapper = CodexNotificationEventMapper::default();
+
+        mapper.map(
+            &Some(event_tx.clone()),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "id": "msg-noisy",
+                        "type": "agentMessage",
+                        "phase": "final_answer",
+                        "text": ""
+                    }
+                }
+            }),
+        );
+        for _ in 0..2_200 {
+            mapper.map(
+                &Some(event_tx.clone()),
+                "device-1",
+                "local-1",
+                &request,
+                json!({
+                    "method": "item/agentMessage/delta",
+                    "params": {
+                        "itemId": "msg-noisy",
+                        "delta": "x"
+                    }
+                }),
+            );
+        }
+        mapper.map(
+            &Some(event_tx),
+            "device-1",
+            "local-1",
+            &request,
+            json!({
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "id": "msg-noisy",
+                        "type": "agentMessage",
+                        "phase": "final_answer",
+                        "text": "NOISY_COMPLETE"
+                    }
+                }
+            }),
+        );
+
+        let mut events = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            events.push(event);
+        }
+
+        assert!(
+            events.len() < 160,
+            "dense text deltas should not flood the desktop transport"
+        );
+        assert_eq!(events[0]["event"], "response.block.created");
+        let completed = events
+            .last()
+            .expect("terminal block update should be emitted");
+        assert_eq!(completed["event"], "response.block.updated");
+        assert_eq!(
+            completed["payload"]["data"]["updates"]["content"],
+            "NOISY_COMPLETE"
+        );
+        assert_eq!(completed["payload"]["data"]["updates"]["status"], "done");
     }
 
     #[test]

--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -1306,6 +1306,17 @@ async function verifyLastUserMessageEdit({ composerSelector, control }) {
     'hover',
     `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"] [data-testid="message-hover-region"]`
   )
+  await control.command('click', '[data-testid="copy-message-button"]')
+  assert.equal(
+    await control.command('getClipboardText', ''),
+    MESSAGE_EDIT_ORIGINAL_PROMPT,
+    'Clicking the user-message copy button did not copy the visible message text'
+  )
+
+  await control.command(
+    'hover',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-user"] [data-testid="message-hover-region"]`
+  )
   await control.command('waitFor', '[data-testid="edit-message-button"]', {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -4136,6 +4136,35 @@ describe('MessageList', () => {
     expect(screen.getByTestId('copy-message-icon')).toBeInTheDocument()
   })
 
+  test('uses the Electron host clipboard when the browser clipboard is unavailable', async () => {
+    runtimeMock.electron = true
+    desktopHostMock.invoke.mockResolvedValue(undefined)
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'electron-copy',
+            role: 'user',
+            content: '复制到系统剪贴板',
+            status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.pointerEnter(screen.getByTestId('message-hover-region'))
+    await userEvent.click(screen.getByTestId('copy-message-button'))
+
+    await waitFor(() =>
+      expect(desktopHostMock.invoke).toHaveBeenCalledWith('clipboard.writeText', {
+        text: '复制到系统剪贴板',
+      })
+    )
+    expect(await screen.findByTestId('copy-message-success-icon')).toBeInTheDocument()
+  })
+
   test('shows edit action only for the final completed user turn and submits edited text', async () => {
     const onEditLastUserMessage = vi.fn().mockResolvedValue(true)
     render(

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -50,6 +50,7 @@ import {
 import { openLocalFile } from '@/lib/local-terminal'
 import { getRecognizedLink } from '@/lib/link-preview'
 import { isDesktopRuntime, isElectronRuntime } from '@/lib/runtime-environment'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { splitRuntimeUserMessage, visibleRuntimeUserMessage } from '@/lib/runtime-user-message'
 import { ComposerLinkChip } from './ComposerLinkChip'
 import { ComposerTextarea } from './composer/ComposerTextarea'
@@ -967,22 +968,6 @@ function formatMessageTime(createdAt: string) {
   return `${date.getFullYear()}年${dateLabel} ${time}`
 }
 
-async function copyText(text: string) {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text)
-    return
-  }
-
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  textarea.style.position = 'fixed'
-  textarea.style.opacity = '0'
-  document.body.appendChild(textarea)
-  textarea.select()
-  document.execCommand('copy')
-  document.body.removeChild(textarea)
-}
-
 function UserMessage({
   message,
   onOpenWorkspaceFile,
@@ -1584,7 +1569,7 @@ function MessageHoverActions({
     if (event.detail > 0) {
       event.currentTarget.blur()
     }
-    void copyText(copyContent).then(() => {
+    void copyTextToClipboard(copyContent).then(() => {
       setCopied(true)
       resetCopiedAfterHideRef.current = false
     })

--- a/wework/src/lib/clipboard.ts
+++ b/wework/src/lib/clipboard.ts
@@ -1,17 +1,16 @@
 import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 import { isElectronRuntime } from '@/lib/runtime-environment'
-import { copyLocalExecutorDebugInfo } from '@/desktop/localExecutor'
 
 export async function copyTextToClipboard(text: string): Promise<void> {
   if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text)
-    return
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch (error) {
+      if (!isElectronRuntime()) throw error
+    }
   }
 
-  if (isElectronRuntime()) {
-    await copyLocalExecutorDebugInfo(text)
-    return
-  }
   if (isElectronRuntime()) {
     await invokeDesktopHost<void>('clipboard.writeText', { text })
     return


### PR DESCRIPTION
## Summary

- route chat message copy actions through the shared clipboard helper
- fall back to the Electron host clipboard when the browser Clipboard API is unavailable or rejects
- add unit coverage for the native Electron clipboard path
- extend the CI-covered `conversation-state` desktop E2E checkpoint to click the user-message copy button and assert the copied text
- coalesce dense single-character Codex text deltas so renderer/IPC updates do not delay terminal completion events

## CI failure root cause

The previous `Wework Desktop E2E (Core / shard 5)` failure was in `codex-notification-isolation`, not the clipboard assertion. The executor emitted a full accumulated `response.block.updated` snapshot for every one-character Codex delta (2,200 updates), flooding the desktop event path and delaying the final completion update until the checkpoint timed out. Dense single-character deltas are now emitted in bounded batches, while multi-character deltas and the final completed content retain their existing behavior.

## Verification

- `pnpm --filter wework typecheck`
- `pnpm --filter wework exec eslint src/lib/clipboard.ts src/components/chat/MessageList.tsx src/components/chat/MessageList.test.tsx e2e/desktop/modules/conversation-navigation.mjs`
- `pnpm --filter wework test -- --run src/components/chat/MessageList.test.tsx` (143 tests passed)
- `cargo fmt --check --manifest-path executor/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml --lib runtime_work::events::tests` (50 tests passed)
- desktop E2E `codex-notification-isolation` checkpoint (passed)
- desktop E2E `conversation-state` checkpoint including the clipboard assertion (passed)
- repository pre-push quality checks, including Executor library tests and Clippy (passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Reduced excessive intermediate updates while streaming text, resulting in smoother response rendering while preserving the final content.
  - Improved message copying in the desktop app by providing a reliable fallback when browser clipboard access is unavailable.

- **Bug Fixes**
  - Copying user messages now consistently displays the successful copy state in desktop environments.
  - Added verification that copied text remains correct during message editing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->