### PR TITLE
feat: expose executor tasks to standard DSH plugins

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -16,6 +16,7 @@ from app.api.endpoints import (
     device_chat_tasks,
     devices,
     dingtalk_docs,
+    dsh_plugin_storage,
     external_tasks,
     feedback,
     groups,
@@ -161,6 +162,11 @@ api_router.include_router(
     runtime_profiles.router,
     prefix="/v1/runtime-profiles",
     tags=["runtime-profiles"],
+)
+api_router.include_router(
+    dsh_plugin_storage.router,
+    prefix="/v1/dsh-plugin-storage",
+    tags=["dsh-plugin-storage"],
 )
 api_router.include_router(
     runtime_profiles.project_router,

--- a/backend/app/api/endpoints/dsh_plugin_storage.py
+++ b/backend/app/api/endpoints/dsh_plugin_storage.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticated generic storage endpoints for DSH plugins."""
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core.security import get_current_user
+from app.models.user import User
+from app.schemas.dsh_plugin_storage import (
+    DshSharedStorageResponse,
+    DshStorageDescriptor,
+    DshStorageGlobalWrite,
+    DshStorageRecordWrite,
+    DshStorageSnapshot,
+)
+from app.services.dsh_plugin_storage import dsh_plugin_storage_service
+
+router = APIRouter()
+
+
+@router.post("/units/{unit}/load", response_model=DshStorageSnapshot)
+def load_unit(
+    unit: str,
+    descriptor: DshStorageDescriptor,
+    package_name: str = Query(alias="package"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return dsh_plugin_storage_service.load_unit(
+        db, current_user.id, package_name, unit, descriptor
+    )
+
+
+@router.put(
+    "/units/{unit}/tables/{table}/records/{key}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def put_record(
+    unit: str,
+    table: str,
+    key: str,
+    request: DshStorageRecordWrite,
+    package_name: str = Query(alias="package"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dsh_plugin_storage_service.put_record(
+        db,
+        current_user.id,
+        package_name,
+        unit,
+        table,
+        key,
+        request,
+        request.value,
+        request.shared,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete(
+    "/units/{unit}/tables/{table}/records/{key}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_record(
+    unit: str,
+    table: str,
+    key: str,
+    descriptor: DshStorageDescriptor,
+    package_name: str = Query(alias="package"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dsh_plugin_storage_service.delete_record(
+        db, current_user.id, package_name, unit, table, key, descriptor
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put("/units/{unit}/global", status_code=status.HTTP_204_NO_CONTENT)
+def set_global(
+    unit: str,
+    request: DshStorageGlobalWrite,
+    package_name: str = Query(alias="package"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dsh_plugin_storage_service.set_global(
+        db, current_user.id, package_name, unit, request, request.value
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/units/{unit}/tables/{table}/shared",
+    response_model=DshSharedStorageResponse,
+)
+def scan_shared_records(
+    unit: str,
+    table: str,
+    package_name: str = Query(alias="package"),
+    limit: int = Query(default=500, ge=1, le=500),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    del current_user
+    return {
+        "records": dsh_plugin_storage_service.scan_shared(
+            db, package_name, unit, table, limit
+        )
+    }

--- a/backend/app/schemas/dsh_plugin_storage.py
+++ b/backend/app/schemas/dsh_plugin_storage.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Schemas for generic DSH plugin storage."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DshStorageDescriptor(BaseModel):
+    version: int = Field(ge=0)
+    tables: List[str] = Field(default_factory=list, max_length=64)
+    has_global: bool = False
+
+
+class DshStorageRecordWrite(DshStorageDescriptor):
+    value: Any
+    shared: bool = False
+
+
+class DshStorageGlobalWrite(DshStorageDescriptor):
+    value: Any
+
+
+class DshStorageSnapshot(BaseModel):
+    version: int
+    tables: Dict[str, Dict[str, Any]]
+    global_value: Optional[Any] = Field(default=None, alias="global")
+
+    model_config = {"populate_by_name": True}
+
+
+class DshSharedStorageRecord(BaseModel):
+    owner_id: int
+    owner_name: str
+    key: str
+    value: Any
+
+
+class DshSharedStorageResponse(BaseModel):
+    records: List[DshSharedStorageRecord]

--- a/backend/app/services/dsh_plugin_storage.py
+++ b/backend/app/services/dsh_plugin_storage.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic DSH plugin KV storage backed by the existing Kind table."""
+
+import re
+from copy import deepcopy
+from typing import Any, Dict, List
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.models.user import User
+from app.schemas.dsh_plugin_storage import DshStorageDescriptor
+
+DSH_PLUGIN_DATA_KIND = "DshPluginData"
+UNIT_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+PACKAGE_NAME_RE = re.compile(r"^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$")
+
+
+class DshPluginStorageService:
+    """Store plugin-owned KV units without introducing plugin-specific tables."""
+
+    def load_unit(
+        self,
+        db: Session,
+        user_id: int,
+        package_name: str,
+        unit: str,
+        descriptor: DshStorageDescriptor,
+    ) -> Dict[str, Any]:
+        self.validate_identity(package_name, unit)
+        self.validate_descriptor(descriptor)
+        resource = self._resource(db, user_id, package_name, unit)
+        if resource is None:
+            return self._empty_snapshot(descriptor)
+        document = self._document(resource)
+        self._require_compatible(document, descriptor)
+        return self._public_snapshot(document)
+
+    def put_record(
+        self,
+        db: Session,
+        user_id: int,
+        package_name: str,
+        unit: str,
+        table: str,
+        key: str,
+        descriptor: DshStorageDescriptor,
+        value: Any,
+        shared: bool,
+    ) -> None:
+        self._validate_record_target(package_name, unit, table, key, descriptor)
+        resource = self._locked_resource(db, user_id, package_name, unit)
+        document = (
+            self._new_document(descriptor)
+            if resource is None
+            else deepcopy(self._document(resource))
+        )
+        self._require_compatible(document, descriptor)
+        document["tables"][table][key] = {"value": value, "shared": shared}
+        self._save(db, resource, user_id, package_name, unit, document)
+
+    def delete_record(
+        self,
+        db: Session,
+        user_id: int,
+        package_name: str,
+        unit: str,
+        table: str,
+        key: str,
+        descriptor: DshStorageDescriptor,
+    ) -> None:
+        self._validate_record_target(package_name, unit, table, key, descriptor)
+        resource = self._locked_resource(db, user_id, package_name, unit)
+        if resource is None:
+            return
+        document = deepcopy(self._document(resource))
+        self._require_compatible(document, descriptor)
+        document["tables"][table].pop(key, None)
+        resource.json = document
+        db.commit()
+
+    def set_global(
+        self,
+        db: Session,
+        user_id: int,
+        package_name: str,
+        unit: str,
+        descriptor: DshStorageDescriptor,
+        value: Any,
+    ) -> None:
+        self.validate_identity(package_name, unit)
+        self.validate_descriptor(descriptor)
+        if not descriptor.has_global:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Storage unit does not declare a global value",
+            )
+        resource = self._locked_resource(db, user_id, package_name, unit)
+        document = (
+            self._new_document(descriptor)
+            if resource is None
+            else deepcopy(self._document(resource))
+        )
+        self._require_compatible(document, descriptor)
+        document["global"] = value
+        self._save(db, resource, user_id, package_name, unit, document)
+
+    def scan_shared(
+        self,
+        db: Session,
+        package_name: str,
+        unit: str,
+        table: str,
+        limit: int,
+    ) -> List[Dict[str, Any]]:
+        self.validate_identity(package_name, unit)
+        self._validate_name(table, "table")
+        rows = (
+            db.query(Kind, User)
+            .join(User, User.id == Kind.user_id)
+            .filter(
+                Kind.kind == DSH_PLUGIN_DATA_KIND,
+                Kind.namespace == package_name,
+                Kind.name == unit,
+                Kind.is_active == True,
+                User.is_active == True,
+            )
+            .order_by(Kind.updated_at.desc(), Kind.id.desc())
+            .all()
+        )
+        records: List[Dict[str, Any]] = []
+        for resource, owner in rows:
+            entries = self._document(resource).get("tables", {}).get(table, {})
+            if not isinstance(entries, dict):
+                continue
+            for key, entry in entries.items():
+                if not isinstance(entry, dict) or entry.get("shared") is not True:
+                    continue
+                records.append(
+                    {
+                        "owner_id": owner.id,
+                        "owner_name": owner.user_name,
+                        "key": key,
+                        "value": entry.get("value"),
+                    }
+                )
+                if len(records) >= limit:
+                    return records
+        return records
+
+    def validate_identity(self, package_name: str, unit: str) -> None:
+        if len(package_name) > 100 or not PACKAGE_NAME_RE.fullmatch(package_name):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid DSH package name",
+            )
+        self._validate_name(unit, "unit")
+
+    def validate_descriptor(self, descriptor: DshStorageDescriptor) -> None:
+        if len(set(descriptor.tables)) != len(descriptor.tables):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Storage descriptor contains duplicate tables",
+            )
+        for table in descriptor.tables:
+            self._validate_name(table, "table")
+
+    def _validate_record_target(
+        self,
+        package_name: str,
+        unit: str,
+        table: str,
+        key: str,
+        descriptor: DshStorageDescriptor,
+    ) -> None:
+        self.validate_identity(package_name, unit)
+        self.validate_descriptor(descriptor)
+        if table not in descriptor.tables:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Table '{table}' is not declared by the storage unit",
+            )
+        if not key or len(key) > 512:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Storage record key must contain 1 to 512 characters",
+            )
+
+    def _validate_name(self, value: str, label: str) -> None:
+        if len(value) > 100 or not UNIT_NAME_RE.fullmatch(value):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid storage {label} name",
+            )
+
+    def _resource(
+        self,
+        db: Session,
+        user_id: int,
+        package_name: str,
+        unit: str,
+    ) -> Kind | None:
+        return (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == user_id,
+                Kind.kind == DSH_PLUGIN_DATA_KIND,
+                Kind.namespace == package_name,
+                Kind.name == unit,
+                Kind.is_active == True,
+            )
+            .order_by(Kind.id.desc())
+            .first()
+        )
+
+    def _locked_resource(
+        self,
+        db: Session,
+        user_id: int,
+        package_name: str,
+        unit: str,
+    ) -> Kind | None:
+        return (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == user_id,
+                Kind.kind == DSH_PLUGIN_DATA_KIND,
+                Kind.namespace == package_name,
+                Kind.name == unit,
+                Kind.is_active == True,
+            )
+            .order_by(Kind.id.desc())
+            .with_for_update()
+            .first()
+        )
+
+    def _save(
+        self,
+        db: Session,
+        resource: Kind | None,
+        user_id: int,
+        package_name: str,
+        unit: str,
+        document: Dict[str, Any],
+    ) -> None:
+        if resource is None:
+            resource = Kind(
+                user_id=user_id,
+                kind=DSH_PLUGIN_DATA_KIND,
+                namespace=package_name,
+                name=unit,
+                json=document,
+            )
+            db.add(resource)
+        else:
+            resource.json = document
+        db.commit()
+
+    def _document(self, resource: Kind) -> Dict[str, Any]:
+        if not isinstance(resource.json, dict):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Stored DSH plugin data is malformed",
+            )
+        return resource.json
+
+    def _require_compatible(
+        self,
+        document: Dict[str, Any],
+        descriptor: DshStorageDescriptor,
+    ) -> None:
+        if document.get("version") != descriptor.version:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Storage unit version does not match",
+            )
+        if document.get("table_names") != descriptor.tables:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Storage unit tables do not match",
+            )
+        if document.get("has_global") is not descriptor.has_global:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Storage unit global declaration does not match",
+            )
+
+    def _new_document(self, descriptor: DshStorageDescriptor) -> Dict[str, Any]:
+        return {
+            "version": descriptor.version,
+            "table_names": list(descriptor.tables),
+            "has_global": descriptor.has_global,
+            "tables": {table: {} for table in descriptor.tables},
+            "global": None,
+        }
+
+    def _empty_snapshot(self, descriptor: DshStorageDescriptor) -> Dict[str, Any]:
+        return self._public_snapshot(self._new_document(descriptor))
+
+    def _public_snapshot(self, document: Dict[str, Any]) -> Dict[str, Any]:
+        tables = {
+            table: {
+                key: entry.get("value")
+                for key, entry in entries.items()
+                if isinstance(entry, dict)
+            }
+            for table, entries in document.get("tables", {}).items()
+            if isinstance(entries, dict)
+        }
+        return {
+            "version": document["version"],
+            "tables": tables,
+            "global": document.get("global"),
+        }
+
+
+dsh_plugin_storage_service = DshPluginStorageService()

