### PR TITLE
fix(execution): preserve Claude sessions across recovery

### DIFF
--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -305,6 +305,7 @@ jobs:
 
       - name: Upload Wework desktop Core E2E build diagnostics
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-core-e2e-build-diagnostics
@@ -407,6 +408,7 @@ jobs:
 
       - name: Upload Wework desktop E2E diagnostics
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-${{ matrix.id }}-e2e-diagnostics
@@ -508,6 +510,7 @@ jobs:
 
       - name: Upload Wework desktop Cloud E2E diagnostics
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-${{ matrix.id }}-e2e-diagnostics
@@ -604,6 +607,7 @@ jobs:
 
       - name: Upload Wework desktop E2E diagnostics
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-${{ matrix.id }}-e2e-diagnostics
@@ -827,6 +831,7 @@ jobs:
 
       - name: Upload Wework desktop memory diagnostics
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-memory-e2e-diagnostics

--- a/backend/app/api/endpoints/internal/workspace_archives.py
+++ b/backend/app/api/endpoints/internal/workspace_archives.py
@@ -154,7 +154,7 @@ async def restore_sandbox_workspace(
         runtime_type="sandbox",
     )
 
-    return SandboxRestoreResponse(success=restored, task_id=task_id)
+    return SandboxRestoreResponse(success=bool(restored), task_id=task_id)
 
 
 @router.get("/{task_id}/download-url", response_model=ArchiveDownloadUrlResponse)

--- a/backend/app/services/execution/recovery_service.py
+++ b/backend/app/services/execution/recovery_service.py
@@ -17,7 +17,7 @@ with git clone enabled.
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
 
@@ -69,7 +69,7 @@ class ExecutorRecoveryService:
 
         return "default"
 
