### PR TITLE
fix(wework): stabilize macOS source dev startup

### DIFF
--- a/docs/en/wework/developer-guide/wework-debug-instance-context.md
+++ b/docs/en/wework/developer-guide/wework-debug-instance-context.md
@@ -6,6 +6,15 @@ sidebar_position: 35
 
 Wework can launch a debug Wework instance from the built-in Terminal of another running Wework window. To keep multiple worktrees and dev apps distinguishable, Wework passes the parent window context into the Terminal, and `wework/scripts/dev-mac-app.sh` forwards it to the debug instance.
 
+The built-in Terminal can also inherit `ELECTRON_RUN_AS_NODE`,
+`WEWORK_NODE_PATH`, and `WEWORK_NODE_RUNTIME_KIND` from the release app's Node
+launcher. Before starting the debug Electron process, `dev-mac-app.sh` clears
+those variables so the source checkout prepares its own Node launcher and
+Electron starts in desktop application mode. The script also generates
+development component resources such as
+`wework/electron/resources/components.json` and explicitly passes that resource
+root to the debug Electron process.
+
 ## Terminal Environment Variables
 
 When Wework creates a local built-in Terminal PTY, it injects:

--- a/docs/zh/wework/developer-guide/wework-debug-instance-context.md
+++ b/docs/zh/wework/developer-guide/wework-debug-instance-context.md
@@ -6,6 +6,13 @@ sidebar_position: 35
 
 Wework 支持从一个正在运行的 Wework 内置 Terminal 中启动另一个调试版 Wework。为了在多个 worktree、多个 dev app 同时打开时分清窗口来源，Wework 会把父窗口上下文传给 Terminal，再由 `wework/scripts/dev-mac-app.sh` 传给新启动的调试实例。
 
