### PR TITLE
fix(wework): recover tasks after system resume

### DIFF
--- a/wework/electron/src/dsh-preload.cts
+++ b/wework/electron/src/dsh-preload.cts
@@ -1,5 +1,13 @@
-import { contextBridge, webUtils } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 contextBridge.exposeInMainWorld('weworkElectronFiles', {
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
+})
+
+contextBridge.exposeInMainWorld('weworkElectronLifecycle', {
+  onSystemResume: (listener: () => void) => {
+    const handler = () => listener()
+    ipcRenderer.on('system:resume', handler)
+    return () => ipcRenderer.off('system:resume', handler)
+  },
 })

--- a/wework/electron/src/host/system-resume-bridge.test.ts
+++ b/wework/electron/src/host/system-resume-bridge.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest'
+import { SystemResumeBridge } from './system-resume-bridge.js'
+
+describe('SystemResumeBridge', () => {
+  test('broadcasts resume events to every live renderer', () => {
+    let resumeListener: (() => void) | null = null
+    const source = {
+      on: vi.fn((_event: 'resume', listener: () => void) => {
+        resumeListener = listener
+      }),
+      off: vi.fn(),
+    }
+    const liveTarget = {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn(),
+    }
+    const destroyedTarget = {
+      isDestroyed: vi.fn(() => true),
+      send: vi.fn(),
+    }
+    const bridge = new SystemResumeBridge(source, () => [liveTarget, destroyedTarget])
+
+    bridge.start()
+    resumeListener?.()
+
+    expect(liveTarget.send).toHaveBeenCalledWith('system:resume')
+    expect(destroyedTarget.send).not.toHaveBeenCalled()
+  })
+
+  test('registers once and removes the listener when stopped', () => {
+    const source = {
+      on: vi.fn(),
+      off: vi.fn(),
+    }
+    const bridge = new SystemResumeBridge(source, () => [])
+
+    bridge.start()
+    bridge.start()
+    bridge.stop()
+    bridge.stop()
+
+    expect(source.on).toHaveBeenCalledTimes(1)
+    expect(source.off).toHaveBeenCalledWith('resume', expect.any(Function))
+    expect(source.off).toHaveBeenCalledTimes(1)
+  })
+})

--- a/wework/electron/src/host/system-resume-bridge.ts
+++ b/wework/electron/src/host/system-resume-bridge.ts
@@ -1,0 +1,35 @@
+interface SystemResumeSource {
+  on(event: 'resume', listener: () => void): void
+  off(event: 'resume', listener: () => void): void
+}
+
+interface SystemResumeTarget {
+  isDestroyed(): boolean
+  send(channel: string): void
+}
+
+export class SystemResumeBridge {
+  private started = false
+  private readonly handleResume = () => {
+    for (const target of this.listTargets()) {
+      if (!target.isDestroyed()) target.send('system:resume')
+    }
+  }
+
+  constructor(
+    private readonly source: SystemResumeSource,
+    private readonly listTargets: () => SystemResumeTarget[]
+  ) {}
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.source.on('resume', this.handleResume)
+  }
+
+  stop(): void {
+    if (!this.started) return
+    this.started = false
+    this.source.off('resume', this.handleResume)
+  }
+}

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -5,11 +5,13 @@ import {
   ipcMain,
   Menu,
   nativeTheme,
+  powerMonitor,
   screen,
   session,
   shell,
   Tray,
   WebContentsView,
+  webContents,
   type MenuItemConstructorOptions,
   type WebContents,
 } from 'electron'
@@ -56,6 +58,7 @@ import {
   resolveRendererImageContext,
   scheduleTemporaryImageCleanup,
 } from './host/image-context-actions.js'
+import { SystemResumeBridge } from './host/system-resume-bridge.js'
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const dshPreloadPath = resolve(packageRoot, 'dist/dsh-preload.cjs')
@@ -104,6 +107,7 @@ const pendingEmbeddedBrowserAttachments = new Map<
 >()
 const rendererHealth = new RendererHealthService()
 const systemSleep = new SystemSleepController()