--- a/backend/tests/api/test_dsh_plugin_storage_api.py
+++ b/backend/tests/api/test_dsh_plugin_storage_api.py
@@ -1,0 +1,140 @@
+"""API coverage for generic DSH plugin storage."""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.security import create_access_token, get_password_hash
+from app.models.kind import Kind
+from app.models.user import User
+
+BASE_URL = "/api/v1/dsh-plugin-storage"
+PACKAGE = "@wegent/ai-fleet-defense"
+DESCRIPTOR = {"version": 1, "tables": ["scores"], "has_global": False}
+
+
+def test_stores_and_loads_private_plugin_records(
+    test_client: TestClient,
+    test_db: Session,
+    test_token: str,
+    test_user: User,
+) -> None:
+    response = test_client.put(
+        f"{BASE_URL}/units/ai_fleet_defense/tables/scores/records/best",
+        params={"package": PACKAGE},
+        headers=_auth(test_token),
+        json={**DESCRIPTOR, "value": {"score": 1200}, "shared": False},
+    )
+
+    assert response.status_code == 204
+    stored = (
+        test_db.query(Kind)
+        .filter(
+            Kind.user_id == test_user.id,
+            Kind.kind == "DshPluginData",
+            Kind.namespace == PACKAGE,
+            Kind.name == "ai_fleet_defense",
+        )
+        .one()
+    )
+    assert stored.json["tables"]["scores"]["best"] == {
+        "value": {"score": 1200},
+        "shared": False,
+    }
+
+    loaded = test_client.post(
+        f"{BASE_URL}/units/ai_fleet_defense/load",
+        params={"package": PACKAGE},
+        headers=_auth(test_token),
+        json=DESCRIPTOR,
+    )
+    assert loaded.status_code == 200
+    assert loaded.json() == {
+        "version": 1,
+        "tables": {"scores": {"best": {"score": 1200}}},
+        "global": None,
+    }
+
+
+def test_shared_scan_returns_only_explicitly_shared_records(
+    test_client: TestClient,
+    test_db: Session,
+    test_token: str,
+    test_user: User,
+) -> None:
+    second_user = User(
+        user_name="fleet-rival",
+        password_hash=get_password_hash("secret-password"),
+        email="fleet-rival@example.com",
+        is_active=True,
+    )
+    test_db.add(second_user)
+    test_db.commit()
+    second_token = create_access_token(data={"sub": second_user.user_name})
+
+    _put_score(test_client, test_token, "best", 1500, shared=True)
+    _put_score(test_client, second_token, "best", 2100, shared=True)
+    _put_score(test_client, second_token, "draft", 9999, shared=False)
+
+    response = test_client.get(
+        f"{BASE_URL}/units/ai_fleet_defense/tables/scores/shared",
+        params={"package": PACKAGE},
+        headers=_auth(test_token),
+    )
+
+    assert response.status_code == 200
+    records = response.json()["records"]
+    assert {
+        (record["owner_name"], record["key"], record["value"]["score"])
+        for record in records
+    } == {
+        (test_user.user_name, "best", 1500),
+        (second_user.user_name, "best", 2100),
+    }
+
+
+def test_rejects_descriptor_version_changes(
+    test_client: TestClient,
+    test_token: str,
+) -> None:
+    _put_score(test_client, test_token, "best", 1500, shared=True)
+
+    response = test_client.post(
+        f"{BASE_URL}/units/ai_fleet_defense/load",
+        params={"package": PACKAGE},
+        headers=_auth(test_token),
+        json={**DESCRIPTOR, "version": 2},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Storage unit version does not match"
+
+
+def test_requires_authentication(test_client: TestClient) -> None:
+    response = test_client.post(
+        f"{BASE_URL}/units/ai_fleet_defense/load",
+        params={"package": PACKAGE},
+        json=DESCRIPTOR,
+    )
+
+    assert response.status_code == 401
+
+
+def _put_score(
+    client: TestClient,
+    token: str,
+    key: str,
+    score: int,
+    *,
+    shared: bool,
+) -> None:
+    response = client.put(
+        f"{BASE_URL}/units/ai_fleet_defense/tables/scores/records/{key}",
+        params={"package": PACKAGE},
+        headers=_auth(token),
+        json={**DESCRIPTOR, "value": {"score": score}, "shared": shared},
+    )
+    assert response.status_code == 204
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}

