### PR TITLE
feat: 修复设置本地代理导致云设备无法使用的问题

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -126,7 +126,6 @@ class UserRuntimeConfigUpdateRequest(BaseModel):
     """Update request for runtime config preferences."""
 
     use_user_config: bool
-    use_proxy: Optional[bool] = None
 
 
 class UserRuntimeAuthJsonRequest(BaseModel):
@@ -364,7 +363,6 @@ async def update_user_runtime_config(
                 user=current_user,
                 runtime=runtime,
                 use_user_config=request.use_user_config,
-                use_proxy=request.use_proxy,
             )
         )
     except UserRuntimeConfigError as exc:

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -42,7 +42,6 @@ class UserRuntimeConfigPreference(BaseModel):
     """User-level runtime configuration preference."""
 
     use_user_config: bool = False
-    use_proxy: bool = False
 
 
 class UserProjectWorkPreference(BaseModel):

--- a/backend/app/services/device/runtime_rpc_service.py
+++ b/backend/app/services/device/runtime_rpc_service.py
@@ -4,7 +4,9 @@
 
 """Typed runtime task RPC over the existing local executor Socket.IO channel."""
 
+import asyncio
 import base64
+import copy
 import gzip
 import json
 import logging
@@ -15,6 +17,8 @@ from socketio.exceptions import BadNamespaceError, DisconnectedError
 from socketio.exceptions import TimeoutError as SocketTimeoutError
 
 from app.core.socketio import get_sio
+from app.db.session import get_db_session
+from app.schemas.device import DeviceType
 from app.services.device.runtime_route import (
     RuntimeRouteError,
     runtime_route_resolver,
@@ -23,6 +27,7 @@ from app.services.device.runtime_task_create_protocol import (
     RuntimeTaskCreateProtocolError,
     negotiate_runtime_task_create_payload,
 )
+from app.services.user_runtime_config import user_runtime_config_service
 from shared.telemetry.decorators import trace_async
 
 logger = logging.getLogger(__name__)
@@ -42,6 +47,97 @@ RETRYABLE_RUNTIME_RPC_CODES = frozenset(
         "runtime_rpc_timeout",
     }
 )
+REMOTE_RUNTIME_DEVICE_TYPES = frozenset({DeviceType.CLOUD, DeviceType.REMOTE})
+RUNTIME_MODEL_CONFIG_METHODS = frozenset(
+    {
+        "runtime.text.generate",
+        "runtime.tasks.create",
+        "runtime.tasks.send",
+        "runtime.tasks.rollback",
+        "runtime.tasks.interrupt_and_send",
+        "runtime.tasks.supervisor.set",
+        "runtime.automations.create",
+        "runtime.automations.update",
+    }
+)
+RUNTIME_MODEL_CONFIG_KEYS = frozenset({"model_config", "modelConfig"})
+
+
+def _load_remote_runtime_proxy_url(user_id: int) -> str:
+    with get_db_session() as db:
+        return user_runtime_config_service.get_proxy_url_for_execution(
+            db,
+            user_id=user_id,
+        )
+
+
+def _runtime_model_configs(value: Any) -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    if isinstance(value, list):
+        for item in value:
+            configs.extend(_runtime_model_configs(item))
+        return configs
+    if not isinstance(value, dict):
+        return configs
+
+    for key, item in value.items():
+        if key in RUNTIME_MODEL_CONFIG_KEYS and isinstance(item, dict):
+            configs.append(item)
+            continue
+        configs.extend(_runtime_model_configs(item))
+    return configs
+
+
+def _set_runtime_proxy(model_config: dict[str, Any], proxy_url: str) -> None:
+    model_config.pop("proxy_url", None)
+    model_config.pop("proxyUrl", None)
+    if proxy_url:
+        model_config["proxy"] = {"url": proxy_url}
+    else:
+        model_config.pop("proxy", None)
+
+    runtime_config = model_config.pop("runtimeConfig", None)
+    if not isinstance(runtime_config, dict):
+        runtime_config = model_config.get("runtime_config")
+    runtime_config = dict(runtime_config) if isinstance(runtime_config, dict) else {}
+    codex_config = runtime_config.get("codex")
+    codex_config = dict(codex_config) if isinstance(codex_config, dict) else {}
+    codex_config["use_proxy"] = bool(proxy_url)
+    codex_config["proxy_configured"] = bool(proxy_url)
+    runtime_config["codex"] = codex_config
+    model_config["runtime_config"] = runtime_config
+
+
+async def _enforce_remote_runtime_proxy(
+    *,
+    user_id: int,
+    device_type: DeviceType,
+    method: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    if (
+        device_type not in REMOTE_RUNTIME_DEVICE_TYPES
+        or method not in RUNTIME_MODEL_CONFIG_METHODS
+    ):
+        return payload
+
+    next_payload = copy.deepcopy(payload)
+    model_configs = _runtime_model_configs(next_payload)
+    if not model_configs:
+        return payload
+
+    proxy_url = await asyncio.to_thread(_load_remote_runtime_proxy_url, user_id)
+    for model_config in model_configs:
+        _set_runtime_proxy(model_config, proxy_url)
+    logger.info(
+        "[RuntimeRpcService] Applied account proxy policy: "
+        "user_id=%s method=%s configured=%s model_config_count=%s",
+        user_id,
+        method,
+        bool(proxy_url),
+        len(model_configs),
+    )
+    return next_payload
 
 
 class RuntimeRpcError(RuntimeError):
@@ -114,6 +210,28 @@ class RuntimeRpcService:
                         "features": list(exc.features),
                     },
                 ) from exc
