### PR TITLE
fix(wework): keep runtime lifecycle aligned across turn handoff

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -42,6 +42,7 @@ import {
   type WorkspaceTabsContextValue,
 } from '@/features/workspace-tabs/workspaceTabsContextValue'
 import {
+  RuntimeTaskLifecycleStreamCoordinator,
   RuntimeTaskLifecycleStore,
   useRuntimeTaskLifecycle,
   useRuntimeTaskLifecycleStore,
@@ -606,6 +607,71 @@ function renderWorkbench(children: React.ReactNode, services = createWorkbenchSe
   return render(
     <CloudConnectionContext.Provider value={cloudConnectionValue}>
       <WorkbenchProvider user={{ id: 1, user_name: 'alice', email: 'a@b.c' }} services={services}>
+        <WorkbenchProbeSessionProvider>{children}</WorkbenchProbeSessionProvider>
+      </WorkbenchProvider>
+    </CloudConnectionContext.Provider>
+  )
+}
+
+function renderWorkbenchWithLifecycleCoordinator(
+  children: React.ReactNode,
+  services = createWorkbenchServices()
+) {
+  const cloudConnectionValue: CloudConnectionContextValue = {
+    ...DISCONNECTED_STATE,
+    isConnected: false,
+    serviceKey: 'test-disconnected',
+    connectWithAuthorization: vi.fn(),
+    refreshUser: vi.fn(),
+    disconnect: vi.fn(),
+  }
+  const lifecycleStore = new RuntimeTaskLifecycleStore('test')
+  const subscribers = new Set<ChatStreamHandlers>()
+  let unsubscribeUpstream: (() => void) | null = null
+  const dispatcher = new Proxy<ChatStreamHandlers>(
+    {},
+    {
+      get: (_, property) => {
+        if (property === 'scope') return undefined
+        return (payload: unknown) => {
+          for (const handlers of subscribers) {
+            const callback = handlers[property as keyof ChatStreamHandlers]
+            if (typeof callback === 'function') {
+              ;(callback as (value: unknown) => void)(payload)
+            }
+          }
+        }
+      },
+    }
+  )
+  const coordinatedServices: WorkbenchServices = {
+    ...services,
+    chatStream: {
+      ...services.chatStream,
+      subscribe: handlers => {
+        subscribers.add(handlers)
+        unsubscribeUpstream ??= services.chatStream.subscribe(dispatcher)
+        return () => {
+          subscribers.delete(handlers)
+          if (subscribers.size === 0) {
+            unsubscribeUpstream?.()
+            unsubscribeUpstream = null
+          }
+        }
+      },
+    },
+  }
+  return render(
+    <CloudConnectionContext.Provider value={cloudConnectionValue}>
+      <RuntimeTaskLifecycleStreamCoordinator
+        services={coordinatedServices}
+        store={lifecycleStore}
+      />
+      <WorkbenchProvider
+        lifecycleStore={lifecycleStore}
+        user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+        services={coordinatedServices}
+      >
         <WorkbenchProbeSessionProvider>{children}</WorkbenchProbeSessionProvider>
       </WorkbenchProvider>
     </CloudConnectionContext.Provider>
@@ -2617,7 +2683,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('automation-task-options')).toHaveTextContent('none')
   })
 
