### PR TITLE
fix(wework): bind default task issues in executor

### DIFF
--- a/docs/en/wegent/developer-guide/runtime-local-work.md
+++ b/docs/en/wegent/developer-guide/runtime-local-work.md
@@ -33,6 +33,14 @@ Codex tasks are discovered and controlled through the `codex app-server --stdio`
 
 `localTaskId` is the Wegent-side local task identity, not the provider runtime's session id. When the frontend, Backend, and executor need to pass provider session identity, they must use the opaque `runtimeHandle`, such as a Codex `threadId`, Claude Code `sessionId`, or OpenCode `sessionId`, or an explicit `providerSessionId`. `runtime.tasks.transcript` must not treat `localTaskId` as a provider session id when there is no LocalTask index mapping and no `runtimeHandle`; optimistic tasks that are still being created should return an empty local transcript until create/link completes.
 
+### My Tasks association and lifecycle
+
+After a non-ephemeral LocalTask is created and accepted by the executor scheduler, the executor associates it with the local system project **My Tasks** in the background. `runtime.tasks.create` does not wait for this association: the runtime task returns and starts first, then the executor idempotently creates the Issue and system binding in one SQLite `IMMEDIATE` transaction. Repeated association attempts must reuse the same binding and must not create duplicate Issues.
+
+The executor exclusively owns automatic writes for the default **My Tasks** association. The Wework frontend only reads the binding created by the executor and must not call `todos.create`, `todos.bind`, or implement a second automatic association path for the default project. An explicitly selected project or existing Issue may still have a separate user binding; system and user bindings have distinct types and may coexist.
+
+The executor is also the only source that projects Issue lifecycle status. After the background association commits, the executor reads the LocalTask's current state and reuses the shared runtime-status projection for queued, running, terminal, and archived states. Because a task may finish while its binding is being created, the association worker must not reuse the state captured at task creation, and the frontend must not write compensating in-progress or review states. Ephemeral tasks do not create My Tasks Issues.
+
 ## List Refresh
 
 Wework requests the task list on startup, explicit refresh, or device-state changes. It no longer refreshes the list through a fixed polling interval.

--- a/docs/zh/wegent/developer-guide/runtime-local-work.md
+++ b/docs/zh/wegent/developer-guide/runtime-local-work.md
@@ -33,6 +33,14 @@ Codex 任务通过 `codex app-server --stdio` 的 JSON-RPC 协议发现和控制
 
 `localTaskId` 是 Wegent 侧本地任务身份，不等同于底层 runtime 的 provider 会话 id。前端、Backend 和 executor 需要传递 provider 会话定位信息时必须使用 opaque `runtimeHandle`，例如 Codex `threadId`、Claude Code `sessionId` 或 OpenCode `sessionId`，也可以使用明确的 `providerSessionId`。`runtime.tasks.transcript` 不能在缺少 LocalTask 索引映射或 `runtimeHandle` 时把 `localTaskId` 当成 provider 会话 id 读取；这种仍在创建中的 optimistic 任务应先返回空本地 transcript，等待 create/link 完成后再读取真实运行时会话。
 
