### PR TITLE
perf(wework): keep pre-push checks under three minutes

### DIFF
--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -139,6 +139,69 @@ collect_wework_renderer_tests() {
     done
 }
 
+run_wework_unit_tests() {
+    local test_exit=0
+
+    : > "$TEMP_DIR/wework_test.log"
+
+    if [ "$WEWORK_RENDERER_CHANGED" -eq 1 ]; then
+        if [ "$WEWORK_RENDERER_FULL_TESTS" -eq 1 ]; then
+            echo -e "   Running full renderer unit tests with $WEWORK_TEST_WORKERS workers..."
+            if ! VITEST_MAX_WORKERS="$WEWORK_TEST_WORKERS" \
+                pnpm --filter wework exec vitest run --dir src --pool=threads \
+                >> "$TEMP_DIR/wework_test.log" 2>&1; then
+                test_exit=1
+            fi
+        else
+            collect_wework_renderer_tests
+            if [ "${#WEWORK_FOCUSED_TEST_FILES[@]}" -gt 0 ]; then
+                echo -e "   Running focused renderer unit tests with $WEWORK_TEST_WORKERS workers..."
+                if ! VITEST_MAX_WORKERS="$WEWORK_TEST_WORKERS" \
+                    pnpm --filter wework exec vitest run --pool=threads \
+                    "${WEWORK_FOCUSED_TEST_FILES[@]}" \
+                    >> "$TEMP_DIR/wework_test.log" 2>&1; then
+                    test_exit=1
+                fi
+            else
+                echo -e "   ${YELLOW}↪ Renderer unit tests: SKIPPED (no colocated tests)${NC}"
+            fi
+        fi
+    fi
+
+    if [ "$WEWORK_ELECTRON_CHANGED" -eq 1 ] && [ "$ELECTRON_INSTALL_EXIT" -eq 0 ]; then
+        echo -e "   Running Electron unit tests..."
+        if ! pnpm --dir wework/electron test >> "$TEMP_DIR/wework_test.log" 2>&1; then
+            test_exit=1
+        fi
+    fi
+
+    if [ "$WEWORK_DSH_CHANGED" -eq 1 ]; then
+        echo -e "   Running DSH unit tests..."
+        DSH_TEST_FILES=()
+        while IFS= read -r test_file; do
+            DSH_TEST_FILES+=("${test_file#wework/}")
+        done < <(collect_node_test_files "wework/dsh")
+        if ! pnpm --filter wework test \
+            "${DSH_TEST_FILES[@]}" >> "$TEMP_DIR/wework_test.log" 2>&1; then
+            test_exit=1
+        fi
+    fi
+
+    if [ "$WEWORK_SCRIPTS_CHANGED" -eq 1 ]; then
+        echo -e "   Running Wework script unit tests..."
+        SCRIPT_TEST_FILES=()
+        while IFS= read -r test_file; do
+            SCRIPT_TEST_FILES+=("${test_file#wework/}")
+        done < <(collect_node_test_files "wework/scripts")
+        if ! pnpm --filter wework test \
+            "${SCRIPT_TEST_FILES[@]}" >> "$TEMP_DIR/wework_test.log" 2>&1; then
+            test_exit=1
+        fi
+    fi
+
+    return "$test_exit"
+}
+
 resolve_default_base() {
     local remote_name="${1:-}"
     local candidate=""
@@ -485,7 +548,7 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
         WARNINGS+=("Wework: node_modules not found, checks skipped")
     else
         collect_wework_test_scope
-        echo -e "   Running static checks in parallel..."
+        echo -e "   Running static checks and unit tests in parallel..."
 
         pnpm --filter wework lint > "$TEMP_DIR/wework_eslint.log" 2>&1 &
         ESLINT_PID=$!
@@ -511,6 +574,10 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
             fi
         fi
 
+        WEWORK_TEST_WORKERS="${WEWORK_PRE_PUSH_TEST_WORKERS:-4}"
+        run_wework_unit_tests &
+        WEWORK_TEST_PID=$!
+
         wait "$ESLINT_PID"
         ESLINT_EXIT=$?
 
@@ -524,59 +591,8 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
             ELECTRON_TSC_EXIT=$?
         fi
 
-        WEWORK_TEST_WORKERS="${WEWORK_PRE_PUSH_TEST_WORKERS:-2}"
-        TEST_EXIT=0
-        : > "$TEMP_DIR/wework_test.log"
-
-        if [ "$WEWORK_RENDERER_CHANGED" -eq 1 ]; then
-            if [ "$WEWORK_RENDERER_FULL_TESTS" -eq 1 ]; then
-                echo -e "   Running full renderer unit tests with $WEWORK_TEST_WORKERS workers..."
-                VITEST_MAX_WORKERS="$WEWORK_TEST_WORKERS" \
-                    pnpm --filter wework exec vitest run >> "$TEMP_DIR/wework_test.log" 2>&1
-            else
-                collect_wework_renderer_tests
-                if [ "${#WEWORK_FOCUSED_TEST_FILES[@]}" -gt 0 ]; then
-                    echo -e "   Running focused renderer unit tests with $WEWORK_TEST_WORKERS workers..."
-                    VITEST_MAX_WORKERS="$WEWORK_TEST_WORKERS" \
-                        pnpm --filter wework exec vitest run \
-                        "${WEWORK_FOCUSED_TEST_FILES[@]}" >> "$TEMP_DIR/wework_test.log" 2>&1
-                else
-                    echo -e "   ${YELLOW}↪ Renderer unit tests: SKIPPED (no colocated tests)${NC}"
-                fi
-            fi
-            TEST_EXIT=$?
-        fi
-
-        if [ "$WEWORK_ELECTRON_CHANGED" -eq 1 ] && [ "$ELECTRON_INSTALL_EXIT" -eq 0 ]; then
-            echo -e "   Running Electron unit tests..."
-            if ! pnpm --dir wework/electron test >> "$TEMP_DIR/wework_test.log" 2>&1; then
-                TEST_EXIT=1
-            fi
-        fi
-
-        if [ "$WEWORK_DSH_CHANGED" -eq 1 ]; then
-            echo -e "   Running DSH unit tests..."
-            DSH_TEST_FILES=()
-            while IFS= read -r test_file; do
-                DSH_TEST_FILES+=("${test_file#wework/}")
-            done < <(collect_node_test_files "wework/dsh")
-            if ! pnpm --filter wework test \
-                "${DSH_TEST_FILES[@]}" >> "$TEMP_DIR/wework_test.log" 2>&1; then
-                TEST_EXIT=1
-            fi
-        fi
-
-        if [ "$WEWORK_SCRIPTS_CHANGED" -eq 1 ]; then
-            echo -e "   Running Wework script unit tests..."
-            SCRIPT_TEST_FILES=()
-            while IFS= read -r test_file; do
-                SCRIPT_TEST_FILES+=("${test_file#wework/}")
-            done < <(collect_node_test_files "wework/scripts")
-            if ! pnpm --filter wework test \
-                "${SCRIPT_TEST_FILES[@]}" >> "$TEMP_DIR/wework_test.log" 2>&1; then
-                TEST_EXIT=1
-            fi
-        fi
+        wait "$WEWORK_TEST_PID"
+        TEST_EXIT=$?
 
         if [ $ESLINT_EXIT -eq 0 ]; then
             echo -e "   ${GREEN}✅ ESLint: PASSED${NC}"

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -10,6 +10,7 @@ CALL_LOG="$TMP_DIR/calls.log"
 DEFAULT_TEST_OUT="$(mktemp "${TMP_DIR}/default-test.XXXXXX")"
 FULL_TEST_OUT="$(mktemp "${TMP_DIR}/full-test.XXXXXX")"
 WEWORK_TEST_OUT="$(mktemp "${TMP_DIR}/wework-test.XXXXXX")"
+WEWORK_FULL_TEST_OUT="$(mktemp "${TMP_DIR}/wework-full-test.XXXXXX")"
 WEWORK_ELECTRON_TEST_OUT="$(mktemp "${TMP_DIR}/wework-electron-test.XXXXXX")"
 WEWORK_MIXED_TEST_OUT="$(mktemp "${TMP_DIR}/wework-mixed-test.XXXXXX")"
 FRONTEND_TEST_OUT="$(mktemp "${TMP_DIR}/frontend-test.XXXXXX")"
@@ -174,7 +175,7 @@ if ! grep -qE '^pnpm --filter wework typecheck$' "$CALL_LOG"; then
     exit 1
 fi
 
-if ! grep -qE '^pnpm --filter wework exec vitest run src/features/workbench/WorkbenchProvider.test.tsx src/features/workbench/runtimeModelSelection.test.ts$' "$CALL_LOG"; then
+if ! grep -qE '^pnpm --filter wework exec vitest run --pool=threads src/features/workbench/WorkbenchProvider.test.tsx src/features/workbench/runtimeModelSelection.test.ts$' "$CALL_LOG"; then
     echo "Expected renderer source changes to run changed and sibling test files."
     echo "Calls:"
     cat "$CALL_LOG"
@@ -188,18 +189,54 @@ if grep -qE '^pnpm --filter wework test$' "$CALL_LOG"; then
     exit 1
 fi
 
-if ! grep -qE 'Running focused renderer unit tests with 2 workers' "$WEWORK_TEST_OUT"; then
-    echo "Expected focused Wework pre-push tests to use two workers by default."
+if ! grep -qE 'Running focused renderer unit tests with 4 workers' "$WEWORK_TEST_OUT"; then
+    echo "Expected focused Wework pre-push tests to use four workers by default."
     cat "$WEWORK_TEST_OUT"
     exit 1
 fi
 
-STATIC_CHECK_LINE=$(grep -n 'Running static checks in parallel' "$WEWORK_TEST_OUT" | cut -d: -f1)
-UNIT_TEST_LINE=$(grep -n 'Running focused renderer unit tests with 2 workers' "$WEWORK_TEST_OUT" | cut -d: -f1)
+STATIC_CHECK_LINE=$(grep -n 'Running static checks and unit tests in parallel' "$WEWORK_TEST_OUT" | cut -d: -f1)
+UNIT_TEST_LINE=$(grep -n 'Running focused renderer unit tests with 4 workers' "$WEWORK_TEST_OUT" | cut -d: -f1)
 if [ -z "$STATIC_CHECK_LINE" ] || [ -z "$UNIT_TEST_LINE" ] ||
     [ "$STATIC_CHECK_LINE" -ge "$UNIT_TEST_LINE" ]; then
     echo "Expected Wework static checks to be reported before unit tests."
     cat "$WEWORK_TEST_OUT"
+    exit 1
+fi
+
+: > "$CALL_LOG"
+
+# Build a synthetic commit changing renderer-wide Vitest configuration. Full
+# renderer checks must stay inside src/ so Electron tests remain package-owned.
+WEWORK_FULL_BASE_SHA=$(git rev-parse HEAD)
+WEWORK_FULL_FIXTURE="$TMP_DIR/vite.config.ts.fixture"
+cp "$PROJECT_ROOT/wework/vite.config.ts" "$WEWORK_FULL_FIXTURE"
+printf '\n' >> "$WEWORK_FULL_FIXTURE"
+WEWORK_FULL_BLOB=$(git hash-object -w "$WEWORK_FULL_FIXTURE")
+WEWORK_FULL_INDEX="$TMP_DIR/wework-full.index"
+GIT_INDEX_FILE="$WEWORK_FULL_INDEX" git read-tree "$WEWORK_FULL_BASE_SHA"
+GIT_INDEX_FILE="$WEWORK_FULL_INDEX" git update-index --cacheinfo \
+    100644 "$WEWORK_FULL_BLOB" wework/vite.config.ts
+WEWORK_FULL_TREE=$(GIT_INDEX_FILE="$WEWORK_FULL_INDEX" git write-tree)
+WEWORK_FULL_LOCAL_SHA=$(printf 'full renderer pre-push fixture\n' |
+    git commit-tree "$WEWORK_FULL_TREE" -p "$WEWORK_FULL_BASE_SHA")
+
+AI_VERIFIED=1 \
+PATH="$TMP_DIR/bin:$PATH" \
+bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >"$WEWORK_FULL_TEST_OUT" 2>&1
+refs/heads/topic $WEWORK_FULL_LOCAL_SHA refs/heads/topic $WEWORK_FULL_BASE_SHA
+EOF
+
+if ! grep -qE '^pnpm --filter wework exec vitest run --dir src --pool=threads$' "$CALL_LOG"; then
+    echo "Expected full renderer tests to exclude Electron-owned test files."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+if ! grep -qE 'Running full renderer unit tests with 4 workers' "$WEWORK_FULL_TEST_OUT"; then
+    echo "Expected full Wework renderer tests to use four workers by default."
+    cat "$WEWORK_FULL_TEST_OUT"
     exit 1
 fi
 
@@ -283,7 +320,7 @@ bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >"$WEWORK_MIXED_TEST_OU
 refs/heads/topic $MIXED_LOCAL_SHA refs/heads/topic $MIXED_BASE_SHA
 EOF
 
-if ! grep -qE '^pnpm --filter wework exec vitest run src/api/changeRequests.test.ts$' "$CALL_LOG"; then
+if ! grep -qE '^pnpm --filter wework exec vitest run --pool=threads src/api/changeRequests.test.ts$' "$CALL_LOG"; then
     echo "Expected merge-like Wework changes to run only the related renderer test."
     echo "Calls:"
     cat "$CALL_LOG"


### PR DESCRIPTION
## Summary

- run Wework static checks and unit tests concurrently in the pre-push gate
- restrict full renderer Vitest runs to `wework/src` so Electron tests remain package-owned
- use four Vitest thread workers to reduce process overhead while preserving isolation and coverage
- extend push-gate regression coverage for worker count and renderer test scope

## Verification

- `bash scripts/hooks/test-ai-push-gate.sh`
- `bash -n scripts/hooks/ai-push-gate.sh scripts/hooks/test-ai-push-gate.sh`
- `git diff --check`
- `pnpm --filter wework lint`
- `pnpm --filter wework typecheck`
- `VITEST_MAX_WORKERS=4 pnpm --filter wework exec vitest run --dir src --pool=threads` (4761 tests passed)
- full Wework pre-push-equivalent parallel run: 142 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation checks by running unit tests, linting, and type checks in parallel.
  * Consolidated test results across renderer, Electron, DSH, and scripts suites for clearer failure reporting.
  * Updated test execution to use threaded Vitest runs with four workers where applicable.

* **Tests**
  * Expanded regression coverage for renderer-only, focused, and mixed-change scenarios.
  * Added checks to ensure unrelated Electron tests are excluded from renderer-only validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->