### PR TITLE
fix(executor): avoid Git probes in plain workspaces

### DIFF
--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -2,17 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
-#[cfg(windows)]
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
 #[cfg(unix)]
-use std::{
-    os::unix::fs::{FileTypeExt, PermissionsExt},
-    path::Path,
-};
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::{collections::HashMap, future::Future, path::Path, pin::Pin, sync::Arc};
+#[cfg(windows)]
+use std::{env, path::PathBuf};
 
 use serde_json::{json, Value};
 #[cfg(windows)]
@@ -62,9 +56,6 @@ use crate::{
     },
     version::get_version,
 };
-
-#[cfg(windows)]
-use crate::local::command::build_env;
 
 const DEFAULT_DEVICE_ID: &str = "local-device";
 pub const APP_IPC_PROTOCOL_VERSION: u64 = 1;
@@ -1350,6 +1341,19 @@ impl AppIpcServer {
             .map_err(|error| AppIpcError::new("internal_error", error.to_string()));
         }
 
+        if is_git_workspace_inspection_command(command_key)
+            && path
+                .as_deref()
+                .is_some_and(|workspace| !git_is_worktree(workspace))
+        {
+            return serde_json::to_value(CommandResult::error(
+                "Workspace is not a Git repository".to_owned(),
+                0.0,
+                false,
+            ))
+            .map_err(|error| AppIpcError::new("internal_error", error.to_string()));
+        }
+
         if let Some((result, post_processor)) =
             handle_builtin_device_command(command_key, &params).await
         {
@@ -2596,10 +2600,7 @@ async fn handle_builtin_device_command(
         "git_is_worktree" => {
             let args = string_list(params.get("args")).ok()?;
             let path = args.first()?;
-            Some((
-                CommandResult::ok(if git_is_worktree(path) { "true" } else { "" }),
-                None,
-            ))
+            Some((git_worktree_probe_result(path), None))
         }
         _ => None,
     }
@@ -2607,36 +2608,82 @@ async fn handle_builtin_device_command(
 
 #[cfg(not(windows))]
 async fn handle_builtin_device_command(
-    _command_key: &str,
-    _params: &Value,
+    command_key: &str,
+    params: &Value,
 ) -> Option<(CommandResult, Option<PostProcessor>)> {
-    None
-}
-
-#[cfg(windows)]
-fn git_is_worktree(path: &str) -> bool {
-    git_stdout(path, &["rev-parse", "--is-inside-work-tree"])
-        .map(|output| output.trim() == "true")
-        .unwrap_or(false)
-        || git_stdout(path, &["rev-parse", "--git-dir"]).is_some()
-}
-
-#[cfg(windows)]
-fn git_stdout(path: &str, args: &[&str]) -> Option<String> {
-    let mut command = std::process::Command::new("git");
-    command
-        .arg("-C")
-        .arg(path)
-        .args(args)
-        .env_clear()
-        .envs(build_env(&HashMap::new()));
-    crate::process::hide_windows_console(&mut command);
-    let output = command.output().ok()?;
-    if !output.status.success() {
-        return None;
+    match command_key {
+        "git_is_worktree" => {
+            let args = string_list(params.get("args")).ok()?;
+            let path = args.first()?;
+            Some((git_worktree_probe_result(path), None))
+        }
+        _ => None,
     }
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
-        .filter(|value| !value.is_empty())
+}
+
+fn git_worktree_probe_result(path: &str) -> CommandResult {
+    if git_is_worktree(path) {
+        CommandResult::ok("true\n")
+    } else {
+        CommandResult::error("Workspace is not a Git repository".to_owned(), 0.0, false)
+    }
+}
+
+fn git_is_worktree(path: &str) -> bool {
+    let path = Path::new(path);
+    if !path.is_dir() {
+        return false;
+    }
+    if looks_like_git_dir(path) {
+        return true;
+    }
+
+    path.ancestors().any(|directory| {
+        let marker = directory.join(".git");
+        if marker.is_dir() {
+            return looks_like_git_dir(&marker);
+        }
+        if !marker.is_file() {
+            return false;
+        }
+        resolve_gitdir_file(&marker, directory)
+            .as_deref()
+            .is_some_and(looks_like_git_dir)
+    })
+}
+
+fn looks_like_git_dir(path: &Path) -> bool {
+    path.join("HEAD").is_file()
+        && (path.join("objects").is_dir()
+            || path.join("refs").is_dir()
+            || path.join("commondir").is_file())
+}
+
+fn resolve_gitdir_file(marker: &Path, worktree_root: &Path) -> Option<std::path::PathBuf> {
+    let content = std::fs::read_to_string(marker).ok()?;
+    let git_dir = Path::new(content.trim().strip_prefix("gitdir:")?.trim());
+    Some(if git_dir.is_absolute() {
+        git_dir.to_path_buf()
+    } else {
+        worktree_root.join(git_dir)
+    })
+}
+
+fn is_git_workspace_inspection_command(command_key: &str) -> bool {
+    matches!(
+        command_key,
+        "git_branch"
+            | "git_branch_list"
+            | "git_diff_shortstat"
+            | "git_diff"
+            | "git_branch_diff"
+            | "git_branch_diff_shortstat"
+            | "git_diff_unstaged"
+            | "git_diff_staged"
+            | "git_diff_last_commit"
+            | "git_status_porcelain"
+            | "git_remote_url"
+    )
 }
 
 #[cfg(windows)]

--- a/executor/tests/local_app_ipc_contract.rs
+++ b/executor/tests/local_app_ipc_contract.rs
@@ -1150,6 +1150,12 @@ async fn app_ipc_lists_codex_skills_from_runtime_directories() {
 
 #[tokio::test]
 async fn app_ipc_resolves_review_and_git_device_commands() {
+    let workspace = tempfile::tempdir().unwrap();
+    let git_dir = workspace.path().join(".git");
+    fs::create_dir_all(git_dir.join("objects")).unwrap();
+    fs::create_dir_all(git_dir.join("refs")).unwrap();
+    fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
     let command_handler = CaptureCommandHandler::default();
     let seen_request = Arc::clone(&command_handler.seen_request);
     let server = AppIpcServer::new().with_command_handler(command_handler);
@@ -1162,7 +1168,7 @@ async fn app_ipc_resolves_review_and_git_device_commands() {
                 "method": "device.execute_command",
                 "params": {
                     "command_key": "git_diff",
-                    "path": "/tmp/project"
+                    "path": workspace.path().display().to_string()
                 }
             })
             .to_string(),

--- a/executor/tests/local_app_ipc_contract.rs
+++ b/executor/tests/local_app_ipc_contract.rs
@@ -1397,6 +1397,72 @@ impl DeviceCommandHandler for JsonCaptureCommandHandler {
 }
 
 #[tokio::test]
+async fn app_ipc_does_not_spawn_git_for_plain_workspaces() {
+    let workspace = tempfile::tempdir().unwrap();
+    let command_handler = JsonCaptureCommandHandler::default();
+    let seen_request = Arc::clone(&command_handler.seen_request);
+    let server = AppIpcServer::new().with_command_handler(command_handler);
+
+    let response = server
+        .handle_line(
+            &json!({
+                "type": "request",
+                "id": "req-plain-workspace-git",
+                "method": "device.execute_command",
+                "params": {
+                    "command_key": "git_branch",
+                    "path": workspace.path().display().to_string()
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response["ok"], true);
+    assert_eq!(response["result"]["success"], false);
+    assert_eq!(
+        response["result"]["error"],
+        "Workspace is not a Git repository"
+    );
+    assert!(seen_request.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn app_ipc_routes_git_inspection_for_repository_workspaces() {
+    let workspace = tempfile::tempdir().unwrap();
+    let git_dir = workspace.path().join(".git");
+    fs::create_dir_all(git_dir.join("objects")).unwrap();
+    fs::create_dir_all(git_dir.join("refs")).unwrap();
+    fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+    let command_handler = JsonCaptureCommandHandler::default();
+    let seen_request = Arc::clone(&command_handler.seen_request);
+    let server = AppIpcServer::new().with_command_handler(command_handler);
+
+    let response = server
+        .handle_line(
+            &json!({
+                "type": "request",
+                "id": "req-repository-workspace-git",
+                "method": "device.execute_command",
+                "params": {
+                    "command_key": "git_branch",
+                    "path": workspace.path().display().to_string()
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response["ok"], true);
+    assert_eq!(response["result"]["success"], true);
+    let request = seen_request.lock().unwrap().clone().unwrap();
+    assert_eq!(request.argv, ["git", "branch", "--show-current"]);
+}
+
+#[tokio::test]
 async fn app_ipc_accepts_gitdir_with_configured_worktree_as_worktree_source() {
     let root = unique_dir("gitdir-worktree-source");
     let source_worktree = root.join("source");


### PR DESCRIPTION
## Summary

- detect Git workspaces from repository metadata before running read-only Git inspection commands
- handle `git_is_worktree` inside the local Executor on every platform so plain folders never invoke the system Git shim
- preserve standard repositories, linked worktrees, and separate/bare git-dir behavior

## Why

Wework loaded branch, diff, status, and remote information before it knew whether a local workspace was a Git repository. On macOS without Apple Command Line Tools, invoking `/usr/bin/git` for an ordinary non-development workspace opens the system installation prompt, which is confusing for non-technical users.

## Verification

- `cargo test --test local_app_ipc_contract app_ipc_accepts_gitdir_with_configured_worktree_as_worktree_source`
- `cargo test --test local_app_ipc_contract app_ipc_does_not_spawn_git_for_plain_workspaces`
- `cargo test --test local_app_ipc_contract app_ipc_routes_git_inspection_for_repository_workspaces`
- `cargo fmt --all -- --check`
- packaged real-Electron `ai:verify`: seeded and opened an empty non-Git local project; Wework loaded the workspace without a Git/developer-tools installation prompt and did not create Git metadata

## Verification note

Source-mode `ai:verify start` currently fails before renderer startup because `wework/resources/components.json` is not generated by its preparation script. Packaged verification was used because the formal packaging flow produces the required desktop component manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git inspection commands now return a clear error when used outside a Git repository.
  * Git repository detection now works consistently across supported platforms.
  * Git branch inspection is correctly routed for valid repository workspaces.

* **Tests**
  * Added coverage for non-Git workspace handling.
  * Added coverage confirming Git commands are dispatched correctly in repository workspaces.
  * Improved validation using temporary Git repository workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->