### PR TITLE
fix(wework): preserve runtime task model selection

### DIFF
--- a/docs/en/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/en/wework/developer-guide/wework-codex-plugins.md
@@ -110,6 +110,8 @@ Codex app-server requests from `item/commandExecution/requestApproval`, `item/fi
 
 Wework requests the model catalog from the Codex app-server's `model/list` method through the local executor, then uses the returned provider and model array order unchanged in the model picker. The frontend does not reorder official or default models or custom providers, and does not add models that Codex did not return. The request uses `includeHidden: false`, so models Codex marks as hidden are not displayed.
 
+Existing tasks preserve the model selection saved when the task was created or last sent. If that model is temporarily absent from the current catalog, Wework requires the user to select an available model and blocks sending; it does not silently replace the task model with the default model for new tasks.
+
 ### Supervisor Models
 
 Task supervision and chat use the same model selector component and the same model catalog, while remembering their most recent selections independently. Supervision must not maintain a second model-filtering or ordering path; official Codex models, custom providers, and local models available in chat must also be selectable for supervision.

--- a/docs/zh/wework/developer-guide/wework-codex-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-codex-plugins.md
@@ -110,6 +110,8 @@ Codex app-server 的 `item/commandExecution/requestApproval`、`item/fileChange/
 
 Wework 通过本机 executor 请求 Codex app-server 的 `model/list` 获取模型目录，并将返回的 provider 和模型数组顺序原样用于模型选择器。前端不会重排官方模型、默认模型或自定义 provider，也不会补充未由 Codex 返回的模型。请求使用 `includeHidden: false`，因此 Codex 标记为隐藏的模型不会显示。
 
+已有任务会保留创建或上次发送时保存的模型选择。如果该模型暂时不在当前模型目录中，Wework 会要求用户重新选择可用模型，并阻止继续发送；它不会把新任务的默认模型静默替换到已有任务中。
+
 ### 监督模型
 
 任务监督与会话共用同一个模型选择组件和同一份模型目录，但分别保存最近一次选择。监督设置不能维护第二套模型过滤或排序逻辑；会话中可选的官方 Codex 模型、自定义 provider 和本地模型也必须在监督中可选。

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -5546,6 +5546,162 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(updateCurrentUser).not.toHaveBeenCalled()
   })
 
