### PR TITLE
fix(wework): correlate logs with request ids

### DIFF
--- a/backend/app/api/ws/wework_runtime_namespace.py
+++ b/backend/app/api/ws/wework_runtime_namespace.py
@@ -209,6 +209,7 @@ class WeworkRuntimeNamespace(socketio.AsyncNamespace):
             return ipc_error(data, "unauthorized", "Not authenticated")
 
         request_id = request_id_from(data)
+        set_request_context(request_id)
         method = string_field(data, "method")
         device_id = string_field(data, "device_id") or string_field(data, "deviceId")
         params = data.get("params")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -820,7 +820,7 @@ def create_app():
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
-        expose_headers=["Content-Disposition"],
+        expose_headers=["Content-Disposition", "X-Request-ID"],
     )
 
     # Register exception handlers

--- a/backend/app/services/device/runtime_rpc_service.py
+++ b/backend/app/services/device/runtime_rpc_service.py
@@ -181,13 +181,32 @@ class RuntimeRpcService:
     ) -> dict[str, Any]:
         """Call `runtime:rpc` on an online local executor and return its result."""
 
+        request_id = get_request_id()
+        started_at = time.perf_counter()
         normalized_timeout = self._normalize_timeout(timeout_seconds)
+        logger.info(
+            "[RuntimeRpcService] Runtime RPC started: request_id=%s "
+            "user_id=%s submitted_device_id=%s method=%s",
+            request_id or "-",
+            user_id,
+            device_id,
+            method,
+        )
         try:
             route = await runtime_route_resolver.resolve(
                 user_id=user_id,
                 submitted_device_id=device_id,
             )
         except RuntimeRouteError as exc:
+            logger.warning(
+                "[RuntimeRpcService] Runtime RPC route failed: request_id=%s "
+                "user_id=%s submitted_device_id=%s method=%s code=%s",
+                request_id or "-",
+                user_id,
+                device_id,
+                method,
+                exc.code,
+            )
             raise RuntimeRpcError(
                 str(exc),
                 code=exc.code,
@@ -202,6 +221,16 @@ class RuntimeRpcService:
                     route.online_info.get("runtime_features"),
                 )
             except RuntimeTaskCreateProtocolError as exc:
+                logger.warning(
+                    "[RuntimeRpcService] Runtime RPC negotiation failed: "
+                    "request_id=%s user_id=%s logical_device_id=%s "
+                    "method=%s features=%s",
+                    request_id or "-",
+                    user_id,
+                    route.logical_device_id,
+                    method,
+                    sorted(exc.features),
+                )
                 raise RuntimeRpcError(
                     str(exc),
                     code="unsupported_runtime_task_create_features",
@@ -222,7 +251,8 @@ class RuntimeRpcService:
         except Exception as exc:
             logger.exception(
                 "[RuntimeRpcService] Failed to resolve account proxy policy: "
-                "user_id=%s logical_device_id=%s method=%s",
+                "request_id=%s user_id=%s logical_device_id=%s method=%s",
+                request_id or "-",
                 user_id,
                 route.logical_device_id,
                 method,
@@ -239,14 +269,13 @@ class RuntimeRpcService:
             "method": method,
             "payload": payload,
         }
-        request_id = get_request_id()
         if request_id:
             request["request_id"] = request_id
-        started_at = time.perf_counter()
         logger.info(
-            "[RuntimeRpcService] Sending runtime RPC: user_id=%s "
+            "[RuntimeRpcService] Sending runtime RPC: request_id=%s user_id=%s "
             "logical_device_id=%s runtime_device_id=%s method=%s "
             "timeout_seconds=%s payload_keys=%s",
+            request_id or "-",
             user_id,
             route.logical_device_id,
             route.runtime_device_id,
@@ -265,9 +294,10 @@ class RuntimeRpcService:
         except Exception as exc:
             elapsed_ms = int((time.perf_counter() - started_at) * 1000)
             logger.warning(
-                "[RuntimeRpcService] Runtime RPC failed: user_id=%s "
+                "[RuntimeRpcService] Runtime RPC failed: request_id=%s user_id=%s "
                 "logical_device_id=%s runtime_device_id=%s method=%s "
                 "elapsed_ms=%s error_type=%s",
+                request_id or "-",
                 user_id,
                 route.logical_device_id,
                 route.runtime_device_id,
@@ -290,9 +320,28 @@ class RuntimeRpcService:
 
         try:
             result = self._decode_response(result, method=method)
-        except RuntimeRpcError:
+        except RuntimeRpcError as exc:
+            logger.warning(
+                "[RuntimeRpcService] Runtime RPC response decoding failed: "
+                "request_id=%s user_id=%s logical_device_id=%s method=%s code=%s",
+                request_id or "-",
+                user_id,
+                route.logical_device_id,
+                method,
+                exc.code,
+            )
             raise
         if not isinstance(result, dict):
+            logger.warning(
+                "[RuntimeRpcService] Runtime RPC returned invalid response: "
+                "request_id=%s user_id=%s logical_device_id=%s method=%s "
+                "response_type=%s",
+                request_id or "-",
+                user_id,
+                route.logical_device_id,
+                method,
+                type(result).__name__,
+            )
             raise RuntimeRpcError(
                 "Runtime RPC returned an invalid response",
                 code="runtime_rpc_invalid_response",
@@ -306,9 +355,10 @@ class RuntimeRpcService:
         )
         elapsed_ms = int((time.perf_counter() - started_at) * 1000)
         logger.info(
-            "[RuntimeRpcService] Runtime RPC completed: user_id=%s "
+            "[RuntimeRpcService] Runtime RPC completed: request_id=%s user_id=%s "
             "logical_device_id=%s runtime_device_id=%s method=%s "
             "elapsed_ms=%s result_keys=%s",
+            request_id or "-",
             user_id,
             route.logical_device_id,
             route.runtime_device_id,

--- a/backend/app/services/device/runtime_rpc_service.py
+++ b/backend/app/services/device/runtime_rpc_service.py
@@ -28,6 +28,7 @@ from app.services.device.runtime_task_create_protocol import (
     negotiate_runtime_task_create_payload,
 )
 from app.services.user_runtime_config import user_runtime_config_service
+from shared.telemetry.context import get_request_id
 from shared.telemetry.decorators import trace_async
 
 logger = logging.getLogger(__name__)
@@ -234,7 +235,13 @@ class RuntimeRpcService:
             ) from exc
 
         sio = get_sio()
-        request = {"method": method, "payload": payload}
+        request = {
+            "method": method,
+            "payload": payload,
+        }
+        request_id = get_request_id()
+        if request_id:
+            request["request_id"] = request_id
         started_at = time.perf_counter()
         logger.info(
             "[RuntimeRpcService] Sending runtime RPC: user_id=%s "

--- a/backend/tests/api/ws/test_wework_runtime_namespace.py
+++ b/backend/tests/api/ws/test_wework_runtime_namespace.py
@@ -15,6 +15,7 @@ from app.api.ws import device_namespace, local_task_responses, wework_runtime_na
 from app.api.ws.device_namespace import DeviceNamespace
 from app.api.ws.wework_runtime_namespace import WeworkRuntimeNamespace
 from app.core.socketio import SOCKETIO_MAX_HTTP_BUFFER_SIZE
+from shared.telemetry.context import get_request_id
 
 
 @pytest.fixture(autouse=True)
@@ -517,6 +518,7 @@ async def test_runtime_request_relays_to_device_runtime_rpc(monkeypatch):
     )
 
     assert response == {"id": "req-1", "ok": True, "result": {"accepted": True}}
+    assert get_request_id() == "req-1"
     runtime_rpc.assert_awaited_once_with(
         user_id=7,
         device_id="cloud-device",

--- a/backend/tests/services/test_runtime_rpc_service.py
+++ b/backend/tests/services/test_runtime_rpc_service.py
@@ -97,13 +97,19 @@ def _socketio_with_call(call: AsyncMock, *, connected: bool = True):
 
 
 @pytest.mark.asyncio
-async def test_runtime_rpc_service_propagates_request_id(monkeypatch):
+async def test_runtime_rpc_service_propagates_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.services.device import runtime_rpc_service as module
+
+    async def resolve_route(**_kwargs):
+        set_request_context("changed-during-route-resolution")
+        return _runtime_route()
 
     monkeypatch.setattr(
         module.runtime_route_resolver,
         "resolve",
-        AsyncMock(return_value=_runtime_route()),
+        AsyncMock(side_effect=resolve_route),
     )
     sio_call = AsyncMock(return_value={"accepted": True})
     monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))

--- a/backend/tests/services/test_runtime_rpc_service.py
+++ b/backend/tests/services/test_runtime_rpc_service.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from shared.telemetry.context import set_request_context
+
 
 def _runtime_route(*, runtime_features=None, device_type=None):
     from app.schemas.device import DeviceType
@@ -92,6 +94,29 @@ def _socketio_with_call(call: AsyncMock, *, connected: bool = True):
             "manager": _SocketManager(connected=connected),
         },
     )()
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_propagates_request_id(monkeypatch):
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.runtime_route_resolver,
+        "resolve",
+        AsyncMock(return_value=_runtime_route()),
+    )
+    sio_call = AsyncMock(return_value={"accepted": True})
+    monkeypatch.setattr(module, "get_sio", lambda: _socketio_with_call(sio_call))
+    set_request_context("cloud-runtime-request-1")
+
+    await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.list",
+        payload={},
+    )
+
+    assert sio_call.await_args.args[1]["request_id"] == "cloud-runtime-request-1"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_request_logging.py
+++ b/backend/tests/test_request_logging.py
@@ -54,6 +54,18 @@ def test_access_logs_include_forwarded_headers(test_client, caplog):
         ) in log_message
 
 