+const systemResume = new SystemResumeBridge(powerMonitor, () => webContents.getAllWebContents())
 const hasSingleInstanceLock = app.requestSingleInstanceLock()
 
 if (!hasSingleInstanceLock) app.quit()
@@ -746,6 +750,7 @@ function installIpc(): void {
 }
 
 async function shutdown(): Promise<void> {
+  systemResume.stop()
   systemSleep.stop()
   trayManager?.destroy()
   trayManager = null
@@ -992,6 +997,7 @@ if (hasSingleInstanceLock) {
     })
     installDshWindowLabelHeaders()
     installIpc()
+    systemResume.start()
     preferences = new PreferencesStore(app.getPath('userData'))
     windowClosePolicy = new WindowClosePolicy({
       read: async () => {

--- a/wework/src/api/backend/backendServices.ts
+++ b/wework/src/api/backend/backendServices.ts
@@ -132,6 +132,10 @@ export function createBackendWorkbenchServices(
     }),
     userApi: createUserApi(client),
     socketClient,
+    async recoverRuntimeConnections() {
+      socketClient.disconnect()
+      await socketClient.connect(undefined, true)
+    },
     projectChatClient,
     projectChatAgentApi,
     projectAutomationApi,

--- a/wework/src/api/backend/runtimeIpc.test.ts
+++ b/wework/src/api/backend/runtimeIpc.test.ts
@@ -8,12 +8,16 @@ const socket = {
   off: vi.fn(),
 }
 const ensureConnected = vi.fn().mockResolvedValue(undefined)
+const connect = vi.fn().mockResolvedValue(undefined)
+const disconnect = vi.fn()
 const dispose = vi.fn()
 
 vi.mock('@wegent/chat-core', () => ({
   createSocketClient: () => ({
     socket,
     ensureConnected,
+    connect,
+    disconnect,
     dispose,
   }),
 }))
@@ -24,6 +28,8 @@ describe('createCloudRuntimeIpcClient', () => {
     socket.on.mockReset()
     socket.off.mockReset()
     ensureConnected.mockClear()
+    connect.mockClear()
+    disconnect.mockClear()
     dispose.mockClear()
   })
 
@@ -135,5 +141,18 @@ describe('createCloudRuntimeIpcClient', () => {
     await expect(
       client.request('device.execute_command', { timeout_seconds: 900 }, 'device-1')
     ).resolves.toEqual({ success: true })
+  })
+
+  it('replaces the runtime socket after system resume', async () => {
+    const client = createCloudRuntimeIpcClient({
+      socketBaseUrl: 'https://cloud.example.com',
+      socketPath: '/socket.io',
+      token: 'token',
+    })
+
+    await client.reconnect()
+
+    expect(disconnect).toHaveBeenCalledTimes(1)
+    expect(connect).toHaveBeenCalledWith(undefined, true)
   })
 })

--- a/wework/src/api/backend/runtimeIpc.ts
+++ b/wework/src/api/backend/runtimeIpc.ts
@@ -38,6 +38,7 @@ export interface CloudRuntimeIpcClient {
     timeoutMs?: number
   ) => Promise<T>
   subscribe: (handler: (event: LocalExecutorEvent) => void) => Promise<() => void>
+  reconnect: () => Promise<void>
   dispose: () => void
 }
 
@@ -71,6 +72,10 @@ export function createCloudRuntimeIpcClient(
       }
       client.socket.on(RUNTIME_EVENT, runtimeHandler)
       return () => client.socket.off(RUNTIME_EVENT, runtimeHandler)
