### PR TITLE
fix(backend): isolate project automation event loops

### DIFF
--- a/backend/app/tasks/project_automation_tasks.py
+++ b/backend/app/tasks/project_automation_tasks.py
@@ -5,6 +5,8 @@
 
 import asyncio
 import logging
+from collections.abc import Coroutine
+from typing import Any, TypeVar
 
 from app.core.celery_app import celery_app
 from app.db.session import SessionLocal
@@ -12,11 +14,19 @@ from app.services.project_automations import project_automation_service
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
+
+def _run_async(coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine without relying on a process-patched asyncio.run."""
+    with asyncio.Runner() as runner:
+        return runner.run(coro)
+
 
 def check_due_project_automations_sync() -> int:
     db = SessionLocal()
     try:
-        return asyncio.run(project_automation_service.check_due(db))
+        return _run_async(project_automation_service.check_due(db))
     except Exception:
         db.rollback()
         logger.exception("Project automation scheduler failed")
@@ -44,7 +54,7 @@ def dispatch_board_robot_execution(*, execution_id: int) -> bool:
 
     db = SessionLocal()
     try:
-        execution = asyncio.run(dispatch_execution(db, execution_id=execution_id))
+        execution = _run_async(dispatch_execution(db, execution_id=execution_id))
         return execution is not None
     except Exception as exc:
         db.rollback()
@@ -112,7 +122,7 @@ def execute_managed_project_automation(
                     "execution_id": execution_id,
                 }
             )
-        dispatched = asyncio.run(
+        dispatched = _run_async(
             project_automation_managed_execution_service.execute(**execute_kwargs)
         )
     except Exception as exc:
@@ -184,7 +194,7 @@ def execute_board_team_continuation(
         source=CONTINUATION_SOURCE,
     )
     try:
-        dispatched = asyncio.run(
+        dispatched = _run_async(
             project_automation_managed_execution_service.execute(
                 handle=handle,
                 user_subtask_id=user_subtask_id,
@@ -220,7 +230,7 @@ def cancel_managed_board_team_execution(*, task_id: int, user_id: int) -> bool:
         project_automation_managed_execution_service,
     )
 
-    return asyncio.run(
+    return _run_async(
         project_automation_managed_execution_service.cancel(
             task_id=task_id,
             user_id=user_id,

--- a/backend/tests/tasks/test_project_automation_tasks.py
+++ b/backend/tests/tasks/test_project_automation_tasks.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for project automation Celery task entry points."""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+
+def test_due_scan_ignores_closed_process_event_loop(monkeypatch) -> None:
+    from app.tasks import project_automation_tasks
+
+    db = MagicMock()
+    check_due = AsyncMock(return_value=3)
+    monkeypatch.setattr(
+        project_automation_tasks,
+        "SessionLocal",
+        MagicMock(return_value=db),
+    )
+    monkeypatch.setattr(
+        project_automation_tasks.project_automation_service,
+        "check_due",
+        check_due,
+    )
+
+    closed_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(closed_loop)
+    closed_loop.close()
+
+    def run_in_process_loop(coro: Coroutine[Any, Any, Any]) -> Any:
+        try:
+            return asyncio.get_event_loop().run_until_complete(coro)
+        except Exception:
+            coro.close()
+            raise
+
+    monkeypatch.setattr(asyncio, "run", run_in_process_loop)
+
+    try:
+        assert project_automation_tasks.check_due_project_automations_sync() == 3
+    finally:
+        asyncio.set_event_loop(None)
+
+    check_due.assert_awaited_once_with(db)
+    db.rollback.assert_not_called()
+    db.close.assert_called_once_with()


### PR DESCRIPTION
## Summary
- run project automation Celery coroutines with asyncio.Runner
- avoid the process-patched asyncio.run reusing a closed loop
- cover the closed process-loop regression

## Verification
- cd backend && uv run pytest tests/services/test_project_automation_managed_execution.py tests/tasks/test_project_automation_tasks.py -q
- cd backend && uv run black --check app/tasks/project_automation_tasks.py tests/tasks/test_project_automation_tasks.py
- cd backend && uv run isort --check-only app/tasks/project_automation_tasks.py tests/tasks/test_project_automation_tasks.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of project automation, board execution, continuation, and cancellation tasks when the process event loop has already been closed.

* **Tests**
  * Added coverage confirming due project automations complete successfully in closed-event-loop scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->