### PR TITLE
fix(wework): clean stale renderer storage origins

### DIFF
--- a/docs/en/wework/developer-guide/wework-cloud-connection.md
+++ b/docs/en/wework/developer-guide/wework-cloud-connection.md
@@ -25,7 +25,14 @@ unsent drafts, layout state, and other UI preferences backed by `localStorage`
 therefore remain available. The main process serializes updates, writes through
 atomic file replacement, and uses mode `0600` on Unix. Explicitly disconnecting,
 deleting a configuration, or clearing its state also removes the durable copy.
-The web app, which has no Electron host, does not use this desktop mirror.
+The web app, which has no Electron host, does not use this desktop mirror. Before
+loading a new Core DSH origin, the main process also removes Chromium
+`localStorage` belonging to the previous origin. When a durable snapshot exists
+without origin metadata, it performs one full migration cleanup; later launches
+clear only the previously recorded `scheme://host:port`. The current origin is
+stored in `renderer-local-storage-origins.json`, and renderer recreation on the
+same origin does not clear storage again. Browser storage remains untouched before
+the first durable snapshot exists so migration data is not lost.
 
 Users may enter either the Backend root URL or an `/api` URL. The frontend normalizes that input into HTTP API and Socket.IO connection settings. Connecting first checks `/health`, then calls `/auth/wework/sessions` to create a short-lived authorization session. Backend returns a complete `authorize_url`; local Wework opens that cloud authorization page in the embedded authorization browser and polls the session result with the client-only `poll_token`.
 

--- a/docs/zh/wework/developer-guide/wework-cloud-connection.md
+++ b/docs/zh/wework/developer-guide/wework-cloud-connection.md
@@ -23,7 +23,11 @@ Wework 默认就是一个完整的本地应用。本机 Codex、本地模型配�
 未发送草稿、布局和其他使用 `localStorage` 的界面偏好仍会保留。主进程串行处理变更，
 通过原子替换写入文件，并在 Unix 系统上使用 `0600` 权限。用户主动断开连接、删除配置
 或清空对应状态时，同样会同步删除持久化副本；不使用 Electron host 的网页版不经过
-这层桌面镜像。
+这层桌面镜像。主进程还会在加载新的 Core DSH origin 前清理旧 origin 的 Chromium
+`localStorage`：已有权威快照但尚无 origin 记录时执行一次全量迁移清理，之后只精确
+清理上一次记录的 `scheme://host:port`。当前 origin 写入
+`renderer-local-storage-origins.json`，同 origin 的 renderer 重建不会重复清理。
+首次还没有权威快照时保留浏览器存储，避免在建立持久化副本前丢失迁移数据。
 
 用户可以输入 Backend 根地址，也可以直接输入 `/api` 地址。前端会把地址归一化为 HTTP API 地址和 Socket.IO 连接信息。连接时先请求 `/health`，再调用 `/auth/wework/sessions` 创建短生命周期授权会话。Backend 返回完整 `authorize_url`，本地 Wework 在内置授权窗打开该云端授权页，并携带 `poll_token` 轮询会话结果。
 

