### PR TITLE
fix(executor): honor full access for MCP approvals

### DIFF
--- a/docs/en/wework/developer-guide/wework-plugin-interactive-forms.md
+++ b/docs/en/wework/developer-guide/wework-plugin-interactive-forms.md
@@ -133,7 +133,7 @@ default_tools_approval_mode = "approve"
 
 Request-level, bot-level, and Wework built-in persistent MCP servers should all follow this rule. For tools from Wegent Connector Apps, Wework writes the built-in persistent MCP server `mcp_servers.wegent_apps` with the same `default_tools_approval_mode = "approve"` and refreshes existing config during connector configure or app sync.
 
-If a plugin tool really needs per-call approval, the plugin config can explicitly declare `default_tools_approval_mode = "prompt"`. Wework must preserve that explicit setting.
+If a plugin tool really needs per-call approval, the plugin config can explicitly declare `default_tools_approval_mode = "prompt"`. Wework must preserve that explicit setting. Read-only and workspace permission modes still show the approval card for these calls. In Full access mode, Wework automatically accepts approval requests marked with `_meta.codex_approval_kind = "mcp_tool_call"` instead of showing them to the user.
 
 Also keep:
 
@@ -147,6 +147,7 @@ These switches control different behavior:
 - `approvalPolicy.granular.mcp_elicitations: true` allows plugin business forms to be forwarded from the MCP runtime to the Wework UI.
 - `mcp_servers.<name>.default_tools_approval_mode = "approve"` makes normal MCP tool calls not require approval cards.
 - `features.tool_call_mcp_elicitation: false` only means Codex should not wrap tool-call approval cards as MCP elicitation forms. If the tool approval mode still requires approval, Codex may fall back to a normal `request_user_input` approval card.
+- Full access mode automatically accepts approvals explicitly marked as `mcp_tool_call` while continuing to forward plugin business forms without that marker.
 
 ## Implementation Boundary
 
@@ -154,7 +155,7 @@ Keep these boundaries when supporting plugin forms so existing approval behavior
 
 - Do not switch `approvalPolicy` to broadly allow every approval type. Wework only needs `mcp_elicitations` enabled; the other approval gates stay disabled.
 - Wework-injected or Wework-managed MCP servers should default to `default_tools_approval_mode = "approve"` to preserve the previous no-prompt behavior for normal tool calls.
-- If an MCP server or tool explicitly declares `default_tools_approval_mode = "prompt"`, Wework must preserve that approval requirement.
+- If an MCP server or tool explicitly declares `default_tools_approval_mode = "prompt"`, Wework must preserve the configuration. Read-only and workspace modes show the approval card, while Full access automatically accepts the tool-call approval.
 - Wework-owned built-in MCP servers, such as `wework_browser` and `wegent_apps`, follow the same default no-normal-tool-approval rule.
 - `mcpServerOpenaiFormElicitation` is not required for standard `mode: "form"`. Do not advertise it in initialize capabilities unless Wework and the downstream client actually support the `openai/form` extension.
 - Shell, file, sandbox, rule, skill, and request-permission approvals should not change because plugin forms are enabled.
@@ -164,6 +165,7 @@ Code-level boundaries:
 - Codex thread/turn params use granular approval policy and only enable `mcp_elicitations`.
 - `features.tool_call_mcp_elicitation=false` prevents normal MCP tool approval from being wrapped as a business form.
 - Request/bot MCP config defaults to `default_tools_approval_mode = "approve"`, with explicit `prompt` taking precedence.
+- Full access recognizes `_meta.codex_approval_kind = "mcp_tool_call"` and returns `accept` without forwarding that approval event to the chat UI.
 - `mcp_servers.wegent_apps` is the Wework Connector Apps built-in persistent server, so Wework writes it and refreshes it during configure/app sync with the same default `approve` behavior.
 
 Use the error location to debug:
