### PR TITLE
fix(wework): remove keychain-backed cloud credentials

### DIFF
--- a/wework/electron/src/host/cloud-credential-service.test.ts
+++ b/wework/electron/src/host/cloud-credential-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -6,18 +6,12 @@ import { CloudCredentialError, CloudCredentialService } from './cloud-credential
 
 const roots: string[] = []
 
-const encryption = {
-  isEncryptionAvailable: () => true,
-  encryptString: (value: string) => Buffer.from(`encrypted:${value}`),
-  decryptString: (value: Buffer) => value.toString().replace(/^encrypted:/, ''),
-}
-
 afterEach(async () => {
   await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
 })
 
 describe('CloudCredentialService', () => {
-  test('stores only encrypted secrets and refreshes with a device proof', async () => {
+  test('stores credentials in a private file and refreshes with a device proof', async () => {
     const root = await mkdtemp(join(tmpdir(), 'wework-cloud-credentials-'))
     roots.push(root)
     const request = vi
@@ -44,7 +38,7 @@ describe('CloudCredentialService', () => {
           { status: 200 }
         )
       )
-    const service = new CloudCredentialService(root, encryption, request)
+    const service = new CloudCredentialService(root, request)
 
     const publicKey = await service.devicePublicKey()
     const claimed = await service.claimAuthorization({
@@ -66,9 +60,42 @@ describe('CloudCredentialService', () => {
     const refreshRequest = JSON.parse(String(request.mock.calls[1][1]?.body))
     expect(refreshRequest.refresh_token).toBe('refresh-secret')
     expect(refreshRequest.proof.split('.')).toHaveLength(3)
-    const stored = await readFile(join(root, 'cloud-credentials.json'), 'utf8')
-    expect(stored).not.toContain('refresh-secret')
-    expect(stored).not.toContain('PRIVATE KEY')
+    const credentialPath = join(root, 'cloud-credentials.json')
+    const stored = JSON.parse(await readFile(credentialPath, 'utf8'))
+    expect(stored).toMatchObject({
+      version: 2,
+      apiBaseUrl: 'https://cloud.example.com/api',
+      refreshToken: 'refresh-secret',
+    })
+    expect(stored.privateKey).toContain('PRIVATE KEY')
+    if (process.platform !== 'win32') {
+      expect((await stat(credentialPath)).mode & 0o777).toBe(0o600)
+    }
+  })
+
+  test('rejects the obsolete encrypted credential format', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'wework-cloud-credentials-'))
+    roots.push(root)
+    await writeFile(
+      join(root, 'cloud-credentials.json'),
+      JSON.stringify({
+        version: 1,
+        apiBaseUrl: 'https://cloud.example.com/api',
+        publicKey: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+        encryptedPrivateKey: 'encrypted-private-key',
+        encryptedRefreshToken: 'encrypted-refresh-token',
+      }),
+      { mode: 0o600 }
+    )
+    const request = vi.fn<typeof fetch>()
+    const service = new CloudCredentialService(root, request)
+
+    await expect(service.refreshAccessToken('https://cloud.example.com/api')).rejects.toMatchObject(
+      {
+        code: 'credentials_unavailable',
+      } satisfies Partial<CloudCredentialError>
+    )
+    expect(request).not.toHaveBeenCalled()
   })
 
   test('returns a legacy access token without retaining desktop credentials', async () => {
@@ -85,7 +112,7 @@ describe('CloudCredentialService', () => {
         { status: 200 }
       )
     )
-    const service = new CloudCredentialService(root, encryption, request)
+    const service = new CloudCredentialService(root, request)
 
     await service.devicePublicKey()
     const claimed = await service.claimAuthorization({
@@ -133,7 +160,7 @@ describe('CloudCredentialService', () => {
           )
         )
       )
-    const service = new CloudCredentialService(root, encryption, request)
+    const service = new CloudCredentialService(root, request)
     await service.devicePublicKey()
     await service.claimAuthorization({
       apiBaseUrl: 'https://cloud.example.com/api',
@@ -167,7 +194,7 @@ describe('CloudCredentialService', () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ detail: 'Desktop login has expired' }), { status: 401 })
       )
-    const service = new CloudCredentialService(root, encryption, request)
+    const service = new CloudCredentialService(root, request)
     await service.devicePublicKey()
     await service.claimAuthorization({
       apiBaseUrl: 'https://cloud.example.com/api',

--- a/wework/electron/src/host/cloud-credential-service.ts
+++ b/wework/electron/src/host/cloud-credential-service.ts
@@ -2,18 +2,12 @@ import { createHash, generateKeyPairSync, randomUUID, sign as signBytes } from '
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-interface EncryptionProvider {
-  isEncryptionAvailable(): boolean
-  encryptString(value: string): Buffer
-  decryptString(value: Buffer): string
-}
-
 interface StoredCloudCredential {
-  version: 1
+  version: 2
   apiBaseUrl: string
   publicKey: DevicePublicKey
-  encryptedPrivateKey: string
-  encryptedRefreshToken: string
+  privateKey: string
+  refreshToken: string
 }
 
 export interface DevicePublicKey {
@@ -60,7 +54,6 @@ export class CloudCredentialService {
 
   constructor(
     private readonly dataDirectory: string,
-    private readonly encryption: EncryptionProvider,
     private readonly request: typeof fetch = fetch
   ) {}
 
@@ -112,7 +105,7 @@ export class CloudCredentialService {
       await this.writeCredential({
         ...credential,
         apiBaseUrl,
-        encryptedRefreshToken: this.encrypt(refreshToken),
+        refreshToken,
       })
       return {
         status,
@@ -134,7 +127,7 @@ export class CloudCredentialService {
           'Desktop cloud credentials are unavailable'
         )
       }
-      const refreshToken = this.decrypt(credential.encryptedRefreshToken)
+      const refreshToken = credential.refreshToken
       if (!refreshToken) {
         throw new CloudCredentialError(
           'credentials_unavailable',
@@ -143,7 +136,7 @@ export class CloudCredentialService {
       }
       const endpoint = `${normalizedApiBaseUrl}/auth/wework/refresh`
       const proof = createDeviceProof(
-        this.decrypt(credential.encryptedPrivateKey),
+        credential.privateKey,
         credential.publicKey,
         refreshToken,
         new URL(endpoint).pathname
@@ -175,18 +168,15 @@ export class CloudCredentialService {
   }
 
   private generateCredential(apiBaseUrl = ''): StoredCloudCredential {
-    this.requireEncryption()
     const { publicKey, privateKey } = generateKeyPairSync('ec', {
       namedCurve: 'prime256v1',
     })
     return {
-      version: 1,
+      version: 2,
       apiBaseUrl,
       publicKey: normalizePublicKey(publicKey.export({ format: 'jwk' })),
-      encryptedPrivateKey: this.encrypt(
-        privateKey.export({ format: 'pem', type: 'pkcs8' }).toString()
-      ),
-      encryptedRefreshToken: this.encrypt(''),
+      privateKey: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+      refreshToken: '',
     }
   }
 
@@ -206,25 +196,6 @@ export class CloudCredentialService {
     const temporary = `${path}.${process.pid}.tmp`
     await writeFile(temporary, `${JSON.stringify(credential, null, 2)}\n`, { mode: 0o600 })
     await rename(temporary, path)
-  }
-
-  private encrypt(value: string): string {
-    this.requireEncryption()
-    return this.encryption.encryptString(value).toString('base64')
-  }
-
-  private decrypt(value: string): string {
-    this.requireEncryption()
-    return this.encryption.decryptString(Buffer.from(value, 'base64'))
-  }
-
-  private requireEncryption(): void {
-    if (!this.encryption.isEncryptionAvailable()) {
-      throw new CloudCredentialError(
-        'credentials_unavailable',
-        'Operating system credential encryption is unavailable'
-      )
-    }
   }
 
   private path(): string {
@@ -309,20 +280,20 @@ function normalizeStoredCredential(value: unknown): StoredCloudCredential | null
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
   const record = value as Partial<StoredCloudCredential>
   if (
-    record.version !== 1 ||
+    record.version !== 2 ||
     typeof record.apiBaseUrl !== 'string' ||
-    typeof record.encryptedPrivateKey !== 'string' ||
-    typeof record.encryptedRefreshToken !== 'string' ||
+    typeof record.privateKey !== 'string' ||
+    typeof record.refreshToken !== 'string' ||
     !record.publicKey
   ) {
     return null
   }
   return {
-    version: 1,
+    version: 2,
     apiBaseUrl: record.apiBaseUrl,
     publicKey: normalizePublicKey(record.publicKey),
-    encryptedPrivateKey: record.encryptedPrivateKey,
-    encryptedRefreshToken: record.encryptedRefreshToken,
+    privateKey: record.privateKey,
+    refreshToken: record.refreshToken,
   }
 }
 

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -8,7 +8,6 @@ import {
   nativeImage,
   nativeTheme,
   powerMonitor,
-  safeStorage,
   screen,
   session,
   shell,
@@ -1225,7 +1224,7 @@ if (hasSingleInstanceLock) {
       console.error('[context-menu] failed to remove stale temporary images', error)
     })
     preferences = new PreferencesStore(app.getPath('userData'))
-    cloudCredentials = new CloudCredentialService(app.getPath('userData'), safeStorage)
+    cloudCredentials = new CloudCredentialService(app.getPath('userData'))
     installDshWindowLabelHeaders()
     installIpc()
     systemResume.start()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated cloud credential storage to use version 2 plaintext PEM keys and refresh tokens.
  * Credentials now validate only supported version 2 records.
  * Obsolete version 1 encrypted credentials are rejected.
  * Existing credential generation, authorization, and token refresh flows continue using the updated storage format.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->