### PR TITLE
fix(wework): bound connector auth resume scans

### DIFF
--- a/docs/en/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/en/wework/developer-guide/wework-codex-plugins.md
@@ -41,6 +41,8 @@ Plugins can declare device-side authorization under `connectors[].localAuth`. `l
 
 The connector authorization preflight before sending a message runs synchronously only for messages that explicitly reference a `plugin://` URI or contain a connector authentication hint; ordinary messages are sent immediately without reading the installed plugin list, so sending is never blocked by local plugin enumeration. When a plugin reference is present, preflight only enriches the mentioned plugins with `plugin/read` and must not call full `plugin/list` / `readState` on the send path, which can stall conversation open by ~10 seconds.
 
+Mid-run authorization recovery checks only the latest assistant or system message in the current conversation; task switching must not rescan the complete transcript. Detection text must have a fixed size bound and may include only message errors, message content, and textual or known structured error fields from tool blocks. It must not serialize `renderPayload` or other unbounded presentation data. This prevents paginated history caches or a single large tool result from blocking the renderer main thread, and prevents stale authorization errors from reopening after later successful replies.
+
 Browser OAuth runs as an asynchronous authorization session with `preparing`, `waiting_browser`, `verifying`, and `ok/error` states. Closing the UI calls the Executor `cancel` RPC and terminates the login process. CLI bridges must emit one status JSON object and must never include tokens, cookies, or other credentials.
 
 Local authorization tools have two sources:

--- a/docs/zh/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-codex-plugins.md
@@ -41,6 +41,8 @@ Renderer 通过白名单 Electron capability 调用列举、安装、更新、�
 
 发送消息前的连接器授权预检只对明确包含 `plugin://` 引用或连接器认证提示的消息同步执行；普通消息直接发送，不读取插件清单，避免每次发送都被本机插件枚举阻塞。带插件引用时也只对消息中提到的插件做 `plugin/read` 补全连接器信息，禁止在发送路径上调用完整 `plugin/list` / `readState`，以免会话打开被拖慢约 10 秒。
 
+运行中授权恢复只检查当前会话最新的 assistant/system 消息，不在任务切换时重新扫描全部历史。检测文本必须有固定大小上限，只读取消息错误、正文以及工具块中的文本或已知结构化错误字段；不得序列化 `renderPayload` 或其它无界展示载荷。这样历史分页缓存或单条大型工具输出不会阻塞渲染进程主线程，旧的授权错误也不会在后续正常回复后重新弹出。
+
 `browser_oauth` 使用异步授权会话，状态依次为 `preparing`、`waiting_browser`、`verifying` 和 `ok/error`。关闭界面会调用 Executor 的 `cancel` RPC 并终止登录子进程。CLI 输出必须是单个状态 JSON，不得包含 token、cookie 或其他凭据。
 
 本地授权工具支持两种来源：

