### PR TITLE
docs: add DingTalk community group

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Bug reports, documentation improvements, code contributions, and new ways of usi
 - [Contributing Guide](CONTRIBUTING.md)
 - [Security Policy](SECURITY.md)
 - [GitHub Issues](https://github.com/wecode-ai/Wegent/issues)
+- DingTalk Community: “wework社区交流”, group ID `190890002451`
 - [Discord Community](https://discord.gg/MVzJzyqEUp)
 - [License](LICENSE)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -162,6 +162,7 @@ pnpm --filter wework dev:mac
 - [贡献指南](CONTRIBUTING.md)
 - [安全策略](SECURITY.md)
 - [问题反馈](https://github.com/wecode-ai/Wegent/issues)
+- 钉钉社区群：“wework社区交流”，群号 `190890002451`
 - [Discord 社区](https://discord.gg/MVzJzyqEUp)
 - [开源许可证](LICENSE)
 


### PR DESCRIPTION
## Summary

- add the “wework社区交流” DingTalk community group number to the Chinese README
- keep the English README community section in sync

## Testing

- `git diff --check`
- documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added community contact information to the contribution sections of the English and Chinese documentation.
  * Included a DingTalk community group for contributors to connect and exchange information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->