### PR TITLE
fix(wework): restore native editing context menu

### DIFF
--- a/docs/en/wework/developer-guide/wework-ai-verification.md
+++ b/docs/en/wework/developer-guide/wework-ai-verification.md
@@ -41,6 +41,16 @@ After startup, the WebView calls `/ready` and then short-polls `/commands`. The 
 
 `ai:verify` and desktop E2E share this protocol, so endpoint and polling semantics must remain aligned when either side changes. Do not convert `/commands` to long polling: it conflicts with the WebView control loop, leaves later commands queued, and surfaces as repeated timeouts. The controller must also remove a timed-out command from the queue so a later poll cannot execute stale work.
 
+## Native context menus
+
+Electron does not create a WebContents context menu automatically. The Wework Electron main process listens for `context-menu` centrally and builds native menus for the main window, workspace windows, and auxiliary windows.
+
+- Image menus retain copy-image, open-image, and local-file actions.
+- Editable contexts must read `params.isEditable` and `params.editFlags`, use Electron's native `undo`, `redo`, `cut`, `copy`, `paste`, `delete`, and `selectAll` roles, and pass `params.frame` to `menu.popup`.
+- Selected text outside an editor uses the native `copy` role. When no meaningful action exists, do not show an empty menu, so React components can keep their own business context menus.
+
+When changing this path, run `wework/electron/src/host/image-context-menu.test.ts`, then verify menu presentation, enabled states, and paste behavior in a real input inside an isolated Electron session. WebView DOM snapshots do not include a native macOS `NSMenu`; a synthetic `contextmenu` event or browser-only screenshot is not a substitute for real desktop verification.
+
 ## AI workflow
 
 An AI should start with `snapshot` to confirm the route and available `data-testid` values, make the smallest required interaction, and use `wait-for` plus `snapshot` or `text` to verify the result. Always call `stop` when finished. On failure, keep the session directory and inspect `app.log`.

--- a/docs/zh/wework/developer-guide/wework-ai-verification.md
+++ b/docs/zh/wework/developer-guide/wework-ai-verification.md
@@ -41,6 +41,16 @@ WebView 启动后先调用 `/ready`，随后用短轮询请求 `/commands`。控
 
 `ai:verify` 和桌面端 E2E 共用这套协议，修改任一端时必须保持端点和轮询语义一致。不要把 `/commands` 改成长轮询：这会与 WebView 的控制循环冲突，使后续命令留在队列中并表现为连续超时。控制器还必须在命令超时后将其从队列移除，避免过期命令在下一次轮询中被执行。
 
+## 原生右键菜单
+
+Electron 不会为 WebContents 自动创建网页右键菜单。Wework 由 Electron 主进程统一监听 `context-menu`，并为主窗口、工作区窗口和辅助窗口构建原生菜单。
+
+- 图片菜单保留复制图片、打开图片和本机文件操作。
+- 可编辑区域必须读取 `params.isEditable` 和 `params.editFlags`，使用 Electron 的 `undo`、`redo`、`cut`、`copy`、`paste`、`delete`、`selectAll` 原生 role，并把 `params.frame` 传给 `menu.popup`。
+- 非编辑区域的选中文本使用原生 `copy` role；没有可执行操作时不弹出空菜单，以免干扰 React 组件自己的业务右键菜单。
+
+修改该链路时，先运行 `wework/electron/src/host/image-context-menu.test.ts`，再在隔离 Electron 会话的真实输入框中验证菜单弹出、菜单项可用状态和粘贴行为。WebView 的 DOM 快照不会包含 macOS 原生 `NSMenu`，不能用合成的 `contextmenu` 事件或仅浏览器截图代替真实桌面验证。
+
 ## AI 验证流程
 
 AI 应先执行 `snapshot` 确认路由和可用的 `data-testid`，再进行最小必要操作，并以 `wait-for` 加 `snapshot` 或 `text` 验证结果。结束时必须执行 `stop`；若失败，保留该会话目录中的 `app.log` 以便诊断。

