### PR TITLE
fix(wework): scope generated release notes

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -89,11 +89,20 @@ jobs:
           fi
           echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve previous Wework release
+        id: previous-release
+        if: steps.version.outputs.publish_release == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          RELEASE_CHANNEL: ${{ steps.version.outputs.channel }}
+        run: echo "tag=$(node wework/scripts/resolve-previous-release-tag.mjs)" >> "$GITHUB_OUTPUT"
+
       - name: Create or update draft release
         if: steps.version.outputs.publish_release == 'true'
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
+          PREVIOUS_TAG: ${{ steps.previous-release.outputs.tag }}
           RELEASE_SHA: ${{ steps.version-files.outputs.release_sha }}
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -166,6 +166,10 @@ describe('bundled plugin resources', () => {
     expect(workflow).toMatch(
       /- name: Create or update draft release[\s\S]*?GH_REPO: \$\{\{ github\.repository \}\}/
     )
+    expect(workflow).toMatch(
+      /- name: Resolve previous Wework release[\s\S]*?resolve-previous-release-tag\.mjs/
+    )
+    expect(workflow).toContain('PREVIOUS_TAG: ${{ steps.previous-release.outputs.tag }}')
     expect(workflow).toMatch(/gh release edit "\$RELEASE_TAG"[\s\S]*--target "\$RELEASE_SHA"/)
     expect(installerHooks).toContain('Software\\you\\WeWork')
     expect(installerHooks).toContain('InstallLocation')


### PR DESCRIPTION
## Summary

- resolve the previous Wework release tag before generating notes
- pass that tag to the release-note generator so it only scans the current release range
- add workflow regression assertions

## Evidence

Release run `32939526016` remained in `Create or update draft release` while the workflow scanned all 728 historical Wework/Executor commits. The existing previous-tag resolver selects `wework-v0.2.6`, reducing the intended range to about 45 commits. The invalid run was cancelled before publishing incorrect full-history notes.

## Verification

- 3 focused test files, 20 tests passed
- Prettier and actionlint passed
- resolver returns `wework-v0.2.6` for `wework-v0.2.7-beta.1`
- pre-push ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wework release publishing by correctly identifying the previous release for publish-enabled workflows.
  * Ensured draft releases receive the correct previous release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->