### PR TITLE
fix(wework): authenticate release version commit

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Commit Wework version files
         id: version-files
         env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           PUBLISH_RELEASE: ${{ steps.version.outputs.publish_release }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
         run: |

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -160,6 +160,9 @@ describe('bundled plugin resources', () => {
     expect(workflow).toContain('generate-desktop-update-manifests.mjs')
     expect(workflow).toContain('TAURI_SIGNING_PRIVATE_KEY')
     expect(workflow).toContain('release-manifests/*')
+    expect(workflow).toMatch(
+      /- name: Commit Wework version files[\s\S]*?GH_TOKEN: \$\{\{ steps\.release-app-token\.outputs\.token \}\}/
+    )
     expect(workflow).toMatch(/gh release edit "\$RELEASE_TAG"[\s\S]*--target "\$RELEASE_SHA"/)
     expect(installerHooks).toContain('Software\\you\\WeWork')
     expect(installerHooks).toContain('InstallLocation')


### PR DESCRIPTION
## Summary

- pass the release app token to the version-file commit step
- add a static regression assertion for the workflow authentication

## Evidence

The beta release run `32933775577` failed in `Commit Wework version files` because `gh api` exited with code 4 and required `GH_TOKEN`.

## Verification

- `pnpm --filter wework exec vitest run src/test/bundled-plugin-resources.test.ts`
- `pnpm --filter wework exec prettier --check ../.github/workflows/wework-app.yml src/test/bundled-plugin-resources.test.ts`
- `actionlint .github/workflows/wework-app.yml`
- pre-push ESLint, TypeScript, and unit tests