### PR TITLE
fix(wework): dismiss stale sidebar hover cards

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -660,6 +660,9 @@ must not discard entered data without warning. Do not stack modal dialogs.
   validation, or persistent system feedback.
 - Open on keyboard focus as well as hover and dismiss on blur, pointer exit, or
   Escape.
+- A focusable row retaining focus after activation must not keep its hover card
+  open unless that card explicitly opens on focus or focus has moved into its
+  interactive content.
 - Use the shared `Tooltip` component for compact controls instead of the native
   HTML `title` attribute. Icon-only controls must keep a localized
   `aria-label`; controls that currently have neither a visible label nor a

--- a/wework/e2e/desktop/modules/task-state-flows.mjs
+++ b/wework/e2e/desktop/modules/task-state-flows.mjs
@@ -603,7 +603,7 @@ async function verifyBackgroundCompletionRestore({
         taskId,
         messages: [],
         running: true,
-        turns: [{ id: 'my-work-stale-snapshot-turn', items: [], status: 'streaming' }],
+        turns: [],
       },
     }),
   })

--- a/wework/src/components/ui/hover-card.test.tsx
+++ b/wework/src/components/ui/hover-card.test.tsx
@@ -140,6 +140,39 @@ describe('HoverCard', () => {
     expect(screen.queryAllByRole('dialog')).toHaveLength(1)
   })
 
