### PR TITLE
fix(wework): decode assistant file paths

### DIFF
--- a/wework/e2e/desktop/modules/desktop-server.mjs
+++ b/wework/e2e/desktop/modules/desktop-server.mjs
@@ -97,6 +97,7 @@ import {
   EMBEDDED_BROWSER_SETUP_PROMPT,
   FILE_PANEL_ANCHOR_PROMPT,
   FILE_PANEL_ANCHOR_RESPONSE,
+  FILE_PANEL_LINK_NAME,
   FOLLOW_UP_COMPLETION_TEXT,
   FOLLOW_UP_PROMPT,
   FORK_ENCRYPTED_CONTENT,
@@ -3033,7 +3034,10 @@ class DesktopE2EServer {
       this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(
-          FILE_PANEL_ANCHOR_RESPONSE.replace('README.md:1', `${this.workspacePath}/README.md:1`)
+          FILE_PANEL_ANCHOR_RESPONSE.replace(
+            `${FILE_PANEL_LINK_NAME.replaceAll(' ', '%20')}:1`,
+            `${encodeURI(`${this.workspacePath}/${FILE_PANEL_LINK_NAME}`)}:1`
+          )
         ),
         responseCompleted(responseId),
       ])

--- a/wework/e2e/desktop/modules/shared.mjs
+++ b/wework/e2e/desktop/modules/shared.mjs
@@ -187,13 +187,14 @@ const MESSAGE_EDIT_UPDATED_COMPLETION_TEXT = 'WEWORK_DESKTOP_E2E_MESSAGE_EDIT_UP
 const FILE_PANEL_ANCHOR_PROMPT =
   'WEWORK_DESKTOP_E2E_FILE_PANEL_ANCHOR: create a long response with a file link in the middle.'
 const FILE_PANEL_ANCHOR_MARKER = 'WEWORK_DESKTOP_E2E_FILE_PANEL_ANCHOR_MARKER'
+const FILE_PANEL_LINK_NAME = 'README file.md'
 const FILE_PREVIEW_RESTORE_MARKER = 'WEWORK_DESKTOP_E2E_FILE_PREVIEW_RESTORED'
 const REVIEW_RESTORE_MARKER = 'WEWORK_DESKTOP_E2E_REVIEW_RESTORED'
 const FILE_PANEL_ANCHOR_RESPONSE = [
   'WEWORK_DESKTOP_E2E_FILE_PANEL_ANCHOR_RESPONSE',
   ...Array.from({ length: 30 }, (_, index) =>
     index === 14
-      ? `${FILE_PANEL_ANCHOR_MARKER}: inspect [README file.md](README%20file.md:1) without moving this paragraph.`
+      ? `${FILE_PANEL_ANCHOR_MARKER}: inspect [${FILE_PANEL_LINK_NAME}](${FILE_PANEL_LINK_NAME.replaceAll(' ', '%20')}:1) without moving this paragraph.`
       : `File panel anchor paragraph ${String(index + 1).padStart(2, '0')}. ${'Scrollable anchor content '.repeat(8)}`
   ),
 ].join('\n\n')
@@ -284,7 +285,7 @@ const CLOUD_MULTIMODAL_VISION_CASE = {
 }
 const IMAGE_ARTIFACT_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEklEQVR4nGP4z8CAB+GTG8HSALfKY52fTcuYAAAAAElFTkSuQmCC'
-const GIT_SEED_NAME = 'README file.md'
+const GIT_SEED_NAME = 'README.md'
 const GIT_SEED_CONTENT = '# Desktop E2E workspace\n'
 const MODEL_API_KEY = 'wework-e2e-test-key'
 const MODEL_PROVIDER_ID = 'wework-e2e'
