### PR TITLE
fix(wework): resolve embedded browser bridge runtime

### DIFF
--- a/docs/en/wework/developer-guide/wework-embedded-browser.md
+++ b/docs/en/wework/developer-guide/wework-embedded-browser.md
@@ -18,6 +18,8 @@ When Executor launches Codex, it injects the browser MCP server configuration. B
 
 Each Wework process binds an independent random local bridge port and atomically writes the bridge identity to `runtime/embedded-browser-bridge.json` under the active Executor home. The identity contains a schema version, process PID, loopback address, authentication token, and start time. Directory and file permissions should be restricted to the current user, and the token must not be logged. The MCP server reads the latest identity before each request and accepts only loopback addresses, so multiple Wework instances do not route browser requests to the wrong window.
 
+After starting the bridge, Electron must pass the runtime file path to the managed Executor. When the Executor builds the Codex browser MCP configuration, it must pass only that file path and must not pin the current bridge URL or token in the configuration. Otherwise, a random Electron port or a restarted bridge leaves the MCP server connected to stale coordinates and bypasses runtime identity refresh.
+
 Bridge requests must include the authentication token. `open` and `navigate` allow only safe web schemes; do not allow `file:`, `javascript:`, or other URLs that could read local files or execute arbitrary script through the Agent navigation path.
 
 The bridge supports limited concurrency. A long `waitFor` request must not block independent `click`, `fill`, or `inspect` requests; when the concurrency limit is reached, return an explicit busy error instead of waiting forever.

--- a/docs/zh/wework/developer-guide/wework-embedded-browser.md
+++ b/docs/zh/wework/developer-guide/wework-embedded-browser.md
@@ -18,6 +18,8 @@ Executor 启动 Codex 时会注入 browser MCP server 配置。模型调用浏�
 
 每个 Wework 进程启动时都会绑定独立的随机本地桥接端口，并把 bridge identity 原子写入当前 Executor home 的 `runtime/embedded-browser-bridge.json`。identity 包含 schema 版本、进程 PID、loopback 地址、认证 token 和启动时间。文件目录权限应限制为当前用户可读写，token 不得写入日志。MCP server 每次请求前读取最新 identity，并只接受 loopback 地址，避免同时运行的多个 Wework 实例把浏览器请求发送到错误窗口。
 
+Electron 启动 bridge 后必须把 runtime 文件路径传给托管 Executor。Executor 生成 Codex browser MCP 配置时只传递该文件路径，不得把当前 bridge URL 或 token 固化到配置中；否则 Electron 使用随机端口或 bridge 重启后，MCP 会继续连接过期地址，并绕过 runtime identity 的刷新机制。
+
 bridge 请求必须携带认证 token。`open` 和 `navigate` 只允许安全的网页 scheme；不要允许 `file:`、`javascript:` 或其它可以读取本机文件或执行任意脚本的地址进入 Agent 导航路径。
 
 bridge 支持有限并发。长时间 `waitFor` 不应阻塞独立的 `click`、`fill` 或 `inspect` 请求；超出并发上限时返回明确的忙碌错误，而不是让调用无限等待。

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -56,9 +56,8 @@ const EXECUTOR_INTERNAL_ENV_KEYS: &[&str] = &[
     "WEWORK_EXECUTOR_SIDECAR",
 ];
 const WEWORK_BROWSER_MCP_SERVER_NAME: &str = "wework_browser";
-const WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR";
-const WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV: &str = "WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN";
-const DEFAULT_WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR: &str = "127.0.0.1:9231";
+const WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV: &str =
+    "WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE";
 const CODEX_APPLY_PATCH_STREAMING_EVENTS_OVERRIDE: &str =
     "features.apply_patch_streaming_events=true";
 const CODEX_APPLY_PATCH_FREEFORM_OVERRIDE: &str = "features.apply_patch_freeform=true";
@@ -3751,11 +3750,11 @@ fn global_mcp_config_overrides() -> Vec<String> {
 fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
     let command =
         env::current_exe().unwrap_or_else(|_| executor_home().join("bin/wegent-executor"));
-    let bridge_addr = env::var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV)
+    let bridge_runtime_file = env::var(WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV)
         .ok()
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| DEFAULT_WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR.to_owned());
-    let bridge_url = format!("http://{bridge_addr}");
+        .map(PathBuf::from)
+        .unwrap_or_else(|| executor_home().join("runtime/embedded-browser-bridge.json"));
     let mut overrides = vec![
         format!(
             "skills.config={}",
@@ -3815,9 +3814,9 @@ fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
                 "mcp_servers",
                 WEWORK_BROWSER_MCP_SERVER_NAME,
                 "env",
-                "WEWORK_EMBEDDED_BROWSER_BRIDGE_URL"
+                WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV
             ]),
