### PR TITLE
fix(wework): embed startup animation in main window

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -1946,6 +1946,16 @@ async fn read_shared_turn_notifications(
         let notification = shared_notification_result(received, last_outcome.clone())?;
         let message = match notification {
             SharedNotification::Message(message) => message,
+            SharedNotification::Lagged(skipped) => {
+                log_executor_event(
+                    "codex shared notification stream recovered from lag",
+                    &[
+                        ("thread_id", thread_id.to_owned()),
+                        ("skipped", skipped.to_string()),
+                    ],
+                );
+                continue;
+            }
             SharedNotification::Completed(outcome) => {
                 if cancellation_requested {
                     return Err(CODEX_APP_SERVER_TURN_CANCELLED.to_owned());
@@ -2194,6 +2204,7 @@ fn codex_notification_has_initial_progress(message: &Value, state: &CodexRunStat
 
 enum SharedNotification {
     Message(Value),
+    Lagged(u64),
     Completed(ExecutionOutcome),
 }
 
@@ -2203,8 +2214,8 @@ fn shared_notification_result(
 ) -> Result<SharedNotification, String> {
     match result {
         Ok(message) => Ok(SharedNotification::Message(message)),
-        Err(broadcast::error::RecvError::Lagged(_)) => {
-            Err("codex app-server notification stream lagged".to_owned())
+        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+            Ok(SharedNotification::Lagged(skipped))
         }
         Err(broadcast::error::RecvError::Closed) => last_outcome
             .map(SharedNotification::Completed)

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -121,6 +121,15 @@ async fn notification_hub_delivers_unscoped_process_exit_to_each_thread() {
     }
 }
 
+#[test]
+fn shared_notification_lag_is_recoverable() {
+    let notification =
+        shared_notification_result(Err(broadcast::error::RecvError::Lagged(37)), None)
+            .expect("lagged notifications should keep the turn alive");
+
+    assert!(matches!(notification, SharedNotification::Lagged(37)));
+}
+
 #[tokio::test]
 async fn interaction_answer_router_matches_reverse_order_answers() {
     let (sender, receiver) = mpsc::channel(2);

--- a/wework/electron/src/host/startup-splash.test.ts
+++ b/wework/electron/src/host/startup-splash.test.ts
@@ -13,11 +13,6 @@ class FakeSplashWindow implements StartupSplashWindow {
   private destroyed = false
   private visible = false
 
-  readonly close = vi.fn(() => {
-    this.destroyed = true
-    this.visible = false
-    this.listeners.get('closed')?.()
-  })
   readonly isDestroyed = vi.fn(() => this.destroyed)
   readonly isVisible = vi.fn(() => this.visible)
   readonly show = vi.fn(() => {
@@ -30,52 +25,57 @@ class FakeSplashWindow implements StartupSplashWindow {
     executeJavaScript: vi.fn(async () => true),
     isDestroyed: vi.fn(() => false),
   }
-  readonly loadFile = vi.fn(async () => {
-    this.listeners.get('ready-to-show')?.()
-  })
 
   once(event: 'closed' | 'ready-to-show', listener: () => void): void {
     this.listeners.set(event, listener)
+  }
+
+  ready(): void {
+    this.listeners.get('ready-to-show')?.()
   }
 }
 
 function createFixture(theme: StartupSplashTheme = 'light') {
   const target = new FakeSplashWindow()
-  const createWindow = vi.fn(() => target)
   const writePng = vi.fn(async () => undefined)
   let timestamp = 100
   const splash = createStartupSplash({
-    createWindow,
-    htmlPath: '/app/startup-splash/index.html',
+    window: target,
     theme,
     now: () => timestamp++,
     writePng,
   })
-  return { createWindow, splash, target, writePng }
+  const show = async () => {
+    const shown = splash.show()
+    target.ready()
+    return shown
+  }
+  return { show, splash, target, writePng }
 }
 
 describe('StartupSplash', () => {
   test('ships a visible loading animation that reports readiness after two frames', async () => {
     const electronRoot =
       basename(process.cwd()) === 'electron' ? process.cwd() : join(process.cwd(), 'electron')
-    const asset = (name: string) =>
+    const shellAsset = (name: string) => readFile(join(electronRoot, 'src', 'shell', name), 'utf8')
+    const splashAsset = (name: string) =>
       readFile(join(electronRoot, 'src', 'shell', 'startup-splash', name), 'utf8')
 
     const [html, styles, script] = await Promise.all([
-      asset('index.html'),
-      asset('styles.css'),
-      asset('splash.js'),
+      shellAsset('index.html'),
+      splashAsset('styles.css'),
+      splashAsset('splash.js'),
     ])
 
     expect(html).toContain('class="workbench-scene"')
     expect(html).toContain('id="morph-primary"')
     expect(html).toContain('class="stage-indicator"')
-    expect(html).toContain('class="robot"')
-    expect(html).toContain('class="human"')
-    expect(html).toContain('class="monitor"')
+    expect(html).toContain('class="workbench-window"')
+    expect(html).toContain('class="side-card side-card-left"')
+    expect(html).toContain('class="connection connection-left"')
     expect(html).toContain('aria-valuemax="3"')
-    expect(styles).toContain('@keyframes robot-bob')
-    expect(styles).toContain('@keyframes working-arm')
+    expect(styles).toContain('@keyframes window-arrive')
+    expect(styles).toContain('@keyframes connection-flow')
     expect(html).toContain('document.documentElement.dataset.theme = theme')
     expect(styles).toContain(":root[data-theme='dark']")
     expect(styles).toContain('@media (prefers-reduced-motion: reduce)')
@@ -88,33 +88,11 @@ describe('StartupSplash', () => {
     )
   })
 
-  test('creates a secure branded splash and records its visible animation timeline', async () => {
-    const { createWindow, splash, target } = createFixture()
+  test('shows the branded animation in the main startup window and records its timeline', async () => {
+    const { show, target } = createFixture()
 
-    const snapshot = await splash.show()
+    const snapshot = await show()
 
-    expect(createWindow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        width: 420,
-        height: 260,
-        show: false,
-        frame: false,
-        transparent: false,
-        resizable: false,
-        alwaysOnTop: true,
-        skipTaskbar: true,
-        hasShadow: false,
-        backgroundColor: '#fafafa',
-        webPreferences: {
-          contextIsolation: true,
-          nodeIntegration: false,
-          sandbox: true,
-        },
-      })
-    )
-    expect(target.loadFile).toHaveBeenCalledWith('/app/startup-splash/index.html', {
-      query: { theme: 'light' },
-    })
     expect(target.show).toHaveBeenCalledOnce()
     expect(target.webContents.executeJavaScript).toHaveBeenCalledWith(
       expect.stringContaining('dataset.animationReady')
@@ -135,19 +113,12 @@ describe('StartupSplash', () => {
     })
   })
 
-  test('uses the saved dark appearance for the native window and splash document', async () => {
-    const { createWindow, splash, target } = createFixture('dark')
+  test('retains the saved dark appearance in the embedded splash snapshot', async () => {
+    const { show } = createFixture('dark')
 
-    await splash.show()
+    const snapshot = await show()
 
-    expect(createWindow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backgroundColor: '#171717',
-      })
-    )
-    expect(target.loadFile).toHaveBeenCalledWith('/app/startup-splash/index.html', {
-      query: { theme: 'dark' },
-    })
+    expect(snapshot.theme).toBe('dark')
   })
 
   test('resolves explicit appearance modes before falling back to the system theme', () => {
@@ -159,26 +130,25 @@ describe('StartupSplash', () => {
   })
 
   test('does not capture or write files during a production close', async () => {
-    const { splash, target, writePng } = createFixture()
-    await splash.show()
+    const { show, splash, target, writePng } = createFixture()
+    await show()
 
     const snapshot = await splash.close()
 
     expect(target.webContents.capturePage).not.toHaveBeenCalled()
     expect(writePng).not.toHaveBeenCalled()
-    expect(target.close).toHaveBeenCalledOnce()
     expect(snapshot.state).toBe('closed')
     expect(snapshot.events.at(-1)).toEqual({ name: 'closed', timestamp: 103 })
     expect(snapshot.window).toEqual({
       exists: true,
-      destroyed: true,
-      visible: false,
+      destroyed: false,
+      visible: true,
     })
   })
 
   test('captures and persists the rendered splash before closing when requested by E2E', async () => {
-    const { splash, target, writePng } = createFixture()
-    await splash.show()
+    const { show, splash, target, writePng } = createFixture()
+    await show()
 
     await splash.close({ capturePath: '/tmp/wework-e2e/startup-splash.png' })
 
@@ -187,17 +157,17 @@ describe('StartupSplash', () => {
       '/tmp/wework-e2e/startup-splash.png',
       Buffer.from('splash-png')
     )
-    expect(writePng.mock.invocationCallOrder[0]).toBeLessThan(
-      target.close.mock.invocationCallOrder[0]
-    )
   })
 
-  test('creates only one native window when show is called concurrently', async () => {
-    const { createWindow, splash } = createFixture()
+  test('shows the main startup window only once when show is called concurrently', async () => {
+    const { splash, target } = createFixture()
 
-    const [first, second] = await Promise.all([splash.show(), splash.show()])
+    const firstPromise = splash.show()
+    const secondPromise = splash.show()
+    target.ready()
+    const [first, second] = await Promise.all([firstPromise, secondPromise])
 
-    expect(createWindow).toHaveBeenCalledOnce()
+    expect(target.show).toHaveBeenCalledOnce()
     expect(first).toEqual(second)
   })
 })

--- a/wework/electron/src/host/startup-splash.ts
+++ b/wework/electron/src/host/startup-splash.ts
@@ -1,6 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import type { BrowserWindowConstructorOptions, LoadFileOptions } from 'electron'
 
 export type StartupSplashEventName = 'created' | 'shown' | 'animation-ready' | 'closed'
 export type StartupSplashTheme = 'light' | 'dark'
@@ -32,18 +31,15 @@ interface SplashWebContents {
 }
 
 export interface StartupSplashWindow {
-  close: () => void
   isDestroyed: () => boolean
   isVisible: () => boolean
-  loadFile: (path: string, options?: LoadFileOptions) => Promise<void>
   once: (event: 'closed' | 'ready-to-show', listener: () => void) => void
   show: () => void
   webContents: SplashWebContents
 }
 
 export interface StartupSplashOptions {
-  createWindow: (options: BrowserWindowConstructorOptions) => StartupSplashWindow
-  htmlPath: string
+  window: StartupSplashWindow
   theme: StartupSplashTheme
   now?: () => number
   writePng?: (path: string, bytes: Buffer) => Promise<void>
@@ -66,38 +62,12 @@ const WAIT_FOR_ANIMATION_READY = `
   })
 `
 
-const WINDOW_OPTIONS: Readonly<BrowserWindowConstructorOptions> = {
-  width: 420,
-  height: 260,
-  show: false,
-  frame: false,
-  transparent: false,
-  resizable: false,
-  minimizable: false,
-  maximizable: false,
-  fullscreenable: false,
-  movable: false,
-  center: true,
-  alwaysOnTop: true,
-  skipTaskbar: true,
-  hasShadow: false,
-  webPreferences: {
-    contextIsolation: true,
-    nodeIntegration: false,
-    sandbox: true,
-  },
-}
-
 export function resolveStartupSplashTheme(
   appearanceMode: unknown,
   systemUsesDarkColors: boolean
 ): StartupSplashTheme {
   if (appearanceMode === 'light' || appearanceMode === 'dark') return appearanceMode
   return systemUsesDarkColors ? 'dark' : 'light'
-}
-
-function startupSplashBackgroundColor(theme: StartupSplashTheme): string {
-  return theme === 'dark' ? '#171717' : '#fafafa'
 }
 
 async function writePng(path: string, bytes: Buffer): Promise<void> {
@@ -109,13 +79,13 @@ export class StartupSplash {
   private readonly events: StartupSplashEvent[] = []
   private readonly now: () => number
   private readonly persistPng: (path: string, bytes: Buffer) => Promise<void>
-  private window: StartupSplashWindow | null = null
   private state: StartupSplashSnapshot['state'] = 'idle'
   private showPromise: Promise<StartupSplashSnapshot> | null = null
 
   constructor(private readonly options: StartupSplashOptions) {
     this.now = options.now ?? Date.now
     this.persistPng = options.writePng ?? writePng
+    this.record('created')
   }
 
   show(): Promise<StartupSplashSnapshot> {
@@ -129,8 +99,8 @@ export class StartupSplash {
   }
 
   async close(options: CloseStartupSplashOptions = {}): Promise<StartupSplashSnapshot> {
-    const target = this.window
-    if (!target || target.isDestroyed()) {
+    const target = this.options.window
+    if (target.isDestroyed()) {
       this.markClosed()
       return this.snapshot()
     }
@@ -141,7 +111,6 @@ export class StartupSplash {
         await this.persistPng(options.capturePath, image.toPNG())
       }
     } finally {
-      if (!target.isDestroyed()) target.close()
       this.markClosed()
     }
 
@@ -149,28 +118,23 @@ export class StartupSplash {
   }
 
   snapshot(): StartupSplashSnapshot {
-    const target = this.window
-    const destroyed = target?.isDestroyed() ?? false
+    const target = this.options.window
+    const destroyed = target.isDestroyed()
     return {
       state: this.state,
       theme: this.options.theme,
       events: this.events.map(event => ({ ...event })),
       window: {
-        exists: target !== null,
+        exists: true,
         destroyed,
-        visible: target !== null && !destroyed && target.isVisible(),
+        visible: !destroyed && target.isVisible(),
       },
     }
   }
 
   private async createAndShow(): Promise<StartupSplashSnapshot> {
     this.state = 'loading'
-    const target = this.options.createWindow({
-      ...WINDOW_OPTIONS,
-      backgroundColor: startupSplashBackgroundColor(this.options.theme),
-    })
-    this.window = target
-    this.record('created')
+    const target = this.options.window
 
     const shown = new Promise<void>(resolve => {
       target.once('ready-to-show', () => {
@@ -184,9 +148,6 @@ export class StartupSplash {
     })
     target.once('closed', () => this.markClosed())
 
-    await target.loadFile(this.options.htmlPath, {
-      query: { theme: this.options.theme },
-    })
     await shown
     if (!target.webContents.isDestroyed()) {
       await target.webContents.executeJavaScript(WAIT_FOR_ANIMATION_READY)

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -49,7 +49,11 @@ import { createSingleFlight, presentWindow } from './host/window-presentation.js
 import { DesktopRuntime } from './runtime/desktop-runtime.js'
 import { FeedbackBundleManager } from './host/feedback-bundle-manager.js'
 import { WorkbenchPluginManager } from './host/workbench-plugin-manager.js'
-import { resolveStartupSplashTheme, StartupSplash } from './host/startup-splash.js'
+import {
+  resolveStartupSplashTheme,
+  StartupSplash,
+  type StartupSplashTheme,
+} from './host/startup-splash.js'
 import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
 import { createTrayIcon } from './host/tray-icon.js'
 import { WindowClosePolicy, type WindowCloseDecision } from './host/window-close-policy.js'
@@ -385,11 +389,6 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
     runtimeError = null
     rendererHealth.ready()
     mainWindow?.show()
-    void startupSplash
-      ?.close({ capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim() })
-      .catch(error => {
-        console.error('[startup-splash] failed to close startup window', error)
-      })
   })
   contents.on('unresponsive', () => rendererHealth.unresponsive())
   contents.on('responsive', () => rendererHealth.responsive())
@@ -407,6 +406,9 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
     })
   })
   try {
+    await startupSplash?.close({
+      capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim(),
+    })
     await contents.loadURL(dshUrl, {
       extraHeaders: 'X-Wework-Window-Label: main',
     })
@@ -608,13 +610,13 @@ async function showPopoutWindow(): Promise<void> {
   presentWindow(target)
 }
 
-async function createWindow(): Promise<void> {
+async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
   mainWindow = new BrowserWindow({
     ...desktopWindowFrameOptions(),
     width: 1440,
     height: 960,
     title: 'Wework',
-    backgroundColor: '#101316',
+    backgroundColor: startupTheme === 'dark' ? '#101316' : '#fafafa',
     show: false,
     webPreferences: {
       backgroundThrottling: false,
@@ -625,6 +627,30 @@ async function createWindow(): Promise<void> {
       webviewTag: true,
     },
   })
+  startupSplash = new StartupSplash({
+    window: {
+      isDestroyed: () => mainWindow?.isDestroyed() ?? true,
+      isVisible: () => mainWindow?.isVisible() ?? false,
+      once: (event, listener) => {
+        if (event === 'closed') mainWindow?.once('closed', listener)
+        else mainWindow?.once('ready-to-show', listener)
+      },
+      show: () => mainWindow?.show(),
+      webContents: {
+        capturePage: async () => {
+          if (!mainWindow) throw new Error('Main window is unavailable')
+          return mainWindow.webContents.capturePage()
+        },
+        executeJavaScript: async code => {
+          if (!mainWindow) throw new Error('Main window is unavailable')
+          return mainWindow.webContents.executeJavaScript(code)
+        },
+        isDestroyed: () => mainWindow?.webContents.isDestroyed() ?? true,
+      },
+    },
+    theme: startupTheme,
+  })
+  const startupShown = startupSplash.show()
   mainWindow.on('resize', layoutPrimaryView)
   mainWindow.on('close', event => {
     if (quitting) return
@@ -637,7 +663,10 @@ async function createWindow(): Promise<void> {
     primaryDshSecurityInstalled = false
     mainWindow = null
   })
-  await mainWindow.loadFile(resolve(packageRoot, 'dist/shell/index.html'))
+  await mainWindow.loadFile(resolve(packageRoot, 'dist/shell/index.html'), {
+    query: { theme: startupTheme },
+  })
+  await startupShown
 }
 
 async function setDockVisible(visible: boolean): Promise<void> {
@@ -1026,33 +1055,9 @@ if (hasSingleInstanceLock) {
     createdTrayManager.create()
     trayManager = createdTrayManager
     const startupPreferences = await preferences.read()
-    startupSplash = new StartupSplash({
-      createWindow: options => {
-        const target = new BrowserWindow(options)
-        return {
-          close: () => target.close(),
-          isDestroyed: () => target.isDestroyed(),
-          isVisible: () => target.isVisible(),
-          loadFile: (path, options) => target.loadFile(path, options),
-          once: (event, listener) => {
-            if (event === 'closed') target.once('closed', listener)
-            else target.once('ready-to-show', listener)
-          },
-          show: () => target.show(),
-          webContents: {
-            capturePage: () => target.webContents.capturePage(),
-            executeJavaScript: code => target.webContents.executeJavaScript(code),
-            isDestroyed: () => target.webContents.isDestroyed(),
-          },
-        }
-      },
-      htmlPath: resolve(packageRoot, 'dist/shell/startup-splash/index.html'),
-      theme: resolveStartupSplashTheme(
-        startupPreferences.appearanceMode,
-        nativeTheme.shouldUseDarkColors
-      ),
-    })
-    await Promise.all([startupSplash.show(), createWindow()])
+    await createWindow(
+      resolveStartupSplashTheme(startupPreferences.appearanceMode, nativeTheme.shouldUseDarkColors)
+    )
     void startDesktopRuntime()
   })
 }

--- a/wework/electron/src/shell/index.html
+++ b/wework/electron/src/shell/index.html
@@ -3,19 +3,79 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Wework</title>
+    <script>
+      const theme = new URLSearchParams(window.location.search).get('theme')
+      document.documentElement.dataset.theme = theme === 'dark' ? 'dark' : 'light'
+    </script>
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./startup-splash/styles.css" />
   </head>
   <body>
     <main id="runtime-overlay" data-phase="initializing">
-      <section class="runtime-card" aria-live="polite">
-        <div class="runtime-spinner" aria-hidden="true"></div>
+      <section id="splash-root" class="splash" aria-label="Wework is starting">
+        <div class="workbench-scene" aria-hidden="true">
+          <svg class="workbench" viewBox="0 0 300 132">
+            <path class="connection connection-left" d="M74 66h36" />
+            <path class="connection connection-right" d="M190 66h36" />
+            <circle class="connection-pulse connection-pulse-left" cx="74" cy="66" r="3" />
+            <circle class="connection-pulse connection-pulse-right" cx="226" cy="66" r="3" />
+
+            <g class="side-card side-card-left">
+              <rect x="24" y="42" width="50" height="48" rx="12" />
+              <path d="M37 56h24M37 65h18M37 74h21" />
+              <circle cx="60" cy="80" r="3" />
+            </g>
+
+            <g class="workbench-window">
+              <rect class="window-shell" x="110" y="24" width="80" height="84" rx="16" />
+              <path class="window-toolbar" d="M110 44h80" />
+              <circle class="window-control" cx="124" cy="34" r="3" />
+              <circle class="window-control" cx="134" cy="34" r="3" />
+              <g class="morph-icon" transform="translate(126 53) scale(2)">
+                <path id="morph-primary" />
+                <path id="morph-secondary" />
+                <path id="morph-tertiary" />
+              </g>
+              <path class="window-content-line" d="M126 94h48" />
+            </g>
+
+            <g class="side-card side-card-right">
+              <rect x="226" y="42" width="50" height="48" rx="12" />
+              <rect x="239" y="55" width="24" height="20" rx="6" />
+              <path d="m244 65 4 4 9-10" />
+            </g>
+
+            <path class="baseline" d="M45 116h210" />
+          </svg>
+        </div>
+        <div class="splash-copy">
+          <h1 id="splash-title">We're preparing your workbench</h1>
+          <p id="splash-status" aria-live="polite">Opening your projects</p>
+        </div>
+        <div
+          id="stage-indicator"
+          class="stage-indicator"
+          role="progressbar"
+          aria-label="Preparing your workbench"
+          aria-valuemin="1"
+          aria-valuemax="3"
+          aria-valuenow="1"
+        >
+          <span class="stage-dot is-active"></span>
+          <span class="stage-dot"></span>
+          <span class="stage-dot"></span>
+        </div>
+      </section>
+      <section class="runtime-card" aria-live="polite" hidden>
         <h1>正在启动 Wework</h1>
-        <p id="status">正在初始化 Core DSH…</p>
+        <p id="runtime-status">正在初始化 Core DSH…</p>
         <pre id="details" hidden></pre>
         <button id="reload-dsh" type="button" hidden>重试启动</button>
       </section>
     </main>
+    <script src="./startup-splash/splash.js"></script>
     <script src="./shell.js"></script>
   </body>
 </html>

--- a/wework/electron/src/shell/shell.js
+++ b/wework/electron/src/shell/shell.js
@@ -1,12 +1,17 @@
-const status = document.querySelector('#status')
+const status = document.querySelector('#runtime-status')
 const details = document.querySelector('#details')
 const reloadButton = document.querySelector('#reload-dsh')
 const overlay = document.querySelector('#runtime-overlay')
+const runtimeCard = document.querySelector('.runtime-card')
+const splash = document.querySelector('#splash-root')
 
 async function refreshState() {
   try {
     const state = await window.weworkElectron.getRuntimeState()
     overlay.dataset.phase = state.phase
+    const failed = state.phase === 'failed'
+    runtimeCard.hidden = !failed
+    splash.hidden = failed
     status.textContent = state.ready
       ? '运行时已就绪'
       : state.phase === 'failed'
@@ -19,6 +24,8 @@ async function refreshState() {
     reloadButton.disabled = false
   } catch (error) {
     overlay.dataset.phase = 'failed'
+    runtimeCard.hidden = false
+    splash.hidden = true
     status.textContent = `无法读取运行时状态：${error instanceof Error ? error.message : String(error)}`
     details.hidden = false
     details.textContent = error instanceof Error ? error.stack || error.message : String(error)

--- a/wework/electron/src/shell/shell.test.ts
+++ b/wework/electron/src/shell/shell.test.ts
@@ -6,7 +6,14 @@ import { describe, expect, test, vi } from 'vitest'
 describe('Electron startup shell', () => {
   test('renders initialization and failure states and retries the runtime', async () => {
     const elements = new Map(
-      ['#status', '#details', '#reload-dsh', '#runtime-overlay'].map(selector => [
+      [
+        '#runtime-status',
+        '#details',
+        '#reload-dsh',
+        '#runtime-overlay',
+        '.runtime-card',
+        '#splash-root',
+      ].map(selector => [
         selector,
         {
           dataset: {} as Record<string, string>,
@@ -40,20 +47,26 @@ describe('Electron startup shell', () => {
 
     vm.runInContext(source, context)
     await vi.waitFor(() => {
-      expect(elements.get('#status')?.textContent).toBe('正在初始化 Core DSH…')
+      expect(elements.get('#runtime-status')?.textContent).toBe('正在初始化 Core DSH…')
       expect(elements.get('#runtime-overlay')?.dataset.phase).toBe('initializing')
       expect(elements.get('#reload-dsh')?.hidden).toBe(true)
+      expect(elements.get('.runtime-card')?.hidden).toBe(true)
+      expect(elements.get('#splash-root')?.hidden).toBe(false)
     })
 
     state.phase = 'failed'
     state.error = 'profile install failed'
     listeners[0]?.()
     await vi.waitFor(() => {
-      expect(elements.get('#status')?.textContent).toBe('运行时启动失败：profile install failed')
+      expect(elements.get('#runtime-status')?.textContent).toBe(
+        '运行时启动失败：profile install failed'
+      )
       expect(elements.get('#reload-dsh')?.textContent).toBe('重试启动')
       expect(elements.get('#runtime-overlay')?.dataset.phase).toBe('failed')
       expect(elements.get('#details')?.hidden).toBe(false)
       expect(elements.get('#reload-dsh')?.hidden).toBe(false)
+      expect(elements.get('.runtime-card')?.hidden).toBe(false)
+      expect(elements.get('#splash-root')?.hidden).toBe(true)
     })
 
     const clickHandler = vi.mocked(elements.get('#reload-dsh')?.addEventListener).mock

--- a/wework/electron/src/shell/startup-splash/styles.css
+++ b/wework/electron/src/shell/startup-splash/styles.css
@@ -46,12 +46,11 @@ body {
   border-radius: 22px;
   background: rgb(250 250 250 / 97%);
   box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
-  -webkit-app-region: drag;
 }
 
 .workbench-scene {
   width: 300px;
-  height: 126px;
+  height: 132px;
 }
 
 .workbench {
@@ -61,163 +60,106 @@ body {
   overflow: visible;
 }
 
-.floor-line {
+.baseline,
+.connection {
   fill: none;
-  stroke: rgb(23 23 23 / 9%);
+  stroke: rgb(23 23 23 / 12%);
   stroke-width: 1.5;
   stroke-linecap: round;
-  stroke-dasharray: 266;
-  animation: floor-arrive 700ms ease-out both;
 }
 
-.robot {
-  transform-box: fill-box;
-  transform-origin: center bottom;
-  animation: robot-bob 2.2s ease-in-out infinite;
+.baseline {
+  stroke-dasharray: 210;
+  animation: baseline-arrive 620ms ease-out both;
 }
 
-.robot-head rect,
-.robot-body rect,
-.toolbox rect,
-.monitor-shell,
-.keyboard rect,
-.assembly-piece rect,
-.assembly-piece circle {
-  fill: #fff;
+.connection {
+  stroke-dasharray: 36;
+  animation: connection-flow 1.8s ease-in-out infinite;
+}
+
+.connection-right {
+  animation-delay: 300ms;
+}
+
+.connection-pulse {
+  fill: #7c3aed;
+  opacity: 0;
+}
+
+.connection-pulse-left {
+  animation: pulse-left 1.8s ease-in-out infinite;
+}
+
+.connection-pulse-right {
+  animation: pulse-right 1.8s 300ms ease-in-out infinite;
+}
+
+.side-card {
+  fill: rgb(23 23 23 / 2%);
   stroke: rgb(23 23 23 / 16%);
   stroke-width: 1.5;
-}
-
-.robot-head,
-.robot-body,
-.robot-antenna,
-.robot-arm,
-.robot-leg,
-.toolbox,
-.monitor,
-.keyboard,
-.human,
-.human-face,
-.human-working-arm,
-.robot-sparks,
-.assembly-piece {
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.robot-head {
   transform-box: fill-box;
   transform-origin: center;
-  animation: robot-head-tilt 2.8s ease-in-out infinite;
 }
 
-.robot-ear,
-.robot-smile,
-.robot-antenna path,
-.robot-arm,
-.robot-leg {
+.side-card path {
   fill: none;
-  stroke: rgb(23 23 23 / 44%);
-  stroke-width: 2;
+  stroke: rgb(23 23 23 / 32%);
+  stroke-width: 1.5;
 }
 
-.robot-antenna {
-  fill: none;
-  stroke: #7c3aed;
-  stroke-width: 1.75;
-  transform-box: fill-box;
-  transform-origin: center bottom;
-  animation: antenna-wiggle 1.8s ease-in-out infinite;
-}
-
-.robot-antenna-tip {
+.side-card circle {
   fill: #7c3aed;
   stroke: none;
-  animation: antenna-pulse 1.2s ease-in-out infinite;
 }
 
-.robot-eyes {
-  fill: #7c3aed;
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: robot-blink 3.6s infinite;
+.side-card-left {
+  animation: card-arrive-left 620ms 120ms cubic-bezier(0.2, 0.85, 0.25, 1) both;
 }
 
-.robot-body {
-  fill: none;
-  stroke: rgb(23 23 23 / 28%);
-  stroke-width: 1.5;
+.side-card-right {
+  animation: card-arrive-right 620ms 220ms cubic-bezier(0.2, 0.85, 0.25, 1) both;
 }
 
-.robot-body circle {
-  fill: rgb(124 58 237 / 8%);
+.side-card-right rect + rect {
+  fill: rgb(124 58 237 / 7%);
   stroke: #7c3aed;
-  stroke-width: 1.5;
-  animation: chest-pulse 1.8s ease-in-out infinite;
 }
 
-.robot-working-arm {
-  transform-box: view-box;
-  transform-origin: 82px 61px;
-  animation: working-arm 800ms ease-in-out infinite alternate;
-}
-
-.robot-hand {
-  fill: #fff;
+.side-card-right path {
   stroke: #7c3aed;
   stroke-width: 1.75;
 }
 
-.toolbox {
-  fill: none;
-  stroke: rgb(23 23 23 / 35%);
-  stroke-width: 1.5;
+.workbench-window {
   transform-box: fill-box;
-  transform-origin: center bottom;
-  animation: toolbox-arrive 540ms 260ms cubic-bezier(0.2, 0.85, 0.25, 1) both;
+  transform-origin: center;
+  animation: window-arrive 560ms cubic-bezier(0.2, 0.85, 0.25, 1) both;
 }
 
-.monitor {
-  transform-box: fill-box;
-  transform-origin: center bottom;
-  animation: monitor-arrive 620ms 120ms cubic-bezier(0.2, 0.85, 0.25, 1) both;
-}
-
-.monitor-shell {
-  fill: rgb(23 23 23 / 3%);
-}
-
-.monitor-screen {
+.window-shell {
   fill: #fff;
-  stroke: rgb(23 23 23 / 10%);
-  stroke-width: 1;
+  stroke: rgb(23 23 23 / 18%);
+  stroke-width: 1.5;
 }
 
-.monitor-stand {
+.window-toolbar,
+.window-content-line {
   fill: none;
-  stroke: rgb(23 23 23 / 24%);
-  stroke-width: 2;
+  stroke: rgb(23 23 23 / 12%);
+  stroke-width: 1.5;
   stroke-linecap: round;
 }
 
-.monitor-status {
-  fill: #7c3aed;
-  transition:
-    fill 260ms ease,
-    opacity 260ms ease;
+.window-control {
+  fill: rgb(23 23 23 / 16%);
 }
 
-body[data-stage='0'] .monitor-status {
-  opacity: 0.4;
-}
-
-body[data-stage='1'] .monitor-status {
-  animation: status-pulse 700ms ease-in-out infinite;
-}
-
-body[data-stage='2'] .monitor-status {
-  fill: #22a06b;
-  opacity: 1;
+.window-content-line {
+  stroke: rgb(23 23 23 / 18%);
 }
 
 .morph-icon {
@@ -228,102 +170,20 @@ body[data-stage='2'] .monitor-status {
   stroke-linejoin: round;
 }
 
-.keyboard {
-  fill: none;
-  stroke: rgb(23 23 23 / 24%);
-  stroke-width: 1;
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: keyboard-place 3.45s cubic-bezier(0.2, 0.85, 0.25, 1) infinite;
-}
-
-.human {
-  transform-box: fill-box;
-  transform-origin: center bottom;
-  animation: human-bob 2.4s 300ms ease-in-out infinite;
-}
-
-.human-head,
-.human-body {
-  fill: #fff;
-  stroke: rgb(23 23 23 / 16%);
-  stroke-width: 1.5;
-}
-
-.human-hair,
-.human-face,
-.human-arm {
-  fill: none;
-  stroke: rgb(23 23 23 / 38%);
-  stroke-width: 1.5;
-}
-
-.human-hair {
-  stroke: #7c3aed;
-  stroke-width: 2;
-}
-
-.human-face circle {
-  fill: rgb(23 23 23 / 48%);
-  stroke: none;
-}
-
-.human-working-arm {
-  transform-box: fill-box;
-  transform-origin: right top;
-  animation: human-arm-place 1.1s ease-in-out infinite alternate;
-}
-
-.human-hand {
-  fill: #fff;
-  stroke: #7c3aed;
-  stroke-width: 1.75;
-}
-
-.robot-sparks {
-  fill: none;
-  stroke: #7c3aed;
-  stroke-width: 1.75;
-  opacity: 0;
-  animation: sparks-pop 800ms ease-out infinite;
-}
-
-.robot-sparks circle {
-  fill: #7c3aed;
-  stroke: none;
-}
-
-.assembly-piece {
-  fill: none;
-  stroke: #7c3aed;
-  stroke-width: 1.25;
-  opacity: 0;
-  transform-box: fill-box;
-  transform-origin: center;
-}
-
-.assembly-piece-one {
-  animation: piece-install 3.45s 180ms ease-in-out infinite;
-}
-
-.assembly-piece-two {
-  animation: piece-install 3.45s 1.9s ease-in-out infinite;
-}
-
 .splash-copy {
   height: 42px;
   margin-top: 2px;
   text-align: center;
 }
 
-h1 {
+.splash h1 {
   margin: 0;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.015em;
 }
 
-p {
+.splash p {
   margin: 4px 0 0;
   color: rgb(23 23 23 / 62%);
   font-size: 12px;
@@ -333,7 +193,7 @@ p {
     transform 140ms ease;
 }
 
-p.is-changing {
+.splash p.is-changing {
   opacity: 0;
   transform: translateY(2px);
 }
@@ -362,9 +222,9 @@ p.is-changing {
   background: #7c3aed;
 }
 
-@keyframes floor-arrive {
+@keyframes baseline-arrive {
   from {
-    stroke-dashoffset: 266;
+    stroke-dashoffset: 210;
   }
 
   to {
@@ -372,189 +232,90 @@ p.is-changing {
   }
 }
 
-@keyframes robot-bob {
+@keyframes connection-flow {
   0%,
   100% {
-    transform: translateY(0);
-  }
-
-  50% {
-    transform: translateY(-2px);
-  }
-}
-
-@keyframes robot-head-tilt {
-  0%,
-  55%,
-  100% {
-    transform: rotate(0);
-  }
-
-  70% {
-    transform: rotate(3deg);
-  }
-}
-
-@keyframes antenna-wiggle {
-  0%,
-  100% {
-    transform: rotate(-5deg);
-  }
-
-  50% {
-    transform: rotate(5deg);
-  }
-}
-
-@keyframes antenna-pulse {
-  0%,
-  100% {
-    opacity: 0.5;
-  }
-
-  50% {
-    opacity: 1;
-  }
-}
-
-@keyframes robot-blink {
-  0%,
-  42%,
-  46%,
-  100% {
-    transform: scaleY(1);
-  }
-
-  44% {
-    transform: scaleY(0.12);
-  }
-}
-
-@keyframes chest-pulse {
-  0%,
-  100% {
-    opacity: 0.55;
-  }
-
-  50% {
-    opacity: 1;
-  }
-}
-
-@keyframes working-arm {
-  from {
-    transform: rotate(-5deg);
-  }
-
-  to {
-    transform: rotate(7deg);
-  }
-}
-
-@keyframes toolbox-arrive {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.94);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes monitor-arrive {
-  from {
-    opacity: 0;
-    transform: translateY(10px) scale(0.94);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes status-pulse {
-  0%,
-  100% {
+    stroke-dashoffset: 36;
     opacity: 0.35;
   }
 
   50% {
+    stroke-dashoffset: 0;
     opacity: 1;
   }
 }
 
-@keyframes keyboard-place {
+@keyframes pulse-left {
   0%,
-  8% {
+  20% {
     opacity: 0;
-    transform: translateX(24px);
-  }
-
-  28%,
-  100% {
-    opacity: 1;
     transform: translateX(0);
-  }
-}
-
-@keyframes human-bob {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-
-  50% {
-    transform: translateY(-1.5px);
-  }
-}
-
-@keyframes human-arm-place {
-  from {
-    transform: rotate(2deg) translateX(2px);
-  }
-
-  to {
-    transform: rotate(-4deg) translateX(-2px);
-  }
-}
-
-@keyframes sparks-pop {
-  0%,
-  100% {
-    opacity: 0;
-    transform: scale(0.7);
   }
 
   35%,
-  60% {
+  65% {
     opacity: 1;
-    transform: scale(1);
+  }
+
+  80%,
+  100% {
+    opacity: 0;
+    transform: translateX(36px);
   }
 }
 
-@keyframes piece-install {
+@keyframes pulse-right {
   0%,
-  10% {
+  20% {
     opacity: 0;
-    transform: translate(0, 0) scale(0.7) rotate(-8deg);
+    transform: translateX(0);
   }
 
-  25% {
+  35%,
+  65% {
     opacity: 1;
   }
 
-  50% {
-    opacity: 1;
-    transform: translate(35px, -10px) scale(1) rotate(4deg);
-  }
-
-  65%,
+  80%,
   100% {
     opacity: 0;
-    transform: translate(47px, -8px) scale(0.65) rotate(0);
+    transform: translateX(-36px);
+  }
+}
+
+@keyframes card-arrive-left {
+  from {
+    opacity: 0;
+    transform: translateX(10px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes card-arrive-right {
+  from {
+    opacity: 0;
+    transform: translateX(-10px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes window-arrive {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 
@@ -565,53 +326,44 @@ p.is-changing {
     box-shadow: 0 8px 24px rgb(0 0 0 / 30%);
   }
 
-  .floor-line {
-    stroke: rgb(255 255 255 / 10%);
+  .baseline,
+  .connection {
+    stroke: rgb(255 255 255 / 12%);
   }
 
-  .robot-head rect,
-  .robot-body rect,
-  .toolbox rect,
-  .monitor-shell,
-  .keyboard rect,
-  .assembly-piece rect,
-  .assembly-piece circle,
-  .robot-hand,
-  .human-head,
-  .human-body,
-  .human-hand {
+  .side-card {
+    fill: rgb(255 255 255 / 2%);
+    stroke: rgb(255 255 255 / 18%);
+  }
+
+  .side-card path {
+    stroke: rgb(255 255 255 / 34%);
+  }
+
+  .side-card-right rect + rect {
+    fill: rgb(124 58 237 / 10%);
+    stroke: #8b5cf6;
+  }
+
+  .side-card-right path {
+    stroke: #8b5cf6;
+  }
+
+  .window-shell {
     fill: #222;
     stroke: rgb(255 255 255 / 18%);
   }
 
-  .assembly-piece rect,
-  .assembly-piece circle {
-    fill: #222;
-    stroke: #7c3aed;
+  .window-toolbar,
+  .window-content-line {
+    stroke: rgb(255 255 255 / 14%);
   }
 
-  .robot-ear,
-  .robot-smile,
-  .robot-arm,
-  .robot-leg,
-  .toolbox,
-  .monitor-stand,
-  .keyboard,
-  .human-face,
-  .human-arm {
-    stroke: rgb(255 255 255 / 42%);
+  .window-control {
+    fill: rgb(255 255 255 / 18%);
   }
 
-  .human-face circle {
-    fill: rgb(255 255 255 / 52%);
-  }
-
-  .monitor-screen {
-    fill: #1b1b1b;
-    stroke: rgb(255 255 255 / 10%);
-  }
-
-  p {
+  .splash p {
     color: rgb(255 255 255 / 52%);
   }
 
@@ -621,37 +373,20 @@ p.is-changing {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .floor-line,
-  .robot,
-  .robot-head,
-  .robot-antenna,
-  .robot-antenna-tip,
-  .robot-eyes,
-  .robot-body circle,
-  .robot-working-arm,
-  .toolbox,
-  .monitor,
-  .monitor-status,
-  .keyboard,
-  .human,
-  .human-working-arm,
-  .robot-sparks,
-  .assembly-piece {
+  .baseline,
+  .connection,
+  .connection-pulse,
+  .side-card,
+  .workbench-window {
     animation: none;
   }
 
-  .floor-line {
-    stroke-dashoffset: 0;
-  }
-
-  .robot-sparks,
-  .assembly-piece {
+  .connection-pulse {
     display: none;
   }
 
-  p,
-  .stage-dot,
-  .monitor-status {
+  .splash p,
+  .stage-dot {
     transition: none;
   }
 }

--- a/wework/electron/src/shell/styles.css
+++ b/wework/electron/src/shell/styles.css
@@ -1,6 +1,6 @@
 :root {
-  color: #f4f4f5;
-  background: #101316;
+  color: #171717;
+  background: #fafafa;
   font-family:
     Inter,
     ui-sans-serif,
@@ -11,8 +11,17 @@
     sans-serif;
 }
 
+:root[data-theme='dark'] {
+  color: #f4f4f5;
+  background: #101316;
+}
+
 * {
   box-sizing: border-box;
+}
+
+[hidden] {
+  display: none !important;
 }
 
 body {
@@ -26,7 +35,7 @@ body {
   min-height: 100vh;
   place-items: center;
   padding: 38px 24px 24px;
-  background: #101316;
+  background: inherit;
 }
 
 .runtime-card {
@@ -38,24 +47,15 @@ body {
   text-align: center;
 }
 
-.runtime-spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid rgb(255 255 255 / 14%);
-  border-top-color: #f4f4f5;
-  border-radius: 999px;
-  animation: spin 0.8s linear infinite;
-}
-
-h1 {
+.runtime-card h1 {
   margin: 4px 0 0;
   font-size: 18px;
   font-weight: 500;
 }
 
-#status {
+#runtime-status {
   margin: 0;
-  color: #a1a1aa;
+  color: rgb(23 23 23 / 62%);
   font-size: 13px;
 }
 
@@ -65,10 +65,10 @@ h1 {
   margin: 4px 0 0;
   overflow: auto;
   padding: 12px;
-  border: 1px solid rgb(255 255 255 / 8%);
+  border: 1px solid rgb(23 23 23 / 8%);
   border-radius: 8px;
-  background: #181b1f;
-  color: #d4d4d8;
+  background: #fff;
+  color: #303030;
   font-size: 12px;
   text-align: left;
   white-space: pre-wrap;
@@ -77,10 +77,10 @@ h1 {
 button {
   height: 30px;
   padding: 0 12px;
-  border: 1px solid rgb(255 255 255 / 12%);
+  border: 1px solid rgb(23 23 23 / 12%);
   border-radius: 8px;
-  background: #24272c;
-  color: #f4f4f5;
+  background: #171717;
+  color: #fafafa;
   cursor: pointer;
 }
 
@@ -89,13 +89,18 @@ button:disabled {
   opacity: 0.5;
 }
 
-#runtime-overlay[data-phase='failed'] .runtime-spinner {
-  border-color: #ef4444;
-  animation: none;
+:root[data-theme='dark'] #runtime-status {
+  color: #a1a1aa;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+:root[data-theme='dark'] #details {
+  border-color: rgb(255 255 255 / 8%);
+  background: #181b1f;
+  color: #d4d4d8;
+}
+
+:root[data-theme='dark'] button {
+  border-color: rgb(255 255 255 / 12%);
+  background: #f4f4f5;
+  color: #171717;
 }

--- a/wework/src/components/layout/useWorkbenchPaneEnvironment.test.ts
+++ b/wework/src/components/layout/useWorkbenchPaneEnvironment.test.ts
@@ -152,4 +152,34 @@ describe('applySharedChangeRequestSnapshot', () => {
       hint: 'Install GitHub CLI',
     })
   })
+
+  test('keeps an explicit Environment lookup failure instead of showing an older shared result', () => {
+    const result = applySharedChangeRequestSnapshot(
+      {
+        ...environmentInfo,
+        changeRequest: {
+          provider: 'github',
+          state: 'unavailable',
+          hint: 'Install GitHub CLI',
+        },
+      },
+      {
+        target: {
+          deviceId: 'local',
+          taskId: 'runtime-48',
+          workspacePath: '/workspace',
+          remoteUrl: 'https://github.com/wecode-ai/Wegent.git',
+          branch: 'fix/shared-pr-state',
+        },
+        changeRequest: environmentInfo.changeRequest?.changeRequest ?? null,
+        fetchedAt: '2026-08-21T00:00:00Z',
+      }
+    )
+
+    expect(result.changeRequest).toEqual({
+      provider: 'github',
+      state: 'unavailable',
+      hint: 'Install GitHub CLI',
+    })
+  })
 })

--- a/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
+++ b/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
@@ -69,6 +69,12 @@ export function applySharedChangeRequestSnapshot(
   snapshot: TaskChangeRequestSnapshot
 ): EnvironmentInfo {
   if (snapshot.error || snapshot.stale) return environmentInfo
+  if (
+    environmentInfo.changeRequest &&
+    ['unavailable', 'unauthenticated', 'error'].includes(environmentInfo.changeRequest.state)
+  ) {
+    return environmentInfo
+  }
   const provider = snapshot.changeRequest?.provider ?? environmentInfo.changeRequest?.provider
   if (!provider) return environmentInfo
   return {


### PR DESCRIPTION
## Summary

- render the Wework startup animation inside the main startup window instead of a separate always-on-top BrowserWindow
- keep startup lifecycle capture and failure recovery on the embedded surface
- represent Wework collaboration with restrained robot and human symbols connected to a shared workbench
- update startup shell and lifecycle regression coverage

## Verification

- `pnpm --dir wework/electron test src/host/startup-splash.test.ts src/shell/shell.test.ts`
- `pnpm --dir wework/electron typecheck`
- Wework pre-push ESLint, Electron TypeScript, and unit tests
- isolated real Electron verification with `ai:verify`
- desktop `native-window-startup` E2E scenario with captured PNG evidence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a redesigned startup splash screen with animated workbench visuals, progress stages, accessible status messaging, and light/dark themes.
  * Added reduced-motion support and clearer runtime error presentation during startup.

* **Bug Fixes**
  * Prevented duplicate splash windows during concurrent startup requests.
  * Improved splash behavior when startup loading succeeds or fails.
  * Continued processing when shared notifications briefly lag.
  * Preserved explicit environment errors over outdated shared results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->