### PR TITLE
fix(wework): use native clipboard for message copy

### DIFF
--- a/wework/electron/src/host/capability-router.ts
+++ b/wework/electron/src/host/capability-router.ts
@@ -45,6 +45,7 @@ export const HOST_CAPABILITIES = [
   'e2e.focusWindow',
   'e2e.getProcessSnapshot',
   'e2e.getRuntimeDiagnostics',
+  'e2e.getClipboardText',
   'e2e.getStartupSplashSnapshot',
   'e2e.getTraySnapshot',
   'e2e.hideMainWindow',

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -344,6 +344,7 @@ export function createElectronCapabilityRouter(
   })
   router.register('e2e.getProcessSnapshot', () => getElectronProcessSnapshot())
   router.register('e2e.getRuntimeDiagnostics', () => e2eHost.runtimeDiagnostics())
+  router.register('e2e.getClipboardText', () => clipboard.readText())
   router.register('e2e.getWindowFocusSnapshot', () => {
     const target = requiredWindow(window)
     const popout = e2eHost.popoutWindowSnapshot()

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -4186,9 +4186,11 @@ describe('MessageList', () => {
     expect(screen.getByTestId('copy-message-icon')).toBeInTheDocument()
   })
 
-  test('uses the Electron host clipboard when the browser clipboard is unavailable', async () => {
+  test('uses the Electron host clipboard instead of the browser clipboard', async () => {
     runtimeMock.electron = true
     desktopHostMock.invoke.mockResolvedValue(undefined)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboardWriteText(writeText)
 
     render(
       <MessageList
@@ -4212,6 +4214,7 @@ describe('MessageList', () => {
         text: '复制到系统剪贴板',
       })
     )
+    expect(writeText).not.toHaveBeenCalled()
     expect(await screen.findByTestId('copy-message-success-icon')).toBeInTheDocument()
   })
 

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -44,7 +44,7 @@ import {
 } from '@/desktop/appPreferences'
 import type { LocalHarnessId } from '@/lib/local-harness'
 import { getDesktopE2ERuntimeConfig, loadDesktopE2ERuntimeConfig } from './runtime-config'
-import { getDesktopE2EClipboardText, installDesktopE2EClipboard } from './clipboard'
+import { installDesktopE2EClipboard } from './clipboard'
 import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 import { suspendDshTerminalEventDelivery } from '@/api/dsh/terminalTransport'
 import { requestLocalExecutor } from '@/desktop/localExecutor'
@@ -1537,7 +1537,7 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
     case 'snapshot':
       return desktopControlSnapshot(command.selector)
     case 'getClipboardText':
-      return getDesktopE2EClipboardText()
+      return invokeDesktopHost<string>('e2e.getClipboardText')
     case 'scrollIntoView': {
       const elements = findDesktopControlElements(command.selector)
       const element = command.visible ? elements.find(desktopControlElementRendered) : elements[0]

--- a/wework/src/lib/clipboard.ts
+++ b/wework/src/lib/clipboard.ts
@@ -2,17 +2,13 @@ import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 import { isElectronRuntime } from '@/lib/runtime-environment'
 
 export async function copyTextToClipboard(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text)
-      return
-    } catch (error) {
-      if (!isElectronRuntime()) throw error
-    }
-  }
-
   if (isElectronRuntime()) {
     await invokeDesktopHost<void>('clipboard.writeText', { text })
+    return
+  }
+
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
     return
   }
 


### PR DESCRIPTION
## Summary

- route Wework desktop copy actions through Electron's native system clipboard
- keep the browser Clipboard API for non-Electron runtimes
- make the existing `e2e:desktop` user-message copy regression read the real Electron clipboard instead of the renderer mock

## Verification

- `pnpm --filter wework test src/components/chat/MessageList.test.tsx` (145 passed)
- `pnpm --dir wework/electron test src/host/electron-capabilities.test.ts` (5 passed)
- `pnpm --filter wework exec prettier --check src/lib/clipboard.ts src/components/chat/MessageList.test.tsx src/e2e/automation.ts electron/src/host/capability-router.ts electron/src/host/electron-capabilities.ts`
- `pnpm --filter wework exec eslint src/lib/clipboard.ts src/components/chat/MessageList.test.tsx src/e2e/automation.ts electron/src/host/capability-router.ts electron/src/host/electron-capabilities.ts`
- `WEWORK_E2E_APP_BIN=... WEWORK_E2E_EXECUTOR_BIN=... pnpm --dir wework e2e:desktop -- --message-edit-only` (passed against the native system clipboard)
- `pnpm --dir wework/electron typecheck`

## Known repository issue

- `pnpm --filter wework typecheck` is currently blocked by duplicate React/csstype installations in unchanged files such as `AssistantMarkdown.tsx`, `FileChangesReviewPanel.tsx`, and `WorkspaceFileTree.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying in the desktop app by prioritizing the native desktop clipboard.
  * Added a browser clipboard fallback when the native desktop clipboard is unavailable.
  * Improved clipboard verification for desktop end-to-end testing.
* **Tests**
  * Updated clipboard coverage to confirm browser clipboard services are not used when the desktop host handles the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->