### PR TITLE
fix(wework): keep text attachments within narrow chats

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -3648,9 +3648,11 @@ describe('ChatInput', () => {
 
     expect(screen.getByTestId('attachment-badge')).toHaveClass(
       'h-[72px]',
+      'max-w-[min(420px,100%)]',
       'rounded-[20px]',
       'bg-muted'
     )
+    expect(screen.getByTestId('attachment-badge')).not.toHaveClass('sm:max-w-[420px]')
     expect(screen.getByTestId('attachment-text-preview')).toHaveTextContent(
       '{ "event_type": "http_exchange", "id": "e9972aac" }'
     )

--- a/wework/src/components/chat/composer/AttachmentBadges.tsx
+++ b/wework/src/components/chat/composer/AttachmentBadges.tsx
@@ -89,7 +89,7 @@ function TextAttachmentCard({
   return (
     <div
       data-testid="attachment-badge"
-      className="relative inline-flex h-[72px] max-w-full items-center gap-3 rounded-[20px] border border-border bg-muted px-3 pr-8 text-left shadow-sm sm:max-w-[420px]"
+      className="relative inline-flex h-[72px] max-w-[min(420px,100%)] items-center gap-3 rounded-[20px] border border-border bg-muted px-3 pr-8 text-left shadow-sm"
     >
       <span
         data-testid="attachment-text-icon"

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -6694,6 +6694,7 @@ describe('DesktopWorkbenchLayout', () => {
     const tabbar = screen.getByTestId('right-workspace-tabbar')
     const sideChat = screen.getByTestId('right-workspace-chat-panel')
     expect(sideChat).toBeInTheDocument()
+    expect(sideChat).toHaveClass('min-w-0')
     expect(screen.getByTestId('side-chat-composer-layout')).toHaveClass(
       'mx-auto',
       'w-[min(46rem,calc(100%_-_2rem))]',

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -693,7 +693,10 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
         {chatTabs.map(tab => (
           <div
             key={tab}
-            className={cn('min-h-0 flex-1 flex-col', activeView === tab ? 'flex' : 'hidden')}
+            className={cn(
+              'min-h-0 min-w-0 flex-1 flex-col',
+              activeView === tab ? 'flex' : 'hidden'
+            )}
           >
             <TemporaryChatPanel
               currentProject={currentProject}

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -734,7 +734,7 @@ export function TemporaryChatPanel({
   }, [address, cancelRuntimePaneTask])
 
   return (
-    <section data-testid={testId} className="flex min-h-0 flex-1 flex-col">
+    <section data-testid={testId} className="flex min-h-0 min-w-0 flex-1 flex-col">
       {messages.length === 0 ? (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-8 text-center text-sm text-text-muted">
           <MessageCircle className="h-5 w-5 text-text-secondary" />


### PR DESCRIPTION
## Summary
- constrain text attachment cards to the actual composer width
- allow right-workspace chat flex containers to shrink with the panel
- add regression coverage for narrow side-chat layouts

## Verification
- focused ChatInput and DesktopWorkbenchLayout tests
- pre-push ESLint, TypeScript, and unit-test suite
- packaged Electron verification at a 420px right panel: panel clientWidth/scrollWidth = 419/419; attachment card remains fully visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat panel layout behavior in narrow or constrained workspaces.
  - Prevented chat content from forcing panels wider than available space.
  - Made text attachment cards responsive across screen sizes, using the smaller of 420px or the available width.

- **Tests**
  - Added regression coverage for responsive attachment sizing and flexible chat panel widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->