### PR TITLE
fix(wework): restore plan panel across tasks

### DIFF
--- a/wework/e2e/desktop/scenarios/offline-local-project-space.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/offline-local-project-space.scenario.mjs
@@ -58,7 +58,7 @@ export function createDesktopScenario({ uiTimeoutMs }) {
         timeoutMs: uiTimeoutMs,
       })
 
-      await control.command('waitFor', '[data-testid="cloud-todo-column-inbox"]', {
+      await control.command('waitFor', '[data-testid="cloud-todo-column-empty-add-inbox"]', {
         timeoutMs: uiTimeoutMs,
       })
       await control.command('click', '[data-testid="cloud-todo-column-empty-add-inbox"]')
@@ -73,6 +73,9 @@ export function createDesktopScenario({ uiTimeoutMs }) {
         timeoutMs: uiTimeoutMs,
       })
       await control.command('press', 'body', { key: 'Escape' })
+      await control.command('waitFor', '[data-testid="cloud-todo-column-empty-add-inbox"]', {
+        timeoutMs: uiTimeoutMs,
+      })
       await control.command('click', '[data-testid="cloud-todo-column-empty-add-inbox"]')
       await control.command('waitFor', '[data-testid="cloud-todo-column-quick-create-inbox"]', {
         timeoutMs: uiTimeoutMs,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -11208,6 +11208,46 @@ describe('DesktopWorkbenchLayout', () => {
     expect(activePane().getByTestId('right-workspace-launcher')).toBeInTheDocument()
   })
 
+  test('restores the opened plan when switching runtime tasks', async () => {
+    const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
+    const planMessage: WorkbenchMessage = {
+      id: 'assistant-plan-block',
+      role: 'assistant',
+      content: '',
+      status: 'done',
+      createdAt: '2026-08-29T00:00:01.000Z',
+      blocks: [
+        {
+          id: 'plan-1',
+          subtaskId: '1',
+          type: 'plan',
+          content: '# Task A 计划\n\n- 切换任务后恢复。',
+          status: 'done',
+          createdAt: Date.parse('2026-08-29T00:00:01.000Z'),
+        },
+      ],
+    }
+    const activePane = () => within(screen.getByTestId('desktop-workbench-main'))
+    const { rerender } = render(
+      <DesktopWorkbenchLayout {...propsForTask(taskA)} messages={[planMessage]} />
+    )
+
+    await userEvent.click(activePane().getByTestId('assistant-plan-expand-button'))
+    expect(activePane().getByTestId('workspace-plan-panel')).toHaveTextContent('Task A 计划')
+
+    rerender(<DesktopWorkbenchLayout {...propsForTask(taskB)} messages={[]} />)
+    expect(activePane().queryByTestId('workspace-plan-panel')).not.toBeInTheDocument()
+
+    rerender(<DesktopWorkbenchLayout {...propsForTask(taskA)} messages={[planMessage]} />)
+
+    expect(activePane().getByTestId('right-workspace-plan-tab')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(activePane().getByTestId('workspace-plan-panel')).toHaveTextContent('Task A 计划')
+    expect(activePane().getByTestId('workspace-plan-panel')).toHaveTextContent('切换任务后恢复。')
+  })
+
   test('restores an ephemeral temporary chat when switching runtime tasks', async () => {
     const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()
     const temporaryAddress: RuntimeTaskAddress = {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -283,6 +283,7 @@ interface WorkbenchPaneWorkspaceState {
   rightPanelExpanded: boolean
   rightPanelView: RightWorkspacePanelView
   rightPanelTabs: RightWorkspacePanelTab[]
+  selectedAssistantPlan: SelectedAssistantPlan | null
   rightPanelExtensionTabs?: Partial<
     Record<RightWorkspaceExtensionTab, RightWorkspaceExtensionTabState>
   >
@@ -1301,6 +1302,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       []) as Array<RightWorkspacePanelTab | 'browser' | 'terminal'>
     return restoredTabs.map(normalizeRightWorkspacePanelTab)
   })
+  const [selectedAssistantPlan, setSelectedAssistantPlan] = useState<SelectedAssistantPlan | null>(
+    () => initialWorkspaceState?.selectedAssistantPlan ?? null
+  )
   const [rightPanelExtensionTabs, setRightPanelExtensionTabs] = useState<
     Partial<Record<RightWorkspaceExtensionTab, RightWorkspaceExtensionTabState>>
   >(() => initialWorkspaceState?.rightPanelExtensionTabs ?? {})
@@ -1441,6 +1445,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       rightPanelExpanded,
       rightPanelTabs,
       rightPanelView,
+      selectedAssistantPlan,
       rightPanelExtensionTabs,
       temporaryChatAddresses,
       browserStates,
@@ -1455,6 +1460,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     rightPanelOpen,
     rightPanelTabs,
     rightPanelView,
+    selectedAssistantPlan,
     rightPanelExtensionTabs,
     temporaryChatAddresses,
     browserStates,
@@ -1467,9 +1473,6 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     text: string
   } | null>(null)
   const temporaryChatInitialInputsRef = useRef(new Map<RightWorkspaceChatTab, string>())
-  const [selectedAssistantPlan, setSelectedAssistantPlan] = useState<SelectedAssistantPlan | null>(
-    null
-  )
   const [bottomPanelOpenByKey, setBottomPanelOpenByKey] = useState<Record<string, boolean>>({})
   const [bottomPanelContexts, setBottomPanelContexts] = useState<BottomPanelRenderContext[]>([])
   const [openFileRequest, setOpenFileRequest] = useState<WorkspaceFileOpenRequest | null>(null)


### PR DESCRIPTION
## Summary

- persist the selected assistant plan in the shared per-pane workspace state
- restore both the plan tab and its content when returning to a runtime task
- add regression coverage for switching away from and back to a task with an open plan

## Verification

- `pnpm --filter wework test DesktopWorkbenchLayout.test.tsx -t "restores the opened plan when switching runtime tasks"`
- `pnpm --filter wework exec prettier --check src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- isolated Electron source build/start, local project selection, plan mode, and runtime task creation verified with `ai:verify`; assistant plan generation was blocked by the synthetic verification account returning 401 unauthorized, with logs retained under `wework/test-results/ai-verify/2026-08-29T16-29-11-186Z-94949/`
- pre-push checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the selected plan panel when returning to a previously viewed runtime task.
  * Ensured plan panel state is preserved while switching between tasks.
* **Tests**
  * Added coverage verifying plan panel restoration and correct workspace tab selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->