### PR TITLE
fix(wework): align embedded browser annotations

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -1021,6 +1021,39 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         `Annotation target click failed: ${JSON.stringify(createAnnotation)}`
       )
       assert.equal(createAnnotation.value, true, 'Annotation target click did not open the editor')
+      const draftAnnotationMarker = await bridgeCall({
+        action: 'evaluate',
+        expression: `(() => {
+          const draft = document.querySelector('[data-wework-annotation="draft-marker"]')
+          return {
+            exists: Boolean(draft),
+            text: draft?.textContent ?? null,
+            fill: draft?.querySelector('path')?.getAttribute('fill') ?? null,
+            transform: draft?.style.transform ?? null,
+            savedCount: document.querySelectorAll('[data-wework-annotation="marker"]').length,
+            annotationCount:
+              window.__WEWORK_BROWSER_ANNOTATION__?.getSnapshot?.().annotations.length ?? null,
+          }
+        })()`,
+        timeoutMs: 5_000,
+      })
+      assert.equal(
+        draftAnnotationMarker.ok,
+        true,
+        `Draft annotation marker evaluation failed: ${JSON.stringify(draftAnnotationMarker)}`
+      )
+      assert.deepEqual(
+        draftAnnotationMarker.value,
+        {
+          exists: true,
+          text: '',
+          fill: '#0069FB',
+          transform: 'translate(-15.689%, -89.696%)',
+          savedCount: 0,
+          annotationCount: 0,
+        },
+        'The first annotation did not show the unnumbered draft marker'
+      )
       const fillAnnotationComment = await bridgeCall({
         action: 'fill',
         selector: '[data-wework-annotation="comment-input"]',
@@ -1046,6 +1079,23 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         text: '1',
         timeoutMs: uiTimeoutMs,
       })
