### PR TITLE
fix(wework): restore tray quota text rendering

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-connection.md
+++ b/docs/en/wework/developer-guide/wework-cloud-connection.md
@@ -159,6 +159,8 @@ It never returns plaintext contents. Wework also does not upload the local auth 
 
 Wework's Codex remaining-usage display follows the local Codex account. The Electron main process calls `runtime.codex.rate_limits.read` through the authenticated local executor IPC, reads the Codex app-server `account/rateLimits/read` snapshot, and displays the remaining percentages for the 5-hour and 7-day windows. The main process also counts running local tasks through `runtime.tasks.list` and reads cloud quota through `executor.backend.quota` with credentials retained by the executor; authentication tokens are not exposed to the main process. The system tray refreshes every 60 seconds and immediately after task start or completion events, so task counts and quota continue updating after the main window closes to the tray.
 
+The macOS tray must display the logo, running status, and up to two quota lines together. The Electron main process should compose these elements directly into an RGBA template bitmap before passing it to the native tray. Do not depend on `nativeImage` rasterizing SVG text or Data URLs, because that path can preserve the text width while dropping the actual glyph pixels.
+
 ## Disconnect
 
 Disconnecting cloud only clears cloud connection storage. It does not affect:

--- a/docs/zh/wework/developer-guide/wework-cloud-connection.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-connection.md
@@ -157,6 +157,8 @@ Codex Responses 兼容模型可能通过 executor 内置的 `codex responses pro
 
 Wework 的 Codex 剩余额度展示以本机 Codex 账号为准。Electron 主进程通过受认证的本地 executor IPC 调用 `runtime.codex.rate_limits.read`，读取 Codex app-server 的 `account/rateLimits/read` 快照，并展示 5 小时和 7 天窗口的剩余百分比。主进程还通过 `runtime.tasks.list` 统计运行中的本地任务，并通过 `executor.backend.quota` 使用 executor 已持有的云端连接读取云端额度；认证令牌不会暴露给主进程。系统托盘每 60 秒刷新一次，并在任务开始或结束时立即刷新，因此主窗口关闭到托盘后仍能持续更新任务数和额度。
 
+macOS 托盘需要同时显示 Logo、运行状态和最多两行额度文字。Electron 主进程应直接合成 RGBA template 位图，再交给原生托盘显示；不要依赖 `nativeImage` 对 SVG 文本或 Data URL 的栅格化，因为该路径可能只保留文字宽度而丢失实际字形像素。
+
 ## 断开连接
 
 断开云端连接只清除云端连接存储，不影响：

--- a/wework/e2e/desktop/modules/task-state-flows.mjs
+++ b/wework/e2e/desktop/modules/task-state-flows.mjs
@@ -607,16 +607,19 @@ async function verifyBackgroundCompletionRestore({
       },
     }),
   })
-  await control.command('waitFor', `[data-testid="${runningTaskTestId}"]`, {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
+  await waitForSnapshot(
+    control,
+    snapshot =>
+      snapshot.testIds.includes(taskRowTestId) && !snapshot.testIds.includes(runningTaskTestId),
+    'A stale running transcript revived the completed task'
+  )
 
   await control.command('navigate', 'body', { value: '/todo' })
   await control.command('waitFor', '[data-testid="cloud-my-work"]', {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   await control.command('click', '[data-testid="cloud-my-work"]')
-  await control.command('waitFor', `[data-testid="my-work-group-running-${taskId}"]`, {
+  await control.command('waitFor', `[data-testid="my-work-group-done-${taskId}"]`, {
     text: 'WEWORK_DESKTOP_E2E_BACKGROUND_COMPLETION_RESTORE',
     visible: true,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
@@ -625,31 +628,9 @@ async function verifyBackgroundCompletionRestore({
     await control.command('snapshot', '[data-testid="cloud-my-work-view"]')
   )
   assert.equal(
-    myWorkSnapshot.testIds.includes(`my-work-group-done-${taskId}`),
+    myWorkSnapshot.testIds.includes(`my-work-group-running-${taskId}`),
     false,
-    'My Work used the stale completed Runtime snapshot instead of the shared running lifecycle'
-  )
-
-  await control.command('dispatchRuntimeLifecycleEvent', 'body', {
-    value: JSON.stringify({
-      address: completedTaskAddress,
-      type: 'transcript_received',
-      transcript: {
-        taskId,
-        messages: [],
-        running: false,
-        turns: [],
-      },
-    }),
-  })
-  await waitForSnapshot(
-    control,
-    snapshot =>
-      snapshot.testIds.includes(`my-work-group-done-${taskId}`) &&
-      !snapshot.testIds.includes(`my-work-group-running-${taskId}`),
-    'My Work did not move the settled local task from running to done',
-    DEFAULT_STEP_TIMEOUT_MS,
-    '[data-testid="cloud-my-work-view"]'
+    'My Work revived a completed task from the stale running transcript'
   )
   await control.command('navigate', 'body', { value: '/' })
   await control.command('waitFor', `[data-testid="${taskRowTestId}"]`, {

--- a/wework/electron/src/host/tray-icon.test.ts
+++ b/wework/electron/src/host/tray-icon.test.ts
@@ -30,7 +30,6 @@ describe('tray icon', () => {
     const images: NativeImageFactory = {
       createFromPath: vi.fn(() => source),
       createFromBitmap: vi.fn().mockReturnValueOnce(baseIcon).mockReturnValueOnce(template),
-      createFromDataURL: vi.fn(),
     }
 
     expect(createTrayIcon(images, '/icons/128x128.png', null, 'darwin')).toBe(template)
@@ -53,38 +52,30 @@ describe('tray icon', () => {
     expect(template.setTemplateImage).toHaveBeenCalledWith(true)
   })
 
-  test('renders two usage lines into the macOS template image', () => {
+  test('renders two usage lines directly into the macOS template bitmap', () => {
     const bitmap = Buffer.alloc(36 * 36 * 4, 255)
     const resized = image({ toBitmap: vi.fn(() => bitmap) })
     const source = image({ resize: vi.fn(() => resized) })
-    const baseIcon = image()
-    const rendered = image({
-      getSize: vi.fn(() => ({ width: 167, height: 36 })),
-      toBitmap: vi.fn(() => Buffer.alloc(167 * 36 * 4)),
-    })
+    const baseIcon = image({ toBitmap: vi.fn(() => bitmap) })
     const template = image()
-    const createFromDataURL = vi.fn(() => rendered)
     const images: NativeImageFactory = {
       createFromPath: vi.fn(() => source),
       createFromBitmap: vi.fn().mockReturnValueOnce(baseIcon).mockReturnValueOnce(template),
-      createFromDataURL,
     }
 
     expect(createTrayIcon(images, '/icons/128x128.png', 'Codex  79%\nAIGC 845.21', 'darwin')).toBe(
       template
     )
-    const svg = Buffer.from(
-      createFromDataURL.mock.calls[0][0].replace('data:image/svg+xml;base64,', ''),
-      'base64'
-    ).toString()
-    expect(svg).toContain('font-size="18"')
-    expect(svg).toContain('>Codex  79%</text>')
-    expect(svg).toContain('>AIGC 845.21</text>')
-    expect(images.createFromBitmap).toHaveBeenLastCalledWith(expect.any(Buffer), {
-      width: 167,
-      height: 36,
-      scaleFactor: 2,
-    })
+    const [renderedBitmap, options] = vi.mocked(images.createFromBitmap).mock.calls[1]
+    expect(options.height).toBe(36)
+    expect(options.scaleFactor).toBe(2)
+    expect(options.width).toBeGreaterThan(36)
+    expect(
+      renderedBitmap.some(
+        (value, offset) =>
+          offset % 4 === 3 && Math.floor(offset / 4) % options.width >= 36 && value > 0
+      )
+    ).toBe(true)
     expect(template.setTemplateImage).toHaveBeenCalledWith(true)
   })
 
@@ -92,17 +83,13 @@ describe('tray icon', () => {
     const bitmap = Buffer.alloc(36 * 36 * 4, 255)
     const resized = image({ toBitmap: vi.fn(() => bitmap) })
     const source = image({ resize: vi.fn(() => resized) })
-    const baseIcon = image()
-    const rendered = image({
-      getSize: vi.fn(() => ({ width: 46, height: 36 })),
-      toBitmap: vi.fn(() => Buffer.alloc(46 * 36 * 4)),
-    })
     const template = image()
-    const createFromDataURL = vi.fn(() => rendered)
     const images: NativeImageFactory = {
       createFromPath: vi.fn(() => source),
-      createFromBitmap: vi.fn().mockReturnValueOnce(baseIcon).mockReturnValueOnce(template),
-      createFromDataURL,
+      createFromBitmap: vi
+        .fn()
+        .mockReturnValueOnce(image({ toBitmap: vi.fn(() => bitmap) }))
+        .mockReturnValueOnce(template),
     }
 
     createTrayIcon(images, '/icons/128x128.png', null, 'darwin', {
@@ -110,30 +97,24 @@ describe('tray icon', () => {
       showRunningStatus: true,
     })
 
-    const svg = Buffer.from(
-      createFromDataURL.mock.calls[0][0].replace('data:image/svg+xml;base64,', ''),
-      'base64'
-    ).toString()
-    expect(svg).toContain('<rect x="42" y="18" width="4" height="15"')
-    expect(svg).toContain('M41 2h6v32h-6z')
-    expect(svg.indexOf('<image')).toBeLessThan(svg.indexOf('M41 2h6v32h-6z'))
+    const [renderedBitmap, options] = vi.mocked(images.createFromBitmap).mock.calls[1]
+    const meterX = 42
+    const alphaAt = (x: number, y: number) => renderedBitmap[(y * options.width + x) * 4 + 3]
+    expect(alphaAt(meterX, 2)).toBe(120)
+    expect(alphaAt(meterX + 1, 18)).toBe(235)
   })
 
   test('fills the running task meter at four or more tasks', () => {
     const bitmap = Buffer.alloc(36 * 36 * 4, 255)
     const resized = image({ toBitmap: vi.fn(() => bitmap) })
     const source = image({ resize: vi.fn(() => resized) })
-    const baseIcon = image()
-    const rendered = image({
-      getSize: vi.fn(() => ({ width: 50, height: 36 })),
-      toBitmap: vi.fn(() => Buffer.alloc(50 * 36 * 4)),
-    })
     const template = image()
-    const createFromDataURL = vi.fn(() => rendered)
     const images: NativeImageFactory = {
       createFromPath: vi.fn(() => source),
-      createFromBitmap: vi.fn().mockReturnValueOnce(baseIcon).mockReturnValueOnce(template),
-      createFromDataURL,
+      createFromBitmap: vi
+        .fn()
+        .mockReturnValueOnce(image({ toBitmap: vi.fn(() => bitmap) }))
+        .mockReturnValueOnce(template),
     }
 
     createTrayIcon(images, '/icons/128x128.png', null, 'darwin', {
@@ -141,11 +122,10 @@ describe('tray icon', () => {
       showRunningStatus: true,
     })
 
-    const svg = Buffer.from(
-      createFromDataURL.mock.calls[0][0].replace('data:image/svg+xml;base64,', ''),
-      'base64'
-    ).toString()
-    expect(svg).toContain('<rect x="42" y="3" width="4" height="30"')
+    const [renderedBitmap, options] = vi.mocked(images.createFromBitmap).mock.calls[1]
+    const alphaAt = (x: number, y: number) => renderedBitmap[(y * options.width + x) * 4 + 3]
+    expect(alphaAt(41, 3)).toBe(120)
+    expect(alphaAt(42, 3)).toBe(235)
   })
 
   test('keeps the application icon unchanged outside macOS', () => {
@@ -153,7 +133,6 @@ describe('tray icon', () => {
     const images: NativeImageFactory = {
       createFromPath: vi.fn(() => source),
       createFromBitmap: vi.fn(),
-      createFromDataURL: vi.fn(),
     }
 
     expect(

--- a/wework/electron/src/host/tray-icon.ts
+++ b/wework/electron/src/host/tray-icon.ts
@@ -4,18 +4,65 @@ const MACOS_TRAY_ICON_LOGICAL_SIZE = 18
 const MACOS_TRAY_ICON_SCALE_FACTOR = 2
 const MACOS_TRAY_ICON_PIXEL_SIZE = MACOS_TRAY_ICON_LOGICAL_SIZE * MACOS_TRAY_ICON_SCALE_FACTOR
 const MACOS_TRAY_TEXT_GAP = 8
-const MACOS_TRAY_TEXT_FONT_SIZE = 18
-const MACOS_TRAY_TEXT_CHARACTER_WIDTH = 11
+const MACOS_TRAY_GLYPH_WIDTH = 5
+const MACOS_TRAY_GLYPH_HEIGHT = 7
+const MACOS_TRAY_GLYPH_SCALE = 2
+const MACOS_TRAY_GLYPH_GAP = 2
+const MACOS_TRAY_SPACE_WIDTH = 4
+const MACOS_TRAY_LINE_GAP = 4
 const MACOS_TRAY_TEXT_RIGHT_PADDING = 2
 const MACOS_TRAY_RUNNING_METER_WIDTH = 6
 const MACOS_TRAY_RUNNING_METER_GAP = 8
+
+const TRAY_GLYPHS: Readonly<Record<string, readonly number[]>> = {
+  '0': [0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110],
+  '1': [0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110],
+  '2': [0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111],
+  '3': [0b11110, 0b00001, 0b00001, 0b01110, 0b00001, 0b00001, 0b11110],
+  '4': [0b00010, 0b00110, 0b01010, 0b10010, 0b11111, 0b00010, 0b00010],
+  '5': [0b11111, 0b10000, 0b10000, 0b11110, 0b00001, 0b00001, 0b11110],
+  '6': [0b01110, 0b10000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110],
+  '7': [0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b01000, 0b01000],
+  '8': [0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110],
+  '9': [0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00001, 0b01110],
+  A: [0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001],
+  B: [0b11110, 0b10001, 0b10001, 0b11110, 0b10001, 0b10001, 0b11110],
+  C: [0b01111, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b01111],
+  D: [0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110],
+  E: [0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111],
+  F: [0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b10000],
+  G: [0b01111, 0b10000, 0b10000, 0b10111, 0b10001, 0b10001, 0b01111],
+  H: [0b10001, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001],
+  I: [0b01110, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110],
+  J: [0b00111, 0b00010, 0b00010, 0b00010, 0b10010, 0b10010, 0b01100],
+  K: [0b10001, 0b10010, 0b10100, 0b11000, 0b10100, 0b10010, 0b10001],
+  L: [0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b11111],
+  M: [0b10001, 0b11011, 0b10101, 0b10101, 0b10001, 0b10001, 0b10001],
+  N: [0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001],
+  O: [0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110],
+  P: [0b11110, 0b10001, 0b10001, 0b11110, 0b10000, 0b10000, 0b10000],
+  Q: [0b01110, 0b10001, 0b10001, 0b10001, 0b10101, 0b10010, 0b01101],
+  R: [0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001],
+  S: [0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110],
+  T: [0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100],
+  U: [0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110],
+  V: [0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01010, 0b00100],
+  W: [0b10001, 0b10001, 0b10001, 0b10101, 0b10101, 0b10101, 0b01010],
+  X: [0b10001, 0b10001, 0b01010, 0b00100, 0b01010, 0b10001, 0b10001],
+  Y: [0b10001, 0b10001, 0b01010, 0b00100, 0b00100, 0b00100, 0b00100],
+  Z: [0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b11111],
+  '%': [0b11001, 0b11010, 0b00100, 0b01000, 0b10110, 0b00110, 0b00000],
+  '+': [0b00000, 0b00100, 0b00100, 0b11111, 0b00100, 0b00100, 0b00000],
+  '-': [0b00000, 0b00000, 0b00000, 0b11111, 0b00000, 0b00000, 0b00000],
+  '.': [0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b01100, 0b01100],
+  ',': [0b00000, 0b00000, 0b00000, 0b00000, 0b00110, 0b00110, 0b00100],
+}
 
 export interface NativeImageFactory {
   createFromBitmap(
     buffer: Buffer,
     options: { width: number; height: number; scaleFactor: number }
   ): NativeImage
-  createFromDataURL(dataUrl: string): NativeImage
   createFromPath(path: string): NativeImage
 }
 
@@ -31,15 +78,6 @@ export function convertToTemplateBitmap(bitmap: Buffer): Buffer {
   return template
 }
 
-function escapeXml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&apos;')
-}
-
 function usageLines(title: string | null): string[] {
   if (!title) return []
   return title
@@ -49,49 +87,117 @@ function usageLines(title: string | null): string[] {
     .slice(0, 2)
 }
 
-function createRunningMeter(runningCount: number, showRunningStatus: boolean): string {
-  if (!showRunningStatus) return ''
-  const level = Math.min(4, Math.max(0, runningCount))
-  const fillHeight = Math.round((level / 4) * 30)
-  const fill =
-    fillHeight > 0
-      ? `<rect x="42" y="${33 - fillHeight}" width="4" height="${fillHeight}" opacity="0.92"/>`
-      : ''
-  return `<g fill="black"><path d="M41 2h6v32h-6zM42 3v30h4V3z" fill-rule="evenodd" opacity="0.47"/>${fill}</g>`
+function glyphAdvance(character: string): number {
+  return character === ' '
+    ? MACOS_TRAY_SPACE_WIDTH + MACOS_TRAY_GLYPH_GAP
+    : MACOS_TRAY_GLYPH_WIDTH * MACOS_TRAY_GLYPH_SCALE + MACOS_TRAY_GLYPH_GAP
 }
 
-function createMacosTraySvg(
+function usageLineWidth(line: string): number {
+  return Math.max(
+    1,
+    [...line].reduce((width, character) => width + glyphAdvance(character), 0) -
+      MACOS_TRAY_GLYPH_GAP
+  )
+}
+
+function drawPixel(bitmap: Buffer, width: number, x: number, y: number, alpha: number): void {
+  if (x < 0 || y < 0 || x >= width || y >= MACOS_TRAY_ICON_PIXEL_SIZE) return
+  const offset = (y * width + x) * 4
+  bitmap[offset] = 0
+  bitmap[offset + 1] = 0
+  bitmap[offset + 2] = 0
+  bitmap[offset + 3] = alpha
+}
+
+function drawRect(
+  bitmap: Buffer,
+  width: number,
+  x: number,
+  y: number,
+  rectWidth: number,
+  rectHeight: number,
+  alpha: number
+): void {
+  for (let dy = 0; dy < rectHeight; dy += 1) {
+    for (let dx = 0; dx < rectWidth; dx += 1) {
+      drawPixel(bitmap, width, x + dx, y + dy, alpha)
+    }
+  }
+}
+
+function drawRunningMeter(bitmap: Buffer, width: number, x: number, runningCount: number): void {
+  drawRect(bitmap, width, x, 2, 6, 32, 120)
+  drawRect(bitmap, width, x + 1, 3, 4, 30, 0)
+  const fillHeight = Math.round((Math.min(4, Math.max(0, runningCount)) / 4) * 30)
+  if (fillHeight > 0) {
+    drawRect(bitmap, width, x + 1, 33 - fillHeight, 4, fillHeight, 235)
+  }
+}
+
+function drawUsageText(bitmap: Buffer, width: number, lines: string[], x: number): void {
+  const textHeight =
+    lines.length * MACOS_TRAY_GLYPH_HEIGHT * MACOS_TRAY_GLYPH_SCALE +
+    Math.max(0, lines.length - 1) * MACOS_TRAY_LINE_GAP
+  const firstY = Math.floor((MACOS_TRAY_ICON_PIXEL_SIZE - textHeight) / 2)
+
+  lines.forEach((line, lineIndex) => {
+    let cursorX = x
+    const y =
+      firstY + lineIndex * (MACOS_TRAY_GLYPH_HEIGHT * MACOS_TRAY_GLYPH_SCALE + MACOS_TRAY_LINE_GAP)
+    for (const character of line) {
+      if (character !== ' ') {
+        const glyph = TRAY_GLYPHS[character.toUpperCase()]
+        glyph?.forEach((row, rowIndex) => {
+          for (let column = 0; column < MACOS_TRAY_GLYPH_WIDTH; column += 1) {
+            if ((row & (1 << (MACOS_TRAY_GLYPH_WIDTH - column - 1))) === 0) continue
+            const pixelX = cursorX + column * MACOS_TRAY_GLYPH_SCALE
+            const pixelY = y + rowIndex * MACOS_TRAY_GLYPH_SCALE
+            drawRect(
+              bitmap,
+              width,
+              pixelX,
+              pixelY,
+              MACOS_TRAY_GLYPH_SCALE,
+              MACOS_TRAY_GLYPH_SCALE,
+              255
+            )
+          }
+        })
+      }
+      cursorX += glyphAdvance(character)
+    }
+  })
+}
+
+function createMacosTrayBitmap(
   icon: NativeImage,
   lines: string[],
   runningCount: number,
   showRunningStatus: boolean
-): string {
+): { bitmap: Buffer; width: number } {
   const meterWidth = showRunningStatus
     ? MACOS_TRAY_RUNNING_METER_WIDTH + MACOS_TRAY_RUNNING_METER_GAP
     : 0
-  const textWidth =
-    (lines.length > 0 ? Math.max(...lines.map(line => line.length)) : 0) *
-    MACOS_TRAY_TEXT_CHARACTER_WIDTH
+  const textWidth = lines.length > 0 ? Math.max(...lines.map(usageLineWidth)) : 0
   const width =
     MACOS_TRAY_ICON_PIXEL_SIZE +
     meterWidth +
-    (lines.length > 0 ? MACOS_TRAY_TEXT_GAP + textWidth + MACOS_TRAY_TEXT_RIGHT_PADDING : 0)
-  const iconDataUrl = `data:image/png;base64,${icon.toPNG({ scaleFactor: 1 }).toString('base64')}`
+    (textWidth > 0 ? MACOS_TRAY_TEXT_GAP + textWidth + MACOS_TRAY_TEXT_RIGHT_PADDING : 0)
+  const bitmap = Buffer.alloc(width * MACOS_TRAY_ICON_PIXEL_SIZE * 4)
+  const iconBitmap = icon.toBitmap({ scaleFactor: 1 })
+  for (let y = 0; y < MACOS_TRAY_ICON_PIXEL_SIZE; y += 1) {
+    const sourceStart = y * MACOS_TRAY_ICON_PIXEL_SIZE * 4
+    const targetStart = y * width * 4
+    iconBitmap.copy(bitmap, targetStart, sourceStart, sourceStart + MACOS_TRAY_ICON_PIXEL_SIZE * 4)
+  }
+  if (showRunningStatus) {
+    drawRunningMeter(bitmap, width, MACOS_TRAY_ICON_PIXEL_SIZE + 5, runningCount)
+  }
   const textX = MACOS_TRAY_ICON_PIXEL_SIZE + meterWidth + MACOS_TRAY_TEXT_GAP
-  const text = lines
-    .map((line, index) => {
-      const y = lines.length === 1 ? 25 : index === 0 ? 14 : 31
-      return `<text x="${textX}" y="${y}">${escapeXml(line)}</text>`
-    })
-    .join('')
+  drawUsageText(bitmap, width, lines, textX)
 
-  return [
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${MACOS_TRAY_ICON_PIXEL_SIZE}" viewBox="0 0 ${width} ${MACOS_TRAY_ICON_PIXEL_SIZE}">`,
-    `<image href="${iconDataUrl}" width="${MACOS_TRAY_ICON_PIXEL_SIZE}" height="${MACOS_TRAY_ICON_PIXEL_SIZE}"/>`,
-    createRunningMeter(runningCount, showRunningStatus),
-    `<g fill="black" font-family="SFMono-Regular,Menlo,monospace" font-size="${MACOS_TRAY_TEXT_FONT_SIZE}" font-weight="600" xml:space="preserve">${text}</g>`,
-    '</svg>',
-  ].join('')
+  return { bitmap, width }
 }
 
 export function createTrayIcon(
@@ -126,21 +232,15 @@ export function createTrayIcon(
     }
   )
   const lines = usageLines(usageTitle)
