### PR TITLE
fix(executor): auto approve full access MCP prompts

### DIFF
--- a/docs/en/wework/developer-guide/wework-plugin-interactive-forms.md
+++ b/docs/en/wework/developer-guide/wework-plugin-interactive-forms.md
@@ -133,7 +133,7 @@ default_tools_approval_mode = "approve"
 
 Request-level, bot-level, and Wework built-in persistent MCP servers should all follow this rule. For tools from Wegent Connector Apps, Wework writes the built-in persistent MCP server `mcp_servers.wegent_apps` with the same `default_tools_approval_mode = "approve"` and refreshes existing config during connector configure or app sync.
 
-If a plugin tool really needs per-call approval, the plugin config can explicitly declare `default_tools_approval_mode = "prompt"`. Wework must preserve that explicit setting. Read-only and workspace permission modes still show the approval card for these calls. In Full access mode, Wework automatically accepts approval requests marked with `_meta.codex_approval_kind = "mcp_tool_call"` instead of showing them to the user.
+If a plugin tool really needs per-call approval, the plugin config can explicitly declare `default_tools_approval_mode = "prompt"`. Wework must preserve that explicit setting. Read-only and workspace permission modes still show the approval card for these calls. In Full access mode, Wework automatically accepts MCP tool approvals explicitly identified by Codex instead of showing them to the user.
 
 Also keep:
 
@@ -146,8 +146,8 @@ These switches control different behavior:
 
 - `approvalPolicy.granular.mcp_elicitations: true` allows plugin business forms to be forwarded from the MCP runtime to the Wework UI.
 - `mcp_servers.<name>.default_tools_approval_mode = "approve"` makes normal MCP tool calls not require approval cards.
-- `features.tool_call_mcp_elicitation: false` only means Codex should not wrap tool-call approval cards as MCP elicitation forms. If the tool approval mode still requires approval, Codex may fall back to a normal `request_user_input` approval card.
-- Full access mode automatically accepts approvals explicitly marked as `mcp_tool_call` while continuing to forward plugin business forms without that marker.
+- `features.tool_call_mcp_elicitation: false` only means Codex should not wrap tool-call approval cards as MCP elicitation forms. If the tool approval mode still requires approval, Codex sends a normal `item/tool/requestUserInput` request whose question ID is `mcp_tool_call_approval_<call-id>`.
+- Full access mode automatically accepts MCP elicitations marked with `_meta.codex_approval_kind = "mcp_tool_call"` and the `requestUserInput` compatibility approval above, while continuing to forward ordinary user questions and plugin business forms.
 
 ## Implementation Boundary
 
@@ -165,19 +165,19 @@ Code-level boundaries:
 - Codex thread/turn params use granular approval policy and only enable `mcp_elicitations`.
 - `features.tool_call_mcp_elicitation=false` prevents normal MCP tool approval from being wrapped as a business form.
 - Request/bot MCP config defaults to `default_tools_approval_mode = "approve"`, with explicit `prompt` taking precedence.
-- Full access recognizes `_meta.codex_approval_kind = "mcp_tool_call"` and returns `accept` without forwarding that approval event to the chat UI.
+- Full access recognizes an MCP elicitation with `_meta.codex_approval_kind = "mcp_tool_call"` or a `requestUserInput` containing exactly one `mcp_tool_call_approval_<call-id>` question. It returns the corresponding `accept` or `Allow` response without forwarding that approval event to the chat UI.
 - `mcp_servers.wegent_apps` is the Wework Connector Apps built-in persistent server, so Wework writes it and refreshes it during configure/app sync with the same default `approve` behavior.
 
 Use the error location to debug:
 
