### PR TITLE
fix(wework): launch legacy signer on Windows

### DIFF
--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -100,6 +100,16 @@ describe('desktop resource migration', () => {
     expect(source).toContain('linux_${installerArchitecture}\\\\.AppImage')
   })
 
+  test('signs legacy updater assets through the Windows command interpreter', async () => {
+    const source = await readFile(
+      join(weworkRoot, 'scripts/prepare-desktop-release-assets.mjs'),
+      'utf8'
+    )
+
+    expect(source).toContain("process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'")
+    expect(source).toContain('wrapWindowsScriptCommand(command, args)')
+  })
+
   test('desktop E2E reuses packaged Harness runtime assets', async () => {
     const source = await readFile(
       join(weworkRoot, 'e2e/desktop/modules/desktop-build-flows.mjs'),

--- a/wework/scripts/prepare-desktop-release-assets.mjs
+++ b/wework/scripts/prepare-desktop-release-assets.mjs
@@ -6,8 +6,11 @@ import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { create } from 'tar'
 
+import { wrapWindowsScriptCommand } from './child-process-command.mjs'
+
 const weworkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const installerRoot = join(weworkRoot, 'electron', 'release-installer')
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const [platform, arch, version, outputDirectory] = process.argv.slice(2)
 
 if (!platform || !arch || !version || !outputDirectory) {
@@ -62,7 +65,7 @@ async function signBridge(path) {
     throw new Error('TAURI_SIGNING_PRIVATE_KEY is required for legacy updater bridge assets.')
   }
   await run(
-    'pnpm',
+    pnpmCommand,
     ['--dir', join(weworkRoot, 'electron'), 'exec', 'tauri', 'signer', 'sign', path],
     weworkRoot
   )
@@ -98,7 +101,8 @@ function escape(value) {
 
 function run(command, args, cwd) {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, { cwd, stdio: 'inherit' })
+    const resolved = wrapWindowsScriptCommand(command, args)
+    const child = spawn(resolved.command, resolved.args, { cwd, stdio: 'inherit' })
     child.once('error', reject)
     child.once('exit', code => {
       if (code === 0) resolvePromise()


### PR DESCRIPTION
## Summary

- run the legacy Tauri bridge signer through `pnpm.cmd` on Windows
- reuse the existing Windows script-command wrapper
- add a structural regression guard for the release asset signer

## Evidence

Beta release run 32952508459 built the Windows Electron installer successfully, then failed in `Prepare installer and legacy bridge assets` with `Error: spawn pnpm ENOENT`. The failing command was `pnpm --dir wework/electron exec tauri signer sign ...windows_x64-setup.exe`.

## Verification

- focused Vitest: 3 files, 36 tests passed
- focused ESLint passed
- `git diff --check` passed
- pre-push Wework ESLint and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows desktop release asset signing by using the appropriate platform-specific command wrapper.
  - Preserved existing signing behavior on non-Windows platforms.

- **Tests**
  - Added coverage to verify that legacy updater assets are signed correctly on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->