### PR TITLE
fix(wework): avoid duplicate task open on rename

### DIFF
--- a/wework/e2e/desktop/scenarios/running-conversation-history.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/running-conversation-history.scenario.mjs
@@ -140,13 +140,43 @@ export function createDesktopScenario({
         timeoutMs: uiTimeoutMs,
       })
       const taskRowTestId = await waitForNewTaskRow(control, knownRows, uiTimeoutMs)
+      const taskId = taskRowTestId.replace('runtime-local-task-row-', '')
+      const taskRow = `[data-testid="${taskRowTestId}"]`
+      const renameInput = `[data-testid="rename-runtime-local-task-input-${taskId}"]`
+      const renameCloseButton = `[data-testid="rename-runtime-local-task-input-${taskId}-close-button"]`
+
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await control.command('doubleClick', taskRow)
+      await control.command('waitFor', renameInput, {
+        visible: true,
+        timeoutMs: uiTimeoutMs,
+      })
+      const doubleClickSnapshot = JSON.parse(
+        await control.command('getWorkbenchDebugSnapshot', 'body')
+      )
+      assert.equal(
+        doubleClickSnapshot.workbench?.currentRuntimeTask?.taskId,
+        taskId,
+        'Double-clicking a sidebar conversation did not open it before rename'
+      )
+      await captureScreenshot(
+        control,
+        'running-conversation-history-00-double-click-rename.png',
+        'body'
+      )
+      await control.command('click', renameCloseButton)
+      await control.command('waitFor', renameInput, {
+        visible: false,
+        timeoutMs: uiTimeoutMs,
+      })
+
       assert.ok(restartDesktopApp, 'The running-history scenario cannot restart Wework')
       await restartDesktopApp(async () => {
         const indexPath = join(executorHome, 'runtime-work', 'index.json')
         const index = JSON.parse(await readFile(indexPath, 'utf8'))
         const task = Object.values(index.tasks ?? {}).find(
-          candidate =>
-            candidate.local_task_id === taskRowTestId.replace('runtime-local-task-row-', '')
+          candidate => candidate.local_task_id === taskId
         )
         assert.ok(task, 'The running-history task was missing from the persisted runtime index')
         delete task.runtime_handle?.completedTranscriptMessages

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -2972,6 +2972,46 @@ describe('DesktopSidebar', () => {
     })
   })
 
+  test('opens a runtime conversation once before double click rename', async () => {
+    const user = userEvent.setup()
+    const onOpenRuntimeTask = vi.fn()
+    const onRenameRuntimeTask = vi.fn().mockResolvedValue(undefined)
+
+    renderSidebar({
+      projects: [],
+      runtimeWork: {
+        projects: [],
+        chats: [
+          {
+            deviceId: 'local-device',
+            available: true,
+            workspacePath: '/workspace/chats/chat-double-click',
+            workspaceKind: 'chat',
+            tasks: [
+              {
+                taskId: 'codex-double-click',
+                workspacePath: '/workspace/chats/chat-double-click',
+                workspaceKind: 'chat',
+                title: 'Double click rename',
+                runtime: 'codex',
+              },
+            ],
+          },
+        ],
+        totalTasks: 1,
+      },
+      onOpenRuntimeTask,
+      onRenameRuntimeTask,
+    })
+
+    await user.dblClick(screen.getByTestId('runtime-local-task-row-codex-double-click'))
+
+    expect(onOpenRuntimeTask).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('rename-runtime-local-task-input-codex-double-click')).toHaveValue(
+      'Double click rename'
+    )
+  })
+
   test('renders project runtime tasks directly under projects and opens by address', async () => {
     const onOpenRuntimeTask = vi.fn()
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1716,7 +1716,10 @@ function RuntimeTaskRow({
                 ? 'page'
                 : undefined
           }
-          onClick={handleOpen}
+          onClick={event => {
+            if (event.detail > 1) return
+            handleOpen()
+          }}
           onContextMenu={event => {
             event.preventDefault()
             event.stopPropagation()

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -989,6 +989,47 @@ function contextMenuDesktopControlElement(selector: string): string {
   return element.textContent?.trim() ?? ''
 }
 
+async function doubleClickDesktopControlElement(selector: string): Promise<string> {
+  const dispatchClick = (element: HTMLElement, detail: number) => {
+    const pressedOptions = {
+      ...desktopControlEventOptions(element),
+      button: 0,
+      buttons: 1,
+      detail,
+    }
+    const releasedOptions = { ...pressedOptions, buttons: 0 }
+    dispatchDesktopControlPointerEvent(element, 'pointerdown', pressedOptions)
+    element.dispatchEvent(new MouseEvent('mousedown', pressedOptions))
+    dispatchDesktopControlPointerEvent(element, 'pointerup', releasedOptions)
+    element.dispatchEvent(new MouseEvent('mouseup', releasedOptions))
+    element.dispatchEvent(new MouseEvent('click', releasedOptions))
+  }
+
+  const firstElement = findDesktopControlElements(selector)[0]
+  if (!firstElement) throw new Error(`Unable to find selector "${selector}"`)
+  if (!desktopControlElementEnabled(firstElement)) {
+    throw new Error(`Selector "${selector}" is disabled`)
+  }
+  dispatchClick(firstElement, 1)
+  await waitForDesktopControlTick()
+
+  const secondElement = findDesktopControlElements(selector)[0]
+  if (!secondElement) throw new Error(`Unable to find selector "${selector}" after first click`)
+  if (!desktopControlElementEnabled(secondElement)) {
+    throw new Error(`Selector "${selector}" became disabled after first click`)
+  }
+  dispatchClick(secondElement, 2)
+  secondElement.dispatchEvent(
+    new MouseEvent('dblclick', {
+      ...desktopControlEventOptions(secondElement),
+      button: 0,
+      buttons: 0,
+      detail: 2,
+    })
+  )
+  return secondElement.textContent?.trim() ?? ''
+}
+
 async function waitForDesktopControlElement(command: DesktopControlCommand): Promise<string> {
   const timeoutMs = command.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
   const startedAt = Date.now()
@@ -1616,6 +1657,8 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
       return endDesktopControlDataTransfer(command)
     case 'contextMenu':
       return contextMenuDesktopControlElement(command.selector)
+    case 'doubleClick':
+      return doubleClickDesktopControlElement(command.selector)
     case 'dragStart':
       return startDesktopControlDrag(command)
     case 'dragEnd':


### PR DESCRIPTION
## Summary

- open a sidebar task immediately on the first click while ignoring the duplicate second click from a double-click sequence
- preserve double-click rename without delaying normal task switching
- add component coverage and a CI-covered desktop E2E flow for task switching plus rename

## Testing

- `pnpm --dir wework test -- --run src/components/layout/DesktopSidebar.test.tsx` (113 passed)
- `pnpm --dir wework typecheck`
- focused ESLint and Prettier checks
- `pnpm --dir wework e2e:desktop --segment running-conversation-history`
- Wework pre-push full static checks and renderer unit tests

## Documentation

- not required; this changes internal sidebar interaction behavior without adding or changing user-facing configuration or contributor workflows

Task: WORK-357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history interactions so double-clicking a chat opens it reliably without triggering duplicate activations.
  * Preserved single-click behavior for opening conversations.
  * Ensured the rename field appears with the existing conversation title when a chat is opened for renaming.

* **Tests**
  * Added coverage confirming conversations open once and rename controls are correctly populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->