### PR TITLE
fix(wework): expose release signing keychain

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -216,6 +216,12 @@ jobs:
           security create-keychain -p "$keychain_password" "$keychain_path"
           security set-keychain-settings -lut 21600 "$keychain_path"
           security unlock-keychain -p "$keychain_password" "$keychain_path"
+          existing_keychains=()
+          while IFS= read -r existing_keychain; do
+            existing_keychains+=("$existing_keychain")
+          done < <(security list-keychains -d user |
+            sed -E 's/^[[:space:]]*"([^"]+)"$/\1/')
+          security list-keychains -d user -s "$keychain_path" "${existing_keychains[@]}"
           security import "$certificate_path" \
             -k "$keychain_path" \
             -P "$MACOS_CERTIFICATE_PASSWORD" \

--- a/wework/electron/scripts/build-release.mjs
+++ b/wework/electron/scripts/build-release.mjs
@@ -2,11 +2,14 @@ import { spawn } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { wrapWindowsScriptCommand } from '../../scripts/child-process-command.mjs'
+
 const electronRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const requestedPlatform = process.env.WEWORK_RELEASE_PLATFORM?.trim()
 const requestedArch = process.env.WEWORK_RELEASE_ARCH?.trim()
 const platform = requestedPlatform || process.platform
 const arch = requestedArch || process.arch
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const platformFlag = {
   darwin: '--mac',
   macos: '--mac',
@@ -23,7 +26,7 @@ if (!['arm64', 'x64'].includes(arch)) {
 }
 
 await run(
-  'pnpm',
+  pnpmCommand,
   [
     'exec',
     'electron-builder',
@@ -39,7 +42,8 @@ await run(
 
 function run(command, args, cwd) {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, { cwd, stdio: 'inherit' })
+    const resolved = wrapWindowsScriptCommand(command, args)
+    const child = spawn(resolved.command, resolved.args, { cwd, stdio: 'inherit' })
     child.once('error', reject)
     child.once('exit', code => {
       if (code === 0) resolvePromise()

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -50,12 +50,21 @@ class FakeWebContents extends EventEmitter {
   getTitle = vi.fn(() => '')
   getURL = vi.fn(() => this.url)
   isDestroyed = vi.fn(() => this.destroyed)
+  isDevToolsOpened = vi.fn(() => this.devToolsOpened)
   isLoading = vi.fn(() => true)
   loadURL = vi.fn<(url: string) => Promise<void>>()
+  openDevTools = vi.fn(() => {
+    this.devToolsOpened = true
+  })
+  closeDevTools = vi.fn(() => {
+    this.devToolsOpened = false
+  })
   capturePage = vi.fn()
   reload = vi.fn()
   setWindowOpenHandler = vi.fn()
   setZoomFactor = vi.fn()
+  devToolsWebContents: object | null = {}
+  private devToolsOpened = false
 
   commitUrl(url: string): void {
     this.url = url
@@ -189,5 +198,43 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     expect(contents.capturePage).toHaveBeenCalledOnce()
     expect(contents.debugger.sendCommand).not.toHaveBeenCalled()
     await rm(directory, { recursive: true, force: true })
+  })
+
+  test('waits for browser layout to settle before verifying a detached Inspector', async () => {
+    vi.useFakeTimers()
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    try {
+      const manager = new EmbeddedBrowserManager(directory)
+      const contents = new FakeWebContents()
+      contents.loadURL.mockImplementation(async url => {
+        contents.commitUrl(url)
+      })
+      manager.attach('workspace-browser', contents as unknown as WebContents)
+      await manager.open({
+        label: 'workspace-browser',
+        url: 'https://example.test/',
+        bounds: { x: 0, y: 0, width: 800, height: 600 },
+        visible: true,
+        navigateExisting: true,
+      })
+
+      const verification = manager.verifyDetachedInspector('workspace-browser')
+      setTimeout(() => {
+        manager.setBounds('workspace-browser', { x: 0, y: 0, width: 801, height: 600 }, true)
+      }, 600)
+      await vi.advanceTimersByTimeAsync(2_500)
+
+      await expect(verification).resolves.toMatchObject({
+        beforeFrame: [0, 0, 801, 600],
+        afterFrame: [0, 0, 801, 600],
+        visible: true,
+        closedVisible: false,
+      })
+      expect(contents.openDevTools).toHaveBeenCalledWith({ mode: 'detach', activate: true })
+      expect(contents.closeDevTools).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 })

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -554,7 +554,7 @@ export class EmbeddedBrowserManager {
   }> {
     const entry = this.required(this.activeLabel(label))
     const contents = entry.contents
-    const beforeFrame = browserFrame(entry.bounds)
+    const beforeFrame = await waitForSettledFrame(entry, 5_000)
     const beforeWindowCount = this.nativeWindowCount()
     contents.openDevTools({ mode: 'detach', activate: true })
     await waitForState(
@@ -821,7 +821,31 @@ async function waitForStableFrame(
     }
     await new Promise(resolve => setTimeout(resolve, 50))
   }
-  throw new Error('Detached embedded browser Inspector changed the browser frame')
+  throw new Error(
+    `Detached embedded browser Inspector changed the browser frame: expected=${expectedFrame.join(
+      ','
+    )} actual=${browserFrame(entry.bounds).join(',')}`
+  )
+}
+
+async function waitForSettledFrame(entry: BrowserEntry, timeoutMs: number): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs
+  let frame = browserFrame(entry.bounds)
+  let stableSamples = 0
+  while (Date.now() <= deadline) {
+    const currentFrame = browserFrame(entry.bounds)
+    if (currentFrame.every((value, index) => value === frame[index])) {
+      stableSamples += 1
+      if (stableSamples >= 20) return currentFrame
+    } else {
+      frame = currentFrame
+      stableSamples = 1
+    }
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+  throw new Error(
+    `Timed out waiting for embedded browser frame to settle: actual=${frame.join(',')}`
+  )
 }
 
 function validBounds(bounds: BrowserBounds): BrowserBounds {

--- a/wework/scripts/deepseek-harness-signing.test.mjs
+++ b/wework/scripts/deepseek-harness-signing.test.mjs
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
+  macosCodesignIdentityArguments,
   macosCodesignKeychainArguments,
   macosSigningFingerprint,
   signPreparedMacOsBinaries,
@@ -45,6 +46,22 @@ describe('macosCodesignKeychainArguments', () => {
 
   test('uses the default keychain search list when no path is configured', () => {
     expect(macosCodesignKeychainArguments()).toEqual([])
+  })
+})
+
+describe('macosCodesignIdentityArguments', () => {
+  test('selects the keychain before resolving the signing identity', () => {
+    expect(
+      macosCodesignIdentityArguments(
+        'Developer ID Application: Example',
+        '/tmp/signing.keychain-db'
+      )
+    ).toEqual([
+      '--keychain',
+      '/tmp/signing.keychain-db',
+      '--sign',
+      'Developer ID Application: Example',
+    ])
   })
 })
 

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -78,7 +78,7 @@ describe('desktop resource migration', () => {
   test('signs the packaged Node runtime with the configured macOS keychain', async () => {
     const source = await readFile(join(weworkRoot, 'scripts/prepare-execution-runtime.mjs'), 'utf8')
 
-    expect(source).toContain('macosCodesignKeychainArguments(process.env.MACOS_KEYCHAIN_PATH)')
+    expect(source).toContain("identity === '-' ? undefined : process.env.MACOS_KEYCHAIN_PATH")
   })
 
   test('collects the electron-builder Linux x64 artifact name', async () => {

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -75,6 +75,13 @@ describe('desktop resource migration', () => {
     expect(source).toContain('wrapWindowsScriptCommand(command, args)')
   })
 
+  test('launches the release builder through the Windows command interpreter', async () => {
+    const source = await readFile(join(weworkRoot, 'electron/scripts/build-release.mjs'), 'utf8')
+
+    expect(source).toContain("process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'")
+    expect(source).toContain('wrapWindowsScriptCommand(command, args)')
+  })
+
   test('signs the packaged Node runtime with the configured macOS keychain', async () => {
     const source = await readFile(join(weworkRoot, 'scripts/prepare-execution-runtime.mjs'), 'utf8')
 

--- a/wework/scripts/lib/deepseek-harness-signing.mjs
+++ b/wework/scripts/lib/deepseek-harness-signing.mjs
@@ -59,6 +59,10 @@ export function macosCodesignKeychainArguments(keychainPath) {
   return normalizedPath ? ['--keychain', normalizedPath] : []
 }
 
+export function macosCodesignIdentityArguments(identity, keychainPath) {
+  return [...macosCodesignKeychainArguments(keychainPath), '--sign', identity]
+}
+
 export async function signPreparedMacOsBinaries(
   directory,
   {
@@ -77,8 +81,7 @@ export async function signPreparedMacOsBinaries(
     if (!description.includes('Mach-O')) continue
 
     const args = ['--force', '--timestamp', '--options', 'runtime']
-    args.push(...macosCodesignKeychainArguments(keychainPath))
-    args.push('--sign', identity, candidate)
+    args.push(...macosCodesignIdentityArguments(identity, keychainPath), candidate)
     logger(`Signing bundled DeepSeek Harness binary: ${path.relative(directory, candidate)}`)
     await execute('codesign', args, directory)
     signed.push(candidate)

--- a/wework/scripts/prepare-execution-runtime.mjs
+++ b/wework/scripts/prepare-execution-runtime.mjs
@@ -9,7 +9,7 @@ import { constants as zlibConstants, createGzip } from 'node:zlib'
 import { spawn } from 'node:child_process'
 
 import {
-  macosCodesignKeychainArguments,
+  macosCodesignIdentityArguments,
   macosSigningFingerprint,
 } from './lib/deepseek-harness-signing.mjs'
 
@@ -55,20 +55,18 @@ async function sha256(pathname) {
 async function signAndValidateNode(nodePath) {
   if (process.platform === 'darwin') {
     const identity = process.env.APPLE_SIGNING_IDENTITY?.trim() || '-'
-    const args = [
-      '--force',
-      '--options',
-      'runtime',
-      '--entitlements',
-      nodeEntitlements,
-      '--sign',
-      identity,
-    ]
+    const args = ['--force', '--options', 'runtime', '--entitlements', nodeEntitlements]
     if (identity !== '-') {
       args.splice(1, 0, '--timestamp')
-      args.push(...macosCodesignKeychainArguments(process.env.MACOS_KEYCHAIN_PATH))
     }
-    await run('codesign', [...args, nodePath])
+    args.push(
+      ...macosCodesignIdentityArguments(
+        identity,
+        identity === '-' ? undefined : process.env.MACOS_KEYCHAIN_PATH
+      ),
+      nodePath
+    )
+    await run('codesign', args)
   }
   await run(nodePath, ['-e', 'process.stdout.write(process.versions.node)'])
 }

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -165,6 +165,7 @@ describe('bundled plugin resources', () => {
     expect(workflow).toMatch(
       /- name: Prepare Apple signing keychain[\s\S]*?security import[\s\S]*?APPLE_SIGNING_IDENTITY=[\s\S]*?MACOS_KEYCHAIN_PATH=/
     )
+    expect(workflow).toContain('security list-keychains -d user -s')
     expect(workflow).toContain('generate-desktop-update-manifests.mjs')
     expect(workflow).toContain('TAURI_SIGNING_PRIVATE_KEY')
     expect(workflow).toContain('release-manifests/*')


### PR DESCRIPTION
## Summary

- register the temporary Developer ID keychain in the macOS user keychain search list
- emit `codesign --keychain ... --sign ...` in deterministic order for both bundled runtime paths
- retain explicit unit and workflow guards for the signing contract

## Evidence

Release run 32947860219 confirmed the previous fix reached `prepare-execution-runtime.mjs`, but `codesign` still reported `The specified item could not be found in the keychain`. The imported certificate was only present in the temporary keychain.

## Verification

- focused Vitest: 3 files, 38 tests passed
- focused ESLint passed
- actionlint passed
- pre-push Wework ESLint, TypeScript, and unit tests passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS signing now preserves existing user keychains while adding the temporary signing keychain.
  * Improved handling of ad-hoc signing identities during runtime packaging.
  * Maintained timestamp support for standard signing identities.
  * Improved Windows release builds by using the correct package manager command handling.

* **Tests**
  * Added coverage for keychain ordering, signing arguments, Windows builds, and release workflow keychain configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->