### PR TITLE
fix(frontend): prevent image build dependency reinstall

### DIFF
--- a/backend/tests/docker/test_frontend_dockerfile_contract.py
+++ b/backend/tests/docker/test_frontend_dockerfile_contract.py
@@ -26,9 +26,16 @@ def test_frontend_builder_includes_chat_core_workspace_dependencies() -> None:
 
 
 def test_frontend_builders_use_workspace_pnpm_version() -> None:
-    """Frontend image builds should not download a second pnpm version."""
+    """Frontend image builds should use the workspace pnpm version."""
     dockerfile = FRONTEND_DOCKERFILE.read_text(encoding="utf-8")
     package_json = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
     prepare_command = f"corepack prepare {package_json['packageManager']} --activate"
 
     assert dockerfile.count(prepare_command) == 2
+
+
+def test_frontend_build_stage_does_not_reinstall_workspace_dependencies() -> None:
+    """The builder must use the dependencies frozen in the deps stage."""
+    dockerfile = FRONTEND_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "pnpm --config.verify-deps-before-run=false run build" in dockerfile

--- a/backend/tests/docker/test_workspace_patch_dockerfiles.py
+++ b/backend/tests/docker/test_workspace_patch_dockerfiles.py
@@ -30,19 +30,3 @@ def test_pnpm_install_stages_copy_workspace_patches(dockerfile: Path):
         copy_index = stage.find("COPY patches ./patches")
         install_index = stage.find("pnpm install --frozen-lockfile")
         assert 0 <= copy_index < install_index
-
-
-def test_frontend_build_stage_copies_workspace_patches() -> None:
-    content = (ROOT / "docker" / "frontend" / "Dockerfile").read_text(
-        encoding="utf-8"
-    )
-    build_stage = next(
-        stage
-        for stage in re.split(r"(?m)^FROM ", content)[1:]
-        if "AS builder" in stage
-    )
-
-    copy_index = build_stage.find("COPY --from=deps /app/patches ./patches")
-    build_index = build_stage.find("pnpm run build")
-
-    assert 0 <= copy_index < build_index

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -41,7 +41,6 @@ ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/frontend/node_modules ./frontend/node_modules
 COPY --from=deps /app/packages/chat-core/node_modules ./packages/chat-core/node_modules
-COPY --from=deps /app/patches ./patches
 
 # Copy source code
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -56,7 +55,7 @@ ENV HUSKY=0
 WORKDIR /app/frontend
 RUN corepack enable \
     && corepack prepare pnpm@11.7.0 --activate \
-    && pnpm run build
+    && pnpm --config.verify-deps-before-run=false run build
 
 # ---- Production Stage ----
 FROM node:22-slim AS runner


### PR DESCRIPTION
## Summary

- keep the frontend Docker build on the workspace pnpm version
- disable pnpm 11 dependency verification only for the builder-stage `pnpm run build` invocation
- remove the now-unnecessary builder-stage patch copy
- add a Dockerfile contract test preventing automatic workspace reinstalls

## Root cause

After #3091 supplied the missing patch file, pnpm 11 continued further and exposed the actual issue: `pnpm run` defaults `verifyDepsBeforeRun` to `install`. The `node_modules` tree copied from the deps stage is treated as stale, so pnpm attempts a full workspace reinstall. The frontend-only build context does not include the Wework dependency that consumes the 2.1.26 drawing patch, causing `ERR_PNPM_UNUSED_PATCH`.

Failed run: https://github.com/wecode-ai/Wegent/actions/runs/33165034746
Follow-up to: #3091

## Verification

- `cd backend && uv run pytest tests/docker` (36 passed)
- `cd frontend && corepack pnpm --config.verify-deps-before-run=false run build` (production build passed)
- `git diff --check`
- Docker Desktop daemon was unavailable locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend build reliability during production deployments.
  * Reduced build interruptions caused by dependency verification checks.
  * Simplified the production build process for more consistent deployment results.
  * Updated build validation to better reflect the current frontend deployment workflow.
  * These changes help ensure frontend releases complete more predictably across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->