### PR TITLE
fix(wework): make ai verify preparation noninteractive

### DIFF
--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -97,7 +97,7 @@ pnpm --filter wework ai:verify close-to-tray --session <session-path>
 pnpm --filter wework ai:verify stop --session <session-path>
 ```
 
-- `start` prepares and launches Electron directly from the source application directory, waits for the WebView, creates an isolated executor home, links local Codex authentication only for that session, and gives the app its own stdio-managed executor child. Use `start --packaged true` only when validating the final app bundle, packaged resources, or macOS application identity.
+- `start` prepares and launches Electron directly from the source application directory, waits for the WebView, creates an isolated executor home, links local Codex authentication only for that session, and gives the app its own stdio-managed executor child. `start --packaged true` builds the app bundle before launching it; use that mode only when validating packaged resources or macOS application identity.
 - Use `start --codex-home-initialization true` to verify the first-run Codex migration flow with a session-local native Codex home and synthetic authentication; it does not read or modify personal Codex credentials.
 - Session files and credentials are secrets: never print their contents. Always stop the session; it removes the auth link and terminates the isolated process group.
 - Begin with `snapshot`, use existing `data-testid` selectors, and assert a visible text or stable element after each critical action.

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -367,19 +367,33 @@ async function resolveSourceElectronBinary() {
   return require('electron')
 }
 
-async function prepareSourceElectron() {
-  await new Promise((resolvePromise, reject) => {
-    const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-    const command = wrapWindowsScriptCommand(pnpmCommand, ['run', 'ai:verify:electron:prepare'])
-    const child = spawn(command.command, command.args, {
+export function prepareElectronApp({
+  packaged,
+  environment = process.env,
+  platform = process.platform,
+  spawnProcess = spawn,
+}) {
+  if (packaged && environment.WEWORK_ELECTRON_APP_BIN?.trim()) return Promise.resolve()
+  const script = packaged ? 'ai:verify:electron:build' : 'ai:verify:electron:prepare'
+  const description = packaged ? 'Electron package build' : 'Electron source preparation'
+  const preparationEnvironment = {
+    ...environment,
+    CI: environment.CI || '1',
+  }
+  return new Promise((resolvePromise, reject) => {
+    const pnpmCommand = platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+    const command = wrapWindowsScriptCommand(pnpmCommand, ['run', script], { platform })
+    const child = spawnProcess(command.command, command.args, {
       cwd: weworkDir,
-      env: process.env,
+      env: preparationEnvironment,
       stdio: 'inherit',
     })
-    child.once('error', reject)
+    child.once('error', error => {
+      reject(new Error(`${description} failed to start: ${error.message}`))
+    })
     child.once('exit', code => {
       if (code === 0) resolvePromise()
-      else reject(new Error(`Electron source preparation exited with code ${code ?? 'unknown'}`))
+      else reject(new Error(`${description} exited with code ${code ?? 'unknown'}`))
     })
   })
 }
@@ -607,7 +621,7 @@ async function main() {
   if (command === 'start') {
     validateStartOptions(options)
     const packaged = resolveOptionalBoolean(options.packaged, 'packaged') ?? false
-    if (!packaged) await prepareSourceElectron()
+    await prepareElectronApp({ packaged })
     const launch = resolveElectronLaunch({
       packaged,
       sourceBinary: packaged ? undefined : await resolveSourceElectronBinary(),

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -10,6 +10,7 @@ import {
   buildSourceRuntimeEnvironment,
   monitorAppProcess,
   parseArgs,
+  prepareElectronApp,
   readSessionForCleanup,
   resolveElectronLaunch,
   resolveHostTarget,
@@ -290,6 +291,105 @@ describe('resolveElectronLaunch', () => {
     ).toMatchObject({
       args: [],
     })
+  })
+})
+
+describe('prepareElectronApp', () => {
+  test.each([
+    [false, 'ai:verify:electron:prepare'],
+    [true, 'ai:verify:electron:build'],
+  ])('runs the required preparation when packaged is %s', async (packaged, script) => {
+    const child = new EventEmitter()
+    const spawnProcess = vi.fn(() => child)
+    const result = prepareElectronApp({
+      packaged,
+      environment: {},
+      platform: 'darwin',
+      spawnProcess,
+    })
+
+    child.emit('exit', 0)
+
+    await expect(result).resolves.toBeUndefined()
+    expect(spawnProcess).toHaveBeenCalledWith('pnpm', ['run', script], {
+      cwd: expect.any(String),
+      env: { CI: '1' },
+      stdio: 'inherit',
+    })
+  })
+
+  test('uses an explicitly configured packaged app without rebuilding', async () => {
+    const spawnProcess = vi.fn()
+
+    await expect(
+      prepareElectronApp({
+        packaged: true,
+        environment: { WEWORK_ELECTRON_APP_BIN: '/tmp/custom-wework' },
+        spawnProcess,
+      })
+    ).resolves.toBeUndefined()
+
+    expect(spawnProcess).not.toHaveBeenCalled()
+  })
+
+  test('wraps the preparation command for Windows', async () => {
+    const child = new EventEmitter()
+    const spawnProcess = vi.fn(() => child)
+    const result = prepareElectronApp({
+      packaged: false,
+      environment: {},
+      platform: 'win32',
+      spawnProcess,
+    })
+
+    child.emit('exit', 0)
+
+    await expect(result).resolves.toBeUndefined()
+    expect(spawnProcess).toHaveBeenCalledWith(
+      process.env.ComSpec || 'cmd.exe',
+      ['/c', 'pnpm.cmd', 'run', 'ai:verify:electron:prepare'],
+      expect.objectContaining({
+        env: { CI: '1' },
+        stdio: 'inherit',
+      })
+    )
+  })
+
+  test('preserves an explicitly configured CI value', async () => {
+    const child = new EventEmitter()
+    const spawnProcess = vi.fn(() => child)
+    const result = prepareElectronApp({
+      packaged: false,
+      environment: { CI: 'custom' },
+      platform: 'darwin',
+      spawnProcess,
+    })
+
+    child.emit('exit', 0)
+
+    await expect(result).resolves.toBeUndefined()
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'pnpm',
+      ['run', 'ai:verify:electron:prepare'],
+      expect.objectContaining({
+        env: { CI: 'custom' },
+      })
+    )
+  })
+
+  test('reports a failed packaged app build', async () => {
+    const child = new EventEmitter()
+    const result = prepareElectronApp({
+      packaged: true,
+      environment: {},
+      platform: 'darwin',
+      spawnProcess: () => child,
+    })
+    const expectation = expect(result).rejects.toThrow('Electron package build exited with code 1')
+
+    child.emit('exit', 1)
+
+    await expectation
   })
 })
 


### PR DESCRIPTION
## Summary

- make `ai:verify start --packaged true` build the Electron app automatically
- run both source and packaged preparation in noninteractive CI mode so pnpm cannot block on confirmation
- preserve explicitly configured packaged binaries and existing CI values
- document the self-contained packaged startup behavior

## Verification

- `pnpm --filter wework test scripts/ai-verify.test.mjs scripts/desktop-resource-migration.test.mjs` (65 tests passed)
- Prettier and ESLint passed
- pre-push Wework static checks and unit tests passed
- real Electron source mode: `pnpm --filter wework ai:verify start`, snapshot, stop
- real Electron packaged mode: `pnpm --filter wework ai:verify start --packaged true`, snapshot, stop
