### PR TITLE
fix(frontend): align workflow video controls and shared panels

### DIFF
--- a/frontend/src/__tests__/app/shared/task/page.test.tsx
+++ b/frontend/src/__tests__/app/shared/task/page.test.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import SharedTaskPage from '@/app/shared/task/page'
+import { openTaskRightPanel, registerTaskRightPanel } from '@/features/tasks/components/right-panel'
+
+const mockGetPublicSharedTask = jest.fn()
+const mockRouterPush = jest.fn()
+const mockTranslate = (key: string) => key
+const mockSearchParams = new URLSearchParams('token=shared-token')
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () =>
+    function MockMessageBubble() {
+      return <div data-testid="shared-message-bubble" />
+    },
+}))
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+jest.mock('@/apis/tasks', () => ({
+  taskApis: {
+    getPublicSharedTask: (token: string) => mockGetPublicSharedTask(token),
+  },
+}))
+
+jest.mock('@/apis/user', () => ({
+  getToken: () => null,
+  userApis: {
+    getCurrentUser: jest.fn(),
+  },
+}))
+
+jest.mock('@/features/theme/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}))
+
+jest.mock('@/features/layout/TopNavigation', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
+}))
+
+jest.mock('@/features/layout/GithubStarButton', () => ({
+  GithubStarButton: () => <div data-testid="github-star" />,
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: mockTranslate }),
+}))
+
+jest.mock('@/utils/browserDetection', () => ({
+  detectInAppBrowser: () => ({ isInAppBrowser: false }),
+}))
+
+registerTaskRightPanel('shared-test-panel', ({ embedded, onClose }) => (
+  <div data-testid="shared-test-panel" data-embedded={String(embedded)}>
+    <button type="button" data-testid="shared-test-panel-close" onClick={onClose}>
+      close panel
+    </button>
+  </div>
+))
+
+describe('SharedTaskPage right panel', () => {
+  beforeEach(() => {
+    mockGetPublicSharedTask.mockReset()
+    mockRouterPush.mockReset()
+    mockGetPublicSharedTask.mockResolvedValue({
+      task_title: 'Shared task',
+      sharer_name: 'Alice',
+      sharer_id: 1,
+      subtasks: [],
+      created_at: '2026-08-31T00:00:00Z',
+    })
+  })
+
+  it('opens and closes registered panels in the shared task view', async () => {
+    render(<SharedTaskPage />)
+
+    await screen.findByRole('heading', { name: 'Shared task' })
+    const content = screen
+      .getByRole('heading', { name: 'Shared task' })
+      .closest('.custom-scrollbar')
+
+    act(() => {
+      openTaskRightPanel({
+        panelType: 'shared-test-panel',
+        panelProps: {},
+      })
+    })
+
+    expect(screen.getByTestId('shared-task-right-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('shared-test-panel')).toHaveAttribute('data-embedded', 'true')
+    expect(content).toHaveClass('lg:mr-[720px]')
+    expect(content).not.toHaveClass('md:mr-[720px]')
+
+    fireEvent.click(screen.getByTestId('shared-test-panel-close'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('shared-task-right-panel')).not.toBeInTheDocument()
+    })
+    expect(content).not.toHaveClass('lg:mr-[720px]')
+  })
+})

--- a/frontend/src/__tests__/features/tasks/components/input/ChatInputControls.toolbar.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/ChatInputControls.toolbar.test.tsx
@@ -374,6 +374,45 @@ describe('ChatInputControls toolbar actions', () => {
     expect(screen.queryByTestId('agent-skill-selector-button')).not.toBeInTheDocument()
   })
 
+  it('hides workflow-owned video controls through hiddenVideoParams', () => {
+    const workflowTeam: Team = {
+      ...selectedTeam,
+      mode_spec: {
+        allowedModelCategories: ['video'],
+        hiddenVideoParams: ['duration', 'model', 'resolution', 'ratio'],
+      },
+    }
+
+    render(
+      <ChatInputControls
+        {...createProps()}
+        selectedTeam={workflowTeam}
+        teams={[workflowTeam]}
+        showVideoControlsInChat
+        selectedVideoModel={null}
+        onVideoModelChange={jest.fn()}
+        selectedResolution="1080p"
+        onResolutionChange={jest.fn()}
+        selectedRatio="9:16"
+        onRatioChange={jest.fn()}
+        selectedDuration={5}
+        onDurationChange={jest.fn()}
+        hideDurationSelector
+        videoGenerationModes={[
+          { id: 'text_to_video', label: '文生视频' },
+          { id: 'omni_reference', label: '全能参考' },
+        ]}
+        selectedVideoGenerationMode="text_to_video"
+        onVideoGenerationModeChange={jest.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('model-selector')).not.toBeInTheDocument()
+    expect(screen.getByTestId('video-generation-mode-selector')).toBeInTheDocument()
+    expect(screen.queryByTestId('video-settings-popover')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('agent-skill-selector-button')).not.toBeInTheDocument()
+  })
+
   it('moves video model and generation mode into more actions in a narrow chat pane', () => {
     const workflowTeam: Team = {
       ...selectedTeam,

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -258,6 +258,69 @@ describe('MobileChatInputControls layout', () => {
     )
   })
 
+  it('hides workflow-owned mobile video controls through hiddenVideoParams', async () => {
+    render(
+      <MobileChatInputControls
+        {...buildProps()}
+        selectedTeam={{
+          ...selectedTeam,
+          mode_spec: {
+            allowedModelCategories: ['video'],
+            hiddenVideoParams: ['duration', 'model', 'resolution', 'ratio'],
+          },
+        }}
+        showVideoControlsInChat
+        selectedVideoModel={null}
+        onVideoModelChange={jest.fn()}
+        selectedResolution="1080p"
+        onResolutionChange={jest.fn()}
+        selectedRatio="9:16"
+        onRatioChange={jest.fn()}
+        selectedDuration={5}
+        onDurationChange={jest.fn()}
+        hideDurationSelector
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mobile-video-model-selector')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('mobile-model-selector')).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    expect(screen.queryByTestId('mobile-video-settings')).not.toBeInTheDocument()
+  })
+
+  it('hides more actions when the workflow exposes no mobile actions', () => {
+    render(
+      <MobileChatInputControls
+        {...buildProps()}
+        selectedTeam={{
+          ...selectedTeam,
+          agent_type: 'dify',
+          mode_spec: {
+            allowedModelCategories: ['video'],
+            hiddenVideoParams: ['duration', 'model', 'resolution', 'ratio'],
+          },
+        }}
+        showVideoControlsInChat
+        selectedVideoGenerationMode="first_last_frame"
+        selectedVideoModel={null}
+        onVideoModelChange={jest.fn()}
+        selectedResolution="1080p"
+        onResolutionChange={jest.fn()}
+        selectedRatio="9:16"
+        onRatioChange={jest.fn()}
+        selectedDuration={5}
+        onDurationChange={jest.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('mobile-input-more-actions-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-input-more-actions-menu')).not.toBeInTheDocument()
+    expect(screen.getByTestId('send-button')).toBeInTheDocument()
+  })
+
   it('keeps long selector labels clipped without clipping the overflow menu', async () => {
     render(<MobileChatInputControls {...buildProps()} />)
 

--- a/frontend/src/__tests__/features/tasks/components/selector/VideoSettingsPopover.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/VideoSettingsPopover.test.tsx
@@ -10,14 +10,13 @@ jest.mock('@/hooks/useTranslation', () => ({
 }))
 
 describe('VideoSettingsPopover', () => {
-  it('keeps ratio and resolution controls while hiding duration', () => {
-    const onRatioChange = jest.fn()
+  it('keeps unowned controls while hiding configured video parameters', () => {
     const onResolutionChange = jest.fn()
 
     render(
       <VideoSettingsPopover
         selectedRatio="16:9"
-        onRatioChange={onRatioChange}
+        onRatioChange={jest.fn()}
         availableRatios={['16:9', '9:16']}
         selectedDuration={5}
         onDurationChange={jest.fn()}
@@ -25,17 +24,16 @@ describe('VideoSettingsPopover', () => {
         selectedResolution="720p"
         onResolutionChange={onResolutionChange}
         availableResolutions={['720p', '1080p']}
-        showDuration={false}
+        hiddenVideoParams={['duration', 'ratio']}
       />
     )
 
-    expect(screen.getByTestId('video-settings-trigger')).toHaveTextContent('16:9 · 720P')
+    expect(screen.getByTestId('video-settings-trigger')).toHaveTextContent('720P')
 
     fireEvent.click(screen.getByTestId('video-settings-trigger'))
     expect(screen.queryByTestId('video-duration-option-5')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByTestId('video-ratio-option-9:16'))
-    expect(onRatioChange).toHaveBeenCalledWith('9:16')
+    expect(screen.getByTestId('video-ratio-option-9:16')).not.toBeVisible()
 
     fireEvent.click(screen.getByTestId('video-resolution-option-1080p'))
     expect(onResolutionChange).toHaveBeenCalledWith('1080p')
@@ -62,5 +60,24 @@ describe('VideoSettingsPopover', () => {
     expect(trigger).not.toHaveTextContent('16:9')
     expect(trigger.getAttribute('aria-label')).toContain('16:9')
     expect(trigger).toHaveClass('h-9', 'w-9', 'justify-center')
+  })
+
+  it('hides the settings trigger when every video parameter is hidden', () => {
+    render(
+      <VideoSettingsPopover
+        selectedRatio="16:9"
+        onRatioChange={jest.fn()}
+        availableRatios={['16:9']}
+        selectedDuration={5}
+        onDurationChange={jest.fn()}
+        availableDurations={[5]}
+        selectedResolution="720p"
+        onResolutionChange={jest.fn()}
+        availableResolutions={['720p']}
+        hiddenVideoParams={['duration', 'ratio', 'resolution']}
+      />
+    )
+
+    expect(screen.queryByTestId('video-settings-trigger')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/features/tasks/utils/teamModeSpec.test.ts
+++ b/frontend/src/__tests__/features/tasks/utils/teamModeSpec.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  getVideoParamVisibility,
   teamHidesVideoParam,
   teamUsesModeSpecCategory,
   usesVideoReferenceStorage,
@@ -29,6 +30,24 @@ describe('teamModeSpec', () => {
     expect(teamHidesVideoParam(minuteVideoTeam, 'duration')).toBe(true)
     expect(teamHidesVideoParam(minuteVideoTeam, 'ratio')).toBe(false)
     expect(teamHidesVideoParam(minuteVideoTeam, 'resolution')).toBe(false)
+  })
+
+  it('resolves workflow-owned video control visibility', () => {
+    expect(getVideoParamVisibility(['duration', 'model', 'ratio'])).toEqual({
+      showModel: false,
+      showRatio: false,
+      showDuration: false,
+      showResolution: true,
+      showSettings: true,
+    })
+    expect(getVideoParamVisibility(['duration', 'ratio', 'resolution'])).toMatchObject({
+      showModel: true,
+      showSettings: false,
+    })
+    expect(getVideoParamVisibility([], false)).toMatchObject({
+      showDuration: false,
+      showSettings: true,
+    })
   })
 
   it('uses video reference storage for video-capable chat teams', () => {

--- a/frontend/src/app/shared/task/page.tsx
+++ b/frontend/src/app/shared/task/page.tsx
@@ -16,6 +16,7 @@ import { useTheme } from '@/features/theme/ThemeProvider'
 import TopNavigation from '@/features/layout/TopNavigation'
 import { GithubStarButton } from '@/features/layout/GithubStarButton'
 import type { Message } from '@/features/tasks/components/message'
+import { TaskRightPanelRenderer, useTaskRightPanel } from '@/features/tasks/components/right-panel'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { User, SubtaskContextBrief } from '@/types/api'
 import { InAppBrowserGuard } from '@/components/InAppBrowserGuard'
@@ -41,6 +42,8 @@ function SharedTaskContent() {
   const [error, setError] = useState<string | null>(null)
   const [currentUser, setCurrentUser] = useState<User | null>(null)
   const [showInAppBrowserGuard, setShowInAppBrowserGuard] = useState(false)
+  const { request: rightPanelRequest, close: closeRightPanel } = useTaskRightPanel()
+  const rightPanelOffsetClassName = rightPanelRequest ? 'lg:mr-[720px]' : ''
 
   // Check if user is logged in
   const isLoggedIn = !!getToken()
@@ -335,7 +338,7 @@ function SharedTaskContent() {
         </TopNavigation>
 
         {/* Main content area */}
-        <div className="flex-1 overflow-y-auto custom-scrollbar">
+        <div className={`flex-1 overflow-y-auto custom-scrollbar ${rightPanelOffsetClassName}`}>
           <div className="w-full max-w-3xl mx-auto flex flex-col px-4 py-6">
             {/* Task title and sharer info */}
             <div className="mb-6">
@@ -396,6 +399,15 @@ function SharedTaskContent() {
             </div>
           </div>
         </div>
+        {rightPanelRequest ? (
+          <aside
+            className="fixed inset-x-0 bottom-0 top-14 z-50 min-h-0 bg-surface lg:left-auto lg:w-[720px] lg:border-l lg:border-border"
+            data-task-right-panel
+            data-testid="shared-task-right-panel"
+          >
+            <TaskRightPanelRenderer request={rightPanelRequest} onClose={closeRightPanel} />
+          </aside>
+        ) : null}
       </div>
     </>
   )

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -50,6 +50,7 @@ import {
   teamSupportsBothGenerationModes,
   type TeamModeFilter,
 } from '../selector/team-selector-utils'
+import { getVideoParamVisibility } from '../../utils/teamModeSpec'
 
 export interface ChatInputControlsProps {
   /** Task type to determine which controls to show */
@@ -294,6 +295,8 @@ export function ChatInputControls({
   // Check if we're in video or image mode
   const isVideoMode = taskType === 'video' || showVideoControlsInChat
   const isImageMode = taskType === 'image'
+  const hiddenVideoParams = selectedTeam?.mode_spec?.hiddenVideoParams ?? []
+  const videoParamVisibility = getVideoParamVisibility(hiddenVideoParams, !hideDurationSelector)
   // Check if we're in generation mode (video or image)
   const isGenerationMode = isVideoMode || isImageMode
   // Always use compact mode (icon only) to save space
@@ -481,7 +484,7 @@ export function ChatInputControls({
   const compactVideoControls = isVideoMode && shouldCollapseSelectors
   const compactVideoMenuItems = compactVideoControls ? (
     <>
-      {onVideoModelChange && (
+      {videoParamVisibility.showModel && onVideoModelChange && (
         <ModelSelector
           selectedModel={selectedVideoModel ?? null}
           setSelectedModel={model => model && onVideoModelChange(model)}
@@ -558,7 +561,7 @@ export function ChatInputControls({
               />
             )}
             {/* Video Model Selector - using unified ModelSelector with video category */}
-            {!compactVideoControls && onVideoModelChange && (
+            {!compactVideoControls && videoParamVisibility.showModel && onVideoModelChange && (
               <ModelSelector
                 selectedModel={selectedVideoModel ?? null}
                 setSelectedModel={model => model && onVideoModelChange(model)}
@@ -572,24 +575,28 @@ export function ChatInputControls({
             )}
 
             {/* Unified Video Settings Popover (ratio + duration + resolution) */}
-            {onResolutionChange && onRatioChange && onDurationChange && (
-              <VideoSettingsPopover
-                selectedRatio={selectedRatio}
-                onRatioChange={onRatioChange}
-                availableRatios={availableRatios ?? ['16:9', '9:16', '1:1']}
-                ratioOptions={ratioOptions}
-                selectedDuration={selectedDuration}
-                onDurationChange={onDurationChange}
-                availableDurations={availableDurations ?? [5, 10]}
-                selectedResolution={selectedResolution}
-                onResolutionChange={onResolutionChange}
-                availableResolutions={availableResolutions ?? ['480p', '720p', '1080p']}
-                resolutionOptions={resolutionOptions}
-                disabled={isStreaming}
-                showDuration={!hideDurationSelector}
-                iconOnly={compactVideoControls}
-              />
-            )}
+            {videoParamVisibility.showSettings &&
+              onResolutionChange &&
+              onRatioChange &&
+              onDurationChange && (
+                <VideoSettingsPopover
+                  selectedRatio={selectedRatio}
+                  onRatioChange={onRatioChange}
+                  availableRatios={availableRatios ?? ['16:9', '9:16', '1:1']}
+                  ratioOptions={ratioOptions}
+                  selectedDuration={selectedDuration}
+                  onDurationChange={onDurationChange}
+                  availableDurations={availableDurations ?? [5, 10]}
+                  selectedResolution={selectedResolution}
+                  onResolutionChange={onResolutionChange}
+                  availableResolutions={availableResolutions ?? ['480p', '720p', '1080p']}
+                  resolutionOptions={resolutionOptions}
+                  disabled={isStreaming}
+                  showDuration={!hideDurationSelector}
+                  hiddenVideoParams={hiddenVideoParams}
+                  iconOnly={compactVideoControls}
+                />
+              )}
             {compactVideoMenuItems && (
               <InputMoreActionsMenu
                 showClarification={false}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -50,6 +50,7 @@ import { getChatSendState } from './chatSendState'
 import { useTranslation } from '@/hooks/useTranslation'
 import { filterTeamsByMode, type TeamModeFilter } from '../selector/team-selector-utils'
 import type { AspectRatioOption, ResolutionOption, VideoGenerationMode } from '@/apis/models'
+import { getVideoParamVisibility } from '../../utils/teamModeSpec'
 
 const MOBILE_ACTION_MENU_WIDTH = 224
 const MOBILE_ACTION_MENU_MARGIN = 12
@@ -242,6 +243,8 @@ export function MobileChatInputControls({
   const [moreMenuStyle, setMoreMenuStyle] = useState<React.CSSProperties>({})
   const showChatContexts = canUseChatContexts(taskType, selectedTeam)
   const isVideoMode = taskType === 'video' || showVideoControlsInChat
+  const hiddenVideoParams = selectedTeam?.mode_spec?.hiddenVideoParams ?? []
+  const videoParamVisibility = getVideoParamVisibility(hiddenVideoParams, !hideDurationSelector)
   const isGenerationMode = taskType === 'image' || isVideoMode
   const showAttachmentAction = isGenerationMode
     ? selectedVideoGenerationMode !== 'first_last_frame'
@@ -271,14 +274,28 @@ export function MobileChatInputControls({
     effectiveRequiresWorkspace !== false
   const showBranchAction = showRepositoryAction && Boolean(selectedRepo)
   const showVideoSettings = Boolean(
-    isVideoMode && onResolutionChange && onRatioChange && onDurationChange
+    isVideoMode &&
+    videoParamVisibility.showSettings &&
+    onResolutionChange &&
+    onRatioChange &&
+    onDurationChange
   )
   const hasSecondaryActions =
     showAttachmentAction || showChatContexts || showSkillAction || showVideoSettings
+  const showMoreActions =
+    hasSecondaryActions ||
+    showClarificationAction ||
+    showCorrectionAction ||
+    showGuidanceAction ||
+    showRepositoryAction ||
+    showBranchAction
   const closeMoreMenu = useCallback(() => {
     setMoreMenuOpen(false)
     setContextSelectorOpen(false)
   }, [])
+  useEffect(() => {
+    if (!showMoreActions && moreMenuOpen) closeMoreMenu()
+  }, [closeMoreMenu, moreMenuOpen, showMoreActions])
   const handleAttachmentFileSelect = useCallback(
     (files: File | File[]) => {
       closeMoreMenu()
@@ -484,28 +501,30 @@ export function MobileChatInputControls({
         data-tour="input-controls"
       >
         {/* Secondary actions menu */}
-        <Button
-          ref={moreMenuButtonRef}
-          type="button"
-          variant="ghost"
-          size="sm"
-          aria-expanded={moreMenuOpen}
-          aria-label="More actions"
-          data-testid="mobile-input-more-actions-button"
-          title="More actions"
-          onClick={() => {
-            if (moreMenuOpen) {
-              closeMoreMenu()
-              return
-            }
-            setMoreMenuOpen(true)
-          }}
-          className="h-8 w-8 p-0 rounded-full border border-border bg-base text-text-muted hover:text-text-primary hover:bg-hover"
-        >
-          <Plus className="h-4 w-4" />
-        </Button>
+        {showMoreActions && (
+          <Button
+            ref={moreMenuButtonRef}
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-expanded={moreMenuOpen}
+            aria-label="More actions"
+            data-testid="mobile-input-more-actions-button"
+            title="More actions"
+            onClick={() => {
+              if (moreMenuOpen) {
+                closeMoreMenu()
+                return
+              }
+              setMoreMenuOpen(true)
+            }}
+            className="h-8 w-8 p-0 rounded-full border border-border bg-base text-text-muted hover:text-text-primary hover:bg-hover"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        )}
 
-        {moreMenuOpen && (
+        {showMoreActions && moreMenuOpen && (
           <div
             ref={moreMenuRef}
             data-testid="mobile-input-more-actions-menu"
@@ -529,6 +548,7 @@ export function MobileChatInputControls({
                     resolutionOptions={resolutionOptions}
                     disabled={isStreaming}
                     showDuration={!hideDurationSelector}
+                    hiddenVideoParams={hiddenVideoParams}
                     triggerVariant="menu-item"
                   />
                 )}
@@ -633,7 +653,7 @@ export function MobileChatInputControls({
             disabled={isStreaming}
           />
         )}
-        {isVideoMode && onVideoModelChange && (
+        {isVideoMode && videoParamVisibility.showModel && onVideoModelChange && (
           <div className="flex-1 min-w-0 overflow-hidden">
             <MobileModelSelector
               selectedModel={selectedVideoModel ?? null}

--- a/frontend/src/features/tasks/components/selector/VideoSettingsPopover.tsx
+++ b/frontend/src/features/tasks/components/selector/VideoSettingsPopover.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils'
 import { useTranslation } from '@/hooks/useTranslation'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { AspectRatioOption, ResolutionOption } from '@/apis/models'
+import { getVideoParamVisibility } from '@/features/tasks/utils/teamModeSpec'
 import { formatVideoDuration } from '@/features/tasks/utils/videoDuration'
 
 export interface VideoSettingsPopoverProps {
@@ -38,6 +39,7 @@ export interface VideoSettingsPopoverProps {
   // State
   disabled?: boolean
   showDuration?: boolean
+  hiddenVideoParams?: string[]
   triggerVariant?: 'default' | 'menu-item'
   iconOnly?: boolean
 }
@@ -79,11 +81,20 @@ export function VideoSettingsPopover({
   resolutionOptions,
   disabled = false,
   showDuration = true,
+  hiddenVideoParams = [],
   triggerVariant = 'default',
   iconOnly = false,
 }: VideoSettingsPopoverProps) {
   const { t } = useTranslation('chat')
   const [isOpen, setIsOpen] = useState(false)
+  const {
+    showRatio,
+    showDuration: showVideoDuration,
+    showResolution,
+    showSettings,
+  } = getVideoParamVisibility(hiddenVideoParams, showDuration)
+
+  if (!showSettings) return null
 
   // Build summary text for trigger button
   const selectedRatioLabel =
@@ -94,9 +105,9 @@ export function VideoSettingsPopover({
   const autoDurationLabel = t('video.duration_auto')
   const selectedDurationLabel = formatVideoDuration(selectedDuration, autoDurationLabel)
   const summaryText = [
-    selectedRatioLabel,
-    ...(showDuration ? [selectedDurationLabel] : []),
-    selectedResolutionLabel,
+    ...(showRatio ? [selectedRatioLabel] : []),
+    ...(showVideoDuration ? [selectedDurationLabel] : []),
+    ...(showResolution ? [selectedResolutionLabel] : []),
   ].join(' · ')
   const displayedRatios = ratioOptions?.length
     ? ratioOptions
@@ -140,7 +151,7 @@ export function VideoSettingsPopover({
       >
         <div className="space-y-4">
           {/* Aspect Ratio Section */}
-          <div>
+          <div hidden={!showRatio}>
             <h4 className="text-sm font-medium text-text-primary mb-2">
               {t('video.ratio_section')}
             </h4>
@@ -166,7 +177,7 @@ export function VideoSettingsPopover({
             </div>
           </div>
 
-          {showDuration && (
+          {showVideoDuration && (
             <div>
               <h4 className="text-sm font-medium text-text-primary mb-2">
                 {t('video.duration_section')}
@@ -193,7 +204,7 @@ export function VideoSettingsPopover({
           )}
 
           {/* Resolution Section */}
-          <div>
+          <div hidden={!showResolution}>
             <h4 className="text-sm font-medium text-text-primary mb-2">
               {t('video.resolution_section')}
             </h4>

--- a/frontend/src/features/tasks/utils/teamModeSpec.ts
+++ b/frontend/src/features/tasks/utils/teamModeSpec.ts
@@ -4,13 +4,39 @@
 
 import type { TaskType, Team } from '@/types/api'
 
+export interface VideoParamVisibility {
+  showModel: boolean
+  showRatio: boolean
+  showDuration: boolean
+  showResolution: boolean
+  showSettings: boolean
+}
+
+/** Resolve video control visibility from workflow ownership and caller constraints. */
+export function getVideoParamVisibility(
+  hiddenVideoParams: readonly string[] | undefined,
+  allowDuration = true
+): VideoParamVisibility {
+  const showRatio = !hiddenVideoParams?.includes('ratio')
+  const showDuration = allowDuration && !hiddenVideoParams?.includes('duration')
+  const showResolution = !hiddenVideoParams?.includes('resolution')
+
+  return {
+    showModel: !hiddenVideoParams?.includes('model'),
+    showRatio,
+    showDuration,
+    showResolution,
+    showSettings: showRatio || showDuration || showResolution,
+  }
+}
+
 export function teamUsesModeSpecCategory(team: Team | null | undefined, category: string): boolean {
   return Boolean(team?.mode_spec?.allowedModelCategories?.includes(category))
 }
 
 export function teamHidesVideoParam(
   team: Team | null | undefined,
-  param: 'duration' | 'ratio' | 'resolution'
+  param: 'duration' | 'model' | 'ratio' | 'resolution'
 ): boolean {
   return team?.mode_spec?.hiddenVideoParams?.includes(param) === true
 }


### PR DESCRIPTION
## Summary

- Respect `hiddenVideoParams` for the video model, aspect ratio, duration, and resolution controls on desktop and mobile.
- Keep visible video settings usable independently, and hide the settings trigger when the workflow owns every setting.
- Mount the task right-panel registry on the shared-task page with a responsive panel container.

## Motivation

Workflow-managed video agents can own generation parameters, but the chat composer only honored the duration visibility setting. This left model, ratio, and resolution controls visible even when the team configuration marked them as hidden.

The shared-task page also rendered cards without mounting the task right-panel host, so cards backed by the existing registry could not open their detail panel from a shared view.

## Implementation

- Reuse the existing `mode_spec.hiddenVideoParams` configuration; no schema or migration changes are required.
- Resolve video model and settings visibility through one shared helper used by desktop, mobile, and the settings popover.
- Start the 720px shared-task split layout at the `lg` breakpoint so tablet widths keep the full overlay layout.
- Hide the mobile More actions trigger when no attachment, context, skill, video setting, chat toggle, guidance, or repository action is available.
- Preserve the existing positive-path coverage and add dedicated hidden-control tests.
- Add a shared-task integration test covering panel open, responsive layout offset, and close behavior.

## Testing

- Focused video and shared-panel tests — 5 suites and 22 tests passed.
- `pnpm --dir frontend exec tsc --noEmit`.
- ESLint and Prettier checks for all changed files.
- `SKIP_FONT_DOWNLOAD=1 pnpm --dir frontend build`.
- Repository pre-push gate — ESLint, TypeScript, and unit tests passed.

## Documentation

No documentation update is required because this change extends an existing team configuration field and existing task-panel registry without introducing a new user-facing configuration format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a right-side panel to shared task pages, with responsive content spacing and close support.
  * Added team-configurable visibility for video controls, including model, ratio, duration, and resolution.
  * Video settings menus now appear only when relevant options are available.
* **Bug Fixes**
  * Prevented hidden video controls and empty settings menus from appearing in desktop and mobile chat interfaces.
  * Hid the mobile More actions menu when no secondary actions are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->