### PR TITLE
fix(wework): repair release runner commands

### DIFF
--- a/wework/electron/scripts/prepare-package-assets.mjs
+++ b/wework/electron/scripts/prepare-package-assets.mjs
@@ -3,6 +3,8 @@ import { chmod, cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { wrapWindowsScriptCommand } from '../../scripts/child-process-command.mjs'
+
 const electronRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const weworkRoot = resolve(electronRoot, '..')
 const repositoryRoot = resolve(weworkRoot, '..')
@@ -10,14 +12,15 @@ const executorRoot = join(repositoryRoot, 'executor')
 const resourcesRoot = join(electronRoot, 'resources')
 const sharedResourcesRoot = join(weworkRoot, 'resources')
 const executorProfile = resolveExecutorProfile()
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 
 const configuredExecutorPath = process.env.WEWORK_EXECUTOR_PATH?.trim()
 const [executorPath] = await Promise.all([
   configuredExecutorPath
     ? Promise.resolve(resolve(configuredExecutorPath))
     : buildExecutor(executorProfile),
-  run('pnpm', ['prepare:harness-runtime', '--materialize'], weworkRoot),
-  run('pnpm', ['prepare:execution-runtime', '--materialize'], weworkRoot),
+  run(pnpmCommand, ['prepare:harness-runtime', '--materialize'], weworkRoot),
+  run(pnpmCommand, ['prepare:execution-runtime', '--materialize'], weworkRoot),
 ])
 
 await rm(resourcesRoot, { recursive: true, force: true })
@@ -100,7 +103,8 @@ async function buildExecutor(profile) {
 
 function run(command, args, cwd) {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, { cwd, stdio: 'inherit' })
+    const resolved = wrapWindowsScriptCommand(command, args)
+    const child = spawn(resolved.command, resolved.args, { cwd, stdio: 'inherit' })
     child.once('error', reject)
     child.once('exit', code => {
       if (code === 0) resolvePromise()
@@ -111,7 +115,8 @@ function run(command, args, cwd) {
 
 function capture(command, args, cwd) {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, {
+    const resolved = wrapWindowsScriptCommand(command, args)
+    const child = spawn(resolved.command, resolved.args, {
       cwd,
       stdio: ['ignore', 'pipe', 'inherit'],
     })

--- a/wework/scripts/deepseek-harness-signing.test.mjs
+++ b/wework/scripts/deepseek-harness-signing.test.mjs
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
+  macosCodesignKeychainArguments,
   macosSigningFingerprint,
   signPreparedMacOsBinaries,
 } from './lib/deepseek-harness-signing.mjs'
@@ -31,6 +32,19 @@ describe('macosSigningFingerprint', () => {
   test('uses the unsigned variant without a macOS signing identity', () => {
     expect(macosSigningFingerprint('linux', 'Developer ID Application: One')).toBe('unsigned')
     expect(macosSigningFingerprint('darwin', '')).toBe('unsigned')
+  })
+})
+
+describe('macosCodesignKeychainArguments', () => {
+  test('selects an explicit keychain for release signing', () => {
+    expect(macosCodesignKeychainArguments(' /tmp/signing.keychain-db ')).toEqual([
+      '--keychain',
+      '/tmp/signing.keychain-db',
+    ])
+  })
+
+  test('uses the default keychain search list when no path is configured', () => {
+    expect(macosCodesignKeychainArguments()).toEqual([])
   })
 })
 

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -69,8 +69,28 @@ describe('desktop resource migration', () => {
     expect(source).toContain("configured === 'debug' || configured === 'release'")
     expect(source).toContain("profile === 'release' ? ['--release'] : []")
     expect(source).toContain('const [executorPath] = await Promise.all([')
-    expect(source).toContain("run('pnpm', ['prepare:harness-runtime', '--materialize']")
-    expect(source).toContain("run('pnpm', ['prepare:execution-runtime', '--materialize']")
+    expect(source).toContain("process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'")
+    expect(source).toContain("run(pnpmCommand, ['prepare:harness-runtime', '--materialize']")
+    expect(source).toContain("run(pnpmCommand, ['prepare:execution-runtime', '--materialize']")
+    expect(source).toContain('wrapWindowsScriptCommand(command, args)')
+  })
+
+  test('signs the packaged Node runtime with the configured macOS keychain', async () => {
+    const source = await readFile(join(weworkRoot, 'scripts/prepare-execution-runtime.mjs'), 'utf8')
+
+    expect(source).toContain('macosCodesignKeychainArguments(process.env.MACOS_KEYCHAIN_PATH)')
+  })
+
+  test('collects the electron-builder Linux x64 artifact name', async () => {
+    const source = await readFile(
+      join(weworkRoot, 'scripts/prepare-desktop-release-assets.mjs'),
+      'utf8'
+    )
+
+    expect(source).toContain(
+      "const installerArchitecture = platform === 'linux' && arch === 'x64' ? 'x86_64' : arch"
+    )
+    expect(source).toContain('linux_${installerArchitecture}\\\\.AppImage')
   })
 
   test('desktop E2E reuses packaged Harness runtime assets', async () => {

--- a/wework/scripts/lib/deepseek-harness-signing.mjs
+++ b/wework/scripts/lib/deepseek-harness-signing.mjs
@@ -54,6 +54,11 @@ export function macosSigningFingerprint(platform, identity) {
   return `developer-id:${identityHash}`
 }
 
+export function macosCodesignKeychainArguments(keychainPath) {
+  const normalizedPath = keychainPath?.trim()
+  return normalizedPath ? ['--keychain', normalizedPath] : []
+}
+
 export async function signPreparedMacOsBinaries(
   directory,
   {
@@ -72,7 +77,7 @@ export async function signPreparedMacOsBinaries(
     if (!description.includes('Mach-O')) continue
 
     const args = ['--force', '--timestamp', '--options', 'runtime']
-    if (keychainPath) args.push('--keychain', keychainPath)
+    args.push(...macosCodesignKeychainArguments(keychainPath))
     args.push('--sign', identity, candidate)
     logger(`Signing bundled DeepSeek Harness binary: ${path.relative(directory, candidate)}`)
     await execute('codesign', args, directory)

--- a/wework/scripts/prepare-desktop-release-assets.mjs
+++ b/wework/scripts/prepare-desktop-release-assets.mjs
@@ -17,6 +17,7 @@ if (!platform || !arch || !version || !outputDirectory) {
 }
 
 const output = resolve(outputDirectory)
+const installerArchitecture = platform === 'linux' && arch === 'x64' ? 'x86_64' : arch
 await rm(output, { recursive: true, force: true })
 await mkdir(output, { recursive: true })
 
@@ -49,7 +50,7 @@ if (platform === 'macos') {
 } else if (platform === 'linux') {
   const appImage = await findFile(
     installerRoot,
-    new RegExp(`^WeWork_${escape(version)}_linux_${arch}\\.AppImage$`)
+    new RegExp(`^WeWork_${escape(version)}_linux_${installerArchitecture}\\.AppImage$`)
   )
   await cp(appImage, join(output, basename(appImage)))
 } else {

--- a/wework/scripts/prepare-execution-runtime.mjs
+++ b/wework/scripts/prepare-execution-runtime.mjs
@@ -8,7 +8,10 @@ import { fileURLToPath } from 'node:url'
 import { constants as zlibConstants, createGzip } from 'node:zlib'
 import { spawn } from 'node:child_process'
 
-import { macosSigningFingerprint } from './lib/deepseek-harness-signing.mjs'
+import {
+  macosCodesignKeychainArguments,
+  macosSigningFingerprint,
+} from './lib/deepseek-harness-signing.mjs'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const resourceDirectory = path.join(root, 'resources', 'bundled-execution-runtimes')
@@ -61,7 +64,10 @@ async function signAndValidateNode(nodePath) {
       '--sign',
       identity,
     ]
-    if (identity !== '-') args.splice(1, 0, '--timestamp')
+    if (identity !== '-') {
+      args.splice(1, 0, '--timestamp')
+      args.push(...macosCodesignKeychainArguments(process.env.MACOS_KEYCHAIN_PATH))
+    }
     await run('codesign', [...args, nodePath])
   }
   await run(nodePath, ['-e', 'process.stdout.write(process.versions.node)'])


### PR DESCRIPTION
## Summary

- run pnpm command scripts through the existing Windows command wrapper while preparing Electron package assets
- pass the temporary macOS signing keychain to packaged Node runtime signing
- map Linux x64 to electron-builder's x86_64 AppImage artifact name

## Evidence

Release run 32945591970 exposed all three failures on the real GitHub runners:

- Windows: `spawn pnpm ENOENT`
- macOS: `codesign` reported `The specified item could not be found in the keychain`
- Linux: builder produced `linux_x86_64.AppImage` while the collector searched for `linux_x64.AppImage`

## Verification

- `pnpm --filter wework exec vitest run scripts/deepseek-harness-signing.test.mjs scripts/child-process-command.test.mjs scripts/desktop-resource-migration.test.mjs` (34 passed)
- focused ESLint passed
- pre-push Wework checks passed (ESLint, Electron TypeScript, unit tests)
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows desktop packaging compatibility by using the appropriate platform command handling.
  - Fixed Linux x64 release asset selection to use the correct architecture naming.
  - Improved macOS code signing by trimming configured keychain paths and ignoring blank values.
  - Ensured custom macOS signing identities receive the correct keychain and timestamp options.

- **Reliability**
  - Updated release preparation workflows to handle platform-specific packaging and signing configurations more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->