### PR TITLE
chore(wework): add file preview latency diagnostics

### DIFF
--- a/docs/en/wework/developer-guide/wework-file-preview.md
+++ b/docs/en/wework/developer-guide/wework-file-preview.md
@@ -42,6 +42,24 @@ The local native command `read_local_workspace_text_file` returns `editable` and
 
 Saving still uses the Rust executor's `workspace_write_text_file` capability because writes retain the task-workspace concurrency check and atomic replacement semantics. The IPC payload carries the file content, file name, and the `revision` returned by the read command. Before writing, the executor rereads the file on disk and compares the SHA-256 revision. If another process changed the file, saving fails and the frontend must block the overwrite and offer reload. Writes must stay inside the same workspace root and replace the target through a same-directory temporary file. Files opened through remote devices remain preview-only.
 
+## Preview Latency Diagnostics
+
+The desktop app associates one file-link click and its subsequent preview work with a shared `traceId`, then writes diagnostic events to `file-preview.log` under Electron's log directory. The log is limited to 2 MiB with two rotated files. It records only the file extension, path length, file size, chunk count, stage, and timing; it does not record complete paths, file contents, or credentials.
+
+For a right panel that appears long after the link is selected, inspect these stages under the same `traceId`:
+
+1. `message_link_click` to `filesystem_stat_end`: determine whether the target is a file or directory before opening the right panel.
+2. `open_file_request_queued` to `open_file_request_effect`: move the request from workbench state into the file panel.
+3. `parent_tree_start` to `parent_tree_end`: read the parent directory and resolve the target entry.
+4. `file_chunk_start` to `file_chunk_end`: read one binary chunk.
+5. `base64_decode_end` and `file_constructed`: decode chunks, copy bytes, and construct the browser `File` in the renderer.
+6. `binary_preview_state_queued` to `binary_preview_committed`: let React receive and commit the binary preview state.
+7. `file_viewer_react_commit`: record the Flyfish Viewer React commit duration and viewer type.
+
+After each important stage, a zero-delay timer measures renderer event-queue latency in `renderer_queue_probe.lagMs`; delays of at least 50 ms include `blocked: true`. If the preceding stage has completed but this probe runs much later, synchronous JavaScript, layout, painting, or another renderer long task is blocking the queue. `preview_loading_clear_skipped` means that a later file request replaced the current request and should be investigated as a request race rather than an unfinished single read.
+
+When a read traverses executor App IPC, `executor.log` records its `command_key`, handling duration, response size, and `queue_wait_ms`. A fast `app IPC request finished` followed by a large `app IPC response queued.queue_wait_ms` indicates backpressure in the response write queue. If the executor queues the response quickly but the frontend logs `file_chunk_end` much later, inspect IPC transport and renderer message consumption next.
+
 ## Preview State Lifecycle
 
 The file panel determines workspace changes from the target's `deviceId`, `path`, `source`, `taskId`, and `workspaceSource`. Task streaming and background polling may create new target objects with the same fields; reference-only changes must not clear the directory tree, reread the file, or unmount the current preview. Reload data only when the target fields actually change, the user selects another file, or the user explicitly refreshes.

--- a/docs/zh/wework/developer-guide/wework-file-preview.md
+++ b/docs/zh/wework/developer-guide/wework-file-preview.md
@@ -42,6 +42,24 @@ Markdown 预览和源码视图都必须拥有独立的纵向滚动区域。软�
 
 保存仍由 Rust executor 通过 `workspace_write_text_file` 实现，因为写入需要沿用任务工作区的并发修改检查和原子替换语义。IPC 载荷携带文件内容、文件名和读取时得到的 `revision`。executor 在写入前重新读取磁盘文件并比对 SHA-256 revision；如果文件已被外部修改，保存会失败，前端必须阻止覆盖并提示用户重新加载。写入必须限制在同一工作区根目录内，并通过同目录临时文件原子替换目标文件。通过远端设备打开的文件仍然只能预览。
 
