### PR TITLE
fix(wework): prevent Issue sidebar header content clipping

### DIFF
--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -401,6 +401,8 @@ async function verifyWorkspaceIssueCreation(control) {
   })
 
   const projectName = 'Workspace Issue E2E'
+  const issueTitle =
+    'WEWORK_DESKTOP_E2E_ISSUE_TITLE Verify that a deliberately long Issue title wraps across multiple lines in the workspace sidebar without clipping or overlapping the description below it.'
   const issueDescription =
     'WEWORK_DESKTOP_E2E_ISSUE Workspace fullscreen issue creation verified with a deliberately long description that spans more than two lines in the Issue sidebar so collapsed overflow treatment remains visible.'
   const twoLineBreakMarker = '换行标记'
@@ -522,6 +524,9 @@ async function verifyWorkspaceIssueCreation(control) {
     visible: true,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await control.command('fill', '[data-testid="workspace-issue-title"]', {
+    value: issueTitle,
+  })
   await control.command('fill', '[data-testid="workspace-issue-description"]', {
     value: issueDescription,
   })
@@ -548,6 +553,12 @@ async function verifyWorkspaceIssueCreation(control) {
     issueDescription,
     'Fullscreen Issue content did not survive closing and reopening'
   )
+  await waitForControlValueIncludes(
+    control,
+    '[data-testid="workspace-issue-title"]',
+    issueTitle,
+    'Fullscreen Issue title did not survive closing and reopening'
+  )
   await control.command('click', '[data-testid="workspace-issue-fullscreen-submit"]')
   await control.command(
     'waitFor',
@@ -568,6 +579,20 @@ async function verifyWorkspaceIssueCreation(control) {
       'getElementMetrics',
       `${boardContentSelector} .task-detail-workspace-description`
     )
+  )
+  const issueTitleLineHeight = Number.parseFloat(
+    await control.command(
+      'getComputedStyleValue',
+      `${boardContentSelector} [data-testid="cloud-todo-detail-title"]`,
+      { value: 'line-height' }
+    )
+  )
+  assert.ok(
+    issueTitleMetrics.scrollHeight >= issueTitleLineHeight * 2,
+    `The Issue sidebar title fixture did not wrap across multiple lines: ${JSON.stringify({
+      metrics: issueTitleMetrics,
+      lineHeight: issueTitleLineHeight,
+    })}`
   )
   assert.ok(
     issueTitleMetrics.clientHeight >= issueTitleMetrics.scrollHeight - 1,

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -403,7 +403,8 @@ async function verifyWorkspaceIssueCreation(control) {
   const projectName = 'Workspace Issue E2E'
   const issueDescription =
     'WEWORK_DESKTOP_E2E_ISSUE Workspace fullscreen issue creation verified with a deliberately long description that spans more than two lines in the Issue sidebar so collapsed overflow treatment remains visible.'
-  const twoLineIssueDescription = '验证侧边栏折叠描述可以完整显示两行内容并且不会出现多余的渐变遮罩'
+  const twoLineBreakMarker = '换行标记'
+  const twoLineIssueDescription = `折叠描述第一行${twoLineBreakMarker}折叠描述第二行`
   await control.command('click', `${boardContentSelector} [data-testid="cloud-project-add"]`)
   await control.command('waitFor', '[data-testid="cloud-project-name"]', {
     visible: true,
@@ -626,6 +627,26 @@ async function verifyWorkspaceIssueCreation(control) {
       value: twoLineIssueDescription,
     }
   )
+  await control.command(
+    'selectText',
+    `${boardContentSelector} [data-testid="cloud-todo-detail-description"]`,
+    {
+      value: twoLineBreakMarker,
+    }
+  )
+  await control.command(
+    'press',
+    `${boardContentSelector} [data-testid="cloud-todo-detail-description"]`,
+    {
+      key: 'Enter',
+    }
+  )
+  await waitForElementCount(
+    control,
+    `${collapsedDescriptionSelector} .bn-block-outer`,
+    2,
+    'The two-line regression fixture did not split into two editor blocks'
+  )
   await waitForAttribute(
     control,
     collapsedDescriptionSelector,
@@ -642,6 +663,7 @@ async function verifyWorkspaceIssueCreation(control) {
   const twoLineDescriptionBlocks = JSON.parse(
     await control.command('getElementMetrics', `${collapsedDescriptionSelector} .bn-block-outer`)
   )
+  const firstTwoLineDescriptionBlock = twoLineDescriptionBlocks.at(0)
   const lastTwoLineDescriptionBlock = twoLineDescriptionBlocks.at(-1)
   const twoLineDescriptionLineHeight = Number.parseFloat(
     await control.command('getComputedStyleValue', `${collapsedDescriptionSelector} p`, {
@@ -649,9 +671,14 @@ async function verifyWorkspaceIssueCreation(control) {
     })
   )
   assert.ok(
-    twoLineDescriptionParagraphMetrics.height >= twoLineDescriptionLineHeight * 2 - 1,
+    firstTwoLineDescriptionBlock &&
+      lastTwoLineDescriptionBlock &&
+      lastTwoLineDescriptionBlock.bottom - firstTwoLineDescriptionBlock.top >=
+        twoLineDescriptionLineHeight * 2 - 1,
     `The two-line regression fixture did not wrap to two lines: ${JSON.stringify({
       paragraph: twoLineDescriptionParagraphMetrics,
+      firstBlock: firstTwoLineDescriptionBlock,
+      lastBlock: lastTwoLineDescriptionBlock,
       lineHeight: twoLineDescriptionLineHeight,
     })}`
   )
@@ -990,6 +1017,17 @@ async function waitForAttribute(control, selector, name, expected, message) {
     await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
   }
   throw new Error(`${message}: expected ${name}=${expected}, received ${actual}`)
+}
+
+async function waitForElementCount(control, selector, expected, message) {
+  const startedAt = Date.now()
+  let actual = 0
+  while (Date.now() - startedAt < DEFAULT_STEP_TIMEOUT_MS) {
+    actual = Number(await control.command('getElementCount', selector))
+    if (actual === expected) return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(`${message}: expected ${expected}, received ${actual}`)
 }
 
 async function verifyWorkspaceTabIsolation(control) {

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -401,6 +401,9 @@ async function verifyWorkspaceIssueCreation(control) {
   })
 
   const projectName = 'Workspace Issue E2E'
+  const issueDescription =
+    'WEWORK_DESKTOP_E2E_ISSUE Workspace fullscreen issue creation verified with a deliberately long description that spans more than two lines in the Issue sidebar so collapsed overflow treatment remains visible.'
+  const twoLineIssueDescription = '考虑为wegent模型设计增加opencode提供商（zen/go/free）'
   await control.command('click', `${boardContentSelector} [data-testid="cloud-project-add"]`)
   await control.command('waitFor', '[data-testid="cloud-project-name"]', {
     visible: true,
@@ -519,7 +522,7 @@ async function verifyWorkspaceIssueCreation(control) {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await control.command('fill', '[data-testid="workspace-issue-description"]', {
-    value: 'WEWORK_DESKTOP_E2E_ISSUE Workspace fullscreen issue creation verified',
+    value: issueDescription,
   })
   await control.command('waitFor', '[data-testid="workspace-issue-draft-status"]', {
     text: '草稿已自动保存',
@@ -541,7 +544,7 @@ async function verifyWorkspaceIssueCreation(control) {
   await waitForControlValueIncludes(
     control,
     '[data-testid="workspace-issue-description"]',
-    'WEWORK_DESKTOP_E2E_ISSUE Workspace fullscreen issue creation verified',
+    issueDescription,
     'Fullscreen Issue content did not survive closing and reopening'
   )
   await control.command('click', '[data-testid="workspace-issue-fullscreen-submit"]')
@@ -553,10 +556,112 @@ async function verifyWorkspaceIssueCreation(control) {
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     }
   )
+  const [issueTitleMetrics] = JSON.parse(
+    await control.command(
+      'getElementMetrics',
+      `${boardContentSelector} [data-testid="cloud-todo-detail-title"]`
+    )
+  )
+  const [issueDescriptionMetrics] = JSON.parse(
+    await control.command(
+      'getElementMetrics',
+      `${boardContentSelector} .task-detail-workspace-description`
+    )
+  )
+  assert.ok(
+    issueTitleMetrics.clientHeight >= issueTitleMetrics.scrollHeight - 1,
+    `The Issue sidebar title clipped wrapped content: ${JSON.stringify(issueTitleMetrics)}`
+  )
+  assert.ok(
+    issueTitleMetrics.bottom <= issueDescriptionMetrics.top,
+    `The Issue sidebar title overlapped the description: ${JSON.stringify({
+      title: issueTitleMetrics,
+      description: issueDescriptionMetrics,
+    })}`
+  )
+  const collapsedDescriptionSelector = `${boardContentSelector} .task-detail-desc.is-collapsed`
+  await waitForAttribute(
+    control,
+    collapsedDescriptionSelector,
+    'data-overflowing',
+    'true',
+    'The collapsed Issue description did not expose its overflow treatment'
+  )
+  const [collapsedDescriptionMetrics] = JSON.parse(
+    await control.command('getElementMetrics', `${collapsedDescriptionSelector} .bn-editor`)
+  )
+  const collapsedDescriptionBlocks = JSON.parse(
+    await control.command('getElementMetrics', `${collapsedDescriptionSelector} .bn-block-outer`)
+  )
+  const lastCollapsedDescriptionBlock = collapsedDescriptionBlocks.at(-1)
+  const descriptionLineHeight = Number.parseFloat(
+    await control.command('getComputedStyleValue', `${collapsedDescriptionSelector} .bn-editor`, {
+      value: 'line-height',
+    })
+  )
+  assert.ok(
+    collapsedDescriptionMetrics.clientHeight >= descriptionLineHeight * 2,
+    `The collapsed Issue description clipped its second line: ${JSON.stringify({
+      metrics: collapsedDescriptionMetrics,
+      lineHeight: descriptionLineHeight,
+    })}`
+  )
+  assert.ok(
+    lastCollapsedDescriptionBlock &&
+      lastCollapsedDescriptionBlock.bottom > collapsedDescriptionMetrics.bottom + 1,
+    `The overflow regression fixture did not exceed the collapsed description: ${JSON.stringify({
+      editor: collapsedDescriptionMetrics,
+      lastBlock: lastCollapsedDescriptionBlock,
+    })}`
+  )
   await captureVerificationScreenshot(
     control,
     'workspace-issue-02-created.png',
     boardContentSelector
+  )
+  await control.command(
+    'fill',
+    `${boardContentSelector} [data-testid="cloud-todo-detail-description"]`,
+    {
+      value: twoLineIssueDescription,
+    }
+  )
+  await waitForAttribute(
+    control,
+    collapsedDescriptionSelector,
+    'data-overflowing',
+    'false',
+    'A fully visible two-line Issue description still exposed its overflow treatment'
+  )
+  const [twoLineDescriptionMetrics] = JSON.parse(
+    await control.command('getElementMetrics', `${collapsedDescriptionSelector} .bn-editor`)
+  )
+  const [twoLineDescriptionParagraphMetrics] = JSON.parse(
+    await control.command('getElementMetrics', `${collapsedDescriptionSelector} p`)
+  )
+  const twoLineDescriptionBlocks = JSON.parse(
+    await control.command('getElementMetrics', `${collapsedDescriptionSelector} .bn-block-outer`)
+  )
+  const lastTwoLineDescriptionBlock = twoLineDescriptionBlocks.at(-1)
+  const twoLineDescriptionLineHeight = Number.parseFloat(
+    await control.command('getComputedStyleValue', `${collapsedDescriptionSelector} p`, {
+      value: 'line-height',
+    })
+  )
+  assert.ok(
+    twoLineDescriptionParagraphMetrics.height >= twoLineDescriptionLineHeight * 2 - 1,
+    `The two-line regression fixture did not wrap to two lines: ${JSON.stringify({
+      paragraph: twoLineDescriptionParagraphMetrics,
+      lineHeight: twoLineDescriptionLineHeight,
+    })}`
+  )
+  assert.ok(
+    lastTwoLineDescriptionBlock &&
+      lastTwoLineDescriptionBlock.bottom <= twoLineDescriptionMetrics.bottom + 1,
+    `The collapsed Issue description clipped a fully visible second line: ${JSON.stringify({
+      editor: twoLineDescriptionMetrics,
+      lastBlock: lastTwoLineDescriptionBlock,
+    })}`
   )
   const issueStatusSelector = `${boardContentSelector} [data-testid="cloud-todo-detail-status"]`
   await control.command('select', issueStatusSelector, { value: 'pending' })

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -403,7 +403,7 @@ async function verifyWorkspaceIssueCreation(control) {
   const projectName = 'Workspace Issue E2E'
   const issueDescription =
     'WEWORK_DESKTOP_E2E_ISSUE Workspace fullscreen issue creation verified with a deliberately long description that spans more than two lines in the Issue sidebar so collapsed overflow treatment remains visible.'
-  const twoLineIssueDescription = '考虑为wegent模型设计增加opencode提供商（zen/go/free）'
+  const twoLineIssueDescription = '验证侧边栏折叠描述可以完整显示两行内容并且不会出现多余的渐变遮罩'
   await control.command('click', `${boardContentSelector} [data-testid="cloud-project-add"]`)
   await control.command('waitFor', '[data-testid="cloud-project-name"]', {
     visible: true,

--- a/wework/electron/src/runtime/managed-executor-runtime.test.ts
+++ b/wework/electron/src/runtime/managed-executor-runtime.test.ts
@@ -158,6 +158,7 @@ describe('managed executor runtime', () => {
         identityPath,
       ],
       environment: {
+        ELECTRON_RUN_AS_NODE: process.env.ELECTRON_RUN_AS_NODE,
         VITE_WEWORK_E2E: 'true',
         WEGENT_EXECUTOR_HOME: join(directory.path, 'executor-home'),
       },

--- a/wework/src/features/todo/TodoEditor.tsx
+++ b/wework/src/features/todo/TodoEditor.tsx
@@ -749,6 +749,7 @@ export function TodoEditor(props: TodoEditorProps) {
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
   const [downloadingAttachmentId, setDownloadingAttachmentId] = useState<string | null>(null)
   const [descriptionExpanded, setDescriptionExpanded] = useState(false)
+  const [descriptionOverflowing, setDescriptionOverflowing] = useState(false)
   const [expandedRailSections, setExpandedRailSections] = useState<Record<string, boolean>>({})
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -758,6 +759,7 @@ export function TodoEditor(props: TodoEditorProps) {
   const [statusHistoryOpen, setStatusHistoryOpen] = useState(false)
   const statusHistoryTriggerRef = useRef<HTMLButtonElement>(null)
   const detailScrollRef = useRef<HTMLDivElement>(null)
+  const descriptionCollapseRef = useRef<HTMLDivElement>(null)
 
   const editItemId = item?.id ?? null
   const editProjectId = item?.cloud_project_id ?? null
@@ -786,6 +788,43 @@ export function TodoEditor(props: TodoEditorProps) {
     if (!node) return
     node.scrollTop = 0
   }, [editItemId, isCreate])
+
+  useEffect(() => {
+    if (!workspacePanel || descriptionExpanded) return
+    const container = descriptionCollapseRef.current
+    if (!container) return
+
+    let frameId: number | null = null
+    const updateOverflow = () => {
+      if (frameId !== null) window.cancelAnimationFrame(frameId)
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null
+        const editor = container.querySelector<HTMLElement>('.bn-editor')
+        const editorBottom = editor?.getBoundingClientRect().bottom ?? 0
+        const overflowing = Array.from(
+          editor?.querySelectorAll<HTMLElement>('.bn-block-outer') ?? []
+        ).some(block => block.getBoundingClientRect().bottom > editorBottom + 1)
+        setDescriptionOverflowing(current => (current === overflowing ? current : overflowing))
+      })
+    }
+
+    updateOverflow()
+    const mutationObserver = new MutationObserver(updateOverflow)
+    mutationObserver.observe(container, {
+      characterData: true,
+      childList: true,
+      subtree: true,
+    })
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateOverflow)
+    resizeObserver?.observe(container)
+
+    return () => {
+      if (frameId !== null) window.cancelAnimationFrame(frameId)
+      mutationObserver.disconnect()
+      resizeObserver?.disconnect()
+    }
+  }, [descriptionExpanded, editItemId, workspacePanel])
 
   useLayoutEffect(() => {
     if (loadedEditItemIdRef.current === editItemId) return
@@ -2009,6 +2048,8 @@ export function TodoEditor(props: TodoEditorProps) {
                   )}
                 >
                   <div
+                    ref={workspacePanel ? descriptionCollapseRef : undefined}
+                    data-overflowing={descriptionOverflowing ? 'true' : 'false'}
                     className={cn(
                       twoColumn && 'task-detail-desc',
                       twoColumn && !descriptionExpanded && 'is-collapsed'

--- a/wework/src/features/todo/task-detail-layout.css
+++ b/wework/src/features/todo/task-detail-layout.css
@@ -340,12 +340,24 @@
 
 .task-detail-workspace-description .task-detail-desc.is-collapsed {
   display: block;
+  position: relative;
 }
 
 .task-detail-workspace-description .task-detail-desc.is-collapsed .bn-editor {
-  max-height: calc(var(--text-sm) * 1.6 * 2);
+  max-height: calc(var(--task-detail-body-font-size) * 1.75 * 2 + 6px);
   overflow: hidden;
   color: rgb(var(--color-text-muted));
+}
+
+.task-detail-workspace-description .task-detail-desc.is-collapsed[data-overflowing='true']::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 16px;
+  background: linear-gradient(to bottom, rgb(var(--color-muted) / 0), rgb(var(--color-muted)) 88%);
+  content: '';
+  pointer-events: none;
 }
 
 .task-detail-workspace-description .task-detail-desc-toggle {
@@ -896,6 +908,7 @@
 }
 
 .task-detail-title {
+  field-sizing: content;
   font-size: var(--task-detail-title-font-size);
   font-weight: 650;
   line-height: 1.3;


### PR DESCRIPTION
## Summary

- let wrapped Issue titles grow with their content instead of clipping at a fixed field height
- size the collapsed description preview to show two complete lines
- apply the bottom fade only when rich-text content actually extends beyond the visible preview
- keep overflow state synchronized as content and layout dimensions change
- add desktop regression coverage for wrapped titles, two-line previews, and overflowing descriptions
- preserve Electron Node mode in the managed executor restart fixture

## Root cause

The title field and collapsed description preview used height constraints that did not match their rendered line metrics. The description fade was also tied to the collapsed state rather than measured content overflow, so complete two-line content could appear truncated while longer content lacked a reliable overflow signal.

## Verification

- Wework formatter, ESLint, and TypeScript checks passed
- Wework renderer unit tests passed: 4,806 tests
- Electron unit tests passed: 207 tests
- focused Todo editor unit tests passed: 25 tests
- full pre-push quality checks passed
- verified the collapsed preview in the packaged Electron UI with both two-line and overflowing content

## Documentation

No documentation changes are needed for this visual layout fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsed task descriptions in workspace panels to detect and indicate when content is clipped.
  * Added a fade effect when descriptions exceed the collapsed two-line limit.
  * Improved multi-line text wrapping for more reliable display.
  * Prevented long task titles from being clipped, overlapping descriptions, or displaying incorrectly.
  * Improved the visual layout and readability of task details in compact workspace views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->