### PR TITLE
fix(frontend): include workspace patches in image build

### DIFF
--- a/backend/tests/docker/test_workspace_patch_dockerfiles.py
+++ b/backend/tests/docker/test_workspace_patch_dockerfiles.py
@@ -30,3 +30,19 @@ def test_pnpm_install_stages_copy_workspace_patches(dockerfile: Path):
         copy_index = stage.find("COPY patches ./patches")
         install_index = stage.find("pnpm install --frozen-lockfile")
         assert 0 <= copy_index < install_index
+
+
+def test_frontend_build_stage_copies_workspace_patches() -> None:
+    content = (ROOT / "docker" / "frontend" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    build_stage = next(
+        stage
+        for stage in re.split(r"(?m)^FROM ", content)[1:]
+        if "AS builder" in stage
+    )
+
+    copy_index = build_stage.find("COPY --from=deps /app/patches ./patches")
+    build_index = build_stage.find("pnpm run build")
+
+    assert 0 <= copy_index < build_index

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -41,6 +41,7 @@ ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/frontend/node_modules ./frontend/node_modules
 COPY --from=deps /app/packages/chat-core/node_modules ./packages/chat-core/node_modules
+COPY --from=deps /app/patches ./patches
 
 # Copy source code
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
## Summary

- copy workspace dependency patches into the frontend builder stage
- add a Dockerfile contract test covering the build-stage patch requirement

## Root cause

The release workflow failed in `build-frontend-arm64` because `pnpm run build` validates patched workspace dependencies, but the builder stage did not contain `/app/patches/@file-viewer__renderer-drawing@2.1.26.patch`.

Failed run: https://github.com/wecode-ai/Wegent/actions/runs/33152529587

## Verification

- `cd backend && uv run pytest tests/docker` (36 passed)
- `git diff --check`
- Docker image build was not run locally because the Docker daemon is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured workspace patches are available during frontend Docker builds.
  * Improved build reliability when applying frontend dependency patches.

* **Tests**
  * Added coverage verifying that frontend builds copy workspace patches before starting the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->