### PR TITLE
fix(wework): reduce desktop e2e build output

### DIFF
--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -283,6 +283,14 @@ application launch to control CI duration. Test artifacts, captured model
 requests, and failure diagnostics are stored in
 `wework/test-results/desktop-e2e/`.
 
+The local runner writes complete stdout and stderr from the prerequisite
+Electron and Executor build to
+`wework/test-results/desktop-e2e/desktop-build-<pid>.log`. The terminal shows
+only the build stage, a liveness message every 30 seconds, elapsed time, and the
+log path so package installation, compilation, and signing output do not bury
+checkpoint results. On build failure, the terminal also prints a bounded tail
+of the log. Test output remains live after the scenario starts.
+
 `ai:verify:electron:build` shares immutable Harness Runtime archives across worktrees. The default archive cache is `~/Library/Caches/wegent/harness-runtime` on macOS, `${XDG_CACHE_HOME:-~/.cache}/wegent/harness-runtime` on Linux, and `%LOCALAPPDATA%\wegent/harness-runtime` on Windows. Materialized development runtimes remain under `wework/node_modules/.cache/harness-runtime-dev` in the current worktree so mutable state is not shared across source trees. Set `WEWORK_HARNESS_RUNTIME_ASSET_CACHE_ROOT` to override the archive cache. If a build only sets the legacy `WEWORK_HARNESS_RUNTIME_CACHE_ROOT`, that value is translated into an archive-only cache override and does not move the current worktree's materialized runtime.
 
 Before launching Electron, desktop E2E removes inherited task, IPC, Node, and Harness runtime variables so a development Wework or Codex session cannot leak personal runtime paths into the test application. To select a Core DSH runtime explicitly for focused diagnosis, set `WEWORK_E2E_HARNESS_RUNTIME_ROOT`; the runner validates that directory and passes it to the test application as `WEWORK_HARNESS_RUNTIME_ROOT`. Do not pass `WEWORK_HARNESS_RUNTIME_ROOT` directly to the test command.

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -248,6 +248,11 @@ Electron 应用；传入的应用必须使用桌面 E2E 的 Vite 环境变量构
 复用一次应用启动以控制 CI 时长；测试过程、捕获的模型请求和失败诊断会保存在
 `wework/test-results/desktop-e2e/`。
 
+本地 runner 会把前置 Electron 和 Executor 构建的完整 stdout、stderr 写入
+`wework/test-results/desktop-e2e/desktop-build-<pid>.log`，终端只显示构建阶段、
+每 30 秒一次的存活提示、耗时和日志路径，避免包安装、编译和签名输出淹没 checkpoint
+结果。构建失败时，终端还会打印日志末尾的有限摘要；场景启动后的测试输出仍实时显示。
+
 `ai:verify:electron:build` 会跨 worktree 复用不可变的 Harness Runtime 归档，macOS 默认缓存到 `~/Library/Caches/wegent/harness-runtime`，Linux 默认缓存到 `${XDG_CACHE_HOME:-~/.cache}/wegent/harness-runtime`，Windows 默认缓存到 `%LOCALAPPDATA%\wegent\harness-runtime`。解压后的开发 Runtime 仍保留在当前 worktree 的 `wework/node_modules/.cache/harness-runtime-dev`，避免不同源码树共享可变状态。可通过 `WEWORK_HARNESS_RUNTIME_ASSET_CACHE_ROOT` 覆盖归档缓存目录；若构建时只设置了旧的 `WEWORK_HARNESS_RUNTIME_CACHE_ROOT`，该值会被转换为仅用于归档的缓存目录，不会改变当前 worktree 的解压目录。
 
 桌面 E2E 启动 Electron 前会移除父进程中的任务、IPC、Node 和 Harness runtime 环境变量，避免从开发中的 Wework 或 Codex 会话继承个人运行时路径。需要为聚焦排查显式指定 Core DSH runtime 时，使用 `WEWORK_E2E_HARNESS_RUNTIME_ROOT`；runner 会校验该目录并将其作为测试应用的 `WEWORK_HARNESS_RUNTIME_ROOT`。不要直接向测试命令传递 `WEWORK_HARNESS_RUNTIME_ROOT`。

--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 
 import { DESKTOP_CHECKPOINTS } from './checkpoints.mjs'
 import { prepareDesktopE2EBuild } from '../../scripts/lib/desktop-e2e-build.mjs'
+import { runCommandToLog } from '../../scripts/lib/command-log.mjs'
 
 const HEARTBEAT_INTERVAL_MS = 30_000
 const DEFAULT_PARALLEL_CHECKPOINTS = 1
@@ -259,21 +260,43 @@ function checkpointScenarioEnv(env, checkpoint) {
   return nextEnv
 }
 