+内置 Terminal 还可能继承正式版用于启动 Node 子进程的
+`ELECTRON_RUN_AS_NODE`、`WEWORK_NODE_PATH` 和 `WEWORK_NODE_RUNTIME_KIND`。
+`dev-mac-app.sh` 在启动调试版 Electron 前会清除这些变量，让源码 checkout
+使用自己准备的 Node launcher，并确保 Electron 以桌面应用模式启动。脚本也会
+先生成 `wework/electron/resources/components.json` 等开发组件资源，再把该
+资源目录显式交给调试版 Electron。
+
 ## Terminal 环境变量
 
 本地内置 Terminal 创建 PTY 时，会注入以下变量：

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -1170,8 +1170,13 @@ if (hasSingleInstanceLock) {
 
 async function desktopEnvironment(): Promise<NodeJS.ProcessEnv> {
   const resourcesRoot = app.isPackaged ? process.resourcesPath : developmentResourcesRoot
+  const configuredComponentResourcesRoot = process.env.WEWORK_COMPONENT_RESOURCES_ROOT?.trim()
+  const componentResourcesRoot =
+    !app.isPackaged && configuredComponentResourcesRoot
+      ? resolve(configuredComponentResourcesRoot)
+      : resourcesRoot
   componentUpdates ??= new ComponentUpdateManager({
-    resourcesRoot,
+    resourcesRoot: componentResourcesRoot,
     dataDirectory: app.getPath('userData'),
     updateBaseUrl,
     currentAppVersion: app.getVersion(),
@@ -1199,7 +1204,7 @@ async function desktopEnvironment(): Promise<NodeJS.ProcessEnv> {
     WEWORK_HARNESS_RESOURCE_ROOT: components.coreDsh,
     WEWORK_CORE_PLUGIN_ROOT: components.weworkCorePlugins,
     WEGENT_BUNDLED_PLUGIN_MARKETPLACE_DIR: join(
-      resourcesRoot,
+      componentResourcesRoot,
       'bundled-plugins',
       'wework-personal'
     ),

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -268,9 +268,12 @@ if [ ! -s "$WEWORK_APP_WATCH_READY_FILE" ]; then
   exit 1
 fi
 
-# The parent Wework terminal may use Electron as its embedded Node runtime.
-# The desktop process itself must always start in Electron app mode.
+# The parent Wework terminal may expose the release app's Electron-backed Node
+# runtime. A source checkout must create its own Node launcher, while the
+# desktop process itself must always start in Electron app mode.
 unset ELECTRON_RUN_AS_NODE
+unset WEWORK_NODE_PATH
+unset WEWORK_NODE_RUNTIME_KIND
 if [ "${#ELECTRON_ARGS[@]}" -gt 0 ]; then
   pnpm --dir electron dev -- "${ELECTRON_ARGS[@]}"
 else

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -228,7 +228,6 @@ if [ -z "${WEWORK_DEV_CODEX_BINARY:-}" ]; then
   WEWORK_CODEX_TARGET="$MACOS_TARGET" pnpm run prepare:codex
 fi
 WEWORK_DWS_TARGET="$MACOS_TARGET" pnpm run prepare:dws
-pnpm run prepare:harness-runtime -- --materialize
 
 if [ "$MANAGED_SOURCE_EXECUTOR" = "true" ]; then
   cargo build --manifest-path "$PROJECT_DIR/executor/Cargo.toml" --bin wegent-executor
@@ -245,6 +244,8 @@ if [ ! -x "$DWS_BINARY_PATH" ]; then
   echo "Error: DWS binary is not executable: $DWS_BINARY_PATH" >&2
   exit 1
 fi
+WEWORK_EXECUTOR_PROFILE=debug pnpm --dir electron prepare:package
+export WEWORK_COMPONENT_RESOURCES_ROOT="$WEWORK_DIR/electron/resources"
 WEWORK_APP_WATCH_READY_FILE="$(mktemp "${TMPDIR:-/tmp}/wework-app-watch.XXXXXX")"
 rm -f "$WEWORK_APP_WATCH_READY_FILE"
 export WEWORK_APP_WATCH_READY_FILE
@@ -267,6 +268,9 @@ if [ ! -s "$WEWORK_APP_WATCH_READY_FILE" ]; then
   exit 1
 fi
 
+# The parent Wework terminal may use Electron as its embedded Node runtime.
+# The desktop process itself must always start in Electron app mode.
+unset ELECTRON_RUN_AS_NODE
 if [ "${#ELECTRON_ARGS[@]}" -gt 0 ]; then
   pnpm --dir electron dev -- "${ELECTRON_ARGS[@]}"
 else

--- a/wework/scripts/dev-mac-app.test.mjs
+++ b/wework/scripts/dev-mac-app.test.mjs
@@ -19,5 +19,15 @@ describe('dev-mac-app', () => {
     )
     expect(source).not.toContain('WEWORK_NODE_PATH=')
     expect(source).not.toContain('prepare:execution-runtime')
+    expect(source).toContain('pnpm --dir electron prepare:package')
+    expect(source).toContain(
+      'export WEWORK_COMPONENT_RESOURCES_ROOT="$WEWORK_DIR/electron/resources"'
+    )
+    expect(source).not.toContain('pnpm run prepare:harness-runtime -- --materialize')
+
+    const electronNodeReset = source.indexOf('unset ELECTRON_RUN_AS_NODE')
+    const electronLaunch = source.indexOf('pnpm --dir electron dev')
+    expect(electronNodeReset).toBeGreaterThan(-1)
+    expect(electronNodeReset).toBeLessThan(electronLaunch)
   })
 })

--- a/wework/scripts/dev-mac-app.test.mjs
+++ b/wework/scripts/dev-mac-app.test.mjs
@@ -26,8 +26,12 @@ describe('dev-mac-app', () => {
     expect(source).not.toContain('pnpm run prepare:harness-runtime -- --materialize')
 
     const electronNodeReset = source.indexOf('unset ELECTRON_RUN_AS_NODE')
+    const inheritedNodePathReset = source.indexOf('unset WEWORK_NODE_PATH')
+    const inheritedNodeKindReset = source.indexOf('unset WEWORK_NODE_RUNTIME_KIND')
     const electronLaunch = source.indexOf('pnpm --dir electron dev')
     expect(electronNodeReset).toBeGreaterThan(-1)
-    expect(electronNodeReset).toBeLessThan(electronLaunch)
+    expect(inheritedNodePathReset).toBeGreaterThan(electronNodeReset)
+    expect(inheritedNodeKindReset).toBeGreaterThan(inheritedNodePathReset)
+    expect(inheritedNodeKindReset).toBeLessThan(electronLaunch)
   })
 })

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -14,6 +14,7 @@ import { AuthProvider } from '@/features/auth/AuthProvider'
 import { useAuth } from '@/features/auth/useAuth'
 import { WorkbenchProvider } from '@/features/workbench/WorkbenchProvider'
 import {
+  registerRuntimeTaskLifecycleAutomation,
   RuntimeTaskLifecycleStore,
   RuntimeTaskLifecycleStreamCoordinator,
 } from '@/features/workbench/runtimeTaskLifecycle'
