### PR TITLE
fix(wework): project live executor model deltas

### DIFF
--- a/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -44,6 +44,14 @@ A plugin that needs live token throughput should subtract adjacent
 interval. It must not add multiple cumulative samples together, and it should
 reset its own delta baseline when a new turn starts.
 
+Accurate Codex usage is normally reported when a model call settles, not for
+every generated token. Plugins that need lower-latency feedback can also
+observe standard `text-delta` and `reasoning-delta` chunks, estimate live
+generation throughput over a sliding window, and calibrate that estimate with
+later usage samples. Executor streaming text and thinking blocks are projected
+into those standard chunks; tool, plan, and other non-model blocks are excluded
+from the model output stream.
+
 ```js
 export const inject = ["sessions"];
 

--- a/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -39,6 +39,12 @@ Codex 的 `tokenUsage.last` 表示最近一次模型调用的用量；同一 Exe
 `outputTokens` 求差分，再除以采样间隔；不能把多个累计值直接相加。新 turn
 开始后应重置插件自己的差分基线。
 
+Codex 的准确 usage 通常按模型调用结算，不会随每个输出 token 上报。需要更低
+延迟反馈的插件可以同时监听标准 `text-delta` 和 `reasoning-delta` chunk，用
+滑动窗口估算实时生成速度，再用后续 usage 样本校准估算结果。Executor 的流式
+文本和思考 block 会被投影成这两类标准 chunk；工具、计划等非模型文本 block
+不会混入模型输出流。
+
 ```js
 export const inject = ["sessions"];
 

--- a/wework/dsh/executor-runtime/session-projector.js
+++ b/wework/dsh/executor-runtime/session-projector.js
@@ -49,6 +49,16 @@ export class ExecutorSessionProjector {
       return
     }
 
+    if (event === 'response.block.created') {
+      this.appendBlockCreated(state, subtaskId, recordField(payload, 'data'))
+      return
+    }
+
+    if (event === 'response.block.updated') {
+      this.appendBlockUpdated(state, subtaskId, recordField(payload, 'data'))
+      return
+    }
+
     if (event === 'thread/tokenUsage/updated' || event === 'thread.tokenUsage.updated') {
       const runtimeUsage = recordField(recordField(payload, 'data'), 'tokenUsage')
       const totalUsage = tokenUsage(recordField(runtimeUsage, 'total'))
@@ -91,6 +101,7 @@ export class ExecutorSessionProjector {
       reasoningStarted: false,
       usage: null,
       sourceUsage: null,
+      blocks: new Map(),
       sourceEventSeqs: [],
       generatedUserMessageIds: new Set(),
     }
@@ -110,6 +121,7 @@ export class ExecutorSessionProjector {
     state.textStarted = false
     state.reasoningStarted = false
     state.usage = null
+    state.blocks.clear()
     state.sourceEventSeqs = []
     state.session.append('turn/start', { turn: state.turn })
     state.session.append('step/start', { turn: state.turn, step: 1 })
@@ -164,6 +176,36 @@ export class ExecutorSessionProjector {
       },
     })
     state.sourceEventSeqs.push(appended.seq)
+  }
+
+  appendBlockCreated(state, subtaskId, data) {
+    const block = recordField(data, 'block')
+    const id = stringField(block, 'id')
+    const kind = projectedBlockKind(block)
+    if (!id || !kind) return
+    const content = stringField(block, 'content') ?? ''
+    state.blocks.set(id, { kind, content })
+    if (content) this.appendDelta(state, subtaskId, kind, content)
+  }
+
+  appendBlockUpdated(state, subtaskId, data) {
+    const id = stringField(data, 'block_id') ?? stringField(data, 'blockId')
+    if (!id) return
+    const tracked = state.blocks.get(id)
+    if (!tracked) return
+    const updates = recordField(data, 'updates')
+    const delta = stringField(updates, 'content_delta') ?? stringField(updates, 'contentDelta')
+    if (delta) {
+      tracked.content += delta
+      this.appendDelta(state, subtaskId, tracked.kind, delta)
+      return
+    }
+    const content = stringField(updates, 'content')
+    if (!content || content === tracked.content) return
+    if (!content.startsWith(tracked.content)) return
+    const suffix = content.slice(tracked.content.length)
+    tracked.content = content
+    if (suffix) this.appendDelta(state, subtaskId, tracked.kind, suffix)
   }
 
   finishTurn(state, subtaskId, event, data) {
@@ -318,6 +360,13 @@ function responseUsage(data) {
       recordField(usage, 'output_tokens_details').reasoning_tokens ??
       recordField(usage, 'outputTokensDetails').reasoningTokens,
   })