+### “我的任务”关联与生命周期
+
+非临时 LocalTask 成功创建并进入 executor 调度后，executor 会在后台把它关联到本地系统项目“我的任务”。`runtime.tasks.create` 不等待这次关联：运行任务先返回并开始执行，随后 executor 在单个 SQLite `IMMEDIATE` 事务中幂等创建 Issue 和系统 binding。重复执行关联任务只能复用同一个 binding，不能创建重复 Issue。
+
+默认“我的任务”关联由 executor 独占写入。Wework 前端只读取 executor 已创建的 binding，不得再为默认项目调用 `todos.create`、`todos.bind` 或实现另一套自动关联逻辑。用户明确选择其他项目或已有 Issue 时，仍可建立独立的用户 binding；系统 binding 与用户 binding 使用不同类型，可以同时存在。
+
+Issue 生命周期状态同样只由 executor 投影。后台关联完成后，executor 重新读取 LocalTask 此刻的实际状态，再复用统一的运行状态投影，把 `queued`、`running`、终态和 `archived` 分别映射到看板状态。绑定期间任务可能已经完成，因此不能缓存任务创建时的状态，也不能由前端补写“进行中”或“待确认”。临时 `ephemeral` 任务不创建“我的任务”Issue。
+
 ## 列表刷新
 
 任务列表由 Wework 在启动、显式刷新或设备状态变化时请求，不再由固定 interval 轮询触发。

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -41,6 +41,7 @@ use crate::{
     protocol::ExecutionRequest,
     runner::ExecutionOutcome,
     server::{executor_loopback_base_url, harness_context, local_model_proxy},
+    task_runtime::LocalTaskStore,
 };
 
 const WORKTREE_RECONCILIATION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
