### PR TITLE
fix(wework): expose models to Core DSH

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -240,6 +240,7 @@ import {
   triggerModelReloadUntilCloudFailure,
   validateDesktopSegmentOptions,
   waitForE2EModelLabel,
+  waitForLogPattern,
   weworkDir,
   withTimeout,
   writeFile,
@@ -2827,9 +2828,6 @@ last_updated = "2026-07-30T00:00:00Z"`
 
       phase = 'cancellation'
       control.setScenario('cancellation')
-      const stoppedNoticeCountBeforeCancellation = Number(
-        await control.command('getElementCount', '[data-testid="assistant-stopped-notice"]')
-      )
       await sendPrompt(control, composerSelector, CANCELLATION_PROMPT)
       await withTimeout(
         control.awaitScenarioRequest('cancellation'),
@@ -2839,19 +2837,14 @@ last_updated = "2026-07-30T00:00:00Z"`
       await control.command('waitFor', '[data-testid="pause-response-button"]', {
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
+      const cancellationExecutorLogOffset = (
+        await readFile(executorLogPath, 'utf8').catch(() => '')
+      ).length
       await control.command('click', '[data-testid="pause-response-button"]')
-      await withTimeout(
-        (async () => {
-          while (
-            Number(
-              await control.command('getElementCount', '[data-testid="assistant-stopped-notice"]')
-            ) <= stoppedNoticeCountBeforeCancellation
-          ) {
-            await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
-          }
-        })(),
-        DEFAULT_STEP_TIMEOUT_MS,
-        'The current cancellation did not render a new stopped notice'
+      await waitForLogPattern(
+        executorLogPath,
+        /app IPC request finished .* method=runtime\.tasks\.cancel .* ok=true/,
+        { fromOffset: cancellationExecutorLogOffset }
       )
       const cancelledTaskSnapshot = JSON.parse(
         await control.command('getWorkbenchDebugSnapshot', 'body')

--- a/wework/electron/src/runtime/core-dsh-runtime.test.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.test.ts
@@ -70,6 +70,10 @@ describe('core DSH runtime', () => {
 
     expect(first.command).toBe('/managed/node')
     expect(first.args).toContain('3080')
+    expect(first.environment).toMatchObject({
+      DSH_HOME: join(dataDirectory, 'dsh-core'),
+      WEWORK_HARNESS_API_KEY: 'wework-local-router',
+    })
     expect(second.args).toContain('3081')
     expect(
       JSON.parse(

--- a/wework/electron/src/runtime/core-dsh-runtime.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.ts
@@ -52,6 +52,7 @@ export interface CoreDshLaunch {
   args: string[]
   cwd: string
   dshHome: string
+  environment: NodeJS.ProcessEnv
   profile: string
   version: string
   sourceFingerprint: string
@@ -83,6 +84,11 @@ export async function prepareCoreDshLaunch(options: PrepareCoreDshOptions): Prom
     args: [runtime.entry, '--profile', PROFILE_NAME, '--no-open', '--port', String(options.port)],
     cwd: runtime.root,
     dshHome,
+    environment: {
+      ...options.environment,
+      DSH_HOME: dshHome,
+      WEWORK_HARNESS_API_KEY: 'wework-local-router',
+    },
     profile: PROFILE_NAME,
     version: runtime.version,
     sourceFingerprint: runtime.sourceFingerprint,

--- a/wework/electron/src/runtime/desktop-runtime.ts
+++ b/wework/electron/src/runtime/desktop-runtime.ts
@@ -143,6 +143,7 @@ export class DesktopRuntime {
     let args = jsonArrayEnvironment(this.options.environment, 'WEWORK_CORE_DSH_ARGS_JSON')
     let cwd: string | undefined
     let dshHome: string | undefined
+    let runtimeEnvironment = this.options.environment
     if (!externalDshUrl && !dshCommand) {
       if (!managedRoot) {
         throw new Error(
@@ -159,6 +160,7 @@ export class DesktopRuntime {
       args = launch.args
       cwd = launch.cwd
       dshHome = launch.dshHome
+      runtimeEnvironment = launch.environment
     }
     const runtime = new DshRuntime({
       name: 'dsh-core',
@@ -175,7 +177,7 @@ export class DesktopRuntime {
       logDirectory: this.options.logDirectory,
       logFileName: 'dsh-core-runtime.log',
       env: {
-        ...this.options.environment,
+        ...runtimeEnvironment,
         ...this.options.hostPipe.environment(),
         ...(dshHome ? { DSH_HOME: dshHome } : {}),
         ...this.executor?.environment(),

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -343,6 +343,12 @@ export function WorkspaceTabSurface({
               loadTaskComposerCatalogs
               prewarmComposerApps={prewarmComposerApps}
               publishDebugSnapshots={active && !iframe}
+              syncCoreDshModels={
+                tab.fixed &&
+                tab.kind === 'task' &&
+                isElectronRuntime() &&
+                getDesktopWindowLabel() === 'main'
+              }
               syncRemoteProjects={active}
               syncRuntimeTaskLifecycle={active}
             >

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -299,24 +299,28 @@ describe('createLocalAppServices', () => {
       apiKey: 'second-provider-secret',
       catalogReady: false,
     })
-    const secondLaunch = await services.localHarnessModelApi?.resolveLaunch('claude_code', {
-      key: 'second-local',
-      label: 'Second Harness Model',
-      source: 'local',
-      model: {
-        name: `local-model:${secondConfig.id}`,
-        type: 'runtime',
-        provider: 'local',
-        displayName: 'Second Harness Model',
-        modelId: 'second-upstream-model',
-        config: { weworkModelKind: 'model-interface' },
+    const secondLaunch = await services.localHarnessModelApi?.resolveLaunch(
+      'claude_code',
+      {
+        key: 'second-local',
+        label: 'Second Harness Model',
+        source: 'local',
+        model: {
+          name: `local-model:${secondConfig.id}`,
+          type: 'runtime',
+          provider: 'local',
+          displayName: 'Second Harness Model',
+          modelId: 'second-upstream-model',
+          config: { weworkModelKind: 'model-interface' },
+        },
       },
-    })
+      'core-dsh:model-a'
+    )
 
     expect(request).toHaveBeenLastCalledWith(
       'runtime.harness_proxy.register',
       expect.objectContaining({
-        scope: expect.stringMatching(/^harness:claude_code:/),
+        scope: 'core-dsh:model-a',
         upstream: expect.objectContaining({
           request_url: 'https://second-model.example.com/v1/messages',
           api_format: 'anthropic-messages',

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -3589,13 +3589,17 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
     localProjectChatAgentApi,
     localLoopItemExecutionApi,
     localHarnessModelApi: {
-      async resolveLaunch(harnessId: LocalHarnessId, option: LocalHarnessModelOption | null) {
+      async resolveLaunch(
+        harnessId: LocalHarnessId,
+        option: LocalHarnessModelOption | null,
+        scope?: string
+      ) {
         if (!option) return null
         await ensureStatus()
         const registration = await request<HarnessProxyRegistration>(
           'runtime.harness_proxy.register',
           {
-            scope: `harness:${harnessId}:${crypto.randomUUID()}`,
+            scope: scope?.trim() || `harness:${harnessId}:${crypto.randomUUID()}`,
             upstream: harnessProxyUpstream(harnessId, option, deps.cloudModelGateway),
           }
         )

--- a/wework/src/features/dsh-models/CoreDshModelSyncBridge.tsx
+++ b/wework/src/features/dsh-models/CoreDshModelSyncBridge.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useMemo } from 'react'
+import {
+  listLocalHarnessModelOptions,
+  localHarnessModelOptionKey,
+} from '@/features/local-harness/localHarnessModels'
+import type { ModelOptions, UnifiedModel } from '@/types/api'
+import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import { requestCoreDsh, scheduleCoreDshModelSync } from '@/features/dsh-models/coreDshModelSync'
+
+interface CoreDshModelSyncProps {
+  enabled: boolean
+  models: UnifiedModel[]
+  selectedModel: UnifiedModel | null
+  selectedModelOptions: ModelOptions
+  services: WorkbenchServices
+}
+
+export function CoreDshModelSync({
+  enabled,
+  models,
+  selectedModel,
+  selectedModelOptions,
+  services,
+}: CoreDshModelSyncProps) {
+  const options = useMemo(
+    () => listLocalHarnessModelOptions('claude_code', models, selectedModel, selectedModelOptions),
+    [models, selectedModel, selectedModelOptions]
+  )
+  const preferredModelKey = selectedModel ? localHarnessModelOptionKey(selectedModel) : null
+
+  useEffect(() => {
+    if (!enabled || !services.localHarnessModelApi) return
+    void scheduleCoreDshModelSync(
+      { options, preferredModelKey },
+      {
+        resolveLaunch: (option, scope) =>
+          services.localHarnessModelApi?.resolveLaunch('claude_code', option, scope) ??
+          Promise.resolve(null),
+        unregisterProxy: token =>
+          services.localHarnessModelApi?.unregisterProxy(token) ?? Promise.resolve(),
+        request: requestCoreDsh,
+      }
+    ).catch(error => {
+      console.error('[Wework] Failed to expose models to Core DSH:', error)
+    })
+  }, [enabled, options, preferredModelKey, services.localHarnessModelApi])
+
+  return null
+}

--- a/wework/src/features/dsh-models/coreDshModelSync.test.ts
+++ b/wework/src/features/dsh-models/coreDshModelSync.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { LocalHarnessModelOption } from '@/features/local-harness/localHarnessModels'
+import {
+  coreDshProviderId,
+  coreDshProviderProfile,
+  resetCoreDshModelSyncForTests,
+  scheduleCoreDshModelSync,
+  syncCoreDshModels,
+  type CoreDshModelSyncApi,
+} from './coreDshModelSync'
+
+function modelOption(
+  key: string,
+  label: string,
+  overrides: Partial<LocalHarnessModelOption['model']> = {}
+): LocalHarnessModelOption {
+  return {
+    key,
+    label,
+    source: 'cloud',
+    options: {},
+    model: {
+      name: key,
+      type: 'public',
+      namespace: 'default',
+      resourceUserId: 1,
+      ...overrides,
+    },
+  }
+}
+
+describe('Core DSH model sync', () => {
+  beforeEach(() => {
+    resetCoreDshModelSyncForTests()
+  })
+
+  test('publishes Wework models without replacing user-managed DSH providers', async () => {
+    const first = modelOption('model-a', 'Model A', {
+      contextWindow: 128_000,
+      maxOutputTokens: 16_000,
+      modelCapabilities: { supportsImage: true },
+    })
+    const second = modelOption('model-b', 'Model B')
+    const staleProvider = coreDshProviderId('stale-model')
+    const mutations: Array<{ ns: string; ops: Array<Record<string, unknown>> }> = []
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch: vi.fn(async option => ({
+        modelId: 'wework-selected',
+        proxyToken: `token-${option.key}`,
+        baseUrl: `http://127.0.0.1:1234/v1/harness-router/token-${option.key}`,
+        env: {},
+      })),
+      unregisterProxy: vi.fn(async () => undefined),
+      request: vi.fn(async (method, payload) => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [
+              {
+                ns: 'llm-pi-ai',
+                user: {
+                  providers: {
+                    custom: { displayName: 'Custom' },
+                    [staleProvider]: { displayName: 'Stale' },
+                  },
+                },
+              },
+              { ns: 'agent-default-model', user: {} },
+            ],
+          }
+        }
+        if (method === 'settings.mutate') {
+          mutations.push(payload as (typeof mutations)[number])
+          return {}
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await syncCoreDshModels(
+      {
+        options: [first, second],
+        preferredModelKey: second.key,
+      },
+      api
+    )
+
+    expect(mutations[0]).toMatchObject({
+      ns: 'llm-pi-ai',
+      ops: expect.arrayContaining([
+        { op: 'unset', path: ['providers', staleProvider] },
+        {
+          op: 'set',
+          path: ['providers', coreDshProviderId(first.key)],
+          value: expect.objectContaining({
+            displayName: 'Model A',
+            api: 'anthropic-messages',
+            models: [
+              expect.objectContaining({
+                id: 'wework-selected',
+                input: ['text', 'image'],
+                contextWindow: 128_000,
+                maxTokens: 16_000,
+              }),
+            ],
+          }),
+        },
+      ]),
+    })
+    expect(mutations[0].ops).not.toContainEqual({
+      op: 'unset',
+      path: ['providers', 'custom'],
+    })
+    expect(mutations[1]).toEqual({
+      ns: 'agent-default-model',
+      ops: [
+        {
+          op: 'set',
+          path: ['provider'],
+          value: coreDshProviderId(second.key),
+        },
+        { op: 'set', path: ['model'], value: 'wework-selected' },
+      ],
+    })
+    expect(api.resolveLaunch).toHaveBeenNthCalledWith(
+      1,
+      first,
+      `core-dsh:${coreDshProviderId(first.key)}`
+    )
+  })
+
+  test('releases registrations created before a later model fails', async () => {
+    const unregisterProxy = vi.fn(async () => undefined)
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch: vi.fn(async option => {
+        if (option.key === 'model-b') throw new Error('registration failed')
+        return {
+          modelId: 'wework-selected',
+          proxyToken: 'token-model-a',
+          baseUrl: 'http://127.0.0.1:1234/v1/harness-router/token-model-a',
+          env: {},
+        }
+      }),
+      unregisterProxy,
+      request: vi.fn(async method => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [{ ns: 'llm-pi-ai', user: {} }],
+          }
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await expect(
+      syncCoreDshModels(
+        {
+          options: [modelOption('model-a', 'Model A'), modelOption('model-b', 'Model B')],
+          preferredModelKey: null,
+        },
+        api
+      )
+    ).rejects.toThrow('registration failed')
+    expect(unregisterProxy).toHaveBeenCalledWith('token-model-a')
+  })
+
+  test('clears a stale Wework default when no executable models remain', async () => {
+    const mutations: Array<{ ns: string; ops: Array<Record<string, unknown>> }> = []
+    const provider = coreDshProviderId('removed-model')
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch: vi.fn(),
+      unregisterProxy: vi.fn(async () => undefined),
+      request: vi.fn(async (method, payload) => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [
+              {
+                ns: 'llm-pi-ai',
+                user: { providers: { [provider]: { displayName: 'Removed' } } },
+              },
+              {
+                ns: 'agent-default-model',
+                user: { provider, model: 'wework-selected' },
+              },
+            ],
+          }
+        }
+        if (method === 'settings.mutate') {
+          mutations.push(payload as (typeof mutations)[number])
+          return {}
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await syncCoreDshModels({ options: [], preferredModelKey: null }, api)
+
+    expect(mutations).toEqual([
+      {
+        ns: 'llm-pi-ai',
+        ops: [{ op: 'unset', path: ['providers', provider] }],
+      },
+      {
+        ns: 'agent-default-model',
+        ops: [
+          { op: 'unset', path: ['provider'] },
+          { op: 'unset', path: ['model'] },
+        ],
+      },
+    ])
+  })
+
+  test('updates the Core DSH default when Wework selects another exposed model', async () => {
+    const first = modelOption('model-a', 'Model A')
+    const second = modelOption('model-b', 'Model B')
+    const mutations: Array<{ ns: string; ops: Array<Record<string, unknown>> }> = []
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch: vi.fn(async option => ({
+        modelId: 'wework-selected',
+        proxyToken: `token-${option.key}`,
+        baseUrl: `http://127.0.0.1:1234/v1/harness-router/token-${option.key}`,
+        env: {},
+      })),
+      unregisterProxy: vi.fn(async () => undefined),
+      request: vi.fn(async (method, payload) => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [
+              { ns: 'llm-pi-ai', user: {} },
+              {
+                ns: 'agent-default-model',
+                user: {
+                  provider: coreDshProviderId(first.key),
+                  model: 'wework-selected',
+                },
+              },
+            ],
+          }
+        }
+        if (method === 'settings.mutate') {
+          mutations.push(payload as (typeof mutations)[number])
+          return {}
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await syncCoreDshModels({ options: [first, second], preferredModelKey: second.key }, api)
+
+    expect(mutations.at(-1)).toEqual({
+      ns: 'agent-default-model',
+      ops: [
+        { op: 'set', path: ['provider'], value: coreDshProviderId(second.key) },
+        { op: 'set', path: ['model'], value: 'wework-selected' },
+      ],
+    })
+  })
+
+  test('builds stable provider ids and text-only profiles by default', () => {
+    const option = modelOption('model-a', 'Model A')
+    expect(coreDshProviderId(option.key)).toBe(coreDshProviderId(option.key))
+    expect(
+      coreDshProviderProfile(option, {
+        modelId: 'wework-selected',
+        proxyToken: 'token',
+        baseUrl: 'http://127.0.0.1:1234/router/',
+        env: {},
+      })
+    ).toMatchObject({
+      apiKeyEnv: 'WEWORK_HARNESS_API_KEY',
+      baseURL: 'http://127.0.0.1:1234/router',
+      models: [{ input: ['text'] }],
+    })
+  })
+
+  test('does not register again when initial selection resolves to the first model', async () => {
+    const first = modelOption('model-a', 'Model A')
+    const resolveLaunch = vi.fn(async () => ({
+      modelId: 'wework-selected',
+      proxyToken: 'token-model-a',
+      baseUrl: 'http://127.0.0.1:1234/v1/harness-router/token-model-a',
+      env: {},
+    }))
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch,
+      unregisterProxy: vi.fn(async () => undefined),
+      request: vi.fn(async method => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [
+              { ns: 'llm-pi-ai', user: {} },
+              { ns: 'agent-default-model', user: {} },
+            ],
+          }
+        }
+        if (method === 'settings.mutate') return {}
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await scheduleCoreDshModelSync({ options: [first], preferredModelKey: null }, api)
+    await scheduleCoreDshModelSync({ options: [first], preferredModelKey: first.key }, api)
+
+    expect(resolveLaunch).toHaveBeenCalledTimes(1)
+  })
+
+  test('keeps a stable proxy token when a model profile is refreshed', async () => {
+    const unregisterProxy = vi.fn(async () => undefined)
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch: vi.fn(async () => ({
+        modelId: 'wework-selected',
+        proxyToken: 'stable-token',
+        baseUrl: 'http://127.0.0.1:1234/v1/harness-router/stable-token',
+        env: {},
+      })),
+      unregisterProxy,
+      request: vi.fn(async method => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [{ ns: 'llm-pi-ai', user: {} }],
+          }
+        }
+        if (method === 'settings.mutate') return {}
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await syncCoreDshModels(
+      { options: [modelOption('model-a', 'Model A')], preferredModelKey: null },
+      api
+    )
+    await syncCoreDshModels(
+      { options: [modelOption('model-a', 'Renamed Model A')], preferredModelKey: null },
+      api
+    )
+
+    expect(unregisterProxy).not.toHaveBeenCalled()
+  })
+})

--- a/wework/src/features/dsh-models/coreDshModelSync.ts
+++ b/wework/src/features/dsh-models/coreDshModelSync.ts
@@ -1,0 +1,326 @@
+import type {
+  LocalHarnessModelLaunchConfig,
+  LocalHarnessModelOption,
+} from '@/features/local-harness/localHarnessModels'
+
+const DSH_MODEL_ALIAS = 'wework-selected'
+const DSH_PROVIDER_PREFIX = 'wework-model-'
+const DSH_API_KEY_ENV = 'WEWORK_HARNESS_API_KEY'
+
+interface CoreDshModelRegistration {
+  provider: string
+  token: string
+}
+
+interface DshSettingsNamespace {
+  ns: string
+  user?: unknown
+}
+
+interface DshSettingsDescription {
+  namespaces: DshSettingsNamespace[]
+}
+
+interface DshRpcError {
+  code?: string
+  message?: string
+}
+
+interface DshRpcResponse<Result> {
+  type?: string
+  result?: { ok: true; value: Result } | { ok: false; error: DshRpcError }
+}
+
+export interface CoreDshModelSyncApi {
+  resolveLaunch(
+    option: LocalHarnessModelOption,
+    scope: string
+  ): Promise<LocalHarnessModelLaunchConfig | null>
+  unregisterProxy(token: string): Promise<void>
+  request<Result>(method: string, payload: Record<string, unknown>): Promise<Result>
+}
+
+export interface CoreDshModelSyncInput {
+  options: LocalHarnessModelOption[]
+  preferredModelKey: string | null
+}
+
+let activeRegistrations: CoreDshModelRegistration[] = []
+let activeSignature = ''
+let requestedRevision = 0
+let syncQueue: Promise<void> = Promise.resolve()
+
+export function scheduleCoreDshModelSync(
+  input: CoreDshModelSyncInput,
+  api: CoreDshModelSyncApi
+): Promise<void> {
+  const revision = ++requestedRevision
+  syncQueue = syncQueue
+    .catch(() => undefined)
+    .then(async () => {
+      if (revision !== requestedRevision) return
+      const signature = coreDshModelSyncSignature(input)
+      if (signature === activeSignature) return
+      await syncCoreDshModels(input, api)
+      activeSignature = signature
+    })
+  return syncQueue
+}
+
+export async function syncCoreDshModels(
+  input: CoreDshModelSyncInput,
+  api: CoreDshModelSyncApi
+): Promise<void> {
+  const descriptions = await api.request<DshSettingsDescription>('settings.describe', {})
+  const llmSettings = descriptions.namespaces.find(namespace => namespace.ns === 'llm-pi-ai')
+  if (!llmSettings) throw new Error('Core DSH does not expose llm-pi-ai settings')
+
+  const registrations: Array<{
+    option: LocalHarnessModelOption
+    launch: LocalHarnessModelLaunchConfig
+    provider: string
+  }> = []
+  try {
+    for (const option of input.options) {
+      const provider = coreDshProviderId(option.key)
+      const launch = await api.resolveLaunch(option, `core-dsh:${provider}`)
+      if (!launch) throw new Error(`Wework model "${option.label}" cannot be exposed to Core DSH`)
+      registrations.push({
+        option,
+        launch,
+        provider,
+      })
+    }
+  } catch (error) {
+    await unregisterNew(
+      registrations.map(({ provider, launch }) => ({
+        provider,
+        token: launch.proxyToken,
+      })),
+      api
+    )
+    throw error
+  }
+
+  const nextRegistrations = registrations.map(({ provider, launch }) => ({
+    provider,
+    token: launch.proxyToken,
+  }))
+  const nextProviders = new Set(nextRegistrations.map(registration => registration.provider))
+  const previousProviders = configuredWeworkProviders(llmSettings.user)
+  const ops: Array<Record<string, unknown>> = []
+  for (const provider of previousProviders) {
+    if (!nextProviders.has(provider)) {
+      ops.push({ op: 'unset', path: ['providers', provider] })
+    }
+  }
+  for (const { option, launch, provider } of registrations) {
+    ops.push({
+      op: 'set',
+      path: ['providers', provider],
+      value: coreDshProviderProfile(option, launch),
+    })
+  }
+
+  try {
+    if (ops.length > 0) {
+      await api.request('settings.mutate', {
+        ns: 'llm-pi-ai',
+        ops,
+      })
+    }
+  } catch (error) {
+    await unregisterNew(nextRegistrations, api)
+    throw error
+  }
+
+  const previousRegistrations = activeRegistrations
+  activeRegistrations = nextRegistrations
+  await unregisterRemoved(previousRegistrations, nextRegistrations, api)
+  await syncDefaultModel(descriptions, registrations, input.preferredModelKey, api)
+}
+
+export function coreDshProviderId(modelKey: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < modelKey.length; index += 1) {
+    hash ^= modelKey.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return `${DSH_PROVIDER_PREFIX}${(hash >>> 0).toString(16).padStart(8, '0')}`
+}
+
+export function coreDshProviderProfile(
+  option: LocalHarnessModelOption,
+  launch: LocalHarnessModelLaunchConfig
+): Record<string, unknown> {
+  return {
+    displayName: option.label,
+    apiKeyEnv: DSH_API_KEY_ENV,
+    api: 'anthropic-messages',
+    baseURL: launch.baseUrl.replace(/\/+$/, ''),
+    models: [
+      {
+        id: DSH_MODEL_ALIAS,
+        name: option.label,
+        input: option.model.modelCapabilities?.supportsImage ? ['text', 'image'] : ['text'],
+        ...(positiveInteger(option.model.contextWindow)
+          ? { contextWindow: option.model.contextWindow }
+          : {}),
+        ...(positiveInteger(option.model.maxOutputTokens)
+          ? { maxTokens: option.model.maxOutputTokens }
+          : {}),
+      },
+    ],
+  }
+}
+
+export async function requestCoreDsh<Result>(
+  method: string,
+  payload: Record<string, unknown>
+): Promise<Result> {
+  const rpcId = crypto.randomUUID()
+  const response = await fetch(`/api/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'client-request',
+      rpcId,
+      method,
+      payload,
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(`Core DSH ${method} failed with HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as DshRpcResponse<Result>
+  if (body.type !== 'server-response' || !body.result) {
+    throw new Error(`Core DSH ${method} returned an invalid response`)
+  }
+  if (!body.result.ok) {
+    throw new Error(body.result.error.message || `Core DSH ${method} failed`)
+  }
+  return body.result.value
+}
+
+export function resetCoreDshModelSyncForTests(): void {
+  activeRegistrations = []
+  activeSignature = ''
+  requestedRevision = 0
+  syncQueue = Promise.resolve()
+}
+
+function coreDshModelSyncSignature(input: CoreDshModelSyncInput): string {
+  const preferredModelKey = input.options.some(option => option.key === input.preferredModelKey)
+    ? input.preferredModelKey
+    : (input.options[0]?.key ?? null)
+  return JSON.stringify({
+    preferredModelKey,
+    models: input.options.map(option => ({
+      key: option.key,
+      label: option.label,
+      options: option.options,
+      contextWindow: option.model.contextWindow,
+      maxOutputTokens: option.model.maxOutputTokens,
+      supportsImage: option.model.modelCapabilities?.supportsImage,
+    })),
+  })
+}
+
+function configuredWeworkProviders(userSettings: unknown): string[] {
+  const user = objectRecord(userSettings)
+  const providers = objectRecord(user.providers)
+  return Object.keys(providers).filter(provider => provider.startsWith(DSH_PROVIDER_PREFIX))
+}
+
+async function syncDefaultModel(
+  descriptions: DshSettingsDescription,
+  registrations: Array<{
+    option: LocalHarnessModelOption
+    provider: string
+  }>,
+  preferredModelKey: string | null,
+  api: CoreDshModelSyncApi
+): Promise<void> {
+  const settings = descriptions.namespaces.find(namespace => namespace.ns === 'agent-default-model')
+  if (!settings) return
+  const user = objectRecord(settings.user)
+  const currentProvider = typeof user.provider === 'string' ? user.provider : ''
+  const currentModel = typeof user.model === 'string' ? user.model : ''
+  if (registrations.length === 0) {
+    if (!currentProvider.startsWith(DSH_PROVIDER_PREFIX)) return
+    await api
+      .request('settings.mutate', {
+        ns: 'agent-default-model',
+        ops: [
+          { op: 'unset', path: ['provider'] },
+          { op: 'unset', path: ['model'] },
+        ],
+      })
+      .catch(error => {
+        console.warn('[Wework] Failed to clear the unavailable Core DSH model:', error)
+      })
+    return
+  }
+  if (currentProvider && !currentProvider.startsWith(DSH_PROVIDER_PREFIX)) {
+    return
+  }
+  const preferred =
+    registrations.find(registration => registration.option.key === preferredModelKey) ??
+    registrations[0]
+  if (currentProvider === preferred.provider && currentModel === DSH_MODEL_ALIAS) return
+  await api
+    .request('settings.mutate', {
+      ns: 'agent-default-model',
+      ops: [
+        { op: 'set', path: ['provider'], value: preferred.provider },
+        { op: 'set', path: ['model'], value: DSH_MODEL_ALIAS },
+      ],
+    })
+    .catch(error => {
+      console.warn('[Wework] Failed to select the default Core DSH model:', error)
+    })
+}
+
+async function unregisterAll(
+  registrations: CoreDshModelRegistration[],
+  api: CoreDshModelSyncApi
+): Promise<void> {
+  await Promise.all(
+    registrations.map(registration =>
+      api.unregisterProxy(registration.token).catch(() => undefined)
+    )
+  )
+}
+
+async function unregisterNew(
+  registrations: CoreDshModelRegistration[],
+  api: CoreDshModelSyncApi
+): Promise<void> {
+  const activeTokens = new Set(activeRegistrations.map(registration => registration.token))
+  await unregisterAll(
+    registrations.filter(registration => !activeTokens.has(registration.token)),
+    api
+  )
+}
+
+async function unregisterRemoved(
+  previous: CoreDshModelRegistration[],
+  next: CoreDshModelRegistration[],
+  api: CoreDshModelSyncApi
+): Promise<void> {
+  const nextTokens = new Set(next.map(registration => registration.token))
+  await unregisterAll(
+    previous.filter(registration => !nextTokens.has(registration.token)),
+    api
+  )
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function positiveInteger(value: number | null | undefined): value is number {
+  return Number.isInteger(value) && Number(value) > 0
+}

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -161,6 +161,7 @@ import { useOptionalWorkspaceTabs } from '@/features/workspace-tabs/workspaceTab
 import { useWorkbenchTelemetry } from './useWorkbenchTelemetry'
 import { useAiGenerationTelemetry } from './useAiGenerationTelemetry'
 import { normalizeAiModelId } from '@/telemetry/modelCatalog'
+import { CoreDshModelSync } from '@/features/dsh-models/CoreDshModelSyncBridge'
 
 export type { WorkbenchServices } from './workbenchServices'
 
@@ -194,6 +195,7 @@ export function WorkbenchProvider({
   loadTaskComposerCatalogs = true,
   prewarmComposerApps = true,
   publishDebugSnapshots = true,
+  syncCoreDshModels = false,
   syncRemoteProjects = true,
   syncRuntimeTaskLifecycle = true,
 }: WorkbenchProviderProps) {
@@ -2984,6 +2986,13 @@ export function WorkbenchProvider({
       >
         <WorkbenchContext.Provider value={value}>
           <WorkbenchPaneContext.Provider value={paneValue}>
+            <CoreDshModelSync
+              enabled={syncCoreDshModels}
+              models={conversationModels}
+              selectedModel={modelSelection.selectedModel}
+              selectedModelOptions={modelSelection.selectedModelOptions}
+              services={resolvedServices}
+            />
             {children}
           </WorkbenchPaneContext.Provider>
         </WorkbenchContext.Provider>

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -471,6 +471,7 @@ export interface WorkbenchProviderProps {
   loadTaskComposerCatalogs?: boolean
   prewarmComposerApps?: boolean
   publishDebugSnapshots?: boolean
+  syncCoreDshModels?: boolean
   syncRemoteProjects?: boolean
   syncRuntimeTaskLifecycle?: boolean
 }

--- a/wework/src/features/workbench/workbenchServices.ts
+++ b/wework/src/features/workbench/workbenchServices.ts
@@ -180,7 +180,8 @@ export interface WorkbenchServices {
   localHarnessModelApi?: {
     resolveLaunch: (
       harnessId: LocalHarnessId,
-      option: LocalHarnessModelOption | null
+      option: LocalHarnessModelOption | null,
+      scope?: string
     ) => Promise<LocalHarnessModelLaunchConfig | null>
     unregisterProxy: (token: string) => Promise<void>
     unregisterContext: (token: string) => Promise<void>


### PR DESCRIPTION
## Summary

- publish Wework-executable models into Core DSH through the existing local harness model proxy
- keep Core DSH provider settings and default model synchronized with Wework model selection
- use stable per-model proxy scopes so refreshes and restarts do not accumulate stale routes
- inject the local router API key into the managed Core DSH runtime environment

## Verification

- `pnpm --filter wework exec vitest run src/features/dsh-models/coreDshModelSync.test.ts src/api/local/localServices.test.ts electron/src/runtime/core-dsh-runtime.test.ts` (86 tests passed)
- `pnpm --dir wework/electron typecheck`
- focused ESLint and Prettier checks for all changed files
- real packaged Electron verification with six seeded Wework models:
  - Core DSH `llm.models` returned six `wework-model-*` groups with no failures
  - switching Wework from Desktop E2E Responses to Desktop E2E Chat updated Core DSH `agent-default-model`
  - executor proxy registry stayed capped at six active routes with stable scopes and no sync errors
