### PR TITLE
fix(wework): avoid refresh when switching models

### DIFF
--- a/docs/en/wework/developer-guide/wework-dsh-ui-plugins.md
+++ b/docs/en/wework/developer-guide/wework-dsh-ui-plugins.md
@@ -29,6 +29,23 @@ layers it needs:
    use only explicitly public Wework client adapters. Plugins in one Core DSH
    page share a JavaScript trust domain, so install only trusted plugins.
 
+## Core DSH model catalog
+
+Wework exposes its executable model catalog as Core DSH providers and
+synchronizes providers and local proxies when models are added, removed, or
+reconfigured. This synchronization owns only the catalog. It must not follow
+the model selected in the Wework composer: the composer selection is an
+execution parameter for the current Wework conversation, while
+`agent-default-model` is the deployment default used when Core DSH creates a
+new Agent. Neither selection may overwrite the other.
+
+Switching the current Wework model must not register model proxies again or
+mutate Core DSH settings. Catalog synchronization preserves an existing Core
+DSH default while that provider remains valid and selects the first catalog
+entry only after the previous default becomes unavailable. This avoids
+`settings/document-updated` and `llm/adapters-updated` events that reload every
+resident model directory and keeps the Wework surface stable.
+
 ## Extension points
 
 | Slot                           | Purpose                                  | Required metadata                 | Component props            |

--- a/docs/zh/wework/developer-guide/wework-dsh-ui-plugins.md
+++ b/docs/zh/wework/developer-guide/wework-dsh-ui-plugins.md
@@ -23,6 +23,19 @@ Wework 的 DSH 扩展分为四层，插件应只依赖实际需要的层：
    依赖这个 host 包，只能使用 Wework 明确公开的 client adapter；同一 Core DSH
    页面中的插件共享 JavaScript 信任域，因此只应安装可信插件。
 
+## Core DSH 模型目录
+
+Wework 会把当前可执行的模型目录暴露为 Core DSH provider，并在目录新增、删除或
+模型配置变化时同步 provider 与本地代理。该同步只管理模型目录，不跟随 Wework
+输入区的当前模型选择：输入区选择是当前 Wework 会话的执行参数，而
+`agent-default-model` 是 Core DSH 创建新 Agent 时使用的部署默认值，两者不能互相
+覆盖。
+
+只切换 Wework 当前模型时，不得重新注册模型代理，也不得写入 Core DSH settings。
+Core DSH 中仍有效的现有默认模型应在目录同步后保留；只有该默认模型已经不可用时，
+才选择目录中的第一个模型。这样可以避免 `settings/document-updated` 和
+`llm/adapters-updated` 事件让所有常驻模型目录重载，并保持 Wework 工作台界面稳定。
+
 ## 扩展点
 
 | Slot                           | 用途                         | 必要元数据                        | 组件 props                |

--- a/wework/src/features/dsh-models/CoreDshModelSyncBridge.tsx
+++ b/wework/src/features/dsh-models/CoreDshModelSyncBridge.tsx
@@ -1,37 +1,22 @@
 import { useEffect, useMemo } from 'react'
-import {
-  listLocalHarnessModelOptions,
-  localHarnessModelOptionKey,
-} from '@/features/local-harness/localHarnessModels'
-import type { ModelOptions, UnifiedModel } from '@/types/api'
+import { listLocalHarnessModelOptions } from '@/features/local-harness/localHarnessModels'
+import type { UnifiedModel } from '@/types/api'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
 import { requestCoreDsh, scheduleCoreDshModelSync } from '@/features/dsh-models/coreDshModelSync'
 
 interface CoreDshModelSyncProps {
   enabled: boolean
   models: UnifiedModel[]
-  selectedModel: UnifiedModel | null
-  selectedModelOptions: ModelOptions
   services: WorkbenchServices
 }
 
