### PR TITLE
fix(wework): provide release repository context

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -93,6 +93,7 @@ jobs:
         if: steps.version.outputs.publish_release == 'true'
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_SHA: ${{ steps.version-files.outputs.release_sha }}
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -163,6 +163,9 @@ describe('bundled plugin resources', () => {
     expect(workflow).toMatch(
       /- name: Commit Wework version files[\s\S]*?GH_TOKEN: \$\{\{ steps\.release-app-token\.outputs\.token \}\}/
     )
+    expect(workflow).toMatch(
+      /- name: Create or update draft release[\s\S]*?GH_REPO: \$\{\{ github\.repository \}\}/
+    )
     expect(workflow).toMatch(/gh release edit "\$RELEASE_TAG"[\s\S]*--target "\$RELEASE_SHA"/)
     expect(installerHooks).toContain('Software\\you\\WeWork')
     expect(installerHooks).toContain('InstallLocation')


### PR DESCRIPTION
## Summary

- pass the GitHub repository slug to release-note generation
- add a static regression assertion for the draft-release step

## Evidence

The release run `32936114664` reached `Create or update draft release` and failed because `generate-release-notes.mjs` requires `GH_REPO`. The version commit succeeded at `8fe5d95ccea9a56ce3f1bdf65112ead4c383e36a`; no release or tag was created, and resolution remains `0.2.7-beta.1`.

## Verification

- `pnpm --filter wework exec vitest run src/test/bundled-plugin-resources.test.ts`
- `pnpm --filter wework exec prettier --check ../.github/workflows/wework-app.yml src/test/bundled-plugin-resources.test.ts`
- `actionlint .github/workflows/wework-app.yml`
- beta resolver still returns `0.2.7-beta.1`
- pre-push ESLint, TypeScript, and unit tests