@@ -488,6 +489,7 @@ function AppRoutes({ onWorkbenchStartupReadyChange, onOpenWeworkForAppshot }: Ap
   }))
   const telemetryEnabled = useTelemetryEnabled()
   const lifecycleStore = useMemo(() => new RuntimeTaskLifecycleStore(user?.id), [user?.id])
+  useEffect(() => registerRuntimeTaskLifecycleAutomation(lifecycleStore), [lifecycleStore])
   const usesFallbackCloudConnection = cloudConnection.serviceKey.startsWith('fallback:')
   const workbenchIdentity = usesFallbackCloudConnection ? user : (cloudConnection.user ?? user)
   const workbenchIdentityId = workbenchIdentity?.id

--- a/wework/src/components/layout/useWorkbenchPaneSession.test.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.test.ts
@@ -4,7 +4,44 @@ import {
   clearRuntimeConversationCacheForTests,
   getRuntimeConversationMessages,
 } from '@/features/workbench/runtimeConversationCache'
-import { rollbackRejectedRuntimeConversationTurn } from './useWorkbenchPaneSession'
+import {
+  resolveRuntimeTranscriptPageSize,
+  rollbackRejectedRuntimeConversationTurn,
+  runtimeTranscriptHasMoreBefore,
+} from './useWorkbenchPaneSession'
+
+describe('resolveRuntimeTranscriptPageSize', () => {
+  afterEach(() => {
+    delete window.__WEWORK_DESKTOP_E2E_RUNTIME_CONFIG__
+  })
+
+  test('reads an Electron override injected after the module was loaded', () => {
+    window.__WEWORK_DESKTOP_E2E_RUNTIME_CONFIG__ = { transcriptPageSize: 20 }
+
+    expect(resolveRuntimeTranscriptPageSize()).toBe(20)
+  })
+
+  test.each([0, -1, Number.NaN, 10.5])(
+    'falls back to the production page size for invalid value %s',
+    configuredPageSize => {
+      expect(resolveRuntimeTranscriptPageSize(configuredPageSize)).toBe(50)
+    }
+  )
+})
+
+describe('runtimeTranscriptHasMoreBefore', () => {
+  test('keeps older pagination available when the server returns a before cursor', () => {
+    expect(
+      runtimeTranscriptHasMoreBefore({
+        taskId: 'task-1',
+        messages: [],
+        turns: [],
+        beforeCursor: 'opaque-older-page',
+        hasMoreBefore: false,
+      })
+    ).toBe(true)
+  })
+})
 
 describe('rollbackRejectedRuntimeConversationTurn', () => {
   afterEach(clearRuntimeConversationCacheForTests)

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -166,16 +166,6 @@ interface PendingRuntimeGoalState {
 
 const runtimePaneGoalSeeds = new Map<string, PendingRuntimeGoalState>()
 const DEFAULT_RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
-const configuredRuntimeTranscriptPageSize = Number(
-  getDesktopE2ERuntimeConfig().transcriptPageSize ??
-    import.meta.env.VITE_WEWORK_E2E_TRANSCRIPT_PAGE_SIZE
-)
-const RUNTIME_TRANSCRIPT_PAGE_SIZE =
-  import.meta.env.VITE_WEWORK_E2E === 'true' &&
-  Number.isInteger(configuredRuntimeTranscriptPageSize) &&
-  configuredRuntimeTranscriptPageSize > 0
-    ? configuredRuntimeTranscriptPageSize
-    : DEFAULT_RUNTIME_TRANSCRIPT_PAGE_SIZE
 const MAX_CACHED_RUNTIME_PANE_GOALS = 3
 const EMPTY_ATTACHMENT_STATE = {
   attachments: [],
@@ -187,6 +177,7 @@ export function useWorkbenchPaneSession({
   currentRuntimeTask,
   debugSnapshotEnabled = true,
 }: WorkbenchPaneSessionOptions) {
+  const runtimeTranscriptPageSize = resolveRuntimeTranscriptPageSize()
   const {
     state: workbenchState,
     projectChat,
@@ -719,7 +710,7 @@ export function useWorkbenchPaneSession({
     void Promise.resolve()
       .then(() =>
         loadRuntimeTranscriptForPaneRef.current(address, {
-          limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+          limit: runtimeTranscriptPageSize,
         })
       )
       .then(transcript => {
@@ -735,7 +726,7 @@ export function useWorkbenchPaneSession({
           )
           loadedRuntimeTranscriptKeyRef.current = loadKey
           setTranscriptFullContent(transcript.fullContent === true)
-          setTranscriptHasMoreBefore(Boolean(transcript.hasMoreBefore))
+          setTranscriptHasMoreBefore(runtimeTranscriptHasMoreBefore(transcript))
           setTranscriptBeforeCursor(transcript.beforeCursor ?? null)
           setLoadedTranscriptRanges(transcriptRangeFromPage(transcript))
           setTurnNavigation(transcript.turnNavigation ?? [])
@@ -788,7 +779,13 @@ export function useWorkbenchPaneSession({
         rebuildingTranscriptIdentityRef.current = null
       }
     }
-  }, [dispatchMessages, lifecycleStore, runtimeTaskLoadTarget, transcriptReloadVersion])
+  }, [
+    dispatchMessages,
+    lifecycleStore,
+    runtimeTaskLoadTarget,
+    runtimeTranscriptPageSize,
+    transcriptReloadVersion,
+  ])
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const reloadRuntimeTranscript = useCallback(() => {
@@ -822,7 +819,7 @@ export function useWorkbenchPaneSession({
 
       void loadRuntimeTranscriptForPaneRef
         .current(address, {
-          limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+          limit: runtimeTranscriptPageSize,
           refresh: true,
         })
         .then(transcript => {
@@ -838,7 +835,7 @@ export function useWorkbenchPaneSession({
           )
           loadedRuntimeTranscriptKeyRef.current = target.key
           setTranscriptFullContent(transcript.fullContent === true)
-          setTranscriptHasMoreBefore(Boolean(transcript.hasMoreBefore))
+          setTranscriptHasMoreBefore(runtimeTranscriptHasMoreBefore(transcript))
           setTranscriptBeforeCursor(transcript.beforeCursor ?? null)
           setLoadedTranscriptRanges(transcriptRangeFromPage(transcript))
           setTurnNavigation(transcript.turnNavigation ?? [])
@@ -865,7 +862,7 @@ export function useWorkbenchPaneSession({
           rebuildingTranscriptIdentityRef.current = null
         })
     })
-  }, [dispatchMessages, lifecycleStore, runtimeTaskLoadTarget])
+  }, [dispatchMessages, lifecycleStore, runtimeTaskLoadTarget, runtimeTranscriptPageSize])
 
   const loadMoreTranscriptBefore = useCallback(async () => {
     if (
@@ -881,7 +878,7 @@ export function useWorkbenchPaneSession({
     setTranscriptLoadingMoreBefore(true)
     try {
       const transcript = await loadRuntimeTranscriptForPaneRef.current(address, {
-        limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+        limit: runtimeTranscriptPageSize,
         beforeCursor,
       })
       const nextMessages = reconcileRuntimeConversationSnapshot(address, transcript.turns)
@@ -889,7 +886,7 @@ export function useWorkbenchPaneSession({
         loadedTranscriptRangesRef.current,
         transcriptRangeFromPage(transcript)
       )
-      setTranscriptHasMoreBefore(Boolean(transcript.hasMoreBefore))
+      setTranscriptHasMoreBefore(runtimeTranscriptHasMoreBefore(transcript))
       setTranscriptBeforeCursor(transcript.beforeCursor ?? null)
       setLoadedTranscriptRanges(nextRanges)
       setTurnNavigation(current =>
@@ -911,6 +908,7 @@ export function useWorkbenchPaneSession({
   }, [
     dispatchMessages,
     runtimeTaskLoadTarget,
+    runtimeTranscriptPageSize,
     transcriptBeforeCursor,
     transcriptFullContent,
     transcriptLoadingMoreBefore,
@@ -929,12 +927,16 @@ export function useWorkbenchPaneSession({
       }
 
       const { address } = runtimeTaskLoadTarget
-      const loadOptions = runtimeTurnNavigationLoadOptions(item, loadedTranscriptRangesRef.current)
+      const loadOptions = runtimeTurnNavigationLoadOptions(
+        item,
+        loadedTranscriptRangesRef.current,
+        runtimeTranscriptPageSize
+      )
       const transcript = await loadRuntimeTranscriptForPaneRef.current(address, loadOptions)
       const nextHasMoreBefore =
         loadOptions.beforeCursor === undefined
           ? transcriptHasMoreBefore
-          : Boolean(transcript.hasMoreBefore)
+          : runtimeTranscriptHasMoreBefore(transcript)
       const nextBeforeCursor =
         loadOptions.beforeCursor === undefined
           ? transcriptBeforeCursor
@@ -957,6 +959,7 @@ export function useWorkbenchPaneSession({
     [
       dispatchMessages,
       runtimeTaskLoadTarget,
+      runtimeTranscriptPageSize,
       transcriptBeforeCursor,
       transcriptFullContent,
       transcriptHasMoreBefore,
@@ -968,7 +971,7 @@ export function useWorkbenchPaneSession({
       if (!runtimeTaskLoadTarget || transcriptFullContent || gap.end <= gap.start) return
 
       const { address } = runtimeTaskLoadTarget
-      const limit = Math.min(RUNTIME_TRANSCRIPT_PAGE_SIZE, gap.end - gap.start)
+      const limit = Math.min(runtimeTranscriptPageSize, gap.end - gap.start)
       const loadOptions = {
         limit,
         afterCursor: `offset:${gap.start}`,
@@ -987,7 +990,7 @@ export function useWorkbenchPaneSession({
       )
       dispatchMessages({ type: 'reset', messages: nextMessages })
     },
-    [dispatchMessages, runtimeTaskLoadTarget, transcriptFullContent]
+    [dispatchMessages, runtimeTaskLoadTarget, runtimeTranscriptPageSize, transcriptFullContent]
   )
 
   const loadFullTranscript = useCallback(async () => {
@@ -1432,7 +1435,7 @@ export function useWorkbenchPaneSession({
           return true
         }
         const transcript = await loadRuntimeTranscriptForPaneRef.current(currentRuntimeTask, {
-          limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+          limit: runtimeTranscriptPageSize,
           refresh: true,
         })
         removeRuntimeConversationTurn(currentRuntimeTask, {
@@ -1447,7 +1450,7 @@ export function useWorkbenchPaneSession({
       } catch (error) {
         const transcript = await loadRuntimeTranscriptForPaneRef
           .current(currentRuntimeTask, {
-            limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+            limit: runtimeTranscriptPageSize,
             refresh: true,
           })
           .catch(() => null)
@@ -1467,7 +1470,14 @@ export function useWorkbenchPaneSession({
         return false
       }
     },
-    [currentRuntimeTask, editLastUserMessage, getRuntimeModelFields, paneStatus.isBusy, setError]
+    [
+      currentRuntimeTask,
+      editLastUserMessage,
+      getRuntimeModelFields,
+      paneStatus.isBusy,
+      runtimeTranscriptPageSize,
+      setError,
+    ]
   )
 
   const ignoreRequestUserInput = useCallback(
@@ -2735,7 +2745,7 @@ export function useWorkbenchPaneSession({
       rebuildingTranscriptIdentityRef.current = identityKey
       try {
         const transcript = await loadRuntimeTranscriptForPaneRef.current(address, {
-          limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+          limit: runtimeTranscriptPageSize,
           refresh: true,
         })
         if (cancelled || runtimeTaskLoadTargetRef.current?.identityKey !== identityKey) {
@@ -2799,6 +2809,7 @@ export function useWorkbenchPaneSession({
     lifecycleStore,
     messages,
     runtimeTaskLoadTarget,
+    runtimeTranscriptPageSize,
     transcriptLoading,
   ])
 
@@ -2938,6 +2949,21 @@ export function useWorkbenchPaneSession({
     resumeCurrentGoal,
     clearCurrentGoal,
   }
+}
+
+export function resolveRuntimeTranscriptPageSize(
+  configuredPageSize = Number(
+    getDesktopE2ERuntimeConfig().transcriptPageSize ??
+      import.meta.env.VITE_WEWORK_E2E_TRANSCRIPT_PAGE_SIZE
+  )
+): number {
+  return Number.isInteger(configuredPageSize) && configuredPageSize > 0
+    ? configuredPageSize
+    : DEFAULT_RUNTIME_TRANSCRIPT_PAGE_SIZE
+}
+
+export function runtimeTranscriptHasMoreBefore(transcript: RuntimePaneTranscript): boolean {
+  return Boolean(transcript.beforeCursor || transcript.hasMoreBefore)
 }
 
 export type WorkbenchPaneSession = ReturnType<typeof useWorkbenchPaneSession>
@@ -3168,21 +3194,19 @@ function cursorOffset(cursor: string | null | undefined): number | null {
 
 function runtimeTurnNavigationLoadOptions(
   item: RuntimeTurnNavigationItem,
-  loadedRanges: LoadedTranscriptRange[]
+  loadedRanges: LoadedTranscriptRange[],
+  pageSize: number
 ) {
   const messageIndex = Number.isFinite(item.messageIndex) ? Math.max(0, item.messageIndex) : 0
   const sortedRanges = mergeTranscriptRanges(loadedRanges, [])
   const nextLoadedRange = sortedRanges.find(range => range.start > messageIndex)
   const pageEnd = Math.max(
     messageIndex + 1,
-    Math.min(
-      nextLoadedRange?.start ?? messageIndex + RUNTIME_TRANSCRIPT_PAGE_SIZE,
-      messageIndex + RUNTIME_TRANSCRIPT_PAGE_SIZE
-    )
+    Math.min(nextLoadedRange?.start ?? messageIndex + pageSize, messageIndex + pageSize)
   )
 
   return {
-    limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+    limit: pageSize,
     beforeCursor: `offset:${pageEnd}`,
   }
 }

--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleProvider.tsx
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleProvider.tsx
@@ -1,10 +1,6 @@
-import { useEffect, type ReactNode } from 'react'
-import type { RuntimeTaskAddress } from '@/types/api'
-import type { RuntimePaneTranscript } from '@/types/workbench'
+import type { ReactNode } from 'react'
 import { RuntimeTaskLifecycleContext, RuntimeTaskLifecycleWriterContext } from './internalContext'
 import type { RuntimeTaskLifecycleStore } from './RuntimeTaskLifecycleStore'
-
-const E2E_RUNTIME_LIFECYCLE_EVENT = 'wework:e2e:runtime-task-lifecycle'
 
 export function RuntimeTaskLifecycleProvider({
   store,
@@ -15,28 +11,6 @@ export function RuntimeTaskLifecycleProvider({
   writerStore?: RuntimeTaskLifecycleStore
   children: ReactNode
 }) {
-  useEffect(() => {
-    if (import.meta.env.VITE_WEWORK_E2E !== 'true') return
-
-    const handleLifecycleEvent = (event: Event) => {
-      const detail = (
-        event as CustomEvent<{
-          address: RuntimeTaskAddress
-          type: string
-          turnId?: string | null
-          transcript?: RuntimePaneTranscript
-        }>
-      ).detail
-      if (detail?.type === 'turn_settled') {
-        writerStore.turnSettled(detail.address, detail.turnId)
-      } else if (detail?.type === 'transcript_received' && detail.transcript) {
-        writerStore.syncTranscript(detail.address, detail.transcript)
-      }
-    }
-    window.addEventListener(E2E_RUNTIME_LIFECYCLE_EVENT, handleLifecycleEvent)
-    return () => window.removeEventListener(E2E_RUNTIME_LIFECYCLE_EVENT, handleLifecycleEvent)
-  }, [writerStore])
-
   return (
     <RuntimeTaskLifecycleContext.Provider value={store}>
       <RuntimeTaskLifecycleWriterContext.Provider value={writerStore}>

--- a/wework/src/features/workbench/runtimeTaskLifecycle/automation.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/automation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+import type { RuntimeTaskAddress } from '@/types/api'
+import { registerRuntimeTaskLifecycleAutomation } from './automation'
+import { RuntimeTaskLifecycleStore } from './RuntimeTaskLifecycleStore'
+
+const address: RuntimeTaskAddress = {
+  deviceId: 'remote-device',
+  taskId: 'claude-task',
+}
+
+describe('runtime task lifecycle automation', () => {
+  test('applies authoritative transcript snapshots to the global store', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+    store.executorSettled(address)
+    const dispose = registerRuntimeTaskLifecycleAutomation(store)
+
+    window.dispatchEvent(
+      new CustomEvent('wework:e2e:runtime-task-lifecycle', {
+        detail: {
+          address,
+          type: 'transcript_received',
+          transcript: {
+            taskId: address.taskId,
+            messages: [],
+            running: false,
+            turns: [{ id: 'restored-turn', items: [], status: 'streaming' }],
+          },
+        },
+      })
+    )
+
+    expect(store.getTask(address)?.turn).toMatchObject({
+      id: 'restored-turn',
+      phase: 'streaming',
+    })
+    dispose()
+  })
+
+  test('stops applying lifecycle events after disposal', () => {
+    const store = new RuntimeTaskLifecycleStore('test')
+    store.executorSettled(address)
+    const dispose = registerRuntimeTaskLifecycleAutomation(store)
+    dispose()
+
+    window.dispatchEvent(
+      new CustomEvent('wework:e2e:runtime-task-lifecycle', {
+        detail: {
+          address,
+          type: 'transcript_received',
+          transcript: {
+            taskId: address.taskId,
+            messages: [],
+            running: true,
+            turns: [{ id: 'ignored-turn', items: [], status: 'streaming' }],
+          },
+        },
+      })
+    )
+
+    expect(store.getTask(address)?.turn.phase).toBe('idle')
+  })
+})

--- a/wework/src/features/workbench/runtimeTaskLifecycle/automation.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/automation.ts
@@ -1,0 +1,28 @@
+import type { RuntimeTaskAddress } from '@/types/api'
+import type { RuntimePaneTranscript } from '@/types/workbench'
+import type { RuntimeTaskLifecycleStore } from './RuntimeTaskLifecycleStore'
+
+const E2E_RUNTIME_LIFECYCLE_EVENT = 'wework:e2e:runtime-task-lifecycle'
+
+interface RuntimeTaskLifecycleAutomationEvent {
+  address: RuntimeTaskAddress
+  type: string
+  turnId?: string | null
+  transcript?: RuntimePaneTranscript
+}
+
+export function registerRuntimeTaskLifecycleAutomation(
+  store: RuntimeTaskLifecycleStore,
+  target: Window = window
+): () => void {
+  const handleLifecycleEvent = (event: Event) => {
+    const detail = (event as CustomEvent<RuntimeTaskLifecycleAutomationEvent>).detail
+    if (detail?.type === 'turn_settled') {
+      store.turnSettled(detail.address, detail.turnId)
+    } else if (detail?.type === 'transcript_received' && detail.transcript) {
+      store.syncTranscript(detail.address, detail.transcript)
+    }
+  }
+  target.addEventListener(E2E_RUNTIME_LIFECYCLE_EVENT, handleLifecycleEvent)
+  return () => target.removeEventListener(E2E_RUNTIME_LIFECYCLE_EVENT, handleLifecycleEvent)
+}

--- a/wework/src/features/workbench/runtimeTaskLifecycle/index.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/index.ts
@@ -6,6 +6,7 @@ export {
   RuntimeTaskLifecycleStore,
 } from './RuntimeTaskLifecycleStore'
 export { RuntimeTaskLifecycleProvider } from './RuntimeTaskLifecycleProvider'
+export { registerRuntimeTaskLifecycleAutomation } from './automation'
 export { RuntimeTaskLifecycleStreamCoordinator } from './RuntimeTaskLifecycleStreamCoordinator'
 export {
   useRuntimeTaskLifecycle,


### PR DESCRIPTION
## Summary

- prepare Electron component resources before launching the macOS source dev app
- resolve component manifests from the generated development resource root
- clear release-app Electron/Node environment variables before starting the source Electron process
- document the inherited Wework built-in Terminal environment contract

## Root cause

A Wework built-in Terminal inherits `ELECTRON_RUN_AS_NODE=1` and the release app's `WEWORK_NODE_PATH`. The source dev script passed those values into Electron, which made Electron run as plain Node and caused `Notification` import failures. After bypassing that variable manually, startup still failed because the source checkout had not generated `wework/resources/components.json`.

## Verification

- real `pnpm --filter wework dev:mac -- --executor-isolation` launch from an inherited Wework Terminal environment
- Electron started in application mode
- generated component manifest loaded successfully
- Core DSH started and exposed its local web endpoint
- focused `dev-mac-app` test passed
- pre-push ESLint, Electron TypeScript, Electron unit tests, and Wework script tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved runtime task lifecycle updates so transcript and turn status changes remain synchronized automatically.
  - Enhanced transcript navigation to support configured page sizes and older-content pagination more reliably.

- **Bug Fixes**
  - Fixed development builds that could launch with an inherited Node runtime instead of desktop application mode.
  - Improved component resource loading for development Electron builds.

- **Documentation**
  - Added English and Chinese guidance for debugging instance context and development app startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->