### PR TITLE
fix(wework): restore embedded browser popup tabs

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
@@ -37,7 +37,7 @@ const OPEN_BROWSER_WHILE_CLOSED_KEY =
   process.platform === 'win32' ? 'Control+Shift+B' : 'Meta+Shift+B'
 const OPEN_BROWSER_WHILE_OPEN_KEY = process.platform === 'win32' ? 'Control+T' : 'Meta+T'
 
-function fixtureHtml(title, text) {
+function fixtureHtml(title, text, popupUrl = null, autoPopup = false) {
   return [
     '<!doctype html>',
     '<html>',
@@ -51,9 +51,15 @@ function fixtureHtml(title, text) {
     '  </head>',
     '  <body>',
     '    <h1>' + text + '</h1>',
+    popupUrl ? '    <a id="popup-link" href="' + popupUrl + '" target="_blank">Open B</a>' : null,
+    autoPopup && popupUrl
+      ? '    <script>window.open(' + JSON.stringify(popupUrl) + ', "_blank")</script>'
+      : null,
     '  </body>',
     '</html>',
-  ].join('\n')
+  ]
+    .filter(line => line !== null)
+    .join('\n')
 }
 
 async function waitForBridgeIdentity(executorHome, timeoutMs) {
@@ -157,7 +163,12 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
     async handleHttp(request, response, url) {
       if (request.method !== 'GET') return false
       if (url.pathname === FIXTURE_A_PATH) {
-        const html = fixtureHtml(FIXTURE_A_TEXT, FIXTURE_A_TEXT)
+        const html = fixtureHtml(
+          FIXTURE_A_TEXT,
+          FIXTURE_A_TEXT,
+          url.origin + FIXTURE_B_PATH,
+          url.searchParams.get('popup') === '1'
+        )
         const responseGate = fixtureAResponseGate
         fixtureAResponseGate = null
         fixtureARequestStartCount += 1
@@ -483,6 +494,37 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
       assert.ok(
         reopenedText.inspectText.includes(FIXTURE_A_TEXT),
         'The reopened browser panel did not render the fresh page'
+      )
+
+      await callBridge(
+        bridgeIdentity,
+        { action: 'open', url: fixtureAUrl + '?popup=1', timeoutMs: 8000 },
+        firstBrowserLabel
+      )
+      await waitForSnapshot(
+        control,
+        snapshot =>
+          snapshot.testIds.filter(testId => /^right-workspace-browser-tab-\d+$/.test(testId))
+            .length >= 2,
+        'A blank-target popup did not open another browser tab',
+        uiTimeoutMs,
+        RIGHT_WORKSPACE_TABBAR_SELECTOR
+      )
+      await waitForValue(
+        control,
+        BROWSER_INPUT_SELECTOR,
+        fixtureBUrl,
+        uiTimeoutMs,
+        'The popup browser tab did not load the linked page'
+      )
+      const popupTabText = await callBridge(bridgeIdentity, {
+        action: 'inspect',
+        options: { includeTextBlocks: true, interactiveOnly: false, maxNodes: 40 },
+        timeoutMs: 5000,
+      })
+      assert.ok(
+        popupTabText.inspectText.includes(FIXTURE_B_TEXT),
+        'The popup browser tab did not retain the linked page state'
       )
     },
   }

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -110,6 +110,46 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  test('routes a popup to the current logical label and native browser identity', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+    const nativeLabel = manager.state('workspace-browser').nativeLabel
+    manager.relabel('workspace-browser', 'workspace-browser-task-1')
+
+    const windowOpenHandler = contents.setWindowOpenHandler.mock.calls[0]?.[0] as
+      | ((details: { url: string }) => { action: string })
+      | undefined
+    expect(windowOpenHandler?.({ url: 'https://example.test/linked-page' })).toEqual({
+      action: 'deny',
+    })
+
+    const events = manager.readEvents(0)
+    expect(events.events).toContainEqual(
+      expect.objectContaining({
+        type: 'popup',
+        payload: expect.objectContaining({
+          parentLabel: 'workspace-browser-task-1',
+          parentNativeLabel: nativeLabel,
+          strategy: 'new-tab',
+          url: 'https://example.test/linked-page',
+        }),
+      })
+    )
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('records, searches, removes, and clears persisted browser history', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
     const manager = new EmbeddedBrowserManager(directory)

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -178,7 +178,7 @@ export class EmbeddedBrowserManager {
         this.emit('popup', {
           popupId: randomUUID(),
           parentLabel: entry.label,
-          parentNativeLabel: entry.label,
+          parentNativeLabel: entry.nativeLabel,
           url,
           origin: new URL(url).origin,
           kind: 'window-open',

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
@@ -78,6 +78,7 @@ export function ElectronEmbeddedBrowserView({
     webview.setAttribute('data-wework-browser-label', initialLabelRef.current)
     webview.setAttribute('data-browser-sidebar-conversation-id', 'wework')
     webview.setAttribute('data-browser-sidebar-browser-tab-id', initialLabelRef.current)
+    webview.setAttribute('allowpopups', 'true')
     webview.setAttribute('partition', routePartition(initialLabelRef.current, hostGeneration))
     webview.setAttribute('src', 'about:blank')
     webview.setAttribute('webviewrole', 'tab')

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -1953,6 +1953,7 @@ describe('WorkspaceBrowserPanel', () => {
       expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalled()
     })
     const webviewHost = await screen.findByTestId('workspace-browser-electron-webview')
+    expect(webviewHost.querySelector('webview')).toHaveAttribute('allowpopups', 'true')
     expect(webviewHost).toHaveStyle({ pointerEvents: 'auto', visibility: 'visible' })
     expect(webviewHost.parentElement).toHaveStyle({ zIndex: '10' })
 


### PR DESCRIPTION
## Summary

- Allow popup windows from the embedded browser webview so `_blank` links and `window.open()` reach the Electron host.
- Emit the real native browser label with popup events, preserving parent-tab routing after relabeling.
- Add focused unit coverage and desktop E2E coverage for popup tabs.

## Root cause

The embedded browser webview did not set `allowpopups`, so Chromium denied popup creation before `setWindowOpenHandler` could emit a new-tab request. The popup payload also used the logical label as `parentNativeLabel`, which could prevent the renderer from finding the parent browser tab after relabeling.

## Verification

- `pnpm --filter wework test electron/src/host/embedded-browser-manager.test.ts src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx src/features/browser-tabs/browserPopupRouting.test.ts` — 83 tests passed.
- `pnpm --filter wework exec prettier --check ...` — passed.
- `pnpm --filter wework exec eslint ...` — passed.
- `git diff --check` — passed.
- Isolated real Electron verification passed: opening `/b` with `_blank` created `right-workspace-browser-tab-2` and loaded the linked page.

Note: a packaged desktop E2E attempt stopped before the popup assertion because Chromium's network service crashed while loading fixture A in that environment. The source-mode isolated Electron verification covered the fixed popup path successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled pop-up windows in embedded browser views.
  - Pop-ups can now open as additional browser tabs while preserving their originating browser context.

- **Bug Fixes**
  - Improved pop-up routing and tracking when embedded browser labels change.

- **Tests**
  - Added coverage verifying pop-up tab creation, loading, routing, and webview configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->