### PR TITLE
fix(wework): persist macOS tray identity

### DIFF
--- a/docs/en/wework/developer-guide/wework-debug-instance-context.md
+++ b/docs/en/wework/developer-guide/wework-debug-instance-context.md
@@ -35,6 +35,7 @@ These values are written only when the Terminal session is created. Existing Ter
 - `WEWORK_DEV_PORT`: the current Vite/ Electron dev server port.
 - `WEWORK_DEV_WORKTREE`: the current worktree root path.
 - `WEWORK_DEV_BRANCH`: the current Git branch, or empty when running on a detached HEAD.
+- `WEWORK_APP_IDENTIFIER`: the current Electron application identity. It defaults to a value derived from the worktree path and isolates the single-instance lock, application data, and macOS menu bar icon position. Override it only when an application identity must intentionally be reused.
 
 The script also exports these values as `VITE_WEWORK_*` so the frontend can display them at runtime.
 

--- a/docs/zh/wework/developer-guide/wework-debug-instance-context.md
+++ b/docs/zh/wework/developer-guide/wework-debug-instance-context.md
@@ -33,6 +33,7 @@ Wework 支持从一个正在运行的 Wework 内置 Terminal 中启动另一个�
 - `WEWORK_DEV_PORT`: 当前 Vite/ Electron dev server 端口。
 - `WEWORK_DEV_WORKTREE`: 当前 worktree 根路径。
 - `WEWORK_DEV_BRANCH`: 当前 Git branch，detached HEAD 时为空。
