### PR TITLE
fix(wework): skip executor backlog on fresh event streams

### DIFF
--- a/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/en/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -16,6 +16,18 @@ connection and resumes the event stream from the last consumed `sequence`.
 Each `(deviceId, taskId)` pair maps to a stable, independent Session, so
 parallel tasks never merge into one event stream.
 
+The Wework renderer uses the browser SSE stream exposed by the same DSH
+runtime. An initial browser subscription explicitly disables history replay.
+The Executor atomically captures the latest journal `sequence`, sends an
+internal `executor.stream.cursor` baseline, and then forwards only new events.
+The browser consumes that baseline without passing it to business listeners.
+Reconnects after the connection is established explicitly enable replay and
+resume from the last consumed `sequence`. A zero `after` cursor alone must not
+identify a fresh connection because a reconnect that has not received an
+ordinary business event can also carry zero. Conflating those cases either
+floods the renderer with the full journal or drops events emitted while the
+stream was disconnected.
+
 The main mappings are:
 
 | Executor event                             | DSH Session event                           |

--- a/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-executor-sessions.md
@@ -15,6 +15,13 @@ Executor。
 消费的 `sequence` 断线续传。每个 `(deviceId, taskId)` 映射为一个稳定、独立的
 Session，因此并行任务不会合并到同一个事件流。
 
+Wework renderer 使用同一 DSH runtime 暴露的浏览器 SSE 事件流。首次浏览器订阅会
+显式关闭历史回放；Executor 原子记录当前 journal 的最新 `sequence`，先发送内部
+`executor.stream.cursor` 基线，再只转发新事件。浏览器消费该基线但不把它交给业务
+listener。连接建立后的重连会显式开启回放，并从最后消费的 `sequence` 补齐断线期间
+的事件。不能仅用 `after=0` 判断是否首次连接，因为尚未收到普通业务事件的重连也可能
+携带零游标；混淆两种语义会导致全量历史事件阻塞 renderer，或漏掉断线期间的事件。
+
 主要映射如下：
 
 | Executor 事件                              | DSH Session 事件                            |