-| Symptom                                                                                      | Meaning                                                                                                       | Action                                                                                                                                       |
-| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `The MCP client does not support openai/form requests.`                                      | The Codex MCP client connected to the plugin does not support `openai/form`; the request did not reach Wework | Switch to `mode: "form"`, or fall back to normal chat/tool parameters                                                                        |
-| Plugin receives `action: "decline"`, but logs do not contain `mcpServer/elicitation/request` | Codex MCP runtime rejected the request before Wework UI                                                       | Check `elicitations_auto_deny`, `approvalPolicy`, granular `mcp_elicitations`, and active-turn routing                                       |
-| No form appears, but logs contain `mcpServer/elicitation/request`                            | The request reached the runtime, but the schema may be unsupported                                            | Check `mode` and `requestedSchema.properties`                                                                                                |
-| Full access still shows an "Allow this MCP tool call" form                                   | The approval was not identified as `mcp_tool_call`, or the runtime did not receive the Full access profile    | Check `_meta.codex_approval_kind` and `runtime_permission_profile`; do not auto-accept ordinary business forms                               |
-| Every MCP tool call shows an approval form in read-only or workspace mode                    | The MCP server/tool approval mode still requires approval                                                     | Set `default_tools_approval_mode="approve"` for plugin servers that do not need approval; explicitly keep `prompt` for servers/tools that do |
-| The form appears but the plugin does not continue after submit                               | Response routing or plugin result handling is broken                                                          | Verify the plugin handles `accept`, `cancel`, and `decline`                                                                                  |
+| Symptom                                                                                      | Meaning                                                                                                       | Action                                                                                                                                             |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `The MCP client does not support openai/form requests.`                                      | The Codex MCP client connected to the plugin does not support `openai/form`; the request did not reach Wework | Switch to `mode: "form"`, or fall back to normal chat/tool parameters                                                                              |
+| Plugin receives `action: "decline"`, but logs do not contain `mcpServer/elicitation/request` | Codex MCP runtime rejected the request before Wework UI                                                       | Check `elicitations_auto_deny`, `approvalPolicy`, granular `mcp_elicitations`, and active-turn routing                                             |
+| No form appears, but logs contain `mcpServer/elicitation/request`                            | The request reached the runtime, but the schema may be unsupported                                            | Check `mode` and `requestedSchema.properties`                                                                                                      |
+| Full access still shows an "Allow this MCP tool call" form                                   | The approval marker was not recognized, or the runtime did not receive the Full access profile                | Check `_meta.codex_approval_kind`, `requestUserInput.questions[].id`, and `runtime_permission_profile`; do not auto-accept ordinary business forms |
+| Every MCP tool call shows an approval form in read-only or workspace mode                    | The MCP server/tool approval mode still requires approval                                                     | Set `default_tools_approval_mode="approve"` for plugin servers that do not need approval; explicitly keep `prompt` for servers/tools that do       |
+| The form appears but the plugin does not continue after submit                               | Response routing or plugin result handling is broken                                                          | Verify the plugin handles `accept`, `cancel`, and `decline`                                                                                        |
 
 ## Schema Mapping
 

--- a/docs/zh/wework/developer-guide/wework-plugin-interactive-forms.md
+++ b/docs/zh/wework/developer-guide/wework-plugin-interactive-forms.md
@@ -133,7 +133,7 @@ default_tools_approval_mode = "approve"
 
 request-level、bot-level 以及 Wework 内置持久 MCP server 都应遵循这个规则。`mcp_servers.wegent_apps` 是 Wegent Connector Apps 的内置持久 server，Wework 会写成同样的 `default_tools_approval_mode = "approve"`，并在 Connector 配置或应用同步时刷新旧配置。
 
-如某个插件工具确实需要每次授权，插件配置可以显式声明 `default_tools_approval_mode = "prompt"`，Wework 必须保留该显式配置。在只读或工作区权限模式下，这类工具调用仍会显示授权卡；在完整访问模式下，Wework 会自动接受带有 `_meta.codex_approval_kind = "mcp_tool_call"` 的授权请求，不再把它显示给用户。
+如某个插件工具确实需要每次授权，插件配置可以显式声明 `default_tools_approval_mode = "prompt"`，Wework 必须保留该显式配置。在只读或工作区权限模式下，这类工具调用仍会显示授权卡；在完整访问模式下，Wework 会自动接受 Codex 明确标记的 MCP 工具审批，不再把它显示给用户。
 
 另外，Wework runtime 应保持：
 