+    },
+    async reconnect() {
+      client.disconnect()
+      await client.connect(undefined, true)
     },
     dispose() {
       client.dispose()

--- a/wework/src/api/dsh/executorTransport.test.ts
+++ b/wework/src/api/dsh/executorTransport.test.ts
@@ -1,7 +1,9 @@
 import {
   describeDshExecutor,
   DshExecutorTransportError,
+  reconnectDshExecutorEvents,
   requestDshExecutor,
+  subscribeDshExecutorEvents,
 } from './executorTransport'
 
 describe('DSH executor transport', () => {
@@ -88,4 +90,71 @@ describe('DSH executor transport', () => {
       retryable: true,
     })
   })
+
+  test('replaces a stale executor event stream after system resume', () => {
+    const sources: FakeEventSource[] = []
+    vi.stubGlobal(
+      'EventSource',
+      class extends FakeEventSource {
+        constructor(url: string) {
+          super(url)
+          sources.push(this)
+        }
+      }
+    )
+    const listener = vi.fn()
+    const unsubscribe = subscribeDshExecutorEvents(listener)
+
+    expect(sources).toHaveLength(1)
+    sources[0].onmessage?.({
+      data: JSON.stringify({
+        protocolVersion: 1,
+        sequence: 7,
+        emittedAt: '2026-08-25T00:00:00.000Z',
+        event: 'response.output_text.delta',
+        payload: { taskId: 'task-1', delta: 'before sleep' },
+      }),
+    } as MessageEvent)
+
+    reconnectDshExecutorEvents()
+
+    expect(sources).toHaveLength(2)
+    expect(sources[0].closed).toBe(true)
+    expect(sources[1].url).toBe('/wework/executor/v1/events?after=7')
+
+    sources[0].onmessage?.({
+      data: JSON.stringify({
+        protocolVersion: 1,
+        sequence: 8,
+        emittedAt: '2026-08-25T00:00:01.000Z',
+        event: 'response.output_text.delta',
+        payload: { taskId: 'task-1', delta: 'stale' },
+      }),
+    } as MessageEvent)
+    sources[1].onmessage?.({
+      data: JSON.stringify({
+        protocolVersion: 1,
+        sequence: 8,
+        emittedAt: '2026-08-25T00:00:01.000Z',
+        event: 'response.output_text.delta',
+        payload: { taskId: 'task-1', delta: 'after wake' },
+      }),
+    } as MessageEvent)
+
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+    expect(sources[1].closed).toBe(true)
+  })
 })
+
+class FakeEventSource {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  closed = false
+
+  constructor(readonly url: string) {}
+
+  close() {
+    this.closed = true
+  }
+}

--- a/wework/src/api/dsh/executorTransport.ts
+++ b/wework/src/api/dsh/executorTransport.ts
@@ -1,4 +1,5 @@
 const EXECUTOR_BASE_PATH = '/wework/executor/v1'
