### PR TITLE
fix(wework): discover and test MiniMax models over CORS-safe API

### DIFF
--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -994,11 +994,11 @@ describe('ConnectionsSettingsPage', () => {
   })
 
   test.each([
-    ['minimax', 'https://api.minimaxi.com/anthropic'],
-    ['minimax-global', 'https://api.minimax.io/anthropic'],
+    ['minimax', 'https://api.minimaxi.com/anthropic', 'https://api.minimaxi.com'],
+    ['minimax-global', 'https://api.minimax.io/anthropic', 'https://api.minimax.io'],
   ] as const)(
     'configures %s through the managed Anthropic-compatible profile',
-    async (providerProfileId, baseUrl) => {
+    async (providerProfileId, baseUrl, modelsBaseUrl) => {
       api.getAllDevices.mockResolvedValue([localDevice()])
       const originalFetch = globalThis.fetch
       const fetchMock = vi.fn().mockResolvedValue(
@@ -1033,8 +1033,8 @@ describe('ConnectionsSettingsPage', () => {
         await userEvent.click(screen.getByTestId('local-model-save-button'))
 
         expect(fetchMock).toHaveBeenCalledWith(
-          `${baseUrl}/v1/models`,
-          expect.objectContaining({ headers: { 'X-Api-Key': 'test-key' } })
+          `${modelsBaseUrl}/v1/models`,
+          expect.objectContaining({ headers: { Authorization: 'Bearer test-key' } })
         )
         const stored = JSON.parse(localStorage.getItem('wework.localModelSettings.v1') ?? '[]')
         expect(stored[0]).toMatchObject({

--- a/wework/src/components/settings/ModelSettingsPage.tsx
+++ b/wework/src/components/settings/ModelSettingsPage.tsx
@@ -1160,10 +1160,11 @@ function LocalModelSettingsSection({
     setTestResult(null)
     setTestingModelKey(targetKey)
     try {
+      const connectionTest = findLocalModelProviderProfile(form.providerProfileId).connectionTest
       await testLocalModelConnection({
-        baseUrl: form.baseUrl,
-        apiFormat: form.apiFormat,
-        requestPath: form.requestPath,
+        baseUrl: connectionTest?.baseUrl ?? form.baseUrl,
+        apiFormat: connectionTest?.apiFormat ?? form.apiFormat,
+        requestPath: connectionTest?.requestPath ?? form.requestPath,
         modelId,
         toolProfile: form.toolProfile,
         apiKey: form.apiKey.trim() ? form.apiKey : editingModel?.apiKey,

--- a/wework/src/features/model-settings/localModelProviders.test.ts
+++ b/wework/src/features/model-settings/localModelProviders.test.ts
@@ -107,11 +107,17 @@ describe('localModelProviders', () => {
         displayName: 'MiniMax (China mainland)',
         displayNameKey: 'workbench.local_model_provider_minimax_cn',
         baseUrl: 'https://api.minimaxi.com/anthropic',
+        modelsBaseUrl: 'https://api.minimaxi.com',
         group: 'MiniMax',
         apiFormat: 'anthropic-messages',
         requestPath: '/v1/messages',
         modelsPath: '/v1/models',
-        modelsApiKeyHeader: 'X-Api-Key',
+        modelsApiKeyHeader: 'Authorization',
+        connectionTest: {
+          baseUrl: 'https://api.minimaxi.com',
+          requestPath: '/v1/text/chatcompletion_v2',
+          apiFormat: 'openai-chat-completions',
+        },
         toolProfile: 'function',
         webSearchMode: 'disabled',
         contextWindow: 204_800,
@@ -132,11 +138,17 @@ describe('localModelProviders', () => {
         displayName: 'MiniMax (Global)',
         displayNameKey: 'workbench.local_model_provider_minimax_global',
         baseUrl: 'https://api.minimax.io/anthropic',
+        modelsBaseUrl: 'https://api.minimax.io',
         group: 'MiniMax',
         apiFormat: 'anthropic-messages',
         requestPath: '/v1/messages',
         modelsPath: '/v1/models',
-        modelsApiKeyHeader: 'X-Api-Key',
+        modelsApiKeyHeader: 'Authorization',
+        connectionTest: {
+          baseUrl: 'https://api.minimax.io',
+          requestPath: '/v1/text/chatcompletion_v2',
+          apiFormat: 'openai-chat-completions',
+        },
         toolProfile: 'function',
         webSearchMode: 'disabled',
         contextWindow: 204_800,
@@ -160,10 +172,10 @@ describe('localModelProviders', () => {
   })
 
   it.each([
-    ['minimax', 'https://api.minimaxi.com/anthropic/v1/models'],
-    ['minimax-global', 'https://api.minimax.io/anthropic/v1/models'],
+    ['minimax', 'https://api.minimaxi.com/v1/models'],
+    ['minimax-global', 'https://api.minimax.io/v1/models'],
   ] as const)(
-    'uses the MiniMax API key header when discovering models for %s',
+    'discovers MiniMax models through the CORS-safe OpenAI-compatible endpoint for %s',
     async (profileId, modelsUrl) => {
       const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
         new Response(JSON.stringify({ data: [{ id: 'MiniMax-M2.7' }] }), {
@@ -180,7 +192,7 @@ describe('localModelProviders', () => {
         modelsUrl,
         expect.objectContaining({
           method: 'GET',
-          headers: { 'X-Api-Key': 'secret-key' },
+          headers: { Authorization: 'Bearer secret-key' },
         })
       )
     }

--- a/wework/src/features/model-settings/localModelProviders.ts
+++ b/wework/src/features/model-settings/localModelProviders.ts
@@ -25,10 +25,12 @@ export interface LocalModelProviderProfile {
   displayNameKey?: string
   description: string
   baseUrl: string
+  modelsBaseUrl?: string
   apiFormat: LocalModelApiFormat
   requestPath: string
   modelsPath?: string
   modelsApiKeyHeader?: 'Authorization' | 'X-Api-Key'
+  connectionTest?: LocalModelProviderConnectionTest
   allowedModelIds?: readonly string[]
   toolProfile: LocalModelToolProfile
   group?: string
@@ -49,6 +51,12 @@ export interface DiscoveredLocalModel {
   displayName: string
 }
 
+export interface LocalModelProviderConnectionTest {
+  baseUrl: string
+  requestPath: string
+  apiFormat: 'openai-chat-completions'
+}
+
 const MINIMAX_MODEL_DEFAULTS = {
   'MiniMax-M2.7': { contextWindow: 204_800 },
   'MiniMax-M2.7-highspeed': { contextWindow: 204_800 },
@@ -63,7 +71,8 @@ function miniMaxProviderProfile(
   id: Extract<LocalModelProviderProfileId, 'minimax' | 'minimax-global'>,
   displayName: string,
   displayNameKey: string,
-  baseUrl: string
+  baseUrl: string,
+  modelsBaseUrl: string
 ): LocalModelProviderProfile {
   return {
     id,
@@ -71,10 +80,16 @@ function miniMaxProviderProfile(
     displayNameKey,
     description: 'MiniMax Anthropic-compatible API',
     baseUrl,
+    modelsBaseUrl,
     apiFormat: 'anthropic-messages',
     requestPath: '/v1/messages',
     modelsPath: '/v1/models',
-    modelsApiKeyHeader: 'X-Api-Key',
+    modelsApiKeyHeader: 'Authorization',
+    connectionTest: {
+      baseUrl: modelsBaseUrl,
+      requestPath: '/v1/text/chatcompletion_v2',
+      apiFormat: 'openai-chat-completions',
+    },
     toolProfile: 'function',
     group: 'MiniMax',
     contextWindow: 204_800,
@@ -194,13 +209,15 @@ export const LOCAL_MODEL_PROVIDER_PROFILES: LocalModelProviderProfile[] = [
     'minimax',
     'MiniMax (China mainland)',
     'workbench.local_model_provider_minimax_cn',
-    'https://api.minimaxi.com/anthropic'
+    'https://api.minimaxi.com/anthropic',
+    'https://api.minimaxi.com'
   ),
   miniMaxProviderProfile(
     'minimax-global',
     'MiniMax (Global)',
     'workbench.local_model_provider_minimax_global',
-    'https://api.minimax.io/anthropic'
+    'https://api.minimax.io/anthropic',
+    'https://api.minimax.io'
   ),
   {
     id: 'custom',
@@ -265,20 +282,18 @@ export async function discoverProviderModels(
   if (!apiKey.trim()) throw new Error('API Key is required')
 
   const fetcher = options.fetcher ?? defaultFetcher()
+  const modelsBaseUrl = (profile.modelsBaseUrl ?? profile.baseUrl).replace(/\/+$/, '')
   const controller = new AbortController()
   const timeout = window.setTimeout(() => controller.abort(), options.timeoutMs ?? 15_000)
   try {
-    const response = await fetcher(
-      `${profile.baseUrl.replace(/\/+$/, '')}/${profile.modelsPath.replace(/^\/+/, '')}`,
-      {
-        method: 'GET',
-        headers:
-          profile.modelsApiKeyHeader === 'X-Api-Key'
-            ? { 'X-Api-Key': apiKey.trim() }
-            : { Authorization: `Bearer ${apiKey.trim()}` },
-        signal: controller.signal,
-      }
-    )
+    const response = await fetcher(`${modelsBaseUrl}/${profile.modelsPath.replace(/^\/+/, '')}`, {
+      method: 'GET',
+      headers:
+        profile.modelsApiKeyHeader === 'X-Api-Key'
+          ? { 'X-Api-Key': apiKey.trim() }
+          : { Authorization: `Bearer ${apiKey.trim()}` },
+      signal: controller.signal,
+    })
     let body: unknown
     try {
       body = await response.json()


### PR DESCRIPTION
## 问题

Wework 设置页添加 MiniMax（中国大陆 / Global）模型时，点击“获取模型”报 `Failed to fetch`，模型列表无法加载。

## 根因

MiniMax 的 Anthropic 兼容网关（`api.minimaxi.com/anthropic` / `api.minimax.io/anthropic`）要求用 `X-Api-Key` 请求头鉴权，但其 CORS 预检响应中的 `Access-Control-Allow-Headers` 并不包含 `X-Api-Key`（也不包含 `anthropic-version`）。Wework 渲染进程（Electron `webSecurity` 默认开启）发起带自定义头的请求前会先走 OPTIONS 预检，预检未通过导致 fetch 直接以 `TypeError: Failed to fetch` 失败，请求根本到不了 MiniMax。

已用 curl 实测验证：

- `OPTIONS /anthropic/v1/models` + `Access-Control-Request-Headers: x-api-key` → 响应 allow-headers 列表无 `x-api-key`（Chromium 会拦截）。
- `GET /v1/models`（OpenAI 兼容端点）要求 `Authorization: Bearer <key>`，且 `Authorization` 在 CORS 允许头列表中，预检可通过。
- MiniMax 的 `X-Api-Key` 仅被 anthropic 路径接受、`Authorization` 仅被 OpenAI 兼容路径接受。

## 修复

- 模型发现：MiniMax 改为请求 OpenAI 兼容端点 `https://api.minimaxi.com/v1/models`（Global 为 `api.minimax.io`），携带 `Authorization: Bearer`。新增 profile 字段 `modelsBaseUrl` 支持模型列表与聊天端点使用不同 host。
- 连接测试：MiniMax 的 anthropic messages 端点同样因 `x-api-key`/`anthropic-version` 被 CORS 拦截，故连接测试（“测试”按钮）对 MiniMax 走 OpenAI 兼容的 `/v1/text/chatcompletion_v2` 探测（验证 key 有效性、模型可用性与函数调用），通过 profile 字段 `connectionTest` 声明，运行时聊天路径不受影响（仍走 DSH 本地路由的 anthropic 端点）。

## 验证

- `wework/src/features/model-settings/` 全部单测通过（9 个文件 / 69 个测试）。
- eslint、prettier 通过。
- 存量 typecheck 报错与本次改动无关（基线上同样存在）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model connection testing by using provider-specific connection settings when available, with form settings as a fallback.
  * Fixed MiniMax model discovery by using compatible model-listing endpoints and Bearer authorization.
  * Improved support for MiniMax configurations that use separate endpoints for model listing and connection testing.
* **Enhancements**
  * Added support for provider-specific model-listing URLs and connection-test settings, improving compatibility across provider API formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->