### PR TITLE
fix(wework): 稳定 macOS 公证与组件产物生成

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -308,6 +308,7 @@ jobs:
           VITE_WEWORK_RUNTIME_MODE: local-first
           WEWORK_CODEX_TARGET: ${{ matrix.codex_target }}
           WEWORK_DWS_TARGET: ${{ matrix.cargo_target }}
+          WEWORK_CUSTOM_MACOS_NOTARIZATION: ${{ matrix.platform == 'macos' && 'true' || '' }}
           WEWORK_RELEASE_ARCH: ${{ matrix.arch }}
           WEWORK_RELEASE_PLATFORM: ${{ matrix.platform }}
           WEWORK_SOURCE_SHA: ${{ needs.prepare-release.outputs.release_sha }}

--- a/wework/electron/electron-builder.config.cjs
+++ b/wework/electron/electron-builder.config.cjs
@@ -6,6 +6,8 @@ const updateBaseUrl =
   process.env.WEWORK_UPDATE_BASE_URL ||
   'https://github.com/wecode-ai/Wegent/releases/download/wework-updater'
 const identity = resolveBuildIdentity()
+const useCustomMacosNotarization =
+  process.env.WEWORK_CUSTOM_MACOS_NOTARIZATION?.trim().toLowerCase() === 'true'
 
 module.exports = {
   appId: identity.identifier,
@@ -40,11 +42,15 @@ module.exports = {
     provider: 'generic',
     url: updateBaseUrl,
   },
+  ...(useCustomMacosNotarization
+    ? { afterSign: path.resolve(__dirname, 'scripts/notarize-macos.cjs') }
+    : {}),
   mac: {
     artifactName: 'WeWork_${version}_macos_${arch}.${ext}',
     category: 'public.app-category.developer-tools',
     electronLanguages: ['en', 'zh_CN'],
     hardenedRuntime: true,
+    ...(useCustomMacosNotarization ? { notarize: false } : {}),
     icon: path.resolve(__dirname, '../resources/icons/icon.icns'),
     signIgnore: ['/Contents/Resources/wework-core-plugins/'],
     target: ['dmg', 'zip'],

--- a/wework/electron/scripts/notarize-macos.cjs
+++ b/wework/electron/scripts/notarize-macos.cjs
@@ -1,0 +1,187 @@
+const { spawn } = require('node:child_process')
+const { mkdtemp, rm, stat } = require('node:fs/promises')
+const { tmpdir } = require('node:os')
+const { join, resolve } = require('node:path')
+
+const { resolveBuildIdentity } = require('./build-identity.cjs')
+
+async function notarizeMacos(context) {
+  if (context.electronPlatformName !== 'darwin') return
+
+  const identity = resolveBuildIdentity()
+  const appPath = join(context.appOutDir, `${identity.productName}.app`)
+  await notarizeApp(appPath)
+}
+
+async function notarizeApp(appPath, environment = process.env) {
+  await requireDirectory(appPath)
+  if (await hasStapledTicket(appPath)) return
+
+  const identity = resolveBuildIdentity(environment)
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'wework-notarize-'))
+  const archivePath = join(temporaryDirectory, `${identity.productName}.zip`)
+  try {
+    await run('codesign', ['--verify', '--deep', '--strict', appPath])
+    await run('ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', appPath, archivePath])
+    const result = await submitArchive(archivePath, environment)
+    if (result.status !== 'Accepted') {
+      throw new Error(`Apple notarization failed with status: ${result.status || 'unknown'}`)
+    }
+    await run('xcrun', ['stapler', 'staple', appPath])
+    await run('xcrun', ['stapler', 'validate', appPath])
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+async function submitArchive(archivePath, environment) {
+  const attempts = retryAttempts(environment.WEWORK_NOTARY_UPLOAD_ATTEMPTS)
+  const args = [
+    'notarytool',
+    'submit',
+    archivePath,
+    ...authorizationArgs(environment),
+    ...s3AccelerationArgs(environment.WEWORK_NOTARYTOOL_S3_ACCELERATION),
+    '--wait',
+    '--timeout',
+    '30m',
+    '--output-format',
+    'json',
+  ]
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return JSON.parse(await run('xcrun', args))
+    } catch (error) {
+      if (!isTransientNotaryFailure(error) || attempt === attempts) throw error
+      const delayMs = attempt * 5000
+      console.warn(
+        `Apple notarization upload failed transiently; retrying attempt ${attempt + 1}/${attempts} in ${delayMs / 1000}s`
+      )
+      await delay(delayMs)
+    }
+  }
+  throw new Error('Apple notarization exhausted all upload attempts')
+}
+
+function authorizationArgs(environment) {
+  const apiKey = environment.APPLE_API_KEY?.trim()
+  const apiKeyId = environment.APPLE_API_KEY_ID?.trim()
+  const apiIssuer = environment.APPLE_API_ISSUER?.trim()
+  if (apiKey || apiKeyId || apiIssuer) {
+    if (!apiKey || !apiKeyId || !apiIssuer) {
+      throw new Error('APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER are required')
+    }
+    return ['--key', apiKey, '--key-id', apiKeyId, '--issuer', apiIssuer]
+  }
+
+  const appleId = environment.APPLE_ID?.trim()
+  const password = environment.APPLE_APP_SPECIFIC_PASSWORD?.trim()
+  const teamId = environment.APPLE_TEAM_ID?.trim()
+  if (appleId || password || teamId) {
+    if (!appleId || !password || !teamId) {
+      throw new Error('APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID are required')
+    }
+    return ['--apple-id', appleId, '--password', password, '--team-id', teamId]
+  }
+
+  const keychainProfile = environment.APPLE_KEYCHAIN_PROFILE?.trim()
+  const keychain = environment.APPLE_KEYCHAIN?.trim()
+  if (keychainProfile) {
+    return ['--keychain-profile', keychainProfile, ...(keychain ? ['--keychain', keychain] : [])]
+  }
+  throw new Error('Apple notarization credentials are required')
+}
+
+function retryAttempts(value) {
+  if (value === undefined || value === '') return 3
+  const attempts = Number(value)
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 5) {
+    throw new Error('WEWORK_NOTARY_UPLOAD_ATTEMPTS must be an integer between 1 and 5')
+  }
+  return attempts
+}
+
+function s3AccelerationArgs(value) {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized || normalized === 'true') return ['--s3-acceleration']
+  if (normalized === 'false') return ['--no-s3-acceleration']
+  throw new Error('WEWORK_NOTARYTOOL_S3_ACCELERATION must be true or false')
+}
+
+function isTransientNotaryFailure(error) {
+  const message = error instanceof Error ? error.message : String(error)
+  return /abortedUpload|deadlineExceeded|timed? ?out|connection (?:reset|lost)|NSURLErrorDomain.*-100[15]/i.test(
+    message
+  )
+}
+
+async function hasStapledTicket(appPath) {
+  try {
+    await run('xcrun', ['stapler', 'validate', appPath])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function requireDirectory(path) {
+  if (!(await stat(path).catch(() => null))?.isDirectory()) {
+    throw new Error(`Signed macOS application is missing: ${path}`)
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise(resolvePromise => setTimeout(resolvePromise, milliseconds))
+}
+
+function run(command, args) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', chunk => {
+      stdout += chunk
+    })
+    child.stderr.on('data', chunk => {
+      stderr += chunk
+    })
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolvePromise(stdout)
+      } else {
+        const details = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n')
+        reject(
+          new Error(
+            `${command} exited with ${signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`}${details ? `: ${details}` : ''}`
+          )
+        )
+      }
+    })
+  })
+}
+
+if (require.main === module) {
+  const appPath = process.argv[2]
+  if (!appPath) {
+    console.error('Usage: node notarize-macos.cjs <signed-app-path>')
+    process.exitCode = 1
+  } else {
+    notarizeApp(resolve(appPath)).catch(error => {
+      console.error(error instanceof Error ? error.message : String(error))
+      process.exitCode = 1
+    })
+  }
+}
+
+module.exports = notarizeMacos
+module.exports.authorizationArgs = authorizationArgs
+module.exports.isTransientNotaryFailure = isTransientNotaryFailure
+module.exports.notarizeApp = notarizeApp
+module.exports.retryAttempts = retryAttempts
+module.exports.s3AccelerationArgs = s3AccelerationArgs

--- a/wework/electron/src/notarize-macos.test.ts
+++ b/wework/electron/src/notarize-macos.test.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, test } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  authorizationArgs,
+  isTransientNotaryFailure,
+  retryAttempts,
+  s3AccelerationArgs,
+} = require('../scripts/notarize-macos.cjs')
+const electronRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('enables the custom notarization hook without embedding credentials', () => {
+  const config = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        '-e',
+        `
+const config = require(process.argv[1])
+process.stdout.write(JSON.stringify({
+  afterSign: config.afterSign,
+  notarize: config.mac.notarize,
+}))
+`,
+        resolve(electronRoot, 'electron-builder.config.cjs'),
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          WEWORK_CUSTOM_MACOS_NOTARIZATION: 'true',
+        },
+      }
+    )
+  )
+
+  expect(config.afterSign).toBe(resolve(electronRoot, 'scripts/notarize-macos.cjs'))
+  expect(config.notarize).toBe(false)
+})
+
+test('builds notarytool API key authorization for CI', () => {
+  expect(
+    authorizationArgs({
+      APPLE_API_KEY: '/tmp/AuthKey_TEST.p8',
+      APPLE_API_KEY_ID: 'KEYID',
+      APPLE_API_ISSUER: 'issuer',
+    })
+  ).toEqual(['--key', '/tmp/AuthKey_TEST.p8', '--key-id', 'KEYID', '--issuer', 'issuer'])
+})
+
+test('builds notarytool password authorization without changing credentials', () => {
+  expect(
+    authorizationArgs({
+      APPLE_ID: 'developer@example.com',
+      APPLE_APP_SPECIFIC_PASSWORD: 'app-password',
+      APPLE_TEAM_ID: 'TEAMID',
+    })
+  ).toEqual([
+    '--apple-id',
+    'developer@example.com',
+    '--password',
+    'app-password',
+    '--team-id',
+    'TEAMID',
+  ])
+})
+
+test('retries only transient notarization transport failures', () => {
+  expect(isTransientNotaryFailure(new Error('HTTPClientError.deadlineExceeded'))).toBe(true)
+  expect(isTransientNotaryFailure(new Error('abortedUpload after connection reset'))).toBe(true)
+  expect(
+    isTransientNotaryFailure(new Error('Apple notarization failed with status: Invalid'))
+  ).toBe(false)
+})
+
+test('limits notarization upload attempts', () => {
+  expect(retryAttempts(undefined)).toBe(3)
+  expect(retryAttempts('5')).toBe(5)
+  expect(() => retryAttempts('0')).toThrow('between 1 and 5')
+  expect(() => retryAttempts('6')).toThrow('between 1 and 5')
+})
+
+test('uses S3 acceleration by default and supports explicit standard S3', () => {
+  expect(s3AccelerationArgs(undefined)).toEqual(['--s3-acceleration'])
+  expect(s3AccelerationArgs('true')).toEqual(['--s3-acceleration'])
+  expect(s3AccelerationArgs('false')).toEqual(['--no-s3-acceleration'])
+  expect(() => s3AccelerationArgs('invalid')).toThrow('must be true or false')
+})

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -123,6 +123,21 @@ describe('desktop resource migration', () => {
     expect(source).toContain('linux_${installerArchitecture}\\\\.AppImage')
   })
 
+  test('creates macOS component archives from the requested packaged application', async () => {
+    const source = await readFile(
+      join(weworkRoot, 'scripts/prepare-desktop-release-assets.mjs'),
+      'utf8'
+    )
+
+    expect(source).toContain("arch === 'arm64' ? 'mac-arm64' : 'mac'")
+    expect(source).toContain(
+      "packagedComponentResourcesRoot = join(appPath, 'Contents', 'Resources')"
+    )
+    expect(source).toContain("join(packagedComponentResourcesRoot, 'components.json')")
+    expect(source).toContain('join(packagedComponentResourcesRoot, component.path)')
+    expect(source).not.toContain('async function findDirectory')
+  })
+
   test('signs legacy updater assets through the Windows command interpreter', async () => {
     const source = await readFile(
       join(weworkRoot, 'scripts/prepare-desktop-release-assets.mjs'),

--- a/wework/scripts/prepare-desktop-release-assets.mjs
+++ b/wework/scripts/prepare-desktop-release-assets.mjs
@@ -19,6 +19,7 @@ const componentResourcesRoot = join(weworkRoot, 'electron', 'resources')
 const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const [platform, arch, version, outputDirectory] = process.argv.slice(2)
 const identity = resolveBuildIdentity()
+let packagedComponentResourcesRoot = componentResourcesRoot
 
 if (!platform || !arch || !version || !outputDirectory) {
   throw new Error(
@@ -32,10 +33,12 @@ await rm(output, { recursive: true, force: true })
 await mkdir(output, { recursive: true })
 
 if (platform === 'macos') {
-  const appDirectory = await findDirectory(installerRoot, /^mac(?:-arm64)?$/)
+  const appDirectory = join(installerRoot, arch === 'arm64' ? 'mac-arm64' : 'mac')
+  await requireDirectory(appDirectory)
   const appName = `${identity.productName}.app`
   const appPath = join(appDirectory, appName)
   await requireDirectory(appPath)
+  packagedComponentResourcesRoot = join(appPath, 'Contents', 'Resources')
   const dmg = await findFile(
     installerRoot,
     new RegExp(`^WeWork_${escape(version)}_macos_${arch}\\.dmg$`)
@@ -71,7 +74,7 @@ await prepareComponentAssets()
 
 async function prepareComponentAssets() {
   const packaged = JSON.parse(
-    await readFile(join(componentResourcesRoot, 'components.json'), 'utf8')
+    await readFile(join(packagedComponentResourcesRoot, 'components.json'), 'utf8')
   )
   const componentAssets = {}
   for (const id of ['coreDsh', 'weworkCorePlugins', 'bundledPlugins', 'executor', 'codex', 'dws']) {
@@ -79,7 +82,7 @@ async function prepareComponentAssets() {
     if (!component?.path || !component?.sha256 || !component?.version) {
       throw new Error(`Packaged component metadata is incomplete: ${id}`)
     }
-    const sourcePath = join(componentResourcesRoot, component.path)
+    const sourcePath = join(packagedComponentResourcesRoot, component.path)
     const source = await stat(sourcePath)
     const temporaryAssetPath = join(output, `.component-${id}.tar.gz`)
     const archiveOptions = {
@@ -138,13 +141,6 @@ async function signBridge(path) {
     ['--dir', join(weworkRoot, 'electron'), 'exec', 'tauri', 'signer', 'sign', path],
     weworkRoot
   )
-}
-
-async function findDirectory(root, pattern) {
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    if (entry.isDirectory() && pattern.test(entry.name)) return join(root, entry.name)
-  }
-  throw new Error(`No directory matching ${pattern} under ${root}`)
 }
 
 async function findFile(root, pattern) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated macOS notarization flow for signed desktop releases.
  * Supports multiple Apple credential methods, retry handling, ticket stapling, and validation.
  * Improves packaged macOS component asset selection across architectures.

* **Bug Fixes**
  * Prevents incorrect component resources from being selected during macOS release preparation.

* **Tests**
  * Added coverage for notarization behavior and macOS resource migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->