### PR TITLE
fix(wework): package required license files

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -185,6 +185,23 @@ with SHA-512. Prepared desktop resources live under `wework/resources/`.
 icons, and runtime descriptors into the application resources. Do not maintain
 a second desktop resource tree or manifest.
 
+Desktop distributions must also include the project and bundled-sidecar
+licenses and attribution notices:
+
+- `LICENSE` at the application resource root contains Wegent's Apache-2.0
+  license;
+- `licenses/` contains third-party licenses for Electron dependencies such as
+  CUA Driver;
+- `codex/legal/` contains the Codex Apache-2.0 license, `NOTICE`, and the
+  Ratatui MIT license.
+
+`prepare-codex-binary.mjs` generates the Codex legal directory, and
+`prepare-package-assets.mjs` must copy it together with the target architecture
+binary. Packaging changes must inspect the real packaged application and
+confirm that these files exist and match their repository sources. Inspecting
+only an intermediate resource directory does not prove that the distribution
+is complete.
+
 ## Local verification
 
 Release changes must run at least:
@@ -200,7 +217,7 @@ Changes to windows, tray behavior, IPC, the built-in browser, sidecars, or
 packaged resources must also be verified in an isolated real Electron session:
 
 ```bash
-pnpm --filter wework ai:verify start
+pnpm --filter wework ai:verify start --packaged true
 ```
 
 Give each concurrent worktree a distinct `WEWORK_PORT`. Isolated sessions use

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -151,6 +151,18 @@ Codex 下载包按 `wework/codex-binaries.lock.json` 固定并校验 SHA-512。�
 `wework/electron/scripts/prepare-package-assets.mjs` 会把 sidecar、插件、图标和运行时
 描述复制到应用资源目录。不要重新建立第二份桌面资源目录或资源清单。
 
+桌面发行物还必须携带项目及 bundled sidecar 的许可证和归属信息：
+
+- 应用资源根目录的 `LICENSE` 是 Wegent 的 Apache-2.0 许可证；
+- `licenses/` 保存 CUA Driver 等 Electron 依赖的第三方许可证；
+- `codex/legal/` 保存 Codex 的 Apache-2.0 许可证、`NOTICE` 和 Ratatui MIT
+  许可证。
+
+`prepare-codex-binary.mjs` 生成 Codex legal 目录，
+`prepare-package-assets.mjs` 必须将其与目标架构二进制一起复制到桌面资源。修改
+打包链路时，应解包或检查真实应用产物，确认这些文件存在且与仓库中的源文件一致；
+仅检查中间资源目录不能证明最终发行物合规。
+
 ## 本地验证
 
 发布相关改动至少运行：
@@ -166,7 +178,7 @@ pnpm --dir wework/electron build:release
 Electron 会话验证：
 
 ```bash
-pnpm --filter wework ai:verify start
+pnpm --filter wework ai:verify start --packaged true
 ```
 
 多个 worktree 并行验证时，为每个实例使用独立 `WEWORK_PORT`。隔离会话会使用独立

