### PR TITLE
fix(backend): retry plugin device install races

### DIFF
--- a/backend/app/services/plugin_device_installation_service.py
+++ b/backend/app/services/plugin_device_installation_service.py
@@ -6,6 +6,7 @@
 
 from datetime import datetime
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.constants import PLUGIN_AUTO_UPDATE_FAILURE_LIMIT
@@ -332,49 +333,84 @@ class PluginDeviceInstallationService:
         normalized_device_id = device_id.strip()
         if not normalized_device_id:
             return 0
+        try:
+            return self._ensure_pending_for_device_once(
+                db,
+                user_id=user_id,
+                device_id=normalized_device_id,
+                manual_retry=manual_retry,
+            )
+        except IntegrityError as exc:
+            db.rollback()
+            if not self._is_device_install_conflict(exc):
+                raise
+            return self._ensure_pending_for_device_once(
+                db,
+                user_id=user_id,
+                device_id=normalized_device_id,
+                manual_retry=manual_retry,
+            )
+
+    def _ensure_pending_for_device_once(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        device_id: str,
+        manual_retry: bool,
+    ) -> int:
         changed = 0
-        for installed in self._desired_installs(db, user_id):
-            release_id = installed.json.get("spec", {}).get("releaseId")
-            if not isinstance(release_id, int):
-                continue
-            row = self._device_row(db, installed.id, normalized_device_id)
-            if not row:
-                db.add(
-                    PluginDeviceInstallation(
-                        installed_kind_id=installed.id,
-                        user_id=user_id,
-                        device_id=normalized_device_id,
-                        desired_release_id=release_id,
-                        state="pending",
+        with db.no_autoflush:
+            for installed in self._desired_installs(db, user_id):
+                release_id = installed.json.get("spec", {}).get("releaseId")
+                if not isinstance(release_id, int):
+                    continue
+                row = self._device_row(db, installed.id, device_id)
+                if not row:
+                    db.add(
+                        PluginDeviceInstallation(
+                            installed_kind_id=installed.id,
+                            user_id=user_id,
+                            device_id=device_id,
+                            desired_release_id=release_id,
+                            state="pending",
+                        )
                     )
-                )
+                    changed += 1
+                    continue
+                desired_changed = row.desired_release_id != release_id
+                row.desired_release_id = release_id
+                if desired_changed or manual_retry:
+                    row.attempt_count = 0
+                if row.state == "installed" and row.actual_release_id == release_id:
+                    continue
+                # Never interrupt an in-flight uninstall; the Kind may still be
+                # active for a brief window before account uninstall completes.
+                if row.state == "uninstalling":
+                    continue
+                if self._auto_update_blocked(row) and not manual_retry:
+                    continue
+                if (
+                    row.state == "pending"
+                    and not row.error_code
+                    and not row.error_message
+                    and row.actual_release_id in {0, release_id}
+                ):
+                    continue
+                row.state = "pending"
+                row.error_code = ""
+                row.error_message = ""
                 changed += 1
-                continue
-            desired_changed = row.desired_release_id != release_id
-            row.desired_release_id = release_id
-            if desired_changed or manual_retry:
-                row.attempt_count = 0
-            if row.state == "installed" and row.actual_release_id == release_id:
-                continue
-            # Never interrupt an in-flight uninstall; the Kind may still be
-            # active for a brief window before account uninstall completes.
-            if row.state == "uninstalling":
-                continue
-            if self._auto_update_blocked(row) and not manual_retry:
-                continue
-            if (
-                row.state == "pending"
-                and not row.error_code
-                and not row.error_message
-                and row.actual_release_id in {0, release_id}
-            ):
-                continue
-            row.state = "pending"
-            row.error_code = ""
-            row.error_message = ""
-            changed += 1
         db.commit()
         return changed
+
+    @staticmethod
+    def _is_device_install_conflict(exc: IntegrityError) -> bool:
+        message = str(exc.orig)
+        return "uniq_plugin_device_installation" in message or (
+            "plugin_device_installations.installed_kind_id" in message
+            and "plugin_device_installations.device_id" in message
+        )
 
     def auto_update_blocked_release_id(
         self,

--- a/backend/tests/services/test_plugin_marketplace_v2.py
+++ b/backend/tests/services/test_plugin_marketplace_v2.py
@@ -1930,6 +1930,45 @@ def test_ensure_pending_for_device_creates_and_resets_failed(test_db, test_user)
     assert row.desired_release_id == release.id
 
 
+def test_ensure_pending_for_device_recovers_from_concurrent_insert(
+    test_db, test_user, monkeypatch
+):
+    installed, release = _device_install(test_db, test_user.id)
+    test_db.add(
+        PluginDeviceInstallation(
+            installed_kind_id=installed.id,
+            user_id=test_user.id,
+            device_id="concurrent-device",
+            desired_release_id=release.id,
+            state="pending",
+        )
+    )
+    test_db.commit()
+    service = PluginDeviceInstallationService()
+    device_row = service._device_row
+    stale_read = True
+
+    def read_after_concurrent_insert(db, installed_kind_id, device_id):
+        nonlocal stale_read
+        if stale_read:
+            stale_read = False
+            return None
+        return device_row(db, installed_kind_id, device_id)
+
+    monkeypatch.setattr(service, "_device_row", read_after_concurrent_insert)
+
+    changed = service.ensure_pending_for_device(
+        test_db,
+        user_id=test_user.id,
+        device_id="concurrent-device",
+    )
+
+    assert changed == 0
+    rows = test_db.query(PluginDeviceInstallation).all()
+    assert len(rows) == 1
+    assert rows[0].state == "pending"
+
+
 def test_auto_update_stops_after_three_failures_until_manual_retry(test_db, test_user):
     installed, old_release = _device_install(test_db, test_user.id)
     new_release = PluginRelease(


### PR DESCRIPTION
## Summary
- retry device installation materialization after the exact unique-key race
- roll back and re-read the concurrently committed row
- keep unrelated integrity errors visible

## Verification
- cd backend && uv run pytest tests/services/test_plugin_marketplace_v2.py -q
- cd backend && uv run black --check app/services/plugin_device_installation_service.py tests/services/test_plugin_marketplace_v2.py
- cd backend && uv run isort --check-only app/services/plugin_device_installation_service.py tests/services/test_plugin_marketplace_v2.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device installation handling during concurrent requests.
  - Prevented duplicate installation records when an installation already exists.
  - Preserved the existing pending status after concurrent updates.

- **Tests**
  - Added regression coverage for stale reads and concurrent installation creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->