-            toml_value(&bridge_url)
+            toml_value(&bridge_runtime_file.display().to_string())
         ),
     ];
 
@@ -3833,21 +3832,6 @@ fn cdp_browser_mcp_config_overrides(request: &ExecutionRequest) -> Vec<String> {
             toml_value(&label)
         ));
     }
-    if let Ok(token) = env::var(WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV) {
-        if !token.trim().is_empty() {
-            overrides.push(format!(
-                "{}={}",
-                toml_key_path(&[
-                    "mcp_servers",
-                    WEWORK_BROWSER_MCP_SERVER_NAME,
-                    "env",
-                    "WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN"
-                ]),
-                toml_value(token.trim())
-            ));
-        }
-    }
-
     overrides
 }
 

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -3227,13 +3227,12 @@ fn codex_launch_config_includes_cdp_browser_mcp_server() {
     let _lock = crate::test_env::lock();
     let home = env::temp_dir().join(format!("codex-browser-mcp-{}", std::process::id()));
     let old_home = env::var_os("WEGENT_EXECUTOR_HOME");
-    let old_bridge_addr = env::var_os(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV);
-    let old_bridge_token = env::var_os(WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV);
+    let old_bridge_runtime_file = env::var_os(WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV);
+    let bridge_runtime_file = home.join("desktop/embedded-browser-bridge.json");
     env::set_var("WEGENT_EXECUTOR_HOME", &home);
-    env::set_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV, "127.0.0.1:43127");
     env::set_var(
-        WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV,
-        "bridge-test-token",
+        WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV,
+        &bridge_runtime_file,
     );
     let request = ExecutionRequest {
         task_id: "task:123".to_owned(),
@@ -3278,16 +3277,18 @@ fn codex_launch_config_includes_cdp_browser_mcp_server() {
         "approve"
     );
     assert_eq!(
-        config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_URL"],
-        "http://127.0.0.1:43127"
+        config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE"],
+        bridge_runtime_file.display().to_string()
     );
     assert_eq!(
         config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_LABEL"],
         "workspace-browser-task-123"
     );
-    assert_eq!(
-        config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN"],
-        "bridge-test-token"
+    assert!(
+        !config.contains_key("mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_URL")
+    );
+    assert!(
+        !config.contains_key("mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN")
     );
 
     if let Some(old_home) = old_home {
@@ -3295,15 +3296,59 @@ fn codex_launch_config_includes_cdp_browser_mcp_server() {
     } else {
         env::remove_var("WEGENT_EXECUTOR_HOME");
     }
-    if let Some(old_bridge_addr) = old_bridge_addr {
-        env::set_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV, old_bridge_addr);
+    if let Some(old_bridge_runtime_file) = old_bridge_runtime_file {
+        env::set_var(
+            WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV,
+            old_bridge_runtime_file,
+        );
     } else {
-        env::remove_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_ADDR_ENV);
+        env::remove_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV);
     }
-    if let Some(old_bridge_token) = old_bridge_token {
-        env::set_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV, old_bridge_token);
+}
+
+#[test]
+fn codex_browser_mcp_defaults_to_executor_home_runtime_file() {
+    let _lock = crate::test_env::lock();
+    let home = env::temp_dir().join(format!("codex-browser-mcp-default-{}", std::process::id()));
+    let old_home = env::var_os("WEGENT_EXECUTOR_HOME");
+    let old_bridge_runtime_file = env::var_os(WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV);
+    env::set_var("WEGENT_EXECUTOR_HOME", &home);
+    env::remove_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV);
+
+    let request = ExecutionRequest {
+        task_id: "task:default-runtime".to_owned(),
+        ..ExecutionRequest::default()
+    };
+    let launch_config =
+        build_codex_launch_config(&request).expect("Codex launch config should be built");
+    let config = thread_start_params(&request, &launch_config)
+        .get("config")
+        .and_then(Value::as_object)
+        .cloned()
+        .expect("thread config should be present");
+
+    assert_eq!(
+        config["mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE"],
+        home.join("runtime/embedded-browser-bridge.json")
+            .display()
+            .to_string()
+    );
+    assert!(
+        !config.contains_key("mcp_servers.wework_browser.env.WEWORK_EMBEDDED_BROWSER_BRIDGE_URL")
+    );
+
+    if let Some(old_home) = old_home {
+        env::set_var("WEGENT_EXECUTOR_HOME", old_home);
     } else {
-        env::remove_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN_ENV);
+        env::remove_var("WEGENT_EXECUTOR_HOME");
+    }
+    if let Some(old_bridge_runtime_file) = old_bridge_runtime_file {
+        env::set_var(
+            WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV,
+            old_bridge_runtime_file,
+        );
+    } else {
+        env::remove_var(WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE_ENV);
     }
 }
 

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -219,20 +219,6 @@ async function waitForBridgeIdentity(executorHome, timeoutMs) {
   throw new Error('Timed out waiting for authenticated embedded browser bridge runtime')
 }
 
