### PR TITLE
fix(runtime): preserve legacy device project binding

### DIFF
--- a/backend/app/services/device/runtime_task_create_protocol.py
+++ b/backend/app/services/device/runtime_task_create_protocol.py
@@ -25,7 +25,6 @@ class RuntimeTaskCreateProtocolError(ValueError):
 
 FEATURE_FIELDS: dict[str, tuple[str, ...]] = {
     "attachments": ("attachments",),
-    "deviceProjectBinding": ("runtimeProjectKey",),
     "goal": ("initialGoal",),
     "permissionMode": ("runtimePermissionMode",),
     "projectPlugins": ("projectPlugins",),

--- a/backend/tests/schemas/test_device_runtime_features.py
+++ b/backend/tests/schemas/test_device_runtime_features.py
@@ -15,7 +15,6 @@ def _runtime_features():
             "features": {
                 "goal": True,
                 "supervisor": True,
-                "deviceProjectBinding": True,
             },
         },
         "worktrees": {

--- a/backend/tests/services/test_runtime_rpc_service.py
+++ b/backend/tests/services/test_runtime_rpc_service.py
@@ -337,6 +337,35 @@ async def test_runtime_rpc_service_losslessly_downgrades_plain_v2(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_runtime_rpc_service_preserves_v1_device_project_binding(monkeypatch):
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.runtime_route_resolver,
+        "resolve",
+        AsyncMock(return_value=_runtime_route()),
+    )
+    sio_call = AsyncMock(return_value={"accepted": True})
+    monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))
+
+    await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.create",
+        payload={
+            "schemaVersion": 2,
+            "runtime": "codex",
+            "message": "Implement",
+            "runtimeProjectKey": "local:wegent",
+        },
+    )
+
+    emitted = sio_call.await_args.args[1]["payload"]
+    assert "schemaVersion" not in emitted
+    assert emitted["runtimeProjectKey"] == "local:wegent"
+
+
+@pytest.mark.asyncio
 async def test_runtime_rpc_service_rejects_lossy_v2_downgrade(monkeypatch):
     from app.services.device import runtime_rpc_service as module
 

--- a/executor/src/runtime_work/mod.rs
+++ b/executor/src/runtime_work/mod.rs
@@ -33,7 +33,6 @@ pub(crate) fn runtime_features() -> serde_json::Value {
             "schemaVersions": [1, 2],
             "features": {
                 "attachments": true,
-                "deviceProjectBinding": true,
                 "goal": true,
                 "supervisor": true,
                 "permissionMode": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the runtime project key when task-create requests are downgraded to the v1 format.
  - Updated runtime capability negotiation so project binding is no longer incorrectly treated as a required feature.
  - Improved compatibility for task creation across runtime protocol versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->