### PR TITLE
fix(wework): support native image and text context menus

### DIFF
--- a/wework/dsh/executor-runtime/executor-http.test.mjs
+++ b/wework/dsh/executor-runtime/executor-http.test.mjs
@@ -52,6 +52,50 @@ test('disconnects an SSE slow consumer instead of buffering indefinitely', async
   assert.equal(listened, false)
 })
 
+test('stops replaying events after disconnecting an SSE slow consumer', async () => {
+  const request = executorEventRequest()
+  const response = responseFixture({ writable: false, throwAfterEnd: true })
+  const client = {
+    replay() {
+      return [executorEvent(1), executorEvent(2)]
+    },
+    listen() {
+      assert.fail('slow replay consumers must not subscribe to live events')
+    },
+  }
+
+  await handleExecutorEvents(request, response, client)
+
+  assert.equal(response.writes, 1)
+  assert.equal(response.writableEnded, true)
+})
+
+test('ignores queued live events after disconnecting an SSE slow consumer', async () => {
+  const request = executorEventRequest()
+  const response = responseFixture({ writableSequence: [true, false], throwAfterEnd: true })
+  let listener
+  let disposeCalls = 0
+  const client = {
+    replay() {
+      return []
+    },
+    listen(nextListener) {
+      listener = nextListener
+      return () => {
+        disposeCalls += 1
+      }
+    },
+  }
+
+  await handleExecutorEvents(request, response, client)
+  listener(executorEvent(1))
+  listener(executorEvent(2))
+
+  assert.equal(response.writes, 2)
+  assert.equal(response.writableEnded, true)
+  assert.equal(disposeCalls, 1)
+})
+
 function executorEventRequest() {
   const request = new EventEmitter()
   request.method = 'GET'
@@ -61,6 +105,16 @@ function executorEventRequest() {
   return request
 }
 
+function executorEvent(sequence) {
+  return {
+    protocolVersion: 1,
+    sequence,
+    emittedAt: new Date().toISOString(),
+    event: 'task.updated',
+    payload: { id: `task-${sequence}` },
+  }
+}
+
 function responseFixture(options = {}) {
   return {
     status: null,
@@ -68,14 +122,21 @@ function responseFixture(options = {}) {
     body: '',
     headersSent: false,
     writableEnded: false,
+    destroyed: false,
+    writes: 0,
     writeHead(status, headers) {
       this.status = status
       this.headers = headers
       this.headersSent = true
     },
     write(body) {
+      if (options.throwAfterEnd && this.writableEnded) {
+        throw new Error('write after end')
+      }
+      const writable = options.writableSequence?.[this.writes] ?? options.writable !== false
+      this.writes += 1
       this.body += body
-      return options.writable !== false
+      return writable
     },
     end(body = '') {
       this.body += body

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -63,6 +63,14 @@ export async function handleExecutorEvents(req, res, client) {
   if (!trustedBrowserRequest(req)) return forbidden(res)
   if (req.method !== 'GET') return methodNotAllowed(res, 'GET')
   const after = eventCursor(req)
+  let active = true
+  let dispose = () => {}
+  const disconnect = () => {
+    if (!active) return
+    active = false
+    dispose()
+  }
+  req.once('close', disconnect)
   try {
     const replay = client.replay(after)
     res.writeHead(200, {
@@ -70,22 +78,35 @@ export async function handleExecutorEvents(req, res, client) {
       'cache-control': 'no-cache, no-store',
       connection: 'keep-alive',
     })
-    let dispose = () => {}
-    const write = event => {
-      const writable = res.write(`id: ${event.sequence}\ndata: ${JSON.stringify(event)}\n\n`)
-      if (!writable) {
-        dispose()
-        res.end()
+    const writeChunk = chunk => {
+      if (!active || res.writableEnded || res.destroyed) {
+        disconnect()
+        return false
       }
+      const writable = res.write(chunk)
+      if (!writable) {
+        disconnect()
+        if (!res.writableEnded && !res.destroyed) res.end()
+      }
+      return writable
     }
-    for (const event of replay) write(event)
-    if (res.writableEnded) return
+    const write = event => writeChunk(`id: ${event.sequence}\ndata: ${JSON.stringify(event)}\n\n`)
+    for (const event of replay) {
+      if (!write(event)) return
+    }
+    if (!active || res.writableEnded || res.destroyed) return
     dispose = client.listen(write)
-    req.on('close', dispose)
-    res.write(': connected\n\n')
+    if (!active) {
+      dispose()
+      return
+    }
+    writeChunk(': connected\n\n')
   } catch (error) {
+    disconnect()
     if (!res.headersSent) sendError(res, error)
-    else res.end(`event: error\ndata: ${JSON.stringify(errorBody(error))}\n\n`)
+    else if (!res.writableEnded && !res.destroyed) {
+      res.end(`event: error\ndata: ${JSON.stringify(errorBody(error))}\n\n`)
+    }
   }
 }
 

--- a/wework/electron/src/host/image-context-actions.test.ts
+++ b/wework/electron/src/host/image-context-actions.test.ts
@@ -1,0 +1,94 @@
+import { readFile, rm } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { WebContents } from 'electron'
+import { materializeTemporaryImage, resolveRendererImageContext } from './image-context-actions.js'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(directory => rm(directory, { force: true, recursive: true }))
+  )
+})
+
+describe('resolveRendererImageContext', () => {
+  test('returns validated renderer metadata for a local image', async () => {
+    const executeJavaScript = vi.fn(async () => ({
+      filename: '../preview.png',
+      localPath: '/tmp/source.png',
+      sourceUrl: 'blob:preview',
+    }))
+    const contents = { executeJavaScript } as unknown as WebContents
+
+    await expect(
+      resolveRendererImageContext(contents, {
+        mediaType: 'image',
+        selectionText: '',
+        x: 120,
+        y: 240,
+      })
+    ).resolves.toEqual({
+      filename: 'preview.png',
+      localPath: '/tmp/source.png',
+      sourceUrl: 'blob:preview',
+    })
+    expect(executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining('elementFromPoint'),
+      true
+    )
+  })
+
+  test('discards a renderer-provided relative local path', async () => {
+    const contents = {
+      executeJavaScript: vi.fn(async () => ({
+        filename: 'preview.png',
+        localPath: '../source.png',
+        sourceUrl: 'blob:preview',
+      })),
+    } as unknown as WebContents
+
+    await expect(
+      resolveRendererImageContext(contents, {
+        mediaType: 'image',
+        selectionText: '',
+        x: 1,
+        y: 2,
+      })
+    ).resolves.toMatchObject({ localPath: null })
+  })
+})
+
+describe('materializeTemporaryImage', () => {
+  test('writes the original remote image bytes to a temporary file', async () => {
+    const bytes = Buffer.from('remote-image')
+    const contents = {
+      executeJavaScript: vi.fn(async () => `data:image/png;base64,${bytes.toString('base64')}`),
+    } as unknown as WebContents
+
+    const path = await materializeTemporaryImage(contents, {
+      filename: 'remote.png',
+      localPath: null,
+      sourceUrl: 'blob:remote',
+    })
+    temporaryDirectories.push(dirname(path))
+
+    expect(path).toMatch(/remote\.png$/)
+    await expect(readFile(path)).resolves.toEqual(bytes)
+  })
+
+  test('adds an extension from the MIME type when the filename has none', async () => {
+    const contents = {
+      executeJavaScript: vi.fn(async () => 'data:image/webp;base64,aW1hZ2U='),
+    } as unknown as WebContents
+
+    const path = await materializeTemporaryImage(contents, {
+      filename: 'remote',
+      localPath: null,
+      sourceUrl: 'blob:remote',
+    })
+    temporaryDirectories.push(dirname(path))
+
+    expect(path).toMatch(/remote\.webp$/)
+  })
+})

--- a/wework/electron/src/host/image-context-actions.test.ts
+++ b/wework/electron/src/host/image-context-actions.test.ts
@@ -2,7 +2,12 @@ import { readFile, rm } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { WebContents } from 'electron'
-import { materializeTemporaryImage, resolveRendererImageContext } from './image-context-actions.js'
+import {
+  cleanupStaleTemporaryImages,
+  materializeTemporaryImage,
+  resolveRendererImageContext,
+  scheduleTemporaryImageCleanup,
+} from './image-context-actions.js'
 
 const temporaryDirectories: string[] = []
 
@@ -75,6 +80,14 @@ describe('materializeTemporaryImage', () => {
 
     expect(path).toMatch(/remote\.png$/)
     await expect(readFile(path)).resolves.toEqual(bytes)
+    expect(contents.executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining('response.body.getReader()'),
+      true
+    )
+    expect(contents.executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining('totalBytes > 104857600'),
+      true
+    )
   })
 
   test('adds an extension from the MIME type when the filename has none', async () => {
@@ -90,5 +103,39 @@ describe('materializeTemporaryImage', () => {
     temporaryDirectories.push(dirname(path))
 
     expect(path).toMatch(/remote\.webp$/)
+  })
+
+  test('removes a materialized image after the cleanup delay', async () => {
+    const contents = {
+      executeJavaScript: vi.fn(async () => 'data:image/png;base64,aW1hZ2U='),
+    } as unknown as WebContents
+    const path = await materializeTemporaryImage(contents, {
+      filename: 'remote.png',
+      localPath: null,
+      sourceUrl: 'blob:remote',
+    })
+    temporaryDirectories.push(dirname(path))
+
+    scheduleTemporaryImageCleanup(path, 0)
+
+    await vi.waitFor(async () => {
+      await expect(readFile(path)).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+  })
+
+  test('removes stale managed temporary image directories', async () => {
+    const contents = {
+      executeJavaScript: vi.fn(async () => 'data:image/png;base64,aW1hZ2U='),
+    } as unknown as WebContents
+    const path = await materializeTemporaryImage(contents, {
+      filename: 'remote.png',
+      localPath: null,
+      sourceUrl: 'blob:remote',
+    })
+    temporaryDirectories.push(dirname(path))
+
+    await cleanupStaleTemporaryImages(0, Date.now() + 1_000)
+
+    await expect(readFile(path)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/wework/electron/src/host/image-context-actions.ts
+++ b/wework/electron/src/host/image-context-actions.ts
@@ -1,10 +1,13 @@
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { basename, extname, isAbsolute, join } from 'node:path'
+import { basename, dirname, extname, isAbsolute, join, resolve } from 'node:path'
 import type { WebContents } from 'electron'
 import type { ImageContext, NativeContextMenuParams } from './image-context-menu.js'
 
 const MAX_IMAGE_BYTES = 100 * 1024 * 1024
+const TEMPORARY_IMAGE_DIRECTORY_PREFIX = 'wework-image-preview-'
+const TEMPORARY_IMAGE_CLEANUP_DELAY_MS = 15 * 60 * 1000
+const STALE_TEMPORARY_IMAGE_AGE_MS = 24 * 60 * 60 * 1000
 const IMAGE_EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
   'image/avif': '.avif',
   'image/bmp': '.bmp',
@@ -59,12 +62,29 @@ function imageDataUrlExpression(sourceUrl: string): string {
   return `(async () => {
     const response = await fetch(${JSON.stringify(sourceUrl)})
     if (!response.ok) throw new Error('Failed to read image: ' + response.status)
-    const blob = await response.blob()
+    if (!response.body) throw new Error('Image response body is unavailable')
+    const reader = response.body.getReader()
+    const chunks = []
+    let totalBytes = 0
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > ${MAX_IMAGE_BYTES}) {
+        await reader.cancel()
+        throw new Error('Image exceeds the supported size limit')
+      }
+      chunks.push(value)
+    }
+    const blob = new Blob(chunks, {
+      type: response.headers.get('content-type') || 'application/octet-stream',
+    })
     return await new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result)
-      reader.onerror = () => reject(reader.error || new Error('Failed to encode image'))
-      reader.readAsDataURL(blob)
+      const fileReader = new FileReader()
+      fileReader.onload = () => resolve(fileReader.result)
+      fileReader.onerror = () =>
+        reject(fileReader.error || new Error('Failed to encode image'))
+      fileReader.readAsDataURL(blob)
     })
   })()`
 }
@@ -95,8 +115,54 @@ export async function materializeTemporaryImage(
   if (typeof dataUrl !== 'string') throw new Error('Renderer did not return image data')
 
   const { bytes, mimeType } = decodeImageDataUrl(dataUrl)
-  const directory = await mkdtemp(join(tmpdir(), 'wework-image-preview-'))
+  const directory = await mkdtemp(join(tmpdir(), TEMPORARY_IMAGE_DIRECTORY_PREFIX))
   const path = join(directory, temporaryImageFilename(image.filename, mimeType))
-  await writeFile(path, bytes, { flag: 'wx' })
+  try {
+    await writeFile(path, bytes, { flag: 'wx' })
+  } catch (error) {
+    await rm(directory, { force: true, recursive: true })
+    throw error
+  }
   return path
+}
+
+function temporaryImageDirectory(path: string): string | null {
+  const directory = resolve(dirname(path))
+  if (dirname(directory) !== resolve(tmpdir())) return null
+  return basename(directory).startsWith(TEMPORARY_IMAGE_DIRECTORY_PREFIX) ? directory : null
+}
+
+export function scheduleTemporaryImageCleanup(
+  path: string,
+  delayMs = TEMPORARY_IMAGE_CLEANUP_DELAY_MS
+): void {
+  const directory = temporaryImageDirectory(path)
+  if (!directory) return
+
+  const timer = setTimeout(() => {
+    void rm(directory, { force: true, recursive: true }).catch(error => {
+      console.error('[context-menu] failed to remove temporary image', error)
+    })
+  }, delayMs)
+  timer.unref()
+}
+
+export async function cleanupStaleTemporaryImages(
+  minimumAgeMs = STALE_TEMPORARY_IMAGE_AGE_MS,
+  nowMs = Date.now()
+): Promise<void> {
+  const cutoff = nowMs - minimumAgeMs
+  const entries = await readdir(tmpdir(), { withFileTypes: true })
+  await Promise.all(
+    entries
+      .filter(
+        entry => entry.isDirectory() && entry.name.startsWith(TEMPORARY_IMAGE_DIRECTORY_PREFIX)
+      )
+      .map(async entry => {
+        const directory = join(tmpdir(), entry.name)
+        const metadata = await stat(directory)
+        if (metadata.mtimeMs > cutoff) return
+        await rm(directory, { force: true, recursive: true })
+      })
+  )
 }

--- a/wework/electron/src/host/image-context-actions.ts
+++ b/wework/electron/src/host/image-context-actions.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, extname, isAbsolute, join } from 'node:path'
+import type { WebContents } from 'electron'
+import type { ImageContext, NativeContextMenuParams } from './image-context-menu.js'
+
+const MAX_IMAGE_BYTES = 100 * 1024 * 1024
+const IMAGE_EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
+  'image/avif': '.avif',
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+}
+
+interface RendererImageContext {
+  filename?: unknown
+  localPath?: unknown
+  sourceUrl?: unknown
+}
+
+function rendererImageContextExpression(params: NativeContextMenuParams): string {
+  return `(() => {
+    const element = document.elementFromPoint(${JSON.stringify(params.x)}, ${JSON.stringify(
+      params.y
+    )})
+    const image = element instanceof Element ? element.closest('img') : null
+    if (!(image instanceof HTMLImageElement)) return null
+    return {
+      filename: image.dataset.contextImageFilename || image.alt || 'image',
+      localPath: image.dataset.contextImageLocalPath || null,
+      sourceUrl: image.currentSrc || image.src || '',
+    }
+  })()`
+}
+
+export async function resolveRendererImageContext(
+  contents: WebContents,
+  params: NativeContextMenuParams
+): Promise<ImageContext | null> {
+  const value = (await contents.executeJavaScript(
+    rendererImageContextExpression(params),
+    true
+  )) as RendererImageContext | null
+  if (!value || typeof value.sourceUrl !== 'string' || !value.sourceUrl) return null
+
+  const localPath =
+    typeof value.localPath === 'string' && isAbsolute(value.localPath) ? value.localPath : null
+  const filename =
+    typeof value.filename === 'string' && value.filename.trim()
+      ? basename(value.filename.trim())
+      : 'image'
+  return { filename, localPath, sourceUrl: value.sourceUrl }
+}
+
+function imageDataUrlExpression(sourceUrl: string): string {
+  return `(async () => {
+    const response = await fetch(${JSON.stringify(sourceUrl)})
+    if (!response.ok) throw new Error('Failed to read image: ' + response.status)
+    const blob = await response.blob()
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result)
+      reader.onerror = () => reject(reader.error || new Error('Failed to encode image'))
+      reader.readAsDataURL(blob)
+    })
+  })()`
+}
+
+function decodeImageDataUrl(dataUrl: string): { bytes: Buffer; mimeType: string } {
+  const match = /^data:([^;,]+)(?:;[^;,]+)*;base64,([a-zA-Z0-9+/=\s]+)$/.exec(dataUrl)
+  if (!match) throw new Error('Renderer returned an invalid image data URL')
+
+  const bytes = Buffer.from(match[2], 'base64')
+  if (bytes.length === 0 || bytes.length > MAX_IMAGE_BYTES) {
+    throw new Error(`Image size is outside the supported range: ${bytes.length}`)
+  }
+  return { bytes, mimeType: match[1].toLowerCase() }
+}
+
+function temporaryImageFilename(filename: string, mimeType: string): string {
+  const safeFilename = basename(filename).replaceAll(/[^a-zA-Z0-9._ -]/g, '_')
+  if (safeFilename && extname(safeFilename)) return safeFilename
+  const extension = IMAGE_EXTENSION_BY_MIME_TYPE[mimeType] ?? '.png'
+  return `${safeFilename || 'image'}${extension}`
+}
+
+export async function materializeTemporaryImage(
+  contents: WebContents,
+  image: ImageContext
+): Promise<string> {
+  const dataUrl = await contents.executeJavaScript(imageDataUrlExpression(image.sourceUrl), true)
+  if (typeof dataUrl !== 'string') throw new Error('Renderer did not return image data')
+
+  const { bytes, mimeType } = decodeImageDataUrl(dataUrl)
+  const directory = await mkdtemp(join(tmpdir(), 'wework-image-preview-'))
+  const path = join(directory, temporaryImageFilename(image.filename, mimeType))
+  await writeFile(path, bytes, { flag: 'wx' })
+  return path
+}

--- a/wework/electron/src/host/image-context-menu.test.ts
+++ b/wework/electron/src/host/image-context-menu.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  installNativeContextMenu,
+  type ImageContext,
+  type NativeContextMenuContents,
+  type NativeContextMenuItem,
+  type NativeContextMenuParams,
+} from './image-context-menu.js'
+
+function imageContext(localPath: string | null = null): ImageContext {
+  return {
+    filename: 'preview.png',
+    localPath,
+    sourceUrl: 'blob:preview',
+  }
+}
+
+function setup(language = 'en-US', resolvedImage = imageContext()) {
+  let listener: ((event: unknown, params: NativeContextMenuParams) => void) | undefined
+  const contents = {
+    copyImageAt: vi.fn(),
+    on: vi.fn((_event, nextListener) => {
+      listener = nextListener
+    }),
+  } as NativeContextMenuContents
+  const popup = vi.fn()
+  const buildMenu = vi.fn((items: NativeContextMenuItem[]) => {
+    void items
+    return { popup }
+  })
+  const actions = {
+    copyPath: vi.fn(),
+    copyText: vi.fn(),
+    openImage: vi.fn(async () => undefined),
+    reportError: vi.fn(),
+    resolveImageContext: vi.fn(async () => resolvedImage),
+    showItemInFolder: vi.fn(),
+  }
+
+  installNativeContextMenu(contents, buildMenu, actions, language)
+
+  return {
+    actions,
+    buildMenu,
+    contents,
+    popup,
+    trigger: async (params: NativeContextMenuParams) => {
+      listener?.({}, params)
+      await vi.waitFor(() => {
+        expect(buildMenu).toHaveBeenCalled()
+      })
+    },
+  }
+}
+
+function imageParams(): NativeContextMenuParams {
+  return { mediaType: 'image', selectionText: '', x: 120, y: 240 }
+}
+
+describe('installNativeContextMenu', () => {
+  test('shows copy and open actions for a remote image', async () => {
+    const { actions, buildMenu, contents, popup, trigger } = setup()
+
+    await trigger(imageParams())
+
+    expect(popup).toHaveBeenCalledOnce()
+    const [items] = buildMenu.mock.calls[0] ?? []
+    expect(items?.map(item => item.label ?? item.type)).toEqual([
+      'Copy Image',
+      'Open in Default Application',
+    ])
+
+    items?.[0]?.click?.()
+    items?.[1]?.click?.()
+    expect(contents.copyImageAt).toHaveBeenCalledWith(120, 240)
+    await vi.waitFor(() => expect(actions.openImage).toHaveBeenCalledWith(imageContext()))
+  })
+
+  test('adds file actions for a local image', async () => {
+    const localImage = imageContext('/tmp/preview.png')
+    const { actions, buildMenu, trigger } = setup('en-US', localImage)
+
+    await trigger(imageParams())
+
+    const [items] = buildMenu.mock.calls[0] ?? []
+    expect(items?.map(item => item.label ?? item.type)).toEqual([
+      'Copy Image',
+      'Open in Default Application',
+      'separator',
+      'Show in Finder / File Explorer',
+      'Copy File Path',
+    ])
+    items?.[3]?.click?.()
+    items?.[4]?.click?.()
+    expect(actions.showItemInFolder).toHaveBeenCalledWith('/tmp/preview.png')
+    expect(actions.copyPath).toHaveBeenCalledWith('/tmp/preview.png')
+  })
+
+  test('uses Chinese labels for image actions', async () => {
+    const { buildMenu, trigger } = setup('zh-CN', imageContext('/tmp/preview.png'))
+
+    await trigger(imageParams())
+
+    const [items] = buildMenu.mock.calls[0] ?? []
+    expect(items?.map(item => item.label ?? item.type)).toEqual([
+      '复制图片',
+      '在系统默认应用中打开',
+      'separator',
+      '在 Finder / 文件资源管理器中显示',
+      '复制文件路径',
+    ])
+  })
+
+  test('shows Copy for selected conversation text', async () => {
+    const { actions, buildMenu, trigger } = setup()
+    const params = {
+      mediaType: 'none',
+      selectionText: 'selected response',
+      x: 10,
+      y: 20,
+    }
+
+    await trigger(params)
+
+    const [items] = buildMenu.mock.calls[0] ?? []
+    expect(items?.map(item => item.label)).toEqual(['Copy'])
+    items?.[0]?.click?.()
+    expect(actions.copyText).toHaveBeenCalledWith('selected response')
+  })
+
+  test('leaves non-image context menus without a selection untouched', async () => {
+    const { buildMenu, popup, contents } = setup()
+    const listener = contents.on.mock.calls[0]?.[1]
+
+    listener?.({}, { mediaType: 'none', selectionText: '  ', x: 10, y: 20 })
+    await Promise.resolve()
+
+    expect(buildMenu).not.toHaveBeenCalled()
+    expect(popup).not.toHaveBeenCalled()
+  })
+})

--- a/wework/electron/src/host/image-context-menu.ts
+++ b/wework/electron/src/host/image-context-menu.ts
@@ -1,0 +1,138 @@
+export interface NativeContextMenuParams {
+  mediaType: string
+  selectionText: string
+  x: number
+  y: number
+}
+
+export interface ImageContext {
+  filename: string
+  localPath: string | null
+  sourceUrl: string
+}
+
+export interface NativeContextMenuContents {
+  copyImageAt: (x: number, y: number) => void
+  on: (
+    event: 'context-menu',
+    listener: (event: unknown, params: NativeContextMenuParams) => void
+  ) => void
+}
+
+export interface NativeContextMenu {
+  popup: () => void
+}
+
+export interface NativeContextMenuItem {
+  click?: () => void
+  label?: string
+  type?: 'separator'
+}
+
+export interface NativeContextMenuActions {
+  copyPath: (path: string) => void
+  copyText: (text: string) => void
+  openImage: (image: ImageContext) => Promise<void>
+  reportError: (action: string, error: unknown) => void
+  resolveImageContext: (params: NativeContextMenuParams) => Promise<ImageContext | null>
+  showItemInFolder: (path: string) => void
+}
+
+interface NativeContextMenuLabels {
+  copy: string
+  copyImage: string
+  copyPath: string
+  openImage: string
+  showItemInFolder: string
+}
+
+const ZH_CN_LABELS: NativeContextMenuLabels = {
+  copy: '复制',
+  copyImage: '复制图片',
+  copyPath: '复制文件路径',
+  openImage: '在系统默认应用中打开',
+  showItemInFolder: '在 Finder / 文件资源管理器中显示',
+}
+
+const EN_LABELS: NativeContextMenuLabels = {
+  copy: 'Copy',
+  copyImage: 'Copy Image',
+  copyPath: 'Copy File Path',
+  openImage: 'Open in Default Application',
+  showItemInFolder: 'Show in Finder / File Explorer',
+}
+
+function labelsForLanguage(language: string): NativeContextMenuLabels {
+  return language.trim().toLowerCase().startsWith('zh') ? ZH_CN_LABELS : EN_LABELS
+}
+
+function runAsyncAction(
+  action: string,
+  operation: () => Promise<void>,
+  reportError: NativeContextMenuActions['reportError']
+): void {
+  void operation().catch(error => reportError(action, error))
+}
+
+async function showContextMenu(
+  contents: NativeContextMenuContents,
+  params: NativeContextMenuParams,
+  buildMenu: (items: NativeContextMenuItem[]) => NativeContextMenu,
+  actions: NativeContextMenuActions,
+  labels: NativeContextMenuLabels
+): Promise<void> {
+  if (params.mediaType === 'image') {
+    const image = await actions.resolveImageContext(params)
+    if (!image) return
+
+    const items: NativeContextMenuItem[] = [
+      {
+        label: labels.copyImage,
+        click: () => contents.copyImageAt(params.x, params.y),
+      },
+      {
+        label: labels.openImage,
+        click: () =>
+          runAsyncAction('open-image', () => actions.openImage(image), actions.reportError),
+      },
+    ]
+    if (image.localPath) {
+      const localPath = image.localPath
+      items.push(
+        { type: 'separator' },
+        {
+          label: labels.showItemInFolder,
+          click: () => actions.showItemInFolder(localPath),
+        },
+        {
+          label: labels.copyPath,
+          click: () => actions.copyPath(localPath),
+        }
+      )
+    }
+    buildMenu(items).popup()
+    return
+  }
+
+  if (!params.selectionText.trim()) return
+  buildMenu([
+    {
+      label: labels.copy,
+      click: () => actions.copyText(params.selectionText),
+    },
+  ]).popup()
+}
+
+export function installNativeContextMenu(
+  contents: NativeContextMenuContents,
+  buildMenu: (items: NativeContextMenuItem[]) => NativeContextMenu,
+  actions: NativeContextMenuActions,
+  language: string
+): void {
+  const labels = labelsForLanguage(language)
+  contents.on('context-menu', (_event, params) => {
+    void showContextMenu(contents, params, buildMenu, actions, labels).catch(error =>
+      actions.reportError('show-context-menu', error)
+    )
+  })
+}

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -1,6 +1,7 @@
 import {
   app,
   BrowserWindow,
+  clipboard,
   ipcMain,
   Menu,
   screen,
@@ -47,6 +48,11 @@ import { WorkbenchPluginManager } from './host/workbench-plugin-manager.js'
 import { StartupSplash } from './host/startup-splash.js'
 import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
 import { WindowClosePolicy, type WindowCloseDecision } from './host/window-close-policy.js'
+import { installNativeContextMenu } from './host/image-context-menu.js'
+import {
+  materializeTemporaryImage,
+  resolveRendererImageContext,
+} from './host/image-context-actions.js'
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const dshPreloadPath = resolve(packageRoot, 'dist/dsh-preload.cjs')
@@ -112,6 +118,25 @@ rendererHealth.on('change', () => {
 
 function secureDshContents(contents: WebContents, dshUrl: string): void {
   const allowedOrigin = new URL(dshUrl).origin
+  installNativeContextMenu(
+    contents,
+    items => Menu.buildFromTemplate(items),
+    {
+      copyPath: path => clipboard.writeText(path),
+      copyText: text => clipboard.writeText(text),
+      openImage: async image => {
+        const path = image.localPath ?? (await materializeTemporaryImage(contents, image))
+        const error = await shell.openPath(path)
+        if (error) throw new Error(error)
+      },
+      reportError: (action, error) => {
+        console.error(`[context-menu] ${action} failed`, error)
+      },
+      resolveImageContext: params => resolveRendererImageContext(contents, params),
+      showItemInFolder: path => shell.showItemInFolder(path),
+    },
+    app.getLocale()
+  )
   contents.setWindowOpenHandler(({ url }) => {
     const target = new URL(url)
     if (target.origin === allowedOrigin) return { action: 'allow' }

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -50,8 +50,10 @@ import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
 import { WindowClosePolicy, type WindowCloseDecision } from './host/window-close-policy.js'
 import { installNativeContextMenu } from './host/image-context-menu.js'
 import {
+  cleanupStaleTemporaryImages,
   materializeTemporaryImage,
   resolveRendererImageContext,
+  scheduleTemporaryImageCleanup,
 } from './host/image-context-actions.js'
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -125,8 +127,13 @@ function secureDshContents(contents: WebContents, dshUrl: string): void {
       copyPath: path => clipboard.writeText(path),
       copyText: text => clipboard.writeText(text),
       openImage: async image => {
-        const path = image.localPath ?? (await materializeTemporaryImage(contents, image))
+        const temporaryPath = image.localPath
+          ? null
+          : await materializeTemporaryImage(contents, image)
+        const path = image.localPath ?? temporaryPath
+        if (!path) throw new Error('Image path is unavailable')
         const error = await shell.openPath(path)
+        if (temporaryPath) scheduleTemporaryImageCleanup(temporaryPath)
         if (error) throw new Error(error)
       },
       reportError: (action, error) => {
@@ -979,6 +986,9 @@ function startDesktopRuntime(): Promise<void> {
 
 if (hasSingleInstanceLock) {
   app.whenReady().then(async () => {
+    await cleanupStaleTemporaryImages().catch(error => {
+      console.error('[context-menu] failed to remove stale temporary images', error)
+    })
     installDshWindowLabelHeaders()
     installIpc()
     preferences = new PreferencesStore(app.getPath('userData'))

--- a/wework/electron/src/runtime/runtime-supervisor.ts
+++ b/wework/electron/src/runtime/runtime-supervisor.ts
@@ -108,7 +108,7 @@ export class RuntimeSupervisor extends EventEmitter<RuntimeSupervisorEvents> {
     this.child = child
     this.attach(child)
     this.emit('spawn', child)
-    await this.writeLog('supervisor', `spawned pid=${child.pid ?? 'unknown'}`)
+    void this.writeLog('supervisor', `spawned pid=${child.pid ?? 'unknown'}`)
 
     try {
       await spawned

--- a/wework/src/components/chat/AttachmentImagePreview.test.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.test.tsx
@@ -108,7 +108,9 @@ describe('AttachmentImagePreview', () => {
     })
     await settleNextFetch()
     await waitFor(() => {
-      expect(screen.getByTestId('preview-image')).toBeInTheDocument()
+      const image = screen.getByTestId('preview-image')
+      expect(image).toHaveAttribute('data-context-image-filename', 'image-1.png')
+      expect(image).not.toHaveAttribute('data-context-image-local-path')
     })
 
     // Runtime turn/block projections produce a fresh attachment object with
@@ -162,27 +164,29 @@ describe('AttachmentImagePreview', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId('preview-image')).toBeInTheDocument()
+      expect(screen.getByTestId('preview-image')).toHaveAttribute(
+        'data-context-image-local-path',
+        '/a.png'
+      )
     })
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('preview-button'))
     })
     await waitFor(() => {
-      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
-        'src',
-        'blob:attachment-preview'
-      )
+      const image = screen.getByTestId('attachment-image-lightbox-image')
+      expect(image).toHaveAttribute('src', 'blob:attachment-preview')
+      expect(image).toHaveAttribute('data-context-image-filename', 'image-1.png')
+      expect(image).toHaveAttribute('data-context-image-local-path', '/a.png')
     })
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('attachment-image-next'))
     })
     await waitFor(() => {
-      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
-        'src',
-        'blob:attachment-preview'
-      )
+      const image = screen.getByTestId('attachment-image-lightbox-image')
+      expect(image).toHaveAttribute('src', 'blob:attachment-preview')
+      expect(image).toHaveAttribute('data-context-image-local-path', '/b.png')
     })
   })
 

--- a/wework/src/components/chat/AttachmentImagePreview.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.tsx
@@ -200,6 +200,12 @@ export function AttachmentImagePreview({
   )
   const currentLightboxAttachment = gallery[clampIndex(lightboxIndex, gallery.length)] ?? attachment
   const canNavigateLightbox = gallery.length > 1
+  const previewLocalPath = getDownloadableLocalPath(
+    attachment.local_preview_url ?? attachment.local_path
+  )
+  const lightboxLocalPath = getDownloadableLocalPath(
+    currentLightboxAttachment.local_preview_url ?? currentLightboxAttachment.local_path
+  )
 
   /* eslint-disable react-hooks/set-state-in-effect -- Attachment identity changes must clear stale preview UI before loading the next image. */
   useEffect(() => {
@@ -483,6 +489,8 @@ export function AttachmentImagePreview({
                   data-testid="attachment-image-lightbox-image"
                   src={lightboxUrl}
                   alt={currentLightboxAttachment.filename}
+                  data-context-image-filename={currentLightboxAttachment.filename}
+                  data-context-image-local-path={lightboxLocalPath ?? undefined}
                   className="max-h-[calc(100dvh-9rem)] max-w-[calc(100dvw-8rem)] rounded-2xl object-contain transition-transform duration-150 ease-out"
                   style={{ transform: `scale(${zoom})` }}
                   onClick={event => event.stopPropagation()}
@@ -525,6 +533,8 @@ export function AttachmentImagePreview({
             data-testid={imageTestId}
             src={previewUrl}
             alt={attachment.filename}
+            data-context-image-filename={attachment.filename}
+            data-context-image-local-path={previewLocalPath ?? undefined}
             loading="lazy"
             className={imageClassName}
             onError={() => {
@@ -551,6 +561,8 @@ export function AttachmentImagePreview({
             data-testid={imageTestId}
             src={previewUrl}
             alt={attachment.filename}
+            data-context-image-filename={attachment.filename}
+            data-context-image-local-path={previewLocalPath ?? undefined}
             loading="lazy"
             className={imageClassName}
             onError={() => {


### PR DESCRIPTION
## Summary

- add a native Electron context menu for image previews with copy image and open-in-default-app actions
- expose local image metadata so local previews can reveal the file and copy its path
- materialize remote preview blobs into bounded temporary files before opening them externally
- add a native Copy action when text is selected in the conversation UI

## Verification

- `pnpm --filter wework typecheck`
- changed-file ESLint and Prettier checks
- `pnpm --dir wework/electron test src/host/image-context-menu.test.ts src/host/image-context-actions.test.ts`
- `pnpm --filter wework test src/components/chat/AttachmentImagePreview.test.tsx`
- full pre-push Wework checks: ESLint, renderer/Electron TypeScript, focused renderer and Electron unit tests
- full Electron package build via `pnpm --filter wework ai:verify:electron:build`
- isolated Electron verification: attach image, open lightbox, trigger image context menu; select conversation text and trigger context menu

Task: WORK-54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native context menus for images and selected text.
  * Image actions include copying, opening, revealing files, and copying file paths.
  * Added English and Simplified Chinese menu labels.
  * Improved image previews with filename and local-path metadata.
* **Bug Fixes**
  * Improved validation and cleanup for remote and local images.
  * Prevented disconnected event streams from receiving additional events.
  * Reduced delays when starting the runtime supervisor.
* **Tests**
  * Expanded coverage for context menus, image handling, metadata, cleanup, and event streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->