### PR TITLE
fix(wework): preserve caret after pasted text

### DIFF
--- a/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
@@ -163,6 +163,7 @@ async function waitForTaskIdle(control, taskRowTestId, timeoutMs) {
         stableSince = null
       }
     } catch (error) {
+      stableSince = null
       lastError = error
     }
     await new Promise(resolvePromise => setTimeout(resolvePromise, 100))

--- a/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
@@ -144,27 +144,35 @@ async function waitForNewTaskRow(control, knownRows, timeoutMs) {
 
 async function waitForTaskIdle(control, taskRowTestId, timeoutMs) {
   const taskId = taskRowTestId.slice('runtime-local-task-row-'.length)
-  const runningSelector =
-    `${ACTIVE_WORKSPACE_TAB_SELECTOR} ` + `[data-testid="runtime-local-task-running-${taskId}"]`
   const startedAt = Date.now()
+  let stableSince = null
+  let lastStatus = null
   let lastError = null
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      if (
-        Number(
-          await control.command('getElementCount', runningSelector, {
-            visible: true,
-          })
-        ) === 0
-      ) {
-        return
+      const snapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+      lastStatus = snapshot.pane?.status ?? null
+      const ready =
+        snapshot.workbench?.currentRuntimeTask?.taskId === taskId &&
+        lastStatus?.isBusy === false &&
+        lastStatus.canSendQueuedMessage === true
+      if (ready) {
+        stableSince ??= Date.now()
+        if (Date.now() - stableSince >= 500) return
+      } else {
+        stableSince = null
       }
     } catch (error) {
       lastError = error
     }
-    await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
   }
-  throw lastError ?? new Error(`Claude Code task ${taskId} did not become visibly idle`)
+  throw (
+    lastError ??
+    new Error(
+      `Claude Code task ${taskId} did not become ready for follow-up: ${JSON.stringify(lastStatus)}`
+    )
+  )
 }
 
 async function configureClaude(control, executablePath, version, timeoutMs) {

--- a/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
@@ -161,6 +161,23 @@ async function verifyMultilineComposerCaret(control, captureScreenshot) {
     /\bcomposer-prosemirror-editor\b/,
     'The split workbench did not render the ProseMirror composer'
   )
+  const beforePaste = '0123456789'
+  const pastedText = 'PASTED'
+  const afterPaste = 'abcdefghij'
+  await control.command('fill', COMPOSER, { value: `${beforePaste}${afterPaste}` })
+  await control.command('setSelectionOffset', COMPOSER, { value: String(beforePaste.length) })
+  await control.command('pasteText', COMPOSER, { value: pastedText })
+  assert.equal(
+    await control.command('getValue', COMPOSER),
+    `${beforePaste}${pastedText}${afterPaste}`,
+    'Pasting text in the middle did not preserve the surrounding composer text'
+  )
+  assert.equal(
+    Number(await control.command('getSelectionOffset', COMPOSER)),
+    beforePaste.length + pastedText.length,
+    'Pasting text in the middle moved the composer caret away from the pasted text'
+  )
+
   await control.command('fill', COMPOSER, { value: '' })
   await control.command('click', COMPOSER)
   const [singleLineCaretMetrics] = JSON.parse(

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -55,6 +55,7 @@ export const AI_VERIFY_ACTIONS = Object.freeze({
   reload: 'reloadApp',
   'close-to-tray': 'closeMainWindowToTray',
   'request-close': 'requestMainWindowClose',
+  'selection-offset': 'getSelectionOffset',
   'dismiss-popout': 'dismissPopoutWindow',
   drag: 'drag',
   'drop-file': 'dropFile',
@@ -65,17 +66,20 @@ export const AI_VERIFY_ACTIONS = Object.freeze({
   metrics: 'getElementMetrics',
   navigate: 'navigate',
   'paste-paths': 'pastePaths',
+  'paste-text': 'pasteText',
   'pointer-move': 'pointerMove',
   press: 'press',
   submit: 'submit',
   'scroll-into-view': 'scrollIntoView',
   'select-text': 'selectText',
+  'set-selection-offset': 'setSelectionOffset',
   'show-popout': 'showPopoutWindow',
   'system-drag-drop': 'completeSystemDragDrop',
   'verify-browser-inspector': 'verifyEmbeddedBrowserDetachedInspector',
   'wait-for': 'waitFor',
   'window-focus-snapshot': 'getWindowFocusSnapshot',
   text: 'getText',
+  value: 'getValue',
 })
 
 const SELECTOR_OPTIONAL_COMMANDS = new Set([
@@ -121,8 +125,8 @@ Options:
                             Seed and verify isolated first-run Codex migration
   --packaged true           Launch the packaged app instead of Electron source mode
   --selector CSS_SELECTOR   Target selector (required by click, fill, press and wait-for)
-  --value TEXT_OR_JSON      Replacement value for fill; JSON for click-at,
-                            seed-local-project, paste-paths, or drop-paths
+  --value TEXT_OR_JSON      Replacement value for fill or paste-text; JSON for
+                            click-at, seed-local-project, paste-paths, or drop-paths
   --target SELECTOR         Event target selector for pointer-move (default: body)
                             Required destination for drag and click-then-macrotask
   --file PATH               File to dispatch for drop-file

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -48,6 +48,7 @@ describe('AI_VERIFY_ACTIONS', () => {
       reload: 'reloadApp',
       'close-to-tray': 'closeMainWindowToTray',
       'request-close': 'requestMainWindowClose',
+      'selection-offset': 'getSelectionOffset',
       'dismiss-popout': 'dismissPopoutWindow',
       drag: 'drag',
       'drop-file': 'dropFile',
@@ -58,17 +59,20 @@ describe('AI_VERIFY_ACTIONS', () => {
       metrics: 'getElementMetrics',
       navigate: 'navigate',
       'paste-paths': 'pastePaths',
+      'paste-text': 'pasteText',
       'pointer-move': 'pointerMove',
       press: 'press',
       submit: 'submit',
       'scroll-into-view': 'scrollIntoView',
       'select-text': 'selectText',
+      'set-selection-offset': 'setSelectionOffset',
       'show-popout': 'showPopoutWindow',
       'system-drag-drop': 'completeSystemDragDrop',
       'verify-browser-inspector': 'verifyEmbeddedBrowserDetachedInspector',
       'wait-for': 'waitFor',
       'window-focus-snapshot': 'getWindowFocusSnapshot',
       text: 'getText',
+      value: 'getValue',
     })
   })
 })

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
@@ -220,7 +220,7 @@ describe('ComposerProseMirrorEditor', () => {
     expect(onChange).toHaveBeenLastCalledWith('existing pasted text')
   })
 
-  test('moves the caret to the end after pasting text', () => {
+  test('keeps the caret immediately after text pasted in the middle', () => {
     const { editorRef } = renderEditor('before after')
     const editor = screen.getByTestId('composer-editor')
 
@@ -236,9 +236,9 @@ describe('ComposerProseMirrorEditor', () => {
 
     expect(editorRef.current?.getSnapshot()).toMatchObject({
       value: 'before pasted after',
-      selectionOffset: 'before pasted after'.length,
-      selectionStart: 'before pasted after'.length,
-      selectionEnd: 'before pasted after'.length,
+      selectionOffset: 'before pasted '.length,
+      selectionStart: 'before pasted '.length,
+      selectionEnd: 'before pasted '.length,
     })
   })
 

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
@@ -273,8 +273,7 @@ export const ComposerProseMirrorEditor = forwardRef<
           event.clipboardData?.getData('text/plain') || event.clipboardData?.getData('text')
         if (!text) return false
         const pastedDocument = createComposerDocument(text)
-        let transaction = view.state.tr.replaceSelection(new Slice(pastedDocument.content, 1, 1))
-        transaction = transaction.setSelection(TextSelection.atEnd(transaction.doc))
+        const transaction = view.state.tr.replaceSelection(new Slice(pastedDocument.content, 1, 1))
         view.dispatch(
           transaction.setMeta('paste', true).setMeta('uiEvent', 'paste').scrollIntoView()
         )

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1199,6 +1199,46 @@ function inputDesktopControlTerminal(selector: string, value: string): string {
   return value
 }
 
+function setDesktopControlSelectionOffset(selector: string, value: string): string {
+  const element = findDesktopControlElements(selector)[0]
+  if (!element) throw new Error(`Unable to find selector "${selector}"`)
+  const offset = Number(value)
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error('setSelectionOffset requires a non-negative integer')
+  }
+
+  element.focus()
+  const range = document.createRange()
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let remaining = offset
+  let node = walker.nextNode()
+  while (node) {
+    const length = node.textContent?.length ?? 0
+    if (remaining <= length) {
+      range.setStart(node, remaining)
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      document.dispatchEvent(new Event('selectionchange'))
+      return String(offset)
+    }
+    remaining -= length
+    node = walker.nextNode()
+  }
+
+  if (offset === 0) {
+    range.selectNodeContents(element)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    document.dispatchEvent(new Event('selectionchange'))
+    return '0'
+  }
+  throw new Error(`Selection offset ${offset} exceeds the text length`)
+}
+
 function dropDesktopControlFile(command: DesktopControlCommand): string {
   const element = findDesktopControlElements(command.selector)[0]
   if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
@@ -1237,6 +1277,23 @@ function pasteDesktopControlFile(command: DesktopControlCommand): string {
   Object.defineProperty(event, 'clipboardData', { value: transfer })
   element.dispatchEvent(event)
   return filename
+}
+
+function pasteDesktopControlText(command: DesktopControlCommand): string {
+  const element = findDesktopControlElements(command.selector)[0]
+  if (!element) throw new Error(`Unable to find selector "${command.selector}"`)
+  const text = command.value ?? ''
+  const transfer = new DataTransfer()
+  transfer.setData('text/plain', text)
+  const event = new ClipboardEvent('paste', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  })
+  Object.defineProperty(event, 'clipboardData', { value: transfer })
+  element.focus()
+  element.dispatchEvent(event)
+  return text
 }
 
 function dispatchDesktopControlPaths(
@@ -1570,6 +1627,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return pasteDesktopControlFile(command)
     case 'pastePaths':
       return dispatchDesktopControlPaths(command, 'paste')
+    case 'pasteText':
+      return pasteDesktopControlText(command)
     case 'waitFor':
       return waitForDesktopControlElement(command)
     case 'getText':
@@ -2095,6 +2154,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return selectDesktopControlTerminalText(command.selector, command.value ?? '')
     case 'terminalInput':
       return inputDesktopControlTerminal(command.selector, command.value ?? '')
+    case 'setSelectionOffset':
+      return setDesktopControlSelectionOffset(command.selector, command.value ?? '')
   }
 
   const extensionResult = await desktopControlExtension.execute(command)

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1202,8 +1202,9 @@ function inputDesktopControlTerminal(selector: string, value: string): string {
 function setDesktopControlSelectionOffset(selector: string, value: string): string {
   const element = findDesktopControlElements(selector)[0]
   if (!element) throw new Error(`Unable to find selector "${selector}"`)
-  const offset = Number(value)
-  if (!Number.isInteger(offset) || offset < 0) {
+  const trimmedValue = value.trim()
+  const offset = Number(trimmedValue)
+  if (trimmedValue === '' || !Number.isInteger(offset) || offset < 0) {
     throw new Error('setSelectionOffset requires a non-negative integer')
   }
 

--- a/wework/src/test/setup.ts
+++ b/wework/src/test/setup.ts
@@ -1,7 +1,9 @@
-import '@testing-library/jest-dom/vitest'
-import { beforeEach } from 'vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
+import { beforeEach, expect } from 'vitest'
 import { WEWORK_DSH_SLOTS, type WeworkDshSlotEntry } from '@/features/dsh-runtime/dshUiSlots'
 import { clearDshUiModuleCache, importDshUiModule } from '@/features/dsh-runtime/dshUiModules'
+
+expect.extend(matchers)
 
 const electronHostInvokePath = '/wework/electron-host/v1/invoke'
 const nativeFetch = globalThis.fetch.bind(globalThis)


### PR DESCRIPTION
## Summary

- preserve ProseMirror selection after plain-text paste instead of moving it to the composer end
- add unit and desktop E2E regression coverage for middle-of-text paste
- expose focused desktop verification commands for paste and caret assertions

## Verification

- `pnpm --filter wework test src/components/chat/composer/ComposerProseMirrorEditor.test.tsx scripts/ai-verify.test.mjs`
- `pnpm --filter wework typecheck`
- changed-file ESLint and Prettier checks
- pre-push Wework, Electron, DSH, script, backend, and executor checks
- real Electron: `0123456789abcdefghij` + paste `PASTED` at offset 10 => `0123456789PASTEDabcdefghij`, caret offset 16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pasting text into the composer now keeps the caret immediately after the inserted content.
  * Improved handling of pasting text at an insertion point within existing content.
  * Empty selection-offset input is now rejected instead of being treated as zero.

* **Tests**
  * Added coverage for pasted text placement and caret position.
  * Expanded desktop automation checks for text selection, pasting, and value retrieval.
  * Improved reliability when detecting task completion in desktop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->