-function runDesktopBuild() {
-  return new Promise((resolvePromise, reject) => {
-    console.log('[desktop-e2e] Building the shared Electron application and executor')
-    const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-    const child = spawn(command, ['run', 'ai:verify:electron:build'], {
+async function runDesktopBuild() {
+  const startedAt = Date.now()
+  const logPath = join(weworkDir, 'test-results', 'desktop-e2e', `desktop-build-${process.pid}.log`)
+  console.log(
+    `[desktop-e2e] Building the shared Electron application and executor. Full log: ${logPath}`
+  )
+  const heartbeat = setInterval(() => {
+    console.log(
+      `[desktop-e2e] Desktop build still running: elapsed=${formatDuration(Date.now() - startedAt)}`
+    )
+  }, HEARTBEAT_INTERVAL_MS)
+
+  let result
+  try {
+    result = await runCommandToLog({
+      args: ['run', 'ai:verify:electron:build'],
+      command: process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
       cwd: weworkDir,
       env: process.env,
-      stdio: 'inherit',
+      logPath,
     })
-    child.once('error', reject)
-    child.once('exit', code => {
-      if (code === 0) resolvePromise()
-      else reject(new Error(`Desktop E2E build exited with code ${code ?? 'unknown'}`))
-    })
-  })
+  } finally {
+    clearInterval(heartbeat)
+  }
+
+  if (result.code !== 0) {
+    console.error(
+      `[desktop-e2e] Desktop build failed: ${result.signal ? `signal=${result.signal}` : `exit=${result.code}`}. Full log: ${logPath}`
+    )
+    if (result.tail.trim()) {
+      console.error(`[desktop-e2e] Desktop build output tail:\n${result.tail.trimEnd()}`)
+    }
+    throw new Error(`Desktop E2E build exited with code ${result.code}`)
+  }
+  console.log(
+    `[desktop-e2e] Desktop build passed: duration=${formatDuration(Date.now() - startedAt)}. Full log: ${logPath}`
+  )
 }
 
 async function sharedBuildEnvironment(environment = process.env) {

--- a/wework/scripts/lib/command-log.mjs
+++ b/wework/scripts/lib/command-log.mjs
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { finished } from 'node:stream/promises'
+
+const DEFAULT_TAIL_CHARACTERS = 12_000
+
+export async function runCommandToLog({
+  args,
+  command,
+  cwd,
+  env,
+  logPath,
+  tailCharacters = DEFAULT_TAIL_CHARACTERS,
+}) {
+  await mkdir(dirname(logPath), { recursive: true })
+  const logStream = createWriteStream(logPath, { encoding: 'utf8' })
+  const logCompletion = finished(logStream)
+  let tail = ''
+
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const capture = chunk => {
+    const text = chunk.toString()
+    tail = `${tail}${text}`.slice(-tailCharacters)
+    logStream.write(text)
+  }
+  child.stdout.on('data', capture)
+  child.stderr.on('data', capture)
+
+  let result
+  try {
+    result = await new Promise((resolvePromise, reject) => {
+      child.once('error', reject)
+      child.once('close', (code, signal) => {
+        resolvePromise({
+          code: code ?? 1,
+          signal,
+        })
+      })
+    })
+  } finally {
+    logStream.end()
+    await logCompletion
+  }
+
+  return {
+    ...result,
+    tail,
+  }
+}

--- a/wework/scripts/lib/command-log.test.mjs
+++ b/wework/scripts/lib/command-log.test.mjs
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { runCommandToLog } from './command-log.mjs'
+
+const temporaryDirectories = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(path => rm(path, { force: true, recursive: true }))
+  )
+})
+
+async function temporaryLogPath() {
+  const directory = await mkdtemp(join(tmpdir(), 'wework-command-log-'))
+  temporaryDirectories.push(directory)
+  return join(directory, 'nested', 'command.log')
+}
+
+describe('runCommandToLog', () => {
+  test('writes stdout and stderr to the log without forwarding them', async () => {
+    const logPath = await temporaryLogPath()
+
+    const result = await runCommandToLog({
+      args: ['-e', "process.stdout.write('stdout\\n'); process.stderr.write('stderr\\n')"],
+      command: process.execPath,
+      logPath,
+    })
+
+    expect(result).toMatchObject({ code: 0, signal: null })
+    expect(await readFile(logPath, 'utf8')).toContain('stdout\n')
+    expect(await readFile(logPath, 'utf8')).toContain('stderr\n')
+    expect(result.tail).toContain('stdout\n')
+    expect(result.tail).toContain('stderr\n')
+  })
+
+  test('returns the exit code and only the configured output tail', async () => {
+    const logPath = await temporaryLogPath()
+
+    const result = await runCommandToLog({
+      args: ['-e', "process.stdout.write('0123456789'); process.exitCode = 7"],
+      command: process.execPath,
+      logPath,
+      tailCharacters: 4,
+    })
+
+    expect(result).toEqual({
+      code: 7,
+      signal: null,
+      tail: '6789',
+    })
+    expect(await readFile(logPath, 'utf8')).toBe('0123456789')
+  })
+
+  test('closes the log when the command cannot be started', async () => {
+    const logPath = await temporaryLogPath()
+
+    await expect(
+      runCommandToLog({
+        args: [],
+        command: join(tmpdir(), 'missing-wework-command'),
+        logPath,
+      })
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(logPath, 'utf8')).resolves.toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

- capture prerequisite Electron and Executor build stdout/stderr in a dedicated desktop E2E log file
- keep the console concise with build lifecycle heartbeats and a bounded failure tail
- document the local runner logging behavior in Chinese and English

## Verification

- `pnpm --filter wework test scripts/lib/command-log.test.mjs scripts/lib/desktop-e2e-build.test.mjs`
- `pnpm --filter wework exec prettier --check e2e/desktop/run-checkpoints.mjs scripts/lib/command-log.mjs scripts/lib/command-log.test.mjs ../docs/zh/wework/developer-guide/wework-e2e-automation.md ../docs/en/wework/developer-guide/wework-e2e-automation.md`
- `pnpm --filter wework exec eslint e2e/desktop/run-checkpoints.mjs scripts/lib/command-log.mjs scripts/lib/command-log.test.mjs`
- pre-push Wework static checks and unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop end-to-end builds now save complete diagnostic output to a per-run log file.
  * Terminal output is streamlined with build progress, periodic status updates, elapsed time, and the log location.
  * Build failures show a concise log tail, while test output remains visible in real time after scenarios begin.

* **Documentation**
  * Updated English and Chinese desktop E2E automation guides with the new build logging and failure-reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->