--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -1102,8 +1102,12 @@ impl AppIpcServer {
         let role = authentication.role;
         let (reader, writer) = split(stream);
         let result = if authentication.event_stream {
-            self.serve_event_stream(writer, authentication.after_sequence)
-                .await
+            self.serve_event_stream(
+                writer,
+                authentication.after_sequence,
+                authentication.replay_existing,
+            )
+            .await
         } else {
             self.serve_io_inner(
                 reader,
@@ -1364,13 +1368,38 @@ impl AppIpcServer {
         }
     }
 
-    async fn serve_event_stream<W>(&self, mut writer: W, after: u64) -> Result<(), String>
+    async fn serve_event_stream<W>(
+        &self,
+        mut writer: W,
+        after: u64,
+        replay_existing: bool,
+    ) -> Result<(), String>
     where
         W: AsyncWrite + Unpin + Send + 'static,
     {
         self.event_hub.ensure_started();
-        let mut subscription = self.event_hub.subscribe_after(after);
-        let mut delivered_sequence = after;
+        let mut subscription = if replay_existing {
+            self.event_hub.subscribe_after(after)
+        } else {
+            self.event_hub.subscribe_from_now()
+        };
+        let mut delivered_sequence = after.max(subscription.resume_after);
+        if !replay_existing {
+            write_message(
+                &mut writer,
+                &json!({
+                    "type": "event",
+                    "protocolVersion": 1,
+                    "sequence": delivered_sequence,
+                    "emittedAt": chrono::Utc::now()
+                        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                    "event": "executor.stream.cursor",
+                    "payload": {},
+                }),
+            )
+            .await
+            .map_err(|error| format!("failed to write executor event stream cursor: {error}"))?;
+        }
         loop {
             for event in subscription.replay.drain(..) {
                 write_message(&mut writer, &event)
@@ -1508,6 +1537,7 @@ struct LocalEndpointAuthentication {
     role: LocalEndpointRole,
     event_stream: bool,
     after_sequence: u64,
+    replay_existing: bool,
     receive_events: bool,
 }
 
@@ -1558,6 +1588,9 @@ where
         role,
         event_stream: request.as_ref().is_some_and(|request| request.event_stream),
         after_sequence: request.as_ref().map_or(0, |request| request.after_sequence),
+        replay_existing: request
+            .as_ref()
+            .map_or(true, |request| request.replay_existing),
         receive_events: request
             .as_ref()
             .map_or(true, |request| request.receive_events),
@@ -1590,6 +1623,7 @@ struct LocalEndpointAuthRequest {
     token: String,
     event_stream: bool,
     after_sequence: u64,
+    replay_existing: bool,
     receive_events: bool,
 }
 
@@ -1614,6 +1648,10 @@ fn parse_auth_request(frame: &[u8]) -> Option<LocalEndpointAuthRequest> {
             .get("after_sequence")
             .and_then(Value::as_u64)
             .unwrap_or(0),
+        replay_existing: value
+            .get("replay_existing")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
         receive_events: value
             .get("receive_events")
             .and_then(Value::as_bool)
@@ -3930,7 +3968,9 @@ mod tests {
         let (_, first_writer) = split(first_executor);
         let first_server = server.clone();
         let first_stream =
-            tokio::spawn(async move { first_server.serve_event_stream(first_writer, 0).await });
+            tokio::spawn(
+                async move { first_server.serve_event_stream(first_writer, 0, true).await },
+            );
         for _ in 0..100 {
             if event_tx.receiver_count() > 0 {
                 break;
@@ -3976,7 +4016,7 @@ mod tests {
         let second_server = server.clone();
         let second_stream = tokio::spawn(async move {
             second_server
-                .serve_event_stream(second_writer, first_sequence)
+                .serve_event_stream(second_writer, first_sequence, true)
                 .await
         });
         let mut second_reader = BufReader::new(second_reader);
@@ -3994,5 +4034,74 @@ mod tests {
         assert_eq!(second_event["payload"]["data"]["delta"], "second");
         assert!(second_event["sequence"].as_u64().unwrap() > first_sequence);
         second_stream.abort();
+    }
+
+    #[tokio::test]
+    async fn fresh_executor_event_stream_skips_journal_backlog() {
+        let server = AppIpcServer::new();
+        let event_tx = server.event_tx.clone();
+        server.event_hub.ensure_started();
+        event_tx
+            .send(json!({
+                "type": "event",
+                "event": "response.output_text.delta",
+                "payload": {"data": {"delta": "stale"}},
+            }))
+            .expect("executor event journal should accept backlog");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .event_hub
+                    .subscribe_after(0)
+                    .replay
+                    .iter()
+                    .any(|event| event["payload"]["data"]["delta"] == "stale")
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("stale executor event should reach the journal");
+
+        let (client, executor) = duplex(16 * 1024);
+        let (reader, _) = split(client);
+        let (_, writer) = split(executor);
+        let fresh_server = server.clone();
+        let fresh_stream =
+            tokio::spawn(async move { fresh_server.serve_event_stream(writer, 0, false).await });
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+        tokio::time::timeout(Duration::from_secs(1), reader.read_line(&mut line))
+            .await
+            .expect("fresh event stream cursor should arrive")
+            .expect("fresh event stream cursor should be readable");
+        let cursor: Value =
+            serde_json::from_str(&line).expect("fresh event stream cursor should be JSON");
+        assert_eq!(cursor["event"], "executor.stream.cursor");
+        assert!(cursor["sequence"].as_u64().unwrap() > 0);
+        line.clear();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), reader.read_line(&mut line))
+                .await
+                .is_err(),
+            "fresh event streams must not replay journal backlog"
+        );
+
+        event_tx
+            .send(json!({
+                "type": "event",
+                "event": "response.output_text.delta",
+                "payload": {"data": {"delta": "live"}},
+            }))
+            .expect("fresh event stream should receive live events");
+        tokio::time::timeout(Duration::from_secs(1), reader.read_line(&mut line))
+            .await
+            .expect("live executor event should arrive")
+            .expect("live executor event should be readable");
+        let event: Value = serde_json::from_str(&line).expect("live executor event should be JSON");
+        assert_eq!(event["payload"]["data"]["delta"], "live");
+        fresh_stream.abort();
     }
 }

--- a/executor/src/local/event_stream.rs
+++ b/executor/src/local/event_stream.rs
@@ -143,6 +143,19 @@ impl ExecutorEventHub {
         self.event_tx.subscribe()
     }
 
+    pub fn subscribe_from_now(&self) -> ExecutorEventSubscription {
+        let state = self
+            .state
+            .lock()
+            .expect("executor event journal should not be poisoned");
+        let receiver = self.event_tx.subscribe();
+        ExecutorEventSubscription {
+            replay: Vec::new(),
+            receiver,
+            resume_after: state.latest_sequence(),
+        }
+    }
+
     pub fn subscribe_after(&self, after: u64) -> ExecutorEventSubscription {
         let mut state = self
             .state

--- a/wework/dsh/executor-runtime/executor-http.test.mjs
+++ b/wework/dsh/executor-runtime/executor-http.test.mjs
@@ -7,19 +7,54 @@ import { handleExecutorEvents } from './index.js'
 test('passes the browser cursor to the executor-owned event stream', async () => {
   const request = executorEventRequest('?after=7')
   const response = responseFixture()
-  let receivedAfter = null
+  let receivedOptions = null
 
   await handleExecutorEvents(request, response, options => {
-    receivedAfter = options.afterSequence
+    receivedOptions = options
     return eventStreamFixture(options, {
       events: [executorEvent(8), executorEvent(9, 'response.completed')],
     })
   })
 
-  assert.equal(receivedAfter, 7)
+  assert.deepEqual(receivedOptions, {
+    afterSequence: 7,
+    replayExisting: true,
+  })
   assert.doesNotMatch(response.body, /id:/)
   assert.match(response.body, /"sequence":8/)
   assert.match(response.body, /"sequence":9/)
+})
+
+test('starts a fresh browser event stream without replaying executor backlog', async () => {
+  const request = executorEventRequest('?after=0&replay=0')
+  const response = responseFixture()
+  let receivedOptions = null
+
+  await handleExecutorEvents(request, response, options => {
+    receivedOptions = options
+    return eventStreamFixture(options)
+  })
+
+  assert.deepEqual(receivedOptions, {
+    afterSequence: 0,
+    replayExisting: false,
+  })
+})
+
+test('replays executor backlog when a zero-cursor browser reconnect requests it', async () => {
+  const request = executorEventRequest('?after=0&replay=1')
+  const response = responseFixture()
+  let receivedOptions = null
+
+  await handleExecutorEvents(request, response, options => {
+    receivedOptions = options
+    return eventStreamFixture(options)
+  })
+
+  assert.deepEqual(receivedOptions, {
+    afterSequence: 0,
+    replayExisting: true,
+  })
 })
 
 test('returns an error before opening SSE when the executor stream cannot connect', async () => {

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -85,6 +85,7 @@ export async function handleExecutorEvents(
   if (!trustedBrowserRequest(req)) return forbidden(res)
   if (req.method !== 'GET') return methodNotAllowed(res, 'GET')
   const after = eventCursor(req)
+  const replayExisting = shouldReplayExistingEvents(req)
   let active = true
   let eventStream = null
   let source = null
@@ -98,7 +99,10 @@ export async function handleExecutorEvents(
   res.once('close', disconnect)
   res.once('error', disconnect)
   try {
-    eventStream = createEventStream({ afterSequence: after })
+    eventStream = createEventStream({
+      afterSequence: after,
+      replayExisting,
+    })
     source = await eventStream.start()
     if (!active || res.writableEnded || res.destroyed) return
     res.writeHead(200, {
@@ -129,6 +133,10 @@ function eventCursor(req) {
   const value = query ?? header ?? '0'
   const parsed = Number(value)
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0
+}
+
+function shouldReplayExistingEvents(req) {
+  return new URL(req.url ?? '/', 'http://localhost').searchParams.get('replay') !== '0'
 }
 
 class NdjsonSseTransform extends Transform {

--- a/wework/dsh/executor-runtime/local-endpoint-event-stream.js
+++ b/wework/dsh/executor-runtime/local-endpoint-event-stream.js
@@ -11,6 +11,7 @@ export class LocalEndpointEventByteStream {
     this.endpoint = options.endpoint
     this.token = options.token
     this.afterSequence = options.afterSequence
+    this.replayExisting = options.replayExisting ?? true
     this.socket = null
     this.authenticated = false
     this.stopped = false
@@ -108,6 +109,7 @@ export class LocalEndpointEventByteStream {
             token: this.token,
             event_stream: true,
             after_sequence: this.afterSequence,
+            replay_existing: this.replayExisting,
           })}\n`
         )
       })

--- a/wework/dsh/executor-runtime/local-endpoint-event-stream.test.mjs
+++ b/wework/dsh/executor-runtime/local-endpoint-event-stream.test.mjs
@@ -17,6 +17,7 @@ test('subscribes to executor events from the requested sequence', async () => {
     endpoint: fixture.endpoint,
     token: fixture.token,
     afterSequence: 42,
+    replayExisting: true,
     onEvent: event => received.push(event),
     onClose: () => {
       closed = true
@@ -28,6 +29,7 @@ test('subscribes to executor events from the requested sequence', async () => {
 
     assert.equal(fixture.authentication.event_stream, true)
     assert.equal(fixture.authentication.after_sequence, 42)
+    assert.equal(fixture.authentication.replay_existing, true)
     assert.equal(received[0].sequence, 43)
     assert.equal(closed, false)
   } finally {

--- a/wework/src/api/dsh/executorTransport.test.ts
+++ b/wework/src/api/dsh/executorTransport.test.ts
@@ -153,6 +153,17 @@ describe('DSH executor transport', () => {
     const unsubscribe = subscribeDshExecutorEvents(listener)
 
     expect(sources).toHaveLength(1)
+    expect(sources[0].url).toBe('/wework/executor/v1/events?after=0&replay=0')
+    sources[0].onopen?.()
+    sources[0].onmessage?.({
+      data: JSON.stringify({
+        protocolVersion: 1,
+        sequence: 6,
+        emittedAt: '2026-08-25T00:00:00.000Z',
+        event: 'executor.stream.cursor',
+        payload: {},
+      }),
+    } as MessageEvent)
     sources[0].onmessage?.({
       data: JSON.stringify({
         protocolVersion: 1,
@@ -167,7 +178,7 @@ describe('DSH executor transport', () => {
 
     expect(sources).toHaveLength(2)
     expect(sources[0].closed).toBe(true)
-    expect(sources[1].url).toBe('/wework/executor/v1/events?after=7')
+    expect(sources[1].url).toBe('/wework/executor/v1/events?after=7&replay=1')
 
     sources[0].onmessage?.({
       data: JSON.stringify({
@@ -208,6 +219,7 @@ describe('DSH executor transport', () => {
     )
     const unsubscribe = subscribeDshExecutorEvents(vi.fn())
 
+    sources[0].onopen?.()
     sources[0].onmessage?.({ data: '{invalid' } as MessageEvent)
 
     expect(sources[0].closed).toBe(true)
@@ -216,7 +228,7 @@ describe('DSH executor transport', () => {
     expect(sources).toHaveLength(1)
     vi.advanceTimersByTime(1)
     expect(sources).toHaveLength(2)
-    expect(sources[1].url).toBe('/wework/executor/v1/events?after=0')
+    expect(sources[1].url).toBe('/wework/executor/v1/events?after=0&replay=1')
 
     unsubscribe()
     consoleError.mockRestore()
@@ -243,12 +255,13 @@ describe('DSH executor transport', () => {
       .mockImplementation(() => undefined)
     const unsubscribe = subscribeDshExecutorEvents(listener)
 
+    sources[0].onopen?.()
     emitExecutorEvent(sources[0].onmessage, eventEnvelope(1, 'response.block.updated'))
     emitExecutorEvent(sources[0].onmessage, eventEnvelope(2, 'response.completed'))
     reconnectDshExecutorEvents()
 
     expect(listener).toHaveBeenCalledTimes(2)
-    expect(sources[1].url).toBe('/wework/executor/v1/events?after=2')
+    expect(sources[1].url).toBe('/wework/executor/v1/events?after=2&replay=1')
 
     unsubscribe()
     consoleError.mockRestore()
@@ -290,6 +303,7 @@ function eventEnvelope(
 }
 
 class FakeEventSource {
+  onopen: (() => void) | null = null
   onmessage: ((event: MessageEvent) => void) | null = null
   onerror: (() => void) | null = null
   closed = false

--- a/wework/src/api/dsh/executorTransport.ts
+++ b/wework/src/api/dsh/executorTransport.ts
@@ -105,6 +105,7 @@ export function subscribeDshExecutorEvents(
   let closed = false
   let reconnectTimer: number | null = null
   let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
+  let connected = false
 
   const scheduleReconnect = () => {
     if (closed || reconnectTimer !== null) return
@@ -119,9 +120,14 @@ export function subscribeDshExecutorEvents(
   const connect = () => {
     if (closed) return
     const nextSource = new EventSource(
-      `${EXECUTOR_BASE_PATH}/events?after=${encodeURIComponent(String(cursor))}`
+      `${EXECUTOR_BASE_PATH}/events?after=${encodeURIComponent(String(cursor))}&replay=${
+        connected ? '1' : '0'
+      }`
     )
     source = nextSource
+    nextSource.onopen = () => {
+      if (source === nextSource) connected = true
+    }
     nextSource.onmessage = message => {
       if (source !== nextSource) return
       let event: DshExecutorEventEnvelope
@@ -151,6 +157,7 @@ export function subscribeDshExecutorEvents(
       if (event.sequence <= cursor) return
       cursor = event.sequence
       reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
+      if (event.event === 'executor.stream.cursor') return
       try {
         listener(event)
       } catch (error) {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -473,6 +473,84 @@ describe('ScrollableMessageArea', () => {
     }
   })
 
+  test('keeps the user anchor when a width reflow clamps the scroller before resize observation', () => {
+    const resizeCallbacks: ResizeObserverCallback[] = []
+    vi.stubGlobal(
+      'ResizeObserver',
+      class ResizeObserverMock {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallbacks.push(callback)
+        }
+        observe() {}
+        disconnect() {}
+      }
+    )
+
+    render(
+      <ScrollableMessageArea
+        conversationKey="width-reflow-clamp"
+        messages={[
+          {
+            id: 'width-reflow-clamp-message',
+            role: 'assistant',
+            content: '关闭文件面板后仍在阅读的段落',
+            status: 'done',
+            createdAt: '2026-08-30T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    const anchor = screen.getByText('关闭文件面板后仍在阅读的段落').closest('[data-scroll-anchor]')!
+    let scrollHeight = 2_000
+    let anchorTopAtScrollZero = 1_300
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 1_800,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Math.min(Number(top), scrollHeight - scroller.clientHeight)
+    })
+    mockRect(scroller, 100, 300)
+    anchor.getBoundingClientRect = vi.fn(() => {
+      const top = anchorTopAtScrollZero - scroller.scrollTop
+      return {
+        top,
+        bottom: top + 40,
+        left: 0,
+        right: 320,
+        width: 320,
+        height: 40,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect
+    })
+
+    fireEvent.scroll(scroller)
+    scroller.scrollTop = 1_200
+    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.scroll(scroller)
+
+    scrollHeight = 1_300
+    anchorTopAtScrollZero = 500
+    scroller.scrollTop = 1_100
+    fireEvent.scroll(scroller)
+    act(() => {
+      resizeCallbacks.forEach(callback => callback([], {} as ResizeObserver))
+    })
+
+    expect(scroller.scrollTop).toBe(400)
+    expect(anchor.getBoundingClientRect().top).toBe(100)
+  })
+
   test('keeps the first visible text line fixed when width changes reflow a paragraph', () => {
     const resizeCallbacks: ResizeObserverCallback[] = []
     const originalResizeObserver = globalThis.ResizeObserver

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -576,7 +576,9 @@ function ScrollableMessagePaneContent({
         lastScrollTopRef.current !== null && element.scrollTop < lastScrollTopRef.current - 0.5
       lastScrollTopRef.current = element.scrollTop
       isAtBottomRef.current = isAtBottom
-      if (isScrolledToBottom) {
+      const layoutMayHaveClampedPausedScroll =
+        userScrollPausedAutoFollowRef.current && !options.forceSave && scrolledUp
+      if (isScrolledToBottom && !layoutMayHaveClampedPausedScroll) {
         userScrollPausedAutoFollowRef.current = false
         userViewportAnchorRef.current = null
       } else if (options.forceSave) {


### PR DESCRIPTION
## Summary

- distinguish a fresh browser event subscription from a reconnect that must replay missing events
- atomically capture the Executor journal cursor and send it to the renderer without delivering it to business listeners
- preserve replay semantics for reconnects and older local-endpoint clients
- document the browser SSE cursor and replay contract in Chinese and English

## Root cause

A new browser SSE subscription started with after=0, which the Executor interpreted as a request to replay the complete in-memory journal. Long-running desktop E2E output could fill that journal and flood DSH/the renderer with historical events, delaying unrelated UI work such as workspace file loading even though the underlying device command had already completed.

## Verification

- pre-push Wework ESLint, TypeScript, renderer unit tests, and DSH unit tests
- pre-push Executor cargo fmt, cargo test --all-features --lib, and cargo clippy
- focused fresh-subscription and reconnect-replay Rust tests
- focused DSH transport tests: 10 passed
- focused renderer transport tests: 7 passed
- real Electron ai:verify: selected a local project, opened the File panel, and observed a stable workspace file tree without the loading state hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved event-stream reconnection so missed events are replayed reliably.
  - Initial connections now receive only new events, avoiding unnecessary history replay.
  - Reconnection state and event positions are handled consistently.

- **Bug Fixes**
  - Fixed chat scrolling so responsive layout changes no longer unexpectedly re-enable automatic scrolling while users are reading older messages.

- **Documentation**
  - Clarified initial connection, reconnection, event replay, and cursor behavior in English and Chinese developer guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->