### PR TITLE
fix(wework): persist runtime task issue status in executor

### DIFF
--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -804,7 +804,7 @@ def _project_bound_runtime_event_status(
         )
         .first()
     )
-    if binding is None or not binding.loop_item_id or not binding.workflow_node_id:
+    if binding is None or not binding.loop_item_id:
         logger.info(
             "[IssueTaskRuntimeSync] binding_miss user=%s device=%s task=%s " "event=%s",
             user_id,
@@ -825,6 +825,65 @@ def _project_bound_runtime_event_status(
             binding.loop_item_id,
         )
         return None
+    if not binding.workflow_node_id:
+        next_status = (
+            "in_progress"
+            if projected_status == "running"
+            else (
+                "in_review"
+                if projected_status in {"succeeded", "failed", "cancelled"}
+                and item_before.status not in {"completed", "in_review"}
+                else None
+            )
+        )
+        if next_status is None or item_before.status == next_status:
+            return None
+        from app.models.delivery import CloudProject
+        from app.services.loop_item_status_history import write_status_change
+
+        project = db.get(CloudProject, item_before.cloud_project_id)
+        metadata = (
+            dict(item_before.metadata_json)
+            if isinstance(item_before.metadata_json, dict)
+            else {}
+        )
+        if project is not None:
+            write_status_change(
+                metadata,
+                project=project,
+                from_status=item_before.status,
+                to_status=next_status,
+                trigger=f"runtime_{projected_status}",
+                by_user_id=None,
+            )
+        item_before.metadata_json = metadata
+        item_before.status = next_status
+        item_before.completed_at = project_chat_service._loop_unset_datetime(db)
+        item_before.sort_order = 0
+        item_before.version += 1
+        db.flush()
+        publish_loop_item_changed(
+            db,
+            item=item_before,
+            reason="runtime_execution_status",
+            actor_user_id=user_id,
+        )
+        logger.info(
+            "[IssueTaskRuntimeSync] projected source=direct_binding user=%s "
+            "device=%s task=%s event=%s status=%s item=%s",
+            user_id,
+            device_id,
+            task_id,
+            event_name,
+            projected_status,
+            item_before.id,
+        )
+        return {
+            "item_id": str(item_before.id),
+            "user_id": user_id,
+            "stage_ids": [],
+        }
+
     ready_before = issue_workflow_start_service.ready_robot_stage_ids(item_before)
     item = update_workflow_task_status(
         db,

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -826,6 +826,47 @@ def _project_bound_runtime_event_status(
         )
         return None
     if not binding.workflow_node_id:
+        raw_event_seq = payload.get("eventSeq", payload.get("event_seq"))
+        if isinstance(raw_event_seq, bool):
+            raw_event_seq = None
+        try:
+            event_seq = int(raw_event_seq)
+        except (TypeError, ValueError):
+            event_seq = 0
+        binding_metadata = (
+            dict(binding.metadata_json)
+            if isinstance(binding.metadata_json, dict)
+            else {}
+        )
+        raw_last_event_seq = binding_metadata.get("runtime_status_event_seq")
+        try:
+            last_event_seq = int(raw_last_event_seq)
+        except (TypeError, ValueError):
+            last_event_seq = 0
+        if event_seq <= 0:
+            logger.warning(
+                "[IssueTaskRuntimeSync] rejected unsequenced direct binding event "
+                "user=%s device=%s task=%s event=%s",
+                user_id,
+                device_id,
+                task_id,
+                event_name,
+            )
+            return None
+        if event_seq <= last_event_seq:
+            logger.info(
+                "[IssueTaskRuntimeSync] ignored reordered direct binding event "
+                "user=%s device=%s task=%s event=%s current_seq=%s incoming_seq=%s",
+                user_id,
+                device_id,
+                task_id,
+                event_name,
+                last_event_seq,
+                event_seq,
+            )
+            return None
+        binding_metadata["runtime_status_event_seq"] = event_seq
+        binding.metadata_json = binding_metadata
         next_status = (
             "in_progress"
             if projected_status == "running"

--- a/backend/tests/services/test_project_chat_service.py
+++ b/backend/tests/services/test_project_chat_service.py
@@ -2141,6 +2141,90 @@ def test_device_runtime_projection_invalidates_only_material_issue_changes(
     ]
 
 
+def test_device_runtime_event_projects_directly_bound_issue_status(
+    test_db: Session, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = create_project(test_db, test_user)
+    task = LoopItem(
+        id="CHAT-RUNTIME-DIRECT-1",
+        cloud_project_id=project.id,
+        sequence_number=2,
+        title="Direct runtime projection",
+        description="",
+        status="in_review",
+        priority="none",
+        sort_order=0,
+        created_by_user_id=test_user.id,
+    )
+    binding = LoopItemTaskBinding(
+        cloud_project_id=str(project.id),
+        loop_item_id=task.id,
+        task_user_id=test_user.id,
+        device_id="local-device",
+        task_id="runtime-direct-1",
+        linked_by_user_id=test_user.id,
+    )
+    test_db.add_all([task, binding])
+    test_db.commit()
+
+    @contextmanager
+    def same_session() -> Iterator[Session]:
+        try:
+            yield test_db
+            test_db.commit()
+        except Exception:
+            test_db.rollback()
+            raise
+
+    published: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "app.api.ws.device_namespace.get_db_session",
+        same_session,
+    )
+    monkeypatch.setattr(
+        "app.api.ws.device_namespace.publish_loop_item_changed",
+        lambda db, *, item, reason, actor_user_id: published.append(
+            (item.id, reason)
+        ),
+    )
+
+    _project_chat_runtime_event_sync(
+        "local-device",
+        {
+            "event": "response.created",
+            "payload": {
+                "taskId": "runtime-direct-1",
+                "eventSeq": 1,
+                "data": {},
+            },
+        },
+        test_user.id,
+    )
+
+    test_db.refresh(task)
+    assert task.status == "in_progress"
+
+    _project_chat_runtime_event_sync(
+        "local-device",
+        {
+            "event": "response.completed",
+            "payload": {
+                "taskId": "runtime-direct-1",
+                "eventSeq": 2,
+                "data": {"value": "Done"},
+            },
+        },
+        test_user.id,
+    )
+
+    test_db.refresh(task)
+    assert task.status == "in_review"
+    assert published == [
+        (task.id, "runtime_execution_status"),
+        (task.id, "runtime_execution_status"),
+    ]
+
+
 def test_device_runtime_event_projects_bound_workflow_task_status(
     test_db: Session, test_user: User, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/services/test_project_chat_service.py
+++ b/backend/tests/services/test_project_chat_service.py
@@ -2219,7 +2219,40 @@ def test_device_runtime_event_projects_directly_bound_issue_status(
 
     test_db.refresh(task)
     assert task.status == "in_review"
+
+    _project_chat_runtime_event_sync(
+        "local-device",
+        {
+            "event": "response.created",
+            "payload": {
+                "taskId": "runtime-direct-1",
+                "eventSeq": 1,
+                "data": {},
+            },
+        },
+        test_user.id,
+    )
+
+    test_db.refresh(task)
+    assert task.status == "in_review"
+
+    _project_chat_runtime_event_sync(
+        "local-device",
+        {
+            "event": "response.created",
+            "payload": {
+                "taskId": "runtime-direct-1",
+                "eventSeq": 3,
+                "data": {},
+            },
+        },
+        test_user.id,
+    )
+
+    test_db.refresh(task)
+    assert task.status == "in_progress"
     assert published == [
+        (task.id, "runtime_execution_status"),
         (task.id, "runtime_execution_status"),
         (task.id, "runtime_execution_status"),
     ]

--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -352,6 +352,10 @@ type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub trait RuntimeWorkHandler: Send + Sync {
     fn handle_runtime_rpc<'a>(&'a self, data: Value) -> BoxFuture<'a, Result<Value, AppIpcError>>;
 
+    fn reconcile_bound_task_statuses<'a>(&'a self) -> BoxFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
     fn handle_codex_app_server_rpc<'a>(
         &'a self,
         _data: Value,
@@ -782,7 +786,20 @@ impl AppIpcServer {
             || method.starts_with("chat_agents.")
             || method.starts_with("executions.")
         {
-            return handle_task_runtime_request(method, params).await;
+            let should_reconcile_before = method == "todos.list";
+            let should_reconcile_after = matches!(method, "todos.bind" | "projects.bind_task");
+            if should_reconcile_before {
+                if let Some(handler) = &self.runtime_work_handler {
+                    handler.reconcile_bound_task_statuses().await;
+                }
+            }
+            let result = handle_task_runtime_request(method, params).await?;
+            if should_reconcile_after {
+                if let Some(handler) = &self.runtime_work_handler {
+                    handler.reconcile_bound_task_statuses().await;
+                }
+            }
+            return Ok(result);
         }
 
         if method.starts_with("runtime.") {

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -785,10 +785,9 @@ impl RuntimeWorkRpcHandler {
         self.store.update_task(&local_task_id, |link| {
             apply_local_execution_state(link, true, None);
             link.completed_at = None;
-            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
         });
         if let Some(link) = self.local_task_link(&local_task_id) {
-            self.project_runtime_link_status(&link);
+            self.project_runtime_link_status_now(&link);
         }
         Ok(execution_id)
     }
@@ -885,7 +884,7 @@ impl RuntimeWorkRpcHandler {
             if thread_id.is_some() {
                 link.thread_id = thread_id;
             }
-            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
+            link.updated_at = now_ms();
             link.completed_at = Some(link.updated_at);
             link.status = status.to_owned();
             apply_local_execution_state(link, false, None);
@@ -894,7 +893,7 @@ impl RuntimeWorkRpcHandler {
             }
         });
         if let Some(link) = self.local_task_link(local_task_id) {
-            self.project_runtime_link_status(&link);
+            self.project_runtime_link_status_now(&link);
         }
         self.schedule_worktree_prune();
         log_executor_event(
@@ -931,13 +930,13 @@ impl RuntimeWorkRpcHandler {
             active.remove(local_task_id);
         }
         self.store.update_task(local_task_id, |link| {
-            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
+            link.updated_at = now_ms();
             link.completed_at = Some(link.updated_at);
             link.status = "cancelled".to_owned();
             apply_local_execution_state(link, false, None);
         });
         if let Some(link) = self.local_task_link(local_task_id) {
-            self.project_runtime_link_status(&link);
+            self.project_runtime_link_status_now(&link);
         }
         self.schedule_worktree_prune();
         true
@@ -1142,7 +1141,7 @@ impl RuntimeWorkRpcHandler {
             if thread_id.is_some() {
                 link.thread_id = thread_id;
             }
-            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
+            link.updated_at = now_ms();
             if status != "running" {
                 link.completed_at = Some(link.updated_at);
                 link.status = status.to_owned();
@@ -1153,7 +1152,7 @@ impl RuntimeWorkRpcHandler {
             }
         });
         if let Some(link) = self.local_task_link(local_task_id) {
-            self.project_runtime_link_status(&link);
+            self.project_runtime_link_status_now(&link);
         }
         if status != "running" {
             self.schedule_worktree_prune();

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -724,6 +724,7 @@ impl RuntimeWorkRpcHandler {
     }
 
     pub(super) fn upsert_local_task(&self, link: RuntimeTaskLink) {
+        self.project_runtime_link_status(&link);
         self.store.upsert_task(link);
     }
 
@@ -785,6 +786,7 @@ impl RuntimeWorkRpcHandler {
             apply_local_execution_state(link, true, None);
             link.completed_at = None;
         });
+        self.project_bound_task_status(&local_task_id, "running");
         Ok(execution_id)
     }
 
@@ -888,6 +890,7 @@ impl RuntimeWorkRpcHandler {
                 clear_runtime_handle_messages(&mut link.runtime_handle);
             }
         });
+        self.project_bound_task_status(local_task_id, status);
         self.schedule_worktree_prune();
         log_executor_event(
             "runtime work local execution force settled",
@@ -928,6 +931,7 @@ impl RuntimeWorkRpcHandler {
             link.status = "cancelled".to_owned();
             apply_local_execution_state(link, false, None);
         });
+        self.project_bound_task_status(local_task_id, "cancelled");
         self.schedule_worktree_prune();
         true
     }
@@ -1141,6 +1145,7 @@ impl RuntimeWorkRpcHandler {
                 clear_runtime_handle_messages(&mut link.runtime_handle);
             }
         });
