### PR TITLE
fix(code-wiki): reserve space for chat input

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/hooks/useFloatingInput.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/hooks/useFloatingInput.test.tsx
@@ -54,4 +54,21 @@ describe('useFloatingInput', () => {
 
     await waitFor(() => expect(result.current.inputHeight).toBe(0))
   })
+
+  it('measures a fixed input while its empty state is visible', async () => {
+    const input = document.createElement('div')
+    Object.defineProperty(input, 'offsetHeight', {
+      configurable: true,
+      value: 216,
+    })
+    const { result } = renderHook(() =>
+      useFloatingInput({ hasMessages: false, inputAlwaysAtBottom: true })
+    )
+
+    act(() => {
+      result.current.floatingInputRef(input)
+    })
+
+    await waitFor(() => expect(result.current.inputHeight).toBe(216))
+  })
 })

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -1300,6 +1300,7 @@ function ChatAreaContent({
     controlsContainerWidth,
   } = useFloatingInput({
     hasMessages: hasMessagesForHooks,
+    inputAlwaysAtBottom,
   })
 
   // For video/image mode, use respective model selection; otherwise use regular model selection
@@ -2700,9 +2701,11 @@ function ChatAreaContent({
           <div
             className="absolute inset-0 flex flex-col items-center w-full px-4 sm:px-6 overflow-y-auto pt-4"
             style={{
-              // Reserve space for: GuidedQuestions (~200px max) + ChatInputCard (~120px) + padding (32px)
-              // This prevents overlap between summary card and guided questions on smaller screens
-              paddingBottom: guidedQuestions && guidedQuestions.length > 0 ? '352px' : '152px',
+              // Keep the empty-state scroller clear of the actual floating input,
+              // whose height varies with the selected controls. The extra space is
+              // for the fade above the input; the floor avoids a first-render jump
+              // before the input has been measured.
+              paddingBottom: `${Math.max(inputHeight + 32, 152)}px`,
             }}
           >
             {emptyStateContent}

--- a/frontend/src/features/tasks/components/hooks/useFloatingInput.ts
+++ b/frontend/src/features/tasks/components/hooks/useFloatingInput.ts
@@ -19,9 +19,13 @@ export interface FloatingMetrics {
 export interface UseFloatingInputOptions {
   /**
    * Whether there are messages to display.
-   * Floating input is only shown when there are messages.
    */
   hasMessages: boolean
+
+  /**
+   * Whether an empty state still renders the floating input.
+   */
+  inputAlwaysAtBottom?: boolean
 }
 
 export interface UseFloatingInputReturn {
@@ -73,7 +77,10 @@ export interface UseFloatingInputReturn {
  * This hook extracts multiple useEffect calls from ChatArea into a single,
  * cohesive unit that manages floating input positioning.
  */
-export function useFloatingInput({ hasMessages }: UseFloatingInputOptions): UseFloatingInputReturn {
+export function useFloatingInput({
+  hasMessages,
+  inputAlwaysAtBottom = false,
+}: UseFloatingInputOptions): UseFloatingInputReturn {
   const chatAreaRef = useRef<HTMLDivElement>(null)
   const inputControlsRef = useRef<HTMLDivElement>(null)
   const [floatingInputElement, setFloatingInputElement] = useState<HTMLDivElement | null>(null)
@@ -181,7 +188,7 @@ export function useFloatingInput({ hasMessages }: UseFloatingInputOptions): UseF
    * Tracks height changes for scroll padding calculation.
    */
   useEffect(() => {
-    if (!hasMessages || !floatingInputElement) {
+    if ((!hasMessages && !inputAlwaysAtBottom) || !floatingInputElement) {
       setInputHeight(0)
       return
     }
@@ -198,7 +205,7 @@ export function useFloatingInput({ hasMessages }: UseFloatingInputOptions): UseF
 
     window.addEventListener('resize', updateHeight)
     return () => window.removeEventListener('resize', updateHeight)
-  }, [floatingInputElement, hasMessages])
+  }, [floatingInputElement, hasMessages, inputAlwaysAtBottom])
 
   return {
     chatAreaRef,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state chat layout when the input is fixed at the bottom.
  * Dynamically adjusts scrolling space based on the input area’s height.
  * Prevents content from being obscured by taller input areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->