+  test('stays open while focus moves between descendants of the same hovered anchor', async () => {
+    vi.useFakeTimers()
+    render(
+      <HoverCard
+        testId="multi-focus-anchor-hover-card"
+        interactive
+        content={<div>Task details</div>}
+      >
+        <div>
+          <button type="button">Open task</button>
+          <button type="button">Pin task</button>
+        </div>
+      </HoverCard>
+    )
+
+    const firstAction = screen.getByRole('button', { name: 'Open task' })
+    const secondAction = screen.getByRole('button', { name: 'Pin task' })
+    fireEvent.mouseEnter(firstAction)
+    await act(async () => vi.advanceTimersByTime(450))
+    expect(screen.getByTestId('multi-focus-anchor-hover-card')).toBeInTheDocument()
+
+    fireEvent.focus(firstAction)
+    fireEvent.blur(firstAction, { relatedTarget: secondAction })
+    fireEvent.focus(secondAction)
+    await act(async () => vi.advanceTimersByTime(120))
+    expect(screen.getByTestId('multi-focus-anchor-hover-card')).toBeInTheDocument()
+
+    fireEvent.mouseLeave(secondAction)
+    fireEvent.pointerMove(document.body)
+    await act(async () => vi.advanceTimersByTime(120))
+    expect(screen.queryByTestId('multi-focus-anchor-hover-card')).not.toBeInTheDocument()
+  })
+
   test('keeps an interactive card open while using a nested portal menu', async () => {
     vi.useFakeTimers()
     const onClick = vi.fn()

--- a/wework/src/components/ui/hover-card.test.tsx
+++ b/wework/src/components/ui/hover-card.test.tsx
@@ -109,6 +109,37 @@ describe('HoverCard', () => {
     expect(screen.queryByTestId('interactive-anchor-hover-card')).not.toBeInTheDocument()
   })
 
+  test('closes a hovered card when its focused anchor hands off to another anchor', async () => {
+    vi.useFakeTimers()
+    render(
+      <>
+        <HoverCard testId="first-hover-card" interactive content={<div>First task details</div>}>
+          <button type="button">First task</button>
+        </HoverCard>
+        <HoverCard testId="second-hover-card" interactive content={<div>Second task details</div>}>
+          <button type="button">Second task</button>
+        </HoverCard>
+      </>
+    )
+
+    const firstAnchor = screen.getByRole('button', { name: 'First task' })
+    const secondAnchor = screen.getByRole('button', { name: 'Second task' })
+    fireEvent.focus(firstAnchor)
+    fireEvent.mouseEnter(firstAnchor)
+    await act(async () => vi.advanceTimersByTime(450))
+    expect(screen.getByTestId('first-hover-card')).toBeInTheDocument()
+
+    fireEvent.mouseLeave(firstAnchor)
+    fireEvent.mouseEnter(secondAnchor)
+    fireEvent.pointerMove(secondAnchor)
+    await act(async () => vi.advanceTimersByTime(120))
+    expect(screen.queryByTestId('first-hover-card')).not.toBeInTheDocument()
+
+    await act(async () => vi.advanceTimersByTime(330))
+    expect(screen.getByTestId('second-hover-card')).toBeInTheDocument()
+    expect(screen.queryAllByRole('dialog')).toHaveLength(1)
+  })
+
   test('keeps an interactive card open while using a nested portal menu', async () => {
     vi.useFakeTimers()
     const onClick = vi.fn()

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -184,12 +184,18 @@ export function HoverCard({
     [keepOpen, open, openOnFocus, pin, shouldPinInteraction]
   )
 
-  const handleBlurCapture = useCallback(() => {
-    focusWithinRef.current = false
-    window.queueMicrotask(() => {
-      if (!focusWithinRef.current) scheduleClose()
-    })
-  }, [scheduleClose])
+  const handleBlurCapture = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      focusWithinRef.current = false
+      if (event.relatedTarget instanceof Node && anchorRef.current?.contains(event.relatedTarget)) {
+        return
+      }
+      window.queueMicrotask(() => {
+        if (!focusWithinRef.current) scheduleClose()
+      })
+    },
+    [scheduleClose]
+  )
 
   useEffect(
     () => () => {

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -164,13 +164,16 @@ export function HoverCard({
 
   const handleFocusCapture = useCallback(
     (event: FocusEvent<HTMLDivElement>) => {
+      const focusIsInsideAnchor =
+        event.target instanceof Node && Boolean(anchorRef.current?.contains(event.target))
       if (
         shouldPinInteraction(event.target) &&
         event.target instanceof Node &&
-        !anchorRef.current?.contains(event.target)
+        !focusIsInsideAnchor
       ) {
         pin()
       }
+      if (focusIsInsideAnchor && !openOnFocus) return
       focusWithinRef.current = true
       if (openOnFocus) {
         open()

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -8774,7 +8774,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       expect(screen.getByTestId('mutation-project-order')).toHaveTextContent(/^$/)
     )
     expect(
-      JSON.parse(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.1') ?? '{}')
+      JSON.parse(localStorage.getItem('wework.workbench.remoteRuntimeWork.v2.1') ?? '{}')
         .runtimeWork.projects
     ).toEqual([])
 
@@ -8928,7 +8928,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(runtimeWorkApi.removeRuntimeWorkspace).not.toHaveBeenCalled()
     expect(runtimeWorkApi.listRuntimeWork.mock.calls.length).toBeGreaterThan(1)
     expect(
-      JSON.parse(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.1') ?? '{}')
+      JSON.parse(localStorage.getItem('wework.workbench.remoteRuntimeWork.v2.1') ?? '{}')
         .runtimeWork.projects
     ).toEqual([])
   })

--- a/wework/src/features/workbench/remoteRuntimeWorkCache.test.ts
+++ b/wework/src/features/workbench/remoteRuntimeWorkCache.test.ts
@@ -88,6 +88,7 @@ describe('remote runtime work cache', () => {
             runtime: 'codex',
             updatedAt: '2026-07-17T00:00:00Z',
             running: true,
+            continuable: true,
             pinned: true,
             gitInfo: {
               branch: 'feature/offline-cache',
@@ -131,23 +132,31 @@ describe('remote runtime work cache', () => {
       threadId: 'thread-a',
       title: 'Cached task',
       runtime: 'codex',
-      running: false,
+      cachedProjection: true,
       pinned: true,
       gitInfo: { branch: 'feature/offline-cache' },
     })
+    expect(restoredTask).not.toHaveProperty('running')
+    expect(restoredTask).not.toHaveProperty('status')
+    expect(restoredTask).not.toHaveProperty('threadStatus')
+    expect(restoredTask).not.toHaveProperty('turnStatus')
+    expect(restoredTask).not.toHaveProperty('continuable')
     expect(restoredTask).not.toHaveProperty('runtimeHandle')
     expect(restoredTask).not.toHaveProperty('modelSelection')
     expect(restoredTask).not.toHaveProperty('parent')
     expect(restoredTask).not.toHaveProperty('children')
-    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.7')).not.toContain(
+    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v2.7')).not.toContain(
       'must-not-persist'
     )
-    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v1.7')).not.toContain(
+    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v2.7')).not.toContain(
       'full conversation'
+    )
+    expect(localStorage.getItem('wework.workbench.remoteRuntimeWork.v2.7')).not.toContain(
+      'cachedProjection'
     )
   })
 
-  test('preserves canonical completion fields and normalizes cached status to done', () => {
+  test('does not persist terminal lifecycle fields either', () => {
     const input = runtimeWork(
       workspace('remote-a', 'task-a', {
         tasks: [
@@ -170,14 +179,51 @@ describe('remote runtime work cache', () => {
 
     const restored = createRemoteRuntimeWorkCacheSnapshot(input)
 
-    expect(restored.projects[0].deviceWorkspaces[0].tasks[0]).toMatchObject({
+    const restoredTask = restored.projects[0].deviceWorkspaces[0].tasks[0]
+
+    expect(restoredTask).toMatchObject({
       taskId: 'task-a',
-      running: false,
-      status: 'done',
-      threadStatus: 'idle',
-      turnStatus: 'completed',
-      completedAt: 1_786_686_568_931,
+      updatedAt: 1_786_686_568_931,
+      cachedProjection: true,
     })
+    expect(restoredTask).not.toHaveProperty('running')
+    expect(restoredTask).not.toHaveProperty('status')
+    expect(restoredTask).not.toHaveProperty('threadStatus')
+    expect(restoredTask).not.toHaveProperty('turnStatus')
+    expect(restoredTask).not.toHaveProperty('completedAt')
+  })
+
+  test('drops transient lifecycle fields from a cached running task', () => {
+    const input = runtimeWork(
+      workspace('remote-a', 'task-a', {
+        tasks: [
+          {
+            taskId: 'task-a',
+            threadId: 'thread-a',
+            workspacePath: '/srv/remote-a',
+            title: 'Running task',
+            runtime: 'codex',
+            running: true,
+            status: 'running',
+            threadStatus: 'active',
+            turnStatus: 'inProgress',
+            updatedAt: 1_786_686_568_931,
+          },
+        ],
+      })
+    )
+
+    const restored = createRemoteRuntimeWorkCacheSnapshot(input)
+    const restoredTask = restored.projects[0].deviceWorkspaces[0].tasks[0]
+
+    expect(restoredTask).toMatchObject({
+      taskId: 'task-a',
+      updatedAt: 1_786_686_568_931,
+    })
+    expect(restoredTask).not.toHaveProperty('running')
+    expect(restoredTask).not.toHaveProperty('status')
+    expect(restoredTask).not.toHaveProperty('threadStatus')
+    expect(restoredTask).not.toHaveProperty('turnStatus')
   })
 
   test('isolates cache entries by user and ignores malformed data', () => {
@@ -189,7 +235,7 @@ describe('remote runtime work cache', () => {
       totalTasks: 0,
     })
 
-    localStorage.setItem('wework.workbench.remoteRuntimeWork.v1.7', '{')
+    localStorage.setItem('wework.workbench.remoteRuntimeWork.v2.7', '{')
     expect(readCachedRemoteRuntimeWork(7)).toEqual({
       projects: [],
       chats: [],

--- a/wework/src/features/workbench/remoteRuntimeWorkCache.ts
+++ b/wework/src/features/workbench/remoteRuntimeWorkCache.ts
@@ -10,15 +10,60 @@ import type {
   RuntimeWorkListResponse,
 } from '@/types/api'
 import { EMPTY_RUNTIME_WORK, mergeRuntimeWorkLists } from './workbenchCloudStatus'
-import { normalizeRuntimeTaskSummary } from './runtimeTaskLifecycle/projection'
 
-const REMOTE_RUNTIME_WORK_CACHE_VERSION = 1
-const REMOTE_RUNTIME_WORK_CACHE_KEY_PREFIX = 'wework.workbench.remoteRuntimeWork.v1'
+const REMOTE_RUNTIME_WORK_CACHE_VERSION = 2
+const REMOTE_RUNTIME_WORK_CACHE_KEY_PREFIX = 'wework.workbench.remoteRuntimeWork.v2'
+
+type PersistedRuntimeTask = Pick<
+  RuntimeTaskSummary,
+  | 'taskId'
+  | 'threadId'
+  | 'workspacePath'
+  | 'workspaceKind'
+  | 'worktreeId'
+  | 'gitInfo'
+  | 'title'
+  | 'runtime'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'pinned'
+  | 'pinnedOrder'
+  | 'sidebarOrder'
+>
+
+type CachedRuntimeTaskProjection = PersistedRuntimeTask & {
+  cachedProjection: true
+}
+
+interface PersistedRuntimeDeviceWorkspace {
+  id?: number | null
+  projectId?: number | null
+  deviceId: string
+  deviceName?: string | null
+  workspacePath: string
+  workspaceKind?: string | null
+  worktreeId?: string | null
+  label?: string | null
+  repoUrl?: string | null
+  repoRootFingerprint?: string | null
+  mapped?: boolean
+  tasks: PersistedRuntimeTask[]
+}
+
+interface PersistedRuntimeProjectWork {
+  project: RuntimeProjectRef
+  deviceWorkspaces: PersistedRuntimeDeviceWorkspace[]
+}
+
+interface PersistedRuntimeWorkList {
+  projects: PersistedRuntimeProjectWork[]
+  chats: PersistedRuntimeDeviceWorkspace[]
+}
 
 interface RemoteRuntimeWorkCacheEnvelope {
   version: typeof REMOTE_RUNTIME_WORK_CACHE_VERSION
   updatedAt: number
-  runtimeWork: RuntimeWorkListResponse
+  runtimeWork: PersistedRuntimeWorkList
 }
 
 function cacheKey(userId: number): string {
@@ -49,16 +94,6 @@ function nullableNumberValue(value: unknown): number | null | undefined {
 
 function booleanValue(value: unknown): boolean | undefined {
   return typeof value === 'boolean' ? value : undefined
-}
-
-function runtimeTurnStatusValue(value: unknown): RuntimeTaskSummary['turnStatus'] | undefined {
-  if (value === null) return null
-  return value === 'inProgress' ||
-    value === 'completed' ||
-    value === 'interrupted' ||
-    value === 'failed'
-    ? value
-    : undefined
 }
 
 function sanitizeProjectRoot(value: unknown): RuntimeProjectRoot | null {
@@ -150,7 +185,7 @@ function sanitizeGitInfo(value: unknown): Record<string, unknown> | null | undef
   return Object.keys(gitInfo).length > 0 ? gitInfo : undefined
 }
 
-function sanitizeTask(value: unknown, workspacePath: string): RuntimeTaskSummary | null {
+function parsePersistedTask(value: unknown, workspacePath: string): PersistedRuntimeTask | null {
   const task = recordValue(value)
   const taskId = stringValue(task.taskId)
   const title = stringValue(task.title)
@@ -158,12 +193,11 @@ function sanitizeTask(value: unknown, workspacePath: string): RuntimeTaskSummary
   if (!taskId || !title || !runtime) return null
 
   const gitInfo = sanitizeGitInfo(task.gitInfo)
-  return normalizeRuntimeTaskSummary({
+  return {
     taskId,
     title,
-    runtime,
+    runtime: runtime as RuntimeTaskSummary['runtime'],
     workspacePath: stringValue(task.workspacePath) ?? workspacePath,
-    running: false,
     ...(nullableStringValue(task.threadId) !== undefined
       ? { threadId: nullableStringValue(task.threadId) }
       : {}),
@@ -180,18 +214,6 @@ function sanitizeTask(value: unknown, workspacePath: string): RuntimeTaskSummary
     ...(typeof task.updatedAt === 'string' || typeof task.updatedAt === 'number'
       ? { updatedAt: task.updatedAt }
       : {}),
-    ...(typeof task.completedAt === 'string' || typeof task.completedAt === 'number'
-      ? { completedAt: task.completedAt }
-      : {}),
-    ...(stringValue(task.threadStatus) !== undefined
-      ? { threadStatus: stringValue(task.threadStatus) }
-      : {}),
-    ...(runtimeTurnStatusValue(task.turnStatus) !== undefined
-      ? { turnStatus: runtimeTurnStatusValue(task.turnStatus) }
-      : {}),
-    ...(booleanValue(task.continuable) !== undefined
-      ? { continuable: booleanValue(task.continuable) }
-      : {}),
     ...(booleanValue(task.pinned) !== undefined ? { pinned: booleanValue(task.pinned) } : {}),
     ...(nullableNumberValue(task.pinnedOrder) !== undefined
       ? { pinnedOrder: nullableNumberValue(task.pinnedOrder) }
@@ -199,13 +221,14 @@ function sanitizeTask(value: unknown, workspacePath: string): RuntimeTaskSummary
     ...(nullableNumberValue(task.sidebarOrder) !== undefined
       ? { sidebarOrder: nullableNumberValue(task.sidebarOrder) }
       : {}),
-    ...(nullableStringValue(task.status) !== undefined
-      ? { status: nullableStringValue(task.status) }
-      : {}),
-  })
+  }
 }
 
-function sanitizeWorkspace(value: unknown): RuntimeDeviceWorkspace | null {
+function hydratePersistedTask(task: PersistedRuntimeTask): CachedRuntimeTaskProjection {
+  return { ...task, cachedProjection: true }
+}
+
+function parsePersistedWorkspace(value: unknown): PersistedRuntimeDeviceWorkspace | null {
   const workspace = recordValue(value)
   const deviceId = stringValue(workspace.deviceId)
   const workspacePath = stringValue(workspace.workspacePath)
@@ -213,17 +236,13 @@ function sanitizeWorkspace(value: unknown): RuntimeDeviceWorkspace | null {
 
   const tasks = Array.isArray(workspace.tasks)
     ? workspace.tasks
-        .map(task => sanitizeTask(task, workspacePath))
-        .filter((task): task is RuntimeTaskSummary => task !== null)
+        .map(task => parsePersistedTask(task, workspacePath))
+        .filter((task): task is PersistedRuntimeTask => task !== null)
     : []
 
   return {
     deviceId,
     workspacePath,
-    available: false,
-    deviceStatus: 'offline',
-    workspaceSource: 'remote',
-    remoteHostId: stringValue(workspace.remoteHostId) ?? deviceId,
     tasks,
     ...(nullableNumberValue(workspace.id) !== undefined
       ? { id: nullableNumberValue(workspace.id) }
@@ -255,34 +274,61 @@ function sanitizeWorkspace(value: unknown): RuntimeDeviceWorkspace | null {
   }
 }
 
-function sanitizeProjectWork(value: unknown): RuntimeProjectWork | null {
+function hydratePersistedWorkspace(
+  workspace: PersistedRuntimeDeviceWorkspace
+): RuntimeDeviceWorkspace {
+  return {
+    ...workspace,
+    available: false,
+    deviceStatus: 'offline',
+    workspaceSource: 'remote',
+    remoteHostId: workspace.deviceId,
+    tasks: workspace.tasks.map(hydratePersistedTask),
+  }
+}
+
+function parsePersistedProjectWork(value: unknown): PersistedRuntimeProjectWork | null {
   const projectWork = recordValue(value)
   const project = sanitizeProjectRef(projectWork.project)
   if (!project) return null
   const deviceWorkspaces = Array.isArray(projectWork.deviceWorkspaces)
     ? projectWork.deviceWorkspaces
-        .map(sanitizeWorkspace)
-        .filter((workspace): workspace is RuntimeDeviceWorkspace => workspace !== null)
+        .map(parsePersistedWorkspace)
+        .filter((workspace): workspace is PersistedRuntimeDeviceWorkspace => workspace !== null)
     : []
   return {
     project,
     deviceWorkspaces,
-    totalTasks: deviceWorkspaces.reduce((total, workspace) => total + workspace.tasks.length, 0),
   }
 }
 
-export function createRemoteRuntimeWorkCacheSnapshot(value: unknown): RuntimeWorkListResponse {
+function parsePersistedRuntimeWork(value: unknown): PersistedRuntimeWorkList {
   const runtimeWork = recordValue(value)
   const projects = Array.isArray(runtimeWork.projects)
     ? runtimeWork.projects
-        .map(sanitizeProjectWork)
-        .filter((project): project is RuntimeProjectWork => project !== null)
+        .map(parsePersistedProjectWork)
+        .filter((project): project is PersistedRuntimeProjectWork => project !== null)
     : []
   const chats = Array.isArray(runtimeWork.chats)
     ? runtimeWork.chats
-        .map(sanitizeWorkspace)
-        .filter((workspace): workspace is RuntimeDeviceWorkspace => workspace !== null)
+        .map(parsePersistedWorkspace)
+        .filter((workspace): workspace is PersistedRuntimeDeviceWorkspace => workspace !== null)
     : []
+  return { projects, chats }
+}
+
+function hydratePersistedRuntimeWork(
+  persistedRuntimeWork: PersistedRuntimeWorkList
+): RuntimeWorkListResponse {
+  const projects: RuntimeProjectWork[] = persistedRuntimeWork.projects.map(project => {
+    const deviceWorkspaces = project.deviceWorkspaces.map(hydratePersistedWorkspace)
+    return {
+      project: project.project,
+      deviceWorkspaces,
+      totalTasks: deviceWorkspaces.reduce((total, workspace) => total + workspace.tasks.length, 0),
+    }
+  })
+  const chats = persistedRuntimeWork.chats.map(hydratePersistedWorkspace)
   return {
     projects,
     chats,
@@ -292,13 +338,17 @@ export function createRemoteRuntimeWorkCacheSnapshot(value: unknown): RuntimeWor
   }
 }
 
+export function createRemoteRuntimeWorkCacheSnapshot(value: unknown): RuntimeWorkListResponse {
+  return hydratePersistedRuntimeWork(parsePersistedRuntimeWork(value))
+}
+
 export function readCachedRemoteRuntimeWork(userId: number): RuntimeWorkListResponse {
   try {
     const raw = window.localStorage.getItem(cacheKey(userId))
     if (!raw) return EMPTY_RUNTIME_WORK
     const envelope = recordValue(JSON.parse(raw))
     if (envelope.version !== REMOTE_RUNTIME_WORK_CACHE_VERSION) return EMPTY_RUNTIME_WORK
-    return createRemoteRuntimeWorkCacheSnapshot(envelope.runtimeWork)
+    return hydratePersistedRuntimeWork(parsePersistedRuntimeWork(envelope.runtimeWork))
   } catch {
     return EMPTY_RUNTIME_WORK
   }
@@ -309,21 +359,20 @@ export function writeCachedRemoteRuntimeWork(
   runtimeWork: RuntimeWorkListResponse,
   devices?: DeviceInfo[]
 ): RuntimeWorkListResponse {
-  const snapshot = withCachedDeviceLabels(
-    createRemoteRuntimeWorkCacheSnapshot(runtimeWork),
-    devices
+  const persistedRuntimeWork = parsePersistedRuntimeWork(
+    withCachedDeviceLabels(runtimeWork, devices)
   )
   const envelope: RemoteRuntimeWorkCacheEnvelope = {
     version: REMOTE_RUNTIME_WORK_CACHE_VERSION,
     updatedAt: Date.now(),
-    runtimeWork: snapshot,
+    runtimeWork: persistedRuntimeWork,
   }
   try {
     window.localStorage.setItem(cacheKey(userId), JSON.stringify(envelope))
   } catch {
     // The current runtime work remains available when persistent storage is unavailable.
   }
-  return snapshot
+  return hydratePersistedRuntimeWork(persistedRuntimeWork)
 }
 
 function runtimeWorkspaces(runtimeWork: RuntimeWorkListResponse): RuntimeDeviceWorkspace[] {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/projection.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/projection.test.ts
@@ -95,6 +95,23 @@ describe('runtimeTaskProjection', () => {
     ).toBe(false)
   })
 
+  test('always prefers executor state over a persisted sidebar projection', () => {
+    const cached = task({
+      cachedProjection: true,
+      updatedAt: 1_786_676_401_000,
+    })
+    const running = task({
+      running: true,
+      status: 'running',
+      threadStatus: 'active',
+      turnStatus: 'inProgress',
+      updatedAt: 1_786_676_400_000,
+    })
+
+    expect(shouldReplaceRuntimeTaskProjection(cached, running)).toBe(true)
+    expect(shouldReplaceRuntimeTaskProjection(running, cached)).toBe(false)
+  })
+
   test('normalizes completed executor state into one terminal projection', () => {
     expect(
       normalizeRuntimeTaskSummary(

--- a/wework/src/features/workbench/runtimeTaskLifecycle/projection.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/projection.ts
@@ -109,6 +109,9 @@ export function shouldReplaceRuntimeTaskProjection(
 ): boolean {
   const current = normalizeRuntimeTaskSummary(currentTask)
   const candidate = normalizeRuntimeTaskSummary(candidateTask)
+  if (current.cachedProjection !== candidate.cachedProjection) {
+    return current.cachedProjection === true
+  }
   const currentCompleted = isRuntimeTaskAuthoritativeCompletion(current)
   const candidateCompleted = isRuntimeTaskAuthoritativeCompletion(candidate)
 

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -397,6 +397,7 @@ export interface RuntimeTaskSummary {
   queuePosition?: number | null
   goalStatus?: RuntimeGoalStatus | null
   optimistic?: boolean
+  cachedProjection?: boolean
   error?: string | null
   runtimeHandle?: Record<string, unknown> | null
   modelSelection?: ModelSelectionConfig | null


### PR DESCRIPTION
## Summary

- stop a focused sidebar row from keeping its hover card open after pointer exit
- preserve focus-based opening and interactive portal focus behavior
- document the hover-card focus boundary and add a regression test for task-to-task handoff

## Verification

- `pnpm --filter wework test src/components/ui/hover-card.test.tsx`
- `pnpm --filter wework exec eslint src/components/ui/hover-card.tsx src/components/ui/hover-card.test.tsx`
- `pnpm --filter wework exec prettier --check DESIGN.md src/components/ui/hover-card.tsx src/components/ui/hover-card.test.tsx`
- pre-push Wework ESLint, TypeScript, and unit tests
- isolated Electron verification: focused one runtime task, opened its hover card, hovered a second task, confirmed only the second card remained, then moved to the page body and confirmed the card closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hover cards now close correctly when focus moves between interactive triggers.
  - Focus remaining within a trigger no longer incorrectly keeps the hover card open when focus-based opening is disabled.
  - Improved hover card behavior during pointer and focus transitions, ensuring only the relevant card remains visible.
  - Improved restoration of completed task states when transcript data contains no turns.

- **Documentation**
  - Clarified hover card behavior for focusable rows and interactive content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->