### PR TITLE
fix(wework): lift file link tooltips above workspace panels

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -3151,6 +3151,8 @@ last_updated = "2026-07-30T00:00:00Z"`
       await sendPrompt(control, composerSelector, FILE_PANEL_ANCHOR_PROMPT)
       const filePanelAnchorScopeSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"] [data-scroll-anchor]`
       const filePanelAnchorSelector = '[data-e2e-anchor-id="file-panel-anchor"]'
+      const filePanelLinkSelector = `${filePanelAnchorSelector} [data-testid="assistant-markdown-link"]`
+      const filePanelLinkTooltipSelector = '[data-testid="assistant-markdown-link-tooltip"]'
       const conversationScrollerSelector = '[data-testid="desktop-workbench-content"]'
       await control.command('waitFor', filePanelAnchorScopeSelector, {
         text: FILE_PANEL_ANCHOR_MARKER,
@@ -3180,10 +3182,7 @@ last_updated = "2026-07-30T00:00:00Z"`
       )
       await captureVerificationScreenshot(control, 'file-panel-anchor-01-before-open.png')
 
-      await control.command(
-        'click',
-        `${filePanelAnchorSelector} [data-testid="assistant-markdown-link"]`
-      )
+      await control.command('click', filePanelLinkSelector)
       await control.command('waitFor', '[data-testid="right-workspace-file-tab"]', {
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
@@ -3252,6 +3251,42 @@ last_updated = "2026-07-30T00:00:00Z"`
         `Closing the file panel moved the linked paragraph from ${filePanelAnchorBeforeOpen.top}px to ${filePanelAnchorAfterClose.top}px`
       )
 
+      await control.command('click', filePanelLinkSelector)
+      await control.command('waitFor', '[data-testid="right-workspace-file-tab"]', {
+        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+      })
+      await control.command('finishAnimations', 'body')
+      await control.command('hover', filePanelLinkSelector)
+      await control.command('waitFor', filePanelLinkTooltipSelector, {
+        visible: true,
+        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+      })
+      const filePanelLinkTooltip = await getSingleElementMetrics(
+        control,
+        filePanelLinkTooltipSelector,
+        'The assistant file-link tooltip'
+      )
+      const rightWorkspacePanel = await getSingleElementMetrics(
+        control,
+        '[data-testid="right-workspace-panel-shell"]',
+        'The right workspace panel'
+      )
+      assert.ok(
+        filePanelLinkTooltip.right > rightWorkspacePanel.left,
+        'The assistant file-link tooltip did not overlap the right workspace panel'
+      )
+      await captureVerificationScreenshot(control, 'file-panel-anchor-03-link-tooltip.png')
+      await control.command('press', filePanelLinkSelector, { key: 'Escape' })
+      await waitForSnapshot(
+        control,
+        snapshot =>
+          snapshot.testIds.includes('right-workspace-file-tab') &&
+          !snapshot.testIds.includes('assistant-markdown-link-tooltip'),
+        'The assistant file-link tooltip did not dismiss above the open file panel',
+        DEFAULT_STEP_TIMEOUT_MS
+      )
+      await control.command('click', '[data-testid="right-workspace-file-tab-close-button"]')
+
       phase = 'workspace-resources-across-conversation-switch'
       await writeFile(
         join(workspacePath, GIT_SEED_NAME),
@@ -3300,10 +3335,7 @@ last_updated = "2026-07-30T00:00:00Z"`
         value: 'file-panel-anchor',
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
-      await control.command(
-        'click',
-        `${filePanelAnchorSelector} [data-testid="assistant-markdown-link"]`
-      )
+      await control.command('click', filePanelLinkSelector)
       await control.command(
         'waitFor',
         `${activeTaskWorkbenchSelector} [data-testid="workspace-markdown-preview"]`,

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -3261,19 +3261,33 @@ last_updated = "2026-07-30T00:00:00Z"`
         visible: true,
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })
-      const filePanelLinkTooltip = await getSingleElementMetrics(
-        control,
+      const filePanelLinkTooltipPosition = await control.command(
+        'getComputedStyleValue',
         filePanelLinkTooltipSelector,
-        'The assistant file-link tooltip'
+        { value: 'position' }
       )
-      const rightWorkspacePanel = await getSingleElementMetrics(
-        control,
-        '[data-testid="right-workspace-panel-shell"]',
-        'The right workspace panel'
+      const filePanelLinkTooltipZIndex = Number(
+        await control.command('getComputedStyleValue', filePanelLinkTooltipSelector, {
+          value: 'z-index',
+        })
+      )
+      const rightWorkspacePanelZIndex = Number(
+        await control.command(
+          'getComputedStyleValue',
+          '[data-testid="right-workspace-panel-shell"]',
+          { value: 'z-index' }
+        )
+      )
+      assert.equal(
+        filePanelLinkTooltipPosition,
+        'fixed',
+        'The assistant file-link tooltip was not lifted into a viewport layer'
       )
       assert.ok(
-        filePanelLinkTooltip.right > rightWorkspacePanel.left,
-        'The assistant file-link tooltip did not overlap the right workspace panel'
+        Number.isFinite(filePanelLinkTooltipZIndex) &&
+          Number.isFinite(rightWorkspacePanelZIndex) &&
+          filePanelLinkTooltipZIndex > rightWorkspacePanelZIndex,
+        `The assistant file-link tooltip layer ${filePanelLinkTooltipZIndex} did not clear the right workspace panel layer ${rightWorkspacePanelZIndex}`
       )
       await captureVerificationScreenshot(control, 'file-panel-anchor-03-link-tooltip.png')
       await control.command('press', filePanelLinkSelector, { key: 'Escape' })

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -3153,6 +3153,7 @@ last_updated = "2026-07-30T00:00:00Z"`
       const filePanelAnchorSelector = '[data-e2e-anchor-id="file-panel-anchor"]'
       const filePanelLinkSelector = `${filePanelAnchorSelector} [data-testid="assistant-markdown-link"]`
       const filePanelLinkTooltipSelector = '[data-testid="assistant-markdown-link-tooltip"]'
+      const rightWorkspacePanelSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="right-workspace-panel-shell"]`
       const conversationScrollerSelector = '[data-testid="desktop-workbench-content"]'
       await control.command('waitFor', filePanelAnchorScopeSelector, {
         text: FILE_PANEL_ANCHOR_MARKER,
@@ -3271,12 +3272,15 @@ last_updated = "2026-07-30T00:00:00Z"`
           value: 'z-index',
         })
       )
+      assert.equal(
+        Number(await control.command('getElementCount', rightWorkspacePanelSelector)),
+        1,
+        'The active workbench did not expose exactly one right workspace panel'
+      )
       const rightWorkspacePanelZIndex = Number(
-        await control.command(
-          'getComputedStyleValue',
-          '[data-testid="right-workspace-panel-shell"]',
-          { value: 'z-index' }
-        )
+        await control.command('getComputedStyleValue', rightWorkspacePanelSelector, {
+          value: 'z-index',
+        })
       )
       assert.equal(
         filePanelLinkTooltipPosition,

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -26,6 +26,7 @@ import { requestEmbeddedBrowserOpen } from '@/lib/embedded-browser'
 import { isElectronRuntime } from '@/lib/runtime-environment'
 import type { WorkspaceFileOpenOptions } from '@/types/workspace-files'
 import type { TurnFileChangesSummary } from '@/types/api'
+import { Tooltip } from '@/components/ui/tooltip'
 import { useAttachmentDownload } from './AttachmentDownloadContext'
 
 const ASSISTANT_MARKDOWN_LINK_CLASS = [
@@ -604,41 +605,42 @@ function AssistantMarkdownLink({
     const tooltip = formatMarkdownFileTooltip(target)
     const openOptions = getMarkdownFileOpenOptions(target)
     return (
-      <button
-        type="button"
-        className={`${ASSISTANT_MARKDOWN_LINK_CLASS} group/file-link relative`}
-        data-testid="assistant-markdown-link"
-        onClick={() => {
-          if (isHtmlFilePath(filePath)) {
-            if (requestEmbeddedBrowserOpen(filePath)) return
-          }
-          if (openOptions) {
-            onOpenFile?.(filePath, openOptions)
-            return
-          }
-          onOpenFile?.(filePath)
-        }}
-        aria-label={tooltip}
+      <Tooltip
+        label={tooltip}
+        align="start"
+        testId="assistant-markdown-link-tooltip"
+        className="min-w-0 max-w-full !shrink align-baseline"
       >
-        {icon}
-        <span
-          className="min-w-0 whitespace-normal [overflow-wrap:anywhere]"
-          data-testid="assistant-markdown-link-label"
+        <button
+          type="button"
+          className={ASSISTANT_MARKDOWN_LINK_CLASS}
+          data-testid="assistant-markdown-link"
+          onClick={() => {
+            if (isHtmlFilePath(filePath)) {
+              if (requestEmbeddedBrowserOpen(filePath)) return
+            }
+            if (openOptions) {
+              onOpenFile?.(filePath, openOptions)
+              return
+            }
+            onOpenFile?.(filePath)
+          }}
+          aria-label={tooltip}
         >
-          {children}
-        </span>
-        {lineLabel ? (
-          <span className="shrink-0" data-testid="assistant-markdown-link-line">
-            ({lineLabel})
+          {icon}
+          <span
+            className="min-w-0 whitespace-normal [overflow-wrap:anywhere]"
+            data-testid="assistant-markdown-link-label"
+          >
+            {children}
           </span>
-        ) : null}
-        <span
-          data-testid="assistant-markdown-link-tooltip"
-          className="pointer-events-none absolute bottom-full left-0 z-30 mb-1 hidden w-max max-w-[min(36rem,calc(100vw-3rem))] whitespace-normal break-all rounded-xl border border-border bg-popover px-3 py-2 text-left text-sm font-normal leading-5 text-text-primary shadow-lg group-hover/file-link:block group-focus-visible/file-link:block"
-        >
-          {tooltip}
-        </span>
-      </button>
+          {lineLabel ? (
+            <span className="shrink-0" data-testid="assistant-markdown-link-line">
+              ({lineLabel})
+            </span>
+          ) : null}
+        </button>
+      </Tooltip>
     )
   }
 

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -2723,37 +2723,50 @@ describe('MessageList', () => {
     )
   })
 
-  test('passes assistant file link line numbers to open-file actions', async () => {
+  test('passes assistant file link line numbers to open-file actions', () => {
+    vi.useFakeTimers()
     const onOpenWorkspaceFile = vi.fn()
-    render(
-      <MessageList
-        onOpenWorkspaceFile={onOpenWorkspaceFile}
-        messages={[
-          {
-            id: 'assistant-file-line-link',
-            role: 'assistant',
-            content:
-              '放在 [references/github-pr-flow.md](references/github-pr-flow.md:18) 的 PR 段落。',
-            status: 'done',
-            createdAt: '2026-06-24T08:00:01.000Z',
-          },
-        ]}
-      />
-    )
+    try {
+      render(
+        <MessageList
+          onOpenWorkspaceFile={onOpenWorkspaceFile}
+          messages={[
+            {
+              id: 'assistant-file-line-link',
+              role: 'assistant',
+              content:
+                '放在 [references/github-pr-flow.md](references/github-pr-flow.md:18) 的 PR 段落。',
+              status: 'done',
+              createdAt: '2026-06-24T08:00:01.000Z',
+            },
+          ]}
+        />
+      )
 
-    expect(screen.getByTestId('assistant-markdown-link-line')).toHaveTextContent('(line 18)')
-    expect(screen.getByTestId('assistant-markdown-link-tooltip')).toHaveTextContent(
-      'references/github-pr-flow.md (line 18)'
-    )
-    expect(screen.getByTestId('assistant-markdown-link-tooltip')).toHaveClass(
-      'max-w-[min(36rem,calc(100vw-3rem))]',
-      'break-all'
-    )
-    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
-    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('references/github-pr-flow.md', {
-      lineStart: 18,
-      lineEnd: undefined,
-    })
+      const link = screen.getByTestId('assistant-markdown-link')
+      const tooltipTrigger = link.parentElement as HTMLElement
+      expect(screen.getByTestId('assistant-markdown-link-line')).toHaveTextContent('(line 18)')
+      expect(screen.queryByTestId('assistant-markdown-link-tooltip')).not.toBeInTheDocument()
+
+      fireEvent.pointerEnter(tooltipTrigger)
+      act(() => {
+        vi.advanceTimersByTime(700)
+      })
+
+      const tooltip = screen.getByTestId('assistant-markdown-link-tooltip')
+      expect(tooltip).toHaveTextContent('references/github-pr-flow.md (line 18)')
+      expect(tooltip).toHaveClass('fixed', 'z-system-popover')
+      expect(document.body).toContainElement(tooltip)
+      expect(link).not.toContainElement(tooltip)
+
+      fireEvent.click(link)
+      expect(onOpenWorkspaceFile).toHaveBeenCalledWith('references/github-pr-flow.md', {
+        lineStart: 18,
+        lineEnd: undefined,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('renders assistant file links with extension-specific Codex-style icons', () => {


### PR DESCRIPTION
## Summary

- render assistant file-link tooltips through the shared portal-based Tooltip layer
- keep existing file-open behavior and line-number metadata unchanged
- add unit and desktop E2E coverage for tooltips overlapping the right workspace panel

## Verification

- `pnpm --filter wework test src/components/chat/MessageList.test.tsx` (145 passed)
- `pnpm --filter wework typecheck`
- focused Prettier and ESLint checks
- repository pre-push Wework checks (ESLint, TypeScript, unit tests)
- `conversation-state` Electron checkpoint passed before syncing the latest main; on the latest main, local macOS execution reached a pre-existing `capture body` timeout before this regression assertion, so PR CI is the authoritative desktop result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File links now display a tooltip after hovering or focusing, with improved positioning above the workspace panel.
  * Tooltips can be dismissed with Escape while keeping the file panel open.
  * File-opening behavior, including line-number navigation, remains unchanged.

* **Bug Fixes**
  * Improved tooltip behavior when switching conversations and interacting with assistant file links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->