### PR TITLE
docs: explain Wework desktop architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,47 @@ Wegent Web provides the browser interface for remote agents. Agents can use conf
 
 ## How it works
 
-Wegent Desktop works directly with local projects and its local runtime. It can connect to Wegent Backend for shared resources and execution devices. Wegent Web is a separate browser interface built on the same Backend.
+Wework is the Wegent desktop workbench. Electron owns desktop windows, system capabilities, and process management. DeepSeek Harness (DSH) is the embedded application and plugin runtime, and the Wework product UI is composed from a set of DSH plugins. Executor manages tasks and sessions, then drives Codex to perform the actual work in local projects.
 
 ```mermaid
 flowchart LR
-    User["User"] --> Desktop["Wegent Desktop"]
-    User --> Web["Wegent Web"]
-    Desktop --> Local["Local project and runtime"]
-    Desktop <--> Backend["Wegent Backend"]
-    Web <--> Backend
-    Backend --> Agents["Shared agents and knowledge"]
-    Backend --> Space["Project spaces"]
-    Backend --> Remote["Cloud and remote devices"]
+    Electron["Electron<br/>Desktop host"]
+
+    subgraph DSH["DSH Runtime"]
+        direction TB
+        Core["DSH Core<br/>Plugin discovery, dependency injection, and lifecycle"]
+        App["dsh-app-wework<br/>Wework product shell and UI extension points"]
+        UI["dsh-ui-*<br/>Tasks, project spaces, settings, apps, and automation"]
+        ElectronPlugin["dsh-electron-host<br/>Electron capability bridge"]
+        ExecutorPlugin["dsh-executor-runtime<br/>Task execution and event adapter"]
+        TerminalPlugin["dsh-terminal-runtime<br/>Local interactive terminals"]
+
+        Core --> App
+        Core --> UI
+        Core --> ElectronPlugin
+        Core --> ExecutorPlugin
+        Core --> TerminalPlugin
+        App --> UI
+    end
+
+    Executor["Executor<br/>Task and session execution"]
+    Codex["Codex<br/>Coding agent"]
+    Workspace["Local project<br/>Files and commands"]
+
+    Electron -->|"Starts and hosts"| Core
+    Electron -->|"Starts and supervises"| Executor
+    ElectronPlugin <-->|"Restricted desktop capabilities"| Electron
+    UI <-->|"User actions and UI updates"| ExecutorPlugin
+    ExecutorPlugin -->|"Create, follow up, approve, cancel"| Executor
+    Executor -->|"Status, messages, tool events, results"| ExecutorPlugin
+    Executor <-->|"Launch, control, and events"| Codex
+    Codex <-->|"Read, modify, and execute"| Workspace
+    TerminalPlugin <-->|"PTY"| Workspace
 ```
+
+DSH does not execute coding tasks itself. `dsh-app-wework` defines the product shell and extension points, `dsh-ui-*` provides the product modules, `dsh-electron-host` bridges restricted Electron capabilities, `dsh-executor-runtime` communicates bidirectionally with Executor throughout execution, and `dsh-terminal-runtime` manages local interactive terminals. Executor is the task execution layer, while Codex is the concrete coding agent it drives.
+
+Wework can also connect to Wegent Backend for shared project spaces, models, and remote execution devices. Wegent Web is a separate browser interface built on the same Backend.
 
 ## Quick start
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,19 +53,47 @@ Wegent Web 提供远程智能体的网页界面。智能体使用配置好的模
 
 ## 工作方式
 