-export function CoreDshModelSync({
-  enabled,
-  models,
-  selectedModel,
-  selectedModelOptions,
-  services,
-}: CoreDshModelSyncProps) {
-  const options = useMemo(
-    () => listLocalHarnessModelOptions('claude_code', models, selectedModel, selectedModelOptions),
-    [models, selectedModel, selectedModelOptions]
-  )
-  const preferredModelKey = selectedModel ? localHarnessModelOptionKey(selectedModel) : null
+export function CoreDshModelSync({ enabled, models, services }: CoreDshModelSyncProps) {
+  const options = useMemo(() => listLocalHarnessModelOptions('claude_code', models), [models])
 
   useEffect(() => {
     if (!enabled || !services.localHarnessModelApi) return
     void scheduleCoreDshModelSync(
-      { options, preferredModelKey },
+      { options },
       {
         resolveLaunch: (option, scope) =>
           services.localHarnessModelApi?.resolveLaunch('claude_code', option, scope) ??
@@ -43,7 +28,7 @@ export function CoreDshModelSync({
     ).catch(error => {
       console.error('[Wework] Failed to expose models to Core DSH:', error)
     })
-  }, [enabled, options, preferredModelKey, services.localHarnessModelApi])
+  }, [enabled, options, services.localHarnessModelApi])
 
   return null
 }

--- a/wework/src/features/dsh-models/coreDshModelSync.test.ts
+++ b/wework/src/features/dsh-models/coreDshModelSync.test.ts
@@ -79,7 +79,6 @@ describe('Core DSH model sync', () => {
     await syncCoreDshModels(
       {
         options: [first, second],
-        preferredModelKey: second.key,
       },
       api
     )
@@ -116,7 +115,7 @@ describe('Core DSH model sync', () => {
         {
           op: 'set',
           path: ['provider'],
-          value: coreDshProviderId(second.key),
+          value: coreDshProviderId(first.key),
         },
         { op: 'set', path: ['model'], value: 'wework-selected' },
       ],
@@ -155,7 +154,6 @@ describe('Core DSH model sync', () => {
       syncCoreDshModels(
         {
           options: [modelOption('model-a', 'Model A'), modelOption('model-b', 'Model B')],
-          preferredModelKey: null,
         },
         api
       )
@@ -192,7 +190,7 @@ describe('Core DSH model sync', () => {
       }),
     }
 
-    await syncCoreDshModels({ options: [], preferredModelKey: null }, api)
+    await syncCoreDshModels({ options: [] }, api)
 
     expect(mutations).toEqual([
       {
@@ -209,7 +207,7 @@ describe('Core DSH model sync', () => {
     ])
   })
 
-  test('updates the Core DSH default when Wework selects another exposed model', async () => {
+  test('preserves a valid Core DSH default when the exposed catalog changes', async () => {
     const first = modelOption('model-a', 'Model A')
     const second = modelOption('model-b', 'Model B')
     const mutations: Array<{ ns: string; ops: Array<Record<string, unknown>> }> = []
@@ -244,15 +242,9 @@ describe('Core DSH model sync', () => {
       }),
     }
 
-    await syncCoreDshModels({ options: [first, second], preferredModelKey: second.key }, api)
+    await syncCoreDshModels({ options: [first, second] }, api)
 
-    expect(mutations.at(-1)).toEqual({
-      ns: 'agent-default-model',
-      ops: [
-        { op: 'set', path: ['provider'], value: coreDshProviderId(second.key) },
-        { op: 'set', path: ['model'], value: 'wework-selected' },
-      ],
-    })
+    expect(mutations.filter(mutation => mutation.ns === 'agent-default-model')).toHaveLength(0)
   })
 
   test('builds stable provider ids and text-only profiles by default', () => {
@@ -272,7 +264,7 @@ describe('Core DSH model sync', () => {
     })
   })
 
-  test('does not register again when initial selection resolves to the first model', async () => {
+  test('does not register again when the exposed catalog is unchanged', async () => {
     const first = modelOption('model-a', 'Model A')
     const resolveLaunch = vi.fn(async () => ({
       modelId: 'wework-selected',
@@ -297,10 +289,48 @@ describe('Core DSH model sync', () => {
       }),
     }
 
-    await scheduleCoreDshModelSync({ options: [first], preferredModelKey: null }, api)
-    await scheduleCoreDshModelSync({ options: [first], preferredModelKey: first.key }, api)
+    await scheduleCoreDshModelSync({ options: [first] }, api)
+    await scheduleCoreDshModelSync({ options: [first] }, api)
 
     expect(resolveLaunch).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not write Core DSH settings when the exposed catalog is unchanged', async () => {
+    const first = modelOption('model-a', 'Model A')
+    const second = modelOption('model-b', 'Model B')
+    const mutations: Array<Record<string, unknown>> = []
+    const resolveLaunch = vi.fn(async option => ({
+      modelId: 'wework-selected',
+      proxyToken: `token-${option.key}`,
+      baseUrl: `http://127.0.0.1:1234/v1/harness-router/token-${option.key}`,
+      env: {},
+    }))
+    const api: CoreDshModelSyncApi = {
+      resolveLaunch,
+      unregisterProxy: vi.fn(async () => undefined),
+      request: vi.fn(async (method, payload) => {
+        if (method === 'settings.describe') {
+          return {
+            namespaces: [
+              { ns: 'llm-pi-ai', user: {} },
+              { ns: 'agent-default-model', user: {} },
+            ],
+          }
+        }
+        if (method === 'settings.mutate') {
+          mutations.push(payload)
+          return {}
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }),
+    }
+
+    await scheduleCoreDshModelSync({ options: [first, second] }, api)
+    const mutationCount = mutations.length
+    await scheduleCoreDshModelSync({ options: [first, second] }, api)
+
+    expect(resolveLaunch).toHaveBeenCalledTimes(2)
+    expect(mutations).toHaveLength(mutationCount)
   })
 
   test('keeps a stable proxy token when a model profile is refreshed', async () => {
@@ -324,14 +354,8 @@ describe('Core DSH model sync', () => {
       }),
     }
 
-    await syncCoreDshModels(
-      { options: [modelOption('model-a', 'Model A')], preferredModelKey: null },
-      api
-    )
-    await syncCoreDshModels(
-      { options: [modelOption('model-a', 'Renamed Model A')], preferredModelKey: null },
-      api
-    )
+    await syncCoreDshModels({ options: [modelOption('model-a', 'Model A')] }, api)
+    await syncCoreDshModels({ options: [modelOption('model-a', 'Renamed Model A')] }, api)
 
     expect(unregisterProxy).not.toHaveBeenCalled()
   })

--- a/wework/src/features/dsh-models/coreDshModelSync.ts
+++ b/wework/src/features/dsh-models/coreDshModelSync.ts
@@ -42,7 +42,6 @@ export interface CoreDshModelSyncApi {
 
 export interface CoreDshModelSyncInput {
   options: LocalHarnessModelOption[]
-  preferredModelKey: string | null
 }
 
 let activeRegistrations: CoreDshModelRegistration[] = []
@@ -137,7 +136,7 @@ export async function syncCoreDshModels(
   const previousRegistrations = activeRegistrations
   activeRegistrations = nextRegistrations
   await unregisterRemoved(previousRegistrations, nextRegistrations, api)
-  await syncDefaultModel(descriptions, registrations, input.preferredModelKey, api)
+  await syncDefaultModel(descriptions, registrations, api)
 }
 
 export function coreDshProviderId(modelKey: string): string {
@@ -210,20 +209,16 @@ export function resetCoreDshModelSyncForTests(): void {
 }
 
 function coreDshModelSyncSignature(input: CoreDshModelSyncInput): string {
-  const preferredModelKey = input.options.some(option => option.key === input.preferredModelKey)
-    ? input.preferredModelKey
-    : (input.options[0]?.key ?? null)
-  return JSON.stringify({
-    preferredModelKey,
-    models: input.options.map(option => ({
+  return JSON.stringify(
+    input.options.map(option => ({
       key: option.key,
       label: option.label,
       options: option.options,
       contextWindow: option.model.contextWindow,
       maxOutputTokens: option.model.maxOutputTokens,
       supportsImage: option.model.modelCapabilities?.supportsImage,
-    })),
-  })
+    }))
+  )
 }
 
 function configuredWeworkProviders(userSettings: unknown): string[] {
@@ -235,10 +230,8 @@ function configuredWeworkProviders(userSettings: unknown): string[] {
 async function syncDefaultModel(
   descriptions: DshSettingsDescription,
   registrations: Array<{
-    option: LocalHarnessModelOption
     provider: string
   }>,
-  preferredModelKey: string | null,
   api: CoreDshModelSyncApi
 ): Promise<void> {
   const settings = descriptions.namespaces.find(namespace => namespace.ns === 'agent-default-model')
@@ -264,15 +257,18 @@ async function syncDefaultModel(
   if (currentProvider && !currentProvider.startsWith(DSH_PROVIDER_PREFIX)) {
     return
   }
-  const preferred =
-    registrations.find(registration => registration.option.key === preferredModelKey) ??
-    registrations[0]
-  if (currentProvider === preferred.provider && currentModel === DSH_MODEL_ALIAS) return
+  if (
+    currentModel === DSH_MODEL_ALIAS &&
+    registrations.some(registration => registration.provider === currentProvider)
+  ) {
+    return
+  }
+  const defaultRegistration = registrations[0]
   await api
     .request('settings.mutate', {
       ns: 'agent-default-model',
       ops: [
-        { op: 'set', path: ['provider'], value: preferred.provider },
+        { op: 'set', path: ['provider'], value: defaultRegistration.provider },
         { op: 'set', path: ['model'], value: DSH_MODEL_ALIAS },
       ],
     })

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -2959,8 +2959,6 @@ export function WorkbenchProvider({
             <CoreDshModelSync
               enabled={syncCoreDshModels}
               models={conversationModels}
-              selectedModel={modelSelection.selectedModel}
-              selectedModelOptions={modelSelection.selectedModelOptions}
               services={resolvedServices}
             />
             {children}


### PR DESCRIPTION
## Summary

- decouple the Wework composer model selection from the Core DSH deployment default
- synchronize Core DSH providers only when the executable model catalog changes
- preserve an existing valid Core DSH default instead of rewriting global settings
- document the Core DSH model catalog boundary in Chinese and English

## Root cause

The Core DSH model bridge treated the currently selected Wework conversation model and its options as part of the exposed provider catalog. Every composer model switch therefore re-registered all model proxies and mutated both `llm-pi-ai` and `agent-default-model` settings.

Core DSH forwards `settings/document-updated` and `llm/adapters-updated` events to every resident model directory, so those global mutations caused the workbench surface to reload. The composer selection is session execution state, while `agent-default-model` is a deployment default for newly created Core DSH agents; they should not be coupled.

## Verification

- `pnpm --filter wework test src/features/dsh-models/coreDshModelSync.test.ts` — 8 passed
- `pnpm --filter wework test src/features/workbench/WorkbenchProvider.test.tsx` — 215 passed
- `pnpm --filter wework typecheck` — passed
- focused ESLint and Prettier checks — passed
- pre-push Wework ESLint, TypeScript, and unit-test checks — passed
- isolated real Electron verification started successfully and reached the intelligent workbench with the local executor online and no renderer errors

The isolated Electron profile had no authenticated model available to the current conversation, so an actual model-selector click could not be exercised there. The regression is covered at the source boundary: selected model state is no longer an input to `CoreDshModelSync`, and repeated synchronization of an unchanged catalog performs no Core DSH settings writes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how Wework’s executable model catalog synchronizes with Core DSH.
  * Clarified separation between catalog synchronization, the currently selected model, and the default model for new agents.
  * Documented default-model preservation and fallback behavior when models become unavailable.

* **Bug Fixes**
  * Prevented model selection changes from unnecessarily re-registering proxies or modifying Core DSH settings.
  * Improved synchronization stability by avoiding redundant updates and preserving proxy tokens across refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->