+## 预览耗时诊断
+
+桌面应用会把单次文件链接点击和后续预览操作关联到同一个 `traceId`，并将诊断事件写入 Electron 日志目录下的 `file-preview.log`。日志采用 2 MiB 上限并保留两个轮转文件，只记录文件扩展名、路径长度、文件大小、分块数量、阶段和耗时，不记录完整路径、文件内容或凭据。
+
+排查“点击后右侧面板迟迟不出现”时，按同一 `traceId` 检查以下阶段：
+
+1. `message_link_click` 到 `filesystem_stat_end`：在打开右侧面板前判断目标是文件还是目录。
+2. `open_file_request_queued` 到 `open_file_request_effect`：文件请求从工作台状态进入文件面板。
+3. `parent_tree_start` 到 `parent_tree_end`：读取父目录并确认目标条目。
+4. `file_chunk_start` 到 `file_chunk_end`：读取一个二进制分块。
+5. `base64_decode_end` 和 `file_constructed`：在 renderer 中解码分块、复制字节并构造浏览器 `File`。
+6. `binary_preview_state_queued` 到 `binary_preview_committed`：React 接收预览状态并提交二进制预览。
+7. `file_viewer_react_commit`：记录 Flyfish Viewer 的 React commit 耗时和查看器类型。
+
+每个关键阶段后还会安排一个零延迟定时器，并通过 `renderer_queue_probe.lagMs` 测量 renderer 事件队列延迟；达到 50 ms 时记录 `blocked: true`。如果前一阶段已经结束，但该探针明显延后，说明同步 JavaScript、布局、绘制或其它 renderer 长任务正在阻塞队列。`preview_loading_clear_skipped` 表示当前请求已被后续文件请求替换，应按请求竞态排查，而不是把它解释为单次读取未结束。
+
+当读取经过 executor App IPC 时，`executor.log` 会为对应请求记录 `command_key`、处理耗时、响应字节数和 `queue_wait_ms`。`app IPC request finished` 很快但 `app IPC response queued.queue_wait_ms` 很大，表示响应写入队列存在背压；executor 已快速入队但前端的 `file_chunk_end` 明显延后，则继续检查 IPC 传输和 renderer 消息消费。
+
 ## 预览状态生命周期
 
 文件面板应按工作区目标的 `deviceId`、`path`、`source`、`taskId` 和 `workspaceSource` 判断工作区是否变化。任务流式更新或后台轮询可能创建字段相同的新目标对象；这种引用变化不得清空目录树、重新读取文件或卸载当前预览。只有目标字段实际变化、用户选择其他文件或主动刷新时才重新加载对应数据。

--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -1238,13 +1238,15 @@ impl AppIpcServer {
                     };
                     let server = self.clone();
                     let response_tx = priority_write_tx.clone();
