### PR TITLE
fix(wework): persist Electron device identity

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1053,6 +1053,7 @@ async function main() {
           }
         : {}),
     }
+    delete appEnvironment.WEGENT_APP_IPC_DEVICE_ID
     const electronLaunchArguments =
       process.platform === 'linux' && typeof process.getuid === 'function' && process.getuid() === 0
         ? (() => {
@@ -1080,6 +1081,13 @@ async function main() {
     app = await startDesktopAppProcess()
     const restartDesktopApp = async (options = null) => {
       const beforeStart = typeof options === 'function' ? options : options?.afterStop
+      const desktopDeviceIdPath = join(resultDir, 'electron-user-data', 'desktop-device-id')
+      const desktopDeviceIdBeforeRestart = (await readFile(desktopDeviceIdPath, 'utf8')).trim()
+      assert.match(
+        desktopDeviceIdBeforeRestart,
+        /^electron-/,
+        'Wework did not persist a valid Electron device identity before restart'
+      )
       const readyCountBeforeRestart = control.readyCount
       await stopDesktopAppProcess(app)
       await beforeStart?.()
@@ -1088,6 +1096,12 @@ async function main() {
         control.awaitReadyAfter(readyCountBeforeRestart),
         WORKBENCH_READY_TIMEOUT_MS,
         'The restarted Wework application did not reconnect to the desktop controller'
+      )
+      const desktopDeviceIdAfterRestart = (await readFile(desktopDeviceIdPath, 'utf8')).trim()
+      assert.equal(
+        desktopDeviceIdAfterRestart,
+        desktopDeviceIdBeforeRestart,
+        'Restarting Wework changed the persisted Electron device identity'
       )
       return app
     }

--- a/wework/electron/src/runtime/desktop-device-id.test.ts
+++ b/wework/electron/src/runtime/desktop-device-id.test.ts
@@ -1,0 +1,90 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { resolveDesktopDeviceId } from './desktop-device-id.js'
+import { temporaryDirectory } from './test-helpers.js'
+
+describe('desktop device identity', () => {
+  test('persists the generated identity across launches', async () => {
+    const directory = await temporaryDirectory('desktop-device-id-')
+    const dataDirectory = join(directory.path, 'data')
+    const executorHome = join(dataDirectory, 'executor')
+
+    const first = await resolveDesktopDeviceId({
+      dataDirectory,
+      executorHome,
+      environment: {},
+    })
+    const second = await resolveDesktopDeviceId({
+      dataDirectory,
+      executorHome,
+      environment: {},
+    })
+
+    expect(first).toMatch(/^electron-/)
+    expect(second).toBe(first)
+    expect(await readFile(join(dataDirectory, 'desktop-device-id'), 'utf8')).toBe(`${first}\n`)
+    await directory.remove()
+  })
+
+  test('adopts the dominant identity from existing managed worktrees', async () => {
+    const directory = await temporaryDirectory('desktop-device-id-migration-')
+    const dataDirectory = join(directory.path, 'data')
+    const executorHome = join(dataDirectory, 'executor')
+    await mkdir(join(executorHome, 'runtime-work'), { recursive: true })
+    await writeFile(
+      join(executorHome, 'runtime-work', 'worktrees.json'),
+      JSON.stringify({
+        records: {
+          '/worktree/one': {
+            deviceId: 'electron-existing',
+            updatedAt: 10,
+          },
+          '/worktree/two': {
+            deviceId: 'electron-existing',
+            updatedAt: 20,
+          },
+          '/worktree/other': {
+            deviceId: 'electron-other',
+            updatedAt: 30,
+          },
+          '/worktree/tauri': {
+            deviceId: 'local-device',
+            updatedAt: 40,
+          },
+        },
+      })
+    )
+
+    await expect(
+      resolveDesktopDeviceId({
+        dataDirectory,
+        executorHome,
+        environment: {},
+      })
+    ).resolves.toBe('electron-existing')
+    expect(await readFile(join(dataDirectory, 'desktop-device-id'), 'utf8')).toBe(
+      'electron-existing\n'
+    )
+    await directory.remove()
+  })
+
+  test('keeps an explicit environment override', async () => {
+    const directory = await temporaryDirectory('desktop-device-id-override-')
+    const dataDirectory = join(directory.path, 'data')
+
+    await expect(
+      resolveDesktopDeviceId({
+        dataDirectory,
+        executorHome: join(dataDirectory, 'executor'),
+        environment: {
+          WEGENT_APP_IPC_DEVICE_ID: 'configured-device',
+        },
+      })
+    ).resolves.toBe('configured-device')
+    await expect(readFile(join(dataDirectory, 'desktop-device-id'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+    await directory.remove()
+  })
+})

--- a/wework/electron/src/runtime/desktop-device-id.ts
+++ b/wework/electron/src/runtime/desktop-device-id.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, open, readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+const DEVICE_ID_FILE = 'desktop-device-id'
+
+interface WorktreeRecord {
+  deviceId?: unknown
+  updatedAt?: unknown
+}
+
+interface WorktreeState {
+  records?: Record<string, WorktreeRecord>
+}
+
+export async function resolveDesktopDeviceId(options: {
+  dataDirectory: string
+  executorHome: string
+  environment: NodeJS.ProcessEnv
+}): Promise<string> {
+  const configured = options.environment.WEGENT_APP_IPC_DEVICE_ID?.trim()
+  if (configured) return configured
+
+  const path = join(options.dataDirectory, DEVICE_ID_FILE)
+  const persisted = await readDeviceId(path)
+  if (persisted) return persisted
+
+  const deviceId =
+    (await inferExistingElectronDeviceId(options.executorHome)) ?? `electron-${randomUUID()}`
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  try {
+    const file = await open(path, 'wx', 0o600)
+    try {
+      await file.writeFile(`${deviceId}\n`)
+    } finally {
+      await file.close()
+    }
+    return deviceId
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+    const winningDeviceId = await readDeviceId(path)
+    if (!winningDeviceId) {
+      throw new Error(`Desktop device identity is empty: ${path}`, { cause: error })
+    }
+    return winningDeviceId
+  }
+}
+
+async function readDeviceId(path: string): Promise<string | null> {
+  try {
+    const deviceId = (await readFile(path, 'utf8')).trim()
+    if (!deviceId) throw new Error(`Desktop device identity is empty: ${path}`)
+    return deviceId
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+}
+
+async function inferExistingElectronDeviceId(executorHome: string): Promise<string | null> {
+  const path = join(executorHome, 'runtime-work', 'worktrees.json')
+  let state: WorktreeState
+  try {
+    state = JSON.parse(await readFile(path, 'utf8')) as WorktreeState
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+
+  const candidates = new Map<string, { count: number; latestUpdatedAt: number }>()
+  for (const record of Object.values(state.records ?? {})) {
+    if (typeof record.deviceId !== 'string' || !record.deviceId.startsWith('electron-')) continue
+    const candidate = candidates.get(record.deviceId) ?? {
+      count: 0,
+      latestUpdatedAt: 0,
+    }
+    candidate.count += 1
+    if (typeof record.updatedAt === 'number') {
+      candidate.latestUpdatedAt = Math.max(candidate.latestUpdatedAt, record.updatedAt)
+    }
+    candidates.set(record.deviceId, candidate)
+  }
+
+  return (
+    [...candidates.entries()].sort(
+      ([leftId, left], [rightId, right]) =>
+        right.count - left.count ||
+        right.latestUpdatedAt - left.latestUpdatedAt ||
+        leftId.localeCompare(rightId)
+    )[0]?.[0] ?? null
+  )
+}

--- a/wework/electron/src/runtime/desktop-runtime.ts
+++ b/wework/electron/src/runtime/desktop-runtime.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from 'node:crypto'
 import { createServer } from 'node:net'
 import type { HostPipeServer } from '../host/host-pipe.js'
 import { prepareCoreDshLaunch } from './core-dsh-runtime.js'
+import { resolveDesktopDeviceId } from './desktop-device-id.js'
 import { DshRuntime } from './dsh-runtime.js'
-import { ManagedExecutorRuntime } from './managed-executor-runtime.js'
+import { ManagedExecutorRuntime, managedExecutorHome } from './managed-executor-runtime.js'
 import {
   WorkbenchRuntimeManager,
   type WorkbenchRuntimeLaunch,
@@ -116,14 +116,18 @@ export class DesktopRuntime {
   private async startExecutor(): Promise<void> {
     const executorPath = this.options.environment.WEWORK_EXECUTOR_PATH?.trim()
     if (!executorPath) return
+    const deviceId = await resolveDesktopDeviceId({
+      environment: this.options.environment,
+      dataDirectory: this.options.dataDirectory,
+      executorHome: managedExecutorHome(this.options),
+    })
     this.executor = new ManagedExecutorRuntime({
       command: executorPath,
       args: jsonArrayEnvironment(this.options.environment, 'WEWORK_EXECUTOR_ARGS_JSON'),
       environment: this.options.environment,
       dataDirectory: this.options.dataDirectory,
       logDirectory: this.options.logDirectory,
-      deviceId:
-        this.options.environment.WEGENT_APP_IPC_DEVICE_ID?.trim() || `electron-${randomUUID()}`,
+      deviceId,
       onEvent: this.options.onExecutorEvent,
     })
     await this.executor.start()

--- a/wework/electron/src/runtime/managed-executor-runtime.ts
+++ b/wework/electron/src/runtime/managed-executor-runtime.ts
@@ -80,8 +80,7 @@ export class ManagedExecutorRuntime {
 export function prepareManagedExecutorEnvironment(
   options: Pick<ManagedExecutorRuntimeOptions, 'environment' | 'dataDirectory'>
 ): NodeJS.ProcessEnv {
-  const executorHome =
-    options.environment.WEGENT_EXECUTOR_HOME?.trim() || join(options.dataDirectory, 'executor')
+  const executorHome = managedExecutorHome(options)
   const codexHome = options.environment.WEGENT_CODEX_HOME?.trim() || join(executorHome, 'codex')
   const nativeCodexHome = resolveNativeCodexHome(options.environment, codexHome)
   if (nativeCodexHome) prepareCodexAuth(nativeCodexHome, codexHome)
@@ -91,6 +90,12 @@ export function prepareManagedExecutorEnvironment(
     WEGENT_CODEX_HOME: codexHome,
     WEGENT_EXECUTOR_HOME: executorHome,
   }
+}
+
+export function managedExecutorHome(
+  options: Pick<ManagedExecutorRuntimeOptions, 'environment' | 'dataDirectory'>
+): string {
+  return options.environment.WEGENT_EXECUTOR_HOME?.trim() || join(options.dataDirectory, 'executor')
 }
 
 function resolveNativeCodexHome(


### PR DESCRIPTION
## Summary

- persist the Electron executor device identity across app restarts
- adopt the dominant existing Electron identity on first upgraded launch so managed worktrees remain usable
- keep explicit device overrides and make first-write races deterministic
- assert real desktop E2E restarts preserve the identity

## Root cause

Electron generated a new `electron-${randomUUID()}` device ID on every launch. Managed worktrees retain their creating device ID, so follow-up messages after a restart failed before the model turn with `worktree_device_mismatch`.

## Verification

- `pnpm --dir wework/electron test` (39 files, 142 tests)
- `pnpm --dir wework/electron typecheck`
- focused ESLint and Prettier checks
- real Electron `--goal-restart-only` desktop E2E
- full repository pre-push Wework checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Desktop installations now retain the same device identity across application restarts.
  - Existing managed desktop environments can preserve their established identity during migration.
  - Device identity data is stored securely and recovered reliably when the app launches.
  - Administrators can explicitly provide a device identity through the supported environment configuration.
- **Reliability**
  - Improved handling prevents unexpected identity changes that could disrupt desktop-to-executor communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->