--- a/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 35
+---
+
+# DSH Session Extensions for Executor Tasks
+
+Wework Core DSH projects Executor-managed running tasks into standard
+`@deepseek-ai/dsh-session` Sessions. An ordinary DSH host plugin only needs to
+inject `sessions` and subscribe to the official `session/event` stream. It does
+not need a Wework-private event bus or a direct Executor connection.
+
+## Event projection
+
+`@wegent/dsh-executor-runtime` uses a dedicated Executor local-endpoint
+connection and resumes the event stream from the last consumed `sequence`.
+Each `(deviceId, taskId)` pair maps to a stable, independent Session, so
+parallel tasks never merge into one event stream.
+
+The main mappings are:
+
+| Executor event                             | DSH Session event                           |
+| ------------------------------------------ | ------------------------------------------- |
+| `response.created`, `response.in_progress` | `turn/start`, `step/start`                  |
+| `runtimeGeneratedUserMessage`              | `user/message`                              |
+| reasoning delta                            | `assistant/chunk` reasoning block           |
+| output text delta                          | `assistant/chunk` text block                |
+| `thread/tokenUsage/updated`                | `assistant/chunk` usage                     |
+| completed, incomplete, failed, error       | `assistant/message`, `step/end`, `turn/end` |
+
+The projection preserves raw user messages and model output. Installing and
+trusting a plugin permits it to read that content through the standard DSH
+Session contract; Wework does not maintain a second anonymized-summary
+extension point for the same data.
+
+Codex `tokenUsage.last` is cumulative for the current turn, and projected usage
+chunks retain that meaning. A plugin that needs live token throughput should
+subtract adjacent `outputTokens` values for the same Session and divide by the
+sample interval. It must not add multiple cumulative samples together.
+
+```js
+export const inject = ["sessions"];
+
+export function apply(ctx) {
+  ctx.on("session/event", (session, event) => {
+    if (event.type === "assistant/chunk" && event.data.chunk.type === "usage") {
+      observeUsage(session.id, event.data.chunk.usage);
+    }
+  });
+}
+```
+
+## Generic Backend plugin storage
+
+A DSH plugin that needs cross-client persistence can use the authenticated
+generic storage API. Data reuses the existing `Kind` table with this identity:
+
+- `kind`: `DshPluginData`
+- `namespace`: npm package name
+- `name`: storage unit name
+- `user_id`: current authenticated user
+
+Every read and write includes a descriptor. The Backend validates its
+`version`, table-name list, and global-value declaration so incompatible plugin
+versions cannot silently reinterpret the same storage unit.
+
+```json
+{
+  "version": 1,
+  "tables": ["scores"],
+  "has_global": false
+}
+```
+
+The API prefix is `/api/v1/dsh-plugin-storage`:
+
+| Method and path                                                       | Purpose                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------- |
+| `POST /units/{unit}/load?package={package}`                           | Load the current user's unit                      |
+| `PUT /units/{unit}/tables/{table}/records/{key}?package={package}`    | Write a record                                    |
+| `DELETE /units/{unit}/tables/{table}/records/{key}?package={package}` | Delete a record                                   |
+| `PUT /units/{unit}/global?package={package}`                          | Write a declared global value                     |
+| `GET /units/{unit}/tables/{table}/shared?package={package}`           | Scan explicitly shared records within the Backend |
+
+A record write body adds `value` and `shared` to the descriptor. Only records
+with `shared: true` appear in a shared scan, while a normal load always returns
+only the current user's data. Plugins should use a stable key for a best record
+instead of appending an unbounded record for every run.
+
+In Wework local-first mode, a plugin client should use the active cloud
+connection's `apiBaseUrl` and token. Local functionality can continue without
+a Backend connection, but shared data is unavailable.