-    def _persist_prepare_failure(
+    def _persist_recovery_failure(
         self,
         db: Session,
         subtask: Subtask,
@@ -84,6 +84,49 @@ class ExecutorRecoveryService:
         db.add(subtask)
         db.add(task)
         db.commit()
+
+    @staticmethod
+    def _requires_claude_session(request: ExecutionRequest) -> bool:
+        if request.new_session:
+            return False
+        bots = request.bot if isinstance(request.bot, list) else [request.bot]
+        return any(
+            isinstance(bot, dict) and bot.get("shell_type") == "ClaudeCode"
+            for bot in bots
+        )
+
+    @staticmethod
+    def _has_inherited_claude_session(request: ExecutionRequest) -> bool:
+        bots = request.bot if isinstance(request.bot, list) else [request.bot]
+        bot_ids = {
+            str(bot["id"])
+            for bot in bots
+            if isinstance(bot, dict) and bot.get("id") is not None
+        }
+        for session in request.inherited_sessions:
+            if not isinstance(session, dict):
+                continue
+            if session.get("agent") not in {"ClaudeCode", "Claude Code"}:
+                continue
+            session_id = session.get("sessionId") or session.get("session_id")
+            if not ExecutorRecoveryService._is_safe_session_identifier(session_id):
+                continue
+            session_bot_id: Any = session.get("botId", session.get("bot_id"))
+            if bot_ids and session_bot_id is not None:
+                if str(session_bot_id) not in bot_ids:
+                    continue
+            return True
+        return False
+
+    @staticmethod
+    def _is_safe_session_identifier(value: Any) -> bool:
+        if not isinstance(value, str):
+            return False
+        value = value.strip()
+        return bool(value) and all(
+            character.isascii() and (character.isalnum() or character in {"-", "_"})
+            for character in value
+        )
 
     async def recover(
         self,
@@ -208,7 +251,7 @@ class ExecutorRecoveryService:
                     f"[RecoveryService] Failed to prepare executor for task {task_id}: {error}"
                 )
                 if error:
-                    self._persist_prepare_failure(db, subtask, task, error)
+                    self._persist_recovery_failure(db, subtask, task, error)
                 return False
 
             executor_name = executor.container_name
@@ -218,14 +261,27 @@ class ExecutorRecoveryService:
             )
 
             # Restore workspace from archive
-            restore_success = await archive_service.restore_workspace(
+            restore_result = await archive_service.restore_workspace(
                 db=db,
                 task=task,
                 executor_name=executor_name,
                 executor_namespace=executor_namespace,
             )
 
-            if not restore_success:
+            session_available = bool(restore_result) and bool(
+                restore_result.get("session_restored", False)
+                or self._has_inherited_claude_session(request)
+            )
+            if self._requires_claude_session(request) and not session_available:
+                error = (
+                    f"Claude session context for task {task_id} was not restored. "
+                    "Refusing to send the continuation to a new session."
+                )
+                logger.error(f"[RecoveryService] {error}")
+                self._persist_recovery_failure(db, subtask, task, error)
+                raise RuntimeError(error)
+
+            if not restore_result:
                 logger.warning(
                     f"[RecoveryService] Failed to restore workspace for task {task_id}, "
                     "continuing with empty workspace"
@@ -244,6 +300,8 @@ class ExecutorRecoveryService:
 
             return True
 
+        except RuntimeError:
+            raise
         except Exception as e:
             logger.error(
                 f"[RecoveryService] Error recovering with archive for task {task_id}: {e}",
@@ -286,7 +344,7 @@ class ExecutorRecoveryService:
                     f"[RecoveryService] Failed to prepare executor for task {task_id}: {error}"
                 )
                 if error:
-                    self._persist_prepare_failure(db, subtask, task, error)
+                    self._persist_recovery_failure(db, subtask, task, error)
                 return False
 
             executor_name = executor.container_name

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -48,7 +48,7 @@ from app.services.skill_resolution import (
     find_skill_by_ref,
 )
 from app.services.user_mcp_service import user_mcp_service
-from app.stores.tasks import task_store
+from app.stores.tasks import subtask_store, task_store
 from shared.models import ExecutionRequest
 from shared.models.db import Kind, User
 
@@ -462,7 +462,20 @@ class TaskRequestBuilder:
         )
         resolved_bot_namespace = getattr(bot, "namespace", None) or "default"
         fork_runtime = self._extract_task_fork_runtime(task)
-        inherited_sessions = self._extract_inherited_sessions(fork_runtime)
+        fork_sessions = self._extract_inherited_sessions(fork_runtime)
+        persisted_sessions: list[dict[str, Any]] = []
+        if getattr(subtask, "executor_deleted_at", False):
+            persisted_sessions = self._extract_persisted_sessions(
+                subtask_store.list_assistant_by_task(
+                    self.db,
+                    task_id=task.id,
+                    owner_user_id=user.id,
+                )
+            )
+        inherited_sessions = self._merge_inherited_sessions(
+            fork_sessions,
+            persisted_sessions,
+        )
 
         execution_request = ExecutionRequest(
             task_id=task.id,
@@ -578,6 +591,63 @@ class TaskRequestBuilder:
         if not isinstance(sessions, list):
             return []
         return [session for session in sessions if isinstance(session, dict)]
+
+    @staticmethod
+    def _extract_persisted_sessions(subtasks: list[Any]) -> list[dict[str, Any]]:
+        sessions: list[dict[str, Any]] = []
+        for subtask in reversed(subtasks):
+            result = getattr(subtask, "result", None)
+            if not isinstance(result, dict):
+                continue
+            session = TaskRequestBuilder._normalize_executor_session(
+                result.get("executor_session")
+            )
+            if session:
+                sessions.append(session)
+        return TaskRequestBuilder._merge_inherited_sessions(sessions)
+
+    @staticmethod
+    def _normalize_executor_session(session: Any) -> dict[str, Any] | None:
+        if not isinstance(session, dict):
+            return None
+        agent = session.get("agent")
+        session_id = session.get("sessionId") or session.get("session_id")
+        thread_id = session.get("threadId") or session.get("thread_id")
+        if not agent or not (session_id or thread_id):
+            return None
+
+        normalized: dict[str, Any] = {"agent": str(agent)}
+        if session_id:
+            normalized["sessionId"] = str(session_id)
+        if thread_id:
+            normalized["threadId"] = str(thread_id)
+        bot_id = session.get("botId", session.get("bot_id"))
+        if bot_id is not None:
+            normalized["botId"] = bot_id
+        return normalized
+
+    @staticmethod
+    def _merge_inherited_sessions(
+        *session_groups: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        merged: list[dict[str, Any]] = []
+        seen: set[tuple[str, str, str, str]] = set()
+        for sessions in session_groups:
+            for session in sessions:
+                normalized = TaskRequestBuilder._normalize_executor_session(session)
+                if not normalized:
+                    continue
+                identity = (
+                    str(normalized.get("agent") or ""),
+                    str(normalized.get("botId") or ""),
+                    str(normalized.get("sessionId") or ""),
+                    str(normalized.get("threadId") or ""),
+                )
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                merged.append(normalized)
+        return merged
 
     def resolve_request_preload_skills(
         self,

--- a/backend/app/services/workspace_archive/archive_service.py
+++ b/backend/app/services/workspace_archive/archive_service.py
@@ -146,7 +146,7 @@ class ArchiveService:
         executor_name: str,
         executor_namespace: str,
         runtime_type: str = "executor",
-    ) -> bool:
+    ) -> Optional[Dict[str, Any]]:
         """Restore workspace files after Pod recreation.
 
         Args:
@@ -156,7 +156,7 @@ class ArchiveService:
             executor_namespace: New executor namespace
 
         Returns:
-            True if restoration successful, False otherwise
+            Restore details if successful, None otherwise
         """
         task_id = task.id
         logger.info(
@@ -174,7 +174,7 @@ class ArchiveService:
                     f"[ArchiveService] No archive found for task {task_id}, "
                     "will use git clone instead"
                 )
-                return False
+                return None
 
             # Check if archive is expired
             if (
@@ -186,7 +186,7 @@ class ArchiveService:
                     f"[ArchiveService] Archive expired for task {task_id}, "
                     f"expired at {archive_info.expiresAt}"
                 )
-                return False
+                return None
 
             # Check if archive file exists
             if not archive_storage_service.archive_exists(archive_info.storageKey):
@@ -194,7 +194,7 @@ class ArchiveService:
                     f"[ArchiveService] Archive file not found for task {task_id}, "
                     f"key={archive_info.storageKey}"
                 )
-                return False
+                return None
 
             # Generate presigned download URL
             download_url = archive_storage_service.generate_download_url(
@@ -210,9 +210,9 @@ class ArchiveService:
                 runtime_type=runtime_type,
             )
 
-            if not restore_result:
+            if not restore_result or not restore_result.get("success", False):
                 logger.warning(f"[ArchiveService] Restore failed for task {task_id}")
-                return False
+                return None
 
             logger.info(
                 f"[ArchiveService] Successfully restored task {task_id}, "
@@ -220,14 +220,14 @@ class ArchiveService:
                 f"git_restored={restore_result.get('git_restored', False)}"
             )
 
-            return True
+            return restore_result
 
         except Exception as e:
             logger.error(
                 f"[ArchiveService] Error restoring workspace for task {task_id}: {e}",
                 exc_info=True,
             )
-            return False
+            return None
 
     def check_archive_available(
         self, task: TaskResource

--- a/backend/tests/api/endpoints/internal/test_workspace_archives_api.py
+++ b/backend/tests/api/endpoints/internal/test_workspace_archives_api.py
@@ -203,7 +203,13 @@ def test_restore_sandbox_endpoint_uses_sandbox_runtime(
     restore_mock = mocker.patch.object(
         archive_service,
         "restore_workspace",
-        new=AsyncMock(return_value=True),
+        new=AsyncMock(
+            return_value={
+                "success": True,
+                "session_restored": False,
+                "git_restored": False,
+            }
+        ),
     )
 
     response = test_client.post(

--- a/backend/tests/services/execution/test_recovery_service.py
+++ b/backend/tests/services/execution/test_recovery_service.py
@@ -119,7 +119,7 @@ async def test_recover_without_archive_uses_normal_clone():
 
 @pytest.mark.asyncio
 async def test_recover_with_archive_continues_when_restore_fails():
-    """Restore failures should keep the recreated sandbox and proceed."""
+    """Non-session runtimes may keep the recreated sandbox after restore failure."""
     service = ExecutorRecoveryService()
     db = MagicMock()
     subtask = SimpleNamespace(
@@ -135,7 +135,7 @@ async def test_recover_with_archive_continues_when_restore_fails():
         user={"id": 7, "name": "user7"},
         user_id=7,
         user_name="user7",
-        bot=[{"shell_type": "ClaudeCode", "agent_config": {"model": "test"}}],
+        bot=[{"shell_type": "Agno", "agent_config": {"model": "test"}}],
         executor_name="old",
     )
     prepared_executor = SimpleNamespace(
@@ -169,7 +169,7 @@ async def test_recover_with_archive_continues_when_restore_fails():
         patch.object(
             recovery_module.archive_service,
             "restore_workspace",
-            AsyncMock(return_value=False),
+            AsyncMock(return_value=None),
         ) as restore_mock,
     ):
         result = await service.recover(
@@ -194,6 +194,141 @@ async def test_recover_with_archive_continues_when_restore_fails():
     assert observed["before"] == (None, True)
     prepare_executor_mock.assert_awaited_once_with(request, True)
     restore_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recover_claude_continuation_rejects_missing_session_context():
+    service = ExecutorRecoveryService()
+    db = MagicMock()
+    subtask = SimpleNamespace(
+        id=11,
+        executor_name="old",
+        executor_namespace="wb-plat-ide",
+        executor_deleted_at=True,
+        error_message="",
+        status="PENDING",
+        progress=0,
+    )
+    task = SimpleNamespace(
+        id=22,
+        json={
+            "status": {
+                "state": "Available",
+                "status": "PENDING",
+                "progress": 0,
+                "errorMessage": "",
+            }
+        },
+    )
+    request = ExecutionRequest(
+        task_id=22,
+        subtask_id=11,
+        bot=[{"id": 987, "shell_type": "ClaudeCode"}],
+    )
+    prepared_executor = SimpleNamespace(
+        container_name="new-executor",
+        executor_namespace="wegent-pod",
+    )
+
+    with (
+        patch.object(
+            recovery_module.archive_service,
+            "check_archive_available",
+            return_value=(True, "workspace-archives/22/archive.tar.gz", None),
+        ),
+        patch.object(
+            service,
+            "_prepare_executor",
+            AsyncMock(return_value=(prepared_executor, None)),
+        ),
+        patch.object(
+            recovery_module.archive_service,
+            "restore_workspace",
+            AsyncMock(
+                return_value={
+                    "success": True,
+                    "session_restored": False,
+                    "git_restored": True,
+                }
+            ),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="session context.*not restored"):
+            await service.recover(
+                db=db,
+                subtask=subtask,
+                task=task,
+                request=request,
+            )
+
+    assert subtask.status == "FAILED"
+    assert "Refusing to send the continuation" in subtask.error_message
+    assert task.json["status"]["status"] == "FAILED"
+    db.commit.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_recover_claude_continuation_uses_persisted_session_mapping():
+    service = ExecutorRecoveryService()
+    db = MagicMock()
+    subtask = SimpleNamespace(
+        id=11,
+        executor_name="old",
+        executor_namespace="wb-plat-ide",
+        executor_deleted_at=True,
+    )
+    task = SimpleNamespace(id=22)
+    request = ExecutionRequest(
+        task_id=22,
+        subtask_id=11,
+        bot=[{"id": 987, "shell_type": "ClaudeCode"}],
+        inherited_sessions=[
+            {
+                "agent": "ClaudeCode",
+                "botId": 987,
+                "sessionId": "claude-session-1",
+            }
+        ],
+    )
+    prepared_executor = SimpleNamespace(
+        container_name="new-executor",
+        executor_namespace="wegent-pod",
+    )
+
+    with (
+        patch.object(
+            recovery_module.archive_service,
+            "check_archive_available",
+            return_value=(True, "workspace-archives/22/archive.tar.gz", None),
+        ),
+        patch.object(
+            service,
+            "_prepare_executor",
+            AsyncMock(return_value=(prepared_executor, None)),
+        ),
+        patch.object(
+            recovery_module.archive_service,
+            "restore_workspace",
+            AsyncMock(
+                return_value={
+                    "success": True,
+                    "session_restored": False,
+                    "git_restored": True,
+                }
+            ),
+        ),
+    ):
+        result = await service.recover(
+            db=db,
+            subtask=subtask,
+            task=task,
+            request=request,
+        )
+
+    assert result == {
+        "executor_name": "new-executor",
+        "executor_namespace": "wegent-pod",
+    }
 
 
 @pytest.mark.asyncio
@@ -249,7 +384,7 @@ async def test_recover_with_archive_persists_prepare_failure_detail():
         )
 
     assert result is None  # Failed recovery returns None
-    # Service still updates subtask on failure via _persist_prepare_failure
+    # Service still updates subtask on failure via _persist_recovery_failure
     assert (
         subtask.error_message
         == "executor-manager prepare failed: Kubernetes API error: webhook refused request_id=req-123"

--- a/backend/tests/services/execution/test_request_builder_fork_runtime.py
+++ b/backend/tests/services/execution/test_request_builder_fork_runtime.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 from app.models.task import TaskResource
 from app.services.execution.request_builder import TaskRequestBuilder
 
@@ -66,3 +68,54 @@ def test_request_builder_extracts_fork_runtime_and_inherited_sessions():
             "threadId": "codex-thread",
         }
     ]
+
+
+def test_request_builder_extracts_latest_persisted_executor_sessions_first():
+    subtasks = [
+        SimpleNamespace(
+            result={
+                "executor_session": {
+                    "agent": "ClaudeCode",
+                    "botId": 654,
+                    "sessionId": "claude-session-old",
+                }
+            }
+        ),
+        SimpleNamespace(result={"executor_session": None}),
+        SimpleNamespace(
+            result={
+                "executor_session": {
+                    "agent": "ClaudeCode",
+                    "botId": 654,
+                    "sessionId": "claude-session-new",
+                }
+            }
+        ),
+    ]
+
+    sessions = TaskRequestBuilder._extract_persisted_sessions(subtasks)
+
+    assert sessions == [
+        {
+            "agent": "ClaudeCode",
+            "botId": 654,
+            "sessionId": "claude-session-new",
+        },
+        {
+            "agent": "ClaudeCode",
+            "botId": 654,
+            "sessionId": "claude-session-old",
+        },
+    ]
+
+
+def test_request_builder_merges_fork_and_persisted_sessions_without_duplicates():
+    session = {
+        "agent": "ClaudeCode",
+        "botId": 654,
+        "sessionId": "claude-session-1",
+    }
+
+    sessions = TaskRequestBuilder._merge_inherited_sessions([session], [session])
+
+    assert sessions == [session]

--- a/backend/tests/services/workspace_archive/test_archive_service.py
+++ b/backend/tests/services/workspace_archive/test_archive_service.py
@@ -6,11 +6,12 @@
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.services.workspace_archive import archive_service
+from app.services.workspace_archive.archive_service import archive_storage_service
 
 
 def _build_task(expires_at: str) -> SimpleNamespace:
@@ -70,7 +71,7 @@ async def test_restore_workspace_rejects_expired_archive():
         executor_namespace="default",
     )
 
-    assert result is False
+    assert result is None
 
 
 def test_check_archive_available_accepts_future_archive():
@@ -83,3 +84,35 @@ def test_check_archive_available_accepts_future_archive():
     assert available is True
     assert storage_key == "workspace-archives/22/archive.tar.gz"
     assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_restore_workspace_returns_executor_restore_details(mocker):
+    expires_at = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    task = _build_task(expires_at)
+    restore_details = {
+        "success": True,
+        "session_restored": True,
+        "git_restored": True,
+    }
+    mocker.patch.object(archive_storage_service, "archive_exists", return_value=True)
+    mocker.patch.object(
+        archive_storage_service,
+        "generate_download_url",
+        return_value="https://storage.example/archive.tar.gz",
+    )
+    restore_mock = mocker.patch.object(
+        archive_service,
+        "_call_executor_restore",
+        new=AsyncMock(return_value=restore_details),
+    )
+
+    result = await archive_service.restore_workspace(
+        db=MagicMock(),
+        task=task,
+        executor_name="executor-22",
+        executor_namespace="default",
+    )
+
+    assert result == restore_details
+    restore_mock.assert_awaited_once()

--- a/executor/src/claude_session.rs
+++ b/executor/src/claude_session.rs
@@ -4,7 +4,7 @@
 
 use std::{env, fs, path::PathBuf};
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::protocol::ExecutionRequest;
 
@@ -33,6 +33,18 @@ pub(crate) fn save_session_id(request: &ExecutionRequest, session_id: &str) {
     }
 }
 
+pub(crate) fn saved_executor_session(request: &ExecutionRequest) -> Option<Value> {
+    let session_id = read_session_file(request)?;
+    let mut session = json!({
+        "agent": "ClaudeCode",
+        "sessionId": session_id,
+    });
+    if let Some(bot_id) = bot_id(&request.bot) {
+        session["botId"] = Value::String(bot_id);
+    }
+    Some(session)
+}
+
 pub(crate) fn preferred_task_dir(request: &ExecutionRequest) -> Option<PathBuf> {
     let task_id = task_session_identifier(&request.task_id)?;
 
@@ -45,6 +57,9 @@ pub(crate) fn preferred_task_dir(request: &ExecutionRequest) -> Option<PathBuf> 
 fn read_session_file(request: &ExecutionRequest) -> Option<String> {
     for path in readable_session_file_candidates(request) {
         let Some(value) = read_trimmed_file(path) else {
+            continue;
+        };
+        let Some(value) = safe_session_identifier(&value) else {
             continue;
         };
         return Some(value);

--- a/executor/src/emitter/mod.rs
+++ b/executor/src/emitter/mod.rs
@@ -34,6 +34,7 @@ pub struct ResponsesEventBuilder {
     message_id: Option<i64>,
     executor_name: Option<String>,
     executor_namespace: Option<String>,
+    executor_session: Option<Value>,
     validation_id: Option<String>,
 }
 
@@ -55,6 +56,7 @@ impl ResponsesEventBuilder {
             message_id: None,
             executor_name: None,
             executor_namespace: None,
+            executor_session: None,
             validation_id: None,
         }
     }
@@ -76,6 +78,11 @@ impl ResponsesEventBuilder {
     ) -> Self {
         self.executor_name = executor_name.map(ToOwned::to_owned);
         self.executor_namespace = executor_namespace.map(ToOwned::to_owned);
+        self
+    }
+
+    pub fn with_executor_session(mut self, executor_session: Option<Value>) -> Self {
+        self.executor_session = executor_session;
         self
     }
 
@@ -414,14 +421,18 @@ impl ResponsesEventBuilder {
     }
 
     fn response_payload(&self, status: &str, output: Value) -> Value {
-        json!({
+        let mut response = json!({
             "id": self.response_id,
             "object": "response",
             "created_at": self.created_at,
             "model": self.model,
             "status": status,
             "output": output
-        })
+        });
+        if let Some(executor_session) = &self.executor_session {
+            response["executor_session"] = executor_session.clone();
+        }
+        response
     }
 }
 

--- a/executor/src/envd/archive.rs
+++ b/executor/src/envd/archive.rs
@@ -21,6 +21,7 @@ pub enum ArchiveMode {
 #[derive(Debug, Clone)]
 pub struct ArchiveOptions {
     pub mode: ArchiveMode,
+    pub task_id: String,
     pub workspace_path: PathBuf,
     pub home_path: PathBuf,
     pub max_size_bytes: u64,
@@ -75,31 +76,34 @@ pub fn create_runtime_archive(options: ArchiveOptions) -> Result<RuntimeArchive,
     // Dereferencing a dangling symlink fails to read the (missing) target and
     // aborts the whole archive; storing the link itself always succeeds.
     builder.follow_symlinks(false);
-    let mut session_file_included = false;
-    let mut git_included = false;
+    let mut contents = ArchiveContents::default();
     let mut member_count = 0usize;
 
     if options.home_path.exists() {
         member_count += append_tree(
             &mut builder,
-            &options.home_path,
-            Path::new("home"),
-            TreeKind::Home,
-            options.mode,
-            &mut session_file_included,
-            &mut git_included,
+            ArchiveTreeContext {
+                source_root: &options.home_path,
+                archive_root: Path::new("home"),
+                kind: TreeKind::Home,
+                mode: options.mode,
+                task_id: &options.task_id,
+            },
+            &mut contents,
         )?;
     }
 
     if options.workspace_path.is_dir() {
         member_count += append_tree(
             &mut builder,
-            &options.workspace_path,
-            Path::new("workspace"),
-            TreeKind::Workspace,
-            options.mode,
-            &mut session_file_included,
-            &mut git_included,
+            ArchiveTreeContext {
+                source_root: &options.workspace_path,
+                archive_root: Path::new("workspace"),
+                kind: TreeKind::Workspace,
+                mode: options.mode,
+                task_id: &options.task_id,
+            },
+            &mut contents,
         )?;
     }
     if options.mode == ArchiveMode::Sandbox && member_count == 0 {
@@ -119,14 +123,15 @@ pub fn create_runtime_archive(options: ArchiveOptions) -> Result<RuntimeArchive,
 
     Ok(RuntimeArchive {
         bytes,
-        session_file_included,
-        git_included,
+        session_file_included: contents.session_file_included,
+        git_included: contents.git_included,
     })
 }
 
 pub fn restore_runtime_archive(
     bytes: &[u8],
     mode: ArchiveMode,
+    task_id: &str,
     workspace_path: &Path,
     home_path: &Path,
 ) -> Result<RestoreResult, ArchiveError> {
@@ -140,28 +145,36 @@ pub fn restore_runtime_archive(
 
     for entry in archive.entries()? {
         let mut entry = entry?;
-        if !is_restorable_entry(entry.header().entry_type()) {
+        let entry_type = entry.header().entry_type();
+        if !is_restorable_entry(entry_type) {
             continue;
         }
 
         let path = entry.path()?.to_path_buf();
-        if is_session_archive_member(&path) {
-            session_restored = true;
+        let session_member = is_session_archive_member(&path, task_id);
+        if session_member && !entry_type.is_file() {
+            continue;
         }
-        if has_component(&path, ".git") {
-            git_restored = true;
-        }
-        let Some(destination) = destination_for_member(&path, mode, workspace_path, home_path)
+        let Some(destination) =
+            destination_for_member(&path, mode, task_id, workspace_path, home_path)
         else {
             continue;
         };
+        if has_component(&path, ".git") {
+            git_restored = true;
+        }
 
         if let Some(parent) = destination.path.parent() {
             fs::create_dir_all(parent)?;
         }
         entry.unpack(&destination.path)?;
-
-        let _ = destination;
+        if session_member {
+            if is_valid_session_marker_file(&destination.path) {
+                session_restored = true;
+            } else {
+                let _ = fs::remove_file(&destination.path);
+            }
+        }
     }
 
     Ok(RestoreResult {
@@ -181,34 +194,34 @@ struct Destination {
     path: PathBuf,
 }
 
-fn append_tree(
-    builder: &mut Builder<GzEncoder<Vec<u8>>>,
-    source_root: &Path,
-    archive_root: &Path,
+#[derive(Clone, Copy)]
+struct ArchiveTreeContext<'a> {
+    source_root: &'a Path,
+    archive_root: &'a Path,
     kind: TreeKind,
     mode: ArchiveMode,
-    session_file_included: &mut bool,
-    git_included: &mut bool,
+    task_id: &'a str,
+}
+
+#[derive(Default)]
+struct ArchiveContents {
+    session_file_included: bool,
+    git_included: bool,
+}
+
+fn append_tree(
+    builder: &mut Builder<GzEncoder<Vec<u8>>>,
+    context: ArchiveTreeContext<'_>,
+    contents: &mut ArchiveContents,
 ) -> Result<usize, ArchiveError> {
     let mut member_count = 0;
-    for path in collect_direct_children(source_root)? {
-        let relative = path.strip_prefix(source_root).unwrap_or(&path);
-        if should_skip_archive_member(kind, mode, relative) {
+    for path in collect_direct_children(context.source_root)? {
+        let relative = path.strip_prefix(context.source_root).unwrap_or(&path);
+        if should_skip_archive_member(context.kind, context.mode, context.task_id, relative) {
             continue;
         }
 
-        if relative
-            .file_name()
-            .is_some_and(|name| name.to_string_lossy().starts_with(".claude_session_id"))
-        {
-            *session_file_included = true;
-        }
-        if relative.file_name().is_some_and(|name| name == ".git") {
-            *git_included = true;
-        }
-
-        member_count +=
-            append_path_recursive(builder, source_root, &path, archive_root, kind, mode)?;
+        member_count += append_path_recursive(builder, &path, context, contents)?;
     }
     Ok(member_count)
 }
@@ -223,20 +236,28 @@ fn collect_direct_children(root: &Path) -> Result<Vec<PathBuf>, ArchiveError> {
 
 fn append_path_recursive(
     builder: &mut Builder<GzEncoder<Vec<u8>>>,
-    source_root: &Path,
     path: &Path,
-    archive_root: &Path,
-    kind: TreeKind,
-    mode: ArchiveMode,
+    context: ArchiveTreeContext<'_>,
+    contents: &mut ArchiveContents,
 ) -> Result<usize, ArchiveError> {
-    let relative = path.strip_prefix(source_root).unwrap_or(path);
-    if should_skip_archive_member(kind, mode, relative) {
+    let relative = path.strip_prefix(context.source_root).unwrap_or(path);
+    if should_skip_archive_member(context.kind, context.mode, context.task_id, relative) {
         return Ok(0);
     }
 
     let metadata = fs::symlink_metadata(path)?;
-    let archive_path = archive_root.join(relative);
+    let archive_path = context.archive_root.join(relative);
+    let session_member = is_session_relative_path(context.kind, relative, context.task_id);
+    if session_member && (!metadata.is_file() || !is_valid_session_marker_file(path)) {
+        return Ok(0);
+    }
+    if has_component(relative, ".git") {
+        contents.git_included = true;
+    }
     if metadata.is_file() || metadata.file_type().is_symlink() {
+        if session_member {
+            contents.session_file_included = true;
+        }
         builder.append_path_with_name(path, archive_path)?;
         return Ok(1);
     }
@@ -247,8 +268,7 @@ fn append_path_recursive(
     builder.append_dir(&archive_path, path)?;
     let mut member_count = 1;
     for child in collect_direct_children(path)? {
-        member_count +=
-            append_path_recursive(builder, source_root, &child, archive_root, kind, mode)?;
+        member_count += append_path_recursive(builder, &child, context, contents)?;
     }
     Ok(member_count)
 }
@@ -256,13 +276,14 @@ fn append_path_recursive(
 fn destination_for_member(
     member: &Path,
     mode: ArchiveMode,
+    task_id: &str,
     workspace_path: &Path,
     home_path: &Path,
 ) -> Option<Destination> {
     let clean = clean_relative_path(member)?;
     let (kind, relative) = split_member(&clean);
 
-    if should_skip_restore_member(kind, mode, &relative) {
+    if should_skip_restore_member(kind, mode, task_id, &relative) {
         return None;
     }
 
@@ -289,30 +310,55 @@ fn split_member(path: &Path) -> (TreeKind, PathBuf) {
     (TreeKind::Workspace, path.to_owned())
 }
 
-fn should_skip_archive_member(kind: TreeKind, mode: ArchiveMode, relative: &Path) -> bool {
+fn should_skip_archive_member(
+    kind: TreeKind,
+    mode: ArchiveMode,
+    task_id: &str,
+    relative: &Path,
+) -> bool {
     if relative.as_os_str().is_empty() {
         return true;
     }
     if kind == TreeKind::Home
         && mode == ArchiveMode::Executor
-        && !is_executor_home_allowed(relative)
+        && !is_executor_home_allowed(relative, task_id)
     {
         return true;
     }
     should_exclude_archive_path(relative)
 }
 
-fn should_skip_restore_member(kind: TreeKind, mode: ArchiveMode, relative: &Path) -> bool {
+fn should_skip_restore_member(
+    kind: TreeKind,
+    mode: ArchiveMode,
+    task_id: &str,
+    relative: &Path,
+) -> bool {
     if relative.as_os_str().is_empty() || should_exclude_archive_path(relative) {
         return true;
     }
-    kind == TreeKind::Home && mode == ArchiveMode::Executor && !is_executor_home_allowed(relative)
+    kind == TreeKind::Home
+        && mode == ArchiveMode::Executor
+        && !is_executor_home_allowed(relative, task_id)
 }
 
-fn is_executor_home_allowed(relative: &Path) -> bool {
-    relative.components().next().is_some_and(|component| {
+fn is_executor_home_allowed(relative: &Path, task_id: &str) -> bool {
+    if relative.components().next().is_some_and(|component| {
         component.as_os_str() == ".claude" || component.as_os_str() == ".claude.json"
-    })
+    }) {
+        return true;
+    }
+
+    let executor_root = Path::new(".wegent-executor");
+    let sessions_root = executor_root.join("sessions");
+    let task_session_root = sessions_root.join(task_id);
+    relative == executor_root
+        || relative == sessions_root
+        || relative == task_session_root
+        || relative
+            .parent()
+            .is_some_and(|parent| parent == task_session_root)
+            && relative.file_name().is_some_and(is_session_marker_name)
 }
 
 fn should_exclude_archive_path(relative: &Path) -> bool {
@@ -365,9 +411,56 @@ fn is_restorable_entry(entry_type: EntryType) -> bool {
     entry_type.is_file() || entry_type.is_dir() || entry_type.is_symlink()
 }
 
-fn is_session_archive_member(path: &Path) -> bool {
-    path.file_name()
-        .is_some_and(|name| name.to_string_lossy().starts_with(".claude_session_id"))
+fn is_session_archive_member(path: &Path, task_id: &str) -> bool {
+    let Some(clean) = clean_relative_path(path) else {
+        return false;
+    };
+    let (kind, relative) = split_member(&clean);
+    is_session_relative_path(kind, &relative, task_id)
+}
+
+fn is_session_relative_path(kind: TreeKind, relative: &Path, task_id: &str) -> bool {
+    match kind {
+        TreeKind::Workspace => {
+            relative
+                .parent()
+                .is_some_and(|parent| parent.as_os_str().is_empty())
+                && relative.file_name().is_some_and(is_session_marker_name)
+        }
+        TreeKind::Home => {
+            let task_session_root = Path::new(".wegent-executor").join("sessions").join(task_id);
+            relative
+                .parent()
+                .is_some_and(|parent| parent == task_session_root)
+                && relative.file_name().is_some_and(is_session_marker_name)
+        }
+    }
+}
+
+fn is_session_marker_name(name: &std::ffi::OsStr) -> bool {
+    let name = name.to_string_lossy();
+    name == ".claude_session_id"
+        || name
+            .strip_prefix(".claude_session_id_")
+            .is_some_and(|suffix| {
+                !suffix.is_empty()
+                    && suffix
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            })
+}
+
+fn is_valid_session_marker_file(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .ok()
+        .is_some_and(|value| is_valid_session_identifier(value.trim()))
+}
+
+fn is_valid_session_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 fn has_component(path: &Path, component: &str) -> bool {

--- a/executor/src/local/backend/tasks.rs
+++ b/executor/src/local/backend/tasks.rs
@@ -13,8 +13,9 @@ use serde_json::Value;
 use tokio::task::JoinHandle;
 
 use crate::{
+    claude_session,
     emitter::{EventEnvelope, ResponsesEventBuilder},
-    protocol::{ExecutionRequest, TaskStatus},
+    protocol::{AgentKind, ExecutionRequest, TaskStatus},
     runner::{AgentEngine, EventSink, ExecutionOutcome},
     server::{RunnerResult, TaskRunner},
 };
@@ -269,9 +270,14 @@ async fn run_managed_task<E, S>(
     S: EventSink,
 {
     let task_id = request.task_id.clone();
+    let session_request = request.clone();
     let outcome = engine
         .run_with_events(request, sink.clone(), builder.clone())
         .await;
+    let executor_session = (session_request.resolved_agent_kind() == AgentKind::ClaudeCode)
+        .then(|| claude_session::saved_executor_session(&session_request))
+        .flatten();
+    let builder = builder.with_executor_session(executor_session);
     running_tasks.remove(&task_id);
     {
         let mut guard = handles.lock().expect("managed task lock");

--- a/executor/src/runner/mod.rs
+++ b/executor/src/runner/mod.rs
@@ -12,9 +12,10 @@ use std::{
 use tokio::{sync::oneshot, task::JoinHandle};
 
 use crate::{
+    claude_session,
     emitter::{EventEnvelope, ResponsesEventBuilder},
     logging::{log_executor_event, task_fields},
-    protocol::{ExecutionRequest, TaskStatus},
+    protocol::{AgentKind, ExecutionRequest, TaskStatus},
     server::{RunnerResult, TaskRunner},
 };
 
@@ -196,9 +197,14 @@ async fn run_in_background<E, S>(
     let _ = start_rx.await;
     let fields = task_fields(&request.task_id, &request.subtask_id);
     log_executor_event("background task started", &fields);
+    let session_request = request.clone();
     let outcome = engine
         .run_with_events(request, sink.clone(), builder.clone())
         .await;
+    let executor_session = (session_request.resolved_agent_kind() == AgentKind::ClaudeCode)
+        .then(|| claude_session::saved_executor_session(&session_request))
+        .flatten();
+    let builder = builder.with_executor_session(executor_session);
     let mut outcome_fields = fields.clone();
     outcome_fields.push(("outcome", outcome_name(&outcome).to_owned()));
     log_executor_event("background task finished", &outcome_fields);

--- a/executor/src/server/mod.rs
+++ b/executor/src/server/mod.rs
@@ -831,6 +831,7 @@ async fn archive_workspace(
     let mode = parse_archive_mode(&request.runtime_type)?;
     let archive = create_runtime_archive(ArchiveOptions {
         mode,
+        task_id: request.task_id.to_string(),
         workspace_path: task_workspace_path(request.task_id),
         home_path: runtime_home_path(mode),
         max_size_bytes: u64::from(request.max_size_mb) * 1024 * 1024,
@@ -892,6 +893,7 @@ async fn restore_workspace(
     let result = restore_runtime_archive(
         &bytes,
         mode,
+        &request.task_id.to_string(),
         &task_workspace_path(request.task_id),
         &runtime_home_path(mode),
     )

--- a/executor/tests/emitter_contract.rs
+++ b/executor/tests/emitter_contract.rs
@@ -53,7 +53,14 @@ fn callback_events_include_validation_id() {
 
 #[test]
 fn response_completed_event_contains_message_output() {
-    let builder = ResponsesEventBuilder::new("1", "2", "gpt-5").with_response_id("resp_done");
+    let executor_session = json!({
+        "agent": "ClaudeCode",
+        "botId": "987",
+        "sessionId": "claude-session-1"
+    });
+    let builder = ResponsesEventBuilder::new("1", "2", "gpt-5")
+        .with_response_id("resp_done")
+        .with_executor_session(Some(executor_session.clone()));
 
     let event = builder.response_completed("finished");
 
@@ -65,12 +72,19 @@ fn response_completed_event_contains_message_output() {
         json!("finished")
     );
     assert_eq!(event.data["response"]["output"][0]["id"], json!("msg_2"));
+    assert_eq!(event.data["response"]["executor_session"], executor_session);
 }
 
 #[test]
 fn response_waiting_for_user_input_event_marks_silent_exit() {
-    let builder =
-        ResponsesEventBuilder::new("1", "2", "claude-sonnet-4").with_response_id("resp_waiting");
+    let executor_session = json!({
+        "agent": "ClaudeCode",
+        "botId": "987",
+        "sessionId": "claude-session-1"
+    });
+    let builder = ResponsesEventBuilder::new("1", "2", "claude-sonnet-4")
+        .with_response_id("resp_waiting")
+        .with_executor_session(Some(executor_session.clone()));
 
     let event = builder.response_waiting_for_user_input("tool_deferred");
 
@@ -87,6 +101,7 @@ fn response_waiting_for_user_input_event_marks_silent_exit() {
         event.data["response"]["silent_exit_reason"],
         json!("waiting_for_user_input")
     );
+    assert_eq!(event.data["response"]["executor_session"], executor_session);
 }
 
 #[test]

--- a/executor/tests/envd_archive_contract.rs
+++ b/executor/tests/envd_archive_contract.rs
@@ -20,13 +20,26 @@ use std::os::unix::fs::symlink;
 #[test]
 fn executor_archive_includes_workspace_and_sanitized_claude_home() {
     let root = temp_root("executor-archive");
-    let workspace = root.join("workspace").join("1385");
+    let task_id = "1385";
+    let workspace = root.join("workspace").join(task_id);
     let home = root.join("home");
     write_file(
         &workspace.join(".claude/workspace-memory.md"),
         "workspace-context",
     );
-    write_file(&workspace.join(".claude_session_id"), "session-id");
+    let session_file = home
+        .join(".wegent-executor/sessions")
+        .join(task_id)
+        .join(".claude_session_id_987");
+    write_file(&session_file, "session-id");
+    write_file(
+        &home.join(".wegent-executor/sessions/other-task/.claude_session_id_987"),
+        "other-session",
+    );
+    write_file(
+        &home.join(".wegent-executor/sessions/1385/request.json"),
+        "sensitive-runtime-state",
+    );
     write_file(&workspace.join(".git/HEAD"), "ref: refs/heads/main");
     write_file(&workspace.join("node_modules/skip.txt"), "skip");
     write_file(&home.join(".claude/home-memory.md"), "home-context");
@@ -41,6 +54,7 @@ fn executor_archive_includes_workspace_and_sanitized_claude_home() {
 
     let archive = create_runtime_archive(ArchiveOptions {
         mode: ArchiveMode::Executor,
+        task_id: task_id.to_owned(),
         workspace_path: workspace.clone(),
         home_path: home.clone(),
         max_size_bytes: 10 * 1024 * 1024,
@@ -51,7 +65,9 @@ fn executor_archive_includes_workspace_and_sanitized_claude_home() {
     assert!(archive.session_file_included);
     assert!(archive.git_included);
     assert!(names.contains(&"workspace/.claude/workspace-memory.md".to_owned()));
-    assert!(names.contains(&"workspace/.claude_session_id".to_owned()));
+    assert!(
+        names.contains(&"home/.wegent-executor/sessions/1385/.claude_session_id_987".to_owned())
+    );
     assert!(names.contains(&"workspace/.git/HEAD".to_owned()));
     assert!(names.contains(&"home/.claude/home-memory.md".to_owned()));
     assert!(names.contains(&"home/.claude.json".to_owned()));
@@ -60,15 +76,24 @@ fn executor_archive_includes_workspace_and_sanitized_claude_home() {
     assert!(!names.contains(&"home/.ssh/id_rsa".to_owned()));
     assert!(!names.contains(&"home/.npmrc".to_owned()));
     assert!(!names.contains(&"home/.local/share/code-server/cert/tls.crt".to_owned()));
+    assert!(!names
+        .contains(&"home/.wegent-executor/sessions/other-task/.claude_session_id_987".to_owned()));
+    assert!(!names.contains(&"home/.wegent-executor/sessions/1385/request.json".to_owned()));
 
     fs::remove_dir_all(workspace.join(".claude")).unwrap();
-    fs::remove_file(workspace.join(".claude_session_id")).unwrap();
     fs::remove_dir_all(workspace.join(".git")).unwrap();
     fs::remove_dir_all(home.join(".claude")).unwrap();
     fs::remove_file(home.join(".claude.json")).unwrap();
+    fs::remove_dir_all(home.join(".wegent-executor")).unwrap();
 
-    let restored =
-        restore_runtime_archive(&archive.bytes, ArchiveMode::Executor, &workspace, &home).unwrap();
+    let restored = restore_runtime_archive(
+        &archive.bytes,
+        ArchiveMode::Executor,
+        task_id,
+        &workspace,
+        &home,
+    )
+    .unwrap();
 
     assert!(restored.success);
     assert!(restored.session_restored);
@@ -89,6 +114,11 @@ fn executor_archive_includes_workspace_and_sanitized_claude_home() {
         fs::read_to_string(home.join(".claude.json")).unwrap(),
         r#"{"theme":"dark"}"#
     );
+    assert_eq!(fs::read_to_string(session_file).unwrap(), "session-id");
+    assert!(!home.join(".wegent-executor/sessions/other-task").exists());
+    assert!(!home
+        .join(".wegent-executor/sessions/1385/request.json")
+        .exists());
 }
 
 #[test]
@@ -103,6 +133,7 @@ fn sandbox_archive_includes_workspace_and_home_but_excludes_runtime_directories(
 
     let archive = create_runtime_archive(ArchiveOptions {
         mode: ArchiveMode::Sandbox,
+        task_id: "4680".to_owned(),
         workspace_path: workspace.clone(),
         home_path: home.clone(),
         max_size_bytes: 10 * 1024 * 1024,
@@ -118,7 +149,14 @@ fn sandbox_archive_includes_workspace_and_home_but_excludes_runtime_directories(
     fs::remove_file(workspace.join("project.txt")).unwrap();
     fs::remove_file(home.join("notes.md")).unwrap();
 
-    restore_runtime_archive(&archive.bytes, ArchiveMode::Sandbox, &workspace, &home).unwrap();
+    restore_runtime_archive(
+        &archive.bytes,
+        ArchiveMode::Sandbox,
+        "4680",
+        &workspace,
+        &home,
+    )
+    .unwrap();
 
     assert_eq!(
         fs::read_to_string(workspace.join("project.txt")).unwrap(),
@@ -139,8 +177,14 @@ fn restore_supports_legacy_archive_without_workspace_prefix() {
     fs::create_dir_all(&home).unwrap();
     let archive = legacy_archive();
 
-    let restored =
-        restore_runtime_archive(&archive, ArchiveMode::Executor, &workspace, &home).unwrap();
+    let restored = restore_runtime_archive(
+        &archive,
+        ArchiveMode::Executor,
+        "5728299",
+        &workspace,
+        &home,
+    )
+    .unwrap();
 
     assert!(restored.success);
     assert!(restored.session_restored);
@@ -171,6 +215,7 @@ fn archive_rejects_missing_workspace_and_max_size_overflow() {
 
     let missing = create_runtime_archive(ArchiveOptions {
         mode: ArchiveMode::Executor,
+        task_id: "3579".to_owned(),
         workspace_path: workspace.clone(),
         home_path: home.clone(),
         max_size_bytes: 1024,
@@ -181,6 +226,7 @@ fn archive_rejects_missing_workspace_and_max_size_overflow() {
     write_file(&workspace.join("keep.txt"), "keep");
     let too_large = create_runtime_archive(ArchiveOptions {
         mode: ArchiveMode::Executor,
+        task_id: "3579".to_owned(),
         workspace_path: workspace,
         home_path: home,
         max_size_bytes: 0,
@@ -201,9 +247,15 @@ fn restore_skips_unsafe_home_members_from_old_archives() {
         ("home/.local/share/code-server/cert/tls.crt", "runtime-cert"),
         ("home/.ssh/id_rsa", "secret"),
         ("home/.claude/home-memory.md", "claude-home"),
+        (
+            "home/.wegent-executor/sessions/9764/.claude_session_id_987",
+            "invalid session id",
+        ),
     ]);
 
-    restore_runtime_archive(&archive, ArchiveMode::Executor, &workspace, &home).unwrap();
+    let restored =
+        restore_runtime_archive(&archive, ArchiveMode::Executor, "9764", &workspace, &home)
+            .unwrap();
 
     assert_eq!(
         fs::read_to_string(workspace.join("keep.txt")).unwrap(),
@@ -215,6 +267,10 @@ fn restore_skips_unsafe_home_members_from_old_archives() {
     );
     assert!(!home.join(".local/share/code-server").exists());
     assert!(!home.join(".ssh").exists());
+    assert!(!restored.session_restored);
+    assert!(!home
+        .join(".wegent-executor/sessions/9764/.claude_session_id_987")
+        .exists());
 }
 
 #[cfg(unix)]
@@ -235,6 +291,7 @@ fn archive_includes_symlink_entries_without_following_targets() {
 
     let archive = create_runtime_archive(ArchiveOptions {
         mode: ArchiveMode::Sandbox,
+        task_id: "2490".to_owned(),
         workspace_path: workspace,
         home_path: home,
         max_size_bytes: 10 * 1024 * 1024,
@@ -264,6 +321,7 @@ fn archive_survives_dangling_symlinks() {
 
     let archive = create_runtime_archive(ArchiveOptions {
         mode: ArchiveMode::Sandbox,
+        task_id: "10170482707511".to_owned(),
         workspace_path: workspace,
         home_path: home,
         max_size_bytes: 10 * 1024 * 1024,
@@ -273,6 +331,36 @@ fn archive_survives_dangling_symlinks() {
 
     assert!(names.contains(&"workspace/keep.txt".to_owned()));
     assert!(names.contains(&"workspace/.gitlab/CLAUDE.md".to_owned()));
+}
+
+#[cfg(unix)]
+#[test]
+fn executor_archive_excludes_symlink_session_markers() {
+    let root = temp_root("executor-session-symlink");
+    let task_id = "1385";
+    let workspace = root.join("workspace").join(task_id);
+    let home = root.join("home");
+    let marker = home.join(".wegent-executor/sessions/1385/.claude_session_id_987");
+    let outside = root.join("outside-session");
+    write_file(&workspace.join("keep.txt"), "keep");
+    write_file(&outside, "session-id");
+    fs::create_dir_all(marker.parent().unwrap()).unwrap();
+    symlink(&outside, &marker).unwrap();
+
+    let archive = create_runtime_archive(ArchiveOptions {
+        mode: ArchiveMode::Executor,
+        task_id: task_id.to_owned(),
+        workspace_path: workspace,
+        home_path: home,
+        max_size_bytes: 10 * 1024 * 1024,
+    })
+    .unwrap();
+    let names = archive_names(&archive.bytes);
+
+    assert!(!archive.session_file_included);
+    assert!(
+        !names.contains(&"home/.wegent-executor/sessions/1385/.claude_session_id_987".to_owned())
+    );
 }
 
 fn archive_names(bytes: &[u8]) -> Vec<String> {


### PR DESCRIPTION
## Summary
- persist completed Claude Code executor session metadata so backend recovery can reuse the same session after executor deletion
- archive and restore only validated, task-scoped session markers while returning detailed restore results
- fail closed when a Claude continuation cannot recover matching session context instead of silently starting a new session
- keep Wework desktop diagnostics uploads non-blocking so ArtifactService outages cannot override successful E2E checkpoints

## Testing
- `cd backend && uv run pytest tests/api/endpoints/internal/test_workspace_archives_api.py tests/services/execution/test_recovery_service.py tests/services/execution/test_request_builder_fork_runtime.py tests/services/workspace_archive/test_archive_service.py -q` (17 passed)
- Backend Black and isort checks
- `cd executor && cargo test`
- scoped pre-push gate: Backend format/syntax, Executor fmt/all-features lib tests/clippy, Alembic multi-head
- workflow YAML policy assertion, Prettier, and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude Code sessions can now be preserved and resumed during workspace recovery.
  - Archived workspaces restore task-specific session context and report detailed restoration status.
  - Execution responses can include restored executor session information.

- **Bug Fixes**
  - Improved validation prevents invalid or mismatched session identifiers from being restored.
  - Prevented unrelated or sensitive session data from being included in archives.
  - Diagnostic artifact upload failures no longer fail end-to-end jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->