-  test('prevents a retained inactive provider from overwriting shared lifecycle state', async () => {
+  test('does not let workbench providers own shared turn lifecycle events', async () => {
     const lifecycleStore = new RuntimeTaskLifecycleStore('test')
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
@@ -2732,8 +2798,8 @@ describe('WorkbenchProvider runtime tasks', () => {
       lifecycleStore.getTask({
         deviceId: 'device-1',
         taskId: 'shared-task',
-      })?.turn.id
-    ).toBe('owned-turn')
+      })
+    ).toBeNull()
   })
 
   test('keeps the runtime event subscription across connected user preference updates', async () => {
@@ -12105,7 +12171,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -12168,7 +12234,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(<FollowUpProbe />, services)
+    renderWorkbenchWithLifecycleCoordinator(<FollowUpProbe />, services)
 
     await userEvent.click(await screen.findByText('open follow-up runtime a'))
     await waitFor(() => expect(streamHandlers.onChatStart).toBeDefined())
@@ -12223,7 +12289,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(<RuntimeOpenProbe />, services)
+    renderWorkbenchWithLifecycleCoordinator(<RuntimeOpenProbe />, services)
 
     await userEvent.click(await screen.findByText('open runtime a'))
     await waitFor(() =>
@@ -13060,7 +13126,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(<RuntimeTopLevelStreamLifecycleProbe />, services)
+    renderWorkbenchWithLifecycleCoordinator(<RuntimeTopLevelStreamLifecycleProbe />, services)
 
     await waitFor(() =>
       expect(screen.getByTestId('top-level-runtime-stream-lifecycle')).toHaveTextContent(
@@ -13719,7 +13785,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -13751,7 +13817,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await act(async () => {
       streamHandlers.onChatDone?.({
         taskId: 'runtime-a',
-        subtaskId: 'provider-turn-101',
+        subtaskId: '101',
         deviceId: 'device-1',
         result: { value: 'done' },
       })
@@ -14335,7 +14401,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -14682,7 +14748,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -14816,7 +14882,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -15419,7 +15485,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -15858,7 +15924,8 @@ describe('WorkbenchProvider runtime tasks', () => {
       error: 'no active turn to guide',
       code: 'no_active_turn',
     })
-    let executorRunning = true
+    const executorRunning = true
+    let turnRunning = true
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockImplementation(() =>
         Promise.resolve(
@@ -15893,20 +15960,24 @@ describe('WorkbenchProvider runtime tasks', () => {
           })
         )
       ),
-      getRuntimeTranscript: vi.fn().mockResolvedValue({
-        taskId: 'runtime-a',
-        workspacePath: '/workspace/project-alpha',
-        runtime: 'claude_code',
-        messages: [
-          { id: 'runtime-a:user:1', role: 'user', content: 'first message' },
-          {
-            id: 'runtime-a:assistant:1',
-            role: 'assistant',
-            content: 'working',
-            status: 'streaming',
-          },
-        ],
-      }),
+      getRuntimeTranscript: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          taskId: 'runtime-a',
+          workspacePath: '/workspace/project-alpha',
+          runtime: 'claude_code',
+          running: turnRunning,
+          messages: [
+            { id: 'runtime-a:user:1', role: 'user', content: 'first message' },
+            {
+              id: 'runtime-a:assistant:1',
+              role: 'assistant',
+              content: turnRunning ? 'working' : 'done',
+              status: turnRunning ? 'streaming' : 'done',
+              subtaskId: '101',
+            },
+          ],
+        })
+      ),
       sendRuntimeMessage,
       guideRuntimeTask,
     })
@@ -15917,7 +15988,7 @@ describe('WorkbenchProvider runtime tasks', () => {
       } as unknown as WorkbenchServices['chatStream'],
     })
 
-    renderWorkbench(
+    renderWorkbenchWithLifecycleCoordinator(
       <>
         <RuntimeOpenProbe />
         <FollowUpProbe />
@@ -15941,6 +16012,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await userEvent.click(screen.getByText('send follow-up'))
     expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:继续修')
 
+    turnRunning = false
     await act(async () => {
       streamHandlers.onChatDone?.({
         taskId: 'runtime-a',
@@ -15949,9 +16021,6 @@ describe('WorkbenchProvider runtime tasks', () => {
         result: { value: 'done' },
       })
     })
-    expect(sendRuntimeMessage).not.toHaveBeenCalled()
-    executorRunning = false
-    await userEvent.click(screen.getByText('refresh work lists'))
     await waitFor(() => expect(sendRuntimeMessage).toHaveBeenCalledTimes(1))
     await waitFor(() =>
       expect(screen.getByTestId('queued-messages')).toHaveTextContent('failed:继续修')

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1960,7 +1960,6 @@ export function WorkbenchProvider({
           onAssistantStart: (address, turnId) => {
             settleRuntimeConversationAcceptedMessage(address)
             markRuntimeConversationAssistantStarted(address)
-            lifecycleStore.turnStarted(address, turnId)
             syncProjectTaskExecutionStatus(address, 'running')
             aiGenerationTelemetry.onAssistantStart(address, turnId)
           },
@@ -1972,7 +1971,6 @@ export function WorkbenchProvider({
           },
           onAssistantSettled: (address, turnId, outcome) => {
             settleRuntimeConversationSubagents(address)
-            lifecycleStore.turnSettled(address, turnId, outcome)
             syncProjectTaskExecutionStatus(address, outcome)
             aiGenerationTelemetry.onAssistantSettled(
               address,

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.test.tsx
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.test.tsx
@@ -432,7 +432,6 @@ describe('RuntimeTaskLifecycleStreamCoordinator', () => {
     store.syncRuntimeWork(runtimeWork(true))
     store.turnStarted(address, 'turn-1')
     store.turnSettled(address, 'turn-1', 'succeeded')
-    store.turnStarted(address, 'turn-2')
     let streamHandlers: ChatStreamHandlers = {}
     const getRuntimeTranscript = vi.fn().mockResolvedValue({
       ...runtimeTranscript(true),
@@ -466,6 +465,16 @@ describe('RuntimeTaskLifecycleStreamCoordinator', () => {
     } as unknown as WorkbenchServices
 
     render(<RuntimeTaskLifecycleStreamCoordinator services={services} store={store} />)
+    await act(async () => {
+      streamHandlers.onChatStart?.({
+        taskId: address.taskId,
+        deviceId: address.deviceId,
+        subtaskId: 'turn-2',
+      })
+    })
+    expect(store.getTask(address)?.turn.id).toBe('turn-2')
+    expect(store.getTask(address)?.derived.shouldShowSidebarRunning).toBe(true)
+
     await act(async () => {
       streamHandlers.onChatDone?.({
         taskId: address.taskId,

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.tsx
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStreamCoordinator.tsx
@@ -16,10 +16,34 @@ import type { RuntimeTaskAddress } from '@/types/api'
 
 type ReconciliationReason = 'event_lagged' | 'runtime_replaced' | 'system_resume'
 
-interface TerminalEventPayload {
+interface LifecycleEventPayload {
   taskId?: string
   subtaskId?: string
   deviceId?: string
+}
+
+function matchingLifecycleAddress(
+  store: RuntimeTaskLifecycleStore,
+  payload: LifecycleEventPayload
+): RuntimeTaskAddress | null {
+  if (!payload.taskId) return null
+  const snapshot = store.getSnapshot()
+  for (const lifecycle of snapshot.tasks.values()) {
+    if (!lifecycle || lifecycle.address.taskId !== payload.taskId) continue
+    if (
+      payload.deviceId &&
+      lifecycle.address.deviceId !== payload.deviceId &&
+      store.getTask({ ...lifecycle.address, deviceId: payload.deviceId })?.key !== lifecycle.key
+    ) {
+      continue
+    }
+    return lifecycle.address
+  }
+  if (!payload.deviceId) return null
+  return {
+    deviceId: payload.deviceId,
+    taskId: payload.taskId,
+  }
 }
 
 export function RuntimeTaskLifecycleStreamCoordinator({
@@ -106,29 +130,18 @@ export function RuntimeTaskLifecycleStreamCoordinator({
     })
 
     const settleMatchingTask = (
-      payload: TerminalEventPayload,
+      payload: LifecycleEventPayload,
       outcome: 'succeeded' | 'failed' | 'cancelled'
     ): { address: RuntimeTaskAddress; settled: boolean } | null => {
-      if (!payload.taskId) return null
-      const snapshot = store.getSnapshot()
-      for (const lifecycle of snapshot.tasks.values()) {
-        if (!lifecycle || lifecycle.address.taskId !== payload.taskId) continue
-        if (
-          payload.deviceId &&
-          lifecycle.address.deviceId !== payload.deviceId &&
-          store.getTask({ ...lifecycle.address, deviceId: payload.deviceId })?.key !== lifecycle.key
-        ) {
-          continue
-        }
-        const terminalTurnId = payload.subtaskId?.trim() || null
-        const activeTurnId = lifecycle.turn.id
-        if (terminalTurnId && activeTurnId && terminalTurnId !== activeTurnId) {
-          return { address: lifecycle.address, settled: false }
-        }
-        store.turnSettled(lifecycle.address, terminalTurnId, outcome)
-        return { address: lifecycle.address, settled: true }
+      const address = matchingLifecycleAddress(store, payload)
+      if (!address) return null
+      const terminalTurnId = payload.subtaskId?.trim() || null
+      const activeTurnId = store.getTask(address)?.turn.id
+      if (terminalTurnId && activeTurnId && terminalTurnId !== activeTurnId) {
+        return { address, settled: false }
       }
-      return null
+      store.turnSettled(address, terminalTurnId, outcome)
+      return { address, settled: true }
     }
 
     const reconcileTerminalTranscript = async (
@@ -160,6 +173,11 @@ export function RuntimeTaskLifecycleStreamCoordinator({
     }
 
     const unsubscribe = services.chatStream.subscribe({
+      onChatStart: payload => {
+        const address = matchingLifecycleAddress(store, payload)
+        if (!address) return
+        store.turnStarted(address, payload.subtaskId?.trim() || null)
+      },
       onChatDone: payload => {
         const match = settleMatchingTask(payload, 'succeeded')
         if (match) {


### PR DESCRIPTION
## 问题

Wework 在旧 turn 结束并立即启动新 turn 时，pane 订阅切换可能漏掉新 turn 的开始事件，但全局 lifecycle 仍收到旧 turn 的结束事件，导致侧边栏显示停止，而执行器实际仍在运行。

## 根因与修复

- 将 `response.created / response.in_progress` 的 turn 开始事实接入长期存活的全局 `RuntimeTaskLifecycleStreamCoordinator`。
- 按 task/device 定位 lifecycle，并保留 turn ID 隔离，旧 turn 的终态不能结束新 turn。
- 删除 `WorkbenchProvider` 对 `turnStarted/turnSettled` 的旧双写路径，使全局事件流成为实时 turn lifecycle 的唯一写入者。
- 测试按生产组件树广播同一条流事件，覆盖 turn handoff 和旧终态重复到达。

## 日志证据

故障现场中旧 turn 于 20:37:41 interrupted，新 turn 于 20:37:42 创建并持续运行，20:38:07 已开始执行命令；截图时执行器仍报告 running，但侧边栏已经停止。

## 验证

- `pnpm --dir wework test -- RuntimeTaskLifecycleStreamCoordinator.test.tsx RuntimeTaskLifecycleStore.test.ts WorkbenchProvider.test.tsx`（290 passed）
- `pnpm --dir wework typecheck`
- pre-push ESLint / TypeScript / focused unit tests
- 真实 Electron 启动验证

关联任务：WEWORKC2FA61-394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task and conversation status accuracy during assistant activity.
  * Prevented outdated completion events from incorrectly ending newer active tasks.
  * Improved handling of queued messages after a conversation turn is confirmed complete.
  * Ensured lifecycle status remains consistent when task details are temporarily unavailable.
* **Tests**
  * Expanded coverage for overlapping turns, stale events, queued messages, and shared lifecycle updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->