-Wegent Desktop 直接使用本地项目和本机运行时，也可以连接 Wegent Backend 使用共享资源和执行设备。Wegent Web 是基于同一 Backend 的独立网页界面。
+Wework 是 Wegent 的桌面工作台。Electron 负责桌面窗口、系统能力和进程管理；DeepSeek Harness（DSH）是内嵌的应用与插件运行时，Wework 的产品界面由一组 DSH 插件组合而成。Executor 负责管理任务与会话，并驱动 Codex 在本地项目中完成实际工作。
 
 ```mermaid
 flowchart LR
-    User["用户"] --> Desktop["Wegent Desktop"]
-    User --> Web["Wegent Web"]
-    Desktop --> Local["本地项目与运行环境"]
-    Desktop <--> Backend["Wegent Backend"]
-    Web <--> Backend
-    Backend --> Agents["共享智能体与知识"]
-    Backend --> Space["项目空间"]
-    Backend --> Remote["云端与远程设备"]
+    Electron["Electron<br/>桌面宿主"]
+
+    subgraph DSH["DSH Runtime"]
+        direction TB
+        Core["DSH Core<br/>插件发现、依赖注入与生命周期"]
+        App["dsh-app-wework<br/>Wework 产品外壳与 UI 扩展点"]
+        UI["dsh-ui-*<br/>任务、项目空间、设置、应用与自动化"]
+        ElectronPlugin["dsh-electron-host<br/>Electron 能力桥接"]
+        ExecutorPlugin["dsh-executor-runtime<br/>任务执行与事件适配"]
+        TerminalPlugin["dsh-terminal-runtime<br/>本地交互式终端"]
+
+        Core --> App
+        Core --> UI
+        Core --> ElectronPlugin
+        Core --> ExecutorPlugin
+        Core --> TerminalPlugin
+        App --> UI
+    end
+
+    Executor["Executor<br/>任务与会话执行"]
+    Codex["Codex<br/>编码 Agent"]
+    Workspace["本地项目<br/>文件与命令"]
+
+    Electron -->|"启动并托管"| Core
+    Electron -->|"启动并监管"| Executor
+    ElectronPlugin <-->|"受限桌面能力"| Electron
+    UI <-->|"用户操作与界面更新"| ExecutorPlugin
+    ExecutorPlugin -->|"创建、追问、审批、取消"| Executor
+    Executor -->|"状态、消息、工具事件、结果"| ExecutorPlugin
+    Executor <-->|"启动、控制与事件"| Codex
+    Codex <-->|"读取、修改与执行"| Workspace
+    TerminalPlugin <-->|"PTY"| Workspace
 ```
+
+DSH 不直接执行编码任务。`dsh-app-wework` 定义产品外壳和扩展点，`dsh-ui-*` 提供具体产品模块，`dsh-electron-host` 桥接受限的 Electron 能力，`dsh-executor-runtime` 在执行过程中与 Executor 双向通信，`dsh-terminal-runtime` 管理本地交互式终端。Executor 是任务执行层，Codex 是由它驱动的具体编码 Agent。
+
+Wework 也可以连接 Wegent Backend 使用共享项目空间、模型和远程执行设备。Wegent Web 是基于同一 Backend 的独立网页界面。
 
 ## 快速开始
 
@@ -105,17 +133,17 @@ pnpm --filter wework dev:mac
 
 ## 仓库结构
 
-| 目录                       | 职责                                 |
-| -------------------------- | ------------------------------------ |
+| 目录                       | 职责                                    |
+| -------------------------- | --------------------------------------- |
 | `wework/`                  | Wegent Desktop（Electron、Vite、React） |
-| `executor/`                | 本地与远程的智能体任务执行环境       |
-| `frontend/`                | Wegent 平台 Web 管理界面             |
-| `backend/`                 | REST API 和核心业务逻辑              |
-| `executor_manager/`        | 执行器调度与编排                     |
-| `chat_shell/`              | 对话运行时                           |
-| `knowledge_runtime/`       | 知识检索服务                         |
-| `knowledge_doc_converter/` | 文档解析与转换                       |
-| `shared/`                  | 跨服务共享模块                       |
+| `executor/`                | 本地与远程的智能体任务执行环境          |
+| `frontend/`                | Wegent 平台 Web 管理界面                |
+| `backend/`                 | REST API 和核心业务逻辑                 |
+| `executor_manager/`        | 执行器调度与编排                        |
+| `chat_shell/`              | 对话运行时                              |
+| `knowledge_runtime/`       | 知识检索服务                            |
+| `knowledge_doc_converter/` | 文档解析与转换                          |
+| `shared/`                  | 跨服务共享模块                          |
 
 ## 文档
 


### PR DESCRIPTION
## Summary

- replace the high-level desktop flow diagram with the current Electron, DSH, Executor, Codex, and workspace architecture
- document the roles of the core Wework DSH plugins and the bidirectional execution event flow
- keep the Chinese and English root READMEs aligned

## Verification

- `git diff --check`
- `pnpm --filter wework exec prettier --check ../README_zh.md ../README.md`
- pre-push quality checks

Task: WEWORKC2FA61-398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English and Chinese “How it works” sections to describe the current desktop architecture.
  * Added diagrams illustrating Electron, the embedded runtime, task execution, Codex, and local project workflows.
  * Clarified the roles of the desktop host, plugins, Executor, and backend connectivity.
  * Cleaned up formatting in the Chinese repository structure table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->