--- a/wework/electron/src/host/image-context-menu.test.ts
+++ b/wework/electron/src/host/image-context-menu.test.ts
@@ -30,7 +30,6 @@ function setup(language = 'en-US', resolvedImage = imageContext()) {
   })
   const actions = {
     copyPath: vi.fn(),
-    copyText: vi.fn(),
     openImage: vi.fn(async () => undefined),
     reportError: vi.fn(),
     resolveImageContext: vi.fn(async () => resolvedImage),
@@ -112,8 +111,10 @@ describe('installNativeContextMenu', () => {
   })
 
   test('shows Copy for selected conversation text', async () => {
-    const { actions, buildMenu, trigger } = setup()
+    const { buildMenu, popup, trigger } = setup()
+    const frame = {}
     const params = {
+      frame,
       mediaType: 'none',
       selectionText: 'selected response',
       x: 10,
@@ -123,9 +124,45 @@ describe('installNativeContextMenu', () => {
     await trigger(params)
 
     const [items] = buildMenu.mock.calls[0] ?? []
-    expect(items?.map(item => item.label)).toEqual(['Copy'])
-    items?.[0]?.click?.()
-    expect(actions.copyText).toHaveBeenCalledWith('selected response')
+    expect(items).toEqual([{ role: 'copy' }])
+    expect(popup).toHaveBeenCalledWith({ frame })
+  })
+
+  test('shows native editing actions with availability from Chromium', async () => {
+    const { buildMenu, popup, trigger } = setup()
+    const frame = {}
+
+    await trigger({
+      editFlags: {
+        canCopy: true,
+        canCut: true,
+        canDelete: true,
+        canPaste: false,
+        canRedo: false,
+        canSelectAll: true,
+        canUndo: true,
+      },
+      frame,
+      isEditable: true,
+      mediaType: 'none',
+      selectionText: '',
+      x: 10,
+      y: 20,
+    })
+
+    const [items] = buildMenu.mock.calls[0] ?? []
+    expect(items).toEqual([
+      { role: 'undo', enabled: true },
+      { role: 'redo', enabled: false },
+      { type: 'separator' },
+      { role: 'cut', enabled: true },
+      { role: 'copy', enabled: true },
+      { role: 'paste', enabled: false },
+      { role: 'delete', enabled: true },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: true },
+    ])
+    expect(popup).toHaveBeenCalledWith({ frame })
   })
 
   test('leaves non-image context menus without a selection untouched', async () => {

--- a/wework/electron/src/host/image-context-menu.ts
+++ b/wework/electron/src/host/image-context-menu.ts
@@ -1,4 +1,17 @@
+import type { WebFrameMain } from 'electron'
+
 export interface NativeContextMenuParams {
+  editFlags?: {
+    canCopy: boolean
+    canCut: boolean
+    canDelete: boolean
+    canPaste: boolean
+    canRedo: boolean
+    canSelectAll: boolean
+    canUndo: boolean
+  }
+  frame?: WebFrameMain | null
+  isEditable?: boolean
   mediaType: string
   selectionText: string
   x: number
@@ -20,18 +33,19 @@ export interface NativeContextMenuContents {
 }
 
 export interface NativeContextMenu {
-  popup: () => void
+  popup: (options?: { frame?: WebFrameMain }) => void
 }
 
 export interface NativeContextMenuItem {
   click?: () => void
+  enabled?: boolean
   label?: string
+  role?: 'copy' | 'cut' | 'delete' | 'paste' | 'redo' | 'selectAll' | 'undo'
   type?: 'separator'
 }
 
 export interface NativeContextMenuActions {
   copyPath: (path: string) => void
-  copyText: (text: string) => void
   openImage: (image: ImageContext) => Promise<void>
   reportError: (action: string, error: unknown) => void
   resolveImageContext: (params: NativeContextMenuParams) => Promise<ImageContext | null>
@@ -39,7 +53,6 @@ export interface NativeContextMenuActions {
 }
 
 interface NativeContextMenuLabels {
-  copy: string
   copyImage: string
   copyPath: string
   openImage: string
@@ -47,7 +60,6 @@ interface NativeContextMenuLabels {
 }
 
 const ZH_CN_LABELS: NativeContextMenuLabels = {
-  copy: '复制',
   copyImage: '复制图片',
   copyPath: '复制文件路径',
   openImage: '在系统默认应用中打开',
@@ -55,7 +67,6 @@ const ZH_CN_LABELS: NativeContextMenuLabels = {
 }
 
 const EN_LABELS: NativeContextMenuLabels = {
-  copy: 'Copy',
   copyImage: 'Copy Image',
   copyPath: 'Copy File Path',
   openImage: 'Open in Default Application',
@@ -114,13 +125,25 @@ async function showContextMenu(
     return
   }
 
+  const frame = params.frame ?? undefined
+  if (params.isEditable) {
+    const editFlags = params.editFlags
+    buildMenu([
+      { role: 'undo', enabled: editFlags?.canUndo },
+      { role: 'redo', enabled: editFlags?.canRedo },
+      { type: 'separator' },
+      { role: 'cut', enabled: editFlags?.canCut },
+      { role: 'copy', enabled: editFlags?.canCopy },
+      { role: 'paste', enabled: editFlags?.canPaste },
+      { role: 'delete', enabled: editFlags?.canDelete },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: editFlags?.canSelectAll },
+    ]).popup({ frame })
+    return
+  }
+
   if (!params.selectionText.trim()) return
-  buildMenu([
-    {
-      label: labels.copy,
-      click: () => actions.copyText(params.selectionText),
-    },
-  ]).popup()
+  buildMenu([{ role: 'copy' }]).popup({ frame })
 }
 
 export function installNativeContextMenu(

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -136,7 +136,6 @@ function secureDshContents(contents: WebContents, dshUrl: string): void {
     items => Menu.buildFromTemplate(items),
     {
       copyPath: path => clipboard.writeText(path),
-      copyText: text => clipboard.writeText(text),
       openImage: async image => {
         const temporaryPath = image.localPath
           ? null


### PR DESCRIPTION
## Summary

- restore native Undo, Redo, Cut, Copy, Paste, Delete, and Select All actions for editable Wework contexts
- use Chromium edit flags and the originating WebFrameMain so native roles target the correct editor
- keep image and selected-text context menus intact and document real Electron verification requirements

## Verification

- `pnpm --dir wework/electron test src/host/image-context-menu.test.ts`
- `pnpm --dir wework/electron typecheck`
- `pnpm --filter wework exec eslint electron/src/host/image-context-menu.ts electron/src/host/image-context-menu.test.ts electron/src/main.ts`
- `pnpm --filter wework exec prettier --check electron/src/host/image-context-menu.ts electron/src/host/image-context-menu.test.ts electron/src/main.ts`
- pre-push Wework static checks, unit tests, and Electron tests
- isolated real Electron verification: the Composer displayed the native editing menu with state-aware enabled and disabled items

Closes WORK-182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native context-menu actions for undo, redo, cut, copy, paste, delete, and select all in editable areas.
  * Improved context-menu behavior across images, selected text, and multiple window types.
  * Suppressed empty context menus and preserved path-copying actions.

* **Documentation**
  * Added English and Chinese guidance for native context menus and real-session verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->