### PR TITLE
fix(wework): keep file preview scroll and copy complete

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5928,6 +5928,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     const content = screen.getByTestId('desktop-workbench-content')
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
+    expect(rightPanelShell).toHaveClass('h-full', 'min-h-0', 'overflow-hidden')
     await waitFor(() => {
       expect(content).toHaveStyle({ width: '420px' })
       expect(rightPanelShell).toHaveStyle({

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -4931,7 +4931,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           id="right-workspace-panel-shell"
           data-testid="right-workspace-panel-shell"
           className={cn(
-            'z-popover flex min-w-0 shrink-0 overflow-hidden',
+            'z-popover flex h-full min-h-0 min-w-0 shrink-0 overflow-hidden',
             rightPanelExpanded ? 'absolute inset-y-0 right-0' : 'relative',
             rightPanelExpanded
               ? 'bg-background'

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
@@ -11,6 +11,7 @@ const codeViewMocks = vi.hoisted(() => ({
 }))
 const appearanceMocks = vi.hoisted(() => ({
   resolvedMode: 'light' as 'dark' | 'light',
+  codeFontSize: 12,
 }))
 
 vi.mock('@/components/chat/AssistantMarkdown', () => ({
@@ -22,7 +23,11 @@ vi.mock('@/components/chat/AssistantMarkdown', () => ({
 }))
 
 vi.mock('@pierre/diffs/react', () => ({
-  CodeView: (props: { options: Record<string, unknown> }) => {
+  CodeView: (props: {
+    options: Record<string, unknown>
+    selectedLines?: unknown
+    style?: Record<string, string>
+  }) => {
     codeViewMocks.render(props)
     return <div data-testid="code-view" />
   },
@@ -60,7 +65,11 @@ vi.mock('@file-viewer/preset-engineering', () => ({ default: {} }))
 vi.mock('@file-viewer/preset-office', () => ({ default: {} }))
 vi.mock('@file-viewer/preset-lite', () => ({ default: {} }))
 vi.mock('@/features/appearance', () => ({
-  useOptionalAppearance: () => ({ resolvedMode: appearanceMocks.resolvedMode }),
+  defaultAppearance: { codeFontSize: 12 },
+  useOptionalAppearance: () => ({
+    resolvedMode: appearanceMocks.resolvedMode,
+    appearance: { codeFontSize: appearanceMocks.codeFontSize },
+  }),
 }))
 
 beforeEach(() => {
@@ -68,6 +77,7 @@ beforeEach(() => {
   fileViewerMocks.render.mockClear()
   codeViewMocks.render.mockClear()
   appearanceMocks.resolvedMode = 'light'
+  appearanceMocks.codeFontSize = 12
 })
 
 const markdownFile = {
@@ -351,6 +361,82 @@ test('keeps CodeView configuration stable across unrelated parent rerenders', ()
   expect(nextProps.onSelectedLinesChange).toBe(firstProps.onSelectedLinesChange)
   expect(nextProps.options).toBe(firstProps.options)
   expect(nextProps.selectedLines).toBe(firstProps.selectedLines)
+})
+
+test('keeps code view metrics aligned with the configured font size', () => {
+  appearanceMocks.codeFontSize = 13
+
+  render(
+    <WorkspaceFilePreview
+      file={{
+        path: '/workspace/project/index.ts',
+        name: 'index.ts',
+        content: 'export const value = true',
+        editable: true,
+        revision: 'revision-1',
+        truncated: false,
+        size: 25,
+      }}
+      loading={false}
+      onRetry={vi.fn()}
+      onAddCodeComment={vi.fn()}
+    />
+  )
+
+  const expectedLineHeight = Math.round(13 * 1.8)
+  expect(codeViewMocks.render).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      options: expect.objectContaining({
+        itemMetrics: { lineHeight: expectedLineHeight },
+        layout: { paddingTop: 0, paddingBottom: expectedLineHeight, gap: 0 },
+        unsafeCSS: expect.stringContaining('--wework-workspace-code-line-height'),
+      }),
+      style: expect.objectContaining({
+        '--wework-workspace-code-line-height': `${expectedLineHeight}px`,
+      }),
+    })
+  )
+})
+
+test('copies the complete file after selecting all lines with the keyboard shortcut', () => {
+  const content = Array.from({ length: 200 }, (_, index) => `第 ${index + 1} 行`).join('\n')
+
+  render(
+    <WorkspaceFilePreview
+      file={{
+        path: '/workspace/project/demo.sh',
+        name: 'demo.sh',
+        content,
+        editable: true,
+        revision: 'revision-1',
+        truncated: false,
+        size: content.length,
+      }}
+      loading={false}
+      onRetry={vi.fn()}
+      onAddCodeComment={vi.fn()}
+    />
+  )
+
+  fireEvent.keyDown(screen.getByTestId('workspace-file-preview'), {
+    key: 'a',
+    ctrlKey: true,
+  })
+
+  expect(codeViewMocks.render).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      selectedLines: {
+        id: '/workspace/project/demo.sh',
+        range: { start: 1, end: 200 },
+      },
+    })
+  )
+  expect(screen.queryByTestId('workspace-file-comment-input')).not.toBeInTheDocument()
+
+  const clipboardData = { setData: vi.fn() }
+  fireEvent.copy(screen.getByTestId('workspace-file-preview'), { clipboardData })
+
+  expect(clipboardData.setData).toHaveBeenCalledWith('text/plain', content)
 })
 
 test('keeps the current text preview visible while the next file is loading', () => {

--- a/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFilePreview.tsx
@@ -14,13 +14,17 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
+  type CSSProperties,
+  type KeyboardEvent,
   type ProfilerOnRenderCallback,
 } from 'react'
 import { AssistantMarkdown } from '@/components/chat/AssistantMarkdown'
 import { DiagramImageActions } from '@/components/chat/DiagramImageActions'
 import { getRuntimeConfig } from '@/config/runtime'
-import { useOptionalAppearance } from '@/features/appearance'
+import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { useTranslation } from '@/hooks/useTranslation'
+import { isEditableShortcutTarget } from '@/lib/keybindings'
 import { publishSelectedTextSelection, writeSelectedTextDragData } from '@/lib/selected-text-drag'
 import {
   logFilePreviewDiagnostic,
@@ -35,7 +39,7 @@ import { isMarkdownFile } from './workspaceFileTypes'
 const PIERRE_WORKSPACE_CODE_VIEW_CSS = `
   :host {
     --diffs-font-size: var(--text-code);
-    --diffs-line-height: calc(var(--text-code) * 1.8);
+    --diffs-line-height: var(--wework-workspace-code-line-height, calc(var(--text-code) * 1.8));
     --diffs-font-family: var(--font-code);
     --diffs-header-font-family: var(--font-ui);
     --diffs-light-bg: rgb(var(--color-bg-base));
@@ -255,6 +259,7 @@ interface SelectionState {
   selectedText: string
   startLine: number
   endLine: number
+  source: 'line' | 'keyboard'
 }
 
 interface CommentState {
@@ -336,10 +341,11 @@ function normalizeTargetLineRange(
 function WorkspaceFilePreviewContent({
   file,
   themeType,
+  codeFontSize,
   targetLineStart,
   targetLineEnd,
   onAddCodeComment,
-}: WorkspaceFilePreviewContentProps) {
+}: WorkspaceFilePreviewContentProps & { codeFontSize: number }) {
   const { t } = useTranslation('common')
   const codeViewRef = useRef<CodeViewHandle<undefined>>(null)
   const codeViewHostRef = useRef<HTMLDivElement>(null)
@@ -356,6 +362,7 @@ function WorkspaceFilePreviewContent({
   const targetLineKey = targetLineRange
     ? `${file.path}:${targetLineRange.start}:${targetLineRange.end}`
     : `${file.path}:none`
+  const codeLineHeight = Math.round(codeFontSize * 1.8)
   const codeViewItems = useMemo<CodeViewItem[]>(
     () => [
       {
@@ -373,6 +380,7 @@ function WorkspaceFilePreviewContent({
   )
   const activeSelection =
     selection?.filePath === file.path && selection.targetKey === targetLineKey ? selection : null
+  const activeCommentSelection = activeSelection?.source === 'line' ? activeSelection : null
   const comment = commentState.filePath === file.path ? commentState.value : ''
   const selectedLines = useMemo<WorkspaceCodeViewLineSelection | null>(
     () =>
@@ -392,22 +400,24 @@ function WorkspaceFilePreviewContent({
           : null,
     [activeSelection, file.path, targetLineRange]
   )
+  const allLinesSelected =
+    activeSelection?.startLine === 1 && activeSelection.endLine === lines.length
 
   useEffect(() => {
     const source = `workspace-preview:${file.path}`
     const host = codeViewHostRef.current
     const cleanup =
-      host && activeSelection
-        ? installCodeViewTextDrag(host, activeSelection.selectedText, rect => {
-            publishSelectedTextSelection(source, activeSelection.selectedText, rect)
+      host && activeCommentSelection
+        ? installCodeViewTextDrag(host, activeCommentSelection.selectedText, rect => {
+            publishSelectedTextSelection(source, activeCommentSelection.selectedText, rect)
           })
         : undefined
-    if (!activeSelection) publishSelectedTextSelection(source, null)
+    if (!activeCommentSelection) publishSelectedTextSelection(source, null)
     return () => {
       cleanup?.()
       publishSelectedTextSelection(source, null)
     }
-  }, [activeSelection, file.path])
+  }, [activeCommentSelection, file.path])
 
   useEffect(() => {
     if (!targetLineRange) return
@@ -443,6 +453,7 @@ function WorkspaceFilePreviewContent({
         selectedText,
         startLine,
         endLine,
+        source: 'line',
       })
       setCommentState({ filePath: file.path, value: '' })
     },
@@ -455,23 +466,24 @@ function WorkspaceFilePreviewContent({
       lineHoverHighlight: 'both' as const,
       overflow: 'scroll' as const,
       stickyHeaders: false,
-      layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
+      itemMetrics: { lineHeight: codeLineHeight },
+      layout: { paddingTop: 0, paddingBottom: codeLineHeight, gap: 0 },
       theme: { dark: 'pierre-dark', light: 'pierre-light' },
       themeType,
       unsafeCSS: PIERRE_WORKSPACE_CODE_VIEW_CSS,
     }),
-    [themeType]
+    [codeLineHeight, themeType]
   )
 
   const addComment = () => {
-    if (!file || !activeSelection || !comment.trim()) return
+    if (!file || !activeCommentSelection || !comment.trim()) return
     onAddCodeComment({
       id: `code-comment-${Date.now()}`,
       filePath: file.path,
       fileName: file.name,
-      startLine: activeSelection.startLine,
-      endLine: activeSelection.endLine,
-      selectedText: activeSelection.selectedText,
+      startLine: activeCommentSelection.startLine,
+      endLine: activeCommentSelection.endLine,
+      selectedText: activeCommentSelection.selectedText,
       comment: comment.trim(),
       createdAt: new Date().toISOString(),
     })
@@ -479,15 +491,50 @@ function WorkspaceFilePreviewContent({
     setCommentState({ filePath: file.path, value: '' })
   }
 
+  const selectEntireFile = () => {
+    setSelection({
+      filePath: file.path,
+      targetKey: targetLineKey,
+      selectedText: file.content,
+      startLine: 1,
+      endLine: lines.length,
+      source: 'keyboard',
+    })
+    setCommentState({ filePath: file.path, value: '' })
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (isEditableShortcutTarget(event.target)) return
+    const usesShortcutModifier = event.ctrlKey || event.metaKey
+    if (
+      !usesShortcutModifier ||
+      event.altKey ||
+      event.shiftKey ||
+      event.key.toLowerCase() !== 'a'
+    ) {
+      return
+    }
+    event.preventDefault()
+    selectEntireFile()
+  }
+
+  const handleCopy = (event: ClipboardEvent<HTMLElement>) => {
+    if (!allLinesSelected) return
+    event.preventDefault()
+    event.clipboardData.setData('text/plain', file.content)
+  }
+
   return (
     <section
       data-testid="workspace-file-preview"
-      draggable={Boolean(activeSelection)}
+      draggable={Boolean(activeCommentSelection)}
       onDragStart={event => {
-        if (!activeSelection) return
-        writeSelectedTextDragData(event.dataTransfer, activeSelection.selectedText)
+        if (!activeCommentSelection) return
+        writeSelectedTextDragData(event.dataTransfer, activeCommentSelection.selectedText)
       }}
       className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-background"
+      onCopy={handleCopy}
+      onKeyDown={handleKeyDown}
     >
       <div
         data-testid="workspace-file-preview-code-view"
@@ -502,7 +549,13 @@ function WorkspaceFilePreviewContent({
           onSelectedLinesChange={captureLineSelection}
           options={codeViewOptions}
           className="h-full min-h-0 w-full scrollbar-soft"
-          style={{ height: '100%', overflow: 'auto' }}
+          style={
+            {
+              height: '100%',
+              overflow: 'auto',
+              '--wework-workspace-code-line-height': `${codeLineHeight}px`,
+            } as CSSProperties
+          }
         />
       </div>
       {file.truncated && (
@@ -510,7 +563,7 @@ function WorkspaceFilePreviewContent({
           {t('workbench.workspace_file_truncated', '文件过大，仅显示前 256 KiB')}
         </div>
       )}
-      {activeSelection && (
+      {activeCommentSelection && (
         <div className="absolute bottom-4 left-4 right-4 rounded-xl border border-border bg-background p-3 shadow-xl">
           <div className="mb-2 flex items-center gap-2 text-sm font-medium text-text-primary">
             <MessageSquare className="h-4 w-4" />
@@ -579,6 +632,7 @@ export function WorkspaceFilePreview({
     (typeof document !== 'undefined' && document.documentElement.dataset.theme === 'dark'
       ? 'dark'
       : 'light')
+  const codeFontSize = appearance?.appearance.codeFontSize ?? defaultAppearance.codeFontSize
 
   if (loading && !file && !binaryFile) {
     const progress =
@@ -664,6 +718,7 @@ export function WorkspaceFilePreview({
     <WorkspaceFilePreviewContent
       file={file}
       themeType={themeType}
+      codeFontSize={codeFontSize}
       targetLineStart={targetLineStart}
       targetLineEnd={targetLineEnd}
       onAddCodeComment={onAddCodeComment}


### PR DESCRIPTION
## Summary
- align workspace file CodeView virtual row metrics with the rendered code line height so long previews can scroll to the bottom
- keep the right workspace panel height constrained for nested scrolling
- make Ctrl/Cmd+A then copy write the full file content without opening the local comment UI

## Tests
- pnpm --filter wework test src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx
- pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx -t "opens and resizes the right workspace panel"
- pnpm --filter wework exec prettier --check src/components/layout/workspace-panels/WorkspaceFilePreview.tsx src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx
- pnpm --filter wework exec eslint src/components/layout/workspace-panels/WorkspaceFilePreview.tsx src/components/layout/workspace-panels/WorkspaceFilePreview.test.tsx src/components/layout/DesktopWorkbenchMain.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx
- AI_VERIFIED=1 git push pre-push checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and copying the complete file from the code preview using Ctrl/Cmd+A.
  * Code preview line spacing and layout now adapt to the configured code font size.

* **Bug Fixes**
  * Improved workspace panel sizing so the right-side preview fills available space and remains usable within the layout.
  * Line-based actions such as comments, publishing, and drag-and-drop no longer apply to full-file keyboard selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->