+      const publishedAnnotationMarker = await bridgeCall({
+        action: 'evaluate',
+        expression: `({
+          draftExists: Boolean(
+            document.querySelector('[data-wework-annotation="draft-marker"]')
+          ),
+          savedText:
+            document.querySelector('[data-wework-annotation="marker"]')?.textContent ?? null,
+        })`,
+        timeoutMs: 5_000,
+      })
+      assert.equal(publishedAnnotationMarker.ok, true)
+      assert.deepEqual(
+        publishedAnnotationMarker.value,
+        { draftExists: false, savedText: '1' },
+        'Publishing did not replace the draft marker with numbered marker 1'
+      )
 
       const annotationMarker = await bridgeCall({
         action: 'click',

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -7,16 +7,28 @@ import type { WebContents } from 'electron'
 import { EmbeddedBrowserManager, type BrowserHostEvent } from './embedded-browser-manager.js'
 
 const electronMocks = vi.hoisted(() => ({
+  appGetLocale: vi.fn(() => 'zh-CN'),
   browserSession: {
     clearCache: vi.fn(),
     clearStorageData: vi.fn(),
     on: vi.fn(),
   },
+  menuPopup: vi.fn(),
+  menuBuildFromTemplate: vi.fn((items: unknown[]) => ({
+    items,
+    popup: electronMocks.menuPopup,
+  })),
 }))
 
 vi.mock('electron', () => ({
+  app: {
+    getLocale: electronMocks.appGetLocale,
+  },
   BrowserWindow: {
     getAllWindows: vi.fn(() => []),
+  },
+  Menu: {
+    buildFromTemplate: electronMocks.menuBuildFromTemplate,
   },
   session: {
     fromPartition: vi.fn(() => electronMocks.browserSession),
@@ -49,6 +61,7 @@ class FakeWebContents extends EventEmitter {
   executeJavaScript = vi.fn()
   getTitle = vi.fn(() => '')
   getURL = vi.fn(() => this.url)
+  inspectElement = vi.fn()
   isDestroyed = vi.fn(() => this.destroyed)
   isDevToolsOpened = vi.fn(() => this.devToolsOpened)
   isLoading = vi.fn(() => true)
@@ -69,6 +82,36 @@ class FakeWebContents extends EventEmitter {
   commitUrl(url: string): void {
     this.url = url
   }
+}
+
+function emitBeforeInput(
+  contents: FakeWebContents,
+  input: Partial<{
+    type: string
+    key: string
+    code: string
+    isAutoRepeat: boolean
+    isComposing: boolean
+    alt: boolean
+    control: boolean
+    meta: boolean
+    shift: boolean
+  }> = {}
+) {
+  const event = { preventDefault: vi.fn() }
+  contents.emit('before-input-event', event, {
+    type: 'keyDown',
+    key: 'F12',
+    code: 'F12',
+    isAutoRepeat: false,
+    isComposing: false,
+    alt: false,
+    control: false,
+    meta: false,
+    shift: false,
+    ...input,
+  })
+  return event
 }
 
 describe('EmbeddedBrowserManager lifecycle', () => {
@@ -108,6 +151,190 @@ describe('EmbeddedBrowserManager lifecycle', () => {
       label: 'workspace-browser',
       url: 'https://example.test/',
     })
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('toggles the detached Inspector with a bare F12 keydown', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    const openEvent = emitBeforeInput(contents)
+
+    expect(openEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(contents.openDevTools).toHaveBeenCalledWith({ mode: 'detach', activate: true })
+
+    const closeEvent = emitBeforeInput(contents)
+
+    expect(closeEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(contents.closeDevTools).toHaveBeenCalledOnce()
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('leaves modified and repeated F12 input to the browser page', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    const events = [
+      emitBeforeInput(contents, { shift: true }),
+      emitBeforeInput(contents, { isAutoRepeat: true }),
+      emitBeforeInput(contents, { type: 'keyUp' }),
+    ]
+
+    for (const event of events) expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(contents.openDevTools).not.toHaveBeenCalled()
+    expect(contents.closeDevTools).not.toHaveBeenCalled()
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('shows the browser context menu and routes its actions', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const events: BrowserHostEvent[] = []
+    const manager = new EmbeddedBrowserManager(directory, event => events.push(event))
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    contents.emit(
+      'context-menu',
+      {},
+      {
+        x: 80,
+        y: 120,
+        isEditable: false,
+        formControlType: 'none',
+        mediaType: 'none',
+        linkURL: '',
+        srcURL: '',
+        selectionText: '',
+      }
+    )
+
+    const items = electronMocks.menuBuildFromTemplate.mock.calls.at(-1)?.[0] as Array<{
+      click?: () => void
+      enabled?: boolean
+      label?: string
+      type?: string
+    }>
+    expect(items.map(item => item.label ?? item.type)).toEqual([
+      '快速评论',
+      '评论',
+      'separator',
+      '返回',
+      '前进',
+      '重新加载',
+      'separator',
+      '检查',
+    ])
+    expect(items[3]).toMatchObject({ enabled: false })
+    expect(items[4]).toMatchObject({ enabled: false })
+    expect(electronMocks.menuPopup).toHaveBeenCalledOnce()
+
+    items[0].click?.()
+    items[1].click?.()
+    items[5].click?.()
+    items[7].click?.()
+
+    expect(contents.reload).toHaveBeenCalledOnce()
+    expect(contents.inspectElement).toHaveBeenCalledWith(80, 120)
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'annotation-request',
+          payload: expect.objectContaining({
+            label: 'workspace-browser',
+            mode: 'quick',
+            x: 80,
+            y: 120,
+          }),
+        }),
+        expect.objectContaining({
+          type: 'annotation-request',
+          payload: expect.objectContaining({
+            label: 'workspace-browser',
+            mode: 'batch',
+            x: 80,
+            y: 120,
+          }),
+        }),
+      ])
+    )
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('omits navigation actions for a non-plain browser context', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    contents.emit(
+      'context-menu',
+      {},
+      {
+        x: 20,
+        y: 30,
+        isEditable: false,
+        formControlType: 'none',
+        mediaType: 'none',
+        linkURL: 'https://example.test/linked',
+        srcURL: '',
+        selectionText: '',
+      }
+    )
+
+    const items = electronMocks.menuBuildFromTemplate.mock.calls.at(-1)?.[0] as Array<{
+      label?: string
+      type?: string
+    }>
+    expect(items.map(item => item.label ?? item.type)).toEqual([
+      '快速评论',
+      '评论',
+      'separator',
+      '检查',
+    ])
     await rm(directory, { recursive: true, force: true })
   })
 

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -1,4 +1,14 @@
-import { BrowserWindow, session, shell, type DownloadItem, type WebContents } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  session,
+  shell,
+  type ContextMenuParams,
+  type DownloadItem,
+  type MenuItemConstructorOptions,
+  type WebContents,
+} from 'electron'
 import { randomUUID } from 'node:crypto'
 import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
@@ -56,6 +66,7 @@ export interface BrowserHostEvent {
     | 'open-request'
     | 'page-state'
     | 'popup'
+    | 'annotation-request'
   payload: Record<string, unknown>
 }
 
@@ -175,6 +186,24 @@ export class EmbeddedBrowserManager {
       historyId: null,
       historyGeneration: this.historyGeneration,
     }
+    contents.on('before-input-event', (event, input) => {
+      const isBareF12 =
+        input.type === 'keyDown' &&
+        (input.key === 'F12' || input.code === 'F12') &&
+        !input.isAutoRepeat &&
+        !input.isComposing &&
+        !input.alt &&
+        !input.control &&
+        !input.meta &&
+        !input.shift
+      if (!isBareF12) return
+      event.preventDefault()
+      if (contents.isDevToolsOpened()) contents.closeDevTools()
+      else contents.openDevTools({ mode: 'detach', activate: true })
+    })
+    contents.on('context-menu', (_event, params) => {
+      this.showContextMenu(entry, params)
+    })
     contents.setWindowOpenHandler(({ url }) => {
       if (isBrowserUrl(url)) {
         this.emit('popup', {
@@ -747,6 +776,56 @@ export class EmbeddedBrowserManager {
     this.emitPageState(entry)
   }
 
+  private showContextMenu(entry: BrowserEntry, params: ContextMenuParams): void {
+    const contents = entry.contents
+    const labels = embeddedBrowserContextMenuLabels(app.getLocale())
+    const requestAnnotation = (mode: 'quick' | 'batch') => {
+      this.emit('annotation-request', {
+        label: entry.label,
+        nativeLabel: entry.nativeLabel,
+        mode,
+        x: params.x,
+        y: params.y,
+      })
+    }
+    const items: MenuItemConstructorOptions[] = [
+      {
+        label: labels.quickAnnotate,
+        click: () => requestAnnotation('quick'),
+      },
+      {
+        label: labels.annotate,
+        click: () => requestAnnotation('batch'),
+      },
+      { type: 'separator' },
+    ]
+    if (isPlainBrowserContext(params)) {
+      items.push(
+        {
+          label: labels.back,
+          enabled: contents.navigationHistory.canGoBack(),
+          click: () => contents.navigationHistory.goBack(),
+        },
+        {
+          label: labels.forward,
+          enabled: contents.navigationHistory.canGoForward(),
+          click: () => contents.navigationHistory.goForward(),
+        },
+        {
+          label: labels.reload,
+          enabled: Boolean(this.currentVisibleUrl(entry) || entry.requestedUrl),
+          click: () => contents.reload(),
+        },
+        { type: 'separator' }
+      )
+    }
+    items.push({
+      label: labels.inspect,
+      click: () => contents.inspectElement(params.x, params.y),
+    })
+    Menu.buildFromTemplate(items).popup()
+  }
+
   private emit(type: BrowserHostEvent['type'], payload: Record<string, unknown>): void {
     this.onEvent({
       sequence: ++this.eventSequence,
@@ -869,6 +948,47 @@ function isBrowserUrl(value: string): boolean {
   } catch {
     return false
   }
+}
+
+interface EmbeddedBrowserContextMenuLabels {
+  quickAnnotate: string
+  annotate: string
+  back: string
+  forward: string
+  reload: string
+  inspect: string
+}
+
+function embeddedBrowserContextMenuLabels(language: string): EmbeddedBrowserContextMenuLabels {
+  if (language.trim().toLowerCase().startsWith('zh')) {
+    return {
+      quickAnnotate: '快速评论',
+      annotate: '评论',
+      back: '返回',
+      forward: '前进',
+      reload: '重新加载',
+      inspect: '检查',
+    }
+  }
+  return {
+    quickAnnotate: 'Quick annotate',
+    annotate: 'Annotate',
+    back: 'Back',
+    forward: 'Forward',
+    reload: 'Reload',
+    inspect: 'Inspect',
+  }
+}
+
+function isPlainBrowserContext(params: ContextMenuParams): boolean {
+  return (
+    !params.isEditable &&
+    params.formControlType === 'none' &&
+    params.mediaType === 'none' &&
+    !params.linkURL &&
+    !params.srcURL &&
+    !params.selectionText.trim()
+  )
 }
 
 function isHistoryRecordableUrl(value: string): boolean {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -437,6 +437,7 @@ class ElectronWorkbenchView implements WorkbenchTabView {
 
 const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
   if (!mainWindow || !desktopRuntime) return
+  if (!desktopRuntime.state().ready) return
   if (primaryDshLoaded) return
   rendererHealth.loading()
   const dshUrl = desktopRuntime.coreDshUrl()

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -34,6 +34,7 @@ const embeddedBrowserMocks = vi.hoisted(() => ({
   goForwardEmbeddedBrowser: vi.fn(),
   isEmbeddedBrowserLabelTransferred: vi.fn(),
   listenEmbeddedBrowserAgentState: vi.fn(),
+  listenEmbeddedBrowserAnnotationRequests: vi.fn(),
   listenEmbeddedBrowserCloseRequests: vi.fn(),
   listenEmbeddedBrowserDownloads: vi.fn(),
   listenEmbeddedBrowserInvalidTlsCertificates: vi.fn(),
@@ -158,6 +159,7 @@ describe('WorkspaceBrowserPanel', () => {
     embeddedBrowserMocks.consumeEmbeddedBrowserLabelTransfer.mockReturnValue(false)
     embeddedBrowserMocks.isEmbeddedBrowserLabelTransferred.mockReturnValue(false)
     embeddedBrowserMocks.listenEmbeddedBrowserAgentState.mockReturnValue(null)
+    embeddedBrowserMocks.listenEmbeddedBrowserAnnotationRequests.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserCloseRequests.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserDownloads.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserInvalidTlsCertificates.mockReturnValue(null)
@@ -2313,6 +2315,169 @@ describe('WorkspaceBrowserPanel', () => {
     expect(selectedText.type).toBe('browser_annotation')
     expect(selectedText.target.tagName).toBe('button')
     expect(screen.getByTestId('workspace-browser-annotation-count')).toHaveTextContent('1')
+  })
+
+  test('opens batch annotation at the browser context-menu point', async () => {
+    mockBrowserHostRect()
+    let handleAnnotationRequest:
+      | ((request: {
+          label: string
+          nativeLabel: string
+          mode: 'quick' | 'batch'
+          x: number
+          y: number
+        }) => void)
+      | undefined
+    embeddedBrowserMocks.listenEmbeddedBrowserAnnotationRequests.mockImplementation(handler => {
+      handleAnnotationRequest = handler
+      return null
+    })
+    render(<WorkspaceBrowserPanel active />)
+
+    const input = screen.getByTestId('workspace-browser-url-input')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.submit(input.closest('form')!)
+    await waitFor(() =>
+      expect(screen.getByTestId('workspace-browser-annotate-button')).toBeEnabled()
+    )
+
+    act(() => {
+      handleAnnotationRequest?.({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        mode: 'batch',
+        x: 20,
+        y: 30,
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        embeddedBrowserMocks.evalEmbeddedBrowser.mock.calls.some(([script]) =>
+          String(script).includes('__WEWORK_BROWSER_ANNOTATION__?.openAt?.(20, 30)')
+        )
+      ).toBe(true)
+    })
+    expect(screen.getByTestId('workspace-browser-annotation-close-button')).toBeInTheDocument()
+  })
+
+  test('exits quick annotation after publishing one context-menu annotation', async () => {
+    mockBrowserHostRect()
+    const onAddCodeComment = vi.fn()
+    let handleAnnotationRequest:
+      | ((request: {
+          label: string
+          nativeLabel: string
+          mode: 'quick' | 'batch'
+          x: number
+          y: number
+        }) => void)
+      | undefined
+    embeddedBrowserMocks.listenEmbeddedBrowserAnnotationRequests.mockImplementation(handler => {
+      handleAnnotationRequest = handler
+      return null
+    })
+    let snapshotReads = 0
+    embeddedBrowserMocks.evalEmbeddedBrowserJson.mockImplementation(async expression => {
+      if (!String(expression).includes('getSnapshot')) return null
+      snapshotReads += 1
+      if (snapshotReads === 1) return annotationSnapshot([], 0)
+      return annotationSnapshot([
+        {
+          id: 'browser-annotation-1',
+          number: 1,
+          comment: 'Quick note',
+        },
+      ])
+    })
+    render(<WorkspaceBrowserPanel active onAddCodeComment={onAddCodeComment} />)
+
+    const input = screen.getByTestId('workspace-browser-url-input')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.submit(input.closest('form')!)
+    await waitFor(() =>
+      expect(screen.getByTestId('workspace-browser-annotate-button')).toBeEnabled()
+    )
+
+    act(() => {
+      handleAnnotationRequest?.({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        mode: 'quick',
+        x: 20,
+        y: 30,
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        embeddedBrowserMocks.evalEmbeddedBrowser.mock.calls.some(([script]) =>
+          String(script).includes('__WEWORK_BROWSER_ANNOTATION__?.openAt?.(20, 30)')
+        )
+      ).toBe(true)
+    })
+    await waitFor(() => expect(onAddCodeComment).toHaveBeenCalledOnce())
+    await waitFor(() => {
+      expect(
+        embeddedBrowserMocks.evalEmbeddedBrowser.mock.calls.some(([script]) =>
+          String(script).includes('__WEWORK_BROWSER_ANNOTATION__?.suspend')
+        )
+      ).toBe(true)
+    })
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('workspace-browser-annotation-close-button')
+      ).not.toBeInTheDocument()
+    )
+  })
+
+  test('does not enter quick annotation without a matching baseline', async () => {
+    mockBrowserHostRect()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let handleAnnotationRequest:
+      | ((request: {
+          label: string
+          nativeLabel: string
+          mode: 'quick' | 'batch'
+          x: number
+          y: number
+        }) => void)
+      | undefined
+    embeddedBrowserMocks.listenEmbeddedBrowserAnnotationRequests.mockImplementation(handler => {
+      handleAnnotationRequest = handler
+      return null
+    })
+    render(<WorkspaceBrowserPanel active />)
+
+    const input = screen.getByTestId('workspace-browser-url-input')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.submit(input.closest('form')!)
+    await waitFor(() =>
+      expect(screen.getByTestId('workspace-browser-annotate-button')).toBeEnabled()
+    )
+
+    act(() => {
+      handleAnnotationRequest?.({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        mode: 'quick',
+        x: 20,
+        y: 30,
+      })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('workspace-browser-error')).toHaveTextContent('无法进入批注模式')
+    )
+    expect(
+      embeddedBrowserMocks.evalEmbeddedBrowser.mock.calls.some(([script]) =>
+        String(script).includes('__WEWORK_BROWSER_ANNOTATION__?.openAt?.(20, 30)')
+      )
+    ).toBe(false)
+    expect(
+      screen.queryByTestId('workspace-browser-annotation-close-button')
+    ).not.toBeInTheDocument()
+    consoleError.mockRestore()
   })
 
   test('hold-to-view-original button is enabled for queued tweaks and toggles the original page runtime', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -29,6 +29,7 @@ import {
   consumeEmbeddedBrowserLabelTransfer,
   deleteEmbeddedBrowserDownload,
   listenEmbeddedBrowserAgentState,
+  listenEmbeddedBrowserAnnotationRequests,
   listenEmbeddedBrowserCloseRequests,
   EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT,
   EMBEDDED_BROWSER_OCCLUSION_EVENT,
@@ -52,6 +53,7 @@ import {
   setEmbeddedBrowserDeviceMetrics,
   setEmbeddedBrowserZoom,
   type EmbeddedBrowserAgentStateEvent,
+  type EmbeddedBrowserAnnotationRequest,
   type EmbeddedBrowserDataKind,
   type EmbeddedBrowserBounds,
   type EmbeddedBrowserDownloadEvent,
@@ -131,6 +133,11 @@ interface BrowserOcclusionState {
   documentOverlayOccluded: boolean
   generation: number
   overlayIds: Set<string>
+}
+
+interface AnnotationEntry {
+  mode?: EmbeddedBrowserAnnotationRequest['mode']
+  point?: { x: number; y: number }
 }
 
 type BrowserOcclusionAction =
@@ -360,6 +367,12 @@ export function WorkspaceBrowserTabPanel({
   const addressInputRef = useRef<HTMLInputElement | null>(null)
   const addressEditingRef = useRef(false)
   const annotationModeRef = useRef(false)
+  const annotationFlowRef = useRef<EmbeddedBrowserAnnotationRequest['mode']>('batch')
+  const quickAnnotationBaselineRef = useRef<{
+    pageSessionId: string
+    revision: number
+    annotationCount: number
+  } | null>(null)
   const annotationCleanupPromiseRef = useRef<Promise<void> | null>(null)
   const annotationInjectionOwnerRef = useRef<number | null>(null)
   const annotationRequestGenerationRef = useRef(0)
@@ -982,51 +995,57 @@ export function WorkspaceBrowserTabPanel({
     })
     annotationRequestGenerationRef.current += 1
     annotationModeRef.current = false
+    annotationFlowRef.current = 'batch'
+    quickAnnotationBaselineRef.current = null
     setAnnotationMode(false)
     setOriginalViewHeld(false)
     void suspendAnnotationLayer(label)
   }, [currentUrl, label, pendingCommentContextCount, suspendAnnotationLayer])
 
-  const enterAnnotationMode = useCallback(async () => {
-    logBrowserAnnotation('enter annotation mode requested', {
-      label,
-      active,
-      currentUrl,
-      embeddedBrowserAvailable,
-      nativeBrowserOpen: nativeBrowserOpenRef.current,
-    })
-    if (
-      internalDesktopPage ||
-      !embeddedBrowserAvailable ||
-      !nativeBrowserOpenRef.current ||
-      !currentUrl
-    ) {
-      logBrowserAnnotation('enter annotation mode skipped', {
+  const enterAnnotationMode = useCallback(
+    async (request: AnnotationEntry = {}) => {
+      const mode = request.mode ?? 'batch'
+      logBrowserAnnotation('enter annotation mode requested', {
         label,
         active,
         currentUrl,
+        mode,
         embeddedBrowserAvailable,
         nativeBrowserOpen: nativeBrowserOpenRef.current,
       })
-      return
-    }
-    const requestGeneration = annotationRequestGenerationRef.current + 1
-    annotationRequestGenerationRef.current = requestGeneration
-    try {
-      const pendingCleanup = annotationCleanupPromiseRef.current
-      if (pendingCleanup) {
-        await pendingCleanup
-      }
       if (
-        !mountedRef.current ||
-        currentLabelRef.current !== label ||
-        annotationRequestGenerationRef.current !== requestGeneration
+        internalDesktopPage ||
+        !embeddedBrowserAvailable ||
+        !nativeBrowserOpenRef.current ||
+        !currentUrl
       ) {
+        logBrowserAnnotation('enter annotation mode skipped', {
+          label,
+          active,
+          currentUrl,
+          embeddedBrowserAvailable,
+          nativeBrowserOpen: nativeBrowserOpenRef.current,
+        })
         return
       }
-      annotationInjectionOwnerRef.current = requestGeneration
-      await evalEmbeddedBrowser(
-        createBrowserAnnotationInjectionScript({
+      annotationFlowRef.current = mode
+      quickAnnotationBaselineRef.current = null
+      const requestGeneration = annotationRequestGenerationRef.current + 1
+      annotationRequestGenerationRef.current = requestGeneration
+      try {
+        const pendingCleanup = annotationCleanupPromiseRef.current
+        if (pendingCleanup) {
+          await pendingCleanup
+        }
+        if (
+          !mountedRef.current ||
+          currentLabelRef.current !== label ||
+          annotationRequestGenerationRef.current !== requestGeneration
+        ) {
+          return
+        }
+        annotationInjectionOwnerRef.current = requestGeneration
+        const injectionScript = createBrowserAnnotationInjectionScript({
           browserTabId,
           uiFontSize: appearance.uiFontSize,
           isDark: resolveAppearanceMode(appearance.mode) === 'dark',
@@ -1064,60 +1083,132 @@ export function WorkspaceBrowserTabPanel({
               'border-width': t('workbench.browser_annotation_adjustment_border-width'),
             },
           },
-        }),
-        label
-      )
+        })
+        const quickBaseline =
+          mode === 'quick'
+            ? await evalEmbeddedBrowserJson<BrowserAnnotationSnapshot | null>(
+                `(() => {
+                  ${injectionScript}
+                  return window.__WEWORK_BROWSER_ANNOTATION__?.getSnapshot?.() ?? null
+                })()`,
+                label
+              )
+            : null
+        if (mode !== 'quick') {
+          await evalEmbeddedBrowser(injectionScript, label)
+        }
+        if (
+          !mountedRef.current ||
+          currentLabelRef.current !== label ||
+          annotationRequestGenerationRef.current !== requestGeneration
+        ) {
+          await cleanupInvalidatedAnnotationRequest(requestGeneration, label)
+          return
+        }
+        if (
+          activePageUrlRef.current &&
+          cloudDesktopExtension.isInternalPageUrl(activePageUrlRef.current)
+        ) {
+          exitAnnotationMode()
+          return
+        }
+        if (mode === 'quick') {
+          if (quickBaseline?.scope.browserTabId !== browserTabId) {
+            logBrowserAnnotation('quick annotation baseline unavailable', {
+              label,
+              browserTabId,
+              baselineBrowserTabId: quickBaseline?.scope.browserTabId ?? null,
+            })
+            throw new Error('Quick annotation baseline is unavailable')
+          }
+          quickAnnotationBaselineRef.current = {
+            pageSessionId: quickBaseline.scope.pageSessionId,
+            revision: quickBaseline.revision,
+            annotationCount: quickBaseline.annotations.length,
+          }
+          annotationSnapshotRef.current = {
+            pageSessionId: quickBaseline.scope.pageSessionId,
+            revision: quickBaseline.revision,
+          }
+        }
+        if (request.point && Number.isFinite(request.point.x) && Number.isFinite(request.point.y)) {
+          await evalEmbeddedBrowser(
+            `window.__WEWORK_BROWSER_ANNOTATION__?.openAt?.(${request.point.x}, ${request.point.y}) ?? false`,
+            label
+          )
+        }
+        annotationEmptyPollLogCountRef.current = 0
+        annotationModeRef.current = true
+        setAnnotationMode(true)
+        logBrowserAnnotation('enter annotation mode succeeded', { label, currentUrl })
+      } catch (error) {
+        if (
+          !mountedRef.current ||
+          currentLabelRef.current !== label ||
+          annotationRequestGenerationRef.current !== requestGeneration
+        ) {
+          await cleanupInvalidatedAnnotationRequest(requestGeneration, label)
+          return
+        }
+        annotationInjectionOwnerRef.current = null
+        console.error('Failed to enter embedded browser annotation mode:', error)
+        logBrowserAnnotation('enter annotation mode failed', {
+          label,
+          currentUrl,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        setStatus('error')
+        setError(t('workbench.browser_annotation_failed'))
+      }
+    },
+    [
+      active,
+      appearance.mode,
+      appearance.uiFontSize,
+      currentUrl,
+      cleanupInvalidatedAnnotationRequest,
+      embeddedBrowserAvailable,
+      exitAnnotationMode,
+      internalDesktopPage,
+      label,
+      browserTabId,
+      t,
+    ]
+  )
+
+  useEffect(() => {
+    const listener = listenEmbeddedBrowserAnnotationRequests(request => {
       if (
-        !mountedRef.current ||
-        currentLabelRef.current !== label ||
-        annotationRequestGenerationRef.current !== requestGeneration
+        !activeRef.current ||
+        request.label !== currentLabelRef.current ||
+        request.nativeLabel !== nativeLabelRef.current
       ) {
-        await cleanupInvalidatedAnnotationRequest(requestGeneration, label)
         return
       }
-      if (
-        activePageUrlRef.current &&
-        cloudDesktopExtension.isInternalPageUrl(activePageUrlRef.current)
-      ) {
-        exitAnnotationMode()
-        return
-      }
-      annotationEmptyPollLogCountRef.current = 0
-      annotationModeRef.current = true
-      setAnnotationMode(true)
-      logBrowserAnnotation('enter annotation mode succeeded', { label, currentUrl })
-    } catch (error) {
-      if (
-        !mountedRef.current ||
-        currentLabelRef.current !== label ||
-        annotationRequestGenerationRef.current !== requestGeneration
-      ) {
-        await cleanupInvalidatedAnnotationRequest(requestGeneration, label)
-        return
-      }
-      annotationInjectionOwnerRef.current = null
-      console.error('Failed to enter embedded browser annotation mode:', error)
-      logBrowserAnnotation('enter annotation mode failed', {
-        label,
-        currentUrl,
-        error: error instanceof Error ? error.message : String(error),
+      void enterAnnotationMode({
+        mode: request.mode,
+        point: { x: request.x, y: request.y },
       })
-      setStatus('error')
-      setError(t('workbench.browser_annotation_failed'))
+    })
+    if (!listener) return undefined
+    let disposed = false
+    let unlisten: (() => void) | null = null
+    void listener
+      .then(nextUnlisten => {
+        if (disposed) {
+          nextUnlisten()
+          return
+        }
+        unlisten = nextUnlisten
+      })
+      .catch(error => {
+        console.error('Failed to listen for embedded browser annotation requests:', error)
+      })
+    return () => {
+      disposed = true
+      unlisten?.()
     }
-  }, [
-    active,
-    appearance.mode,
-    appearance.uiFontSize,
-    currentUrl,
-    cleanupInvalidatedAnnotationRequest,
-    embeddedBrowserAvailable,
-    exitAnnotationMode,
-    internalDesktopPage,
-    label,
-    browserTabId,
-    t,
-  ])
+  }, [enterAnnotationMode])
 
   useEffect(() => {
     if (
@@ -1650,6 +1741,16 @@ export function WorkspaceBrowserTabPanel({
         } else {
           contexts.forEach(context => onAddCodeComment?.(context))
         }
+        const quickBaseline = quickAnnotationBaselineRef.current
+        if (
+          annotationFlowRef.current === 'quick' &&
+          quickBaseline &&
+          snapshot.scope.pageSessionId === quickBaseline.pageSessionId &&
+          snapshot.revision > quickBaseline.revision &&
+          snapshot.annotations.length > quickBaseline.annotationCount
+        ) {
+          exitAnnotationMode()
+        }
       } catch (error) {
         if (cancelled) return
         console.error('Failed to consume embedded browser annotations:', error)
@@ -1676,6 +1777,7 @@ export function WorkspaceBrowserTabPanel({
     annotationMode,
     browserTabId,
     embeddedBrowserAvailable,
+    exitAnnotationMode,
     internalDesktopPage,
     label,
     onAddCodeComment,

--- a/wework/src/components/layout/workspace-panels/browser-annotation-injection.test.ts
+++ b/wework/src/components/layout/workspace-panels/browser-annotation-injection.test.ts
@@ -4,6 +4,7 @@ import { browserAnnotationInjectionScript } from './browser-annotation/injection
 interface RuntimeApi {
   scope: { browserTabId: string; pageSessionId: string; url: string }
   getSnapshot: () => { revision: number; annotations: Array<{ comment: string; number: number }> }
+  openAt: (x: number, y: number) => boolean
   setOriginalViewEnabled: (enabled: boolean) => {
     revision: number
     annotations: Array<{ comment: string; number: number }>
@@ -76,6 +77,15 @@ describe('browser annotation injection', () => {
 
   test('publishes a non-destructive revision snapshot', () => {
     const input = openEditor(document.querySelector('#first-target')!)
+    const draftMarker = document.querySelector<HTMLElement>(
+      '[data-wework-annotation="draft-marker"]'
+    )
+
+    expect(draftMarker).not.toBeNull()
+    expect(draftMarker?.textContent).toBe('')
+    expect(draftMarker?.querySelector('svg')).not.toBeNull()
+    expect(annotationWindow.__WEWORK_BROWSER_ANNOTATION__?.getSnapshot().annotations).toEqual([])
+
     input!.value = 'First comment'
     input!.dispatchEvent(new Event('input', { bubbles: true }))
     click(saveButton()!)
@@ -87,6 +97,30 @@ describe('browser annotation injection', () => {
       revision: 1,
       annotations: [{ comment: 'First comment', number: 1 }],
     })
+    expect(document.querySelector('[data-wework-annotation="draft-marker"]')).toBeNull()
+    expect(document.querySelectorAll('[data-wework-annotation="marker"]')).toHaveLength(1)
+    expect(document.querySelector('[data-wework-annotation="marker"]')?.textContent).toBe('1')
+  })
+
+  test('opens the annotation editor at a context-menu point', () => {
+    elementsFromPointTarget = document.querySelector('#second-target')
+
+    expect(annotationWindow.__WEWORK_BROWSER_ANNOTATION__?.openAt(180, 90)).toBe(true)
+    expect(document.querySelector('[data-wework-annotation="draft-marker"]')).not.toBeNull()
+    expect(
+      document.querySelector<HTMLInputElement>('[data-wework-annotation="comment-input"]')
+    ).toBe(document.activeElement)
+  })
+
+  test('previews the next annotation number after the first published comment', () => {
+    const firstInput = openEditor(document.querySelector('#first-target')!)
+    firstInput!.value = 'First comment'
+    firstInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    click(saveButton()!)
+
+    openEditor(document.querySelector('#second-target')!)
+
+    expect(document.querySelector('[data-wework-annotation="draft-marker"]')?.textContent).toBe('2')
     expect(document.querySelectorAll('[data-wework-annotation="marker"]')).toHaveLength(1)
   })
 
@@ -246,6 +280,7 @@ describe('browser annotation injection', () => {
       new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
     )
     expect(document.querySelector('[data-wework-annotation="editor"]')).toBeNull()
+    expect(document.querySelector('[data-wework-annotation="draft-marker"]')).toBeNull()
   })
 
   test('intercepts link clicks instead of navigating away', () => {

--- a/wework/src/components/layout/workspace-panels/browser-annotation/injection-script.ts
+++ b/wework/src/components/layout/workspace-panels/browser-annotation/injection-script.ts
@@ -81,7 +81,7 @@ export function browserAnnotationInjectionScript({
   const state = {
     annotations: [], nextNumber: 1, revision: 0, layer: null, hoverBox: null, hoverElement: null,
     activeEditor: null, activeInput: null, attached: false, animationFrame: null, resizeObserver: null,
-    baselineByElement: new Map(), blocker: null,
+    baselineByElement: new Map(), blocker: null, draftMarker: null, draftMarkerPoint: null,
   };
 
   const dark = config.isDark === true;
@@ -183,31 +183,56 @@ export function browserAnnotationInjectionScript({
     state.annotations.filter(annotation => annotation.element?.isConnected).sort((a, b) => a.number - b.number).forEach(annotation => annotation.adjustments.forEach(adjustment => applyAdjustment(annotation.element, adjustment)));
   };
   const clearHover = () => { state.hoverBox?.remove(); state.hoverBox = null; state.hoverElement = null; };
-  const closeEditor = () => { state.activeEditor?.remove(); state.activeEditor = null; state.activeInput = null; };
+  const removeDraftMarker = () => { state.draftMarker?.remove(); state.draftMarker = null; state.draftMarkerPoint = null; };
+  const closeEditor = () => { state.activeEditor?.remove(); state.activeEditor = null; state.activeInput = null; removeDraftMarker(); };
+  const positionPointMarker = (marker, point) => {
+    if (!marker || !point) return;
+    marker.style.left = point.x - window.scrollX + 'px';
+    marker.style.top = point.y - window.scrollY + 'px';
+  };
+  const createMarker = (label, kind) => {
+    const marker = document.createElement('button');
+    marker.type = 'button';
+    marker.dataset.weworkAnnotation = kind;
+    marker.setAttribute('aria-label', label === null ? config.strings.comment : String(label));
+    marker.innerHTML = '<svg aria-hidden="true" viewBox="0 0 26 25" width="26" height="25" style="position:absolute;inset:0;display:block;width:100%;height:100%;pointer-events:none"><path d="M12.6504 0.824799C6.21496 0.824799 0.825466 5.77554 0.825195 12.0885C0.825245 14.2375 1.46183 16.2421 2.55176 17.943L2.02148 20.235L1.99316 20.3756C1.77603 21.655 2.78945 22.7791 4.02832 22.7691L4.0791 22.8209L4.53418 22.7047L7.12305 22.0426C8.77593 22.8778 10.6577 23.3531 12.6504 23.3531C19.086 23.3531 24.4754 18.4014 24.4756 12.0885C24.4753 5.77554 19.0858 0.824799 12.6504 0.824799Z" fill="#0069FB" stroke="white" stroke-width="1.65"/></svg>';
+    if (label !== null) {
+      const markerLabel = document.createElement('span');
+      markerLabel.textContent = String(label);
+      style(markerLabel, { position: 'relative', color: 'white', fontSize: ${JSON.stringify(typography['--text-2xs'])}, fontWeight: '700', lineHeight: '1', transform: 'translateY(-0.5px)', pointerEvents: 'none' });
+      marker.appendChild(markerLabel);
+    }
+    style(marker, { position: 'fixed', left: '0', top: '0', width: '26px', height: '25px', border: '0', background: 'transparent', color: 'white', cursor: 'pointer', pointerEvents: 'auto', display: 'flex', alignItems: 'center', justifyContent: 'center', transform: 'translate(-15.689%,-89.696%)', transformOrigin: '15.689% 89.696%', zIndex: '1', padding: '0' });
+    return marker;
+  };
+  const renderDraftMarker = clickPoint => {
+    removeDraftMarker();
+    const markerPoint = clickPoint ? { x: clickPoint.x + window.scrollX, y: clickPoint.y + window.scrollY } : null;
+    if (!markerPoint) return;
+    const marker = createMarker(state.annotations.length === 0 ? null : state.nextNumber, 'draft-marker');
+    marker.addEventListener('click', event => { event.preventDefault(); event.stopPropagation(); state.activeInput?.focus(); });
+    state.draftMarker = marker;
+    state.draftMarkerPoint = markerPoint;
+    positionPointMarker(marker, markerPoint);
+    state.layer?.appendChild(marker);
+  };
   const positionMarker = annotation => {
     if (!annotation.marker) return;
-    let x;
-    let y;
     if (annotation.markerPoint) {
-      x = annotation.markerPoint.x - window.scrollX;
-      y = annotation.markerPoint.y - window.scrollY;
+      positionPointMarker(annotation.marker, annotation.markerPoint);
     } else {
       const rect = annotation.lastKnownRect;
-      x = rect.x + rect.width / 2;
-      y = rect.y + rect.height / 2;
+      annotation.marker.style.left = rect.x + rect.width / 2 + 'px';
+      annotation.marker.style.top = rect.y + rect.height / 2 + 'px';
     }
-    annotation.marker.style.left = x + 'px';
-    annotation.marker.style.top = y + 'px';
   };
   const renderAnnotation = annotation => {
     annotation.marker?.remove();
-    const marker = document.createElement('button');
-    marker.type = 'button'; marker.dataset.weworkAnnotation = 'marker'; marker.textContent = String(annotation.number); marker.setAttribute('aria-label', String(annotation.number));
-    style(marker, { position: 'fixed', left: '0', top: '0', width: '25px', height: '25px', borderRadius: '50%', border: '0', background: '#1683ff', color: 'white', cursor: 'pointer', pointerEvents: 'auto', fontSize: ${JSON.stringify(typography['--text-2xs'])}, fontWeight: '700', lineHeight: '1', display: 'flex', alignItems: 'center', justifyContent: 'center', transform: 'translate(-50%,-50%)', zIndex: '1', padding: '0' });
+    const marker = createMarker(annotation.number, 'marker');
     marker.addEventListener('click', event => { event.preventDefault(); event.stopPropagation(); showEditor(annotation.element, annotation); });
     annotation.marker = marker; positionMarker(annotation); state.layer?.appendChild(marker);
   };
-  const schedulePositionUpdate = () => { if (state.animationFrame !== null) return; state.animationFrame = window.requestAnimationFrame(() => { state.animationFrame = null; state.annotations.forEach(annotation => { if (annotation.element?.isConnected) annotation.lastKnownRect = rectFor(annotation.element); positionMarker(annotation); }); if (state.hoverBox && state.hoverElement?.isConnected) positionBox(state.hoverBox, rectFor(state.hoverElement)); }); };
+  const schedulePositionUpdate = () => { if (state.animationFrame !== null) return; state.animationFrame = window.requestAnimationFrame(() => { state.animationFrame = null; state.annotations.forEach(annotation => { if (annotation.element?.isConnected) annotation.lastKnownRect = rectFor(annotation.element); positionMarker(annotation); }); positionPointMarker(state.draftMarker, state.draftMarkerPoint); if (state.hoverBox && state.hoverElement?.isConnected) positionBox(state.hoverBox, rectFor(state.hoverElement)); }); };
   const normalize = (property, value) => {
     const raw = String(value).trim();
     if (!raw || /(?:calc|var|url)\(|\b(?:auto|inherit|initial|unset)\b/i.test(raw)) return null;
@@ -407,6 +432,7 @@ export function browserAnnotationInjectionScript({
     content.append(chipRow, inputShell); editor.append(adjust, content, footer); if (submit) editor.appendChild(submit);
     if (isEdit) { footer.style.display = 'flex'; }
     if (designOpen) { openDesign(); }
+    if (!isEdit) renderDraftMarker(clickPoint);
     state.layer?.appendChild(editor); state.activeEditor = editor; state.activeInput = input; autoGrow(); input.focus();
   };
   const topPageElementAt = (x, y) => {
@@ -422,7 +448,8 @@ export function browserAnnotationInjectionScript({
   const onBlockerClick = event => { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation(); if (state.activeEditor) return; const target = topPageElementAt(event.clientX, event.clientY); if (!target) return; clearHover(); showEditor(target, null, { x: event.clientX, y: event.clientY }); };
   const attach = () => { if (state.attached) return; const layer = document.createElement('div'); layer.dataset.weworkAnnotationLayer = 'true'; style(layer, { position: 'fixed', inset: '0', zIndex: '2147483647', pointerEvents: 'none', userSelect: 'none' }); const blocker = document.createElement('div'); blocker.dataset.weworkAnnotation = 'blocker'; style(blocker, { position: 'absolute', inset: '0', pointerEvents: 'auto', cursor: 'crosshair', touchAction: 'pan-x pan-y' }); blocker.addEventListener('mousemove', onBlockerMove); blocker.addEventListener('click', onBlockerClick); layer.appendChild(blocker); state.blocker = blocker; document.documentElement.appendChild(layer); state.layer = layer; state.attached = true; state.annotations.forEach(annotation => { if (annotation.element?.isConnected) replayElement(annotation.element); renderAnnotation(annotation); }); document.addEventListener('scroll', schedulePositionUpdate, true); window.addEventListener('resize', schedulePositionUpdate); window.visualViewport?.addEventListener('resize', schedulePositionUpdate); window.visualViewport?.addEventListener('scroll', schedulePositionUpdate); if (typeof ResizeObserver !== 'undefined') { state.resizeObserver = new ResizeObserver(schedulePositionUpdate); state.resizeObserver.observe(document.documentElement); state.annotations.forEach(annotation => annotation.element?.isConnected && state.resizeObserver.observe(annotation.element)); } schedulePositionUpdate(); };
   const detach = () => { if (!state.attached) return; closeEditor(); clearHover(); document.removeEventListener('scroll', schedulePositionUpdate, true); window.removeEventListener('resize', schedulePositionUpdate); window.visualViewport?.removeEventListener('resize', schedulePositionUpdate); window.visualViewport?.removeEventListener('scroll', schedulePositionUpdate); state.resizeObserver?.disconnect(); state.resizeObserver = null; if (state.animationFrame !== null) window.cancelAnimationFrame(state.animationFrame); state.animationFrame = null; state.layer?.remove(); state.layer = null; state.blocker = null; state.annotations.forEach(annotation => { annotation.marker = null; }); state.attached = false; };
-  const api = { scope, getSnapshot: snapshot, setOriginalViewEnabled: enabled => { if (enabled) restoreAll(); else replayAll(); return snapshot(); }, clear: () => { closeEditor(); state.annotations.forEach(annotation => annotation.marker?.remove()); state.annotations = []; state.nextNumber = 1; restoreAll(); state.baselineByElement.clear(); bumpRevision(); return snapshot(); }, suspend: () => { closeEditor(); restoreAll(); detach(); return snapshot(); }, resume: () => { attach(); return snapshot(); }, destroy: () => { api.clear(); detach(); delete window.__WEWORK_BROWSER_ANNOTATION__; } };
+  const openAt = (x, y) => { if (!Number.isFinite(x) || !Number.isFinite(y)) return false; attach(); const target = topPageElementAt(x, y); if (!target) return false; clearHover(); showEditor(target, null, { x, y }); return true; };
+  const api = { scope, getSnapshot: snapshot, openAt, setOriginalViewEnabled: enabled => { if (enabled) restoreAll(); else replayAll(); return snapshot(); }, clear: () => { closeEditor(); state.annotations.forEach(annotation => annotation.marker?.remove()); state.annotations = []; state.nextNumber = 1; restoreAll(); state.baselineByElement.clear(); bumpRevision(); return snapshot(); }, suspend: () => { closeEditor(); restoreAll(); detach(); return snapshot(); }, resume: () => { attach(); return snapshot(); }, destroy: () => { api.clear(); detach(); delete window.__WEWORK_BROWSER_ANNOTATION__; } };
   window.__WEWORK_BROWSER_ANNOTATION__ = api; attach(); return true;
 })();`
 }

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -4,6 +4,7 @@ import {
   clearEmbeddedBrowserData,
   closeEmbeddedBrowser,
   evalEmbeddedBrowserJson,
+  listenEmbeddedBrowserAnnotationRequests,
   listenEmbeddedBrowserAgentState,
   listenEmbeddedBrowserOpenRequests,
   listenEmbeddedBrowserPageStateChanges,
@@ -229,6 +230,42 @@ describe('embedded-browser', () => {
     })
     expect(desktopHostMocks.subscribe).toHaveBeenCalledOnce()
 
+    const release = await unlisten
+    release?.()
+  })
+
+  test('dispatches embedded browser annotation requests', async () => {
+    desktopHostMocks.subscribe.mockImplementation(handler => {
+      handler({
+        sequence: 2,
+        type: 'browser.event',
+        payload: {
+          sequence: 2,
+          type: 'annotation-request',
+          payload: {
+            label: 'workspace-browser',
+            nativeLabel: 'workspace-browser-native-1',
+            mode: 'quick',
+            x: 20,
+            y: 30,
+          },
+        },
+      })
+      return () => {}
+    })
+    const handler = vi.fn()
+
+    const unlisten = listenEmbeddedBrowserAnnotationRequests(handler)
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledWith({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        mode: 'quick',
+        x: 20,
+        y: 30,
+      })
+    })
     const release = await unlisten
     release?.()
   })

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -128,6 +128,14 @@ export interface EmbeddedBrowserPopupRequest {
   warning: string | null
 }
 
+export interface EmbeddedBrowserAnnotationRequest {
+  label: string
+  nativeLabel: string
+  mode: 'quick' | 'batch'
+  x: number
+  y: number
+}
+
 export interface EmbeddedBrowserInvalidTlsCertificateEvent {
   nativeLabel: string
   url: string
@@ -139,6 +147,7 @@ interface ElectronBrowserHostEvent {
   sequence: number
   type:
     | 'agent-state'
+    | 'annotation-request'
     | 'close-request'
     | 'download'
     | 'local-file-preview'
@@ -168,6 +177,13 @@ export function listenEmbeddedBrowserPopupRequests(
 ): Promise<UnlistenFn> | null {
   if (!canUseEmbeddedBrowser()) return null
   return listenElectronBrowserEvents('popup', handler)
+}
+
+export function listenEmbeddedBrowserAnnotationRequests(
+  handler: (request: EmbeddedBrowserAnnotationRequest) => void
+): Promise<UnlistenFn> | null {
+  if (!canUseEmbeddedBrowser()) return null
+  return listenElectronBrowserEvents('annotation-request', handler)
 }
 
 export async function pauseEmbeddedBrowserDownload(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

- open quick or batch annotations at the right-click point
- show an unnumbered blue speech-bubble marker while the first comment is a draft, then number it after publish and preview the next number for subsequent drafts
- avoid reactivating the primary DSH view before the desktop runtime is ready

## Verification

- focused Vitest suite: 118 tests passed
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- pre-push Wework static checks and unit tests
- real Electron verification: first draft is unnumbered, publish creates marker 1, next draft previews 2, and detached Inspector preserves the browser frame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser context-menu actions for creating annotations, navigating, reloading, and inspecting elements.
  * Added support for opening annotations at specific page coordinates in batch and quick modes.
  * Draft annotation markers now appear before publishing and are replaced by numbered markers after saving.
  * Added detached Developer Tools support through the F12 shortcut.
  * Added localized context-menu labels and context-sensitive navigation options.
* **Bug Fixes**
  * Prevented the primary view from loading before the desktop runtime is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->