--- a/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 35
+---
+
+# Executor 任务的 DSH Session 扩展
+
+Wework Core DSH 将 Executor 管理的运行中任务投影为标准
+`@deepseek-ai/dsh-session` Session。普通 DSH host 插件只需注入
+`sessions` 并监听官方 `session/event`，不需要依赖 Wework 私有事件总线或直接连接
+Executor。
+
+## 事件投影
+
+`@wegent/dsh-executor-runtime` 使用独立的 Executor 本地端点连接订阅事件流，并按最后
+消费的 `sequence` 断线续传。每个 `(deviceId, taskId)` 映射为一个稳定、独立的
+Session，因此并行任务不会合并到同一个事件流。
+
+主要映射如下：
+
+| Executor 事件                              | DSH Session 事件                            |
+| ------------------------------------------ | ------------------------------------------- |
+| `response.created`、`response.in_progress` | `turn/start`、`step/start`                  |
+| `runtimeGeneratedUserMessage`              | `user/message`                              |
+| reasoning delta                            | `assistant/chunk` reasoning block           |
+| output text delta                          | `assistant/chunk` text block                |
+| `thread/tokenUsage/updated`                | `assistant/chunk` usage                     |
+| completed、incomplete、failed、error       | `assistant/message`、`step/end`、`turn/end` |
+
+投影保留原始用户消息和模型输出。安装并信任插件意味着允许插件按标准 DSH
+Session 契约读取这些内容；Wework 不再为同一数据维护一套匿名摘要扩展点。
+
+Codex 的 `tokenUsage.last` 表示当前 turn 的累计用量，投影后的 usage chunk
+也保持这一语义。需要实时 token 速度的插件应对同一 Session 的相邻
+`outputTokens` 求差分，再除以采样间隔；不能把多个累计值直接相加。
+
+```js
+export const inject = ["sessions"];
+
+export function apply(ctx) {
+  ctx.on("session/event", (session, event) => {
+    if (event.type === "assistant/chunk" && event.data.chunk.type === "usage") {
+      observeUsage(session.id, event.data.chunk.usage);
+    }
+  });
+}
+```
+
+## Backend 通用插件存储
+
+需要跨客户端保存数据的 DSH 插件可以使用认证后的通用存储 API。数据复用现有
+`Kind` 表，资源身份为：
+
+- `kind`: `DshPluginData`
+- `namespace`: npm package name
+- `name`: storage unit name
+- `user_id`: 当前认证用户
+
+插件每次读写都提交 descriptor。Backend 会校验 `version`、表名列表和是否声明
+global value，避免同一 storage unit 被不兼容版本静默解释。
+
+```json
+{
+  "version": 1,
+  "tables": ["scores"],
+  "has_global": false
+}
+```
+
+API 前缀为 `/api/v1/dsh-plugin-storage`：
+
+| 方法与路径                                                            | 用途                              |
+| --------------------------------------------------------------------- | --------------------------------- |
+| `POST /units/{unit}/load?package={package}`                           | 读取当前用户的 unit               |
+| `PUT /units/{unit}/tables/{table}/records/{key}?package={package}`    | 写入记录                          |
+| `DELETE /units/{unit}/tables/{table}/records/{key}?package={package}` | 删除记录                          |
+| `PUT /units/{unit}/global?package={package}`                          | 写入声明过的 global value         |
+| `GET /units/{unit}/tables/{table}/shared?package={package}`           | 扫描 Backend 范围内显式共享的记录 |
+
+记录写入体在 descriptor 之外包含 `value` 和 `shared`。只有
+`shared: true` 的记录会出现在 shared scan 中；普通 load 始终只返回当前用户自己的
+数据。插件应使用稳定 key 保存最佳记录，而不是每局追加一条无界记录。
+
+Wework 本地优先模式的插件 client 应读取当前云端连接的 `apiBaseUrl` 和 token；
+未连接 Backend 时，本地功能可以继续运行，但共享数据不可用。