@@ -146,8 +146,8 @@ tool_call_mcp_elicitation = false
 
 - `approvalPolicy.granular.mcp_elicitations: true` 允许插件业务表单从 MCP runtime 转发到 Wework UI。
 - `mcp_servers.<name>.default_tools_approval_mode = "approve"` 让普通 MCP tool call 不需要授权卡。
-- `features.tool_call_mcp_elicitation: false` 只表示不要把 Codex tool-call 授权卡包装成 MCP elicitation 表单；如果 tool approval mode 仍然要求审批，Codex 还可能退回普通 `request_user_input` 授权卡。
-- 完整访问模式会自动接受明确标记为 `mcp_tool_call` 的审批，同时继续转发没有该标记的插件业务表单。
+- `features.tool_call_mcp_elicitation: false` 只表示不要把 Codex tool-call 授权卡包装成 MCP elicitation 表单；如果 tool approval mode 仍然要求审批，Codex 会通过普通 `item/tool/requestUserInput` 请求，并使用 `mcp_tool_call_approval_<call-id>` 问题 ID。
+- 完整访问模式会自动接受 `_meta.codex_approval_kind = "mcp_tool_call"` 的 MCP elicitation 审批，以及上述 `requestUserInput` 兼容审批，同时继续转发普通用户问题和插件业务表单。
 
 ## 实现边界
 
@@ -165,19 +165,19 @@ tool_call_mcp_elicitation = false
 - Codex thread/turn 参数使用 granular approval policy，只打开 `mcp_elicitations`。
 - `features.tool_call_mcp_elicitation=false` 防止普通 MCP tool approval 被包装成业务表单。
 - request/bot MCP config 默认补 `default_tools_approval_mode = "approve"`，显式 `prompt` 优先。
-- 完整访问模式识别 `_meta.codex_approval_kind = "mcp_tool_call"` 并直接返回 `accept`，不向聊天界面发送该授权事件。
+- 完整访问模式识别 `_meta.codex_approval_kind = "mcp_tool_call"` 的 MCP elicitation，或仅含一个 `mcp_tool_call_approval_<call-id>` 问题的 `requestUserInput`，直接返回对应的 `accept`/`Allow`，不向聊天界面发送该授权事件。
 - `mcp_servers.wegent_apps` 是 Wework Connector Apps 的内置持久 server，由 Wework 写入并在 configure/app sync 时刷新，同样默认 `approve`。
 
 因此，排查问题时可以按错误位置判断：
 