--- a/wework/src/features/plugins/localConnectorAuthGate.test.ts
+++ b/wework/src/features/plugins/localConnectorAuthGate.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test, vi } from 'vitest'
 import {
+  connectorAuthMessageText,
   enrichInstalledPluginsForLocalAuth,
   extractConnectorAuthConnectorSlug,
   filterLocalRequirements,
   findLocalConnectorsForMessage,
+  latestConnectorAuthMessage,
   listLocalConnectors,
   listMentionedPluginNames,
   messageNeedsConnectorPreflight,
@@ -11,6 +13,7 @@ import {
   resolveLocalConnectorAuthHint,
 } from '@/features/plugins/localConnectorAuthGate'
 import type { InstalledPlugin } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
 
 function pluginWithLocalQr(overrides?: Partial<InstalledPlugin>): InstalledPlugin {
   return {
@@ -165,6 +168,80 @@ describe('localConnectorAuthGate', () => {
         '账号信息显示你有 2 个公开项目，但 GitHub 连接器的项目搜索结果暂时返回 0 个项目。可能是项目索引同步延迟或连接器查询异常。'
       )
     ).toBe(false)
+  })
+
+  test('only checks the latest assistant or system message for auth resume', () => {
+    const messages: WorkbenchMessage[] = [
+      {
+        id: 'assistant-old',
+        role: 'assistant',
+        content: 'weibo-wiki Connector needs login',
+      },
+      {
+        id: 'user-latest',
+        role: 'user',
+        content: 'continue',
+      },
+      {
+        id: 'assistant-latest',
+        role: 'assistant',
+        content: 'done',
+      },
+    ]
+
+    expect(latestConnectorAuthMessage(messages)).toBeNull()
+  })
+
+  test('bounds connector auth text and keeps auth details at the end of large tool output', () => {
+    const message: WorkbenchMessage = {
+      id: 'assistant-large-output',
+      role: 'assistant',
+      content: '',
+      blocks: [
+        {
+          id: 'tool-1',
+          type: 'tool',
+          status: 'error',
+          toolOutput: `${'x'.repeat(200_000)} connector_auth_required connectorSlug=weibo-wiki`,
+          renderPayload: { content: 'y'.repeat(200_000) },
+        },
+      ],
+    }
+
+    const text = connectorAuthMessageText(message)
+
+    expect(text.length).toBeLessThanOrEqual(64 * 1024 + 2)
+    expect(text).toContain('connector_auth_required')
+    expect(text).toContain('connectorSlug=weibo-wiki')
+    expect(text).not.toContain('yyyy')
+    expect(latestConnectorAuthMessage([message])?.message.id).toBe(message.id)
+  })
+
+  test('extracts structured auth fields without serializing arbitrary tool payloads', () => {
+    const message: WorkbenchMessage = {
+      id: 'assistant-structured-output',
+      role: 'assistant',
+      content: '',
+      blocks: [
+        {
+          id: 'tool-1',
+          type: 'tool',
+          status: 'error',
+          toolOutput: {
+            error: 'connector_auth_required',
+            pluginKey: 'weibo-api-wiki',
+            connectorSlug: 'weibo-wiki',
+            unrelated: 'x'.repeat(200_000),
+          },
+        },
+      ],
+    }
+
+    const candidate = latestConnectorAuthMessage([message])
+
+    expect(candidate?.text).toContain('pluginKey=weibo-api-wiki')
+    expect(candidate?.text).toContain('connectorSlug=weibo-wiki')
+    expect(candidate?.text).not.toContain('xxxx')
   })
 
   test('extracts connector slug and filters requirements', () => {

--- a/wework/src/features/plugins/localConnectorAuthGate.ts
+++ b/wework/src/features/plugins/localConnectorAuthGate.ts
@@ -5,8 +5,28 @@ import {
 } from '@/api/local/localConnectorAuth'
 import { parsePluginUri } from '@/features/plugins/pluginNavigation'
 import type { InstalledPlugin, PluginLocalAuthDefinition } from '@/types/api'
+import type { WorkbenchMessage } from '@/types/workbench'
 
 const PLUGIN_URI_PATTERN = /plugin:\/\/[^\s)\]]+/g
+const CONNECTOR_AUTH_TEXT_LIMIT = 64 * 1024
+const CONNECTOR_AUTH_FIELD_TEXT_LIMIT = 16 * 1024
+const CONNECTOR_AUTH_OBJECT_KEYS = [
+  'error',
+  'message',
+  'detail',
+  'content',
+  'text',
+  'output',
+  'stderr',
+  'pluginKey',
+  'plugin_key',
+  'connectorSlug',
+  'connector_slug',
+  'data',
+  'result',
+  'cause',
+  'response',
+] as const
 
 export interface LocalConnectorRequirement {
   plugin: InstalledPlugin
@@ -165,6 +185,76 @@ export async function findFirstLocalNeedingLogin(
     }
   }
   return null
+}
+
+function appendBoundedText(parts: string[], value: string, remaining: number): number {
+  if (remaining <= 0 || !value) return remaining
+  const separatorLength = parts.length > 0 ? 1 : 0
+  const available = Math.min(remaining - separatorLength, CONNECTOR_AUTH_FIELD_TEXT_LIMIT)
+  if (available <= 0) return remaining
+  if (value.length <= available) {
+    parts.push(value)
+    return remaining - separatorLength - value.length
+  }
+
+  const headLength = Math.floor(available / 2)
+  const tailLength = available - headLength
+  parts.push(value.slice(0, headLength) + value.slice(-tailLength))
+  return remaining - separatorLength - available
+}
+
+function appendConnectorAuthObjectText(
+  parts: string[],
+  value: unknown,
+  remaining: number,
+  depth = 0
+): number {
+  if (remaining <= 0 || value == null || depth > 3) return remaining
+  if (typeof value === 'string') return appendBoundedText(parts, value, remaining)
+  if (typeof value !== 'object') return remaining
+
+  const record = value as Record<string, unknown>
+  for (const key of CONNECTOR_AUTH_OBJECT_KEYS) {
+    const field = record[key]
+    if (field == null) continue
+    if (typeof field === 'string') {
+      remaining = appendBoundedText(parts, `${key}=${field}`, remaining)
+    } else {
+      remaining = appendConnectorAuthObjectText(parts, field, remaining, depth + 1)
+    }
+    if (remaining <= 0) break
+  }
+  return remaining
+}
+
+export function connectorAuthMessageText(message: WorkbenchMessage): string {
+  const parts: string[] = []
+  let remaining = CONNECTOR_AUTH_TEXT_LIMIT
+  remaining = appendBoundedText(parts, message.error ?? '', remaining)
+
+  for (const block of [...(message.blocks ?? [])].reverse()) {
+    if (remaining <= 0) break
+    if ('content' in block && typeof block.content === 'string') {
+      remaining = appendBoundedText(parts, block.content, remaining)
+    }
+    if ('toolOutput' in block) {
+      remaining = appendConnectorAuthObjectText(parts, block.toolOutput, remaining)
+    }
+  }
+  appendBoundedText(parts, message.content, remaining)
+  return parts.join('\n')
+}
+
+export function latestConnectorAuthMessage(
+  messages: WorkbenchMessage[]
+): { message: WorkbenchMessage; text: string } | null {
+  const message = messages.findLast(
+    candidate => candidate.role === 'assistant' || candidate.role === 'system'
+  )
+  if (!message) return null
+
+  const text = connectorAuthMessageText(message)
+  return messageRequiresConnectorAuth(text) ? { message, text } : null
 }
 
 export function messageRequiresConnectorAuth(text: string | null | undefined): boolean {

--- a/wework/src/features/plugins/useLocalConnectorAuthGate.ts
+++ b/wework/src/features/plugins/useLocalConnectorAuthGate.ts
@@ -13,10 +13,10 @@ import {
   findFirstLocalNeedingLogin,
   findLocalConnectorsForMessage,
   installedPluginMatchesName,
+  latestConnectorAuthMessage,
   listMentionedPluginReferences,
   listMentionedPluginNames,
   messageNeedsConnectorPreflight,
-  messageRequiresConnectorAuth,
   resolveLocalConnectorAuthHint,
   toLocalConnectorAuthTarget,
   type LocalConnectorRequirement,
@@ -69,32 +69,6 @@ async function loadInstalledPlugins(options?: {
           : () => false,
     }
   )
-}
-
-function messageText(message: WorkbenchMessage): string {
-  const parts: string[] = [message.content, message.error ?? '']
-  for (const block of message.blocks ?? []) {
-    const maybeContent = Reflect.get(block, 'content')
-    if (typeof maybeContent === 'string') parts.push(maybeContent)
-    const maybeToolOutput = Reflect.get(block, 'toolOutput') ?? Reflect.get(block, 'tool_output')
-    if (typeof maybeToolOutput === 'string') parts.push(maybeToolOutput)
-    else if (maybeToolOutput != null) {
-      try {
-        parts.push(JSON.stringify(maybeToolOutput))
-      } catch {
-        // ignore
-      }
-    }
-    const renderPayload = Reflect.get(block, 'renderPayload')
-    if (renderPayload && typeof renderPayload === 'object') {
-      try {
-        parts.push(JSON.stringify(renderPayload))
-      } catch {
-        // ignore
-      }
-    }
-  }
-  return parts.filter(Boolean).join('\n')
 }
 
 async function targetNeedsLogin(target: LocalConnectorAuthTarget): Promise<boolean> {
@@ -235,17 +209,14 @@ export function useLocalConnectorAuthGate(options: {
 
   useEffect(() => {
     if (pending) return
-    const latest = [...options.messages].reverse().find(message => {
-      if (message.role !== 'assistant' && message.role !== 'system') return false
-      return messageRequiresConnectorAuth(messageText(message))
-    })
-    if (!latest) return
-    const key = latest.id
+    const candidate = latestConnectorAuthMessage(options.messages)
+    if (!candidate) return
+    const key = candidate.message.id
     if (handledResumeKeysRef.current.has(key)) return
 
     void (async () => {
       try {
-        const text = messageText(latest)
+        const { message: latest, text } = candidate
         const pluginKey = extractConnectorAuthPluginKey(text)
         const connectorSlug = extractConnectorAuthConnectorSlug(text)
         const hint = resolveLocalConnectorAuthHint(text)


### PR DESCRIPTION
## Summary

- only inspect the latest assistant/system message when restoring connector authorization
- cap inspected message text at 64 KiB and avoid serializing unbounded render payloads
- preserve structured connector auth detection and document the runtime constraint

## Root cause

Task switching seeded cached transcript messages into the pane. The connector auth recovery effect synchronously rebuilt and regex-scanned full message content, tool outputs, and render payloads. A captured trace showed a 2.57s renderer-main-thread task dominated by repeated connector auth regex scans.

## Verification

- `pnpm --filter wework test src/features/plugins/localConnectorAuthGate.test.ts`
- `pnpm --filter wework typecheck`
- focused Prettier and ESLint checks
- pre-push Wework static checks and unit tests

Task: WEWORKC2FA61-426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from connector authorization errors during an active session.
  * Prevented outdated authorization prompts from reappearing after successful replies.
  * Limited error detection processing to avoid delays caused by large tool outputs or history data.

* **Documentation**
  * Updated English and Chinese developer guides with details about authorization recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->