### PR TITLE
fix(wework): unify desktop startup loading

### DIFF
--- a/wework/README.md
+++ b/wework/README.md
@@ -15,15 +15,20 @@ workflows. It is built with Electron, Vite, React, and TypeScript.
 
 ## Startup Experience
 
-Wework 启动时以“人和机器人共同准备工作台”为核心语义，依次呈现整理项目、连接工具和唤醒智能体三个阶段。启动动效必须保持文案与阶段图形同步，支持深色模式和减少动态效果偏好，并避免原生窗口阴影形成额外黑色边框。Core DSH 最多等待 120 秒完成启动；超时或其他桌面运行时启动失败时必须退出准备动画，显示具体错误和重试入口。
+Wework 启动时只显示一个独立的原生准备窗口，以“人和机器人共同准备工作台”为核心语义，依次呈现整理项目、连接工具和唤醒智能体三个阶段。主窗口在此期间保持隐藏；只有当前路由所需的项目、任务和会话恢复完成，或登录页、运行时错误页已经可以操作时，Renderer 才通过 `renderer.startupReady` 请求 Electron 原子切换到实际工作台。启动超过 10 秒时继续保留同一个动画，并提示仍在加载项目和会话，不得提前显示空白 Shell 或第二套加载状态。启动动效必须保持文案与阶段图形同步，支持深色模式和减少动态效果偏好。Core DSH 最多等待 120 秒完成启动；超时或其他桌面运行时启动失败时必须退出准备动画，显示具体错误和重试入口。
 
-The Wework startup experience represents a person and a robot preparing the
-workbench together. It progresses through project organization, tool
-connection, and agent activation. Keep the copy synchronized with the visual
-stage, support dark mode and reduced motion, and avoid native window shadows
-that create an extra dark outline. Core DSH has up to 120 seconds to become
-ready. If it times out or another desktop runtime fails to start, replace the
-preparation animation with the concrete error and a retry action.
+Wework startup uses one independent native preparation window representing a
+person and a robot preparing the workbench together. It progresses through
+project organization, tool connection, and agent activation while the main
+window remains hidden. The Renderer invokes `renderer.startupReady` only after
+the projects, task, and conversation required by the active route are restored,
+or when a login or runtime-error surface is actionable; Electron then switches
+atomically to the real workbench. After 10 seconds, the same animation explains
+that projects and conversations are still loading instead of revealing a blank
+Shell or a second loading state. Keep the copy synchronized with the visual
+stage and support dark mode and reduced motion. Core DSH has up to 120 seconds
+to become ready. If it times out or another desktop runtime fails to start,
+replace the preparation animation with the concrete error and a retry action.
 
 ## Development
 

