### PR TITLE
fix(wework): unblock panel resize drags over the embedded browser

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5944,8 +5944,10 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 422 })
+    expect(document.body).toHaveAttribute('data-wework-panel-resizing', 'true')
     fireEvent.pointerMove(document, { clientX: 582 })
     fireEvent.pointerUp(document)
+    expect(document.body).not.toHaveAttribute('data-wework-panel-resizing')
 
     expect(content).toHaveStyle({ width: '580px' })
     expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 580px)' })

--- a/wework/src/components/layout/useResizableSidebar.ts
+++ b/wework/src/components/layout/useResizableSidebar.ts
@@ -1,4 +1,5 @@
 import { useState, type PointerEvent } from 'react'
+import { setPanelResizeShieldActive } from '@/lib/panel-resize-shield'
 
 const DEFAULT_SIDEBAR_WIDTH = 240
 const MIN_SIDEBAR_WIDTH = 240
@@ -49,12 +50,14 @@ export function useResizableSidebar({
     onResizeStateChange?.(true)
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
+    setPanelResizeShieldActive(true)
 
     const finishResize = () => {
       setResizing(false)
       onResizeStateChange?.(false)
       document.body.style.cursor = previousCursor
       document.body.style.userSelect = previousUserSelect
+      setPanelResizeShieldActive(false)
       document.removeEventListener('pointermove', handlePointerMove)
       document.removeEventListener('pointerup', handlePointerUp)
     }

--- a/wework/src/components/layout/workspace-panels/useResizableWorkspacePanel.ts
+++ b/wework/src/components/layout/workspace-panels/useResizableWorkspacePanel.ts
@@ -7,6 +7,7 @@ import {
   type RefObject,
 } from 'react'
 import { DEFAULT_CODE_FONT_SIZE } from '@/features/appearance/typography'
+import { setPanelResizeShieldActive } from '@/lib/panel-resize-shield'
 
 const RIGHT_SPLIT_CHAT_DEFAULT_WIDTH = 420
 const RIGHT_SPLIT_CHAT_MIN_WIDTH = 360
@@ -98,6 +99,7 @@ export function useResizableRightSplitChat({
       document.removeEventListener('pointerup', handleUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+      setPanelResizeShieldActive(false)
       setResizing(false)
     }
 
@@ -144,6 +146,7 @@ export function useResizableRightSplitChat({
     setResizing(true)
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
+    setPanelResizeShieldActive(true)
     document.addEventListener('pointermove', handleMove)
     document.addEventListener('pointerup', handleUp)
   }
@@ -223,6 +226,7 @@ export function useResizableBottomPanel(codeFontSize = DEFAULT_CODE_FONT_SIZE) {
       }
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+      setPanelResizeShieldActive(false)
       activeResizeCleanupRef.current = null
     }
 
@@ -242,6 +246,7 @@ export function useResizableBottomPanel(codeFontSize = DEFAULT_CODE_FONT_SIZE) {
     setResizing(true)
     document.body.style.cursor = 'row-resize'
     document.body.style.userSelect = 'none'
+    setPanelResizeShieldActive(true)
     document.addEventListener('pointermove', handleMove)
     document.addEventListener('pointerup', handleUp)
     document.addEventListener('pointercancel', handleCancel)

--- a/wework/src/lib/panel-resize-shield.ts
+++ b/wework/src/lib/panel-resize-shield.ts
@@ -1,0 +1,13 @@
+const PANEL_RESIZING_ATTRIBUTE = 'data-wework-panel-resizing'
+
+// Embedded browser surfaces (<webview> or iframe fallback) swallow pointer
+// events while the cursor is over them, which stalls document-level panel
+// resize drags. Flag active drags on <body> so global CSS can temporarily
+// disable pointer events on those surfaces.
+export function setPanelResizeShieldActive(active: boolean): void {
+  if (active) {
+    document.body.setAttribute(PANEL_RESIZING_ATTRIBUTE, 'true')
+    return
+  }
+  document.body.removeAttribute(PANEL_RESIZING_ATTRIBUTE)
+}

--- a/wework/src/lib/panel-resize-shield.ts
+++ b/wework/src/lib/panel-resize-shield.ts
@@ -3,7 +3,8 @@ const PANEL_RESIZING_ATTRIBUTE = 'data-wework-panel-resizing'
 // Embedded browser surfaces (<webview> or iframe fallback) swallow pointer
 // events while the cursor is over them, which stalls document-level panel
 // resize drags. Flag active drags on <body> so global CSS can temporarily
-// disable pointer events on those surfaces.
+// disable pointer events on those surfaces. All panel resize hooks must call
+// this in pairs so the flag is always cleared when a drag ends or cancels.
 export function setPanelResizeShieldActive(active: boolean): void {
   if (active) {
     document.body.setAttribute(PANEL_RESIZING_ATTRIBUTE, 'true')

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -10,6 +10,15 @@
   -webkit-app-region: no-drag;
 }
 
+/* While a panel resize drag is active, embedded browser surfaces (<webview>
+   guest content or the iframe fallback) must not intercept pointer events,
+   otherwise document-level drag handlers stop receiving pointermove/pointerup
+   and the resize stalls. */
+body[data-wework-panel-resizing] [data-wework-browser-webview],
+body[data-wework-panel-resizing] [data-testid='workspace-browser-frame'] {
+  pointer-events: none !important;
+}
+
 :root {
   color-scheme: light;
   --color-bg-base: 255 255 255;


### PR DESCRIPTION
## Summary

Fixes a bug where dragging the divider to resize the Wework sidebar browser panel would get stuck.

**Root cause:** the workspace browser renders pages in an Electron `<webview>` (or an iframe fallback in non-Electron runtimes), whose guest content swallows all pointer events within its bounds. Panel resize drags listen for `pointermove`/`pointerup` on `document`, so once the cursor crossed into the webview area the events were consumed by the guest page: the width froze, `pointerup` was lost, and the drag state got stuck.

**Fix:** a shared panel-resize shield helper flags active panel resize drags on `<body>` (`data-wework-panel-resizing`). While the flag is set, global CSS disables pointer events on the browser webview container and the iframe fallback, so drag events pass through to the document handlers. All three resize hooks are wired in: the right workspace panel, the bottom panel, and the left sidebar.

## Changes

- Add `wework/src/lib/panel-resize-shield.ts` with a shared `setPanelResizeShieldActive` helper
- Wire the shield into `useResizableWorkspacePanel` (right split + bottom panel) and `useResizableSidebar`
- Add a global CSS rule disabling pointer events on browser surfaces during resize drags
- Extend the right-panel resize test with shield attribute assertions

## Verification

- `pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx` — 210 tests passed
- Prettier and ESLint pass on changed files
- Real Electron verification via `ai:verify`: opened the browser panel, loaded example.com, dragged the divider back and forth across the webview area multiple times — panel width updated correctly (780 → 840), `data-wework-panel-resizing` was set during the drag and cleared on release, sidebar drag and page loading showed no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace panel resizing by preventing embedded browser content from interrupting drag interactions.
  * Resize interactions now reliably complete when dragging across browser panels or iframe content.

* **Tests**
  * Added coverage confirming the resize protection activates during dragging and is removed afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->