+        self.project_bound_task_status(local_task_id, status);
         if status != "running" {
             self.schedule_worktree_prune();
         }

--- a/executor/src/runtime_work/handler/collection.rs
+++ b/executor/src/runtime_work/handler/collection.rs
@@ -785,8 +785,11 @@ impl RuntimeWorkRpcHandler {
         self.store.update_task(&local_task_id, |link| {
             apply_local_execution_state(link, true, None);
             link.completed_at = None;
+            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
         });
-        self.project_bound_task_status(&local_task_id, "running");
+        if let Some(link) = self.local_task_link(&local_task_id) {
+            self.project_runtime_link_status(&link);
+        }
         Ok(execution_id)
     }
 
@@ -882,7 +885,7 @@ impl RuntimeWorkRpcHandler {
             if thread_id.is_some() {
                 link.thread_id = thread_id;
             }
-            link.updated_at = now_ms();
+            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
             link.completed_at = Some(link.updated_at);
             link.status = status.to_owned();
             apply_local_execution_state(link, false, None);
@@ -890,7 +893,9 @@ impl RuntimeWorkRpcHandler {
                 clear_runtime_handle_messages(&mut link.runtime_handle);
             }
         });
-        self.project_bound_task_status(local_task_id, status);
+        if let Some(link) = self.local_task_link(local_task_id) {
+            self.project_runtime_link_status(&link);
+        }
         self.schedule_worktree_prune();
         log_executor_event(
             "runtime work local execution force settled",
@@ -926,12 +931,14 @@ impl RuntimeWorkRpcHandler {
             active.remove(local_task_id);
         }
         self.store.update_task(local_task_id, |link| {
-            link.updated_at = now_ms();
+            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
             link.completed_at = Some(link.updated_at);
             link.status = "cancelled".to_owned();
             apply_local_execution_state(link, false, None);
         });
-        self.project_bound_task_status(local_task_id, "cancelled");
+        if let Some(link) = self.local_task_link(local_task_id) {
+            self.project_runtime_link_status(&link);
+        }
         self.schedule_worktree_prune();
         true
     }
@@ -1135,7 +1142,7 @@ impl RuntimeWorkRpcHandler {
             if thread_id.is_some() {
                 link.thread_id = thread_id;
             }
-            link.updated_at = now_ms();
+            link.updated_at = now_ms().max(link.updated_at.saturating_add(1));
             if status != "running" {
                 link.completed_at = Some(link.updated_at);
                 link.status = status.to_owned();
@@ -1145,7 +1152,9 @@ impl RuntimeWorkRpcHandler {
                 clear_runtime_handle_messages(&mut link.runtime_handle);
             }
         });
-        self.project_bound_task_status(local_task_id, status);
+        if let Some(link) = self.local_task_link(local_task_id) {
+            self.project_runtime_link_status(&link);
+        }
         if status != "running" {
             self.schedule_worktree_prune();
         }

