### PR TITLE
fix(knowledge): 完善外部文档预览与资料展示

### DIFF
--- a/frontend/src/__tests__/features/knowledge/document/document-detail-dialog.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/document-detail-dialog.test.tsx
@@ -416,6 +416,38 @@ describe('DocumentDetailDialog original file preview', () => {
     expect(sourceActions).not.toHaveClass('invisible')
   })
 
+  it.each(['pptx', 'xlsx'])(
+    'previews and downloads an imported %s without replacing its filename',
+    async extension => {
+      const user = userEvent.setup()
+      render(
+        <DocumentDetailDialog
+          open
+          onOpenChange={jest.fn()}
+          document={{
+            ...officeDocument,
+            source_type: 'external',
+            name: '导入资料',
+            file_extension: extension,
+          }}
+          knowledgeBaseId={21}
+        />
+      )
+
+      expect(screen.getByTestId('mock-knowledge-source-preview')).toHaveAttribute(
+        'data-active',
+        'true'
+      )
+      await user.click(screen.getByTestId('knowledge-source-preview-download'))
+      expect(mockDownloadAttachment).toHaveBeenCalledWith(32, undefined)
+      await user.click(screen.getByTestId('knowledge-document-parsed-tab'))
+      expect(screen.getByTestId('mock-knowledge-source-preview')).toHaveClass('hidden')
+      expect(
+        screen.queryByRole('button', { name: 'document.document.detail.edit' })
+      ).not.toBeInTheDocument()
+    }
+  )
+
   it('hides the source preview tab for non-file documents', () => {
     render(
       <DocumentDetailDialog

--- a/frontend/src/__tests__/features/knowledge/document/document-upload-splitter-config.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/document-upload-splitter-config.test.tsx
@@ -273,6 +273,25 @@ describe('DocumentUpload source interactions', () => {
     await waitFor(() => expect(screen.getByTestId('document-upload-submit')).toBeEnabled())
   }
 
+  it('keeps file validation errors before the scrollable upload contents', async () => {
+    mount()
+    fireEvent.change(screen.getByTestId('document-upload-file-input'), {
+      target: { files: [new File(['image'], 'unsupported.jpg', { type: 'image/jpeg' })] },
+    })
+
+    const error = await screen.findByRole('alert')
+    const dropzone = screen.getByTestId('document-upload-dropzone')
+    expect(error).toHaveTextContent('document.upload.unsupportedFileType')
+    expect(dropzone.parentElement).not.toContainElement(error)
+    expect(error.compareDocumentPosition(dropzone) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(screen.getByTestId('document-upload-cancel')).toBeEnabled()
+
+    selectSource('text')
+    expect(error).not.toBeVisible()
+    selectSource('file')
+    expect(error).toBeVisible()
+  })
+
   it('adds text in one submission without submitting or clearing local file drafts', async () => {
     mount()
     await addLocalFile()

--- a/frontend/src/__tests__/features/knowledge/document/folder-tree-query-separation.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/folder-tree-query-separation.test.tsx
@@ -286,6 +286,34 @@ describe('FolderTree query/result separation', () => {
 })
 
 describe('DocumentItem table grid', () => {
+  it.each([
+    [true, 42, ' .xlsx ', 'XLSX'],
+    [false, 42, 'pptx', 'PPTX'],
+    [true, 42, 'md', 'MD'],
+    [false, 42, '', null],
+    [true, 0, 'md', null],
+    [false, null, 'md', null],
+  ] as const)(
+    'shows external format only after attachment creation (compact=%s, attachment=%s, extension=%s)',
+    (compact, attachmentId, extension, expectedFormat) => {
+      const document = createDocument({
+        name: 'Imported title',
+        source_type: 'external',
+        attachment_id: attachmentId,
+        file_extension: extension,
+      })
+      render(<DocumentItem document={document} compact={compact} canManage={false} />)
+
+      expect(screen.getByText('Imported title')).toBeInTheDocument()
+      expect(screen.getByText('document.document.type.external')).toBeInTheDocument()
+      if (expectedFormat) {
+        expect(screen.getByText(expectedFormat)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText('MD')).not.toBeInTheDocument()
+      }
+    }
+  )
+
   it.each([false, true])('shows the document format in compact=%s mode', compact => {
     const { container } = render(
       <DocumentItem document={createDocument({ file_extension: '.xlsx' })} compact={compact} />

--- a/frontend/src/__tests__/features/knowledge/document/knowledge-document-tree-grid.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/knowledge-document-tree-grid.test.tsx
@@ -74,8 +74,15 @@ const requiredTreeGridProps = {
 }
 
 describe('KnowledgeDocumentTreeGrid', () => {
-  it('identifies imported documents as external rather than just their file extension', () => {
-    const documents = [createDocument({ source_type: 'external', file_extension: '.PDF' })]
+  it('shows the imported file format alongside its external origin without renaming it', () => {
+    const documents = [
+      createDocument({
+        source_type: 'external',
+        file_extension: '.PDF',
+        attachment_id: 42,
+        name: 'Imported report',
+      }),
+    ]
     const { nodes, index } = buildKnowledgeResourceTree([], documents)
     render(
       <KnowledgeDocumentTreeGrid
@@ -91,8 +98,10 @@ describe('KnowledgeDocumentTreeGrid', () => {
       />
     )
     expect(screen.getByText('document.document.type.external')).toBeInTheDocument()
+    expect(screen.getByText('PDF')).toBeInTheDocument()
     expect(screen.queryByText('.PDF')).not.toBeInTheDocument()
-    expect(screen.getByText('doc.txt').parentElement?.querySelector('svg')).toHaveClass(
+    expect(screen.queryByText('Imported report.pdf')).not.toBeInTheDocument()
+    expect(screen.getByText('Imported report').parentElement?.querySelector('svg')).toHaveClass(
       'lucide-file-text',
       'text-error'
     )

--- a/frontend/src/__tests__/features/knowledge/document/knowledge-source-preview.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/knowledge-source-preview.test.tsx
@@ -75,7 +75,6 @@ describe('KnowledgeSourcePreview', () => {
     await waitFor(() => expect(screen.getByTestId('mock-file-preview')).toBeInTheDocument())
     expect(screen.queryByTestId('knowledge-source-preview-download')).not.toBeInTheDocument()
     expect(fetchAttachmentFile).toHaveBeenCalledWith(3, {
-      filename: 'report.docx',
       signal: expect.any(AbortSignal),
     })
   })
@@ -100,6 +99,46 @@ describe('KnowledgeSourcePreview', () => {
     expect(screen.getByTestId('mock-file-preview')).toBeInTheDocument()
     expect(fetchAttachmentFile).toHaveBeenCalledTimes(1)
   })
+
+  it.each([
+    ['pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+    ['xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+  ])(
+    'preserves the downloaded %s filename when the document title has no extension',
+    async (extension, mimeType) => {
+      const filename = `原始资料.${extension}`
+      jest
+        .mocked(fetchAttachmentFile)
+        .mockImplementation(jest.requireActual('@/apis/attachments').fetchAttachmentFile)
+      const originalFetch = global.fetch
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({
+          'Content-Type': mimeType,
+          'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+        }),
+        blob: async () => new Blob(['office'], { type: mimeType }),
+      } as Response)
+      try {
+        render(
+          <KnowledgeSourcePreview
+            document={{
+              ...document,
+              name: '重命名后的资料',
+              source_type: 'external',
+              file_extension: extension,
+            }}
+            active
+            onDownload={onDownload}
+          />
+        )
+
+        expect(await screen.findByTestId('mock-file-preview')).toHaveTextContent(filename)
+      } finally {
+        global.fetch = originalFetch
+      }
+    }
+  )
 
   it('clears the loaded file when deactivated and fetches it again after reactivation', async () => {
     const { rerender } = render(

--- a/frontend/src/__tests__/features/knowledge/document/source-preview.test.ts
+++ b/frontend/src/__tests__/features/knowledge/document/source-preview.test.ts
@@ -27,7 +27,17 @@ describe('source preview rules', () => {
     }
   )
 
-  it('requires a file source and attachment', () => {
+  it.each(['pptx', 'xlsx'])('supports imported external %s attachments', fileExtension => {
+    expect(
+      isKnowledgeSourcePreviewSupported({
+        source_type: 'external',
+        attachment_id: 10,
+        file_extension: fileExtension,
+      })
+    ).toBe(true)
+  })
+
+  it('requires a supported source and attachment', () => {
     expect(
       isKnowledgeSourcePreviewSupported({
         source_type: 'text',
@@ -55,6 +65,29 @@ describe('source preview rules', () => {
       ).toBe(false)
     }
   })
+
+  it.each([null, 0])('rejects external placeholders without an attachment (%s)', attachmentId => {
+    expect(
+      isKnowledgeSourcePreviewSupported({
+        source_type: 'external',
+        attachment_id: attachmentId,
+        file_extension: 'xlsx',
+      })
+    ).toBe(false)
+  })
+
+  it.each(['md', 'ppt', ''])(
+    'keeps external %s content out of the Office preview',
+    fileExtension => {
+      expect(
+        isKnowledgeSourcePreviewSupported({
+          source_type: 'external',
+          attachment_id: 10,
+          file_extension: fileExtension,
+        })
+      ).toBe(false)
+    }
+  )
 
   it.each([null, undefined])('rejects a missing extension (%s)', fileExtension => {
     expect(

--- a/frontend/src/features/knowledge/document/components/DocumentDetailDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentDetailDialog.tsx
@@ -240,11 +240,14 @@ export function DocumentDetailDialog({
   const handleSourceDownload = useCallback(async () => {
     if (!document?.attachment_id) return
     try {
-      await downloadAttachment(document.attachment_id, document.name)
+      await downloadAttachment(
+        document.attachment_id,
+        document.source_type === 'external' ? undefined : document.name
+      )
     } catch {
       toast.error(t('document.document.detail.sourcePreview.downloadFailed'))
     }
-  }, [document?.attachment_id, document?.name, t])
+  }, [document?.attachment_id, document?.name, document?.source_type, t])
 
   const handleEdit = useCallback(async () => {
     if (!isEditable) return

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -392,7 +392,7 @@ export function DocumentItem({
                   {t('knowledge:document.document.type.web')}
                 </Badge>
               ) : isExternal ? (
-                <ExternalDocumentBadge className="text-[9px] px-1 py-0" />
+                <ExternalDocumentBadge document={document} className="text-[9px] px-1 py-0" />
               ) : (
                 <span className="text-[9px] text-text-muted uppercase">
                   {document.file_extension}
@@ -647,7 +647,7 @@ export function DocumentItem({
             {t('knowledge:document.document.type.web')}
           </Badge>
         ) : isExternal ? (
-          <ExternalDocumentBadge />
+          <ExternalDocumentBadge document={document} />
         ) : (
           <span className="text-xs text-text-muted uppercase">{document.file_extension}</span>
         )}

--- a/frontend/src/features/knowledge/document/components/DocumentUpload.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentUpload.tsx
@@ -75,7 +75,7 @@ function buildDefaultSplitterConfig(): Partial<SplitterConfig> {
 type UploadMode = 'file' | 'text' | 'web' | 'dingtalk'
 
 const SOURCE_HEIGHT: Record<UploadMode, string> = {
-  file: 'h-[540px] md:h-[480px]',
+  file: 'h-auto',
   web: 'h-[440px] md:h-[344px]',
   text: 'h-[580px]',
   dingtalk: 'h-[720px]',
@@ -511,6 +511,9 @@ function DocumentUploadSession({
             className="mt-0 flex min-h-0 flex-1 flex-col border-t border-border"
             hidden={uploadMode !== 'file'}
           >
+            {validationError && (
+              <div className="shrink-0 px-5 pt-3">{errorMessage(validationError)}</div>
+            )}
             <div className="min-h-0 flex-1 overflow-y-auto p-5">
               <div
                 className={cn(
@@ -567,7 +570,6 @@ function DocumentUploadSession({
                   }}
                 />
               </div>
-              {validationError && <div className="mt-3">{errorMessage(validationError)}</div>}
               {state.files.length > 0 && (
                 <div className="mt-4 space-y-3">
                   <div className="flex items-center justify-between">

--- a/frontend/src/features/knowledge/document/components/ExternalDocumentBadge.tsx
+++ b/frontend/src/features/knowledge/document/components/ExternalDocumentBadge.tsx
@@ -5,16 +5,29 @@
 import { Badge } from '@/components/ui/badge'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
+import type { KnowledgeDocument } from '@/types/knowledge'
 
-export function ExternalDocumentBadge({ className }: { className?: string }) {
+export function ExternalDocumentBadge({
+  document,
+  className,
+}: {
+  document: Pick<KnowledgeDocument, 'attachment_id' | 'file_extension'>
+  className?: string
+}) {
   const { t } = useTranslation('knowledge')
+  const extension = document.attachment_id
+    ? document.file_extension?.trim().replace(/^\.+/, '').toUpperCase()
+    : ''
   return (
-    <Badge
-      variant="default"
-      size="sm"
-      className={cn('bg-amber-500/10 text-amber-600 border-amber-500/20', className)}
-    >
-      {t('document.document.type.external')}
-    </Badge>
+    <span className="inline-flex max-w-full flex-wrap items-center justify-center gap-1 align-middle">
+      {extension && <span className="text-xs text-text-muted">{extension}</span>}
+      <Badge
+        variant="default"
+        size="sm"
+        className={cn('bg-amber-500/10 text-amber-600 border-amber-500/20', className)}
+      >
+        {t('document.document.type.external')}
+      </Badge>
+    </span>
   )
 }

--- a/frontend/src/features/knowledge/document/components/KnowledgeSourcePreview.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeSourcePreview.tsx
@@ -57,7 +57,6 @@ export function KnowledgeSourcePreview({
     setRenderError(null)
 
     fetchAttachmentFile(document.attachment_id, {
-      filename: document.name,
       signal: controller.signal,
     })
       .then(setFile)
@@ -70,7 +69,7 @@ export function KnowledgeSourcePreview({
       })
 
     return () => controller.abort()
-  }, [active, document.attachment_id, document.id, document.name, retryKey, tooLarge])
+  }, [active, document.attachment_id, document.id, retryKey, tooLarge])
 
   let content: ReactNode
   if (tooLarge) {

--- a/frontend/src/features/knowledge/document/components/knowledge-document-tree-grid.tsx
+++ b/frontend/src/features/knowledge/document/components/knowledge-document-tree-grid.tsx
@@ -528,7 +528,7 @@ export function KnowledgeDocumentTreeGrid({
           }
           const document = node.document
           if (document.source_type === 'external') {
-            return <ExternalDocumentBadge />
+            return <ExternalDocumentBadge document={document} />
           }
           if (document.source_type === 'table') {
             return (

--- a/frontend/src/features/knowledge/document/utils/sourcePreview.ts
+++ b/frontend/src/features/knowledge/document/utils/sourcePreview.ts
@@ -16,7 +16,7 @@ export function isKnowledgeSourcePreviewSupported(
   document: Pick<KnowledgeDocument, 'source_type' | 'attachment_id' | 'file_extension'>
 ): boolean {
   return (
-    document.source_type === 'file' &&
+    (document.source_type === 'file' || document.source_type === 'external') &&
     Boolean(document.attachment_id) &&
     SUPPORTED_SOURCE_PREVIEW_EXTENSIONS.has(
       normalizeSourcePreviewExtension(document.file_extension ?? '')


### PR DESCRIPTION
## 概述

修复钉钉文档导入后的原文件预览、类型展示，以及添加资料时错误提示不易被发现的问题。

## 改动

### 外部 Office 文档原文件预览

- 支持有有效附件的外部文档复用现有 Office/PDF 预览，保留“原文件／解析内容”切换。
- 预览和下载使用附件真实文件名，避免无扩展名的文档标题影响格式识别。
- 保持外部文档正文只读，不改变来源身份或权限规则。

### 同时展示格式与来源

- 类型区域同时展示 `XLSX/PPTX/MD` 等实际附件格式和“外部”标记。
- 保留原标题，不强制追加后缀。
- 覆盖树表、普通行和紧凑行；无附件的占位记录不展示初始占位格式。

### 保持上传错误提示可见

- 将文件校验错误放到滚动内容上方。
- 文件上传页改为自适应高度，避免错误被挤出可见区域。
- 保留来源切换、草稿和取消操作的现有行为。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for previewing and downloading external PPTX and XLSX attachments.
  - External documents now display their file type when an attachment is available.
  - Preserved downloaded filenames provided by the source attachment.

- **Bug Fixes**
  - Improved external-document downloads by avoiding incorrect renamed filenames.
  - Moved upload validation errors above the scrollable content for better visibility.
  - Prevented unsupported or missing attachments from being treated as previewable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->