### PR TITLE
fix(wework): reload hydrated task transcripts

### DIFF
--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -25,7 +25,10 @@ import {
   resolveAutomaticModel,
   selectedModelExecutionFields,
 } from '@/features/workbench/runtimeModelSelection'
-import { findRuntimeTask } from '@/features/workbench/workbenchRuntimeHelpers'
+import {
+  findRuntimeTask,
+  getRuntimeTaskRouteKey,
+} from '@/features/workbench/workbenchRuntimeHelpers'
 import { getRuntimeTaskChatScopeKey } from '@/features/workbench/workbenchProviderHelpers'
 import { persistAttachmentReferences } from '@/lib/attachments'
 import { localRuntimeAttachments, remoteAttachmentIds } from '@/lib/runtime-attachments'
@@ -563,12 +566,6 @@ export function useWorkbenchPaneSession({
       setTaskPlan(metadata.taskPlan)
       setGoalContinuation(metadata.goalContinuation)
       setThreadGoal(metadata.goal)
-      if (metadata.goal) {
-        clearRuntimePaneGoalSeed(address)
-        setPendingGoalState(current =>
-          current && isPendingGoalVisibleForRuntimeTarget(current, address) ? null : current
-        )
-      }
     }
     syncConversationState()
     return subscribeRuntimeConversation(address, action => {
@@ -3026,13 +3023,30 @@ function isInterruptedGuidance(message: RuntimePaneQueuedMessage): boolean {
 
 function runtimeTaskLoadTargetFromAddress(address: RuntimeTaskAddress): RuntimeTaskLoadTarget {
   return {
-    key: runtimeTranscriptPaneKey(address),
+    key: runtimeTaskLoadAddressKey(address),
     identityKey: runtimeTranscriptPaneIdentityKey(address),
     address,
   }
 }
 
 const runtimeTranscriptPaneKey = runtimeConversationKey
+
+function runtimeTaskLoadAddressKey(address: RuntimeTaskAddress): string {
+  const runtimeHandleThreadId =
+    typeof address.runtimeHandle?.threadId === 'string'
+      ? address.runtimeHandle.threadId.trim()
+      : typeof address.runtimeHandle?.thread_id === 'string'
+        ? address.runtimeHandle.thread_id.trim()
+        : ''
+
+  return JSON.stringify({
+    route: getRuntimeTaskRouteKey(address),
+    runtime: address.runtime ?? null,
+    threadId: address.threadId?.trim() || runtimeHandleThreadId || null,
+    workspaceKind: address.workspaceKind ?? null,
+    worktreeId: address.worktreeId ?? null,
+  })
+}
 
 function runtimeTranscriptPaneIdentityKey(address: RuntimeTaskAddress): string {
   return `${address.deviceId}:${address.taskId}`

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1573,6 +1573,39 @@ function RuntimePaneSessionIdentityProbe() {
   )
 }
 
+function RuntimePaneAddressHydrationProbe() {
+  const [address, setAddress] = useState<RuntimeTaskAddress>({
+    deviceId: 'device-1',
+    taskId: 'runtime-a',
+  })
+  const paneSession = useWorkbenchPaneSession({ currentRuntimeTask: address })
+
+  return (
+    <div>
+      <span data-testid="hydrated-runtime-messages">
+        {paneSession.messages.map(message => message.content).join('|')}
+      </span>
+      <span data-testid="hydrated-runtime-transcript-error">
+        {paneSession.transcriptError ?? 'none'}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          setAddress({
+            deviceId: 'device-1',
+            taskId: 'runtime-a',
+            runtime: 'codex',
+            threadId: 'thread-a',
+            workspacePath: '/workspace/project-alpha',
+          })
+        }
+      >
+        hydrate runtime address
+      </button>
+    </div>
+  )
+}
+
 function RuntimePlanScopeProbe() {
   const { workbench, paneSession } = useWorkbenchProbeSession()
   const runtimeTask = {
@@ -11065,6 +11098,58 @@ describe('WorkbenchProvider runtime tasks', () => {
 
     expect(globalSubscribeCount()).toBe(1)
     expect(paneSubscribeCount()).toBe(0)
+  })
+
+  test('reloads an empty runtime transcript after the task address is hydrated', async () => {
+    const getRuntimeTranscript = vi.fn((address: RuntimeTaskAddress) => {
+      if (!address.workspacePath) {
+        return Promise.resolve({
+          taskId: 'runtime-a',
+          messages: [],
+        } satisfies RuntimeTranscriptResponse)
+      }
+      return Promise.resolve({
+        taskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'codex',
+        messages: [
+          { id: 'runtime-a:user:1', role: 'user', content: 'restored user message' },
+          {
+            id: 'runtime-a:assistant:1',
+            role: 'assistant',
+            content: 'restored assistant message',
+          },
+        ],
+      } satisfies RuntimeTranscriptResponse)
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({ getRuntimeTranscript })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimePaneAddressHydrationProbe />, services)
+
+    await waitFor(() => expect(getRuntimeTranscript).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('hydrated-runtime-messages')).toBeEmptyDOMElement()
+    expect(screen.getByTestId('hydrated-runtime-transcript-error')).toHaveTextContent('none')
+
+    await userEvent.click(screen.getByText('hydrate runtime address'))
+
+    await waitFor(() => expect(getRuntimeTranscript).toHaveBeenCalledTimes(2))
+    expect(getRuntimeTranscript).toHaveBeenLastCalledWith({
+      deviceId: 'device-1',
+      taskId: 'runtime-a',
+      runtime: 'codex',
+      threadId: 'thread-a',
+      workspacePath: '/workspace/project-alpha',
+      limit: 50,
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('hydrated-runtime-messages')).toHaveTextContent(
+        'restored user message|restored assistant message'
+      )
+    )
+    expect(screen.getByTestId('hydrated-runtime-transcript-error')).toHaveTextContent('none')
   })
 
   test('clears the task plan progress when starting a new chat', async () => {


### PR DESCRIPTION
## Summary

- reload a runtime transcript when its persisted task address is hydrated with workspace/thread routing details
- keep the stable device/task identity separate from the load-address key
- retain optimistic goal seeds until the runtime confirms a goal, preventing address hydration from clearing a newly created goal
- add regression coverage for an initially empty transcript that becomes available after address hydration

## Verification

- `pnpm --filter wework test src/features/workbench/WorkbenchProvider.test.tsx` (214 passed)
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- pre-push Wework ESLint, TypeScript, and unit tests
- real Electron `split-workbench` run confirmed the reloaded pane had the hydrated task address and restored two transcript messages; the later scenario screenshot capture timed out on `body`, after the target restoration assertion and UI state had succeeded

Project task: WEWORKC2FA61-453