### PR TITLE
feat(wework): document and verify DSH extension points

### DIFF
--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -291,6 +291,7 @@ classify_wework_path() {
     # DSH UI composition verifies that Wework starts empty and gains each
     # application, route, settings page, and navigation item from plugins.
     wework/dsh/app-wework/* | \
+      wework/dsh/examples/ui-extension-demo/* | \
       wework/dsh/ui-*/* | \
       wework/src/features/dsh-runtime/*)
       select_target "plugins:core-dsh-ui-plugin-composition"

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -634,6 +634,14 @@ wework_desktop_other_e2e=true
 wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-core-dsh-ui-plugin-composition","name":"Plugins / core-dsh-ui-plugin-composition","command":"e2e:desktop:plugins","segment":"core-dsh-ui-plugin-composition"}]}' \
   "wework/dsh/ui-applications/client.js"
 
+assert_desktop_case "DSH extension Demo files select composition coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_core_e2e=false
+wework_desktop_core_e2e_matrix={"include":[]}
+wework_desktop_other_e2e=true
+wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-core-dsh-ui-plugin-composition","name":"Plugins / core-dsh-ui-plugin-composition","command":"e2e:desktop:plugins","segment":"core-dsh-ui-plugin-composition"}]}' \
+  "wework/dsh/examples/ui-extension-demo/client.js"
+
 assert_desktop_case "desktop sidebar selects all owned checkpoints" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true

--- a/docs/en/wework/developer-guide/wework-dsh-ui-plugins.md
+++ b/docs/en/wework/developer-guide/wework-dsh-ui-plugins.md
@@ -10,25 +10,55 @@ Applications, routes, settings pages, and workspace panels are contributed by
 independent DSH client plugins. Do not add a Wework-specific manifest, dynamic
 module loader, or second Cordis `Context`.
 
+## Extension layers
+
+Wework DSH extensions have four layers. A plugin should depend only on the
+layers it needs:
+
+1. The UI slots documented here inject navigation, pages, applications, and
+   workspace surfaces into the desktop workbench.
+2. Standard DSH services such as `sessions`, `tools`, and model services remain
+   owned by DSH and need no Wework-private event bus.
+3. [Executor Session projection](./wework-dsh-executor-sessions.md) projects
+   running Wework tasks into standard DSH Sessions and provides generic Backend
+   plugin storage.
+4. The Electron host boundary is owned by the first-party
+   `@wegent/dsh-electron-host` package. It exposes narrow capabilities rather
+   than Electron objects, file descriptors, or authentication tokens.
+   Third-party plugins must not depend on that host package directly; they may
+   use only explicitly public Wework client adapters. Plugins in one Core DSH
+   page share a JavaScript trust domain, so install only trusted plugins.
+
 ## Extension points
 
-| Slot                           | Purpose                           | Required metadata                 |
-| ------------------------------ | --------------------------------- | --------------------------------- |
-| `wework.app`                   | Product switcher and app surfaces | `id`, `label`, `mode`             |
-| `wework.route`                 | Top-level auxiliary pages         | `id`, `path`, `telemetryFeature`  |
-| `wework.sidebar.navigation`    | Left sidebar navigation entries   | `id`, `path`, `label`             |
-| `wework.settings.page`         | Settings navigation and content   | `id`, `path`, `label`, `category` |
-| `wework.workspace.tab`         | Closable top workspace tabs       | `id`, `label`                     |
-| `wework.workspace.sidebar.tab` | Right workspace panel tabs        | `id`, `label`                     |
-| `wework.shell.before`          | Content before the workbench root | `id`                              |
-| `wework.shell.after`           | Content after the workbench root  | `id`                              |
-| `wework.shell.overlay`         | Global overlays                   | `id`                              |
+| Slot                           | Purpose                                  | Required metadata                 | Component props            |
+| ------------------------------ | ---------------------------------------- | --------------------------------- | -------------------------- |
+| `wework.action`                | Host-invoked navigation action           | `id`, `path`                      | No component               |
+| `wework.app`                   | Product switcher and app surface         | `id`, `label`, `mode`             | `visible`, `tab`           |
+| `wework.route`                 | Top-level auxiliary page                 | `id`, `path`, `telemetryFeature`  | `search`, `onNavigate`     |
+| `wework.sidebar.navigation`    | Left-sidebar navigation entry            | `id`, `path`, `label`             | Usually metadata-only      |
+| `wework.settings.page`         | Settings navigation and content          | `id`, `path`, `label`, `category` | Settings context, `onBack` |
+| `wework.workspace.tab`         | Closable top workspace tab               | `id`, `label`                     | `visible`, `tab`           |
+| `wework.workspace.sidebar.tab` | Right workspace-panel tab type           | `id`, `label`                     | `visible`, `scope`, `tab`  |
+| `wework.shell.before`          | Before the workbench root                | `id`                              | Empty object               |
+| `wework.shell.after`           | After the workbench root                 | `id`                              | Empty object               |
+| `wework.shell.overlay`         | Global pointer-transparent overlay layer | `id`                              | Empty object               |
 
 `wework.app` supports three modes:
 
 - `native`: navigate to `path` and let the native Wework workspace handle it.
 - `iframe`: open `url` in a Wework application WebView.
 - `surface`: render the registered plugin component at `/app/<id>`.
+
+`wework.action` is a stable path-action descriptor, not an arbitrary callback
+channel. Register `{ id, path }` so existing host entry points can resolve the
+action by id and navigate. Do not put functions, tokens, or non-serializable
+state in a descriptor.
+
+Third-party `wework.settings.page` and `wework.route` contributions must not set
+the Wework-internal `module` or `component` fields. Pass the React component as
+the fourth argument to `ctx.wework.ui.register`. `telemetryFeature` must use an
+existing low-cardinality Wework value; generic third-party pages use `apps`.
 
 ## Registration contract
 
@@ -87,6 +117,38 @@ Wework descriptors directly in DSH options. DSH re-runs the `slots.inject`
 callback when the host slot mounts, unmounts, or is rebuilt and keeps the
 plugin lifecycle scoped to that declaration.
 
+## Runnable plugin demo
+
+The repository's
+[`wework/dsh/examples/ui-extension-demo`](https://github.com/wecode-ai/Wegent/tree/main/wework/dsh/examples/ui-extension-demo)
+is a complete third-party plugin with no imports from Wework-private React
+modules. It contains a standard `package.json`, `cordis.patch.yml`, host entry,
+client entry, and Node regression tests, and covers every slot in the table.
+
+In development, install the Demo's absolute directory from **Plugins → Manage
+→ Wework plugins**, or use:
+
+```text
+file:/absolute/path/to/Wegent/wework/dsh/examples/ui-extension-demo
+```
+
+Installation, update, enablement, and removal mutate the managed `wework-core`
+profile. Restart Core DSH after configuration changes. The install flow
+snapshots the profile, runs the package manager, validates `dsh.bundle.patch`,
+and preflights `dsh --profile wework-core --dump-config`; it restores the
+snapshot on failure. Plugins must not depend on immediate hot activation after
+installation.
+
+When copying the Demo:
+
+1. Replace the npm package name, Loader entry id, and every contribution id.
+2. Keep only the slots you need and give each interactive element a stable
+   `data-testid`.
+3. Do not import Wework source pages or Contexts. Communicate through component
+   props, standard DSH services, and public capabilities.
+4. Run the Demo Node tests before installing the absolute local directory into
+   an isolated Wework environment.
+
 ## First-party Wework plugins
 
 Wework bundles these UI plugins with Core DSH:
@@ -144,3 +206,7 @@ When adding a DSH plugin shipped with Wework:
 3. Add Node tests for slot metadata and registration behavior.
 4. Run Wework typecheck, focused Vitest coverage, DSH client tests, and a real
    desktop plugin verification.
+
+Ordinary third-party plugins must not be added to
+`prepare-harness-runtime.mjs`; that path is only for first-party managed
+components shipped and updated with Wework.

--- a/docs/zh/wework/developer-guide/wework-dsh-ui-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-ui-plugins.md
@@ -9,25 +9,49 @@ Wework 的桌面 UI 以 Core DSH 为唯一插件运行时。`@wegent/dsh-app-wew
 client 插件通过 slot 注入。不要再创建 Wework 私有 manifest、动态模块加载器或
 第二个 Cordis `Context`。
 
+## 扩展层次
+
+Wework 的 DSH 扩展分为四层，插件应只依赖实际需要的层：
+
+1. 本文描述的 UI slot：向桌面工作台注入导航、页面、应用和工作区 surface。
+2. 标准 DSH service：例如 `sessions`、`tools` 和模型相关 service，由 DSH
+   本身管理，不需要 Wework 私有事件总线。
+3. [Executor Session 投影](./wework-dsh-executor-sessions.md)：把运行中的 Wework
+   任务投影为标准 DSH Session，并提供 Backend 通用插件存储。
+4. Electron 宿主边界：由第一方 `@wegent/dsh-electron-host` 管理，只暴露窄
+   capability，不暴露 Electron 对象、文件描述符或鉴权 token。第三方插件不应直接
+   依赖这个 host 包，只能使用 Wework 明确公开的 client adapter；同一 Core DSH
+   页面中的插件共享 JavaScript 信任域，因此只应安装可信插件。
+
 ## 扩展点
 
-| Slot                           | 用途                     | 必要元数据                        |
-| ------------------------------ | ------------------------ | --------------------------------- |
-| `wework.app`                   | 产品切换器与应用 surface | `id`、`label`、`mode`             |
-| `wework.route`                 | 顶层辅助页面             | `id`、`path`、`telemetryFeature`  |
-| `wework.sidebar.navigation`    | 左侧边栏导航入口         | `id`、`path`、`label`             |
-| `wework.settings.page`         | 设置导航与设置内容       | `id`、`path`、`label`、`category` |
-| `wework.workspace.tab`         | 顶部可关闭工作区 Tab     | `id`、`label`                     |
-| `wework.workspace.sidebar.tab` | 右侧工作区面板 Tab       | `id`、`label`                     |
-| `wework.shell.before`          | 工作台根节点之前         | `id`                              |
-| `wework.shell.after`           | 工作台根节点之后         | `id`                              |
-| `wework.shell.overlay`         | 全局浮层                 | `id`                              |
+| Slot                           | 用途                         | 必要元数据                        | 组件 props                |
+| ------------------------------ | ---------------------------- | --------------------------------- | ------------------------- |
+| `wework.action`                | 可由宿主入口调用的导航动作   | `id`、`path`                      | 无组件                    |
+| `wework.app`                   | 产品切换器与应用 surface     | `id`、`label`、`mode`             | `visible`、`tab`          |
+| `wework.route`                 | 顶层辅助页面                 | `id`、`path`、`telemetryFeature`  | `search`、`onNavigate`    |
+| `wework.sidebar.navigation`    | 左侧边栏导航入口             | `id`、`path`、`label`             | 元数据入口通常无组件      |
+| `wework.settings.page`         | 设置导航与设置内容           | `id`、`path`、`label`、`category` | 设置上下文与 `onBack`     |
+| `wework.workspace.tab`         | 顶部可关闭工作区 Tab         | `id`、`label`                     | `visible`、`tab`          |
+| `wework.workspace.sidebar.tab` | 右侧工作区面板 Tab 类型      | `id`、`label`                     | `visible`、`scope`、`tab` |
+| `wework.shell.before`          | 工作台根节点之前             | `id`                              | 空对象                    |
+| `wework.shell.after`           | 工作台根节点之后             | `id`                              | 空对象                    |
+| `wework.shell.overlay`         | 全局浮层，容器不接收指针事件 | `id`                              | 空对象                    |
 
 `wework.app` 的 `mode` 可以是：
 
 - `native`：导航到 `path`，由 Wework 原生工作区处理。
 - `iframe`：在 Wework 应用 WebView 中打开 `url`。
 - `surface`：在 `/app/<id>` 中直接渲染插件注册的 React 组件。
+
+`wework.action` 当前是稳定的路径动作描述，不是任意回调通道。插件注册
+`{ id, path }` 后，宿主内已有入口可以通过 action id 查找并执行导航；不要把函数、
+token 或不可序列化状态写入 descriptor。
+
+第三方 `wework.settings.page` 和 `wework.route` 不应设置 Wework 内部使用的
+`module` 或 `component` 字段。直接把 React 组件作为
+`ctx.wework.ui.register` 的第四个参数传入即可。`telemetryFeature` 应使用 Wework
+现有的低基数字段；通用第三方页面使用 `apps`。
 
 ## 注册规则
 
@@ -83,6 +107,34 @@ DSH 管理，没有第二套 Wework 注册表。
 Wework 描述直接塞进 DSH options。DSH 会在宿主 slot 挂载、卸载或重建时重新执行
 `slots.inject` 回调，并自动收敛插件生命周期。
 
+## 可运行插件 Demo
+
+仓库中的
+[`wework/dsh/examples/ui-extension-demo`](https://github.com/wecode-ai/Wegent/tree/main/wework/dsh/examples/ui-extension-demo)
+是一个不依赖 Wework 私有 React 模块的完整第三方插件。它包含标准
+`package.json`、`cordis.patch.yml`、host 入口、client 入口和 Node 回归测试，并
+覆盖上表全部 slot。
+
+开发环境中可以在“插件 → 管理 → Wework 插件”安装 Demo 目录的绝对路径，或者
+使用：
+
+```text
+file:/absolute/path/to/Wegent/wework/dsh/examples/ui-extension-demo
+```
+
+安装、更新、启停或卸载会修改受管的 `wework-core` profile；配置变更后需要重启
+Core DSH。安装流程会先快照 profile，再运行包管理命令、校验
+`dsh.bundle.patch`、执行 `dsh --profile wework-core --dump-config` 预检；失败时
+恢复快照。插件不能依赖“安装后立即热生效”。
+
+复制 Demo 开发自己的插件时：
+
+1. 更换 npm 包名、Loader entry id 和所有 contribution id。
+2. 只保留需要的 slot；每个交互元素提供稳定的 `data-testid`。
+3. 不 import Wework 源码中的页面或 Context；通过组件 props、标准 DSH service
+   和公开 capability 通信。
+4. 先运行 Demo 的 Node 测试，再用绝对本地目录安装到隔离 Wework 环境验证。
+
 ## Wework 内置插件
 
 Wework 当前随 Core DSH 打包以下 UI 插件：
@@ -129,3 +181,6 @@ DSH 进程每次启动都会重新加载插件 JS；stamp 只决定是否需要�
 2. 将目录加入 `wework/scripts/prepare-harness-runtime.mjs` 的 `dshPlugins`。
 3. 为 slot 元数据与注册行为增加 Node 单测。
 4. 运行 Wework typecheck、聚焦 Vitest、DSH client 单测和桌面真实插件验证。
+
+普通第三方插件不应加入 `prepare-harness-runtime.mjs`；该步骤只适用于随 Wework
+发布和更新的第一方受管组件。

--- a/wework/dsh/app-wework/README.en.md
+++ b/wework/dsh/app-wework/README.en.md
@@ -6,8 +6,10 @@ lifecycle, and UI registration.
 
 The host declares these standard extension points:
 
+- `wework.action`
 - `wework.app`
 - `wework.route`
+- `wework.sidebar.navigation`
 - `wework.settings.page`
 - `wework.shell.before` / `wework.shell.after` / `wework.shell.overlay`
 - `wework.workspace.tab`
@@ -49,3 +51,7 @@ capabilities.
 The package must explicitly export `./package.json`. The DSH client module
 registry resolves that subpath to read the `dsh.client` declaration; without
 the export, the plugin is omitted from the browser boot graph.
+
+The installable third-party example at
+[`../examples/ui-extension-demo`](../examples/ui-extension-demo) covers every
+extension point above.

--- a/wework/dsh/app-wework/README.md
+++ b/wework/dsh/app-wework/README.md
@@ -5,8 +5,10 @@
 
 宿主声明以下标准扩展点：
 
+- `wework.action`
 - `wework.app`
 - `wework.route`
+- `wework.sidebar.navigation`
 - `wework.settings.page`
 - `wework.shell.before` / `wework.shell.after` / `wework.shell.overlay`
 - `wework.workspace.tab`
@@ -45,3 +47,6 @@ desktop capability 调用这些能力。
 
 该包必须显式导出 `./package.json`。DSH client module registry 通过这个子路径读取
 `dsh.client` 声明；缺少导出会导致插件不进入 browser boot graph。
+
+可安装的第三方示例位于
+[`../examples/ui-extension-demo`](../examples/ui-extension-demo)，覆盖以上全部扩展点。

--- a/wework/dsh/examples/ui-extension-demo/README.en.md
+++ b/wework/dsh/examples/ui-extension-demo/README.en.md
@@ -1,0 +1,27 @@
+# Wework DSH Extension Demo
+
+This is an installable third-party Core DSH plugin example covering every public
+Wework UI extension point. It is not a built-in Wework plugin and is not enabled
+in desktop distributions.
+
+Enter the absolute directory in **Plugins → Manage → Wework plugins**, or use:
+
+```text
+file:/absolute/path/to/Wegent/wework/dsh/examples/ui-extension-demo
+```
+
+Restart Core DSH after installation. The plugin adds a `DSH Demo` sidebar item,
+surface app, settings page, workspace tab, and global overlay. Disabling or
+uninstalling the package and restarting removes every contribution through the
+same DSH lifecycle.
+
+Key files:
+
+- `package.json` declares the DSH bundle, client dependencies, and web platform.
+- `cordis.patch.yml` inserts the plugin into the DSH Loader tree.
+- `index.js` is the host entry; a UI-only plugin can keep it empty.
+- `client.js` registers UI through `slots.inject` and
+  `ctx.wework.ui.register`.
+
+Production plugins should replace the package name, IDs, copy, and styles, and
+register only the extension points they need.

--- a/wework/dsh/examples/ui-extension-demo/README.md
+++ b/wework/dsh/examples/ui-extension-demo/README.md
@@ -1,0 +1,23 @@
+# Wework DSH 扩展 Demo
+
+这是一个可直接安装的第三方 Core DSH 插件示例，覆盖 Wework 当前公开的全部 UI
+扩展点。它不是 Wework 内置插件，也不会随桌面安装包启用。
+
+在 Wework 的“插件 → 管理 → Wework 插件”中输入该目录的绝对路径，或输入：
+
+```text
+file:/absolute/path/to/Wegent/wework/dsh/examples/ui-extension-demo
+```
+
+安装完成后重启 Core DSH。左侧会出现 `DSH Demo`，应用切换器、设置页、新建工作区
+Tab 菜单和全局 overlay 也会出现对应示例。停用或卸载插件并重启后，所有贡献会随
+同一 DSH 生命周期一起移除。
+
+关键文件：
+
+- `package.json` 声明 DSH bundle、client 依赖和浏览器平台。
+- `cordis.patch.yml` 把插件加入 DSH Loader 树。
+- `index.js` 是 host 入口；纯 UI 插件可以保持为空。
+- `client.js` 通过 `slots.inject` 和 `ctx.wework.ui.register` 注册 UI。
+
+生产插件应更换包名、ID、文案和样式，并只注册实际需要的扩展点。

--- a/wework/dsh/examples/ui-extension-demo/client.js
+++ b/wework/dsh/examples/ui-extension-demo/client.js
@@ -1,0 +1,264 @@
+window.__ModuleLoader__.load({
+  id: '@wegent/dsh-wework-extension-demo',
+  factory: require => {
+    const React = require('react')
+    const { createElement } = React
+
+    const colors = {
+      border: 'rgb(var(--color-border))',
+      muted: 'rgb(var(--color-text-muted))',
+      primary: 'rgb(var(--color-text-primary))',
+      surface: 'rgb(var(--color-background))',
+    }
+
+    function DemoPanel({ children, testId, title }) {
+      return createElement(
+        'section',
+        {
+          'data-testid': testId,
+          style: {
+            background: colors.surface,
+            color: colors.primary,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px',
+            height: '100%',
+            overflow: 'auto',
+            padding: '24px',
+          },
+        },
+        createElement('h1', { style: { fontWeight: 600, margin: 0 } }, title),
+        createElement(
+          'p',
+          { style: { color: colors.muted, lineHeight: 1.6, margin: 0 } },
+          'This surface is rendered by a third-party Core DSH client plugin.'
+        ),
+        children
+      )
+    }
+
+    function DemoRoute({ onNavigate, search }) {
+      return createElement(
+        DemoPanel,
+        { testId: 'dsh-extension-demo-route', title: 'DSH extension route' },
+        createElement('code', null, search || '(no query string)'),
+        createElement(
+          'button',
+          {
+            'data-testid': 'dsh-extension-demo-open-settings',
+            onClick: () => onNavigate?.('/settings/dsh-extension-demo'),
+            style: {
+              alignSelf: 'flex-start',
+              border: `1px solid ${colors.border}`,
+              borderRadius: '8px',
+              cursor: 'pointer',
+              padding: '8px 12px',
+            },
+            type: 'button',
+          },
+          'Open demo settings'
+        )
+      )
+    }
+
+    function DemoApp({ visible }) {
+      return createElement(
+        'div',
+        { hidden: !visible, style: { height: '100%' } },
+        createElement(DemoPanel, {
+          testId: 'dsh-extension-demo-app',
+          title: 'DSH extension app',
+        })
+      )
+    }
+
+    function DemoSettings({ onBack }) {
+      return createElement(
+        DemoPanel,
+        { testId: 'dsh-extension-demo-settings', title: 'DSH extension settings' },
+        createElement(
+          'button',
+          {
+            'data-testid': 'dsh-extension-demo-settings-back',
+            onClick: onBack,
+            style: {
+              alignSelf: 'flex-start',
+              border: `1px solid ${colors.border}`,
+              borderRadius: '8px',
+              cursor: 'pointer',
+              padding: '8px 12px',
+            },
+            type: 'button',
+          },
+          'Back'
+        )
+      )
+    }
+
+    function DemoWorkspaceTab({ tab, visible }) {
+      return createElement(
+        'div',
+        { hidden: !visible, style: { height: '100%' } },
+        createElement(
+          DemoPanel,
+          { testId: 'dsh-extension-demo-workspace-tab', title: 'DSH workspace tab' },
+          createElement('code', null, tab?.id || '(no tab id)')
+        )
+      )
+    }
+
+    function DemoWorkspaceSidebar({ scope, tab, visible }) {
+      return createElement(
+        'aside',
+        {
+          'data-testid': 'dsh-extension-demo-workspace-sidebar',
+          hidden: !visible,
+          style: { color: colors.primary, padding: '16px' },
+        },
+        createElement('strong', null, tab?.title || 'Demo inspector'),
+        createElement('div', { style: { color: colors.muted } }, scope?.cwd || '(no workspace)')
+      )
+    }
+
+    function DemoShellBefore() {
+      return createElement('span', {
+        'data-testid': 'dsh-extension-demo-shell-before',
+        hidden: true,
+      })
+    }
+
+    function DemoShellAfter() {
+      return createElement('span', {
+        'data-testid': 'dsh-extension-demo-shell-after',
+        hidden: true,
+      })
+    }
+
+    function DemoOverlay() {
+      return createElement(
+        'div',
+        {
+          'data-testid': 'dsh-extension-demo-overlay',
+          style: {
+            background: colors.primary,
+            borderRadius: '999px',
+            bottom: '16px',
+            color: colors.surface,
+            padding: '6px 10px',
+            pointerEvents: 'none',
+            position: 'absolute',
+            right: '16px',
+          },
+        },
+        'DSH Demo'
+      )
+    }
+
+    const contributions = [
+      {
+        slot: 'wework.action',
+        descriptor: {
+          id: 'dsh-extension-demo.open',
+          path: '/dsh-extension-demo',
+        },
+      },
+      {
+        slot: 'wework.app',
+        descriptor: {
+          description: 'Third-party surface application',
+          id: 'dsh-extension-demo',
+          label: 'DSH Demo',
+          mode: 'surface',
+          order: 90,
+        },
+        component: DemoApp,
+      },
+      {
+        slot: 'wework.route',
+        descriptor: {
+          icon: 'blocks',
+          id: 'dsh-extension-demo.route',
+          path: '/dsh-extension-demo',
+          restorePolicy: 'session',
+          telemetryFeature: 'apps',
+          title: 'DSH Demo',
+        },
+        component: DemoRoute,
+      },
+      {
+        slot: 'wework.sidebar.navigation',
+        descriptor: {
+          activeItem: 'dsh-extension-demo',
+          icon: 'blocks',
+          id: 'dsh-extension-demo.navigation',
+          label: 'DSH Demo',
+          order: 90,
+          path: '/dsh-extension-demo',
+          testId: 'dsh-extension-demo-navigation',
+        },
+      },
+      {
+        slot: 'wework.settings.page',
+        descriptor: {
+          category: 'extensions',
+          categoryLabel: 'Extensions',
+          icon: 'blocks',
+          id: 'dsh-extension-demo.settings',
+          label: 'DSH Demo',
+          order: 90,
+          path: '/settings/dsh-extension-demo',
+        },
+        component: DemoSettings,
+      },
+      {
+        slot: 'wework.workspace.tab',
+        descriptor: {
+          id: 'dsh-extension-demo.workspace',
+          label: 'DSH Demo',
+          order: 90,
+        },
+        component: DemoWorkspaceTab,
+      },
+      {
+        slot: 'wework.workspace.sidebar.tab',
+        descriptor: {
+          id: 'dsh-extension-demo.inspector',
+          label: 'Demo inspector',
+          order: 90,
+        },
+        component: DemoWorkspaceSidebar,
+      },
+      {
+        slot: 'wework.shell.before',
+        descriptor: { id: 'dsh-extension-demo.before' },
+        component: DemoShellBefore,
+      },
+      {
+        slot: 'wework.shell.after',
+        descriptor: { id: 'dsh-extension-demo.after' },
+        component: DemoShellAfter,
+      },
+      {
+        slot: 'wework.shell.overlay',
+        descriptor: { id: 'dsh-extension-demo.overlay' },
+        component: DemoOverlay,
+      },
+    ]
+
+    return {
+      inject: ['slots', 'wework'],
+      apply(ctx) {
+        for (const contribution of contributions) {
+          ctx.slots.inject(contribution.slot, () =>
+            ctx.wework.ui.register(
+              ctx,
+              contribution.slot,
+              contribution.descriptor,
+              contribution.component
+            )
+          )
+        }
+      },
+    }
+  },
+})

--- a/wework/dsh/examples/ui-extension-demo/client.test.mjs
+++ b/wework/dsh/examples/ui-extension-demo/client.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+async function loadPlugin() {
+  const source = await readFile(new URL('./client.js', import.meta.url), 'utf8')
+  let handoff
+  const window = {
+    __ModuleLoader__: {
+      load(value) {
+        handoff = value
+      },
+    },
+  }
+  vm.runInNewContext(source, { window })
+  assert.ok(handoff)
+  return handoff.factory(id => {
+    assert.equal(id, 'react')
+    return React
+  })
+}
+
+test('registers every public Wework UI extension point through slot injection', async () => {
+  const plugin = await loadPlugin()
+  const injections = []
+  const registrations = []
+  const ctx = {
+    slots: {
+      inject(slot, factory) {
+        injections.push(slot)
+        factory()
+      },
+      register(options, component) {
+        registrations.push({ component, options })
+        return () => {}
+      },
+    },
+    wework: {
+      ui: {
+        register(contributionCtx, slot, descriptor, component = () => null) {
+          Object.defineProperty(component, 'wework', {
+            value: Object.freeze({ ...descriptor }),
+          })
+          return contributionCtx.slots.register(
+            {
+              name: slot,
+              id: descriptor.id,
+              ...(descriptor.label === undefined ? {} : { label: descriptor.label }),
+              ...(descriptor.order === undefined ? {} : { order: descriptor.order }),
+            },
+            component
+          )
+        },
+      },
+    },
+  }
+
+  plugin.apply(ctx)
+
+  assert.deepEqual(Array.from(plugin.inject), ['slots', 'wework'])
+  assert.deepEqual(injections, [
+    'wework.action',
+    'wework.app',
+    'wework.route',
+    'wework.sidebar.navigation',
+    'wework.settings.page',
+    'wework.workspace.tab',
+    'wework.workspace.sidebar.tab',
+    'wework.shell.before',
+    'wework.shell.after',
+    'wework.shell.overlay',
+  ])
+  assert.deepEqual(
+    registrations.map(entry => entry.options.name),
+    injections
+  )
+  assert.ok(
+    registrations.every(
+      entry => !('path' in entry.options) && Object.isFrozen(entry.component.wework)
+    )
+  )
+})
+
+test('renders the demo components without Wework-private React imports', async () => {
+  const plugin = await loadPlugin()
+  const components = new Map()
+  const ctx = {
+    slots: {
+      inject(_slot, factory) {
+        factory()
+      },
+      register(options, component) {
+        components.set(options.name, component)
+        return () => {}
+      },
+    },
+    wework: {
+      ui: {
+        register(contributionCtx, slot, descriptor, component = () => null) {
+          Object.defineProperty(component, 'wework', {
+            value: Object.freeze({ ...descriptor }),
+          })
+          return contributionCtx.slots.register({ name: slot, id: descriptor.id }, component)
+        },
+      },
+    },
+  }
+  plugin.apply(ctx)
+
+  const cases = [
+    ['wework.app', { visible: true }, 'dsh-extension-demo-app'],
+    ['wework.route', { search: '?demo=1' }, 'dsh-extension-demo-route'],
+    ['wework.settings.page', {}, 'dsh-extension-demo-settings'],
+    [
+      'wework.workspace.tab',
+      { tab: { id: 'tab-1' }, visible: true },
+      'dsh-extension-demo-workspace-tab',
+    ],
+    [
+      'wework.workspace.sidebar.tab',
+      { scope: { cwd: '/workspace' }, tab: { title: 'Inspector' }, visible: true },
+      'dsh-extension-demo-workspace-sidebar',
+    ],
+    ['wework.shell.before', {}, 'dsh-extension-demo-shell-before'],
+    ['wework.shell.after', {}, 'dsh-extension-demo-shell-after'],
+    ['wework.shell.overlay', {}, 'dsh-extension-demo-overlay'],
+  ]
+  for (const [slot, props, testId] of cases) {
+    const Component = components.get(slot)
+    assert.equal(typeof Component, 'function', `${slot} did not register a component`)
+    assert.match(renderToStaticMarkup(React.createElement(Component, props)), new RegExp(testId))
+  }
+})

--- a/wework/dsh/examples/ui-extension-demo/cordis.patch.yml
+++ b/wework/dsh/examples/ui-extension-demo/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: wework-extension-demo
+      name: '@wegent/dsh-wework-extension-demo'

--- a/wework/dsh/examples/ui-extension-demo/index.js
+++ b/wework/dsh/examples/ui-extension-demo/index.js
@@ -1,0 +1,2 @@
+export const name = 'wework-extension-demo'
+export function apply() {}

--- a/wework/dsh/examples/ui-extension-demo/package.json
+++ b/wework/dsh/examples/ui-extension-demo/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@wegent/dsh-wework-extension-demo",
+  "displayName": "Wework DSH 扩展 Demo",
+  "description": "A runnable third-party plugin demonstrating Wework DSH UI extension points.",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./client": "./client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-runtime",
+        "@wegent/dsh-app-wework"
+      ],
+      "platform": "web"
+    }
+  },
+  "files": [
+    "README.en.md",
+    "README.md",
+    "client.js",
+    "cordis.patch.yml",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-client-runtime": "0.1.1-rc.2"
+  }
+}

--- a/wework/e2e/desktop/modules/core-dsh-ui-plugin-flows.mjs
+++ b/wework/e2e/desktop/modules/core-dsh-ui-plugin-flows.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFile, readdir } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   DEFAULT_STEP_TIMEOUT_MS,
@@ -94,6 +95,22 @@ const UI_PLUGINS = [
     testId: 'cloud-work-page',
   },
 ]
+const DEMO_PLUGIN = {
+  name: '@wegent/dsh-wework-extension-demo',
+  directory: fileURLToPath(new URL('../../../dsh/examples/ui-extension-demo', import.meta.url)),
+  contributions: {
+    'wework.action': ['dsh-extension-demo.open'],
+    'wework.app': ['dsh-extension-demo'],
+    'wework.route': ['dsh-extension-demo.route'],
+    'wework.sidebar.navigation': ['dsh-extension-demo.navigation'],
+    'wework.settings.page': ['dsh-extension-demo.settings'],
+    'wework.workspace.tab': ['dsh-extension-demo.workspace'],
+    'wework.workspace.sidebar.tab': ['dsh-extension-demo.inspector'],
+    'wework.shell.before': ['dsh-extension-demo.before'],
+    'wework.shell.after': ['dsh-extension-demo.after'],
+    'wework.shell.overlay': ['dsh-extension-demo.overlay'],
+  },
+}
 
 export async function verifyCoreDshUiPluginComposition({
   control,
@@ -205,6 +222,47 @@ export async function verifyCoreDshUiPluginComposition({
     await assertInstalledFeatureVisible(control, plugin)
   }
 
+  rendererOrigin = await installDemoPlugin({
+    control,
+    pluginSource: pluginSources.get(DEMO_PLUGIN.name),
+    rendererOrigin,
+    restartDesktopApp,
+  })
+  await assertDemoPluginVisible(control)
+
+  rendererOrigin = await setPluginEnabledAndRestart(
+    control,
+    rendererOrigin,
+    restartDesktopApp,
+    DEMO_PLUGIN,
+    false
+  )
+  await assertDemoPluginAbsent(control)
+
+  rendererOrigin = await setPluginEnabledAndRestart(
+    control,
+    rendererOrigin,
+    restartDesktopApp,
+    DEMO_PLUGIN,
+    true
+  )
+  await assertDemoPluginVisible(control)
+
+  const afterUninstall = await invokeCoreDshPluginCapability(
+    rendererOrigin,
+    'runtime.uninstallCoreDshPlugin',
+    { name: DEMO_PLUGIN.name }
+  )
+  assert.equal(
+    afterUninstall.some(item => item.name === DEMO_PLUGIN.name),
+    false,
+    `${DEMO_PLUGIN.name} remained in the Core DSH inventory after uninstall`
+  )
+  await restartDesktopApp()
+  await dismissCodexHomeInitializer(control)
+  rendererOrigin = await control.command('getLocationOrigin', 'body')
+  await assertDemoPluginAbsent(control)
+
   const inventory = await readCoreDshPlugins(rendererOrigin)
   for (const plugin of UI_PLUGINS) {
     const installed = inventory.find(item => item.name === plugin.name)
@@ -213,6 +271,84 @@ export async function verifyCoreDshUiPluginComposition({
   }
   await control.command('navigate', 'body', { value: '/' })
   await ensureExperimentalFeaturesDisabled(control)
+}
+
+async function installDemoPlugin({ control, pluginSource, rendererOrigin, restartDesktopApp }) {
+  assert.ok(pluginSource, `${DEMO_PLUGIN.name} source is unavailable`)
+  await assertDemoPluginAbsent(control)
+  const plugins = await invokeCoreDshPluginCapability(
+    rendererOrigin,
+    'runtime.installCoreDshPlugin',
+    { spec: `file:${pluginSource}` }
+  )
+  const installed = plugins.find(item => item.name === DEMO_PLUGIN.name)
+  assert.ok(installed, `${DEMO_PLUGIN.name} was absent after install`)
+  assert.equal(installed.enabled, true, `${DEMO_PLUGIN.name} was disabled after install`)
+  await restartDesktopApp()
+  await dismissCodexHomeInitializer(control)
+  return control.command('getLocationOrigin', 'body')
+}
+
+async function assertDemoPluginVisible(control) {
+  await waitForSlotState(control, slots =>
+    Object.entries(DEMO_PLUGIN.contributions).every(([slot, ids]) =>
+      ids.every(id => slots[slot]?.includes(id))
+    )
+  )
+  await control.command('waitFor', '[data-testid="dsh-extension-demo-overlay"]')
+  assert.equal(
+    Number(
+      await control.command('getElementCount', '[data-testid="dsh-extension-demo-shell-before"]')
+    ),
+    1,
+    'Demo shell-before component was not mounted'
+  )
+  assert.equal(
+    Number(
+      await control.command('getElementCount', '[data-testid="dsh-extension-demo-shell-after"]')
+    ),
+    1,
+    'Demo shell-after component was not mounted'
+  )
+
+  await control.command('click', '[data-testid="dsh-extension-demo-navigation"]')
+  await control.command('waitFor', '[data-testid="dsh-extension-demo-route"]')
+  await control.command('click', '[data-testid="dsh-extension-demo-open-settings"]')
+  await control.command('waitFor', '[data-testid="dsh-extension-demo-settings"]')
+
+  await control.command('navigate', 'body', { value: '/app/dsh-extension-demo' })
+  await control.command('waitFor', '[data-testid="dsh-extension-demo-app"]')
+
+  await control.command('navigate', 'body', { value: '/' })
+  await control.command('click', '[data-testid="workspace-tab-add"]')
+  await control.command(
+    'click',
+    '[data-testid="workspace-tab-add-dsh-dsh-extension-demo.workspace"]'
+  )
+  await control.command('waitFor', '[data-testid="dsh-extension-demo-workspace-tab"]')
+}
+
+async function assertDemoPluginAbsent(control) {
+  await waitForSlotState(control, slots =>
+    Object.entries(DEMO_PLUGIN.contributions).every(([slot, ids]) =>
+      ids.every(id => !slots[slot]?.includes(id))
+    )
+  )
+  for (const selector of [
+    '[data-testid="dsh-extension-demo-navigation"]',
+    '[data-testid="dsh-extension-demo-overlay"]',
+    '[data-testid="dsh-extension-demo-route"]',
+    '[data-testid="dsh-extension-demo-settings"]',
+    '[data-testid="dsh-extension-demo-app"]',
+    '[data-testid="dsh-extension-demo-workspace-tab"]',
+  ]) {
+    assert.equal(
+      Number(await control.command('getElementCount', selector)),
+      0,
+      `${selector} remained mounted after the Demo plugin was removed`
+    )
+  }
+  await control.command('navigate', 'body', { value: '/' })
 }
 
 async function assertFeatureAbsent(control, plugin) {
@@ -342,6 +478,7 @@ async function resolveCoreUiPluginSources(runtimeRoot, pluginsRoot) {
   const sources = new Map(
     UI_PLUGINS.map(plugin => [plugin.name, join(resolve(pluginsRoot), plugin.directory)])
   )
+  sources.set(DEMO_PLUGIN.name, DEMO_PLUGIN.directory)
   const missing = (
     await Promise.all(
       [...sources].map(async ([name, source]) => [


### PR DESCRIPTION
## Summary

- document the complete Wework Core DSH extension model and all 10 public UI slots in Chinese and English
- add an installable third-party UI extension demo without Wework-private React imports
- extend desktop plugin E2E to verify install, render, navigation, disable, re-enable, uninstall, and lifecycle cleanup
- route demo changes to the CI-covered `core-dsh-ui-plugin-composition` desktop segment

## Verification

- `node --test dsh/examples/ui-extension-demo/client.test.mjs dsh/app-wework/client.test.mjs dsh/ui-plugins.test.mjs`
- focused ESLint, typography lint, Prettier, and `git diff --check`
- `/bin/bash .github/scripts/test-classify-ci-changes.sh`
- `pnpm --filter wework e2e:desktop:plugins -- --segment core-dsh-ui-plugin-composition` with a built Electron app
- packaged `ai:verify` flow: install demo, restart Core DSH, open route, navigate to settings, open app surface, and create workspace tab

## Notes

- third-party plugins remain outside `prepare-harness-runtime.mjs`; that path is reserved for first-party managed plugins
- the demo registers through standard DSH `slots.inject` and `ctx.wework.ui.register` only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an installable third-party Wework DSH UI extension demo covering apps, routes, settings, workspaces, navigation, sidebars, shell content, and overlays.
  * Added support and documentation for the `wework.action` and `wework.sidebar.navigation` extension points.
* **Documentation**
  * Expanded English and Chinese guides with extension layers, supported metadata, lifecycle guidance, safety restrictions, and installation instructions.
* **Tests**
  * Added automated coverage for demo plugin installation, visibility, lifecycle actions, rendering, and CI classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->