### PR TITLE
fix(wework): accumulate executor token usage per turn

### DIFF
--- a/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -32,10 +32,17 @@ trusting a plugin permits it to read that content through the standard DSH
 Session contract; Wework does not maintain a second anonymized-summary
 extension point for the same data.
 
-Codex `tokenUsage.last` is cumulative for the current turn, and projected usage
-chunks retain that meaning. A plugin that needs live token throughput should
-subtract adjacent `outputTokens` values for the same Session and divide by the
-sample interval. It must not add multiple cumulative samples together.
+Codex `tokenUsage.last` describes the most recent model call. One Executor turn
+can contain multiple model calls, so this value resets between calls. The
+projection derives adjacent deltas from thread-level `tokenUsage.total` and
+accumulates those deltas into usage for the current DSH turn. Projected
+`outputTokens` therefore increases monotonically within one turn, and
+`assistant/message.usage` uses the same whole-turn cumulative value.
+
+A plugin that needs live token throughput should subtract adjacent
+`outputTokens` values for the same Session and turn, then divide by the sample
+interval. It must not add multiple cumulative samples together, and it should
+reset its own delta baseline when a new turn starts.
 
 ```js
 export const inject = ["sessions"];

--- a/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -29,9 +29,15 @@ Session，因此并行任务不会合并到同一个事件流。
 投影保留原始用户消息和模型输出。安装并信任插件意味着允许插件按标准 DSH
 Session 契约读取这些内容；Wework 不再为同一数据维护一套匿名摘要扩展点。
 
-Codex 的 `tokenUsage.last` 表示当前 turn 的累计用量，投影后的 usage chunk
-也保持这一语义。需要实时 token 速度的插件应对同一 Session 的相邻
-`outputTokens` 求差分，再除以采样间隔；不能把多个累计值直接相加。
+Codex 的 `tokenUsage.last` 表示最近一次模型调用的用量；同一 Executor turn
+可能包含多次模型调用，因此该值会在调用之间重置。投影层使用 thread 级
+`tokenUsage.total` 计算相邻增量，再把增量累计为当前 DSH turn 的 usage。
+所以投影后的 `outputTokens` 在同一 turn 内单调递增，`assistant/message.usage`
+也使用相同的整轮累计口径。
+
+需要实时 token 速度的插件应对同一 Session、同一 turn 的相邻
+`outputTokens` 求差分，再除以采样间隔；不能把多个累计值直接相加。新 turn
+开始后应重置插件自己的差分基线。
 
 ```js
 export const inject = ["sessions"];