@@ -1524,6 +1525,7 @@ export {
   MESSAGE_EDIT_UPDATED_COMPLETION_TEXT,
   FILE_PANEL_ANCHOR_PROMPT,
   FILE_PANEL_ANCHOR_MARKER,
+  FILE_PANEL_LINK_NAME,
   FILE_PREVIEW_RESTORE_MARKER,
   REVIEW_RESTORE_MARKER,
   FILE_PANEL_ANCHOR_RESPONSE,

--- a/wework/e2e/desktop/modules/shared.mjs
+++ b/wework/e2e/desktop/modules/shared.mjs
@@ -193,7 +193,7 @@ const FILE_PANEL_ANCHOR_RESPONSE = [
   'WEWORK_DESKTOP_E2E_FILE_PANEL_ANCHOR_RESPONSE',
   ...Array.from({ length: 30 }, (_, index) =>
     index === 14
-      ? `${FILE_PANEL_ANCHOR_MARKER}: inspect [README.md](README.md:1) without moving this paragraph.`
+      ? `${FILE_PANEL_ANCHOR_MARKER}: inspect [README file.md](README%20file.md:1) without moving this paragraph.`
       : `File panel anchor paragraph ${String(index + 1).padStart(2, '0')}. ${'Scrollable anchor content '.repeat(8)}`
   ),
 ].join('\n\n')
@@ -284,7 +284,7 @@ const CLOUD_MULTIMODAL_VISION_CASE = {
 }
 const IMAGE_ARTIFACT_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEklEQVR4nGP4z8CAB+GTG8HSALfKY52fTcuYAAAAAElFTkSuQmCC'
-const GIT_SEED_NAME = 'README.md'
+const GIT_SEED_NAME = 'README file.md'
 const GIT_SEED_CONTENT = '# Desktop E2E workspace\n'
 const MODEL_API_KEY = 'wework-e2e-test-key'
 const MODEL_PROVIDER_ID = 'wework-e2e'

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -141,6 +141,7 @@ import {
   E2E_TRANSCRIPT_PAGE_SIZE,
   FILE_PANEL_ANCHOR_MARKER,
   FILE_PANEL_ANCHOR_PROMPT,
+  FILE_PANEL_LINK_NAME,
   FILE_PREVIEW_RESTORE_MARKER,
   GIT_SEED_CONTENT,
   GIT_SEED_NAME,
@@ -816,7 +817,13 @@ async function main() {
     mkdir(composerProjectPath, { recursive: true }),
     mkdir(homePath, { recursive: true }),
   ])
-  await writeFile(join(workspacePath, GIT_SEED_NAME), GIT_SEED_CONTENT)
+  await Promise.all([
+    writeFile(join(workspacePath, GIT_SEED_NAME), GIT_SEED_CONTENT),
+    writeFile(
+      join(workspacePath, FILE_PANEL_LINK_NAME),
+      `${GIT_SEED_CONTENT}${FILE_PREVIEW_RESTORE_MARKER}\n`
+    ),
+  ])
   await writeFile(join(workspacePath, 'auth.ts'), 'export const authenticated = true\n')
   await writeFile(
     join(workspacePath, IMAGE_ARTIFACT_NAME),
@@ -851,9 +858,13 @@ async function main() {
   await runChecked('git', ['config', 'user.email', 'desktop-e2e@wework.local'], {
     cwd: workspacePath,
   })
-  await runChecked('git', ['add', GIT_SEED_NAME, 'auth.ts', IMAGE_ARTIFACT_NAME], {
-    cwd: workspacePath,
-  })
+  await runChecked(
+    'git',
+    ['add', GIT_SEED_NAME, FILE_PANEL_LINK_NAME, 'auth.ts', IMAGE_ARTIFACT_NAME],
+    {
+      cwd: workspacePath,
+    }
+  )
   await runChecked('git', ['commit', '-m', 'test: initialize desktop e2e workspace'], {
     cwd: workspacePath,
   })
@@ -2998,7 +3009,7 @@ last_updated = "2026-07-30T00:00:00Z"`
       })
       assert.equal(
         await control.command('getText', '[data-testid="workspace-file-path"]'),
-        join(workspacePath, GIT_SEED_NAME),
+        join(workspacePath, FILE_PANEL_LINK_NAME),
         'The encoded Markdown file link did not resolve to the workspace file path'
       )
       await control.command('finishAnimations', 'body')
@@ -3126,7 +3137,7 @@ last_updated = "2026-07-30T00:00:00Z"`
           'getText',
           `${activeTaskWorkbenchSelector} [data-testid="workspace-file-path"]`
         ),
-        join(workspacePath, GIT_SEED_NAME),
+        join(workspacePath, FILE_PANEL_LINK_NAME),
         'The linked absolute file opened from the wrong workspace target'
       )
       await control.command('click', '[data-testid="right-workspace-new-tab-button"]')
@@ -3294,7 +3305,7 @@ last_updated = "2026-07-30T00:00:00Z"`
           'getText',
           `${activeTaskWorkbenchSelector} [data-testid="workspace-file-path"]`
         ),
-        join(workspacePath, GIT_SEED_NAME),
+        join(workspacePath, FILE_PANEL_LINK_NAME),
         'The linked absolute file path was lost after switching conversations'
       )
       await control.command('click', rightBrowserTabSelector)

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -2996,6 +2996,11 @@ last_updated = "2026-07-30T00:00:00Z"`
       await control.command('waitFor', '[data-testid="right-workspace-file-tab"]', {
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
+      assert.equal(
+        await control.command('getText', '[data-testid="workspace-file-path"]'),
+        join(workspacePath, GIT_SEED_NAME),
+        'The encoded Markdown file link did not resolve to the workspace file path'
+      )
       await control.command('finishAnimations', 'body')
       await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
       const filePanelScrollerAfterOpen = await getSingleElementMetrics(

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -7,6 +7,7 @@ import { ComposerLinkChip } from './ComposerLinkChip'
 import 'streamdown/styles.css'
 import {
   classifyMarkdownLink,
+  decodeMarkdownFilePath,
   getAuthenticatedAttachmentId,
   isAuthenticatedAttachmentImageSrc,
   isHtmlFilePath,
@@ -481,7 +482,9 @@ function encodeLocalMarkdownLinks(content: string): string {
     const href = String(rawHref).trim()
     const target = classifyMarkdownLink(href)
     if (target.kind !== 'file') return match
-    return `[${label}](${WEWORK_MARKDOWN_FILE_LINK_PREFIX}${encodeURIComponent(href)})`
+    return `[${label}](${WEWORK_MARKDOWN_FILE_LINK_PREFIX}${encodeURIComponent(
+      decodeMarkdownFilePath(href)
+    )})`
   })
 }
 

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -2583,6 +2583,56 @@ describe('MessageList', () => {
     expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/dev/repo/docs/zh/managing-tasks.md')
   })
 
+  test('decodes URL-encoded assistant file paths before opening the workspace file panel', () => {
+    const onOpenWorkspaceFile = vi.fn()
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'assistant-encoded-file-link',
+            role: 'assistant',
+            content:
+              '[startup-splash.png](/Users/dev/Library/Application%20Support/Wework/startup-splash.png)',
+            status: 'done',
+            createdAt: '2026-08-25T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
+
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith(
+      '/Users/dev/Library/Application Support/Wework/startup-splash.png'
+    )
+  })
+
+  test('decodes an encoded relative file path before extracting its line number', () => {
+    const onOpenWorkspaceFile = vi.fn()
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'assistant-encoded-relative-file-link',
+            role: 'assistant',
+            content: '[README file.md](README%20file.md:1)',
+            status: 'done',
+            createdAt: '2026-08-25T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
+
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('README file.md', {
+      lineStart: 1,
+      lineEnd: undefined,
+    })
+  })
+
   test('routes assistant folder links to the workspace directory panel', () => {
     const onOpenWorkspaceFile = vi.fn()
     render(

--- a/wework/src/components/chat/assistantMarkdownLinks.test.ts
+++ b/wework/src/components/chat/assistantMarkdownLinks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+import { decodeMarkdownFilePath } from './assistantMarkdownLinks'
+
+describe('decodeMarkdownFilePath', () => {
+  test('fully decodes a file path after repeated Markdown URL encoding', () => {
+    const filePath = '/Users/dev/Library/Application Support/Wework/README file.md'
+    const encodedPath = Array.from({ length: 8 }).reduce(
+      currentPath => encodeURIComponent(currentPath),
+      filePath
+    )
+
+    expect(decodeMarkdownFilePath(encodedPath)).toBe(filePath)
+  })
+
+  test('leaves the path unchanged when an encoded sequence is malformed', () => {
+    expect(decodeMarkdownFilePath('/workspace/valid%20path/%E0%A4%A')).toBe(
+      '/workspace/valid%20path/%E0%A4%A'
+    )
+  })
+})

--- a/wework/src/components/chat/assistantMarkdownLinks.ts
+++ b/wework/src/components/chat/assistantMarkdownLinks.ts
@@ -14,6 +14,22 @@ export type MarkdownLinkTarget =
     }
 
 const HTML_FILE_PATTERN = /\.(?:html?|xhtml)$/i
+// Protected Markdown links may be encoded again by intermediate URL normalizers.
+const MAX_MARKDOWN_FILE_PATH_DECODE_PASSES = 16
+
+export function decodeMarkdownFilePath(path: string): string {
+  let decodedPath = path
+  for (let pass = 0; pass < MAX_MARKDOWN_FILE_PATH_DECODE_PASSES; pass += 1) {
+    try {
+      const nextPath = decodeURIComponent(decodedPath)
+      if (nextPath === decodedPath) return decodedPath
+      decodedPath = nextPath
+    } catch {
+      return decodedPath
+    }
+  }
+  return decodedPath
+}
 
 // Assistant responses frequently reference repository files with relative or
 // absolute filesystem paths. Rendering those as plain anchors makes the browser
@@ -32,7 +48,7 @@ export function classifyMarkdownLink(href?: string): MarkdownLinkTarget {
     try {
       return {
         kind: 'file',
-        path: decodeURIComponent(value.slice('folder://'.length)),
+        path: decodeMarkdownFilePath(value.slice('folder://'.length)),
         isDirectory: true,
       }
     } catch {
@@ -43,7 +59,10 @@ export function classifyMarkdownLink(href?: string): MarkdownLinkTarget {
     return { kind: 'file', ...splitMarkdownFileLineSuffix(localPathFromMarkdownImageSrc(value)) }
   }
   if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return { kind: 'external' }
-  return { kind: 'file', ...splitMarkdownFileLineSuffix(value) }
+  return {
+    kind: 'file',
+    ...splitMarkdownFileLineSuffix(decodeMarkdownFilePath(value)),
+  }
 }
 
 export function isHtmlFilePath(path: string): boolean {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -7880,6 +7880,65 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
+  test('decodes an encoded assistant file path before opening it in the workspace panel', async () => {
+    const user = userEvent.setup()
+    const workspacePanelState = createCloudWorkspacePanelState()
+    const filePath = '/workspace/project/README file.md'
+    const readWorkspaceTextFile = vi.fn().mockResolvedValue({
+      path: filePath,
+      name: 'README file.md',
+      content: 'opened encoded file path',
+      truncated: false,
+      size: 24,
+      modifiedAt: null,
+    })
+    const listWorkspaceEntries = vi.fn().mockResolvedValue({
+      path: '/workspace/project',
+      entries: [],
+    })
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        workspaceFileApi={{
+          listWorkspaceEntries,
+          readWorkspaceTextFile,
+        }}
+        state={{
+          ...baseProps.state,
+          ...workspacePanelState,
+        }}
+        messages={[
+          {
+            id: 'assistant-encoded-file-link',
+            role: 'assistant',
+            content: '[README file.md](/workspace/project/README%2520file.md)',
+            status: 'done',
+            createdAt: '2026-08-25T08:00:00.000Z',
+          },
+        ]}
+        projectWork={{
+          ...baseProps.projectWork,
+          projects: workspacePanelState.projects,
+          devices: workspacePanelState.devices,
+          currentProjectId: workspacePanelState.currentProject.id,
+        }}
+      />
+    )
+
+    await user.click(screen.getByTestId('assistant-markdown-link'))
+
+    expect(await screen.findByTestId('workspace-markdown-preview')).toHaveTextContent(
+      'opened encoded file path'
+    )
+    expect(readWorkspaceTextFile).toHaveBeenCalledWith(
+      'local-device',
+      filePath,
+      '/workspace/project'
+    )
+    expect(screen.getByTestId('workspace-file-path')).toHaveTextContent(filePath)
+  })
+
   test('opens a markdown directory link in the workspace tree without reading it as a file', async () => {
     const user = userEvent.setup()
     const workspacePanelState = createCloudWorkspacePanelState()

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react'
 import type { ProjectChatControls } from '@/components/chat/ChatInput'
 import type { AssistantPlanOpenRequest } from '@/components/chat/AssistantPlanCard'
+import { decodeMarkdownFilePath } from '@/components/chat/assistantMarkdownLinks'
 import { RequestUserInputCard } from '@/components/chat/RequestUserInputCard'
 import { ConnectorAuthCard } from '@/components/chat/ConnectorAuthCard'
 import { useLocalConnectorAuthGate } from '@/features/plugins/useLocalConnectorAuthGate'
@@ -3711,7 +3712,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
 
   const openWorkspaceFileFromMessage = useCallback(
     async (path: string, options?: WorkspaceFileOpenOptions) => {
-      const trimmedPath = path.trim()
+      const trimmedPath = decodeMarkdownFilePath(path.trim())
       if (!trimmedPath) return
       const attachmentTarget = createLocalAttachmentWorkspaceTarget(trimmedPath, devices)
       const absoluteLocalTarget = createLocalFileWorkspaceTarget(trimmedPath, devices)

--- a/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
+import { decodeMarkdownFilePath } from '@/components/chat/assistantMarkdownLinks'
 import { useTranslation } from '@/hooks/useTranslation'
 import { isWorkspaceDirectoryCacheFresh } from '@/features/workbench/workspaceFileDirectoryCache'
 import { cn } from '@/lib/utils'
@@ -124,7 +125,7 @@ function mimeTypeForFileName(name: string): string {
 }
 
 function resolveWorkspaceFilePath(target: WorkspaceTarget, path: string): string | null {
-  const normalizedPath = path.trim().replace(/\\/g, '/')
+  const normalizedPath = decodeMarkdownFilePath(path.trim()).replace(/\\/g, '/')
   if (!normalizedPath) return null
   if (normalizedPath.startsWith('/')) return normalizedPath
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace file links so URL-encoded and repeatedly encoded paths open the correct files.
  * Improved handling of file paths containing special or malformed encoded characters.
  * Preserved line references and folder links when opening files from assistant messages.
  * Updated desktop file-panel and conversation restoration flows to use the correct linked file.

* **Tests**
  * Added regression coverage for encoded paths, file previews, workspace navigation, and restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->