### PR TITLE
fix(wework): ignore stale running transcripts

### DIFF
--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
@@ -557,6 +557,113 @@ describe('RuntimeTaskLifecycleStore', () => {
     expect(snapshot?.derived.isBusy).toBe(false)
   })
 
+  test('ignores a stale streaming transcript after the current turn settles', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+
+    store.sendRequested(address)
+    store.sendAccepted(address)
+    store.turnStarted(address, 'turn-1')
+    store.turnSettled(address, 'turn-1', 'succeeded')
+    store.executorSettled(address)
+    store.syncTranscript(
+      address,
+      transcript({
+        running: true,
+        turns: [{ id: 'turn-1', items: [], status: 'streaming' }],
+      })
+    )
+
+    const snapshot = store.getTask(address)
+    expect(snapshot?.execution.phase).toBe('idle')
+    expect(snapshot?.turn.phase).toBe('idle')
+    expect(snapshot?.turn.outcome).toBe('succeeded')
+    expect(snapshot?.derived.isBusy).toBe(false)
+  })
+
+  test('does not revive authoritative completion from a stale streaming transcript', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+
+    store.syncRuntimeWork(
+      runtimeWork(
+        task({
+          running: false,
+          status: 'done',
+          completedAt: 1_787_200_000_000,
+          turnStatus: 'completed',
+        })
+      )
+    )
+    store.syncTranscript(
+      address,
+      transcript({
+        running: true,
+        turns: [{ id: 'stale-turn', items: [], status: 'streaming' }],
+      })
+    )
+
+    const snapshot = store.getTask(address)
+    expect(snapshot?.execution.phase).toBe('idle')
+    expect(snapshot?.turn.phase).toBe('idle')
+    expect(snapshot?.derived.isBusy).toBe(false)
+  })
+
+  test('recovers a streaming transcript after an explicit send restarts a completed task', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+
+    store.syncRuntimeWork(
+      runtimeWork(
+        task({
+          running: false,
+          status: 'done',
+          completedAt: 1_787_200_000_000,
+          turnStatus: 'completed',
+        })
+      )
+    )
+    store.sendRequested(address)
+    store.sendAccepted(address)
+    store.syncTranscript(
+      address,
+      transcript({
+        running: true,
+        turns: [{ id: 'turn-2', items: [], status: 'streaming' }],
+      })
+    )
+
+    const snapshot = store.getTask(address)
+    expect(snapshot?.execution.phase).toBe('running')
+    expect(snapshot?.turn.phase).toBe('streaming')
+    expect(snapshot?.turn.id).toBe('turn-2')
+  })
+
+  test('recovers a streaming transcript while an active Goal continues', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+
+    store.syncRuntimeWork(
+      runtimeWork(
+        task({
+          running: false,
+          status: 'done',
+          completedAt: 1_787_200_000_000,
+          turnStatus: 'completed',
+          goalStatus: 'active',
+        })
+      )
+    )
+    store.syncTranscript(
+      address,
+      transcript({
+        running: true,
+        turns: [{ id: 'goal-turn-2', items: [], status: 'streaming' }],
+      })
+    )
+
+    const snapshot = store.getTask(address)
+    expect(snapshot?.execution.phase).toBe('running')
+    expect(snapshot?.turn.phase).toBe('streaming')
+    expect(snapshot?.turn.id).toBe('goal-turn-2')
+  })
+
   test('ignores a stale running transcript snapshot after the current turn settles', () => {
     const store = new RuntimeTaskLifecycleStore('test')
 

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
@@ -6,7 +6,11 @@ import type {
   RuntimeWorkListResponse,
 } from '@/types/api'
 import type { RuntimePaneTranscript } from '@/types/workbench'
-import { normalizeRuntimeTaskSummary, shouldReplaceRuntimeTaskProjection } from './projection'
+import {
+  isRuntimeTaskAuthoritativeCompletion,
+  normalizeRuntimeTaskSummary,
+  shouldReplaceRuntimeTaskProjection,
+} from './projection'
 import { RuntimeTaskMachine, getRuntimeTaskLifecycleKey } from './RuntimeTaskMachine'
 import type {
   RuntimeTaskLifecycleEvent,
@@ -139,7 +143,7 @@ export class RuntimeTaskLifecycleStore {
   ): void {
     if (transcript.running === true) {
       const current = this.getTask(address)
-      if (current && current.turn.outcome !== null && !current.derived.isRunning) return
+      if (shouldIgnoreStaleRunningTranscript(current)) return
       this.executorStarted(address)
       return
     }
@@ -256,12 +260,15 @@ export class RuntimeTaskLifecycleStore {
       turn => turn.status === 'pending' || turn.status === 'streaming'
     )
     const hasStreamingTurn = Boolean(streamingTurn)
+    const current = this.getTask(address)
+    const ignoreStaleRunningTranscript = shouldIgnoreStaleRunningTranscript(current)
     const ignoreStaleIdleTranscript =
       transcript.running === false &&
       options.preserveActiveTurn === true &&
-      (this.getTask(address)?.derived.isRunning ?? false)
+      (current?.derived.isRunning ?? false)
 
     if (hasStreamingTurn) {
+      if (ignoreStaleRunningTranscript) return
       this.executorStarted(address)
       this.dispatch(address, {
         type: 'turn_recovered',
@@ -269,8 +276,7 @@ export class RuntimeTaskLifecycleStore {
         turnId: streamingTurn?.id,
       })
     } else if (transcript.running === true) {
-      const current = this.getTask(address)
-      if (current && current.turn.outcome !== null && !current.derived.isRunning) return
+      if (ignoreStaleRunningTranscript) return
       this.executorStarted(address)
     } else if (transcript.running === false && !ignoreStaleIdleTranscript) {
       this.executorSettled(address)
@@ -565,6 +571,17 @@ export function runtimeTaskLifecycleTransitionChanged(
     expected.turn.outcome !== current.turn.outcome ||
     expected.goalStatus !== current.goalStatus ||
     expected.continuable !== current.continuable
+  )
+}
+
+function shouldIgnoreStaleRunningTranscript(current: RuntimeTaskLifecycleSnapshot | null): boolean {
+  return Boolean(
+    current &&
+    !current.derived.isRunning &&
+    (current.turn.outcome !== null ||
+      (current.goalStatus !== 'active' &&
+        current.task !== null &&
+        isRuntimeTaskAuthoritativeCompletion(current.task)))
   )
 }
 


### PR DESCRIPTION
## Summary

- prevent late running or streaming transcript snapshots from reviving a settled runtime task
- preserve explicit follow-up sends and active Goal turn recovery
- add lifecycle regression coverage for stale streaming transcripts and valid recovery paths

## Verification

- pre-push Wework ESLint: passed
- pre-push Wework TypeScript: passed
- pre-push focused unit tests: passed
- `pnpm --filter wework test src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.test.tsx src/features/workbench/runtimePaneStatus.test.ts` (90 tests passed)
- `pnpm --filter wework exec prettier --check ...`: passed
- `pnpm --filter wework exec eslint ...`: passed
- Electron verification build completed successfully

## Desktop verification note

The existing `runtime-terminal-convergence` checkpoint was attempted with a freshly built Electron app, but the shared runner timed out during bootstrap waiting for `telemetry-consent-overlay` and never reached the scenario assertions. An isolated `ai:verify` source session started and loaded the local project successfully, but had no available model, so no real task was sent. No E2E logic was modified.