+- `WEWORK_APP_IDENTIFIER`: 当前 Electron 应用身份。默认根据 worktree 路径生成，用于隔离单实例锁、应用数据和 macOS 菜单栏图标位置；只有明确需要复用某个应用身份时才应手动覆盖。
 
 脚本也会把这些值导出为 `VITE_WEWORK_*`，供前端在运行时显示。
 

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1149,6 +1149,7 @@ async function main() {
       WEWORK_EXECUTOR_SIDECAR: executorBinary,
       WEWORK_DESKTOP_RUNTIME: 'electron',
       WEWORK_EXECUTOR_PATH: executorBinary,
+      WEWORK_APP_IDENTIFIER: appIdentifier,
       WEWORK_USER_DATA_DIR: electronUserDataDirectory,
       ...(RUNS_PLUGIN_E2E && shouldRunPluginSegment('core-dsh-ui-plugin-composition')
         ? { WEWORK_E2E_EMPTY_CORE_DSH_UI_PROFILE: '1' }

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1149,7 +1149,6 @@ async function main() {
       WEWORK_EXECUTOR_SIDECAR: executorBinary,
       WEWORK_DESKTOP_RUNTIME: 'electron',
       WEWORK_EXECUTOR_PATH: executorBinary,
-      WEWORK_APP_IDENTIFIER: appIdentifier,
       WEWORK_USER_DATA_DIR: electronUserDataDirectory,
       ...(RUNS_PLUGIN_E2E && shouldRunPluginSegment('core-dsh-ui-plugin-composition')
         ? { WEWORK_E2E_EMPTY_CORE_DSH_UI_PROFILE: '1' }
@@ -1190,6 +1189,7 @@ async function main() {
       appEnvironment.WEWORK_HARNESS_RUNTIME_ROOT = electronCoreRuntimeRoot
     }
     Object.assign(appEnvironment, desktopScenario?.appEnvironment ?? {})
+    appEnvironment.WEWORK_APP_IDENTIFIER = appIdentifier
     const electronLaunchArguments = resolveElectronLaunchArguments()
     const startDesktopAppProcess = async () => {
       const child = spawn(appBinary, electronLaunchArguments, {

--- a/wework/e2e/desktop/scenarios/tray-lifecycle.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/tray-lifecycle.scenario.mjs
@@ -31,6 +31,11 @@ export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) 
     async verify(control) {
       const tray = JSON.parse(await control.command('getTraySnapshot', 'body'))
       assert.equal(tray.created, true, 'The Electron Tray was not created')
+      assert.match(
+        tray.guid,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        'The Electron Tray did not expose a persistent application GUID'
+      )
       assert.ok(
         tray.menu.some(item => item.id === 'settings'),
         'The Electron Tray did not expose Settings'

--- a/wework/electron/src/host/tray-guid.test.ts
+++ b/wework/electron/src/host/tray-guid.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { trayGuidForApplicationId } from './tray-guid.js'
+
+describe('trayGuidForApplicationId', () => {
+  test('returns a stable UUID v5 for the same application identity', () => {
+    const first = trayGuidForApplicationId('io.wecode.wework')
+    const second = trayGuidForApplicationId('io.wecode.wework')
+
+    expect(first).toBe(second)
+    expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  test('isolates tray identities for branded applications', () => {
+    expect(trayGuidForApplicationId('io.wecode.wework')).not.toBe(
+      trayGuidForApplicationId('com.example.workbench')
+    )
+  })
+})

--- a/wework/electron/src/host/tray-guid.ts
+++ b/wework/electron/src/host/tray-guid.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto'
+
+const WEWORK_TRAY_NAMESPACE = '69ef5f47-9421-53b7-8c12-5a09a4450863'
+
+function uuidBytes(uuid: string): Buffer {
+  return Buffer.from(uuid.replaceAll('-', ''), 'hex')
+}
+
+function formatUuid(bytes: Buffer): string {
+  const hex = bytes.toString('hex')
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-')
+}
+
+export function trayGuidForApplicationId(applicationId: string): string {
+  const bytes = createHash('sha1')
+    .update(uuidBytes(WEWORK_TRAY_NAMESPACE))
+    .update(applicationId)
+    .digest()
+    .subarray(0, 16)
+  bytes[6] = (bytes[6] & 0x0f) | 0x50
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  return formatUuid(bytes)
+}

--- a/wework/electron/src/host/tray-manager.test.ts
+++ b/wework/electron/src/host/tray-manager.test.ts
@@ -34,6 +34,7 @@ function setup(
   platform: NodeJS.Platform = 'darwin',
   applyIcon?: TrayManagerDependencies['applyIcon']
 ) {
+  const guid = 'b626b80b-4514-5b9d-861c-25d34fdcf250'
   const listeners = new Map<'click' | 'double-click', () => void>()
   const tray: TrayAdapter = {
     on: vi.fn((event, listener) => {
@@ -42,6 +43,7 @@ function setup(
     setContextMenu: vi.fn(),
     setToolTip: vi.fn(),
     setTitle: vi.fn(),
+    getGUID: vi.fn(() => guid),
     destroy: vi.fn(),
   }
   const dispatchAction = vi.fn<(action: TrayAction) => void>()
@@ -55,7 +57,7 @@ function setup(
   }
   const manager = new ElectronTrayManager(dependencies)
 
-  return { buildMenu, dependencies, dispatchAction, listeners, manager, tray }
+  return { buildMenu, dependencies, dispatchAction, guid, listeners, manager, tray }
 }
 
 function findItem(template: TrayMenuTemplateItem[], id: string): TrayMenuTemplateItem | undefined {
@@ -73,7 +75,7 @@ function findItem(template: TrayMenuTemplateItem[], id: string): TrayMenuTemplat
 
 describe('ElectronTrayManager', () => {
   test('creates and destroys one tray while applying the latest state', () => {
-    const { buildMenu, dependencies, manager, tray } = setup()
+    const { buildMenu, dependencies, guid, manager, tray } = setup()
     manager.setState(state())
 
     manager.create()
@@ -86,13 +88,13 @@ describe('ElectronTrayManager', () => {
     })
     expect(tray.setToolTip).toHaveBeenCalledWith('Codex: 42%')
     expect(tray.setTitle).toHaveBeenCalledWith('42%')
-    expect(manager.snapshot().created).toBe(true)
+    expect(manager.snapshot()).toMatchObject({ created: true, guid })
 
     manager.destroy()
     manager.destroy()
 
     expect(tray.destroy).toHaveBeenCalledTimes(1)
-    expect(manager.snapshot().created).toBe(false)
+    expect(manager.snapshot()).toMatchObject({ created: false, guid: null })
   })
 
   test('builds localized running, unread, pinned, recent, and action menus', () => {

--- a/wework/electron/src/host/tray-manager.ts
+++ b/wework/electron/src/host/tray-manager.ts
@@ -55,6 +55,7 @@ export interface TrayAdapter<TMenu = unknown> {
   setContextMenu(menu: TMenu): void
   setToolTip(tooltip: string): void
   setTitle?(title: string): void
+  getGUID?(): string | null
   destroy(): void
 }
 
@@ -80,6 +81,7 @@ export interface TrayMenuSnapshotItem {
 
 export interface TraySnapshot {
   created: boolean
+  guid: string | null
   title: string | null
   titleSupported: boolean
   tooltip: string
@@ -271,6 +273,7 @@ export class ElectronTrayManager<
     const state = this.effectiveState()
     return {
       created: this.tray !== null,
+      guid: this.tray?.getGUID?.() ?? null,
       title: state.usageTitle,
       titleSupported: this.platform === 'darwin',
       tooltip: state.usageTooltip?.trim() || this.defaultTooltip,

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -66,6 +66,7 @@ import {
 } from './host/startup-splash.js'
 import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
 import { createTrayIcon } from './host/tray-icon.js'
+import { trayGuidForApplicationId } from './host/tray-guid.js'
 import { TrayNativeStatusController } from './host/tray-native-status.js'
 import { WindowClosePolicy, type WindowCloseDecision } from './host/window-close-policy.js'
 import { AppUpdateService } from './host/app-update-service.js'
@@ -110,7 +111,10 @@ const updateBaseUrl =
   process.env.WEWORK_UPDATE_BASE_URL?.trim() ||
   packageMetadata.weworkUpdateBaseUrl?.trim() ||
   'https://github.com/wecode-ai/Wegent/releases/download/wework-updater'
-const applicationId = packageMetadata.weworkAppId?.trim() || 'io.wecode.wework'
+const applicationId =
+  process.env.WEWORK_APP_IDENTIFIER?.trim() ||
+  packageMetadata.weworkAppId?.trim() ||
+  'io.wecode.wework'
 const DEFAULT_POPOUT_WINDOW_SHORTCUT = 'Alt+Shift+Space'
 
 const configuredUserDataPath = process.env.WEWORK_USER_DATA_DIR?.trim()
@@ -930,8 +934,9 @@ function dispatchTrayAction(action: TrayAction): void {
 function createTrayManager(): ElectronTrayManager<Electron.Menu | null, Tray> {
   const resourcesRoot = app.isPackaged ? process.resourcesPath : developmentResourcesRoot
   const iconPath = join(resourcesRoot, 'icons', '128x128.png')
+  const trayGuid = trayGuidForApplicationId(applicationId)
   return new ElectronTrayManager({
-    createTray: () => new Tray(createTrayIcon(nativeImage, iconPath)),
+    createTray: () => new Tray(createTrayIcon(nativeImage, iconPath), trayGuid),
     buildMenu: template => Menu.buildFromTemplate(template as MenuItemConstructorOptions[]),
     dispatchAction: dispatchTrayAction,
     applyIcon: (tray, state) => {

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -33,6 +33,7 @@ Options:
 Environment:
   VITE_WEGENT_BACKEND_URL          Backend URL. Defaults to WEWORK_HOST/BACKEND_PORT.
   WEWORK_USER_DATA_DIR             Electron user data. Defaults to a directory isolated by worktree.
+  WEWORK_APP_IDENTIFIER            Application identity. Defaults to one isolated by worktree.
   WEWORK_DEV_EXECUTOR_PATH         Executor command. Defaults to the source sidecar.
   WEWORK_DEV_CACHE_ROOT            Shared immutable dev cache. Defaults to ~/Library/Caches/wegent.
   WEWORK_DEV_HARNESS_RUNTIME_ROOT  Harness runtime. Defaults to the worktree runtime.
@@ -165,6 +166,7 @@ export VITE_WEWORK_PARENT_TITLE="${WEWORK_PARENT_TITLE:-}"
 export VITE_WEWORK_PARENT_PROJECT="${WEWORK_PARENT_PROJECT:-}"
 export VITE_WEWORK_PARENT_WORKSPACE="${WEWORK_PARENT_WORKSPACE:-}"
 WEWORK_DEV_INSTANCE_ID="$(build_dev_instance_id)"
+export WEWORK_APP_IDENTIFIER="${WEWORK_APP_IDENTIFIER:-io.wecode.wework.dev.$WEWORK_DEV_INSTANCE_ID}"
 export WEWORK_USER_DATA_DIR="${WEWORK_USER_DATA_DIR:-$HOME/Library/Application Support/io.wecode.wework.dev/$WEWORK_DEV_INSTANCE_ID}"
 export VITE_WEGENT_BACKEND_URL="${VITE_WEGENT_BACKEND_URL:-$(wework_resolve_backend_base_url)}"
 export VITE_WEWORK_RELEASE_CHANNEL="${VITE_WEWORK_RELEASE_CHANNEL:-development}"
@@ -216,6 +218,7 @@ print_configuration() {
   echo "  WEWORK_DEV_TITLE=$WEWORK_DEV_TITLE"
   echo "  WEWORK_DEV_WORKTREE=$WEWORK_DEV_WORKTREE"
   echo "  WEWORK_DEV_BRANCH=${WEWORK_DEV_BRANCH:-<detached>}"
+  echo "  WEWORK_APP_IDENTIFIER=$WEWORK_APP_IDENTIFIER"
   echo "  WEWORK_USER_DATA_DIR=$WEWORK_USER_DATA_DIR"
   echo "  VITE_WEGENT_BACKEND_URL=$VITE_WEGENT_BACKEND_URL"
   echo "  WEWORK_EXECUTOR_PATH=$WEWORK_EXECUTOR_PATH"

--- a/wework/scripts/dev-mac-app.test.mjs
+++ b/wework/scripts/dev-mac-app.test.mjs
@@ -10,6 +10,7 @@ describe('dev-mac-app', () => {
     const source = await readFile(scriptPath, 'utf8')
 
     expect(source).toContain('node "$SCRIPT_DIR/resolve-dev-user-data.mjs"')
+    expect(source).toContain('WEWORK_APP_IDENTIFIER:-io.wecode.wework.dev.$WEWORK_DEV_INSTANCE_ID')
     expect(source).toContain('WEWORK_HARNESS_RUNTIME_ASSET_CACHE_ROOT')
     expect(source).toContain('$WEWORK_DIR/node_modules/.cache/harness-runtime-dev')
     expect(source).toContain('WEWORK_DEV_EXECUTOR_PATH')


### PR DESCRIPTION
## Summary

- assign each Wework application identity a deterministic UUID v5 when creating the Electron Tray
- preserve macOS menu bar icon identity and position across relaunches, including in menu bar managers such as iBar Pro
- isolate release, worktree development, AI verification, branded, and desktop E2E tray identities
- expose the native Tray GUID in the existing E2E snapshot and document the development application identity

## Verification

- `pnpm test src/host/tray-guid.test.ts src/host/tray-manager.test.ts` in `wework/electron` (11 tests)
- `pnpm --filter wework test scripts/dev-mac-app.test.mjs scripts/ai-verify-environment.test.mjs` (2 tests)
- `pnpm run typecheck` in `wework/electron`
- focused Prettier, ESLint, `bash -n`, and ShellCheck
- `pnpm --filter wework ai:verify:electron:build`
- `WEWORK_E2E_APP_BIN=... WEWORK_E2E_EXECUTOR_BIN=... pnpm --filter wework e2e:desktop -- --segment tray-lifecycle`
- pre-commit and pre-push quality checks

## Migration note

The first release containing this change may appear as a new tray item once because previous releases did not provide a GUID. After the user places it in the visible section once, subsequent launches and updates retain the same identity and position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `WEWORK_APP_IDENTIFIER` to identify development app instances.
  - Development instances now isolate single-instance behavior, app data, and macOS menu bar icon placement.
  - Tray identities are generated consistently per application instance.

- **Bug Fixes**
  - Prevented tray identity conflicts between separately branded or concurrently running app instances.

- **Documentation**
  - Documented configuration and usage of `WEWORK_APP_IDENTIFIER` in English and Chinese developer guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->