+const executorEventReconnectors = new Set<() => void>()
 
 export interface DshExecutorDescription {
   protocol_version: number
@@ -104,10 +105,12 @@ export function subscribeDshExecutorEvents(
 
   const connect = () => {
     if (closed) return
-    source = new EventSource(
+    const nextSource = new EventSource(
       `${EXECUTOR_BASE_PATH}/events?after=${encodeURIComponent(String(cursor))}`
     )
-    source.onmessage = message => {
+    source = nextSource
+    nextSource.onmessage = message => {
+      if (source !== nextSource) return
       const event = JSON.parse(message.data) as DshExecutorEventEnvelope
       if (
         event.protocolVersion !== 1 ||
@@ -119,8 +122,9 @@ export function subscribeDshExecutorEvents(
       cursor = Math.max(cursor, event.sequence)
       listener(event)
     }
-    source.onerror = () => {
-      source?.close()
+    nextSource.onerror = () => {
+      if (source !== nextSource) return
+      nextSource.close()
       source = null
       if (!closed) {
         reconnectTimer = window.setTimeout(connect, 500)
@@ -128,13 +132,30 @@ export function subscribeDshExecutorEvents(
     }
   }
 
+  const reconnect = () => {
+    if (closed) return
+    if (reconnectTimer !== null) {
+      window.clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    source?.close()
+    source = null
+    connect()
+  }
+
+  executorEventReconnectors.add(reconnect)
   connect()
   return () => {
     closed = true
+    executorEventReconnectors.delete(reconnect)
     if (reconnectTimer !== null) window.clearTimeout(reconnectTimer)
     source?.close()
     source = null
   }
+}
+
+export function reconnectDshExecutorEvents(): void {
+  executorEventReconnectors.forEach(reconnect => reconnect())
 }
 
 function transportError(status: number, body: DshExecutorErrorBody): DshExecutorTransportError {

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -26,8 +26,11 @@ const mocks = vi.hoisted(() => {
   const cloudCreateDockerRemoteDeviceCommand = vi.fn()
   const cloudRuntimeIpcRequest = vi.fn()
   const cloudRuntimeIpcSubscribe = vi.fn(async () => vi.fn())
+  const cloudRuntimeIpcReconnect = vi.fn().mockResolvedValue(undefined)
   const localChatStreamSubscribe = vi.fn(() => vi.fn())
   const cloudRuntimeChatStreamSubscribe = vi.fn(() => vi.fn())
+  const localRecoverRuntimeConnections = vi.fn().mockResolvedValue(undefined)
+  const cloudRecoverRuntimeConnections = vi.fn().mockResolvedValue(undefined)
   const readElectronLocalFile = vi.fn()
   const localUploadAttachment = vi.fn()
   const localDeleteAttachment = vi.fn()
@@ -101,6 +104,7 @@ const mocks = vi.hoisted(() => {
       deleteAttachment: localDeleteAttachment,
     },
     chatStream: { subscribe: localChatStreamSubscribe },
+    recoverRuntimeConnections: localRecoverRuntimeConnections,
   }
 
   const cloudServices = {
@@ -143,6 +147,7 @@ const mocks = vi.hoisted(() => {
     userApi: { updateCurrentUser: cloudUpdateCurrentUser },
     chatStream: { subscribe: vi.fn(() => vi.fn()) },
     socketClient: { ensureConnected: vi.fn(), dispose: vi.fn() },
+    recoverRuntimeConnections: cloudRecoverRuntimeConnections,
     workspaceSessionApi: cloudWorkspaceSessionApi,
   }
 
@@ -169,8 +174,11 @@ const mocks = vi.hoisted(() => {
     cloudCreateDockerRemoteDeviceCommand,
     cloudRuntimeIpcRequest,
     cloudRuntimeIpcSubscribe,
+    cloudRuntimeIpcReconnect,
     localChatStreamSubscribe,
     cloudRuntimeChatStreamSubscribe,
+    localRecoverRuntimeConnections,
+    cloudRecoverRuntimeConnections,
     readElectronLocalFile,
     localUploadAttachment,
     localDeleteAttachment,
@@ -304,6 +312,7 @@ vi.mock('@/api/backend/runtimeIpc', () => ({
   createCloudRuntimeIpcClient: () => ({
     request: mocks.cloudRuntimeIpcRequest,
     subscribe: mocks.cloudRuntimeIpcSubscribe,
+    reconnect: mocks.cloudRuntimeIpcReconnect,
     dispose: vi.fn(),
   }),
 }))
@@ -513,6 +522,16 @@ describe('createHybridWorkbenchServices', () => {
       file_extension: '.png',
       created_at: '2026-08-11T00:00:00.000Z',
     })
+  })
+
+  it('recovers local and cloud runtime transports together', async () => {
+    const services = createServices()
+
+    await services.recoverRuntimeConnections?.()
+
+    expect(mocks.localRecoverRuntimeConnections).toHaveBeenCalledTimes(1)
+    expect(mocks.cloudRecoverRuntimeConnections).toHaveBeenCalledTimes(1)
+    expect(mocks.cloudRuntimeIpcReconnect).toHaveBeenCalledTimes(1)
   })
 
   it('reads a local attachment through the Electron host before uploading it to cloud', async () => {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -1358,6 +1358,13 @@ export function createHybridWorkbenchServices(
       resolveDevice: resolveExecutorDevice,
     }),
     chatStream: hybridChatStream,
+    async recoverRuntimeConnections() {
+      await Promise.all([
+        localServices.recoverRuntimeConnections?.(),
+        cloudServices.recoverRuntimeConnections?.(),
+        cloudRuntimeIpc.reconnect(),
+      ])
+    },
   }
 }
 

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -9,6 +9,7 @@ import {
   buildHarnessUserContext,
   type HarnessContextRegistration,
 } from '@/features/harness-apps/harnessContext'
+import { reconnectDshExecutorEvents } from '@/api/dsh/executorTransport'
 import { createExecutorClientFromApis } from '@/api/executorAccess'
 import { createLocalCodexPluginApi } from '@/api/local/codexPlugins'
 import { buildProjectPluginCatalog } from '@/features/plugins/projectPluginCatalog'
@@ -3667,5 +3668,8 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
       importRuntimeAuthJson: () => cloudConnectionRequired('importRuntimeAuthJson'),
     },
     chatStream: getRuntimeChatStream(subscribe, request),
+    async recoverRuntimeConnections() {
+      reconnectDshExecutorEvents()
+    },
   } as unknown as WorkbenchServices
 }

--- a/wework/src/desktop/systemResume.test.ts
+++ b/wework/src/desktop/systemResume.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { subscribeSystemResume } from './systemResume'
+
+describe('subscribeSystemResume', () => {
+  afterEach(() => {
+    delete window.weworkElectronLifecycle
+  })
+
+  test('subscribes through the Electron lifecycle preload bridge', () => {
+    const listener = vi.fn()
+    const unsubscribe = vi.fn()
+    const onSystemResume = vi.fn(() => unsubscribe)
+    window.weworkElectronLifecycle = { onSystemResume }
+
+    const cleanup = subscribeSystemResume(listener)
+
+    expect(onSystemResume).toHaveBeenCalledWith(listener)
+    cleanup()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  test('is a no-op outside Electron', () => {
+    expect(() => subscribeSystemResume(vi.fn())()).not.toThrow()
+  })
+})

--- a/wework/src/desktop/systemResume.ts
+++ b/wework/src/desktop/systemResume.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    weworkElectronLifecycle?: {
+      onSystemResume(listener: () => void): () => void
+    }
+  }
+}
+
+export function subscribeSystemResume(listener: () => void): () => void {
+  return window.weworkElectronLifecycle?.onSystemResume(listener) ?? (() => undefined)
+}

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.test.tsx
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.test.tsx
@@ -17,6 +17,7 @@ describe('RuntimeTaskLifecycleStreamCoordinator', () => {
   afterEach(() => {
     vi.useRealTimers()
     clearRuntimeConversationCacheForTests()
+    delete window.weworkElectronLifecycle
   })
 
   test('does not poll running task transcripts or work lists', async () => {
@@ -42,6 +43,53 @@ describe('RuntimeTaskLifecycleStreamCoordinator', () => {
 
     expect(listRuntimeWork).not.toHaveBeenCalled()
     expect(getRuntimeTranscript).not.toHaveBeenCalled()
+  })
+
+  test('reconnects and reconciles running tasks after system resume', async () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+    const address = runtimeTaskAddress()
+    store.syncRuntimeWork(runtimeWork(true))
+    store.setCurrentTask(address)
+    let resumeListener: (() => void) | null = null
+    window.weworkElectronLifecycle = {
+      onSystemResume(listener) {
+        resumeListener = listener
+        return () => {
+          resumeListener = null
+        }
+      },
+    }
+    const recoverRuntimeConnections = vi.fn().mockResolvedValue(undefined)
+    const listRuntimeWork = vi.fn().mockResolvedValue(runtimeWork(false))
+    const getRuntimeTranscript = vi.fn().mockResolvedValue(runtimeTranscript(false))
+    const services = {
+      chatStream: {
+        subscribe: vi.fn(() => vi.fn()),
+      },
+      recoverRuntimeConnections,
+      executorClient: {
+        runtime: {
+          listRuntimeWork,
+          getRuntimeTranscript,
+        },
+      },
+    } as unknown as WorkbenchServices
+
+    render(<RuntimeTaskLifecycleStreamCoordinator services={services} store={store} />)
+    await act(async () => {
+      resumeListener?.()
+    })
+
+    expect(recoverRuntimeConnections).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(listRuntimeWork).toHaveBeenCalledTimes(1))
+    await waitFor(() => {
+      expect(getRuntimeTranscript).toHaveBeenCalledWith({
+        ...address,
+        limit: 50,
+        refresh: true,
+      })
+    })
+    expect(store.getTask(address)?.derived.isRunning).toBe(false)
   })
 
   test('serializes stale-projection recovery with one trailing reconciliation', async () => {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.tsx
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.tsx
@@ -8,12 +8,13 @@ import {
   reconcileRuntimeConversationSnapshot,
   runtimeConversationKey,
 } from '../runtimeConversationCache'
+import { subscribeSystemResume } from '@/desktop/systemResume'
 import type { RuntimeTaskLifecycleStore } from './RuntimeTaskLifecycleStore'
 import { runtimeTaskLifecycleTransitionChanged } from './RuntimeTaskLifecycleStore'
 import { isRuntimePaneTranscriptConfirmedIdle, projectRuntimePaneTranscript } from './projection'
 import type { RuntimeTaskAddress } from '@/types/api'
 
-type ReconciliationReason = 'event_lagged' | 'runtime_replaced'
+type ReconciliationReason = 'event_lagged' | 'runtime_replaced' | 'system_resume'
 
 interface TerminalEventPayload {
   taskId?: string
@@ -32,6 +33,7 @@ export function RuntimeTaskLifecycleStreamCoordinator({
     () => createExecutorClientForWorkbenchServices(services),
     [services]
   )
+  const recoverRuntimeConnections = services.recoverRuntimeConnections
 
   useEffect(() => {
     let disposed = false
@@ -93,6 +95,15 @@ export function RuntimeTaskLifecycleStreamCoordinator({
         reconciliation = null
       })
     }
+
+    const unsubscribeSystemResume = subscribeSystemResume(() => {
+      void Promise.resolve()
+        .then(() => recoverRuntimeConnections?.())
+        .catch(error => {
+          console.warn('[Wework] Runtime transport recovery after system resume failed', error)
+        })
+        .finally(() => reconcile('system_resume'))
+    })
 
     const settleMatchingTask = (
       payload: TerminalEventPayload,
@@ -176,9 +187,10 @@ export function RuntimeTaskLifecycleStreamCoordinator({
 
     return () => {
       disposed = true
+      unsubscribeSystemResume()
       unsubscribe()
     }
-  }, [executorClient, services.chatStream, store])
+  }, [executorClient, recoverRuntimeConnections, services.chatStream, store])
 
   return null
 }

--- a/wework/src/features/workbench/workbenchServices.ts
+++ b/wework/src/features/workbench/workbenchServices.ts
@@ -168,6 +168,7 @@ export interface WorkbenchServices {
   executorClient?: ExecutorClient
   userApi?: ReturnType<typeof createUserApi>
   socketClient?: Pick<AuthenticatedSocketClient, 'ensureConnected' | 'dispose'>
+  recoverRuntimeConnections?: () => Promise<void>
   projectChatClient?: ProjectChatClient
   localProjectChatClient?: ProjectChatClient
   projectChatAgentApi?: ReturnType<typeof createProjectChatAgentApi>


### PR DESCRIPTION
## Summary

- forward Electron `powerMonitor.resume` events to every live Wework renderer through the DSH preload bridge
- replace potentially half-open local SSE and cloud runtime sockets after wake
- reconcile runtime work and transcripts for current/running tasks so stale running state settles without restarting Wework
- clean up the main-process resume listener during shutdown

## Root cause

After system sleep, SSE/WebSocket transports could remain logically connected while the underlying connection was no longer delivering events. Runtime task panes intentionally do not poll running transcripts, so a missed terminal event left the task UI stuck until an application restart rebuilt transports and refreshed state.

## Verification

- `pnpm --filter wework typecheck`
- `pnpm --dir wework/electron typecheck`
- `pnpm --dir wework/electron test src/host/system-resume-bridge.test.ts`
- `pnpm --filter wework test src/desktop/systemResume.test.ts src/api/dsh/executorTransport.test.ts src/api/backend/runtimeIpc.test.ts src/api/hybrid/hybridServices.test.ts src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.test.tsx`
- pre-push Wework quality checks: ESLint, TypeScript, Electron TypeScript, unit tests
- isolated real Electron verification: final source started successfully, returned the Wework workbench snapshot, and stopped cleanly

Wework task: WORK-100