@@ -554,6 +555,7 @@ pub struct RuntimeWorkRpcHandler {
     notification_router: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     archived_delete_tx: mpsc::UnboundedSender<RuntimeTaskLink>,
     automation_store: AutomationStore,
+    task_store_path: Arc<PathBuf>,
     store: RuntimeWorkStore,
     worktrees: WorktreeManager,
     worktree_reconciliation_state: Arc<AsyncMutex<WorktreeReconciliationState>>,
@@ -763,6 +765,7 @@ impl RuntimeWorkRpcHandler {
             notification_router: Arc::new(Mutex::new(None)),
             archived_delete_tx,
             automation_store: AutomationStore::from_env(),
+            task_store_path: Arc::new(LocalTaskStore::default_path()),
             store,
             worktrees,
             worktree_reconciliation_state: Arc::new(AsyncMutex::new(

--- a/executor/src/runtime_work/handler/robot_queue_rpc.rs
+++ b/executor/src/runtime_work/handler/robot_queue_rpc.rs
@@ -4,7 +4,6 @@
 
 use super::*;
 use crate::runtime_work::automations::AutomationRunStatus;
-use crate::task_runtime::LocalTaskStore;
 
 static LAST_RUNTIME_STATUS_OBSERVATION: AtomicU64 = AtomicU64::new(0);
 
@@ -34,10 +33,11 @@ impl RuntimeWorkRpcHandler {
     ) {
         let handler = self.clone();
         let device_id = self.device_id.clone();
+        let task_store_path = self.task_store_path.clone();
         let worker_task_id = local_task_id.clone();
         tokio::spawn(async move {
             let binding_result = tokio::task::spawn_blocking(move || {
-                let store = LocalTaskStore::from_env()?;
+                let store = LocalTaskStore::open(task_store_path.as_ref())?;
                 store.ensure_default_work_item_binding(
                     &device_id,
                     &worker_task_id,
@@ -92,9 +92,11 @@ impl RuntimeWorkRpcHandler {
         execution_status: &str,
         observed_at_ms: i64,
     ) {
-        let store = match LocalTaskStore::from_env_if_exists() {
-            Ok(Some(store)) => store,
-            Ok(None) => return,
+        if !self.task_store_path.exists() {
+            return;
+        }
+        let store = match LocalTaskStore::open(self.task_store_path.as_ref()) {
+            Ok(store) => store,
             Err(error) => {
                 log_executor_event(
                     "runtime task Issue status store unavailable",
@@ -163,7 +165,7 @@ impl RuntimeWorkRpcHandler {
     }
 
     pub(super) fn start_queue_run(&self, local_task_id: &str) {
-        let Ok(store) = LocalTaskStore::from_env() else {
+        let Ok(store) = LocalTaskStore::open(self.task_store_path.as_ref()) else {
             return;
         };
         let _ = store.mark_runtime_running(local_task_id);
@@ -182,7 +184,7 @@ impl RuntimeWorkRpcHandler {
         error: Option<String>,
         result_content: Option<String>,
     ) {
-        let Ok(store) = LocalTaskStore::from_env() else {
+        let Ok(store) = LocalTaskStore::open(self.task_store_path.as_ref()) else {
             return;
         };
         let Ok(Some(execution)) = store.execution_by_runtime_task_id(local_task_id) else {

--- a/executor/src/runtime_work/handler/robot_queue_rpc.rs
+++ b/executor/src/runtime_work/handler/robot_queue_rpc.rs
@@ -26,6 +26,60 @@ fn next_runtime_status_observation() -> i64 {
 }
 
 impl RuntimeWorkRpcHandler {
+    pub(super) fn track_default_work_item_async(
+        &self,
+        local_task_id: String,
+        task_title: String,
+        description: String,
+    ) {
+        let handler = self.clone();
+        let device_id = self.device_id.clone();
+        let worker_task_id = local_task_id.clone();
+        tokio::spawn(async move {
+            let binding_result = tokio::task::spawn_blocking(move || {
+                let store = LocalTaskStore::from_env()?;
+                store.ensure_default_work_item_binding(
+                    &device_id,
+                    &worker_task_id,
+                    &task_title,
+                    &description,
+                )
+            })
+            .await;
+            match binding_result {
+                Ok(Ok(binding)) => {
+                    log_executor_event(
+                        "runtime task default Issue bound",
+                        &[
+                            ("local_task_id", binding.task_id.clone()),
+                            (
+                                "loop_item_id",
+                                binding.loop_item_id.clone().unwrap_or_default(),
+                            ),
+                        ],
+                    );
+                    if let Some(link) = handler.local_task_link(&binding.task_id) {
+                        handler.project_runtime_link_status_now(&link);
+                    }
+                }
+                Ok(Err(error)) => log_executor_event(
+                    "runtime task default Issue binding failed",
+                    &[
+                        ("local_task_id", local_task_id),
+                        ("error", error.to_string()),
+                    ],
+                ),
+                Err(error) => log_executor_event(
+                    "runtime task default Issue binding worker failed",
+                    &[
+                        ("local_task_id", local_task_id),
+                        ("error", error.to_string()),
+                    ],
+                ),
+            }
+        });
+    }
+
     pub(crate) async fn reconcile_bound_task_statuses(&self) {
         for link in self.collect_links(false).await {
             self.project_runtime_link_status_now(&link);

--- a/executor/src/runtime_work/handler/tasks.rs
+++ b/executor/src/runtime_work/handler/tasks.rs
@@ -637,6 +637,16 @@ impl RuntimeWorkRpcHandler {
         {
             runtime_handle.insert("queuePosition".to_owned(), json!(queue_position));
         }
+        if !self
+            .local_task_link(&local_task_id)
+            .is_some_and(|link| link.ephemeral)
+        {
+            self.track_default_work_item_async(
+                local_task_id.clone(),
+                title.clone(),
+                string_field(&payload, "message").unwrap_or_default(),
+            );
+        }
         match payload
             .get("friendlyTitleExecutionRequest")
             .cloned()

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -90,6 +90,40 @@ async fn runtime_capacity_rpc_reports_scheduler_truth() {
     assert_eq!(active_task_ids, HashSet::from(["active-1", "active-2"]));
 }
 
+#[tokio::test]
+async fn default_work_item_binding_uses_the_handler_store_path() {
+    let root = temp_runtime_work_index_path("default-work-item-store").with_extension("directory");
+    let database_path = root.join("tasks.sqlite");
+    let handler = RuntimeWorkRpcHandler {
+        task_store_path: Arc::new(database_path.clone()),
+        ..RuntimeWorkRpcHandler::new("device-1", "/bin/false")
+    };
+
+    handler.track_default_work_item_async(
+        "runtime-task-1".to_owned(),
+        "Executor-owned Issue".to_owned(),
+        "Created after runtime acceptance".to_owned(),
+    );
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if database_path.exists() {
+            let store = LocalTaskStore::open(&database_path).unwrap();
+            if let Ok(binding) = store.find_system_task_binding("device-1", "runtime-task-1") {
+                assert_eq!(binding.task_title.as_deref(), Some("Executor-owned Issue"));
+                break;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "executor-owned binding was not written to the handler store"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn deferred_worktree_preparation_can_be_cancelled_before_runtime_start() {
     let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");

--- a/executor/src/task_runtime/store.rs
+++ b/executor/src/task_runtime/store.rs
@@ -55,12 +55,16 @@ pub struct LocalTaskStore {
 }
 
 impl LocalTaskStore {
+    pub(crate) fn default_path() -> PathBuf {
+        local_database_path()
+    }
+
     pub fn from_env() -> Result<Self, TaskRuntimeError> {
-        Self::open(local_database_path())
+        Self::open(Self::default_path())
     }
 
     pub fn from_env_if_exists() -> Result<Option<Self>, TaskRuntimeError> {
-        let path = local_database_path();
+        let path = Self::default_path();
         if !path.exists() {
             return Ok(None);
         }

--- a/executor/src/task_runtime/store.rs
+++ b/executor/src/task_runtime/store.rs
@@ -2106,6 +2106,85 @@ impl LocalTaskStore {
         self.get_binding(&id)
     }
 
+    pub fn ensure_default_work_item_binding(
+        &self,
+        device_id: &str,
+        task_id: &str,
+        task_title: &str,
+        description: &str,
+    ) -> Result<TaskBinding, TaskRuntimeError> {
+        validate_name(device_id, "device id")?;
+        validate_name(task_id, "task id")?;
+        validate_name(task_title, "task title")?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if let Some(active) = get_binding_by_kind(&transaction, device_id, task_id, true)? {
+            transaction.execute(
+                "UPDATE loop_items SET task_title = ?1, updated_at = ?2 WHERE id = ?3",
+                params![task_title, now(), active.id],
+            )?;
+            transaction.commit()?;
+            drop(connection);
+            return self.get_binding(&active.id);
+        }
+
+        let project = get_item_from(&transaction, DEFAULT_WORK_ITEM_PROJECT_ID, "project")?
+            .ok_or(TaskRuntimeError::ProjectNotFound)?;
+        let sequence = project.next_item_number.unwrap_or(1);
+        let item_id = format!("{DEFAULT_WORK_ITEM_PROJECT_KEY}-{sequence}");
+        let timestamp = now();
+        transaction.execute(
+            "UPDATE loop_items SET next_item_number = ?1, version = version + 1,
+                    updated_at = ?2 WHERE id = ?3",
+            params![sequence + 1, timestamp, DEFAULT_WORK_ITEM_PROJECT_ID],
+        )?;
+        transaction.execute(
+            "INSERT INTO loop_items (
+                id, resource_type, project_space, cloud_project_id, title, description,
+                sequence_number, status, priority, sort_order, metadata, version,
+                created_at, updated_at
+             ) VALUES (?1, 'task', 'default', ?2, ?3, ?4, ?5, 'inbox', 'none',
+                       0, ?6, 1, ?7, ?7)",
+            params![
+                item_id,
+                DEFAULT_WORK_ITEM_PROJECT_ID,
+                task_title,
+                description,
+                sequence,
+                json!({"tags": []}).to_string(),
+                timestamp,
+            ],
+        )?;
+        let binding_id = numeric_id();
+        let metadata = json!({
+            "external_item_id": Value::Null,
+            "project_id": DEFAULT_WORK_ITEM_PROJECT_ID,
+            "workflow_node_id": Value::Null,
+            "workflow_stage_input": Value::Null,
+        });
+        transaction.execute(
+            "INSERT INTO loop_items (
+                id, resource_type, project_space, cloud_project_id, loop_item_id,
+                task_user_id, device_id, task_id, task_title, linked_by_user_id,
+                linked_at, metadata, version, created_at, updated_at
+             ) VALUES (?1, 'execution', 'default', ?2, ?3, 0, ?4, ?5, ?6, 0,
+                       ?7, ?8, 1, ?7, ?7)",
+            params![
+                binding_id,
+                DEFAULT_WORK_ITEM_PROJECT_ID,
+                item_id,
+                device_id,
+                task_id,
+                task_title,
+                timestamp,
+                metadata.to_string(),
+            ],
+        )?;
+        transaction.commit()?;
+        drop(connection);
+        self.get_binding(&binding_id)
+    }
+
     pub fn list_task_bindings(&self, item_id: &str) -> Result<Vec<TaskBinding>, TaskRuntimeError> {
         self.list_task_bindings_batch(&[item_id.to_owned()])
     }
@@ -6237,6 +6316,36 @@ mod tests {
                 .as_deref(),
             Some("completed")
         );
+    }
+
+    #[test]
+    fn creates_and_reuses_default_work_item_binding_atomically() {
+        let (_directory, store) = store();
+
+        let first = store
+            .ensure_default_work_item_binding(
+                "local-device",
+                "runtime-default-1",
+                "Create from executor",
+                "Track after runtime creation",
+            )
+            .unwrap();
+        let second = store
+            .ensure_default_work_item_binding(
+                "local-device",
+                "runtime-default-1",
+                "Updated runtime title",
+                "Ignored duplicate description",
+            )
+            .unwrap();
+
+        assert_eq!(second.id, first.id);
+        assert_eq!(second.loop_item_id, first.loop_item_id);
+        assert_eq!(second.task_title.as_deref(), Some("Updated runtime title"));
+        let items = store.list_tasks(DEFAULT_WORK_ITEM_PROJECT_ID).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title.as_deref(), Some("Create from executor"));
+        assert_eq!(items[0].description, "Track after runtime creation");
     }
 
     #[test]

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
@@ -354,14 +354,7 @@ describe('useWorkbenchCloudProjectContext', () => {
     firstHook.rerender({ currentRuntimeTask: firstTask })
     secondHook.rerender({ currentRuntimeTask: secondTask })
 
-    await waitFor(() =>
-      expect(firstTrackProjectTask).toHaveBeenCalledWith(
-        firstProject.id,
-        firstTask,
-        'First task',
-        'First task'
-      )
-    )
+    expect(firstTrackProjectTask).not.toHaveBeenCalled()
     await waitFor(() =>
       expect(secondTrackProjectTask).toHaveBeenCalledWith(
         secondProject.id,
@@ -429,7 +422,7 @@ describe('useWorkbenchCloudProjectContext', () => {
     )
   })
 
-  test('tracks the default work-item project when the user configured nothing', async () => {
+  test('waits for the executor to bind the default work-item project', async () => {
     const defaultBoard = {
       ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),
       project_key: DEFAULT_WORK_ITEM_PROJECT_KEY,
@@ -445,7 +438,13 @@ describe('useWorkbenchCloudProjectContext', () => {
       listCloudFiles: vi.fn().mockResolvedValue({ items: [] }),
       listLoopItems: vi.fn().mockResolvedValue({ items: [] }),
       listDeliveries: vi.fn().mockResolvedValue({ items: [] }),
-      findCloudContextForTask: vi.fn().mockRejectedValue(new Error('Not bound yet')),
+      findCloudContextForTask: vi.fn().mockResolvedValue({
+        id: 1,
+        cloud_project_id: defaultBoard.id,
+        loop_item_id: trackedItem.id,
+        project: defaultBoard,
+        loop_item: trackedItem,
+      }),
       trackProjectTask: vi.fn().mockResolvedValue({ item: trackedItem }),
     }
     const services = {
@@ -478,17 +477,11 @@ describe('useWorkbenchCloudProjectContext', () => {
     act(() => submission?.onRuntimeTaskCreated(runtimeTask))
     rerender({ currentRuntimeTask: runtimeTask })
 
-    await waitFor(() =>
-      expect(localApi.trackProjectTask).toHaveBeenCalledWith(
-        defaultBoard.id,
-        runtimeTask,
-        '完成零配置任务',
-        '完成零配置任务'
-      )
-    )
+    await waitFor(() => expect(result.current.boundCloudItem).toEqual(trackedItem))
+    expect(localApi.trackProjectTask).not.toHaveBeenCalled()
   })
 
-  test('submits synchronously and joins a default project after its background lookup resolves', async () => {
+  test('submits immediately and delegates a late default-project association to executor', async () => {
     const defaultBoard = {
       ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),
       project_key: DEFAULT_WORK_ITEM_PROJECT_KEY,
@@ -549,14 +542,8 @@ describe('useWorkbenchCloudProjectContext', () => {
     await waitFor(() => expect(localApi.listCloudProjects).toHaveBeenCalledOnce())
     await act(async () => resolveLocalProjects?.({ items: [defaultBoard] }))
 
-    await waitFor(() =>
-      expect(localApi.trackProjectTask).toHaveBeenCalledWith(
-        defaultBoard.id,
-        runtimeTask,
-        '继续发送',
-        '继续发送'
-      )
-    )
+    await waitFor(() => expect(result.current.pendingCloudProject).toEqual(defaultBoard))
+    expect(localApi.trackProjectTask).not.toHaveBeenCalled()
   })
 
   test('recovers when the first context lookup races with default-board binding', async () => {
@@ -623,7 +610,7 @@ describe('useWorkbenchCloudProjectContext', () => {
     expect(result.current.pendingCloudProject).toBeNull()
   })
 
-  test('keeps the created work item visible when the runtime title arrives during binding', async () => {
+  test('keeps the executor-created work item visible when the runtime title arrives', async () => {
     const defaultBoard = {
       ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),
       project_key: DEFAULT_WORK_ITEM_PROJECT_KEY,
@@ -634,19 +621,27 @@ describe('useWorkbenchCloudProjectContext', () => {
       deviceId: 'device-1',
       taskId: 'runtime-1',
     }
-    let resolveTracking: ((value: { item: CloudLoopItem }) => void) | undefined
+    let resolveContext:
+      | ((value: {
+          id: number
+          cloud_project_id: string
+          loop_item_id: string
+          project: CloudProject
+          loop_item: CloudLoopItem
+        }) => void)
+      | undefined
     const localApi = {
       listCloudProjects: vi.fn().mockResolvedValue({ items: [defaultBoard] }),
       listCloudFiles: vi.fn().mockResolvedValue({ items: [] }),
       listLoopItems: vi.fn().mockResolvedValue({ items: [] }),
       listDeliveries: vi.fn().mockResolvedValue({ items: [] }),
-      findCloudContextForTask: vi.fn().mockRejectedValue(new Error('Not bound yet')),
-      trackProjectTask: vi.fn(
+      findCloudContextForTask: vi.fn(
         () =>
-          new Promise<{ item: CloudLoopItem }>(resolve => {
-            resolveTracking = resolve
+          new Promise(resolve => {
+            resolveContext = resolve
           })
       ),
+      trackProjectTask: vi.fn(),
     }
     const services = {
       projectSpaceApis: {
@@ -687,29 +682,34 @@ describe('useWorkbenchCloudProjectContext', () => {
     })
     act(() => submission?.onRuntimeTaskCreated(runtimeTask))
     rerender({ currentRuntimeTask: runtimeTask, runtimeTaskTitle: null })
-    await waitFor(() => expect(localApi.trackProjectTask).toHaveBeenCalledOnce())
+    await waitFor(() => expect(localApi.findCloudContextForTask).toHaveBeenCalled())
 
     rerender({ currentRuntimeTask: runtimeTask, runtimeTaskTitle: '运行时生成的标题' })
-    await act(async () => resolveTracking?.({ item: trackedItem }))
+    await act(async () =>
+      resolveContext?.({
+        id: 1,
+        cloud_project_id: defaultBoard.id,
+        loop_item_id: trackedItem.id,
+        project: defaultBoard,
+        loop_item: trackedItem,
+      })
+    )
 
     await waitFor(() => expect(result.current.boundCloudItem).toEqual(trackedItem))
     expect(result.current.boundCloudProject).toEqual(defaultBoard)
+    expect(localApi.trackProjectTask).not.toHaveBeenCalled()
   })
 
-  test('ignores an older missing-context response after binding succeeds', async () => {
-    const defaultBoard = {
-      ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),
-      project_key: DEFAULT_WORK_ITEM_PROJECT_KEY,
-      name: '我的任务',
-    }
-    const trackedItem = loopItem(defaultBoard.id)
+  test('ignores an older missing-context response after an explicit project binding succeeds', async () => {
+    const selectedProject = project('selected-project', 'local')
+    const trackedItem = loopItem(selectedProject.id)
     const runtimeTask = {
       deviceId: 'device-1',
       taskId: 'runtime-1',
     }
     let rejectInitialLookup: ((reason: Error) => void) | undefined
     const localApi = {
-      listCloudProjects: vi.fn().mockResolvedValue({ items: [defaultBoard] }),
+      listCloudProjects: vi.fn().mockResolvedValue({ items: [selectedProject] }),
       listCloudFiles: vi.fn().mockResolvedValue({ items: [] }),
       listLoopItems: vi.fn().mockResolvedValue({ items: [] }),
       listDeliveries: vi.fn().mockResolvedValue({ items: [] }),
@@ -733,7 +733,10 @@ describe('useWorkbenchCloudProjectContext', () => {
           active: true,
           currentRuntimeTask,
           currentProjectId: 42,
-          defaultProjectSpace: null,
+          defaultProjectSpace: {
+            projectStore: selectedProject.project_store,
+            projectId: selectedProject.id,
+          },
           paneKey: 'project:42',
           runtimeTaskTitle: null,
           services,
@@ -742,7 +745,7 @@ describe('useWorkbenchCloudProjectContext', () => {
       { initialProps: { currentRuntimeTask: null } }
     )
 
-    await waitFor(() => expect(result.current.pendingCloudProject).toEqual(defaultBoard))
+    await waitFor(() => expect(result.current.pendingCloudProject).toEqual(selectedProject))
     let submission: Awaited<ReturnType<typeof result.current.prepareSubmission>> | undefined
     await act(async () => {
       submission = await result.current.prepareSubmission('完成零配置任务')
@@ -754,7 +757,7 @@ describe('useWorkbenchCloudProjectContext', () => {
     await act(async () => rejectInitialLookup?.(new Error('Cloud context not found')))
 
     expect(result.current.boundCloudItem).toEqual(trackedItem)
-    expect(result.current.boundCloudProject).toEqual(defaultBoard)
+    expect(result.current.boundCloudProject).toEqual(selectedProject)
   })
 
   test('reloads project spaces when a retained workbench becomes active again', async () => {

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
@@ -546,6 +546,50 @@ describe('useWorkbenchCloudProjectContext', () => {
     expect(localApi.trackProjectTask).not.toHaveBeenCalled()
   })
 
+  test('does not bind My Tasks from the frontend after runtime creation', async () => {
+    const defaultBoard = {
+      ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),
+      project_key: DEFAULT_WORK_ITEM_PROJECT_KEY,
+      name: '我的任务',
+    }
+    const runtimeTask = {
+      deviceId: 'device-1',
+      taskId: 'runtime-1',
+    }
+    const bindProjectTask = vi.fn()
+    const localApi = {
+      listCloudProjects: vi.fn().mockResolvedValue({ items: [defaultBoard] }),
+      listCloudFiles: vi.fn().mockResolvedValue({ items: [] }),
+      listLoopItems: vi.fn().mockResolvedValue({ items: [] }),
+      listDeliveries: vi.fn().mockResolvedValue({ items: [] }),
+      findCloudContextForTask: vi.fn().mockRejectedValue(new Error('Not bound yet')),
+      bindProjectTask,
+    }
+    const services = {
+      projectSpaceApis: {
+        local: localApi,
+        defaultLocation: 'local',
+      },
+    } as unknown as WorkbenchServices
+    const { result } = renderHook(() =>
+      useWorkbenchCloudProjectContext({
+        active: true,
+        currentRuntimeTask: runtimeTask,
+        currentProjectId: 42,
+        defaultProjectSpace: null,
+        paneKey: 'project:42',
+        runtimeTaskTitle: 'Runtime task',
+        services,
+        userId: 1,
+      })
+    )
+
+    await waitFor(() => expect(localApi.listCloudProjects).toHaveBeenCalledOnce())
+    act(() => result.current.handleSelectCloudProject(defaultBoard))
+
+    expect(bindProjectTask).not.toHaveBeenCalled()
+  })
+
   test('recovers when the first context lookup races with default-board binding', async () => {
     const defaultBoard = {
       ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
@@ -498,6 +498,9 @@ export function useWorkbenchCloudProjectContext({
     }
     const api = projectSpaceApiFor(projectToBind)
     if (!api) return
+    if (isDefaultWorkItemProject(projectToBind) && !itemToBind) {
+      return
+    }
     const bindingTaskTitle =
       runtimeTaskTitleRef.current ||
       truncateRuntimeTaskTitle(pendingBinding?.description) ||

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
@@ -768,6 +768,9 @@ export function useWorkbenchCloudProjectContext({
         setPendingCloudContext(project, null)
         return
       }
+      if (isDefaultWorkItemProject(project)) {
+        return
+      }
       const api = projectSpaceApiFor(project)
       if (!api) return
       void api


### PR DESCRIPTION
## Summary

- move automatic `我的任务` / My Tasks Issue creation and system binding from the Wework renderer to the local executor
- run the association after `runtime.tasks.create` is accepted without blocking the create response
- create the Issue and binding atomically and idempotently in SQLite, then project the executor's current runtime status through the existing single lifecycle source
- keep ephemeral tasks out of My Tasks and document the ownership boundary in Chinese and English

## Root cause

The renderer created the default Issue and binding from a post-create React effect. Background or unmounted panes and startup project lookup races could let a local runtime task start without a binding. Executor status projection then matched zero Issues, so running tasks were absent from the board. Moving creation before runtime startup fixed the race but made task creation synchronously depend on board storage. This change removes both renderer write paths from the default-project flow and makes the executor own the asynchronous association.

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test creates_and_reuses_default_work_item_binding_atomically --lib`
- `cargo test projects_runtime_status_to_bound_issue_without_renderer_writeback --lib`
- `pnpm --filter wework test src/components/layout/useWorkbenchCloudProjectContext.test.tsx src/features/workbench/WorkbenchProvider.test.tsx` (232 passed)
- `pnpm --filter wework exec tsc --noEmit`
- focused ESLint and Prettier checks
- `pnpm --filter wework e2e:desktop -- --segment task-status-sync`
  - passed on August 31, 2026
  - evidence: `wework/test-results/desktop-e2e/2026-08-31T09-57-40-963Z-17181`
  - executor log order: `runtime.tasks.create` finished in 99 ms, then `runtime task default Issue bound`, then `runtime task Issue status projected ... running ... changed=1`
- pre-push: Wework static checks/unit tests, `cargo test --all-features --lib`, and `cargo clippy` passed

Tracks Wework task WORK-292.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local tasks are now automatically associated with the default **My Tasks** project.
  * Associations are created asynchronously and safely reuse existing items without duplicates.
  * Task status is synchronized with the task’s actual lifecycle, including completed and archived states.
  * Temporary tasks remain excluded from automatic My Tasks creation.

* **Bug Fixes**
  * Prevented duplicate or conflicting default project associations between the executor and frontend.
  * Explicit project selections continue to override the default association.
  * Improved reliability when storing and retrieving task associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->