--- a/wework/dsh/executor-runtime/cordis.patch.yml
+++ b/wework/dsh/executor-runtime/cordis.patch.yml
@@ -3,3 +3,4 @@
       name: '@wegent/dsh-executor-runtime'
       inject:
         - webServer
+        - sessions

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -1,8 +1,10 @@
 import { ExecutorRuntimeClient, ExecutorRuntimeError } from './executor-runtime-client.js'
 import { LocalEndpointEventStream } from './local-endpoint-event-stream.js'
+import { ExecutorSessionProjector } from './session-projector.js'
+import { ExecutorSessionProjectionStream } from './session-projection-stream.js'
 
 export const name = 'wework-executor-runtime'
-export const inject = ['webServer']
+export const inject = ['webServer', 'sessions']
 
 const BASE_PATH = '/wework/executor/v1'
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024
@@ -11,6 +13,16 @@ export async function apply(ctx) {
   const client = ExecutorRuntimeClient.fromEnvironment()
   await client.start()
   ctx.effect(() => () => client.stop(), 'wework-executor-runtime: transport')
+  const projector = new ExecutorSessionProjector(ctx.sessions)
+  const projectionStream = new ExecutorSessionProjectionStream(projector, {
+    onError: error => {
+      console.error('[wework-executor-runtime] DSH session projection failed', error)
+    },
+  })
+  ctx.effect(() => {
+    projectionStream.start()
+    return () => projectionStream.stop()
+  }, 'wework-executor-runtime: session projection')
   register(ctx, BASE_PATH, (req, res) => describe(req, res, client))
   register(ctx, `${BASE_PATH}/rpc`, (req, res) => rpc(req, res, client))
   register(ctx, `${BASE_PATH}/events`, (req, res) => handleExecutorEvents(req, res))

--- a/wework/dsh/executor-runtime/package.json
+++ b/wework/dsh/executor-runtime/package.json
@@ -17,6 +17,7 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2"
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.1-rc.2"
   }
 }

--- a/wework/dsh/executor-runtime/session-projection-stream.js
+++ b/wework/dsh/executor-runtime/session-projection-stream.js
@@ -1,0 +1,64 @@
+import { LocalEndpointEventStream } from './local-endpoint-event-stream.js'
+
+const RECONNECT_DELAY_MS = 250
+
+export class ExecutorSessionProjectionStream {
+  constructor(projector, options = {}) {
+    this.projector = projector
+    this.createEventStream =
+      options.createEventStream ??
+      (streamOptions => LocalEndpointEventStream.fromEnvironment(streamOptions))
+    this.onError = options.onError ?? (() => {})
+    this.afterSequence = 0
+    this.active = false
+    this.stream = null
+    this.reconnectTimer = null
+  }
+
+  start() {
+    if (this.active) return
+    this.active = true
+    this.connect()
+  }
+
+  stop() {
+    this.active = false
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = null
+    this.stream?.stop()
+    this.stream = null
+  }
+
+  connect() {
+    if (!this.active) return
+    const stream = this.createEventStream({
+      afterSequence: this.afterSequence,
+      onEvent: event => {
+        if (Number.isSafeInteger(event.sequence) && event.sequence > this.afterSequence) {
+          this.afterSequence = event.sequence
+        }
+        try {
+          this.projector.handle(event)
+        } catch (error) {
+          this.onError(error)
+        }
+      },
+      onClose: () => this.reconnect(),
+    })
+    this.stream = stream
+    Promise.resolve(stream.start()).catch(error => {
+      this.onError(error)
+      this.reconnect()
+    })
+  }
+
+  reconnect() {
+    if (!this.active || this.reconnectTimer) return
+    this.stream?.stop()
+    this.stream = null
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.connect()
+    }, RECONNECT_DELAY_MS)
+  }
+}

--- a/wework/dsh/executor-runtime/session-projection-stream.test.mjs
+++ b/wework/dsh/executor-runtime/session-projection-stream.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ExecutorSessionProjectionStream } from './session-projection-stream.js'
+
+test('resumes projection after the latest accepted executor sequence', async () => {
+  const cursors = []
+  const handled = []
+  let connection = 0
+  const stream = new ExecutorSessionProjectionStream(
+    { handle: event => handled.push(event.sequence) },
+    {
+      createEventStream(options) {
+        cursors.push(options.afterSequence)
+        connection += 1
+        return {
+          async start() {
+            options.onEvent({ sequence: connection })
+            if (connection === 1) options.onClose()
+          },
+          stop() {},
+        }
+      },
+    }
+  )
+
+  stream.start()
+  await waitFor(() => cursors.length === 2)
+  stream.stop()
+
+  assert.deepEqual(cursors, [0, 1])
+  assert.deepEqual(handled, [1, 2])
+})
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('Timed out waiting for projection reconnect')
+}

