### PR TITLE
fix(wework): launch ai verify from Electron source

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -76,6 +76,7 @@ Any Wework UI, Electron host command, local-runtime, IPC, or desktop integration
 
 ```bash
 pnpm --filter wework ai:verify start
+pnpm --filter wework ai:verify start --packaged true
 pnpm --filter wework ai:verify snapshot --session <session-path>
 pnpm --filter wework ai:verify debug --session <session-path>
 pnpm --filter wework ai:verify active-element --session <session-path>
@@ -96,7 +97,7 @@ pnpm --filter wework ai:verify close-to-tray --session <session-path>
 pnpm --filter wework ai:verify stop --session <session-path>
 ```
 
-- `start` waits for the WebView, creates an isolated executor home, links local Codex authentication only for that session, and gives the app its own stdio-managed executor child.
+- `start` prepares and launches Electron directly from the source application directory, waits for the WebView, creates an isolated executor home, links local Codex authentication only for that session, and gives the app its own stdio-managed executor child. Use `start --packaged true` only when validating the final app bundle, packaged resources, or macOS application identity.
 - Use `start --codex-home-initialization true` to verify the first-run Codex migration flow with a session-local native Codex home and synthetic authentication; it does not read or modify personal Codex credentials.
 - Session files and credentials are secrets: never print their contents. Always stop the session; it removes the auth link and terminates the isolated process group.
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -71,6 +71,7 @@ import { SystemResumeBridge } from './host/system-resume-bridge.js'
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const dshPreloadPath = resolve(packageRoot, 'dist/dsh-preload.cjs')
+const developmentResourcesRoot = resolve(packageRoot, '..', 'resources')
 const { autoUpdater } = electronUpdater
 const updateBaseUrl =
   process.env.WEWORK_UPDATE_BASE_URL?.trim() ||
