### PR TITLE
fix(wework): keep model picker above embedded browser

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,9 @@ importers:
       '@pierre/trees':
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.5(@types/react@19.2.17)(react@19.2.7)

--- a/wework/e2e/desktop/modules/window-attachment-flows.mjs
+++ b/wework/e2e/desktop/modules/window-attachment-flows.mjs
@@ -72,6 +72,63 @@ function desktopWindowLogPath() {
   return join(resultDir, 'app.log')
 }
 
+async function waitForInlineStyleValue(control, selector, property, expected, message) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < DEFAULT_STEP_TIMEOUT_MS) {
+    const value = await control.command('getInlineStyle', selector, { value: property })
+    if (value === expected) return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(message)
+}
+
+async function openBrowserForModelSwitchWarning(control) {
+  const browserInputSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-url-input"]`
+  let snapshot = JSON.parse(await control.command('snapshot', ACTIVE_WORKBENCH_SELECTOR))
+  if (!snapshot.testIds.includes('workspace-browser-url-input')) {
+    if (!snapshot.testIds.includes('right-workspace-browser-option')) {
+      await control.command('click', '[data-testid="toggle-right-workspace-panel-button"]')
+      snapshot = await waitForSnapshot(
+        control,
+        value =>
+          value.testIds.includes('right-workspace-browser-option') ||
+          value.testIds.includes('right-workspace-new-tab-button'),
+        'The right workspace did not expose a browser launcher',
+        DEFAULT_STEP_TIMEOUT_MS,
+        ACTIVE_WORKBENCH_SELECTOR
+      )
+    }
+    if (!snapshot.testIds.includes('right-workspace-browser-option')) {
+      await control.command('click', '[data-testid="right-workspace-new-tab-button"]')
+      await control.command('waitFor', '[data-testid="right-workspace-browser-option"]', {
+        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+      })
+    }
+    await control.command('click', '[data-testid="right-workspace-browser-option"]')
+  }
+  await control.command('waitFor', browserInputSelector, {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('fill', browserInputSelector, {
+    value: new URL(control.url).origin,
+  })
+  await control.command('submit', browserInputSelector)
+  await control.command(
+    'waitFor',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-native-view"]`,
+    { timeoutMs: DEFAULT_STEP_TIMEOUT_MS }
+  )
+  await control.command('waitFor', '[data-testid="workspace-browser-electron-webview"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('waitFor', '[data-testid="right-workspace-resize-handle"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command('drag', '[data-testid="right-workspace-resize-handle"]', {
+    target: ACTIVE_SWITCH_MODEL_RETRY_SELECTOR,
+  })
+}
+
 async function verifyCrossProviderSwitchRetry(control, composerSelector) {
   control.setScenario('provider_switch_retry')
   await control.command('click', '[data-testid="new-chat-button"]')
@@ -90,6 +147,7 @@ async function verifyCrossProviderSwitchRetry(control, composerSelector) {
     'The failed Luna turn was unexpectedly sent more than once'
   )
 
+  await openBrowserForModelSwitchWarning(control)
   await control.command('scrollIntoView', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR)
   await control.command('clickWhenEnabled', ACTIVE_SWITCH_MODEL_RETRY_SELECTOR, {
     stableMs: COMPOSER_READY_STABILITY_MS,
@@ -99,6 +157,58 @@ async function verifyCrossProviderSwitchRetry(control, composerSelector) {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await ensureModelOptionVisible(control, `model-option-${PROVIDER_SWITCH_OFFICIAL_OPTION_ID}`)
+  const modelSubmenuMetrics = await getSingleElementMetrics(
+    control,
+    '[data-testid="model-selector-submenu"]',
+    'The narrow-pane model submenu'
+  )
+  const viewportMetrics = await getSingleElementMetrics(
+    control,
+    ACTIVE_WORKBENCH_SELECTOR,
+    'The desktop viewport'
+  )
+  const rightPanelMetrics = await getSingleElementMetrics(
+    control,
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`,
+    'The right workspace panel'
+  )
+  const browserHostMetrics = await getSingleElementMetrics(
+    control,
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-native-view"]`,
+    'The embedded browser host'
+  )
+  assert.ok(
+    modelSubmenuMetrics.top >= 64 && modelSubmenuMetrics.bottom <= viewportMetrics.bottom - 16,
+    `The narrow-pane model submenu exceeded the desktop viewport: ${JSON.stringify({
+      modelSubmenuMetrics,
+      viewportMetrics,
+    })}`
+  )
+  assert.ok(
+    modelSubmenuMetrics.width >= 280 &&
+      modelSubmenuMetrics.left >= 16 &&
+      modelSubmenuMetrics.right <= viewportMetrics.right - 16 &&
+      modelSubmenuMetrics.right > rightPanelMetrics.left &&
+      modelSubmenuMetrics.right > browserHostMetrics.left &&
+      modelSubmenuMetrics.left < browserHostMetrics.right &&
+      modelSubmenuMetrics.bottom > browserHostMetrics.top &&
+      modelSubmenuMetrics.top < browserHostMetrics.bottom,
+    `The narrow-pane model submenu was compressed instead of using the browser overlay: ${JSON.stringify(
+      {
+        browserHostMetrics,
+        modelSubmenuMetrics,
+        rightPanelMetrics,
+      }
+    )}`
+  )
+  await waitForInlineStyleValue(
+    control,
+    '[data-testid="workspace-browser-electron-webview"]',
+    'pointer-events',
+    'none',
+    'The model flyout did not block interaction with the embedded browser'
+  )
+  await captureVerificationScreenshot(control, 'model-switch-browser-picker-open.png')
   const officialModelSelector = `[data-testid="model-option-${PROVIDER_SWITCH_OFFICIAL_OPTION_ID}"]`
   await control.command('waitFor', officialModelSelector, {
     text: PROVIDER_SWITCH_OFFICIAL_LABEL,
@@ -108,9 +218,33 @@ async function verifyCrossProviderSwitchRetry(control, composerSelector) {
   await control.command('waitFor', '[data-testid="model-switch-warning-dialog"]', {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await waitForInlineStyleValue(
+    control,
+    '[data-testid="workspace-browser-electron-webview"]',
+    'pointer-events',
+    'none',
+    'The model switch dialog did not block interaction with the embedded browser'
+  )
+  await captureVerificationScreenshot(control, 'model-switch-browser-dialog-open.png')
   await control.command('clickWhenEnabled', '[data-testid="model-switch-warning-confirm-button"]', {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await waitForSnapshot(
+    control,
+    snapshot =>
+      !snapshot.testIds.includes('model-switch-warning-dialog') &&
+      snapshot.testIds.includes('workspace-browser-native-view'),
+    'The model switch dialog did not restore the embedded browser',
+    DEFAULT_STEP_TIMEOUT_MS
+  )
+  await waitForInlineStyleValue(
+    control,
+    '[data-testid="workspace-browser-electron-webview"]',
+    'pointer-events',
+    'auto',
+    'The embedded browser remained blocked after the model switch dialog closed'
+  )
+  await captureVerificationScreenshot(control, 'model-switch-browser-dialog-closed.png')
   await control.command('waitFor', '[data-testid="message-assistant"]', {
     text: PROVIDER_SWITCH_COMPLETION,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,

--- a/wework/package.json
+++ b/wework/package.json
@@ -80,6 +80,7 @@
     "@mantine/hooks": "^8.3.18",
     "@pierre/diffs": "^1.2.11",
     "@pierre/trees": "1.0.0-beta.4",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/react": "^8.55.0",
     "@tailwindcss/typography": "^0.5.19",

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -670,6 +670,7 @@ describe('ChatInput', () => {
       config: { ui: { family: 'local' } },
     }
     const setSelectedModel = vi.fn()
+    const onModelSelectorOpenChange = vi.fn()
 
     render(
       <ChatInput
@@ -683,6 +684,7 @@ describe('ChatInput', () => {
           activeModel,
           selectedModel: activeModel,
           setSelectedModel,
+          onModelSelectorOpenChange,
         })}
       />
     )
@@ -694,13 +696,18 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('model-switch-warning-dialog')).toHaveTextContent(
       'Switching to Second Model may change how the existing context is understood.'
     )
-    expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
+    expect(screen.getByTestId('model-switch-warning-dialog-overlay').parentElement).toBe(
+      document.body
+    )
+    expect(screen.queryByTestId('model-selector-menu')).not.toBeInTheDocument()
     expect(setSelectedModel).not.toHaveBeenCalled()
+    expect(onModelSelectorOpenChange).toHaveBeenLastCalledWith(false, 'selection')
 
     await userEvent.click(screen.getByTestId('model-switch-warning-cancel-button'))
 
     expect(screen.queryByTestId('model-switch-warning-dialog')).not.toBeInTheDocument()
     expect(setSelectedModel).not.toHaveBeenCalled()
+    expect(onModelSelectorOpenChange).toHaveBeenLastCalledWith(false, 'dismiss')
 
     await userEvent.click(screen.getByTestId('model-selector-button'))
     await userEvent.hover(screen.getByTestId('model-control-menu-model'))
@@ -1084,6 +1091,7 @@ describe('ChatInput', () => {
     await userEvent.click(screen.getByTestId('send-message-button'))
 
     expect(screen.getByTestId('paused-queue-send-dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('paused-queue-send-dialog-overlay').parentElement).toBe(document.body)
     expect(onSubmit).not.toHaveBeenCalled()
 
     await userEvent.click(screen.getByTestId('paused-queue-send-preserve-button'))
@@ -1744,7 +1752,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('model-selector-menu').parentElement).toHaveClass(
       'fixed',
       'z-system-popover',
-      'w-64'
+      'w-[224px]'
     )
     expect(screen.getByTestId('model-selector-menu').parentElement?.parentElement).toBe(
       document.body
@@ -1768,7 +1776,7 @@ describe('ChatInput', () => {
       'data-enter-animation',
       'submenu'
     )
-    expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ left: '256px' })
+    expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ width: '280px' })
     const modelOption = screen.getByTestId('model-option-overseas-gpt-5.5')
     expect(modelOption).toHaveTextContent('海外:gpt-5.5')
     expect(modelOption).not.toHaveTextContent('High')
@@ -1840,7 +1848,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('model-control-speed-fast')).toBeInTheDocument()
     expect(screen.getByTestId('model-control-speed-fast')).toHaveTextContent('快速')
     expect(screen.getByTestId('model-control-speed-fast')).not.toHaveTextContent('⚡')
-    expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ left: '256px' })
+    expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({ width: '233px' })
 
     const speedMenuItem = screen.getByTestId('model-control-menu-speed')
     const resetRow = screen.getByTestId('model-reset-default-row')
@@ -2753,7 +2761,7 @@ describe('ChatInput', () => {
     expect(screen.queryByTestId('model-selector-menu')).not.toBeInTheDocument()
   })
 
-  test('keeps the desktop model submenu inside the viewport near the bottom edge', async () => {
+  test('constrains the desktop model submenu to the available viewport height', async () => {
     const originalInnerHeight = window.innerHeight
     Object.defineProperty(window, 'innerHeight', {
       configurable: true,
@@ -2837,9 +2845,9 @@ describe('ChatInput', () => {
       await userEvent.hover(screen.getByTestId('model-control-menu-model'))
 
       await waitFor(() => {
-        expect(screen.getByTestId('model-selector-submenu')).toHaveStyle({
-          top: '20px',
-        })
+        expect(screen.getByTestId('model-selector-submenu').style.maxHeight).toBe(
+          'min(var(--radix-popover-content-available-height), calc(100vh - 16px))'
+        )
       })
     } finally {
       Object.defineProperty(window, 'innerHeight', {

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -10,6 +10,7 @@ import {
   X,
 } from 'lucide-react'
 import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import type { TFunction } from 'i18next'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -55,6 +56,7 @@ import {
 import type { PluginTrialRefinementRequest } from '@/features/plugins/usePluginTrialPromptRefinement'
 import type { ComposerTextareaHandle } from './composer/ComposerTextarea'
 import { ComposerPluginIcon } from './composer/ComposerPluginIcon'
+import type { ModelSelectorCloseReason } from './composer/model-selector-types'
 import { runtimeProjectUiId } from '@/lib/runtime-project'
 import type { QuickPhrase } from '@/desktop/appPreferences'
 
@@ -86,7 +88,7 @@ export interface ProjectChatControls {
   contextUsage?: RuntimeContextUsage
   isOptionsLocked: boolean
   modelSelectorOpenSignal?: number
-  onModelSelectorOpenChange?: (open: boolean) => void
+  onModelSelectorOpenChange?: (open: boolean, closeReason?: ModelSelectorCloseReason) => void
   setSelectedModel: (model: UnifiedModel | null) => void
   setSelectedModelAndOptions?: (model: UnifiedModel, options: ModelOptions) => void
   setSelectedModelOption: (optionId: string, value: string) => void
@@ -766,6 +768,10 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     setPendingModelSelection(null)
     applyModelSelection(model, options)
   }
+  const cancelModelSelection = () => {
+    setPendingModelSelection(null)
+    controls.onModelSelectorOpenChange?.(false, 'dismiss')
+  }
 
   const handleSubmit = (valueOverride?: string, options?: ChatSubmitOptions) => {
     const submittedValue = (valueOverride ?? value).trim()
@@ -862,7 +868,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
         pendingModelSelection.model?.name ||
         t('workbench.model_auto_select', 'Auto select')
       }
-      onCancel={() => setPendingModelSelection(null)}
+      onCancel={cancelModelSelection}
       onConfirm={confirmModelSelection}
     />
   ) : null
@@ -1109,7 +1115,7 @@ function QueueResumeDialog({
   onPreserve: () => void
   onClear: () => void
 }) {
-  return (
+  return createPortal(
     <div
       data-testid="paused-queue-send-dialog-overlay"
       className="fixed inset-0 z-modal flex items-center justify-center bg-black/35 px-4"
@@ -1163,7 +1169,8 @@ function QueueResumeDialog({
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }
 
@@ -1178,7 +1185,7 @@ function ModelSwitchWarningDialog({
   onCancel: () => void
   onConfirm: () => void
 }) {
-  return (
+  return createPortal(
     <div
       data-testid="model-switch-warning-dialog-overlay"
       className="fixed inset-0 z-modal flex items-center justify-center bg-black/35 px-4"
@@ -1232,6 +1239,7 @@ function ModelSwitchWarningDialog({
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -9,6 +9,7 @@ import { AddContextMenu } from './AddContextMenu'
 import { ComposerModePill, GoalDraftPill } from './GoalDraftPill'
 import { ContextUsageIndicator } from './ContextUsageIndicator'
 import { ModelSelector } from './ModelSelector'
+import type { ModelSelectorCloseReason } from './model-selector-types'
 import { PluginPickerMenu } from './PluginPickerMenu'
 import { PopoutWorkspaceMenu } from './PopoutWorkspaceMenu'
 import { QuickPhraseMenu } from './QuickPhraseMenu'
@@ -31,7 +32,7 @@ interface ComposerToolbarProps {
   activeModel?: UnifiedModel | null
   selectedModelOptions: ModelOptions
   modelSelectorOpenSignal?: number
-  onModelSelectorOpenChange?: (open: boolean) => void
+  onModelSelectorOpenChange?: (open: boolean, closeReason?: ModelSelectorCloseReason) => void
   isModelSelectionReady: boolean
   contextUsage?: RuntimeContextUsage
   onSelectModel: (model: UnifiedModel | null) => boolean | void

--- a/wework/src/components/chat/composer/ModelSelector.module.css
+++ b/wework/src/components/chat/composer/ModelSelector.module.css
@@ -4,8 +4,13 @@
 }
 
 .submenu {
-  transform-origin: left bottom;
+  transform-origin: var(--radix-popover-content-transform-origin);
+  --model-selector-submenu-enter-x: -7px;
   animation: model-selector-submenu-enter 170ms cubic-bezier(0.2, 0, 0, 1) both;
+}
+
+.submenu[data-side='left'] {
+  --model-selector-submenu-enter-x: 7px;
 }
 
 .advancedPanel {
@@ -28,7 +33,7 @@
 @keyframes model-selector-submenu-enter {
   from {
     opacity: 0;
-    transform: translate3d(-7px, 3px, 0) scale(0.985);
+    transform: translate3d(var(--model-selector-submenu-enter-x), 3px, 0) scale(0.985);
   }
 
   to {

--- a/wework/src/components/chat/composer/ModelSelector.module.css
+++ b/wework/src/components/chat/composer/ModelSelector.module.css
@@ -6,6 +6,7 @@
 .submenu {
   transform-origin: var(--radix-popover-content-transform-origin);
   --model-selector-submenu-enter-x: -7px;
+
   animation: model-selector-submenu-enter 170ms cubic-bezier(0.2, 0, 0, 1) both;
 }
 

--- a/wework/src/components/chat/composer/ModelSelector.test.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.test.tsx
@@ -17,6 +17,11 @@ vi.mock('@/lib/navigation', () => ({
   navigateTo: navigateToMock,
 }))
 
+const embeddedBrowserOcclusionMock = vi.hoisted(() => vi.fn())
+vi.mock('@/hooks/useEmbeddedBrowserOcclusion', () => ({
+  useEmbeddedBrowserOcclusion: embeddedBrowserOcclusionMock,
+}))
+
 const modelExecutionMock = vi.hoisted(() => ({
   supportsResponsesApi: vi.fn().mockReturnValue(false),
 }))
@@ -29,12 +34,13 @@ vi.mock('@/hooks/useTranslation', () => ({
 }))
 
 import { ModelSelector } from './ModelSelector'
+import { getDesktopModelSelectorCollisionPadding } from './model-selector-layout'
 
 const SHELL_LEFT = 800
 const WINDOW_INNER_WIDTH = 1200
 const WINDOW_INNER_HEIGHT = 900
 
-function createShellElement(options?: { hidden?: boolean }): HTMLDivElement {
+function createShellElement(options?: { hidden?: boolean; left?: number }): HTMLDivElement {
   const shell = document.createElement('div')
   shell.id = 'right-workspace-panel-shell'
   shell.setAttribute('data-testid', 'right-workspace-panel-shell')
@@ -43,15 +49,16 @@ function createShellElement(options?: { hidden?: boolean }): HTMLDivElement {
   } else {
     shell.setAttribute('aria-hidden', 'false')
   }
+  const shellLeft = options?.left ?? SHELL_LEFT
   shell.getBoundingClientRect = () =>
     ({
       top: 0,
-      left: options?.hidden ? WINDOW_INNER_WIDTH : SHELL_LEFT,
+      left: options?.hidden ? WINDOW_INNER_WIDTH : shellLeft,
       right: WINDOW_INNER_WIDTH,
       bottom: WINDOW_INNER_HEIGHT,
-      width: options?.hidden ? 0 : WINDOW_INNER_WIDTH - SHELL_LEFT,
+      width: options?.hidden ? 0 : WINDOW_INNER_WIDTH - shellLeft,
       height: WINDOW_INNER_HEIGHT,
-      x: options?.hidden ? WINDOW_INNER_WIDTH : SHELL_LEFT,
+      x: options?.hidden ? WINDOW_INNER_WIDTH : shellLeft,
       y: 0,
       toJSON: () => {},
     }) as DOMRect
@@ -107,6 +114,7 @@ describe('ModelSelector desktop layout', () => {
     isMobileMock.mockReturnValue(false)
     configuredKeybindingMock.mockReturnValue(null)
     navigateToMock.mockReset()
+    embeddedBrowserOcclusionMock.mockClear()
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       value: WINDOW_INNER_WIDTH,
@@ -257,6 +265,187 @@ describe('ModelSelector desktop layout', () => {
     expect(submenu).toHaveTextContent('Claude')
     expect(screen.getByTestId(`model-option-${SECOND_FAMILY_MODEL.name}`)).toBeInTheDocument()
     expect(screen.getByTestId(`model-option-${SAMPLE_MODEL.name}`)).toBeInTheDocument()
+  })
+
+  test('closes the picker when model selection is deferred to a confirmation dialog', async () => {
+    createShellElement({ hidden: true })
+    const onSelectModel = vi.fn().mockReturnValue(false)
+    const onOpenChange = vi.fn()
+
+    render(
+      <ModelSelector
+        models={[SAMPLE_MODEL]}
+        selectedModel={SAMPLE_MODEL}
+        selectedModelOptions={{}}
+        disabled={false}
+        onSelectModel={onSelectModel}
+        onSelectModelOption={vi.fn()}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('model-selector-button'))
+    fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
+    fireEvent.click(await screen.findByTestId(`model-option-${SAMPLE_MODEL.name}`))
+
+    expect(onSelectModel).toHaveBeenCalledWith(SAMPLE_MODEL)
+    expect(screen.queryByTestId('model-selector-menu')).not.toBeInTheDocument()
+    await waitFor(() => expect(onOpenChange).toHaveBeenLastCalledWith(false, 'selection'))
+    expect(embeddedBrowserOcclusionMock).toHaveBeenLastCalledWith('model-selector-flyout', false)
+  })
+
+  test('uses the available viewport height for a long model list', async () => {
+    createShellElement({ hidden: true })
+    const models = Array.from({ length: 30 }, (_, index) => ({
+      ...SAMPLE_MODEL,
+      name: `gpt-5.5-${index}`,
+      modelId: `gpt-5.5-${index}`,
+      displayName: `GPT 5.5 ${index}`,
+    }))
+
+    render(
+      <ModelSelector
+        models={models}
+        selectedModel={models[0]}
+        selectedModelOptions={{}}
+        disabled={false}
+        onSelectModel={vi.fn()}
+        onSelectModelOption={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('model-selector-button'))
+    fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
+
+    const submenu = await screen.findByTestId('model-selector-submenu')
+    expect(submenu.style.maxHeight).toBe(
+      'min(var(--radix-popover-content-available-height), calc(100vh - 16px))'
+    )
+  })
+
+  test('uses the Codex flyout viewport contract in a narrow viewport', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 500,
+    })
+    createShellElement({ hidden: true })
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      const testId = this.getAttribute('data-testid')
+      if (testId === 'model-selector-button') {
+        return {
+          top: 500,
+          left: 230,
+          right: 470,
+          bottom: 540,
+          width: 240,
+          height: 40,
+          x: 230,
+          y: 500,
+          toJSON: () => {},
+        } as DOMRect
+      }
+      if (testId === 'model-selector-menu') {
+        return {
+          top: 300,
+          left: 246,
+          right: 470,
+          bottom: 500,
+          width: 224,
+          height: 200,
+          x: 246,
+          y: 300,
+          toJSON: () => {},
+        } as DOMRect
+      }
+      if (testId === 'model-control-menu-model') {
+        return {
+          top: 308,
+          left: 254,
+          right: 462,
+          bottom: 340,
+          width: 208,
+          height: 32,
+          x: 254,
+          y: 308,
+          toJSON: () => {},
+        } as DOMRect
+      }
+      if (testId === 'model-selector-submenu') {
+        return {
+          top: 308,
+          left: 0,
+          right: 280,
+          bottom: 608,
+          width: 280,
+          height: 300,
+          x: 0,
+          y: 308,
+          toJSON: () => {},
+        } as DOMRect
+      }
+      return originalGetBoundingClientRect.call(this)
+    }
+
+    try {
+      render(
+        <ModelSelector
+          models={[SAMPLE_MODEL]}
+          selectedModel={SAMPLE_MODEL}
+          selectedModelOptions={{}}
+          disabled={false}
+          onSelectModel={vi.fn()}
+          onSelectModelOption={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('model-selector-button'))
+      fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
+
+      const submenu = await screen.findByTestId('model-selector-submenu')
+      await waitFor(() => expect(submenu).toHaveAttribute('data-side', 'left'))
+      expect(submenu).toHaveAttribute('data-align', 'start')
+      expect(submenu.style.width).toBe('280px')
+      expect(submenu.style.maxWidth).toBe(
+        'min(var(--radix-popover-content-available-width), calc(100vw - 16px))'
+      )
+      expect(submenu.parentElement?.parentElement).toBe(document.body)
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    }
+  })
+
+  test('uses the full viewport for Codex flyouts over a narrow browser split', async () => {
+    createShellElement({ left: 430 })
+
+    expect(getDesktopModelSelectorCollisionPadding()).toEqual({
+      top: 64,
+      right: 16,
+      bottom: 16,
+      left: 16,
+    })
+
+    render(
+      <ModelSelector
+        models={[SAMPLE_MODEL]}
+        selectedModel={SAMPLE_MODEL}
+        selectedModelOptions={{}}
+        disabled={false}
+        onSelectModel={vi.fn()}
+        onSelectModelOption={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('model-selector-button'))
+    fireEvent.mouseEnter(await screen.findByTestId('model-control-menu-model'))
+
+    const submenu = await screen.findByTestId('model-selector-submenu')
+    expect(submenu.style.width).toBe('280px')
+    expect(submenu).toHaveAttribute('data-embedded-browser-occlusion')
+    expect(embeddedBrowserOcclusionMock).toHaveBeenLastCalledWith('model-selector-flyout', true)
+
+    fireEvent.click(screen.getByTestId('model-selector-button'))
+    expect(embeddedBrowserOcclusionMock).toHaveBeenLastCalledWith('model-selector-flyout', false)
   })
 
   test('caps the trigger width when maxClosedWidth is provided', () => {

--- a/wework/src/components/chat/composer/ModelSelector.tsx
+++ b/wework/src/components/chat/composer/ModelSelector.tsx
@@ -1,8 +1,9 @@
-import { Check, ChevronRight, Cloud, LogIn, Plus, Search, X } from 'lucide-react'
+import { Check, Cloud, LogIn, Plus, Search, X } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useConfiguredKeybinding } from '@/hooks/useConfiguredKeybinding'
+import { useEmbeddedBrowserOcclusion } from '@/hooks/useEmbeddedBrowserOcclusion'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import {
   type ModelControlConfig,
@@ -21,15 +22,22 @@ import type { UnifiedModel } from '@/types/api'
 import { FastModeIcon } from './FastModeIcon'
 import { ModelAdvancedHeader } from './ModelAdvancedHeader'
 import { ModelAutomaticReasoningOption } from './ModelAutomaticReasoningOption'
+import { ModelSelectorFlyout } from './ModelSelectorFlyout'
+import { ModelSelectorMenuRow } from './ModelSelectorMenuRow'
 import { ModelPowerSlider } from './ModelPowerSlider'
 import { ModelResetDefaultRow } from './ModelResetDefaultRow'
 import { ModelSelectorTrigger } from './ModelSelectorTrigger'
 import { ReasoningSlider } from './ReasoningSlider'
-import type { ModelSelectorProps } from './model-selector-types'
+import type { ModelSelectorCloseReason, ModelSelectorProps } from './model-selector-types'
 import {
   handleMobileModelSelectorDialogKeyDown,
   useMobileModelSelectorFocus,
 } from './model-selector-mobile-utils'
+import {
+  getDesktopModelSelectorCollisionPadding,
+  MODEL_SELECTOR_VIEWPORT_MARGIN,
+  MODEL_SELECTOR_VIEWPORT_TOP,
+} from './model-selector-layout'
 import {
   MODEL_SELECTOR_VIEW_CHANGED_EVENT,
   readModelSelectorPowerViewPreference,
@@ -49,16 +57,12 @@ import {
 } from './model-selector-utils'
 import styles from './ModelSelector.module.css'
 
-const MAIN_MENU_WIDTH = 256
-const SUBMENU_WIDTH = 288
-const SUBMENU_GAP = 0
-const VIEWPORT_MARGIN = 16
-const DESKTOP_MENU_VIEWPORT_TOP = 64
+const MAIN_MENU_WIDTH = 224
+const MODEL_SUBMENU_WIDTH = 280
+const CONTROL_SUBMENU_MIN_WIDTH = 180
+const SPEED_SUBMENU_WIDTH = 233
 const MAIN_MENU_TRIGGER_GAP = 8
 const MAIN_MENU_MAX_HEIGHT = 608
-const SUBMENU_RIGHT_OFFSET = MAIN_MENU_WIDTH + SUBMENU_GAP
-const SUBMENU_MAX_HEIGHT = 448
-const SUBMENU_VIEWPORT_VERTICAL_GAP = 128
 const DESKTOP_HIDDEN_CONTROL_IDS = new Set(['collaborationMode'])
 type DesktopSubmenuTarget = { type: 'models' } | { type: 'control'; id: string } | { type: 'none' }
 
@@ -69,6 +73,17 @@ function getDesktopViewportRightBoundary(): number {
     if (rect.width > 0) return Math.round(rect.left)
   }
   return window.innerWidth
+}
+
+function isDesktopSubmenuTargetActive(
+  current: DesktopSubmenuTarget | null,
+  target: DesktopSubmenuTarget
+): boolean {
+  if (current?.type !== target.type) return false
+  if (current.type === 'control' && target.type === 'control') {
+    return current.id === target.id
+  }
+  return true
 }
 
 function isCloudModel(model: UnifiedModel): boolean {
@@ -103,21 +118,15 @@ export function ModelSelector({
   const buttonRef = useRef<HTMLButtonElement>(null)
   const desktopMenuWrapperRef = useRef<HTMLDivElement>(null)
   const menuPanelRef = useRef<HTMLDivElement>(null)
-  const submenuPanelRef = useRef<HTMLDivElement>(null)
   const mobileMenuRef = useRef<HTMLDivElement>(null)
   const mobileCloseButtonRef = useRef<HTMLButtonElement>(null)
-  const modelButtonRef = useRef<HTMLButtonElement>(null)
-  const reasoningButtonRef = useRef<HTMLButtonElement>(null)
-  const speedButtonRef = useRef<HTMLButtonElement>(null)
   const handledOpenSignalRef = useRef<number | undefined>(undefined)
   const [open, setOpen] = useState(false)
+  const [closeReason, setCloseReason] = useState<ModelSelectorCloseReason>('dismiss')
   const [mobileQuery, setMobileQuery] = useState('')
   const [desktopMenuTop, setDesktopMenuTop] = useState(0)
   const [desktopMenuLeft, setDesktopMenuLeft] = useState(0)
   const [desktopMenuMaxHeight, setDesktopMenuMaxHeight] = useState(MAIN_MENU_MAX_HEIGHT)
-  const [submenuOffset, setSubmenuOffset] = useState(0)
-  const [submenuLeft, setSubmenuLeft] = useState(SUBMENU_RIGHT_OFFSET)
-  const [submenuWidth, setSubmenuWidth] = useState<number | undefined>()
   const [activeDesktopSubmenu, setActiveDesktopSubmenu] = useState<DesktopSubmenuTarget | null>(
     null
   )
@@ -125,12 +134,16 @@ export function ModelSelector({
   const [powerSliderInteracting, setPowerSliderInteracting] = useState(false)
   const modelSelectorShortcut = useConfiguredKeybinding(TOGGLE_MODEL_SELECTOR_COMMAND)
   const reportedOpenRef = useRef(open)
+  const desktopFlyoutOpen =
+    open && !isMobile && activeDesktopSubmenu !== null && activeDesktopSubmenu.type !== 'none'
+
+  useEmbeddedBrowserOcclusion('model-selector-flyout', desktopFlyoutOpen)
 
   useEffect(() => {
     if (reportedOpenRef.current === open) return
     reportedOpenRef.current = open
-    onOpenChange?.(open)
-  }, [onOpenChange, open])
+    onOpenChange?.(open, open ? undefined : closeReason)
+  }, [closeReason, onOpenChange, open])
   const familyGroups = useMemo(() => groupModelsByFamily(models), [models])
   const selectedFamily = selectedModel
     ? inferModelFamily(selectedModel)
@@ -148,12 +161,16 @@ export function ModelSelector({
     buttonRef.current?.click()
   }, [disabled, open, openSignal])
 
-  const closeMenu = useCallback(() => {
-    setOpen(false)
-    setMobileQuery('')
-    setActiveDesktopSubmenu(null)
-    setPowerSliderInteracting(false)
-  }, [setActiveDesktopSubmenu, setMobileQuery, setOpen, setPowerSliderInteracting])
+  const closeMenu = useCallback(
+    (reason: ModelSelectorCloseReason = 'dismiss') => {
+      setCloseReason(reason)
+      setOpen(false)
+      setMobileQuery('')
+      setActiveDesktopSubmenu(null)
+      setPowerSliderInteracting(false)
+    },
+    [setActiveDesktopSubmenu, setCloseReason, setMobileQuery, setOpen, setPowerSliderInteracting]
+  )
   const openModelSettings = useCallback(() => {
     closeMenu()
     navigateTo('/settings/personal/models')
@@ -186,8 +203,8 @@ export function ModelSelector({
     const menuPanel = menuPanelRef.current
     if (!button || !menuPanel) return
 
-    const viewportTop = DESKTOP_MENU_VIEWPORT_TOP
-    const viewportBottom = window.innerHeight - VIEWPORT_MARGIN
+    const viewportTop = MODEL_SELECTOR_VIEWPORT_TOP
+    const viewportBottom = window.innerHeight - MODEL_SELECTOR_VIEWPORT_MARGIN
     const maxAvailableHeight = Math.max(0, viewportBottom - viewportTop)
     const measuredHeight = menuPanel.getBoundingClientRect().height
     const contentHeight = menuPanel.scrollHeight
@@ -202,93 +219,16 @@ export function ModelSelector({
     const clampedTop = Math.round(Math.max(viewportTop, Math.min(preferredTop, maxTop)))
     const menuWidth = menuPanel.getBoundingClientRect().width || MAIN_MENU_WIDTH
     const viewportRight = getDesktopViewportRightBoundary()
-    const maxLeft = viewportRight - VIEWPORT_MARGIN - menuWidth
+    const maxLeft = viewportRight - MODEL_SELECTOR_VIEWPORT_MARGIN - menuWidth
     const preferredLeft = buttonRect.right - menuWidth
-    const clampedLeft = Math.round(Math.max(VIEWPORT_MARGIN, Math.min(preferredLeft, maxLeft)))
+    const clampedLeft = Math.round(
+      Math.max(MODEL_SELECTOR_VIEWPORT_MARGIN, Math.min(preferredLeft, maxLeft))
+    )
 
     setDesktopMenuTop(clampedTop)
     setDesktopMenuLeft(clampedLeft)
     setDesktopMenuMaxHeight(menuHeight)
   }, [menuPlacement])
-  const updateSubmenuLayout = useCallback((target: HTMLElement | null) => {
-    if (!target || !menuPanelRef.current) {
-      setSubmenuOffset(0)
-      setSubmenuLeft(SUBMENU_RIGHT_OFFSET)
-      setSubmenuWidth(undefined)
-      return
-    }
-
-    const menuRect = menuPanelRef.current.getBoundingClientRect()
-    const menuTop = menuRect.top
-    const targetTop = target.getBoundingClientRect().top
-    const preferredOffset = Math.round(targetTop - menuTop)
-    const submenuRect = submenuPanelRef.current?.getBoundingClientRect()
-    const submenuScrollHeight = submenuPanelRef.current?.scrollHeight ?? 0
-    const maxSubmenuHeight = Math.min(
-      SUBMENU_MAX_HEIGHT,
-      Math.max(0, window.innerHeight - SUBMENU_VIEWPORT_VERTICAL_GAP)
-    )
-    const measuredSubmenuHeight = submenuRect?.height ?? 0
-    const submenuHeight = Math.min(
-      Math.max(measuredSubmenuHeight, submenuScrollHeight),
-      maxSubmenuHeight
-    )
-
-    if (submenuHeight > 0) {
-      const viewportTop = DESKTOP_MENU_VIEWPORT_TOP
-      const viewportBottom = window.innerHeight - VIEWPORT_MARGIN
-      const maxOffset = viewportBottom - submenuHeight - menuTop
-      const minOffset = viewportTop - menuTop
-      setSubmenuOffset(Math.round(Math.max(minOffset, Math.min(preferredOffset, maxOffset))))
-    } else {
-      setSubmenuOffset(preferredOffset)
-    }
-
-    const measuredMenuWidth = menuRect.width || MAIN_MENU_WIDTH
-    const measuredSubmenuWidth = submenuRect?.width || SUBMENU_WIDTH
-    const rightSideLeft = measuredMenuWidth + SUBMENU_GAP
-    const viewportWidth = getDesktopViewportRightBoundary()
-    const availableRight = viewportWidth - VIEWPORT_MARGIN - menuRect.left - rightSideLeft
-    const availableLeft = menuRect.left - VIEWPORT_MARGIN - SUBMENU_GAP
-    const rightSideWidth = Math.max(0, Math.min(measuredSubmenuWidth, availableRight))
-    const leftSideWidth = Math.max(0, Math.min(measuredSubmenuWidth, availableLeft))
-
-    const rightSideEdge = menuRect.left + rightSideLeft + measuredSubmenuWidth
-    if (rightSideEdge <= viewportWidth - VIEWPORT_MARGIN) {
-      setSubmenuWidth(undefined)
-      setSubmenuLeft(rightSideLeft)
-      return
-    }
-
-    const leftSideLeft = -(measuredSubmenuWidth + SUBMENU_GAP)
-    if (menuRect.left + leftSideLeft >= VIEWPORT_MARGIN) {
-      setSubmenuWidth(undefined)
-      setSubmenuLeft(leftSideLeft)
-      return
-    }
-
-    if (leftSideWidth >= rightSideWidth) {
-      setSubmenuWidth(Math.round(leftSideWidth))
-      setSubmenuLeft(-Math.round(leftSideWidth + SUBMENU_GAP))
-      return
-    }
-
-    if (rightSideWidth > 0) {
-      setSubmenuWidth(Math.round(rightSideWidth))
-      setSubmenuLeft(rightSideLeft)
-      return
-    }
-
-    const viewportFittedLeft = Math.max(
-      VIEWPORT_MARGIN - menuRect.left,
-      Math.min(
-        rightSideLeft,
-        viewportWidth - VIEWPORT_MARGIN - measuredSubmenuWidth - menuRect.left
-      )
-    )
-    setSubmenuWidth(undefined)
-    setSubmenuLeft(Math.round(viewportFittedLeft))
-  }, [])
   const activateControl = useCallback(
     (controlId: string) => {
       setActiveDesktopSubmenu(current =>
@@ -305,6 +245,15 @@ export function ModelSelector({
   const clearDesktopSubmenu = useCallback(() => {
     setActiveDesktopSubmenu(current => (current?.type === 'none' ? current : { type: 'none' }))
   }, [setActiveDesktopSubmenu])
+  const setDesktopSubmenuOpen = useCallback(
+    (target: DesktopSubmenuTarget, nextOpen: boolean) => {
+      setActiveDesktopSubmenu(current => {
+        if (nextOpen) return target
+        return isDesktopSubmenuTargetActive(current, target) ? { type: 'none' } : current
+      })
+    },
+    [setActiveDesktopSubmenu]
+  )
   const activateMobileFamily = useCallback(
     (familyId: string) => {
       setActiveFamilyId(current => (current === familyId ? current : familyId))
@@ -329,7 +278,8 @@ export function ModelSelector({
       if (!(target instanceof Node)) return
       if (
         containerRef.current?.contains(target) ||
-        desktopMenuWrapperRef.current?.contains(target)
+        desktopMenuWrapperRef.current?.contains(target) ||
+        (target instanceof Element && target.closest('[data-model-selector-layer="true"]'))
       ) {
         return
       }
@@ -340,23 +290,6 @@ export function ModelSelector({
     document.addEventListener('pointerdown', handlePointerDown)
     return () => document.removeEventListener('pointerdown', handlePointerDown)
   }, [closeMenu, isMobile, open])
-
-  useLayoutEffect(() => {
-    if (!open) return
-    if (activeDesktopSubmenu?.type === 'models') {
-      updateSubmenuLayout(modelButtonRef.current)
-      return
-    }
-    if (activeDesktopSubmenu?.type === 'control') {
-      const buttonRef =
-        activeDesktopSubmenu.id === 'reasoning'
-          ? reasoningButtonRef.current
-          : speedButtonRef.current
-      updateSubmenuLayout(buttonRef)
-      return
-    }
-    updateSubmenuLayout(null)
-  }, [activeDesktopSubmenu, open, updateSubmenuLayout])
 
   useEffect(() => {
     if (!open || isMobile) return
@@ -436,11 +369,6 @@ export function ModelSelector({
       : null
   const advancedReasoningAvailable = advancedReasoningMode !== null
   const powerViewOpen = advancedOpen && advancedReasoningAvailable
-  const activeControl =
-    activeDesktopSubmenu?.type === 'control'
-      ? desktopControls.find(control => control.id === activeDesktopSubmenu.id)
-      : undefined
-
   useLayoutEffect(() => {
     if (!open || isMobile) return
 
@@ -545,6 +473,7 @@ export function ModelSelector({
   }
 
   function renderControlMenuItem(control: ModelControlConfig) {
+    const target: DesktopSubmenuTarget = { type: 'control', id: control.id }
     const active =
       activeDesktopSubmenu?.type === 'control' && activeDesktopSubmenu.id === control.id
     const selectedOption = selectedControlOption(control, selectedModelOptions)
@@ -555,28 +484,30 @@ export function ModelSelector({
       : control.defaultValue
 
     return (
-      <button
-        ref={control.id === 'reasoning' ? reasoningButtonRef : speedButtonRef}
+      <ModelSelectorFlyout
         key={control.id}
-        type="button"
-        data-testid={`model-control-menu-${control.id}`}
-        onMouseEnter={() => activateControl(control.id)}
-        onPointerEnter={() => activateControl(control.id)}
-        onFocus={() => activateControl(control.id)}
-        onClick={() => activateControl(control.id)}
-        className={[
-          'flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-normal leading-[18px]',
-          active
-            ? 'bg-muted text-text-primary'
-            : 'text-text-secondary hover:bg-muted hover:text-text-primary',
-        ].join(' ')}
+        open={active}
+        onOpenChange={nextOpen => setDesktopSubmenuOpen(target, nextOpen)}
+        collisionPadding={getDesktopModelSelectorCollisionPadding()}
+        contentStyle={{
+          width: control.id === 'speed' ? SPEED_SUBMENU_WIDTH : undefined,
+          minWidth: CONTROL_SUBMENU_MIN_WIDTH,
+        }}
+        anchor={
+          <ModelSelectorMenuRow
+            active={active}
+            label={control.labelKey ? t(control.labelKey, control.label) : control.label}
+            value={selectedLabel}
+            testId={`model-control-menu-${control.id}`}
+            onActivate={() => activateControl(control.id)}
+          />
+        }
       >
-        <span className="min-w-0 flex-1 truncate">
-          {control.labelKey ? t(control.labelKey, control.label) : control.label}
-        </span>
-        <span className="max-w-24 truncate text-text-muted">{selectedLabel}</span>
-        <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
-      </button>
+        {renderControlSection(control, {
+          clearSubmenuOnHover: false,
+          reasoningAsSlider: false,
+        })}
+      </ModelSelectorFlyout>
     )
   }
 
@@ -600,9 +531,8 @@ export function ModelSelector({
               onBlockedModelSelect?.(model, disabledMessage)
               return
             }
-            if (handleSelectModel(model) !== false) {
-              closeMenu()
-            }
+            handleSelectModel(model)
+            closeMenu('selection')
           }}
           className={[
             `flex h-8 w-full items-center gap-2 rounded-lg ${indented ? 'pl-5 pr-2' : 'px-2'} text-left text-sm leading-[18px]`,
@@ -727,7 +657,7 @@ export function ModelSelector({
 
   function renderMobileSheet() {
     return createPortal(
-      <div className="fixed inset-0 z-modal bg-black/25" onClick={closeMenu}>
+      <div className="fixed inset-0 z-modal bg-black/25" onClick={() => closeMenu()}>
         <div
           ref={mobileMenuRef}
           role="dialog"
@@ -757,7 +687,7 @@ export function ModelSelector({
               ref={mobileCloseButtonRef}
               data-testid="model-selector-close-button"
               aria-label={t('workbench.close_menu')}
-              onClick={closeMenu}
+              onClick={() => closeMenu()}
               className="flex h-11 w-11 items-center justify-center rounded-full bg-surface text-text-primary"
             >
               <X className="h-5 w-5" />
@@ -906,7 +836,7 @@ export function ModelSelector({
             <button
               type="button"
               data-testid="model-selector-confirm-button"
-              onClick={closeMenu}
+              onClick={() => closeMenu()}
               className="h-11 flex-1 rounded-full bg-text-primary text-sm font-semibold text-background"
             >
               {t('workbench.use_current_model')}
@@ -934,7 +864,9 @@ export function ModelSelector({
           <div
             ref={desktopMenuWrapperRef}
             style={{ left: desktopMenuLeft, top: desktopMenuTop }}
-            className={cn('fixed z-system-popover w-64', menuClassName)}
+            data-model-selector-layer="true"
+            data-embedded-browser-occlusion
+            className={cn('fixed z-system-popover w-[224px]', menuClassName)}
           >
             <div
               ref={menuPanelRef}
@@ -942,7 +874,7 @@ export function ModelSelector({
               data-enter-animation="main"
               style={{ maxHeight: desktopMenuMaxHeight }}
               className={cn(
-                'w-64 shrink-0 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
+                'w-[224px] shrink-0 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
                 styles.mainMenu
               )}
             >
@@ -950,27 +882,35 @@ export function ModelSelector({
               {desktopModels.length > 0 && !powerViewOpen ? (
                 <>
                   <div className="space-y-0.5">
-                    <button
-                      ref={modelButtonRef}
-                      type="button"
-                      data-testid="model-control-menu-model"
-                      onMouseEnter={activateModels}
-                      onPointerEnter={activateModels}
-                      onFocus={activateModels}
-                      onClick={activateModels}
-                      className={cn(
-                        'flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-normal leading-[18px]',
-                        modelRowActive
-                          ? 'bg-muted text-text-primary'
-                          : 'text-text-secondary hover:bg-muted hover:text-text-primary'
-                      )}
+                    <ModelSelectorFlyout
+                      open={modelRowActive}
+                      onOpenChange={nextOpen => setDesktopSubmenuOpen({ type: 'models' }, nextOpen)}
+                      collisionPadding={getDesktopModelSelectorCollisionPadding()}
+                      contentClassName="min-h-48"
+                      contentStyle={{ width: MODEL_SUBMENU_WIDTH }}
+                      anchor={
+                        <ModelSelectorMenuRow
+                          active={modelRowActive}
+                          label={t('workbench.model_version', '模型')}
+                          value={desktopModelLabel}
+                          testId="model-control-menu-model"
+                          onActivate={activateModels}
+                        />
+                      }
                     >
-                      <span className="min-w-0 flex-1 truncate">
-                        {t('workbench.model_version', '模型')}
-                      </span>
-                      <span className="max-w-24 truncate text-text-muted">{desktopModelLabel}</span>
-                      <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
-                    </button>
+                      <div className="space-y-0.5 py-0.5">
+                        {familyGroups.length <= 1
+                          ? renderDesktopModelOptions(desktopModels)
+                          : familyGroups.map(group => (
+                              <div key={group.config.id}>
+                                <div className="px-2 pb-0.5 pt-2 text-xs font-medium leading-4 text-text-muted first:pt-0.5">
+                                  {group.config.label}
+                                </div>
+                                {renderDesktopModelOptions(group.models, true)}
+                              </div>
+                            ))}
+                      </div>
+                    </ModelSelectorFlyout>
                     {desktopReasoningControl ? (
                       renderControlMenuItem(desktopReasoningControl)
                     ) : (
@@ -1074,50 +1014,6 @@ export function ModelSelector({
                 </div>
               ) : null}
             </div>
-
-            {activeControl ? (
-              <div
-                key={`control:${activeControl.id}`}
-                ref={submenuPanelRef}
-                data-testid="model-selector-submenu"
-                data-enter-animation="submenu"
-                style={{ top: submenuOffset, left: submenuLeft, width: submenuWidth }}
-                className={cn(
-                  'absolute max-h-[min(28rem,calc(100vh-8rem))] w-72 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
-                  styles.submenu
-                )}
-              >
-                {renderControlSection(activeControl, {
-                  clearSubmenuOnHover: false,
-                  reasoningAsSlider: false,
-                })}
-              </div>
-            ) : activeDesktopSubmenu?.type === 'models' ? (
-              <div
-                key="models"
-                ref={submenuPanelRef}
-                data-testid="model-selector-submenu"
-                data-enter-animation="submenu"
-                style={{ top: submenuOffset, left: submenuLeft, width: submenuWidth }}
-                className={cn(
-                  'absolute max-h-[min(28rem,calc(100vh-8rem))] min-h-48 w-72 overflow-y-auto rounded-xl border border-border/70 bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
-                  styles.submenu
-                )}
-              >
-                <div className="space-y-0.5 py-0.5">
-                  {familyGroups.length <= 1
-                    ? renderDesktopModelOptions(desktopModels)
-                    : familyGroups.map(group => (
-                        <div key={group.config.id}>
-                          <div className="px-2 pb-0.5 pt-2 text-xs font-medium leading-4 text-text-muted first:pt-0.5">
-                            {group.config.label}
-                          </div>
-                          {renderDesktopModelOptions(group.models, true)}
-                        </div>
-                      ))}
-                </div>
-              </div>
-            ) : null}
           </div>,
           document.body
         )}
@@ -1151,8 +1047,11 @@ export function ModelSelector({
           setOpen(current => {
             const nextOpen = !current
             if (nextOpen) {
+              setCloseReason('dismiss')
               setActiveDesktopSubmenu({ type: 'none' })
               setPowerSliderInteracting(false)
+            } else {
+              setCloseReason('dismiss')
             }
             return nextOpen
           })

--- a/wework/src/components/chat/composer/ModelSelectorFlyout.tsx
+++ b/wework/src/components/chat/composer/ModelSelectorFlyout.tsx
@@ -1,0 +1,60 @@
+import * as Popover from '@radix-ui/react-popover'
+import type { CSSProperties, ReactElement, ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import styles from './ModelSelector.module.css'
+
+type CollisionPadding = number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>
+
+interface ModelSelectorFlyoutProps {
+  anchor: ReactElement
+  children: ReactNode
+  collisionPadding: CollisionPadding
+  contentClassName?: string
+  contentStyle?: CSSProperties
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ModelSelectorFlyout({
+  anchor,
+  children,
+  collisionPadding,
+  contentClassName,
+  contentStyle,
+  open,
+  onOpenChange,
+}: ModelSelectorFlyoutProps) {
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Anchor asChild>{anchor}</Popover.Anchor>
+      <Popover.Portal>
+        <Popover.Content
+          data-model-selector-layer="true"
+          data-embedded-browser-occlusion
+          data-testid="model-selector-submenu"
+          data-enter-animation="submenu"
+          side="right"
+          align="start"
+          sideOffset={4}
+          alignOffset={-4}
+          collisionPadding={collisionPadding}
+          avoidCollisions
+          onOpenAutoFocus={event => event.preventDefault()}
+          onCloseAutoFocus={event => event.preventDefault()}
+          style={{
+            maxWidth: 'min(var(--radix-popover-content-available-width), calc(100vw - 16px))',
+            maxHeight: 'min(var(--radix-popover-content-available-height), calc(100vh - 16px))',
+            ...contentStyle,
+          }}
+          className={cn(
+            'z-system-popover overflow-y-auto rounded-xl bg-popover/95 p-1 shadow-[0_8px_16px_-4px_rgba(0,0,0,0.18)] ring-1 ring-border/30 backdrop-blur-xl',
+            styles.submenu,
+            contentClassName
+          )}
+        >
+          {children}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  )
+}

--- a/wework/src/components/chat/composer/ModelSelectorMenuRow.tsx
+++ b/wework/src/components/chat/composer/ModelSelectorMenuRow.tsx
@@ -1,0 +1,43 @@
+import { ChevronRight } from 'lucide-react'
+import { forwardRef, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface ModelSelectorMenuRowProps {
+  active: boolean
+  label: ReactNode
+  onActivate: () => void
+  testId: string
+  value: ReactNode
+}
+
+export const ModelSelectorMenuRow = forwardRef<HTMLButtonElement, ModelSelectorMenuRowProps>(
+  function ModelSelectorMenuRow({ active, label, onActivate, testId, value }, ref) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-testid={testId}
+        onMouseEnter={onActivate}
+        onPointerEnter={onActivate}
+        onFocus={onActivate}
+        onClick={onActivate}
+        onKeyDown={event => {
+          if (['ArrowRight', 'Enter', ' '].includes(event.key)) {
+            event.preventDefault()
+            onActivate()
+          }
+        }}
+        className={cn(
+          'flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm font-normal leading-[18px]',
+          active
+            ? 'bg-muted text-text-primary'
+            : 'text-text-secondary hover:bg-muted hover:text-text-primary'
+        )}
+      >
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        <span className="max-w-24 truncate text-text-muted">{value}</span>
+        <ChevronRight className="h-4 w-4 shrink-0 text-text-muted" />
+      </button>
+    )
+  }
+)

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -45,6 +45,7 @@ import type {
   ComposerConversationMentionCandidate,
 } from './composerMentionCandidates'
 import type { ComposerExternalMentionCandidate } from './composerTextareaTypes'
+import type { ModelSelectorCloseReason } from './model-selector-types'
 import { applyWorkspacePathTransfer } from './composerPathTransfer'
 import styles from './ProjectChatComposer.module.css'
 
@@ -68,7 +69,7 @@ interface ProjectChatComposerProps {
   activeModel?: UnifiedModel | null
   selectedModelOptions: ModelOptions
   modelSelectorOpenSignal?: number
-  onModelSelectorOpenChange?: (open: boolean) => void
+  onModelSelectorOpenChange?: (open: boolean, closeReason?: ModelSelectorCloseReason) => void
   isModelSelectionReady: boolean
   attachments: Attachment[]
   codeComments?: CodeCommentContext[]

--- a/wework/src/components/chat/composer/model-selector-layout.ts
+++ b/wework/src/components/chat/composer/model-selector-layout.ts
@@ -1,0 +1,13 @@
+export const MODEL_SELECTOR_VIEWPORT_MARGIN = 16
+export const MODEL_SELECTOR_VIEWPORT_TOP = 64
+
+export function getDesktopModelSelectorCollisionPadding() {
+  // Match Codex by using the full workbench viewport. The browser panel
+  // separately occludes its native view when a flyout intersects it.
+  return {
+    top: MODEL_SELECTOR_VIEWPORT_TOP,
+    right: MODEL_SELECTOR_VIEWPORT_MARGIN,
+    bottom: MODEL_SELECTOR_VIEWPORT_MARGIN,
+    left: MODEL_SELECTOR_VIEWPORT_MARGIN,
+  }
+}

--- a/wework/src/components/chat/composer/model-selector-types.ts
+++ b/wework/src/components/chat/composer/model-selector-types.ts
@@ -1,5 +1,7 @@
 import type { ModelOptions, UnifiedModel } from '@/types/api'
 
+export type ModelSelectorCloseReason = 'dismiss' | 'selection'
+
 export interface ModelSelectorProps {
   models: UnifiedModel[]
   selectedModel: UnifiedModel | null
@@ -10,7 +12,7 @@ export interface ModelSelectorProps {
   onSelectModelAndOptions?: (model: UnifiedModel, options: ModelOptions) => void
   onSelectModelOption: (optionId: string, value: string) => void
   onBlockedModelSelect?: (model: UnifiedModel, message?: string) => void
-  onOpenChange?: (open: boolean) => void
+  onOpenChange?: (open: boolean, closeReason?: ModelSelectorCloseReason) => void
   openSignal?: number
   menuPlacement?: 'above' | 'below'
   buttonClassName?: string

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -202,6 +202,10 @@ async function waitForSidebarPointerSensorCleanup() {
   })
 }
 
+// Compile the injected DSH modules outside the per-test hook timeout. The setup hook
+// still clears and restores the module cache before every test to preserve isolation.
+await preloadDefaultDshUiTestModules()
+
 describe('DesktopSidebar', () => {
   beforeEach(async () => {
     await preloadDefaultDshUiTestModules()

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -2664,8 +2664,8 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             retryFailedMessageAfterModelSelect()
           }
         : undefined,
-      onModelSelectorOpenChange: open => {
-        if (!open) pendingModelRetryRef.current = null
+      onModelSelectorOpenChange: (open, closeReason) => {
+        if (!open && closeReason !== 'selection') pendingModelRetryRef.current = null
       },
       onRefineTrialPrompt: refinePluginTrialPrompt,
     }),

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -218,8 +218,8 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
           retryFailedMessageAfterModelSelect()
         }
       : undefined,
-    onModelSelectorOpenChange: open => {
-      if (!open) pendingModelRetryRef.current = null
+    onModelSelectorOpenChange: (open, closeReason) => {
+      if (!open && closeReason !== 'selection') pendingModelRetryRef.current = null
     },
     onRefineTrialPrompt: refinePluginTrialPrompt,
   }

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1829,6 +1829,9 @@ export function useWorkbenchPaneSession({
         const submittedInput = (inputOverride ?? input).trim()
         const currentAttachments = attachmentState.attachments
         const hasCodeComments = codeCommentContexts.length > 0
+        const paneIsBusy = currentRuntimeTask
+          ? (lifecycleStore.getTask(currentRuntimeTask)?.derived.isBusy ?? paneStatus.isBusy)
+          : paneStatus.isBusy
         debugComposerEvent('pane-send-called', {
           hasSubmittedValue: inputOverride !== undefined,
           submittedValue: textMetrics(inputOverride),
@@ -1841,7 +1844,7 @@ export function useWorkbenchPaneSession({
           guideWhenBusy: options.guideWhenBusy === true,
           interruptWhenBusy: options.interruptWhenBusy === true,
           hasCurrentRuntimeTask: Boolean(currentRuntimeTask),
-          paneBusy: paneStatus.isBusy,
+          paneBusy: paneIsBusy,
         })
 
         if (goalDraftActive) {
@@ -1871,7 +1874,7 @@ export function useWorkbenchPaneSession({
             }
 
             resetAttachments()
-            if (paneStatus.isBusy && options.guideWhenBusy) {
+            if (paneIsBusy && options.guideWhenBusy) {
               const response = await setRuntimeGoal({
                 address: currentRuntimeTask,
                 objective: submittedInput,
@@ -1895,7 +1898,7 @@ export function useWorkbenchPaneSession({
               ...baseMessage,
               initialGoal,
             }
-            if (paneStatus.isBusy) {
+            if (paneIsBusy) {
               setInput('')
               setRuntimeConversationGoal(currentRuntimeTask, draftGoal)
               lifecycleStore.goalStatusReceived(currentRuntimeTask, draftGoal.status)
@@ -2008,7 +2011,7 @@ export function useWorkbenchPaneSession({
             setError('当前对话还没有可压缩的 Codex 线程')
             return false
           }
-          if (paneStatus.isBusy) {
+          if (paneIsBusy) {
             setError('当前回复进行中，完成后再压缩上下文')
             return false
           }
@@ -2168,7 +2171,7 @@ export function useWorkbenchPaneSession({
             ...getRuntimeModelFields(),
           }
 
-          if (paneStatus.isBusy) {
+          if (paneIsBusy) {
             resetAttachments()
             setCodeCommentContexts([])
             if (options.interruptWhenBusy) {
@@ -2222,7 +2225,7 @@ export function useWorkbenchPaneSession({
         }
 
         resetAttachments()
-        if (paneStatus.isBusy) {
+        if (paneIsBusy) {
           if (options.interruptWhenBusy) {
             const sent = await interruptAndSendQueuedMessage(queuedMessage)
             if (!sent) {

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -448,6 +448,13 @@ export function useWorkbenchPaneSession({
       }),
     [currentRuntimeTask, messages, taskLifecycle]
   )
+  const readCurrentPaneBusy = useCallback(
+    () =>
+      currentRuntimeTask
+        ? (lifecycleStore.getTask(currentRuntimeTask)?.derived.isBusy ?? paneStatus.isBusy)
+        : paneStatus.isBusy,
+    [currentRuntimeTask, lifecycleStore, paneStatus.isBusy]
+  )
   const activeAssistantMessage = paneStatus.activeAssistantMessage
   const goal = useMemo(() => {
     let resolvedGoal: RuntimeGoal | null
@@ -1672,7 +1679,7 @@ export function useWorkbenchPaneSession({
   }, [runtimeTaskLoadTarget])
 
   const sendQueuedMessageAsGuidance = useCallback(
-    async (queuedMessage: RuntimePaneQueuedMessage) => {
+    async (queuedMessage: RuntimePaneQueuedMessage, forceActiveTurn = false) => {
       const id = queuedMessage.id
       queuedMessageBusyBlockSnapshotsRef.current.delete(id)
       if (!currentRuntimeTask) {
@@ -1690,7 +1697,7 @@ export function useWorkbenchPaneSession({
       if (queuedMessage.status === 'sending') return
 
       setError(null)
-      if (!paneStatus.isBusy) {
+      if (!readCurrentPaneBusy() && !forceActiveTurn) {
         setQueuedMessages(messages =>
           messages.map(message =>
             message.id === id
@@ -1815,7 +1822,7 @@ export function useWorkbenchPaneSession({
     },
     [
       currentRuntimeTask,
-      paneStatus.isBusy,
+      readCurrentPaneBusy,
       sendRuntimeMessage,
       sendRuntimePaneGuidance,
       setError,
@@ -1829,9 +1836,7 @@ export function useWorkbenchPaneSession({
         const submittedInput = (inputOverride ?? input).trim()
         const currentAttachments = attachmentState.attachments
         const hasCodeComments = codeCommentContexts.length > 0
-        const paneIsBusy = currentRuntimeTask
-          ? (lifecycleStore.getTask(currentRuntimeTask)?.derived.isBusy ?? paneStatus.isBusy)
-          : paneStatus.isBusy
+        const paneIsBusy = readCurrentPaneBusy()
         debugComposerEvent('pane-send-called', {
           hasSubmittedValue: inputOverride !== undefined,
           submittedValue: textMetrics(inputOverride),
@@ -1890,7 +1895,7 @@ export function useWorkbenchPaneSession({
               lifecycleStore.goalStatusReceived(currentRuntimeTask, response.goal.status)
               setGoalDraftActive(false)
               setQueuedMessages(messages => [...messages, baseMessage])
-              await sendQueuedMessageAsGuidance(baseMessage)
+              await sendQueuedMessageAsGuidance(baseMessage, true)
               return true
             }
 
@@ -2238,7 +2243,7 @@ export function useWorkbenchPaneSession({
           setQueuedMessages(messages => [...messages, queuedMessage])
           setInput('')
           if (options.guideWhenBusy) {
-            await sendQueuedMessageAsGuidance(queuedMessage)
+            await sendQueuedMessageAsGuidance(queuedMessage, true)
           }
           return true
         }
@@ -2282,8 +2287,8 @@ export function useWorkbenchPaneSession({
         lifecycleStore,
         loadRuntimeTranscriptForPane,
         pendingGoalState,
-        paneStatus.isBusy,
         queuedMessages.length,
+        readCurrentPaneBusy,
         resetAttachments,
         restoreInputAfterFailure,
         sendCurrentInput,

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type FocusEvent,
   type ReactNode,
 } from 'react'
@@ -30,7 +31,7 @@ interface HoverCardProps {
   estimatedHeight?: number
 }
 
-interface HoverCardPosition {
+type HoverCardPosition = CSSProperties & {
   left: number
   top: number
 }

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2061,6 +2061,7 @@ function FollowUpProbe() {
   const localImageAttachment = createLocalImageAttachment()
   const firstQueuedMessage = paneSession.queuedMessages[0]
   const busyResumeQueuedMessagesWithInputRef = useRef(paneSession.resumeQueuedMessagesWithInput)
+  const idleSendRef = useRef(paneSession.send)
   useEffect(() => {
     if (paneSession.status.isBusy) {
       busyResumeQueuedMessagesWithInputRef.current = paneSession.resumeQueuedMessagesWithInput
@@ -2260,6 +2261,15 @@ function FollowUpProbe() {
         send follow-up
       </button>
       <button
+        data-testid="capture-idle-follow-up-send"
+        type="button"
+        onClick={() => {
+          idleSendRef.current = paneSession.send
+        }}
+      >
+        capture idle follow-up send
+      </button>
+      <button
         type="button"
         onClick={() => void busyResumeQueuedMessagesWithInputRef.current('手动消息')}
       >
@@ -2267,7 +2277,7 @@ function FollowUpProbe() {
       </button>
       <button
         type="button"
-        onClick={() => void paneSession.send(undefined, { guideWhenBusy: true })}
+        onClick={() => void idleSendRef.current(undefined, { guideWhenBusy: true })}
       >
         send follow-up as guidance
       </button>
@@ -15474,6 +15484,10 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() =>
       expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
     )
+    await userEvent.click(screen.getByText('set follow-up goal'))
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('add local image attachment'))
+    await userEvent.click(screen.getByTestId('capture-idle-follow-up-send'))
     await act(async () => {
       streamHandlers.onChatStart?.({
         taskId: 'runtime-a',
@@ -15482,9 +15496,6 @@ describe('WorkbenchProvider runtime tasks', () => {
         deviceId: 'device-1',
       })
     })
-    await userEvent.click(screen.getByText('set follow-up goal'))
-    await userEvent.click(screen.getByText('set follow-up'))
-    await userEvent.click(screen.getByText('add local image attachment'))
     await userEvent.click(screen.getByText('send follow-up as guidance'))
     const queuedMessageId = screen.getByTestId('queued-message-ids').textContent
 

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2060,6 +2060,12 @@ function FollowUpProbe() {
   const imageAttachment = createImageAttachment()
   const localImageAttachment = createLocalImageAttachment()
   const firstQueuedMessage = paneSession.queuedMessages[0]
+  const busyResumeQueuedMessagesWithInputRef = useRef(paneSession.resumeQueuedMessagesWithInput)
+  useEffect(() => {
+    if (paneSession.status.isBusy) {
+      busyResumeQueuedMessagesWithInputRef.current = paneSession.resumeQueuedMessagesWithInput
+    }
+  }, [paneSession.resumeQueuedMessagesWithInput, paneSession.status.isBusy])
   const gptModel =
     workbench.projectChat.models.find(model => model.name === 'gpt-5-2025-08-07') ?? null
 
@@ -2255,7 +2261,7 @@ function FollowUpProbe() {
       </button>
       <button
         type="button"
-        onClick={() => void paneSession.resumeQueuedMessagesWithInput('手动消息')}
+        onClick={() => void busyResumeQueuedMessagesWithInputRef.current('手动消息')}
       >
         resume queue with manual input
       </button>

--- a/wework/src/features/workspace-tabs/WorkspaceTabStrip.tsx
+++ b/wework/src/features/workspace-tabs/WorkspaceTabStrip.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
+  type CSSProperties,
   type DragEvent,
   type RefObject,
 } from 'react'
@@ -25,7 +26,7 @@ import { dshWorkspaceTabs, dshWorkspaceTabRoute } from '@/features/dsh-runtime/d
 import { DshIcon } from '@/features/dsh-runtime/DshIcon'
 import { resolveDshRoute } from '@/features/dsh-runtime/dshRoutes'
 
-interface MenuPosition {
+type MenuPosition = CSSProperties & {
   left: number
   top: number
 }


### PR DESCRIPTION
## Summary

- render model selector flyouts and switch-confirmation dialogs in document-level portals with viewport collision handling
- coordinate overlay state with the Electron embedded browser so flyouts can cross the browser pane without clipping or click-through
- preserve switch-and-retry intent across the picker-to-dialog handoff, clearing it only on cancellation
- add desktop E2E coverage for narrow composer layout, browser overlap, interaction blocking, restoration, and automatic retry
- preload sidebar DSH test modules outside the per-test hook timeout found by the full pre-push suite

## Verification

- `pnpm exec vitest run src/components/chat/composer/ModelSelector.test.tsx src/components/chat/ChatInput.test.tsx src/components/ui/hover-card.test.tsx src/features/workspace-tabs/WorkspaceTabStrip.test.tsx` — 158 passed
- `VITEST_MAX_WORKERS=4 pnpm exec vitest run src/components/layout/DesktopSidebar.test.tsx --pool=threads` — 112 passed
- focused ESLint and `pnpm exec tsc -b --pretty false`
- `pnpm ai:verify:electron:build`
- `WEWORK_E2E_BACKGROUND_WINDOW=0 ... pnpm e2e:desktop -- --model-switch-only` — six-way Electron model-switch E2E passed
- repository pre-push gate — ESLint, TypeScript, and full renderer unit suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the desktop model selector with flyout menus that adapt to available screen space.
  * Improved model menus in narrow layouts and alongside the embedded browser with viewport-aware sizing and positioning.
  * Added clearer handling for model selection versus dismissal, preserving queued retries after selection.

* **Bug Fixes**
  * Fixed warning and queue dialogs so they layer correctly and restore browser interaction after dismissal.
  * Improved model-switch interactions, browser overlap behavior, and queued message handling while panes are busy.
  * Ensured follow-up guidance can be delivered reliably during active pane turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->