--- a/wework/e2e/desktop/scenarios/native-window-startup.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/native-window-startup.scenario.mjs
@@ -9,7 +9,7 @@ export async function createDesktopScenario({ resultDir }) {
       assert.equal(snapshot.state, 'closed', 'The Electron startup splash was not closed')
       assert.deepEqual(
         snapshot.events.map(event => event.name),
-        ['created', 'shown', 'animation-ready', 'closed'],
+        ['created', 'animation-ready', 'shown', 'closed'],
         'The Electron startup splash did not complete its animated lifecycle'
       )
       assert.ok(

--- a/wework/electron/src/host/capability-router.ts
+++ b/wework/electron/src/host/capability-router.ts
@@ -82,6 +82,7 @@ export const HOST_CAPABILITIES = [
   'plugins.start',
   'plugins.stop',
   'rendererHealth.getState',
+  'renderer.startupReady',
   'runtime.installCoreDshPlugin',
   'runtime.listCoreDshPlugins',
   'runtime.restartCoreDsh',

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -120,6 +120,7 @@ export interface ElectronE2EHost {
     executorPid: number | null
     workbenchRuntimes: unknown[]
   }
+  rendererStartupReady: () => void | Promise<void>
   startupSplashSnapshot: () => StartupSplashSnapshot | null
   trayActivate: (activation: TrayActivation) => boolean
   traySetState: (state: TrayMenuState) => void
@@ -175,6 +176,7 @@ export function createElectronCapabilityRouter(
       executorPid: null,
       workbenchRuntimes: [],
     }),
+    rendererStartupReady: () => undefined,
     startupSplashSnapshot: () => null,
     trayActivate: () => false,
     traySetState: () => undefined,
@@ -200,6 +202,7 @@ export function createElectronCapabilityRouter(
   router.register('desktop.events', params =>
     desktopServices.events.read(integerParam(params, 'after') ?? 0)
   )
+  router.register('renderer.startupReady', () => e2eHost.rendererStartupReady())
   registerAppUpdateCapabilities(router, desktopServices.appUpdates)
   router.register('attachment.begin', params =>
     attachments.begin(stringParam(params, 'filename'), requiredIntegerParam(params, 'size'))

--- a/wework/electron/src/host/startup-splash.test.ts
+++ b/wework/electron/src/host/startup-splash.test.ts
@@ -11,14 +11,18 @@ import {
 } from './startup-splash.js'
 
 class FakeSplashWindow implements StartupSplashWindow {
-  private readonly listeners = new Map<string, () => void>()
+  private readonly closeListeners: Array<(event: { preventDefault: () => void }) => void> = []
+  private readonly closedListeners: Array<() => void> = []
   private destroyed = false
   private visible = false
 
   readonly close = vi.fn(() => {
+    const event = { preventDefault: vi.fn() }
+    this.closeListeners.forEach(listener => listener(event))
+    if (event.preventDefault.mock.calls.length > 0) return
     this.destroyed = true
     this.visible = false
-    this.listeners.get('closed')?.()
+    this.closedListeners.forEach(listener => listener())
   })
   readonly isDestroyed = vi.fn(() => this.destroyed)
   readonly isVisible = vi.fn(() => this.visible)
@@ -33,8 +37,22 @@ class FakeSplashWindow implements StartupSplashWindow {
     isDestroyed: vi.fn(() => false),
   }
 
+  on(event: 'close', listener: (event: { preventDefault: () => void }) => void): void {
+    if (event === 'close') this.closeListeners.push(listener)
+  }
+
   once(event: 'closed', listener: () => void): void {
-    this.listeners.set(event, listener)
+    if (event === 'closed') this.closedListeners.push(listener)
+  }
+
+  requestNativeClose(): boolean {
+    const event = { preventDefault: vi.fn() }
+    this.closeListeners.forEach(listener => listener(event))
+    if (event.preventDefault.mock.calls.length > 0) return false
+    this.destroyed = true
+    this.visible = false
+    this.closedListeners.forEach(listener => listener())
+    return true
   }
 }
 
@@ -170,6 +188,21 @@ describe('StartupSplash', () => {
       destroyed: true,
       visible: false,
     })
+  })
+
+  test('prevents native close requests until renderer startup readiness closes it', async () => {
+    const { show, splash, target } = createFixture()
+    await show()
+
+    expect(target.requestNativeClose()).toBe(false)
+    expect(splash.snapshot().state).toBe('visible')
+    expect(target.isDestroyed()).toBe(false)
+
+    await splash.close()
+
+    expect(target.close).toHaveBeenCalledOnce()
+    expect(splash.snapshot().state).toBe('closed')
+    expect(target.isDestroyed()).toBe(true)
   })
 
   test('captures and persists the rendered splash before closing when requested by E2E', async () => {

--- a/wework/electron/src/host/startup-splash.test.ts
+++ b/wework/electron/src/host/startup-splash.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, test, vi } from 'vitest'
 import {
   createStartupSplash,
   resolveStartupSplashTheme,
+  startupSplashBlocksMainWindowActivation,
+  type StartupSplashSnapshot,
   type StartupSplashTheme,
   type StartupSplashWindow,
 } from './startup-splash.js'
@@ -13,6 +15,11 @@ class FakeSplashWindow implements StartupSplashWindow {
   private destroyed = false
   private visible = false
 
+  readonly close = vi.fn(() => {
+    this.destroyed = true
+    this.visible = false
+    this.listeners.get('closed')?.()
+  })
   readonly isDestroyed = vi.fn(() => this.destroyed)
   readonly isVisible = vi.fn(() => this.visible)
   readonly show = vi.fn(() => {
@@ -26,12 +33,8 @@ class FakeSplashWindow implements StartupSplashWindow {
     isDestroyed: vi.fn(() => false),
   }
 
-  once(event: 'closed' | 'ready-to-show', listener: () => void): void {
+  once(event: 'closed', listener: () => void): void {
     this.listeners.set(event, listener)
-  }
-
-  ready(): void {
-    this.listeners.get('ready-to-show')?.()
   }
 }
 
@@ -45,11 +48,7 @@ function createFixture(theme: StartupSplashTheme = 'light') {
     now: () => timestamp++,
     writePng,
   })
-  const show = async () => {
-    const shown = splash.show()
-    target.ready()
-    return shown
-  }
+  const show = () => splash.show()
   return { show, splash, target, writePng }
 }
 
@@ -57,17 +56,18 @@ describe('StartupSplash', () => {
   test('ships a visible loading animation that reports readiness after two frames', async () => {
     const electronRoot =
       basename(process.cwd()) === 'electron' ? process.cwd() : join(process.cwd(), 'electron')
-    const shellAsset = (name: string) => readFile(join(electronRoot, 'src', 'shell', name), 'utf8')
     const splashAsset = (name: string) =>
       readFile(join(electronRoot, 'src', 'shell', 'startup-splash', name), 'utf8')
 
     const [html, styles, script] = await Promise.all([
-      shellAsset('index.html'),
+      splashAsset('index.html'),
       splashAsset('styles.css'),
       splashAsset('splash.js'),
     ])
 
     expect(html).toContain('class="workbench-scene"')
+    expect(html).toContain('class="ambient-workflow"')
+    expect(html).toContain('stage-corner-top-left')
     expect(html).toContain('id="morph-primary"')
     expect(html).toContain('class="stage-indicator"')
     expect(html).toContain('class="robot"')
@@ -77,6 +77,8 @@ describe('StartupSplash', () => {
     expect(html).toContain('aria-valuemax="3"')
     expect(styles).toContain('@keyframes robot-bob')
     expect(styles).toContain('@keyframes human-bob')
+    expect(styles).toContain('@keyframes splash-enter')
+    expect(styles).toContain('@keyframes ambient-line-arrive')
     expect(html).toContain('document.documentElement.dataset.theme = theme')
     expect(styles).toContain(":root[data-theme='dark']")
     expect(styles).toContain('@media (prefers-reduced-motion: reduce)')
@@ -84,6 +86,9 @@ describe('StartupSplash', () => {
     expect(script).toContain('requestAnimationFrame(animateMorph)')
     expect(script).toContain("navigator.language.toLowerCase().startsWith('zh')")
     expect(script).toContain("stageIndicator.setAttribute('aria-valuenow'")
+    expect(script).toContain('启动时间比预期稍长')
+    expect(script).toContain('仍在加载项目和会话，请稍候…')
+    expect(script).toContain('}, 10_000)')
     expect(script).toMatch(
       /requestAnimationFrame\(\(\) => \{\s+requestAnimationFrame\(\(\) => \{\s+document\.documentElement\.dataset\.animationReady = 'true'/
     )
@@ -103,8 +108,8 @@ describe('StartupSplash', () => {
       theme: 'light',
       events: [
         { name: 'created', timestamp: 100 },
-        { name: 'shown', timestamp: 101 },
-        { name: 'animation-ready', timestamp: 102 },
+        { name: 'animation-ready', timestamp: 101 },
+        { name: 'shown', timestamp: 102 },
       ],
       window: {
         exists: true,
@@ -130,6 +135,25 @@ describe('StartupSplash', () => {
     expect(resolveStartupSplashTheme(undefined, true)).toBe('dark')
   })
 
+  test('blocks main-window activation until the startup splash closes', () => {
+    const snapshot = (state: StartupSplashSnapshot['state']): StartupSplashSnapshot => ({
+      state,
+      theme: 'light',
+      events: [],
+      window: {
+        exists: true,
+        destroyed: state === 'closed',
+        visible: state === 'visible',
+      },
+    })
+
+    expect(startupSplashBlocksMainWindowActivation(null)).toBe(false)
+    expect(startupSplashBlocksMainWindowActivation(snapshot('idle'))).toBe(true)
+    expect(startupSplashBlocksMainWindowActivation(snapshot('loading'))).toBe(true)
+    expect(startupSplashBlocksMainWindowActivation(snapshot('visible'))).toBe(true)
+    expect(startupSplashBlocksMainWindowActivation(snapshot('closed'))).toBe(false)
+  })
+
   test('does not capture or write files during a production close', async () => {
     const { show, splash, target, writePng } = createFixture()
     await show()
@@ -138,12 +162,13 @@ describe('StartupSplash', () => {
 
     expect(target.webContents.capturePage).not.toHaveBeenCalled()
     expect(writePng).not.toHaveBeenCalled()
+    expect(target.close).toHaveBeenCalledOnce()
     expect(snapshot.state).toBe('closed')
     expect(snapshot.events.at(-1)).toEqual({ name: 'closed', timestamp: 103 })
     expect(snapshot.window).toEqual({
       exists: true,
-      destroyed: false,
-      visible: true,
+      destroyed: true,
+      visible: false,
     })
   })
 
@@ -160,6 +185,7 @@ describe('StartupSplash', () => {
       Buffer.from('splash-png')
     )
     expect(writePng).toHaveBeenCalledOnce()
+    expect(target.close).toHaveBeenCalledOnce()
   })
 
   test('shares one close operation across concurrent callers', async () => {
@@ -191,7 +217,6 @@ describe('StartupSplash', () => {
 
     const firstPromise = splash.show()
     const secondPromise = splash.show()
-    target.ready()
     const [first, second] = await Promise.all([firstPromise, secondPromise])
 
     expect(target.show).toHaveBeenCalledOnce()

--- a/wework/electron/src/host/startup-splash.ts
+++ b/wework/electron/src/host/startup-splash.ts
@@ -31,9 +31,10 @@ interface SplashWebContents {
 }
 
 export interface StartupSplashWindow {
+  close: () => void
   isDestroyed: () => boolean
   isVisible: () => boolean
-  once: (event: 'closed' | 'ready-to-show', listener: () => void) => void
+  once: (event: 'closed', listener: () => void) => void
   show: () => void
   webContents: SplashWebContents
 }
@@ -68,6 +69,12 @@ export function resolveStartupSplashTheme(
 ): StartupSplashTheme {
   if (appearanceMode === 'light' || appearanceMode === 'dark') return appearanceMode
   return systemUsesDarkColors ? 'dark' : 'light'
+}
+
+export function startupSplashBlocksMainWindowActivation(
+  snapshot: StartupSplashSnapshot | null
+): boolean {
+  return snapshot !== null && snapshot.state !== 'closed'
 }
 
 async function writePng(path: string, bytes: Buffer): Promise<void> {
@@ -123,6 +130,7 @@ export class StartupSplash {
         await this.persistPng(options.capturePath, image.toPNG())
       }
     } finally {
+      if (!target.isDestroyed()) target.close()
       this.markClosed()
     }
 
@@ -147,23 +155,16 @@ export class StartupSplash {
   private async createAndShow(): Promise<StartupSplashSnapshot> {
     this.state = 'loading'
     const target = this.options.window
-
-    const shown = new Promise<void>(resolve => {
-      target.once('ready-to-show', () => {
-        if (!target.isDestroyed()) {
-          target.show()
-          this.state = 'visible'
-          this.record('shown')
-        }
-        resolve()
-      })
-    })
     target.once('closed', () => this.markClosed())
 
-    await shown
     if (!target.webContents.isDestroyed()) {
       await target.webContents.executeJavaScript(WAIT_FOR_ANIMATION_READY)
       this.record('animation-ready')
+    }
+    if (!target.isDestroyed()) {
+      target.show()
+      this.state = 'visible'
+      this.record('shown')
     }
     return this.snapshot()
   }

--- a/wework/electron/src/host/startup-splash.ts
+++ b/wework/electron/src/host/startup-splash.ts
@@ -34,9 +34,14 @@ export interface StartupSplashWindow {
   close: () => void
   isDestroyed: () => boolean
   isVisible: () => boolean
+  on: (event: 'close', listener: (event: StartupSplashCloseEvent) => void) => void
   once: (event: 'closed', listener: () => void) => void
   show: () => void
   webContents: SplashWebContents
+}
+
+export interface StartupSplashCloseEvent {
+  preventDefault: () => void
 }
 
 export interface StartupSplashOptions {
@@ -89,10 +94,14 @@ export class StartupSplash {
   private state: StartupSplashSnapshot['state'] = 'idle'
   private showPromise: Promise<StartupSplashSnapshot> | null = null
   private closePromise: Promise<StartupSplashSnapshot> | null = null
+  private controlledClose = false
 
   constructor(private readonly options: StartupSplashOptions) {
     this.now = options.now ?? Date.now
     this.persistPng = options.writePng ?? writePng
+    options.window.on('close', event => {
+      if (!this.controlledClose) event.preventDefault()
+    })
     this.record('created')
   }
 
@@ -130,7 +139,10 @@ export class StartupSplash {
         await this.persistPng(options.capturePath, image.toPNG())
       }
     } finally {
-      if (!target.isDestroyed()) target.close()
+      if (!target.isDestroyed()) {
+        this.controlledClose = true
+        target.close()
+      }
       this.markClosed()
     }
 

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -56,6 +56,7 @@ import { WorkbenchPluginManager } from './host/workbench-plugin-manager.js'
 import {
   resolveStartupSplashTheme,
   StartupSplash,
+  startupSplashBlocksMainWindowActivation,
   type StartupSplashTheme,
 } from './host/startup-splash.js'
 import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
@@ -117,6 +118,7 @@ app.setPath('userData', userDataPath)
 if (configuredUserDataPath) app.setAppLogsPath(join(userDataPath, 'logs'))
 
 let mainWindow: BrowserWindow | null = null
+let startupSplashWindow: BrowserWindow | null = null
 const workspaceWindows = new Map<string, BrowserWindow>()
 const dshWindowLabels = new Map<number, string>()
 let primaryDshLoaded = false
@@ -187,8 +189,18 @@ if (keepE2EWindowInBackground) {
 
 if (!hasSingleInstanceLock) app.quit()
 
+function focusStartupSplashIfActive(): boolean {
+  const snapshot = startupSplash?.snapshot()
+  if (!startupSplashBlocksMainWindowActivation(snapshot ?? null)) return false
+
+  const target = startupSplashWindow
+  if (target && !target.isDestroyed() && target.isVisible()) target.focus()
+  return true
+}
+
 app.on('second-instance', () => {
   if (keepE2EWindowInBackground) return
+  if (focusStartupSplashIfActive()) return
   if (!mainWindow) return
   if (mainWindow.isMinimized()) mainWindow.restore()
   mainWindow.show()
@@ -385,7 +397,6 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
     primaryDshLoaded = true
     runtimeError = null
     rendererHealth.ready()
-    mainWindow?.show()
   })
   contents.on('unresponsive', () => rendererHealth.unresponsive())
   contents.on('responsive', () => rendererHealth.responsive())
@@ -403,9 +414,6 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
     })
   })
   try {
-    await startupSplash?.close({
-      capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim(),
-    })
     await contents.loadURL(dshUrl, {
       extraHeaders: 'X-Wework-Window-Label: main',
     })
@@ -717,32 +725,45 @@ async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
       webviewTag: true,
     },
   })
+  startupSplashWindow = new BrowserWindow({
+    ...desktopWindowFrameOptions(),
+    width: 1440,
+    height: 960,
+    title: 'Wework',
+    backgroundColor: startupTheme === 'dark' ? '#101316' : '#fafafa',
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+    },
+  })
   startupSplash = new StartupSplash({
     window: {
-      isDestroyed: () => mainWindow?.isDestroyed() ?? true,
-      isVisible: () => mainWindow?.isVisible() ?? false,
-      once: (event, listener) => {
-        if (event === 'closed') mainWindow?.once('closed', listener)
-        else mainWindow?.once('ready-to-show', listener)
-      },
+      close: () => startupSplashWindow?.close(),
+      isDestroyed: () => startupSplashWindow?.isDestroyed() ?? true,
+      isVisible: () => startupSplashWindow?.isVisible() ?? false,
+      once: (_event, listener) => startupSplashWindow?.once('closed', listener),
       show: () => {
-        if (!keepE2EWindowInBackground) mainWindow?.show()
+        if (!keepE2EWindowInBackground) startupSplashWindow?.show()
       },
       webContents: {
         capturePage: async () => {
-          if (!mainWindow) throw new Error('Main window is unavailable')
-          return mainWindow.webContents.capturePage()
+          if (!startupSplashWindow) throw new Error('Startup splash window is unavailable')
+          return startupSplashWindow.webContents.capturePage()
         },
         executeJavaScript: async code => {
-          if (!mainWindow) throw new Error('Main window is unavailable')
-          return mainWindow.webContents.executeJavaScript(code)
+          if (!startupSplashWindow) throw new Error('Startup splash window is unavailable')
+          return startupSplashWindow.webContents.executeJavaScript(code)
         },
-        isDestroyed: () => mainWindow?.webContents.isDestroyed() ?? true,
+        isDestroyed: () => startupSplashWindow?.webContents.isDestroyed() ?? true,
       },
     },
     theme: startupTheme,
   })
-  const startupShown = startupSplash.show()
+  startupSplashWindow.on('closed', () => {
+    startupSplashWindow = null
+  })
   mainWindow.on('resize', layoutPrimaryView)
   mainWindow.on('close', event => {
     if (quitting) return
@@ -754,10 +775,14 @@ async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
     primaryDshSecurityInstalled = false
     mainWindow = null
   })
-  await mainWindow.loadFile(resolve(packageRoot, 'dist/shell/index.html'), {
+  const mainShellLoading = mainWindow.loadFile(resolve(packageRoot, 'dist/shell/index.html'), {
     query: { theme: startupTheme },
   })
-  await startupShown
+  await startupSplashWindow.loadFile(resolve(packageRoot, 'dist/shell/startup-splash/index.html'), {
+    query: { theme: startupTheme },
+  })
+  await startupSplash.show()
+  await mainShellLoading
 }
 
 async function setDockVisible(visible: boolean): Promise<void> {
@@ -823,6 +848,7 @@ async function cancelMainWindowClose(): Promise<void> {
 }
 
 async function reactivateMainWindow(): Promise<void> {
+  if (focusStartupSplashIfActive()) return
   const target = mainWindow
   if (!target || target.isDestroyed()) return
   if (keepE2EWindowInBackground) {
@@ -1106,6 +1132,13 @@ async function configureDesktopRuntime(): Promise<void> {
           },
           hideMainWindow: hideMainWindowToBackground,
           dockVisible: () => dockVisible,
+          rendererStartupReady: async () => {
+            if (!mainWindow || mainWindow.isDestroyed()) return
+            if (!keepE2EWindowInBackground) mainWindow.show()
+            await startupSplash?.close({
+              capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim(),
+            })
+          },
           startupSplashSnapshot: () => startupSplash?.snapshot() ?? null,
           trayActivate: activation => trayManager?.activate(activation) ?? false,
           traySetState: state => {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -743,6 +743,7 @@ async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
       close: () => startupSplashWindow?.close(),
       isDestroyed: () => startupSplashWindow?.isDestroyed() ?? true,
       isVisible: () => startupSplashWindow?.isVisible() ?? false,
+      on: (_event, listener) => startupSplashWindow?.on('close', listener),
       once: (_event, listener) => startupSplashWindow?.once('closed', listener),
       show: () => {
         if (!keepE2EWindowInBackground) startupSplashWindow?.show()

--- a/wework/electron/src/shell/index.html
+++ b/wework/electron/src/shell/index.html
@@ -10,116 +10,9 @@
       document.documentElement.dataset.theme = theme === 'dark' ? 'dark' : 'light'
     </script>
     <link rel="stylesheet" href="./styles.css" />
-    <link rel="stylesheet" href="./startup-splash/styles.css" />
   </head>
   <body>
     <main id="runtime-overlay" data-phase="initializing">
-      <section id="splash-root" class="splash" aria-label="Wework is starting">
-        <div class="workbench-scene" aria-hidden="true">
-          <svg class="workbench" viewBox="0 0 300 126">
-            <path class="floor-line" d="M17 108h266" />
-
-            <g transform="translate(27 18)">
-              <g class="robot">
-                <g class="robot-antenna">
-                  <path d="M35 7V1" />
-                  <circle class="robot-antenna-tip" cx="35" cy="0" r="3" />
-                </g>
-                <g class="robot-head">
-                  <rect x="5" y="7" width="60" height="40" rx="14" />
-                  <path class="robot-ear" d="M5 21H1v13h4M65 21h4v13h-4" />
-                  <g class="robot-eyes">
-                    <rect x="19" y="23" width="8" height="5" rx="2.5" />
-                    <rect x="43" y="23" width="8" height="5" rx="2.5" />
-                  </g>
-                  <path class="robot-smile" d="M29 36h12" />
-                </g>
-
-                <g class="robot-body">
-                  <rect x="14" y="50" width="42" height="38" rx="12" />
-                  <circle cx="35" cy="63" r="7" />
-                  <path d="M29 77h12" />
-                </g>
-
-                <path class="robot-arm robot-arm-back" d="M15 57C3 59 1 72 9 78" />
-                <g class="robot-working-arm">
-                  <path class="robot-arm" d="M55 57c13 0 17-8 24-14" />
-                  <circle class="robot-hand" cx="80" cy="42" r="5" />
-                </g>
-                <path class="robot-leg" d="M25 87v13M46 87v13M19 101h12M40 101h12" />
-              </g>
-            </g>
-
-            <g class="toolbox">
-              <rect x="108" y="70" width="32" height="28" rx="8" />
-              <path d="M117 70v-6h14v6M114 82h20" />
-            </g>
-
-            <g class="monitor">
-              <rect class="monitor-shell" x="139" y="18" width="105" height="68" rx="14" />
-              <rect class="monitor-screen" x="147" y="26" width="89" height="52" rx="9" />
-              <path class="monitor-stand" d="M192 86v9M173 96h38" />
-              <g class="morph-icon" transform="translate(171 27) scale(2)">
-                <path id="morph-primary" />
-                <path id="morph-secondary" />
-                <path id="morph-tertiary" />
-              </g>
-              <circle class="monitor-status" cx="229" cy="71" r="2" />
-            </g>
-
-            <g class="keyboard">
-              <rect x="157" y="99" width="72" height="10" rx="5" />
-              <path d="M168 104h50" />
-            </g>
-
-            <g class="human">
-              <circle class="human-head" cx="270" cy="34" r="15" />
-              <path class="human-hair" d="M256 34c1-10 6-15 14-15 9 0 14 6 15 15" />
-              <g class="human-face">
-                <circle cx="265" cy="34" r="1.5" />
-                <circle cx="275" cy="34" r="1.5" />
-                <path d="M266 41h8" />
-              </g>
-              <path class="human-body" d="M248 108V82c0-18 9-29 22-29s22 11 22 29v26" />
-              <g class="human-working-arm">
-                <path class="human-arm" d="M256 68c-8 7-10 22-25 29" />
-                <circle class="human-hand" cx="228" cy="99" r="5" />
-              </g>
-            </g>
-
-            <g class="robot-sparks">
-              <path d="m113 48 5-3M114 55h6M110 42v-5" />
-              <circle cx="121" cy="40" r="2" />
-            </g>
-
-            <g class="assembly-piece assembly-piece-one">
-              <rect x="121" y="39" width="12" height="12" rx="3" />
-              <path d="M125 45h4" />
-            </g>
-            <g class="assembly-piece assembly-piece-two">
-              <circle cx="127" cy="45" r="6" />
-              <path d="m124 45 2 2 4-5" />
-            </g>
-          </svg>
-        </div>
-        <div class="splash-copy">
-          <h1 id="splash-title">We're preparing your workbench</h1>
-          <p id="splash-status" aria-live="polite">Opening your projects</p>
-        </div>
-        <div
-          id="stage-indicator"
-          class="stage-indicator"
-          role="progressbar"
-          aria-label="Preparing your workbench"
-          aria-valuemin="1"
-          aria-valuemax="3"
-          aria-valuenow="1"
-        >
-          <span class="stage-dot is-active"></span>
-          <span class="stage-dot"></span>
-          <span class="stage-dot"></span>
-        </div>
-      </section>
       <section class="runtime-card" aria-live="polite" hidden>
         <h1>正在启动 Wework</h1>
         <p id="runtime-status">正在初始化 Core DSH…</p>
@@ -127,7 +20,6 @@
         <button id="reload-dsh" type="button" hidden>重试启动</button>
       </section>
     </main>
-    <script src="./startup-splash/splash.js"></script>
     <script src="./shell.js"></script>
   </body>
 </html>

--- a/wework/electron/src/shell/shell.js
+++ b/wework/electron/src/shell/shell.js
@@ -3,7 +3,6 @@ const details = document.querySelector('#details')
 const reloadButton = document.querySelector('#reload-dsh')
 const overlay = document.querySelector('#runtime-overlay')
 const runtimeCard = document.querySelector('.runtime-card')
-const splash = document.querySelector('#splash-root')
 
 async function refreshState() {
   try {
@@ -11,7 +10,6 @@ async function refreshState() {
     overlay.dataset.phase = state.phase
     const failed = state.phase === 'failed'
     runtimeCard.hidden = !failed
-    splash.hidden = failed
     status.textContent = state.ready
       ? '运行时已就绪'
       : state.phase === 'failed'
@@ -25,7 +23,6 @@ async function refreshState() {
   } catch (error) {
     overlay.dataset.phase = 'failed'
     runtimeCard.hidden = false
-    splash.hidden = true
     status.textContent = `无法读取运行时状态：${error instanceof Error ? error.message : String(error)}`
     details.hidden = false
     details.textContent = error instanceof Error ? error.stack || error.message : String(error)

--- a/wework/electron/src/shell/shell.test.ts
+++ b/wework/electron/src/shell/shell.test.ts
@@ -6,23 +6,18 @@ import { describe, expect, test, vi } from 'vitest'
 describe('Electron startup shell', () => {
   test('renders initialization and failure states and retries the runtime', async () => {
     const elements = new Map(
-      [
-        '#runtime-status',
-        '#details',
-        '#reload-dsh',
-        '#runtime-overlay',
-        '.runtime-card',
-        '#splash-root',
-      ].map(selector => [
-        selector,
-        {
-          dataset: {} as Record<string, string>,
-          disabled: false,
-          hidden: false,
-          textContent: '',
-          addEventListener: vi.fn(),
-        },
-      ])
+      ['#runtime-status', '#details', '#reload-dsh', '#runtime-overlay', '.runtime-card'].map(
+        selector => [
+          selector,
+          {
+            dataset: {} as Record<string, string>,
+            disabled: false,
+            hidden: false,
+            textContent: '',
+            addEventListener: vi.fn(),
+          },
+        ]
+      )
     )
     const state = {
       phase: 'initializing',
@@ -51,7 +46,6 @@ describe('Electron startup shell', () => {
       expect(elements.get('#runtime-overlay')?.dataset.phase).toBe('initializing')
       expect(elements.get('#reload-dsh')?.hidden).toBe(true)
       expect(elements.get('.runtime-card')?.hidden).toBe(true)
-      expect(elements.get('#splash-root')?.hidden).toBe(false)
     })
 
     state.phase = 'failed'
@@ -66,7 +60,6 @@ describe('Electron startup shell', () => {
       expect(elements.get('#details')?.hidden).toBe(false)
       expect(elements.get('#reload-dsh')?.hidden).toBe(false)
       expect(elements.get('.runtime-card')?.hidden).toBe(false)
-      expect(elements.get('#splash-root')?.hidden).toBe(true)
     })
 
     const clickHandler = vi.mocked(elements.get('#reload-dsh')?.addEventListener).mock

--- a/wework/electron/src/shell/startup-splash/index.html
+++ b/wework/electron/src/shell/startup-splash/index.html
@@ -12,112 +12,131 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <main id="splash-root" class="splash" aria-label="Wework is starting">
-      <div class="workbench-scene" aria-hidden="true">
-        <svg class="workbench" viewBox="0 0 300 126">
-          <path class="floor-line" d="M17 108h266" />
+    <div class="startup-stage">
+      <svg class="ambient-workflow" viewBox="0 0 760 520" aria-hidden="true">
+        <path class="ambient-path ambient-path-primary" d="M56 164h112c30 0 44-18 44-46V72" />
+        <path class="ambient-path ambient-path-secondary" d="M704 356H592c-30 0-44 18-44 46v46" />
+        <path class="ambient-path ambient-path-tertiary" d="M104 400h74c24 0 36 12 36 36v26" />
+        <path class="ambient-path ambient-path-tertiary" d="M656 120h-74c-24 0-36-12-36-36V58" />
+        <circle class="ambient-node ambient-node-one" cx="56" cy="164" r="4" />
+        <circle class="ambient-node ambient-node-two" cx="704" cy="356" r="4" />
+        <circle class="ambient-node ambient-node-three" cx="104" cy="400" r="3" />
+        <circle class="ambient-node ambient-node-four" cx="656" cy="120" r="3" />
+        <circle class="ambient-node ambient-node-accent" cx="212" cy="88" r="3" />
+        <circle class="ambient-node ambient-node-accent" cx="548" cy="432" r="3" />
+      </svg>
+      <span class="stage-corner stage-corner-top-left" aria-hidden="true"></span>
+      <span class="stage-corner stage-corner-top-right" aria-hidden="true"></span>
+      <span class="stage-corner stage-corner-bottom-left" aria-hidden="true"></span>
+      <span class="stage-corner stage-corner-bottom-right" aria-hidden="true"></span>
 
-          <g transform="translate(27 18)">
-            <g class="robot">
-              <g class="robot-antenna">
-                <path d="M35 7V1" />
-                <circle class="robot-antenna-tip" cx="35" cy="0" r="3" />
-              </g>
-              <g class="robot-head">
-                <rect x="5" y="7" width="60" height="40" rx="14" />
-                <path class="robot-ear" d="M5 21H1v13h4M65 21h4v13h-4" />
-                <g class="robot-eyes">
-                  <rect x="19" y="23" width="8" height="5" rx="2.5" />
-                  <rect x="43" y="23" width="8" height="5" rx="2.5" />
+      <main id="splash-root" class="splash" aria-label="Wework is starting">
+        <div class="workbench-scene" aria-hidden="true">
+          <svg class="workbench" viewBox="0 0 300 126">
+            <path class="floor-line" d="M17 108h266" />
+
+            <g transform="translate(27 18)">
+              <g class="robot">
+                <g class="robot-antenna">
+                  <path d="M35 7V1" />
+                  <circle class="robot-antenna-tip" cx="35" cy="0" r="3" />
                 </g>
-                <path class="robot-smile" d="M29 36h12" />
+                <g class="robot-head">
+                  <rect x="5" y="7" width="60" height="40" rx="14" />
+                  <path class="robot-ear" d="M5 21H1v13h4M65 21h4v13h-4" />
+                  <g class="robot-eyes">
+                    <rect x="19" y="23" width="8" height="5" rx="2.5" />
+                    <rect x="43" y="23" width="8" height="5" rx="2.5" />
+                  </g>
+                  <path class="robot-smile" d="M29 36h12" />
+                </g>
+
+                <g class="robot-body">
+                  <rect x="14" y="50" width="42" height="38" rx="12" />
+                  <circle cx="35" cy="63" r="7" />
+                  <path d="M29 77h12" />
+                </g>
+
+                <path class="robot-arm robot-arm-back" d="M15 57C3 59 1 72 9 78" />
+                <g class="robot-working-arm">
+                  <path class="robot-arm" d="M55 57c13 0 17-8 24-14" />
+                  <circle class="robot-hand" cx="80" cy="42" r="5" />
+                </g>
+                <path class="robot-leg" d="M25 87v13M46 87v13M19 101h12M40 101h12" />
               </g>
+            </g>
 
-              <g class="robot-body">
-                <rect x="14" y="50" width="42" height="38" rx="12" />
-                <circle cx="35" cy="63" r="7" />
-                <path d="M29 77h12" />
+            <g class="toolbox">
+              <rect x="108" y="70" width="32" height="28" rx="8" />
+              <path d="M117 70v-6h14v6M114 82h20" />
+            </g>
+
+            <g class="monitor">
+              <rect class="monitor-shell" x="139" y="18" width="105" height="68" rx="14" />
+              <rect class="monitor-screen" x="147" y="26" width="89" height="52" rx="9" />
+              <path class="monitor-stand" d="M192 86v9M173 96h38" />
+              <g class="morph-icon" transform="translate(171 27) scale(2)">
+                <path id="morph-primary" />
+                <path id="morph-secondary" />
+                <path id="morph-tertiary" />
               </g>
+              <circle class="monitor-status" cx="229" cy="71" r="2" />
+            </g>
 
-              <path class="robot-arm robot-arm-back" d="M15 57C3 59 1 72 9 78" />
-              <g class="robot-working-arm">
-                <path class="robot-arm" d="M55 57c13 0 17-8 24-14" />
-                <circle class="robot-hand" cx="80" cy="42" r="5" />
+            <g class="keyboard">
+              <rect x="157" y="99" width="72" height="10" rx="5" />
+              <path d="M168 104h50" />
+            </g>
+
+            <g class="human">
+              <circle class="human-head" cx="270" cy="34" r="15" />
+              <path class="human-hair" d="M256 34c1-10 6-15 14-15 9 0 14 6 15 15" />
+              <g class="human-face">
+                <circle cx="265" cy="34" r="1.5" />
+                <circle cx="275" cy="34" r="1.5" />
+                <path d="M266 41h8" />
               </g>
-              <path class="robot-leg" d="M25 87v13M46 87v13M19 101h12M40 101h12" />
+              <path class="human-body" d="M248 108V82c0-18 9-29 22-29s22 11 22 29v26" />
+              <g class="human-working-arm">
+                <path class="human-arm" d="M256 68c-8 7-10 22-25 29" />
+                <circle class="human-hand" cx="228" cy="99" r="5" />
+              </g>
             </g>
-          </g>
 
-          <g class="toolbox">
-            <rect x="108" y="70" width="32" height="28" rx="8" />
-            <path d="M117 70v-6h14v6M114 82h20" />
-          </g>
-
-          <g class="monitor">
-            <rect class="monitor-shell" x="139" y="18" width="105" height="68" rx="14" />
-            <rect class="monitor-screen" x="147" y="26" width="89" height="52" rx="9" />
-            <path class="monitor-stand" d="M192 86v9M173 96h38" />
-            <g class="morph-icon" transform="translate(171 27) scale(2)">
-              <path id="morph-primary" />
-              <path id="morph-secondary" />
-              <path id="morph-tertiary" />
+            <g class="robot-sparks">
+              <path d="m113 48 5-3M114 55h6M110 42v-5" />
+              <circle cx="121" cy="40" r="2" />
             </g>
-            <circle class="monitor-status" cx="229" cy="71" r="2" />
-          </g>
 
-          <g class="keyboard">
-            <rect x="157" y="99" width="72" height="10" rx="5" />
-            <path d="M168 104h50" />
-          </g>
-
-          <g class="human">
-            <circle class="human-head" cx="270" cy="34" r="15" />
-            <path class="human-hair" d="M256 34c1-10 6-15 14-15 9 0 14 6 15 15" />
-            <g class="human-face">
-              <circle cx="265" cy="34" r="1.5" />
-              <circle cx="275" cy="34" r="1.5" />
-              <path d="M266 41h8" />
+            <g class="assembly-piece assembly-piece-one">
+              <rect x="121" y="39" width="12" height="12" rx="3" />
+              <path d="M125 45h4" />
             </g>
-            <path class="human-body" d="M248 108V82c0-18 9-29 22-29s22 11 22 29v26" />
-            <g class="human-working-arm">
-              <path class="human-arm" d="M256 68c-8 7-10 22-25 29" />
-              <circle class="human-hand" cx="228" cy="99" r="5" />
+            <g class="assembly-piece assembly-piece-two">
+              <circle cx="127" cy="45" r="6" />
+              <path d="m124 45 2 2 4-5" />
             </g>
-          </g>
-
-          <g class="robot-sparks">
-            <path d="m113 48 5-3M114 55h6M110 42v-5" />
-            <circle cx="121" cy="40" r="2" />
-          </g>
-
-          <g class="assembly-piece assembly-piece-one">
-            <rect x="121" y="39" width="12" height="12" rx="3" />
-            <path d="M125 45h4" />
-          </g>
-          <g class="assembly-piece assembly-piece-two">
-            <circle cx="127" cy="45" r="6" />
-            <path d="m124 45 2 2 4-5" />
-          </g>
-        </svg>
-      </div>
-      <div class="splash-copy">
-        <h1 id="splash-title">We're preparing your workbench</h1>
-        <p id="splash-status" aria-live="polite">Opening your projects</p>
-      </div>
-      <div
-        id="stage-indicator"
-        class="stage-indicator"
-        role="progressbar"
-        aria-label="Preparing your workbench"
-        aria-valuemin="1"
-        aria-valuemax="3"
-        aria-valuenow="1"
-      >
-        <span class="stage-dot is-active"></span>
-        <span class="stage-dot"></span>
-        <span class="stage-dot"></span>
-      </div>
-    </main>
+          </svg>
+        </div>
+        <div class="splash-copy">
+          <h1 id="splash-title">We're preparing your workbench</h1>
+          <p id="splash-status" aria-live="polite">Opening your projects</p>
+        </div>
+        <div
+          id="stage-indicator"
+          class="stage-indicator"
+          role="progressbar"
+          aria-label="Preparing your workbench"
+          aria-valuemin="1"
+          aria-valuemax="3"
+          aria-valuenow="1"
+        >
+          <span class="stage-dot is-active"></span>
+          <span class="stage-dot"></span>
+          <span class="stage-dot"></span>
+        </div>
+      </main>
+    </div>
     <script src="./splash.js"></script>
   </body>
 </html>

--- a/wework/electron/src/shell/startup-splash/splash.js
+++ b/wework/electron/src/shell/startup-splash/splash.js
@@ -44,6 +44,7 @@ const currentPaths = stages[0].paths.map(path => [...path])
 const velocities = stages[0].paths.map(path => path.map(() => 0))
 let stageIndex = prefersReducedMotion ? stages.length - 1 : 0
 let previousTime = performance.now()
+let slowStartup = false
 
 function pathData(points) {
   let data = `M${points[0]} ${points[1]}`
@@ -63,7 +64,13 @@ function updateCopy(index, animate) {
   const stage = stages[index]
   document.documentElement.lang = isChinese ? 'zh-CN' : 'en'
   document.body.dataset.stage = String(index)
-  titleElement.textContent = isChinese ? '我们正在准备工作台' : "We're preparing your workbench"
+  titleElement.textContent = slowStartup
+    ? isChinese
+      ? '启动时间比预期稍长'
+      : 'Startup is taking longer than expected'
+    : isChinese
+      ? '我们正在准备工作台'
+      : "We're preparing your workbench"
   splashRoot.setAttribute('aria-label', isChinese ? 'Wework 正在启动' : 'Wework is starting')
   stageIndicator.setAttribute(
     'aria-label',
@@ -72,7 +79,13 @@ function updateCopy(index, animate) {
   stageIndicator.setAttribute('aria-valuenow', String(index + 1))
 
   const replaceStatus = () => {
-    statusElement.textContent = isChinese ? stage.zh : stage.en
+    statusElement.textContent = slowStartup
+      ? isChinese
+        ? '仍在加载项目和会话，请稍候…'
+        : 'Still loading your projects and conversations…'
+      : isChinese
+        ? stage.zh
+        : stage.en
     statusElement.classList.remove('is-changing')
   }
 
@@ -120,9 +133,15 @@ if (prefersReducedMotion) {
   requestAnimationFrame(animateMorph)
   window.setInterval(() => {
     stageIndex = (stageIndex + 1) % stages.length
-    updateCopy(stageIndex, true)
+    if (!slowStartup) updateCopy(stageIndex, true)
   }, 1150)
 }
+
+window.setTimeout(() => {
+  slowStartup = true
+  document.body.dataset.slowStartup = 'true'
+  updateCopy(stageIndex, true)
+}, 10_000)
 
 requestAnimationFrame(() => {
   requestAnimationFrame(() => {

--- a/wework/electron/src/shell/startup-splash/styles.css
+++ b/wework/electron/src/shell/startup-splash/styles.css
@@ -33,8 +33,133 @@ body {
   place-items: center;
 }
 
-.splash {
+.startup-stage {
   position: relative;
+  width: min(760px, calc(100vw - 64px));
+  height: min(520px, calc(100vh - 80px));
+  min-height: 360px;
+  opacity: 0;
+  transform: scale(0.985);
+}
+
+:root[data-animation-ready='true'] .startup-stage {
+  animation: stage-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.ambient-workflow {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.ambient-path {
+  fill: none;
+  stroke: rgb(23 23 23 / 8%);
+  stroke-width: 1;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 1 7;
+  vector-effect: non-scaling-stroke;
+}
+
+.ambient-path-primary,
+.ambient-path-secondary {
+  stroke-dasharray: 240;
+  stroke-dashoffset: 240;
+}
+
+:root[data-animation-ready='true'] .ambient-path-primary {
+  animation: ambient-line-arrive 820ms 100ms ease-out both;
+}
+
+:root[data-animation-ready='true'] .ambient-path-secondary {
+  animation: ambient-line-arrive 820ms 180ms ease-out both;
+}
+
+.ambient-node {
+  fill: #fafafa;
+  stroke: rgb(23 23 23 / 14%);
+  stroke-width: 1;
+  opacity: 0;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.ambient-node-accent {
+  fill: #7c3aed;
+  stroke: none;
+}
+
+:root[data-animation-ready='true'] .ambient-node {
+  animation:
+    ambient-node-arrive 380ms 400ms ease-out both,
+    ambient-node-breathe 3.2s 900ms ease-in-out infinite;
+}
+
+:root[data-animation-ready='true'] .ambient-node-two,
+:root[data-animation-ready='true'] .ambient-node-four {
+  animation-delay: 500ms, 1.1s;
+}
+
+.stage-corner {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  opacity: 0;
+}
+
+.stage-corner::before,
+.stage-corner::after {
+  position: absolute;
+  content: '';
+  background: rgb(23 23 23 / 9%);
+  border-radius: 999px;
+}
+
+.stage-corner::before {
+  width: 28px;
+  height: 1px;
+}
+
+.stage-corner::after {
+  width: 1px;
+  height: 28px;
+}
+
+.stage-corner-top-left {
+  top: 64px;
+  left: 64px;
+}
+
+.stage-corner-top-right {
+  top: 64px;
+  right: 64px;
+  transform: rotate(90deg);
+}
+
+.stage-corner-bottom-left {
+  bottom: 64px;
+  left: 64px;
+  transform: rotate(-90deg);
+}
+
+.stage-corner-bottom-right {
+  right: 64px;
+  bottom: 64px;
+  transform: rotate(180deg);
+}
+
+:root[data-animation-ready='true'] .stage-corner {
+  animation: corner-arrive 500ms 260ms ease-out both;
+}
+
+.splash {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   display: flex;
   width: 392px;
   height: 232px;
@@ -46,6 +171,12 @@ body {
   border-radius: 22px;
   background: rgb(250 250 250 / 97%);
   box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+  opacity: 0;
+  transform: translate(-50%, calc(-50% + 12px)) scale(0.97);
+}
+
+:root[data-animation-ready='true'] .splash {
+  animation: splash-enter 560ms 90ms cubic-bezier(0.2, 0.85, 0.25, 1) both;
 }
 
 .workbench-scene {
@@ -371,6 +502,73 @@ body[data-stage='2'] .monitor-status {
   }
 }
 
+@keyframes stage-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes splash-enter {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 12px)) scale(0.97);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 4%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+  }
+}
+
+@keyframes ambient-line-arrive {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes ambient-node-arrive {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ambient-node-breathe {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes corner-arrive {
+  from {
+    opacity: 0;
+    clip-path: inset(0 100% 100% 0);
+  }
+
+  to {
+    opacity: 1;
+    clip-path: inset(0);
+  }
+}
+
 @keyframes robot-bob {
   0%,
   100% {
@@ -558,6 +756,25 @@ body[data-stage='2'] .monitor-status {
 }
 
 :root[data-theme='dark'] {
+  .ambient-path {
+    stroke: rgb(255 255 255 / 9%);
+  }
+
+  .ambient-node {
+    fill: #171717;
+    stroke: rgb(255 255 255 / 16%);
+  }
+
+  .ambient-node-accent {
+    fill: #8b5cf6;
+    stroke: none;
+  }
+
+  .stage-corner::before,
+  .stage-corner::after {
+    background: rgb(255 255 255 / 10%);
+  }
+
   .splash {
     color: #f5f5f5;
     background: rgb(23 23 23 / 97%);
@@ -620,6 +837,11 @@ body[data-stage='2'] .monitor-status {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .startup-stage,
+  .splash,
+  .ambient-path,
+  .ambient-node,
+  .stage-corner,
   .floor-line,
   .robot,
   .robot-head,
@@ -637,6 +859,26 @@ body[data-stage='2'] .monitor-status {
   .robot-sparks,
   .assembly-piece {
     animation: none;
+  }
+
+  .startup-stage {
+    opacity: 1;
+    transform: none;
+  }
+
+  .splash {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+
+  .ambient-path-primary,
+  .ambient-path-secondary {
+    stroke-dashoffset: 0;
+  }
+
+  .ambient-node,
+  .stage-corner {
+    opacity: 1;
   }
 
   .floor-line {

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -1082,7 +1082,7 @@ describe('App plugins route', () => {
     expect(workbenchProviderMocks.mounts).toHaveBeenCalledWith(true)
   })
 
-  test('closes the idle maintenance gate when the active app changes after startup timeout', async () => {
+  test('does not bypass startup readiness after ten seconds or an active app change', async () => {
     vi.useFakeTimers()
     workbenchProviderMocks.autoReady = false
     window.history.pushState({}, '', '/')
@@ -1097,9 +1097,9 @@ describe('App plugins route', () => {
     expect(idleTaskCoordinatorMocks.active).toHaveBeenLastCalledWith(false)
 
     await act(async () => {
-      vi.advanceTimersByTime(6000)
+      vi.advanceTimersByTime(10_000)
     })
-    expect(idleTaskCoordinatorMocks.active).toHaveBeenLastCalledWith(true)
+    expect(idleTaskCoordinatorMocks.active).toHaveBeenLastCalledWith(false)
 
     await act(async () => {
       window.history.pushState({}, '', '/todo')

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -126,8 +126,8 @@ import { WEWORK_DSH_SLOTS } from '@/features/dsh-runtime/dshUiSlots'
 import { useDshSlotEntries } from '@/features/dsh-runtime/useDshSlotEntries'
 import { dshWorkspaceTabIdFromPath } from '@/features/dsh-runtime/dshWorkspaceTabs'
 import { ComputerUseActivityIndicator } from '@/features/computer-use/ComputerUseActivityIndicator'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 
-const WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS = 6000
 const POPOUT_WINDOW_LABEL = 'popout-window'
 
 function isPopoutWindowRuntime() {
@@ -759,6 +759,14 @@ function AppShell() {
   const cloudToken = cloudConnection.token
   const titlebarOverlaysContent = false
   const showChromeTitlebar = (isDesktop || isElectron) && !isPopoutWindow
+  useEffect(() => {
+    const startupRouteReady =
+      path === '/login' || path === '/login/oidc' || path === '/auth/wework/authorize'
+    if (!startupRouteReady || isLoading || !isMainWindow) return
+    void invokeDesktopHost<void>('renderer.startupReady').catch(error => {
+      console.error('[Wework] Failed to reveal the startup route', error)
+    })
+  }, [isLoading, isMainWindow, path])
   const workspaceTabStorageScope = useMemo(
     () => (isElectron ? (currentWindowLabel ?? 'main') : browserWorkspaceTabStorageScope()),
     [currentWindowLabel, isElectron]
@@ -816,10 +824,6 @@ function AppShell() {
       : fixedWorkspaceTabs[0]?.id
   }, [appPreferences, fixedWorkspaceTabs, isMainWindow])
   const [workbenchStartupReady, setWorkbenchStartupReady] = useState(false)
-  const [workbenchStartupRevealAppKey, setWorkbenchStartupRevealAppKey] = useState<string | null>(
-    null
-  )
-  const workbenchStartupRevealTimedOut = workbenchStartupRevealAppKey === activeAppKey
   const updateImNotificationPresence = useMemo(() => {
     if (!cloudApiBaseUrl || !cloudToken) return undefined
     return createRuntimeWorkApi(
@@ -969,27 +973,6 @@ function AppShell() {
     return installMacOSInputArrowKeyGuard()
   }, [])
 
-  useEffect(() => {
-    if (
-      path === '/login' ||
-      path === '/login/oidc' ||
-      isLoading ||
-      !user ||
-      workbenchStartupReady
-    ) {
-      return undefined
-    }
-
-    const timer = window.setTimeout(() => {
-      console.warn(
-        `[Wework] Workbench startup has not completed after ${WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS}ms; revealing shell while requests continue.`
-      )
-      setWorkbenchStartupRevealAppKey(activeAppKey)
-    }, WORKBENCH_STARTUP_REVEAL_TIMEOUT_MS)
-
-    return () => window.clearTimeout(timer)
-  }, [activeAppKey, isLoading, path, user, workbenchStartupReady])
-
   // No chrome on login/setup pages
   if (path === '/login' || path === '/login/oidc') {
     return <AppRoutes />
@@ -1056,7 +1039,7 @@ function AppShell() {
         ) : null}
         {isMainWindow && isElectron ? (
           <>
-            <IdleTaskCoordinator active={workbenchStartupReady || workbenchStartupRevealTimedOut} />
+            <IdleTaskCoordinator active={workbenchStartupReady} />
             <WeworkIdleTasks />
           </>
         ) : null}
@@ -1088,7 +1071,7 @@ function AppShell() {
     <CodexHomeInitializer>
       <LocalRuntimeInitializer
         initialCloudConnection={initialCloudConnection}
-        startupReady={workbenchStartupReady || workbenchStartupRevealTimedOut}
+        startupReady={workbenchStartupReady}
       >
         {shell}
       </LocalRuntimeInitializer>

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -10892,6 +10892,72 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
+  test('reveals the Electron startup window only after the active transcript is ready', async () => {
+    runtimeMocks.electron = true
+    const { rerender } = render(
+      <DesktopWorkbenchLayout {...baseProps} isRuntimeTranscriptLoading />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady')
+
+    rerender(<DesktopWorkbenchLayout {...baseProps} isRuntimeTranscriptLoading={false} />)
+
+    await waitFor(() => {
+      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady')
+    })
+  })
+
+  test('keeps the startup animation visible until the routed task is restored', async () => {
+    runtimeMocks.electron = true
+    window.history.pushState({}, '', '/runtime-tasks?deviceId=local-device&taskId=runtime-a')
+    const { propsForTask, taskA } = createLocalRuntimeTaskPanelFixture()
+    const { rerender } = render(<DesktopWorkbenchLayout {...baseProps} />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady')
+
+    rerender(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
+
+    await waitFor(() => {
+      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady')
+    })
+  })
+
+  test('does not reveal an inactive project-space surface during startup', async () => {
+    runtimeMocks.electron = true
+    deliveryApiMock.available = true
+    window.history.pushState({}, '', '/todo')
+    const props = {
+      ...baseProps,
+      surfaceKind: 'board' as const,
+      state: {
+        ...baseProps.state,
+        user: {
+          id: 1,
+          user_name: 'local',
+          email: 'local@example.com',
+        },
+      },
+    }
+    const { rerender } = render(<DesktopWorkbenchLayout {...props} routeActive={false} />)
+
+    await waitFor(() => {
+      expect(deliveryApiMock.listCloudProjects).toHaveBeenCalled()
+    })
+    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady')
+
+    rerender(<DesktopWorkbenchLayout {...props} routeActive />)
+
+    await waitFor(() => {
+      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady')
+    })
+  })
+
   test('does not reuse a migrated default browser label after switching panes', async () => {
     runtimeMocks.electron = true
     const { propsForTask, taskA, taskB } = createLocalRuntimeTaskPanelFixture()

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -1063,6 +1063,7 @@ export function DesktopWorkbenchLayout({
                 runtimeWork={state.runtimeWork}
                 runtimeTaskLifecycle={runtimeTaskLifecycle}
                 services={services}
+                startupActive={routeActive && todoOpen}
                 onCreateLocalCodeProject={onCreateLocalRuntimeProject}
                 onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
                 onListDeviceDirectories={onListDeviceDirectories}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -118,7 +118,12 @@ import {
 import { DESKTOP_TOP_BAR_BUTTON_CLASS, DesktopTopBar } from './DesktopTopBar'
 import { DesktopWindowControls } from './DesktopWindowControls'
 import { MacOSTitleBarDragRegion } from './MacOSTitleBarDragRegion'
-import { isDesktopRuntime } from '@/lib/runtime-environment'
+import {
+  getDesktopWindowLabel,
+  isDesktopRuntime,
+  isElectronRuntime,
+} from '@/lib/runtime-environment'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 import { getPlatform } from '@/lib/platform'
 import { createLocalCodexPluginApi } from '@/api/local/codexPlugins'
 import {
@@ -193,8 +198,11 @@ import {
 } from './desktopWorkbenchPaneTypes'
 import {
   findRuntimeTask,
+  isSameRuntimeTaskAddress,
   truncateRuntimeTaskTitle,
 } from '@/features/workbench/workbenchRuntimeHelpers'
+import { stripAppBasePath } from '@/config/runtime'
+import { parseRuntimeTaskRoute } from '@/lib/navigation'
 import { useWorkbenchPaneEnvironment } from './useWorkbenchPaneEnvironment'
 import { useWorkbenchProjectWorkControls } from './useWorkbenchProjectWorkControls'
 import { useRuntimeTaskContinueInIm } from './useRuntimeTaskContinueInIm'
@@ -903,7 +911,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     createDeviceDirectory,
     startNewChat,
   } = useWorkbenchPaneContext()
-  const { services, openRuntimeTask, workspaceTabId } = useWorkbench()
+  const { services, openRuntimeTask, workspaceTabId, isStartupReady } = useWorkbench()
   const { t } = useTranslation('common')
   const [harnessSessionPickerTarget, setHarnessSessionPickerTarget] = useState<
     'main' | 'right' | null
@@ -929,6 +937,27 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     currentRuntimeTask,
     debugSnapshotEnabled: paneActive && paneVisible && workbenchVisible,
   })
+  const startupTaskRoute = parseRuntimeTaskRoute(
+    stripAppBasePath(window.location.pathname),
+    window.location.search
+  )
+  const startupTaskRouteReady =
+    !startupTaskRoute || isSameRuntimeTaskAddress(currentRuntimeTask, startupTaskRoute)
+  const startupSurfaceReady =
+    isStartupReady &&
+    startupTaskRouteReady &&
+    !paneSession.transcriptLoading &&
+    paneActive &&
+    paneVisible &&
+    workbenchVisible
+  useEffect(() => {
+    if (!startupSurfaceReady || !isElectronRuntime() || getDesktopWindowLabel() !== 'main') {
+      return
+    }
+    void invokeDesktopHost<void>('renderer.startupReady').catch(error => {
+      console.error('[Wework] Failed to reveal the ready workbench', error)
+    })
+  }, [startupSurfaceReady])
   const refinePluginTrialPrompt = usePluginTrialPromptRefinement({
     source: currentRuntimeTask,
     project: currentProject,

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -18,6 +18,8 @@ import {
   type LocalExecutorLog,
   type LocalExecutorStatus,
 } from '@/desktop/localExecutor'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
+import { getDesktopWindowLabel, isElectronRuntime } from '@/lib/runtime-environment'
 
 function getLocalExecutorLogDisplayPath(): string {
   return getPlatform() === 'win'
@@ -268,6 +270,15 @@ export function LocalRuntimeInitializer({
       console.error('[Wework] Failed to apply cloud connection to local executor:', error)
     })
   }, [enabled, state.phase])
+
+  useEffect(() => {
+    if (state.phase !== 'failed' || !isElectronRuntime() || getDesktopWindowLabel() !== 'main') {
+      return
+    }
+    void invokeDesktopHost<void>('renderer.startupReady').catch(error => {
+      console.error('[Wework] Failed to reveal the local runtime error', error)
+    })
+  }, [state.phase])
 
   const handleCopyDebugInfo = useCallback(async () => {
     setCopyDebugState('copying')

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -2089,9 +2089,9 @@ export function CloudTodoWorkspace({
   // `boardError` distinguishes a failed fetch (skeleton stays) from a
   // successfully loaded but empty project (renders the empty columns).
   const boardItemsLoading = selectedProject !== null && itemsProjectKey !== selectedProjectKey
-  const startupProjectsLoading = projectSpaceApis.local
-    ? localProjectsLoading
-    : cloudProjectsLoading
+  const startupProjectsLoading =
+    (Boolean(projectSpaceApis.local) && localProjectsLoading) ||
+    (Boolean(projectSpaceApis.cloud) && cloudProjectsLoading)
   const startupProjectRouteReady =
     !activeProjectRef ||
     Boolean(selectedProject && sameProjectSpace(projectSpaceRef(selectedProject), activeProjectRef))
@@ -2101,7 +2101,7 @@ export function CloudTodoWorkspace({
   const startupFocusedItemReady =
     !focusedItemId ||
     selectedItem?.id === focusedItemId ||
-    (!boardItemsLoading && !focusedStartupItem)
+    (!boardItemsLoading && (!focusedStartupItem || focusedStartupItem.can_view_detail === false))
   const startupBoardReady =
     startupActive &&
     Boolean(workbench?.isStartupReady) &&

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -83,6 +83,8 @@ import { runtimeTaskProjectUiId } from '@/lib/runtime-task-workspace-binding'
 import { localRuntimeAttachments, remoteAttachmentIds } from '@/lib/runtime-attachments'
 import { cn } from '@/lib/utils'
 import { track } from '@/telemetry/client'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
+import { getDesktopWindowLabel, isElectronRuntime } from '@/lib/runtime-environment'
 import { runtimeConversationKey } from '@/features/workbench/runtimeConversationCache'
 import { WorkbenchContext } from '@/features/workbench/workbenchContexts'
 import { getRuntimeTaskChatScopeKey } from '@/features/workbench/workbenchProviderHelpers'
@@ -541,6 +543,7 @@ interface CloudTodoWorkspaceProps {
   runtimeTaskLifecycle?: RuntimeTaskLifecycleStoreSnapshot
   services: WorkbenchServices
   embedded?: boolean
+  startupActive?: boolean
   activeProjectRef?: RuntimeProjectSpaceRef | null
   defaultProjectRequested?: boolean
   focusedItemId?: string | null
@@ -1088,6 +1091,7 @@ export function CloudTodoWorkspace({
   runtimeTaskLifecycle,
   services,
   embedded = false,
+  startupActive = false,
   activeProjectRef,
   defaultProjectRequested = false,
   focusedItemId,
@@ -2085,6 +2089,34 @@ export function CloudTodoWorkspace({
   // `boardError` distinguishes a failed fetch (skeleton stays) from a
   // successfully loaded but empty project (renders the empty columns).
   const boardItemsLoading = selectedProject !== null && itemsProjectKey !== selectedProjectKey
+  const startupProjectsLoading = projectSpaceApis.local
+    ? localProjectsLoading
+    : cloudProjectsLoading
+  const startupProjectRouteReady =
+    !activeProjectRef ||
+    Boolean(selectedProject && sameProjectSpace(projectSpaceRef(selectedProject), activeProjectRef))
+  const focusedStartupItem = focusedItemId
+    ? items.find(item => item.id === focusedItemId)
+    : undefined
+  const startupFocusedItemReady =
+    !focusedItemId ||
+    selectedItem?.id === focusedItemId ||
+    (!boardItemsLoading && !focusedStartupItem)
+  const startupBoardReady =
+    startupActive &&
+    Boolean(workbench?.isStartupReady) &&
+    !startupProjectsLoading &&
+    startupProjectRouteReady &&
+    !boardItemsLoading &&
+    startupFocusedItemReady
+  useEffect(() => {
+    if (!startupBoardReady || !isElectronRuntime() || getDesktopWindowLabel() !== 'main') {
+      return
+    }
+    void invokeDesktopHost<void>('renderer.startupReady').catch(error => {
+      console.error('[Wework] Failed to reveal the ready project space', error)
+    })
+  }, [startupBoardReady])
   const selectedItemProject = selectedItem ? projectForItem(selectedItem) : undefined
   const selectedItemApi = apiForProject(selectedItemProject)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- replace overlapping startup loading surfaces with one independent native splash window
- keep the main window hidden until the active login, task, project-space, transcript, or runtime-error surface is actionable
- prevent macOS activation and second-instance events from revealing the blank main window during startup
- retain the same animation after 10 seconds with a longer-startup explanation
- add restrained workflow-line decoration and layered entry motion with dark-mode and reduced-motion support
- document the renderer-to-Electron startup readiness lifecycle

## Verification

- `pnpm --filter wework test electron/src/host/startup-splash.test.ts electron/src/shell/shell.test.ts src/App.plugins.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx` (258 passed)
- Electron and renderer TypeScript checks
- ESLint on changed TypeScript files
- pre-push Wework quality checks
- `pnpm --filter wework e2e:desktop --segment native-window-startup`
- isolated real Electron startup verification; splash lifecycle: `created -> animation-ready -> shown -> closed`

## Visual evidence

`wework/test-results/desktop-e2e/2026-08-31T09-54-51-480Z-14324/startup-splash.png` was inspected locally during verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated animated startup window with synchronized workflow visuals.
  * Main content now appears only after login, routing, and runtime state are ready.
  * Added clearer messaging when startup takes longer than 10 seconds.
  * Startup errors remain visible with actionable retry options.
* **Bug Fixes**
  * Prevented blank or prematurely displayed main windows.
  * Improved restoration of routes, tasks, transcripts, and project views.
  * Kept startup messaging visible during required window activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->