### PR TITLE
feat(wework): support dynamic DSH icons

### DIFF
--- a/docs/en/wework/developer-guide/wework-dsh-ui-plugins.md
+++ b/docs/en/wework/developer-guide/wework-dsh-ui-plugins.md
@@ -16,6 +16,7 @@ module loader, or second Cordis `Context`.
 | ------------------------------ | --------------------------------- | --------------------------------- |
 | `wework.app`                   | Product switcher and app surfaces | `id`, `label`, `mode`             |
 | `wework.route`                 | Top-level auxiliary pages         | `id`, `path`, `telemetryFeature`  |
+| `wework.sidebar.navigation`    | Left sidebar navigation entries   | `id`, `path`, `label`             |
 | `wework.settings.page`         | Settings navigation and content   | `id`, `path`, `label`, `category` |
 | `wework.workspace.tab`         | Closable top workspace tabs       | `id`, `label`                     |
 | `wework.workspace.sidebar.tab` | Right workspace panel tabs        | `id`, `label`                     |
@@ -73,6 +74,13 @@ as `path`, `category`, and `mode` on the standard DSH component's static
 `wework` property, then calls `ctx.slots.register`. Discovery, dependency
 management, rendering, and disposal therefore remain owned by DSH, with no
 second Wework registry.
+
+The `icon` field on `wework.route` and `wework.sidebar.navigation` accepts any
+valid [Lucide icon name](https://lucide.dev/icons/) in kebab-case, such as
+`shield`, `rocket`, or `gamepad-2`. Wework loads the icon dynamically and
+falls back to the default grid icon when the name is missing or invalid. The
+legacy `applications` value remains an alias for the default application icon,
+so icon names do not need to be registered individually in Wework core.
 
 Do not register directly into a Wework slot that is not live, and do not put
 Wework descriptors directly in DSH options. DSH re-runs the `slots.inject`

--- a/docs/zh/wework/developer-guide/wework-dsh-ui-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-ui-plugins.md
@@ -15,6 +15,7 @@ client 插件通过 slot 注入。不要再创建 Wework 私有 manifest、动�
 | ------------------------------ | ------------------------ | --------------------------------- |
 | `wework.app`                   | 产品切换器与应用 surface | `id`、`label`、`mode`             |
 | `wework.route`                 | 顶层辅助页面             | `id`、`path`、`telemetryFeature`  |
+| `wework.sidebar.navigation`    | 左侧边栏导航入口         | `id`、`path`、`label`             |
 | `wework.settings.page`         | 设置导航与设置内容       | `id`、`path`、`label`、`category` |
 | `wework.workspace.tab`         | 顶部可关闭工作区 Tab     | `id`、`label`                     |
 | `wework.workspace.sidebar.tab` | 右侧工作区面板 Tab       | `id`、`label`                     |
@@ -71,6 +72,12 @@ export function apply(ctx) {
 `path`、`category`、`mode` 等 Wework 描述冻结到标准 DSH component 的
 `wework` 静态属性，再调用 `ctx.slots.register`。因此发现、依赖、渲染与释放仍由
 DSH 管理，没有第二套 Wework 注册表。
+
+`wework.route` 与 `wework.sidebar.navigation` 的 `icon` 字段接受任意有效的
+[Lucide 图标名称](https://lucide.dev/icons/)，使用 kebab-case，例如
+`shield`、`rocket` 或 `gamepad-2`。Wework 会按名称动态加载图标；名称无效或
+未填写时回退为默认九宫格图标。旧插件使用的 `applications` 名称会继续映射到
+默认应用图标，无需逐个在 Wework 核心中注册图标白名单。
 
 不要直接调用 `ctx.slots.register` 注册到尚未存活的 Wework slot，也不要把
 Wework 描述直接塞进 DSH options。DSH 会在宿主 slot 挂载、卸载或重建时重新执行

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1975,6 +1975,43 @@ describe('DesktopSidebar', () => {
     expect(window.location.pathname).toBe('/sites')
   })
 
+  test('keeps a dynamic DSH navigation icon mounted across unrelated sidebar rerenders', async () => {
+    const runtime = window.__WEWORK_DSH_UI__
+    expect(runtime).toBeDefined()
+    const navigation = [
+      ...runtime!.getEntries(WEWORK_DSH_SLOTS.sidebarNavigation),
+      {
+        id: 'shield.navigation',
+        label: 'Shield',
+        icon: 'shield',
+        path: '/shield',
+        surface: 'route',
+        testId: 'shield-button',
+      },
+    ]
+    window.__WEWORK_DSH_UI__ = {
+      ...runtime!,
+      getEntries: slotName =>
+        slotName === WEWORK_DSH_SLOTS.sidebarNavigation
+          ? navigation
+          : runtime!.getEntries(slotName),
+    }
+    renderSidebar()
+
+    const shieldButton = screen.getByTestId('shield-button')
+    const shieldIcon = await waitFor(() => {
+      const icon = shieldButton.querySelector('.lucide-shield')
+      expect(icon).toBeInTheDocument()
+      return icon
+    })
+
+    fireEvent.scroll(screen.getByTestId('sidebar-worklists-scroll'), {
+      target: { scrollTop: 24 },
+    })
+
+    expect(shieldButton.querySelector('.lucide-shield')).toBe(shieldIcon)
+  })
+
   test('removes sidebar entries when their DSH plugins stop contributing them', () => {
     const runtime = window.__WEWORK_DSH_UI__
     expect(runtime).toBeDefined()

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -20,7 +20,6 @@ import {
   MessageSquarePlus,
   Pause,
   Pin,
-  Plug,
   Plus,
   RotateCw,
   Search,
@@ -56,6 +55,7 @@ import { AppReleaseNotesDialog } from '@/features/app-update/AppReleaseNotesDial
 import { useOptionalAppUpdate } from '@/features/app-update/app-update-context'
 import type { WeworkInstalledReleaseNotes } from '@/features/app-update/app-release-notes'
 import type { WeworkDshSidebarNavigationItem } from '@/features/dsh-runtime/dshSidebarNavigation'
+import { DshIcon } from '@/features/dsh-runtime/DshIcon'
 import { WEWORK_DSH_SLOTS } from '@/features/dsh-runtime/dshUiSlots'
 import { useDshSlotEntries } from '@/features/dsh-runtime/useDshSlotEntries'
 import { getRuntimeTaskReminderItemKey } from '@/features/workbench/runtimeTaskReminders'
@@ -402,11 +402,6 @@ interface ArchiveConversationsConfirmDialogProps {
 const RUNTIME_ARCHIVE_UNDO_DELAY_MS = 3000
 const EMPTY_RUNTIME_TASK_KEYS: ReadonlySet<string> = new Set()
 const EMPTY_SPLIT_GROUP_MEMBERSHIPS: Readonly<Record<string, WorkbenchSplitGroupMembership>> = {}
-const DSH_SIDEBAR_NAVIGATION_ICONS = {
-  'alarm-clock': AlarmClock,
-  applications: Grid3X3,
-  plug: Plug,
-} as const
 const PROJECT_APPEARANCE_COLORS = [
   'blue',
   'green',
@@ -4056,7 +4051,9 @@ export function DesktopSidebar({
                   )
                 }
 
-                const Icon = DSH_SIDEBAR_NAVIGATION_ICONS[item.icon ?? 'applications'] ?? Grid3X3
+                const Icon = (props: React.ComponentProps<typeof Grid3X3>) => (
+                  <DshIcon {...props} name={item.icon} />
+                )
                 return (
                   <DesktopSidebarNavItem
                     key={item.id}

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -12,7 +12,6 @@ import {
   FolderPlus,
   Globe2,
   GitCompareArrows,
-  Grid3X3,
   Laptop,
   Loader2,
   MessageCircle,
@@ -4051,13 +4050,16 @@ export function DesktopSidebar({
                   )
                 }
 
-                const Icon = (props: React.ComponentProps<typeof Grid3X3>) => (
-                  <DshIcon {...props} name={item.icon} />
-                )
                 return (
                   <DesktopSidebarNavItem
                     key={item.id}
-                    icon={Icon}
+                    iconElement={
+                      <DshIcon
+                        name={item.icon}
+                        aria-hidden="true"
+                        className="h-4 w-4 text-current"
+                      />
+                    }
                     label={t(item.labelKey ?? item.id, item.label)}
                     testId={item.testId ?? `dsh-sidebar-navigation-${item.id}`}
                     selected={activeItem === (item.activeItem ?? item.id)}

--- a/wework/src/components/layout/DesktopSidebarPrimitives.tsx
+++ b/wework/src/components/layout/DesktopSidebarPrimitives.tsx
@@ -1,6 +1,6 @@
-import type { LucideIcon } from 'lucide-react'
+import type { LucideProps } from 'lucide-react'
 import { ChevronRight } from 'lucide-react'
-import type { ReactNode } from 'react'
+import type { ComponentType, ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
 interface DesktopSidebarHeaderProps {
@@ -29,7 +29,7 @@ export function DesktopSidebarHeader({
 }
 
 interface DesktopSidebarNavItemProps {
-  icon: LucideIcon
+  icon: ComponentType<LucideProps>
   label: string
   onClick: () => void
   selected?: boolean

--- a/wework/src/components/layout/DesktopSidebarPrimitives.tsx
+++ b/wework/src/components/layout/DesktopSidebarPrimitives.tsx
@@ -29,7 +29,8 @@ export function DesktopSidebarHeader({
 }
 
 interface DesktopSidebarNavItemProps {
-  icon: ComponentType<LucideProps>
+  icon?: ComponentType<LucideProps>
+  iconElement?: ReactNode
   label: string
   onClick: () => void
   selected?: boolean
@@ -39,6 +40,7 @@ interface DesktopSidebarNavItemProps {
 
 export function DesktopSidebarNavItem({
   icon: Icon,
+  iconElement,
   label,
   onClick,
   selected,
@@ -59,7 +61,7 @@ export function DesktopSidebarNavItem({
           : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'
       )}
     >
-      <Icon className="h-4 w-4 text-current" />
+      {iconElement ?? (Icon ? <Icon className="h-4 w-4 text-current" /> : null)}
       <span>{label}</span>
     </button>
   )

--- a/wework/src/features/dsh-runtime/DshIcon.test.tsx
+++ b/wework/src/features/dsh-runtime/DshIcon.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { DshIcon } from './DshIcon'
+
+describe('DshIcon', () => {
+  it('loads any valid Lucide icon name dynamically', async () => {
+    render(<DshIcon name="shield" data-testid="dsh-icon" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dsh-icon')).toHaveClass('lucide-shield')
+    })
+  })
+
+  it('keeps legacy aliases and falls back for unknown names', () => {
+    const { rerender } = render(<DshIcon name="applications" data-testid="dsh-icon" />)
+    expect(screen.getByTestId('dsh-icon')).toHaveClass('lucide-grid3x3')
+
+    rerender(<DshIcon name="not-a-real-icon" data-testid="dsh-icon" />)
+    expect(screen.getByTestId('dsh-icon')).toHaveClass('lucide-grid3x3')
+  })
+})

--- a/wework/src/features/dsh-runtime/DshIcon.tsx
+++ b/wework/src/features/dsh-runtime/DshIcon.tsx
@@ -1,0 +1,30 @@
+import { AlarmClock, Cloud, Grid3X3, Plug, type LucideIcon, type LucideProps } from 'lucide-react'
+import { DynamicIcon, iconNames, type IconName } from 'lucide-react/dynamic.js'
+
+const DSH_ICON_NAMES = new Set<string>(iconNames)
+const DSH_ICON_ALIASES: Record<string, LucideIcon> = {
+  'alarm-clock': AlarmClock,
+  applications: Grid3X3,
+  cloud: Cloud,
+  plug: Plug,
+}
+
+interface DshIconProps extends LucideProps {
+  name?: string
+}
+
+export function DshIcon({ name, ...props }: DshIconProps) {
+  const AliasIcon = name ? DSH_ICON_ALIASES[name] : undefined
+  if (AliasIcon) return <AliasIcon {...props} />
+  if (!name || !DSH_ICON_NAMES.has(name)) return <Grid3X3 {...props} />
+
+  const className = [props.className, `lucide-${name}`].filter(Boolean).join(' ')
+  return (
+    <DynamicIcon
+      {...props}
+      className={className}
+      name={name as IconName}
+      fallback={() => <Grid3X3 {...props} />}
+    />
+  )
+}

--- a/wework/src/features/dsh-runtime/dshRoutes.ts
+++ b/wework/src/features/dsh-runtime/dshRoutes.ts
@@ -2,7 +2,7 @@ import type { AnalyticsEventMap } from '@/telemetry/events'
 import { getDshSlotEntries, WEWORK_DSH_SLOTS, type WeworkDshSlotEntry } from './dshUiSlots'
 
 export interface WeworkDshRoute extends WeworkDshSlotEntry {
-  icon?: 'alarm-clock' | 'applications' | 'cloud' | 'plug'
+  icon?: string
   module?: string
   path: string
   restorePolicy?: 'none' | 'session'

--- a/wework/src/features/dsh-runtime/dshSidebarNavigation.ts
+++ b/wework/src/features/dsh-runtime/dshSidebarNavigation.ts
@@ -8,7 +8,7 @@ import { getDshSlotEntries, WEWORK_DSH_SLOTS, type WeworkDshSlotEntry } from './
 export interface WeworkDshSidebarNavigationItem extends WeworkDshSlotEntry {
   activeItem?: string
   experimental?: boolean
-  icon?: 'alarm-clock' | 'applications' | 'plug'
+  icon?: string
   label: string
   labelKey?: string
   module?: string

--- a/wework/src/features/workspace-tabs/WorkspaceTabStrip.test.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabStrip.test.tsx
@@ -204,6 +204,49 @@ describe('WorkspaceTabStrip', () => {
     )
   })
 
+  test.each([
+    ['dynamic', 'shield', 'lucide-shield'],
+    ['legacy', 'applications', 'lucide-grid-3x3'],
+    ['invalid', 'not-a-real-icon', 'lucide-grid-3x3'],
+    ['empty', '', 'lucide-grid-3x3'],
+    ['missing', undefined, 'lucide-square-check'],
+  ])('renders the %s DSH route icon on the workspace tab surface', async (_, icon, className) => {
+    window.__WEWORK_DSH_UI__ = {
+      getEntries: slot => {
+        if (slot !== 'wework.route') return []
+        return [
+          {
+            id: 'icon-route',
+            path: '/dsh/icon-route',
+            telemetryFeature: 'plugins',
+            ...(icon === undefined ? {} : { icon }),
+          },
+        ]
+      },
+      subscribe: () => () => undefined,
+      attach: vi.fn(),
+    }
+    localStorage.setItem(
+      workspaceTabsStorageKey('strip-test'),
+      JSON.stringify({
+        activeTabId: 'icon-tab',
+        tabs: [
+          {
+            id: 'icon-tab',
+            kind: 'auxiliary',
+            title: 'Icon route',
+            contentRoute: '/dsh/icon-route',
+          },
+        ],
+      })
+    )
+
+    renderStrip('', undefined, '/dsh/icon-route')
+
+    const tab = screen.getByTestId('workspace-tab-select-icon-tab')
+    await waitFor(() => expect(tab.querySelector(`.${className}`)).toBeInTheDocument())
+  })
+
   test('hides Smart apps from the top tab add menu while experiments are disabled', async () => {
     experimentalFeatures.enabled = false
     const user = userEvent.setup()

--- a/wework/src/features/workspace-tabs/WorkspaceTabStrip.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabStrip.tsx
@@ -1,16 +1,4 @@
-import {
-  AlarmClock,
-  Bot,
-  Boxes,
-  CheckSquare2,
-  Cloud,
-  CloudOff,
-  Columns3,
-  Pin,
-  Plug,
-  Plus,
-  X,
-} from 'lucide-react'
+import { Bot, Boxes, CheckSquare2, CloudOff, Columns3, Pin, Plus, X } from 'lucide-react'
 import {
   useEffect,
   useMemo,
@@ -34,6 +22,7 @@ import type { WorkspaceTab, WorkspaceTabKind } from './workspaceTabs'
 import { harnessAppsApi, type HarnessAppInstallation } from '@/api/local/harnessApps'
 import { harnessAppRoute } from '@/features/harness-apps/harnessAppTabs'
 import { dshWorkspaceTabs, dshWorkspaceTabRoute } from '@/features/dsh-runtime/dshWorkspaceTabs'
+import { DshIcon } from '@/features/dsh-runtime/DshIcon'
 import { resolveDshRoute } from '@/features/dsh-runtime/dshRoutes'
 
 interface MenuPosition {
@@ -54,17 +43,11 @@ interface WorkspaceTabStripProps {
 function tabKindIcon(tab: WorkspaceTab, unavailable = false) {
   const pathname = tab.contentRoute.split('?', 1)[0]
   const routeIcon = resolveDshRoute(pathname)?.icon
-  if (routeIcon === 'applications' || pathname.startsWith('/app/harness-')) {
+  if (pathname.startsWith('/app/harness-')) {
     return <Boxes aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
   }
-  if (routeIcon === 'alarm-clock') {
-    return <AlarmClock aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
-  }
-  if (routeIcon === 'cloud') {
-    return <Cloud aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
-  }
-  if (routeIcon === 'plug') {
-    return <Plug aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
+  if (routeIcon) {
+    return <DshIcon name={routeIcon} aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
   }
   if (tab.kind === 'board') {
     return <Columns3 aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />

--- a/wework/src/features/workspace-tabs/WorkspaceTabStrip.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabStrip.tsx
@@ -46,7 +46,7 @@ function tabKindIcon(tab: WorkspaceTab, unavailable = false) {
   if (pathname.startsWith('/app/harness-')) {
     return <Boxes aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
   }
-  if (routeIcon) {
+  if (routeIcon !== undefined) {
     return <DshIcon name={routeIcon} aria-hidden="true" className="h-4 w-4 shrink-0 opacity-75" />
   }
   if (tab.kind === 'board') {


### PR DESCRIPTION
## Summary
- allow DSH routes and sidebar navigation entries to declare arbitrary Lucide icon names
- resolve icons through a shared host component with invalid-name fallback and legacy `applications` compatibility
- keep existing built-in icons synchronous while dynamically loading all other valid Lucide icons
- use the same resolver in the desktop sidebar and workspace tab strip
- document the icon contract in the English and Chinese plugin guides

## Verification
- Wework pre-push quality checks: ESLint, TypeScript, and focused unit tests passed
- `DshIcon.test.tsx` covers dynamic names, legacy aliases, and invalid-name fallback
- focused `DesktopSidebar` compatibility test passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom Lucide icons in sidebar navigation, routes, and workspace tabs.
  * Added fallback handling for missing or invalid icons.
  * Preserved legacy icon aliases for compatibility.
* **Documentation**
  * Updated English and Chinese guides with the new sidebar navigation extension point and icon configuration details.
* **Tests**
  * Added coverage for dynamic icon loading, legacy aliases, fallback behavior, and icon persistence during navigation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->