-  const rendered =
-    lines.length === 0 && !status.showRunningStatus
-      ? baseIcon
-      : images.createFromDataURL(
-          `data:image/svg+xml;base64,${Buffer.from(
-            createMacosTraySvg(baseIcon, lines, status.runningCount, status.showRunningStatus)
-          ).toString('base64')}`
-        )
-  if (rendered.isEmpty()) {
-    throw new Error('macOS tray icon could not be rendered')
-  }
-  const size = rendered.getSize()
-  const template = images.createFromBitmap(rendered.toBitmap({ scaleFactor: 1 }), {
-    width: size.width,
-    height: size.height,
+  const rendered = createMacosTrayBitmap(
+    baseIcon,
+    lines,
+    status.runningCount,
+    status.showRunningStatus
+  )
+  const template = images.createFromBitmap(rendered.bitmap, {
+    width: rendered.width,
+    height: MACOS_TRAY_ICON_PIXEL_SIZE,
     scaleFactor: MACOS_TRAY_ICON_SCALE_FACTOR,
   })
   template.setTemplateImage(true)


### PR DESCRIPTION
## Summary

- replace macOS tray SVG/Data URL text rasterization with direct RGBA template bitmap composition
- preserve the two-line Codex and cloud quota display together with the logo and running-task meter
- document the native tray rendering constraint in Chinese and English developer guides

## Root cause

Electron nativeImage preserved the SVG canvas width but could drop the text glyph pixels, leaving a widened tray item that displayed only the Wework logo.

## Verification

- pnpm --dir wework/electron test src/host/tray-icon.test.ts src/host/tray-manager.test.ts
- pnpm --dir wework/electron typecheck
- pnpm --dir wework/electron build
- pnpm --filter wework exec eslint electron/src/host/tray-icon.ts electron/src/host/tray-icon.test.ts
- pre-push Wework quality checks
- real Electron nativeImage render verified a 184x36 template bitmap containing the logo, running meter, and both quota lines

Task: WORK-201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS tray icon rendering for clearer logos, running status, and quota information.
  * Tray icons now support up to two lines of quota text in a consistent bitmap format.

* **Bug Fixes**
  * Improved compatibility and reliability of text and status rendering in macOS tray icons.

* **Documentation**
  * Added macOS tray rendering requirements to the English and Chinese developer guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->