--- a/wework/dsh/executor-runtime/session-projector.js
+++ b/wework/dsh/executor-runtime/session-projector.js
@@ -1,0 +1,339 @@
+import { randomUUID } from 'node:crypto'
+
+const TERMINAL_EVENTS = new Set([
+  'response.completed',
+  'response.failed',
+  'response.incomplete',
+  'error',
+])
+
+export class ExecutorSessionProjector {
+  constructor(sessions) {
+    this.sessions = sessions
+    this.tasks = new Map()
+  }
+
+  handle(envelope) {
+    if (!isRecord(envelope) || envelope.type !== 'event' || !isRecord(envelope.payload)) return
+    const payload = envelope.payload
+    const taskId = stringField(payload, 'taskId')
+    if (!taskId) return
+
+    const state = this.taskState(payload, taskId)
+    const event = stringField(envelope, 'event')
+    if (!event) return
+    const subtaskId = stringField(payload, 'subtaskId')
+
+    if (event === 'response.created' || event === 'response.in_progress') {
+      this.openTurn(state, subtaskId)
+      this.appendGeneratedUserMessage(state, payload)
+      return
+    }
+
+    if (event === 'response.output_text.delta' || event === 'response.refusal.delta') {
+      const text = stringField(recordField(payload, 'data'), 'delta')
+      if (text) this.appendDelta(state, subtaskId, 'text', text)
+      return
+    }
+
+    if (
+      event === 'response.reasoning_summary_text.delta' ||
+      event === 'response.reasoning_summary_part.added'
+    ) {
+      const data = recordField(payload, 'data')
+      const text =
+        stringField(data, 'delta') ??
+        stringField(data, 'text') ??
+        stringField(recordField(data, 'part'), 'text')
+      if (text) this.appendDelta(state, subtaskId, 'reasoning', text)
+      return
+    }
+
+    if (event === 'thread/tokenUsage/updated' || event === 'thread.tokenUsage.updated') {
+      const runtimeUsage = recordField(recordField(payload, 'data'), 'tokenUsage')
+      const usage = tokenUsage(
+        Object.keys(recordField(runtimeUsage, 'last')).length
+          ? recordField(runtimeUsage, 'last')
+          : recordField(runtimeUsage, 'total')
+      )
+      if (!usage) return
+      this.ensureOpenTurn(state, subtaskId)
+      state.usage = usage
+      const appended = state.session.append('assistant/chunk', {
+        turn: state.turn,
+        step: 1,
+        chunk: { type: 'usage', usage },
+      })
+      state.sourceEventSeqs.push(appended.seq)
+      return
+    }
+
+    if (TERMINAL_EVENTS.has(event)) {
+      this.finishTurn(state, subtaskId, event, recordField(payload, 'data'))
+    }
+  }
+
+  taskState(payload, taskId) {
+    const deviceId = stringField(payload, 'deviceId') ?? 'local'
+    const key = `${deviceId}\u0000${taskId}`
+    const existing = this.tasks.get(key)
+    if (existing) return existing
+
+    const sessionId = executorSessionId(deviceId, taskId)
+    const session = this.sessions.get(sessionId) ?? this.sessions.create(sessionId)
+    const state = {
+      session,
+      turn: completedTurns(session),
+      subtaskId: null,
+      open: false,
+      text: '',
+      reasoning: '',
+      textStarted: false,
+      reasoningStarted: false,
+      usage: null,
+      sourceEventSeqs: [],
+      generatedUserMessageIds: new Set(),
+    }
+    this.tasks.set(key, state)
+    return state
+  }
+
+  openTurn(state, subtaskId) {
+    if (state.open && (!subtaskId || state.subtaskId === subtaskId)) return
+    if (state.open) this.closeTurn(state, 'response.incomplete', {})
+
+    state.turn += 1
+    state.subtaskId = subtaskId ?? null
+    state.open = true
+    state.text = ''
+    state.reasoning = ''
+    state.textStarted = false
+    state.reasoningStarted = false
+    state.usage = null
+    state.sourceEventSeqs = []
+    state.session.append('turn/start', { turn: state.turn })
+    state.session.append('step/start', { turn: state.turn, step: 1 })
+  }
+
+  ensureOpenTurn(state, subtaskId) {
+    if (!state.open || (subtaskId && state.subtaskId && subtaskId !== state.subtaskId)) {
+      this.openTurn(state, subtaskId)
+    }
+  }
+
+  appendGeneratedUserMessage(state, payload) {
+    const generated = recordField(payload, 'runtimeGeneratedUserMessage')
+    const text = stringField(generated, 'message')
+    if (!text) return
+    const id = stringField(generated, 'id') ?? randomUUID()
+    if (state.generatedUserMessageIds.has(id)) return
+    state.generatedUserMessageIds.add(id)
+    state.session.append(
+      'user/message',
+      {
+        id,
+        role: 'user',
+        content: [{ type: 'text', text }],
+        source: { kind: 'user' },
+      },
+      { surfaceOp: 'append' }
+    )
+  }
+
+  appendDelta(state, subtaskId, kind, text) {
+    this.ensureOpenTurn(state, subtaskId)
+    const index = kind === 'reasoning' ? 0 : 1
+    const startedKey = kind === 'reasoning' ? 'reasoningStarted' : 'textStarted'
+    if (!state[startedKey]) {
+      const start = state.session.append('assistant/chunk', {
+        turn: state.turn,
+        step: 1,
+        chunk: { type: 'block-start', index, blockType: kind },
+      })
+      state.sourceEventSeqs.push(start.seq)
+      state[startedKey] = true
+    }
+    state[kind] += text
+    const appended = state.session.append('assistant/chunk', {
+      turn: state.turn,
+      step: 1,
+      chunk: {
+        type: kind === 'reasoning' ? 'reasoning-delta' : 'text-delta',
+        index,
+        text,
+      },
+    })
+    state.sourceEventSeqs.push(appended.seq)
+  }
+
+  finishTurn(state, subtaskId, event, data) {
+    if (!state.open) {
+      if (!subtaskId || subtaskId === state.subtaskId) return
+      this.openTurn(state, subtaskId)
+    } else {
+      this.ensureOpenTurn(state, subtaskId)
+    }
+
+    const completedText = responseText(data)
+    if (!state.text && completedText) this.appendDelta(state, subtaskId, 'text', completedText)
+    const completedUsage = responseUsage(data)
+    if (completedUsage) state.usage = completedUsage
+    this.closeTurn(state, event, data)
+  }
+
+  closeTurn(state, event, data) {
+    if (!state.open) return
+    if (state.reasoningStarted) this.appendBlockEnd(state, 'reasoning', 0)
+    if (state.textStarted) this.appendBlockEnd(state, 'text', 1)
+    if (event === 'response.completed') {
+      const finish = state.session.append('assistant/chunk', {
+        turn: state.turn,
+        step: 1,
+        chunk: { type: 'finish', reason: { kind: 'stop' } },
+      })
+      state.sourceEventSeqs.push(finish.seq)
+    }
+
+    const content = []
+    if (state.reasoning) content.push({ type: 'reasoning', text: state.reasoning })
+    if (state.text) content.push({ type: 'text', text: state.text })
+    state.session.append(
+      'assistant/message',
+      {
+        turn: state.turn,
+        step: 1,
+        message: {
+          id: randomUUID(),
+          role: 'assistant',
+          content,
+          source: {
+            kind: 'model',
+            provider: 'wegent-executor',
+            model: 'executor-managed',
+          },
+        },
+        ...(state.usage ? { usage: state.usage } : {}),
+        ...(event === 'response.completed' ? {} : { interrupted: true }),
+      },
+      { surfaceOp: 'append', sourceEventSeqs: state.sourceEventSeqs }
+    )
+    state.session.append('step/end', { turn: state.turn, step: 1 })
+    state.session.append('turn/end', {
+      turn: state.turn,
+      reason: turnEndReason(event, data),
+    })
+    state.open = false
+  }
+
+  appendBlockEnd(state, kind, index) {
+    const appended = state.session.append('assistant/chunk', {
+      turn: state.turn,
+      step: 1,
+      chunk: { type: 'block-end', index, block: { type: kind, text: state[kind] } },
+    })
+    state.sourceEventSeqs.push(appended.seq)
+  }
+}
+
+export function executorSessionId(deviceId, taskId) {
+  return `wegent-executor-${encodeId(deviceId)}-${encodeId(taskId)}`
+}
+
+function encodeId(value) {
+  return Buffer.from(value).toString('base64url')
+}
+
+function completedTurns(session) {
+  return session.events.reduce(
+    (maximum, event) =>
+      event.type === 'turn/end' && Number.isSafeInteger(event.data?.turn)
+        ? Math.max(maximum, event.data.turn)
+        : maximum,
+    0
+  )
+}
+
+function tokenUsage(value) {
+  if (!isRecord(value)) return null
+  const total = isRecord(value.total) ? value.total : value
+  const input = nonNegativeInteger(total.inputTokens)
+  const output = nonNegativeInteger(total.outputTokens)
+  if (input === null || output === null) return null
+  const cached = nonNegativeInteger(total.cachedInputTokens) ?? 0
+  const reasoning = nonNegativeInteger(total.reasoningOutputTokens)
+  return {
+    inputTokens: Math.max(0, input - cached),
+    outputTokens: output,
+    ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(reasoning === null ? {} : { reasoningTokens: reasoning }),
+  }
+}
+
+function responseUsage(data) {
+  const response = recordField(data, 'response')
+  const usage = recordField(response, 'usage')
+  if (!Object.keys(usage).length) return null
+  return tokenUsage({
+    inputTokens: usage.input_tokens ?? usage.inputTokens,
+    outputTokens: usage.output_tokens ?? usage.outputTokens,
+    cachedInputTokens:
+      recordField(usage, 'input_tokens_details').cached_tokens ??
+      recordField(usage, 'inputTokensDetails').cachedTokens,
+    reasoningOutputTokens:
+      recordField(usage, 'output_tokens_details').reasoning_tokens ??
+      recordField(usage, 'outputTokensDetails').reasoningTokens,
+  })
+}
+
+function responseText(data) {
+  const direct = stringField(data, 'value') ?? stringField(data, 'output_text')
+  if (direct) return direct
+  const output = recordField(data, 'response').output
+  if (!Array.isArray(output)) return ''
+  return output
+    .flatMap(item => {
+      const content = isRecord(item) ? item.content : null
+      return Array.isArray(content)
+        ? content.flatMap(part => {
+            const record = isRecord(part) ? part : {}
+            return record.type === 'output_text' && typeof record.text === 'string'
+              ? [record.text]
+              : []
+          })
+        : []
+    })
+    .join('')
+}
+
+function turnEndReason(event, data) {
+  if (event === 'response.completed') return { kind: 'completed' }
+  if (event === 'response.incomplete') return { kind: 'interrupted' }
+  return {
+    kind: 'error',
+    error: {
+      message:
+        stringField(data, 'message') ??
+        stringField(recordField(data, 'error'), 'message') ??
+        'Executor response failed',
+      code: stringField(recordField(data, 'error'), 'code') ?? 'WEGENT_EXECUTOR_ERROR',
+    },
+  }
+}
+
+function nonNegativeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : null
+}
+
+function stringField(record, key) {
+  const value = record[key]
+  return typeof value === 'string' && value ? value : null
+}
+
+function recordField(record, key) {
+  const value = record[key]
+  return isRecord(value) ? value : {}
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}

