### PR TITLE
fix(wework): load models for smart app workspaces

### DIFF
--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -340,7 +340,7 @@ export function WorkspaceTabSurface({
               workspaceTabId={tab.id}
               debugSnapshotEnabled={active && nativeWorkbenchActive}
               consumePluginTrials={active && !iframe}
-              loadTaskComposerCatalogs={(nativeWorkbenchKind ?? tab.kind) !== 'board'}
+              loadTaskComposerCatalogs
               prewarmComposerApps={prewarmComposerApps}
               publishDebugSnapshots={active && !iframe}
               syncRemoteProjects={active}

--- a/wework/src/WorkspaceTabSurface.test.tsx
+++ b/wework/src/WorkspaceTabSurface.test.tsx
@@ -141,7 +141,7 @@ describe('WorkspaceTabSurface', () => {
 
     const { rerender, unmount } = render(<WorkspaceTabSurface {...props} active />)
     expect(screen.getByTestId('mock-workbench-board')).toHaveAttribute('data-route-active', 'true')
-    expect(workbenchProviderMocks.loadTaskComposerCatalogs).toHaveBeenLastCalledWith(false)
+    expect(workbenchProviderMocks.loadTaskComposerCatalogs).toHaveBeenLastCalledWith(true)
     expect(workbenchProviderMocks.prewarm).toHaveBeenLastCalledWith(false)
 
     rerender(<WorkspaceTabSurface {...props} active={false} />)
@@ -155,6 +155,50 @@ describe('WorkspaceTabSurface', () => {
 
     unmount()
     expect(workbenchProviderMocks.cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('keeps composer catalogs loaded when a retained board tab displays an auxiliary page', () => {
+    const dispose = getWorkbenchPluginRuntime().routes.register({
+      id: 'board-auxiliary-catalog-test',
+      path: '/board-auxiliary-catalog-test',
+      telemetryFeature: 'apps',
+      render: () => <div data-testid="mock-board-auxiliary-page" />,
+    })
+    const props = {
+      active: true,
+      cloudWebUrl: null,
+      lifecycleStore: {} as never,
+      nativeWorkbenchKind: 'board' as const,
+      services: {} as never,
+      tab: {
+        id: 'fixed-board',
+        kind: 'board' as const,
+        title: '项目空间',
+        contentRoute: '/todo',
+      },
+      user: {
+        id: 1,
+        user_name: 'tester',
+        email: 'tester@example.com',
+      },
+    }
+
+    const { rerender, unmount } = render(<WorkspaceTabSurface {...props} />)
+    expect(workbenchProviderMocks.loadTaskComposerCatalogs).toHaveBeenLastCalledWith(true)
+
+    rerender(
+      <WorkspaceTabSurface
+        {...props}
+        tab={{ ...props.tab, contentRoute: '/board-auxiliary-catalog-test' }}
+      />
+    )
+
+    expect(screen.getByTestId('mock-board-auxiliary-page')).toBeInTheDocument()
+    expect(workbenchProviderMocks.loadTaskComposerCatalogs.mock.calls).toEqual([[true], [true]])
+    expect(workbenchProviderMocks.cleanup).not.toHaveBeenCalled()
+
+    unmount()
+    dispose()
   })
 
   test('keeps an inactive iframe app connected so its page state survives tab switches', () => {


### PR DESCRIPTION
## Summary

- keep task composer model catalogs loaded for retained board/workspace tabs
- ensure Smart Workbench auxiliary pages receive available Wework models without requiring a refresh
- add regression coverage for transitioning a retained board tab from `/todo` to an auxiliary page

Fixes WORK-47.

## Verification

- `pnpm --filter wework test src/WorkspaceTabSurface.test.tsx src/features/harness-apps/useHarnessAppManagement.test.tsx src/pages/SmartAppsMarketplacePage.test.tsx` (29 tests passed)
- Prettier and ESLint checks passed
- Wework pre-commit and pre-push checks passed, including TypeScript and focused renderer tests
- desktop Electron verification confirmed imported Smart Workbench model selectors list available Wework models without refreshing the auxiliary page