--- a/wework/dsh/executor-runtime/session-projector.js
+++ b/wework/dsh/executor-runtime/session-projector.js
@@ -51,18 +51,17 @@ export class ExecutorSessionProjector {
 
     if (event === 'thread/tokenUsage/updated' || event === 'thread.tokenUsage.updated') {
       const runtimeUsage = recordField(recordField(payload, 'data'), 'tokenUsage')
-      const usage = tokenUsage(
-        Object.keys(recordField(runtimeUsage, 'last')).length
-          ? recordField(runtimeUsage, 'last')
-          : recordField(runtimeUsage, 'total')
-      )
-      if (!usage) return
+      const totalUsage = tokenUsage(recordField(runtimeUsage, 'total'))
+      const lastUsage = tokenUsage(recordField(runtimeUsage, 'last'))
+      const increment = usageIncrement(totalUsage, state.sourceUsage, lastUsage)
+      if (!increment || !totalUsage) return
       this.ensureOpenTurn(state, subtaskId)
-      state.usage = usage
+      state.sourceUsage = totalUsage
+      state.usage = addUsage(state.usage, increment)
       const appended = state.session.append('assistant/chunk', {
         turn: state.turn,
         step: 1,
-        chunk: { type: 'usage', usage },
+        chunk: { type: 'usage', usage: state.usage },
       })
       state.sourceEventSeqs.push(appended.seq)
       return
@@ -91,6 +90,7 @@ export class ExecutorSessionProjector {
       textStarted: false,
       reasoningStarted: false,
       usage: null,
+      sourceUsage: null,
       sourceEventSeqs: [],
       generatedUserMessageIds: new Set(),
     }
@@ -177,7 +177,7 @@ export class ExecutorSessionProjector {
     const completedText = responseText(data)
     if (!state.text && completedText) this.appendDelta(state, subtaskId, 'text', completedText)
     const completedUsage = responseUsage(data)
-    if (completedUsage) state.usage = completedUsage
+    if (!state.usage && completedUsage) state.usage = completedUsage
     this.closeTurn(state, event, data)
   }
 
@@ -260,13 +260,48 @@ function tokenUsage(value) {
   const output = nonNegativeInteger(total.outputTokens)
   if (input === null || output === null) return null
   const cached = nonNegativeInteger(total.cachedInputTokens) ?? 0
+  const cacheWrite = nonNegativeInteger(total.cacheWriteInputTokens) ?? 0
   const reasoning = nonNegativeInteger(total.reasoningOutputTokens)
   return {
     inputTokens: Math.max(0, input - cached),
     outputTokens: output,
     ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(cacheWrite ? { cacheWriteTokens: cacheWrite } : {}),
     ...(reasoning === null ? {} : { reasoningTokens: reasoning }),
   }
+}
+
+function usageIncrement(total, previousTotal, last) {
+  if (!total) return null
+  if (!previousTotal) return last ?? total
+  const keys = usageKeys(total, previousTotal)
+  if (keys.some(key => usageValue(total, key) < usageValue(previousTotal, key))) {
+    return last ?? total
+  }
+  return Object.fromEntries(
+    keys.map(key => [key, usageValue(total, key) - usageValue(previousTotal, key)])
+  )
+}
+
+function addUsage(current, increment) {
+  const keys = usageKeys(current, increment)
+  return Object.fromEntries(
+    keys.map(key => [key, usageValue(current, key) + usageValue(increment, key)])
+  )
+}
+
+function usageKeys(...values) {
+  return [
+    'inputTokens',
+    'outputTokens',
+    'cacheReadTokens',
+    'cacheWriteTokens',
+    'reasoningTokens',
+  ].filter(key => values.some(value => value && Object.hasOwn(value, key)))
+}
+
+function usageValue(usage, key) {
+  return usage?.[key] ?? 0
 }
 
 function responseUsage(data) {

--- a/wework/dsh/executor-runtime/session-projector.test.mjs
+++ b/wework/dsh/executor-runtime/session-projector.test.mjs
@@ -116,6 +116,127 @@ test('uses final response usage when no live token update was emitted', () => {
   })
 })
 
+test('projects per-call Codex usage as cumulative usage within the DSH turn', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(executorEvent(1, 'response.created', {}))
+  projector.handle(
+    executorEvent(2, 'thread/tokenUsage/updated', {
+      tokenUsage: {
+        total: usageBreakdown(1000, 100, 400, 10, 20),
+        last: usageBreakdown(1000, 100, 400, 10, 20),
+      },
+    })
+  )
+  projector.handle(
+    executorEvent(3, 'thread/tokenUsage/updated', {
+      tokenUsage: {
+        total: usageBreakdown(2200, 160, 1200, 20, 25),
+        last: usageBreakdown(1200, 60, 800, 10, 5),
+      },
+    })
+  )
+  projector.handle(
+    executorEvent(4, 'thread/tokenUsage/updated', {
+      tokenUsage: {
+        total: usageBreakdown(3100, 220, 1900, 30, 35),
+        last: usageBreakdown(900, 60, 700, 10, 10),
+      },
+    })
+  )
+  projector.handle(
+    executorEvent(5, 'response.completed', {
+      response: {
+        usage: {
+          input_tokens: 900,
+          output_tokens: 60,
+          input_tokens_details: { cached_tokens: 700 },
+          output_tokens_details: { reasoning_tokens: 10 },
+        },
+      },
+    })
+  )
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  const usageEvents = session.events.filter(
+    event => event.type === 'assistant/chunk' && event.data.chunk.type === 'usage'
+  )
+  assert.deepEqual(
+    usageEvents.map(event => event.data.chunk.usage),
+    [
+      {
+        inputTokens: 600,
+        outputTokens: 100,
+        cacheReadTokens: 400,
+        cacheWriteTokens: 10,
+        reasoningTokens: 20,
+      },
+      {
+        inputTokens: 1000,
+        outputTokens: 160,
+        cacheReadTokens: 1200,
+        cacheWriteTokens: 20,
+        reasoningTokens: 25,
+      },
+      {
+        inputTokens: 1200,
+        outputTokens: 220,
+        cacheReadTokens: 1900,
+        cacheWriteTokens: 30,
+        reasoningTokens: 35,
+      },
+    ]
+  )
+  assert.deepEqual(
+    session.events.find(event => event.type === 'assistant/message').data.usage,
+    usageEvents.at(-1).data.chunk.usage
+  )
+})
+
+test('keeps the source usage baseline while resetting projected usage for a new turn', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(executorEvent(1, 'response.created', {}))
+  projector.handle(
+    executorEvent(2, 'thread/tokenUsage/updated', {
+      tokenUsage: {
+        total: usageBreakdown(1000, 100, 400, 10, 20),
+        last: usageBreakdown(1000, 100, 400, 10, 20),
+      },
+    })
+  )
+  projector.handle(executorEvent(3, 'response.completed', {}))
+  projector.handle(executorEvent(4, 'response.created', {}, 'task-1', 'turn-2'))
+  projector.handle(
+    executorEvent(
+      5,
+      'thread/tokenUsage/updated',
+      {
+        tokenUsage: {
+          total: usageBreakdown(1800, 150, 1000, 20, 25),
+          last: usageBreakdown(800, 50, 600, 10, 5),
+        },
+      },
+      'task-1',
+      'turn-2'
+    )
+  )
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  const usageEvents = session.events.filter(
+    event => event.type === 'assistant/chunk' && event.data.chunk.type === 'usage'
+  )
+  assert.deepEqual(usageEvents.at(-1).data.chunk.usage, {
+    inputTokens: 200,
+    outputTokens: 50,
+    cacheReadTokens: 600,
+    cacheWriteTokens: 10,
+    reasoningTokens: 5,
+  })
+})
+
 test('marks failed executor responses as interrupted error turns', () => {
   const sessions = new SessionStoreFixture()
   const projector = new ExecutorSessionProjector(sessions)
@@ -170,7 +291,7 @@ class SessionFixture {
   }
 }
 
-function executorEvent(sequence, event, data, taskId = 'task-1') {
+function executorEvent(sequence, event, data, taskId = 'task-1', subtaskId = `${taskId}-turn-1`) {
   return {
     type: 'event',
     protocolVersion: 1,
@@ -178,12 +299,29 @@ function executorEvent(sequence, event, data, taskId = 'task-1') {
     event,
     payload: {
       taskId,
-      subtaskId: `${taskId}-turn-1`,
+      subtaskId,
       deviceId: 'device-1',
       data,
       ...(data.runtimeGeneratedUserMessage
         ? { runtimeGeneratedUserMessage: data.runtimeGeneratedUserMessage }
         : {}),
     },
+  }
+}
+
+function usageBreakdown(
+  inputTokens,
+  outputTokens,
+  cachedInputTokens,
+  cacheWriteInputTokens,
+  reasoningOutputTokens
+) {
+  return {
+    totalTokens: inputTokens + outputTokens,
+    inputTokens,
+    cachedInputTokens,
+    cacheWriteInputTokens,
+    outputTokens,
+    reasoningOutputTokens,
   }
 }


### PR DESCRIPTION
## Summary

- derive per-model-call token deltas from Executor thread-level cumulative usage
- expose monotonic, turn-cumulative standard DSH usage chunks and final message usage
- preserve cache-write and reasoning token fields
- document the corrected usage semantics for DSH plugins in Chinese and English

## Root cause

Codex `tokenUsage.last` resets for every model call inside one Executor turn. The projector forwarded it as if it were cumulative for the DSH turn. Plugins calculating throughput from adjacent `outputTokens` therefore clamped most samples to zero after a larger model call.

## Verification

- `node --test wework/dsh/executor-runtime/*.test.mjs` (18 passed)
- `npm test` in `ai-fleet-defense` (8 passed)
- pre-push Wework ESLint, unit tests, and DSH tests passed
- cross-repository simulation with reset-per-call usage produced monotonic projected usage and non-zero game throughput
- `pnpm --filter wework ai:verify start` was attempted, but the isolated app failed before renderer startup because `wework/resources/components.json` was absent (`ENOENT`); evidence: `wework/test-results/ai-verify/2026-08-27T07-29-55-694Z-10588/app.log`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token-usage tracking across multiple model calls within a DSH turn.
  - Preserved cumulative output and final-message usage during streaming updates.
  - Included cache-write tokens in runtime usage totals.
  - Reset projected usage correctly when a new DSH turn begins.

- **Documentation**
  - Clarified token-usage fields, cumulative calculations, and guidance for real-time usage-rate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->