@@ -173,7 +175,8 @@ Use the error location to debug:
 | `The MCP client does not support openai/form requests.`                                      | The Codex MCP client connected to the plugin does not support `openai/form`; the request did not reach Wework | Switch to `mode: "form"`, or fall back to normal chat/tool parameters                                                                        |
 | Plugin receives `action: "decline"`, but logs do not contain `mcpServer/elicitation/request` | Codex MCP runtime rejected the request before Wework UI                                                       | Check `elicitations_auto_deny`, `approvalPolicy`, granular `mcp_elicitations`, and active-turn routing                                       |
 | No form appears, but logs contain `mcpServer/elicitation/request`                            | The request reached the runtime, but the schema may be unsupported                                            | Check `mode` and `requestedSchema.properties`                                                                                                |
-| Every MCP tool call shows an "Allow this MCP tool call" form                                 | The MCP server/tool approval mode still requires approval                                                     | Set `default_tools_approval_mode="approve"` for plugin servers that do not need approval; explicitly keep `prompt` for servers/tools that do |
+| Full access still shows an "Allow this MCP tool call" form                                   | The approval was not identified as `mcp_tool_call`, or the runtime did not receive the Full access profile    | Check `_meta.codex_approval_kind` and `runtime_permission_profile`; do not auto-accept ordinary business forms                               |
+| Every MCP tool call shows an approval form in read-only or workspace mode                    | The MCP server/tool approval mode still requires approval                                                     | Set `default_tools_approval_mode="approve"` for plugin servers that do not need approval; explicitly keep `prompt` for servers/tools that do |
 | The form appears but the plugin does not continue after submit                               | Response routing or plugin result handling is broken                                                          | Verify the plugin handles `accept`, `cancel`, and `decline`                                                                                  |
 
 ## Schema Mapping

--- a/docs/zh/wework/developer-guide/wework-plugin-interactive-forms.md
+++ b/docs/zh/wework/developer-guide/wework-plugin-interactive-forms.md
@@ -133,7 +133,7 @@ default_tools_approval_mode = "approve"
 
 request-level、bot-level 以及 Wework 内置持久 MCP server 都应遵循这个规则。`mcp_servers.wegent_apps` 是 Wegent Connector Apps 的内置持久 server，Wework 会写成同样的 `default_tools_approval_mode = "approve"`，并在 Connector 配置或应用同步时刷新旧配置。
 
-如某个插件工具确实需要每次授权，插件配置可以显式声明 `default_tools_approval_mode = "prompt"`，Wework 必须保留该显式配置。
+如某个插件工具确实需要每次授权，插件配置可以显式声明 `default_tools_approval_mode = "prompt"`，Wework 必须保留该显式配置。在只读或工作区权限模式下，这类工具调用仍会显示授权卡；在完整访问模式下，Wework 会自动接受带有 `_meta.codex_approval_kind = "mcp_tool_call"` 的授权请求，不再把它显示给用户。
 
 另外，Wework runtime 应保持：
 
@@ -147,6 +147,7 @@ tool_call_mcp_elicitation = false
 - `approvalPolicy.granular.mcp_elicitations: true` 允许插件业务表单从 MCP runtime 转发到 Wework UI。
 - `mcp_servers.<name>.default_tools_approval_mode = "approve"` 让普通 MCP tool call 不需要授权卡。
 - `features.tool_call_mcp_elicitation: false` 只表示不要把 Codex tool-call 授权卡包装成 MCP elicitation 表单；如果 tool approval mode 仍然要求审批，Codex 还可能退回普通 `request_user_input` 授权卡。
+- 完整访问模式会自动接受明确标记为 `mcp_tool_call` 的审批，同时继续转发没有该标记的插件业务表单。
 
 ## 实现边界
 
@@ -154,7 +155,7 @@ tool_call_mcp_elicitation = false
 
 - 不要把 `approvalPolicy` 简单改成允许所有审批。Wework 只需要把 `mcp_elicitations` 打开，其它审批项继续关闭。
 - Wework 注入或托管的 MCP server 应默认写 `default_tools_approval_mode = "approve"`，以保持旧的普通 tool call 不弹授权行为。
-- 如果 MCP server 或 tool 显式声明 `default_tools_approval_mode = "prompt"`，Wework 必须保留显式授权要求。
+- 如果 MCP server 或 tool 显式声明 `default_tools_approval_mode = "prompt"`，Wework 必须保留该配置；只读和工作区模式显示授权卡，完整访问模式自动接受工具调用审批。
 - Wework 自己生成并托管的内置 MCP server，例如 `wework_browser` 和 `wegent_apps`，也遵循同一条默认免普通 tool approval 规则。
 - `mcpServerOpenaiFormElicitation` 不是标准 `mode: "form"` 的必要 capability。除非 Wework 和下游 client 都真正支持 `openai/form` extension，否则不要在 initialize capability 中声明它。
 - 普通 shell、文件、sandbox、规则、技能或 request permission 的审批不应因为表单能力而改变。
