### PR TITLE
fix(wework): stop dev hot reload loop

### DIFF
--- a/wework/dsh/app-wework/index-hot-reload.test.mjs
+++ b/wework/dsh/app-wework/index-hot-reload.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
-import { injectDevelopmentReload } from './index.js'
+import { injectDevelopmentReload, weworkIndexInjection } from './index.js'
 
 test('injects reload polling only into the original development application', () => {
   const html = '<html><head></head><body></body></html>'
@@ -10,4 +13,29 @@ test('injects reload polling only into the original development application', ()
   assert.match(developmentHtml, /x-wework-app-build-id/)
   assert.match(developmentHtml, /"build-1"/)
   assert.match(developmentHtml, /window\.location\.reload/)
+})
+
+test('reads the current application assets and build id for every page injection', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'wework-app-hot-reload-'))
+  const indexPath = join(directory, 'index.html')
+
+  try {
+    await writeFile(
+      indexPath,
+      '<html><head><script type="module" src="/assets/first.js"></script></head></html>'
+    )
+    const firstInjection = weworkIndexInjection({ WEWORK_APP_HOT_RELOAD: '1' }, indexPath)
+
+    await writeFile(
+      indexPath,
+      '<html><head><script type="module" src="/assets/second-build.js"></script></head></html>'
+    )
+    const secondInjection = weworkIndexInjection({ WEWORK_APP_HOT_RELOAD: '1' }, indexPath)
+
+    assert.match(firstInjection[0].html, /first\.js/)
+    assert.match(secondInjection[0].html, /second-build\.js/)
+    assert.notEqual(firstInjection[2].html, secondInjection[2].html)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })

--- a/wework/dsh/app-wework/index.js
+++ b/wework/dsh/app-wework/index.js
@@ -38,28 +38,8 @@ const MIME_TYPES = {
 
 export function apply(ctx) {
   const backendUrl = resolveBackendUrl(process.env)
-  const assets = weworkIndexAssets(readFileSync(indexPath, 'utf8'))
-  const developmentReload = injectDevelopmentReload('', process.env, fileBuildId(indexPath))
   ctx.on('webserver/index-inject', table => {
-    table.push(
-      {
-        kind: 'html',
-        placement: 'head',
-        html: assets.head,
-      },
-      {
-        kind: 'html',
-        placement: 'body',
-        html: `<script src="${APP_BASE_PATH}/runtime-config.js"></script>`,
-      }
-    )
-    if (developmentReload) {
-      table.push({
-        kind: 'html',
-        placement: 'body',
-        html: developmentReload,
-      })
-    }
+    table.push(...weworkIndexInjection(process.env, indexPath))
   })
   register(ctx, 'prefix', APP_BASE_PATH, serveWeworkApp)
   if (!backendUrl) return
@@ -175,6 +155,31 @@ export function injectDevelopmentReload(html, environment, buildId) {
     `${APP_BASE_PATH}/`
   )},{method:'HEAD',cache:'no-store'});const next=response.headers.get('x-wework-app-build-id');if(next&&next!==current)window.location.reload()}catch{}finally{checking=false}},500)})()</script>`
   return html.includes('</head>') ? html.replace('</head>', `${script}</head>`) : `${script}${html}`
+}
+
+export function weworkIndexInjection(environment = process.env, appIndexPath = indexPath) {
+  const assets = weworkIndexAssets(readFileSync(appIndexPath, 'utf8'))
+  const developmentReload = injectDevelopmentReload('', environment, fileBuildId(appIndexPath))
+  const injection = [
+    {
+      kind: 'html',
+      placement: 'head',
+      html: assets.head,
+    },
+    {
+      kind: 'html',
+      placement: 'body',
+      html: `<script src="${APP_BASE_PATH}/runtime-config.js"></script>`,
+    },
+  ]
+  if (developmentReload) {
+    injection.push({
+      kind: 'html',
+      placement: 'body',
+      html: developmentReload,
+    })
+  }
+  return injection
 }
 
 function fileBuildId(path) {


### PR DESCRIPTION
## Summary

- read the current Wework application assets for every DSH index response
- inject the current build id after a development reload instead of reusing the startup value
- add regression coverage for refreshed assets and build ids

## Root cause

The development reload script captured the build id when the DSH plugin started. After the first rebuild, every reloaded page still compared the current build against that stale startup id, causing an endless reload loop.

## Verification

- `node --test dsh/app-wework/*.test.mjs`
- `pnpm --filter wework test scripts/desktop-resource-migration.test.mjs`
- `pnpm --filter wework exec prettier --check dsh/app-wework/index.js dsh/app-wework/index-hot-reload.test.mjs`
- `pnpm --filter wework exec eslint dsh/app-wework/index.js dsh/app-wework/index-hot-reload.test.mjs`
- pre-push Wework static checks and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated page injections to consistently use the latest application assets and build identifier after asset changes.
  - Ensured development reload content reflects the current application state for each page injection.

- **Tests**
  - Added coverage verifying that successive page injections detect updated assets and generate distinct build identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->