### PR TITLE
fix(wework): remember task model selection

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -3,6 +3,8 @@ import {
   verifyLocalExecutorUsesCloudSocketUrl,
 } from './cloud-environment.mjs'
 
+import { tmpdir } from 'node:os'
+
 import { verifyCloudCheckpoint } from './cloud-checkpoint-flows.mjs'
 
 import {
@@ -869,6 +871,7 @@ async function main() {
   const homePath = join(resultDir, 'home')
   const executorHome = join(resultDir, 'executor-home')
   const codexHome = join(executorHome, 'codex')
+  const codexSqliteHome = join(tmpdir(), 'wework-desktop-e2e', String(process.pid), 'codex-sqlite')
   const nativeCodexHome = join(resultDir, 'native-codex')
   const pluginMarketplacePath = join(resultDir, 'plugin-marketplace')
   const marketplacePluginPath = join(resultDir, 'marketplace-plugin')
@@ -880,6 +883,7 @@ async function main() {
     mkdir(secondaryProjectPath, { recursive: true }),
     mkdir(composerProjectPath, { recursive: true }),
     mkdir(homePath, { recursive: true }),
+    mkdir(codexSqliteHome, { recursive: true }),
   ])
   await Promise.all([
     writeFile(join(workspacePath, GIT_SEED_NAME), GIT_SEED_CONTENT),
@@ -1078,6 +1082,7 @@ async function main() {
       ...process.env,
       CODEX_BINARY_PATH: resolvedAppCodexBinary,
       CODEX_BIN: resolvedAppCodexBinary,
+      CODEX_SQLITE_HOME: codexSqliteHome,
       HOME: homePath,
       WEGENT_CODEX_HOME: codexHome,
       WEGENT_EXECUTOR_HOME: executorHome,
@@ -3821,6 +3826,7 @@ last_updated = "2026-07-30T00:00:00Z"`
     await blockingNetworkProxy?.stop()
     await stopDesktopAppProcess(app)
     await control.close()
+    await rm(codexSqliteHome, { recursive: true, force: true })
     if (appBundlePath && process.platform === 'darwin') {
       spawnSync(MACOS_LAUNCH_SERVICES_REGISTER, ['-u', appBundlePath])
     }

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -284,6 +284,9 @@ const PROJECT_AI_MODEL_ID = 'wework-deepseek-v4-pro'
 const PROJECT_AI_MODEL_LABEL = 'wework-deepseek-v4-pro'
 const PROJECT_AI_MODEL_VALUE = `runtime:${PROJECT_AI_MODEL_ID}`
 const PROJECT_AI_UPSTREAM_MODEL_ID = 'deepseek-v4-pro'
+const REMEMBERED_TASK_MODEL_ID = 'gpt-5.6-sol'
+const REMEMBERED_TASK_MODEL_LABEL = 'GPT 5.6 Sol'
+const REMEMBERED_TASK_REASONING = 'high'
 const PROJECT_QUICK_PHRASE_TITLE = 'Project constraint review'
 const PROJECT_QUICK_PHRASE_CONTENT = 'Review the project constraints before implementation.'
 
@@ -426,6 +429,23 @@ async function waitForProjectComposerPlugin(control) {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   return itemTestId
+}
+
+async function selectRememberedTaskModel(control) {
+  await selectE2EModel(control, REMEMBERED_TASK_MODEL_ID, REMEMBERED_TASK_MODEL_LABEL)
+  await control.command('click', '[data-testid="model-selector-button"]')
+  await control.command('click', '[data-testid="model-control-menu-reasoning"]')
+  await control.command('waitFor', '[data-testid="model-control-reasoning-high"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    visible: true,
+  })
+  await control.command('click', '[data-testid="model-control-reasoning-high"]')
+  assert.match(
+    await control.command('getText', '[data-testid="model-control-menu-reasoning"]'),
+    /High|高/,
+    'The task composer did not select GPT 5.6 Sol with high reasoning'
+  )
+  await control.command('press', 'body', { key: 'Escape' })
 }
 
 async function verifyProjectAiSettings({
@@ -640,6 +660,50 @@ async function verifyProjectAiSettings({
     'A new conversation retained obsolete project instructions'
   )
   await captureVerificationScreenshot(control, 'project-ai-settings-10-next-conversation.png')
+
+  setPhase('project-ai-settings-remember-task-model')
+  await control.command('clickWhenEnabled', newConversationSelector)
+  await control.command('waitFor', composerSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await selectRememberedTaskModel(control)
+  const overriddenConversationRequest = await sendProjectAiCheckpointPrompt(
+    control,
+    composerSelector,
+    { createsConversation: true }
+  )
+  assert.equal(
+    overriddenConversationRequest.body.model,
+    REMEMBERED_TASK_MODEL_ID,
+    'The task-specific model override was not forwarded to Codex'
+  )
+  assert.equal(
+    overriddenConversationRequest.body.reasoning?.effort,
+    REMEMBERED_TASK_REASONING,
+    'The task-specific reasoning effort was not forwarded to Codex'
+  )
+  assert.ok(
+    JSON.stringify(overriddenConversationRequest.body).includes(PROJECT_AI_UPDATED_INSTRUCTIONS),
+    'The task-specific model override dropped the project instructions'
+  )
+
+  setPhase('project-ai-settings-next-task-remembers-model')
+  await control.command('clickWhenEnabled', newConversationSelector)
+  await control.command('waitFor', composerSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await waitForE2EModelLabel(control, [REMEMBERED_TASK_MODEL_LABEL])
+  await control.command('click', '[data-testid="model-selector-button"]')
+  assert.match(
+    await control.command('getText', '[data-testid="model-control-menu-reasoning"]'),
+    /High|高/,
+    'The next task did not remember the selected model and reasoning effort'
+  )
+  await captureVerificationScreenshot(
+    control,
+    'project-ai-settings-11-next-task-model-remembered.png'
+  )
+  await control.command('press', 'body', { key: 'Escape' })
 }
 
 async function verifyLocalModelRouting({

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1014,6 +1014,12 @@ function ProjectSendProbe({
       <span data-testid="project-collaboration-mode">
         {workbench.projectChat.selectedModelOptions.collaborationMode ?? 'default'}
       </span>
+      <span data-testid="project-selected-model">
+        {workbench.projectChat.selectedModel?.name ?? 'none'}
+      </span>
+      <span data-testid="project-reasoning-effort">
+        {workbench.projectChat.selectedModelOptions.reasoning ?? 'none'}
+      </span>
       <span data-testid="runtime-context-window">
         {workbench.projectChat.contextUsage?.modelContextWindow ?? 'none'}
       </span>
@@ -1224,6 +1230,21 @@ function ProjectSendProbe({
         onClick={() => workbench.projectChat.setSelectedModelOption('collaborationMode', 'plan')}
       >
         enable plan mode
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const model = workbench.projectChat.models.find(item => item.name === 'override-model')
+          if (model) workbench.projectChat.setSelectedModel(model)
+        }}
+      >
+        select override model
+      </button>
+      <button
+        type="button"
+        onClick={() => workbench.projectChat.setSelectedModelOption('reasoning', 'high')}
+      >
+        set high reasoning
       </button>
       <button
         type="button"
@@ -6917,6 +6938,117 @@ describe('WorkbenchProvider runtime tasks', () => {
         ],
       })
     )
+  })
+
+  test('remembers a local project task model and reasoning for the next task', async () => {
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: {
+                id: 7,
+                key: 'project-7',
+                name: 'Wegent',
+                source: 'local_project',
+                aiSettings: {
+                  modelSelection: {
+                    modelName: 'project-model',
+                    modelType: 'runtime',
+                    options: { reasoning: 'medium' },
+                  },
+                },
+              },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [],
+                },
+              ],
+            },
+          ],
+          totalTasks: 0,
+        })
+      ),
+      createRuntimeTask: vi.fn(async request => ({
+        accepted: true,
+        deviceId: request.deviceId,
+        taskId: request.taskId,
+        workspacePath: request.workspacePath,
+        runtime: 'codex',
+      })),
+      getRuntimeTranscript: vi.fn(async (address: RuntimeTranscriptRequest) => ({
+        taskId: address.taskId,
+        workspacePath: address.workspacePath,
+        runtime: 'codex',
+        messages: [],
+      })),
+    })
+    const models: UnifiedModel[] = [
+      {
+        name: 'project-model',
+        type: 'runtime',
+        provider: 'local',
+        config: {
+          weworkModelKind: 'codex-provider',
+          ui: {
+            family: 'codex-provider',
+            reasoningEfforts: ['low', 'medium', 'high'],
+          },
+        },
+      },
+      {
+        name: 'override-model',
+        type: 'runtime',
+        provider: 'local',
+        config: {
+          weworkModelKind: 'codex-provider',
+          ui: {
+            family: 'codex-provider',
+            reasoningEfforts: ['low', 'medium', 'high'],
+          },
+        },
+      },
+    ]
+    const services = createWorkbenchServices({
+      modelApi: {
+        listModels: vi.fn().mockResolvedValue({ data: models }),
+      },
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    } as Partial<WorkbenchServices>)
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(await screen.findByText('select project'))
+    await waitFor(() =>
+      expect(screen.getByTestId('project-selected-model')).toHaveTextContent('project-model')
+    )
+    expect(screen.getByTestId('project-reasoning-effort')).toHaveTextContent('medium')
+
+    await userEvent.click(screen.getByText('select override model'))
+    await userEvent.click(screen.getByText('set high reasoning'))
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: 'override-model',
+        modelOptions: expect.objectContaining({ reasoning: 'high' }),
+      })
+    )
+
+    await userEvent.click(screen.getByText('start new project chat'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-selected-model')).toHaveTextContent('override-model')
+    )
+    expect(screen.getByTestId('project-reasoning-effort')).toHaveTextContent('high')
   })
 
   test('stores one canonical model identity for selection and execution', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -383,6 +383,11 @@ export function WorkbenchProvider({
     currentRuntimeTask: state.currentRuntimeTask,
     standaloneChatKey: state.standaloneChatKey,
   })
+  const modelSelectionScopeKey = getModelSelectionScopeKey({
+    userId: currentUser.id,
+    currentProjectId: state.currentProject?.id ?? null,
+    currentRuntimeTask: state.currentRuntimeTask,
+  })
   const [draftInputByScope, setDraftInputByScope] = useState<Record<string, string>>(() =>
     workspaceTabId ? (consumeWorkspaceTabTransfer(workspaceTabId)?.draftInputByScope ?? {}) : {}
   )
@@ -891,7 +896,7 @@ export function WorkbenchProvider({
     api: resolvedServices.modelApi,
     locked: false,
     enabled: taskComposerCatalogsEnabled,
-    scopeKey: projectChatScopeKey,
+    scopeKey: modelSelectionScopeKey,
     persistSelection: !state.currentRuntimeTask && !usesLocalProjectScopedSelection,
     selectionConfig: modelSelectionConfig,
     defaultSelectionConfig: defaultModelSelectionConfig,
@@ -3003,4 +3008,21 @@ function getProjectChatScopeKey({
     return getRuntimeTaskChatScopeKey(currentRuntimeTask)
   }
   return `blank:${standaloneChatKey}`
+}
+
+function getModelSelectionScopeKey({
+  userId,
+  currentProjectId,
+  currentRuntimeTask,
+}: {
+  userId: number
+  currentProjectId: number | null
+  currentRuntimeTask: RuntimeTaskAddress | null
+}): string {
+  if (currentRuntimeTask) {
+    return `user:${userId}:${getRuntimeTaskChatScopeKey(currentRuntimeTask)}`
+  }
+  return currentProjectId === null
+    ? `user:${userId}:new-task:standalone`
+    : `user:${userId}:new-task:project:${currentProjectId}`
 }

--- a/wework/src/features/workbench/useWorkbenchModels.ts
+++ b/wework/src/features/workbench/useWorkbenchModels.ts
@@ -67,33 +67,13 @@ function areModelOptionsEqual(left: ModelOptions, right: ModelOptions): boolean 
   return leftKeys.every(key => left[key] === right[key])
 }
 
-function getSelectionKey(
-  models: UnifiedModel[],
-  selectionConfig?: ModelSelectionConfig | null
-): string {
-  const modelsKey = models
-    .map(model => {
-      const identity = modelSelectionIdentityOptions(model)
-      return [
-        model.type,
-        model.name,
-        identity.codexProviderId ?? '',
-        identity.weworkCloudModelNamespace ?? '',
-        identity.weworkCloudModelResourceUserId ?? '',
-      ].join(':')
-    })
-    .join('|')
+function getSelectionKey(selectionConfig?: ModelSelectionConfig | null): string {
   const options = selectionConfig?.options ?? {}
   const optionsKey = Object.keys(options)
     .sort()
     .map(key => `${key}:${options[key]}`)
     .join('|')
-  return [
-    modelsKey,
-    selectionConfig?.modelType ?? '',
-    selectionConfig?.modelName ?? '',
-    optionsKey,
-  ].join('::')
+  return [selectionConfig?.modelType ?? '', selectionConfig?.modelName ?? '', optionsKey].join('::')
 }
 
 export function useWorkbenchModels({
@@ -137,8 +117,8 @@ export function useWorkbenchModels({
     return defaultSelectionConfig?.(models) ?? selectionConfig ?? null
   }, [defaultSelectionConfig, models, selectionConfig])
   const selectionKey = useMemo(
-    () => getSelectionKey(models, effectiveSelectionConfig),
-    [models, effectiveSelectionConfig]
+    () => getSelectionKey(effectiveSelectionConfig),
+    [effectiveSelectionConfig]
   )
   const selectionMatchesConfig = Boolean(
     effectiveSelectionConfig?.modelName &&
@@ -272,7 +252,15 @@ export function useWorkbenchModels({
           Object.prototype.hasOwnProperty.call(selectedModelRef.current, scopeKey) ||
           Object.prototype.hasOwnProperty.call(selectedModelOptionsRef.current, scopeKey)
         const scopeSelectionAlreadyRestored = restoredSelectionKeyByScope[scopeKey] === selectionKey
-        if (!hasScopeSelection || !scopeSelectionAlreadyRestored) {
+        const configuredModelAvailable = Boolean(
+          effectiveSelectionConfig?.modelName &&
+          findModelForSelection(models, effectiveSelectionConfig)
+        )
+        if (
+          !hasScopeSelection ||
+          !scopeSelectionAlreadyRestored ||
+          (configuredModelAvailable && !selectedModelRef.current[scopeKey])
+        ) {
           restoreSelection(models, effectiveSelectionConfig)
         }
         setRestoredSelectionKeyByScope(current =>

--- a/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
+++ b/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
@@ -179,6 +179,65 @@ describe('workbench project chat hooks', () => {
     expect(onSelectionChange).not.toHaveBeenCalled()
   })
 
+  test('preserves a task composer override when the model catalog refreshes', async () => {
+    const projectModel: UnifiedModel = {
+      name: 'project-model',
+      type: 'runtime',
+      config: {
+        weworkModelKind: 'codex-provider',
+        ui: {
+          family: 'codex-provider',
+          reasoningEfforts: ['low', 'medium', 'high'],
+        },
+      },
+    }
+    const overrideModel: UnifiedModel = {
+      name: 'override-model',
+      type: 'runtime',
+      config: {
+        weworkModelKind: 'codex-provider',
+        ui: {
+          family: 'codex-provider',
+          reasoningEfforts: ['low', 'medium', 'high'],
+        },
+      },
+    }
+    const refreshedProjectModel = { ...projectModel, displayName: 'Project Model Updated' }
+    const refreshedOverrideModel = { ...overrideModel, displayName: 'Override Model Updated' }
+    const api = {
+      listModels: vi
+        .fn()
+        .mockResolvedValueOnce({ data: [projectModel, overrideModel] })
+        .mockResolvedValueOnce({ data: [refreshedProjectModel, refreshedOverrideModel] }),
+    }
+    const { result } = renderHook(() =>
+      useWorkbenchModels({
+        api,
+        locked: false,
+        scopeKey: 'new-task:project:7',
+        persistSelection: false,
+        selectionConfig: {
+          modelName: projectModel.name,
+          modelType: projectModel.type,
+          options: { reasoning: 'medium' },
+        },
+      })
+    )
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(projectModel))
+    act(() => {
+      result.current.setSelectedModel(overrideModel)
+      result.current.setSelectedModelOption('reasoning', 'high')
+    })
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(LOCAL_MODEL_SETTINGS_CHANGED_EVENT))
+    })
+
+    await waitFor(() => expect(result.current.selectedModel).toBe(refreshedOverrideModel))
+    expect(result.current.selectedModelOptions).toEqual({ reasoning: 'high' })
+  })
+
   test('falls back to the refreshed model default when the selected option is removed', async () => {
     const originalModel: UnifiedModel = {
       name: 'local-model:api-sol',


### PR DESCRIPTION
## Summary
- keep new-task model selection scoped to the user and project instead of each blank chat instance
- preserve manual model and reasoning choices across model catalog refreshes
- cover the behavior in unit tests and the CI-covered desktop project AI settings checkpoint

## Verification
- `pnpm --filter wework test workbenchProjectChatHooks.test.tsx WorkbenchProvider.test.tsx`
- `pnpm --filter wework exec eslint src/features/workbench/useWorkbenchModels.ts src/features/workbench/WorkbenchProvider.tsx src/features/workbench/workbenchProjectChatHooks.test.tsx src/features/workbench/WorkbenchProvider.test.tsx e2e/desktop/modules/task-flow-main.mjs`
- `WEWORK_HARNESS_RUNTIME_ROOT=$PWD/wework/node_modules/.cache/harness-runtime-dev WEWORK_E2E_APP_BIN=... WEWORK_E2E_EXECUTOR_BIN=... pnpm --filter wework e2e:desktop -- --segment project-ai-settings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-specific AI model preferences for project chats, standalone chats, and tasks.
  * Task-specific model and reasoning selections now persist to future conversations.
  * High-reasoning settings can be selected and remembered for subsequent project tasks.

* **Bug Fixes**
  * Preserved manually selected models and reasoning settings when the available model catalog refreshes.
  * Restored configured models when they become available again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->