-async function writeStaleBridgeRuntime(identity) {
-  await writeFile(
-    identity.runtimePath,
-    `${JSON.stringify({
-      schemaVersion: 1,
-      pid: process.pid,
-      address: '127.0.0.1:9',
-      token: 'stale-upgrade-token',
-      startedAtUnixMs: Date.now() - 60_000,
-    })}\n`,
-    'utf8'
-  )
-}
-
 async function callBridge(identity, payload, label = BROWSER_LABEL) {
   const body = await callBridgeResponse(identity, payload, label)
   assert.equal(body.ok, true, `Bridge action failed: ${JSON.stringify(body)}`)
@@ -367,8 +353,6 @@ async function withBrowserMcp(identity, label, callback) {
     cwd: repoDir,
     env: {
       ...process.env,
-      WEWORK_EMBEDDED_BROWSER_BRIDGE_URL: identity.baseUrl,
-      WEWORK_EMBEDDED_BROWSER_BRIDGE_TOKEN: identity.token,
       WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE: identity.runtimePath,
       WEWORK_EMBEDDED_BROWSER_LABEL: label,
     },
@@ -1346,7 +1330,6 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         `The embedded browser fixture did not reload after annotation checks: ${JSON.stringify(restoredFixtureReady)}`
       )
 
-      await writeStaleBridgeRuntime(bridgeIdentity)
       const mcpResult = await withBrowserMcp(bridgeIdentity, browserLabel, async callTool => {
         const openText = await callTool('browser_open_and_inspect', {
           url: redirectUrl,

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { mkdir, readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -949,7 +949,7 @@ async function configureDesktopRuntime(): Promise<void> {
     embeddedBrowser,
     environment.WEGENT_EXECUTOR_HOME?.trim() || join(app.getPath('home'), '.wework')
   )
-  await embeddedBrowserBridge.start()
+  environment.WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE = await embeddedBrowserBridge.start()
   const runtimeRoot = environment.WEWORK_HARNESS_RUNTIME_ROOT?.trim()
   if (runtimeRoot) {
     smartApps = new SmartAppManager({


### PR DESCRIPTION
## Summary

- pass the authenticated embedded-browser runtime file from Electron to the managed Executor
- configure Codex browser MCP to resolve the current bridge identity from that runtime file instead of pinning a stale URL and token
- make the desktop browser E2E exercise runtime-file discovery rather than injecting the bridge URL and token
- document the runtime identity handoff in Chinese and English

## Root cause

The Codex MCP configuration defaulted to `127.0.0.1:9231` when bridge environment variables were absent. Electron actually binds a random loopback port and publishes it in `runtime/embedded-browser-bridge.json`, but the explicit URL took precedence over runtime-file discovery. The existing E2E injected the correct URL and token directly, masking the production path.

## Verification

- `cargo test browser_mcp --lib` (30 passed)
- `pnpm --filter wework test electron/src/host/embedded-browser-bridge.test.ts` (6 passed)
- `pnpm --dir wework/electron test` (52 files, 231 tests passed)
- pre-push: Wework ESLint, Electron TypeScript, Wework unit tests, `cargo fmt`, `cargo test --all-features --lib`, and `cargo clippy` passed
- isolated real Electron session: launched browser MCP with only `WEWORK_EMBEDDED_BROWSER_BRIDGE_RUNTIME_FILE`; it resolved the dynamic bridge port, `browser_open` returned success, and the Wework built-in browser panel opened at `https://example.com/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded browser connections now use a runtime configuration file, automatically reflecting random port assignments and bridge restarts.
  * The Electron desktop app shares the active bridge location with the Executor for reliable browser connectivity.

* **Bug Fixes**
  * Prevented browser integrations from connecting to stale bridge addresses or tokens after restarts.

* **Documentation**
  * Updated English and Chinese embedded browser guides with the new runtime configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->