--- a/wework/dsh/executor-runtime/session-projector.test.mjs
+++ b/wework/dsh/executor-runtime/session-projector.test.mjs
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ExecutorSessionProjector, executorSessionId } from './session-projector.js'
+
+test('projects executor text, reasoning, usage, and completion into standard session events', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(
+    executorEvent(1, 'response.created', {
+      runtimeGeneratedUserMessage: { id: 'user-1', message: 'Build the feature' },
+    })
+  )
+  projector.handle(executorEvent(2, 'response.reasoning_summary_text.delta', { delta: 'Think' }))
+  projector.handle(executorEvent(3, 'response.output_text.delta', { delta: 'Done' }))
+  projector.handle(
+    executorEvent(4, 'thread/tokenUsage/updated', {
+      tokenUsage: {
+        total: {
+          inputTokens: 1000,
+          cachedInputTokens: 400,
+          outputTokens: 250,
+          reasoningOutputTokens: 50,
+        },
+        last: {
+          inputTokens: 100,
+          cachedInputTokens: 40,
+          outputTokens: 25,
+          reasoningOutputTokens: 5,
+        },
+      },
+    })
+  )
+  projector.handle(executorEvent(5, 'response.completed', {}))
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  assert.ok(session)
+  assert.deepEqual(
+    session.events.map(event => event.type),
+    [
+      'turn/start',
+      'step/start',
+      'user/message',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/chunk',
+      'assistant/message',
+      'step/end',
+      'turn/end',
+    ]
+  )
+  const message = session.events.find(event => event.type === 'assistant/message')
+  assert.deepEqual(message.data.message.content, [
+    { type: 'reasoning', text: 'Think' },
+    { type: 'text', text: 'Done' },
+  ])
+  assert.deepEqual(message.data.usage, {
+    inputTokens: 60,
+    outputTokens: 25,
+    cacheReadTokens: 40,
+    reasoningTokens: 5,
+  })
+  assert.equal(session.events.at(-1).data.reason.kind, 'completed')
+})
+
+test('keeps parallel executor tasks in independent DSH sessions', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(executorEvent(1, 'response.output_text.delta', { delta: 'A' }, 'task-a'))
+  projector.handle(executorEvent(2, 'response.output_text.delta', { delta: 'B' }, 'task-b'))
+
+  const first = sessions.get(executorSessionId('device-1', 'task-a'))
+  const second = sessions.get(executorSessionId('device-1', 'task-b'))
+  assert.equal(first.events.find(event => event.type === 'assistant/chunk').data.turn, 1)
+  assert.equal(second.events.find(event => event.type === 'assistant/chunk').data.turn, 1)
+  assert.notEqual(first, second)
+})
+
+test('uses final response usage when no live token update was emitted', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(
+    executorEvent(1, 'response.completed', {
+      response: {
+        output: [
+          {
+            type: 'message',
+            content: [{ type: 'output_text', text: 'Final answer' }],
+          },
+        ],
+        usage: {
+          input_tokens: 30,
+          output_tokens: 10,
+          input_tokens_details: { cached_tokens: 20 },
+          output_tokens_details: { reasoning_tokens: 3 },
+        },
+      },
+    })
+  )
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  const message = session.events.find(event => event.type === 'assistant/message')
+  assert.deepEqual(message.data.message.content, [{ type: 'text', text: 'Final answer' }])
+  assert.deepEqual(message.data.usage, {
+    inputTokens: 10,
+    outputTokens: 10,
+    cacheReadTokens: 20,
+    reasoningTokens: 3,
+  })
+})
+
+test('marks failed executor responses as interrupted error turns', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(executorEvent(1, 'response.output_text.delta', { delta: 'Partial' }))
+  projector.handle(
+    executorEvent(2, 'response.failed', {
+      error: { code: 'MODEL_FAILED', message: 'Provider failed' },
+    })
+  )
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  const message = session.events.find(event => event.type === 'assistant/message')
+  assert.equal(message.data.interrupted, true)
+  assert.deepEqual(session.events.at(-1).data.reason, {
+    kind: 'error',
+    error: { message: 'Provider failed', code: 'MODEL_FAILED' },
+  })
+})
+
+class SessionStoreFixture {
+  constructor() {
+    this.values = new Map()
+  }
+
+  get(id) {
+    return this.values.get(id)
+  }
+
+  create(id) {
+    const session = new SessionFixture(id)
+    this.values.set(id, session)
+    return session
+  }
+}
+
+class SessionFixture {
+  constructor(id) {
+    this.id = id
+    this.events = []
+  }
+
+  append(type, data, options) {
+    const event = {
+      type,
+      data: structuredClone(data),
+      seq: this.events.length,
+      ...(options ?? {}),
+    }
+    this.events.push(event)
+    return event
+  }
+}
+
+function executorEvent(sequence, event, data, taskId = 'task-1') {
+  return {
+    type: 'event',
+    protocolVersion: 1,
+    sequence,
+    event,
+    payload: {
+      taskId,
+      subtaskId: `${taskId}-turn-1`,
+      deviceId: 'device-1',
+      data,
+      ...(data.runtimeGeneratedUserMessage
+        ? { runtimeGeneratedUserMessage: data.runtimeGeneratedUserMessage }
+        : {}),
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- project Executor-managed Wework tasks into standard DSH Sessions and publish the official `session/event` stream
- preserve raw user/model messages, reasoning, live cumulative turn usage, terminal state, parallel task isolation, and reconnect sequencing
- add authenticated generic DSH plugin storage backed by the existing `Kind` model, including explicitly shared record scans
- document the extension and storage contracts in Chinese and English

## Why

Standard DSH plugins previously could not observe Wework Executor task execution because Core DSH and Executor had no Session projection bridge. This change makes ordinary host plugins sufficient for features such as aggregate live token-throughput telemetry without introducing a Wework-private plugin event API.

## Verification

- `node --test wework/dsh/executor-runtime/session-projector.test.mjs wework/dsh/executor-runtime/session-projection-stream.test.mjs`
- `cd backend && uv run pytest tests/api/test_dsh_plugin_storage_api.py -q`
- real DSH 0.1.1-rc.2 Session reconstruction with `deriveMessages()`
- real DSH CLI profile install, config validation, host boot, and telemetry endpoint
- real Wework Electron `ai:verify`: local plugin install, Core DSH restart, sidebar route, game start, score progression
- repository pre-push ESLint, Wework unit tests, DSH tests, Black, isort, Python syntax, settings, and Alembic checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated storage APIs for DSH plugins, supporting private and shared records, global values, snapshots, and record management.
  * Executor tasks now appear in standard DSH Sessions, including messages, reasoning, output, token usage, completion, and error events.
  * Session event processing automatically reconnects and resumes without losing progress.

* **Documentation**
  * Added English and Chinese guides for Executor Sessions and plugin storage APIs.

* **Tests**
  * Added coverage for storage security, sharing, version validation, session projection, reconnection, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->