### PR TITLE
fix(wework): show PR repair user messages

### DIFF
--- a/wework/e2e/desktop/scenarios/change-request-status.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/change-request-status.scenario.mjs
@@ -45,6 +45,9 @@ if [ "$state" = "pending" ]; then
 elif [ "$state" = "success" ]; then
   checks_state='SUCCESS'
   pr_state='OPEN'
+elif [ "$state" = "failure" ]; then
+  checks_state='FAILURE'
+  pr_state='OPEN'
 else
   checks_state='SUCCESS'
   pr_state='MERGED'
@@ -207,12 +210,35 @@ export async function createDesktopScenario({
       )
       await capture(control, 'change-request-status-02-pending.png')
 
+      await writeFile(statePath, 'failure\n')
+      await refreshEnvironment(control)
+      await control.command('waitFor', '[data-testid="change-request-checks"]', {
+        text: '检查失败',
+      })
+      await control.command('click', ENVIRONMENT_BUTTON)
+      await control.command('click', '[data-testid^="runtime-local-task-change-request-"]')
+      await control.command(
+        'waitFor',
+        '[data-testid^="runtime-local-task-change-request-"][data-testid$="-popover"]'
+      )
+      await control.command(
+        'click',
+        '[data-testid^="runtime-local-task-change-request-"][data-testid$="-repair"]'
+      )
+      await control.command('waitFor', '[data-testid="user-message-content"]', {
+        text: '修复 PR/MR #2631',
+        timeoutMs: uiTimeoutMs,
+      })
+      await capture(control, 'change-request-status-03-repair-user-message.png')
+      await control.command('click', ENVIRONMENT_BUTTON)
+      await control.command('waitFor', '[data-testid="environment-info-popover"]')
+
       await writeFile(statePath, 'success\n')
       await refreshEnvironment(control)
       await control.command('waitFor', '[data-testid="change-request-checks"]', {
         text: '检查通过',
       })
-      await capture(control, 'change-request-status-03-checks-passed.png')
+      await capture(control, 'change-request-status-04-checks-passed.png')
 
       await writeFile(statePath, 'unavailable\n')
       await refreshEnvironment(control)
@@ -220,7 +246,7 @@ export async function createDesktopScenario({
         text: '安装 GitHub CLI',
       })
       await control.command('waitFor', '[data-testid="create-pull-request-button"]')
-      await capture(control, 'change-request-status-04-cli-unavailable.png')
+      await capture(control, 'change-request-status-05-cli-unavailable.png')
 
       await control.command('click', '[data-testid="change-request-open-settings"]')
       await control.command('waitFor', '[data-testid="git-hosting-settings-page"]', {
@@ -237,7 +263,7 @@ export async function createDesktopScenario({
         'true',
         'PR/MR status lookup should be enabled by default'
       )
-      await capture(control, 'change-request-status-05-settings-enabled.png', 'body')
+      await capture(control, 'change-request-status-06-settings-enabled.png', 'body')
 
       await control.command('click', '[data-testid="change-request-status-switch"]')
       await waitForAttribute(
@@ -259,7 +285,7 @@ export async function createDesktopScenario({
         'false',
         'Disabled PR/MR status lookup should remain disabled after reopening settings'
       )
-      await capture(control, 'change-request-status-06-settings-disabled.png', 'body')
+      await capture(control, 'change-request-status-07-settings-disabled.png', 'body')
 
       await control.command('click', '[data-testid="change-request-status-switch"]')
       await waitForAttribute(
@@ -285,7 +311,7 @@ export async function createDesktopScenario({
       await control.command('waitFor', '[data-testid="change-request-checks"]', {
         text: '检查通过',
       })
-      await capture(control, 'change-request-status-07-recovered-merged.png')
+      await capture(control, 'change-request-status-08-recovered-merged.png')
     },
 
     diagnostics() {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -68,6 +68,7 @@ import {
   autoRepairStatus,
   buildChangeRequestRepairPrompt,
 } from '@/features/workbench/changeRequestStatus'
+import { createRuntimeUserMessage } from '@/features/workbench/runtimeUserMessage'
 import {
   getRuntimeConversationQueuePaused,
   subscribeRuntimeConversation,
@@ -1638,11 +1639,16 @@ function RuntimeTaskRow({
     if (!workbench || !changeRequest || !autoRepairStatus(changeRequest)) return
     setRepairingChangeRequest(true)
     try {
-      await workbench.sendRuntimePaneMessage({
-        address: taskAddress,
-        message: buildChangeRequestRepairPrompt(changeRequest, task.title),
-        source: { source: 'manual' },
-      })
+      const prompt = buildChangeRequestRepairPrompt(changeRequest, task.title)
+      const optimisticUserMessage = createRuntimeUserMessage(prompt)
+      await workbench.sendRuntimePaneMessage(
+        {
+          address: taskAddress,
+          message: prompt,
+          source: { source: 'manual' },
+        },
+        { optimisticUserMessage }
+      )
     } finally {
       setRepairingChangeRequest(false)
     }

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -104,6 +104,7 @@ import {
   resolveAutomaticModel,
   selectedModelExecutionFields,
 } from '@/features/workbench/runtimeModelSelection'
+import { createRuntimeUserMessage } from '@/features/workbench/runtimeUserMessage'
 import { projectRuntimeConversationTurns } from '@/features/workbench/runtimeConversationTurns'
 import {
   runtimeMessagesToWorkbenchMessages,
@@ -1606,16 +1607,21 @@ export function CloudTodoWorkspace({
       deviceId: binding.device_id,
       taskId: binding.task_id,
     })
-    const accepted = await workbench.sendRuntimePaneMessage({
-      address,
-      message: buildChangeRequestRepairPrompt(
-        changeRequest,
-        binding.task_title || binding.task_id,
-        selectedProject.pull_request_automation?.prompt
-      ),
-      source: { source: 'manual' },
-      cloudProjectId: String(selectedProject.id),
-    })
+    const prompt = buildChangeRequestRepairPrompt(
+      changeRequest,
+      binding.task_title || binding.task_id,
+      selectedProject.pull_request_automation?.prompt
+    )
+    const optimisticUserMessage = createRuntimeUserMessage(prompt)
+    const accepted = await workbench.sendRuntimePaneMessage(
+      {
+        address,
+        message: prompt,
+        source: { source: 'manual' },
+        cloudProjectId: String(selectedProject.id),
+      },
+      { optimisticUserMessage }
+    )
     if (!accepted) {
       throw new Error(t('workbench.change_request_continue_repair_failed', '无法继续任务'))
     }
@@ -1643,15 +1649,19 @@ export function CloudTodoWorkspace({
     const selectedAttachments = attachmentState?.attachments ?? []
     const attachmentIds = remoteAttachmentIds(selectedAttachments)
     const attachments = localRuntimeAttachments(selectedAttachments)
-    const accepted = await workbench.sendRuntimePaneMessage({
-      address,
-      message,
-      ...selectedModelExecutionFields(selectedModel, selectedModelOptions),
-      ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
-      ...(attachments.length > 0 ? { attachments } : {}),
-      source: { source: 'manual' },
-      cloudProjectId: String(selectedProject.id),
-    })
+    const optimisticUserMessage = createRuntimeUserMessage(message, selectedAttachments)
+    const accepted = await workbench.sendRuntimePaneMessage(
+      {
+        address,
+        message,
+        ...selectedModelExecutionFields(selectedModel, selectedModelOptions),
+        ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
+        source: { source: 'manual' },
+        cloudProjectId: String(selectedProject.id),
+      },
+      { optimisticUserMessage }
+    )
     if (accepted) projectChat.resetAttachmentsForScope(scopeKey)
     return accepted
   }

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -59,6 +59,7 @@ import {
   getRuntimeConversationMessages,
   getRuntimeConversationQueuedMessages,
 } from './runtimeConversationCache'
+import { createRuntimeUserMessage } from './runtimeUserMessage'
 import {
   getComposerApps,
   resetComposerAppsMemory,
@@ -2190,6 +2191,32 @@ function FollowUpProbe() {
         interrupt first queued
       </button>
     </div>
+  )
+}
+
+function ExternalRuntimeSendProbe() {
+  const workbench = useWorkbench()
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        const optimisticUserMessage = createRuntimeUserMessage('修复 PR #2631')
+        void workbench.sendRuntimePaneMessage(
+          {
+            address: {
+              deviceId: 'device-1',
+              workspacePath: '/workspace/project-alpha',
+              taskId: 'runtime-a',
+            },
+            message: optimisticUserMessage.content,
+          },
+          { optimisticUserMessage }
+        )
+      }}
+    >
+      repair pull request
+    </button>
   )
 }
 
@@ -10651,6 +10678,88 @@ describe('WorkbenchProvider runtime tasks', () => {
       modelOptions: { collaborationMode: 'default' },
     })
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('继续修')
+  })
+
+  test('shows user messages sent from an external runtime action', async () => {
+    const sendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: true,
+      taskId: 'runtime-a',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <ExternalRuntimeSendProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    await userEvent.click(screen.getByText('repair pull request'))
+
+    await waitFor(() => expect(sendRuntimeMessage).toHaveBeenCalledTimes(1))
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({
+      address: {
+        deviceId: 'device-1',
+        workspacePath: '/workspace/project-alpha',
+        taskId: 'runtime-a',
+      },
+      clientUserMessageId: expect.stringMatching(/^runtime-local-pane-/),
+      message: '修复 PR #2631',
+    })
+    expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('修复 PR #2631')
+  })
+
+  test('removes an external optimistic user message when sending fails', async () => {
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage: vi.fn().mockResolvedValue({
+        accepted: false,
+        taskId: 'runtime-a',
+        error: 'send failed',
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <ExternalRuntimeSendProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    await userEvent.click(screen.getByText('repair pull request'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).not.toHaveTextContent('修复 PR #2631')
+    )
   })
 
   test('only emits browser cleanup commands when browser annotations are cleared', async () => {

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -78,7 +78,10 @@ import {
   mergeRuntimeTaskHandles,
 } from './workbenchRuntimeHelpers'
 import type { WorkbenchRuntimeTasks } from './useWorkbenchRuntimeTasks'
-import { applyRuntimeConversationAction } from './runtimeConversationCache'
+import {
+  applyRuntimeConversationAction,
+  removeRuntimeConversationTurn,
+} from './runtimeConversationCache'
 import { findFileChangesBySubtaskId } from './runtimePaneMessages'
 import { isRuntimeTaskBusyError } from './runtimePaneStatus'
 import type { RuntimeTaskLifecycleStore } from './runtimeTaskLifecycle'
@@ -420,8 +423,21 @@ export function useWorkbenchRuntimeMessaging({
   const sendRuntimePaneMessage = useCallback(
     async (request: RuntimeSendRequest, options?: RuntimePaneActionOptions): Promise<boolean> => {
       let sendRequested = false
+      const optimisticUserMessage = options?.optimisticUserMessage
+      const outboundRequestWithClientId = optimisticUserMessage
+        ? {
+            ...request,
+            clientUserMessageId: optimisticUserMessage.id,
+          }
+        : request
+      if (optimisticUserMessage) {
+        applyRuntimeConversationAction(request.address, {
+          type: 'user_added',
+          message: optimisticUserMessage,
+        })
+      }
       try {
-        const outboundRequest = await prepareRuntimeSendRequest(request)
+        const outboundRequest = await prepareRuntimeSendRequest(outboundRequestWithClientId)
         if (!options?.silentBusyRetry) {
           lifecycleStore.sendRequested(outboundRequest.address)
           sendRequested = true
@@ -444,6 +460,11 @@ export function useWorkbenchRuntimeMessaging({
         }
         return true
       } catch (error) {
+        if (optimisticUserMessage) {
+          removeRuntimeConversationTurn(request.address, {
+            clientUserMessageId: optimisticUserMessage.id,
+          })
+        }
         const errorMessage = error instanceof Error ? error.message : '发送失败'
         const blockedByActiveTurn = isRuntimeTaskBusyError(errorMessage)
         if (sendRequested) {

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -169,6 +169,7 @@ export interface CreateProjectRuntimeTaskOptions {
 export interface RuntimePaneActionOptions {
   onError?: (error: string) => void
   silentBusyRetry?: boolean
+  optimisticUserMessage?: WorkbenchMessage & { role: 'user' }
 }
 
 export interface RuntimePaneGuidanceResult {


### PR DESCRIPTION
## Summary
- append PR repair prompts to the runtime conversation as optimistic user messages before sending
- bind the optimistic message to the executor turn with the same client user message ID and roll it back on send failure
- apply the same behavior to project-space PR repair and compact task replies
- extend the desktop change-request regression scenario to verify the user message is visible

## Verification
- `pnpm --filter wework test src/features/workbench/WorkbenchProvider.test.tsx -t "external runtime action|removes an external optimistic user message"`
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- pre-push Wework ESLint, TypeScript, and unit-test suite
- `pnpm --filter wework e2e:desktop -- --segment change-request-status` with prebuilt Electron app
- isolated `pnpm --filter wework ai:verify start/snapshot/stop`

Wework task: WORK-101