--- a/wework/electron/electron-builder.config.cjs
+++ b/wework/electron/electron-builder.config.cjs
@@ -38,6 +38,7 @@ module.exports = {
     { from: 'resources/bundled-plugins', to: 'bundled-plugins' },
     { from: '../resources/licenses', to: 'licenses' },
     { from: '../resources/icons', to: 'icons' },
+    { from: '../../LICENSE', to: 'LICENSE' },
   ],
   publish: {
     provider: 'generic',

--- a/wework/electron/scripts/package-app.mjs
+++ b/wework/electron/scripts/package-app.mjs
@@ -15,6 +15,7 @@ const output = join(electronRoot, 'release')
 const staging = join(electronRoot, '.package-staging')
 const electronZipDir = process.env.WEWORK_ELECTRON_ZIP_DIR?.trim() || undefined
 const sharedResourcesRoot = join(electronRoot, '..', 'resources')
+const repositoryRoot = resolve(electronRoot, '..', '..')
 const sourcePackage = JSON.parse(await readFile(join(electronRoot, 'package.json'), 'utf8'))
 const identity = resolveBuildIdentity()
 const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
@@ -95,6 +96,7 @@ try {
       join(electronRoot, 'resources', 'bundled-plugins'),
       join(sharedResourcesRoot, 'licenses'),
       join(sharedResourcesRoot, 'icons'),
+      join(repositoryRoot, 'LICENSE'),
     ],
     icon,
     prune: false,

--- a/wework/electron/scripts/prepare-package-assets.mjs
+++ b/wework/electron/scripts/prepare-package-assets.mjs
@@ -86,6 +86,9 @@ const codexTarget = packageTargets.codexTarget
 const codexSource = join(sharedResourcesRoot, 'binaries', 'codex', codexTarget)
 const codexResources = join(resourcesRoot, 'codex')
 await cp(codexSource, codexResources, { recursive: true })
+await cp(join(sharedResourcesRoot, 'binaries', 'codex', 'legal'), join(codexResources, 'legal'), {
+  recursive: true,
+})
 const executorName = targetExecutableName(packageTargets.cargoTarget, 'wegent-executor')
 const packagedExecutor = join(resourcesRoot, 'bin', executorName)
 await cp(executorPath, packagedExecutor)

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -161,6 +161,7 @@ describe('desktop resource migration', () => {
     expect(codexPreparation).toContain("join(repoRoot, 'LICENSES', 'Apache-2.0.txt')")
     expect(codexPreparation).toContain("'RATATUI-LICENSE.txt'")
     expect(codexPreparation).toContain('await rm(legalDir, { recursive: true, force: true })')
+    expect(codexPreparation).toContain('resolveCodexLegalSources(')
     expect(packagePreparation).toContain("join(sharedResourcesRoot, 'binaries', 'codex', 'legal')")
     expect(packagePreparation).toContain("join(codexResources, 'legal')")
     expect(ratatuiLicense).toContain('Copyright (c) 2023-2025 The Ratatui Developers')

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -128,22 +128,42 @@ describe('desktop resource migration', () => {
     expect(source).toContain('Reusing prepared DWS sidecar')
   })
 
-  test('packages CUA native libraries and license outside ASAR', async () => {
-    const [packageApp, builderConfig, electronWorkspace, asarPatch, license] = await Promise.all([
+  test('packages application and third-party licenses outside ASAR', async () => {
+    const [
+      packageApp,
+      builderConfig,
+      electronWorkspace,
+      asarPatch,
+      cuaLicense,
+      codexPreparation,
+      packagePreparation,
+      ratatuiLicense,
+    ] = await Promise.all([
       readFile(join(weworkRoot, 'electron/scripts/package-app.mjs'), 'utf8'),
       readFile(join(weworkRoot, 'electron/electron-builder.config.cjs'), 'utf8'),
       readFile(join(weworkRoot, 'electron/pnpm-workspace.yaml'), 'utf8'),
       readFile(join(weworkRoot, 'electron/patches/@trycua__cua-driver@0.22.1.patch'), 'utf8'),
       readFile(join(weworkRoot, 'resources/licenses/cua-driver-LICENSE.md'), 'utf8'),
+      readFile(join(weworkRoot, 'scripts/prepare-codex-binary.mjs'), 'utf8'),
+      readFile(join(weworkRoot, 'electron/scripts/prepare-package-assets.mjs'), 'utf8'),
+      readFile(join(weworkRoot, 'third_party/codex/RATATUI-LICENSE.txt'), 'utf8'),
     ])
 
     expect(packageApp).toContain("unpack: '**/*.{node,dylib,so,dll}'")
     expect(packageApp).toContain("join(sharedResourcesRoot, 'licenses')")
+    expect(packageApp).toContain("join(repositoryRoot, 'LICENSE')")
     expect(builderConfig).toContain("asarUnpack: ['**/*.{node,dylib,so,dll}']")
     expect(builderConfig).toContain("{ from: '../resources/licenses', to: 'licenses' }")
+    expect(builderConfig).toContain("{ from: '../../LICENSE', to: 'LICENSE' }")
     expect(electronWorkspace).toContain("'@trycua/cua-driver@0.22.1':")
     expect(asarPatch).toContain('app.asar.unpacked')
-    expect(license).toContain('Copyright (c) 2025 Cua AI, Inc.')
+    expect(cuaLicense).toContain('Copyright (c) 2025 Cua AI, Inc.')
+    expect(codexPreparation).toContain("join(repoRoot, 'LICENSES', 'Apache-2.0.txt')")
+    expect(codexPreparation).toContain("'RATATUI-LICENSE.txt'")
+    expect(codexPreparation).toContain('await rm(legalDir, { recursive: true, force: true })')
+    expect(packagePreparation).toContain("join(sharedResourcesRoot, 'binaries', 'codex', 'legal')")
+    expect(packagePreparation).toContain("join(codexResources, 'legal')")
+    expect(ratatuiLicense).toContain('Copyright (c) 2023-2025 The Ratatui Developers')
   })
 
   test('defaults packaged executors to release with an explicit debug E2E profile', async () => {

--- a/wework/scripts/prepare-codex-binary.mjs
+++ b/wework/scripts/prepare-codex-binary.mjs
@@ -221,6 +221,26 @@ async function findLegacyTarball(paths) {
   return existingPaths.find(Boolean)
 }
 
+export async function resolveCodexLegalSources(
+  codexRepo,
+  bundledLicense,
+  bundledNotice,
+  pathExistsImpl = pathExists
+) {
+  const sourceLicensePath = codexRepo ? join(codexRepo, 'LICENSE') : null
+  const sourceNoticePath = codexRepo ? join(codexRepo, 'NOTICE') : null
+  return {
+    license:
+      sourceLicensePath && (await pathExistsImpl(sourceLicensePath))
+        ? sourceLicensePath
+        : bundledLicense,
+    notice:
+      sourceNoticePath && (await pathExistsImpl(sourceNoticePath))
+        ? sourceNoticePath
+        : bundledNotice,
+  }
+}
+
 async function ensureTarballIntegrity(tarballPath, entry, target) {
   const actualIntegrity = await integrityFile(tarballPath)
   if (actualIntegrity === entry.integrity) return
@@ -302,17 +322,9 @@ async function copyLegalFiles() {
   await rm(join(outputRoot, '.resource-placeholder'), { force: true })
   await rm(legalDir, { recursive: true, force: true })
   await mkdir(legalDir, { recursive: true })
-  if (codexRepo && (await pathExists(join(codexRepo, 'LICENSE')))) {
-    await cp(join(codexRepo, 'LICENSE'), join(legalDir, 'LICENSE'))
-    if (await pathExists(join(codexRepo, 'NOTICE'))) {
-      await cp(join(codexRepo, 'NOTICE'), join(legalDir, 'NOTICE'))
-    } else {
-      await cp(bundledNotice, join(legalDir, 'NOTICE'))
-    }
-  } else {
-    await cp(bundledLicense, join(legalDir, 'LICENSE'))
-    await cp(bundledNotice, join(legalDir, 'NOTICE'))
-  }
+  const sources = await resolveCodexLegalSources(codexRepo, bundledLicense, bundledNotice)
+  await cp(sources.license, join(legalDir, 'LICENSE'))
+  await cp(sources.notice, join(legalDir, 'NOTICE'))
   await cp(bundledRatatuiLicense, join(legalDir, 'RATATUI-LICENSE.txt'))
 }
 

--- a/wework/scripts/prepare-codex-binary.mjs
+++ b/wework/scripts/prepare-codex-binary.mjs
@@ -296,19 +296,24 @@ async function copyLegalFiles() {
   const codexRepo = process.env.CODEX_SOURCE_DIR
   const legalDir = join(outputRoot, 'legal')
   const repoRoot = resolve(weworkDir, '..')
+  const bundledLicense = join(repoRoot, 'LICENSES', 'Apache-2.0.txt')
   const bundledNotice = join(weworkDir, 'third_party', 'codex', 'NOTICE')
+  const bundledRatatuiLicense = join(weworkDir, 'third_party', 'codex', 'RATATUI-LICENSE.txt')
   await rm(join(outputRoot, '.resource-placeholder'), { force: true })
+  await rm(legalDir, { recursive: true, force: true })
   await mkdir(legalDir, { recursive: true })
   if (codexRepo && (await pathExists(join(codexRepo, 'LICENSE')))) {
     await cp(join(codexRepo, 'LICENSE'), join(legalDir, 'LICENSE'))
     if (await pathExists(join(codexRepo, 'NOTICE'))) {
       await cp(join(codexRepo, 'NOTICE'), join(legalDir, 'NOTICE'))
+    } else {
+      await cp(bundledNotice, join(legalDir, 'NOTICE'))
     }
-    return
+  } else {
+    await cp(bundledLicense, join(legalDir, 'LICENSE'))
+    await cp(bundledNotice, join(legalDir, 'NOTICE'))
   }
-
-  await cp(join(repoRoot, 'LICENSE'), join(legalDir, 'LICENSE'))
-  await cp(bundledNotice, join(legalDir, 'NOTICE'))
+  await cp(bundledRatatuiLicense, join(legalDir, 'RATATUI-LICENSE.txt'))
 }
 
 async function main() {

--- a/wework/scripts/prepare-codex-binary.test.mjs
+++ b/wework/scripts/prepare-codex-binary.test.mjs
@@ -2,7 +2,11 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { codexTarballName, downloadWithRetry } from './prepare-codex-binary.mjs'
+import {
+  codexTarballName,
+  downloadWithRetry,
+  resolveCodexLegalSources,
+} from './prepare-codex-binary.mjs'
 
 const temporaryDirectories = []
 
@@ -75,5 +79,21 @@ describe('codexTarballName', () => {
         'aarch64-apple-darwin'
       )
     )
+  })
+})
+
+describe('resolveCodexLegalSources', () => {
+  test('selects source license and notice independently', async () => {
+    const sources = await resolveCodexLegalSources(
+      '/tmp/codex-source',
+      '/tmp/bundled/LICENSE',
+      '/tmp/bundled/NOTICE',
+      async path => path.endsWith('/NOTICE')
+    )
+
+    expect(sources).toEqual({
+      license: '/tmp/bundled/LICENSE',
+      notice: '/tmp/codex-source/NOTICE',
+    })
   })
 })

--- a/wework/third_party/codex/RATATUI-LICENSE.txt
+++ b/wework/third_party/codex/RATATUI-LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Florian Dehau
+Copyright (c) 2023-2025 The Ratatui Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- package Wegent's root Apache-2.0 license in both Electron packaging paths
- preserve Codex Apache-2.0 and NOTICE files without reusing Wegent's copyright-bearing license
- bundle the full Ratatui MIT license and copy Codex legal resources with the target binary
- document packaged-license requirements in Chinese and English release guides

## Root cause

The Electron packagers copied the third-party license directory but not the repository root LICENSE. Codex preparation also used Wegent's root LICENSE as its fallback, and package preparation copied only the architecture-specific Codex directory while dropping the sibling legal directory.

## Verification

- `pnpm --filter wework test scripts/desktop-resource-migration.test.mjs` — 36 passed
- focused Prettier checks — passed
- pre-push Wework ESLint, Electron TypeScript, and unit tests — passed
- `pnpm --filter wework ai:verify start --packaged true` — packaged application built and launched successfully
- verified the packaged application contains and byte-matches:
  - `Contents/Resources/LICENSE`
  - `Contents/Resources/licenses/cua-driver-LICENSE.md`
  - `Contents/Resources/codex/legal/LICENSE`
  - `Contents/Resources/codex/legal/NOTICE`
  - `Contents/Resources/codex/legal/RATATUI-LICENSE.txt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop application packages now include required project, third-party, Codex, and Ratatui license and attribution notices.
  * Bundled legal resources are included alongside packaged Codex components.

* **Bug Fixes**
  * Improved license-resource handling when preparing and packaging desktop applications.

* **Documentation**
  * Updated macOS release guidance with required legal resources and packaged-artifact verification steps.

* **Tests**
  * Expanded packaging checks to verify license assets and related application resources.
  * Verification now checks the packaged application artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->