### PR TITLE
fix(chat_shell): pre-cache o200k tokenizer

### DIFF
--- a/chat_shell/pyproject.toml
+++ b/chat_shell/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "langchain-anthropic>=1.4.0,<2.0.0",
     "langchain-google-genai>=4.0.0,<5.0.0",
     "langchain-mcp-adapters>=0.2.2",
-    "tiktoken>=0.5.0",
+    "tiktoken>=0.7.0",
     # Utilities
     "python-dotenv>=1.0.0",
     "tenacity>=8.2.3",

--- a/chat_shell/tests/test_dockerfile.py
+++ b/chat_shell/tests/test_dockerfile.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHAT_SHELL_DOCKERFILE = REPO_ROOT / "docker" / "chat_shell" / "Dockerfile"
+CHAT_SHELL_PYPROJECT = REPO_ROOT / "chat_shell" / "pyproject.toml"
 
 
 def test_chat_shell_image_precaches_tiktoken_encoding() -> None:
@@ -14,3 +15,9 @@ def test_chat_shell_image_precaches_tiktoken_encoding() -> None:
     assert 'ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"' in dockerfile
     assert 'tiktoken.get_encoding("cl100k_base")' in dockerfile
     assert 'tiktoken.get_encoding("o200k_base")' in dockerfile
+
+
+def test_chat_shell_requires_tiktoken_with_o200k_support() -> None:
+    pyproject = CHAT_SHELL_PYPROJECT.read_text(encoding="utf-8")
+
+    assert '"tiktoken>=0.7.0"' in pyproject

--- a/chat_shell/tests/test_dockerfile.py
+++ b/chat_shell/tests/test_dockerfile.py
@@ -13,3 +13,4 @@ def test_chat_shell_image_precaches_tiktoken_encoding() -> None:
 
     assert 'ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"' in dockerfile
     assert 'tiktoken.get_encoding("cl100k_base")' in dockerfile
+    assert 'tiktoken.get_encoding("o200k_base")' in dockerfile

--- a/chat_shell/uv.lock
+++ b/chat_shell/uv.lock
@@ -4195,7 +4195,7 @@ requires-dist = [
     { name = "sse-starlette", specifier = ">=1.6.5" },
     { name = "structlog", specifier = ">=23.1.0" },
     { name = "tenacity", specifier = ">=8.2.3" },
-    { name = "tiktoken", specifier = ">=0.5.0" },
+    { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
     { name = "wegent-shared", editable = "../shared" },
 ]

--- a/docker/chat_shell/Dockerfile
+++ b/docker/chat_shell/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i '/\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && \
 # not block while downloading the tokenizer vocabulary.
 ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"
 RUN mkdir -p "${TIKTOKEN_CACHE_DIR}" && \
-    python -c 'import tiktoken; tiktoken.get_encoding("cl100k_base").encode("warmup")'
+    python -c 'import tiktoken; tiktoken.get_encoding("cl100k_base").encode("warmup"); tiktoken.get_encoding("o200k_base").encode("warmup")'
 
 # Copy application code
 COPY chat_shell/chat_shell /app/chat_shell


### PR DESCRIPTION
## Summary

- pre-cache `o200k_base` alongside `cl100k_base` in the Chat Shell image
- prevent the first attachment request on each pod from downloading the tokenizer vocabulary at runtime
- extend the Dockerfile regression test to cover both encodings

## Root cause

Newer OpenAI model mappings use `o200k_base`, while the image only included the `cl100k_base` cache. The first request that counted attachment tokens therefore downloaded the missing vocabulary synchronously in `build_messages`.

## Verification

- `cd chat_shell && uv run pytest tests/test_dockerfile.py`
- built `docker/chat_shell/Dockerfile` successfully
- loaded both encodings from the built image with `--network none`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved chat shell startup by precaching multiple tokenizer encodings, helping reduce delays when processing compatible requests.

* **Compatibility**
  * Updated tokenizer support to accommodate newer encoding requirements and improve compatibility with supported models.

* **Tests**
  * Added coverage to verify that all required tokenizer encodings are precached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->