+
+        try:
+            payload = await _enforce_remote_runtime_proxy(
+                user_id=user_id,
+                device_type=route.device_type,
+                method=method,
+                payload=payload,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[RuntimeRpcService] Failed to resolve account proxy policy: "
+                "user_id=%s logical_device_id=%s method=%s",
+                user_id,
+                route.logical_device_id,
+                method,
+            )
+            raise RuntimeRpcError(
+                "Failed to resolve cloud device proxy configuration",
+                code="runtime_proxy_config_failed",
+                retryable=False,
+                details={"deviceId": route.logical_device_id},
+            ) from exc
 
         sio = get_sio()
         request = {"method": method, "payload": payload}

--- a/backend/app/services/user_runtime_config.py
+++ b/backend/app/services/user_runtime_config.py
@@ -161,24 +161,10 @@ def is_runtime_user_config_enabled(preferences: Any, runtime: str) -> bool:
     return bool(config.get("use_user_config"))
 
 
-def is_runtime_proxy_enabled(preferences: Any, runtime: str) -> bool:
-    """Return whether the user preference enables proxy for a runtime."""
-    normalized_runtime = _normalize_runtime(runtime)
-    parsed = load_runtime_preferences(preferences)
-    runtime_configs = parsed.get(USER_RUNTIME_CONFIG_PREFERENCE_KEY) or {}
-    if not isinstance(runtime_configs, dict):
-        return False
-    config = runtime_configs.get(normalized_runtime) or {}
-    if not isinstance(config, dict):
-        return False
-    return bool(config.get("use_proxy"))
-
-
 def set_runtime_user_config_enabled(
     preferences: Any,
     runtime: str,
     enabled: bool,
-    use_proxy: Optional[bool] = None,
 ) -> dict[str, Any]:
     """Return preferences with the runtime config enablement updated."""
     normalized_runtime = _normalize_runtime(runtime)
@@ -188,30 +174,9 @@ def set_runtime_user_config_enabled(
         runtime_configs = {}
     runtime_config = dict(runtime_configs.get(normalized_runtime) or {})
     runtime_config["use_user_config"] = bool(enabled)
-    if use_proxy is not None:
-        runtime_config["use_proxy"] = bool(use_proxy)
+    runtime_config.pop("use_proxy", None)
     runtime_configs[normalized_runtime] = runtime_config
     parsed[USER_RUNTIME_CONFIG_PREFERENCE_KEY] = runtime_configs
-    return parsed
-
-
-def clear_runtime_proxy_preferences(preferences: Any) -> dict[str, Any]:
-    """Return preferences with all runtime proxy enablement disabled."""
-    parsed = load_runtime_preferences(preferences)
-    runtime_configs = parsed.get(USER_RUNTIME_CONFIG_PREFERENCE_KEY) or {}
-    if not isinstance(runtime_configs, dict):
-        return parsed
-
-    next_runtime_configs = {}
-    for runtime, config in runtime_configs.items():
-        if not isinstance(config, dict):
-            next_runtime_configs[runtime] = config
-            continue
-        next_config = dict(config)
-        next_config["use_proxy"] = False
-        next_runtime_configs[runtime] = next_config
-
-    parsed[USER_RUNTIME_CONFIG_PREFERENCE_KEY] = next_runtime_configs
     return parsed
 
 
@@ -254,7 +219,6 @@ class UserRuntimeConfigService:
         user: User,
         runtime: str,
         use_user_config: bool,
-        use_proxy: Optional[bool] = None,
     ) -> dict[str, Any]:
         """Update whether the runtime should use this user's saved config."""
         normalized_runtime = _normalize_runtime(runtime)
@@ -262,11 +226,7 @@ class UserRuntimeConfigService:
             user.preferences,
             normalized_runtime,
             use_user_config,
-            use_proxy,
         )
-        proxy_kind = self._get_proxy_kind(db, user_id=user.id)
-        if use_proxy is True and not self._get_proxy_url(proxy_kind):
-            raise UserRuntimeConfigError("proxy is not configured")
 
         user.preferences = json.dumps(preferences)
         db.add(user)
