### PR TITLE
fix(wework): avoid layout thrash when switching long tasks

### DIFF
--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -135,7 +135,6 @@ interface MessageListProps {
   hiddenRequestUserInputIds?: ReadonlySet<string>
   onAddSelectionToConversation?: (text: string) => void
   onAskSelectionInSidebar?: (text: string) => void
-  onVirtualLayoutChange?: () => void
   virtualAnchorToEnd?: boolean
   renderGapAfterMessage?: (
     message: WorkbenchMessage,
@@ -229,7 +228,6 @@ export const MessageList = memo(function MessageList({
   hiddenRequestUserInputIds,
   onAddSelectionToConversation,
   onAskSelectionInSidebar,
-  onVirtualLayoutChange,
   virtualAnchorToEnd = true,
   renderGapAfterMessage,
 }: MessageListProps) {
@@ -342,11 +340,6 @@ export const MessageList = memo(function MessageList({
   messageVirtualizer.shouldAdjustScrollPositionOnItemSizeChange =
     preserveScrollPositionOutsideVirtualizer
   const virtualTotalSize = virtualMessages ? messageVirtualizer.getTotalSize() : 0
-
-  useLayoutEffect(() => {
-    if (!virtualMessages) return
-    onVirtualLayoutChange?.()
-  }, [onVirtualLayoutChange, virtualMessages, virtualTotalSize])
 
   useLayoutEffect(() => {
     const previousIds = previousVisibleMessageIdsRef.current
@@ -784,7 +777,6 @@ function areMessageListPropsEqual(previous: MessageListProps, next: MessageListP
     previous.onAskSelectionInSidebar !== next.onAskSelectionInSidebar
       ? 'onAskSelectionInSidebar'
       : null,
-    previous.onVirtualLayoutChange !== next.onVirtualLayoutChange ? 'onVirtualLayoutChange' : null,
     previous.virtualAnchorToEnd !== next.virtualAnchorToEnd ? 'virtualAnchorToEnd' : null,
     previous.renderGapAfterMessage !== next.renderGapAfterMessage ? 'renderGapAfterMessage' : null,
   ].filter((key): key is string => key !== null)

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -838,6 +838,11 @@ function ScrollableMessagePaneContent({
       preserveLatestUserTurnRef.current = true
     }
 
+    if (virtualInitialPositionOwnerRef.current?.key === currentScrollKey) {
+      clearScheduledScrolls()
+      return
+    }
+
     if (messages.length === 0) {
       return
     }

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -277,6 +277,7 @@ function ScrollableMessagePaneContent({
     key: string
     snapshot: ConversationScrollSnapshot
   } | null>(null)
+  const virtualInitialPositionKeyRef = useRef<string | null>(null)
   const followingBottomKeyRef = useRef<string | null>(null)
   const preserveLatestUserTurnRef = useRef(false)
   const userScrollPausedAutoFollowRef = useRef(false)
@@ -698,6 +699,8 @@ function ScrollableMessagePaneContent({
   const adoptVirtualBottomPosition = useCallback(
     (scrollTopPx: number | null = null) => {
       clearScheduledScrolls()
+      virtualInitialPositionKeyRef.current = currentScrollKey
+      restoredScrollSnapshotRef.current = null
       followingBottomKeyRef.current = currentScrollKey
       markCurrentConversationPinnedToBottom()
       lastScrollTopRef.current = scrollTopPx
@@ -828,6 +831,7 @@ function ScrollableMessagePaneContent({
     if (conversationChanged) {
       userViewportAnchorRef.current = null
       restoredScrollSnapshotRef.current = null
+      virtualInitialPositionKeyRef.current = null
       preserveLatestUserTurnRef.current = false
       releasePendingLayoutScrollPosition()
     } else if (latestUserMessageChanged) {
@@ -993,6 +997,10 @@ function ScrollableMessagePaneContent({
   }, [])
 
   const handleContentLayoutChange = useCallback(() => {
+    if (virtualInitialPositionKeyRef.current === currentScrollKey) {
+      virtualInitialPositionKeyRef.current = null
+      return
+    }
     if (restorePendingLayoutScrollPosition()) {
       return
     }

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -277,7 +277,7 @@ function ScrollableMessagePaneContent({
     key: string
     snapshot: ConversationScrollSnapshot
   } | null>(null)
-  const virtualInitialPositionKeyRef = useRef<string | null>(null)
+  const virtualInitialPositionOwnerRef = useRef<{ key: string | null } | null>(null)
   const followingBottomKeyRef = useRef<string | null>(null)
   const preserveLatestUserTurnRef = useRef(false)
   const userScrollPausedAutoFollowRef = useRef(false)
@@ -699,7 +699,7 @@ function ScrollableMessagePaneContent({
   const adoptVirtualBottomPosition = useCallback(
     (scrollTopPx: number | null = null) => {
       clearScheduledScrolls()
-      virtualInitialPositionKeyRef.current = currentScrollKey
+      virtualInitialPositionOwnerRef.current = { key: currentScrollKey }
       restoredScrollSnapshotRef.current = null
       followingBottomKeyRef.current = currentScrollKey
       markCurrentConversationPinnedToBottom()
@@ -831,7 +831,7 @@ function ScrollableMessagePaneContent({
     if (conversationChanged) {
       userViewportAnchorRef.current = null
       restoredScrollSnapshotRef.current = null
-      virtualInitialPositionKeyRef.current = null
+      virtualInitialPositionOwnerRef.current = null
       preserveLatestUserTurnRef.current = false
       releasePendingLayoutScrollPosition()
     } else if (latestUserMessageChanged) {
@@ -997,8 +997,8 @@ function ScrollableMessagePaneContent({
   }, [])
 
   const handleContentLayoutChange = useCallback(() => {
-    if (virtualInitialPositionKeyRef.current === currentScrollKey) {
-      virtualInitialPositionKeyRef.current = null
+    if (virtualInitialPositionOwnerRef.current?.key === currentScrollKey) {
+      virtualInitialPositionOwnerRef.current = null
       return
     }
     if (restorePendingLayoutScrollPosition()) {

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import type { RefObject } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
+import { isDesktopRuntime } from '@/lib/runtime-environment'
 import type {
   DeviceInfo,
   RequestUserInputResponse,
@@ -287,6 +288,10 @@ function ScrollableMessagePaneContent({
   const loadingTranscriptGapKeyRef = useRef<string | null>(null)
   const autoLoadedTranscriptGapKeysRef = useRef(new Set<string>())
   const pendingLayoutScrollPositionRef = useRef<PendingLayoutScrollPosition | null>(null)
+  const lastMeasuredScrollSnapshotRef = useRef<{
+    key: string
+    snapshot: ConversationScrollSnapshot
+  } | null>(null)
   const [showScrollButton, setShowScrollButton] = useState(false)
   const [turnNavigationLoading, setTurnNavigationLoading] = useState(false)
   const [turnNavigationTargetMessageId, setTurnNavigationTargetMessageId] = useState<string | null>(
@@ -296,6 +301,7 @@ function ScrollableMessagePaneContent({
   const lastMessage = messages[messages.length - 1]
   const latestGuidanceMessageId = findLatestGuidanceMessageId(messages)
   const currentScrollKey = useMemo(() => scrollPositionKey(conversationKey), [conversationKey])
+  const virtualScrollOwnsInitialPosition = isDesktopRuntime()
   const messageScrollSignature = useMemo(() => {
     if (!lastMessage) return 'empty'
 
@@ -482,11 +488,32 @@ function ScrollableMessagePaneContent({
     [currentScrollKey, messages.length]
   )
 
+  const saveCurrentScrollPositionWithoutLayout = useCallback(() => {
+    const element = activeScrollRefRef.current.current
+    if (!element || currentScrollKey === null || messages.length === 0) return
+
+    const measuredSnapshot = lastMeasuredScrollSnapshotRef.current
+    if (measuredSnapshot?.key === currentScrollKey) {
+      setConversationScrollSnapshot(currentScrollKey, {
+        ...measuredSnapshot.snapshot,
+        scrollTopPx: element.scrollTop,
+      })
+      return
+    }
+
+    const existingSnapshot = getConversationScrollSnapshot(currentScrollKey)
+    setConversationScrollSnapshot(currentScrollKey, {
+      distanceFromBottomPx: existingSnapshot?.distanceFromBottomPx ?? 0,
+      pinnedToBottom: existingSnapshot?.pinnedToBottom ?? isAtBottomRef.current,
+      scrollTopPx: element.scrollTop,
+    })
+  }, [currentScrollKey, messages.length])
+
   useLayoutEffect(
     () => () => {
-      saveCurrentScrollPosition()
+      saveCurrentScrollPositionWithoutLayout()
     },
-    [saveCurrentScrollPosition]
+    [saveCurrentScrollPositionWithoutLayout]
   )
 
   const updateScrollState = useCallback(
@@ -504,6 +531,16 @@ function ScrollableMessagePaneContent({
       const distanceToBottom = element.scrollHeight - element.clientHeight - element.scrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
       const isScrolledToBottom = distanceToBottom <= SCROLLED_TO_BOTTOM_THRESHOLD
+      if (currentScrollKey !== null) {
+        lastMeasuredScrollSnapshotRef.current = {
+          key: currentScrollKey,
+          snapshot: {
+            distanceFromBottomPx: Math.max(0, distanceToBottom),
+            pinnedToBottom: isScrolledToBottom,
+            scrollTopPx: element.scrollTop,
+          },
+        }
+      }
       const scrolledUp =
         lastScrollTopRef.current !== null && element.scrollTop < lastScrollTopRef.current - 0.5
       lastScrollTopRef.current = element.scrollTop
@@ -525,7 +562,7 @@ function ScrollableMessagePaneContent({
       }
       setShowScrollButton(overflow && !isAtBottom)
     },
-    [clearScheduledScrolls, messages.length, saveCurrentScrollPosition]
+    [clearScheduledScrolls, currentScrollKey, messages.length, saveCurrentScrollPosition]
   )
 
   const restorePendingLayoutScrollPosition = useCallback(() => {
@@ -556,24 +593,39 @@ function ScrollableMessagePaneContent({
       const element = activeScrollRefRef.current.current
       if (!element) return
 
+      const scrollHeight = element.scrollHeight
       if (typeof element.scrollTo === 'function') {
         element.scrollTo({
-          top: element.scrollHeight,
+          top: scrollHeight,
           behavior,
         })
       } else {
-        element.scrollTop = element.scrollHeight
+        element.scrollTop = scrollHeight
       }
       lastScrollTopRef.current = element.scrollTop
+      if (currentScrollKey !== null) {
+        const distanceFromBottomPx = Math.max(
+          0,
+          scrollHeight - element.clientHeight - element.scrollTop
+        )
+        lastMeasuredScrollSnapshotRef.current = {
+          key: currentScrollKey,
+          snapshot: {
+            distanceFromBottomPx,
+            pinnedToBottom: distanceFromBottomPx <= SCROLLED_TO_BOTTOM_THRESHOLD,
+            scrollTopPx: element.scrollTop,
+          },
+        }
+      }
       if (options.saveSnapshot) {
-        saveCurrentScrollPosition(element.scrollHeight)
+        saveCurrentScrollPosition(scrollHeight)
       }
       isAtBottomRef.current = true
       userScrollPausedAutoFollowRef.current = false
       userViewportAnchorRef.current = null
       setShowScrollButton(false)
     },
-    [saveCurrentScrollPosition]
+    [currentScrollKey, saveCurrentScrollPosition]
   )
 
   const restoreSavedScrollPosition = useCallback(
@@ -597,6 +649,14 @@ function ScrollableMessagePaneContent({
       const distanceToBottom = element.scrollHeight - element.clientHeight - nextScrollTop
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
       const isScrolledToBottom = distanceToBottom <= SCROLLED_TO_BOTTOM_THRESHOLD
+      lastMeasuredScrollSnapshotRef.current = {
+        key,
+        snapshot: {
+          distanceFromBottomPx: Math.max(0, distanceToBottom),
+          pinnedToBottom: isScrolledToBottom,
+          scrollTopPx: element.scrollTop,
+        },
+      }
       isAtBottomRef.current = isAtBottom
       userScrollPausedAutoFollowRef.current = !isScrolledToBottom
       setShowScrollButton(overflow && !isAtBottom)
@@ -624,11 +684,30 @@ function ScrollableMessagePaneContent({
 
   const markCurrentConversationPinnedToBottom = useCallback(() => {
     if (currentScrollKey === null) return
-    setConversationScrollSnapshot(currentScrollKey, {
+    const snapshot = {
       distanceFromBottomPx: 0,
       pinnedToBottom: true,
-    })
+    }
+    lastMeasuredScrollSnapshotRef.current = {
+      key: currentScrollKey,
+      snapshot,
+    }
+    setConversationScrollSnapshot(currentScrollKey, snapshot)
   }, [currentScrollKey])
+
+  const adoptVirtualBottomPosition = useCallback(
+    (scrollTopPx: number | null = null) => {
+      clearScheduledScrolls()
+      followingBottomKeyRef.current = currentScrollKey
+      markCurrentConversationPinnedToBottom()
+      lastScrollTopRef.current = scrollTopPx
+      isAtBottomRef.current = true
+      userScrollPausedAutoFollowRef.current = false
+      userViewportAnchorRef.current = null
+      requestAnimationFrame(() => setShowScrollButton(false))
+    },
+    [clearScheduledScrolls, currentScrollKey, markCurrentConversationPinnedToBottom]
+  )
 
   const scheduleStableScrollToBottom = useCallback(
     (
@@ -769,6 +848,10 @@ function ScrollableMessagePaneContent({
       const snapshot = getConversationScrollSnapshot(currentScrollKey)
       if (snapshot) {
         restoredScrollSnapshotRef.current = { key: currentScrollKey, snapshot }
+        if (virtualScrollOwnsInitialPosition && snapshot.pinnedToBottom) {
+          adoptVirtualBottomPosition(snapshot.scrollTopPx ?? null)
+          return
+        }
         restoreSavedScrollPosition(currentScrollKey, snapshot)
       }
       return
@@ -777,6 +860,10 @@ function ScrollableMessagePaneContent({
     if (shouldForceBottom) {
       restoredScrollSnapshotRef.current = null
       pendingAssistantResponseStartRef.current = false
+      if (virtualScrollOwnsInitialPosition && (conversationChanged || messagesLoaded)) {
+        adoptVirtualBottomPosition()
+        return
+      }
       setScrollToBottom('auto', { saveSnapshot: false })
       if (preserveLatestUserTurnRef.current) {
         scheduleStableScrollToBottom('auto', {
@@ -809,6 +896,7 @@ function ScrollableMessagePaneContent({
     }
   }, [
     conversationKey,
+    adoptVirtualBottomPosition,
     autoScrollSuspended,
     currentScrollKey,
     clearScheduledScrolls,
@@ -826,6 +914,7 @@ function ScrollableMessagePaneContent({
     scheduleStableScrollToBottom,
     scrollToBottom,
     setScrollToBottom,
+    virtualScrollOwnsInitialPosition,
   ])
 
   useLayoutEffect(() => {
@@ -1199,7 +1288,6 @@ function ScrollableMessagePaneContent({
                 hiddenRequestUserInputIds={hiddenRequestUserInputIds}
                 onAddSelectionToConversation={onAddSelectionToConversation}
                 onAskSelectionInSidebar={onAskSelectionInSidebar}
-                onVirtualLayoutChange={handleContentLayoutChange}
                 virtualAnchorToEnd={!showScrollButton}
                 renderGapAfterMessage={renderTranscriptGapAfterMessage}
               />

--- a/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
@@ -108,6 +108,12 @@ describe('ScrollableMessageArea virtual layout ownership', () => {
     })
 
     rerender(<ScrollableMessageArea conversationKey="long-b" messages={[message('b')]} />)
+    rerender(
+      <ScrollableMessageArea
+        conversationKey="long-b"
+        messages={[message('b'), message('b-follow-up')]}
+      />
+    )
     const callback = resizeObserverCallback
     expect(callback).not.toBeNull()
     act(() => {

--- a/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
@@ -1,10 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ScrollableMessageArea } from './ScrollableMessageArea'
 
 interface MockMessageListProps {
   virtualAnchorToEnd?: boolean
 }
+
+let resizeObserverCallback: ResizeObserverCallback | null = null
 
 vi.mock('@/lib/runtime-environment', () => ({
   isDesktopRuntime: () => true,
@@ -24,6 +26,10 @@ describe('ScrollableMessageArea virtual layout ownership', () => {
     vi.stubGlobal(
       'ResizeObserver',
       class ResizeObserverMock {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallback = callback
+        }
+
         observe() {}
         disconnect() {}
       }
@@ -31,6 +37,7 @@ describe('ScrollableMessageArea virtual layout ownership', () => {
   })
 
   afterEach(() => {
+    resizeObserverCallback = null
     vi.unstubAllGlobals()
   })
 
@@ -101,6 +108,9 @@ describe('ScrollableMessageArea virtual layout ownership', () => {
     })
 
     rerender(<ScrollableMessageArea conversationKey="long-b" messages={[message('b')]} />)
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver)
+    })
 
     expect(scrollHeightGetter).not.toHaveBeenCalled()
     requestAnimationFrameSpy.mockRestore()

--- a/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
@@ -108,11 +108,52 @@ describe('ScrollableMessageArea virtual layout ownership', () => {
     })
 
     rerender(<ScrollableMessageArea conversationKey="long-b" messages={[message('b')]} />)
+    const callback = resizeObserverCallback
+    expect(callback).not.toBeNull()
     act(() => {
-      resizeObserverCallback?.([], {} as ResizeObserver)
+      callback!([], {} as ResizeObserver)
     })
 
     expect(scrollHeightGetter).not.toHaveBeenCalled()
+    requestAnimationFrameSpy.mockRestore()
+  })
+
+  test('releases virtual ownership for a keyless conversation after the first layout', () => {
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 1)
+    render(
+      <ScrollableMessageArea
+        conversationKey={null}
+        messages={[
+          {
+            id: 'keyless-message',
+            role: 'assistant',
+            content: 'Keyless conversation',
+            status: 'done',
+            createdAt: '2026-08-29T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    const scrollHeightGetter = vi.fn(() => 10_000)
+    Object.defineProperty(scroller, 'scrollHeight', {
+      get: scrollHeightGetter,
+      configurable: true,
+    })
+    const callback = resizeObserverCallback
+    expect(callback).not.toBeNull()
+
+    act(() => {
+      callback!([], {} as ResizeObserver)
+    })
+    expect(scrollHeightGetter).not.toHaveBeenCalled()
+
+    act(() => {
+      callback!([], {} as ResizeObserver)
+    })
+    expect(scrollHeightGetter).toHaveBeenCalled()
     requestAnimationFrameSpy.mockRestore()
   })
 })

--- a/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx
@@ -6,6 +6,10 @@ interface MockMessageListProps {
   virtualAnchorToEnd?: boolean
 }
 
+vi.mock('@/lib/runtime-environment', () => ({
+  isDesktopRuntime: () => true,
+}))
+
 vi.mock('./MessageList', () => ({
   MessageList: ({ virtualAnchorToEnd }: MockMessageListProps) => (
     <div
@@ -68,5 +72,37 @@ describe('ScrollableMessageArea virtual layout ownership', () => {
       'data-virtual-anchor-to',
       'start'
     )
+  })
+
+  test('switches bottom-pinned conversations without synchronously measuring layout', () => {
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 1)
+    const message = (id: string) => ({
+      id,
+      role: 'assistant' as const,
+      content: `Conversation ${id}`,
+      status: 'done' as const,
+      createdAt: '2026-08-29T00:00:00.000Z',
+    })
+    const { rerender } = render(
+      <ScrollableMessageArea conversationKey="long-a" messages={[message('a')]} />
+    )
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    const scrollHeightGetter = vi.fn(() => 10_000)
+    Object.defineProperty(scroller, 'scrollHeight', {
+      get: scrollHeightGetter,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 9_000,
+      writable: true,
+      configurable: true,
+    })
+
+    rerender(<ScrollableMessageArea conversationKey="long-b" messages={[message('b')]} />)
+
+    expect(scrollHeightGetter).not.toHaveBeenCalled()
+    requestAnimationFrameSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

- avoid synchronously reading the previous long conversation's `scrollHeight` during conversation cleanup
- let the desktop virtualizer own the initial bottom position for new and bottom-pinned conversations
- remove the duplicate virtual-layout callback that forced another parent layout pass
- preserve exact saved positions for conversations that were intentionally scrolled away from the bottom

## Trace evidence

The supplied Chrome trace shows the task click spending about 654 ms in one renderer main-thread task. The hottest layout-triggering stack was a React layout-effect commit reading `scrollHeight` while the old long conversation DOM was being removed. The trace also showed repeated synchronous layout work from the virtual-list layout callback.

## Verification

- `pnpm --filter wework test src/components/chat/ScrollableMessageArea.virtual-layout.test.tsx src/components/chat/ScrollableMessageArea.test.tsx src/components/chat/MessageList.virtualization.test.tsx` (79 tests passed)
- focused ESLint and Prettier checks passed
- `git diff --check` passed
- `pnpm --filter wework ai:verify:electron:build` passed
- real `ai:verify` Electron session launched, initialized the workbench, created/reloaded a local project, and stopped cleanly
- added a regression test proving a bottom-pinned conversation switch does not synchronously read `scrollHeight`

## Known unrelated verification issue

The focused desktop E2E reached `close-to-tray-and-reopen` before the long-conversation assertions, then the reopened WebView failed to reconnect. Its app log records the Electron network/GPU processes terminating and sandbox initialization failing (`MachPortRendezvous` permission denied / `Failed to initialize sandbox`). No E2E code was changed or retried to mask this environment-level failure.

The standalone Wework typecheck also reports existing duplicate React/csstype resolution errors from `/Users/axb-mac/node_modules` in unchanged files; no changed file produced a type error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop chat scrolling when switching conversations and restoring message views.
  * Preserved scroll position more reliably during message updates, restoration, unmounting, and scrolling to the bottom.
  * Reduced unnecessary layout measurements to help prevent visual jumping and improve responsiveness.
  * Improved handling of initial positioning for virtualized message lists.

* **Tests**
  * Added coverage for conversation switching and keyless conversations to verify efficient layout measurement and scroll ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->