--- a/executor/src/runtime_work/handler/queries.rs
+++ b/executor/src/runtime_work/handler/queries.rs
@@ -59,6 +59,9 @@ impl RuntimeWorkRpcHandler {
         );
         let stage_started_at = Instant::now();
         let collected_links = self.collect_links(false).await;
+        for link in &collected_links {
+            self.project_runtime_link_status(link);
+        }
         log_runtime_work_list_diagnostic(
             "links_collected",
             started_at,

--- a/executor/src/runtime_work/handler/robot_queue_rpc.rs
+++ b/executor/src/runtime_work/handler/robot_queue_rpc.rs
@@ -6,14 +6,29 @@ use super::*;
 use crate::runtime_work::automations::AutomationRunStatus;
 use crate::task_runtime::LocalTaskStore;
 
+static LAST_RUNTIME_STATUS_OBSERVATION: AtomicU64 = AtomicU64::new(0);
+
+fn next_runtime_status_observation() -> i64 {
+    let wall_clock = now_ms().max(1) as u64;
+    let mut previous = LAST_RUNTIME_STATUS_OBSERVATION.load(Ordering::Relaxed);
+    loop {
+        let next = wall_clock.max(previous.saturating_add(1));
+        match LAST_RUNTIME_STATUS_OBSERVATION.compare_exchange_weak(
+            previous,
+            next,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return next.min(i64::MAX as u64) as i64,
+            Err(actual) => previous = actual,
+        }
+    }
+}
+
 impl RuntimeWorkRpcHandler {
     pub(crate) async fn reconcile_bound_task_statuses(&self) {
-        let observed_at_ms = now_ms();
         for link in self.collect_links(false).await {
-            self.project_runtime_link_status_at(
-                &link,
-                observed_at_ms.max(link.updated_at.saturating_add(1)),
-            );
+            self.project_runtime_link_status_now(&link);
         }
     }
 
@@ -67,6 +82,10 @@ impl RuntimeWorkRpcHandler {
 
     pub(super) fn project_runtime_link_status(&self, link: &RuntimeTaskLink) {
         self.project_runtime_link_status_at(link, link.updated_at);
+    }
+
+    pub(super) fn project_runtime_link_status_now(&self, link: &RuntimeTaskLink) {
+        self.project_runtime_link_status_at(link, next_runtime_status_observation());
     }
 
     fn project_runtime_link_status_at(&self, link: &RuntimeTaskLink, observed_at_ms: i64) {

--- a/executor/src/runtime_work/handler/robot_queue_rpc.rs
+++ b/executor/src/runtime_work/handler/robot_queue_rpc.rs
@@ -7,6 +7,62 @@ use crate::runtime_work::automations::AutomationRunStatus;
 use crate::task_runtime::LocalTaskStore;
 
 impl RuntimeWorkRpcHandler {
+    pub(super) fn project_bound_task_status(&self, local_task_id: &str, execution_status: &str) {
+        let store = match LocalTaskStore::from_env_if_exists() {
+            Ok(Some(store)) => store,
+            Ok(None) => return,
+            Err(error) => {
+                log_executor_event(
+                    "runtime task Issue status store unavailable",
+                    &[
+                        ("local_task_id", local_task_id.to_owned()),
+                        ("error", error.to_string()),
+                    ],
+                );
+                return;
+            }
+        };
+        match store.project_bound_task_status(&self.device_id, local_task_id, execution_status) {
+            Ok(0) => {}
+            Ok(changed) => log_executor_event(
+                "runtime task Issue status projected",
+                &[
+                    ("local_task_id", local_task_id.to_owned()),
+                    ("execution_status", execution_status.to_owned()),
+                    ("changed", changed.to_string()),
+                ],
+            ),
+            Err(error) => log_executor_event(
+                "runtime task Issue status projection failed",
+                &[
+                    ("local_task_id", local_task_id.to_owned()),
+                    ("execution_status", execution_status.to_owned()),
+                    ("error", error.to_string()),
+                ],
+            ),
+        }
+    }
+
+    pub(super) fn project_runtime_link_status(&self, link: &RuntimeTaskLink) {
+        let execution_status = if link.status == "archived" {
+            Some("archived")
+        } else if link.running || link.status == "running" {
+            Some("running")
+        } else {
+            match link.status.as_str() {
+                "queued" | "pending" => Some("queued"),
+                "failed" | "error" => Some("failed"),
+                "cancelled" | "canceled" | "interrupted" => Some("cancelled"),
+                "done" | "completed" | "succeeded" => Some("succeeded"),
+                _ if link.completed_at.is_some() => Some("succeeded"),
+                _ => None,
+            }
+        };
+        if let Some(execution_status) = execution_status {
+            self.project_bound_task_status(&link.local_task_id, execution_status);
+        }
+    }
+
     pub(super) fn start_queue_run(&self, local_task_id: &str) {
         let Ok(store) = LocalTaskStore::from_env() else {
             return;

--- a/executor/src/runtime_work/handler/robot_queue_rpc.rs
+++ b/executor/src/runtime_work/handler/robot_queue_rpc.rs
@@ -7,7 +7,22 @@ use crate::runtime_work::automations::AutomationRunStatus;
 use crate::task_runtime::LocalTaskStore;
 
 impl RuntimeWorkRpcHandler {
-    pub(super) fn project_bound_task_status(&self, local_task_id: &str, execution_status: &str) {
+    pub(crate) async fn reconcile_bound_task_statuses(&self) {
+        let observed_at_ms = now_ms();
+        for link in self.collect_links(false).await {
+            self.project_runtime_link_status_at(
+                &link,
+                observed_at_ms.max(link.updated_at.saturating_add(1)),
+            );
+        }
+    }
+
+    pub(super) fn project_bound_task_status(
+        &self,
+        local_task_id: &str,
+        execution_status: &str,
+        observed_at_ms: i64,
+    ) {
         let store = match LocalTaskStore::from_env_if_exists() {
             Ok(Some(store)) => store,
             Ok(None) => return,
@@ -22,13 +37,19 @@ impl RuntimeWorkRpcHandler {
                 return;
             }
         };
-        match store.project_bound_task_status(&self.device_id, local_task_id, execution_status) {
+        match store.project_bound_task_status(
+            &self.device_id,
+            local_task_id,
+            execution_status,
+            observed_at_ms,
+        ) {
             Ok(0) => {}
             Ok(changed) => log_executor_event(
                 "runtime task Issue status projected",
                 &[
                     ("local_task_id", local_task_id.to_owned()),
                     ("execution_status", execution_status.to_owned()),
+                    ("observed_at_ms", observed_at_ms.to_string()),
                     ("changed", changed.to_string()),
                 ],
             ),
@@ -37,6 +58,7 @@ impl RuntimeWorkRpcHandler {
                 &[
                     ("local_task_id", local_task_id.to_owned()),
                     ("execution_status", execution_status.to_owned()),
+                    ("observed_at_ms", observed_at_ms.to_string()),
                     ("error", error.to_string()),
                 ],
             ),
@@ -44,6 +66,10 @@ impl RuntimeWorkRpcHandler {
     }
 
     pub(super) fn project_runtime_link_status(&self, link: &RuntimeTaskLink) {
+        self.project_runtime_link_status_at(link, link.updated_at);
+    }
+
+    fn project_runtime_link_status_at(&self, link: &RuntimeTaskLink, observed_at_ms: i64) {
         let execution_status = if link.status == "archived" {
             Some("archived")
         } else if link.running || link.status == "running" {
@@ -59,7 +85,7 @@ impl RuntimeWorkRpcHandler {
             }
         };
         if let Some(execution_status) = execution_status {
-            self.project_bound_task_status(&link.local_task_id, execution_status);
+            self.project_bound_task_status(&link.local_task_id, execution_status, observed_at_ms);
         }
     }
 

--- a/executor/src/runtime_work/handler/runtime_rpc.rs
+++ b/executor/src/runtime_work/handler/runtime_rpc.rs
@@ -5,6 +5,14 @@
 use super::*;
 
 impl RuntimeWorkHandler for RuntimeWorkRpcHandler {
+    fn reconcile_bound_task_statuses<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            RuntimeWorkRpcHandler::reconcile_bound_task_statuses(self).await;
+        })
+    }
+
     fn handle_runtime_rpc<'a>(
         &'a self,
         data: Value,

--- a/executor/src/task_runtime/store.rs
+++ b/executor/src/task_runtime/store.rs
@@ -2170,7 +2170,13 @@ impl LocalTaskStore {
         device_id: &str,
         task_id: &str,
         execution_status: &str,
+        observed_at_ms: i64,
     ) -> Result<usize, TaskRuntimeError> {
+        if observed_at_ms <= 0 {
+            return Err(TaskRuntimeError::Invalid(
+                "runtime task status observation requires a positive timestamp".to_owned(),
+            ));
+        }
         let next_status = match execution_status {
             "queued" | "pending" => "pending",
             "running" => "in_progress",
@@ -2183,7 +2189,8 @@ impl LocalTaskStore {
                 )));
             }
         };
-        let connection = self.connection()?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let timestamp = now();
         let preserve_reviewed = matches!(
             execution_status,
@@ -2196,7 +2203,7 @@ impl LocalTaskStore {
                 | "interrupted"
                 | "error"
         );
-        let changed = connection.execute(
+        let changed = transaction.execute(
             "UPDATE loop_items
              SET status = ?1,
                  completed_at = CASE WHEN ?1 = 'completed' THEN ?2 ELSE NULL END,
@@ -2209,6 +2216,10 @@ impl LocalTaskStore {
                      AND device_id = ?3 AND task_id = ?4
                      AND unlinked_at IS NULL AND loop_item_id IS NOT NULL
                      AND json_extract(metadata, '$.workflow_node_id') IS NULL
+                     AND CAST(COALESCE(
+                         json_extract(metadata, '$.runtime_status_observed_at_ms'),
+                         0
+                     ) AS INTEGER) < ?6
                )
                AND status != ?1
                AND (NOT ?5 OR status NOT IN ('completed', 'in_review'))",
@@ -2217,9 +2228,30 @@ impl LocalTaskStore {
                 timestamp,
                 device_id,
                 task_id,
-                preserve_reviewed
+                preserve_reviewed,
+                observed_at_ms
             ],
         )?;
+        transaction.execute(
+            "UPDATE loop_items
+             SET metadata = json_set(
+                     COALESCE(metadata, '{}'),
+                     '$.runtime_status_observed_at_ms',
+                     ?1
+                 ),
+                 version = version + 1,
+                 updated_at = ?2
+             WHERE resource_type = 'execution'
+               AND device_id = ?3 AND task_id = ?4
+               AND unlinked_at IS NULL AND loop_item_id IS NOT NULL
+               AND json_extract(metadata, '$.workflow_node_id') IS NULL
+               AND CAST(COALESCE(
+                   json_extract(metadata, '$.runtime_status_observed_at_ms'),
+                   0
+               ) AS INTEGER) < ?1",
+            params![observed_at_ms, timestamp, device_id, task_id],
+        )?;
+        transaction.commit()?;
         Ok(changed)
     }
 
@@ -6127,7 +6159,7 @@ mod tests {
 
         assert_eq!(
             store
-                .project_bound_task_status("local-device", "runtime-status-1", "running")
+                .project_bound_task_status("local-device", "runtime-status-1", "running", 100,)
                 .unwrap(),
             1
         );
@@ -6142,7 +6174,7 @@ mod tests {
 
         assert_eq!(
             store
-                .project_bound_task_status("local-device", "runtime-status-1", "succeeded")
+                .project_bound_task_status("local-device", "runtime-status-1", "succeeded", 200,)
                 .unwrap(),
             1
         );
@@ -6157,7 +6189,43 @@ mod tests {
 
         assert_eq!(
             store
-                .project_bound_task_status("local-device", "runtime-status-1", "archived")
+                .project_bound_task_status("local-device", "runtime-status-1", "running", 150,)
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            store
+                .project_bound_task_status("local-device", "runtime-status-1", "queued", 175,)
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            store
+                .get_task(DEFAULT_WORK_ITEM_PROJECT_ID, &task.id)
+                .unwrap()
+                .status
+                .as_deref(),
+            Some("in_review")
+        );
+
+        assert_eq!(
+            store
+                .project_bound_task_status("local-device", "runtime-status-1", "running", 300,)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_task(DEFAULT_WORK_ITEM_PROJECT_ID, &task.id)
+                .unwrap()
+                .status
+                .as_deref(),
+            Some("in_progress")
+        );
+
+        assert_eq!(
+            store
+                .project_bound_task_status("local-device", "runtime-status-1", "archived", 400,)
                 .unwrap(),
             1
         );

--- a/executor/src/task_runtime/store.rs
+++ b/executor/src/task_runtime/store.rs
@@ -59,6 +59,14 @@ impl LocalTaskStore {
         Self::open(local_database_path())
     }
 
+    pub fn from_env_if_exists() -> Result<Option<Self>, TaskRuntimeError> {
+        let path = local_database_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+        Self::open(path).map(Some)
+    }
+
     pub fn open(path: impl AsRef<Path>) -> Result<Self, TaskRuntimeError> {
         let path = path.as_ref().to_path_buf();
         if let Some(parent) = path.parent() {
@@ -2155,6 +2163,64 @@ impl LocalTaskStore {
         let connection = self.connection()?;
         get_effective_binding(&connection, device_id, task_id)?
             .ok_or(TaskRuntimeError::TaskNotFound)
+    }
+
+    pub fn project_bound_task_status(
+        &self,
+        device_id: &str,
+        task_id: &str,
+        execution_status: &str,
+    ) -> Result<usize, TaskRuntimeError> {
+        let next_status = match execution_status {
+            "queued" | "pending" => "pending",
+            "running" => "in_progress",
+            "done" | "completed" | "succeeded" | "failed" | "cancelled" | "canceled"
+            | "interrupted" | "error" => "in_review",
+            "archived" => "completed",
+            _ => {
+                return Err(TaskRuntimeError::Invalid(format!(
+                    "unsupported runtime task status '{execution_status}'"
+                )));
+            }
+        };
+        let connection = self.connection()?;
+        let timestamp = now();
+        let preserve_reviewed = matches!(
+            execution_status,
+            "done"
+                | "completed"
+                | "succeeded"
+                | "failed"
+                | "cancelled"
+                | "canceled"
+                | "interrupted"
+                | "error"
+        );
+        let changed = connection.execute(
+            "UPDATE loop_items
+             SET status = ?1,
+                 completed_at = CASE WHEN ?1 = 'completed' THEN ?2 ELSE NULL END,
+                 sort_order = 0, version = version + 1, updated_at = ?2
+             WHERE resource_type = 'task'
+               AND id IN (
+                   SELECT loop_item_id
+                   FROM loop_items
+                   WHERE resource_type = 'execution'
+                     AND device_id = ?3 AND task_id = ?4
+                     AND unlinked_at IS NULL AND loop_item_id IS NOT NULL
+                     AND json_extract(metadata, '$.workflow_node_id') IS NULL
+               )
+               AND status != ?1
+               AND (NOT ?5 OR status NOT IN ('completed', 'in_review'))",
+            params![
+                next_status,
+                timestamp,
+                device_id,
+                task_id,
+                preserve_reviewed
+            ],
+        )?;
+        Ok(changed)
     }
 
     pub fn find_system_task_binding(
@@ -6025,6 +6091,84 @@ mod tests {
             store.find_task_binding("local-device", "runtime-1"),
             Err(TaskRuntimeError::TaskNotFound)
         ));
+    }
+
+    #[test]
+    fn projects_runtime_status_to_bound_issue_without_renderer_writeback() {
+        let (_directory, store) = store();
+        let task = store
+            .create_task(
+                DEFAULT_WORK_ITEM_PROJECT_ID,
+                TaskCreate {
+                    title: "Runtime-owned status".to_owned(),
+                    description: String::new(),
+                    status: "in_review".to_owned(),
+                    priority: "none".to_owned(),
+                    parent_id: None,
+                    tags: vec![],
+                    workflow: None,
+                },
+            )
+            .unwrap();
+        store
+            .bind_task(
+                DEFAULT_WORK_ITEM_PROJECT_ID,
+                Some(&task.id),
+                None,
+                RuntimeTaskAddress {
+                    device_id: "local-device".to_owned(),
+                    task_id: "runtime-status-1".to_owned(),
+                    task_title: task.title.clone(),
+                    backend_task_id: None,
+                    workflow_node_id: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            store
+                .project_bound_task_status("local-device", "runtime-status-1", "running")
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_task(DEFAULT_WORK_ITEM_PROJECT_ID, &task.id)
+                .unwrap()
+                .status
+                .as_deref(),
+            Some("in_progress")
+        );
+
+        assert_eq!(
+            store
+                .project_bound_task_status("local-device", "runtime-status-1", "succeeded")
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_task(DEFAULT_WORK_ITEM_PROJECT_ID, &task.id)
+                .unwrap()
+                .status
+                .as_deref(),
+            Some("in_review")
+        );
+
+        assert_eq!(
+            store
+                .project_bound_task_status("local-device", "runtime-status-1", "archived")
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_task(DEFAULT_WORK_ITEM_PROJECT_ID, &task.id)
+                .unwrap()
+                .status
+                .as_deref(),
+            Some("completed")
+        );
     }
 
     #[test]

--- a/executor/tests/local_app_ipc_contract.rs
+++ b/executor/tests/local_app_ipc_contract.rs
@@ -431,6 +431,64 @@ async fn app_ipc_manages_local_projects_and_nested_todos() {
 }
 
 #[tokio::test]
+async fn app_ipc_reconciles_runtime_status_at_task_service_boundaries() {
+    let _lock = env_lock().await;
+    let executor_home = tempfile::tempdir().unwrap();
+    let _executor_home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &executor_home.path().display().to_string(),
+    );
+    let reconciliations = Arc::new(Mutex::new(0));
+    let server = AppIpcServer::new().with_runtime_work_handler(ProjectionRuntimeHandler {
+        reconciliations: Arc::clone(&reconciliations),
+    });
+    let project = server
+        .dispatch(
+            "projects.create",
+            json!({
+                "name": "Bound Runtime",
+                "project_key": "BOUND",
+                "task_provider": "local"
+            }),
+        )
+        .await
+        .unwrap();
+    let task = server
+        .dispatch(
+            "todos.create",
+            json!({
+                "project_id": project["id"],
+                "todo": {"title": "Track running task"}
+            }),
+        )
+        .await
+        .unwrap();
+
+    server
+        .dispatch(
+            "todos.bind",
+            json!({
+                "project_id": project["id"],
+                "item_id": task["id"],
+                "task": {
+                    "device_id": "local-device",
+                    "task_id": "runtime-running-1",
+                    "task_title": "Track running task"
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+    server
+        .dispatch("todos.list", json!({"project_id": project["id"]}))
+        .await
+        .unwrap();
+
+    assert_eq!(*reconciliations.lock().unwrap(), 2);
+}
+
+#[tokio::test]
 async fn app_ipc_stores_project_files_attachments_and_deliveries_locally() {
     let _lock = env_lock().await;
     let executor_home = tempfile::tempdir().unwrap();
@@ -1879,6 +1937,27 @@ impl RuntimeWorkHandler for RuntimeHandler {
                 })
             );
             Ok(json!({"success": true, "workspaces": []}))
+        })
+    }
+}
+
+struct ProjectionRuntimeHandler {
+    reconciliations: Arc<Mutex<usize>>,
+}
+
+impl RuntimeWorkHandler for ProjectionRuntimeHandler {
+    fn handle_runtime_rpc<'a>(
+        &'a self,
+        _data: Value,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, AppIpcError>> + Send + 'a>> {
+        Box::pin(async { Ok(json!({})) })
+    }
+
+    fn reconcile_bound_task_statuses<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            *self.reconciliations.lock().unwrap() += 1;
         })
     }
 }

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -927,6 +927,55 @@ async function verifyTrackedTaskRunningStatus(control, taskTabTestId) {
     'workspace-02-running-task-synchronized.png',
     activeBoardContentSelector
   )
+
+  const boardCardSelector = [
+    `${activeBoardContentSelector} button[data-testid^="cloud-todo-card-"]`,
+    ':not([data-testid^="cloud-todo-card-task-"])',
+    ':not([data-testid^="cloud-todo-card-more-"])',
+    ':not([data-testid^="cloud-todo-card-archive-"])',
+    ':not([data-testid^="cloud-todo-card-add-child-"])',
+  ].join('')
+  await control.command('markElementWithText', boardCardSelector, {
+    text: 'WEWORK_DESKTOP_E2E_TASK',
+    value: 'running-work-item-card',
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await control.command(
+    'drag',
+    `${activeBoardContentSelector} [data-e2e-anchor-id="running-work-item-card"]`,
+    {
+      target: `${activeBoardContentSelector} [data-testid="cloud-todo-column-dropzone-in_review"]`,
+    }
+  )
+  await control.command('waitFor', reviewColumnSelector, {
+    text: 'WEWORK_DESKTOP_E2E_TASK',
+    visible: true,
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  await captureVerificationScreenshot(
+    control,
+    'workspace-02a-running-task-stale-review.png',
+    activeBoardContentSelector
+  )
+
+  await reloadMainWindow(
+    control,
+    'The Wework WebView did not reconnect while restoring a running My Tasks Issue'
+  )
+  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await control.command('waitFor', runningColumnSelector, {
+    text: 'WEWORK_DESKTOP_E2E_TASK',
+    visible: true,
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  assert.doesNotMatch(
+    await control.command('getText', reviewColumnSelector),
+    /WEWORK_DESKTOP_E2E_TASK/,
+    'Reloading left the active task Issue in the review column'
+  )
+
   await control.command('click', `[data-testid="${taskTabTestId}"]`)
   await control.command('waitFor', `[data-testid="${taskTabTestId}"][aria-selected="true"]`, {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
@@ -969,11 +1018,6 @@ async function verifyTrackedTaskSettledStatus(control) {
     await control.command('getText', runningColumnSelector),
     /WEWORK_DESKTOP_E2E_TASK/,
     'The settled task remained in the running column'
-  )
-  await captureVerificationScreenshot(
-    control,
-    'workspace-03-settled-task-synchronized.png',
-    activeBoardContentSelector
   )
 }
 

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -433,7 +433,6 @@ export function WorkspaceTabSurface({
                 isElectronRuntime() &&
                 getDesktopWindowLabel() === 'main'
               }
-              syncProjectTaskTracking={tab.fixed && tab.kind === 'task'}
               syncRemoteProjects={active}
               syncRuntimeTaskLifecycle={active}
             >
@@ -618,7 +617,6 @@ function AppRoutes({ onWorkbenchStartupReadyChange, onOpenWeworkForAppshot }: Ap
           services={services}
           user={user}
           onStartupReadyChange={onWorkbenchStartupReadyChange}
-          syncProjectTaskTracking={false}
         >
           {isElectronRuntime() && <SystemDragBridge />}
           <PopoutWorkbenchPage />

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -13,7 +13,6 @@ import { flushSync } from 'react-dom'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { LOCAL_USER } from '@/api/local/localSession'
 import { resetLocalRuntimeChatStreamsForTests } from '@/api/local/localServices'
-import type { CloudLoopItem, TaskExecutionStatus } from '@/api/deliveries'
 import i18n from '@/i18n'
 import {
   CloudConnectionContext,
@@ -9742,13 +9741,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(screen.getByTestId('archive-result')).toHaveTextContent('archived'))
     expect(screen.getByTestId('workbench-error')).toHaveTextContent('')
     expect(runtimeWorkApi.archiveConversation).toHaveBeenCalledTimes(1)
-    expect(updateTaskTrackingStatus).toHaveBeenCalledWith(
-      expect.objectContaining({
-        deviceId: 'device-1',
-        taskId: 'runtime-worktree',
-      }),
-      'archived'
-    )
+    expect(updateTaskTrackingStatus).not.toHaveBeenCalled()
     expect(getRuntimeConversationMessages(archivedAddress)).toEqual([])
     expect(runtimeWorkApi.deleteWorktree).toHaveBeenCalledWith({
       deviceId: 'device-1',
@@ -13458,7 +13451,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
   })
 
-  test('syncs board completion and canonical completed task status', async () => {
+  test('keeps board status writes out of renderer lifecycle reconciliation', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
       if (handlers.onChatStart) streamHandlers = handlers
@@ -13566,12 +13559,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     await waitFor(() => expect(streamHandlers.onChatStart).toBeDefined())
     await waitFor(() => expect(listRuntimeWork).toHaveBeenCalledTimes(1))
-    await waitFor(() =>
-      expect(updateTaskTrackingStatus).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceId: 'device-1', taskId: 'runtime-a' }),
-        'succeeded'
-      )
-    )
+    expect(updateTaskTrackingStatus).not.toHaveBeenCalled()
 
     act(() => {
       streamHandlers.onChatStart?.({
@@ -13605,12 +13593,7 @@ describe('WorkbenchProvider runtime tasks', () => {
         result: { value: 'done' },
       })
     })
-    await waitFor(() =>
-      expect(updateTaskTrackingStatus).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceId: 'device-1', taskId: 'runtime-a' }),
-        'succeeded'
-      )
-    )
+    expect(updateTaskTrackingStatus).not.toHaveBeenCalled()
     await waitFor(() => expect(listRuntimeWork).toHaveBeenCalledTimes(2))
     expect(screen.getByTestId('runtime-local-task-titles')).toHaveTextContent(
       '修复登录回调|Runtime B'
@@ -13619,7 +13602,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('runtime-a-task-status')).toHaveTextContent('done')
   })
 
-  test('reconciles restored runtime state without creating board items', async () => {
+  test('does not write board status while restoring runtime state', async () => {
     const updateTaskTrackingStatus = vi.fn().mockResolvedValue(null)
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(
@@ -13666,15 +13649,10 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbench(<RuntimeTopLevelStreamLifecycleProbe />, services)
 
     await waitFor(() => expect(runtimeWorkApi.listRuntimeWork).toHaveBeenCalledTimes(1))
-    await waitFor(() =>
-      expect(updateTaskTrackingStatus).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceId: 'device-1', taskId: 'runtime-a' }),
-        'running'
-      )
-    )
+    expect(updateTaskTrackingStatus).not.toHaveBeenCalled()
   })
 
-  test('routes task status to the project store recorded in the runtime handle', async () => {
+  test('routes task titles to the project store recorded in the runtime handle', async () => {
     let streamHandlers: ChatStreamHandlers = {}
     const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
       if (handlers.onRuntimeTaskTitleUpdated) streamHandlers = handlers
@@ -13741,24 +13719,8 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     renderWorkbench(<RuntimeTopLevelStreamLifecycleProbe />, services)
 
-    await waitFor(() => expect(streamHandlers.onChatStart).toBeDefined())
-    act(() => {
-      streamHandlers.onChatStart?.({
-        taskId: 'runtime-cloud',
-        subtaskId: '101',
-        shellType: 'Codex',
-        deviceId: 'local-device',
-      })
-    })
-    await waitFor(() =>
-      expect(updateCloudTaskStatus).toHaveBeenCalledWith(
-        expect.objectContaining({
-          deviceId: 'local-device',
-          taskId: 'runtime-cloud',
-        }),
-        'running'
-      )
-    )
+    await waitFor(() => expect(streamHandlers.onRuntimeTaskTitleUpdated).toBeDefined())
+    expect(updateCloudTaskStatus).not.toHaveBeenCalled()
     expect(updateLocalTaskStatus).not.toHaveBeenCalled()
 
     act(() => {
@@ -13847,115 +13809,7 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     await waitFor(() => expect(runtimeWorkApi.listRuntimeWork).toHaveBeenCalledTimes(1))
     expect(trackProjectTask).not.toHaveBeenCalled()
-    await waitFor(() =>
-      expect(updateTaskTrackingStatus).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceId: 'device-1', taskId: 'runtime-bound' }),
-        'queued'
-      )
-    )
-  })
-
-  test('waits for canonical executor settlement before projecting completion', async () => {
-    let streamHandlers: ChatStreamHandlers = {}
-    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
-      if (handlers.onChatStart) streamHandlers = handlers
-      return vi.fn()
-    })
-    const staleRunningUpdate = deferred<null>()
-    const updateTaskTrackingStatus = vi.fn(
-      (_address: RuntimeTaskAddress, status: TaskExecutionStatus) =>
-        status === 'running'
-          ? staleRunningUpdate.promise
-          : Promise.resolve({ id: 'tracked-item' } as CloudLoopItem)
-    )
-    const runningRuntimeWork = createRuntimeWork({
-      projects: [
-        {
-          project: { id: 7, name: 'Wegent' },
-          deviceWorkspaces: [
-            {
-              deviceId: 'device-1',
-              deviceName: 'Project Device',
-              deviceStatus: 'online',
-              workspacePath: '/workspace/project-alpha',
-              mapped: true,
-              available: true,
-              tasks: [
-                {
-                  taskId: 'runtime-a',
-                  workspacePath: '/workspace/project-alpha',
-                  title: 'Runtime A',
-                  runtime: 'codex',
-                  running: true,
-                  status: 'running',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      totalTasks: 1,
-    })
-    const staleRuntimeWorkRefresh = deferred<RuntimeWorkListResponse>()
-    const listRuntimeWork = vi
-      .fn()
-      .mockResolvedValueOnce(runningRuntimeWork)
-      .mockImplementationOnce(() => staleRuntimeWorkRefresh.promise)
-    const runtimeWorkApi = createRuntimeWorkApiMock({ listRuntimeWork })
-    const services = createWorkbenchServices({
-      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
-      chatStream: {
-        subscribe,
-      } as unknown as WorkbenchServices['chatStream'],
-      projectSpaceApis: {
-        local: {
-          updateTaskTrackingStatus,
-          updateTaskTrackingTitle: vi.fn().mockResolvedValue(null),
-        },
-      } as unknown as WorkbenchServices['projectSpaceApis'],
-    })
-
-    renderWorkbench(<RuntimeTopLevelStreamLifecycleProbe />, services)
-    await waitFor(() => expect(streamHandlers.onChatStart).toBeDefined())
-    act(() => {
-      streamHandlers.onChatStart?.({
-        taskId: 'runtime-a',
-        subtaskId: '101',
-        shellType: 'Codex',
-        deviceId: 'device-1',
-      })
-    })
-    await waitFor(() =>
-      expect(updateTaskTrackingStatus).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceId: 'device-1', taskId: 'runtime-a' }),
-        'running'
-      )
-    )
-
-    act(() => {
-      streamHandlers.onChatDone?.({
-        taskId: 'runtime-a',
-        subtaskId: '101',
-        deviceId: 'device-1',
-        result: { value: 'done' },
-      })
-    })
-
-    await waitFor(() => expect(listRuntimeWork).toHaveBeenCalledTimes(2))
-    await act(async () => {
-      staleRunningUpdate.reject(new Error('stale running update failed'))
-      await staleRunningUpdate.promise.catch(() => undefined)
-    })
-    await act(async () => {
-      staleRuntimeWorkRefresh.resolve(runningRuntimeWork)
-      await staleRuntimeWorkRefresh.promise
-    })
-    expect(updateTaskTrackingStatus).toHaveBeenCalledTimes(2)
-    expect(updateTaskTrackingStatus.mock.calls.map(([, status]) => status)).toEqual([
-      'running',
-      'running',
-    ])
-    expect(updateTaskTrackingStatus.mock.calls.at(-1)?.[1]).toBe('running')
+    expect(updateTaskTrackingStatus).not.toHaveBeenCalled()
   })
 
   test('polls the cloud executor until idle when the cached snapshot predates the active turn', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -31,12 +31,10 @@ import {
 } from '@/desktop/runtimeWorkSync'
 import { disposeDesktopListener } from '@/desktop/disposeDesktopListener'
 import { createLocalCodexPluginApi, peekLocalCodexPluginsReadState } from '@/api/local/codexPlugins'
-import type { TaskExecutionStatus } from '@/api/deliveries'
 import { createHttpClient } from '@/api/http'
 import { createPluginApi } from '@/api/plugins'
 import { listWegentInstalledConnectorApps } from '@/api/cloud/connectorApps'
 import { startLocalRobotQueueDispatcher } from '@/features/todo/localRobotQueueDispatcher'
-import { subscribeProjectSpaceTaskBindingChanged } from '@/features/todo/projectSpaceSelection'
 import {
   getComposerApps,
   publishComposerApps,
@@ -84,11 +82,7 @@ import { initialWorkbenchState, workbenchReducer } from './workbenchReducer'
 import { useRuntimeTaskReminders } from './runtimeTaskReminders'
 import { sendSystemNotification } from './runtimeTaskSystemNotifications'
 import { WorkbenchContext, WorkbenchPaneContext } from './useWorkbench'
-import {
-  projectTaskTrackingApi,
-  reconcileProjectTaskTrackingStatus,
-  runtimeTaskTrackingStatus,
-} from './projectTaskTracking'
+import { projectTaskTrackingApi } from './projectTaskTracking'
 import {
   buildTrialTemplatePrompt,
   consumePluginTrial,
@@ -200,7 +194,6 @@ export function WorkbenchProvider({
   prewarmComposerApps = true,
   publishDebugSnapshots = true,
   syncCoreDshModels = false,
-  syncProjectTaskTracking = true,
   syncRemoteProjects = true,
   syncRuntimeTaskLifecycle = true,
 }: WorkbenchProviderProps) {
@@ -264,7 +257,6 @@ export function WorkbenchProvider({
     [canSyncRuntimeTaskLifecycle, sharedLifecycleStore]
   )
   const lifecycleSnapshot = useRuntimeTaskLifecycleStoreSnapshot(sharedLifecycleStore)
-  const trackingStatusSignaturesRef = useRef(new Map<string, string>())
   const trackingTitleSignaturesRef = useRef(new Map<string, string>())
   const runtimeTaskSettleSyncGenerationRef = useRef(new Map<string, number>())
   const runtimeTaskSettleSyncGenerationCounterRef = useRef(0)
@@ -1910,48 +1902,6 @@ export function WorkbenchProvider({
         })
       })
   })
-  const syncProjectTaskExecutionStatus = useStableEvent(
-    (address: RuntimeTaskAddress, executionStatus: TaskExecutionStatus) => {
-      const trackedAddress = lifecycleStore.getTask(address)?.address ?? address
-      const key = runtimeConversationKey(trackedAddress)
-      if (trackingStatusSignaturesRef.current.get(key) === executionStatus) return
-      trackingStatusSignaturesRef.current.set(key, executionStatus)
-      void reconcileProjectTaskTrackingStatus(
-        resolvedServices,
-        trackedAddress,
-        executionStatus
-      ).catch(error => {
-        if (trackingStatusSignaturesRef.current.get(key) === executionStatus) {
-          trackingStatusSignaturesRef.current.delete(key)
-        }
-        console.warn('[Wework] Failed to synchronize project task execution status', {
-          address: trackedAddress,
-          executionStatus,
-          error,
-        })
-      })
-    }
-  )
-  useEffect(() => {
-    if (!syncProjectTaskTracking) return
-    for (const lifecycle of lifecycleSnapshot.tasks.values()) {
-      const executionStatus = runtimeTaskTrackingStatus(lifecycle)
-      if (executionStatus) {
-        syncProjectTaskExecutionStatus(lifecycle.address, executionStatus)
-      }
-    }
-  }, [lifecycleSnapshot, syncProjectTaskExecutionStatus, syncProjectTaskTracking])
-  useEffect(() => {
-    if (!syncProjectTaskTracking) return
-    return subscribeProjectSpaceTaskBindingChanged(address => {
-      const lifecycle = lifecycleStore.getTask(address)
-      if (!lifecycle) return
-      const executionStatus = runtimeTaskTrackingStatus(lifecycle)
-      if (!executionStatus) return
-      trackingStatusSignaturesRef.current.delete(runtimeConversationKey(address))
-      syncProjectTaskExecutionStatus(address, executionStatus)
-    })
-  }, [lifecycleStore, syncProjectTaskExecutionStatus, syncProjectTaskTracking])
   const updateCanonicalRuntimeContextUsage = useStableEvent(
     (address: RuntimeTaskAddress, usage: RuntimeContextUsage) => {
       const currentAddress =

--- a/wework/src/features/workbench/projectTaskTracking.test.ts
+++ b/wework/src/features/workbench/projectTaskTracking.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import type { RuntimeTaskLifecycleSnapshot } from './runtimeTaskLifecycle'
 import type { WorkbenchServices } from './workbenchServices'
-import {
-  projectTaskTrackingApi,
-  reconcileProjectTaskTrackingStatus,
-  rememberProjectTaskStore,
-  runtimeTaskTrackingStatus,
-} from './projectTaskTracking'
+import { projectTaskTrackingApi, rememberProjectTaskStore } from './projectTaskTracking'
 
 describe('projectTaskTrackingApi', () => {
   test.each([
@@ -55,68 +49,5 @@ describe('projectTaskTrackingApi', () => {
     rememberProjectTaskStore(address, 'local')
 
     expect(projectTaskTrackingApi(services, address)).toBe(local)
-  })
-
-  test.each([
-    [{ isQueued: true, isRunning: false }, null, 'queued'],
-    [{ isQueued: false, isRunning: true }, null, 'running'],
-    [{ isQueued: false, isRunning: false }, 'succeeded', 'succeeded'],
-    [{ isQueued: false, isRunning: false }, 'failed', 'failed'],
-    [{ isQueued: false, isRunning: false }, 'cancelled', 'cancelled'],
-  ] as const)(
-    'projects lifecycle state through the canonical mapper',
-    (derived, outcome, expected) => {
-      const lifecycle = {
-        derived: {
-          ...derived,
-        },
-        turn: {
-          active: false,
-          outcome,
-        },
-        task: null,
-      } as RuntimeTaskLifecycleSnapshot
-
-      expect(runtimeTaskTrackingStatus(lifecycle)).toBe(expected)
-    }
-  )
-
-  test('projects authoritative completed snapshots as succeeded', () => {
-    const lifecycle = {
-      derived: {
-        isQueued: false,
-        isRunning: false,
-      },
-      turn: {
-        active: false,
-        outcome: null,
-      },
-      task: {
-        running: false,
-        completedAt: 1_787_563_200_000,
-      },
-    } as RuntimeTaskLifecycleSnapshot
-
-    expect(runtimeTaskTrackingStatus(lifecycle)).toBe('succeeded')
-  })
-
-  test('persists status and publishes through the single reconciler', async () => {
-    const item = { id: 'WORK-1' }
-    const updateTaskTrackingStatus = vi.fn().mockResolvedValue(item)
-    const services = {
-      projectSpaceApis: {
-        local: { updateTaskTrackingStatus },
-        defaultLocation: 'local',
-      },
-    } as unknown as WorkbenchServices
-    const address = {
-      deviceId: 'local-device',
-      taskId: 'runtime-1',
-    }
-
-    await expect(reconcileProjectTaskTrackingStatus(services, address, 'running')).resolves.toBe(
-      item
-    )
-    expect(updateTaskTrackingStatus).toHaveBeenCalledWith(address, 'running')
   })
 })

--- a/wework/src/features/workbench/projectTaskTracking.ts
+++ b/wework/src/features/workbench/projectTaskTracking.ts
@@ -1,8 +1,4 @@
-import type { CloudLoopItem, TaskExecutionStatus } from '@/api/deliveries'
-import { publishProjectSpaceTaskContextChanged } from '@/features/todo/projectSpaceSelection'
 import type { RuntimeTaskAddress } from '@/types/api'
-import type { RuntimeTaskLifecycleSnapshot } from './runtimeTaskLifecycle'
-import { runtimeTaskTrackingExecutionStatus } from './runtimeTaskLifecycle/projection'
 import type { WorkbenchServices } from './workbenchServices'
 
 const projectStoreByRuntimeTask = new Map<string, 'backend' | 'local'>()
@@ -19,12 +15,6 @@ export function rememberProjectTaskStore(
   if (projectStoreByRuntimeTask.get(key) === projectStore) return false
   projectStoreByRuntimeTask.set(key, projectStore)
   return true
-}
-
-export function runtimeTaskTrackingStatus(
-  lifecycle: RuntimeTaskLifecycleSnapshot
-): TaskExecutionStatus | null {
-  return runtimeTaskTrackingExecutionStatus(lifecycle)
 }
 
 export function projectTaskTrackingApi(services: WorkbenchServices, address: RuntimeTaskAddress) {
@@ -50,16 +40,4 @@ export function projectTaskTrackingApi(services: WorkbenchServices, address: Run
           ? 'cloud'
           : 'local'
   return apis[location] ?? null
-}
-
-export async function reconcileProjectTaskTrackingStatus(
-  services: WorkbenchServices,
-  address: RuntimeTaskAddress,
-  executionStatus: TaskExecutionStatus
-): Promise<CloudLoopItem | null> {
-  const api = projectTaskTrackingApi(services, address)
-  if (!api) return null
-  const item = await api.updateTaskTrackingStatus(address, executionStatus)
-  if (item) publishProjectSpaceTaskContextChanged(address)
-  return item
 }

--- a/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeTasks.ts
@@ -17,7 +17,6 @@ import type {
   RuntimeWorkSearchRequest,
   User,
 } from '@/types/api'
-import { reconcileProjectTaskTrackingStatus } from './projectTaskTracking'
 import type {
   RuntimePaneTranscript,
   RuntimePaneTranscriptLoadOptions,
@@ -255,24 +254,6 @@ export function useWorkbenchRuntimeTasks({
     [dispatch, services.runtimeWorkApi, t]
   )
 
-  const completeArchivedBoardTasks = useCallback(
-    async (addresses: RuntimeTaskAddress[]) => {
-      await Promise.all(
-        addresses.map(async address => {
-          try {
-            await reconcileProjectTaskTrackingStatus(services, address, 'archived')
-          } catch (error) {
-            console.warn('[Wework] Failed to complete archived task on project board', {
-              address: runtimeAddressDebug(address),
-              error,
-            })
-          }
-        })
-      )
-    },
-    [services]
-  )
-
   const archiveRuntimeConversations = useCallback(
     async (
       addresses: RuntimeTaskAddress[],
@@ -303,7 +284,6 @@ export function useWorkbenchRuntimeTasks({
       ]
       let worktreeCleanupSucceeded = true
       if (archivedAddresses.length > 0) {
-        await completeArchivedBoardTasks(archivedAddresses)
         archivedAddresses.forEach(evictRuntimeConversation)
         archivedAddresses.forEach(address => lifecycleStore.remove(address))
         markRuntimeTasksArchived(archivedAddresses)
@@ -332,7 +312,6 @@ export function useWorkbenchRuntimeTasks({
     },
     [
       clearCurrentRuntimeTaskIfArchived,
-      completeArchivedBoardTasks,
       dispatch,
       executorClient,
       lifecycleStore,

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -472,7 +472,6 @@ export interface WorkbenchProviderProps {
   prewarmComposerApps?: boolean
   publishDebugSnapshots?: boolean
   syncCoreDshModels?: boolean
-  syncProjectTaskTracking?: boolean
   syncRemoteProjects?: boolean
   syncRuntimeTaskLifecycle?: boolean
 }


### PR DESCRIPTION
## 问题

Wework「我的任务」中的 Issue 状态由 renderer 生命周期补偿更新。renderer 被隐藏或重载时不会可靠运行，导致实际运行中的任务仍停留在「待确认」。

## 修复

- 由 Executor 在任务 queued/running/terminal/archived 生命周期中持久化本地绑定 Issue 状态
- Executor 在广播终态事件前先提交 Issue 终态，避免页面收到事件后读到旧状态
- `runtime.tasks.list` 按 Executor 权威快照修复重载期间的陈旧状态
- 后端设备运行事件同步更新直接绑定的云端 Issue，并发布变更事件
- 删除 renderer 的运行状态写回路径；保留标题同步与人工看板操作 API
- 扩展现有 CI 覆盖的桌面 E2E：将运行中 Issue 手动拖到「待确认」，重载后断言恢复到「进行中」，完成后断言进入「等待确认」

## 验证

- `cargo test -p wegent-executor projects_runtime_status_to_bound_issue_without_renderer_writeback`
- `cd backend && uv run pytest tests/services/test_project_chat_service.py -k directly_bound_issue_status`
- Wework 聚焦 Vitest：8 passed
- `pnpm --filter wework e2e:desktop --segment task-status-sync`：PASS，1m54s，无断言错误
- Prettier 与 `git diff --check` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime task execution statuses now sync directly to linked project tasks.
  * Manually linked tasks without workflow nodes update correctly as work starts and finishes.
  * Task status changes are reflected in project boards and task listings.

* **Bug Fixes**
  * Prevented stale board statuses caused by renderer-side reconciliation.
  * Improved status restoration after reloads and runtime task completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->