-| 现象                                                                         | 含义                                                                    | 处理                                                                                                                 |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `The MCP client does not support openai/form requests.`                      | 插件连接到的 Codex MCP client 不支持 `openai/form`，请求没有进入 Wework | 改用 `mode: "form"`，或走普通对话/tool 参数降级                                                                      |
-| 插件收到 `action: "decline"`，但运行日志没有 `mcpServer/elicitation/request` | Codex MCP runtime 在 Wework UI 之前提前拒绝                             | 检查 `elicitations_auto_deny`、`approvalPolicy`、granular `mcp_elicitations`、是否 active turn                       |
-| 表单没有出现，但运行日志里有 `mcpServer/elicitation/request`                 | 请求到达运行时，可能 schema 不受支持                                    | 检查 `mode` 和 `requestedSchema.properties`                                                                          |
-| 完整访问下仍弹出“Allow this MCP tool call”表单                               | 工具审批没有被识别为 `mcp_tool_call`，或 full-access 标记未传入运行时   | 检查 `_meta.codex_approval_kind` 和 `runtime_permission_profile`；不要自动接受普通业务表单                           |
-| 只读或工作区模式下每次 MCP tool call 都弹出授权表单                          | 该 MCP server/tool 的 tool approval mode 仍然要求审批                   | 对不需要授权的插件 server 设置 `default_tools_approval_mode="approve"`；确实需要授权的 server/tool 显式保留 `prompt` |
-| 表单出现但提交后插件没有继续                                                 | 响应路由或插件侧结果处理有问题                                          | 检查插件是否处理 `accept`、`cancel`、`decline`                                                                       |
+| 现象                                                                         | 含义                                                                    | 处理                                                                                                                          |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `The MCP client does not support openai/form requests.`                      | 插件连接到的 Codex MCP client 不支持 `openai/form`，请求没有进入 Wework | 改用 `mode: "form"`，或走普通对话/tool 参数降级                                                                               |
+| 插件收到 `action: "decline"`，但运行日志没有 `mcpServer/elicitation/request` | Codex MCP runtime 在 Wework UI 之前提前拒绝                             | 检查 `elicitations_auto_deny`、`approvalPolicy`、granular `mcp_elicitations`、是否 active turn                                |
+| 表单没有出现，但运行日志里有 `mcpServer/elicitation/request`                 | 请求到达运行时，可能 schema 不受支持                                    | 检查 `mode` 和 `requestedSchema.properties`                                                                                   |
+| 完整访问下仍弹出“Allow this MCP tool call”表单                               | 工具审批标记未被识别，或 full-access 标记未传入运行时                   | 检查 `_meta.codex_approval_kind`、`requestUserInput.questions[].id` 和 `runtime_permission_profile`；不要自动接受普通业务表单 |
+| 只读或工作区模式下每次 MCP tool call 都弹出授权表单                          | 该 MCP server/tool 的 tool approval mode 仍然要求审批                   | 对不需要授权的插件 server 设置 `default_tools_approval_mode="approve"`；确实需要授权的 server/tool 显式保留 `prompt`          |
+| 表单出现但提交后插件没有继续                                                 | 响应路由或插件侧结果处理有问题                                          | 检查插件是否处理 `accept`、`cancel`、`decline`                                                                                |
 
 ## Schema 到界面的映射
 

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2037,12 +2037,8 @@ async fn read_shared_turn_notifications(
         {
             waiting_for_initial_progress = false;
         }
-        let auto_approve_mcp_tool_call = options.auto_approve_mcp_tool_calls
-            && message
-                .get("method")
-                .and_then(Value::as_str)
-                .is_some_and(|method| method == "mcpServer/elicitation/request")
-            && is_mcp_tool_call_approval(message_params(&message));
+        let auto_approve_mcp_tool_call =
+            options.auto_approve_mcp_tool_calls && is_mcp_tool_call_approval_request(&message);
         if !auto_approve_mcp_tool_call {
             if let Some(sender) = &options.notifications {
                 let _ = sender.send(message.clone());
@@ -2059,6 +2055,7 @@ async fn read_shared_turn_notifications(
                 &message,
                 request_user_input_answers.clone(),
                 response_error_tx.clone(),
+                options.auto_approve_mcp_tool_calls,
             )?;
             continue;
         }
@@ -2247,9 +2244,21 @@ fn spawn_shared_request_user_input_response(
     message: &Value,
     request_user_input_answers: Option<Arc<InteractionAnswerRouter>>,
     response_error_tx: mpsc::UnboundedSender<String>,
+    auto_approve_mcp_tool_calls: bool,
 ) -> Result<(), String> {
     let request_id = json_rpc_request_id(message)
         .ok_or_else(|| "request_user_input message is missing JSON-RPC id".to_owned())?;
+    if auto_approve_mcp_tool_calls {
+        if let Some(response) = mcp_tool_call_request_user_input_response(message_params(message)) {
+            let client = client.clone();
+            tokio::spawn(async move {
+                if let Err(error) = client.send_response(request_id, response).await {
+                    let _ = response_error_tx.send(error);
+                }
+            });
+            return Ok(());
+        }
+    }
     let Some(receiver) = request_user_input_answers else {
         return Err("request_user_input requires a runtime response channel".to_owned());
     };
@@ -5202,6 +5211,36 @@ const MCP_ELICITATION_ALLOW: &str = "Allow";
 const MCP_ELICITATION_ALLOW_SESSION: &str = "Allow for this session";
 const MCP_ELICITATION_ALLOW_ALWAYS: &str = "Allow and don't ask me again";
 const MCP_ELICITATION_DECLINE: &str = "Decline";
+const MCP_TOOL_CALL_APPROVAL_QUESTION_ID_PREFIX: &str = "mcp_tool_call_approval_";
+
+fn is_mcp_tool_call_approval_request(message: &Value) -> bool {
+    match message.get("method").and_then(Value::as_str) {
+        Some("item/tool/requestUserInput") => {
+            mcp_tool_call_request_user_input_response(message_params(message)).is_some()
+        }
+        Some("mcpServer/elicitation/request") => is_mcp_tool_call_approval(message_params(message)),
+        _ => false,
+    }
+}
+
+fn mcp_tool_call_request_user_input_response(params: &Value) -> Option<Value> {
+    let questions = params.get("questions")?.as_array()?;
+    let [question] = questions.as_slice() else {
+        return None;
+    };
+    let question_id = question.get("id")?.as_str()?;
+    let call_id = question_id.strip_prefix(MCP_TOOL_CALL_APPROVAL_QUESTION_ID_PREFIX)?;
+    if call_id.is_empty() {
+        return None;
+    }
+    Some(json!({
+        "answers": {
+            question_id: {
+                "answers": [MCP_ELICITATION_ALLOW]
+            }
+        }
+    }))
+}
 
 async fn receive_mcp_server_elicitation_response(
     message: &Value,

--- a/executor/src/agents/codex/json_rpc.rs
+++ b/executor/src/agents/codex/json_rpc.rs
@@ -15,10 +15,10 @@ use crate::runner::ExecutionOutcome;
 
 use super::{
     codex_error_message, codex_notification_has_initial_progress,
-    codex_turn_startup_timeout_seconds, is_mcp_tool_call_approval, json_rpc_request_id,
-    log_codex_raw_turn_message, message_params, receive_mcp_server_elicitation_response,
-    request_user_input_result, response_id, response_result, CodexNotificationSender,
-    CodexRequestUserInputReceiver, CodexRunState,
+    codex_turn_startup_timeout_seconds, is_mcp_tool_call_approval_request, json_rpc_request_id,
+    log_codex_raw_turn_message, mcp_tool_call_request_user_input_response, message_params,
+    receive_mcp_server_elicitation_response, request_user_input_result, response_id,
+    response_result, CodexNotificationSender, CodexRequestUserInputReceiver, CodexRunState,
 };
 
 pub(super) struct JsonRpcConnection {
@@ -141,12 +141,8 @@ impl JsonRpcConnection {
             {
                 waiting_for_initial_progress = false;
             }
-            let auto_approve_mcp_tool_call = auto_approve_mcp_tool_calls
-                && message
-                    .get("method")
-                    .and_then(Value::as_str)
-                    .is_some_and(|method| method == "mcpServer/elicitation/request")
-                && is_mcp_tool_call_approval(message_params(&message));
+            let auto_approve_mcp_tool_call =
+                auto_approve_mcp_tool_calls && is_mcp_tool_call_approval_request(&message);
             if !auto_approve_mcp_tool_call {
                 if let Some(sender) = &notifications {
                     let _ = sender.send(message.clone());
@@ -157,8 +153,12 @@ impl JsonRpcConnection {
                 .and_then(Value::as_str)
                 .is_some_and(|method| method == "item/tool/requestUserInput")
             {
-                self.answer_request_user_input(&message, &mut request_user_input_answers)
-                    .await?;
+                self.answer_request_user_input(
+                    &message,
+                    &mut request_user_input_answers,
+                    auto_approve_mcp_tool_calls,
+                )
+                .await?;
                 continue;
             }
             if message
@@ -187,9 +187,22 @@ impl JsonRpcConnection {
         &mut self,
         message: &Value,
         request_user_input_answers: &mut Option<CodexRequestUserInputReceiver>,
+        auto_approve_mcp_tool_calls: bool,
     ) -> Result<(), String> {
         let request_id = json_rpc_request_id(message)
             .ok_or_else(|| "request_user_input message is missing JSON-RPC id".to_owned())?;
+        if auto_approve_mcp_tool_calls {
+            if let Some(response) =
+                mcp_tool_call_request_user_input_response(message_params(message))
+            {
+                return self
+                    .write_message(json!({
+                        "id": request_id,
+                        "result": response,
+                    }))
+                    .await;
+            }
+        }
         let Some(receiver) = request_user_input_answers else {
             return Err("request_user_input requires a runtime response channel".to_owned());
         };

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -431,6 +431,83 @@ fn mcp_tool_call_elicitation_can_be_auto_approved() {
 }
 
 #[test]
+fn mcp_tool_call_request_user_input_can_be_auto_approved() {
+    let message = json!({
+        "id": 75,
+        "method": "item/tool/requestUserInput",
+        "params": {
+            "threadId": "thread-input",
+            "turnId": "turn-input",
+            "itemId": "call-1",
+            "questions": [{
+                "id": "mcp_tool_call_approval_call-1",
+                "header": "Approve app tool call?",
+                "question": "Allow the wework_space MCP server to run tool \"get_board_item\"?",
+                "options": [
+                    {"label": "Allow", "description": "Run the tool and continue."},
+                    {
+                        "label": "Allow for this session",
+                        "description": "Run the tool and remember this choice for this session."
+                    },
+                    {"label": "Cancel", "description": "Cancel this tool call."}
+                ]
+            }],
+            "autoResolutionMs": Value::Null
+        }
+    });
+
+    assert!(is_mcp_tool_call_approval_request(&message));
+    assert_eq!(
+        mcp_tool_call_request_user_input_response(message_params(&message)),
+        Some(json!({
+            "answers": {
+                "mcp_tool_call_approval_call-1": {
+                    "answers": ["Allow"]
+                }
+            }
+        }))
+    );
+}
+
+#[test]
+fn ordinary_request_user_input_is_not_treated_as_mcp_tool_approval() {
+    for questions in [
+        json!([{
+            "id": "goal",
+            "header": "工作目标",
+            "question": "你希望我接下来问你哪些问题？"
+        }]),
+        json!([{
+            "id": "mcp_tool_call_approval_",
+            "header": "Approve app tool call?",
+            "question": "Missing call id"
+        }]),
+        json!([
+            {
+                "id": "mcp_tool_call_approval_call-1",
+                "header": "Approve app tool call?",
+                "question": "Allow the tool?"
+            },
+            {
+                "id": "follow-up",
+                "header": "Follow up",
+                "question": "Choose a scope"
+            }
+        ]),
+    ] {
+        let message = json!({
+            "id": 76,
+            "method": "item/tool/requestUserInput",
+            "params": {
+                "questions": questions
+            }
+        });
+        assert!(!is_mcp_tool_call_approval_request(&message));
+        assert!(mcp_tool_call_request_user_input_response(message_params(&message)).is_none());
+    }
+}
+
+#[test]
 fn mcp_business_form_is_not_treated_as_tool_call_approval() {
     let params = json!({
         "serverName": "wegent-sites",

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -2046,6 +2046,77 @@ async fn runtime_tasks_auto_approve_mcp_tool_calls_with_full_access() {
 }
 
 #[tokio::test]
+async fn runtime_tasks_auto_approve_legacy_mcp_tool_prompts_with_full_access() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-mcp-tool-prompt-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-mcp-tool-prompt-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let log_path = temp_path("runtime-mcp-tool-prompt-log", "jsonl");
+    let fake_codex = write_fake_codex_mcp_tool_request_user_input(&log_path);
+    let (event_tx, mut events) = broadcast::channel(32);
+    let handler = RuntimeWorkRpcHandler::with_event_sender(
+        "device-1",
+        fake_codex.display().to_string(),
+        event_tx,
+    );
+
+    let created = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.create",
+            "payload": {
+                "taskId": "local-task-mcp-tool-prompt",
+                "workspacePath": "/tmp/project",
+                "message": "read the current board item",
+                "executionRequest": {
+                    "task_id": 3004,
+                    "subtask_id": 4004,
+                    "prompt": "read the current board item",
+                    "project_workspace_path": "/tmp/project",
+                    "bot": [{"shell_type": "ClaudeCode"}],
+                    "model_config": {
+                        "model": "openai",
+                        "model_id": "gpt-5.5",
+                        "api_format": "responses"
+                    }
+                }
+            }
+        }))
+        .await
+        .expect("create should be accepted");
+    assert_eq!(created["accepted"], true);
+
+    wait_until_task_idle(&handler, "local-task-mcp-tool-prompt").await;
+    wait_for_json_call(&log_path, |call| {
+        call["id"] == 99
+            && call["result"]["answers"]["mcp_tool_call_approval_call-board"]["answers"][0]
+                == "Allow"
+    })
+    .await;
+
+    let mut runtime_events = Vec::new();
+    while let Ok(event) = events.try_recv() {
+        runtime_events.push(event);
+    }
+    assert!(
+        find_runtime_event(&runtime_events, "response.block.created", |event| {
+            let block = &event["payload"]["data"]["block"];
+            block["tool_name"] == "request_user_input" && block["render_payload"]["requestId"] == 99
+        })
+        .is_none(),
+        "full access should not surface legacy MCP tool approval as request_user_input"
+    );
+}
+
+#[tokio::test]
 async fn runtime_tasks_interrupt_and_send_unblocks_pending_request_user_input() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
@@ -4073,6 +4144,15 @@ fn write_fake_codex_mcp_tool_approval(log_path: &Path) -> PathBuf {
         log_path,
         "fake-codex-mcp-tool-approval",
         r#"{"id":99,"method":"mcpServer/elicitation/request","params":{"threadId":"thread-input","turnId":"turn-input","serverName":"GitHub","mode":"form","message":"Allow GitHub to enable pull request auto-merge?","requestedSchema":{"type":"object","properties":{}},"_meta":{"codex_approval_kind":"mcp_tool_call","persist":["session"]}}}"#,
+        0,
+    )
+}
+
+fn write_fake_codex_mcp_tool_request_user_input(log_path: &Path) -> PathBuf {
+    write_fake_codex_interaction(
+        log_path,
+        "fake-codex-mcp-tool-request-user-input",
+        r#"{"id":99,"method":"item/tool/requestUserInput","params":{"threadId":"thread-input","turnId":"turn-input","itemId":"call-board","questions":[{"id":"mcp_tool_call_approval_call-board","header":"Approve app tool call?","question":"Allow the wework_space MCP server to run tool \"get_board_item\"?","options":[{"label":"Allow","description":"Run the tool and continue."},{"label":"Allow for this session","description":"Run the tool and remember this choice for this session."},{"label":"Cancel","description":"Cancel this tool call."}]}],"autoResolutionMs":null}}"#,
         0,
     )
 }

--- a/wework/e2e/desktop/modules/desktop-build-flows.mjs
+++ b/wework/e2e/desktop/modules/desktop-build-flows.mjs
@@ -284,7 +284,7 @@ function mcpElicitationConfigToml(evidencePath) {
     '[mcp_servers.wegent_sites_interactions]',
     `command = ${command}`,
     `args = [${server}, ${evidence}]`,
-    'default_tools_approval_mode = "approve"',
+    'default_tools_approval_mode = "prompt"',
     '',
   ].join('\n')
 }


### PR DESCRIPTION
## Summary

- recognize Codex MCP tool approvals delivered through both mcpServer/elicitation/request and compatibility item/tool/requestUserInput messages
- auto-answer compatibility approvals with Allow in Full access mode without forwarding an approval card to the Wework UI
- keep ordinary user questions and MCP business forms interactive
- exercise the real prompt path in the desktop permission-mode checkpoint and document both protocol forms

## Verification

- cargo fmt --check
- cargo test mcp_tool_call_request_user_input_can_be_auto_approved --lib
- cargo test ordinary_request_user_input_is_not_treated_as_mcp_tool_approval --lib
- cargo test --test app_runtime_work_send_contract runtime_tasks_auto_approve_legacy_mcp_tool_prompts_with_full_access
- cargo test --test app_runtime_work_send_contract runtime_tasks_auto_approve_mcp_tool_calls_with_full_access
- pnpm --filter wework exec prettier --check for the changed E2E fixture and bilingual docs
- real Electron desktop E2E: pnpm --filter wework e2e:desktop --segment permission-modes
- pre-push checks: Wework ESLint/unit tests, Executor all-features lib tests, fmt, and clippy

## Evidence

Desktop E2E passed with no assertion errors. Local evidence directory: wework/test-results/desktop-e2e/2026-08-27T02-12-57-819Z-43926