@@ -164,6 +165,7 @@ tool_call_mcp_elicitation = false
 - Codex thread/turn 参数使用 granular approval policy，只打开 `mcp_elicitations`。
 - `features.tool_call_mcp_elicitation=false` 防止普通 MCP tool approval 被包装成业务表单。
 - request/bot MCP config 默认补 `default_tools_approval_mode = "approve"`，显式 `prompt` 优先。
+- 完整访问模式识别 `_meta.codex_approval_kind = "mcp_tool_call"` 并直接返回 `accept`，不向聊天界面发送该授权事件。
 - `mcp_servers.wegent_apps` 是 Wework Connector Apps 的内置持久 server，由 Wework 写入并在 configure/app sync 时刷新，同样默认 `approve`。
 
 因此，排查问题时可以按错误位置判断：
@@ -173,7 +175,8 @@ tool_call_mcp_elicitation = false
 | `The MCP client does not support openai/form requests.`                      | 插件连接到的 Codex MCP client 不支持 `openai/form`，请求没有进入 Wework | 改用 `mode: "form"`，或走普通对话/tool 参数降级                                                                      |
 | 插件收到 `action: "decline"`，但运行日志没有 `mcpServer/elicitation/request` | Codex MCP runtime 在 Wework UI 之前提前拒绝                             | 检查 `elicitations_auto_deny`、`approvalPolicy`、granular `mcp_elicitations`、是否 active turn                       |
 | 表单没有出现，但运行日志里有 `mcpServer/elicitation/request`                 | 请求到达运行时，可能 schema 不受支持                                    | 检查 `mode` 和 `requestedSchema.properties`                                                                          |
-| 每次 MCP tool call 都弹出“Allow this MCP tool call”表单                      | 该 MCP server/tool 的 tool approval mode 仍然要求审批                   | 对不需要授权的插件 server 设置 `default_tools_approval_mode="approve"`；确实需要授权的 server/tool 显式保留 `prompt` |
+| 完整访问下仍弹出“Allow this MCP tool call”表单                               | 工具审批没有被识别为 `mcp_tool_call`，或 full-access 标记未传入运行时   | 检查 `_meta.codex_approval_kind` 和 `runtime_permission_profile`；不要自动接受普通业务表单                           |
+| 只读或工作区模式下每次 MCP tool call 都弹出授权表单                          | 该 MCP server/tool 的 tool approval mode 仍然要求审批                   | 对不需要授权的插件 server 设置 `default_tools_approval_mode="approve"`；确实需要授权的 server/tool 显式保留 `prompt` |
 | 表单出现但提交后插件没有继续                                                 | 响应路由或插件侧结果处理有问题                                          | 检查插件是否处理 `accept`、`cancel`、`decline`                                                                       |
 
 ## Schema 到界面的映射

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -1482,6 +1482,7 @@ async fn run_codex_app_server_turn_on_shared_client(
         }
         let wait_for_goal_continuation = state.goal_is_active();
         let expected_client_user_message_id = request_client_user_message_id(request);
+        let auto_approve_mcp_tool_calls = codex_auto_approve_mcp_tool_calls(request);
 
         let mut turn_fields = codex_turn_fields(request, &thread_id);
         client.mark_thread_active(&thread_id).await;
@@ -1546,6 +1547,7 @@ async fn run_codex_app_server_turn_on_shared_client(
                 active_turn_started,
                 active_turn_finished,
                 wait_for_goal_continuation,
+                auto_approve_mcp_tool_calls,
             },
         )
         .await;
@@ -1785,6 +1787,7 @@ pub async fn run_codex_app_server_turn_with_cancel(
         }
 
         let turn_input = turn_input(&request.prompt);