-                    let (request_id, method) = app_ipc_request_metadata(&request_line);
+                    let (request_id, method, command_key) =
+                        app_ipc_request_metadata(&request_line);
                     tokio::spawn(async move {
                         let started_at = Instant::now();
                         log_app_ipc_request(
                             "app IPC request started",
                             request_id.as_deref(),
                             method.as_deref(),
+                            command_key.as_deref(),
                             None,
                             None,
                         );
@@ -1260,6 +1262,7 @@ impl AppIpcServer {
                                     "app IPC request timed out",
                                     request_id.as_deref(),
                                     method.as_deref(),
+                                    command_key.as_deref(),
                                     Some(started_at.elapsed().as_millis()),
                                     None,
                                 );
@@ -1278,10 +1281,13 @@ impl AppIpcServer {
                         if let Some(response) = response {
                             let ok = response.get("ok").and_then(Value::as_bool);
                             let elapsed_ms = started_at.elapsed().as_millis();
+                            let response_bytes =
+                                serde_json::to_vec(&response).map_or(0, |bytes| bytes.len());
                             log_app_ipc_request(
                                 "app IPC request finished",
                                 request_id.as_deref(),
                                 method.as_deref(),
+                                command_key.as_deref(),
                                 Some(elapsed_ms),
                                 ok,
                             );
@@ -1293,20 +1299,41 @@ impl AppIpcServer {
                                     &response,
                                 );
                             }
+                            let queue_started_at = Instant::now();
                             if response_tx.send(response).await.is_err() {
                                 log_app_ipc_request(
                                     "app IPC response dropped",
                                     request_id.as_deref(),
                                     method.as_deref(),
+                                    command_key.as_deref(),
                                     Some(elapsed_ms),
                                     ok,
                                 );
+                            } else {
+                                let queue_wait_ms = queue_started_at.elapsed().as_millis();
+                                let mut fields = Vec::new();
+                                if let Some(request_id) = request_id.as_deref() {
+                                    fields.push(("request_id", request_id.to_owned()));
+                                }
+                                if let Some(method) = method.as_deref() {
+                                    fields.push(("method", method.to_owned()));
+                                }
+                                if let Some(command_key) = command_key.as_deref() {
+                                    fields.push(("command_key", command_key.to_owned()));
+                                }
+                                fields.push(("response_bytes", response_bytes.to_string()));
+                                fields.push(("queue_wait_ms", queue_wait_ms.to_string()));
+                                write_executor_log_line(&format_executor_log(
+                                    "app IPC response queued",
+                                    &fields,
+                                ));
                             }
                         } else {
                             log_app_ipc_request(
                                 "app IPC request ignored",
                                 request_id.as_deref(),
                                 method.as_deref(),
+                                command_key.as_deref(),
                                 Some(started_at.elapsed().as_millis()),
                                 None,
                             );
@@ -2878,7 +2905,7 @@ pub fn app_ipc_stdio_ready_log_line(device_id: &str) -> String {
     )
 }
 
-fn app_ipc_request_metadata(line: &str) -> (Option<String>, Option<String>) {
+fn app_ipc_request_metadata(line: &str) -> (Option<String>, Option<String>, Option<String>) {
     match serde_json::from_str::<Value>(line) {
         Ok(Value::Object(message)) => {
             let request_id = message
@@ -2891,9 +2918,16 @@ fn app_ipc_request_metadata(line: &str) -> (Option<String>, Option<String>) {
                 .and_then(Value::as_str)
                 .filter(|value| !value.trim().is_empty())
                 .map(str::to_owned);
-            (request_id, method)
+            let command_key = message
+                .get("params")
+                .and_then(Value::as_object)
+                .and_then(|params| params.get("command_key"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned);
+            (request_id, method, command_key)
         }
-        _ => (None, None),
+        _ => (None, None, None),
     }
 }
 
@@ -2901,6 +2935,7 @@ fn log_app_ipc_request(
     event: &str,
     request_id: Option<&str>,
     method: Option<&str>,
+    command_key: Option<&str>,
     elapsed_ms: Option<u128>,
     ok: Option<bool>,
 ) {
@@ -2910,6 +2945,9 @@ fn log_app_ipc_request(
     }
     if let Some(method) = method {
         fields.push(("method", method.to_owned()));
+    }
+    if let Some(command_key) = command_key {
+        fields.push(("command_key", command_key.to_owned()));
     }
     if let Some(elapsed_ms) = elapsed_ms {
         fields.push(("elapsed_ms", elapsed_ms.to_string()));
@@ -3479,7 +3517,32 @@ mod tests {
     use tokio::net::UnixStream;
     use tokio::time::Duration;
 
-    use super::{is_bulk_app_ipc_event, local_app_command, AppIpcServer, BlockingSingleFlight};
+    use super::{
+        app_ipc_request_metadata, is_bulk_app_ipc_event, local_app_command, AppIpcServer,
+        BlockingSingleFlight,
+    };
+
+    #[test]
+    fn app_ipc_request_metadata_includes_device_command_key() {
+        let line = json!({
+            "id": "request-1",
+            "method": "device.execute_command",
+            "params": {
+                "command_key": "workspace_read_file_chunk",
+                "path": "/workspace"
+            }
+        })
+        .to_string();
+
+        assert_eq!(
+            app_ipc_request_metadata(&line),
+            (
+                Some("request-1".to_owned()),
+                Some("device.execute_command".to_owned()),
+                Some("workspace_read_file_chunk".to_owned())
+            )
+        );
+    }
 
     #[tokio::test]
     async fn blocking_single_flight_survives_a_timed_out_waiter() {

--- a/wework/electron/src/host/capability-router.ts
+++ b/wework/electron/src/host/capability-router.ts
@@ -44,6 +44,7 @@ export const HOST_CAPABILITIES = [
   'dialog.open',
   'dialog.save',
   'desktop.events',
+  'diagnostics.filePreview',
   'developer.openDevTools',
   'developer.openLogDirectory',
   'e2e.capturePopoutWindow',

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -45,6 +45,7 @@ import {
   saveCustomWorkspaceOpener,
 } from './local-workspace-openers.js'
 import type { DesktopHostEventBroker } from './desktop-host-events.js'
+import { RotatingLog } from '../runtime/rotating-log.js'
 
 export { captureWebContentsDataUrl } from './web-contents-capture.js'
 
@@ -196,6 +197,11 @@ export function createElectronCapabilityRouter(
 ): HostCapabilityRouter {
   const router = new HostCapabilityRouter()
   const attachments = new LocalAttachmentStore(localAttachmentRoot())
+  const filePreviewLog = new RotatingLog({
+    path: join(app.getPath('logs'), 'file-preview.log'),
+    maxBytes: 2 * 1024 * 1024,
+    retainedFiles: 2,
+  })
   router.grant(WEWORK_APP_PRINCIPAL, HOST_CAPABILITIES)
 
   router.register('app.getVersion', () => ({ version: app.getVersion() }))
@@ -203,6 +209,10 @@ export function createElectronCapabilityRouter(
     desktopServices.events.read(integerParam(params, 'after') ?? 0)
   )
   router.register('renderer.startupReady', () => e2eHost.rendererStartupReady())
+  router.register('diagnostics.filePreview', params => {
+    const event = recordParam(params, 'event')
+    return filePreviewLog.write('supervisor', JSON.stringify(event))
+  })
   registerAppUpdateCapabilities(router, desktopServices.appUpdates)
   router.register('attachment.begin', params =>
     attachments.begin(stringParam(params, 'filename'), requiredIntegerParam(params, 'size'))

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -62,6 +62,13 @@ import type {
 import { cn } from '@/lib/utils'
 import { runtimeProjectUiId } from '@/lib/runtime-project'
 import {
+  createFilePreviewTraceId,
+  filePreviewElapsedMs,
+  filePreviewPathMetadata,
+  logFilePreviewDiagnostic,
+  scheduleFilePreviewMainThreadProbe,
+} from '@/lib/file-preview-diagnostics'
+import {
   defaultAppearance,
   getWorkbenchBackground,
   useOptionalAppearance,
@@ -3715,6 +3722,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     async (path: string, options?: WorkspaceFileOpenOptions) => {
       const trimmedPath = decodeMarkdownFilePath(path.trim())
       if (!trimmedPath) return
+      const traceId = createFilePreviewTraceId()
+      const pathMetadata = filePreviewPathMetadata(trimmedPath)
+      logFilePreviewDiagnostic(traceId, 'message_link_click', pathMetadata)
+      scheduleFilePreviewMainThreadProbe(traceId, 'message_link_click')
       const attachmentTarget = createLocalAttachmentWorkspaceTarget(trimmedPath, devices)
       const absoluteLocalTarget = createLocalFileWorkspaceTarget(trimmedPath, devices)
       let localTarget =
@@ -3727,7 +3738,15 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           : null)
       let isDirectory = options?.isDirectory
       if (localTarget && isDirectory === undefined) {
+        const statStartedAt = performance.now()
+        logFilePreviewDiagnostic(traceId, 'filesystem_stat_start', pathMetadata)
         isDirectory = (await getLocalPathKind(trimmedPath)) === 'directory'
+        logFilePreviewDiagnostic(traceId, 'filesystem_stat_end', {
+          ...pathMetadata,
+          durationMs: filePreviewElapsedMs(statStartedAt),
+          isDirectory,
+        })
+        scheduleFilePreviewMainThreadProbe(traceId, 'filesystem_stat_end')
       }
       if (localTarget && isDirectory) {
         localTarget = {
@@ -3741,9 +3760,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         lineStart: options?.lineStart,
         lineEnd: options?.lineEnd,
         isDirectory,
+        traceId,
         target: localTarget ?? undefined,
       }))
+      logFilePreviewDiagnostic(traceId, 'open_file_request_queued', {
+        ...pathMetadata,
+        hasLocalTarget: Boolean(localTarget),
+        isDirectory: isDirectory ?? null,
+      })
       openRightPanelTab('files')
+      logFilePreviewDiagnostic(traceId, 'right_panel_open_requested')
+      scheduleFilePreviewMainThreadProbe(traceId, 'right_panel_open_requested')
     },
     [devices, effectiveWorkspaceTarget, openRightPanelTab, setOpenFileRequest]
   )

--- a/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/FileWorkspacePanel.tsx
@@ -21,6 +21,13 @@ import {
   isAbsoluteWorkspacePath,
   normalizeAbsoluteWorkspacePath,
 } from '@/lib/workspace-file-contract'
+import {
+  createFilePreviewTraceId,
+  filePreviewElapsedMs,
+  filePreviewPathMetadata,
+  logFilePreviewDiagnostic,
+  scheduleFilePreviewMainThreadProbe,
+} from '@/lib/file-preview-diagnostics'
 import { cn } from '@/lib/utils'
 import { track } from '@/telemetry/client'
 import {
@@ -85,6 +92,7 @@ interface WorkspaceBinaryPreview {
   size: number
   modifiedAt?: string | null
   file: File
+  traceId: string
 }
 
 interface FilePreviewLoadingProgress {
@@ -347,9 +355,16 @@ export function FileWorkspacePanel({
   const openFile = useCallback(
     async (entry: WorkspaceFileEntry, options?: WorkspaceFileOpenOptions) => {
       if (!stableTarget || entry.isDirectory) return
+      const traceId = options?.traceId ?? createFilePreviewTraceId()
+      const pathMetadata = filePreviewPathMetadata(entry.path)
       const requestId = fileRequestSequence.current + 1
       const nextLineTarget = createPreviewLineTarget(entry.path, options)
       fileRequestSequence.current = requestId
+      logFilePreviewDiagnostic(traceId, 'open_file_start', {
+        ...pathMetadata,
+        requestId,
+        workspaceSource: stableTarget.workspaceSource ?? null,
+      })
       flushSync(() => setPreviewTransitionVisible(true))
       setSelectedFilePath(entry.path)
       onSelectionChange?.({ path: entry.path, isDirectory: false })
@@ -358,6 +373,8 @@ export function FileWorkspacePanel({
       setSelectedApplicationPath(null)
       setPreviewLineTarget(nextLineTarget)
       setPreviewLoading(true)
+      logFilePreviewDiagnostic(traceId, 'preview_loading_set', { requestId })
+      scheduleFilePreviewMainThreadProbe(traceId, 'preview_loading_set')
       setPreviewLoadingProgress(null)
       setPreviewError(null)
       setEditing(false)
@@ -411,15 +428,36 @@ export function FileWorkspacePanel({
           })
         }
         while (!chunk?.eof) {
+          const chunkStartedAt = performance.now()
+          logFilePreviewDiagnostic(traceId, 'file_chunk_start', {
+            requestId,
+            offset,
+          })
           const nextChunk = await readWorkspaceFileChunk(
             stableTarget.deviceId,
             entry.path,
             offset,
             stableTarget.path
           )
+          logFilePreviewDiagnostic(traceId, 'file_chunk_end', {
+            requestId,
+            offset,
+            durationMs: filePreviewElapsedMs(chunkStartedAt),
+            responseBytes: nextChunk.contentBase64.length,
+            fileSize: nextChunk.size,
+            eof: nextChunk.eof,
+          })
+          scheduleFilePreviewMainThreadProbe(traceId, 'file_chunk_end')
           if (fileRequestSequence.current !== requestId) return
           chunk = nextChunk
+          const decodeStartedAt = performance.now()
           chunks.push(decodeBase64(chunk.contentBase64))
+          logFilePreviewDiagnostic(traceId, 'base64_decode_end', {
+            requestId,
+            offset,
+            durationMs: filePreviewElapsedMs(decodeStartedAt),
+            decodedBytes: chunks[chunks.length - 1].byteLength,
+          })
           offset += chunks[chunks.length - 1].byteLength
           setPreviewLoadingProgress({
             loadedBytes: Math.min(offset, chunk.size),
@@ -428,24 +466,39 @@ export function FileWorkspacePanel({
         }
         if (fileRequestSequence.current !== requestId) return
         if (!chunk) throw new Error('Failed to read workspace file')
+        const fileConstructionStartedAt = performance.now()
+        const binaryFile = new File(
+          chunks.map(part => {
+            const copy = new Uint8Array(part.byteLength)
+            copy.set(part)
+            return copy.buffer
+          }),
+          chunk.name,
+          { type: mimeTypeForFileName(chunk.name) }
+        )
+        logFilePreviewDiagnostic(traceId, 'file_constructed', {
+          requestId,
+          durationMs: filePreviewElapsedMs(fileConstructionStartedAt),
+          fileSize: chunk.size,
+          chunkCount: chunks.length,
+        })
         setPreview(null)
         setBinaryPreview({
           path: chunk.path,
           name: chunk.name,
           size: chunk.size,
           modifiedAt: chunk.modifiedAt,
-          file: new File(
-            chunks.map(part => {
-              const copy = new Uint8Array(part.byteLength)
-              copy.set(part)
-              return copy.buffer
-            }),
-            chunk.name,
-            { type: mimeTypeForFileName(chunk.name) }
-          ),
+          file: binaryFile,
+          traceId,
         })
+        logFilePreviewDiagnostic(traceId, 'binary_preview_state_queued', { requestId })
+        scheduleFilePreviewMainThreadProbe(traceId, 'binary_preview_state_queued')
       } catch (error) {
         if (fileRequestSequence.current !== requestId) return
+        logFilePreviewDiagnostic(traceId, 'open_file_failed', {
+          requestId,
+          errorName: error instanceof Error ? error.name : 'UnknownError',
+        })
         setPreview(null)
         setEditing(false)
         setEditedContent('')
@@ -462,6 +515,13 @@ export function FileWorkspacePanel({
           setPreviewLoading(false)
           setPreviewTransitionVisible(false)
           setPreviewLoadingProgress(null)
+          logFilePreviewDiagnostic(traceId, 'preview_loading_clear_queued', { requestId })
+          scheduleFilePreviewMainThreadProbe(traceId, 'preview_loading_clear_queued')
+        } else {
+          logFilePreviewDiagnostic(traceId, 'preview_loading_clear_skipped', {
+            requestId,
+            currentRequestId: fileRequestSequence.current,
+          })
         }
       }
     },
@@ -480,6 +540,11 @@ export function FileWorkspacePanel({
       if (!stableTarget) return
       const resolvedPath = resolveWorkspaceFilePath(stableTarget, path)
       if (!resolvedPath) return
+      const traceId = options?.traceId ?? createFilePreviewTraceId()
+      const tracedOptions = { ...options, traceId }
+      const pathMetadata = filePreviewPathMetadata(resolvedPath)
+      logFilePreviewDiagnostic(traceId, 'open_file_path_start', pathMetadata)
+      scheduleFilePreviewMainThreadProbe(traceId, 'open_file_path_start')
 
       const openDirectoryPath = (entries?: WorkspaceFileEntry[]) => {
         fileRequestSequence.current += 1
@@ -526,7 +591,7 @@ export function FileWorkspacePanel({
             isDirectory: false,
             size: 0,
           },
-          options
+          tracedOptions
         )
 
       if (options?.lineStart !== undefined) {
@@ -534,18 +599,36 @@ export function FileWorkspacePanel({
         return
       }
 
+      const parentListStartedAt = performance.now()
+      logFilePreviewDiagnostic(traceId, 'parent_tree_start', pathMetadata)
       void listWorkspaceEntries(
         stableTarget.deviceId,
         workspaceParentPath(resolvedPath),
         stableTarget.path
-      ).then(result => {
-        const entry = result.entries.find(candidate => candidate.path === resolvedPath)
-        if (entry?.isDirectory) {
-          openDirectoryPath()
-          return
+      ).then(
+        result => {
+          logFilePreviewDiagnostic(traceId, 'parent_tree_end', {
+            ...pathMetadata,
+            durationMs: filePreviewElapsedMs(parentListStartedAt),
+            entryCount: result.entries.length,
+          })
+          scheduleFilePreviewMainThreadProbe(traceId, 'parent_tree_end')
+          const entry = result.entries.find(candidate => candidate.path === resolvedPath)
+          if (entry?.isDirectory) {
+            openDirectoryPath()
+            return
+          }
+          openAsFile()
+        },
+        error => {
+          logFilePreviewDiagnostic(traceId, 'parent_tree_failed', {
+            ...pathMetadata,
+            durationMs: filePreviewElapsedMs(parentListStartedAt),
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+          })
+          openAsFile()
         }
-        openAsFile()
-      }, openAsFile)
+      )
     },
     [listWorkspaceEntries, loadTree, onSelectionChange, openFile, stableTarget]
   )
@@ -649,6 +732,12 @@ export function FileWorkspacePanel({
 
   useEffect(() => {
     if (!openFileRequest?.path) return
+    const traceId = openFileRequest.traceId ?? createFilePreviewTraceId()
+    logFilePreviewDiagnostic(traceId, 'open_file_request_effect', {
+      ...filePreviewPathMetadata(openFileRequest.path),
+      requestVersion: openFileRequest.id,
+    })
+    scheduleFilePreviewMainThreadProbe(traceId, 'open_file_request_effect')
     let cancelled = false
     void Promise.resolve().then(() => {
       if (!cancelled) {
@@ -658,6 +747,7 @@ export function FileWorkspacePanel({
             lineStart: openFileRequest.lineStart,
             lineEnd: openFileRequest.lineEnd,
             isDirectory: openFileRequest.isDirectory,
+            traceId,
           })
         })
       }
@@ -673,6 +763,7 @@ export function FileWorkspacePanel({
     openFileRequest?.lineStart,
     openFileRequest?.isDirectory,
     openFileRequest?.path,
+    openFileRequest?.traceId,
   ])
 
   useEffect(() => {

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
@@ -187,14 +187,15 @@ const WorkspaceBinaryFilePreview = memo(function WorkspaceBinaryFilePreview({
   )
 
   useLayoutEffect(() => {
-    if (!file.traceId) return
-    logFilePreviewDiagnostic(file.traceId, 'binary_preview_committed', {
+    const traceId = file.traceId
+    if (!traceId) return
+    logFilePreviewDiagnostic(traceId, 'binary_preview_committed', {
       fileSize: file.size,
       viewerType: viewerType ?? null,
     })
-    scheduleFilePreviewMainThreadProbe(file.traceId, 'binary_preview_committed')
+    scheduleFilePreviewMainThreadProbe(traceId, 'binary_preview_committed')
     return () => {
-      logFilePreviewDiagnostic(file.traceId, 'binary_preview_unmounted')
+      logFilePreviewDiagnostic(traceId, 'binary_preview_unmounted')
     }
   }, [file.size, file.traceId, viewerType])
 

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
@@ -5,13 +5,27 @@ import engineeringRenderers from '@file-viewer/preset-engineering'
 import officeRenderers from '@file-viewer/preset-office'
 import liteRenderers from '@file-viewer/preset-lite'
 import { MessageSquare } from 'lucide-react'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  memo,
+  Profiler,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ProfilerOnRenderCallback,
+} from 'react'
 import { AssistantMarkdown } from '@/components/chat/AssistantMarkdown'
 import { DiagramImageActions } from '@/components/chat/DiagramImageActions'
 import { getRuntimeConfig } from '@/config/runtime'
 import { useOptionalAppearance } from '@/features/appearance'
 import { useTranslation } from '@/hooks/useTranslation'
 import { publishSelectedTextSelection, writeSelectedTextDragData } from '@/lib/selected-text-drag'
+import {
+  logFilePreviewDiagnostic,
+  scheduleFilePreviewMainThreadProbe,
+} from '@/lib/file-preview-diagnostics'
 import { installCodeViewTextDrag } from './codeViewTextDrag'
 import type { CodeCommentContext, WorkspaceTextFileResponse } from '@/types/workspace-files'
 import { WorkspaceXMindPreview } from './WorkspaceXMindPreview'
@@ -96,6 +110,7 @@ interface WorkspaceFilePreviewProps {
     name: string
     size: number
     file: File
+    traceId?: string
   } | null
   loading: boolean
   loadingProgress?: { loadedBytes: number; totalBytes: number | null } | null
@@ -171,6 +186,33 @@ const WorkspaceBinaryFilePreview = memo(function WorkspaceBinaryFilePreview({
     [themeType]
   )
 
+  useLayoutEffect(() => {
+    if (!file.traceId) return
+    logFilePreviewDiagnostic(file.traceId, 'binary_preview_committed', {
+      fileSize: file.size,
+      viewerType: viewerType ?? null,
+    })
+    scheduleFilePreviewMainThreadProbe(file.traceId, 'binary_preview_committed')
+    return () => {
+      logFilePreviewDiagnostic(file.traceId, 'binary_preview_unmounted')
+    }
+  }, [file.size, file.traceId, viewerType])
+
+  const handleFileViewerRender = useCallback<ProfilerOnRenderCallback>(
+    (_id, phase, actualDuration, baseDuration, startTime, commitTime) => {
+      if (!file.traceId) return
+      logFilePreviewDiagnostic(file.traceId, 'file_viewer_react_commit', {
+        phase,
+        actualDurationMs: Math.round(actualDuration * 10) / 10,
+        baseDurationMs: Math.round(baseDuration * 10) / 10,
+        startTimeMs: Math.round(startTime * 10) / 10,
+        commitTimeMs: Math.round(commitTime * 10) / 10,
+        viewerType: viewerType ?? null,
+      })
+    },
+    [file.traceId, viewerType]
+  )
+
   if (/\.xmind$/i.test(file.name)) {
     return (
       <WorkspaceXMindPreview key={`${file.path}:${file.size}`} file={file.file} name={file.name} />
@@ -183,16 +225,18 @@ const WorkspaceBinaryFilePreview = memo(function WorkspaceBinaryFilePreview({
       ref={containerRef}
       className="wework-diagram-preview relative min-w-0 flex-1 overflow-hidden bg-background"
     >
-      <FileViewer
-        key={`${file.path}:${file.size}`}
-        file={file.file}
-        filename={file.name}
-        type={viewerType}
-        size={file.size}
-        data-viewer-theme={themeType}
-        className="wework-workspace-file-viewer h-full w-full"
-        options={viewerOptions}
-      />
+      <Profiler id="workspace-file-viewer" onRender={handleFileViewerRender}>
+        <FileViewer
+          key={`${file.path}:${file.size}`}
+          file={file.file}
+          filename={file.name}
+          type={viewerType}
+          size={file.size}
+          data-viewer-theme={themeType}
+          className="wework-workspace-file-viewer h-full w-full"
+          options={viewerOptions}
+        />
+      </Profiler>
       {isDiagram ? (
         <DiagramImageActions
           containerRef={containerRef}

--- a/wework/src/lib/file-preview-diagnostics.ts
+++ b/wework/src/lib/file-preview-diagnostics.ts
@@ -1,0 +1,71 @@
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
+import { isElectronRuntime } from './runtime-environment'
+
+const FILE_PREVIEW_DIAGNOSTIC_CAPABILITY = 'diagnostics.filePreview'
+const MAIN_THREAD_PROBE_WARN_MS = 50
+
+let traceSequence = 0
+let persistenceWarningLogged = false
+
+export function createFilePreviewTraceId(): string {
+  traceSequence += 1
+  return `file-preview-${Date.now().toString(36)}-${traceSequence.toString(36)}`
+}
+
+export function filePreviewPathMetadata(path: string): {
+  extension: string
+  pathLength: number
+} {
+  const normalized = path.trim()
+  const fileName = normalized.split(/[\\/]/).at(-1) ?? ''
+  const extensionIndex = fileName.lastIndexOf('.')
+  return {
+    extension:
+      extensionIndex > 0 && extensionIndex < fileName.length - 1
+        ? fileName.slice(extensionIndex + 1).toLowerCase()
+        : '',
+    pathLength: normalized.length,
+  }
+}
+
+export function logFilePreviewDiagnostic(
+  traceId: string,
+  stage: string,
+  data: Record<string, unknown> = {}
+): void {
+  const event = {
+    traceId,
+    stage,
+    timestampMs: Date.now(),
+    performanceNowMs: roundTiming(performance.now()),
+    ...data,
+  }
+  console.info('[Wework][file-preview]', event)
+  if (!isElectronRuntime()) return
+
+  void invokeDesktopHost(FILE_PREVIEW_DIAGNOSTIC_CAPABILITY, { event }).catch(error => {
+    if (persistenceWarningLogged) return
+    persistenceWarningLogged = true
+    console.warn('[Wework][file-preview] persistent diagnostics unavailable', error)
+  })
+}
+
+export function scheduleFilePreviewMainThreadProbe(traceId: string, afterStage: string): void {
+  const scheduledAt = performance.now()
+  window.setTimeout(() => {
+    const lagMs = performance.now() - scheduledAt
+    logFilePreviewDiagnostic(traceId, 'renderer_queue_probe', {
+      afterStage,
+      lagMs: roundTiming(lagMs),
+      blocked: lagMs >= MAIN_THREAD_PROBE_WARN_MS,
+    })
+  }, 0)
+}
+
+export function filePreviewElapsedMs(startedAt: number): number {
+  return roundTiming(performance.now() - startedAt)
+}
+
+function roundTiming(value: number): number {
+  return Math.round(value * 10) / 10
+}

--- a/wework/src/types/workspace-files.ts
+++ b/wework/src/types/workspace-files.ts
@@ -77,6 +77,7 @@ export interface WorkspaceFileOpenOptions {
   lineStart?: number
   lineEnd?: number
   isDirectory?: boolean
+  traceId?: string
 }
 
 export interface WorkspaceFileOpenRequest extends WorkspaceFileOpenOptions {


### PR DESCRIPTION
## Summary

- add a persisted per-preview trace from message link click through path stat, directory resolution, chunk reads, base64 decode, File construction, React commit, and FileViewer render
- add renderer event-queue probes and executor App IPC response queue timing so a release reproduction can distinguish filesystem, IPC, renderer queue, decode/copy, and viewer stalls
- document the diagnostic timeline and privacy boundaries in Chinese and English

Tracks WEWORKC2FA61-481.

## Validation

- `pnpm --filter wework typecheck`
- focused Wework tests: 227 passed
- Electron capability tests: 16 passed
- executor App IPC tests: 10 passed
- isolated `pnpm --filter wework ai:verify start` + snapshot + stop
- pre-push: ESLint, Wework TypeScript, Electron TypeScript, unit tests, cargo fmt, cargo test, and cargo clippy passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end diagnostics for file preview performance.
  * Added trace-based timing across file opening, loading, rendering, and completion stages.
  * Added rotating diagnostic logs with non-sensitive metadata and main-thread responsiveness measurements.
  * Added IPC queue and response metrics to help identify preview delays.
* **Documentation**
  * Added English and Chinese guidance for investigating slow file previews and interpreting diagnostic logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->