### PR TITLE
fix(wework): restore running task lifecycle state

### DIFF
--- a/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts
@@ -1160,6 +1160,8 @@ describe('RuntimeTaskLifecycleStore', () => {
   test('accepts an executor-confirmed autonomous turn after the previous turn settles', () => {
     const store = new RuntimeTaskLifecycleStore('test')
     store.syncRuntimeWork(runtimeWork(task({ running: true })))
+    store.turnStarted(address, 'turn-1')
+    store.turnSettled(address, 'turn-1', 'succeeded')
     store.executorSettled(address)
 
     store.syncRuntimeWork(
@@ -1175,7 +1177,11 @@ describe('RuntimeTaskLifecycleStore', () => {
 
     const snapshot = store.getTask(address)
     expect(snapshot?.execution.running).toBe(true)
+    expect(snapshot?.turn.outcome).toBe('succeeded')
     expect(snapshot?.derived.shouldShowSidebarRunning).toBe(true)
+    expect(store.getSnapshot().runningTaskKeys).toEqual(
+      new Set([getRuntimeTaskLifecycleKey(address)])
+    )
   })
 
   test('does not let an optimistic projection settle an executor that remains active', () => {

--- a/wework/src/features/workbench/runtimeTaskLifecycle/reducer.ts
+++ b/wework/src/features/workbench/runtimeTaskLifecycle/reducer.ts
@@ -19,8 +19,7 @@ export function reduceRuntimeTaskLifecycle(
         terminalStatus && (!hasIdentifiedActiveTurn || completionAdvanced)
       const transitionMismatch =
         snapshotRunning !== null && expectedRunning !== null && snapshotRunning !== expectedRunning
-      const snapshotConfirmsAutonomousTurn =
-        isRuntimeTaskConfirmedActive(event.task) && state.turnOutcome === null
+      const snapshotConfirmsAutonomousTurn = isRuntimeTaskConfirmedActive(event.task)
       const snapshotRevivesSettledTaskWithoutIntent =
         Boolean(state.task && isRuntimeTaskAuthoritativeCompletion(state.task)) &&
         isRuntimeTaskConfirmedActive(event.task) &&


### PR DESCRIPTION
## Summary

- accept executor-confirmed active task snapshots even when the previous turn outcome is already settled
- keep authoritative completion and stale-revival guards unchanged
- cover the regression sequence: successful turn -> executor settled -> autonomous active turn

## Verification

- `pnpm --filter wework test src/features/workbench/runtimeTaskLifecycle/RuntimeTaskLifecycleStore.test.ts` (68 passed)
- focused lifecycle/sidebar/composer suite (304 passed)
- Prettier and ESLint checks for changed files
- real packaged Electron lifecycle verification: first turn settled -> second turn running -> second turn settled
  - running state asserted both `runtime-local-task-running-*` and `pause-response-button`, with `send-message-button` absent
  - settled state asserted the ring and stop button absent, with the send button restored

## Root cause

The reducer only accepted an executor-confirmed autonomous active snapshot while `turnOutcome` was null. After a previous successful turn, `turnOutcome` remains `succeeded`, so an authoritative later snapshot (`running: true`, active thread, in-progress turn) was rejected as a transition mismatch. Both the sidebar ring and composer primary action consume this lifecycle state, causing the two visible status errors together.