--- a/wework/dsh/electron-host/electron-host-client.js
+++ b/wework/dsh/electron-host/electron-host-client.js
@@ -2,7 +2,7 @@ import { createReadStream, createWriteStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 
 export const ELECTRON_HOST_PROTOCOL_VERSION = 1
-const MAX_FRAME_BYTES = 1024 * 1024
+const MAX_FRAME_BYTES = 64 * 1024 * 1024
 const DEFAULT_TIMEOUT_MS = 120_000
 
 export class ElectronHostError extends Error {

--- a/wework/dsh/electron-host/electron-host-client.test.mjs
+++ b/wework/dsh/electron-host/electron-host-client.test.mjs
@@ -56,6 +56,52 @@ test('negotiates capabilities and invokes the Electron host', async () => {
   client.stop()
 })
 
+test('accepts host responses larger than the previous one MiB limit', async () => {
+  const hostToDsh = new PassThrough()
+  const dshToHost = new PassThrough()
+  const client = new ElectronHostClient({
+    token: 'test-token',
+    input: hostToDsh,
+    output: dshToHost,
+  })
+  const largeValue = 'x'.repeat(2 * 1024 * 1024)
+  let requestBuffer = ''
+  dshToHost.setEncoding('utf8')
+  dshToHost.on('data', chunk => {
+    requestBuffer += chunk
+    for (;;) {
+      const newline = requestBuffer.indexOf('\n')
+      if (newline < 0) break
+      const line = requestBuffer.slice(0, newline)
+      requestBuffer = requestBuffer.slice(newline + 1)
+      const message = JSON.parse(line)
+      if (message.type === 'hello') {
+        hostToDsh.write(
+          `${JSON.stringify({
+            type: 'hello',
+            ok: true,
+            protocolVersion: ELECTRON_HOST_PROTOCOL_VERSION,
+            capabilities: ['preferences.get'],
+          })}\n`
+        )
+        continue
+      }
+      hostToDsh.write(
+        `${JSON.stringify({
+          type: 'response',
+          id: message.id,
+          ok: true,
+          result: { largeValue },
+        })}\n`
+      )
+    }
+  })
+
+  await client.start()
+  assert.deepEqual(await client.invoke('preferences.get'), { largeValue })
+  client.stop()
+})
+
 test('rejects capabilities not granted by Electron', async () => {
   const hostToDsh = new PassThrough()
   const dshToHost = new PassThrough()

--- a/wework/dsh/electron-host/index.js
+++ b/wework/dsh/electron-host/index.js
@@ -5,7 +5,7 @@ export const name = 'wework-electron-host'
 export const inject = ['webServer']
 
 const BASE_PATH = '/wework/electron-host/v1'
-const MAX_REQUEST_BODY_BYTES = 1024 * 1024
+const MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
 
 export async function apply(ctx) {
   const client = ElectronHostClient.fromEnvironment(process.env, {

--- a/wework/e2e/desktop/scenarios/renderer-storage.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/renderer-storage.scenario.mjs
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
 const STORAGE_ENTRIES = {
   'wework.e2e.renderer-storage.model': 'model-config',
@@ -6,7 +8,9 @@ const STORAGE_ENTRIES = {
   'wework.e2e.renderer-storage.layout': 'layout-state',
 }
 
-export async function createDesktopScenario({ uiTimeoutMs }) {
+export async function createDesktopScenario({ electronUserDataDirectory, uiTimeoutMs }) {
+  const originStatePath = join(electronUserDataDirectory, 'renderer-local-storage-origins.json')
+
   return {
     async verify(control) {
       await control.command('snapshot', 'body')
@@ -35,6 +39,29 @@ export async function createDesktopScenario({ uiTimeoutMs }) {
         originBeforeRestart,
         'The Core DSH restart reused the previous origin and did not exercise storage migration'
       )
+      assert.deepEqual(JSON.parse(await readFile(originStatePath, 'utf8')), {
+        version: 1,
+        origins: [originAfterRestart],
+      })
+
+      const readyCountBeforeSecondRestart = control.readyCount
+      await control.command('restartCoreDsh', 'body')
+      await control.awaitReadyAfter(readyCountBeforeSecondRestart)
+      await control.command('waitFor', 'body', {
+        timeoutMs: uiTimeoutMs,
+        stableMs: 300,
+      })
+
+      const originAfterSecondRestart = await control.command('getLocationOrigin', 'body')
+      assert.notEqual(
+        originAfterSecondRestart,
+        originAfterRestart,
+        'The second Core DSH restart reused the previous origin'
+      )
+      assert.deepEqual(JSON.parse(await readFile(originStatePath, 'utf8')), {
+        version: 1,
+        origins: [originAfterSecondRestart],
+      })
       for (const [key, value] of Object.entries(STORAGE_ENTRIES)) {
         assert.equal(
           await control.command('getLocalStorageItem', 'body', { value: key }),

--- a/wework/electron/src/host/host-pipe.test.ts
+++ b/wework/electron/src/host/host-pipe.test.ts
@@ -98,6 +98,53 @@ describe('HostPipeServer', () => {
     server.stop()
   })
 
+  test('accepts requests larger than the previous one MiB limit', async () => {
+    const router = new HostCapabilityRouter()
+    router.grant('@wegent/dsh-app-wework', ['preferences.update'])
+    const updatePreferences = vi.fn(async () => ({ updated: true }))
+    router.register('preferences.update', updatePreferences)
+    const server = new HostPipeServer(router)
+    const childToHost = new PassThrough()
+    const hostToChild = new PassThrough()
+    const replies = createInterface({ input: hostToChild })
+    const nextReply = () =>
+      new Promise<Record<string, unknown>>(resolve =>
+        replies.once('line', line => resolve(JSON.parse(line) as Record<string, unknown>))
+      )
+    server.attachStreams(childToHost, hostToChild)
+
+    let response = nextReply()
+    childToHost.write(
+      `${JSON.stringify({
+        type: 'hello',
+        protocolVersion: 1,
+        token: server.environment().WEWORK_ELECTRON_HOST_TOKEN,
+        principal: '@wegent/dsh-app-wework',
+      })}\n`
+    )
+    await response
+
+    const largeValue = 'x'.repeat(2 * 1024 * 1024)
+    response = nextReply()
+    childToHost.write(
+      `${JSON.stringify({
+        type: 'request',
+        id: 'large-request',
+        capability: 'preferences.update',
+        params: { patch: { largeValue } },
+      })}\n`
+    )
+
+    await expect(response).resolves.toEqual({
+      type: 'response',
+      id: 'large-request',
+      ok: true,
+      result: { updated: true },
+    })
+    expect(updatePreferences).toHaveBeenCalledWith({ patch: { largeValue } }, expect.any(Object))
+    server.stop()
+  })
+
   test('writes the install response before running application shutdown', async () => {
     const router = new HostCapabilityRouter()
     router.grant('@wegent/dsh-app-wework', ['appUpdate.install'])

--- a/wework/electron/src/host/host-pipe.ts
+++ b/wework/electron/src/host/host-pipe.ts
@@ -12,7 +12,7 @@ import {
 
 const REQUEST_FD = 3
 const RESPONSE_FD = 4
-const MAX_FRAME_BYTES = 1024 * 1024
+const MAX_FRAME_BYTES = 64 * 1024 * 1024
 
 interface HostPipeSession {
   input: Readable

--- a/wework/electron/src/host/renderer-storage-store.test.ts
+++ b/wework/electron/src/host/renderer-storage-store.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RendererStorageStore } from './renderer-storage-store.js'
 
 const roots: string[] = []
@@ -17,6 +17,49 @@ async function createStore(): Promise<{ root: string; store: RendererStorageStor
 }
 
 describe('RendererStorageStore', () => {
+  it('preserves browser storage until a durable snapshot exists', async () => {
+    const { store } = await createStore()
+    const cleanup = {
+      clearAll: vi.fn(async () => undefined),
+      clearOrigin: vi.fn(async () => undefined),
+    }
+
+    await store.prepareOrigin('http://127.0.0.1:4101', cleanup)
+
+    expect(cleanup.clearAll).not.toHaveBeenCalled()
+    expect(cleanup.clearOrigin).not.toHaveBeenCalled()
+  })
+
+  it('clears legacy browser storage once and later clears only the previous origin', async () => {
+    const { root, store } = await createStore()
+    const cleanup = {
+      clearAll: vi.fn(async () => undefined),
+      clearOrigin: vi.fn(async () => undefined),
+    }
+    await store.initialize({ appearance: 'dark' })
+
+    await store.prepareOrigin('http://127.0.0.1:4101', cleanup)
+
+    expect(cleanup.clearAll).toHaveBeenCalledOnce()
+    expect(cleanup.clearOrigin).not.toHaveBeenCalled()
+    expect(await readFile(join(root, 'renderer-local-storage-origins.json'), 'utf8')).toBe(
+      '{"version":1,"origins":["http://127.0.0.1:4101"]}\n'
+    )
+
+    cleanup.clearAll.mockClear()
+    await store.prepareOrigin('http://127.0.0.1:4102', cleanup)
+
+    expect(cleanup.clearAll).not.toHaveBeenCalled()
+    expect(cleanup.clearOrigin).toHaveBeenCalledWith('http://127.0.0.1:4101')
+    expect(await readFile(join(root, 'renderer-local-storage-origins.json'), 'utf8')).toBe(
+      '{"version":1,"origins":["http://127.0.0.1:4102"]}\n'
+    )
+
+    cleanup.clearOrigin.mockClear()
+    await store.prepareOrigin('http://127.0.0.1:4102', cleanup)
+    expect(cleanup.clearOrigin).not.toHaveBeenCalled()
+  })
+
   it('seeds the durable store once and restores it on later origins', async () => {
     const { root, store } = await createStore()
 

--- a/wework/electron/src/host/renderer-storage-store.test.ts
+++ b/wework/electron/src/host/renderer-storage-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -58,6 +58,27 @@ describe('RendererStorageStore', () => {
     cleanup.clearOrigin.mockClear()
     await store.prepareOrigin('http://127.0.0.1:4102', cleanup)
     expect(cleanup.clearOrigin).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty origin list as legacy browser storage', async () => {
+    const { root, store } = await createStore()
+    const cleanup = {
+      clearAll: vi.fn(async () => undefined),
+      clearOrigin: vi.fn(async () => undefined),
+    }
+    await store.initialize({ appearance: 'dark' })
+    await writeFile(
+      join(root, 'renderer-local-storage-origins.json'),
+      '{"version":1,"origins":[]}\n'
+    )
+
+    await store.prepareOrigin('http://127.0.0.1:4101', cleanup)
+
+    expect(cleanup.clearAll).toHaveBeenCalledOnce()
+    expect(cleanup.clearOrigin).not.toHaveBeenCalled()
+    expect(await readFile(join(root, 'renderer-local-storage-origins.json'), 'utf8')).toBe(
+      '{"version":1,"origins":["http://127.0.0.1:4101"]}\n'
+    )
   })
 
   it('seeds the durable store once and restores it on later origins', async () => {

--- a/wework/electron/src/host/renderer-storage-store.ts
+++ b/wework/electron/src/host/renderer-storage-store.ts
@@ -104,6 +104,7 @@ export class RendererStorageStore {
       if (
         record.version !== 1 ||
         !Array.isArray(record.origins) ||
+        record.origins.length === 0 ||
         record.origins.some(origin => typeof origin !== 'string')
       ) {
         return null

--- a/wework/electron/src/host/renderer-storage-store.ts
+++ b/wework/electron/src/host/renderer-storage-store.ts
@@ -6,15 +6,44 @@ interface RendererStorageState {
   entries: Record<string, string>
 }
 
+interface RendererStorageOriginState {
+  version: 1
+  origins: string[]
+}
+
 export interface RendererStorageUpdate {
   clear: boolean
   changes: Record<string, string | null>
+}
+
+export interface RendererStorageCleanup {
+  clearAll(): Promise<void>
+  clearOrigin(origin: string): Promise<void>
 }
 
 export class RendererStorageStore {
   private operation = Promise.resolve()
 
   constructor(private readonly dataDirectory: string) {}
+
+  prepareOrigin(origin: string, cleanup: RendererStorageCleanup): Promise<void> {
+    return this.serial(async () => {
+      if (!(await this.readFile())) return
+
+      const state = await this.readOriginFile()
+      if (!state) {
+        await cleanup.clearAll()
+      } else {
+        await Promise.all(
+          state.origins
+            .filter(previousOrigin => previousOrigin !== origin)
+            .map(previousOrigin => cleanup.clearOrigin(previousOrigin))
+        )
+      }
+      if (state?.origins.length === 1 && state.origins[0] === origin) return
+      await this.writeOriginFile({ version: 1, origins: [origin] })
+    })
+  }
 
   initialize(seed: Record<string, string>): Promise<Record<string, string>> {
     return this.serial(async () => {
@@ -50,6 +79,10 @@ export class RendererStorageStore {
     return join(this.dataDirectory, 'renderer-local-storage.json')
   }
 
+  private originPath(): string {
+    return join(this.dataDirectory, 'renderer-local-storage-origins.json')
+  }
+
   private async readFile(): Promise<RendererStorageState | null> {
     try {
       const value = JSON.parse(await readFile(this.path(), 'utf8')) as unknown
@@ -63,11 +96,37 @@ export class RendererStorageStore {
     }
   }
 
+  private async readOriginFile(): Promise<RendererStorageOriginState | null> {
+    try {
+      const value = JSON.parse(await readFile(this.originPath(), 'utf8')) as unknown
+      if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+      const record = value as Partial<RendererStorageOriginState>
+      if (
+        record.version !== 1 ||
+        !Array.isArray(record.origins) ||
+        record.origins.some(origin => typeof origin !== 'string')
+      ) {
+        return null
+      }
+      return { version: 1, origins: record.origins }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw error
+    }
+  }
+
   private async writeFile(state: RendererStorageState): Promise<void> {
-    const path = this.path()
+    await this.writeJsonFile(this.path(), state)
+  }
+
+  private async writeOriginFile(state: RendererStorageOriginState): Promise<void> {
+    await this.writeJsonFile(this.originPath(), state)
+  }
+
+  private async writeJsonFile(path: string, value: unknown): Promise<void> {
     await mkdir(dirname(path), { recursive: true, mode: 0o700 })
     const temporary = `${path}.${process.pid}.tmp`
-    await writeFile(temporary, `${JSON.stringify(state)}\n`, { mode: 0o600 })
+    await writeFile(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 })
     await rename(temporary, path)
   }
 

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -152,6 +152,7 @@ let shutdownPromise: Promise<void> | null = null
 let dockVisible = true
 let e2eForegroundActivationAllowed = false
 let preferences: PreferencesStore | null = null
+let rendererStorage: RendererStorageStore | null = null
 let cloudCredentials: CloudCredentialService | null = null
 let windowClosePolicy: WindowClosePolicy | null = null
 let startupSplash: StartupSplash | null = null
@@ -417,6 +418,11 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
     })
   })
   try {
+    await rendererStorage?.prepareOrigin(new URL(dshUrl).origin, {
+      clearAll: () => contents.session.clearStorageData({ storages: ['localstorage'] }),
+      clearOrigin: origin =>
+        contents.session.clearStorageData({ origin, storages: ['localstorage'] }),
+    })
     await contents.loadURL(dshUrl, {
       extraHeaders: 'X-Wework-Window-Label: main',
     })
@@ -1046,7 +1052,7 @@ async function configureDesktopRuntime(): Promise<void> {
   if (desktopRuntime) return
   const environment = await desktopEnvironment()
   if (!preferences) throw new Error('Desktop preferences are unavailable')
-  const rendererStorage = new RendererStorageStore(app.getPath('userData'))
+  rendererStorage = new RendererStorageStore(app.getPath('userData'))
   workbenchPlugins = new WorkbenchPluginManager()
   const feedback = new FeedbackBundleManager({
     appVersion: () => app.getVersion(),

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -419,9 +419,13 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
   })
   try {
     await rendererStorage?.prepareOrigin(new URL(dshUrl).origin, {
-      clearAll: () => contents.session.clearStorageData({ storages: ['localstorage'] }),
+      clearAll: () => contents.session.clearData({ dataTypes: ['localStorage'] }),
       clearOrigin: origin =>
-        contents.session.clearStorageData({ origin, storages: ['localstorage'] }),
+        contents.session.clearData({
+          dataTypes: ['localStorage'],
+          origins: [origin],
+          originMatchingMode: 'origin-in-all-contexts',
+        }),
     })
     await contents.loadURL(dshUrl, {
       extraHeaders: 'X-Wework-Window-Label: main',


### PR DESCRIPTION
## Summary

- clear stale Chromium localStorage origins immediately before loading a new Core DSH URL, then restore the durable renderer-local-storage.json snapshot
- perform a one-time migration cleanup when origin metadata is absent, and track only the current Core DSH origin afterward
- raise Electron host request and response frame limits from 1 MiB to 64 MiB
- document the renderer storage lifecycle in Chinese and English

## Verification

- DSH Electron host Node tests (6 passed)
- Electron renderer storage and host pipe unit tests (11 passed)
- Electron TypeScript, ESLint, and Prettier checks
- official desktop E2E checkpoint: pnpm --filter wework e2e:desktop --segment renderer-storage
- real Electron verification across two Core DSH port changes with localStorage state preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Desktop storage now safely clears stale Chromium `localStorage` data when switching origins while preserving data during same-origin restarts.
  - Electron host communication now supports messages up to 64 MiB.

- **Bug Fixes**
  - Prevented outdated origin data from persisting across desktop connection changes.
  - Preserved storage before the first durable snapshot is created.

- **Tests**
  - Added coverage for large host messages and origin-specific storage cleanup.
  - Expanded desktop scenarios to verify origin tracking across restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->