+}
+
+function projectedBlockKind(block) {
+  const processKind = stringField(block, 'process_kind') ?? stringField(block, 'processKind')
+  if (processKind === 'assistant_message') return 'text'
+  if (processKind === 'reasoning') return 'reasoning'
+  return null
 }
 
 function responseText(data) {

--- a/wework/dsh/executor-runtime/session-projector.test.mjs
+++ b/wework/dsh/executor-runtime/session-projector.test.mjs
@@ -68,6 +68,84 @@ test('projects executor text, reasoning, usage, and completion into standard ses
   assert.equal(session.events.at(-1).data.reason.kind, 'completed')
 })
 
+test('projects streamed Executor text blocks into standard assistant deltas', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(executorEvent(1, 'response.created', {}))
+  projector.handle(
+    executorEvent(2, 'response.block.created', {
+      block: {
+        id: 'reasoning-1',
+        type: 'thinking',
+        process_kind: 'reasoning',
+        content: 'Inspect',
+        status: 'streaming',
+      },
+    })
+  )
+  projector.handle(
+    executorEvent(3, 'response.block.updated', {
+      block_id: 'reasoning-1',
+      updates: { content_delta: ' logs', status: 'streaming' },
+    })
+  )
+  projector.handle(
+    executorEvent(4, 'response.block.created', {
+      block: {
+        id: 'message-1',
+        type: 'text',
+        process_kind: 'assistant_message',
+        content: 'Fix',
+        status: 'streaming',
+      },
+    })
+  )
+  projector.handle(
+    executorEvent(5, 'response.block.updated', {
+      block_id: 'message-1',
+      updates: { content: 'Fixed', status: 'done' },
+    })
+  )
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  const deltas = session.events
+    .filter(
+      event =>
+        event.type === 'assistant/chunk' &&
+        (event.data.chunk.type === 'text-delta' || event.data.chunk.type === 'reasoning-delta')
+    )
+    .map(event => [event.data.chunk.type, event.data.chunk.text])
+  assert.deepEqual(deltas, [
+    ['reasoning-delta', 'Inspect'],
+    ['reasoning-delta', ' logs'],
+    ['text-delta', 'Fix'],
+    ['text-delta', 'ed'],
+  ])
+})
+
+test('ignores non-model workbench blocks in the standard assistant stream', () => {
+  const sessions = new SessionStoreFixture()
+  const projector = new ExecutorSessionProjector(sessions)
+
+  projector.handle(
+    executorEvent(1, 'response.block.created', {
+      block: {
+        id: 'tool-1',
+        type: 'tool',
+        content: 'command output',
+        status: 'streaming',
+      },
+    })
+  )
+
+  const session = sessions.get(executorSessionId('device-1', 'task-1'))
+  assert.equal(
+    session.events.some(event => event.type === 'assistant/chunk'),
+    false
+  )
+})
+
 test('keeps parallel executor tasks in independent DSH sessions', () => {
   const sessions = new SessionStoreFixture()
   const projector = new ExecutorSessionProjector(sessions)


### PR DESCRIPTION
## Summary

- project Executor streaming text and thinking blocks into standard DSH `text-delta` and `reasoning-delta` chunks
- keep tool, plan, and other non-model blocks out of the model output stream
- document the real-time estimation plus exact usage calibration contract for plugins

## Root cause

Executor already receives high-frequency Codex model deltas, but exposes them to the workbench as `response.block.created/updated`. The DSH Session projector ignored those events, so standard plugins only received sparse usage samples after model calls settled and could not calculate live throughput.

## Verification

- `node --test wework/dsh/executor-runtime/*.test.mjs` (20 passed)
- pre-push Wework ESLint and DSH unit tests passed
- AI Fleet Defense telemetry consumes the projected deltas and passes 10 local tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming text and thinking output is now projected into standard text and reasoning updates.
  * Non-model blocks, such as tools and plans, are excluded from model output streams.
  * Added guidance for estimating real-time generation speed using streamed updates and later usage data.
* **Bug Fixes**
  * Improved handling of streamed response blocks, including blocks received without an earlier response event.
* **Documentation**
  * Updated English and Chinese Executor session guides with streaming and usage-reporting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->