+        let auto_approve_mcp_tool_calls = codex_auto_approve_mcp_tool_calls(request);
         let mut turn_fields = codex_turn_fields(request, &thread_id);
         turn_fields.push(("input_items", turn_input.len().to_string()));
         log_executor_event("codex turn request started", &turn_fields);
@@ -1805,6 +1808,7 @@ pub async fn run_codex_app_server_turn_with_cancel(
                     &mut state,
                     notifications,
                     request_user_input_answers,
+                    auto_approve_mcp_tool_calls,
                 ) => outcome?,
                 _ = cancellation => return Err(CODEX_APP_SERVER_TURN_CANCELLED.to_owned()),
             }
@@ -1814,6 +1818,7 @@ pub async fn run_codex_app_server_turn_with_cancel(
                 &mut state,
                 notifications,
                 request_user_input_answers,
+                auto_approve_mcp_tool_calls,
             )
             .await?
         };
@@ -1866,6 +1871,7 @@ struct SharedTurnNotificationOptions {
     active_turn_started: Option<CodexActiveTurnCallback>,
     active_turn_finished: Option<CodexActiveTurnFinishedCallback>,
     wait_for_goal_continuation: bool,
+    auto_approve_mcp_tool_calls: bool,
 }
 
 async fn read_shared_turn_notifications(
@@ -2021,8 +2027,16 @@ async fn read_shared_turn_notifications(
         {
             waiting_for_initial_progress = false;
         }
-        if let Some(sender) = &options.notifications {
-            let _ = sender.send(message.clone());
+        let auto_approve_mcp_tool_call = options.auto_approve_mcp_tool_calls
+            && message
+                .get("method")
+                .and_then(Value::as_str)
+                .is_some_and(|method| method == "mcpServer/elicitation/request")
+            && is_mcp_tool_call_approval(message_params(&message));
+        if !auto_approve_mcp_tool_call {
+            if let Some(sender) = &options.notifications {
+                let _ = sender.send(message.clone());
+            }
         }
 
         if message
@@ -2063,6 +2077,7 @@ async fn read_shared_turn_notifications(
                 &message,
                 request_user_input_answers.clone(),
                 response_error_tx.clone(),
+                options.auto_approve_mcp_tool_calls,
             )?;
             continue;
         }
@@ -2438,6 +2453,7 @@ fn spawn_shared_mcp_server_elicitation_response(
     message: &Value,
     request_user_input_answers: Option<Arc<InteractionAnswerRouter>>,
     response_error_tx: mpsc::UnboundedSender<String>,
+    auto_approve_mcp_tool_calls: bool,
 ) -> Result<(), String> {
     let request_id = json_rpc_request_id(message)
         .ok_or_else(|| "mcpServer/elicitation/request is missing JSON-RPC id".to_owned())?;
@@ -2447,6 +2463,10 @@ fn spawn_shared_mcp_server_elicitation_response(
     let message = message.clone();
     tokio::spawn(async move {
         let result = async {
+            if auto_approve_mcp_tool_calls && is_mcp_tool_call_approval(message_params(&message)) {
+                let result = mcp_server_tool_call_approval_response(&message)?;
+                return client.send_response(request_id, result).await;
+            }
             let has_response_router = request_user_input_answers.is_some();
             let response = match request_user_input_answers {
                 Some(receiver) => receiver.receive(correlation_key).await?,
@@ -4555,6 +4575,10 @@ pub(crate) fn codex_runtime_approval_policy(request: &ExecutionRequest) -> Value
     }
 }
 
+fn codex_auto_approve_mcp_tool_calls(request: &ExecutionRequest) -> bool {
+    codex_runtime_permission_profile(request) == CODEX_DANGER_FULL_ACCESS_PERMISSION_PROFILE
+}
+
 fn codex_runtime_permission_profile(request: &ExecutionRequest) -> &'static str {
     match request
         .extra
@@ -5171,7 +5195,11 @@ const MCP_ELICITATION_DECLINE: &str = "Decline";
 async fn receive_mcp_server_elicitation_response(
     message: &Value,
     request_user_input_answers: Option<&mut CodexRequestUserInputReceiver>,
+    auto_approve_mcp_tool_calls: bool,
 ) -> Result<Value, String> {
+    if auto_approve_mcp_tool_calls && is_mcp_tool_call_approval(message_params(message)) {
+        return mcp_server_tool_call_approval_response(message);
+    }
     if mcp_server_elicitation_request_user_input_params(message_params(message)).is_none() {
         return mcp_server_elicitation_response(message, None);
     }
@@ -5183,6 +5211,26 @@ async fn receive_mcp_server_elicitation_response(
         .await
         .ok_or_else(|| "mcp elicitation response channel closed".to_owned())?;
     mcp_server_elicitation_response(message, Some(&response))
+}
+
+fn mcp_server_tool_call_approval_response(message: &Value) -> Result<Value, String> {
+    let response = json!({
+        "answers": {
+            MCP_ELICITATION_APPROVAL_QUESTION_ID: {
+                "answers": [MCP_ELICITATION_ALLOW]
+            }
+        }
+    });
+    mcp_server_elicitation_response(message, Some(&response))
+}
+
+fn is_mcp_tool_call_approval(params: &Value) -> bool {
+    params
+        .get("_meta")
+        .and_then(Value::as_object)
+        .and_then(|meta| meta.get("codex_approval_kind"))
+        .and_then(Value::as_str)
+        == Some("mcp_tool_call")
 }
 
 fn mcp_server_elicitation_response(
@@ -5258,10 +5306,7 @@ pub(crate) fn mcp_server_elicitation_request_user_input_params(params: &Value) -
     let schema = params.get("requestedSchema")?;
     let properties = schema.get("properties").and_then(Value::as_object)?;
     let meta = params.get("_meta").and_then(Value::as_object);
-    let is_tool_approval = meta
-        .and_then(|meta| meta.get("codex_approval_kind"))
-        .and_then(Value::as_str)
-        == Some("mcp_tool_call");
+    let is_tool_approval = is_mcp_tool_call_approval(params);
     let mut questions = Vec::new();
 
     if is_tool_approval || properties.is_empty() {

--- a/executor/src/agents/codex/json_rpc.rs
+++ b/executor/src/agents/codex/json_rpc.rs
@@ -15,10 +15,10 @@ use crate::runner::ExecutionOutcome;
 
 use super::{
     codex_error_message, codex_notification_has_initial_progress,
-    codex_turn_startup_timeout_seconds, json_rpc_request_id, log_codex_raw_turn_message,
-    message_params, receive_mcp_server_elicitation_response, request_user_input_result,
-    response_id, response_result, CodexNotificationSender, CodexRequestUserInputReceiver,
-    CodexRunState,
+    codex_turn_startup_timeout_seconds, is_mcp_tool_call_approval, json_rpc_request_id,
+    log_codex_raw_turn_message, message_params, receive_mcp_server_elicitation_response,
+    request_user_input_result, response_id, response_result, CodexNotificationSender,
+    CodexRequestUserInputReceiver, CodexRunState,
 };
 
 pub(super) struct JsonRpcConnection {
@@ -111,6 +111,7 @@ impl JsonRpcConnection {
         state: &mut CodexRunState,
         notifications: Option<CodexNotificationSender>,
         mut request_user_input_answers: Option<CodexRequestUserInputReceiver>,
+        auto_approve_mcp_tool_calls: bool,
     ) -> Result<ExecutionOutcome, String> {
         let mut saw_turn_response = false;
         let startup_timeout_seconds = codex_turn_startup_timeout_seconds();
@@ -140,8 +141,16 @@ impl JsonRpcConnection {
             {
                 waiting_for_initial_progress = false;
             }
-            if let Some(sender) = &notifications {
-                let _ = sender.send(message.clone());
+            let auto_approve_mcp_tool_call = auto_approve_mcp_tool_calls
+                && message
+                    .get("method")
+                    .and_then(Value::as_str)
+                    .is_some_and(|method| method == "mcpServer/elicitation/request")
+                && is_mcp_tool_call_approval(message_params(&message));
+            if !auto_approve_mcp_tool_call {
+                if let Some(sender) = &notifications {
+                    let _ = sender.send(message.clone());
+                }
             }
             if message
                 .get("method")
@@ -157,8 +166,12 @@ impl JsonRpcConnection {
                 .and_then(Value::as_str)
                 .is_some_and(|method| method == "mcpServer/elicitation/request")
             {
-                self.answer_mcp_server_elicitation(&message, &mut request_user_input_answers)
-                    .await?;
+                self.answer_mcp_server_elicitation(
+                    &message,
+                    &mut request_user_input_answers,
+                    auto_approve_mcp_tool_calls,
+                )
+                .await?;
                 continue;
             }
             if let Some(outcome) = state.handle_message(&message) {
@@ -195,12 +208,16 @@ impl JsonRpcConnection {
         &mut self,
         message: &Value,
         request_user_input_answers: &mut Option<CodexRequestUserInputReceiver>,
+        auto_approve_mcp_tool_calls: bool,
     ) -> Result<(), String> {
         let request_id = json_rpc_request_id(message)
             .ok_or_else(|| "mcpServer/elicitation/request is missing JSON-RPC id".to_owned())?;
-        let result =
-            receive_mcp_server_elicitation_response(message, request_user_input_answers.as_mut())
-                .await?;
+        let result = receive_mcp_server_elicitation_response(
+            message,
+            request_user_input_answers.as_mut(),
+            auto_approve_mcp_tool_calls,
+        )
+        .await?;
         self.write_message(json!({
             "id": request_id,
             "result": result,

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -390,6 +390,59 @@ fn mcp_form_elicitation_returns_accepted_form_content() {
 }
 
 #[test]
+fn mcp_tool_call_elicitation_can_be_auto_approved() {
+    let message = json!({
+        "id": 74,
+        "method": "mcpServer/elicitation/request",
+        "params": {
+            "serverName": "GitHub",
+            "mode": "form",
+            "message": "Allow GitHub to enable pull request auto-merge?",
+            "requestedSchema": {
+                "type": "object",
+                "properties": {}
+            },
+            "_meta": {
+                "codex_approval_kind": "mcp_tool_call",
+                "persist": ["session"]
+            }
+        }
+    });
+
+    assert!(is_mcp_tool_call_approval(message_params(&message)));
+    assert_eq!(
+        mcp_server_tool_call_approval_response(&message)
+            .expect("MCP tool call approval should be accepted"),
+        json!({
+            "action": "accept",
+            "content": Value::Null,
+            "_meta": Value::Null
+        })
+    );
+}
+
+#[test]
+fn mcp_business_form_is_not_treated_as_tool_call_approval() {
+    let params = json!({
+        "serverName": "wegent-sites",
+        "mode": "form",
+        "message": "请选择内网访问范围。",
+        "requestedSchema": {
+            "type": "object",
+            "properties": {
+                "audience": {
+                    "type": "string",
+                    "enum": ["all", "owner"]
+                }
+            }
+        }
+    });
+
+    assert!(!is_mcp_tool_call_approval(&params));
+    assert!(mcp_server_elicitation_request_user_input_params(&params).is_some());
+}
+
+#[test]
 fn wework_codex_home_defaults_to_executor_home_codex() {
     let _lock = crate::test_env::lock();
     let home = unique_test_path("wework-codex-home-default");
@@ -2525,6 +2578,24 @@ fn codex_full_access_permission_profile_is_applied_by_default() {
         );
         assert!(params.get("sandboxPolicy").is_none());
         assert!(params.get("sandbox").is_none());
+    }
+}
+
+#[test]
+fn codex_only_auto_approves_mcp_tool_calls_with_full_access() {
+    let full_access = ExecutionRequest::default();
+    assert!(codex_auto_approve_mcp_tool_calls(&full_access));
+
+    for profile in [
+        CODEX_WORKSPACE_PERMISSION_PROFILE,
+        CODEX_READ_ONLY_PERMISSION_PROFILE,
+    ] {
+        let mut request = ExecutionRequest::default();
+        request.extra.insert(
+            "runtime_permission_profile".to_owned(),
+            Value::String(profile.to_owned()),
+        );
+        assert!(!codex_auto_approve_mcp_tool_calls(&request));
     }
 }
 

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -1975,6 +1975,77 @@ async fn runtime_tasks_forward_and_accept_mcp_form_elicitation() {
 }
 
 #[tokio::test]
+async fn runtime_tasks_auto_approve_mcp_tool_calls_with_full_access() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-mcp-tool-approval-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-mcp-tool-approval-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let log_path = temp_path("runtime-mcp-tool-approval-log", "jsonl");
+    let fake_codex = write_fake_codex_mcp_tool_approval(&log_path);
+    let (event_tx, mut events) = broadcast::channel(32);
+    let handler = RuntimeWorkRpcHandler::with_event_sender(
+        "device-1",
+        fake_codex.display().to_string(),
+        event_tx,
+    );
+
+    let created = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.create",
+            "payload": {
+                "taskId": "local-task-mcp-tool-approval",
+                "workspacePath": "/tmp/project",
+                "message": "enable auto merge",
+                "executionRequest": {
+                    "task_id": 3003,
+                    "subtask_id": 4003,
+                    "prompt": "enable auto merge",
+                    "project_workspace_path": "/tmp/project",
+                    "bot": [{"shell_type": "ClaudeCode"}],
+                    "model_config": {
+                        "model": "openai",
+                        "model_id": "gpt-5.5",
+                        "api_format": "responses"
+                    }
+                }
+            }
+        }))
+        .await
+        .expect("create should be accepted");
+    assert_eq!(created["accepted"], true);
+
+    wait_until_task_idle(&handler, "local-task-mcp-tool-approval").await;
+    wait_for_json_call(&log_path, |call| {
+        call["id"] == 99
+            && call["result"]["action"] == "accept"
+            && call["result"]["content"].is_null()
+    })
+    .await;
+
+    let mut runtime_events = Vec::new();
+    while let Ok(event) = events.try_recv() {
+        runtime_events.push(event);
+    }
+    assert!(
+        find_runtime_event(&runtime_events, "response.block.created", |event| {
+            let block = &event["payload"]["data"]["block"];
+            block["tool_name"] == "request_user_input" && block["render_payload"]["requestId"] == 99
+        })
+        .is_none(),
+        "full access should not surface MCP tool approval as request_user_input"
+    );
+}
+
+#[tokio::test]
 async fn runtime_tasks_interrupt_and_send_unblocks_pending_request_user_input() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
@@ -3936,6 +4007,15 @@ fn write_fake_codex_mcp_elicitation(log_path: &Path) -> PathBuf {
         log_path,
         "fake-codex-mcp-elicitation",
         r#"{"id":99,"method":"mcpServer/elicitation/request","params":{"threadId":"thread-input","turnId":"turn-input","serverName":"wegent-sites","mode":"form","message":"请选择内网访问范围。","requestedSchema":{"type":"object","properties":{"audience":{"type":"string","title":"访问范围","enum":["all","owner"],"enumNames":["所有人","仅自己"]}},"required":["audience"]}}}"#,
+        0,
+    )
+}
+
+fn write_fake_codex_mcp_tool_approval(log_path: &Path) -> PathBuf {
+    write_fake_codex_interaction(
+        log_path,
+        "fake-codex-mcp-tool-approval",
+        r#"{"id":99,"method":"mcpServer/elicitation/request","params":{"threadId":"thread-input","turnId":"turn-input","serverName":"GitHub","mode":"form","message":"Allow GitHub to enable pull request auto-merge?","requestedSchema":{"type":"object","properties":{}},"_meta":{"codex_approval_kind":"mcp_tool_call","persist":["session"]}}}"#,
         0,
     )
 }


### PR DESCRIPTION
## Summary

- automatically accept MCP tool-call approval elicitations when the runtime permission profile is Full access
- keep read-only/workspace approval prompts and ordinary plugin business forms unchanged
- suppress auto-approved tool approval events from the Wework chat UI in both shared and legacy Codex app-server paths
- document the permission-mode behavior in Chinese and English

## Validation

- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`
- `cargo test --lib` — 1015 passed, 1 ignored
- `cargo test --test app_runtime_work_send_contract` — 41 passed
- Wework Prettier checks for both updated docs
- pre-push quality checks passed

Task: WORK-55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tool-call approvals are automatically accepted in Full access mode.
  * Regular plugin business forms continue to be shown to users.
  * Read-only and workspace permission modes continue displaying approval cards.

* **Bug Fixes**
  * Prevented automatically approved MCP requests from appearing as user-input events.

* **Documentation**
  * Updated English and Chinese guides with permission-mode behavior, configuration details, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->