+  test('does not replace an unavailable runtime task model with the new-chat default', async () => {
+    const deepseekModel: UnifiedModel = {
+      name: 'deepseek-v4-flash-responses(公网)',
+      type: 'public',
+      provider: 'cloud',
+      runtime: { family: 'openai.openai-responses' },
+    }
+    const sendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: true,
+      taskId: 'runtime-a',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  id: 22,
+                  projectId: 7,
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [
+                    {
+                      taskId: 'runtime-a',
+                      workspacePath: '/workspace/project-alpha',
+                      title: 'Runtime A',
+                      runtime: 'codex',
+                      modelSelection: {
+                        modelName: 'gpt-5.6-sol',
+                        modelType: 'runtime',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        })
+      ),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      modelApi: {
+        listModels: vi.fn().mockResolvedValue({ data: [deepseekModel] }),
+      },
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    } as Partial<WorkbenchServices>)
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await userEvent.click(await screen.findByText('open project runtime task'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-selected-model')).toHaveTextContent('none')
+    )
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pane-session-error')).toHaveTextContent('请选择 Wework 模型')
+    )
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
+  test('blocks interrupt-and-send when the runtime task model is unavailable', async () => {
+    const deepseekModel: UnifiedModel = {
+      name: 'deepseek-v4-flash-responses(公网)',
+      type: 'public',
+      provider: 'cloud',
+      runtime: { family: 'openai.openai-responses' },
+    }
+    const interruptAndSendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: true,
+      taskId: 'runtime-a',
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  id: 22,
+                  projectId: 7,
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  tasks: [
+                    {
+                      taskId: 'runtime-a',
+                      workspacePath: '/workspace/project-alpha',
+                      title: 'Runtime A',
+                      runtime: 'codex',
+                      running: true,
+                      modelSelection: {
+                        modelName: 'gpt-5.6-sol',
+                        modelType: 'runtime',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          totalTasks: 1,
+        })
+      ),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'codex',
+        messages: [],
+      }),
+      interruptAndSendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      modelApi: {
+        listModels: vi.fn().mockResolvedValue({ data: [deepseekModel] }),
+      },
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    } as Partial<WorkbenchServices>)
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <FollowUpProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() => expect(screen.getByTestId('follow-up-pane-busy')).toHaveTextContent('busy'))
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+    await waitFor(() =>
+      expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:继续修')
+    )
+    await userEvent.click(screen.getByTestId('queued-interrupt-and-send-first'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pane-session-error')).toHaveTextContent('请选择 Wework 模型')
+    )
+    expect(interruptAndSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
   test('only exposes an active model while a runtime task owns the conversation', async () => {
     const models: UnifiedModel[] = [
       {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -907,6 +907,7 @@ export function WorkbenchProvider({
     persistSelection: !state.currentRuntimeTask && !usesLocalProjectScopedSelection,
     selectionConfig: modelSelectionConfig,
     defaultSelectionConfig: defaultModelSelectionConfig,
+    fallbackWhenConfiguredModelUnavailable: !state.currentRuntimeTask,
     selectionReady: !state.isBootstrapping,
     onSelectionChange: persistNewChatModelSelection,
     onSelectionBlocked: handleBlockedModelSelection,

--- a/wework/src/features/workbench/useWorkbenchModels.ts
+++ b/wework/src/features/workbench/useWorkbenchModels.ts
@@ -31,6 +31,7 @@ interface UseWorkbenchModelsOptions {
   persistSelection?: boolean
   selectionConfig?: ModelSelectionConfig | null
   defaultSelectionConfig?: (models: UnifiedModel[]) => ModelSelectionConfig | null
+  fallbackWhenConfiguredModelUnavailable?: boolean
   selectionReady?: boolean
   onSelectionChange?: (selection: ModelSelectionConfig) => void
   onSelectionBlocked?: (
@@ -85,6 +86,7 @@ export function useWorkbenchModels({
   persistSelection = true,
   selectionConfig,
   defaultSelectionConfig,
+  fallbackWhenConfiguredModelUnavailable = true,
   selectionReady = true,
   onSelectionChange,
   onSelectionBlocked,
@@ -110,30 +112,54 @@ export function useWorkbenchModels({
   const [restoredSelectionKeyByScope, setRestoredSelectionKeyByScope] = useState<
     Record<string, string | null>
   >({})
+  const [locallySelectedReplacementByScope, setLocallySelectedReplacementByScope] = useState<
+    Record<string, boolean>
+  >({})
   const effectiveSelectionConfig = useMemo(() => {
-    if (selectionConfig?.modelName && findModelForSelection(models, selectionConfig)) {
-      return selectionConfig
+    if (selectionConfig?.modelName) {
+      if (
+        findModelForSelection(models, selectionConfig) ||
+        !fallbackWhenConfiguredModelUnavailable
+      ) {
+        return selectionConfig
+      }
     }
     return defaultSelectionConfig?.(models) ?? selectionConfig ?? null
-  }, [defaultSelectionConfig, models, selectionConfig])
+  }, [defaultSelectionConfig, fallbackWhenConfiguredModelUnavailable, models, selectionConfig])
   const selectionKey = useMemo(
     () => getSelectionKey(effectiveSelectionConfig),
     [effectiveSelectionConfig]
   )
+  const configuredModelAvailable = Boolean(
+    effectiveSelectionConfig?.modelName && findModelForSelection(models, effectiveSelectionConfig)
+  )
+  const selectedModelAvailable = Boolean(
+    selectedModel && models.some(model => isSameModelSelection(model, selectedModel))
+  )
+  const hasLocallySelectedReplacement = Boolean(
+    !persistSelection &&
+    !configuredModelAvailable &&
+    locallySelectedReplacementByScope[scopeKey] &&
+    selectedModelAvailable
+  )
   const selectionMatchesConfig = Boolean(
+    hasLocallySelectedReplacement ||
+    (selectedModel && findModelForSelection([selectedModel], effectiveSelectionConfig))
+  )
+  const configuredModelUnavailable = Boolean(
     effectiveSelectionConfig?.modelName &&
-    selectedModel &&
-    selectedModel.name === effectiveSelectionConfig.modelName &&
-    (!effectiveSelectionConfig.modelType ||
-      selectedModel.type === effectiveSelectionConfig.modelType)
+    !configuredModelAvailable &&
+    !hasLocallySelectedReplacement
   )
   const isSelectionReady = useMemo(
     () =>
       !enabled ||
       (selectionReady &&
         !isLoading &&
+        !configuredModelUnavailable &&
         (restoredSelectionKeyByScope[scopeKey] === selectionKey || selectionMatchesConfig)),
     [
+      configuredModelUnavailable,
       enabled,
       isLoading,
       restoredSelectionKeyByScope,
@@ -160,6 +186,9 @@ export function useWorkbenchModels({
         if (areModelOptionsEqual(current[scopeKey] ?? {}, nextOptions)) return current
         return { ...current, [scopeKey]: nextOptions }
       })
+      setLocallySelectedReplacementByScope(current =>
+        current[scopeKey] ? { ...current, [scopeKey]: false } : current
+      )
     },
     [scopeKey]
   )
@@ -308,6 +337,10 @@ export function useWorkbenchModels({
       selectedModelOptionsRef.current[scopeKey] = nextOptions
       setSelectedModelByScope(current => ({ ...current, [scopeKey]: model }))
       setSelectedModelOptionsByScope(current => ({ ...current, [scopeKey]: nextOptions }))
+      setLocallySelectedReplacementByScope(current => ({
+        ...current,
+        [scopeKey]: !persistSelection && Boolean(model),
+      }))
       if (model && persistSelection) {
         onSelectionChange?.(toSelectionConfig(model, nextOptions))
       }
@@ -378,6 +411,7 @@ export function useWorkbenchModels({
     selectedModel,
     selectedModelOptions,
     isSelectionReady,
+    isConfiguredModelUnavailable: configuredModelUnavailable,
     setSelectedModel,
     setSelectedModelAndOptions,
     setSelectedModelOption,

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -227,6 +227,8 @@ interface RuntimeMessagingModelSelection {
   models: UnifiedModel[]
   selectedModel: UnifiedModel | null
   selectedModelOptions: ModelOptions
+  isSelectionReady?: boolean
+  isConfiguredModelUnavailable?: boolean
   getSelectedModel?: () => UnifiedModel | null
   getSelectedModelOptions?: () => ModelOptions
   setSelectionForScope?: (
@@ -420,8 +422,36 @@ export function useWorkbenchRuntimeMessaging({
     [services.attachmentApi, state.devices]
   )
 
+  const blockRuntimeSendForUnavailableModel = useCallback(
+    (address: RuntimeTaskAddress, options?: RuntimePaneActionOptions): boolean => {
+      const isCurrentTask =
+        state.currentRuntimeTask && isSameRuntimeTaskIdentity(state.currentRuntimeTask, address)
+      if (
+        !isCurrentTask ||
+        (modelSelection.isSelectionReady !== false &&
+          modelSelection.isConfiguredModelUnavailable !== true)
+      ) {
+        return false
+      }
+      reportSendBlocked(
+        i18n.t('workbench.harness_model_required', '请选择可用的 Wework 模型'),
+        undefined,
+        options
+      )
+      return true
+    },
+    [
+      modelSelection.isConfiguredModelUnavailable,
+      modelSelection.isSelectionReady,
+      reportSendBlocked,
+      state.currentRuntimeTask,
+    ]
+  )
+
   const sendRuntimePaneMessage = useCallback(
     async (request: RuntimeSendRequest, options?: RuntimePaneActionOptions): Promise<boolean> => {
+      if (blockRuntimeSendForUnavailableModel(request.address, options)) return false
+
       let sendRequested = false
       const optimisticUserMessage = options?.optimisticUserMessage
       const outboundRequestWithClientId = optimisticUserMessage
@@ -497,11 +527,20 @@ export function useWorkbenchRuntimeMessaging({
         return false
       }
     },
-    [executorClient, lifecycleStore, prepareRuntimeSendRequest, refreshWorkLists, reportError]
+    [
+      blockRuntimeSendForUnavailableModel,
+      executorClient,
+      lifecycleStore,
+      prepareRuntimeSendRequest,
+      refreshWorkLists,
+      reportError,
+    ]
   )
 
   const interruptAndSendRuntimePaneMessage = useCallback(
     async (request: RuntimeSendRequest, options?: RuntimePaneActionOptions): Promise<boolean> => {
+      if (blockRuntimeSendForUnavailableModel(request.address, options)) return false
+
       let sendRequested = false
       try {
         const outboundRequest = await prepareRuntimeSendRequest(request)
@@ -532,11 +571,20 @@ export function useWorkbenchRuntimeMessaging({
         return false
       }
     },
-    [executorClient, lifecycleStore, prepareRuntimeSendRequest, refreshWorkLists, reportError]
+    [
+      blockRuntimeSendForUnavailableModel,
+      executorClient,
+      lifecycleStore,
+      prepareRuntimeSendRequest,
+      refreshWorkLists,
+      reportError,
+    ]
   )
 
   const editLastUserMessage = useCallback(
     async (request: RuntimeRollbackRequest): Promise<boolean> => {
+      if (blockRuntimeSendForUnavailableModel(request.address)) return false
+
       let sendRequested = false
       try {
         const outboundRequest = await prepareRuntimeSendRequest(request)
@@ -577,7 +625,14 @@ export function useWorkbenchRuntimeMessaging({
         return false
       }
     },
-    [dispatch, executorClient, lifecycleStore, prepareRuntimeSendRequest, refreshWorkLists]
+    [
+      blockRuntimeSendForUnavailableModel,
+      dispatch,
+      executorClient,
+      lifecycleStore,
+      prepareRuntimeSendRequest,
+      refreshWorkLists,
+    ]
   )
 
   const sendRuntimePaneGuidance = useCallback(

--- a/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
+++ b/wework/src/features/workbench/workbenchProjectChatHooks.test.tsx
@@ -687,6 +687,47 @@ describe('workbench project chat hooks', () => {
     expect(result.current.selectedModelOptions).toEqual({})
   })
 
+  test('does not replace an unavailable configured task model with the default model', async () => {
+    const deepseekModel: UnifiedModel = {
+      name: 'deepseek-v4-flash-responses(公网)',
+      type: 'public',
+    }
+    const api = {
+      listModels: vi.fn().mockResolvedValue({ data: [deepseekModel] }),
+    }
+    const onSelectionChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useWorkbenchModels({
+        api,
+        locked: false,
+        persistSelection: false,
+        selectionConfig: {
+          modelName: 'gpt-5.6-sol',
+          modelType: 'runtime',
+        },
+        defaultSelectionConfig: () => ({
+          modelName: deepseekModel.name,
+          modelType: deepseekModel.type,
+        }),
+        fallbackWhenConfiguredModelUnavailable: false,
+        onSelectionChange,
+      })
+    )
+
+    await waitFor(() => expect(result.current.models).toEqual([deepseekModel]))
+    expect(result.current.selectedModel).toBeNull()
+    expect(result.current.isSelectionReady).toBe(false)
+    expect(result.current.isConfiguredModelUnavailable).toBe(true)
+
+    act(() => result.current.setSelectedModel(deepseekModel))
+
+    expect(result.current.selectedModel).toEqual(deepseekModel)
+    expect(result.current.isSelectionReady).toBe(true)
+    expect(result.current.isConfiguredModelUnavailable).toBe(false)
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
   test('persists options when using the default model selection', async () => {
     const gptModel: UnifiedModel = {
       name: 'overseas-gpt-5.4',


### PR DESCRIPTION
## Summary

- preserve the model saved on an existing runtime task when it is temporarily absent from the current catalog
- block sends instead of silently substituting the default model for new tasks
- document the behavior in the Chinese and English Codex runtime guides

## Root cause

When an existing task model could not be resolved from the current catalog, the workbench reused the new-task default selection. The pane send path then resolved and submitted that fallback model, which could switch a Codex task to a configured DeepSeek model.

## Verification

- `pnpm --filter wework test src/features/workbench/workbenchProjectChatHooks.test.tsx src/features/workbench/WorkbenchProvider.test.tsx` (236 passed)
- `pnpm --filter wework exec tsc --noEmit`
- focused Prettier and ESLint checks
- pre-push Wework ESLint, TypeScript, and unit test gates
- isolated real Electron startup and composer smoke verification

Task: WEWORKC2FA61-424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Existing tasks now retain their saved model selection.
  * If that model is unavailable, users must select an available model before sending messages.
  * Prevented unavailable models from being silently replaced with the default model.
  * Added a clear localized message when sending is blocked due to an unavailable model.

* **Documentation**
  * Updated English and Chinese guides to describe the model selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->