+def test_cors_exposes_request_id_header(test_client):
+    response = test_client.get(
+        "/api/health",
+        headers={"Origin": "https://wework.example.com"},
+    )
+
+    assert response.status_code == 200
+    exposed_headers = response.headers["access-control-expose-headers"]
+    assert "X-Request-ID" in exposed_headers
+    assert response.headers["X-Request-ID"]
+
+
 def test_access_logs_redact_sensitive_query_parameters(test_client, caplog):
     with caplog.at_level(logging.INFO, logger="app.main"):
         response = test_client.get("/api/health?token=opencut-secret&probe=visible")

--- a/docs/en/wegent/developer-guide/local-device-architecture.md
+++ b/docs/en/wegent/developer-guide/local-device-architecture.md
@@ -78,6 +78,18 @@ The Electron layer does not retain an event journal, generate sequences, or impl
 
 Backend connectivity is optional, not a required dependency for the local app. When login, model/capability sync, cloud projects, or web control of the local computer are needed, the executor can register as a local device over the Backend Socket.IO channel. The same executor sidecar reuses one command handler and one runtime work handler while serving Wework App and core DSH over the local App IPC endpoint and Backend over Socket.IO. This design does not introduce a local HTTP gateway and does not require Wework App to start Backend itself.
 
+### Cross-Component Request Log Correlation
+
+Wework generates a request ID when a request enters a cross-process or cross-service boundary and reuses it in downstream logs for that request. This field diagnoses one request only. It does not replace task IDs, device IDs, thread IDs, or OpenTelemetry trace IDs, and it must not be used to infer business state.
+
+- Renderer HTTP requests to Backend use `wework-http-<uuid>` and pass it through `X-Request-ID`. Backend reuses that value in its request context and returns `X-Request-ID` in the response; CORS explicitly exposes the response header.
+- Renderer calls through core DSH to the local executor use `wework-local-<uuid>`. The same `request_id` appears in DSH request-started, completed, or failed logs and in the executor's `runtime:rpc` received and responded logs.
+- Wework calls to a remote executor through Backend Socket.IO use `cloud-runtime-<uuid>`. Backend binds the value to the request context while handling `runtime:request` and copies it unchanged into the downstream `runtime:rpc` envelope; the remote executor continues logging the same value.
+
+When no request ID exists, the protocol layer omits the `request_id` field instead of sending a null value, and each component uses its normal no-context log placeholder. Request IDs must be bounded printable diagnostic identifiers. Logs must not pair them with request bodies, authentication data, model keys, or local credentials.
+
+To investigate a request, take the `request_id` from the Wework frontend, DSH, or Backend log near the user-visible failure, then search for that exact value in the same diagnostic directory or centralized log system. Start and finish entries also record the method, outcome, and elapsed time, so a missing boundary identifies the component where the request stopped without relying on approximate timestamps or task names.
+
 ### Executor Startup Environment and Codex Home Initialization
 
 Before creating its asynchronous runtime or starting Agent child processes, a Unix executor runs the current user's interactive login shell to read the complete environment. It prefers the login shell from the system user database and falls back through `$SHELL`, `zsh`, `bash`, and `sh`. Environment capture has a fixed timeout. On failure, the executor keeps its parent environment and still appends standard developer locations such as Homebrew and `/usr/local`. The executor then passes the resulting environment consistently to Codex, Claude Code, plugins, skills, hooks, PTYs, and device commands, so Wework local sidecars, standalone local devices, and Linux cloud or remote devices share the same PATH resolution behavior.

--- a/docs/zh/wegent/developer-guide/local-device-architecture.md
+++ b/docs/zh/wegent/developer-guide/local-device-architecture.md
@@ -78,6 +78,18 @@ Electron 层不保存事件日志、不生成序号，也不实现重放或合�
 
 Backend 是可选能力，而不是本地 app 的必需依赖。需要登录、模型/能力同步、云端项目或网页版控制本机时，executor 可以使用 Backend Socket.IO 通道注册为本地设备；同一个 executor sidecar 会复用同一个 command handler 和 runtime work handler，一边通过本地 app IPC 端点服务 Wework App 和 core DSH，一边通过 Socket.IO 服务 Backend。这个设计不引入本机 HTTP gateway，也不要求 Wework App 自己启动 Backend。
 