@@ -304,10 +264,6 @@ class UserRuntimeConfigService:
             }
         else:
             spec.pop("proxy", None)
-            user.preferences = json.dumps(
-                clear_runtime_proxy_preferences(user.preferences)
-            )
-            db.add(user)
         spec["updatedAt"] = now
         data["spec"] = spec
         kind.json = data
@@ -339,6 +295,15 @@ class UserRuntimeConfigService:
         if response["use_proxy"] and proxy_url:
             response["proxy_url"] = proxy_url
         return response
+
+    def get_proxy_url_for_execution(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+    ) -> str:
+        """Return the decrypted user proxy used by cloud and remote runtimes."""
+        return self._get_proxy_url(self._get_proxy_kind(db, user_id=user_id))
 
     def save_auth_json(
         self,
@@ -654,7 +619,7 @@ class UserRuntimeConfigService:
             "runtime": runtime,
             "display_name": RUNTIME_AUTH_FILES[runtime]["display_name"],
             "use_user_config": is_runtime_user_config_enabled(preferences, runtime),
-            "use_proxy": is_runtime_proxy_enabled(preferences, runtime),
+            "use_proxy": bool(proxy_url),
             "configured": bool(auth.get("encryptedValue")),
             "target_path": auth.get("targetPath")
             or RUNTIME_AUTH_FILES[runtime]["target_path"],

--- a/backend/tests/services/chat/test_trigger_unified.py
+++ b/backend/tests/services/chat/test_trigger_unified.py
@@ -69,9 +69,7 @@ def test_apply_user_runtime_config_adds_codex_status(monkeypatch):
     def fake_get_execution_config(db, *, user_id, runtime, preferences=None):
         assert user_id == 7
         assert runtime == "codex"
-        assert preferences == {
-            "runtime_configs": {"codex": {"use_user_config": True, "use_proxy": True}}
-        }
+        assert preferences == {"runtime_configs": {"codex": {"use_user_config": True}}}
         return {
             "runtime": "codex",
             "display_name": "Codex",
@@ -95,11 +93,7 @@ def test_apply_user_runtime_config_adds_codex_status(monkeypatch):
         request=request,
         user=SimpleNamespace(
             id=7,
-            preferences={
-                "runtime_configs": {
-                    "codex": {"use_user_config": True, "use_proxy": True}
-                }
-            },
+            preferences={"runtime_configs": {"codex": {"use_user_config": True}}},
         ),
     )
 

--- a/backend/tests/services/test_runtime_rpc_service.py
+++ b/backend/tests/services/test_runtime_rpc_service.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 
-def _runtime_route(*, runtime_features=None):
+def _runtime_route(*, runtime_features=None, device_type=None):
     from app.schemas.device import DeviceType
     from app.services.device.runtime_route import RuntimeRoute
 
@@ -15,7 +15,7 @@ def _runtime_route(*, runtime_features=None):
         logical_device_id="device-1",
         runtime_device_id="runtime-device-1",
         runtime_instance_id="runtime-instance-1",
-        device_type=DeviceType.CLOUD,
+        device_type=device_type or DeviceType.CLOUD,
         socket_id="socket-1",
         online_info={
             "socket_id": "socket-1",
@@ -92,6 +92,182 @@ def _socketio_with_call(call: AsyncMock, *, connected: bool = True):
             "manager": _SocketManager(connected=connected),
         },
     )()
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_applies_account_proxy_to_remote_model_configs(
+    monkeypatch,
+):
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.runtime_route_resolver,
+        "resolve",
+        AsyncMock(return_value=_runtime_route()),
+    )
+    monkeypatch.setattr(
+        module,
+        "_load_remote_runtime_proxy_url",
+        lambda user_id: (
+            "socks5://proxy.internal:7890"
+            if user_id == 7
+            else pytest.fail("unexpected user")
+        ),
+    )
+    sio_call = AsyncMock(return_value={"accepted": True})
+    monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))
+
+    await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.create",
+        payload={
+            "runtime": "codex",
+            "executionRequest": {
+                "model_config": {
+                    "proxy": {"url": "http://127.0.0.1:7897"},
+                    "runtime_config": {
+                        "codex": {
+                            "use_user_config": True,
+                            "configured": True,
+                        }
+                    },
+                }
+            },
+            "friendlyTitleExecutionRequest": {"model_config": {}},
+            "initialSupervisor": {"modelConfig": {}},
+        },
+    )
+
+    emitted = sio_call.await_args.args[1]["payload"]
+    for model_config in (
+        emitted["executionRequest"]["model_config"],
+        emitted["friendlyTitleExecutionRequest"]["model_config"],
+        emitted["initialSupervisor"]["modelConfig"],
+    ):
+        assert model_config["proxy"] == {"url": "socks5://proxy.internal:7890"}
+        assert model_config["runtime_config"]["codex"]["use_proxy"] is True
+        assert model_config["runtime_config"]["codex"]["proxy_configured"] is True
+    assert (
+        emitted["executionRequest"]["model_config"]["runtime_config"]["codex"][
+            "use_user_config"
+        ]
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_removes_client_proxy_without_account_proxy(
+    monkeypatch,
+):
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.runtime_route_resolver,
+        "resolve",
+        AsyncMock(return_value=_runtime_route()),
+    )
+    monkeypatch.setattr(module, "_load_remote_runtime_proxy_url", lambda _user_id: "")
+    sio_call = AsyncMock(return_value={"accepted": True})
+    monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))
+
+    await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.send",
+        payload={
+            "executionRequest": {
+                "model_config": {
+                    "proxy": {"url": "http://127.0.0.1:7897"},
+                    "proxy_url": "http://127.0.0.1:7897",
+                }
+            }
+        },
+    )
+
+    model_config = sio_call.await_args.args[1]["payload"]["executionRequest"][
+        "model_config"
+    ]
+    assert "proxy" not in model_config
+    assert "proxy_url" not in model_config
+    assert model_config["runtime_config"]["codex"] == {
+        "use_proxy": False,
+        "proxy_configured": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_applies_account_proxy_to_automation_payloads(
+    monkeypatch,
+):
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.runtime_route_resolver,
+        "resolve",
+        AsyncMock(return_value=_runtime_route()),
+    )
+    monkeypatch.setattr(
+        module,
+        "_load_remote_runtime_proxy_url",
+        lambda _user_id: "http://proxy.internal:7890",
+    )
+    sio_call = AsyncMock(return_value={"automation": {"id": "automation-1"}})
+    monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))
+
+    await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.automations.create",
+        payload={
+            "automation": {
+                "taskPayload": {"executionRequest": {"model_config": {}}},
+                "continuationPayload": {"executionRequest": {"model_config": {}}},
+            }
+        },
+    )
+
+    automation = sio_call.await_args.args[1]["payload"]["automation"]
+    for model_config in (
+        automation["taskPayload"]["executionRequest"]["model_config"],
+        automation["continuationPayload"]["executionRequest"]["model_config"],
+    ):
+        assert model_config["proxy"] == {"url": "http://proxy.internal:7890"}
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_preserves_local_device_proxy(monkeypatch):
+    from app.schemas.device import DeviceType
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.runtime_route_resolver,
+        "resolve",
+        AsyncMock(return_value=_runtime_route(device_type=DeviceType.LOCAL)),
+    )
+    load_proxy = AsyncMock()
+    monkeypatch.setattr(module, "_load_remote_runtime_proxy_url", load_proxy)
+    sio_call = AsyncMock(return_value={"accepted": True})
+    monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))
+
+    await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.send",
+        payload={
+            "executionRequest": {
+                "model_config": {
+                    "proxy": {"url": "http://127.0.0.1:7897"},
+                }
+            }
+        },
+    )
+
+    emitted = sio_call.await_args.args[1]["payload"]
+    assert emitted["executionRequest"]["model_config"]["proxy"] == {
+        "url": "http://127.0.0.1:7897"
+    }
+    load_proxy.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_user_runtime_config_service.py
+++ b/backend/tests/services/test_user_runtime_config_service.py
@@ -109,44 +109,24 @@ def test_set_use_user_config_stores_preference(test_db: Session) -> None:
     }
 
 
