### PR TITLE
fix(wework): restore goals after task address hydration

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -135,6 +135,13 @@ to the current task, that empty result must not clear the lifecycle Goal
 status. This lets an active Goal continue to constrain task lifecycle even
 when stream settlement races ahead of Goal persistence.
 
+When restoring a runtime task from the URL, the pane may initially know only
+the device ID and task ID before the task list hydrates its workspace, thread,
+and runtime fields. Goal and transcript loading must run again after that
+address hydration, while both addresses still belong to the same stable task
+identity. Rehydration must not create a new conversation or replay turn
+lifecycle events that were already processed.
+
 ### Claude Code Conversation Executor
 
 Claude Code uses the same ordinary runtime-task conversation UI as Codex in

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -106,6 +106,11 @@ WebView 或 executor 重建后启动的新 turn 不会让历史 assistant 回复
 空值；在 seed 仍属于当前任务时，空结果不能清除 lifecycle 中的 Goal 状态。这样即使
 stream 结算先于 Goal 持久化完成，active Goal 也能继续约束任务生命周期。
 
+从 URL 恢复 runtime task 时，pane 最初可能只有 device ID 和 task ID，随后才从任务
+列表补全 workspace、thread 和 runtime 信息。Goal 和 transcript 加载请求都必须在
+地址补全后重新发起，但补全前后仍属于同一个稳定任务身份；重新水合不能创建新会话，
+也不能重放已经处理过的 turn 生命周期事件。
+
 ### Claude Code 普通会话执行器
 
 Wework 中的 Claude Code 与 Codex 一样使用普通 runtime task 会话界面，不使用终端

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1588,6 +1588,7 @@ function RuntimePaneAddressHydrationProbe() {
       <span data-testid="hydrated-runtime-transcript-error">
         {paneSession.transcriptError ?? 'none'}
       </span>
+      <span data-testid="hydrated-runtime-goal">{paneSession.goal?.objective ?? 'none'}</span>
       <button
         type="button"
         onClick={() =>
@@ -12945,6 +12946,55 @@ describe('WorkbenchProvider runtime tasks', () => {
       expect(screen.getByTestId('runtime-goal-objective')).toHaveTextContent('恢复中的目标')
     )
     expect(screen.getByTestId('runtime-goal-status')).toHaveTextContent('active')
+  })
+
+  test('reloads the runtime goal after the persisted task address is hydrated', async () => {
+    const getRuntimeGoal = vi.fn().mockImplementation(({ address }) =>
+      Promise.resolve(
+        address.workspacePath
+          ? {
+              accepted: true,
+              goal: createRuntimeGoal({
+                objective: '重载后恢复的目标',
+                status: 'active',
+              }),
+            }
+          : {
+              accepted: false,
+              goal: null,
+              error: 'runtime task was not found',
+            }
+      )
+    )
+    const runtimeWorkApi = createRuntimeWorkApiMock({ getRuntimeGoal })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimePaneAddressHydrationProbe />, services)
+
+    await waitFor(() => expect(getRuntimeGoal).toHaveBeenCalledTimes(1))
+    expect(getRuntimeGoal).toHaveBeenLastCalledWith({
+      address: {
+        deviceId: 'device-1',
+        taskId: 'runtime-a',
+      },
+    })
+    expect(screen.getByTestId('hydrated-runtime-goal')).toHaveTextContent('none')
+
+    await userEvent.click(screen.getByText('hydrate runtime address'))
+
+    await waitFor(() => expect(getRuntimeGoal).toHaveBeenCalledTimes(2))
+    expect(getRuntimeGoal).toHaveBeenLastCalledWith({
+      address: {
+        deviceId: 'device-1',
+        taskId: 'runtime-a',
+        runtime: 'codex',
+        threadId: 'thread-a',
+        workspacePath: '/workspace/project-alpha',
+      },
+    })
+    expect(screen.getByTestId('hydrated-runtime-goal')).toHaveTextContent('重载后恢复的目标')
   })
 
   test('restores a goal task as running when reopened with a streaming transcript', async () => {


### PR DESCRIPTION
## Summary

- reload runtime Goal state when a URL-restored task address is enriched with workspace, thread, and runtime fields
- keep transcript identity stable while the Goal request address changes, avoiding duplicate transcript and turn lifecycle loading
- retain optimistic Goal seeds until a persisted Goal is actually returned
- document the address-hydration invariant in the Chinese and English state-source guides

## Evidence and root cause

For the affected real task, the persisted Codex goal exists and remains active. The first `runtime.tasks.goal.get` ran while the frontend only had the bare device/task address and returned `runtime task was not found`; later requests with the hydrated workspace/thread address succeeded. The pane retained its load target by conversation key only, so enriching the same task address did not trigger Goal hydration again.

## Verification

- `WorkbenchProvider.test.tsx`: focused regression tests passed (2 passed)
- full `WorkbenchProvider.test.tsx`: 214 passed
- `pnpm --filter wework typecheck`
- changed-file ESLint and Prettier checks
- real packaged Electron checkpoint `goal-lifecycle`: PASS in 1m57s, assertion errors: none
- pre-push quality gate: ESLint, TypeScript, and unit tests passed

Task: WEWORKC2FA61-455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored runtime tasks now reload their goals and transcripts after URL-provided task details are completed.
  * Rehydration preserves the existing conversation and avoids replaying previously processed turn events.

* **Documentation**
  * Added guidance in English and Chinese on URL-based task restoration and address hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->