+### 跨组件请求日志关联
+
+Wework 在请求进入跨进程或跨服务边界时生成 request ID，并在同一次请求的后续日志中复用它。该字段只用于诊断单次请求，不替代任务 ID、设备 ID、线程 ID 或 OpenTelemetry trace ID，也不能用于推断业务状态。
+
+- Renderer 发往 Backend 的 HTTP 请求使用 `wework-http-<uuid>`，通过 `X-Request-ID` 传递。Backend 复用该值写入请求上下文，并在响应中返回 `X-Request-ID`；CORS 配置显式暴露该响应头。
+- Renderer 通过 core DSH 调用本地 executor 时使用 `wework-local-<uuid>`。同一个 `request_id` 同时写入 DSH 的请求开始、完成或失败日志，以及 executor 的 `runtime:rpc` 接收与响应日志。
+- Wework 通过 Backend Socket.IO 调用远程 executor 时使用 `cloud-runtime-<uuid>`。Backend 在处理 `runtime:request` 时把该值绑定到请求上下文，并原样放入下游 `runtime:rpc` 信封；远程 executor 的对应日志继续使用同一个值。
+
+调用方没有 request ID 时，协议层不发送空的 `request_id` 字段；各组件日志使用自身的无上下文占位符。请求 ID 必须是有界、可打印的诊断标识，日志不得同时记录请求正文、认证信息、模型密钥或本地凭据。
+
+排查一条请求时，先从用户可见失败附近的 Wework frontend、DSH 或 Backend 日志取得 `request_id`，再在同一诊断目录或集中式日志系统中按精确值搜索。开始和结束日志还会记录方法名、结果与耗时，因此缺失的边界可以直接定位请求停留在哪个组件，而不需要按相近时间或任务名称猜测。
+
 ### Executor 启动环境与 Codex Home 初始化
 
 Unix executor 在创建异步运行时和启动 Agent 子进程之前，通过运行当前用户的交互式登录 shell 读取完整环境。shell 优先使用系统用户数据库中的登录 shell，并依次回退到 `$SHELL`、`zsh`、`bash` 和 `sh`。采集过程有固定超时；失败时 executor 保留父进程环境，并继续补充 Homebrew、`/usr/local` 等标准开发目录。最终环境由 executor 统一传递给 Codex、Claude Code、插件、技能、Hooks、PTY 和设备命令，因此 Wework 本地 sidecar、独立本地设备以及 Linux 云端或远程设备使用同一套 PATH 解析逻辑。

--- a/executor/src/local/backend.rs
+++ b/executor/src/local/backend.rs
@@ -744,16 +744,16 @@ where
                         ("method", method.clone()),
                     ],
                 ));