-def test_set_use_proxy_stores_runtime_preference(test_db: Session) -> None:
-    user = _create_user(
-        test_db,
-        1202,
-        preferences='{"runtime_configs":{"codex":{"use_user_config":true}}}',
-    )
+def test_saving_proxy_enables_runtime_proxy_without_hidden_preference(
+    test_db: Session,
+) -> None:
+    user = _create_user(test_db, 1202)
     user_runtime_config_service.save_proxy_url(
         test_db,
         user=user,
         proxy_url="http://127.0.0.1:7890",
     )
 
-    response = user_runtime_config_service.set_use_user_config(
+    response = user_runtime_config_service.get_execution_config(
         test_db,
-        user=user,
+        user_id=user.id,
         runtime="codex",
-        use_user_config=True,
-        use_proxy=True,
     )
 
-    test_db.refresh(user)
     assert response["use_proxy"] is True
-    assert json.loads(user.preferences) == {
-        "runtime_configs": {"codex": {"use_user_config": True, "use_proxy": True}},
-    }
-
-
-def test_set_use_proxy_requires_configured_proxy(test_db: Session) -> None:
-    user = _create_user(test_db, 1203)
-
-    with pytest.raises(UserRuntimeConfigError, match="proxy is not configured"):
-        user_runtime_config_service.set_use_user_config(
-            test_db,
-            user=user,
-            runtime="codex",
-            use_user_config=False,
-            use_proxy=True,
-        )
+    assert response["proxy_url"] == "http://127.0.0.1:7890"
 
 
 def test_save_proxy_url_encrypts_and_masks_proxy_config(test_db: Session) -> None:
@@ -169,12 +149,8 @@ def test_save_proxy_url_encrypts_and_masks_proxy_config(test_db: Session) -> Non
     assert decrypt_sensitive_data(encrypted_url) == "http://user:secret@127.0.0.1:7890"
 
 
-def test_clearing_proxy_disables_runtime_proxy_preferences(test_db: Session) -> None:
-    user = _create_user(
-        test_db,
-        108,
-        preferences='{"runtime_configs":{"codex":{"use_user_config":true,"use_proxy":true}}}',
-    )
+def test_clearing_proxy_disables_runtime_proxy(test_db: Session) -> None:
+    user = _create_user(test_db, 108)
     user_runtime_config_service.save_proxy_url(
         test_db,
         user=user,
@@ -187,11 +163,14 @@ def test_clearing_proxy_disables_runtime_proxy_preferences(test_db: Session) -> 
         proxy_url="",
     )
 
-    test_db.refresh(user)
     assert response["configured"] is False
-    assert json.loads(user.preferences) == {
-        "runtime_configs": {"codex": {"use_user_config": True, "use_proxy": False}},
-    }
+    execution_config = user_runtime_config_service.get_execution_config(
+        test_db,
+        user_id=user.id,
+        runtime="codex",
+    )
+    assert execution_config["use_proxy"] is False
+    assert "proxy_url" not in execution_config
 
 
 def test_get_execution_config_includes_proxy_url_when_enabled(
@@ -208,9 +187,7 @@ def test_get_execution_config_includes_proxy_url_when_enabled(
         test_db,
         user_id=106,
         runtime="codex",
-        preferences={
-            "runtime_configs": {"codex": {"use_user_config": True, "use_proxy": True}}
-        },
+        preferences={"runtime_configs": {"codex": {"use_user_config": True}}},
     )
 
     assert response["use_proxy"] is True

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -984,6 +984,9 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     await control.command('select', executionModel, { value: `public:${CLOUD_MODEL_NAME}` })
     await control.command('select', executionProject, { value: 'standalone' })
     const initialUpstreamRequestOffset = upstreamResponseRequests.length
+    await control.command('setLocalProxyUrl', 'body', {
+      value: 'http://127.0.0.1:1',
+    })
     await control.command('clickWhenEnabled', '[data-testid="issue-execution-config-confirm"]', {
       timeoutMs: uiTimeoutMs,
     })
@@ -1066,6 +1069,7 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
       initialIssueRequests.every(request => request.model === CLOUD_MODEL_UPSTREAM_ID),
       'The Issue produced a duplicate request through a model other than Moonshot'
     )
+    await control.command('setLocalProxyUrl', 'body', { value: '' })
 
     const runtimeWork = await waitForValue(
       () => cloudRequest('/api/runtime-work'),

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -2283,7 +2283,8 @@ describe('createLocalAppServices', () => {
     )
   })
 
-  test('sends configured model settings to a cloud device executor', async () => {
+  test('sends configured model settings without leaking local proxy to a cloud device', async () => {
+    saveLocalProxyUrl('http://127.0.0.1:7890')
     saveLocalModelConfig({
       id: 'cloud-ollama',
       displayName: 'Cloud Ollama',
@@ -2361,6 +2362,19 @@ describe('createLocalAppServices', () => {
     expect(createPayload.executionRequest.model_config).toEqual(expectedModelConfig)
     expect(sendPayload.executionRequest.model_config).toEqual(expectedModelConfig)
     expect(supervisorPayload.modelConfig).toEqual(expectedModelConfig)
+    for (const modelConfig of [
+      createPayload.executionRequest.model_config,
+      sendPayload.executionRequest.model_config,
+      supervisorPayload.modelConfig,
+    ]) {
+      expect(modelConfig).not.toHaveProperty('proxy')
+      expect(modelConfig.runtime_config?.codex).not.toEqual(
+        expect.objectContaining({
+          use_proxy: true,
+          proxy_configured: true,
+        })
+      )
+    }
     expect(requestModelCatalogSync).toHaveBeenCalledWith(
       expect.objectContaining({
         deviceId: 'cloud-device',
@@ -2398,7 +2412,8 @@ describe('createLocalAppServices', () => {
     })
   })
 
-  test('builds cloud automation payloads from a remotely synchronized model catalog', async () => {
+  test('builds cloud automation payloads without leaking the local proxy', async () => {
+    saveLocalProxyUrl('http://127.0.0.1:7890')
     saveLocalModelConfig({
       id: 'cloud-automation-task',
       displayName: 'Cloud Automation Task',
@@ -2489,6 +2504,8 @@ describe('createLocalAppServices', () => {
       model_id: 'qwen3-coder-continuation',
       api_key: 'cloud-device-key',
     })
+    expect(automation.taskPayload.executionRequest.model_config).not.toHaveProperty('proxy')
+    expect(automation.continuationPayload.executionRequest.model_config).not.toHaveProperty('proxy')
     expect(prepareRuntimeModel).toHaveBeenCalledWith({
       deviceId: 'cloud-device',
       modelId: 'local-model:cloud-automation-task',
@@ -3652,7 +3669,7 @@ describe('createLocalAppServices', () => {
     )
   })
 
-  test('adds configured local proxy to local runtime execution requests', async () => {
+  test('adds configured local proxy to local runtime model configurations', async () => {
     saveLocalProxyUrl('http://127.0.0.1:7890')
     const request = vi.fn().mockResolvedValue({ accepted: true })
     const services = createLocalAppServices({
@@ -3670,21 +3687,53 @@ describe('createLocalAppServices', () => {
       title: 'Hello',
       modelId: 'gpt-5.4',
     })
+    await services.runtimeWorkApi?.sendRuntimeMessage({
+      address: {
+        deviceId: 'device-uuid',
+        workspacePath: '/Users/me/project',
+        taskId: 'task-1',
+      },
+      message: 'continue',
+      modelId: 'gpt-5.4',
+    })
+    await services.runtimeWorkApi?.setRuntimeSupervisor({
+      address: {
+        deviceId: 'device-uuid',
+        workspacePath: '/Users/me/project',
+        taskId: 'task-1',
+      },
+      mode: 'auto',
+      modelSelection: {
+        modelName: 'gpt-5.4',
+        modelType: 'runtime',
+        options: {},
+      },
+      intervalSeconds: 30,
+    })
 
     const createPayload = request.mock.calls.find(
       ([method]) => method === 'runtime.tasks.create'
     )?.[1]
-    const modelConfig = createPayload.executionRequest.model_config
+    const sendPayload = request.mock.calls.find(([method]) => method === 'runtime.tasks.send')?.[1]
+    const supervisorPayload = request.mock.calls.find(
+      ([method]) => method === 'runtime.tasks.supervisor.set'
+    )?.[1]
 
-    expect(modelConfig.proxy).toEqual({ url: 'http://127.0.0.1:7890' })
-    expect(modelConfig.runtime_config.codex).toEqual(
-      expect.objectContaining({
-        use_user_config: true,
-        configured: true,
-        use_proxy: true,
-        proxy_configured: true,
-      })
-    )
+    for (const modelConfig of [
+      createPayload.executionRequest.model_config,
+      sendPayload.executionRequest.model_config,
+      supervisorPayload.modelConfig,
+    ]) {
+      expect(modelConfig.proxy).toEqual({ url: 'http://127.0.0.1:7890' })
+      expect(modelConfig.runtime_config.codex).toEqual(
+        expect.objectContaining({
+          use_user_config: true,
+          configured: true,
+          use_proxy: true,
+          proxy_configured: true,
+        })
+      )
+    }
   })
 
   test('rejects missing local model config instead of falling back to built-in Codex', async () => {

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -521,6 +521,7 @@ interface RuntimeWorkIpcOptions {
   normalizeDeviceRecord?: <T extends Record<string, unknown>>(data: T, deviceId: string) => T
   adaptListResponse?: (response: unknown, deviceId: string) => RuntimeWorkListResponse
   cloudModelGateway?: CloudModelGateway
+  getRuntimeProxyUrl?: () => string
   user?: User
   transportLabel?: 'Local' | 'Cloud'
   syncConfiguredModelCatalog?: boolean
@@ -1194,8 +1195,11 @@ function harnessProxyUpstream(
   }
 }
 
-function applyLocalProxyConfig(modelConfig: Record<string, unknown>): Record<string, unknown> {
-  const proxyUrl = getLocalProxyUrl().trim()
+function applyRuntimeProxyConfig(
+  modelConfig: Record<string, unknown>,
+  runtimeProxyUrl?: string
+): Record<string, unknown> {
+  const proxyUrl = runtimeProxyUrl?.trim()
   if (!proxyUrl) return modelConfig
 
   const runtimeConfig = {
@@ -1221,9 +1225,10 @@ function applyLocalProxyConfig(modelConfig: Record<string, unknown>): Record<str
 
 function applyRuntimeModelOptions(
   modelConfig: Record<string, unknown>,
-  modelOptions?: Record<string, string>
+  modelOptions?: Record<string, string>,
+  runtimeProxyUrl?: string
 ): Record<string, unknown> {
-  modelConfig = applyLocalProxyConfig(modelConfig)
+  modelConfig = applyRuntimeProxyConfig(modelConfig, runtimeProxyUrl)
   const reasoning = runtimeReasoning(modelOptions)
   if (reasoning) modelConfig.reasoning = reasoning
   const serviceTier = runtimeServiceTier(modelOptions)
@@ -1335,6 +1340,7 @@ interface BuildLocalRuntimeExecutionRequestInput {
   modelOptions?: RuntimeTaskCreateRequest['modelOptions']
   modelConfig?: Record<string, unknown>
   cloudModelGateway?: CloudModelGateway
+  runtimeProxyUrl?: string
   additionalSkills?: RuntimeTaskCreateRequest['additionalSkills']
   additionalContext?: RuntimeTaskCreateRequest['additionalContext']
   attachments?: RuntimeTaskCreateRequest['attachments']
@@ -1413,7 +1419,11 @@ function buildLocalRuntimeExecutionRequest(
           input.modelOptions,
           input.cloudModelGateway
         ))
-  const modelConfig = applyRuntimeModelOptions({ ...baseModelConfig }, input.modelOptions)
+  const modelConfig = applyRuntimeModelOptions(
+    { ...baseModelConfig },
+    input.modelOptions,
+    input.runtimeProxyUrl
+  )
   const reasoning = runtimeReasoning(input.modelOptions)
   const collaborationMode = runtimeCollaborationMode(input.modelOptions)
   const skillNames = (input.additionalSkills ?? []).map(skillName).filter(isNonEmptyString)
@@ -1697,6 +1707,7 @@ async function createLocalRuntimeTaskPayload(
   localDeviceId: string,
   requestWithLocalDevice: RequestWithLocalDevice,
   cloudModelGateway: CloudModelGateway | undefined,
+  runtimeProxyUrl: string | undefined,
   user: User,
   requireLocalCodexCatalog: boolean
 ): Promise<Record<string, unknown>> {
@@ -1725,7 +1736,8 @@ async function createLocalRuntimeTaskPayload(
           initialSupervisor.modelSelection.options,
           cloudModelGateway
         ),
-        initialSupervisor.modelSelection.options
+        initialSupervisor.modelSelection.options,
+        runtimeProxyUrl
       ),
     }
   }
@@ -1745,6 +1757,7 @@ async function createLocalRuntimeTaskPayload(
         modelType: normalizedData.friendlyTitle.modelType,
         modelOptions: normalizedData.friendlyTitle.modelOptions,
         cloudModelGateway,
+        runtimeProxyUrl,
         localDeviceId,
         workspacePath: runtimeWorkspace?.workspacePath,
         standaloneChatWorkspace: normalizedData.standaloneChatWorkspace,
@@ -1776,6 +1789,7 @@ async function createLocalRuntimeTaskPayload(
       modelOptions: normalizedData.modelOptions,
       modelConfig: normalizedData.modelConfig,
       cloudModelGateway,
+      runtimeProxyUrl,
       additionalSkills: normalizedData.additionalSkills,
       additionalContext: normalizedData.additionalContext,
       attachments: normalizedData.attachments,
@@ -1804,6 +1818,7 @@ function createLocalRuntimeSendPayload(
   data: RuntimeSendRequest,
   localDeviceId: string,
   cloudModelGateway: CloudModelGateway | undefined,
+  runtimeProxyUrl: string | undefined,
   user: User,
   requireLocalCodexCatalog: boolean
 ): Record<string, unknown> {
@@ -1854,6 +1869,7 @@ function createLocalRuntimeSendPayload(
         modelType: normalizedData.modelType,
         modelOptions: normalizedData.modelOptions,
         cloudModelGateway,
+        runtimeProxyUrl,
         attachments: normalizedData.attachments,
         additionalContext: normalizedData.additionalContext,
         cloudProjectId: normalizedData.cloudProjectId,
@@ -1897,6 +1913,7 @@ function createLocalRuntimeSendPayload(
       modelType: normalizedData.modelType,
       modelOptions: normalizedData.modelOptions,
       cloudModelGateway,
+      runtimeProxyUrl,
       attachments: normalizedData.attachments,
       additionalContext: normalizedData.additionalContext,
       cloudProjectId: normalizedData.cloudProjectId,
@@ -2577,6 +2594,7 @@ export function createRuntimeWorkApiFromIpc(
         data,
         localDeviceId,
         options.cloudModelGateway,
+        options.getRuntimeProxyUrl?.(),
         user,
         requireLocalCodexCatalog
       )
@@ -2605,6 +2623,7 @@ export function createRuntimeWorkApiFromIpc(
         data,
         localDeviceId,
         options.cloudModelGateway,
+        options.getRuntimeProxyUrl?.(),
         user,
         requireLocalCodexCatalog
       )
@@ -2667,6 +2686,7 @@ export function createRuntimeWorkApiFromIpc(
         data,
         localDeviceId,
         options.cloudModelGateway,
+        options.getRuntimeProxyUrl?.(),
         user,
         requireLocalCodexCatalog
       )
@@ -2722,7 +2742,8 @@ export function createRuntimeWorkApiFromIpc(
           selection.options,
           options.cloudModelGateway
         ),
-        selection.options
+        selection.options,
+        options.getRuntimeProxyUrl?.()
       )
       const normalizedAddress = normalizeLocalDeviceRecord({ address: data.address }, localDeviceId)
         .address as RuntimeTaskAddress
@@ -2950,6 +2971,7 @@ export function createRuntimeWorkApiFromIpc(
         localDeviceId,
         requestWithLocalDevice,
         options.cloudModelGateway,
+        options.getRuntimeProxyUrl?.(),
         user,
         requireLocalCodexCatalog
       )
@@ -3164,6 +3186,7 @@ export function createAutomationApiFromIpc(
       localDeviceId,
       requestWithLocalDevice,
       options.cloudModelGateway,
+      options.getRuntimeProxyUrl?.(),
       user,
       requireLocalCodexCatalog
     )
@@ -3172,6 +3195,7 @@ export function createAutomationApiFromIpc(
           continuationRequest,
           localDeviceId,
           options.cloudModelGateway,
+          options.getRuntimeProxyUrl?.(),
           user,
           requireLocalCodexCatalog
         )
@@ -3466,6 +3490,7 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
     getLocalDeviceId,
     {
       cloudModelGateway: deps.cloudModelGateway,
+      getRuntimeProxyUrl: getLocalProxyUrl,
       user: deps.user,
     }
   ) as unknown as NonNullable<WorkbenchServices['runtimeWorkApi']>
@@ -3474,6 +3499,7 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
     (method, params) => request(method, params as Record<string, unknown>),
     {
       cloudModelGateway: deps.cloudModelGateway,
+      getRuntimeProxyUrl: getLocalProxyUrl,
       user: deps.user,
       prepareRuntimeModel: data => runtimeWorkApi.prepareRuntimeModel(data),
     }
@@ -3549,6 +3575,7 @@ export function createLocalAppServices(deps: LocalAppServicesDeps = {}): Workben
         modelType: data.modelType,
         modelOptions: data.modelOptions,
         cloudModelGateway: deps.cloudModelGateway,
+        runtimeProxyUrl: getLocalProxyUrl(),
         localDeviceId: deviceId,
         workspaceSource: 'local_path',
         newSession: true,

--- a/wework/src/api/users.ts
+++ b/wework/src/api/users.ts
@@ -31,7 +31,6 @@ export interface UserProxyConfig {
 
 export interface UpdateUserRuntimeConfigRequest {
   use_user_config: boolean
-  use_proxy?: boolean
 }
 
 function runtimeConfigPath(runtime: UserRuntime) {
@@ -48,7 +47,7 @@ export function createUserApi(client: HttpClient) {
     },
     updateRuntimeConfig(
       runtime: UserRuntime,
-      data: UpdateUserRuntimeConfigRequest,
+      data: UpdateUserRuntimeConfigRequest
     ): Promise<UserRuntimeConfig> {
       return client.put(runtimeConfigPath(runtime), data)
     },
@@ -60,18 +59,12 @@ export function createUserApi(client: HttpClient) {
         proxy_url: proxyUrl,
       })
     },
-    uploadRuntimeAuthJson(
-      runtime: UserRuntime,
-      authJson: string,
-    ): Promise<UserRuntimeConfig> {
+    uploadRuntimeAuthJson(runtime: UserRuntime, authJson: string): Promise<UserRuntimeConfig> {
       return client.post(`${runtimeConfigPath(runtime)}/auth-json`, {
         auth_json: authJson,
       })
     },
-    importRuntimeAuthJson(
-      runtime: UserRuntime,
-      deviceId: string,
-    ): Promise<UserRuntimeConfig> {
+    importRuntimeAuthJson(runtime: UserRuntime, deviceId: string): Promise<UserRuntimeConfig> {
       return client.post(`${runtimeConfigPath(runtime)}/import-device`, {
         device_id: deviceId,
       })

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -24,7 +24,6 @@ export interface UserPreferences {
     string,
     {
       use_user_config?: boolean
-      use_proxy?: boolean
     }
   > | null
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote runtime requests now automatically apply the account’s configured proxy settings.
  - Local runtime requests consistently preserve and propagate the local proxy configuration.
  - Proxy settings are derived from the configured proxy URL, simplifying runtime preferences.

- **Bug Fixes**
  - Prevented local proxy settings from leaking into cloud-device and automation requests.
  - Clearing a proxy URL now disables proxy usage and removes it from execution requests.
  - Improved error handling when remote proxy configuration cannot be resolved.

- **Tests**
  - Expanded coverage for proxy behavior across local, remote, automation, and model execution flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->