### PR TITLE
fix(wework): scope smart app previews to active tasks

### DIFF
--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -877,22 +877,24 @@ async function reopenCurrentTurnNavigationTask(
     )
   }
   if (expectedTurnCount > E2E_TRANSCRIPT_PAGE_SIZE) {
-    await control.command('waitFor', '[data-testid="load-older-runtime-transcript-button"]', {
-      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-    })
-    await control.command('click', '[data-testid="load-older-runtime-transcript-button"]')
     const expectedMessageCount = expectedConversationTurnCount * 2
-    const paginationStartedAt = Date.now()
-    let paginatedSnapshot
-    while (Date.now() - paginationStartedAt < DEFAULT_STEP_TIMEOUT_MS) {
-      paginatedSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
-      if (
-        paginatedSnapshot.pane?.transcript.loadingMoreBefore === false &&
-        paginatedSnapshot.pane?.messageSummary.total === expectedMessageCount
-      ) {
-        break
+    let paginatedSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    if (paginatedSnapshot.pane?.messageSummary.total !== expectedMessageCount) {
+      await control.command('waitFor', '[data-testid="load-older-runtime-transcript-button"]', {
+        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+      })
+      await control.command('click', '[data-testid="load-older-runtime-transcript-button"]')
+      const paginationStartedAt = Date.now()
+      while (Date.now() - paginationStartedAt < DEFAULT_STEP_TIMEOUT_MS) {
+        paginatedSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+        if (
+          paginatedSnapshot.pane?.transcript.loadingMoreBefore === false &&
+          paginatedSnapshot.pane?.messageSummary.total === expectedMessageCount
+        ) {
+          break
+        }
+        await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
       }
-      await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
     }
     assert.equal(
       paginatedSnapshot?.pane?.messageSummary.total,

--- a/wework/e2e/desktop/modules/goal-flows.mjs
+++ b/wework/e2e/desktop/modules/goal-flows.mjs
@@ -271,9 +271,10 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     control,
     snapshot =>
       snapshot.workbench?.lifecycleCurrentTaskRunning === true &&
-      snapshot.pane?.status?.isAssistantStreaming === true &&
-      snapshot.pane?.status?.isBusy === true,
-    'The active turn did not remain authoritative after receiving stale transcript running state'
+      snapshot.pane?.status?.taskExecution?.running === true &&
+      snapshot.pane?.status?.isBusy === true &&
+      snapshot.pane?.status?.canSendQueuedMessage === false,
+    'The active response did not remain authoritative after receiving stale transcript running state'
   )
   assert.equal(
     staleTranscriptDebugSnapshot.pane?.status?.taskExecution?.running,

--- a/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
@@ -638,18 +638,12 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         uiTimeoutMs,
         'Returning to the Smart app development task did not restore its native browser'
       )
+      await control.command('waitFor', '[data-testid^="right-workspace-browser-tab-"]', {
+        timeoutMs: uiTimeoutMs,
+      })
       await control.command(
         'waitFor',
-        `[data-testid="workspace-tab-content-${developmentTaskTabId}"] ` +
-          '[data-testid^="right-workspace-browser-tab-"]',
-        {
-          timeoutMs: uiTimeoutMs,
-        }
-      )
-      await control.command(
-        'waitFor',
-        `[data-testid="workspace-tab-content-${developmentTaskTabId}"] ` +
-          '[data-testid^="right-workspace-browser-tab-"][data-testid$="-close-button"]',
+        '[data-testid^="right-workspace-browser-tab-"][data-testid$="-close-button"]',
         {
           timeoutMs: uiTimeoutMs,
         }

--- a/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
@@ -564,9 +564,14 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
       const developmentPreviewSelector =
         `[data-testid="workspace-tab-content-${developmentTaskTabId}"] ` +
         '[data-testid="smart-app-development-preview"]'
+      const developmentBrowserSelector =
+        `${developmentPreviewSelector} ` + '[data-embedded-browser-label]'
+      await control.command('waitFor', developmentBrowserSelector, {
+        timeoutMs: uiTimeoutMs,
+      })
       const developmentBrowserLabel = await control.command(
         'getAttribute',
-        `${developmentPreviewSelector} [data-embedded-browser-label]`,
+        developmentBrowserSelector,
         { value: 'data-embedded-browser-label' }
       )
       assert.ok(
@@ -638,12 +643,24 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         uiTimeoutMs,
         'Returning to the Smart app development task did not restore its native browser'
       )
-      await control.command('waitFor', '[data-testid^="right-workspace-browser-tab-"]', {
+      const developmentBrowserTabSelector =
+        '[role="tab"][data-testid^="right-workspace-browser-tab-"]'
+      await control.command('waitFor', developmentBrowserTabSelector, {
+        text: '空白 E2E 工作台',
         timeoutMs: uiTimeoutMs,
       })
+      const developmentBrowserTabTestId = await control.command(
+        'getAttribute',
+        developmentBrowserTabSelector,
+        { value: 'data-testid' }
+      )
+      assert.ok(
+        developmentBrowserTabTestId,
+        'The restored Smart app preview did not expose its right-workspace tab identity'
+      )
       await control.command(
         'waitFor',
-        '[data-testid^="right-workspace-browser-tab-"][data-testid$="-close-button"]',
+        `[data-testid="${developmentBrowserTabTestId}-close-button"]`,
         {
           timeoutMs: uiTimeoutMs,
         }

--- a/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
@@ -68,6 +68,33 @@ async function waitForElementCount(control, selector, expected, timeoutMs, messa
   throw new Error(message)
 }
 
+async function waitForEmbeddedBrowserVisibility(
+  control,
+  label,
+  expectedVisible,
+  timeoutMs,
+  message
+) {
+  const startedAt = Date.now()
+  let lastState = null
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      lastState = JSON.parse(
+        await control.command('getEmbeddedBrowserPageState', 'body', {
+          value: label,
+        })
+      )
+      if (lastState.visible === expectedVisible && lastState.url && lastState.isLoading === false) {
+        return lastState
+      }
+    } catch {
+      // Reloading temporarily removes the native browser before opening its replacement.
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`${message}: ${JSON.stringify(lastState)}`)
+}
+
 async function waitForManifestPlugin(manifestPath, pluginSpec, timeoutMs) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < timeoutMs) {
@@ -524,10 +551,77 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         blankWorkbenchSnapshot.workbench?.standaloneWorkspacePath,
         join(resultDir, CREATED_INSTALLATION_ID)
       )
+      const developmentTaskTabTestId = await control.command(
+        'getAttribute',
+        '[data-tab-kind="task"][aria-selected="true"]',
+        { value: 'data-testid' }
+      )
+      assert.ok(
+        developmentTaskTabTestId,
+        'Smart app development preview did not expose its owning task tab'
+      )
+      const developmentTaskTabId = developmentTaskTabTestId.replace('workspace-tab-select-', '')
+      const developmentPreviewSelector =
+        `[data-testid="workspace-tab-content-${developmentTaskTabId}"] ` +
+        '[data-testid="smart-app-development-preview"]'
+      const developmentBrowserLabel = await control.command(
+        'getAttribute',
+        `${developmentPreviewSelector} [data-embedded-browser-label]`,
+        { value: 'data-embedded-browser-label' }
+      )
+      assert.ok(
+        developmentBrowserLabel,
+        'Smart app development preview did not expose its native browser label'
+      )
       await captureScreenshot(control, 'harness-apps-03b-builder-chat.png', 'body')
       await control.command(
         'clickWhenEnabled',
         '[data-testid="smart-app-development-preview-reload"]',
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await control.command('click', '[data-testid="workspace-tab-add"]')
+      await control.command('waitFor', '[data-testid="workspace-tab-add-menu"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="workspace-tab-add-task"]')
+      const secondTaskStartedAt = Date.now()
+      let secondTaskTabTestId = ''
+      while (Date.now() - secondTaskStartedAt < uiTimeoutMs) {
+        secondTaskTabTestId = await control.command(
+          'getAttribute',
+          '[data-tab-kind="task"][aria-selected="true"]',
+          { value: 'data-testid' }
+        )
+        if (secondTaskTabTestId && secondTaskTabTestId !== developmentTaskTabTestId) break
+        await new Promise(resolve => setTimeout(resolve, 100))
+      }
+      assert.ok(
+        secondTaskTabTestId && secondTaskTabTestId !== developmentTaskTabTestId,
+        'Opening another task did not make the Smart app development task inactive'
+      )
+      const secondTaskTabId = secondTaskTabTestId.replace('workspace-tab-select-', '')
+      await waitForElementCount(
+        control,
+        `[data-testid="workspace-tab-content-${secondTaskTabId}"] ` +
+          '[data-testid="smart-app-development-preview"]',
+        0,
+        uiTimeoutMs,
+        'The new task rendered the inactive Smart app development preview'
+      )
+      await waitForEmbeddedBrowserVisibility(
+        control,
+        developmentBrowserLabel,
+        false,
+        120_000,
+        'The inactive Smart app preview reclaimed the native browser after reloading'
+      )
+      await captureScreenshot(control, 'harness-apps-03b2-preview-task-scoped.png', 'body')
+      await control.command('click', developmentTaskTabTestId)
+      await control.command(
+        'waitFor',
+        `[data-testid="${developmentTaskTabTestId}"][aria-selected="true"]`,
         {
           timeoutMs: uiTimeoutMs,
         }
@@ -537,6 +631,40 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         stableMs: 500,
         timeoutMs: 120_000,
       })
+      await waitForEmbeddedBrowserVisibility(
+        control,
+        developmentBrowserLabel,
+        true,
+        uiTimeoutMs,
+        'Returning to the Smart app development task did not restore its native browser'
+      )
+      await control.command(
+        'waitFor',
+        `[data-testid="workspace-tab-content-${developmentTaskTabId}"] ` +
+          '[data-testid^="right-workspace-browser-tab-"]',
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      await control.command(
+        'waitFor',
+        `[data-testid="workspace-tab-content-${developmentTaskTabId}"] ` +
+          '[data-testid^="right-workspace-browser-tab-"][data-testid$="-close-button"]',
+        {
+          timeoutMs: uiTimeoutMs,
+        }
+      )
+      for (const action of ['add-plugins', 'refresh', 'reload']) {
+        await control.command(
+          'waitFor',
+          `[data-testid="smart-app-development-preview-${action}"]`,
+          {
+            enabled: true,
+            timeoutMs: uiTimeoutMs,
+          }
+        )
+      }
+      await control.command('click', `[data-testid="workspace-tab-close-${secondTaskTabId}"]`)
       await captureScreenshot(control, 'harness-apps-03b2-dsh-reloaded.png', 'body')
       await control.command(
         'clickWhenEnabled',

--- a/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
@@ -618,7 +618,7 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         'The inactive Smart app preview reclaimed the native browser after reloading'
       )
       await captureScreenshot(control, 'harness-apps-03b2-preview-task-scoped.png', 'body')
-      await control.command('click', developmentTaskTabTestId)
+      await control.command('click', `[data-testid="${developmentTaskTabTestId}"]`)
       await control.command(
         'waitFor',
         `[data-testid="${developmentTaskTabTestId}"][aria-selected="true"]`,

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -101,6 +101,7 @@ describe('EmbeddedBrowserManager lifecycle', () => {
 
     expect(manager.has('workspace-browser')).toBe(true)
     expect(manager.state('workspace-browser').url).toBe('https://example.test/')
+    expect(manager.state('workspace-browser').visible).toBe(true)
 
     finishNavigation?.()
     await expect(opening).resolves.toMatchObject({

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -23,6 +23,7 @@ export interface BrowserPageState {
   title: string | null
   url: string | null
   isLoading: boolean
+  visible: boolean
   navigationError: {
     code: number
     message: string
@@ -332,6 +333,7 @@ export class EmbeddedBrowserManager {
       title: contents.getTitle() || null,
       url: pendingUrl || visibleCurrentUrl || entry.requestedUrl,
       isLoading: contents.isLoading(),
+      visible: entry.visible,
       navigationError: entry.navigationError,
     }
   }

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -742,6 +742,7 @@ describe('DesktopWorkbenchLayout', () => {
     harnessAppMocks.start.mockReset()
     harnessAppMocks.stop.mockReset().mockResolvedValue(undefined)
     embeddedBrowserMocks.closeEmbeddedBrowser.mockClear()
+    embeddedBrowserMocks.setEmbeddedBrowserActiveTab.mockClear()
     harnessAppTabMocks.takeProxyToken.mockResolvedValue(null)
     harnessAppTabMocks.takeContextToken.mockResolvedValue(null)
     unregisterHarnessProxyMock.mockResolvedValue(undefined)
@@ -10706,6 +10707,86 @@ describe('DesktopWorkbenchLayout', () => {
       )
     )
     expect(screen.queryByTestId('smart-app-development-preview')).not.toBeInTheDocument()
+  })
+
+  test('keeps an inactive Smart app preview from reclaiming the browser after switching tasks', async () => {
+    const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
+    const installed = {
+      id: 'task-scoped-workbench',
+      manifest: {
+        name: 'task-scoped-workbench',
+        displayName: '任务内工作台',
+        version: '0.1.0',
+        type: 'deepseek-harness-plugin-bundle' as const,
+        description: 'Web preset',
+        entry: {
+          installPackage: 'packages/bundle/web-app',
+          profile: 'task-scoped-workbench',
+        },
+        requirements: { dsh: '0.1.0-rc.8', node: '>=22' },
+      },
+      packagePath: '/tmp/task-scoped-workbench',
+      sha256: 'c'.repeat(64),
+      modelKey: null,
+      resident: false,
+      runtimeVersion: null,
+      state: 'installed' as const,
+      webUrl: null,
+      error: null,
+      source: 'linked' as const,
+    }
+    const running = {
+      ...installed,
+      state: 'running' as const,
+      webUrl: 'http://127.0.0.1:43125/',
+    }
+    const start = createDeferred<typeof running>()
+    harnessAppMocks.list.mockResolvedValue([installed])
+    harnessAppMocks.start.mockImplementation(() => start.promise)
+    queueSmartAppDevelopmentPreview({
+      installationId: installed.id,
+      displayName: installed.manifest.displayName,
+    })
+
+    const { rerender } = render(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('smart-app-development-preview-starting')).toBeInTheDocument()
+    )
+
+    rerender(<DesktopWorkbenchLayout {...propsForTask(taskB)} />)
+
+    expect(
+      within(screen.getByTestId('desktop-workbench-main')).queryByTestId(
+        'smart-app-development-preview'
+      )
+    ).not.toBeInTheDocument()
+
+    embeddedBrowserMocks.setEmbeddedBrowserActiveTab.mockClear()
+    await act(async () => {
+      start.resolve(running)
+      await start.promise
+    })
+    await waitFor(() => expect(harnessAppTabMocks.register).toHaveBeenCalledWith(running))
+    expect(embeddedBrowserMocks.setEmbeddedBrowserActiveTab).not.toHaveBeenCalled()
+
+    rerender(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('desktop-workbench-main')).getByTestId(
+          'right-workspace-browser-tab-1'
+        )
+      ).toHaveTextContent(installed.manifest.displayName)
+    )
+    expect(
+      within(screen.getByTestId('desktop-workbench-main')).getByTestId(
+        'right-workspace-browser-tab-1-close-button'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('smart-app-development-preview-add-plugins')).toBeEnabled()
+    expect(screen.getByTestId('smart-app-development-preview-refresh')).toBeEnabled()
+    expect(screen.getByTestId('smart-app-development-preview-reload')).toBeEnabled()
   })
 
   test('closes the Smart app browser and runtime when the development tab is disposed', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1438,12 +1438,28 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     [defaultEmbeddedBrowserLabel]
   )
   useEffect(() => {
-    if (!isRightWorkspaceBrowserTab(rightPanelView)) return
+    if (
+      !paneActive ||
+      !paneVisible ||
+      !workbenchVisible ||
+      !rightPanelOpen ||
+      !isRightWorkspaceBrowserTab(rightPanelView)
+    ) {
+      return
+    }
     const activeBrowserLabel = browserStates[rightPanelView]?.label
     if (!activeBrowserLabel) return
 
     syncActiveEmbeddedBrowserLabel(activeBrowserLabel)
-  }, [browserStates, rightPanelView, syncActiveEmbeddedBrowserLabel])
+  }, [
+    browserStates,
+    paneActive,
+    paneVisible,
+    rightPanelOpen,
+    rightPanelView,
+    syncActiveEmbeddedBrowserLabel,
+    workbenchVisible,
+  ])
   useEffect(() => {
     onWorkspaceStateChange(paneKey, {
       rightPanelOpen,

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1162,6 +1162,12 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return invokeDesktopHost<string>('e2e.captureWorkspaceWindow')
     case 'captureEmbeddedBrowser':
       return captureEmbeddedBrowserWhenReady(command)
+    case 'getEmbeddedBrowserPageState':
+      return JSON.stringify(
+        await invokeDesktopHost('browser.pageState', {
+          label: command.value,
+        })
+      )
     case 'verifyEmbeddedBrowserDetachedInspector':
       return JSON.stringify(
         await invokeDesktopHost('e2e.verifyEmbeddedBrowserDetachedInspector', {


### PR DESCRIPTION
## Summary

- prevent inactive cached task panes from reactivating their native embedded browser after async Smart app preview updates
- keep Smart app development previews in the normal closable right-workspace tab lifecycle with add-plugin, refresh, and reload actions
- add CI-covered desktop E2E coverage that switches tasks during preview reload and verifies the native browser remains hidden

## Verification

- focused DesktopWorkbenchLayout tests: 3 passed
- focused Electron browser manager and bridge tests: 10 passed
- Wework typecheck and changed-file ESLint passed
- pre-push checks passed, including renderer and Electron unit suites

## Environment note

- local real-Electron ai:verify startup was blocked before interaction because wework/resources/components.json is absent in this worktree; no E2E behavior was weakened or skipped to work around it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Embedded development previews now hide automatically when switching to another task.
  - Returning to the development task restores the preview, browser tab, and browser controls.
  - Browser visibility and loading states are handled more reliably during reloads and transitions.
  - Browser labels remain synchronized only when the relevant panel and preview are active and visible.
  - Preview state is restored more consistently when moving between tasks.
  - Automated controls can now report embedded browser page state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->