-                let Some(handler) = runtime_work_handler else {
-                    return Some(runtime_error_response(AppIpcError::new(
+                let response = if let Some(handler) = runtime_work_handler {
+                    match handler.handle_runtime_rpc(payload).await {
+                        Ok(result) => result,
+                        Err(error) => runtime_error_response(error),
+                    }
+                } else {
+                    runtime_error_response(AppIpcError::new(
                         "runtime_unavailable",
                         "Runtime work handler is not available",
-                    )));
-                };
-
-                let response = match handler.handle_runtime_rpc(payload).await {
-                    Ok(result) => result,
-                    Err(error) => runtime_error_response(error),
+                    ))
                 };
                 write_executor_log_line(&format_executor_log(
                     "runtime:rpc responded",

--- a/executor/src/local/backend.rs
+++ b/executor/src/local/backend.rs
@@ -731,9 +731,18 @@ where
                     .and_then(Value::as_str)
                     .unwrap_or("<missing>")
                     .to_owned();
+                let request_id = payload
+                    .get("request_id")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or("-")
+                    .to_owned();
                 write_executor_log_line(&format_executor_log(
                     "runtime:rpc received",
-                    &[("method", method.clone())],
+                    &[
+                        ("request_id", request_id.clone()),
+                        ("method", method.clone()),
+                    ],
                 ));
                 let Some(handler) = runtime_work_handler else {
                     return Some(runtime_error_response(AppIpcError::new(
@@ -749,6 +758,8 @@ where
                 write_executor_log_line(&format_executor_log(
                     "runtime:rpc responded",
                     &[
+                        ("request_id", request_id),
+                        ("method", method.clone()),
                         (
                             "ok",
                             response

--- a/executor/tests/local_backend_contract.rs
+++ b/executor/tests/local_backend_contract.rs
@@ -558,6 +558,31 @@ async fn local_backend_runtime_rpc_handler_uses_default_runtime_work_handler() {
 }
 
 #[tokio::test]
+async fn local_backend_runtime_rpc_logs_accept_request_id_field() {
+    let transport = RecordingTransport::default();
+    let (event_tx, event_rx) = broadcast::channel(8);
+    let runner = LocalBackendRunner::new_for_app_sidecar_with_shared_runtime_work_handler(
+        local_backend_config(),
+        transport.clone(),
+        Arc::new(StaticRuntimeWorkHandler(json!({"success": true}))),
+        event_rx,
+    );
+    drop(event_tx);
+    runner.register_handlers();
+
+    let handler = transport.handler("runtime:rpc").unwrap();
+    let ack = handler(json!({
+        "request_id": "cloud-runtime-request-1",
+        "method": "runtime.tasks.list",
+        "payload": {}
+    }))
+    .await
+    .unwrap();
+
+    assert_eq!(ack["success"], true, "{ack}");
+}
+
+#[tokio::test]
 async fn local_backend_runtime_rpc_handler_compresses_large_ack_payloads() {
     let transport = RecordingTransport::default();
     let (event_tx, event_rx) = broadcast::channel(8);

--- a/wework/dsh/executor-runtime/executor-http.test.mjs
+++ b/wework/dsh/executor-runtime/executor-http.test.mjs
@@ -27,6 +27,28 @@ test('preserves one request id across browser, DSH, and executor RPC', async () 
   assert.deepEqual(JSON.parse(response.body), { ok: true, result: { items: [] } })
 })
 
+test('does not forward an unsafe browser request id to the executor', async () => {
+  const request = executorRpcRequest({
+    id: 'unsafe\nrequest-id',
+    method: 'runtime.tasks.list',
+    params: {},
+  })
+  const response = responseFixture()
+  let receivedRequestId = null
+  const client = {
+    request: async (_method, _params, _timeoutMs, requestId) => {
+      receivedRequestId = requestId
+      return { items: [] }
+    },
+  }
+
+  await handleExecutorRpc(request, response, client)
+
+  assert.match(receivedRequestId, /^[0-9a-f-]{36}$/)
+  assert.notEqual(receivedRequestId, 'unsafe\nrequest-id')
+  assert.equal(response.headers['x-request-id'], receivedRequestId)
+})
+
 test('passes the browser cursor to the executor-owned event stream', async () => {
   const request = executorEventRequest('?after=7')
   const response = responseFixture()

--- a/wework/dsh/executor-runtime/executor-http.test.mjs
+++ b/wework/dsh/executor-runtime/executor-http.test.mjs
@@ -2,7 +2,30 @@ import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { Readable } from 'node:stream'
 import test from 'node:test'
-import { handleExecutorEvents } from './index.js'
+import { handleExecutorEvents, handleExecutorRpc } from './index.js'
+
+test('preserves one request id across browser, DSH, and executor RPC', async () => {
+  const request = executorRpcRequest(
+    { id: 'wework-local-request-1', method: 'runtime.tasks.list', params: {} },
+    { 'x-request-id': 'wework-local-request-1' }
+  )
+  const response = responseFixture()
+  const client = {
+    request: async (method, params, timeoutMs, requestId) => {
+      assert.equal(method, 'runtime.tasks.list')
+      assert.deepEqual(params, {})
+      assert.equal(timeoutMs, undefined)
+      assert.equal(requestId, 'wework-local-request-1')
+      return { items: [] }
+    },
+  }
+
+  await handleExecutorRpc(request, response, client)
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers['x-request-id'], 'wework-local-request-1')
+  assert.deepEqual(JSON.parse(response.body), { ok: true, result: { items: [] } })
+})
 
 test('passes the browser cursor to the executor-owned event stream', async () => {
   const request = executorEventRequest('?after=7')
@@ -173,6 +196,15 @@ function executorEventRequest(query = '') {
   request.method = 'GET'
   request.url = `/wework/executor/v1/events${query}`
   request.headers = {}
+  request.socket = { remoteAddress: '127.0.0.1' }
+  return request
+}
+
+function executorRpcRequest(body, headers = {}) {
+  const request = Readable.from([Buffer.from(JSON.stringify(body))])
+  request.method = 'POST'
+  request.url = '/wework/executor/v1/rpc'
+  request.headers = headers
   request.socket = { remoteAddress: '127.0.0.1' }
   return request
 }

--- a/wework/dsh/executor-runtime/executor-runtime-client.js
+++ b/wework/dsh/executor-runtime/executor-runtime-client.js
@@ -69,10 +69,12 @@ export class ExecutorRuntimeClient {
     return this.description
   }
 
-  request(method, params = {}, timeoutMs = this.requestTimeoutMs) {
+  request(method, params = {}, timeoutMs = this.requestTimeoutMs, requestId) {
     if (method !== 'executor.protocol.describe') {
       if (!this.description && this.negotiationPromise) {
-        return this.negotiationPromise.then(() => this.request(method, params, timeoutMs))
+        return this.negotiationPromise.then(() =>
+          this.request(method, params, timeoutMs, requestId)
+        )
       }
       assertRendererMethod(method, this.description?.renderer_methods)
     }
@@ -81,7 +83,7 @@ export class ExecutorRuntimeClient {
         new ExecutorRuntimeError('runtime_not_ready', 'Executor runtime is not ready', true)
       )
     }
-    const id = randomUUID()
+    const id = requestId?.trim() || randomUUID()
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id)

--- a/wework/dsh/executor-runtime/executor-runtime-client.js
+++ b/wework/dsh/executor-runtime/executor-runtime-client.js
@@ -84,6 +84,14 @@ export class ExecutorRuntimeClient {
       )
     }
     const id = requestId?.trim() || randomUUID()
+    if (this.pending.has(id)) {
+      return Promise.reject(
+        new ExecutorRuntimeError(
+          'duplicate_request_id',
+          `Executor request ID ${id} is already in flight`
+        )
+      )
+    }
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id)

--- a/wework/dsh/executor-runtime/executor-runtime-client.test.mjs
+++ b/wework/dsh/executor-runtime/executor-runtime-client.test.mjs
@@ -93,6 +93,25 @@ test('decodes compressed local endpoint responses without disconnecting', async 
   }
 })
 
+test('uses a caller-provided request id for downstream log correlation', async () => {
+  const fixture = await executorFixture()
+  const client = new ExecutorRuntimeClient({
+    transport: new LocalEndpointTransport({
+      endpoint: fixture.endpoint,
+      token: fixture.token,
+      reconnectDelayMs: 10,
+    }),
+  })
+  try {
+    await client.start()
+    await client.request('executor.health', {}, undefined, 'wework-local-request-1')
+    assert.equal(fixture.lastRequestId(), 'wework-local-request-1')
+  } finally {
+    await client.stop()
+    await fixture.stop()
+  }
+})
+
 async function executorFixture(options = {}) {
   const directory = await mkdtemp(join(tmpdir(), 'dsh-executor-runtime-'))
   const endpoint =
@@ -102,6 +121,7 @@ async function executorFixture(options = {}) {
   const token = '0123456789abcdef0123456789abcdef'
   const clients = new Set()
   let connectionCount = 0
+  let lastRequestId = null
   const server = createServer(socket => {
     connectionCount += 1
     clients.add(socket)
@@ -159,6 +179,7 @@ async function executorFixture(options = {}) {
             )
           }, options.descriptionDelayMs ?? 0)
         } else {
+          lastRequestId = message.id
           const result = options.compressedHealthResponse
             ? {
                 __runtimeRpcEncoding: 'gzip+base64+json',
@@ -197,6 +218,9 @@ async function executorFixture(options = {}) {
     },
     connectionCount() {
       return connectionCount
+    },
+    lastRequestId() {
+      return lastRequestId
     },
     disconnect() {
       for (const client of clients) client.destroy()

--- a/wework/dsh/executor-runtime/executor-runtime-client.test.mjs
+++ b/wework/dsh/executor-runtime/executor-runtime-client.test.mjs
@@ -112,6 +112,30 @@ test('uses a caller-provided request id for downstream log correlation', async (
   }
 })
 
+test('rejects a duplicate caller-provided request id while the first request is in flight', async () => {
+  const fixture = await executorFixture({ healthResponseDelayMs: 25 })
+  const client = new ExecutorRuntimeClient({
+    transport: new LocalEndpointTransport({
+      endpoint: fixture.endpoint,
+      token: fixture.token,
+      reconnectDelayMs: 10,
+    }),
+  })
+  try {
+    await client.start()
+    const firstRequest = client.request('executor.health', {}, undefined, 'wework-local-request-1')
+
+    await assert.rejects(
+      client.request('executor.health', {}, undefined, 'wework-local-request-1'),
+      error => error instanceof ExecutorRuntimeError && error.code === 'duplicate_request_id'
+    )
+    await assert.doesNotReject(firstRequest)
+  } finally {
+    await client.stop()
+    await fixture.stop()
+  }
+})
+
 async function executorFixture(options = {}) {
   const directory = await mkdtemp(join(tmpdir(), 'dsh-executor-runtime-'))
   const endpoint =
@@ -191,14 +215,16 @@ async function executorFixture(options = {}) {
                 ).toString('base64'),
               }
             : { healthy: true }
-          socket.write(
-            `${JSON.stringify({
-              type: 'response',
-              id: message.id,
-              ok: true,
-              result,
-            })}\n`
-          )
+          setTimeout(() => {
+            socket.write(
+              `${JSON.stringify({
+                type: 'response',
+                id: message.id,
+                ok: true,
+                result,
+              })}\n`
+            )
+          }, options.healthResponseDelayMs ?? 0)
         }
       }
     })

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -352,7 +352,10 @@ function requestIdFromBody(body) {
 }
 
 function normalizedRequestId(value) {
-  return typeof value === 'string' && value.trim() ? value.trim().slice(0, 128) : null
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!normalized || normalized.length > 128 || /[^\x20-\x7e]/.test(normalized)) return null
+  return normalized
 }
 
 function isRecord(value) {

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { Transform, Writable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { ExecutorRuntimeClient, ExecutorRuntimeError } from './executor-runtime-client.js'
@@ -28,7 +29,7 @@ export async function apply(ctx) {
     return () => projectionStream.stop()
   }, 'wework-executor-runtime: session projection')
   register(ctx, BASE_PATH, (req, res) => describe(req, res, client))
-  register(ctx, `${BASE_PATH}/rpc`, (req, res) => rpc(req, res, client))
+  register(ctx, `${BASE_PATH}/rpc`, (req, res) => handleExecutorRpc(req, res, client))
   register(ctx, `${BASE_PATH}/events`, (req, res) => handleExecutorEvents(req, res))
 }
 
@@ -61,18 +62,40 @@ async function describe(req, res, client) {
   }
 }
 
-async function rpc(req, res, client) {
+export async function handleExecutorRpc(req, res, client) {
   if (!trustedBrowserRequest(req)) return forbidden(res)
   if (req.method !== 'POST') return methodNotAllowed(res, 'POST')
+  const startedAt = Date.now()
+  let requestId = requestIdFromRequest(req)
+  let method = '<invalid>'
   try {
     const body = await readJsonBody(req)
     if (!isRecord(body) || typeof body.method !== 'string' || !isRecord(body.params)) {
       throw new ExecutorRuntimeError('invalid_params', 'Request must contain method and params')
     }
-    const result = await client.request(body.method, body.params)
-    sendJson(res, 200, { ok: true, result: result ?? null })
+    requestId = requestId ?? requestIdFromBody(body) ?? randomUUID()
+    method = body.method
+    console.info('[wework-executor-runtime] RPC request started', {
+      request_id: requestId,
+      method,
+    })
+    const result = await client.request(body.method, body.params, undefined, requestId)
+    console.info('[wework-executor-runtime] RPC request finished', {
+      request_id: requestId,
+      method,
+      elapsed_ms: Date.now() - startedAt,
+      ok: true,
+    })
+    sendJson(res, 200, { ok: true, result: result ?? null }, false, requestId)
   } catch (error) {
-    sendError(res, error)
+    requestId ??= randomUUID()
+    console.error('[wework-executor-runtime] RPC request failed', {
+      request_id: requestId,
+      method,
+      elapsed_ms: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    sendError(res, error, requestId)
   }
 }
 
@@ -261,7 +284,7 @@ function trustedBrowserRequest(req) {
   }
 }
 
-function sendError(res, error) {
+function sendError(res, error, requestId) {
   const body = errorBody(error)
   const status = ['invalid_json', 'invalid_params', 'request_too_large'].includes(body.error.code)
     ? 400
@@ -270,7 +293,7 @@ function sendError(res, error) {
       : body.error.retryable
         ? 503
         : 500
-  sendJson(res, status, body)
+  sendJson(res, status, body, false, requestId)
 }
 
 function errorBody(error) {
@@ -293,12 +316,13 @@ function errorBody(error) {
   }
 }
 
-function sendJson(res, status, value, head = false) {
+function sendJson(res, status, value, head = false, requestId) {
   const body = JSON.stringify(value)
   res.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
     'cache-control': 'no-store',
     'content-length': Buffer.byteLength(body),
+    ...(requestId ? { 'x-request-id': requestId } : {}),
   })
   res.end(head ? undefined : body)
 }
@@ -317,6 +341,18 @@ function methodNotAllowed(res, allow) {
 
 function singleHeader(value) {
   return Array.isArray(value) ? value[0] : value
+}
+
+function requestIdFromRequest(req) {
+  return normalizedRequestId(singleHeader(req.headers['x-request-id']))
+}
+
+function requestIdFromBody(body) {
+  return normalizedRequestId(body.id) ?? normalizedRequestId(body.request_id)
+}
+
+function normalizedRequestId(value) {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, 128) : null
 }
 
 function isRecord(value) {

--- a/wework/e2e/desktop/modules/cloud-worktree-flows.mjs
+++ b/wework/e2e/desktop/modules/cloud-worktree-flows.mjs
@@ -373,12 +373,12 @@ async function verifyCapability(context) {
   const log = await readFile(cloudEnvironment.remoteExecutorLogPath, 'utf8')
   assert.match(
     log,
-    /runtime:rpc received method=runtime\.worktrees\.capabilities/,
+    /runtime:rpc received [^\n]*method=runtime\.worktrees\.capabilities/,
     'The capability assertion did not cross the real Backend-to-Executor RPC route'
   )
   assert.match(
     log,
-    /runtime:rpc received method=runtime\.worktrees\.preflight/,
+    /runtime:rpc received [^\n]*method=runtime\.worktrees\.preflight/,
     'The preflight assertion did not cross the real Backend-to-Executor RPC route'
   )
 }

--- a/wework/e2e/desktop/modules/response-protocol.mjs
+++ b/wework/e2e/desktop/modules/response-protocol.mjs
@@ -391,7 +391,7 @@ function json(response, statusCode, value) {
 
 function cors(response) {
   response.setHeader('Access-Control-Allow-Origin', '*')
-  response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Request-ID')
   response.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
 }
 

--- a/wework/src/api/backend/runtimeIpc.test.ts
+++ b/wework/src/api/backend/runtimeIpc.test.ts
@@ -63,7 +63,8 @@ describe('createCloudRuntimeIpcClient', () => {
   })
 
   it('preserves ordinary runtime results', async () => {
-    socket.emit.mockImplementation((_event, _request, acknowledge) => {
+    socket.emit.mockImplementation((_event, request, acknowledge) => {
+      expect(request.id).toMatch(/^cloud-runtime-/)
       acknowledge({ ok: true, result: { success: true } })
     })
     const client = createCloudRuntimeIpcClient({

--- a/wework/src/api/backend/runtimeIpc.test.ts
+++ b/wework/src/api/backend/runtimeIpc.test.ts
@@ -27,7 +27,7 @@ describe('createCloudRuntimeIpcClient', () => {
     socket.emit.mockReset()
     socket.on.mockReset()
     socket.off.mockReset()
-    ensureConnected.mockClear()
+    ensureConnected.mockReset().mockResolvedValue(undefined)
     connect.mockClear()
     disconnect.mockClear()
     dispose.mockClear()
@@ -76,6 +76,69 @@ describe('createCloudRuntimeIpcClient', () => {
     await expect(client.request('runtime.tasks.list', {}, 'cloud-device')).resolves.toEqual({
       success: true,
     })
+  })
+
+  it('keeps one request id when the cloud socket connection fails', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    ensureConnected.mockRejectedValueOnce(new Error('socket unavailable'))
+    const client = createCloudRuntimeIpcClient({
+      socketBaseUrl: 'https://cloud.example.com',
+      socketPath: '/socket.io',
+      token: 'token',
+    })
+
+    await expect(client.request('runtime.tasks.list', {}, 'cloud-device')).rejects.toThrow(
+      'socket unavailable'
+    )
+    expect(warning).toHaveBeenCalledWith(
+      '[Wework] Cloud runtime RPC connection failed',
+      expect.objectContaining({
+        request_id: expect.stringMatching(/^cloud-runtime-/),
+        method: 'runtime.tasks.list',
+        device_id: 'cloud-device',
+      })
+    )
+    warning.mockRestore()
+  })
+
+  it('does not finish a timed out request when a late acknowledgement arrives', async () => {
+    vi.useFakeTimers()
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined)
+    let acknowledge: ((ack: { ok: true; result: { success: boolean } }) => void) | undefined
+    socket.emit.mockImplementation((_event, _request, callback) => {
+      acknowledge = callback
+    })
+    const client = createCloudRuntimeIpcClient({
+      socketBaseUrl: 'https://cloud.example.com',
+      socketPath: '/socket.io',
+      token: 'token',
+    })
+
+    try {
+      const request = client.request('runtime.tasks.list', {}, 'cloud-device', 10)
+      const timedOut = expect(request).rejects.toThrow('runtime.tasks.list timed out')
+      await vi.advanceTimersByTimeAsync(10)
+      await timedOut
+
+      acknowledge?.({ ok: true, result: { success: true } })
+
+      expect(warning).toHaveBeenCalledWith(
+        '[Wework] Cloud runtime RPC acknowledgement arrived after settlement',
+        expect.objectContaining({
+          request_id: expect.stringMatching(/^cloud-runtime-/),
+          method: 'runtime.tasks.list',
+        })
+      )
+      expect(debug).not.toHaveBeenCalledWith(
+        '[Wework] Cloud runtime RPC request finished',
+        expect.anything()
+      )
+    } finally {
+      warning.mockRestore()
+      debug.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
   it('uses the requested device command timeout for the relay and acknowledgement', async () => {

--- a/wework/src/api/backend/runtimeIpc.ts
+++ b/wework/src/api/backend/runtimeIpc.ts
@@ -1,5 +1,6 @@
 import { createSocketClient, type AuthenticatedSocketClient } from '@wegent/chat-core'
 import type { LocalExecutorEvent } from '@/desktop/localExecutor'
+import { createRequestId } from '@/lib/request-id'
 
 const WEWORK_RUNTIME_NAMESPACE = '/wework-runtime'
 const REQUEST_EVENT = 'runtime:request'
@@ -41,8 +42,6 @@ export interface CloudRuntimeIpcClient {
   reconnect: () => Promise<void>
   dispose: () => void
 }
-
-let nextRequestId = 1
 
 export function createCloudRuntimeIpcClient(
   options: RuntimeIpcClientOptions
@@ -91,7 +90,7 @@ async function emitRuntimeRequest<T>(
   timeoutMs = ACK_TIMEOUT_MS
 ): Promise<T> {
   await client.ensureConnected()
-  const requestId = `cloud-runtime-${nextRequestId++}`
+  const requestId = createRequestId('cloud-runtime')
   const targetDeviceId = deviceId ?? deviceIdFromParams(params)
   if (!targetDeviceId) {
     throw new Error(`Cloud runtime request ${method} missing deviceId`)
@@ -101,9 +100,21 @@ async function emitRuntimeRequest<T>(
     method === 'device.execute_command'
       ? relayTimeoutSeconds * 1000 + COMMAND_ACK_GRACE_MS
       : timeoutMs
+  const startedAt = Date.now()
+  console.debug('[Wework] Cloud runtime RPC request started', {
+    request_id: requestId,
+    method,
+    device_id: targetDeviceId,
+  })
 
   return new Promise<T>((resolve, reject) => {
     const timeout = window.setTimeout(() => {
+      console.warn('[Wework] Cloud runtime RPC request timed out', {
+        request_id: requestId,
+        method,
+        device_id: targetDeviceId,
+        elapsed_ms: Date.now() - startedAt,
+      })
       reject(new Error(`${method} timed out`))
     }, acknowledgementTimeoutMs)
 
@@ -120,14 +131,46 @@ async function emitRuntimeRequest<T>(
       (ack: RuntimeIpcAck<T> | undefined) => {
         window.clearTimeout(timeout)
         if (!ack) {
+          console.warn('[Wework] Cloud runtime RPC returned an empty acknowledgement', {
+            request_id: requestId,
+            method,
+            device_id: targetDeviceId,
+            elapsed_ms: Date.now() - startedAt,
+          })
           reject(new Error(`${method} returned an empty acknowledgement`))
           return
         }
         if (ack.ok === false || ack.error) {
+          console.warn('[Wework] Cloud runtime RPC request failed', {
+            request_id: requestId,
+            method,
+            device_id: targetDeviceId,
+            elapsed_ms: Date.now() - startedAt,
+            code: ack.error?.code,
+          })
           reject(new Error(formatRuntimeIpcError(ack)))
           return
         }
-        void decodeRuntimeIpcResult<T>(ack.result ?? null).then(resolve, reject)
+        void decodeRuntimeIpcResult<T>(ack.result ?? null).then(
+          result => {
+            console.debug('[Wework] Cloud runtime RPC request finished', {
+              request_id: requestId,
+              method,
+              device_id: targetDeviceId,
+              elapsed_ms: Date.now() - startedAt,
+            })
+            resolve(result)
+          },
+          error => {
+            console.warn('[Wework] Cloud runtime RPC response decoding failed', {
+              request_id: requestId,
+              method,
+              device_id: targetDeviceId,
+              elapsed_ms: Date.now() - startedAt,
+            })
+            reject(error)
+          }
+        )
       }
     )
   })

--- a/wework/src/api/backend/runtimeIpc.ts
+++ b/wework/src/api/backend/runtimeIpc.ts
@@ -89,26 +89,39 @@ async function emitRuntimeRequest<T>(
   deviceId?: string,
   timeoutMs = ACK_TIMEOUT_MS
 ): Promise<T> {
-  await client.ensureConnected()
   const requestId = createRequestId('cloud-runtime')
+  const startedAt = Date.now()
   const targetDeviceId = deviceId ?? deviceIdFromParams(params)
   if (!targetDeviceId) {
     throw new Error(`Cloud runtime request ${method} missing deviceId`)
+  }
+  console.debug('[Wework] Cloud runtime RPC request started', {
+    request_id: requestId,
+    method,
+    device_id: targetDeviceId,
+  })
+  try {
+    await client.ensureConnected()
+  } catch (error) {
+    console.warn('[Wework] Cloud runtime RPC connection failed', {
+      request_id: requestId,
+      method,
+      device_id: targetDeviceId,
+      elapsed_ms: Date.now() - startedAt,
+    })
+    throw error
   }
   const relayTimeoutSeconds = resolveRelayTimeoutSeconds(method, params, timeoutMs)
   const acknowledgementTimeoutMs =
     method === 'device.execute_command'
       ? relayTimeoutSeconds * 1000 + COMMAND_ACK_GRACE_MS
       : timeoutMs
-  const startedAt = Date.now()
-  console.debug('[Wework] Cloud runtime RPC request started', {
-    request_id: requestId,
-    method,
-    device_id: targetDeviceId,
-  })
 
   return new Promise<T>((resolve, reject) => {
+    let settled = false
     const timeout = window.setTimeout(() => {
+      if (settled) return
+      settled = true
       console.warn('[Wework] Cloud runtime RPC request timed out', {
         request_id: requestId,
         method,
@@ -129,6 +142,16 @@ async function emitRuntimeRequest<T>(
         timeout_seconds: relayTimeoutSeconds,
       },
       (ack: RuntimeIpcAck<T> | undefined) => {
+        if (settled) {
+          console.warn('[Wework] Cloud runtime RPC acknowledgement arrived after settlement', {
+            request_id: requestId,
+            method,
+            device_id: targetDeviceId,
+            elapsed_ms: Date.now() - startedAt,
+          })
+          return
+        }
+        settled = true
         window.clearTimeout(timeout)
         if (!ack) {
           console.warn('[Wework] Cloud runtime RPC returned an empty acknowledgement', {

--- a/wework/src/api/dsh/executorTransport.test.ts
+++ b/wework/src/api/dsh/executorTransport.test.ts
@@ -74,6 +74,7 @@ describe('DSH executor transport', () => {
   })
 
   test('preserves structured executor errors', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     vi.stubGlobal(
       'fetch',
       vi.fn(
@@ -98,6 +99,37 @@ describe('DSH executor transport', () => {
       code: 'runtime_unavailable',
       retryable: true,
     })
+    expect(warning).toHaveBeenCalledWith(
+      '[Wework] Executor RPC request failed',
+      expect.objectContaining({
+        request_id: expect.stringMatching(/^wework-local-/),
+        method: 'runtime.tasks.list',
+        status: 503,
+        code: 'runtime_unavailable',
+        retryable: true,
+      })
+    )
+    warning.mockRestore()
+  })
+
+  test('logs correlated metadata when an executor response is not valid json', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('not-json', { status: 502 }))
+    )
+
+    await expect(requestDshExecutor('runtime.tasks.list')).rejects.toBeInstanceOf(SyntaxError)
+    expect(warning).toHaveBeenCalledWith(
+      '[Wework] Executor RPC response parsing failed',
+      expect.objectContaining({
+        request_id: expect.stringMatching(/^wework-local-/),
+        method: 'runtime.tasks.list',
+        status: 502,
+        error_type: 'SyntaxError',
+      })
+    )
+    warning.mockRestore()
   })
 
   test('delivers text deltas without waiting for animation frames', () => {

--- a/wework/src/api/dsh/executorTransport.test.ts
+++ b/wework/src/api/dsh/executorTransport.test.ts
@@ -56,11 +56,20 @@ describe('DSH executor transport', () => {
       '/wework/executor/v1/rpc',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({
-          method: 'runtime.tasks.list',
-          params: { archived: false },
+        headers: expect.objectContaining({
+          'x-request-id': expect.stringMatching(/^wework-local-/),
         }),
+        body: expect.stringContaining('"method":"runtime.tasks.list"'),
       })
+    )
+    const request = JSON.parse(fetchMock.mock.calls[0][1]?.body as string)
+    expect(request).toMatchObject({
+      id: expect.stringMatching(/^wework-local-/),
+      method: 'runtime.tasks.list',
+      params: { archived: false },
+    })
+    expect(request.id).toBe(
+      (fetchMock.mock.calls[0][1]?.headers as Record<string, string>)['x-request-id']
     )
   })
 

--- a/wework/src/api/dsh/executorTransport.ts
+++ b/wework/src/api/dsh/executorTransport.ts
@@ -114,11 +114,32 @@ export async function requestDshExecutor<T>(
     elapsed_ms: Date.now() - startedAt,
     status: response.status,
   })
-  const body = (await response.json()) as
-    | { ok: true; result: T }
-    | ({ ok?: false } & DshExecutorErrorBody)
+  let body: { ok: true; result: T } | ({ ok?: false } & DshExecutorErrorBody)
+  try {
+    body = (await response.json()) as
+      | { ok: true; result: T }
+      | ({ ok?: false } & DshExecutorErrorBody)
+  } catch (error) {
+    console.warn('[Wework] Executor RPC response parsing failed', {
+      request_id: requestId,
+      method,
+      elapsed_ms: Date.now() - startedAt,
+      status: response.status,
+      error_type: error instanceof Error ? error.name : typeof error,
+    })
+    throw error
+  }
   if (!response.ok || body.ok !== true) {
-    throw transportError(response.status, body as DshExecutorErrorBody)
+    const error = transportError(response.status, body as DshExecutorErrorBody)
+    console.warn('[Wework] Executor RPC request failed', {
+      request_id: requestId,
+      method,
+      elapsed_ms: Date.now() - startedAt,
+      status: response.status,
+      code: error.code,
+      retryable: error.retryable,
+    })
+    throw error
   }
   return body.result
 }

--- a/wework/src/api/dsh/executorTransport.ts
+++ b/wework/src/api/dsh/executorTransport.ts
@@ -1,3 +1,5 @@
+import { createRequestId } from '@/lib/request-id'
+
 const EXECUTOR_BASE_PATH = '/wework/executor/v1'
 const executorEventReconnectors = new Set<() => void>()
 const INITIAL_RECONNECT_DELAY_MS = 500
@@ -80,13 +82,37 @@ export async function requestDshExecutor<T>(
   method: string,
   params: Record<string, unknown> = {}
 ): Promise<T> {
-  const response = await fetch(`${EXECUTOR_BASE_PATH}/rpc`, {
-    method: 'POST',
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({ method, params }),
+  const requestId = createRequestId('wework-local')
+  const startedAt = Date.now()
+  console.debug('[Wework] Executor RPC request started', {
+    request_id: requestId,
+    method,
+  })
+  let response: Response
+  try {
+    response = await fetch(`${EXECUTOR_BASE_PATH}/rpc`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify({ id: requestId, method, params }),
+    })
+  } catch (error) {
+    console.warn('[Wework] Executor RPC transport failed', {
+      request_id: requestId,
+      method,
+      elapsed_ms: Date.now() - startedAt,
+      error,
+    })
+    throw error
+  }
+  console.debug('[Wework] Executor RPC response received', {
+    request_id: requestId,
+    method,
+    elapsed_ms: Date.now() - startedAt,
+    status: response.status,
   })
   const body = (await response.json()) as
     | { ok: true; result: T }

--- a/wework/src/api/http.test.ts
+++ b/wework/src/api/http.test.ts
@@ -34,7 +34,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer token-1',
-        'X-Request-ID': expect.stringMatching(/^wework-/),
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -61,7 +61,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer cloud-token',
-        'X-Request-ID': expect.stringMatching(/^wework-/),
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
       body: JSON.stringify({ version: 1, status: 'in_progress' }),
     })
@@ -92,7 +92,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer cloud-token',
-        'X-Request-ID': expect.stringMatching(/^wework-/),
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
     expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:8000/api/v1/cloud-projects', {
@@ -100,7 +100,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer cloud-token',
-        'X-Request-ID': expect.stringMatching(/^wework-/),
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -127,7 +127,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer token-1',
-        'X-Request-ID': expect.stringMatching(/^wework-/),
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -172,7 +172,7 @@ describe('createHttpClient', () => {
       expect(warn).toHaveBeenCalledWith(
         '[Wework] HTTP GET /devices is still pending after 5000ms.',
         expect.objectContaining({
-          request_id: expect.stringMatching(/^wework-/),
+          request_id: expect.stringMatching(/^wework-http-/),
           phase: 'waiting_for_response',
           endpoint: '/devices',
           transport: 'fetch',
@@ -355,7 +355,7 @@ describe('createHttpClient', () => {
       body: formData,
       headers: {
         Authorization: 'Bearer token-1',
-        'X-Request-ID': expect.stringMatching(/^wework-/),
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })

--- a/wework/src/api/http.test.ts
+++ b/wework/src/api/http.test.ts
@@ -34,6 +34,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer token-1',
+        'X-Request-ID': expect.stringMatching(/^wework-/),
       },
     })
   })
@@ -60,6 +61,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer cloud-token',
+        'X-Request-ID': expect.stringMatching(/^wework-/),
       },
       body: JSON.stringify({ version: 1, status: 'in_progress' }),
     })
@@ -90,6 +92,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer cloud-token',
+        'X-Request-ID': expect.stringMatching(/^wework-/),
       },
     })
     expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:8000/api/v1/cloud-projects', {
@@ -97,6 +100,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer cloud-token',
+        'X-Request-ID': expect.stringMatching(/^wework-/),
       },
     })
   })
@@ -123,6 +127,7 @@ describe('createHttpClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer token-1',
+        'X-Request-ID': expect.stringMatching(/^wework-/),
       },
     })
   })
@@ -167,7 +172,7 @@ describe('createHttpClient', () => {
       expect(warn).toHaveBeenCalledWith(
         '[Wework] HTTP GET /devices is still pending after 5000ms.',
         expect.objectContaining({
-          requestId: expect.stringMatching(/^wework-/),
+          request_id: expect.stringMatching(/^wework-/),
           phase: 'waiting_for_response',
           endpoint: '/devices',
           transport: 'fetch',
@@ -185,7 +190,7 @@ describe('createHttpClient', () => {
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('completed slowly'),
         expect.objectContaining({
-          backendRequestId: 'backend-request-1',
+          backend_request_id: 'backend-request-1',
           phase: 'response_received',
           status: 200,
         })
@@ -240,7 +245,7 @@ describe('createHttpClient', () => {
         '[Wework] HTTP GET /attachments/1 returned 502.',
         expect.objectContaining({
           phase: 'http_error',
-          backendRequestId: 'backend-blob-request',
+          backend_request_id: 'backend-blob-request',
         })
       )
       expect(JSON.stringify(warn.mock.calls)).not.toContain('secret-cloud-token')
@@ -350,6 +355,7 @@ describe('createHttpClient', () => {
       body: formData,
       headers: {
         Authorization: 'Bearer token-1',
+        'X-Request-ID': expect.stringMatching(/^wework-/),
       },
     })
   })

--- a/wework/src/api/http.ts
+++ b/wework/src/api/http.ts
@@ -161,7 +161,7 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
     const isFormData = init.body instanceof FormData
     const method = init.method ?? 'GET'
     const startedAt = nowMs()
-    const requestId = createRequestId('wework')
+    const requestId = createRequestId('wework-http')
     const logContext = {
       requestId,
       method,

--- a/wework/src/api/http.ts
+++ b/wework/src/api/http.ts
@@ -1,16 +1,11 @@
 import { removeToken } from './auth'
 import { redirectToLogin } from '@/features/auth/redirect'
+import { createRequestId } from '@/lib/request-id'
 
 const SLOW_HTTP_REQUEST_MS = 5000
-let requestSequence = 0
 
 function nowMs(): number {
   return typeof performance !== 'undefined' ? performance.now() : Date.now()
-}
-
-function createRequestId(): string {
-  requestSequence += 1
-  return `wework-${Date.now().toString(36)}-${requestSequence.toString(36)}`
 }
 
 function transportName(): 'fetch' {
@@ -53,7 +48,7 @@ function requestLogFields(
   fields: Record<string, unknown> = {}
 ): Record<string, unknown> {
   return {
-    requestId: context.requestId,
+    request_id: context.requestId,
     method: context.method,
     baseUrl: context.baseUrl,
     endpoint: context.endpoint,
@@ -166,7 +161,7 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
     const isFormData = init.body instanceof FormData
     const method = init.method ?? 'GET'
     const startedAt = nowMs()
-    const requestId = createRequestId()
+    const requestId = createRequestId('wework')
     const logContext = {
       requestId,
       method,
@@ -180,6 +175,10 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
         requestLogFields(logContext, { phase: 'waiting_for_response' })
       )
     }, SLOW_HTTP_REQUEST_MS)
+    console.debug(
+      `[Wework] HTTP ${method} ${endpoint} started.`,
+      requestLogFields(logContext, { phase: 'request_started' })
+    )
     let response: Response
     try {
       response = await httpFetch()(requestUrl(options.baseUrl, endpoint), {
@@ -195,6 +194,7 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
               : {}),
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
           ...init.headers,
+          'X-Request-ID': requestId,
         },
       })
     } catch (error) {
@@ -211,13 +211,21 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
     window.clearTimeout(slowTimer)
     const elapsedMs = Math.round(nowMs() - startedAt)
     const backendRequestId = response.headers?.get?.('X-Request-ID') || null
+    console.debug(
+      `[Wework] HTTP ${method} ${endpoint} completed in ${elapsedMs}ms.`,
+      requestLogFields(logContext, {
+        phase: 'response_received',
+        status: response.status,
+        backend_request_id: backendRequestId,
+      })
+    )
     if (elapsedMs >= SLOW_HTTP_REQUEST_MS) {
       console.warn(
         `[Wework] HTTP ${method} ${endpoint} completed slowly in ${elapsedMs}ms.`,
         requestLogFields(logContext, {
           phase: 'response_received',
           status: response.status,
-          backendRequestId,
+          backend_request_id: backendRequestId,
           serverTiming: response.headers?.get?.('Server-Timing') || null,
         })
       )
@@ -236,7 +244,7 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
       requestLogFields(diagnostics.logContext, {
         phase: 'http_error',
         status: response.status,
-        backendRequestId: diagnostics.backendRequestId,
+        backend_request_id: diagnostics.backendRequestId,
         error: errorDetails(error),
       })
     )

--- a/wework/src/api/sites.test.ts
+++ b/wework/src/api/sites.test.ts
@@ -63,6 +63,7 @@ describe('createSitesApi', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer wegent-secret',
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -84,6 +85,7 @@ describe('createSitesApi', () => {
         headers: {
           'Content-Type': 'application/json',
           Authorization: 'Bearer wegent-secret',
+          'X-Request-ID': expect.stringMatching(/^wework-http-/),
         },
       }
     )
@@ -131,6 +133,7 @@ describe('createSitesApi', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer wegent-secret',
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -157,6 +160,7 @@ describe('createSitesApi', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer wegent-secret',
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -188,6 +192,7 @@ describe('createSitesApi', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer wegent-secret',
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })
@@ -200,9 +205,11 @@ describe('createSitesApi', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('/api/sites/site%2F1', {
       method: 'DELETE',
+      body: undefined,
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer wegent-secret',
+        'X-Request-ID': expect.stringMatching(/^wework-http-/),
       },
     })
   })

--- a/wework/src/lib/request-id.ts
+++ b/wework/src/lib/request-id.ts
@@ -1,0 +1,3 @@
+export function createRequestId(prefix: string): string {
+  return `${prefix}-${globalThis.crypto.randomUUID()}`
+}


### PR DESCRIPTION
## Summary

- generate and propagate request IDs across Wework HTTP, local DSH/executor RPC, and cloud Socket.IO/executor RPC boundaries
- log the same `request_id` at request start and completion/failure without logging payloads or credentials
- expose `X-Request-ID` through Backend CORS and document the cross-component correlation contract in Chinese and English

## Verification

- `pnpm --filter wework test src/api/http.test.ts src/api/dsh/executorTransport.test.ts src/api/backend/runtimeIpc.test.ts`
- `node --test executor-http.test.mjs executor-runtime-client.test.mjs`
- focused Backend pytest coverage for request logging and runtime RPC propagation
- focused executor contract test and clippy
- real Electron `ai:verify` run confirmed one request ID in DSH and executor logs
- repository pre-push quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end request ID propagation across browser, backend, local executor, and remote runtime requests.
  * Request IDs are included in relevant request and response headers, enabling easier troubleshooting and log correlation.
  * Runtime activity logs now consistently include request IDs, timing, methods, and outcomes.
  * Added safeguards for unsafe or duplicate request IDs.

* **Documentation**
  * Added English and Chinese guidance for tracing requests across components using request IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->