### PR TITLE
fix(wework): settle completed chat lifecycle

### DIFF
--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -2842,6 +2842,15 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
         timeoutMs: uiTimeoutMs,
         visible: true,
       })
+      await waitForValue(
+        async () => JSON.parse(await control.command('snapshot', projectChatPanel)),
+        snapshot =>
+          !snapshot.testIds.includes('thinking-indicator') &&
+          !snapshot.testIds.includes('message-assistant-waiting') &&
+          !snapshot.testIds.includes('pause-response-button'),
+        'Project chat remained in the thinking state after the runtime task completed',
+        uiTimeoutMs
+      )
       await captureScreenshot(control, 'project-chat-model-routing.png')
       await control.command(
         'click',

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
@@ -26,6 +26,14 @@ const mocks = vi.hoisted(() => ({
   resetAttachments: vi.fn(),
   sendRuntimePaneMessage: vi.fn(async () => true),
   createTask: vi.fn(),
+  loadRuntimeTranscriptForPane: vi.fn(),
+  syncTranscript: vi.fn(),
+  lifecycleSnapshot: null as {
+    derived: {
+      isRunning: boolean
+      isTurnActive: boolean
+    }
+  } | null,
   activeModelSelection: null as ModelSelectionConfig | null,
 }))
 
@@ -97,7 +105,7 @@ vi.mock('@/features/workbench/useWorkbench', () => ({
     sendRuntimePaneGuidance: vi.fn(),
     cancelRuntimePaneTask: vi.fn(),
     subscribeRuntimeTaskStream: () => () => undefined,
-    loadRuntimeTranscriptForPane: vi.fn(),
+    loadRuntimeTranscriptForPane: mocks.loadRuntimeTranscriptForPane,
   }),
 }))
 
@@ -146,10 +154,10 @@ vi.mock('@/features/workbench/temporaryChatModelContext', () => ({
 }))
 
 vi.mock('@/features/workbench/runtimeTaskLifecycle', () => ({
-  useRuntimeTaskLifecycle: () => null,
+  useRuntimeTaskLifecycle: () => mocks.lifecycleSnapshot,
   useRuntimeTaskLifecycleStore: () => ({
-    getTask: () => null,
-    syncTranscript: vi.fn(),
+    getTask: () => mocks.lifecycleSnapshot,
+    syncTranscript: mocks.syncTranscript,
   }),
 }))
 
@@ -158,7 +166,50 @@ describe('TemporaryChatPanel', () => {
     mocks.resetAttachments.mockReset()
     mocks.sendRuntimePaneMessage.mockClear()
     mocks.createTask.mockReset()
+    mocks.loadRuntimeTranscriptForPane.mockReset()
+    mocks.loadRuntimeTranscriptForPane.mockResolvedValue({
+      running: false,
+      messages: [],
+      turns: [],
+      contextUsage: null,
+      turnNavigation: [],
+      fullContent: false,
+      rangeStart: null,
+      rangeEnd: null,
+      hasMoreBefore: false,
+      beforeCursor: null,
+      hasMoreAfter: false,
+      afterCursor: null,
+    })
+    mocks.syncTranscript.mockReset()
+    mocks.lifecycleSnapshot = null
     mocks.activeModelSelection = null
+  })
+
+  it('lets an idle transcript settle a stale running execution without an active turn', async () => {
+    mocks.lifecycleSnapshot = {
+      derived: {
+        isRunning: true,
+        isTurnActive: false,
+      },
+    }
+
+    render(
+      <TemporaryChatPanel
+        currentProject={null}
+        source={address}
+        instanceId="settled-task"
+        initialAddress={address}
+        sendEphemeral={false}
+      />
+    )
+
+    await waitFor(() => expect(mocks.syncTranscript).toHaveBeenCalledTimes(1))
+    expect(mocks.syncTranscript).toHaveBeenCalledWith(
+      address,
+      expect.objectContaining({ running: false }),
+      { preserveActiveTurn: false }
+    )
   })
 
   it('keeps sent attachments on the user message after clearing the composer', async () => {

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -242,7 +242,7 @@ export function TemporaryChatPanel({
           return
         }
         lifecycleStore.syncTranscript(address, transcript, {
-          preserveActiveTurn: lifecycleStore.getTask(address)?.derived.isRunning ?? false,
+          preserveActiveTurn: lifecycleStore.getTask(address)?.derived.isTurnActive ?? false,
         })
         const nextMessages = completeRuntimeConversationHydration(
           address,
@@ -273,7 +273,7 @@ export function TemporaryChatPanel({
         refresh: true,
       })
       lifecycleStore.syncTranscript(address, transcript, {
-        preserveActiveTurn: lifecycleStore.getTask(address)?.derived.isRunning ?? false,
+        preserveActiveTurn: lifecycleStore.getTask(address)?.derived.isTurnActive ?? false,
       })
       const nextMessages = completeRuntimeConversationHydration(
         address,


### PR DESCRIPTION
## 问题

任务已经结束后，项目聊天仍可能显示“正在思考”。恢复会话时，转录同步用聚合的 `isRunning` 决定是否保护活跃轮次；一旦该聚合状态自身陈旧，就会拒绝服务端转录中的 `running=false`，形成无法收敛的循环。

## 修改

- 会话转录同步改为仅在 `isTurnActive` 时保护活跃轮次
- 增加组件回归测试：陈旧 `isRunning=true`、无活跃 turn、转录已结束时必须收敛
- 在现有 project automation 桌面 E2E 中断言任务完成后不再出现思考/等待/停止状态

## 验证

- `pnpm --dir wework test -- TemporaryChatPanel.test.tsx runtimePaneStatus.test.ts`
- `pnpm --filter wework ai:verify:electron:build`
- `pnpm --filter wework e2e:desktop --segment project-automation`
- pre-push ESLint、TypeScript、unit tests

关联：WEWORKC2FA61-396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat panels remaining stuck in a thinking or running state after a response has completed.
  * Idle conversation transcripts now correctly clear stale execution indicators when no active turn is present.
  * Improved completion handling so waiting and pause controls disappear reliably after the assistant finishes responding.
* **Tests**
  * Added coverage to verify correct synchronization between transcript loading and conversation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->