### PR TITLE
fix(wework): omit SSH port from merge request URL

### DIFF
--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -103,6 +103,28 @@ describe('buildPullRequestUrl', () => {
       'https://gitlab.com/wecode-ai/Wegent/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fcontext-info'
     )
   })
+
+  test('does not use the SSH transport port as the GitLab web port', () => {
+    expect(
+      buildPullRequestUrl(
+        'ssh://git@gitlab.example.com:2222/wecode-ai/Wegent.git',
+        'feature/context-info'
+      )
+    ).toBe(
+      'https://gitlab.example.com/wecode-ai/Wegent/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fcontext-info'
+    )
+  })
+
+  test('preserves an explicit HTTPS web port', () => {
+    expect(
+      buildPullRequestUrl(
+        'https://gitlab.example.com:8443/wecode-ai/Wegent.git',
+        'feature/context-info'
+      )
+    ).toBe(
+      'https://gitlab.example.com:8443/wecode-ai/Wegent/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fcontext-info'
+    )
+  })
 })
 
 describe('workspaceHasUncommittedChanges', () => {

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -593,8 +593,9 @@ export function parseGitRemote(remoteUrl: string): GitRemoteParts | null {
 
   try {
     const url = new URL(trimmed)
+    const host = url.protocol === 'ssh:' || url.protocol === 'git+ssh:' ? url.hostname : url.host
     return {
-      host: url.host,
+      host,
       repoPath: url.pathname.replace(/^\/+/, ''),
     }
   } catch {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
@@ -608,7 +608,7 @@ describe('RuntimeTaskLifecycleStore', () => {
     expect(snapshot?.derived.isBusy).toBe(false)
   })
 
-  test('recovers a new streaming turn after the previous turn completed', () => {
+  test('waits for executor confirmation before recovering a new transcript turn', () => {
     const store = new RuntimeTaskLifecycleStore('test')
 
     store.syncRuntimeWork(
@@ -630,10 +630,31 @@ describe('RuntimeTaskLifecycleStore', () => {
       })
     )
 
-    const snapshot = store.getTask(address)
-    expect(snapshot?.execution.phase).toBe('running')
-    expect(snapshot?.turn.phase).toBe('streaming')
-    expect(snapshot?.turn.id).toBe('turn-2')
+    expect(store.getTask(address)?.execution.phase).toBe('idle')
+    expect(store.getTask(address)?.turn.phase).toBe('idle')
+
+    store.syncRuntimeWork(
+      runtimeWork(
+        task({
+          running: true,
+          status: 'active',
+          threadStatus: 'active',
+          turnStatus: 'inProgress',
+          runtimeHandle: { lastTurnId: 'turn-2' },
+        })
+      )
+    )
+    store.syncTranscript(
+      address,
+      transcript({
+        running: true,
+        turns: [{ id: 'turn-2', items: [], status: 'streaming' }],
+      })
+    )
+
+    expect(store.getTask(address)?.execution.phase).toBe('running')
+    expect(store.getTask(address)?.turn.phase).toBe('streaming')
+    expect(store.getTask(address)?.turn.id).toBe('turn-2')
   })
 
   test('recovers a streaming transcript after an explicit send restarts a completed task', () => {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.ts
@@ -261,8 +261,7 @@ export class RuntimeTaskLifecycleStore {
     )
     const hasStreamingTurn = Boolean(streamingTurn)
     const current = this.getTask(address)
-    const ignoreStaleRunningTranscript =
-      shouldIgnoreStaleRunningTranscript(current) && !isNewStreamingTurn(current, streamingTurn?.id)
+    const ignoreStaleRunningTranscript = shouldIgnoreStaleRunningTranscript(current)
     const ignoreStaleIdleTranscript =
       transcript.running === false &&
       options.preserveActiveTurn === true &&
@@ -584,17 +583,6 @@ function shouldIgnoreStaleRunningTranscript(current: RuntimeTaskLifecycleSnapsho
         current.task !== null &&
         isRuntimeTaskAuthoritativeCompletion(current.task)))
   )
-}
-
-function isNewStreamingTurn(
-  current: RuntimeTaskLifecycleSnapshot | null,
-  turnId: string | null | undefined
-): boolean {
-  const normalizedTurnId = turnId?.trim()
-  if (!current || !normalizedTurnId) return false
-  const runtimeHandle = current.address.runtimeHandle ?? current.task?.runtimeHandle
-  const lastTurnId = runtimeHandle?.lastTurnId
-  return typeof lastTurnId === 'string' && lastTurnId.trim() !== normalizedTurnId
 }
 
 export function consumeRuntimeTaskLifecycleBlock(


### PR DESCRIPTION
## Summary

- omit SSH transport ports when deriving GitHub/GitLab web URLs
- preserve explicit ports for HTTP(S) remotes
- add regression coverage using a non-production GitLab example URL

## Verification

- `pnpm --filter wework test src/api/environment.test.ts`
- Wework pre-push ESLint, TypeScript, and unit tests
- Prettier and `git diff --check`
- isolated Electron build/start and SSH repository branch detection

Task: WEWORKC2FA61-392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git repository URL parsing for SSH remotes using nonstandard transport ports.
  * Correctly handles HTTPS remotes with explicit web ports.
  * Added coverage for these GitLab URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->