@@ -765,7 +766,7 @@ function dispatchTrayAction(action: TrayAction): void {
 }
 
 function createTrayManager(): ElectronTrayManager<Electron.Menu | null, Tray> {
-  const resourcesRoot = app.isPackaged ? process.resourcesPath : resolve(packageRoot, 'resources')
+  const resourcesRoot = app.isPackaged ? process.resourcesPath : developmentResourcesRoot
   const iconPath = join(resourcesRoot, 'icons', '128x128.png')
   return new ElectronTrayManager({
     createTray: () => new Tray(createTrayIcon(nativeImage, iconPath)),
@@ -1105,7 +1106,7 @@ if (hasSingleInstanceLock) {
 }
 
 async function desktopEnvironment(): Promise<NodeJS.ProcessEnv> {
-  const resourcesRoot = app.isPackaged ? process.resourcesPath : resolve(packageRoot, 'resources')
+  const resourcesRoot = app.isPackaged ? process.resourcesPath : developmentResourcesRoot
   const developmentRuntimeRoot = resolve(
     packageRoot,
     '..',

--- a/wework/package.json
+++ b/wework/package.json
@@ -40,6 +40,7 @@
     "e2e:desktop:local-terminal": "WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/local-terminal.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "e2e:desktop:streaming-text": "WEWORK_E2E_DESKTOP_SCENARIO_ONLY=true WEWORK_E2E_DESKTOP_SCENARIO_MODULE=./scenarios/streaming-text.scenario.mjs node e2e/desktop/task-flow.e2e.mjs",
     "ai:verify": "node scripts/ai-verify.mjs",
+    "ai:verify:electron:prepare": "node scripts/prepare-ai-verify-electron.mjs",
     "ai:verify:electron:build": "pnpm run prepare:electron && VITE_WEWORK_E2E=true VITE_WEWORK_RELEASE_CHANNEL=stable VITE_WEWORK_RUNTIME_MODE=local-first pnpm --dir electron build:package",
     "e2e:ui": "playwright test --ui"
   },

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -9,12 +9,16 @@ import { createServer } from 'node:http'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { execFile, spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { basename, dirname, extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { buildAiVerifyEnvironment } from './ai-verify-environment.mjs'
+import { wrapWindowsScriptCommand } from './child-process-command.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const weworkDir = resolve(scriptDir, '..')
+const repositoryDir = resolve(weworkDir, '..')
+const electronDir = join(weworkDir, 'electron')
 const defaultTimeoutMs = 30_000
 const startupTimeoutMs = 120_000
 const commandResultGraceMs = 5_000
@@ -99,11 +103,13 @@ const SELECTOR_OPTIONAL_COMMANDS = new Set([
 function usage() {
   console.error(`Usage:
   pnpm --filter wework ai:verify start
+  pnpm --filter wework ai:verify start --packaged true
   pnpm --filter wework ai:verify <${Object.keys(AI_VERIFY_ACTIONS).join('|')}|status|stop> --session PATH [options]
 
 Options:
   --codex-home-initialization true
                             Seed and verify isolated first-run Codex migration
+  --packaged true           Launch the packaged app instead of Electron source mode
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
   --value TEXT_OR_JSON      Replacement value for fill; JSON for click-at,
                             seed-local-project, paste-paths, or drop-paths
@@ -159,11 +165,12 @@ export function resolveOptionalBoolean(value, optionName) {
 }
 
 export function validateStartOptions(options) {
-  const allowedOptions = new Set(['codex-home-initialization', 'timeout'])
+  const allowedOptions = new Set(['codex-home-initialization', 'packaged', 'timeout'])
   const unexpectedOption = Object.keys(options).find(option => !allowedOptions.has(option))
   if (unexpectedOption) {
     throw new Error(`Unexpected option for start: --${unexpectedOption}`)
   }
+  resolveOptionalBoolean(options.packaged, 'packaged')
 }
 
 function json(response, status, value) {
@@ -293,6 +300,88 @@ export function resolveElectronAppBinary(platform = process.platform, arch = pro
   return platform === 'darwin'
     ? join(appRoot, 'WeWork.app', 'Contents', 'MacOS', executable)
     : join(appRoot, executable)
+}
+
+export function resolveElectronLaunch({
+  packaged,
+  sourceBinary,
+  platform = process.platform,
+  arch = process.arch,
+}) {
+  if (packaged) {
+    return {
+      command: resolveElectronAppBinary(platform, arch),
+      args: [],
+      cwd: weworkDir,
+    }
+  }
+  return {
+    command: sourceBinary,
+    args: ['.'],
+    cwd: electronDir,
+  }
+}
+
+export function resolveHostTarget(platform = process.platform, arch = process.arch) {
+  const target = {
+    'darwin:arm64': 'aarch64-apple-darwin',
+    'darwin:x64': 'x86_64-apple-darwin',
+    'linux:arm64': 'aarch64-unknown-linux-gnu',
+    'linux:x64': 'x86_64-unknown-linux-gnu',
+    'win32:x64': 'x86_64-pc-windows-msvc',
+  }[`${platform}:${arch}`]
+  if (!target) throw new Error(`Unsupported Electron source platform: ${platform}/${arch}`)
+  return target
+}
+
+export async function buildSourceRuntimeEnvironment(
+  platform = process.platform,
+  arch = process.arch
+) {
+  const target = resolveHostTarget(platform, arch)
+  const lock = JSON.parse(await readFile(join(weworkDir, 'codex-binaries.lock.json'), 'utf8'))
+  const codex = lock.targets[target]
+  if (!codex?.binaryPath) throw new Error(`Codex binary is not configured for ${target}`)
+  const executorTargetDir =
+    process.env.CARGO_TARGET_DIR?.trim() || join(repositoryDir, 'executor', 'target')
+  return {
+    CODEX_BINARY_PATH: join(weworkDir, 'resources', 'binaries', 'codex', target, codex.binaryPath),
+    DWS_BINARY_PATH: join(
+      weworkDir,
+      'resources',
+      'binaries',
+      `dws-${target}${platform === 'win32' ? '.exe' : ''}`
+    ),
+    WEWORK_EXECUTOR_PATH: join(
+      executorTargetDir,
+      'debug',
+      platform === 'win32' ? 'wegent-executor.exe' : 'wegent-executor'
+    ),
+    WEWORK_HARNESS_RUNTIME_ROOT: join(weworkDir, 'node_modules', '.cache', 'harness-runtime-dev'),
+    WEWORK_NODE_PATH: process.execPath,
+  }
+}
+
+async function resolveSourceElectronBinary() {
+  const require = createRequire(join(electronDir, 'package.json'))
+  return require('electron')
+}
+
+async function prepareSourceElectron() {
+  await new Promise((resolvePromise, reject) => {
+    const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+    const command = wrapWindowsScriptCommand(pnpmCommand, ['run', 'ai:verify:electron:prepare'])
+    const child = spawn(command.command, command.args, {
+      cwd: weworkDir,
+      env: process.env,
+      stdio: 'inherit',
+    })
+    child.once('error', reject)
+    child.once('exit', code => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(`Electron source preparation exited with code ${code ?? 'unknown'}`))
+    })
+  })
 }
 
 export function monitorAppProcess(app, pending, onExit) {
@@ -457,11 +546,18 @@ async function runServer(sessionPath, token) {
     executorHome,
     sessionDirectory: session.directory,
   })
-  app = spawn(resolveElectronAppBinary(), [], {
-    cwd: weworkDir,
+  const sourceEnvironment =
+    session.launchMode === 'source' ? await buildSourceRuntimeEnvironment() : {}
+  const launch = resolveElectronLaunch({
+    packaged: session.launchMode === 'packaged',
+    sourceBinary: session.launchMode === 'source' ? await resolveSourceElectronBinary() : undefined,
+  })
+  app = spawn(launch.command, launch.args, {
+    cwd: launch.cwd,
     detached: true,
     env: {
       ...environment,
+      ...sourceEnvironment,
       WEWORK_DESKTOP_RUNTIME: 'electron',
       WEWORK_E2E_CONTROL_TOKEN: token,
       WEWORK_USER_DATA_DIR: join(session.directory, 'user-data'),
@@ -510,6 +606,12 @@ async function main() {
   if (command === 'serve') return runServer(options.session, options.token)
   if (command === 'start') {
     validateStartOptions(options)
+    const packaged = resolveOptionalBoolean(options.packaged, 'packaged') ?? false
+    if (!packaged) await prepareSourceElectron()
+    const launch = resolveElectronLaunch({
+      packaged,
+      sourceBinary: packaged ? undefined : await resolveSourceElectronBinary(),
+    })
     const directory = join(
       weworkDir,
       'test-results',
@@ -518,7 +620,7 @@ async function main() {
     )
     await mkdir(directory, { recursive: true })
     const token = randomBytes(32).toString('hex')
-    await readFile(resolveElectronAppBinary())
+    await readFile(launch.command)
     const sessionPath = join(directory, 'session.json')
     await writeFile(
       sessionPath,
@@ -529,6 +631,7 @@ async function main() {
           directory,
           token,
           status: 'starting',
+          launchMode: packaged ? 'packaged' : 'source',
           verifyCodexHomeInitialization: options['codex-home-initialization'] === 'true',
         },
         null,

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -7,9 +7,12 @@ import {
   AI_VERIFY_ACTIONS,
   acknowledgeStartedCommand,
   appExitMessage,
+  buildSourceRuntimeEnvironment,
   monitorAppProcess,
   parseArgs,
   readSessionForCleanup,
+  resolveElectronLaunch,
+  resolveHostTarget,
   resolveCommandTimeout,
   resolveOptionalBoolean,
   resolveStartupTimeout,
@@ -244,6 +247,7 @@ describe('validateStartOptions', () => {
     expect(() =>
       validateStartOptions({
         'codex-home-initialization': 'true',
+        packaged: 'false',
         timeout: '180000',
       })
     ).not.toThrow()
@@ -253,5 +257,65 @@ describe('validateStartOptions', () => {
     expect(() => validateStartOptions({ runtime: 'electron' })).toThrow(
       'Unexpected option for start: --runtime'
     )
+  })
+
+  test('rejects an invalid packaged option', () => {
+    expect(() => validateStartOptions({ packaged: 'yes' })).toThrow(
+      '--packaged must be "true" or "false"'
+    )
+  })
+})
+
+describe('resolveElectronLaunch', () => {
+  test('launches the Electron development binary from the source application directory', () => {
+    expect(
+      resolveElectronLaunch({
+        packaged: false,
+        sourceBinary: '/electron/Electron',
+      })
+    ).toMatchObject({
+      command: '/electron/Electron',
+      args: ['.'],
+    })
+  })
+
+  test('launches the packaged application without source arguments', () => {
+    expect(
+      resolveElectronLaunch({
+        packaged: true,
+        sourceBinary: '/electron/Electron',
+        platform: 'darwin',
+        arch: 'arm64',
+      })
+    ).toMatchObject({
+      args: [],
+    })
+  })
+})
+
+describe('resolveHostTarget', () => {
+  test.each([
+    ['darwin', 'arm64', 'aarch64-apple-darwin'],
+    ['darwin', 'x64', 'x86_64-apple-darwin'],
+    ['linux', 'x64', 'x86_64-unknown-linux-gnu'],
+    ['win32', 'x64', 'x86_64-pc-windows-msvc'],
+  ])('maps %s/%s to %s', (platform, arch, target) => {
+    expect(resolveHostTarget(platform, arch)).toBe(target)
+  })
+
+  test('rejects unsupported source platforms', () => {
+    expect(() => resolveHostTarget('win32', 'arm64')).toThrow(
+      'Unsupported Electron source platform: win32/arm64'
+    )
+  })
+})
+
+describe('buildSourceRuntimeEnvironment', () => {
+  test('uses the current Node executable without preparing packaged Node resources', async () => {
+    const environment = await buildSourceRuntimeEnvironment('darwin', 'arm64')
+
+    expect(environment.WEWORK_NODE_PATH).toBe(process.execPath)
+    expect(environment.WEWORK_EXECUTOR_PATH).toContain('/debug/wegent-executor')
+    expect(environment.WEWORK_HARNESS_RUNTIME_ROOT).toContain('harness-runtime-dev')
   })
 })

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -10,6 +10,7 @@ const scripts = [
   'electron/scripts/package-app.mjs',
   'electron/scripts/prepare-package-assets.mjs',
   'scripts/dev-mac-app.sh',
+  'scripts/prepare-ai-verify-electron.mjs',
   'scripts/prepare-codex-binary.mjs',
   'scripts/prepare-dws-binary.mjs',
   'scripts/prepare-execution-runtime.mjs',
@@ -25,6 +26,9 @@ describe('desktop resource migration', () => {
     )
     expect(packageJson.scripts['dev:desktop']).toContain('pnpm run prepare:electron')
     expect(packageJson.scripts['dev:mac']).toBe('bash scripts/dev-mac-app.sh')
+    expect(packageJson.scripts['ai:verify:electron:prepare']).toBe(
+      'node scripts/prepare-ai-verify-electron.mjs'
+    )
     expect(packageJson.scripts['ai:verify:electron:build']).toContain('pnpm run prepare:electron')
     expect(packageJson.scripts['ai:verify:electron:build']).not.toContain('pnpm run build:dsh-app')
   })
@@ -70,6 +74,15 @@ describe('desktop resource migration', () => {
     expect(source).toContain('const packagedResources = join(')
     expect(source).toContain("['resources', 'harness-runtime']")
     expect(source).not.toContain("['prepare:harness-runtime', '--materialize']")
+  })
+
+  test('prepares AI verification source mode without packaged Node resources', async () => {
+    const source = await readFile(
+      join(weworkRoot, 'scripts/prepare-ai-verify-electron.mjs'),
+      'utf8'
+    )
+
+    expect(source).not.toContain('prepare:execution-runtime')
   })
 
   test.each([

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -186,17 +186,11 @@ fi
 cd "$WEWORK_DIR"
 pnpm run prepare:electron
 node electron/node_modules/electron/install.js
-mkdir -p electron/resources
-for resource in icons bundled-plugins; do
-  if [ ! -e "electron/resources/$resource" ]; then
-    ln -s "../../resources/$resource" "electron/resources/$resource"
-  fi
-done
-if [ ! -f electron/resources/icons/32x32.png ]; then
+if [ ! -f resources/icons/32x32.png ]; then
   echo "Error: Electron development icons are unavailable." >&2
   exit 1
 fi
-if [ ! -f electron/resources/bundled-plugins/wework-personal/.agents/plugins/marketplace.json ]; then
+if [ ! -f resources/bundled-plugins/wework-personal/.agents/plugins/marketplace.json ]; then
   echo "Error: Electron bundled plugins are unavailable." >&2
   exit 1
 fi

--- a/wework/scripts/prepare-ai-verify-electron.mjs
+++ b/wework/scripts/prepare-ai-verify-electron.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { wrapWindowsScriptCommand } from './child-process-command.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const weworkDir = resolve(scriptDir, '..')
+const repositoryDir = resolve(weworkDir, '..')
+const executorTargetDir =
+  process.env.CARGO_TARGET_DIR?.trim() || join(repositoryDir, 'executor', 'target')
+const electronInstallScript = join(weworkDir, 'electron', 'node_modules', 'electron', 'install.js')
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const buildEnvironment = {
+  ...process.env,
+  VITE_WEWORK_E2E: 'true',
+  VITE_WEWORK_RELEASE_CHANNEL: 'stable',
+  VITE_WEWORK_RUNTIME_MODE: 'local-first',
+}
+
+function run(command, args, cwd = weworkDir, environment = process.env) {
+  return new Promise((resolvePromise, reject) => {
+    const resolved = wrapWindowsScriptCommand(command, args)
+    const child = spawn(resolved.command, resolved.args, {
+      cwd,
+      env: environment,
+      stdio: 'inherit',
+    })
+    child.once('error', reject)
+    child.once('exit', code => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(`${command} exited with code ${code ?? 'unknown'}`))
+    })
+  })
+}
+
+await run(pnpmCommand, ['run', 'prepare:electron'])
+await run(process.execPath, [electronInstallScript])
+await Promise.all([
+  run(pnpmCommand, ['run', 'prepare:codex']),
+  run(pnpmCommand, ['run', 'prepare:dws']),
+  run(
+    pnpmCommand,
+    ['run', 'prepare:harness-runtime', '--', '--materialize'],
+    weworkDir,
+    buildEnvironment
+  ),
+  run(pnpmCommand, ['--dir', 'electron', 'run', 'build']),
+  run(
+    'cargo',
+    [
+      'build',
+      '--manifest-path',
+      join(repositoryDir, 'executor', 'Cargo.toml'),
+      '--bin',
+      'wegent-executor',
+    ],
+    repositoryDir,
+    {
+      ...process.env,
+      CARGO_TARGET_DIR: executorTargetDir,
+    }
+  ),
+])


### PR DESCRIPTION
## Summary

- make `ai:verify start` prepare and launch the unpackaged Electron source app by default
- retain `ai:verify start --packaged true` for app bundle and packaged-resource verification
- resolve development resources directly from `wework/resources` and remove the temporary Electron resource symlink path
- use the current Node executable in source mode so verification does not rewrite packaged runtime descriptors

## Verification

- `pnpm --filter wework test scripts/ai-verify.test.mjs scripts/desktop-resource-migration.test.mjs` (58 tests passed)
- `pnpm --dir wework/electron typecheck`
- focused ESLint and Prettier checks
- pre-push Wework checks passed
- real unpackaged Electron verification: `ai:verify start`, visible `projects-create-button`, workbench snapshot, local Executor online, clean shutdown

Task: WORK-185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for launching desktop verification in either source or packaged-app mode.
  - Added a preparation command that builds and assembles the required desktop verification resources.
  - Added launch-mode details to verification session metadata.
  - Improved development resource discovery for tray icons and desktop environments.

- **Documentation**
  - Updated desktop verification guidance with source-launch and packaged-app validation instructions.

- **Bug Fixes**
  - Improved resource handling for development and packaged desktop launches.

- **Tests**
  - Added coverage for launch modes, runtime environment setup, option validation, and resource preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->